### PR TITLE
fix(ui): mobile viewport fits — settings panel, interior pages, collection cards

### DIFF
--- a/Jellyfin.Plugin.JellyfinElevate/src/arr/calendar/render-views.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/arr/calendar/render-views.ts
@@ -375,7 +375,7 @@ export function createPageContainer(): HTMLElement {
         page.innerHTML = `
         <div data-role="content">
           <div class="content-primary je-calendar-page">
-            <div id="je-calendar-container" style="padding-top: 5em; padding-left: 0.5em; padding-right: 0.5em;"></div>
+            <div id="je-calendar-container" class="je-interior-page-top" style="padding-left: 0.5em; padding-right: 0.5em;"></div>
           </div>
         </div>
       `;

--- a/Jellyfin.Plugin.JellyfinElevate/src/arr/requests/render.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/arr/requests/render.ts
@@ -440,7 +440,7 @@ export function createPageContainer(): HTMLElement {
         page.innerHTML = `
         <div data-role="content">
           <div class="content-primary je-downloads-page">
-            <div id="je-downloads-container" style="padding-top: 5em;"></div>
+            <div id="je-downloads-container" class="je-interior-page-top"></div>
           </div>
         </div>
       `;

--- a/Jellyfin.Plugin.JellyfinElevate/src/arr/requests/styles.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/arr/requests/styles.ts
@@ -525,6 +525,14 @@ const CSS_STYLES = `
           from { transform: rotate(0deg); }
           to { transform: rotate(360deg); }
         }
+        /* Phone layout: the desktop page reserves 2em padding + 85vw max-width
+           and lays cards out in a 340px-min grid — on a 360px phone that single
+           column is wider than the content box and scrolls horizontally. Fill
+           the width and drop to a single full-width card column. */
+        @media (max-width: 768px) {
+          .je-downloads-page { padding: 0.75em; max-width: 100%; }
+          .je-downloads-grid { grid-template-columns: 1fr; }
+        }
     `;
 
 /**

--- a/Jellyfin.Plugin.JellyfinElevate/src/core/layout.test.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/core/layout.test.ts
@@ -1,0 +1,118 @@
+// Unit tests for src/core/layout.ts — modern-vs-legacy detection and the
+// <html> class stamp that lets CSS scope rules per layout (v12-platform.md §1:
+// the html element itself carries `layout-desktop` on BOTH layouts, so DOM
+// visibility is the only discriminator).
+//
+// jsdom does no layout, so `offsetParent` is always null and
+// `getClientRects()` always empty. The tests therefore stub exactly the two
+// signals the module reads: `.headerRight`'s offsetParent (legacy visibility)
+// and the MUI toolbar's client rects (modern visibility).
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { detectLayoutMode, resetLayoutCacheForTests, stampLayoutClass } from './layout';
+
+/** Give an element a non-null offsetParent (jsdom reports null for everything). */
+function markVisibleViaOffsetParent(el: HTMLElement): void {
+    Object.defineProperty(el, 'offsetParent', { value: document.body, configurable: true });
+}
+
+/** Give an element a non-empty getClientRects() (jsdom returns empty). */
+function markVisibleViaClientRects(el: HTMLElement): void {
+    const rects = [{ width: 100, height: 48 }] as unknown as DOMRectList;
+    el.getClientRects = () => rects;
+}
+
+function addLegacyHeader(visible: boolean): HTMLElement {
+    const header = document.createElement('div');
+    header.className = 'headerRight';
+    document.body.appendChild(header);
+    if (visible) markVisibleViaOffsetParent(header);
+    return header;
+}
+
+function addMuiToolbar(visible: boolean): HTMLElement {
+    const bar = document.createElement('div');
+    bar.className = 'MuiAppBar-root';
+    const toolbar = document.createElement('div');
+    toolbar.className = 'MuiToolbar-root';
+    bar.appendChild(toolbar);
+    document.body.appendChild(bar);
+    if (visible) markVisibleViaClientRects(toolbar);
+    return toolbar;
+}
+
+beforeEach(() => {
+    document.body.innerHTML = '';
+    document.documentElement.className = '';
+    resetLayoutCacheForTests();
+});
+
+afterEach(() => {
+    document.body.innerHTML = '';
+    document.documentElement.className = '';
+    resetLayoutCacheForTests();
+});
+
+describe('detectLayoutMode', () => {
+    it('returns legacy when .headerRight is present and visible', () => {
+        addLegacyHeader(true);
+        expect(detectLayoutMode()).toBe('legacy');
+    });
+
+    it('returns modern when the MUI toolbar is visible and .headerRight is not', () => {
+        addLegacyHeader(false); // present but hidden (display:none wrapper on modern)
+        addMuiToolbar(true);
+        expect(detectLayoutMode()).toBe('modern');
+    });
+
+    it('prefers legacy when the legacy header is genuinely visible', () => {
+        addLegacyHeader(true);
+        addMuiToolbar(true); // MUI stylesheet/DOM can coexist on legacy
+        expect(detectLayoutMode()).toBe('legacy');
+    });
+
+    it('returns null when no header has rendered yet (not cached)', () => {
+        expect(detectLayoutMode()).toBeNull();
+        // A later render must still resolve — a null result is never cached.
+        addMuiToolbar(true);
+        expect(detectLayoutMode()).toBe('modern');
+    });
+
+    it('caches the first successful resolution', () => {
+        addMuiToolbar(true);
+        expect(detectLayoutMode()).toBe('modern');
+        // Even after the DOM changes to look legacy, the cached value wins
+        // (layout is fixed per page load).
+        document.body.innerHTML = '';
+        addLegacyHeader(true);
+        expect(detectLayoutMode()).toBe('modern');
+    });
+});
+
+describe('stampLayoutClass', () => {
+    it('stamps je-modern-layout on <html> for the modern layout', () => {
+        addMuiToolbar(true);
+        stampLayoutClass();
+        expect(document.documentElement.classList.contains('je-modern-layout')).toBe(true);
+        expect(document.documentElement.classList.contains('je-legacy-layout')).toBe(false);
+    });
+
+    it('stamps je-legacy-layout on <html> for the legacy layout', () => {
+        addLegacyHeader(true);
+        stampLayoutClass();
+        expect(document.documentElement.classList.contains('je-legacy-layout')).toBe(true);
+        expect(document.documentElement.classList.contains('je-modern-layout')).toBe(false);
+    });
+
+    it('stamps nothing while the layout is undeterminable (safe default holds)', () => {
+        stampLayoutClass();
+        expect(document.documentElement.classList.contains('je-modern-layout')).toBe(false);
+        expect(document.documentElement.classList.contains('je-legacy-layout')).toBe(false);
+    });
+
+    it('is idempotent', () => {
+        addMuiToolbar(true);
+        stampLayoutClass();
+        stampLayoutClass();
+        expect(document.documentElement.classList.contains('je-modern-layout')).toBe(true);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinElevate/src/core/layout.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/core/layout.ts
@@ -1,0 +1,97 @@
+// src/core/layout.ts
+//
+// Single owner of modern-vs-legacy layout detection for the whole plugin.
+//
+// Jellyfin 12 ships TWO layouts and the `html` element cannot discriminate
+// them: both the React/MUI "modern" layout (the default) and the classic
+// "legacy" layout stamp `layout-desktop` on <html> at every viewport
+// (docs/v12-platform.md §1). The layout is chosen once at boot and only
+// changes on reload, so the distinction is stable for the session — but CSS
+// that must differ per layout has nothing on <html> to hang off.
+//
+// This module reuses the SAME DOM discriminator the header-container resolver
+// relies on (docs/v12-platform.md §1: "detect by DOM — visible
+// `.MuiAppBar-root .MuiToolbar-root` vs visible `.headerRight`"), caches the
+// result (R4 — read the DOM at most once per resolution, never per tick), and
+// stamps `je-modern-layout` / `je-legacy-layout` on <html> so plugin CSS can
+// scope rules to the active layout.
+//
+// Why this exists: the standalone interior pages (Hidden Content, Calendar,
+// Requests) share `.je-interior-page-top` for header clearance. On the LEGACY
+// layout `.skinHeader` is `position:fixed` and clearance for these custom
+// `page type-interior` pages comes ONLY from that top padding (the per-page
+// classes that carry legacy header padding — `.libraryPage` etc. — are absent
+// here). A viewport-only phone media query that shrank the padding therefore
+// clipped headings under the legacy fixed header. Scoping the reduced padding
+// to `.je-modern-layout` keeps legacy clearance intact.
+
+import { onNavigate } from './navigation';
+
+/** The two Jellyfin 12 layouts the plugin distinguishes. */
+export type LayoutMode = 'modern' | 'legacy';
+
+// Cached resolution (R4). Layout is fixed per page load, so once resolved this
+// never changes; `null` means "not determinable yet" (the header has not
+// rendered) and is deliberately NOT cached so retries still work.
+let cachedLayout: LayoutMode | null = null;
+
+/**
+ * Detect the active layout by DOM visibility.
+ *
+ * Legacy iff the classic `.headerRight` is present AND visible (on the modern
+ * layout the whole legacy header lives inside a `display:none` wrapper, so
+ * `.headerRight` exists but has no `offsetParent`). Otherwise, once the MUI
+ * toolbar has rendered visibly, the layout is modern. Returns `null` while
+ * neither header is ready yet.
+ * @returns The layout mode, or null when it cannot be determined yet.
+ */
+export function detectLayoutMode(): LayoutMode | null {
+    if (cachedLayout) return cachedLayout;
+
+    const legacyHeader = document.querySelector<HTMLElement>('.headerRight');
+    if (legacyHeader && legacyHeader.offsetParent !== null) {
+        cachedLayout = 'legacy';
+        return cachedLayout;
+    }
+
+    // `.MuiAppBar-root` is `position:fixed` (offsetParent === null even when
+    // visible), so probe the toolbar's own layout boxes instead of offsetParent.
+    const toolbar = document.querySelector<HTMLElement>('.MuiAppBar-root .MuiToolbar-root');
+    if (toolbar && toolbar.getClientRects().length > 0) {
+        cachedLayout = 'modern';
+        return cachedLayout;
+    }
+
+    return null;
+}
+
+/**
+ * Reset the cached layout resolution. Test-only: layout is fixed per page load
+ * in production, so nothing calls this at runtime.
+ */
+export function resetLayoutCacheForTests(): void {
+    cachedLayout = null;
+}
+
+/**
+ * Stamp `je-modern-layout` / `je-legacy-layout` on <html> from the detected
+ * layout. Idempotent and safe to call repeatedly: it is a no-op once the
+ * layout has been resolved and stamped, and does nothing while the layout is
+ * still undeterminable (the CSS default — full header clearance — stays in
+ * force until then, so nothing is ever clipped in the interim).
+ */
+export function stampLayoutClass(): void {
+    const mode = detectLayoutMode();
+    if (!mode) return;
+    const root = document.documentElement;
+    root.classList.toggle('je-modern-layout', mode === 'modern');
+    root.classList.toggle('je-legacy-layout', mode === 'legacy');
+}
+
+// Stamp as early as possible, then keep retrying on every navigation until the
+// header has rendered and the layout resolves. Detection caches after the first
+// success, so post-resolution navigations are cheap no-ops.
+stampLayoutClass();
+onNavigate(() => {
+    if (!cachedLayout) stampLayoutClass();
+});

--- a/Jellyfin.Plugin.JellyfinElevate/src/enhanced/events.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/enhanced/events.ts
@@ -7,6 +7,7 @@ import { JE } from '../globals';
 import { createObserver } from '../core/dom-observer';
 import { isAnyModalOpen } from '../core/modal-a11y';
 import { toast } from '../core/ui-kit';
+import { stampLayoutClass } from '../core/layout';
 import { throttle } from './helpers';
 
 /**
@@ -343,6 +344,10 @@ JE.initializeElevateScript = function() {
 
     // Initial UI setup
     (JE as any).injectGlobalStyles();
+    // Stamp the modern/legacy layout class on <html> now that the app has
+    // booted (the header is normally rendered by this point). The stamp is
+    // idempotent and self-retries on navigation until the layout resolves.
+    stampLayoutClass();
     (JE as any).addPluginMenuButton();
     (JE as any).applySavedStylesWhenReady();
 

--- a/Jellyfin.Plugin.JellyfinElevate/src/enhanced/hidden-content-page/nav.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/enhanced/hidden-content-page/nav.ts
@@ -93,7 +93,10 @@ export function createPageContainer(): HTMLElement {
 
         const container = document.createElement("div");
         container.id = "je-hidden-content-container";
-        container.style.cssText = "padding-top: 5em; padding-left: 0.5em; padding-right: 0.5em;";
+        // Shared responsive top offset (see JE.injectGlobalStyles .je-interior-page-top):
+        // compact on phones, generous on desktop — replaces a hardcoded padding-top:5em.
+        container.className = "je-interior-page-top";
+        container.style.cssText = "padding-left: 0.5em; padding-right: 0.5em;";
 
         contentPrimary.appendChild(container);
         contentWrapper.appendChild(contentPrimary);

--- a/Jellyfin.Plugin.JellyfinElevate/src/enhanced/hidden-content-page/nav.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/enhanced/hidden-content-page/nav.ts
@@ -93,8 +93,9 @@ export function createPageContainer(): HTMLElement {
 
         const container = document.createElement("div");
         container.id = "je-hidden-content-container";
-        // Shared responsive top offset (see JE.injectGlobalStyles .je-interior-page-top):
-        // compact on phones, generous on desktop — replaces a hardcoded padding-top:5em.
+        // Shared header-clearance offset (see JE.injectGlobalStyles
+        // .je-interior-page-top): full ~5em everywhere by default, compacted on
+        // phones only on the modern layout — replaces a hardcoded padding-top:5em.
         container.className = "je-interior-page-top";
         container.style.cssText = "padding-left: 0.5em; padding-right: 0.5em;";
 

--- a/Jellyfin.Plugin.JellyfinElevate/src/enhanced/hidden-content-page/styles.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/enhanced/hidden-content-page/styles.ts
@@ -486,13 +486,27 @@ const CSS_STYLES = `
         font-size: 1.3em;
       }
 
+      /* Compact touch toolbar instead of a column of full-width slabs: the
+         search field takes the first row, and the filter / unhide-all / admin
+         controls share the next row and wrap as needed. */
       .je-hidden-content-toolbar {
-        flex-direction: column;
-        align-items: stretch;
+        flex-wrap: wrap;
+        gap: 8px;
       }
 
       .je-hidden-content-page-search {
+        flex: 1 1 100%;
         max-width: none;
+      }
+
+      .je-hidden-scoped-filter,
+      .je-hidden-content-page-unhide-all,
+      .je-hidden-admin-user-filter,
+      .je-hidden-admin-edit-toggle,
+      .je-hidden-admin-add-btn {
+        flex: 1 1 auto;
+        padding: 8px 12px;
+        font-size: 12px;
       }
 
       .je-hidden-content-page-grid {

--- a/Jellyfin.Plugin.JellyfinElevate/src/enhanced/hidden-content-page/styles.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/enhanced/hidden-content-page/styles.ts
@@ -505,6 +505,13 @@ const CSS_STYLES = `
       .je-hidden-admin-edit-toggle,
       .je-hidden-admin-add-btn {
         flex: 1 1 auto;
+        /* min-width:0 lets a control shrink below its content width, and
+           max-width:100% caps it to the row — together with the container's
+           flex-wrap this keeps a long localized label or admin username from
+           forcing horizontal overflow (it wraps to its own row instead). The
+           admin user-filter <select> also drops its desktop 240px cap. */
+        min-width: 0;
+        max-width: 100%;
         padding: 8px 12px;
         font-size: 12px;
       }

--- a/Jellyfin.Plugin.JellyfinElevate/src/enhanced/settings-panel/styles.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/enhanced/settings-panel/styles.ts
@@ -25,13 +25,26 @@ JE.injectGlobalStyles = (): void => {
             /* Shared top offset for JE standalone interior pages (Hidden Content,
                Calendar, Requests) — the single source every one of those page
                containers inherits, replacing a per-page hardcoded padding-top:5em.
-               Both the modern and legacy layouts already position .mainAnimatedPages
-               below the fixed header, so this padding is breathing room, not header
-               clearance; the old fixed 5em wasted roughly a third of a phone screen
-               (the page heading sat far down the viewport). Keyed on the viewport so
-               phones get a compact offset while desktop keeps its generous spacing. */
+               This padding is the ONLY header clearance these custom
+               'page type-interior' pages get: they carry none of the per-page
+               classes (.libraryPage 7em etc.) that give native pages their
+               offset under the fixed header. On the LEGACY layout .skinHeader
+               is position:fixed, so the full ~5em is real clearance and must
+               stay at every viewport or headings clip under the header. The 5em
+               is over-generous on the modern (MUI) layout, where it wasted about
+               a third of a phone screen, so the compact phone offset is scoped to
+               .je-modern-layout (stamped on html by core/layout.ts). Before
+               the layout resolves, or on legacy, the safe 5em default holds.
+               Legacy at phone widths needs MORE than 5em: the legacy header
+               stacks a second row (the tab strip) under the title row there,
+               measuring ~110px on a 390px viewport (live-verified on
+               jellyfin-12 with layout=desktop), so phones get 7em on legacy —
+               matching the native .libraryPage clearance. */
             .je-interior-page-top { padding-top: 5em; }
-            @media (max-width: 768px) { .je-interior-page-top { padding-top: 1.25em; } }
+            @media (max-width: 768px) {
+                .je-modern-layout .je-interior-page-top { padding-top: 1.25em; }
+                .je-legacy-layout .je-interior-page-top { padding-top: 7em; }
+            }
             /* Remove menu items render like native action-sheet items; only dim them while the removal is in flight. */
             .actionSheetMenuItem[data-id="remove-continue-watching"]:disabled,
             .actionSheetMenuItem[data-id="je-multiselect-remove"]:disabled { opacity: 0.6; cursor: default; }

--- a/Jellyfin.Plugin.JellyfinElevate/src/enhanced/settings-panel/styles.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/enhanced/settings-panel/styles.ts
@@ -22,6 +22,16 @@ JE.injectGlobalStyles = (): void => {
             @keyframes dice { 0%, 100% { transform: rotate(0deg) scale(1); } 10%, 30%, 50% { transform: rotate(-10deg) scale(1.1); } 20%, 40% { transform: rotate(10deg) scale(1.1); } 60% { transform: rotate(360deg) scale(1); } }
             button#randomItemButton:not(.loading):hover .material-icons { animation: dice 1.5s; }
             .layout-desktop #enhancedSettingsBtn { display: none !important; }
+            /* Shared top offset for JE standalone interior pages (Hidden Content,
+               Calendar, Requests) — the single source every one of those page
+               containers inherits, replacing a per-page hardcoded padding-top:5em.
+               Both the modern and legacy layouts already position .mainAnimatedPages
+               below the fixed header, so this padding is breathing room, not header
+               clearance; the old fixed 5em wasted roughly a third of a phone screen
+               (the page heading sat far down the viewport). Keyed on the viewport so
+               phones get a compact offset while desktop keeps its generous spacing. */
+            .je-interior-page-top { padding-top: 5em; }
+            @media (max-width: 768px) { .je-interior-page-top { padding-top: 1.25em; } }
             /* Remove menu items render like native action-sheet items; only dim them while the removal is in flight. */
             .actionSheetMenuItem[data-id="remove-continue-watching"]:disabled,
             .actionSheetMenuItem[data-id="je-multiselect-remove"]:disabled { opacity: 0.6; cursor: default; }

--- a/Jellyfin.Plugin.JellyfinElevate/src/enhanced/settings-panel/styles.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/enhanced/settings-panel/styles.ts
@@ -25,6 +25,14 @@ JE.injectGlobalStyles = (): void => {
             /* Remove menu items render like native action-sheet items; only dim them while the removal is in flight. */
             .actionSheetMenuItem[data-id="remove-continue-watching"]:disabled,
             .actionSheetMenuItem[data-id="je-multiselect-remove"]:disabled { opacity: 0.6; cursor: default; }
+            /* Phone layout for the settings/help panel. Keyed on the VIEWPORT
+               (@media), not the legacy .layout-mobile html class: on the Jellyfin 12
+               modern (MUI) layout the html carries layout-desktop at every viewport
+               (docs/v12-platform.md §1 — "html classes cannot discriminate layouts"),
+               so a .layout-mobile-gated rule never applied on a real phone and the
+               panel kept its desktop widths (50vw settings tab, two 400px shortcut
+               columns) → horizontal clipping. The .layout-mobile selectors are kept
+               as a belt-and-braces for the legacy mobile layout. */
             .layout-mobile #jellyfin-elevate-panel { width: 95vw; max-width: 95vw; }
             .layout-mobile #jellyfin-elevate-panel .shortcuts-container { flex-direction: column; }
             .layout-mobile #jellyfin-elevate-panel #settings-content { width: auto !important; }
@@ -33,6 +41,22 @@ JE.injectGlobalStyles = (): void => {
             .layout-mobile #jellyfin-elevate-panel .close-helptext { display: none; }
             .layout-mobile #jellyfin-elevate-panel .footer-buttons { flex-direction: column; align-items: flex-end !important; width: 100%; gap: 10px; }
             .layout-mobile #jellyfin-elevate-panel .footer-buttons > * { justify-content: center; }
+            @media (max-width: 768px) {
+                /* Fill the viewport width; drop the desktop min-width (350px would
+                   overflow a 320px phone) and the 90vw inline max-width. */
+                #jellyfin-elevate-panel { width: 95vw !important; max-width: 95vw !important; min-width: 0 !important; }
+                /* Shortcuts: stack the two columns and release the 400px min-width
+                   inline on each so they fit the narrow panel instead of clipping. */
+                #jellyfin-elevate-panel .shortcuts-container { flex-direction: column; gap: 14px; }
+                #jellyfin-elevate-panel .shortcuts-container > div { min-width: 0 !important; flex: 1 1 auto !important; }
+                /* Settings tab: fill the panel instead of the fixed 50vw. */
+                #jellyfin-elevate-panel #settings-content { width: auto !important; }
+                #jellyfin-elevate-panel .panel-main-content { padding: 0 15px; }
+                #jellyfin-elevate-panel .panel-footer { flex-direction: row; gap: 16px; }
+                #jellyfin-elevate-panel .close-helptext { display: none; }
+                #jellyfin-elevate-panel .footer-buttons { flex-direction: column; align-items: flex-end !important; width: 100%; gap: 10px; }
+                #jellyfin-elevate-panel .footer-buttons > * { justify-content: center; }
+            }
             @keyframes longPressGlow { from { box-shadow: 0 0 5px 2px var(--primary-accent-color, #fff); } to { box-shadow: 0 0 8px 15px transparent; } }
             .headerUserButton.long-press-active { animation: longPressGlow 750ms ease-out; }
             #jellyfin-elevate-panel kbd {

--- a/Jellyfin.Plugin.JellyfinElevate/src/jellyseerr/discovery/base.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/jellyseerr/discovery/base.ts
@@ -125,7 +125,12 @@ function createDiscovery(spec: any): DiscoveryController {
     const sectionSelector = `.jellyseerr-${key}-discovery-section`;
     const isDualFeed = spec.mode === 'dual-feed';
     const isClientPaged = spec.mode === 'client-paged';
-    const cardClass = isDualFeed ? 'portraitCard' : 'overflowPortraitCard';
+    // All discovery sections render into wrapping grids (vertical-wrap), so every
+    // mode uses the native percentage-width portraitCard — matching the native
+    // library poster rows at every breakpoint. overflowPortraitCard (vw-based,
+    // for horizontal scrollers) previously made the detail-page sections
+    // (person "More from …") ~2× the native card size on phones.
+    const cardClass = 'portraitCard';
     const PAGE_SIZE = spec.pageSize || 40;
 
     // ---- Chassis state (all modes) -------------------------------------

--- a/Jellyfin.Plugin.JellyfinElevate/src/jellyseerr/discovery/base.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/jellyseerr/discovery/base.ts
@@ -321,7 +321,9 @@ function createDiscovery(spec: any): DiscoveryController {
         itemsContainer.setAttribute('is', 'emby-itemscontainer');
         itemsContainer.className = isDualFeed
             ? 'vertical-wrap itemsContainer centered'
-            : 'itemsContainer padded-right vertical-wrap';
+            // Native library grid uses padded-left AND padded-right so 33.33%
+            // portraitCards fill the row without overflow on narrow phones.
+            : 'itemsContainer padded-left padded-right vertical-wrap';
         section.appendChild(itemsContainer);
 
         return section;

--- a/Jellyfin.Plugin.JellyfinElevate/src/jellyseerr/discovery/collection.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/jellyseerr/discovery/collection.ts
@@ -80,7 +80,13 @@ async function isBoxSetPage(itemId: string, signal?: AbortSignal): Promise<any> 
  * @returns {DocumentFragment} Fragment containing rendered card elements
  */
 function createCardsFragment(results: any[]): DocumentFragment {
-    return JE.discoveryFilter!.createCardsFragment(results, { cardClass: 'overflowPortraitCard' });
+    // Native library-grid sizing: portraitCard is percentage-width and matches
+    // the native poster rows on the same page at every breakpoint (33% on a
+    // phone → 3 across). overflowPortraitCard is vw-based (40vw on a phone → 2
+    // giant cards) — it is only meant for horizontal scrollers, but this
+    // section is a wrapping grid (vertical-wrap), so it produced cards ~2× the
+    // size of the native cards in the row above.
+    return JE.discoveryFilter!.createCardsFragment(results, { cardClass: 'portraitCard' });
 }
 
 /**

--- a/Jellyfin.Plugin.JellyfinElevate/src/jellyseerr/discovery/collection.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/jellyseerr/discovery/collection.ts
@@ -108,7 +108,10 @@ function createSectionContainer(title: string): HTMLElement {
 
     const itemsContainer = document.createElement('div');
     itemsContainer.setAttribute('is', 'emby-itemscontainer');
-    itemsContainer.className = 'itemsContainer padded-right vertical-wrap';
+    // Match the native library grid exactly: padded-left AND padded-right (3.3%
+    // each) so three 33.33% portraitCards fill the row without horizontal
+    // overflow. padded-right alone left the row 3.3% too wide on narrow phones.
+    itemsContainer.className = 'itemsContainer padded-left padded-right vertical-wrap';
     section.appendChild(itemsContainer);
 
     return section;

--- a/Jellyfin.Plugin.JellyfinElevate/src/jellyseerr/more-info-modal/styles.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/jellyseerr/more-info-modal/styles.ts
@@ -1092,6 +1092,16 @@ const css = `
     }
 
     @media (max-width: 768px) {
+        /* Release the desktop 70vw cap on phones. The dead .layout-mobile
+           override above never fires on the Jellyfin 12 modern layout (the html
+           carries layout-desktop at every viewport — docs/v12-platform.md §1),
+           so without this the fullscreen modal's container stayed pinned to
+           ~70vw on a real phone. This is the viewport-keyed equivalent, matching
+           the settings-panel fix. */
+        .je-more-info-modal .modal-container {
+            max-width: 100vw;
+        }
+
         .je-more-info-modal .modal-backdrop {
             height: 200px;
             background-position: center;

--- a/Jellyfin.Plugin.JellyfinElevate/src/jellyseerr/ui/styles.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/jellyseerr/ui/styles.ts
@@ -79,6 +79,23 @@ ui.addMainStyles = function () {
         .jellyseerr-request-button svg { width: 1.2em; height: 1.2em; flex-shrink: 0; vertical-align: middle; }
         .layout-mobile .jellyseerr-request-button svg { width: 1em; height: 1em; }
         .layout-mobile .jellyseerr-request-button span { font-size: 0.8em !important; }
+        /* Phone sizing for Seerr card overlays — keyed on the VIEWPORT, not the
+           inert .layout-mobile html class. On the Jellyfin 12 modern layout the
+           html carries layout-desktop at every viewport (docs/v12-platform.md
+           §1), so the .layout-mobile rules above never fired on a real phone:
+           the MOVIE/SERIES badge, provider-logo strip, request button and hide
+           overlay all stayed desktop-sized on top of the cards — most visible in
+           the collection "Missing from …" grid once the cards match native width. */
+        @media (max-width: 768px) {
+            .jellyseerr-media-badge { font-size: 0.75em; padding: 2px 7px; letter-spacing: 1px; }
+            .jellyseerr-request-button svg { width: 1em; height: 1em; }
+            .jellyseerr-request-button span { font-size: 0.8em !important; }
+            .jellyseerr-elsewhere-icons { gap: 0.4em; padding: 0.35em 0 0.15em 0; }
+            .jellyseerr-elsewhere-icons img { width: 1.4em; }
+            .jellyseerr-card .je-hide-btn,
+            .jellyseerr-card .je-hide-btn.je-already-hidden { width: 24px; height: 24px; font-size: 14px; }
+            .jellyseerr-card .je-hide-btn .material-icons { font-size: 14px; }
+        }
         .jellyseerr-request-button.jellyseerr-button-offline, .jellyseerr-request-button.jellyseerr-button-no-user { opacity: .6; cursor: not-allowed; }
         .jellyseerr-request-button.jellyseerr-button-request { background-color: #5a3fb8 !important; color: #fff !important; }
         .jellyseerr-request-button.jellyseerr-button-request:hover:not(:disabled) { background-color: #6b4bb5 !important; transform: translateY(-2px); box-shadow: 0 4px 12px rgba(90, 63, 184, 0.4); }

--- a/Jellyfin.Plugin.JellyfinElevate/src/main.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/main.ts
@@ -30,6 +30,8 @@ const _jePublicApiIsFrozen: _FrozenPublicApi = true;
 void _jePublicApiIsFrozen;
 
 import './core/navigation';
+// layout imports navigation (self-wires a nav-driven retry of the layout stamp)
+import './core/layout';
 import './core/details-view';
 import './core/lifecycle';
 import './core/dom-observer';

--- a/e2e/mobile-fits.spec.ts
+++ b/e2e/mobile-fits.spec.ts
@@ -34,6 +34,122 @@ async function goHome(page: any): Promise<void> {
     await page.waitForTimeout(500);
 }
 
+/** Outcome of {@link ensureRenderableBoxSet}. */
+interface BoxSetFixture {
+    /** Id of the BoxSet to open (null only when the library has < 2 movies). */
+    boxsetId: string | null;
+    /** Id to delete in teardown; null when we reused an existing BoxSet. */
+    createdId: string | null;
+    /** True when the BoxSet is anchored to a TMDB collection with missing parts. */
+    anchored: boolean;
+}
+
+/**
+ * Guarantee a BoxSet exists to open, and — whenever the environment allows —
+ * one whose "Missing from …" section will actually render, so the flagship
+ * card assertions run instead of silently skipping.
+ *
+ * Strategy (all admin-API, in the browser's authenticated ApiClient context):
+ *  1. Reuse an existing BoxSet whose TMDB collection still has missing parts.
+ *  2. Otherwise discover a TMDB collection with missing parts from the library's
+ *     movies (via the plugin's Seerr proxy), CREATE a BoxSet from two library
+ *     movies, and anchor it to that collection (ProviderIds.Tmdb) so the
+ *     section renders. Tracked for teardown.
+ *  3. If Seerr yields no incomplete collection, still create a plain BoxSet so
+ *     the "no BoxSet in the library" skip can never fire; the section-render
+ *     skip then covers only the genuinely-cannot-render case.
+ */
+async function ensureRenderableBoxSet(page: any): Promise<BoxSetFixture> {
+    return page.evaluate(async () => {
+        const api = (window as any).ApiClient;
+        const uid = api.getCurrentUserId();
+
+        /** A TMDB collection has "missing" parts when any part isn't available (status 5). */
+        const collectionHasMissing = async (collectionId: string | number): Promise<boolean> => {
+            try {
+                const c = await api.getJSON(api.getUrl('JellyfinElevate/jellyseerr/collection/' + collectionId));
+                const parts = (c && c.parts) || [];
+                return parts.length > 0 && parts.some((p: any) => ((p.mediaInfo && p.mediaInfo.status) || 1) !== 5);
+            } catch {
+                return false;
+            }
+        };
+
+        // 1) Reuse an existing renderable BoxSet.
+        const existing = await api.getItems(uid, {
+            IncludeItemTypes: 'BoxSet', Recursive: true, Fields: 'ProviderIds', Limit: 50,
+        });
+        for (const bs of (existing.Items || [])) {
+            const tmdb = bs.ProviderIds && bs.ProviderIds.Tmdb;
+            if (tmdb && await collectionHasMissing(tmdb)) {
+                return { boxsetId: bs.Id, createdId: null, anchored: true };
+            }
+        }
+
+        // Library movies (for both discovery and seeding the created BoxSet).
+        const movies = await api.getItems(uid, {
+            IncludeItemTypes: 'Movie', Recursive: true, Fields: 'ProviderIds', Limit: 200,
+        });
+        const movieItems = movies.Items || [];
+
+        // 2) Discover a TMDB collection with missing parts from a library movie.
+        let collectionId: string | null = null;
+        for (const m of movieItems) {
+            const tmdb = m.ProviderIds && m.ProviderIds.Tmdb;
+            if (!tmdb) continue;
+            let detail: any;
+            try {
+                detail = await api.getJSON(api.getUrl('JellyfinElevate/jellyseerr/movie/' + tmdb));
+            } catch {
+                continue;
+            }
+            const cid = detail && detail.collection && detail.collection.id;
+            if (cid && await collectionHasMissing(cid)) {
+                collectionId = String(cid);
+                break;
+            }
+        }
+
+        // Need two library movies to seed a BoxSet.
+        const seedIds = movieItems.slice(0, 2).map((m: any) => m.Id);
+        if (seedIds.length < 2) return { boxsetId: null, createdId: null, anchored: false };
+
+        const created = await api.ajax({
+            type: 'POST',
+            url: api.getUrl('Collections', { Name: 'JE E2E Fixture Collection', Ids: seedIds.join(',') }),
+            dataType: 'json',
+        });
+        const createdId = created && created.Id;
+        if (!createdId) return { boxsetId: null, createdId: null, anchored: false };
+
+        // 3) Anchor to the discovered collection so the section can render.
+        if (collectionId) {
+            const dto = await api.getJSON(api.getUrl('Users/' + uid + '/Items/' + createdId, { Fields: 'ProviderIds,Path' }));
+            dto.ProviderIds = dto.ProviderIds || {};
+            dto.ProviderIds.Tmdb = collectionId;
+            await api.ajax({
+                type: 'POST',
+                url: api.getUrl('Items/' + createdId),
+                data: JSON.stringify(dto),
+                contentType: 'application/json',
+            });
+        }
+
+        return { boxsetId: createdId, createdId, anchored: !!collectionId };
+    });
+}
+
+/** Best-effort teardown of a BoxSet created by the fixture. */
+async function deleteBoxSet(page: any, id: string): Promise<void> {
+    await page.evaluate(async (bid: string) => {
+        try {
+            await (window as any).ApiClient.ajax({ type: 'DELETE', url: (window as any).ApiClient.getUrl('Items/' + bid) });
+        } catch {
+            // best-effort — a leaked fixture BoxSet is harmless in the dev library.
+        }
+    }, id);
+}
+
 test.describe('mobile viewport fits', () => {
     test('settings panel + shortcuts fit the phone (no clipping)', async ({ page, consoleErrors }) => {
         await loginAs(page, 'admin', consoleErrors);
@@ -121,53 +237,66 @@ test.describe('mobile viewport fits', () => {
     test('collection Missing-from cards are native-grid-sized (≈3 across)', async ({ page, consoleErrors }) => {
         await loginAs(page, 'admin', consoleErrors);
 
-        // Find a BoxSet to open. Skip if the library has none.
-        const boxsetId = await page.evaluate(async () => {
-            const uid = (window as any).ApiClient.getCurrentUserId();
-            const res = await (window as any).ApiClient.getItems(uid, {
-                IncludeItemTypes: 'BoxSet', Recursive: true, Limit: 1,
+        // Guarantee a BoxSet to open (creating one when the library has none),
+        // anchored to a TMDB collection with missing parts whenever Seerr can
+        // supply one — so the assertions below actually run.
+        const fixture = await ensureRenderableBoxSet(page);
+        expect(fixture.boxsetId, 'a BoxSet must exist or be creatable (library needs >= 2 movies)').toBeTruthy();
+
+        try {
+            // Fixture setup is admin-API infrastructure, not the surface under
+            // test — drop any noise it produced so only the detail-page render
+            // counts toward the runtime-error assertion.
+            consoleErrors.reset();
+
+            await page.evaluate((id: string) => { void (window as any).Emby.Page.show('/details?id=' + id); }, fixture.boxsetId!);
+
+            // The Missing-from section only renders when Seerr is active AND the
+            // collection has movies not yet in the library.
+            const appeared = await page
+                .waitForFunction(
+                    () => !!document.querySelector('.jellyseerr-collection-discovery-section .card'),
+                    undefined,
+                    { timeout: 20_000 }
+                )
+                .then(() => true, () => false);
+
+            if (!appeared) {
+                // Loud, explicit — the ONLY remaining legitimate skip. Never the
+                // old "no BoxSet in the library" skip, which can no longer occur.
+                console.warn(
+                    `[mobile-fits] collection Missing-from section did NOT render for BoxSet ${fixture.boxsetId} ` +
+                    `(anchored=${fixture.anchored}) — Seerr inactive or collection complete; skipping card assertions.`
+                );
+                test.skip(true, 'collection Missing-from section did not render (Seerr inactive or collection complete)');
+            }
+
+            const m = await page.evaluate(() => {
+                const section = document.querySelector('.jellyseerr-collection-discovery-section')!;
+                const cards = [...section.querySelectorAll<HTMLElement>('.card')];
+                let maxRight = 0;
+                for (const c of cards) maxRight = Math.max(maxRight, c.getBoundingClientRect().right);
+                return {
+                    cardW: Math.round(cards[0].getBoundingClientRect().width),
+                    sectionMaxRight: Math.round(maxRight),
+                    innerW: window.innerWidth,
+                    usesPortraitCard: cards[0].classList.contains('portraitCard'),
+                    usesOverflowCard: cards[0].classList.contains('overflowPortraitCard'),
+                };
             });
-            return res.Items?.[0]?.Id ?? null;
-        });
-        test.skip(!boxsetId, 'no BoxSet in the library');
 
-        await page.evaluate((id) => { void (window as any).Emby.Page.show('/details?id=' + id); }, boxsetId);
+            // Native portraitCard sizing: ~33% of the row → roughly 3 across, never
+            // the old vw-based overflowPortraitCard (~40vw → 2 giant cards).
+            expect(m.usesPortraitCard).toBe(true);
+            expect(m.usesOverflowCard).toBe(false);
+            expect(m.cardW).toBeGreaterThan(Math.round(m.innerW * 0.24));
+            expect(m.cardW).toBeLessThan(Math.round(m.innerW * 0.37));
+            // The section itself never scrolls the page sideways.
+            expect(m.sectionMaxRight).toBeLessThanOrEqual(m.innerW + 1);
 
-        // The Missing-from section only renders when Seerr is active and the
-        // collection has movies not yet in the library. If it never appears
-        // (no Seerr / complete collection), there is nothing to assert here.
-        const appeared = await page
-            .waitForFunction(
-                () => !!document.querySelector('.jellyseerr-collection-discovery-section .card'),
-                undefined,
-                { timeout: 20_000 }
-            )
-            .then(() => true, () => false);
-        test.skip(!appeared, 'collection Missing-from section did not render (Seerr inactive or complete)');
-
-        const m = await page.evaluate(() => {
-            const section = document.querySelector('.jellyseerr-collection-discovery-section')!;
-            const cards = [...section.querySelectorAll<HTMLElement>('.card')];
-            let maxRight = 0;
-            for (const c of cards) maxRight = Math.max(maxRight, c.getBoundingClientRect().right);
-            return {
-                cardW: Math.round(cards[0].getBoundingClientRect().width),
-                sectionMaxRight: Math.round(maxRight),
-                innerW: window.innerWidth,
-                usesPortraitCard: cards[0].classList.contains('portraitCard'),
-                usesOverflowCard: cards[0].classList.contains('overflowPortraitCard'),
-            };
-        });
-
-        // Native portraitCard sizing: ~33% of the row → roughly 3 across, never
-        // the old vw-based overflowPortraitCard (~40vw → 2 giant cards).
-        expect(m.usesPortraitCard).toBe(true);
-        expect(m.usesOverflowCard).toBe(false);
-        expect(m.cardW).toBeGreaterThan(Math.round(m.innerW * 0.24));
-        expect(m.cardW).toBeLessThan(Math.round(m.innerW * 0.37));
-        // The section itself never scrolls the page sideways.
-        expect(m.sectionMaxRight).toBeLessThanOrEqual(m.innerW + 1);
-
-        assertNoRuntimeErrors(consoleErrors);
+            assertNoRuntimeErrors(consoleErrors);
+        } finally {
+            if (fixture.createdId) await deleteBoxSet(page, fixture.createdId);
+        }
     });
 });

--- a/e2e/mobile-fits.spec.ts
+++ b/e2e/mobile-fits.spec.ts
@@ -1,0 +1,173 @@
+// Mobile-viewport fit checks for the plugin's injected surfaces (issues 31/32/33).
+//
+// On the Jellyfin 12 modern layout the html carries `layout-desktop` at every
+// viewport (docs/v12-platform.md §1), so the plugin's old `.layout-mobile`-gated
+// responsive CSS never fired on a real phone. These checks run at a phone
+// viewport and assert the surfaces fit:
+//   - the settings/help panel and its shortcuts columns fit the panel (no clip),
+//   - the standalone pages (Hidden Content, Calendar, Requests) don't scroll
+//     horizontally and the Hidden Content heading clears the header,
+//   - the collection "Missing from …" cards are native-grid-sized (≈3 across),
+//     not the vw-based giants (≈2 across) they used to be.
+import { test, expect, loginAs, assertNoRuntimeErrors } from './fixtures/auth';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// Phone viewport. isMobile/hasTouch make the context behave like a touch device;
+// the layout still resolves to the modern (layout-desktop) layout, which is
+// exactly the case the old .layout-mobile rules missed.
+test.use({
+    viewport: { width: 390, height: 844 },
+    isMobile: true,
+    hasTouch: true,
+    deviceScaleFactor: 3,
+});
+
+/** Horizontal overflow of the whole document (px). 0 = no horizontal scroll. */
+async function docOverflow(page: any): Promise<number> {
+    return page.evaluate(() => document.scrollingElement!.scrollWidth - window.innerWidth);
+}
+
+/** Navigate back to home so the next standalone page opens from a clean state. */
+async function goHome(page: any): Promise<void> {
+    await page.evaluate(() => { window.location.hash = '#/home'; });
+    await page.waitForTimeout(500);
+}
+
+test.describe('mobile viewport fits', () => {
+    test('settings panel + shortcuts fit the phone (no clipping)', async ({ page, consoleErrors }) => {
+        await loginAs(page, 'admin', consoleErrors);
+
+        await page.evaluate(() => { void (window as any).JellyfinElevate.showEnhancedPanel(); });
+        const panel = page.locator('#jellyfin-elevate-panel');
+        await expect(panel).toBeVisible({ timeout: 15_000 });
+
+        // Show the shortcuts tab if present (config may disable shortcuts).
+        const shortcutsTab = panel.locator('.tab-button[data-tab="shortcuts"]');
+        if (await shortcutsTab.count()) {
+            await shortcutsTab.click();
+            await page.waitForTimeout(200);
+        }
+
+        const geom = await page.evaluate(() => {
+            const p = document.getElementById('jellyfin-elevate-panel')!;
+            const pr = p.getBoundingClientRect();
+            const cols = [...p.querySelectorAll('.shortcuts-container > div')].map(
+                (c) => Math.round(c.getBoundingClientRect().width)
+            );
+            return {
+                left: Math.round(pr.left),
+                right: Math.round(pr.right),
+                width: Math.round(pr.width),
+                innerW: window.innerWidth,
+                // widest shortcut column — must fit inside the panel (the old
+                // 400px min-width made these overflow and clip).
+                maxCol: cols.length ? Math.max(...cols) : 0,
+            };
+        });
+
+        // Panel is within the viewport.
+        expect(geom.left).toBeGreaterThanOrEqual(-1);
+        expect(geom.right).toBeLessThanOrEqual(geom.innerW + 1);
+        // Shortcut columns fit inside the panel (no clipped labels).
+        expect(geom.maxCol).toBeLessThanOrEqual(geom.width + 1);
+        // The panel does not force the page to scroll sideways.
+        expect(await docOverflow(page)).toBeLessThanOrEqual(1);
+
+        await page.keyboard.press('Escape');
+        await expect(panel).toBeHidden({ timeout: 10_000 });
+        assertNoRuntimeErrors(consoleErrors);
+    });
+
+    test('Hidden Content page: heading clears the header, no horizontal scroll', async ({ page, consoleErrors }) => {
+        await loginAs(page, 'admin', consoleErrors);
+
+        await page.evaluate(() => { (window as any).JellyfinElevate.hiddenContentPage.showPage(); });
+        await page.waitForSelector('.je-hidden-content-title', { state: 'visible', timeout: 30_000 });
+
+        const layout = await page.evaluate(() => {
+            const header = document.querySelector('.MuiAppBar-root') || document.querySelector('.skinHeader');
+            const headerBottom = header ? header.getBoundingClientRect().bottom : 0;
+            const title = document.querySelector('.je-hidden-content-title')!;
+            return {
+                headerBottom: Math.round(headerBottom),
+                titleTop: Math.round(title.getBoundingClientRect().top),
+            };
+        });
+
+        // The heading sits fully below the fixed header (not clipped under it).
+        expect(layout.titleTop).toBeGreaterThanOrEqual(layout.headerBottom - 1);
+        expect(await docOverflow(page)).toBeLessThanOrEqual(1);
+        assertNoRuntimeErrors(consoleErrors);
+    });
+
+    test('standalone pages do not scroll horizontally', async ({ page, consoleErrors }) => {
+        await loginAs(page, 'admin', consoleErrors);
+
+        await page.evaluate(() => { (window as any).JellyfinElevate.calendarPage.showPage(); });
+        await page.waitForSelector('#je-calendar-container', { state: 'visible', timeout: 30_000 });
+        await page.waitForTimeout(1000);
+        expect(await docOverflow(page), 'calendar page horizontal overflow').toBeLessThanOrEqual(1);
+
+        await goHome(page);
+        await page.evaluate(() => { (window as any).JellyfinElevate.downloadsPage.showPage(); });
+        await page.waitForSelector('#je-downloads-container', { state: 'visible', timeout: 30_000 });
+        await page.waitForTimeout(1500);
+        expect(await docOverflow(page), 'requests page horizontal overflow').toBeLessThanOrEqual(1);
+
+        assertNoRuntimeErrors(consoleErrors);
+    });
+
+    test('collection Missing-from cards are native-grid-sized (≈3 across)', async ({ page, consoleErrors }) => {
+        await loginAs(page, 'admin', consoleErrors);
+
+        // Find a BoxSet to open. Skip if the library has none.
+        const boxsetId = await page.evaluate(async () => {
+            const uid = (window as any).ApiClient.getCurrentUserId();
+            const res = await (window as any).ApiClient.getItems(uid, {
+                IncludeItemTypes: 'BoxSet', Recursive: true, Limit: 1,
+            });
+            return res.Items?.[0]?.Id ?? null;
+        });
+        test.skip(!boxsetId, 'no BoxSet in the library');
+
+        await page.evaluate((id) => { void (window as any).Emby.Page.show('/details?id=' + id); }, boxsetId);
+
+        // The Missing-from section only renders when Seerr is active and the
+        // collection has movies not yet in the library. If it never appears
+        // (no Seerr / complete collection), there is nothing to assert here.
+        const appeared = await page
+            .waitForFunction(
+                () => !!document.querySelector('.jellyseerr-collection-discovery-section .card'),
+                undefined,
+                { timeout: 20_000 }
+            )
+            .then(() => true, () => false);
+        test.skip(!appeared, 'collection Missing-from section did not render (Seerr inactive or complete)');
+
+        const m = await page.evaluate(() => {
+            const section = document.querySelector('.jellyseerr-collection-discovery-section')!;
+            const cards = [...section.querySelectorAll<HTMLElement>('.card')];
+            let maxRight = 0;
+            for (const c of cards) maxRight = Math.max(maxRight, c.getBoundingClientRect().right);
+            return {
+                cardW: Math.round(cards[0].getBoundingClientRect().width),
+                sectionMaxRight: Math.round(maxRight),
+                innerW: window.innerWidth,
+                usesPortraitCard: cards[0].classList.contains('portraitCard'),
+                usesOverflowCard: cards[0].classList.contains('overflowPortraitCard'),
+            };
+        });
+
+        // Native portraitCard sizing: ~33% of the row → roughly 3 across, never
+        // the old vw-based overflowPortraitCard (~40vw → 2 giant cards).
+        expect(m.usesPortraitCard).toBe(true);
+        expect(m.usesOverflowCard).toBe(false);
+        expect(m.cardW).toBeGreaterThan(Math.round(m.innerW * 0.24));
+        expect(m.cardW).toBeLessThan(Math.round(m.innerW * 0.37));
+        // The section itself never scrolls the page sideways.
+        expect(m.sectionMaxRight).toBeLessThanOrEqual(m.innerW + 1);
+
+        assertNoRuntimeErrors(consoleErrors);
+    });
+});


### PR DESCRIPTION
Closes #31, closes #32, closes #33.

## What & why

Three user-reported UI bugs from a physical Android phone: the JE settings/shortcuts panel misfitting phones, enhanced pages (Hidden Content, Calendar, Requests) clipping under the header with awkward control layouts, and the collection "Missing from" section rendering oversized cards that don't match native rows (desktop included).

## Root cause & implementation

- **Unifying root cause**: the plugin's mobile CSS was gated on `.layout-mobile`, which Jellyfin 12 never sets — both layouts report `layout-desktop` at every viewport. None of the mobile rules ever fired on a real phone. Fixes use `@media (max-width: 768px)` with the `.layout-mobile` selectors retained for legacy-layout belt-and-braces.
- **New `src/core/layout.ts`**: cached (R4) modern-vs-legacy detection via the platform-doc signals (visible `.headerRight` = legacy, visible MUI toolbar = modern), stamping `je-modern-layout`/`je-legacy-layout` on the root. This closes the gap that both layouts are indistinguishable by html class — available to all future responsive work.
- **Settings/shortcuts panel**: 95vw phone panel, single-column shortcuts, no clipped labels; desktop unchanged.
- **Interior pages**: one shared `.je-interior-page-top` class replaces three duplicated hardcoded `padding-top: 5em`s. Modern phones get a compact 1.25em offset; legacy keeps measured header clearance (7em on phones — the legacy header is two rows there; verified live at 390×844). Hidden Content toolbar reworked to a compact wrapping layout; Requests grid single-column on phones.
- **Collection "Missing from" (also person "More from")**: switched `overflowPortraitCard` (vw-based; 2 giant cards on phones) to `portraitCard` — the exact class native library rows use, identical 150% padder, native 3-across math at every viewport including desktop. Native grid padding, phone-scaled badges/overlays/provider icons.
- **Bonus from the review sweep**: fixed a 4th instance of the same dead-gating class — the Seerr more-info modal was pinned to 70vw on phones; now full-width ≤768px.

## Test plan

- Gates: typecheck, lint 0 errors (cap unchanged), client **506/506**, bundle, syntax, `dotnet build -c Release` 0 warnings, `dotnet test` **734/734**.
- New `e2e/mobile-fits.spec.ts` (4 phone-viewport assertions: panel fit, heading clears header, no horizontal overflow, collection cards native-sized) — the collection assertion now self-seeds a BoxSet fixture via the Collections API so it can never silently skip; confirmed executed in both runs.
- Full committed suite: **58 passed, 1 known flake (passed on retry), 0 failed, 0 skipped**.
- Verified with before/after screenshots at 360×800 / 390×844 / 412×915 + desktop 1440×900, judged against native; legacy layout verified via isolated browser profile on jellyfin-12.
- Review: codex xhigh (one finding adopted) + two adversarial Opus xhigh reviews; all three surviving findings (legacy-layout clearance regression, more-info modal width, e2e skip gap) fixed and re-verified.

## Limitations

- A few **native** Jellyfin elements (collection detail action row, overview text) still overflow slightly at 360px — pre-existing platform behavior, not JE surfaces.
- Tablet-band (769–1024px) settings-panel sizing is a pre-existing gap (never handled by the old dead rules either); tracked mentally for the accessibility/UX-polish milestone rather than scope-crept here.

This PR was developed with AI assistance per CONTRIBUTING.
