### PR TITLE
fix(tags): suppress poster tag overlays on library list-view rows

### DIFF
--- a/Jellyfin.Plugin.JellyfinElevate/src/enhanced/tag-pipeline.test.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/enhanced/tag-pipeline.test.ts
@@ -1,0 +1,56 @@
+// issue 34: the tag pipeline is a poster-CARD decorator only — list-view rows must
+// never receive card-sized tag overlays. isListViewRow is the single shared gate
+// (used by shouldSkipElement, before any renderer runs) that excludes every
+// `.listItem` row. These cases lock the gate's behaviour: a `.cardImageContainer`
+// nested in a list row is a list row (skipped), a bare card is not, and the legacy
+// no-image `.listItemImage.cardImageContainer` variant — the one shape the modern
+// card scan selector could otherwise surface — is still caught.
+import { describe, expect, it } from 'vitest';
+import { isListViewRow } from './tag-pipeline';
+
+/** Build a `.cardImageContainer` nested inside a `.listItem` row. */
+function listRowImage(): HTMLElement {
+    const row = document.createElement('div');
+    row.className = 'listItem';
+    const img = document.createElement('div');
+    img.className = 'cardImageContainer';
+    row.appendChild(img);
+    return img;
+}
+
+/** Build a bare poster-card `.cardImageContainer` (grid/home rail — should be tagged). */
+function gridCardImage(): HTMLElement {
+    const card = document.createElement('div');
+    card.className = 'card';
+    const scalable = document.createElement('div');
+    scalable.className = 'cardScalable';
+    const img = document.createElement('div');
+    img.className = 'cardImageContainer';
+    scalable.appendChild(img);
+    card.appendChild(scalable);
+    return img;
+}
+
+/** Legacy no-image row: native renders the image element as `.listItemImage.cardImageContainer`. */
+function legacyNoImageRow(): HTMLElement {
+    const row = document.createElement('div');
+    row.className = 'listItem';
+    const img = document.createElement('div');
+    img.className = 'listItemImage cardImageContainer';
+    row.appendChild(img);
+    return img;
+}
+
+describe('isListViewRow — the single list-view gate (issue 34)', () => {
+    it('treats a .cardImageContainer nested in a .listItem row as a list row (skipped)', () => {
+        expect(isListViewRow(listRowImage())).toBe(true);
+    });
+
+    it('does NOT treat a bare poster-card .cardImageContainer as a list row (still tagged)', () => {
+        expect(isListViewRow(gridCardImage())).toBe(false);
+    });
+
+    it('catches the legacy .listItemImage.cardImageContainer no-image variant', () => {
+        expect(isListViewRow(legacyNoImageRow())).toBe(true);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinElevate/src/enhanced/tag-pipeline.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/enhanced/tag-pipeline.ts
@@ -450,8 +450,6 @@ function processCard(el: HTMLElement, fadeIn: boolean): void {
 
     const card = el.closest('.card');
     if (card && card.classList.contains('je-hidden')) return;
-    const listItem = el.closest('.listItem');
-    if (listItem && listItem.classList.contains('je-hidden')) return;
 
     // Skip contexts that should never have tags
     if (shouldSkipElement(el)) {

--- a/Jellyfin.Plugin.JellyfinElevate/src/enhanced/tag-pipeline.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/enhanced/tag-pipeline.ts
@@ -108,10 +108,32 @@ const PIPELINE_SKIP_SELECTORS = [
 ];
 
 /**
+ * List-view rows (`.listItem`) show a tiny thumbnail — native `.listItemImage`
+ * is 4em (~64px, min ~44px) square (jellyfin-web `components/listview/listview.scss`).
+ * Card-sized tag overlays scaled onto that thumbnail are illegible noise that
+ * completely buries the artwork (issue 34). List view already surfaces the
+ * genuinely useful, legible info inline via the native side media-info block and
+ * user-data buttons — community rating (star), runtime, resolution, subtitles,
+ * played/favorite state (`listview.js` `getPrimaryMediaInfoHtml` + `listViewUserDataButtons`).
+ * So the tag pipeline is a poster-CARD decorator only: every list row is excluded
+ * here, at the single shared gate — once, before any renderer runs — rather than
+ * by per-renderer patches. `closest('.listItem')` is robust across every shape a
+ * list row takes:
+ *   - `div.listItemImage` rows (library List view, season/episode lists);
+ *   - the no-image variant native renders as `.listItemImage.cardImageContainer`
+ *     (`listview.js:294`), which the card scan selector would otherwise catch;
+ *   - virtualized/recycled rows (re-scanned on reuse → always re-skipped).
+ */
+function isListViewRow(el: HTMLElement): boolean {
+    return el.closest('.listItem') !== null;
+}
+
+/**
  * Check if an element should be skipped by the pipeline entirely.
  * @param el - The cardImageContainer element.
  */
 function shouldSkipElement(el: HTMLElement): boolean {
+    if (isListViewRow(el)) return true;
     return PIPELINE_SKIP_SELECTORS.some(sel => el.matches(sel) || el.closest(sel));
 }
 
@@ -388,7 +410,7 @@ function scheduleFetchIfQueued(): void {
  * BEFORE the overlay container so Jellyfin's hover overlay naturally covers
  * tags (DOM order). Never renders into cardImageContainer — that triggers
  * Jellyfin's lazy-load to reset opacity:0, breaking image display.
- * @param el - The cardImageContainer/listItemImage element.
+ * @param el - The cardImageContainer element.
  */
 function resolveRenderTarget(el: HTMLElement): HTMLElement {
     const scalable = el.closest<HTMLElement>('.cardScalable');
@@ -501,14 +523,17 @@ function syncScanAddedCards(mutations: MutationRecord[]): void {
             const node = added[j];
             if (node.nodeType !== 1) continue;
             const elNode = node as HTMLElement;
-            if (elNode.matches('.cardImageContainer, div.listItemImage')) {
+            // Poster cards only — list rows (`.listItem`) are never tagged (issue 34,
+            // see shouldSkipElement/isListViewRow). Not scanned here so tiny list
+            // thumbnails cost zero pipeline work.
+            if (elNode.matches('.cardImageContainer')) {
                 if (performance.now() - start > SYNC_SCAN_BUDGET_MS) {
                     scheduleFetchIfQueued();
                     return;
                 }
                 processCard(elNode, false);
             }
-            const nested = elNode.querySelectorAll<HTMLElement>('.cardImageContainer, div.listItemImage');
+            const nested = elNode.querySelectorAll<HTMLElement>('.cardImageContainer');
             for (let k = 0; k < nested.length; k++) {
                 if (performance.now() - start > SYNC_SCAN_BUDGET_MS) {
                     scheduleFetchIfQueued();
@@ -531,7 +556,8 @@ function runScan(): void {
     if (!hasAnyEnabledRenderer()) return;
     if (typeof ApiClient === 'undefined') return;
 
-    const elements = document.querySelectorAll<HTMLElement>('.cardImageContainer, div.listItemImage');
+    // Poster cards only — list rows are excluded (issue 34, see isListViewRow).
+    const elements = document.querySelectorAll<HTMLElement>('.cardImageContainer');
     const unprocessed: HTMLElement[] = [];
     for (const el of elements) {
         if (!processedCards.has(el)) unprocessed.push(el);
@@ -904,23 +930,22 @@ function initialize(): void {
     // Without this, Jellyfin's overlay already covers tags (they're behind it).
     // This setting makes them completely invisible for users who want zero clutter.
     //
-    // The tag layer lives in one of three shapes depending on the card context
+    // The tag layer lives in one of two shapes depending on the card context
     // (see resolveRenderTarget): a `.je-tag-host` wrapper on cards that have a
     // `.cardOverlayContainer` (library grid, home rows, similar-items, season
     // posters), OR the bare `*-overlay-container` elements rendered straight into
     // `.cardScalable` (the primary detail-page poster — a `.card` with no hover
-    // menu) or into `.listItemImage` (list-view episode rows — a `.listItem`,
-    // NOT a `.card`). Keying only on `.card:hover .je-tag-host` matched the first
-    // group but missed the poster and the episode rows, so their tags never hid.
-    // Match the overlay containers directly under BOTH hover roots.
+    // menu). Keying only on `.card:hover .je-tag-host` matched the first group but
+    // missed the poster, so its tags never hid. Match the overlay containers
+    // directly under the hover root. (List rows never carry tags — issue 34,
+    // isListViewRow — so there is no `.listItem` hover case to cover.)
     // `[class*="-overlay-container"]` hits exactly the four JE containers — the
     // native `cardOverlayContainer` has no hyphen, so nothing else is affected.
     // PERF(R2): compositor-only opacity transition on absolutely-positioned
     // overlays — no layout/reflow on hover.
     addCSS('je-tag-hover-fade', `
         body.je-tags-hide-on-hover .card:hover .je-tag-host,
-        body.je-tags-hide-on-hover .card:hover [class*="-overlay-container"],
-        body.je-tags-hide-on-hover .listItem:hover [class*="-overlay-container"] {
+        body.je-tags-hide-on-hover .card:hover [class*="-overlay-container"] {
             opacity: 0 !important;
             transition: opacity 0.15s ease;
         }

--- a/Jellyfin.Plugin.JellyfinElevate/src/enhanced/tag-pipeline.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/enhanced/tag-pipeline.ts
@@ -128,7 +128,7 @@ const PIPELINE_SKIP_SELECTORS = [
  *     card scan selector, so without the gate the legacy list would get tagged;
  *   - virtualized/recycled rows (re-scanned on reuse → always re-skipped).
  */
-function isListViewRow(el: HTMLElement): boolean {
+export function isListViewRow(el: HTMLElement): boolean {
     return el.closest('.listItem') !== null;
 }
 

--- a/Jellyfin.Plugin.JellyfinElevate/src/enhanced/tag-pipeline.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/enhanced/tag-pipeline.ts
@@ -117,11 +117,15 @@ const PIPELINE_SKIP_SELECTORS = [
  * played/favorite state (`listview.js` `getPrimaryMediaInfoHtml` + `listViewUserDataButtons`).
  * So the tag pipeline is a poster-CARD decorator only: every list row is excluded
  * here, at the single shared gate — once, before any renderer runs — rather than
- * by per-renderer patches. `closest('.listItem')` is robust across every shape a
- * list row takes:
- *   - `div.listItemImage` rows (library List view, season/episode lists);
- *   - the no-image variant native renders as `.listItemImage.cardImageContainer`
- *     (`listview.js:294`), which the card scan selector would otherwise catch;
+ * by per-renderer patches.
+ *
+ * In the modern React app this gate is belt-and-suspenders: the scan selectors are
+ * `.cardImageContainer` ONLY (never `.listItemImage`), so no list-row thumbnail is
+ * ever handed to the pipeline in the first place. The gate earns its keep on two
+ * remaining fronts, and `closest('.listItem')` covers both robustly:
+ *   - legacy web layouts, where the no-image row native-renders as
+ *     `.listItemImage.cardImageContainer` (`listview.js:294`) — that DOES match the
+ *     card scan selector, so without the gate the legacy list would get tagged;
  *   - virtualized/recycled rows (re-scanned on reuse → always re-skipped).
  */
 function isListViewRow(el: HTMLElement): boolean {
@@ -436,8 +440,8 @@ function resolveRenderTarget(el: HTMLElement): HTMLElement {
  * (server cache first, then localStorage/hot cache), queueing misses for the
  * batch fetch. Shared by the idle-scheduled chunk scan and the synchronous
  * pre-paint pass. List rows (`.listItem`) are excluded here via shouldSkipElement
- * (issue 34), covering the no-image `.listItemImage.cardImageContainer` variant
- * the scan selector can still surface.
+ * (issue 34) as legacy-layout belt-and-suspenders plus recycling safety — see
+ * isListViewRow for why the modern React scan can't surface a list row anyway.
  * @param el - The cardImageContainer element.
  * @param fadeIn - True for async (post-paint) passes: newly added overlays get
  *   the compositor-only fade so late tags appear smoothly. The pre-paint pass

--- a/Jellyfin.Plugin.JellyfinElevate/src/enhanced/tag-pipeline.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/enhanced/tag-pipeline.ts
@@ -435,8 +435,10 @@ function resolveRenderTarget(el: HTMLElement): HTMLElement {
  * Process a single card: skip checks, render-target resolution, cache render
  * (server cache first, then localStorage/hot cache), queueing misses for the
  * batch fetch. Shared by the idle-scheduled chunk scan and the synchronous
- * pre-paint pass.
- * @param el - The cardImageContainer/listItemImage element.
+ * pre-paint pass. List rows (`.listItem`) are excluded here via shouldSkipElement
+ * (issue 34), covering the no-image `.listItemImage.cardImageContainer` variant
+ * the scan selector can still surface.
+ * @param el - The cardImageContainer element.
  * @param fadeIn - True for async (post-paint) passes: newly added overlays get
  *   the compositor-only fade so late tags appear smoothly. The pre-paint pass
  *   passes false — its tags are part of the card's first frame.

--- a/e2e/list-view-tags.spec.ts
+++ b/e2e/list-view-tags.spec.ts
@@ -12,11 +12,18 @@
 // real library toggled to List view):
 //   - positive control: in the default GRID view the same items DO get tagged,
 //     so the pipeline is provably alive and fast this session;
-//   - the assertion: after switching the same library to List view, no `.listItem`
-//     row carries a `.je-tag-host`, any `*-overlay-container`, or a
-//     `data-je-*-tagged` marker (a zero-overlay result is strictly stronger than
-//     any "overlay narrower than X% of the thumbnail" heuristic).
-// It restores the library's original view-mode setting on the way out.
+//   - the assertion (real regression guard): after switching the same library to
+//     List view, no `.listItem` row carries any `*-overlay-container`. THIS is what
+//     the bug produced (card-sized overlays rendered into the tiny row thumbnail)
+//     and what the fix removes.
+//
+// The spec also checks that no row carries a `.je-tag-host` or a `data-je-*-tagged`
+// marker, but those are INVARIANT SANITY CHECKS, not proof of the fix: even with
+// the bug present neither artifact ever landed on a list row — `.je-tag-host` is
+// only ever created inside a `.cardScalable` (resolveRenderTarget) and the
+// `data-je-*-tagged` markers stamp onto `.card`, neither of which exists on a
+// `.listItem`. They guard against a future renderer regressing that invariant.
+// It restores the library's original view-mode setting on the way out (try/finally).
 import { test, expect, loginAs, showRoute, waitForHash } from './fixtures/auth';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -89,44 +96,53 @@ test.describe('list-view tags', () => {
         expect(gridTagged, 'grid CARD view must still get tags (regression guard)').toBeGreaterThan(0);
 
         // ── Switch the same library to LIST view and remount it ─────────────
-        await page.evaluate(({ k, v }) => localStorage.setItem(k, JSON.stringify(v)),
-            { k: viewKey, v: LIST_VIEW_SETTINGS });
-        // Navigate away and back so LibraryPage remounts and re-reads the setting.
-        await showRoute(page, '/home');
-        await waitForHash(page, '/home');
-        await showRoute(page, `/movies?topParentId=${libraryId}`);
-        await waitForHash(page, libraryId!);
-        await page.waitForSelector('.listItem[data-id]', { state: 'attached', timeout: 60_000 });
+        // From here we've mutated the library's view-mode setting, so the restore
+        // must run even if an assertion throws — otherwise a failure leaves the
+        // library pinned to list view for the next run.
+        try {
+            await page.evaluate(({ k, v }) => localStorage.setItem(k, JSON.stringify(v)),
+                { k: viewKey, v: LIST_VIEW_SETTINGS });
+            // Navigate away and back so LibraryPage remounts and re-reads the setting.
+            await showRoute(page, '/home');
+            await waitForHash(page, '/home');
+            await showRoute(page, `/movies?topParentId=${libraryId}`);
+            await waitForHash(page, libraryId!);
+            await page.waitForSelector('.listItem[data-id]', { state: 'attached', timeout: 60_000 });
 
-        // Let the pipeline settle: the sync pass runs inside the mutation batch
-        // and the idle scan within ~100ms, so any tagging it were going to do has
-        // happened well before this. (The grid control above proved it is active.)
-        await page.waitForLoadState('networkidle');
-        await page.waitForTimeout(1500);
+            // Let the pipeline settle: the sync pass runs inside the mutation batch
+            // and the idle scan within ~100ms, so any tagging it were going to do has
+            // happened well before this. (The grid control above proved it is active.)
+            await page.waitForLoadState('networkidle');
+            await page.waitForTimeout(1500);
 
-        const listState = await page.evaluate((attrs) => {
-            const rows = [...document.querySelectorAll('.listItem[data-id]')];
-            let overlays = 0, hosts = 0, marked = 0;
-            for (const row of rows) {
-                overlays += row.querySelectorAll('[class*="-overlay-container"]').length;
-                hosts += row.querySelectorAll('.je-tag-host').length;
-                for (const a of attrs) {
-                    if (row.matches(`[${a}]`) || row.querySelector(`[${a}]`)) { marked++; break; }
+            const listState = await page.evaluate((attrs) => {
+                const rows = [...document.querySelectorAll('.listItem[data-id]')];
+                let overlays = 0, hosts = 0, marked = 0;
+                for (const row of rows) {
+                    overlays += row.querySelectorAll('[class*="-overlay-container"]').length;
+                    hosts += row.querySelectorAll('.je-tag-host').length;
+                    for (const a of attrs) {
+                        if (row.matches(`[${a}]`) || row.querySelector(`[${a}]`)) { marked++; break; }
+                    }
                 }
-            }
-            return { rows: rows.length, overlays, hosts, marked };
-        }, enabled);
+                return { rows: rows.length, overlays, hosts, marked };
+            }, enabled);
 
-        expect(listState.rows, 'library should be showing list rows').toBeGreaterThan(0);
-        expect(listState.overlays, 'list rows must carry NO JE tag overlay containers').toBe(0);
-        expect(listState.hosts, 'list rows must carry NO je-tag-host').toBe(0);
-        expect(listState.marked, 'no list row may be stamped as tag-rendered').toBe(0);
-
-        // ── Restore the library's original view mode ────────────────────────
-        await page.evaluate(({ k, original }) => {
-            if (original === null) localStorage.removeItem(k);
-            else localStorage.setItem(k, original);
-        }, { k: viewKey, original: originalSetting });
+            expect(listState.rows, 'library should be showing list rows').toBeGreaterThan(0);
+            // The real regression guard: the bug rendered card-sized overlay
+            // containers into the tiny row thumbnail. The fix produces zero.
+            expect(listState.overlays, 'list rows must carry NO JE tag overlay containers').toBe(0);
+            // Invariant sanity checks (never landed on a list row even with the bug —
+            // see header): guard against a future renderer breaking that invariant.
+            expect(listState.hosts, 'list rows must carry NO je-tag-host (invariant)').toBe(0);
+            expect(listState.marked, 'no list row may be stamped as tag-rendered (invariant)').toBe(0);
+        } finally {
+            // ── Restore the library's original view mode ────────────────────
+            await page.evaluate(({ k, original }) => {
+                if (original === null) localStorage.removeItem(k);
+                else localStorage.setItem(k, original);
+            }, { k: viewKey, original: originalSetting });
+        }
 
         expect(consoleErrors.real()).toEqual([]);
     });

--- a/e2e/list-view-tags.spec.ts
+++ b/e2e/list-view-tags.spec.ts
@@ -1,0 +1,133 @@
+// List-view tag suppression (issue 34).
+//
+// In library List view the native row thumbnail is a tiny ~4em (64px, min ~44px)
+// `.listItemImage` (jellyfin-web components/listview/listview.scss). The tag
+// pipeline used to scan `div.listItemImage` alongside `.cardImageContainer` and
+// render the full-size genre/language/quality/rating overlays straight into that
+// thumbnail, burying the artwork. The fix excludes every `.listItem` row at the
+// single shared pipeline gate (src/enhanced/tag-pipeline.ts isListViewRow), so
+// list rows carry NO JE tag overlays while poster/grid CARD views are untouched.
+//
+// This spec proves BOTH halves in one session, on the exact reported surface (a
+// real library toggled to List view):
+//   - positive control: in the default GRID view the same items DO get tagged,
+//     so the pipeline is provably alive and fast this session;
+//   - the assertion: after switching the same library to List view, no `.listItem`
+//     row carries a `.je-tag-host`, any `*-overlay-container`, or a
+//     `data-je-*-tagged` marker (a zero-overlay result is strictly stronger than
+//     any "overlay narrower than X% of the thumbnail" heuristic).
+// It restores the library's original view-mode setting on the way out.
+import { test, expect, loginAs, showRoute, waitForHash } from './fixtures/auth';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// setting flag → the marker each family's renderer stamps when it renders.
+const FAMILIES = [
+    { setting: 'qualityTagsEnabled', attr: 'data-je-quality-tagged' },
+    { setting: 'genreTagsEnabled', attr: 'data-je-genre-tagged' },
+    { setting: 'languageTagsEnabled', attr: 'data-je-language-tagged' },
+    { setting: 'ratingTagsEnabled', attr: 'data-je-rating-tagged' },
+] as const;
+
+// A full LibraryViewSettings object (jellyfin-web
+// apps/modern/features/libraries/utils/settings.ts) with ViewMode:'list'.
+// Written whole because the modern useLocalStorage hook stores the value as-is
+// (no merge with defaults).
+const LIST_VIEW_SETTINGS = {
+    ShowTitle: true,
+    ShowYear: true,
+    ViewMode: 'list',
+    ImageType: 'Primary',
+    CardLayout: false,
+    SortBy: 'SortName',
+    SortOrder: 'Ascending',
+    StartIndex: 0,
+};
+
+test.describe('list-view tags', () => {
+    test('List view row thumbnails carry no tag overlays; grid cards still do', async ({ page, consoleErrors }) => {
+        await loginAs(page, 'admin', consoleErrors);
+
+        const enabled: string[] = await page.evaluate((families) => {
+            const settings = (window as any).JellyfinElevate?.currentSettings || {};
+            return families.filter((f) => settings[f.setting] === true).map((f) => f.attr);
+        }, FAMILIES.map((f) => ({ setting: f.setting, attr: f.attr })));
+        test.skip(enabled.length === 0, 'no tag renderer enabled for this user');
+
+        // Pick a movies library (rich tag data in the seed: genres, community
+        // rating, English audio, SD resolution — all four families apply).
+        const libraryId: string | null = await page.evaluate(async () => {
+            const apiClient = (window as any).ApiClient;
+            const url = apiClient.getUrl(`/UserViews?userId=${apiClient.getCurrentUserId()}`);
+            const views = await apiClient.ajax({ type: 'GET', url, dataType: 'json' });
+            const movies = (views.Items || []).find((v: any) => v.CollectionType === 'movies');
+            return (movies || (views.Items || [])[0])?.Id || null;
+        });
+        test.skip(!libraryId, 'no library available');
+
+        const viewKey = `movies - ${libraryId}`;
+
+        // ── Positive control: GRID view (default) tags the cards ────────────
+        await showRoute(page, `/movies?topParentId=${libraryId}`);
+        await waitForHash(page, libraryId!);
+        // state:'attached' — the library ships a hidden `.cardImageContainer`
+        // template that never becomes visible, so the default visibility wait
+        // would hang on it; we only need the real cards present in the DOM.
+        await page.waitForSelector('.cardImageContainer', { state: 'attached', timeout: 60_000 });
+        // Snapshot the pre-existing view setting so we can restore it later.
+        const originalSetting = await page.evaluate((k) => localStorage.getItem(k), viewKey);
+
+        await page.waitForFunction(
+            (attrs) => attrs.some((a) => document.querySelectorAll(`.card[${a}]`).length > 0),
+            enabled,
+            { timeout: 60_000 }
+        );
+        const gridTagged = await page.evaluate(
+            (attrs) => attrs.reduce((n, a) => n + document.querySelectorAll(`.card[${a}]`).length, 0),
+            enabled
+        );
+        expect(gridTagged, 'grid CARD view must still get tags (regression guard)').toBeGreaterThan(0);
+
+        // ── Switch the same library to LIST view and remount it ─────────────
+        await page.evaluate(({ k, v }) => localStorage.setItem(k, JSON.stringify(v)),
+            { k: viewKey, v: LIST_VIEW_SETTINGS });
+        // Navigate away and back so LibraryPage remounts and re-reads the setting.
+        await showRoute(page, '/home');
+        await waitForHash(page, '/home');
+        await showRoute(page, `/movies?topParentId=${libraryId}`);
+        await waitForHash(page, libraryId!);
+        await page.waitForSelector('.listItem[data-id]', { state: 'attached', timeout: 60_000 });
+
+        // Let the pipeline settle: the sync pass runs inside the mutation batch
+        // and the idle scan within ~100ms, so any tagging it were going to do has
+        // happened well before this. (The grid control above proved it is active.)
+        await page.waitForLoadState('networkidle');
+        await page.waitForTimeout(1500);
+
+        const listState = await page.evaluate((attrs) => {
+            const rows = [...document.querySelectorAll('.listItem[data-id]')];
+            let overlays = 0, hosts = 0, marked = 0;
+            for (const row of rows) {
+                overlays += row.querySelectorAll('[class*="-overlay-container"]').length;
+                hosts += row.querySelectorAll('.je-tag-host').length;
+                for (const a of attrs) {
+                    if (row.matches(`[${a}]`) || row.querySelector(`[${a}]`)) { marked++; break; }
+                }
+            }
+            return { rows: rows.length, overlays, hosts, marked };
+        }, enabled);
+
+        expect(listState.rows, 'library should be showing list rows').toBeGreaterThan(0);
+        expect(listState.overlays, 'list rows must carry NO JE tag overlay containers').toBe(0);
+        expect(listState.hosts, 'list rows must carry NO je-tag-host').toBe(0);
+        expect(listState.marked, 'no list row may be stamped as tag-rendered').toBe(0);
+
+        // ── Restore the library's original view mode ────────────────────────
+        await page.evaluate(({ k, original }) => {
+            if (original === null) localStorage.removeItem(k);
+            else localStorage.setItem(k, original);
+        }, { k: viewKey, original: originalSetting });
+
+        expect(consoleErrors.real()).toEqual([]);
+    });
+});


### PR DESCRIPTION
Closes #34.

## What & why

In library list view, the plugin's poster tags (genre icons, language flags, quality badges) rendered at full card size on the ~64px row thumbnails, completely burying the artwork (reported from desktop; reproduced at all viewports).

## Implementation

- **Decision — suppress, don't shrink**: native list rows already show the legible, useful info inline (rating, runtime, resolution, played/favorite); at 4em thumbnail size scaled-down tags are illegible noise. Poster-overlay tags are now suppressed on every `.listItem` row; card/grid views untouched.
- **One gate at the source**: `isListViewRow()` early-return in the shared `shouldSkipElement()` (tag pipeline) — no per-tag-type patches — plus `div.listItemImage` dropped from the scan selectors so list rows incur zero pipeline work. Review confirmed the modern React app never emits `cardImageContainer` on list thumbnails, so the selector removal alone covers modern; the gate is legacy-layout belt-and-suspenders and recycling safety. A vestigial second `.listItem` branch in `processCard` was deleted so the gate is genuinely the single decision point.
- Dead `.listItem:hover` CSS removed; stale comments corrected. No new settings (goldens untouched).
- Live-verified: 63 overlay containers on list thumbnails before → 0 after, both roles, desktop 1440×900 + phone 390×844; grid view unchanged (all tag families still render).

## Test plan

- Gates: typecheck, lint 0 errors (cap unchanged), client **509/509** (+3 new jsdom tests pinning the gate incl. the legacy variant), bundle, syntax, Release build 0 warnings, `dotnet test` **734/734**.
- New `e2e/list-view-tags.spec.ts`: grid positive control (tags present) → native view toggle to list → zero overlay containers on rows (the real regression guard; two additional invariant sanity checks labeled as such) → view mode restored via try/finally.
- Full suite: **58 passed, 2 pre-existing login-race flakes (passed on retry), 0 failed**, exit 0.
- Review: codex xhigh clean (gate layer, virtualization, R1–R8 confirmed); two adversarial Opus xhigh reviews — production logic zero survivors (over/under-suppression both refuted against native markup); four low test/dead-code findings all addressed.

This PR was developed with AI assistance per CONTRIBUTING.
