### PR TITLE
feat(seerr): 4K request gating and 4K collection requests

### DIFF
--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Controllers/ArrRequestsControllerParentalTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Controllers/ArrRequestsControllerParentalTests.cs
@@ -225,7 +225,7 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Controllers
 
             public Task<bool> GetStatusActiveAsync() => throw new NotImplementedException();
 
-            public Task<Seerr4kCapability> GetSeerr4kCapabilityAsync(string jellyfinUserId)
+            public Task<Seerr4kCapability> GetSeerr4kCapabilityAsync(string jellyfinUserId, bool isAdmin = false)
                 => throw new NotImplementedException();
 
             public Task<IActionResult> ProxyRequestAsync(string apiPath, HttpMethod method, string? content, JellyseerrCaller caller)

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Controllers/ArrRequestsControllerParentalTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Controllers/ArrRequestsControllerParentalTests.cs
@@ -225,6 +225,9 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Controllers
 
             public Task<bool> GetStatusActiveAsync() => throw new NotImplementedException();
 
+            public Task<Seerr4kCapability> GetSeerr4kCapabilityAsync(string jellyfinUserId)
+                => throw new NotImplementedException();
+
             public Task<IActionResult> ProxyRequestAsync(string apiPath, HttpMethod method, string? content, JellyseerrCaller caller)
                 => throw new NotImplementedException();
 

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Controllers/TmdbProxyAppendToResponseTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Controllers/TmdbProxyAppendToResponseTests.cs
@@ -132,6 +132,8 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Controllers
 
             public Task<bool> GetStatusActiveAsync() => throw new NotImplementedException();
 
+            public Task<Seerr4kCapability> GetSeerr4kCapabilityAsync(string jellyfinUserId) => throw new NotImplementedException();
+
             public Task<IActionResult> ProxyRequestAsync(string apiPath, HttpMethod method, string? content, JellyseerrCaller caller) => throw new NotImplementedException();
 
             public Task<List<WatchlistItem>?> GetWatchlistForUser(string jellyseerrUserId) => throw new NotImplementedException();

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Controllers/TmdbProxyAppendToResponseTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Controllers/TmdbProxyAppendToResponseTests.cs
@@ -132,7 +132,7 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Controllers
 
             public Task<bool> GetStatusActiveAsync() => throw new NotImplementedException();
 
