### PR TITLE
fix: escape @-mention tokens in generated release changelogs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,12 @@ jobs:
               range="$GITHUB_REF_NAME"
               echo "No previous tag found; changelog from all commits"
             fi
+            # Neutralize @-mention-shaped tokens (e.g. a commit subject citing
+            # "@font-face") by wrapping them in backticks: on the GitHub release
+            # page a bare @word renders as a user mention AND credits that user
+            # in the release's Contributors section.
             git log --no-merges --pretty='%s' "$range" \
+              | sed -E 's/(^|[^`[:alnum:]])@([[:alnum:]][[:alnum:]-]*)/\1`@\2`/g' \
               | awk 'NR==1 { print "- " $0; next } { print " - " $0 }' > changelog.txt
           fi
           if [ ! -s changelog.txt ]; then


### PR DESCRIPTION
A historical commit subject ("Embed Material Symbols Rounded via @font-face") rendered as a user @-mention on the 1.0.0.0 release page, which also made GitHub credit that unrelated account in the release Contributors section. The changelog generator now wraps mention-shaped tokens in backticks (verified against mention, email, and already-escaped cases). The live 1.0.0.0 release body was edited in place separately.