### PR TITLE
ci: pin the ESLint warning count as a true ratchet

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,7 +187,9 @@ npm install
 
 # Client
 npm run typecheck:src          # tsc --strict over the TypeScript module tree (src/)
-npm run lint                   # ESLint (errors gate CI; warnings are advisory)
+npm run lint                   # ESLint (errors gate CI; warning count is a ratchet
+                               # via --max-warnings — lower the cap in package.json
+                               # when you reduce warnings, never raise it)
 npm run test:client            # vitest unit tests for src/ modules
 npm run test:client:coverage   # + the src/core line-coverage ratchet
 npm run build:bundle           # esbuild bundle — fails on unreachable src/ modules
@@ -205,6 +207,8 @@ npm run e2e:headed             # watch it run
 ```
 
 Coverage thresholds are **ratchets**: they were set just below measured coverage when introduced (`vitest.config.ts` for `src/core`, `scripts/check-dotnet-coverage.js` for the plugin assembly). Raise them as you add tests; never lower them.
+
+The ESLint warning cap (`--max-warnings` in the `lint` script) is the same idea inverted: it is pinned at the current count of typed-lint `no-unsafe-*` warnings in the converted legacy feature areas (`src/core` and `src/types` treat those rules as errors). New code must not add warnings; when you type legacy shapes and the count drops, lower the cap to match — never raise it.
 
 ### E2E against a disposable server
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Development tooling for the Jellyfin Elevate plugin (lint, type-check, translation validation). The plugin itself ships as embedded resources from the C# project.",
   "scripts": {
-    "lint": "eslint \"Jellyfin.Plugin.JellyfinElevate/js/**/*.js\" \"Jellyfin.Plugin.JellyfinElevate/src/**/*.ts\" \"Jellyfin.Plugin.JellyfinElevate/Configuration/*.js\" \"scripts/**/*.js\"",
+    "lint": "eslint --max-warnings 6751 \"Jellyfin.Plugin.JellyfinElevate/js/**/*.js\" \"Jellyfin.Plugin.JellyfinElevate/src/**/*.ts\" \"Jellyfin.Plugin.JellyfinElevate/Configuration/*.js\" \"scripts/**/*.js\"",
     "lint:fix": "eslint --fix \"Jellyfin.Plugin.JellyfinElevate/js/**/*.js\" \"Jellyfin.Plugin.JellyfinElevate/src/**/*.ts\" \"Jellyfin.Plugin.JellyfinElevate/Configuration/*.js\" \"scripts/**/*.js\"",
     "typecheck": "tsc -p jsconfig.json",
     "typecheck:src": "tsc -p tsconfig.src.json",


### PR DESCRIPTION
From code review: the 6,751 typed-lint no-unsafe-* warnings (untyped external-API payload flows in the converted legacy feature areas) did not gate CI, so the count could silently drift upward. This pins --max-warnings at the current count, turning it into an enforced ratchet like the coverage thresholds: new code cannot add warnings; typing work that reduces the count should lower the cap. src/core and src/types already treat these rules as errors. Verified locally: lint passes at 6751 and fails at 6750.