-            public Task<Seerr4kCapability> GetSeerr4kCapabilityAsync(string jellyfinUserId) => throw new NotImplementedException();
+            public Task<Seerr4kCapability> GetSeerr4kCapabilityAsync(string jellyfinUserId, bool isAdmin = false) => throw new NotImplementedException();
 
             public Task<IActionResult> ProxyRequestAsync(string apiPath, HttpMethod method, string? content, JellyseerrCaller caller) => throw new NotImplementedException();
 

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Helpers/Jellyseerr/Jellyseerr4kPermissionTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Helpers/Jellyseerr/Jellyseerr4kPermissionTests.cs
@@ -1,0 +1,59 @@
+using Jellyfin.Plugin.JellyfinElevate.Helpers.Jellyseerr;
+using Jellyfin.Plugin.JellyfinElevate.Model.Jellyseerr;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinElevate.Tests.Helpers.Jellyseerr
+{
+    /// <summary>
+    /// Pins <see cref="JellyseerrPermissionHelper.CanRequest4k"/> to Seerr's own
+    /// 4K request rule (server/entity/MediaRequest.ts): admins bypass, otherwise
+    /// REQUEST_4K OR the media-specific 4K bit is required. This one helper is the
+    /// single source of truth for both the server request gate and the
+    /// client-facing 4K capability projection, so both directions are covered.
+    /// </summary>
+    public class Jellyseerr4kPermissionTests
+    {
+        [Fact]
+        public void Admin_CanRequest4k_ForBothMediaTypes()
+        {
+            Assert.True(JellyseerrPermissionHelper.CanRequest4k(JellyseerrPermission.ADMIN, isTv: false));
+            Assert.True(JellyseerrPermissionHelper.CanRequest4k(JellyseerrPermission.ADMIN, isTv: true));
+        }
+
+        [Fact]
+        public void GlobalRequest4k_CanRequest4k_ForBothMediaTypes()
+        {
+            Assert.True(JellyseerrPermissionHelper.CanRequest4k(JellyseerrPermission.REQUEST_4K, isTv: false));
+            Assert.True(JellyseerrPermissionHelper.CanRequest4k(JellyseerrPermission.REQUEST_4K, isTv: true));
+        }
+
+        [Fact]
+        public void MovieBit_AllowsMovie_ButNotTv()
+        {
+            Assert.True(JellyseerrPermissionHelper.CanRequest4k(JellyseerrPermission.REQUEST_4K_MOVIE, isTv: false));
+            Assert.False(JellyseerrPermissionHelper.CanRequest4k(JellyseerrPermission.REQUEST_4K_MOVIE, isTv: true));
+        }
+
+        [Fact]
+        public void TvBit_AllowsTv_ButNotMovie()
+        {
+            Assert.True(JellyseerrPermissionHelper.CanRequest4k(JellyseerrPermission.REQUEST_4K_TV, isTv: true));
+            Assert.False(JellyseerrPermissionHelper.CanRequest4k(JellyseerrPermission.REQUEST_4K_TV, isTv: false));
+        }
+
+        [Fact]
+        public void PlainRequest_WithoutAny4kBit_CannotRequest4k()
+        {
+            var perms = JellyseerrPermission.REQUEST | JellyseerrPermission.REQUEST_MOVIE | JellyseerrPermission.REQUEST_TV;
+            Assert.False(JellyseerrPermissionHelper.CanRequest4k(perms, isTv: false));
+            Assert.False(JellyseerrPermissionHelper.CanRequest4k(perms, isTv: true));
+        }
+
+        [Fact]
+        public void None_CannotRequest4k()
+        {
+            Assert.False(JellyseerrPermissionHelper.CanRequest4k(JellyseerrPermission.NONE, isTv: false));
+            Assert.False(JellyseerrPermissionHelper.CanRequest4k(JellyseerrPermission.NONE, isTv: true));
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Services/Jellyseerr4kMasterSwitchTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Services/Jellyseerr4kMasterSwitchTests.cs
@@ -1,0 +1,79 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinElevate.Configuration;
+using Jellyfin.Plugin.JellyfinElevate.Services.Jellyseerr;
+using Jellyfin.Plugin.JellyfinElevate.Tests.TestDoubles;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services;
+
+/// <summary>
+/// Pins that a crafted truthy <c>is4k</c> value (a nonzero number or the strings
+/// "true"/"1") is recognised as a 4K request, so it can't dodge the JE admin 4K
+/// master switch by slipping past a strict <c>== true</c> check and falling
+/// through to Seerr. Master switch off + truthy is4k must be blocked with
+/// <c>4k_requests_disabled</c>.
+/// </summary>
+public class Jellyseerr4kMasterSwitchTests
+{
+    private const string UserId = "3f2504e04f8941d39a0c0305e82c3301";
+
+    private static PluginConfiguration ConfigMasterOff() => new()
+    {
+        JellyseerrEnabled = true,
+        JellyseerrUrls = "http://seerr:5055",
+        JellyseerrApiKey = "test-key",
+        JellyseerrEnable4KRequests = false,
+        JellyseerrEnable4KTvRequests = false,
+    };
+
+    private static (JellyseerrClient client, RecordingHttpMessageHandler handler) NewClient()
+    {
+        var handler = new RecordingHttpMessageHandler();
+        var provider = new FakePluginConfigProvider(ConfigMasterOff());
+        var client = new JellyseerrClient(
+            new RecordingHttpClientFactory(handler),
+            NullLogger<JellyseerrClient>.Instance,
+            null!,
+            new SeerrCache(provider),
+            provider,
+            new PassthroughParentalFilter());
+        // A resolvable user so the gate is reached; permissions are irrelevant here.
+        handler.AddResponse("/api/v1/user", $"{{\"results\":[{{\"id\":42,\"jellyfinUserId\":\"{UserId}\",\"permissions\":2048}}]}}");
+        return (client, handler);
+    }
+
+    private static string? GetCode(object? value)
+        => value?.GetType().GetProperty("code")?.GetValue(value) as string;
+
+    [Theory]
+    [InlineData("{\"mediaType\":\"movie\",\"mediaId\":123,\"is4k\":1}")]        // nonzero number
+    [InlineData("{\"mediaType\":\"movie\",\"mediaId\":123,\"is4k\":\"true\"}")] // string "true"
+    [InlineData("{\"mediaType\":\"movie\",\"mediaId\":123,\"is4k\":\"1\"}")]    // string "1"
+    public async Task CraftedTruthyIs4k_WithMasterSwitchOff_IsBlocked(string body)
+    {
+        var (client, _) = NewClient();
+
+        var result = await client.ProxyRequestAsync(
+            "/api/v1/request", HttpMethod.Post, body,
+            new JellyseerrCaller(UserId, false));
+
+        var obj = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(403, obj.StatusCode);
+        Assert.Equal("4k_requests_disabled", GetCode(obj.Value));
+    }
+
+    private sealed class PassthroughParentalFilter : ISeerrParentalFilter
+    {
+        public Task<SeerrParentalResult> ApplyAsync(string json, string apiPath, JellyseerrCaller caller)
+            => Task.FromResult(new SeerrParentalResult(false, json));
+
+        public Task<bool> IsBlockedAsync(string mediaType, int tmdbId, JellyseerrCaller caller)
+            => Task.FromResult(false);
+
+        public Task<bool> IsTmdbProxyPathBlockedAsync(string tmdbApiPath, JellyseerrCaller caller)
+            => Task.FromResult(false);
+    }
+}

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Services/Jellyseerr4kRequestGateTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Services/Jellyseerr4kRequestGateTests.cs
@@ -1,0 +1,100 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinElevate.Configuration;
+using Jellyfin.Plugin.JellyfinElevate.Services.Jellyseerr;
+using Jellyfin.Plugin.JellyfinElevate.Tests.TestDoubles;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services;
+
+/// <summary>
+/// Pins that the proxy-side request gate in <see cref="JellyseerrClient.ProxyRequestAsync"/>
+/// decouples the 4K permission bits from the base request bits, matching Seerr's
+/// own rule (server/entity/MediaRequest.ts): a user holding only REQUEST_4K_MOVIE
+/// may submit a 4K request with no base REQUEST / REQUEST_MOVIE / REQUEST_TV bit,
+/// and a 4K request from a user with no 4K bit is rejected up front with
+/// <c>no_4k_request_permission</c>.
+/// </summary>
+public class Jellyseerr4kRequestGateTests
+{
+    private const string UserId = "3f2504e04f8941d39a0c0305e82c3301";
+
+    private static PluginConfiguration Config() => new()
+    {
+        JellyseerrEnabled = true,
+        JellyseerrUrls = "http://seerr:5055",
+        JellyseerrApiKey = "test-key",
+        // 4K master switch on so the request reaches the permission gate under test.
+        JellyseerrEnable4KRequests = true,
+        JellyseerrEnable4KTvRequests = true,
+    };
+
+    private static (JellyseerrClient client, RecordingHttpMessageHandler handler) NewClient()
+    {
+        var handler = new RecordingHttpMessageHandler();
+        var provider = new FakePluginConfigProvider(Config());
+        var client = new JellyseerrClient(
+            new RecordingHttpClientFactory(handler),
+            NullLogger<JellyseerrClient>.Instance,
+            null!,
+            new SeerrCache(provider),
+            provider,
+            new PassthroughParentalFilter());
+        return (client, handler);
+    }
+
+    private static void SeedUser(RecordingHttpMessageHandler handler, long permissions)
+        => handler.AddResponse("/api/v1/user", $"{{\"results\":[{{\"id\":42,\"jellyfinUserId\":\"{UserId}\",\"permissions\":{permissions}}}]}}");
+
+    private static string? GetCode(object? value)
+        => value?.GetType().GetProperty("code")?.GetValue(value) as string;
+
+    [Fact]
+    public async Task Only4kMoviePermission_NoBaseBit_4kRequestPassesGate()
+    {
+        var (client, handler) = NewClient();
+        // 2048 == REQUEST_4K_MOVIE only. NO base REQUEST / REQUEST_MOVIE / REQUEST_TV bit.
+        SeedUser(handler, 2048);
+        handler.AddResponse("/api/v1/request", "{\"id\":1}", HttpStatusCode.Created);
+
+        var result = await client.ProxyRequestAsync(
+            "/api/v1/request", HttpMethod.Post,
+            "{\"mediaType\":\"movie\",\"mediaId\":123,\"is4k\":true}",
+            new JellyseerrCaller(UserId, false));
+
+        // The gate did NOT 403 on the missing base bit — the request proxied through.
+        Assert.IsType<ContentResult>(result);
+    }
+
+    [Fact]
+    public async Task No4kBit_4kRequest_Returns403No4kRequestPermission()
+    {
+        var (client, handler) = NewClient();
+        // 262144 == REQUEST_MOVIE (base only) — has the base bit but NO 4K bit.
+        SeedUser(handler, 262144);
+
+        var result = await client.ProxyRequestAsync(
+            "/api/v1/request", HttpMethod.Post,
+            "{\"mediaType\":\"movie\",\"mediaId\":123,\"is4k\":true}",
+            new JellyseerrCaller(UserId, false));
+
+        var obj = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(403, obj.StatusCode);
+        Assert.Equal("no_4k_request_permission", GetCode(obj.Value));
+    }
+
+    private sealed class PassthroughParentalFilter : ISeerrParentalFilter
+    {
+        public Task<SeerrParentalResult> ApplyAsync(string json, string apiPath, JellyseerrCaller caller)
+            => Task.FromResult(new SeerrParentalResult(false, json));
+
+        public Task<bool> IsBlockedAsync(string mediaType, int tmdbId, JellyseerrCaller caller)
+            => Task.FromResult(false);
+
+        public Task<bool> IsTmdbProxyPathBlockedAsync(string tmdbApiPath, JellyseerrCaller caller)
+            => Task.FromResult(false);
+    }
+}

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Services/Seerr4kCapabilityTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Services/Seerr4kCapabilityTests.cs
@@ -1,0 +1,118 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinElevate.Configuration;
+using Jellyfin.Plugin.JellyfinElevate.Services.Jellyseerr;
+using Jellyfin.Plugin.JellyfinElevate.Tests.TestDoubles;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services;
+
+/// <summary>
+/// Pins <see cref="JellyseerrClient.GetSeerr4kCapabilityAsync"/>: the server 4K
+/// capability comes from Seerr's user-neutral <c>/api/v1/settings/public</c>
+/// (fetched with NO per-user header so it is safe to share-cache) combined with
+/// the caller's own Seerr 4K permissions, and short-circuits without a user
+/// lookup when the server has no 4K at all.
+/// </summary>
+public class Seerr4kCapabilityTests
+{
+    private const string UserId = "3f2504e04f8941d39a0c0305e82c3301";
+
+    private static PluginConfiguration Config() => new()
+    {
+        JellyseerrEnabled = true,
+        JellyseerrUrls = "http://seerr:5055",
+        JellyseerrApiKey = "test-key",
+    };
+
+    private static (JellyseerrClient client, RecordingHttpMessageHandler handler) NewClient()
+    {
+        var handler = new RecordingHttpMessageHandler();
+        var provider = new FakePluginConfigProvider(Config());
+        var client = new JellyseerrClient(
+            new RecordingHttpClientFactory(handler),
+            NullLogger<JellyseerrClient>.Instance,
+            null!,
+            new SeerrCache(provider),
+            provider,
+            new PassthroughParentalFilter());
+        return (client, handler);
+    }
+
+    [Fact]
+    public async Task Capability_CombinesPublicSettingsWithUserPermissions()
+    {
+        var (client, handler) = NewClient();
+        handler.AddResponse("/api/v1/settings/public", "{\"movie4kEnabled\":true,\"series4kEnabled\":false}");
+        // permissions 1024 == REQUEST_4K (global 4K grant, covers movie + TV).
+        handler.AddResponse("/api/v1/user", $"{{\"results\":[{{\"id\":42,\"jellyfinUserId\":\"{UserId}\",\"permissions\":1024}}]}}");
+
+        var cap = await client.GetSeerr4kCapabilityAsync(UserId);
+
+        Assert.True(cap.Movie4kEnabled);
+        Assert.False(cap.Series4kEnabled);
+        // Movie 4K available (server enabled + REQUEST_4K); TV hidden (server off).
+        Assert.True(cap.CanRequest4kMovie);
+        Assert.False(cap.CanRequest4kTv);
+    }
+
+    [Fact]
+    public async Task PublicSettingsFetch_CarriesNoXApiUser()
+    {
+        var (client, handler) = NewClient();
+        handler.AddResponse("/api/v1/settings/public", "{\"movie4kEnabled\":true,\"series4kEnabled\":true}");
+        handler.AddResponse("/api/v1/user", $"{{\"results\":[{{\"id\":42,\"jellyfinUserId\":\"{UserId}\",\"permissions\":1024}}]}}");
+
+        await client.GetSeerr4kCapabilityAsync(UserId);
+
+        var settingsRequest = Assert.Single(handler.Requests.FindAll(r => r.RequestUri!.AbsolutePath == "/api/v1/settings/public"));
+        Assert.False(
+            settingsRequest.Headers.Contains("X-Api-User"),
+            "settings/public is user-neutral and share-cached — it must not carry the per-user X-Api-User header");
+    }
+
+    [Fact]
+    public async Task NoServer4k_ShortCircuits_WithoutUserLookup()
+    {
+        var (client, handler) = NewClient();
+        handler.AddResponse("/api/v1/settings/public", "{\"movie4kEnabled\":false,\"series4kEnabled\":false}");
+
+        var cap = await client.GetSeerr4kCapabilityAsync(UserId);
+
+        Assert.False(cap.Movie4kEnabled);
+        Assert.False(cap.Series4kEnabled);
+        Assert.False(cap.CanRequest4kMovie);
+        Assert.False(cap.CanRequest4kTv);
+        // With no server 4K there is nothing to request — the user lookup is skipped.
+        Assert.Empty(handler.Requests.FindAll(r => r.RequestUri!.AbsolutePath == "/api/v1/user"));
+    }
+
+    [Fact]
+    public async Task NoUserPermission_HidesEvenWhenServerEnabled()
+    {
+        var (client, handler) = NewClient();
+        handler.AddResponse("/api/v1/settings/public", "{\"movie4kEnabled\":true,\"series4kEnabled\":true}");
+        // permissions 262144 == REQUEST_MOVIE only (base request, no 4K bits).
+        handler.AddResponse("/api/v1/user", $"{{\"results\":[{{\"id\":42,\"jellyfinUserId\":\"{UserId}\",\"permissions\":262144}}]}}");
+
+        var cap = await client.GetSeerr4kCapabilityAsync(UserId);
+
+        Assert.True(cap.Movie4kEnabled);
+        Assert.True(cap.Series4kEnabled);
+        Assert.False(cap.CanRequest4kMovie);
+        Assert.False(cap.CanRequest4kTv);
+    }
+
+    private sealed class PassthroughParentalFilter : ISeerrParentalFilter
+    {
+        public Task<SeerrParentalResult> ApplyAsync(string json, string apiPath, JellyseerrCaller caller)
+            => Task.FromResult(new SeerrParentalResult(false, json));
+
+        public Task<bool> IsBlockedAsync(string mediaType, int tmdbId, JellyseerrCaller caller)
+            => Task.FromResult(false);
+
+        public Task<bool> IsTmdbProxyPathBlockedAsync(string tmdbApiPath, JellyseerrCaller caller)
+            => Task.FromResult(false);
+    }
+}

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Services/Seerr4kCapabilityTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Services/Seerr4kCapabilityTests.cs
@@ -27,9 +27,12 @@ public class Seerr4kCapabilityTests
     };
 
     private static (JellyseerrClient client, RecordingHttpMessageHandler handler) NewClient()
+        => NewClient(Config());
+
+    private static (JellyseerrClient client, RecordingHttpMessageHandler handler) NewClient(PluginConfiguration config)
     {
         var handler = new RecordingHttpMessageHandler();
-        var provider = new FakePluginConfigProvider(Config());
+        var provider = new FakePluginConfigProvider(config);
         var client = new JellyseerrClient(
             new RecordingHttpClientFactory(handler),
             NullLogger<JellyseerrClient>.Instance,
@@ -97,6 +100,42 @@ public class Seerr4kCapabilityTests
         handler.AddResponse("/api/v1/user", $"{{\"results\":[{{\"id\":42,\"jellyfinUserId\":\"{UserId}\",\"permissions\":262144}}]}}");
 
         var cap = await client.GetSeerr4kCapabilityAsync(UserId);
+
+        Assert.True(cap.Movie4kEnabled);
+        Assert.True(cap.Series4kEnabled);
+        Assert.False(cap.CanRequest4kMovie);
+        Assert.False(cap.CanRequest4kTv);
+    }
+
+    [Fact]
+    public async Task AdminCaller_ProjectsServer4kAndMasterSwitch_IgnoringUserPermission()
+    {
+        // A Jellyfin admin bypasses the Seerr per-user 4K gate in the proxy, so the
+        // capability projection must report server-4K-enabled (AND the JE master
+        // switch) even though the linked Seerr user holds no 4K bits.
+        var config = Config();
+        config.JellyseerrEnable4KRequests = true;
+        config.JellyseerrEnable4KTvRequests = true;
+        var (client, handler) = NewClient(config);
+        handler.AddResponse("/api/v1/settings/public", "{\"movie4kEnabled\":true,\"series4kEnabled\":true}");
+        // 262144 == REQUEST_MOVIE (base only, no 4K bits) — irrelevant for an admin.
+        handler.AddResponse("/api/v1/user", $"{{\"results\":[{{\"id\":42,\"jellyfinUserId\":\"{UserId}\",\"permissions\":262144}}]}}");
+
+        var cap = await client.GetSeerr4kCapabilityAsync(UserId, isAdmin: true);
+
+        Assert.True(cap.CanRequest4kMovie);
+        Assert.True(cap.CanRequest4kTv);
+    }
+
+    [Fact]
+    public async Task AdminCaller_MasterSwitchOff_HidesEvenThoughServerEnabled()
+    {
+        // The JE 4K master switch applies to admins too (consistent with the gate
+        // order): with it off, an admin gets no 4K capability despite server 4K.
+        var (client, handler) = NewClient(Config()); // master switches default false
+        handler.AddResponse("/api/v1/settings/public", "{\"movie4kEnabled\":true,\"series4kEnabled\":true}");
+
+        var cap = await client.GetSeerr4kCapabilityAsync(UserId, isAdmin: true);
 
         Assert.True(cap.Movie4kEnabled);
         Assert.True(cap.Series4kEnabled);

--- a/Jellyfin.Plugin.JellyfinElevate/Controllers/JellyseerrUserController.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Controllers/JellyseerrUserController.cs
@@ -108,7 +108,7 @@ namespace Jellyfin.Plugin.JellyfinElevate.Controllers
                 // UI on Seerr actually having 4K enabled AND this user holding the
                 // 4K permission (degrade-by-hiding), rather than on the admin
                 // toggle alone.
-                var cap = await _jellyseerr.GetSeerr4kCapabilityAsync(jellyfinUserId);
+                var cap = await _jellyseerr.GetSeerr4kCapabilityAsync(jellyfinUserId, IsAdminUser());
                 return Ok(new
                 {
                     active = true,

--- a/Jellyfin.Plugin.JellyfinElevate/Controllers/JellyseerrUserController.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Controllers/JellyseerrUserController.cs
@@ -104,7 +104,22 @@ namespace Jellyfin.Plugin.JellyfinElevate.Controllers
             var jellyseerrUserId = await _jellyseerr.GetJellyseerrUserId(jellyfinUserId);
             if (!string.IsNullOrEmpty(jellyseerrUserId))
             {
-                return Ok(new { active = true, userFound = true, jellyseerrUserId = jellyseerrUserId, reason = "linked" });
+                // Surface the 4K capability so the client can gate its 4K request
+                // UI on Seerr actually having 4K enabled AND this user holding the
+                // 4K permission (degrade-by-hiding), rather than on the admin
+                // toggle alone.
+                var cap = await _jellyseerr.GetSeerr4kCapabilityAsync(jellyfinUserId);
+                return Ok(new
+                {
+                    active = true,
+                    userFound = true,
+                    jellyseerrUserId = jellyseerrUserId,
+                    reason = "linked",
+                    movie4kEnabled = cap.Movie4kEnabled,
+                    series4kEnabled = cap.Series4kEnabled,
+                    canRequest4kMovie = cap.CanRequest4kMovie,
+                    canRequest4kTv = cap.CanRequest4kTv
+                });
             }
 
             // User not found — could be server unreachable, HTML challenge from

--- a/Jellyfin.Plugin.JellyfinElevate/Helpers/Jellyseerr/JellyseerrPermissionHelper.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Helpers/Jellyseerr/JellyseerrPermissionHelper.cs
@@ -15,5 +15,20 @@ namespace Jellyfin.Plugin.JellyfinElevate.Helpers.Jellyseerr
             if (permissionsToCheck == JellyseerrPermission.NONE) return false;
             return (userPermissions & permissionsToCheck) != 0;
         }
+
+        /// <summary>
+        /// Whether these Seerr permissions allow requesting a 4K movie/TV item.
+        /// Mirrors Seerr's own rule (server/entity/MediaRequest.ts): admins bypass,
+        /// otherwise REQUEST_4K OR the media-specific REQUEST_4K_MOVIE / REQUEST_4K_TV
+        /// bit is required. Single source of truth for both the request gate and the
+        /// client-facing 4K capability projection.
+        /// </summary>
+        public static bool CanRequest4k(JellyseerrPermission userPermissions, bool isTv)
+        {
+            if (HasPermission(userPermissions, JellyseerrPermission.ADMIN)) return true;
+            var need = JellyseerrPermission.REQUEST_4K
+                | (isTv ? JellyseerrPermission.REQUEST_4K_TV : JellyseerrPermission.REQUEST_4K_MOVIE);
+            return HasAnyPermission(userPermissions, need);
+        }
     }
 }

--- a/Jellyfin.Plugin.JellyfinElevate/Services/Jellyseerr/IJellyseerrClient.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/Jellyseerr/IJellyseerrClient.cs
@@ -88,9 +88,12 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Jellyseerr
         /// Seerr's user-neutral <c>/api/v1/settings/public</c> (cached) for the
         /// server 4K capability and combines it with the user's Seerr 4K
         /// permissions. Degrades to all-false when Seerr is unconfigured/unreachable
-        /// or the user is unlinked.
+        /// or the user is unlinked. When <paramref name="isAdmin"/> is true the
+        /// caller is a Jellyfin admin who bypasses the Seerr per-user 4K permission
+        /// gate in the proxy, so capability is projected as server-4K-enabled AND the
+        /// JE admin master switch (not the linked Seerr user's own 4K bits).
         /// </summary>
-        Task<Seerr4kCapability> GetSeerr4kCapabilityAsync(string jellyfinUserId);
+        Task<Seerr4kCapability> GetSeerr4kCapabilityAsync(string jellyfinUserId, bool isAdmin = false);
 
         /// <summary>
         /// The proxy core: authenticated fan-out of <paramref name="apiPath"/> to the

--- a/Jellyfin.Plugin.JellyfinElevate/Services/Jellyseerr/IJellyseerrClient.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/Jellyseerr/IJellyseerrClient.cs
@@ -36,6 +36,22 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Jellyseerr
     }
 
     /// <summary>
+    /// Whether the Seerr server has 4K enabled (a default 4K Radarr/Sonarr is
+    /// configured) and whether the acting user may request it. The two
+    /// <c>CanRequest4k*</c> flags already fold in the server-capability check, so a
+    /// client can gate its 4K UI on the single relevant flag.
+    /// </summary>
+    /// <param name="Movie4kEnabled">Seerr's <c>movie4kEnabled</c> (a default 4K Radarr exists).</param>
+    /// <param name="Series4kEnabled">Seerr's <c>series4kEnabled</c> (a default 4K Sonarr exists).</param>
+    /// <param name="CanRequest4kMovie"><see cref="Movie4kEnabled"/> AND the user has the 4K movie permission.</param>
+    /// <param name="CanRequest4kTv"><see cref="Series4kEnabled"/> AND the user has the 4K TV permission.</param>
+    public sealed record Seerr4kCapability(
+        bool Movie4kEnabled,
+        bool Series4kEnabled,
+        bool CanRequest4kMovie,
+        bool CanRequest4kTv);
+
+    /// <summary>
     /// All Seerr (Jellyseerr) plumbing that used to live on
     /// <c>JellyfinElevateControllerBase</c>: configured-URL fan-out, user
     /// resolution with TTL cache + optional just-in-time import, the proxy core
@@ -66,6 +82,15 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Jellyseerr
 
         /// <summary>Live /api/v1/status probe across the configured URLs (uncached).</summary>
         Task<bool> GetStatusActiveAsync();
+
+        /// <summary>
+        /// Resolves whether 4K requests are available for a Jellyfin user: reads
+        /// Seerr's user-neutral <c>/api/v1/settings/public</c> (cached) for the
+        /// server 4K capability and combines it with the user's Seerr 4K
+        /// permissions. Degrades to all-false when Seerr is unconfigured/unreachable
+        /// or the user is unlinked.
+        /// </summary>
+        Task<Seerr4kCapability> GetSeerr4kCapabilityAsync(string jellyfinUserId);
 
         /// <summary>
         /// The proxy core: authenticated fan-out of <paramref name="apiPath"/> to the

--- a/Jellyfin.Plugin.JellyfinElevate/Services/Jellyseerr/ISeerrCache.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/Jellyseerr/ISeerrCache.cs
@@ -71,6 +71,19 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Jellyseerr
 
         TimeSpan SeerrStatusCacheTtl { get; }
 
+        /// <summary>
+        /// Caches Seerr's <c>/api/v1/settings/public</c> 4K flags
+        /// (<c>movie4kEnabled</c> / <c>series4kEnabled</c>). User-neutral by
+        /// construction — the fetch sends no per-user header — so it is safe to
+        /// share across users. Short TTL so an admin toggling 4K in Seerr is
+        /// reflected promptly.
+        /// </summary>
+        (bool Movie4kEnabled, bool Series4kEnabled, DateTime CachedAt)? Public4kSettingsCache { get; set; }
+
+        object Public4kSettingsCacheLock { get; }
+
+        TimeSpan Public4kSettingsCacheTtl { get; }
+
         /// <summary>Cache for request-page TMDB enrichments (movie/tv detail lookups via Jellyseerr).</summary>
         Dictionary<string, (TmdbEnrichmentResult Data, DateTime CachedAt)> TmdbEnrichmentCache { get; }
 

--- a/Jellyfin.Plugin.JellyfinElevate/Services/Jellyseerr/JellyseerrClient.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/Jellyseerr/JellyseerrClient.cs
@@ -134,7 +134,7 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Jellyseerr
 
         // ── 4K capability ────────────────────────────────────────────────────
 
-        public async Task<Seerr4kCapability> GetSeerr4kCapabilityAsync(string jellyfinUserId)
+        public async Task<Seerr4kCapability> GetSeerr4kCapabilityAsync(string jellyfinUserId, bool isAdmin = false)
         {
             var (movie4k, series4k) = await GetPublic4kSettingsAsync();
 
@@ -142,6 +142,20 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Jellyseerr
             if (!movie4k && !series4k)
             {
                 return new Seerr4kCapability(false, false, false, false);
+            }
+
+            if (isAdmin)
+            {
+                // A Jellyfin admin bypasses the Seerr per-user 4K permission gate in
+                // the proxy (caller.IsAdmin), so projecting only the linked Seerr
+                // user's bits would show canRequest4k*=false while the server would
+                // actually accept the request. Mirror the gate: their capability is
+                // server-4K-enabled, still AND'd with the JE admin master switch
+                // (which applies to admins too — consistent with the gate order).
+                var adminConfig = _configProvider.ConfigurationOrNull;
+                bool masterMovie = adminConfig?.JellyseerrEnable4KRequests ?? false;
+                bool masterTv = adminConfig?.JellyseerrEnable4KTvRequests ?? false;
+                return new Seerr4kCapability(movie4k, series4k, movie4k && masterMovie, series4k && masterTv);
             }
 
             var user = await GetJellyseerrUser(jellyfinUserId);

--- a/Jellyfin.Plugin.JellyfinElevate/Services/Jellyseerr/JellyseerrClient.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/Jellyseerr/JellyseerrClient.cs
@@ -765,20 +765,24 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Jellyseerr
                         // POST /api/v1/request — make a request
                         if (method == HttpMethod.Post && apiPath.StartsWith("/api/v1/request", StringComparison.OrdinalIgnoreCase))
                         {
-                            if (!JellyseerrPermissionHelper.HasAnyPermission(perms,
-                                JellyseerrPermission.REQUEST | JellyseerrPermission.REQUEST_MOVIE | JellyseerrPermission.REQUEST_TV))
-                                return new ObjectResult(new { code = "no_request_permission", message = "You do not have permission to make requests in Seerr." }) { StatusCode = 403 };
-
-                            // A 4K request needs the 4K bit. Mirror Seerr's own
-                            // server enforcement so a non-admin without REQUEST_4K
-                            // gets a clear, typed 403 up front instead of a generic
-                            // Seerr rejection after the round trip.
+                            // Seerr fully decouples the 4K permission bits from the
+                            // base request bits (server/entity/MediaRequest.ts:80-112):
+                            // a user holding only REQUEST_4K / REQUEST_4K_MOVIE /
+                            // REQUEST_4K_TV may submit a 4K request without ANY base
+                            // REQUEST / REQUEST_MOVIE / REQUEST_TV bit. So for a 4K
+                            // request we SKIP the base precondition and gate solely on
+                            // the 4K helper; only the non-4K path requires a base bit.
                             if (content != null && TryGetIs4k(content))
                             {
                                 bool isTv = TryGetRequestMedia(content, out var mt4k, out _)
                                     && string.Equals(mt4k, "tv", StringComparison.OrdinalIgnoreCase);
                                 if (!JellyseerrPermissionHelper.CanRequest4k(perms, isTv))
                                     return new ObjectResult(new { code = "no_4k_request_permission", message = "You do not have permission to request 4K in Seerr." }) { StatusCode = 403 };
+                            }
+                            else if (!JellyseerrPermissionHelper.HasAnyPermission(perms,
+                                JellyseerrPermission.REQUEST | JellyseerrPermission.REQUEST_MOVIE | JellyseerrPermission.REQUEST_TV))
+                            {
+                                return new ObjectResult(new { code = "no_request_permission", message = "You do not have permission to make requests in Seerr." }) { StatusCode = 403 };
                             }
                         }
 

--- a/Jellyfin.Plugin.JellyfinElevate/Services/Jellyseerr/JellyseerrClient.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/Jellyseerr/JellyseerrClient.cs
@@ -132,6 +132,109 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Jellyseerr
             return active;
         }
 
+        // ── 4K capability ────────────────────────────────────────────────────
+
+        public async Task<Seerr4kCapability> GetSeerr4kCapabilityAsync(string jellyfinUserId)
+        {
+            var (movie4k, series4k) = await GetPublic4kSettingsAsync();
+
+            // No server-side 4K at all → nothing to request; skip the user lookup.
+            if (!movie4k && !series4k)
+            {
+                return new Seerr4kCapability(false, false, false, false);
+            }
+
+            var user = await GetJellyseerrUser(jellyfinUserId);
+            var perms = user?.Permissions ?? JellyseerrPermission.NONE;
+            bool canMovie = movie4k && JellyseerrPermissionHelper.CanRequest4k(perms, isTv: false);
+            bool canTv = series4k && JellyseerrPermissionHelper.CanRequest4k(perms, isTv: true);
+            return new Seerr4kCapability(movie4k, series4k, canMovie, canTv);
+        }
+
+        /// <summary>
+        /// Fetches Seerr's user-neutral <c>/api/v1/settings/public</c> 4K flags,
+        /// cached. Sends NO per-user header so the cached value is safe to share
+        /// across users. Returns (false, false) when Seerr is unconfigured or
+        /// every configured URL fails.
+        /// </summary>
+        private async Task<(bool Movie4k, bool Series4k)> GetPublic4kSettingsAsync()
+        {
+            var config = _configProvider.ConfigurationOrNull;
+            if (config == null || string.IsNullOrEmpty(config.JellyseerrUrls) || string.IsNullOrEmpty(config.JellyseerrApiKey))
+            {
+                return (false, false);
+            }
+
+            if (!config.JellyseerrDisableCache)
+            {
+                lock (_seerrCache.Public4kSettingsCacheLock)
+                {
+                    if (_seerrCache.Public4kSettingsCache.HasValue
+                        && DateTime.UtcNow - _seerrCache.Public4kSettingsCache.Value.CachedAt < _seerrCache.Public4kSettingsCacheTtl)
+                    {
+                        var c = _seerrCache.Public4kSettingsCache.Value;
+                        return (c.Movie4kEnabled, c.Series4kEnabled);
+                    }
+                }
+            }
+
+            var urls = GetConfiguredUrls(config.JellyseerrUrls);
+            var httpClient = SeerrHttpHelper.CreateClient(_httpClientFactory);
+            httpClient.Timeout = TimeSpan.FromSeconds(15);
+
+            foreach (var url in urls)
+            {
+                var requestUri = $"{url}/api/v1/settings/public";
+                try
+                {
+                    // User-neutral: no X-Api-User — the response is identical for
+                    // all users, so it is share-cached (see cache user-neutrality
+                    // invariant in docs/v12-platform.md).
+                    using var request = SeerrHttpHelper.BuildRequest(HttpMethod.Get, requestUri, config.JellyseerrApiKey);
+                    using var response = await httpClient.SendAsync(request);
+                    var (json, error) = await SeerrHttpHelper.ReadResponseAsync(response, requestUri);
+                    if (error != null || string.IsNullOrEmpty(json))
+                    {
+                        if (error != null)
+                        {
+                            _logger.LogWarning($"Failed to fetch Seerr public settings at {url}: code={error.Code} status={error.HttpStatus} — {error.Message}");
+                        }
+
+                        continue;
+                    }
+
+                    using var doc = JsonDocument.Parse(json);
+                    var root = doc.RootElement;
+                    bool movie4k = root.TryGetProperty("movie4kEnabled", out var m) && m.ValueKind == JsonValueKind.True;
+                    bool series4k = root.TryGetProperty("series4kEnabled", out var s) && s.ValueKind == JsonValueKind.True;
+
+                    if (!config.JellyseerrDisableCache)
+                    {
+                        lock (_seerrCache.Public4kSettingsCacheLock)
+                        {
+                            _seerrCache.Public4kSettingsCache = (movie4k, series4k, DateTime.UtcNow);
+                        }
+                    }
+
+                    return (movie4k, series4k);
+                }
+                catch (JsonException ex)
+                {
+                    _logger.LogWarning(ex, "Malformed Seerr public-settings response at {Url}", url);
+                }
+                catch (HttpRequestException ex)
+                {
+                    _logger.LogWarning(ex, "Transport error fetching Seerr public settings at {Url}", url);
+                }
+                catch (TaskCanceledException)
+                {
+                    // timeout — try next URL
+                }
+            }
+
+            return (false, false);
+        }
+
         // ── User resolution ──────────────────────────────────────────────────
 
         public bool IsImportBlocked(string jellyfinUserId, PluginConfiguration config)
@@ -497,6 +600,23 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Jellyseerr
                 : new ContentResult { Content = result.Body, ContentType = "application/json" };
         }
 
+        /// <summary>True when a Seerr request POST body sets <c>is4k: true</c>.</summary>
+        private static bool TryGetIs4k(string content)
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(content);
+                var root = doc.RootElement;
+                return root.ValueKind == JsonValueKind.Object
+                    && root.TryGetProperty("is4k", out var is4k)
+                    && is4k.ValueKind == JsonValueKind.True;
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+        }
+
         /// <summary>Reads mediaType + tmdbId (the <c>mediaId</c> field) from a Seerr request POST body.</summary>
         private static bool TryGetRequestMedia(string content, out string mediaType, out int tmdbId)
         {
@@ -631,6 +751,18 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Jellyseerr
                             if (!JellyseerrPermissionHelper.HasAnyPermission(perms,
                                 JellyseerrPermission.REQUEST | JellyseerrPermission.REQUEST_MOVIE | JellyseerrPermission.REQUEST_TV))
                                 return new ObjectResult(new { code = "no_request_permission", message = "You do not have permission to make requests in Seerr." }) { StatusCode = 403 };
+
+                            // A 4K request needs the 4K bit. Mirror Seerr's own
+                            // server enforcement so a non-admin without REQUEST_4K
+                            // gets a clear, typed 403 up front instead of a generic
+                            // Seerr rejection after the round trip.
+                            if (content != null && TryGetIs4k(content))
+                            {
+                                bool isTv = TryGetRequestMedia(content, out var mt4k, out _)
+                                    && string.Equals(mt4k, "tv", StringComparison.OrdinalIgnoreCase);
+                                if (!JellyseerrPermissionHelper.CanRequest4k(perms, isTv))
+                                    return new ObjectResult(new { code = "no_4k_request_permission", message = "You do not have permission to request 4K in Seerr." }) { StatusCode = 403 };
+                            }
                         }
 
                         // POST /api/v1/issue — report an issue

--- a/Jellyfin.Plugin.JellyfinElevate/Services/Jellyseerr/JellyseerrClient.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/Jellyseerr/JellyseerrClient.cs
@@ -730,6 +730,23 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Jellyseerr
                 });
             }
 
+            // JE 4K master switch (applies to EVERY caller, admins included): when
+            // the admin has disabled 4K requests for this media type, no 4K request
+            // may be submitted through JE. The client hides the option; this enforces
+            // it server-side so a crafted POST with is4k can't bypass the toggle the
+            // docs describe as a master switch.
+            if (method == HttpMethod.Post
+                && apiPath.StartsWith("/api/v1/request", StringComparison.OrdinalIgnoreCase)
+                && content != null
+                && TryGetIs4k(content))
+            {
+                bool isTv4k = TryGetRequestMedia(content, out var mtSwitch, out _)
+                    && string.Equals(mtSwitch, "tv", StringComparison.OrdinalIgnoreCase);
+                bool adminEnabled = isTv4k ? config.JellyseerrEnable4KTvRequests : config.JellyseerrEnable4KRequests;
+                if (!adminEnabled)
+                    return new ObjectResult(new { code = "4k_requests_disabled", message = "4K requests are disabled." }) { StatusCode = 403 };
+            }
+
             // Enforce Seerr permissions for write operations and sensitive reads.
             // Jellyfin admins bypass all permission checks (they can do anything in Seerr).
             // For non-admins, validate before proxying so we return a clear 403 rather than

--- a/Jellyfin.Plugin.JellyfinElevate/Services/Jellyseerr/JellyseerrClient.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/Jellyseerr/JellyseerrClient.cs
@@ -614,16 +614,42 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Jellyseerr
                 : new ContentResult { Content = result.Body, ContentType = "application/json" };
         }
 
-        /// <summary>True when a Seerr request POST body sets <c>is4k: true</c>.</summary>
+        /// <summary>
+        /// True when a Seerr request POST body carries a truthy <c>is4k</c>. Treats
+        /// JSON <c>true</c>, a nonzero number, and the strings "true"/"1"
+        /// (case-insensitive) all as 4K — so a crafted <c>{"is4k":1}</c> or
+        /// <c>{"is4k":"true"}</c> can't dodge the 4K master switch / permission
+        /// gates by slipping past a strict <c>== true</c> check and falling through
+        /// to Seerr.
+        /// </summary>
         private static bool TryGetIs4k(string content)
         {
             try
             {
                 using var doc = JsonDocument.Parse(content);
                 var root = doc.RootElement;
-                return root.ValueKind == JsonValueKind.Object
-                    && root.TryGetProperty("is4k", out var is4k)
-                    && is4k.ValueKind == JsonValueKind.True;
+                if (root.ValueKind != JsonValueKind.Object
+                    || !root.TryGetProperty("is4k", out var is4k))
+                {
+                    return false;
+                }
+
+                switch (is4k.ValueKind)
+                {
+                    case JsonValueKind.True:
+                        return true;
+                    case JsonValueKind.False:
+                    case JsonValueKind.Null:
+                        return false;
+                    case JsonValueKind.Number:
+                        return is4k.TryGetDouble(out var n) && n != 0;
+                    case JsonValueKind.String:
+                        var s = is4k.GetString();
+                        return string.Equals(s, "true", StringComparison.OrdinalIgnoreCase)
+                            || string.Equals(s, "1", StringComparison.OrdinalIgnoreCase);
+                    default:
+                        return false;
+                }
             }
             catch (JsonException)
             {

--- a/Jellyfin.Plugin.JellyfinElevate/Services/Jellyseerr/SeerrCache.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/Jellyseerr/SeerrCache.cs
@@ -57,6 +57,15 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Jellyseerr
 
         public TimeSpan SeerrStatusCacheTtl { get; } = TimeSpan.FromSeconds(30);
 
+        // Cache of Seerr's /api/v1/settings/public 4K flags. User-neutral (the
+        // fetch sends no per-user header). Short TTL so a Seerr-side 4K toggle
+        // surfaces promptly without a per-request round trip.
+        public (bool Movie4kEnabled, bool Series4kEnabled, DateTime CachedAt)? Public4kSettingsCache { get; set; }
+
+        public object Public4kSettingsCacheLock { get; } = new();
+
+        public TimeSpan Public4kSettingsCacheTtl { get; } = TimeSpan.FromMinutes(5);
+
         // Cache for request-page TMDB enrichments (movie/tv detail lookups via Jellyseerr)
         public Dictionary<string, (TmdbEnrichmentResult Data, DateTime CachedAt)> TmdbEnrichmentCache { get; } = new();
 
@@ -128,6 +137,9 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Jellyseerr
             // also flush the cached status probe so admins see fresh
             // reachability immediately after fixing config.
             lock (SeerrStatusCacheLock) { SeerrStatusCache = null; }
+            // Flush the cached 4K capability so a changed Seerr URL / key
+            // re-resolves movie4kEnabled/series4kEnabled immediately.
+            lock (Public4kSettingsCacheLock) { Public4kSettingsCache = null; }
         }
     }
 }

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/ar.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/ar.json
@@ -148,6 +148,7 @@
   "jellyseerr_btn_error": "خطأ",
   "jellyseerr_btn_user_not_found": "المستخدم غير موجود",
   "jellyseerr_err_no_request_permission": "لا توجد صلاحية لتقديم الطلبات",
+  "jellyseerr_err_no_4k_request_permission": "لا تملك صلاحية طلب جودة 4K",
   "jellyseerr_err_no_issue_permission": "لا توجد صلاحية للإبلاغ عن المشكلات",
   "jellyseerr_err_no_issue_view_permission": "لا توجد صلاحية لعرض المشكلات",
   "jellyseerr_err_load_server_options": "فشل تحميل خيارات الخادم",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/ar.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/ar.json
@@ -149,6 +149,7 @@
   "jellyseerr_btn_user_not_found": "المستخدم غير موجود",
   "jellyseerr_err_no_request_permission": "لا توجد صلاحية لتقديم الطلبات",
   "jellyseerr_err_no_4k_request_permission": "لا تملك صلاحية طلب جودة 4K",
+  "jellyseerr_err_4k_requests_disabled": "طلبات 4K معطّلة",
   "jellyseerr_err_no_issue_permission": "لا توجد صلاحية للإبلاغ عن المشكلات",
   "jellyseerr_err_no_issue_view_permission": "لا توجد صلاحية لعرض المشكلات",
   "jellyseerr_err_load_server_options": "فشل تحميل خيارات الخادم",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/bg.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/bg.json
@@ -149,6 +149,7 @@
   "jellyseerr_btn_user_not_found": "Потребителят не е намерен",
   "jellyseerr_err_no_request_permission": "Нямате разрешение за създаване на заявки",
   "jellyseerr_err_no_4k_request_permission": "Няма разрешение за заявка за 4K",
+  "jellyseerr_err_4k_requests_disabled": "Заявките за 4K са изключени",
   "jellyseerr_err_no_issue_permission": "Нямате разрешение за докладване на проблеми",
   "jellyseerr_err_no_issue_view_permission": "Нямате разрешение за преглед на проблеми",
   "jellyseerr_err_load_server_options": "Грешка при зареждане на опциите на сървъра",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/bg.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/bg.json
@@ -148,6 +148,7 @@
   "jellyseerr_btn_error": "Грешка",
   "jellyseerr_btn_user_not_found": "Потребителят не е намерен",
   "jellyseerr_err_no_request_permission": "Нямате разрешение за създаване на заявки",
+  "jellyseerr_err_no_4k_request_permission": "Няма разрешение за заявка за 4K",
   "jellyseerr_err_no_issue_permission": "Нямате разрешение за докладване на проблеми",
   "jellyseerr_err_no_issue_view_permission": "Нямате разрешение за преглед на проблеми",
   "jellyseerr_err_load_server_options": "Грешка при зареждане на опциите на сървъра",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/ca.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/ca.json
@@ -149,6 +149,7 @@
   "jellyseerr_btn_user_not_found": "Usuari no trobat",
   "jellyseerr_err_no_request_permission": "Sense permís per fer sol·licituds",
   "jellyseerr_err_no_4k_request_permission": "Sense permís per sol·licitar 4K",
+  "jellyseerr_err_4k_requests_disabled": "Les sol·licituds 4K estan desactivades",
   "jellyseerr_err_no_issue_permission": "Sense permís per informar de problemes",
   "jellyseerr_err_no_issue_view_permission": "Sense permís per veure problemes",
   "jellyseerr_err_load_server_options": "Error en carregar les opcions del servidor",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/ca.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/ca.json
@@ -148,6 +148,7 @@
   "jellyseerr_btn_error": "Error",
   "jellyseerr_btn_user_not_found": "Usuari no trobat",
   "jellyseerr_err_no_request_permission": "Sense permís per fer sol·licituds",
+  "jellyseerr_err_no_4k_request_permission": "Sense permís per sol·licitar 4K",
   "jellyseerr_err_no_issue_permission": "Sense permís per informar de problemes",
   "jellyseerr_err_no_issue_view_permission": "Sense permís per veure problemes",
   "jellyseerr_err_load_server_options": "Error en carregar les opcions del servidor",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/cs.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/cs.json
@@ -149,6 +149,7 @@
   "jellyseerr_btn_user_not_found": "Uživatel nenalezen",
   "jellyseerr_err_no_request_permission": "Nemáte oprávnění k podávání žádostí",
   "jellyseerr_err_no_4k_request_permission": "Nemáte oprávnění požadovat 4K",
+  "jellyseerr_err_4k_requests_disabled": "Požadavky na 4K jsou vypnuté",
   "jellyseerr_err_no_issue_permission": "Nemáte oprávnění hlásit problémy",
   "jellyseerr_err_no_issue_view_permission": "Nemáte oprávnění zobrazovat problémy",
   "jellyseerr_err_load_server_options": "Nepodařilo se načíst možnosti serveru",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/cs.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/cs.json
@@ -148,6 +148,7 @@
   "jellyseerr_btn_error": "Chyba",
   "jellyseerr_btn_user_not_found": "Uživatel nenalezen",
   "jellyseerr_err_no_request_permission": "Nemáte oprávnění k podávání žádostí",
+  "jellyseerr_err_no_4k_request_permission": "Nemáte oprávnění požadovat 4K",
   "jellyseerr_err_no_issue_permission": "Nemáte oprávnění hlásit problémy",
   "jellyseerr_err_no_issue_view_permission": "Nemáte oprávnění zobrazovat problémy",
   "jellyseerr_err_load_server_options": "Nepodařilo se načíst možnosti serveru",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/da.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/da.json
@@ -149,6 +149,7 @@
   "jellyseerr_btn_user_not_found": "Bruger ikke fundet",
   "jellyseerr_err_no_request_permission": "Ingen tilladelse til at lave anmodninger",
   "jellyseerr_err_no_4k_request_permission": "Ingen tilladelse til at anmode om 4K",
+  "jellyseerr_err_4k_requests_disabled": "4K-anmodninger er deaktiveret",
   "jellyseerr_err_no_issue_permission": "Ingen tilladelse til at rapportere problemer",
   "jellyseerr_err_no_issue_view_permission": "Ingen tilladelse til at se problemer",
   "jellyseerr_err_load_server_options": "Kunne ikke indlæse serverindstillinger",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/da.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/da.json
@@ -148,6 +148,7 @@
   "jellyseerr_btn_error": "Fejl",
   "jellyseerr_btn_user_not_found": "Bruger ikke fundet",
   "jellyseerr_err_no_request_permission": "Ingen tilladelse til at lave anmodninger",
+  "jellyseerr_err_no_4k_request_permission": "Ingen tilladelse til at anmode om 4K",
   "jellyseerr_err_no_issue_permission": "Ingen tilladelse til at rapportere problemer",
   "jellyseerr_err_no_issue_view_permission": "Ingen tilladelse til at se problemer",
   "jellyseerr_err_load_server_options": "Kunne ikke indlæse serverindstillinger",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/de.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/de.json
@@ -149,6 +149,7 @@
   "jellyseerr_btn_user_not_found": "Benutzer nicht gefunden",
   "jellyseerr_err_no_request_permission": "Keine Berechtigung zum Stellen von Anfragen",
   "jellyseerr_err_no_4k_request_permission": "Keine Berechtigung, 4K anzufordern",
+  "jellyseerr_err_4k_requests_disabled": "4K-Anfragen sind deaktiviert",
   "jellyseerr_err_no_issue_permission": "Keine Berechtigung zum Melden von Problemen",
   "jellyseerr_err_no_issue_view_permission": "Keine Berechtigung zum Anzeigen von Problemen",
   "jellyseerr_err_load_server_options": "Serveroptionen konnten nicht geladen werden",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/de.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/de.json
@@ -148,6 +148,7 @@
   "jellyseerr_btn_error": "Fehler",
   "jellyseerr_btn_user_not_found": "Benutzer nicht gefunden",
   "jellyseerr_err_no_request_permission": "Keine Berechtigung zum Stellen von Anfragen",
+  "jellyseerr_err_no_4k_request_permission": "Keine Berechtigung, 4K anzufordern",
   "jellyseerr_err_no_issue_permission": "Keine Berechtigung zum Melden von Problemen",
   "jellyseerr_err_no_issue_view_permission": "Keine Berechtigung zum Anzeigen von Problemen",
   "jellyseerr_err_load_server_options": "Serveroptionen konnten nicht geladen werden",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/en-GB.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/en-GB.json
@@ -150,6 +150,7 @@
   "jellyseerr_btn_user_not_found": "User Not Found",
   "jellyseerr_err_no_request_permission": "No permission to make requests",
   "jellyseerr_err_no_4k_request_permission": "No permission to request 4K",
+  "jellyseerr_err_4k_requests_disabled": "4K requests are disabled",
   "jellyseerr_err_no_issue_permission": "No permission to report issues",
   "jellyseerr_err_no_issue_view_permission": "No permission to view issues",
   "jellyseerr_err_load_server_options": "Failed to load server options",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/en-GB.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/en-GB.json
@@ -149,6 +149,7 @@
   "jellyseerr_btn_error": "Error",
   "jellyseerr_btn_user_not_found": "User Not Found",
   "jellyseerr_err_no_request_permission": "No permission to make requests",
+  "jellyseerr_err_no_4k_request_permission": "No permission to request 4K",
   "jellyseerr_err_no_issue_permission": "No permission to report issues",
   "jellyseerr_err_no_issue_view_permission": "No permission to view issues",
   "jellyseerr_err_load_server_options": "Failed to load server options",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/en-US.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/en-US.json
@@ -150,6 +150,7 @@
   "jellyseerr_btn_user_not_found": "User Not Found",
   "jellyseerr_err_no_request_permission": "No permission to make requests",
   "jellyseerr_err_no_4k_request_permission": "No permission to request 4K",
+  "jellyseerr_err_4k_requests_disabled": "4K requests are disabled",
   "jellyseerr_err_no_issue_permission": "No permission to report issues",
   "jellyseerr_err_no_issue_view_permission": "No permission to view issues",
   "jellyseerr_err_load_server_options": "Failed to load server options",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/en-US.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/en-US.json
@@ -149,6 +149,7 @@
   "jellyseerr_btn_error": "Error",
   "jellyseerr_btn_user_not_found": "User Not Found",
   "jellyseerr_err_no_request_permission": "No permission to make requests",
+  "jellyseerr_err_no_4k_request_permission": "No permission to request 4K",
   "jellyseerr_err_no_issue_permission": "No permission to report issues",
   "jellyseerr_err_no_issue_view_permission": "No permission to view issues",
   "jellyseerr_err_load_server_options": "Failed to load server options",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/en.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/en.json
@@ -150,6 +150,7 @@
   "jellyseerr_btn_user_not_found": "User Not Found",
   "jellyseerr_err_no_request_permission": "No permission to make requests",
   "jellyseerr_err_no_4k_request_permission": "No permission to request 4K",
+  "jellyseerr_err_4k_requests_disabled": "4K requests are disabled",
   "jellyseerr_err_no_issue_permission": "No permission to report issues",
   "jellyseerr_err_no_issue_view_permission": "No permission to view issues",
   "jellyseerr_err_load_server_options": "Failed to load server options",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/en.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/en.json
@@ -149,6 +149,7 @@
   "jellyseerr_btn_error": "Error",
   "jellyseerr_btn_user_not_found": "User Not Found",
   "jellyseerr_err_no_request_permission": "No permission to make requests",
+  "jellyseerr_err_no_4k_request_permission": "No permission to request 4K",
   "jellyseerr_err_no_issue_permission": "No permission to report issues",
   "jellyseerr_err_no_issue_view_permission": "No permission to view issues",
   "jellyseerr_err_load_server_options": "Failed to load server options",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/es.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/es.json
@@ -148,6 +148,7 @@
   "jellyseerr_btn_error": "Error",
   "jellyseerr_btn_user_not_found": "Usuario no encontrado",
   "jellyseerr_err_no_request_permission": "Sin permiso para realizar solicitudes",
+  "jellyseerr_err_no_4k_request_permission": "Sin permiso para solicitar 4K",
   "jellyseerr_err_no_issue_permission": "Sin permiso para reportar problemas",
   "jellyseerr_err_no_issue_view_permission": "Sin permiso para ver problemas",
   "jellyseerr_err_load_server_options": "Error al cargar las opciones del servidor",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/es.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/es.json
@@ -149,6 +149,7 @@
   "jellyseerr_btn_user_not_found": "Usuario no encontrado",
   "jellyseerr_err_no_request_permission": "Sin permiso para realizar solicitudes",
   "jellyseerr_err_no_4k_request_permission": "Sin permiso para solicitar 4K",
+  "jellyseerr_err_4k_requests_disabled": "Las solicitudes 4K están desactivadas",
   "jellyseerr_err_no_issue_permission": "Sin permiso para reportar problemas",
   "jellyseerr_err_no_issue_view_permission": "Sin permiso para ver problemas",
   "jellyseerr_err_load_server_options": "Error al cargar las opciones del servidor",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/fr.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/fr.json
@@ -149,6 +149,7 @@
   "jellyseerr_btn_user_not_found": "Utilisateur non trouvé",
   "jellyseerr_err_no_request_permission": "Pas de permission pour faire des demandes",
   "jellyseerr_err_no_4k_request_permission": "Pas d'autorisation pour demander en 4K",
+  "jellyseerr_err_4k_requests_disabled": "Les demandes 4K sont désactivées",
   "jellyseerr_err_no_issue_permission": "Pas de permission pour signaler des problèmes",
   "jellyseerr_err_no_issue_view_permission": "Pas de permission pour voir les problèmes",
   "jellyseerr_err_load_server_options": "Échec du chargement des options du serveur",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/fr.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/fr.json
@@ -148,6 +148,7 @@
   "jellyseerr_btn_error": "Erreur",
   "jellyseerr_btn_user_not_found": "Utilisateur non trouvé",
   "jellyseerr_err_no_request_permission": "Pas de permission pour faire des demandes",
+  "jellyseerr_err_no_4k_request_permission": "Pas d'autorisation pour demander en 4K",
   "jellyseerr_err_no_issue_permission": "Pas de permission pour signaler des problèmes",
   "jellyseerr_err_no_issue_view_permission": "Pas de permission pour voir les problèmes",
   "jellyseerr_err_load_server_options": "Échec du chargement des options du serveur",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/he.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/he.json
@@ -378,6 +378,7 @@
   "hidden_content_confirm_cancel": "Cancel",
   "jellyseerr_modal_budget": "Budget",
   "jellyseerr_err_no_request_permission": "No permission to make requests",
+  "jellyseerr_err_no_4k_request_permission": "אין הרשאה לבקש 4K",
   "jellyseerr_report_unavailable_toast": "Reporting is unavailable for this item (no TMDB match)",
   "jellyseerr_report_issue_type_other": "Other",
   "jellyseerr_seasons_available_count": "{count}/{total} available",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/he.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/he.json
@@ -379,6 +379,7 @@
   "jellyseerr_modal_budget": "Budget",
   "jellyseerr_err_no_request_permission": "No permission to make requests",
   "jellyseerr_err_no_4k_request_permission": "אין הרשאה לבקש 4K",
+  "jellyseerr_err_4k_requests_disabled": "בקשות 4K מושבתות",
   "jellyseerr_report_unavailable_toast": "Reporting is unavailable for this item (no TMDB match)",
   "jellyseerr_report_issue_type_other": "Other",
   "jellyseerr_seasons_available_count": "{count}/{total} available",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/hu.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/hu.json
@@ -149,6 +149,7 @@
   "jellyseerr_btn_user_not_found": "Felhasználó nem található",
   "jellyseerr_err_no_request_permission": "Nincs jogosultság kérések benyújtásához",
   "jellyseerr_err_no_4k_request_permission": "Nincs jogosultság 4K kéréséhez",
+  "jellyseerr_err_4k_requests_disabled": "A 4K kérések le vannak tiltva",
   "jellyseerr_err_no_issue_permission": "Nincs jogosultság problémák jelentéséhez",
   "jellyseerr_err_no_issue_view_permission": "Nincs jogosultság problémák megtekintéséhez",
   "jellyseerr_err_load_server_options": "A szerver beállítások betöltése sikertelen",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/hu.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/hu.json
@@ -148,6 +148,7 @@
   "jellyseerr_btn_error": "Hiba",
   "jellyseerr_btn_user_not_found": "Felhasználó nem található",
   "jellyseerr_err_no_request_permission": "Nincs jogosultság kérések benyújtásához",
+  "jellyseerr_err_no_4k_request_permission": "Nincs jogosultság 4K kéréséhez",
   "jellyseerr_err_no_issue_permission": "Nincs jogosultság problémák jelentéséhez",
   "jellyseerr_err_no_issue_view_permission": "Nincs jogosultság problémák megtekintéséhez",
   "jellyseerr_err_load_server_options": "A szerver beállítások betöltése sikertelen",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/it.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/it.json
@@ -149,6 +149,7 @@
   "jellyseerr_btn_user_not_found": "Utente non trovato",
   "jellyseerr_err_no_request_permission": "Nessun permesso per effettuare richieste",
   "jellyseerr_err_no_4k_request_permission": "Nessun permesso per richiedere il 4K",
+  "jellyseerr_err_4k_requests_disabled": "Le richieste 4K sono disattivate",
   "jellyseerr_err_no_issue_permission": "Nessun permesso per segnalare problemi",
   "jellyseerr_err_no_issue_view_permission": "Nessun permesso per visualizzare i problemi",
   "jellyseerr_err_load_server_options": "Impossibile caricare le opzioni del server",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/it.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/it.json
@@ -148,6 +148,7 @@
   "jellyseerr_btn_error": "Errore",
   "jellyseerr_btn_user_not_found": "Utente non trovato",
   "jellyseerr_err_no_request_permission": "Nessun permesso per effettuare richieste",
+  "jellyseerr_err_no_4k_request_permission": "Nessun permesso per richiedere il 4K",
   "jellyseerr_err_no_issue_permission": "Nessun permesso per segnalare problemi",
   "jellyseerr_err_no_issue_view_permission": "Nessun permesso per visualizzare i problemi",
   "jellyseerr_err_load_server_options": "Impossibile caricare le opzioni del server",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/nl.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/nl.json
@@ -148,6 +148,7 @@
   "jellyseerr_btn_error": "Fout",
   "jellyseerr_btn_user_not_found": "Gebruiker niet gevonden",
   "jellyseerr_err_no_request_permission": "Geen toestemming om verzoeken in te dienen",
+  "jellyseerr_err_no_4k_request_permission": "Geen toestemming om 4K aan te vragen",
   "jellyseerr_err_no_issue_permission": "Geen toestemming om problemen te melden",
   "jellyseerr_err_no_issue_view_permission": "Geen toestemming om problemen te bekijken",
   "jellyseerr_err_load_server_options": "Serveropties konden niet worden geladen",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/nl.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/nl.json
@@ -149,6 +149,7 @@
   "jellyseerr_btn_user_not_found": "Gebruiker niet gevonden",
   "jellyseerr_err_no_request_permission": "Geen toestemming om verzoeken in te dienen",
   "jellyseerr_err_no_4k_request_permission": "Geen toestemming om 4K aan te vragen",
+  "jellyseerr_err_4k_requests_disabled": "4K-aanvragen zijn uitgeschakeld",
   "jellyseerr_err_no_issue_permission": "Geen toestemming om problemen te melden",
   "jellyseerr_err_no_issue_view_permission": "Geen toestemming om problemen te bekijken",
   "jellyseerr_err_load_server_options": "Serveropties konden niet worden geladen",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/no.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/no.json
@@ -149,6 +149,7 @@
   "jellyseerr_btn_user_not_found": "Bruker ikke funnet",
   "jellyseerr_err_no_request_permission": "Ingen tillatelse til å sende forespørsler",
   "jellyseerr_err_no_4k_request_permission": "Ingen tillatelse til å be om 4K",
+  "jellyseerr_err_4k_requests_disabled": "4K-forespørsler er deaktivert",
   "jellyseerr_err_no_issue_permission": "Ingen tillatelse til å rapportere problemer",
   "jellyseerr_err_no_issue_view_permission": "Ingen tillatelse til å se problemer",
   "jellyseerr_err_load_server_options": "Kunne ikke laste inn serveralternativer",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/no.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/no.json
@@ -148,6 +148,7 @@
   "jellyseerr_btn_error": "Feil",
   "jellyseerr_btn_user_not_found": "Bruker ikke funnet",
   "jellyseerr_err_no_request_permission": "Ingen tillatelse til å sende forespørsler",
+  "jellyseerr_err_no_4k_request_permission": "Ingen tillatelse til å be om 4K",
   "jellyseerr_err_no_issue_permission": "Ingen tillatelse til å rapportere problemer",
   "jellyseerr_err_no_issue_view_permission": "Ingen tillatelse til å se problemer",
   "jellyseerr_err_load_server_options": "Kunne ikke laste inn serveralternativer",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/pl.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/pl.json
@@ -148,6 +148,7 @@
   "jellyseerr_btn_error": "Błąd",
   "jellyseerr_btn_user_not_found": "Nie znaleziono użytkownika",
   "jellyseerr_err_no_request_permission": "Brak uprawnień do składania wniosków",
+  "jellyseerr_err_no_4k_request_permission": "Brak uprawnień do żądania 4K",
   "jellyseerr_err_no_issue_permission": "Brak uprawnień do zgłaszania problemów",
   "jellyseerr_err_no_issue_view_permission": "Brak uprawnień do przeglądania problemów",
   "jellyseerr_err_load_server_options": "Nie udało się załadować opcji serwera",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/pl.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/pl.json
@@ -149,6 +149,7 @@
   "jellyseerr_btn_user_not_found": "Nie znaleziono użytkownika",
   "jellyseerr_err_no_request_permission": "Brak uprawnień do składania wniosków",
   "jellyseerr_err_no_4k_request_permission": "Brak uprawnień do żądania 4K",
+  "jellyseerr_err_4k_requests_disabled": "Żądania 4K są wyłączone",
   "jellyseerr_err_no_issue_permission": "Brak uprawnień do zgłaszania problemów",
   "jellyseerr_err_no_issue_view_permission": "Brak uprawnień do przeglądania problemów",
   "jellyseerr_err_load_server_options": "Nie udało się załadować opcji serwera",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/pr.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/pr.json
@@ -149,6 +149,7 @@
   "jellyseerr_btn_user_not_found": "Sailor Not Found",
   "jellyseerr_err_no_request_permission": "Ye have no right to make requests, landlubber!",
   "jellyseerr_err_no_4k_request_permission": "No leave t' demand 4K glory",
+  "jellyseerr_err_4k_requests_disabled": "4K requests be scuttled",
   "jellyseerr_err_no_issue_permission": "Ye have no right to report issues, scallywag!",
   "jellyseerr_err_no_issue_view_permission": "Ye have no right to view issues, bilge rat!",
   "jellyseerr_err_load_server_options": "Failed to plunder server options",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/pr.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/pr.json
@@ -148,6 +148,7 @@
   "jellyseerr_btn_error": "Error",
   "jellyseerr_btn_user_not_found": "Sailor Not Found",
   "jellyseerr_err_no_request_permission": "Ye have no right to make requests, landlubber!",
+  "jellyseerr_err_no_4k_request_permission": "No leave t' demand 4K glory",
   "jellyseerr_err_no_issue_permission": "Ye have no right to report issues, scallywag!",
   "jellyseerr_err_no_issue_view_permission": "Ye have no right to view issues, bilge rat!",
   "jellyseerr_err_load_server_options": "Failed to plunder server options",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/pt-BR.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/pt-BR.json
@@ -149,6 +149,7 @@
   "jellyseerr_btn_user_not_found": "Usuário Não Encontrado",
   "jellyseerr_err_no_request_permission": "Sem permissão para fazer solicitações",
   "jellyseerr_err_no_4k_request_permission": "Sem permissão para solicitar 4K",
+  "jellyseerr_err_4k_requests_disabled": "As solicitações 4K estão desativadas",
   "jellyseerr_err_no_issue_permission": "Sem permissão para reportar problemas",
   "jellyseerr_err_no_issue_view_permission": "Sem permissão para visualizar problemas",
   "jellyseerr_err_load_server_options": "Falha ao carregar opções do servidor",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/pt-BR.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/pt-BR.json
@@ -148,6 +148,7 @@
   "jellyseerr_btn_error": "Erro",
   "jellyseerr_btn_user_not_found": "Usuário Não Encontrado",
   "jellyseerr_err_no_request_permission": "Sem permissão para fazer solicitações",
+  "jellyseerr_err_no_4k_request_permission": "Sem permissão para solicitar 4K",
   "jellyseerr_err_no_issue_permission": "Sem permissão para reportar problemas",
   "jellyseerr_err_no_issue_view_permission": "Sem permissão para visualizar problemas",
   "jellyseerr_err_load_server_options": "Falha ao carregar opções do servidor",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/pt.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/pt.json
@@ -148,6 +148,7 @@
   "jellyseerr_btn_error": "Erro",
   "jellyseerr_btn_user_not_found": "Usuário Não Encontrado",
   "jellyseerr_err_no_request_permission": "Sem permissão para fazer pedidos",
+  "jellyseerr_err_no_4k_request_permission": "Sem permissão para solicitar 4K",
   "jellyseerr_err_no_issue_permission": "Sem permissão para reportar problemas",
   "jellyseerr_err_no_issue_view_permission": "Sem permissão para ver problemas",
   "jellyseerr_err_load_server_options": "Falha ao carregar opções do servidor",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/pt.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/pt.json
@@ -149,6 +149,7 @@
   "jellyseerr_btn_user_not_found": "Usuário Não Encontrado",
   "jellyseerr_err_no_request_permission": "Sem permissão para fazer pedidos",
   "jellyseerr_err_no_4k_request_permission": "Sem permissão para solicitar 4K",
+  "jellyseerr_err_4k_requests_disabled": "Os pedidos 4K estão desativados",
   "jellyseerr_err_no_issue_permission": "Sem permissão para reportar problemas",
   "jellyseerr_err_no_issue_view_permission": "Sem permissão para ver problemas",
   "jellyseerr_err_load_server_options": "Falha ao carregar opções do servidor",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/ru.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/ru.json
@@ -148,6 +148,7 @@
   "jellyseerr_btn_error": "Ошибка",
   "jellyseerr_btn_user_not_found": "Пользователь не найден",
   "jellyseerr_err_no_request_permission": "Нет разрешения на создание запросов",
+  "jellyseerr_err_no_4k_request_permission": "Нет прав на запрос 4K",
   "jellyseerr_err_no_issue_permission": "Нет разрешения на сообщение о проблемах",
   "jellyseerr_err_no_issue_view_permission": "Нет разрешения на просмотр проблем",
   "jellyseerr_err_load_server_options": "Не удалось загрузить параметры сервера",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/ru.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/ru.json
@@ -149,6 +149,7 @@
   "jellyseerr_btn_user_not_found": "Пользователь не найден",
   "jellyseerr_err_no_request_permission": "Нет разрешения на создание запросов",
   "jellyseerr_err_no_4k_request_permission": "Нет прав на запрос 4K",
+  "jellyseerr_err_4k_requests_disabled": "Запросы 4K отключены",
   "jellyseerr_err_no_issue_permission": "Нет разрешения на сообщение о проблемах",
   "jellyseerr_err_no_issue_view_permission": "Нет разрешения на просмотр проблем",
   "jellyseerr_err_load_server_options": "Не удалось загрузить параметры сервера",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/sk.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/sk.json
@@ -149,6 +149,7 @@
   "jellyseerr_btn_user_not_found": "Používateľ nenájdený",
   "jellyseerr_err_no_request_permission": "Nemáte oprávnenie na podávanie žiadostí",
   "jellyseerr_err_no_4k_request_permission": "Nemáte oprávnenie požiadať o 4K",
+  "jellyseerr_err_4k_requests_disabled": "Požiadavky na 4K sú vypnuté",
   "jellyseerr_err_no_issue_permission": "Nemáte oprávnenie na hlásenie problémov",
   "jellyseerr_err_no_issue_view_permission": "Nemáte oprávnenie na zobrazenie problémov",
   "jellyseerr_err_load_server_options": "Nepodarilo sa načítať možnosti servera",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/sk.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/sk.json
@@ -148,6 +148,7 @@
   "jellyseerr_btn_error": "Chyba",
   "jellyseerr_btn_user_not_found": "Používateľ nenájdený",
   "jellyseerr_err_no_request_permission": "Nemáte oprávnenie na podávanie žiadostí",
+  "jellyseerr_err_no_4k_request_permission": "Nemáte oprávnenie požiadať o 4K",
   "jellyseerr_err_no_issue_permission": "Nemáte oprávnenie na hlásenie problémov",
   "jellyseerr_err_no_issue_view_permission": "Nemáte oprávnenie na zobrazenie problémov",
   "jellyseerr_err_load_server_options": "Nepodarilo sa načítať možnosti servera",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/sv.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/sv.json
@@ -149,6 +149,7 @@
   "jellyseerr_btn_user_not_found": "Användare hittades inte",
   "jellyseerr_err_no_request_permission": "Ingen behörighet att göra förfrågningar",
   "jellyseerr_err_no_4k_request_permission": "Ingen behörighet att begära 4K",
+  "jellyseerr_err_4k_requests_disabled": "4K-förfrågningar är inaktiverade",
   "jellyseerr_err_no_issue_permission": "Ingen behörighet att rapportera problem",
   "jellyseerr_err_no_issue_view_permission": "Ingen behörighet att visa problem",
   "jellyseerr_err_load_server_options": "Det gick inte att läsa in serveralternativ",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/sv.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/sv.json
@@ -148,6 +148,7 @@
   "jellyseerr_btn_error": "Fel",
   "jellyseerr_btn_user_not_found": "Användare hittades inte",
   "jellyseerr_err_no_request_permission": "Ingen behörighet att göra förfrågningar",
+  "jellyseerr_err_no_4k_request_permission": "Ingen behörighet att begära 4K",
   "jellyseerr_err_no_issue_permission": "Ingen behörighet att rapportera problem",
   "jellyseerr_err_no_issue_view_permission": "Ingen behörighet att visa problem",
   "jellyseerr_err_load_server_options": "Det gick inte att läsa in serveralternativ",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/tr.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/tr.json
@@ -148,6 +148,7 @@
   "jellyseerr_btn_error": "Hata",
   "jellyseerr_btn_user_not_found": "Kullanıcı Bulunamadı",
   "jellyseerr_err_no_request_permission": "İstek yapmak için izin yok",
+  "jellyseerr_err_no_4k_request_permission": "4K talep etme izniniz yok",
   "jellyseerr_err_no_issue_permission": "Sorun bildirmek için izin yok",
   "jellyseerr_err_no_issue_view_permission": "Sorunları görüntülemek için izin yok",
   "jellyseerr_err_load_server_options": "Sunucu seçenekleri yüklenemedi",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/tr.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/tr.json
@@ -149,6 +149,7 @@
   "jellyseerr_btn_user_not_found": "Kullanıcı Bulunamadı",
   "jellyseerr_err_no_request_permission": "İstek yapmak için izin yok",
   "jellyseerr_err_no_4k_request_permission": "4K talep etme izniniz yok",
+  "jellyseerr_err_4k_requests_disabled": "4K talepleri devre dışı",
   "jellyseerr_err_no_issue_permission": "Sorun bildirmek için izin yok",
   "jellyseerr_err_no_issue_view_permission": "Sorunları görüntülemek için izin yok",
   "jellyseerr_err_load_server_options": "Sunucu seçenekleri yüklenemedi",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/zh-CN.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/zh-CN.json
@@ -148,6 +148,7 @@
   "jellyseerr_btn_error": "错误",
   "jellyseerr_btn_user_not_found": "找不到用户",
   "jellyseerr_err_no_request_permission": "没有提交请求的权限",
+  "jellyseerr_err_no_4k_request_permission": "无权请求 4K",
   "jellyseerr_err_no_issue_permission": "没有报告问题的权限",
   "jellyseerr_err_no_issue_view_permission": "没有查看问题的权限",
   "jellyseerr_err_load_server_options": "加载服务器选项失败",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/zh-CN.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/zh-CN.json
@@ -149,6 +149,7 @@
   "jellyseerr_btn_user_not_found": "找不到用户",
   "jellyseerr_err_no_request_permission": "没有提交请求的权限",
   "jellyseerr_err_no_4k_request_permission": "无权请求 4K",
+  "jellyseerr_err_4k_requests_disabled": "4K 请求已禁用",
   "jellyseerr_err_no_issue_permission": "没有报告问题的权限",
   "jellyseerr_err_no_issue_view_permission": "没有查看问题的权限",
   "jellyseerr_err_load_server_options": "加载服务器选项失败",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/zh-HK.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/zh-HK.json
@@ -148,6 +148,7 @@
   "jellyseerr_btn_error": "錯誤",
   "jellyseerr_btn_user_not_found": "找不到用戶",
   "jellyseerr_err_no_request_permission": "沒有提交請求的權限",
+  "jellyseerr_err_no_4k_request_permission": "無權請求 4K",
   "jellyseerr_err_no_issue_permission": "沒有回報問題的權限",
   "jellyseerr_err_no_issue_view_permission": "沒有查看問題的權限",
   "jellyseerr_err_load_server_options": "載入伺服器選項失敗",

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/zh-HK.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/zh-HK.json
@@ -149,6 +149,7 @@
   "jellyseerr_btn_user_not_found": "找不到用戶",
   "jellyseerr_err_no_request_permission": "沒有提交請求的權限",
   "jellyseerr_err_no_4k_request_permission": "無權請求 4K",
+  "jellyseerr_err_4k_requests_disabled": "4K 請求已停用",
   "jellyseerr_err_no_issue_permission": "沒有回報問題的權限",
   "jellyseerr_err_no_issue_view_permission": "沒有查看問題的權限",
   "jellyseerr_err_load_server_options": "載入伺服器選項失敗",

--- a/Jellyfin.Plugin.JellyfinElevate/src/jellyseerr/api.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/jellyseerr/api.ts
@@ -38,6 +38,14 @@ export interface JellyseerrApi {
     fetchCollectionDetails: (collectionId: any) => Promise<any>;
     fetchGenreSlider: (mediaType: any) => Promise<any[]>;
     resolveJellyseerrBaseUrl: () => string;
+    /**
+     * Whether the 4K request affordance should be offered for a media type.
+     * Combines the JE admin toggle (master switch) with the Seerr-reported
+     * capability + this user's Seerr 4K permission from the cached user-status.
+     * Synchronous (reads the memoized status); degrades to hidden until status
+     * resolves. The single source of truth for every 4K UI gate.
+     */
+    canRequest4k: (mediaType: any) => boolean;
 }
 
 declare module '../types/je' {
@@ -50,6 +58,8 @@ declare module '../types/je' {
     interface PluginConfig {
         JellyseerrEnabled?: boolean;
         JellyseerrShowSearchResults?: boolean;
+        JellyseerrEnable4KRequests?: boolean;
+        JellyseerrEnable4KTvRequests?: boolean;
         JellyseerrShowAdvanced?: boolean;
         JellyseerrShowQuotaInfo?: boolean;
         JellyseerrShowGenreDiscovery?: boolean;
@@ -285,6 +295,38 @@ api.surfaceUserStatusBanner = function(status) {
 api.clearUserStatusCache = function() {
     cachedUserStatus = null;
     cachedUserStatusAt = 0;
+};
+
+/**
+ * Whether to offer the 4K request affordance for a media type. Master switch is
+ * the JE admin toggle; on top of that the Seerr server must actually have 4K
+ * enabled AND this user must hold the 4K permission — both carried on the cached
+ * user-status (server-resolved). Degrades to hidden until status resolves, and
+ * the server enforces the same rule regardless (defense in depth).
+ */
+api.canRequest4k = function(mediaType) {
+    const isTv = String(mediaType || '').toLowerCase() === 'tv';
+    // Admin master switch first — an admin who disabled 4K keeps it hidden even
+    // if Seerr and permissions would allow it.
+    const adminEnabled = isTv
+        ? !!JE.pluginConfig.JellyseerrEnable4KTvRequests
+        : !!JE.pluginConfig.JellyseerrEnable4KRequests;
+    if (!adminEnabled) return false;
+
+    const status = cachedUserStatus as {
+        active?: boolean;
+        userFound?: boolean;
+        canRequest4kMovie?: boolean;
+        canRequest4kTv?: boolean;
+    } | null;
+    if (!status || !status.active || !status.userFound) {
+        // Capability not resolved yet. PERF(R9) late-beats-never: kick off the
+        // memoized status fetch (fire-and-forget) so the next render self-heals,
+        // and hide for now rather than showing an option the server may reject.
+        if (cachedUserStatus === null) { void api.checkUserStatus(); }
+        return false;
+    }
+    return isTv ? !!status.canRequest4kTv : !!status.canRequest4kMovie;
 };
 
 /**

--- a/Jellyfin.Plugin.JellyfinElevate/src/jellyseerr/api.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/jellyseerr/api.ts
@@ -320,9 +320,10 @@ api.canRequest4k = function(mediaType) {
         canRequest4kTv?: boolean;
     } | null;
     if (!status || !status.active || !status.userFound) {
-        // Capability not resolved yet. PERF(R9) late-beats-never: kick off the
-        // memoized status fetch (fire-and-forget) so the next render self-heals,
-        // and hide for now rather than showing an option the server may reject.
+        // Capability not resolved yet — hide for now rather than showing an option
+        // the server may reject. Callers resolve status before rendering, so this
+        // path is belt-and-suspenders; the fire-and-forget fetch just guards against
+        // a stray early call leaving the capability permanently unresolved.
         if (cachedUserStatus === null) { void api.checkUserStatus(); }
         return false;
     }

--- a/Jellyfin.Plugin.JellyfinElevate/src/jellyseerr/canrequest4k.test.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/jellyseerr/canrequest4k.test.ts
@@ -1,0 +1,72 @@
+// Unit test for api.canRequest4k — the single client-side gate for the 4K
+// request affordance. It must combine the JE admin toggle (master switch) with
+// the Seerr-reported capability + per-user 4K permission carried on the cached
+// user-status, and degrade to hidden until that status resolves.
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+
+describe('jellyseerr api.canRequest4k gating', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(async () => {
+        vi.resetModules();
+        fetchMock = vi.fn();
+        const JE = window.JellyfinElevate as unknown as Record<string, unknown>;
+        JE.core = { api: { fetch: fetchMock } };
+        JE.pluginConfig = {};
+        JE.t = (k: string) => k;
+        JE.toast = vi.fn();
+        JE.escapeHtml = (s: unknown) => String(s);
+        await import('./api');
+    });
+
+    function api(): {
+        checkUserStatus: () => Promise<unknown>;
+        canRequest4k: (mediaType: string) => boolean;
+    } {
+        return (window.JellyfinElevate as unknown as {
+            jellyseerrAPI: { checkUserStatus: () => Promise<unknown>; canRequest4k: (m: string) => boolean };
+        }).jellyseerrAPI;
+    }
+
+    function setConfig(cfg: Record<string, unknown>): void {
+        (window.JellyfinElevate as unknown as { pluginConfig: unknown }).pluginConfig = cfg;
+    }
+
+    async function primeStatus(status: Record<string, unknown>): Promise<void> {
+        fetchMock.mockResolvedValue(status);
+        await api().checkUserStatus();
+    }
+
+    it('hides 4K when the admin toggle is off, even if the user is capable', async () => {
+        setConfig({ JellyseerrEnable4KRequests: false });
+        await primeStatus({ active: true, userFound: true, canRequest4kMovie: true });
+        expect(api().canRequest4k('movie')).toBe(false);
+    });
+
+    it('hides 4K when the Seerr/user capability is false, even if admin-enabled', async () => {
+        setConfig({ JellyseerrEnable4KRequests: true });
+        await primeStatus({ active: true, userFound: true, canRequest4kMovie: false });
+        expect(api().canRequest4k('movie')).toBe(false);
+    });
+
+    it('shows 4K per media type only when admin toggle AND capability agree', async () => {
+        setConfig({ JellyseerrEnable4KRequests: true, JellyseerrEnable4KTvRequests: true });
+        await primeStatus({ active: true, userFound: true, canRequest4kMovie: true, canRequest4kTv: false });
+        expect(api().canRequest4k('movie')).toBe(true);
+        expect(api().canRequest4k('tv')).toBe(false);
+    });
+
+    it('respects the separate TV admin toggle', async () => {
+        setConfig({ JellyseerrEnable4KRequests: false, JellyseerrEnable4KTvRequests: true });
+        await primeStatus({ active: true, userFound: true, canRequest4kMovie: true, canRequest4kTv: true });
+        expect(api().canRequest4k('movie')).toBe(false);
+        expect(api().canRequest4k('tv')).toBe(true);
+    });
+
+    it('degrades to hidden until user-status resolves', () => {
+        setConfig({ JellyseerrEnable4KRequests: true });
+        // No primeStatus — cached status is still null.
+        fetchMock.mockResolvedValue({ active: true, userFound: true, canRequest4kMovie: true });
+        expect(api().canRequest4k('movie')).toBe(false);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinElevate/src/jellyseerr/more-info-modal/actions.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/jellyseerr/more-info-modal/actions.ts
@@ -305,7 +305,7 @@ if (mediaType === 'movie') {
     const downloads4k = mediaInfo.downloadStatus4k || [];
     const jellyfinMediaId = mediaInfo.jellyfinMediaId || null;
     const jellyfinMediaId4k = mediaInfo.jellyfinMediaId4k || null;
-    const show4k = !!JE.pluginConfig.JellyseerrEnable4KRequests;
+    const show4k = JE.jellyseerrAPI!.canRequest4k('movie');
 
     // Show both chips if both statuses exist
     const hasNormalStatus = JE.seerrStatus!.hasStatus(status);
@@ -361,7 +361,7 @@ if (mediaType === 'movie') {
     const downloads4k = mediaInfo.downloadStatus4k || [];
     const jellyfinMediaId = mediaInfo.jellyfinMediaId || null;
     const jellyfinMediaId4k = mediaInfo.jellyfinMediaId4k || null;
-    const show4kTv = !!JE.pluginConfig.JellyseerrEnable4KTvRequests;
+    const show4kTv = JE.jellyseerrAPI!.canRequest4k('tv');
 
     // Show both chips if both statuses exist
     const hasNormalStatus = JE.seerrStatus!.hasStatus(status);

--- a/Jellyfin.Plugin.JellyfinElevate/src/jellyseerr/ui/buttons.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/jellyseerr/ui/buttons.ts
@@ -90,7 +90,8 @@ function configureTvShowButton(button: any, overallStatus: any, seasonAnalysis: 
         default: setButton(JE.t!('jellyseerr_btn_request'), icons.request, 'jellyseerr-button-request', false, seasonAnalysis?.total > 1 ? JE.t!('jellyseerr_seasons_available', {count: Number(seasonAnalysis.total) || 0}) : null); break;
     }
 
-    const show4KOption = !!JE.pluginConfig.JellyseerrEnable4KTvRequests;
+    // Gate on admin toggle AND Seerr 4K capability AND this user's 4K permission.
+    const show4KOption = JE.jellyseerrAPI!.canRequest4k('tv');
     const status4k = item.mediaInfo ? item.mediaInfo.status4k : 1;
 
     if (show4KOption && !button.closest('.jellyseerr-button-group')) {
@@ -146,8 +147,9 @@ function configureMovieButton(button: any, item: any) {
     const status = item.mediaInfo ? item.mediaInfo.status : 1;
     const status4k = item.mediaInfo ? item.mediaInfo.status4k : 1;
 
-    // Show split button when the 4K feature is enabled
-    const show4KOption = !!JE.pluginConfig.JellyseerrEnable4KRequests;
+    // Show split button when 4K is offered: admin toggle AND Seerr 4K capability
+    // AND this user's 4K permission.
+    const show4KOption = JE.jellyseerrAPI!.canRequest4k('movie');
 
     const setButton = (text: any, icon: any, className: any, disabled: any = false) => {
         button.innerHTML = `${icon || ''}<span>${text}</span>`;

--- a/Jellyfin.Plugin.JellyfinElevate/src/jellyseerr/ui/request-modals.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/jellyseerr/ui/request-modals.ts
@@ -83,6 +83,45 @@ ui.showMovieRequestModal = async function (tmdbId: any, title: any, searchResult
 };
 
 /**
+ * Resolves a collection movie row's badge + selectability from a Seerr media
+ * status. Shared between the initial (standard-quality) render and the 4K-mode
+ * re-evaluation so the two never drift. Already-available, already-requested and
+ * blocklisted movies are non-selectable.
+ */
+function describeCollectionRowStatus(status: number, hasActiveDownloads: boolean): { statusClass: string; statusText: string; isDisabled: boolean } {
+    let statusClass = 'not-requested';
+    let statusText = JE.t!('jellyseerr_season_status_not_requested') || 'Not Requested';
+
+    if (status === MediaStatus.AVAILABLE) {
+        statusClass = 'available';
+        statusText = JE.t!('jellyseerr_btn_available') || 'Available';
+    } else if (status === MediaStatus.PARTIALLY_AVAILABLE) {
+        statusClass = 'partially-available';
+        statusText = JE.t!('jellyseerr_btn_partially_available') || 'Partially Available';
+    } else if (status === MediaStatus.PROCESSING) {
+        if (hasActiveDownloads) {
+            statusClass = 'processing';
+            statusText = JE.t!('jellyseerr_btn_processing') || 'Processing';
+        } else {
+            statusClass = 'pending';
+            statusText = JE.t!('jellyseerr_btn_requested') || 'Requested';
+        }
+    } else if (status === MediaStatus.PENDING) {
+        statusClass = 'pending';
+        statusText = JE.t!('jellyseerr_btn_pending') || 'Pending';
+    } else if (status === MediaStatus.BLOCKED) {
+        statusClass = 'blocklisted';
+        statusText = JE.t!('jellyseerr_btn_blocklisted') || 'Blocklisted';
+    }
+
+    const isDisabled = status === MediaStatus.AVAILABLE
+        || status === MediaStatus.PENDING
+        || status === MediaStatus.PROCESSING
+        || status === MediaStatus.BLOCKED;
+    return { statusClass, statusText, isDisabled };
+}
+
+/**
  * Shows a modal for requesting a collection (all movies in a TMDB collection).
  * @param {number} collectionId - The TMDB collection IDisplayStatus.
  * @param {string} collectionName - The name of the collection.
@@ -107,53 +146,47 @@ ui.showCollectionRequestModal = async function (collectionId: any, collectionNam
     }
 
     const showAdvanced = JE.pluginConfig.JellyseerrShowAdvanced;
+    // Offer a "request the whole collection in 4K" toggle only when 4K requests
+    // are actually available to this user (admin toggle AND Seerr 4K capability
+    // AND the user's 4K permission). Collections are movies, so gate on 'movie'.
+    const show4k = JE.jellyseerrAPI!.canRequest4k('movie');
 
-    // Create checkbox list of movies in the collection with posters and status badges
+    // Create checkbox list of movies in the collection with posters and status badges.
+    // Each row carries BOTH the standard and 4K status so the 4K toggle can
+    // re-evaluate which movies are already available/requested without re-fetching.
     const movieListHtml = collectionDetails.parts.map((movie: any) => {
-        const status = movie.mediaInfo?.status || MediaStatus.UNKNOWN;
-        const downloads = movie.mediaInfo?.downloadStatus || [];
-        const hasActiveDownloads = downloads && downloads.length > 0;
-        const isAvailable = status === MediaStatus.AVAILABLE;
-        const isRequested = status === MediaStatus.PENDING || status === MediaStatus.PROCESSING;
-        const isDisabled = isAvailable || isRequested;
+        const m = movie as {
+            id?: number | string;
+            title?: string;
+            releaseDate?: string;
+            posterPath?: string;
+            mediaInfo?: { status?: number; status4k?: number; downloadStatus?: unknown[]; downloadStatus4k?: unknown[] };
+        };
+        const status = m.mediaInfo?.status || MediaStatus.UNKNOWN;
+        const status4k = m.mediaInfo?.status4k || MediaStatus.UNKNOWN;
+        const hasActiveDownloads = (m.mediaInfo?.downloadStatus?.length ?? 0) > 0;
+        const hasActiveDownloads4k = (m.mediaInfo?.downloadStatus4k?.length ?? 0) > 0;
+        const { statusClass, statusText, isDisabled } = describeCollectionRowStatus(status, hasActiveDownloads);
 
-        let statusClass = 'not-requested';
-        let statusText = JE.t!('jellyseerr_season_status_not_requested') || 'Not Requested';
-
-        if (status === MediaStatus.AVAILABLE) {
-            statusClass = 'available';
-            statusText = JE.t!('jellyseerr_btn_available') || 'Available';
-        } else if (status === MediaStatus.PARTIALLY_AVAILABLE) {
-            statusClass = 'partially-available';
-            statusText = JE.t!('jellyseerr_btn_partially_available') || 'Partially Available';
-        } else if (status === MediaStatus.PROCESSING) {
-            if (hasActiveDownloads) {
-                statusClass = 'processing';
-                statusText = JE.t!('jellyseerr_btn_processing') || 'Processing';
-            } else {
-                statusClass = 'pending';
-                statusText = JE.t!('jellyseerr_btn_requested') || 'Requested';
-            }
-        } else if (status === MediaStatus.PENDING) {
-            statusClass = 'pending';
-            statusText = JE.t!('jellyseerr_btn_pending') || 'Pending';
-        }
-
-        const year = movie.releaseDate ? new Date(movie.releaseDate).getFullYear() : '';
-        const poster = movie.posterPath
-            ? `https://image.tmdb.org/t/p/w92${movie.posterPath}`
+        const year = m.releaseDate ? new Date(m.releaseDate).getFullYear() : '';
+        const poster = m.posterPath
+            ? `https://image.tmdb.org/t/p/w92${m.posterPath}`
             : assetUrl('jellyseerr/poster-fallback.svg');
 
         return `
-            <div class="jellyseerr-collection-movie-row">
+            <div class="jellyseerr-collection-movie-row"
+                 data-status="${Number(status) || 1}"
+                 data-status4k="${Number(status4k) || 1}"
+                 data-has-downloads="${hasActiveDownloads ? '1' : '0'}"
+                 data-has-downloads4k="${hasActiveDownloads4k ? '1' : '0'}">
                 <input type="checkbox"
                        class="jellyseerr-collection-checkbox"
-                       id="movie-${escapeHtml(movie.id)}"
-                       data-tmdb-id="${escapeHtml(movie.id)}"
+                       id="movie-${escapeHtml(m.id)}"
+                       data-tmdb-id="${escapeHtml(m.id)}"
                        ${isDisabled ? 'disabled' : 'checked'}>
-                <img src="${escapeHtml(poster)}" alt="${escapeHtml(movie.title)}" class="jellyseerr-collection-movie-poster">
+                <img src="${escapeHtml(poster)}" alt="${escapeHtml(m.title)}" class="jellyseerr-collection-movie-poster">
                 <div class="jellyseerr-collection-movie-details">
-                    <div class="title">${escapeHtml(movie.title)}</div>
+                    <div class="title">${escapeHtml(m.title)}</div>
                     <div class="year">${escapeHtml(year)}</div>
                 </div>
                 <div class="jellyseerr-season-status jellyseerr-season-status-${escapeHtml(statusClass)}">${escapeHtml(statusText)}</div>
@@ -161,7 +194,16 @@ ui.showCollectionRequestModal = async function (collectionId: any, collectionNam
         `;
     }).join('');
 
+    const request4kLabel = JE.t!('jellyseerr_btn_request_4k') || 'Request in 4K';
+    const the4kToggleHtml = show4k
+        ? `<label class="jellyseerr-collection-4k-toggle">
+               <input type="checkbox" id="jellyseerr-collection-4k">
+               <span>${escapeHtml(request4kLabel)}</span>
+           </label>`
+        : '';
+
     const bodyHtml = `
+        ${the4kToggleHtml}
         <div class="jellyseerr-collection-list" style="max-height: 600px; overflow-y: auto;">
             <div class="jellyseerr-collection-header-row">
                 <input type="checkbox" class="jellyseerr-collection-checkbox" id="jellyseerr-select-all-movies">
@@ -183,6 +225,8 @@ ui.showCollectionRequestModal = async function (collectionId: any, collectionNam
         onSave: async (modalEl: any, requestBtn: any, closeFn: any) => {
             requestBtn.disabled = true;
             requestBtn.innerHTML = `${JE.t!('jellyseerr_modal_requesting') || 'Requesting'}<span class="jellyseerr-button-spinner"></span>`;
+
+            const is4k = !!(modalEl.querySelector('#jellyseerr-collection-4k') as HTMLInputElement | null)?.checked;
 
             let settings = {};
             if (showAdvanced) {
@@ -214,7 +258,7 @@ ui.showCollectionRequestModal = async function (collectionId: any, collectionNam
                 let quotaHitError: any = null;
                 for (const tmdbId of selectedMovies) {
                     try {
-                        await requestMedia(tmdbId, 'movie', settings, false, searchResultItem);
+                        await requestMedia(tmdbId, 'movie', settings, is4k, searchResultItem);
                         successCount++;
                     } catch (error: any) {
                         // Once quota is hit every remaining request will also fail — break.
@@ -294,6 +338,28 @@ ui.showCollectionRequestModal = async function (collectionId: any, collectionNam
                 updateSelectAllState();
             }
         });
+
+        // 4K toggle: re-evaluate every row against the standard vs 4K status so
+        // the "already available/requested" disabling and badges track the mode.
+        const fourKToggle = modalInstance.modalElement.querySelector<HTMLInputElement>('#jellyseerr-collection-4k');
+        if (fourKToggle) {
+            fourKToggle.addEventListener('change', () => {
+                const is4k = fourKToggle.checked;
+                movieList.querySelectorAll<HTMLElement>('.jellyseerr-collection-movie-row').forEach((row) => {
+                    const checkbox = row.querySelector<HTMLInputElement>('.jellyseerr-collection-checkbox');
+                    const badge = row.querySelector<HTMLElement>('.jellyseerr-season-status');
+                    if (!checkbox || !badge) return;
+                    const status = Number(is4k ? row.dataset.status4k : row.dataset.status) || MediaStatus.UNKNOWN;
+                    const hasDownloads = (is4k ? row.dataset.hasDownloads4k : row.dataset.hasDownloads) === '1';
+                    const { statusClass, statusText, isDisabled } = describeCollectionRowStatus(status, hasDownloads);
+                    checkbox.disabled = isDisabled;
+                    checkbox.checked = !isDisabled;
+                    badge.className = `jellyseerr-season-status jellyseerr-season-status-${statusClass}`;
+                    badge.textContent = statusText;
+                });
+                updateSelectAllState();
+            });
+        }
 
         updateSelectAllState();
     }

--- a/Jellyfin.Plugin.JellyfinElevate/src/jellyseerr/ui/request-modals.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/jellyseerr/ui/request-modals.ts
@@ -352,8 +352,17 @@ ui.showCollectionRequestModal = async function (collectionId: any, collectionNam
                     const status = Number(is4k ? row.dataset.status4k : row.dataset.status) || MediaStatus.UNKNOWN;
                     const hasDownloads = (is4k ? row.dataset.hasDownloads4k : row.dataset.hasDownloads) === '1';
                     const { statusClass, statusText, isDisabled } = describeCollectionRowStatus(status, hasDownloads);
+                    const wasDisabled = checkbox.disabled;
                     checkbox.disabled = isDisabled;
-                    checkbox.checked = !isDisabled;
+                    // Preserve the user's manual selections across a mode toggle: only
+                    // force-uncheck rows that just became disabled. Rows that stay
+                    // selectable keep their current checked state; rows that flip from
+                    // disabled→enabled default to checked.
+                    if (isDisabled) {
+                        checkbox.checked = false;
+                    } else if (wasDisabled) {
+                        checkbox.checked = true;
+                    }
                     badge.className = `jellyseerr-season-status jellyseerr-season-status-${statusClass}`;
                     badge.textContent = statusText;
                 });

--- a/Jellyfin.Plugin.JellyfinElevate/src/jellyseerr/ui/styles.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/jellyseerr/ui/styles.ts
@@ -335,6 +335,8 @@ ui.addSeasonModalStyles = function () {
         .jellyseerr-inline-progress-bar { height: .5rem; background: rgba(255,255,255,0.1); border-radius: 3px; overflow: hidden; margin-bottom: .5rem; }
         .jellyseerr-inline-progress-fill { height: 100%; background: linear-gradient(90deg, #3b82f6, #8b5cf6); transition: width 0.3s ease; border-radius: 3px; }
         .jellyseerr-inline-progress-text { font-size: 0.75rem; color: #94a3b8; font-weight: 500; }
+        .jellyseerr-collection-4k-toggle { display: inline-flex; align-items: center; gap: 8px; padding: 10px 16px; margin-bottom: 12px; background: rgba(51, 65, 85, 0.3); border: 1px solid rgba(71, 85, 105, 0.4); border-radius: 12px; font-weight: 600; color: #e2e8f0; cursor: pointer; }
+        .jellyseerr-collection-4k-toggle input { width: 20px; height: 20px; accent-color: #4f46e5; border-radius: 4px; cursor: pointer; }
         .jellyseerr-collection-list { display: grid; gap: 4px; }
         .jellyseerr-collection-header-row { display: grid; grid-template-columns: 40px 1fr auto auto; align-items: center; gap: 16px; padding: 12px 20px; background: rgba(51, 65, 85, 0.3); border: 1px solid rgba(71, 85, 105, 0.4); border-radius: 12px; margin-bottom: 8px; font-weight: 600; color: #e2e8f0; }
         .jellyseerr-collection-header-row .jellyseerr-collection-checkbox { cursor: pointer; }

--- a/docs/seerr/seerr-features.md
+++ b/docs/seerr/seerr-features.md
@@ -39,12 +39,21 @@ Search, request, and discover media directly from Jellyfin using your Seerr inst
 3. Seerr results show request status
 4. Click to request or view details
 
-#### 4K TV Requesting:
+#### 4K Requesting:
 
-1. Enable **4K TV Requests** in plugin settings.
-2. For TV results, use the request split-button dropdown and choose **Request in 4K**.
-3. The season selection modal opens in 4K mode.
-4. The modal header shows **Request Series - 4K** and the primary button shows **Request in 4K**.
+1. Enable **4K Requests** / **4K TV Requests** in plugin settings (master switch).
+2. For movie/TV results, use the request split-button dropdown and choose **Request in 4K**.
+3. For TV, the season selection modal opens in 4K mode — the header shows **Request Series - 4K** and the primary button shows **Request in 4K**.
+
+!!! note "When the 4K option appears"
+
+    Beyond the admin master switch, the 4K option is only offered when the Seerr
+    server actually has 4K enabled for that media type (a default 4K Radarr /
+    Sonarr — Seerr's `movie4kEnabled` / `series4kEnabled`) **and** the signed-in
+    user holds the Seerr **REQUEST_4K** (or the media-specific
+    **REQUEST_4K_MOVIE** / **REQUEST_4K_TV**) permission. Otherwise the 4K
+    affordance is hidden. The server enforces the same rule on the request
+    itself, so a 4K request can never be made without permission.
 
 !!! tip
 

--- a/docs/seerr/seerr-settings.md
+++ b/docs/seerr/seerr-settings.md
@@ -107,6 +107,18 @@ When enabled, new Jellyfin users are automatically imported into Seerr the first
     - Seerr instance with **4K configuration**
     - Permissions for users to request 4K quality
 
+This is a **master switch**. Even with it on, the 4K movie option is only shown
+when **both** of the following hold, and is hidden otherwise:
+
+- Seerr actually reports 4K movies as enabled (a default 4K Radarr is configured
+  — Seerr's `movie4kEnabled`), and
+- the signed-in user holds the Seerr **REQUEST_4K** (or **REQUEST_4K_MOVIE**)
+  permission.
+
+So a user without 4K permission, or a Seerr server with no 4K Radarr, simply
+never sees the 4K affordance. The server enforces the same rule on the request
+itself, so the option can never be used without permission.
+
 ### Enable 4K TV Requests
 
 !!! note "Requirements"
@@ -115,7 +127,11 @@ When enabled, new Jellyfin users are automatically imported into Seerr the first
     - Seerr instance with **4K Sonarr configured**
     - Permissions for users to request **4K Sonarr** quality
 
-  When enabled:
+Also a **master switch**, gated the same way: the 4K TV option is shown only when
+Seerr reports 4K series enabled (`series4kEnabled`, a default 4K Sonarr) **and**
+the user holds **REQUEST_4K** (or **REQUEST_4K_TV**).
+
+  When enabled and available:
 
   - TV request buttons include a 4K dropdown action.
   - Choosing **Request in 4K** opens the season modal in 4K mode.
@@ -129,6 +145,13 @@ When enabled, new Jellyfin users are automatically imported into Seerr the first
 ### Show Collections in Seerr Results
 - Display TMDB collections (e.g., Harry Potter, Marvel Cinematic Universe) in Seerr search results
 - Includes an option to request the entire collection at once
+- The collection request modal lists every movie with its current status; movies
+  that are already available, already requested or blocklisted are pre-disabled,
+  and only the selected, still-requestable movies are submitted (one request per
+  movie, matching Seerr's own behaviour)
+- When 4K movie requests are available to you (see **Enable 4K Requests**), the
+  collection modal shows a **Request in 4K** toggle that submits the selected
+  movies in 4K and re-evaluates each movie against its 4K status
 - Enabled by default
 
 ### Auto Import Jellyfin Users to Seerr

--- a/e2e/seerr-4k-collections.spec.ts
+++ b/e2e/seerr-4k-collections.spec.ts
@@ -1,0 +1,92 @@
+// Feature guard: Seerr 4K requests are gated on the Seerr server's real 4K
+// capability AND the signed-in user's 4K permission — not on the JE admin toggle
+// alone. This spec drives the booted plugin's own gate (canRequest4k) and the
+// user-status endpoint against the LIVE server for both an admin and a non-admin
+// session, and proves that with the admin toggle forced ON the 4K option still
+// stays hidden unless the server actually reports the capability for that user.
+//
+// It also asserts the collection request surface (showCollectionRequestModal)
+// is present, and that the whole flow produces no runtime errors.
+import { test, expect, loginAs, assertNoRuntimeErrors, type Role } from './fixtures/auth';
+import { seerrReady } from './fixtures/seerr';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const SEERR_OFF = 'Seerr not configured — set JELLYSEERR_* at seed time to run';
+
+interface UserStatus {
+    active?: boolean;
+    userFound?: boolean;
+    reason?: string;
+    movie4kEnabled?: boolean;
+    series4kEnabled?: boolean;
+    canRequest4kMovie?: boolean;
+    canRequest4kTv?: boolean;
+}
+
+async function fetchUserStatus(page: any): Promise<UserStatus> {
+    return page.evaluate(async () => {
+        const api = (window as any).ApiClient;
+        return api.getJSON(api.getUrl('/JellyfinElevate/jellyseerr/user-status'));
+    });
+}
+
+/** Resolve user-status, force the admin master switch, then read the gate. */
+async function gateWithAdminToggle(page: any, mediaType: 'movie' | 'tv', adminToggle: boolean): Promise<boolean> {
+    return page.evaluate(async (args: { mediaType: string; adminToggle: boolean }) => {
+        const je = (window as any).JellyfinElevate;
+        await je.jellyseerrAPI.checkUserStatus(); // ensure capability is resolved
+        je.pluginConfig.JellyseerrEnable4KRequests = args.adminToggle;
+        je.pluginConfig.JellyseerrEnable4KTvRequests = args.adminToggle;
+        return je.jellyseerrAPI.canRequest4k(args.mediaType) as boolean;
+    }, { mediaType, adminToggle });
+}
+
+for (const role of ['admin', 'user'] as Role[]) {
+    test.describe(`Seerr 4K & collection requests — ${role}`, () => {
+        test(`4K option is gated on Seerr capability + permission, not the admin toggle (${role})`, async ({ page, consoleErrors }) => {
+            await loginAs(page, role, consoleErrors);
+            test.skip(!(await seerrReady(page)), SEERR_OFF);
+
+            // The shared gate and the collection modal are present on the facade.
+            const surface = await page.evaluate(() => {
+                const je = (window as any).JellyfinElevate;
+                return {
+                    hasGate: typeof je?.jellyseerrAPI?.canRequest4k === 'function',
+                    hasCollectionModal: typeof je?.jellyseerrUI?.showCollectionRequestModal === 'function',
+                };
+            });
+            expect(surface.hasGate, 'canRequest4k gate exposed').toBe(true);
+            expect(surface.hasCollectionModal, 'showCollectionRequestModal exposed').toBe(true);
+
+            // With the admin master switch OFF, the 4K option is always hidden.
+            expect(await gateWithAdminToggle(page, 'movie', false)).toBe(false);
+            expect(await gateWithAdminToggle(page, 'tv', false)).toBe(false);
+
+            // The user-status endpoint always answers with a typed reason.
+            const status = await fetchUserStatus(page);
+            expect(status, 'user-status responds').toBeTruthy();
+
+            // With the admin master switch ON, the option follows the server-
+            // reported capability + permission — never the toggle alone.
+            const movieOn = await gateWithAdminToggle(page, 'movie', true);
+            const tvOn = await gateWithAdminToggle(page, 'tv', true);
+
+            if (status.userFound) {
+                // Linked user: the capability fields are present and are booleans,
+                // and the gate matches them exactly.
+                expect(typeof status.canRequest4kMovie).toBe('boolean');
+                expect(typeof status.canRequest4kTv).toBe('boolean');
+                expect(movieOn).toBe(!!status.canRequest4kMovie);
+                expect(tvOn).toBe(!!status.canRequest4kTv);
+            } else {
+                // Unlinked user (no resolvable Seerr permissions): 4K stays hidden
+                // EVEN with the admin toggle ON — the capability/permission gate.
+                expect(movieOn, 'no 4K for an unlinked user even with toggle on').toBe(false);
+                expect(tvOn, 'no 4K TV for an unlinked user even with toggle on').toBe(false);
+            }
+
+            assertNoRuntimeErrors(consoleErrors);
+        });
+    });
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Development tooling for the Jellyfin Elevate plugin (lint, type-check, translation validation). The plugin itself ships as embedded resources from the C# project.",
   "scripts": {
-    "lint": "eslint --max-warnings 6751 \"Jellyfin.Plugin.JellyfinElevate/js/**/*.js\" \"Jellyfin.Plugin.JellyfinElevate/src/**/*.ts\" \"Jellyfin.Plugin.JellyfinElevate/Configuration/*.js\" \"scripts/**/*.js\"",
+    "lint": "eslint --max-warnings 6738 \"Jellyfin.Plugin.JellyfinElevate/js/**/*.js\" \"Jellyfin.Plugin.JellyfinElevate/src/**/*.ts\" \"Jellyfin.Plugin.JellyfinElevate/Configuration/*.js\" \"scripts/**/*.js\"",
     "lint:fix": "eslint --fix \"Jellyfin.Plugin.JellyfinElevate/js/**/*.js\" \"Jellyfin.Plugin.JellyfinElevate/src/**/*.ts\" \"Jellyfin.Plugin.JellyfinElevate/Configuration/*.js\" \"scripts/**/*.js\"",
     "typecheck": "tsc -p jsconfig.json",
     "typecheck:src": "tsc -p tsconfig.src.json",


### PR DESCRIPTION
## What & why

Milestone **Seerr Requests: 4K & Collections** (upstream asks 97, 156, 162, 502, 288). Most of the surface already existed in main (4K request flags, collection modal with per-movie fan-out). This PR implements the genuine gaps: capability/permission gating so 4K affordances only appear when they can actually succeed, server-side enforcement of the 4K master switch, and 4K collection requests.

## Implementation notes

- **Server capability projection**: `GetSeerr4kCapabilityAsync` reads Seerr `GET /api/v1/settings/public` (`movie4kEnabled`/`series4kEnabled`) — fetched user-neutrally (no `X-Api-User`, pinned by test), share-cached 5 min, flushed on config change — and folds in the caller's Seerr 4K permission bits after cache retrieval. Surfaced on the existing `jellyseerr/user-status` payload. Jellyfin admins project server-capability AND master switch (mirrors the proxy gate's admin bypass).
- **Client gate**: new shared `api.canRequest4k(mediaType)` = admin master switch AND server capability AND user permission — replaced the four scattered admin-toggle-only checks (search buttons ×2, more-info modal ×2). Degrades to hidden until status resolves.
- **Server request gates** (defense in depth; Seerr remains authoritative): non-admin `is4k` requests require the 4K permission bits per Seerr's own rule in `MediaRequest.ts` — fully decoupled from base request bits (typed 403 `no_4k_request_permission`); the admin master switch is enforced for every caller including admins (typed 403 `4k_requests_disabled`); `is4k` parsing treats any truthy value (true / 1 / "true") as 4K so crafted bodies can't dodge the gates.
- **4K collection requests**: the collection modal gains a "Request in 4K" toggle (rendered only when 4K movie requests are available) that submits selected parts with `is4k` and re-evaluates rows against `status4k`. Toggle preserves manual deselections; blocklisted movies are now non-selectable (pre-existing gap). Row-status logic extracted to one shared `describeCollectionRowStatus` helper used by initial render and re-evaluation.
- Verified against the Seerr source: `is4k` on `MediaRequestBody`, `movie4kEnabled`/`series4kEnabled` derivation from default 4K arr servers, 4K permission decoupling, and collection request fan-out (one POST per part) — the existing JE fan-out matches Seerr's own UI mechanism.
- i18n: 2 new error keys in all 26 locales. Docs: `seerr-features.md` + `seerr-settings.md` updated; `mkdocs build --strict` clean.

## Limitations

- seerr-dev has no 4K Radarr/Sonarr and the dev users aren't Seerr-linked, so the 4K affordances correctly do not render there — the e2e spec instead asserts the client gate agrees with the live server-reported capability for both roles.
- Capability is session-sticky up to the 5-min server TTL (consistent with existing user-status semantics); reload or config save refreshes.

## Test plan

- Gates: typecheck, lint 0 errors (warning cap lowered 6751 → 6738), client tests **413/413**, bundle, syntax, `dotnet build -c Release` 0 warnings, `dotnet test` **676/676** (+12 new across capability, permission-parity, request-gate, and master-switch tests).
- e2e against deployed jellyfin-12: full committed suite green (44 specs incl. new `seerr-4k-collections.spec.ts`, both `je_arradmin` and `je_arruser`, zero real console errors; one pre-existing login flake passed on retry).
- Review: independent codex pass (GPT-5.5 xhigh) + two adversarial Opus xhigh reviews; all confirmed findings fixed in-branch (4K/base permission decoupling, admin capability projection, truthy `is4k` hardening, toggle deselection UX), remaining reports verified clean.

This PR was developed with AI assistance per CONTRIBUTING.
