### PR TITLE
Awards & Extended Metadata: Wikidata-sourced awards on detail pages

### DIFF
--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Controllers/AwardsControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Controllers/AwardsControllerTests.cs
@@ -1,0 +1,167 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Security.Claims;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.JellyfinElevate.Configuration;
+using Jellyfin.Plugin.JellyfinElevate.Controllers;
+using Jellyfin.Plugin.JellyfinElevate.Model.Awards;
+using Jellyfin.Plugin.JellyfinElevate.Services.Awards;
+using Jellyfin.Plugin.JellyfinElevate.Services.Jellyseerr;
+using Jellyfin.Plugin.JellyfinElevate.Tests.TestDoubles;
+using MediaBrowser.Controller.Entities.Movies;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinElevate.Tests.Controllers
+{
+    /// <summary>
+    /// HTTP-surface coverage for AwardsController: the admin enable gate, caller-scoped item
+    /// resolution (CSCTRL-4 — a non-admin can't confirm existence of items outside their
+    /// libraries), and the "empty, not an error" contract for disabled/unknown/awardless items.
+    /// </summary>
+    public sealed class AwardsControllerTests : IDisposable
+    {
+        private readonly string _dir;
+
+        public AwardsControllerTests()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "je-awards-ctrl-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_dir, recursive: true); } catch { /* best-effort */ }
+        }
+
+        private sealed class Harness
+        {
+            public required AwardsController Controller { get; init; }
+            public required CountingLibraryManager Lib { get; init; }
+            public required AwardsCacheService Cache { get; init; }
+        }
+
+        private Harness Build(bool enabled, bool authenticated = true)
+        {
+            var cfg = new PluginConfiguration { ShowAwards = enabled };
+            var provider = new FakePluginConfigProvider(cfg);
+            var user = new User("awards", "Prov", "PwProv");
+            var userManager = new StubUserManager(user);
+            var lib = new CountingLibraryManager();
+            var cache = new AwardsCacheService(new StubAppPaths(_dir), NullLogger<AwardsCacheService>.Instance);
+
+            var controller = new AwardsController(
+                new RecordingHttpClientFactory(new HttpClientHandler()),
+                NullLogger<AwardsController>.Instance,
+                userManager,
+                new SeerrCache(provider),
+                provider,
+                lib,
+                cache);
+
+            var identity = authenticated
+                ? new ClaimsIdentity(new[] { new Claim("Jellyfin-UserId", user.Id.ToString()) }, "TestAuth")
+                : new ClaimsIdentity();
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) },
+            };
+
+            return new Harness { Controller = controller, Lib = lib, Cache = cache };
+        }
+
+        private static ItemAwardsResponse Unwrap(ActionResult<ItemAwardsResponse> result)
+        {
+            Assert.NotNull(result.Value);
+            return result.Value!;
+        }
+
+        [Fact]
+        public void Disabled_ReturnsNotEnabled_AndNeverTouchesLibrary()
+        {
+            var h = Build(enabled: false);
+            var libTouched = false;
+            h.Lib.GetItemByIdUserHook = (_, _) => { libTouched = true; return null; };
+
+            var response = Unwrap(h.Controller.GetItemAwards(Guid.NewGuid()));
+
+            Assert.False(response.Enabled);
+            Assert.Empty(response.Awards);
+            Assert.False(libTouched); // disabled short-circuits before any lookup
+        }
+
+        [Fact]
+        public void Enabled_ItemWithAwards_ReturnsThem_ScopedToCaller()
+        {
+            var h = Build(enabled: true);
+            h.Cache.ReplaceFrom(new[]
+            {
+                new AwardRow { Ceremony = "Academy Awards", Category = "Best Picture", Won = true, Year = 2024, ImdbId = "tt1" },
+            });
+            var itemId = Guid.NewGuid();
+            User? scopedUser = null;
+            h.Lib.GetItemByIdUserHook = (id, user) =>
+            {
+                scopedUser = user; // prove the user-scoped overload was used
+                if (id != itemId) return null;
+                var m = new Movie { Id = itemId };
+                m.ProviderIds["Imdb"] = "tt1";
+                return m;
+            };
+
+            var response = Unwrap(h.Controller.GetItemAwards(itemId));
+
+            Assert.True(response.Enabled);
+            var award = Assert.Single(response.Awards);
+            Assert.Equal("Best Picture", award.Category);
+            Assert.NotNull(scopedUser); // the lookup was scoped, not global
+        }
+
+        [Fact]
+        public void Enabled_UnknownItem_ReturnsEmpty()
+        {
+            var h = Build(enabled: true);
+            h.Cache.ReplaceFrom(new[]
+            {
+                new AwardRow { Ceremony = "Academy Awards", Category = "Best Picture", Won = true, Year = 2024, ImdbId = "tt1" },
+            });
+            h.Lib.GetItemByIdUserHook = (_, _) => null; // not visible to this caller / doesn't exist
+
+            var response = Unwrap(h.Controller.GetItemAwards(Guid.NewGuid()));
+
+            Assert.True(response.Enabled);
+            Assert.Empty(response.Awards);
+        }
+
+        [Fact]
+        public void Enabled_NoUser_FailsClosed_AndNeverTouchesLibrary()
+        {
+            var h = Build(enabled: true, authenticated: false);
+            var libTouched = false;
+            h.Lib.GetItemByIdUserHook = (_, _) => { libTouched = true; return null; };
+
+            var response = Unwrap(h.Controller.GetItemAwards(Guid.NewGuid()));
+
+            Assert.True(response.Enabled);
+            Assert.Empty(response.Awards);
+            Assert.False(libTouched); // no resolvable user id → no lookup
+        }
+
+        [Fact]
+        public void Enabled_EmptyItemId_ReturnsEmpty_WithoutLookup()
+        {
+            var h = Build(enabled: true);
+            var libTouched = false;
+            h.Lib.GetItemByIdUserHook = (_, _) => { libTouched = true; return null; };
+
+            var response = Unwrap(h.Controller.GetItemAwards(Guid.Empty));
+
+            Assert.True(response.Enabled);
+            Assert.Empty(response.Awards);
+            Assert.False(libTouched);
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/ScheduledTasks/BuildAwardsCacheTaskTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/ScheduledTasks/BuildAwardsCacheTaskTests.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinElevate.Model.Awards;
+using Jellyfin.Plugin.JellyfinElevate.ScheduledTasks;
+using Jellyfin.Plugin.JellyfinElevate.Services.Awards;
+using Jellyfin.Plugin.JellyfinElevate.Tests.TestDoubles;
+using MediaBrowser.Controller.Entities.Movies;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinElevate.Tests.ScheduledTasks
+{
+    /// <summary>
+    /// The refresh task must never publish a PARTIAL fetch over an existing complete index —
+    /// a single timed-out ceremony query would otherwise erase that ceremony's awards until a
+    /// later full run. A partial fetch is only accepted when there is no index yet (first install).
+    /// </summary>
+    public sealed class BuildAwardsCacheTaskTests : IDisposable
+    {
+        private readonly string _dir;
+
+        public BuildAwardsCacheTaskTests()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "je-awards-task-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_dir, recursive: true); } catch { /* best-effort */ }
+        }
+
+        private sealed class FakeProvider : IAwardsProvider
+        {
+            public AwardsFetchResult Result { get; set; } = new(Array.Empty<AwardRow>(), true);
+
+            public Task<AwardsFetchResult> FetchAllAsync(IProgress<double>? progress, CancellationToken cancellationToken)
+                => Task.FromResult(Result);
+        }
+
+        private AwardsCacheService NewCache() =>
+            new(new StubAppPaths(_dir), NullLogger<AwardsCacheService>.Instance);
+
+        private static AwardRow Row(string ceremony, string category, string imdb) =>
+            new() { Ceremony = ceremony, Category = category, Won = true, Year = 2024, ImdbId = imdb, MediaType = "movie" };
+
+        private static Movie Movie(string imdb)
+        {
+            var m = new Movie { Id = Guid.NewGuid() };
+            m.ProviderIds["Imdb"] = imdb;
+            return m;
+        }
+
+        private static Task Run(IAwardsProvider provider, AwardsCacheService cache) =>
+            new BuildAwardsCacheTask(provider, cache, NullLogger<BuildAwardsCacheTask>.Instance)
+                .ExecuteAsync(new Progress<double>(), CancellationToken.None);
+
+        [Fact]
+        public async Task CompleteFetch_PublishesIndex()
+        {
+            var cache = NewCache();
+            var provider = new FakeProvider { Result = new(new[] { Row("Academy Awards", "Best Picture", "tt1") }, true) };
+
+            await Run(provider, cache);
+
+            Assert.Single(cache.LookupForItem(Movie("tt1")));
+            Assert.Equal(1, cache.Version);
+        }
+
+        [Fact]
+        public async Task PartialFetch_OverExistingIndex_IsNotPublished()
+        {
+            var cache = NewCache();
+            cache.ReplaceFrom(new[] { Row("Academy Awards", "Best Picture", "tt1") }); // existing complete index
+            var versionBefore = cache.Version;
+
+            // A partial refresh returns different data (as if only one ceremony query succeeded).
+            var provider = new FakeProvider { Result = new(new[] { Row("BAFTA Awards", "Best Film", "tt2") }, false) };
+            await Run(provider, cache);
+
+            // The old award survives; the partial data was NOT published.
+            Assert.Single(cache.LookupForItem(Movie("tt1")));
+            Assert.Empty(cache.LookupForItem(Movie("tt2")));
+            Assert.Equal(versionBefore, cache.Version);
+        }
+
+        [Fact]
+        public async Task PartialFetch_OnFirstInstall_IsPublished()
+        {
+            var cache = NewCache(); // empty — first install
+            var provider = new FakeProvider { Result = new(new[] { Row("Academy Awards", "Best Picture", "tt1") }, false) };
+
+            await Run(provider, cache);
+
+            // Partial beats an empty section when there is nothing yet.
+            Assert.Single(cache.LookupForItem(Movie("tt1")));
+            Assert.Equal(1, cache.Version);
+        }
+
+        [Fact]
+        public async Task EmptyFetch_LeavesExistingIndexUntouched()
+        {
+            var cache = NewCache();
+            cache.ReplaceFrom(new[] { Row("Academy Awards", "Best Picture", "tt1") });
+            var versionBefore = cache.Version;
+
+            var provider = new FakeProvider { Result = new(Array.Empty<AwardRow>(), true) };
+            await Run(provider, cache);
+
+            Assert.Single(cache.LookupForItem(Movie("tt1")));
+            Assert.Equal(versionBefore, cache.Version);
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Services/AwardsCacheServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Services/AwardsCacheServiceTests.cs
@@ -79,8 +79,11 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
             Assert.True(award.Won);
             Assert.Equal(2024, award.Year);
 
+            // An empty row set never clears an existing index (a fetch that returns nothing is
+            // treated as "keep what we have", never "wipe it").
             svc.ReplaceFrom(Array.Empty<AwardRow>());
-            Assert.Equal(2, svc.Version); // monotonic even when cleared
+            Assert.Equal(1, svc.Version);
+            Assert.Single(svc.LookupForItem(Movie(imdb: "tt6710474")));
         }
 
         [Fact]
@@ -187,6 +190,47 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
             Assert.Equal(versionBefore, reloaded.Version);
             Assert.Single(reloaded.LookupForItem(Movie(imdb: "tt1")));
             Assert.Equal("Palme d'Or", reloaded.LookupForItem(Movie(tmdb: "77")).Single().Category);
+        }
+
+        [Fact]
+        public void TryReplaceFrom_Complete_Publishes()
+        {
+            var svc = NewService();
+            Assert.True(svc.TryReplaceFrom(new[] { Row("Academy Awards", "Best Picture", true, 2024, imdb: "tt1") }, complete: true));
+            Assert.Single(svc.LookupForItem(Movie(imdb: "tt1")));
+        }
+
+        [Fact]
+        public void TryReplaceFrom_PartialOverExistingIndex_IsRejected()
+        {
+            var svc = NewService();
+            svc.TryReplaceFrom(new[] { Row("Academy Awards", "Best Picture", true, 2024, imdb: "tt1") }, complete: true);
+            var versionBefore = svc.Version;
+
+            // Partial run with different data must NOT replace the complete index.
+            Assert.False(svc.TryReplaceFrom(new[] { Row("BAFTA Awards", "Best Film", true, 2024, imdb: "tt2") }, complete: false));
+            Assert.Single(svc.LookupForItem(Movie(imdb: "tt1"))); // old award survives
+            Assert.Empty(svc.LookupForItem(Movie(imdb: "tt2")));
+            Assert.Equal(versionBefore, svc.Version);
+        }
+
+        [Fact]
+        public void TryReplaceFrom_PartialOnFirstInstall_Publishes()
+        {
+            var svc = NewService(); // empty
+            Assert.True(svc.TryReplaceFrom(new[] { Row("Academy Awards", "Best Picture", true, 2024, imdb: "tt1") }, complete: false));
+            Assert.Single(svc.LookupForItem(Movie(imdb: "tt1")));
+        }
+
+        [Fact]
+        public void TryReplaceFrom_EmptyRows_DoesNotPublish()
+        {
+            var svc = NewService();
+            svc.TryReplaceFrom(new[] { Row("Academy Awards", "Best Picture", true, 2024, imdb: "tt1") }, complete: true);
+            var versionBefore = svc.Version;
+
+            Assert.False(svc.TryReplaceFrom(Array.Empty<AwardRow>(), complete: true));
+            Assert.Equal(versionBefore, svc.Version); // unchanged — empty never clears
         }
 
         [Fact]

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Services/AwardsCacheServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Services/AwardsCacheServiceTests.cs
@@ -126,6 +126,24 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
         }
 
         [Fact]
+        public void Lookup_WinSuppressesMatchingNomination_SameCategoryAndYear()
+        {
+            var svc = NewService();
+            svc.ReplaceFrom(new[]
+            {
+                Row("Academy Awards", "Best Sound Editing", true, 1986, imdb: "tt1"),   // win
+                Row("Academy Awards", "Best Sound Editing", false, 1986, imdb: "tt1"),  // redundant nomination
+                Row("Academy Awards", "Best Original Screenplay", false, 1986, imdb: "tt1"), // distinct nomination
+            });
+
+            var awards = svc.LookupForItem(Movie(imdb: "tt1"));
+            Assert.Equal(2, awards.Count);
+            var soundEditing = Assert.Single(awards, a => a.Category == "Best Sound Editing");
+            Assert.True(soundEditing.Won); // only the win survives for that category/year
+            Assert.Contains(awards, a => a.Category == "Best Original Screenplay" && !a.Won); // untouched
+        }
+
+        [Fact]
         public void Sort_NewestYearFirst_WinsBeforeNominations()
         {
             var svc = NewService();

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Services/AwardsCacheServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Services/AwardsCacheServiceTests.cs
@@ -237,12 +237,30 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
             Assert.Equal(0, before.Version);
             Assert.Empty(before.Awards);
 
+            Assert.False(before.Complete);
+
             svc.ReplaceFrom(new[] { Row("Academy Awards", "Best Picture", true, 2024, imdb: "tt1") });
 
             var after = svc.GetAwardsView(Movie(imdb: "tt1"));
             Assert.False(after.IsEmpty);
+            Assert.True(after.Complete); // ReplaceFrom publishes a complete snapshot
             Assert.Equal(1, after.Version);
             Assert.Single(after.Awards);
+        }
+
+        [Fact]
+        public void GetAwardsView_PartialIndex_ReportsIncomplete()
+        {
+            var svc = NewService();
+            // A partial first-install build (some ceremony failed).
+            svc.TryReplaceFrom(new[] { Row("BAFTA Awards", "Best Film", true, 2024, imdb: "tt-bafta") }, complete: false, svc.NextRefreshGeneration());
+
+            // A movie whose awards are in a not-yet-fetched ceremony reads empty but INCOMPLETE,
+            // so the client keeps trying rather than caching "no awards".
+            var view = svc.GetAwardsView(Movie(imdb: "tt-oscar-only"));
+            Assert.False(view.IsEmpty);   // index has BAFTA rows
+            Assert.False(view.Complete);  // but it is partial
+            Assert.Empty(view.Awards);
         }
 
         [Fact]

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Services/AwardsCacheServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Services/AwardsCacheServiceTests.cs
@@ -242,6 +242,27 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
         }
 
         [Fact]
+        public void TryReplaceFrom_CompleteEmpty_OnFirstInstall_MarksBuiltNotStuck()
+        {
+            var svc = NewService();
+            // A complete build that legitimately yields no awards must mark the index BUILT (not
+            // "never built"), so the client stops treating it as not-ready.
+            Assert.True(svc.TryReplaceFrom(Array.Empty<AwardRow>(), complete: true, svc.NextRefreshGeneration()));
+            Assert.False(svc.IsEmpty);
+            Assert.Equal(1, svc.Version);
+            Assert.False(svc.GetAwardsView(Movie(imdb: "tt1")).IsEmpty);
+        }
+
+        [Fact]
+        public void TryReplaceFrom_PartialEmpty_OnFirstInstall_DoesNotPublish()
+        {
+            var svc = NewService();
+            // A partial fetch that produced nothing is not a built index — stay empty and wait.
+            Assert.False(svc.TryReplaceFrom(Array.Empty<AwardRow>(), complete: false, svc.NextRefreshGeneration()));
+            Assert.True(svc.IsEmpty);
+        }
+
+        [Fact]
         public void TryReplaceFrom_EmptyRows_DoesNotPublish()
         {
             var svc = NewService();

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Services/AwardsCacheServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Services/AwardsCacheServiceTests.cs
@@ -146,6 +146,22 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
         }
 
         [Fact]
+        public void Lookup_NonMovieOrSeriesItem_ReturnsEmpty_EvenOnTmdbCollision()
+        {
+            var svc = NewService();
+            svc.ReplaceFrom(new[] { Row("Academy Awards", "Best Picture", true, 2024, tmdb: "100", media: "movie") });
+
+            // An Episode whose TMDb id numerically collides with the awarded movie's must not
+            // surface that movie's awards — awards are Movie/Series only.
+            var ep = new Episode { Id = Guid.NewGuid() };
+            ep.ProviderIds["Tmdb"] = "100";
+            Assert.Empty(svc.LookupForItem(ep));
+
+            // The real movie still resolves.
+            Assert.Single(svc.LookupForItem(Movie(tmdb: "100")));
+        }
+
+        [Fact]
         public void PersonId_IsNotIndexed()
         {
             var svc = NewService();

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Services/AwardsCacheServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Services/AwardsCacheServiceTests.cs
@@ -193,6 +193,25 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
         }
 
         [Fact]
+        public void GetAwardsView_ReturnsConsistentSnapshot()
+        {
+            var svc = NewService();
+
+            // Before any build: empty + version 0 + no awards, all from one snapshot.
+            var before = svc.GetAwardsView(Movie(imdb: "tt1"));
+            Assert.True(before.IsEmpty);
+            Assert.Equal(0, before.Version);
+            Assert.Empty(before.Awards);
+
+            svc.ReplaceFrom(new[] { Row("Academy Awards", "Best Picture", true, 2024, imdb: "tt1") });
+
+            var after = svc.GetAwardsView(Movie(imdb: "tt1"));
+            Assert.False(after.IsEmpty);
+            Assert.Equal(1, after.Version);
+            Assert.Single(after.Awards);
+        }
+
+        [Fact]
         public void TryReplaceFrom_Complete_Publishes()
         {
             var svc = NewService();

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Services/AwardsCacheServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Services/AwardsCacheServiceTests.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Jellyfin.Plugin.JellyfinElevate.Model.Awards;
+using Jellyfin.Plugin.JellyfinElevate.Services.Awards;
+using Jellyfin.Plugin.JellyfinElevate.Tests.TestDoubles;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
+{
+    /// <summary>
+    /// Covers the awards index: grouping/dedup/sort on rebuild, IMDb and TMDb (movie vs tv)
+    /// lookup, person-id rejection, the atomic version bump, and the disk round-trip. These
+    /// are the stateful, bug-prone parts — the lookup path is what every detail-page view hits.
+    /// </summary>
+    public sealed class AwardsCacheServiceTests : IDisposable
+    {
+        private readonly string _dir;
+
+        public AwardsCacheServiceTests()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "je-awards-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_dir, recursive: true); } catch { /* best-effort */ }
+        }
+
+        private AwardsCacheService NewService() =>
+            new(new StubAppPaths(_dir), NullLogger<AwardsCacheService>.Instance);
+
+        private static Movie Movie(string? imdb = null, string? tmdb = null)
+        {
+            var m = new Movie { Id = Guid.NewGuid() };
+            if (imdb != null) m.ProviderIds["Imdb"] = imdb;
+            if (tmdb != null) m.ProviderIds["Tmdb"] = tmdb;
+            return m;
+        }
+
+        private static Series Series(string? imdb = null, string? tmdb = null)
+        {
+            var s = new Series { Id = Guid.NewGuid() };
+            if (imdb != null) s.ProviderIds["Imdb"] = imdb;
+            if (tmdb != null) s.ProviderIds["Tmdb"] = tmdb;
+            return s;
+        }
+
+        private static AwardRow Row(string ceremony, string category, bool won, int? year, string? imdb = null, string? tmdb = null, string media = "movie") =>
+            new() { Ceremony = ceremony, Category = category, Won = won, Year = year, ImdbId = imdb, TmdbId = tmdb, MediaType = media };
+
+        [Fact]
+        public void NewService_IsEmpty_AndVersionZero()
+        {
+            var svc = NewService();
+            Assert.True(svc.IsEmpty);
+            Assert.Equal(0, svc.Version);
+            Assert.Empty(svc.LookupForItem(Movie(imdb: "tt1")));
+        }
+
+        [Fact]
+        public void ReplaceFrom_ImdbLookup_ReturnsEntry_AndBumpsVersion()
+        {
+            var svc = NewService();
+            svc.ReplaceFrom(new[] { Row("Academy Awards", "Academy Award for Best Picture", true, 2024, imdb: "tt6710474") });
+
+            Assert.False(svc.IsEmpty);
+            Assert.Equal(1, svc.Version);
+
+            var awards = svc.LookupForItem(Movie(imdb: "tt6710474"));
+            var award = Assert.Single(awards);
+            Assert.Equal("Academy Awards", award.Ceremony);
+            Assert.Equal("Academy Award for Best Picture", award.Category);
+            Assert.True(award.Won);
+            Assert.Equal(2024, award.Year);
+
+            svc.ReplaceFrom(Array.Empty<AwardRow>());
+            Assert.Equal(2, svc.Version); // monotonic even when cleared
+        }
+
+        [Fact]
+        public void TmdbLookup_SeparatesMovieAndTvNamespaces()
+        {
+            var svc = NewService();
+            svc.ReplaceFrom(new[]
+            {
+                Row("Academy Awards", "Best Picture", true, 2020, tmdb: "100", media: "movie"),
+                Row("Primetime Emmy Awards", "Outstanding Drama Series", true, 2020, tmdb: "100", media: "tv"),
+            });
+
+            // A movie with TMDb 100 sees only the movie-namespaced award, never the tv one.
+            var movieAwards = svc.LookupForItem(Movie(tmdb: "100"));
+            Assert.Single(movieAwards);
+            Assert.Equal("Academy Awards", movieAwards[0].Ceremony);
+
+            // A series with TMDb 100 sees only the tv-namespaced award.
+            var seriesAwards = svc.LookupForItem(Series(tmdb: "100"));
+            Assert.Single(seriesAwards);
+            Assert.Equal("Primetime Emmy Awards", seriesAwards[0].Ceremony);
+        }
+
+        [Fact]
+        public void Lookup_MergesImdbAndTmdb_AndDeduplicates()
+        {
+            var svc = NewService();
+            // Same award reachable by both ids, plus an exact duplicate row — one entry survives.
+            svc.ReplaceFrom(new[]
+            {
+                Row("Academy Awards", "Best Picture", true, 2024, imdb: "tt1", tmdb: "50", media: "movie"),
+                Row("Academy Awards", "Best Picture", true, 2024, imdb: "tt1", tmdb: "50", media: "movie"),
+                Row("BAFTA Awards", "Best Film", true, 2024, tmdb: "50", media: "movie"),
+            });
+
+            var awards = svc.LookupForItem(Movie(imdb: "tt1", tmdb: "50"));
+            Assert.Equal(2, awards.Count);
+            Assert.Contains(awards, a => a.Ceremony == "Academy Awards");
+            Assert.Contains(awards, a => a.Ceremony == "BAFTA Awards");
+        }
+
+        [Fact]
+        public void Sort_NewestYearFirst_WinsBeforeNominations()
+        {
+            var svc = NewService();
+            svc.ReplaceFrom(new[]
+            {
+                Row("Academy Awards", "Old Nomination", false, 2000, imdb: "tt1"),
+                Row("Academy Awards", "Recent Nomination", false, 2024, imdb: "tt1"),
+                Row("Academy Awards", "Recent Win", true, 2024, imdb: "tt1"),
+            });
+
+            var awards = svc.LookupForItem(Movie(imdb: "tt1"));
+            Assert.Equal(3, awards.Count);
+            // 2024 win first, then 2024 nomination, then the 2000 nomination.
+            Assert.Equal("Recent Win", awards[0].Category);
+            Assert.True(awards[0].Won);
+            Assert.Equal("Recent Nomination", awards[1].Category);
+            Assert.Equal(2000, awards[2].Year);
+        }
+
+        [Fact]
+        public void PersonId_IsNotIndexed()
+        {
+            var svc = NewService();
+            // A person award row (nm…) with no TMDb id must not be stored or matchable.
+            svc.ReplaceFrom(new[] { Row("Academy Awards", "Best Actor", true, 2024, imdb: "nm123") });
+
+            Assert.Equal(0, svc.TitleCount);
+            Assert.Empty(svc.LookupForItem(Movie(imdb: "nm123")));
+        }
+
+        [Fact]
+        public void BlankCeremonyOrCategory_IsSkipped()
+        {
+            var svc = NewService();
+            svc.ReplaceFrom(new[]
+            {
+                Row("", "Best Picture", true, 2024, imdb: "tt1"),
+                Row("Academy Awards", "", true, 2024, imdb: "tt1"),
+                Row("Academy Awards", "Best Picture", true, 2024, imdb: "tt1"),
+            });
+
+            var awards = svc.LookupForItem(Movie(imdb: "tt1"));
+            Assert.Single(awards);
+        }
+
+        [Fact]
+        public void DiskRoundTrip_RestoresIndexAndVersion()
+        {
+            var first = NewService();
+            first.ReplaceFrom(new[]
+            {
+                Row("Academy Awards", "Best Picture", true, 2024, imdb: "tt1"),
+                Row("Cannes Film Festival", "Palme d'Or", true, 2019, tmdb: "77", media: "movie"),
+            });
+            var versionBefore = first.Version;
+
+            // A fresh instance (as on server restart) loads the same data from disk.
+            var reloaded = NewService();
+            reloaded.LoadFromDisk();
+
+            Assert.False(reloaded.IsEmpty);
+            Assert.Equal(versionBefore, reloaded.Version);
+            Assert.Single(reloaded.LookupForItem(Movie(imdb: "tt1")));
+            Assert.Equal("Palme d'Or", reloaded.LookupForItem(Movie(tmdb: "77")).Single().Category);
+        }
+
+        [Fact]
+        public void MissingYear_IsPreservedAsNull_AndSortsLast()
+        {
+            var svc = NewService();
+            svc.ReplaceFrom(new[]
+            {
+                Row("Academy Awards", "No Year", true, null, imdb: "tt1"),
+                Row("Academy Awards", "Has Year", true, 2010, imdb: "tt1"),
+            });
+
+            var awards = svc.LookupForItem(Movie(imdb: "tt1"));
+            Assert.Equal("Has Year", awards[0].Category);
+            Assert.Null(awards[1].Year);
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Services/AwardsCacheServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Services/AwardsCacheServiceTests.cs
@@ -234,6 +234,22 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
         }
 
         [Fact]
+        public void TryReplaceFrom_StaleGeneration_IsRejected()
+        {
+            var svc = NewService();
+            var genEarly = svc.NextRefreshGeneration(); // an earlier-started refresh
+            var genLate = svc.NextRefreshGeneration();  // a later-started refresh
+
+            // The later-started refresh completes and publishes first.
+            Assert.True(svc.TryReplaceFrom(new[] { Row("Academy Awards", "Newer", true, 2024, imdb: "tt-new") }, complete: true, genLate));
+            // The earlier-started refresh finishes afterwards — its stale generation is rejected.
+            Assert.False(svc.TryReplaceFrom(new[] { Row("Academy Awards", "Older", true, 2024, imdb: "tt-old") }, complete: true, genEarly));
+
+            Assert.Single(svc.LookupForItem(Movie(imdb: "tt-new")));
+            Assert.Empty(svc.LookupForItem(Movie(imdb: "tt-old")));
+        }
+
+        [Fact]
         public void LoadFromDisk_DoesNotDowngradeNewerInMemoryIndex()
         {
             var svc = NewService();

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Services/AwardsCacheServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Services/AwardsCacheServiceTests.cs
@@ -306,29 +306,44 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
         }
 
         [Fact]
-        public void LoadFromDisk_DoesNotDowngradeNewerInMemoryIndex()
+        public void LoadFromDisk_AfterInProcessPublish_KeepsFreshDataOverHigherVersionDisk()
         {
             var svc = NewService();
-            // Drive the in-memory index to v2 with a distinctive award.
-            svc.ReplaceFrom(new[] { Row("Academy Awards", "First", true, 2024, imdb: "tt-new") });
-            svc.ReplaceFrom(new[] { Row("Academy Awards", "Second", true, 2024, imdb: "tt-new") });
-            Assert.Equal(2, svc.Version);
+            // A refresh publishes fresh data in-process (in-memory version restarts at 1).
+            svc.ReplaceFrom(new[] { Row("Academy Awards", "Fresh", true, 2024, imdb: "tt-fresh") });
 
-            // Simulate an OLDER snapshot on disk (v1) with different data — as if LoadFromDisk read
-            // it before a concurrent rebuild published v2. Property names match the on-disk format.
+            // A stale snapshot with a much HIGHER persisted version sits on disk (as if written
+            // before a restart). Version comparison alone would wrongly install it.
             var path = Path.Combine(_dir, "configurations", "Jellyfin.Plugin.JellyfinElevate", "awards-cache.json");
             File.WriteAllText(
                 path,
-                "{\"SchemaVersion\":1,\"Version\":1,\"LastModified\":0,\"BuiltAtUtc\":null,"
-                + "\"ByImdb\":{\"tt-old\":[{\"ceremony\":\"Old\",\"category\":\"Old\",\"year\":2000,\"won\":true}]},"
+                "{\"SchemaVersion\":2,\"Version\":99,\"LastModified\":0,\"BuiltAtUtc\":null,\"Complete\":true,"
+                + "\"ByImdb\":{\"tt-stale\":[{\"ceremony\":\"Old\",\"category\":\"Old\",\"year\":2000,\"won\":true}]},"
                 + "\"ByTmdb\":{}}");
 
             svc.LoadFromDisk();
 
-            // The newer in-memory index wins; the stale disk read is discarded.
-            Assert.Equal(2, svc.Version);
-            Assert.Empty(svc.LookupForItem(Movie(imdb: "tt-old")));
-            Assert.Single(svc.LookupForItem(Movie(imdb: "tt-new")));
+            // The fresh in-process data is kept; the higher-version but stale disk snapshot is ignored.
+            Assert.Single(svc.LookupForItem(Movie(imdb: "tt-fresh")));
+            Assert.Empty(svc.LookupForItem(Movie(imdb: "tt-stale")));
+        }
+
+        [Fact]
+        public void TryReplaceFrom_CompleteSupersedesPartialFirstBuild_RegardlessOfGeneration()
+        {
+            var svc = NewService();
+            var genComplete = svc.NextRefreshGeneration(); // started first (older generation)
+            var genPartial = svc.NextRefreshGeneration();  // started later (newer generation)
+
+            // The later-started PARTIAL first-build finishes first and publishes.
+            Assert.True(svc.TryReplaceFrom(new[] { Row("BAFTA Awards", "Best Film", true, 2024, imdb: "tt-partial") }, complete: false, genPartial));
+
+            // The earlier-started COMPLETE build finishes afterwards — it MUST supersede the partial
+            // despite carrying an older generation (completeness outranks generation).
+            Assert.True(svc.TryReplaceFrom(new[] { Row("Academy Awards", "Best Picture", true, 2024, imdb: "tt-complete") }, complete: true, genComplete));
+
+            Assert.Single(svc.LookupForItem(Movie(imdb: "tt-complete")));
+            Assert.Empty(svc.LookupForItem(Movie(imdb: "tt-partial")));
         }
 
         [Fact]

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Services/AwardsCacheServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Services/AwardsCacheServiceTests.cs
@@ -347,6 +347,21 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
         }
 
         [Fact]
+        public void TryReplaceFrom_PartialOverExistingPartial_IsRejected()
+        {
+            var svc = NewService();
+            // First install publishes a PARTIAL snapshot (one ceremony query failed).
+            Assert.True(svc.TryReplaceFrom(new[] { Row("Academy Awards", "Best Picture", true, 2024, imdb: "tt-a") }, complete: false, svc.NextRefreshGeneration()));
+
+            // A later PARTIAL refresh (different ceremony lost) must NOT replace it — that would
+            // erase tt-a's awards. A partial only ever publishes onto an empty index.
+            Assert.False(svc.TryReplaceFrom(new[] { Row("BAFTA Awards", "Best Film", true, 2024, imdb: "tt-b") }, complete: false, svc.NextRefreshGeneration()));
+
+            Assert.Single(svc.LookupForItem(Movie(imdb: "tt-a")));
+            Assert.Empty(svc.LookupForItem(Movie(imdb: "tt-b")));
+        }
+
+        [Fact]
         public void TryReplaceFrom_CompleteSupersedesPartialFirstBuild_RegardlessOfGeneration()
         {
             var svc = NewService();

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Services/AwardsCacheServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Services/AwardsCacheServiceTests.cs
@@ -234,6 +234,32 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
         }
 
         [Fact]
+        public void LoadFromDisk_DoesNotDowngradeNewerInMemoryIndex()
+        {
+            var svc = NewService();
+            // Drive the in-memory index to v2 with a distinctive award.
+            svc.ReplaceFrom(new[] { Row("Academy Awards", "First", true, 2024, imdb: "tt-new") });
+            svc.ReplaceFrom(new[] { Row("Academy Awards", "Second", true, 2024, imdb: "tt-new") });
+            Assert.Equal(2, svc.Version);
+
+            // Simulate an OLDER snapshot on disk (v1) with different data — as if LoadFromDisk read
+            // it before a concurrent rebuild published v2. Property names match the on-disk format.
+            var path = Path.Combine(_dir, "configurations", "Jellyfin.Plugin.JellyfinElevate", "awards-cache.json");
+            File.WriteAllText(
+                path,
+                "{\"SchemaVersion\":1,\"Version\":1,\"LastModified\":0,\"BuiltAtUtc\":null,"
+                + "\"ByImdb\":{\"tt-old\":[{\"ceremony\":\"Old\",\"category\":\"Old\",\"year\":2000,\"won\":true}]},"
+                + "\"ByTmdb\":{}}");
+
+            svc.LoadFromDisk();
+
+            // The newer in-memory index wins; the stale disk read is discarded.
+            Assert.Equal(2, svc.Version);
+            Assert.Empty(svc.LookupForItem(Movie(imdb: "tt-old")));
+            Assert.Single(svc.LookupForItem(Movie(imdb: "tt-new")));
+        }
+
+        [Fact]
         public void MissingYear_IsPreservedAsNull_AndSortsLast()
         {
             var svc = NewService();

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Services/WikidataAwardsProviderTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Services/WikidataAwardsProviderTests.cs
@@ -1,0 +1,126 @@
+using System.Collections.Generic;
+using System.Linq;
+using Jellyfin.Plugin.JellyfinElevate.Model.Awards;
+using Jellyfin.Plugin.JellyfinElevate.Services.Awards;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
+{
+    /// <summary>
+    /// No-network coverage for the Wikidata provider's pure parts: the SPARQL the wins/noms
+    /// templates emit, the parsing of a WDQS JSON result set, and the ceremony coverage (all
+    /// requested ceremonies present; festivals correctly wins-only).
+    /// </summary>
+    public sealed class WikidataAwardsProviderTests
+    {
+        [Fact]
+        public void BuildQuery_Wins_UsesAwardReceivedPredicate()
+        {
+            var q = WikidataAwardsProvider.BuildQuery("(wdt:P31 wd:Q19020)", "wd:Q11424 wd:Q5398426", won: true);
+            Assert.Contains("p:P166 ?st", q);
+            Assert.Contains("ps:P166 ?cat", q);
+            Assert.DoesNotContain("P1411", q);
+            Assert.Contains("(wdt:P31 wd:Q19020)", q);
+            Assert.Contains("wd:Q11424 wd:Q5398426", q);
+            // Must be matchable to a library item and take English labels.
+            Assert.Contains("FILTER(BOUND(?imdb) || BOUND(?tmdb))", q);
+            Assert.Contains("LANG(?category) = \"en\"", q);
+        }
+
+        [Fact]
+        public void BuildQuery_Nominations_UsesNominatedForPredicate()
+        {
+            var q = WikidataAwardsProvider.BuildQuery("(wdt:P361 wd:Q1044427)", "wd:Q5398426", won: false);
+            Assert.Contains("p:P1411 ?st", q);
+            Assert.Contains("ps:P1411 ?cat", q);
+            Assert.DoesNotContain("P166", q);
+        }
+
+        [Fact]
+        public void ParseInto_ExtractsIdsYearAndMediaType_AndSetsWonFlag()
+        {
+            const string json = """
+            {
+              "results": {
+                "bindings": [
+                  {
+                    "imdb": { "type": "literal", "value": "tt6710474" },
+                    "tmdb": { "type": "literal", "value": "545611" },
+                    "mediaType": { "type": "literal", "value": "movie" },
+                    "category": { "type": "literal", "value": "Academy Award for Best Picture" },
+                    "year": { "type": "literal", "value": "2023" }
+                  }
+                ]
+              }
+            }
+            """;
+
+            var sink = new List<AwardRow>();
+            WikidataAwardsProvider.ParseInto(json, "Academy Awards", won: true, sink);
+
+            var row = Assert.Single(sink);
+            Assert.Equal("tt6710474", row.ImdbId);
+            Assert.Equal("545611", row.TmdbId);
+            Assert.Equal("movie", row.MediaType);
+            Assert.Equal("Academy Awards", row.Ceremony);
+            Assert.Equal("Academy Award for Best Picture", row.Category);
+            Assert.Equal(2023, row.Year);
+            Assert.True(row.Won);
+        }
+
+        [Fact]
+        public void ParseInto_SkipsRowsWithNeitherId_AndToleratesMissingYear()
+        {
+            const string json = """
+            {
+              "results": {
+                "bindings": [
+                  { "category": { "type": "literal", "value": "Best Picture" } },
+                  {
+                    "tmdb": { "type": "literal", "value": "76331" },
+                    "mediaType": { "type": "literal", "value": "tv" },
+                    "category": { "type": "literal", "value": "Outstanding Drama Series" }
+                  }
+                ]
+              }
+            }
+            """;
+
+            var sink = new List<AwardRow>();
+            WikidataAwardsProvider.ParseInto(json, "Primetime Emmy Awards", won: false, sink);
+
+            var row = Assert.Single(sink); // the id-less row is dropped
+            Assert.Null(row.ImdbId);
+            Assert.Equal("76331", row.TmdbId);
+            Assert.Equal("tv", row.MediaType);
+            Assert.Null(row.Year); // missing year tolerated
+            Assert.False(row.Won);
+        }
+
+        [Fact]
+        public void Ceremonies_CoverRequestedSet_AndFestivalsAreWinsOnly()
+        {
+            var meta = WikidataAwardsProvider.CeremonyMetaForTest;
+            var names = meta.Select(m => m.Name).ToList();
+
+            foreach (var expected in new[]
+            {
+                "Academy Awards", "Golden Globe Awards", "BAFTA Awards",
+                "Cannes Film Festival", "Venice Film Festival", "Berlin International Film Festival",
+                "Screen Actors Guild Awards", "Critics' Choice Awards", "Primetime Emmy Awards",
+            })
+            {
+                Assert.Contains(expected, names);
+            }
+
+            // Film festivals don't record nominations in Wikidata → wins-only.
+            foreach (var festival in new[] { "Cannes Film Festival", "Venice Film Festival", "Berlin International Film Festival" })
+            {
+                Assert.False(meta.Single(m => m.Name == festival).Nominations, $"{festival} should be wins-only");
+            }
+
+            // A ceremony that does record nominations still runs both.
+            Assert.True(meta.Single(m => m.Name == "Academy Awards").Nominations);
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Services/WikidataAwardsProviderTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Services/WikidataAwardsProviderTests.cs
@@ -98,6 +98,27 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
         }
 
         [Fact]
+        public void ParseInto_MalformedSuccessResponse_Throws()
+        {
+            // A 200 with an error/proxy payload lacking results.bindings must be treated as a
+            // FAILURE, not an empty success — otherwise it would falsely count as a successful
+            // ceremony query and let a partial refresh publish as "complete".
+            var sink = new List<AwardRow>();
+            Assert.Throws<FormatException>(() =>
+                WikidataAwardsProvider.ParseInto("{\"results\":{}}", "Academy Awards", won: true, sink));
+            Assert.Throws<FormatException>(() =>
+                WikidataAwardsProvider.ParseInto("{}", "Academy Awards", won: true, sink));
+        }
+
+        [Fact]
+        public void ParseInto_EmptyBindings_IsValidZeroRows()
+        {
+            var sink = new List<AwardRow>();
+            WikidataAwardsProvider.ParseInto("{\"results\":{\"bindings\":[]}}", "Academy Awards", won: true, sink);
+            Assert.Empty(sink); // a legitimately empty result is success with zero rows, not a failure
+        }
+
+        [Fact]
         public void Ceremonies_CoverRequestedSet_AndFestivalsAreWinsOnly()
         {
             var meta = WikidataAwardsProvider.CeremonyMetaForTest;

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Snapshots/configpage-save-keys.json
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Snapshots/configpage-save-keys.json
@@ -192,6 +192,7 @@
   "ShowArrLinksAsText",
   "ShowAudioInfoTag",
   "ShowAudioLanguages",
+  "ShowAwards",
   "ShowCollectionsInSearch",
   "ShowDownloadsInRequests",
   "ShowDynamicRangeTag",

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Snapshots/public-config.default.anonymous.json
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Snapshots/public-config.default.anonymous.json
@@ -248,6 +248,7 @@
   "ShowArrLinksAsText": false,
   "ShowAudioInfoTag": true,
   "ShowAudioLanguages": true,
+  "ShowAwards": false,
   "ShowCollectionsInSearch": true,
   "ShowDownloadsInRequests": true,
   "ShowDynamicRangeTag": true,

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Snapshots/public-config.default.authenticated.json
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Snapshots/public-config.default.authenticated.json
@@ -248,6 +248,7 @@
   "ShowArrLinksAsText": false,
   "ShowAudioInfoTag": true,
   "ShowAudioLanguages": true,
+  "ShowAwards": false,
   "ShowCollectionsInSearch": true,
   "ShowDownloadsInRequests": true,
   "ShowDynamicRangeTag": true,

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Snapshots/public-config.distinctive.anonymous.json
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Snapshots/public-config.distinctive.anonymous.json
@@ -248,6 +248,7 @@
   "ShowArrLinksAsText": true,
   "ShowAudioInfoTag": false,
   "ShowAudioLanguages": false,
+  "ShowAwards": true,
   "ShowCollectionsInSearch": false,
   "ShowDownloadsInRequests": false,
   "ShowDynamicRangeTag": false,
@@ -265,8 +266,8 @@
   "ShowUserReviews": true,
   "ShowVideoCodecTag": false,
   "ShowWatchProgress": true,
-  "SourceTagOrder": 1219,
-  "SpecialFormatTagOrder": 1220,
+  "SourceTagOrder": 1220,
+  "SpecialFormatTagOrder": 1221,
   "SplashScreenImageUrl": "cfg-SplashScreenImageUrl",
   "SpoilerBlurEnabled": true,
   "SpoilerBlurStrictRefresh": true,
@@ -281,11 +282,11 @@
   "SpoilerStripTags": false,
   "SyncJellyseerrWatchlist": true,
   "TagCacheServerMode": false,
-  "TagsCacheTtlDays": 1246,
+  "TagsCacheTtlDays": 1247,
   "TagsHideOnHover": true,
   "ThemeSelectorEnabled": true,
   "TmdbEnabled": true,
-  "ToastDuration": 1249,
+  "ToastDuration": 1250,
   "UseIcons": false,
-  "VideoCodecTagOrder": 1252
+  "VideoCodecTagOrder": 1253
 }

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Snapshots/public-config.distinctive.authenticated.json
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Snapshots/public-config.distinctive.authenticated.json
@@ -248,6 +248,7 @@
   "ShowArrLinksAsText": true,
   "ShowAudioInfoTag": false,
   "ShowAudioLanguages": false,
+  "ShowAwards": true,
   "ShowCollectionsInSearch": false,
   "ShowDownloadsInRequests": false,
   "ShowDynamicRangeTag": false,
@@ -265,8 +266,8 @@
   "ShowUserReviews": true,
   "ShowVideoCodecTag": false,
   "ShowWatchProgress": true,
-  "SourceTagOrder": 1219,
-  "SpecialFormatTagOrder": 1220,
+  "SourceTagOrder": 1220,
+  "SpecialFormatTagOrder": 1221,
   "SplashScreenImageUrl": "cfg-SplashScreenImageUrl",
   "SpoilerBlurEnabled": true,
   "SpoilerBlurStrictRefresh": true,
@@ -281,11 +282,11 @@
   "SpoilerStripTags": false,
   "SyncJellyseerrWatchlist": true,
   "TagCacheServerMode": false,
-  "TagsCacheTtlDays": 1246,
+  "TagsCacheTtlDays": 1247,
   "TagsHideOnHover": true,
   "ThemeSelectorEnabled": true,
   "TmdbEnabled": true,
-  "ToastDuration": 1249,
+  "ToastDuration": 1250,
   "UseIcons": false,
-  "VideoCodecTagOrder": 1252
+  "VideoCodecTagOrder": 1253
 }

--- a/Jellyfin.Plugin.JellyfinElevate/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Configuration/PluginConfiguration.cs
@@ -75,6 +75,7 @@ namespace Jellyfin.Plugin.JellyfinElevate.Configuration
             HideReviewsFromHiddenUsers = true;
             HideReviewsFromDisabledUsers = true;
             ShowReleaseDates = false;
+            ShowAwards = false;
             ShowUserRatingOnPosters = false;
             ShowUserRatingDash = true;
             PauseScreenEnabled = true;
@@ -424,6 +425,15 @@ namespace Jellyfin.Plugin.JellyfinElevate.Configuration
         public bool HideReviewsFromHiddenUsers { get; set; } = true;
         public bool HideReviewsFromDisabledUsers { get; set; } = true;
         public bool ShowReleaseDates { get; set; }
+
+        /// <summary>
+        /// Show an "Awards" section (wins and nominations from Oscars, Golden Globes, BAFTA,
+        /// Cannes, Venice, Berlin, SAG, Critics' Choice and the Emmys) on movie and series
+        /// detail pages. The award data is a global index the server builds from Wikidata on
+        /// an infrequent scheduled refresh and looks up locally per item by IMDb/TMDb id, so
+        /// enabling this adds no per-item network cost at view time even on large libraries.
+        /// </summary>
+        public bool ShowAwards { get; set; }
         public bool ShowUserRatingOnPosters { get; set; } = false;
         /// <summary>
         /// When true (default), shows a "—" on poster cards for items the user hasn't rated yet.

--- a/Jellyfin.Plugin.JellyfinElevate/Configuration/SettingDescriptors.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Configuration/SettingDescriptors.cs
@@ -171,6 +171,7 @@ namespace Jellyfin.Plugin.JellyfinElevate.Configuration
                 Public("HideReviewsFromHiddenUsers", c => c.HideReviewsFromHiddenUsers),
                 Public("HideReviewsFromDisabledUsers", c => c.HideReviewsFromDisabledUsers),
                 Public("ShowReleaseDates", c => c.ShowReleaseDates),
+                Public("ShowAwards", c => c.ShowAwards),
                 Public("ShowUserRatingOnPosters", c => c.ShowUserRatingOnPosters),
                 Public("ShowUserRatingDash", c => c.ShowUserRatingDash),
                 PublicUser("PauseScreenEnabled", c => c.PauseScreenEnabled, nameof(UserSettings.PauseScreenEnabled)),

--- a/Jellyfin.Plugin.JellyfinElevate/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinElevate/Configuration/configPage.html
@@ -1982,6 +1982,16 @@
                     </fieldset>
 
                     <fieldset>
+                        <legend class="sectionTitle">Awards</legend>
+                        <div class="configSection">
+                            <div class="checkboxContainer je-main-feature"><label><input id="showAwards" data-config-key="ShowAwards" is="emby-checkbox" type="checkbox"/><span>Show Awards</span></label></div>
+                            <div class="je-setting-description" data-desc-for="showAwards">
+                                <div class="fieldDescription je-field-desc-sm-font-lg">Shows an Awards section on Movie and Series detail pages listing wins and nominations from the Oscars, Golden Globes, BAFTA, Cannes, Venice, Berlin, Screen Actors Guild, Critics' Choice and the Emmys. No API key required — the data comes from Wikidata (open data). The server builds one global award index on an infrequent scheduled refresh ("Build Awards Cache" under Scheduled Tasks) and matches each item locally by its IMDb/TMDb id, so this adds no per-item network requests at view time, even on large libraries. Run "Build Awards Cache" once after enabling to populate the initial index.</div>
+                            </div>
+                        </div>
+                    </fieldset>
+
+                    <fieldset>
                         <legend class="sectionTitle">User Reviews</legend>
                         <div class="configSection">
                             <div class="je-info-banner-inline je-banner-managed">

--- a/Jellyfin.Plugin.JellyfinElevate/Controllers/AwardsController.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Controllers/AwardsController.cs
@@ -66,6 +66,9 @@ namespace Jellyfin.Plugin.JellyfinElevate.Controllers
                 return response;
             }
 
+            // From here we read a single consistent index snapshot (GetAwardsView) so version,
+            // emptiness and awards can't disagree if a rebuild publishes mid-request.
+
             // Resolve the item in the CALLER's scope (CSCTRL-4): the user-scoped GetItemById
             // overload only returns items in libraries the caller can access, so a non-admin
             // can't confirm the existence of — or read awards for — items outside their view.
@@ -88,7 +91,10 @@ namespace Jellyfin.Plugin.JellyfinElevate.Controllers
                 return response;
             }
 
-            response.Awards = _awardsCache.LookupForItem(item);
+            var view = _awardsCache.GetAwardsView(item);
+            response.Version = view.Version;
+            response.IndexEmpty = view.IsEmpty;
+            response.Awards = view.Awards;
             return response;
         }
     }

--- a/Jellyfin.Plugin.JellyfinElevate/Controllers/AwardsController.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Controllers/AwardsController.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Net.Http;
 using Jellyfin.Plugin.JellyfinElevate.Configuration;
+using Jellyfin.Plugin.JellyfinElevate.Helpers;
 using Jellyfin.Plugin.JellyfinElevate.Model.Awards;
 using Jellyfin.Plugin.JellyfinElevate.Services;
 using Jellyfin.Plugin.JellyfinElevate.Services.Awards;
 using Jellyfin.Plugin.JellyfinElevate.Services.Jellyseerr;
+using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -64,7 +66,23 @@ namespace Jellyfin.Plugin.JellyfinElevate.Controllers
                 return response;
             }
 
-            var item = _libraryManager.GetItemById(itemId);
+            // Resolve the item in the CALLER's scope (CSCTRL-4): the user-scoped GetItemById
+            // overload only returns items in libraries the caller can access, so a non-admin
+            // can't confirm the existence of — or read awards for — items outside their view.
+            // Fail closed when the principal carries no resolvable user id.
+            var userId = UserHelper.GetCurrentUserId(User);
+            if (!userId.HasValue)
+            {
+                return response;
+            }
+
+            var user = _userManager.GetUserById(userId.Value);
+            if (user == null)
+            {
+                return response;
+            }
+
+            var item = _libraryManager.GetItemById<BaseItem>(itemId, user);
             if (item == null)
             {
                 return response;

--- a/Jellyfin.Plugin.JellyfinElevate/Controllers/AwardsController.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Controllers/AwardsController.cs
@@ -58,7 +58,8 @@ namespace Jellyfin.Plugin.JellyfinElevate.Controllers
             {
                 Enabled = enabled,
                 Version = _awardsCache.Version,
-                IndexEmpty = _awardsCache.IsEmpty
+                IndexEmpty = _awardsCache.IsEmpty,
+                IndexComplete = _awardsCache.IsComplete
             };
 
             if (!enabled || itemId == Guid.Empty)
@@ -94,6 +95,7 @@ namespace Jellyfin.Plugin.JellyfinElevate.Controllers
             var view = _awardsCache.GetAwardsView(item);
             response.Version = view.Version;
             response.IndexEmpty = view.IsEmpty;
+            response.IndexComplete = view.Complete;
             response.Awards = view.Awards;
             return response;
         }

--- a/Jellyfin.Plugin.JellyfinElevate/Controllers/AwardsController.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Controllers/AwardsController.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Net.Http;
+using Jellyfin.Plugin.JellyfinElevate.Configuration;
+using Jellyfin.Plugin.JellyfinElevate.Model.Awards;
+using Jellyfin.Plugin.JellyfinElevate.Services;
+using Jellyfin.Plugin.JellyfinElevate.Services.Awards;
+using Jellyfin.Plugin.JellyfinElevate.Services.Jellyseerr;
+using MediaBrowser.Controller.Library;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.JellyfinElevate.Controllers
+{
+    /// <summary>
+    /// Serves the awards for a single item out of the server-side awards index. This never
+    /// fetches from an external source at request time — it resolves the item's IMDb/TMDb
+    /// provider ids and does an in-memory lookup against the index built by
+    /// <c>BuildAwardsCacheTask</c>. That is what lets the feature scale: the per-view cost is
+    /// one dictionary lookup regardless of library size.
+    /// </summary>
+    [Route("JellyfinElevate")]
+    [ApiController]
+    public sealed class AwardsController : JellyfinElevateControllerBase
+    {
+        private readonly ILibraryManager _libraryManager;
+        private readonly AwardsCacheService _awardsCache;
+
+        public AwardsController(
+            IHttpClientFactory httpClientFactory,
+            ILogger<AwardsController> logger,
+            IUserManager userManager,
+            ISeerrCache seerrCache,
+            IPluginConfigProvider configProvider,
+            ILibraryManager libraryManager,
+            AwardsCacheService awardsCache)
+            : base(httpClientFactory, logger, userManager, seerrCache, configProvider)
+        {
+            _libraryManager = libraryManager;
+            _awardsCache = awardsCache;
+        }
+
+        /// <summary>
+        /// Awards for the given library item. Returns an empty award list (not an error) when
+        /// the feature is disabled, the item is unknown, or the item simply has no tracked
+        /// awards, so the client can render nothing without treating any of those as failures.
+        /// </summary>
+        [HttpGet("awards/{itemId}")]
+        [Authorize]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        public ActionResult<ItemAwardsResponse> GetItemAwards(Guid itemId)
+        {
+            var enabled = _configProvider.ConfigurationOrNull?.ShowAwards == true;
+            var response = new ItemAwardsResponse
+            {
+                Enabled = enabled,
+                Version = _awardsCache.Version,
+                IndexEmpty = _awardsCache.IsEmpty
+            };
+
+            if (!enabled || itemId == Guid.Empty)
+            {
+                return response;
+            }
+
+            var item = _libraryManager.GetItemById(itemId);
+            if (item == null)
+            {
+                return response;
+            }
+
+            response.Awards = _awardsCache.LookupForItem(item);
+            return response;
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinElevate/Helpers/PluginHttpClients.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Helpers/PluginHttpClients.cs
@@ -36,6 +36,13 @@ namespace Jellyfin.Plugin.JellyfinElevate.Helpers
         /// </summary>
         public const string AssetsClient = "JellyfinElevateAssets";
 
+        /// <summary>
+        /// Wikidata Query Service client (query.wikidata.org) — the awards data source. The
+        /// host is hardcoded and no credentials travel on these requests; Wikidata's policy
+        /// requires a descriptive User-Agent, which the caller attaches per request.
+        /// </summary>
+        public const string WikidataClient = "JellyfinElevateWikidata";
+
         public static HttpClient CreateArrClient(IHttpClientFactory factory)
         {
             // Same fallback pattern as SeerrHttpHelper.CreateClient: if the named
@@ -61,6 +68,20 @@ namespace Jellyfin.Plugin.JellyfinElevate.Helpers
             try { client = factory.CreateClient(AssetsClient); }
             catch { client = factory.CreateClient(); }
             client.Timeout = System.TimeSpan.FromSeconds(30);
+            return client;
+        }
+
+        /// <summary>
+        /// Wikidata Query Service client with a 120-second deadline (instance-scoped, per the
+        /// hygiene rules above): SPARQL aggregate queries over the awards graph are legitimately
+        /// slow, but must never pin a thread indefinitely on a hung endpoint.
+        /// </summary>
+        public static HttpClient CreateWikidataClient(IHttpClientFactory factory)
+        {
+            HttpClient client;
+            try { client = factory.CreateClient(WikidataClient); }
+            catch { client = factory.CreateClient(); }
+            client.Timeout = System.TimeSpan.FromSeconds(120);
             return client;
         }
 

--- a/Jellyfin.Plugin.JellyfinElevate/Model/Awards/AwardEntry.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Model/Awards/AwardEntry.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+
+namespace Jellyfin.Plugin.JellyfinElevate.Model.Awards
+{
+    /// <summary>
+    /// A single award a title received or was nominated for — the unit stored in the
+    /// awards index and returned to the client. Ceremony/Category are human-readable
+    /// English labels sourced from Wikidata (e.g. "Academy Awards" / "Best Picture").
+    /// Deliberately small: the global index holds tens of thousands of these, so it
+    /// avoids per-entry ids/urls the client never needs.
+    /// </summary>
+    public sealed class AwardEntry
+    {
+        /// <summary>The awarding body/ceremony, e.g. "Academy Awards", "Golden Globe Awards".</summary>
+        [JsonPropertyName("ceremony")]
+        public string Ceremony { get; set; } = string.Empty;
+
+        /// <summary>The award category, e.g. "Best Picture", "Best Actor".</summary>
+        [JsonPropertyName("category")]
+        public string Category { get; set; } = string.Empty;
+
+        /// <summary>Ceremony year (year the award was given), when Wikidata records it.</summary>
+        [JsonPropertyName("year")]
+        public int? Year { get; set; }
+
+        /// <summary>True for a win; false for a nomination.</summary>
+        [JsonPropertyName("won")]
+        public bool Won { get; set; }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinElevate/Model/Awards/AwardRow.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Model/Awards/AwardRow.cs
@@ -1,0 +1,32 @@
+namespace Jellyfin.Plugin.JellyfinElevate.Model.Awards
+{
+    /// <summary>
+    /// A flat award record as produced by an <c>IAwardsProvider</c> before it is grouped
+    /// into the per-title index. Each row identifies a title by whatever external ids the
+    /// source exposed (IMDb and/or TMDb) plus one award result. The cache service groups
+    /// rows by title and deduplicates them; providers only need to emit rows.
+    /// </summary>
+    public sealed class AwardRow
+    {
+        /// <summary>IMDb id including the "tt" prefix (e.g. "tt6710474"), or null.</summary>
+        public string? ImdbId { get; set; }
+
+        /// <summary>TMDb numeric id as a string (e.g. "545611"), or null.</summary>
+        public string? TmdbId { get; set; }
+
+        /// <summary>"movie" or "tv" — selects which TMDb id namespace <see cref="TmdbId"/> lives in.</summary>
+        public string MediaType { get; set; } = "movie";
+
+        /// <summary>The awarding body/ceremony label.</summary>
+        public string Ceremony { get; set; } = string.Empty;
+
+        /// <summary>The award category label.</summary>
+        public string Category { get; set; } = string.Empty;
+
+        /// <summary>Ceremony year, when known.</summary>
+        public int? Year { get; set; }
+
+        /// <summary>True for a win; false for a nomination.</summary>
+        public bool Won { get; set; }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinElevate/Model/Awards/AwardsView.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Model/Awards/AwardsView.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.JellyfinElevate.Model.Awards
+{
+    /// <summary>
+    /// A mutually-consistent read of the awards index for one item: the index version, whether the
+    /// index has never been built, and the item's awards — all taken from the same snapshot, so a
+    /// concurrent rebuild can never make these three disagree (e.g. "empty" while carrying awards).
+    /// </summary>
+    public sealed record AwardsView(long Version, bool IsEmpty, IReadOnlyList<AwardEntry> Awards);
+}

--- a/Jellyfin.Plugin.JellyfinElevate/Model/Awards/AwardsView.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Model/Awards/AwardsView.cs
@@ -4,8 +4,11 @@ namespace Jellyfin.Plugin.JellyfinElevate.Model.Awards
 {
     /// <summary>
     /// A mutually-consistent read of the awards index for one item: the index version, whether the
-    /// index has never been built, and the item's awards — all taken from the same snapshot, so a
-    /// concurrent rebuild can never make these three disagree (e.g. "empty" while carrying awards).
+    /// index has never been built, whether the current snapshot came from a fully successful fetch,
+    /// and the item's awards — all taken from the same snapshot, so a concurrent rebuild can never
+    /// make these disagree (e.g. "empty" while carrying awards). <see cref="Complete"/> lets the
+    /// client distinguish a genuine "no awards" (complete index) from "not fetched yet" (a partial
+    /// index that may be missing this item's ceremony).
     /// </summary>
-    public sealed record AwardsView(long Version, bool IsEmpty, IReadOnlyList<AwardEntry> Awards);
+    public sealed record AwardsView(long Version, bool IsEmpty, bool Complete, IReadOnlyList<AwardEntry> Awards);
 }

--- a/Jellyfin.Plugin.JellyfinElevate/Model/Awards/ItemAwardsResponse.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Model/Awards/ItemAwardsResponse.cs
@@ -28,6 +28,14 @@ namespace Jellyfin.Plugin.JellyfinElevate.Model.Awards
         [JsonPropertyName("indexEmpty")]
         public bool IndexEmpty { get; set; }
 
+        /// <summary>
+        /// True when the current index came from a fully successful fetch. When false (a partial
+        /// index, e.g. one ceremony query failed on first install), an empty award list means
+        /// "not fetched yet", not "no awards" — the client keeps retrying rather than caching it.
+        /// </summary>
+        [JsonPropertyName("indexComplete")]
+        public bool IndexComplete { get; set; }
+
         /// <summary>Awards for this item, most recent first. Empty when the item has none.</summary>
         [JsonPropertyName("awards")]
         public IReadOnlyList<AwardEntry> Awards { get; set; } = System.Array.Empty<AwardEntry>();

--- a/Jellyfin.Plugin.JellyfinElevate/Model/Awards/ItemAwardsResponse.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Model/Awards/ItemAwardsResponse.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Jellyfin.Plugin.JellyfinElevate.Model.Awards
+{
+    /// <summary>
+    /// The awards payload returned to the client for a single item. The client renders
+    /// the section only when <see cref="Enabled"/> is true and <see cref="Awards"/> is
+    /// non-empty; <see cref="Version"/> lets the client cache per index build.
+    /// </summary>
+    public sealed class ItemAwardsResponse
+    {
+        /// <summary>Whether the Awards feature is enabled by the admin.</summary>
+        [JsonPropertyName("enabled")]
+        public bool Enabled { get; set; }
+
+        /// <summary>
+        /// Version of the awards index this response was served from. Monotonic per rebuild,
+        /// so the client can key a local cache on it and drop stale entries after a refresh.
+        /// </summary>
+        [JsonPropertyName("version")]
+        public long Version { get; set; }
+
+        /// <summary>
+        /// True when the server has never built the index yet (first install before the
+        /// scheduled task ran). The client treats this as "not ready" rather than "no awards".
+        /// </summary>
+        [JsonPropertyName("indexEmpty")]
+        public bool IndexEmpty { get; set; }
+
+        /// <summary>Awards for this item, most recent first. Empty when the item has none.</summary>
+        [JsonPropertyName("awards")]
+        public IReadOnlyList<AwardEntry> Awards { get; set; } = System.Array.Empty<AwardEntry>();
+    }
+}

--- a/Jellyfin.Plugin.JellyfinElevate/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/PluginServiceRegistrator.cs
@@ -50,6 +50,9 @@ namespace Jellyfin.Plugin.JellyfinElevate
                 .ConfigurePrimaryHttpMessageHandler(() => Helpers.ArrUrlGuard.CreateGuardedHandler(allowAutoRedirect: true));
             serviceCollection.AddHttpClient(Helpers.PluginHttpClients.TmdbClient);
             serviceCollection.AddHttpClient(Helpers.PluginHttpClients.AssetsClient);
+            // Wikidata Query Service (query.wikidata.org) — the awards data source. Hardcoded
+            // allowlisted host, no credentials; default handler like the TMDB/assets clients.
+            serviceCollection.AddHttpClient(Helpers.PluginHttpClients.WikidataClient);
             // Dedicated JellyfinElevate_*.log sink (a documented product feature)
             // plus a closed-generic ILogger<T> registration for every plugin type.
             // Each FileForwardingLogger<T> writes the file AND forwards to the host
@@ -115,6 +118,13 @@ namespace Jellyfin.Plugin.JellyfinElevate
             serviceCollection.AddSingleton<SeerrScanTriggerService>();
             serviceCollection.AddSingleton<TagCacheService>();
             serviceCollection.AddSingleton<TagCacheMonitor>();
+            // Awards index: a global, disk-persisted map of award-winning/nominated titles the
+            // client looks up per item with no per-view network cost. The provider does the bulk
+            // Wikidata fetch; the cache service holds/persists the index; the build task refreshes
+            // it on an infrequent cadence. Provider is HttpClient-backed, hence a singleton.
+            serviceCollection.AddSingleton<Services.Awards.AwardsCacheService>();
+            serviceCollection.AddSingleton<Services.Awards.IAwardsProvider, Services.Awards.WikidataAwardsProvider>();
+            serviceCollection.AddTransient<BuildAwardsCacheTask>();
             serviceCollection.AddTransient<ArrTagsSyncTask>();
             serviceCollection.AddTransient<BuildTagCacheTask>();
             serviceCollection.AddTransient<JellyseerrWatchlistSyncTask>();

--- a/Jellyfin.Plugin.JellyfinElevate/ScheduledTasks/BuildAwardsCacheTask.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/ScheduledTasks/BuildAwardsCacheTask.cs
@@ -75,31 +75,22 @@ namespace Jellyfin.Plugin.JellyfinElevate.ScheduledTasks
                 return;
             }
 
-            if (result.Rows.Count == 0)
-            {
-                _logger.LogWarning("[Awards] Provider returned no rows; keeping the existing index rather than clearing it.");
-                progress?.Report(100);
-                return;
-            }
-
-            // A partial fetch (some ceremony queries failed) must not overwrite an existing
-            // complete index — that would erase the failed ceremonies' awards until a later full
-            // run. Only publish a partial result when there is no index yet (first install),
-            // where partial data still beats an empty section.
-            if (!result.Complete && !_cache.IsEmpty)
-            {
-                _logger.LogWarning(
-                    "[Awards] Refresh was partial (some ceremony queries failed); keeping the existing complete index of {Titles} titles.",
-                    _cache.TitleCount);
-                progress?.Report(100);
-                return;
-            }
-
-            _cache.ReplaceFrom(result.Rows);
+            // TryReplaceFrom decides publication atomically: a complete run always publishes; a
+            // partial run (some ceremony queries failed) publishes only when the index is still
+            // empty (first install), never over an existing complete index — so a single timed-out
+            // query can't erase that ceremony's awards, and it can't race the startup build.
+            var published = _cache.TryReplaceFrom(result.Rows, result.Complete);
             progress?.Report(100);
-            _logger.LogInformation(
-                "[Awards] Awards cache build complete ({Completeness}): {Titles} titles indexed.",
-                result.Complete ? "full" : "partial first build", _cache.TitleCount);
+            if (published)
+            {
+                _logger.LogInformation(
+                    "[Awards] Awards cache build complete ({Completeness}): {Titles} titles indexed.",
+                    result.Complete ? "full" : "partial first build", _cache.TitleCount);
+            }
+            else
+            {
+                _logger.LogWarning("[Awards] Refresh not published (empty or partial over an existing index); kept the existing index.");
+            }
         }
     }
 }

--- a/Jellyfin.Plugin.JellyfinElevate/ScheduledTasks/BuildAwardsCacheTask.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/ScheduledTasks/BuildAwardsCacheTask.cs
@@ -57,10 +57,10 @@ namespace Jellyfin.Plugin.JellyfinElevate.ScheduledTasks
             _logger.LogInformation("[Awards] Building awards cache from provider...");
             progress?.Report(0);
 
-            IReadOnlyList<Model.Awards.AwardRow> rows;
+            Services.Awards.AwardsFetchResult result;
             try
             {
-                rows = await _provider.FetchAllAsync(progress, cancellationToken).ConfigureAwait(false);
+                result = await _provider.FetchAllAsync(progress, cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
@@ -75,16 +75,31 @@ namespace Jellyfin.Plugin.JellyfinElevate.ScheduledTasks
                 return;
             }
 
-            if (rows.Count == 0)
+            if (result.Rows.Count == 0)
             {
                 _logger.LogWarning("[Awards] Provider returned no rows; keeping the existing index rather than clearing it.");
                 progress?.Report(100);
                 return;
             }
 
-            _cache.ReplaceFrom(rows);
+            // A partial fetch (some ceremony queries failed) must not overwrite an existing
+            // complete index — that would erase the failed ceremonies' awards until a later full
+            // run. Only publish a partial result when there is no index yet (first install),
+            // where partial data still beats an empty section.
+            if (!result.Complete && !_cache.IsEmpty)
+            {
+                _logger.LogWarning(
+                    "[Awards] Refresh was partial (some ceremony queries failed); keeping the existing complete index of {Titles} titles.",
+                    _cache.TitleCount);
+                progress?.Report(100);
+                return;
+            }
+
+            _cache.ReplaceFrom(result.Rows);
             progress?.Report(100);
-            _logger.LogInformation("[Awards] Awards cache build complete: {Titles} titles indexed.", _cache.TitleCount);
+            _logger.LogInformation(
+                "[Awards] Awards cache build complete ({Completeness}): {Titles} titles indexed.",
+                result.Complete ? "full" : "partial first build", _cache.TitleCount);
         }
     }
 }

--- a/Jellyfin.Plugin.JellyfinElevate/ScheduledTasks/BuildAwardsCacheTask.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/ScheduledTasks/BuildAwardsCacheTask.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinElevate.Services.Awards;
+using MediaBrowser.Model.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.JellyfinElevate.ScheduledTasks
+{
+    /// <summary>
+    /// Rebuilds the global awards index from the awards provider (Wikidata). Runs on an
+    /// infrequent cadence — every 7 days by default — because award data changes rarely
+    /// (a handful of new results per ceremony each year). There is deliberately NO startup
+    /// trigger: the index is loaded from disk on startup and only built there if it has
+    /// never been populated, so restarting the server never re-fetches. Admins can retune
+    /// the cadence or run it manually from Jellyfin's Scheduled Tasks dashboard.
+    ///
+    /// The whole run is one bounded set of bulk queries independent of library size, so it
+    /// costs the same for a 200-title library as for a 15,000-title one.
+    /// </summary>
+    public sealed class BuildAwardsCacheTask : IScheduledTask
+    {
+        private readonly IAwardsProvider _provider;
+        private readonly AwardsCacheService _cache;
+        private readonly ILogger<BuildAwardsCacheTask> _logger;
+
+        public BuildAwardsCacheTask(IAwardsProvider provider, AwardsCacheService cache, ILogger<BuildAwardsCacheTask> logger)
+        {
+            _provider = provider;
+            _cache = cache;
+            _logger = logger;
+        }
+
+        public string Name => "Build Awards Cache";
+
+        public string Key => "JellyfinElevateBuildAwardsCache";
+
+        public string Description => "Rebuilds the awards index (wins and nominations from the Oscars, Golden Globes, BAFTA, Cannes, Venice, Berlin, SAG, Critics' Choice and the Emmys) from Wikidata. One bulk fetch, independent of library size, matched to items locally by IMDb/TMDb id. Runs weekly; run it manually once after enabling the Awards feature.";
+
+        public string Category => "Jellyfin Elevate";
+
+        public IEnumerable<TaskTriggerInfo> GetDefaultTriggers()
+        {
+            return new[]
+            {
+                new TaskTriggerInfo
+                {
+                    Type = TaskTriggerInfoType.IntervalTrigger,
+                    IntervalTicks = TimeSpan.FromDays(7).Ticks
+                }
+            };
+        }
+
+        public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("[Awards] Building awards cache from provider...");
+            progress?.Report(0);
+
+            IReadOnlyList<Model.Awards.AwardRow> rows;
+            try
+            {
+                rows = await _provider.FetchAllAsync(progress, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // Keep the previous (disk-loaded) index rather than wiping it on a transient
+                // fetch failure — a stale index is far better than an empty one.
+                _logger.LogError("[Awards] Awards fetch failed; keeping the existing index. {Message}", ex.Message);
+                progress?.Report(100);
+                return;
+            }
+
+            if (rows.Count == 0)
+            {
+                _logger.LogWarning("[Awards] Provider returned no rows; keeping the existing index rather than clearing it.");
+                progress?.Report(100);
+                return;
+            }
+
+            _cache.ReplaceFrom(rows);
+            progress?.Report(100);
+            _logger.LogInformation("[Awards] Awards cache build complete: {Titles} titles indexed.", _cache.TitleCount);
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinElevate/ScheduledTasks/BuildAwardsCacheTask.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/ScheduledTasks/BuildAwardsCacheTask.cs
@@ -57,6 +57,10 @@ namespace Jellyfin.Plugin.JellyfinElevate.ScheduledTasks
             _logger.LogInformation("[Awards] Building awards cache from provider...");
             progress?.Report(0);
 
+            // Reserve the refresh generation BEFORE fetching so start-order (not completion-order)
+            // decides which of two concurrent refreshes wins on publish.
+            var generation = _cache.NextRefreshGeneration();
+
             Services.Awards.AwardsFetchResult result;
             try
             {
@@ -79,7 +83,7 @@ namespace Jellyfin.Plugin.JellyfinElevate.ScheduledTasks
             // partial run (some ceremony queries failed) publishes only when the index is still
             // empty (first install), never over an existing complete index — so a single timed-out
             // query can't erase that ceremony's awards, and it can't race the startup build.
-            var published = _cache.TryReplaceFrom(result.Rows, result.Complete);
+            var published = _cache.TryReplaceFrom(result.Rows, result.Complete, generation);
             progress?.Report(100);
             if (published)
             {

--- a/Jellyfin.Plugin.JellyfinElevate/Services/Awards/AwardsCacheService.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/Awards/AwardsCacheService.cs
@@ -201,13 +201,23 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
         /// newest-first. Empty when the item has no tracked awards or no external id.
         /// </summary>
         public IReadOnlyList<AwardEntry> LookupForItem(BaseItem item)
-        {
-            if (item == null)
-            {
-                return Array.Empty<AwardEntry>();
-            }
+            => item == null ? Array.Empty<AwardEntry>() : LookupInIndex(_index, item);
 
-            var index = _index;
+        /// <summary>
+        /// The item's awards together with the version and emptiness of the SAME index snapshot,
+        /// read once. This keeps the three values mutually consistent even if a rebuild publishes
+        /// mid-request — the response can't claim the index is empty while also carrying awards.
+        /// </summary>
+        public AwardsView GetAwardsView(BaseItem item)
+        {
+            var index = _index; // single consistent snapshot
+            var isEmpty = index.Version == 0 && index.ByImdb.Count == 0 && index.ByTmdb.Count == 0;
+            var awards = item == null ? Array.Empty<AwardEntry>() : LookupInIndex(index, item);
+            return new AwardsView(index.Version, isEmpty, awards);
+        }
+
+        private static IReadOnlyList<AwardEntry> LookupInIndex(AwardsIndex index, BaseItem item)
+        {
             List<AwardEntry>? merged = null;
 
             var imdb = NormalizeImdb(item.GetProviderId(MetadataProvider.Imdb));

--- a/Jellyfin.Plugin.JellyfinElevate/Services/Awards/AwardsCacheService.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/Awards/AwardsCacheService.cs
@@ -43,6 +43,12 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
         // volatile snapshot reference directly.
         private readonly object _rebuildLock = new();
 
+        // Monotonic refresh generation: a caller stamps its refresh with NextRefreshGeneration()
+        // BEFORE fetching, so a slower older-started refresh that finishes late can be rejected in
+        // favor of a newer one — publication order follows freshness, not completion order.
+        private long _generationCounter;
+        private long _lastPublishedGeneration;
+
         private volatile AwardsIndex _index = AwardsIndex.Empty;
 
         public AwardsCacheService(IApplicationPaths applicationPaths, ILogger<AwardsCacheService> logger)
@@ -74,18 +80,35 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
         /// complete index; this primitive is for callers that always want to publish.
         /// </summary>
         public void ReplaceFrom(IReadOnlyCollection<AwardRow> rows)
-            => TryReplaceFrom(rows, complete: true);
+            => TryReplaceFrom(rows, complete: true, NextRefreshGeneration());
+
+        /// <summary>
+        /// Reserve a monotonic refresh generation. A refresh caller calls this BEFORE it starts
+        /// fetching, then passes the value to <see cref="TryReplaceFrom(IReadOnlyCollection{AwardRow}, bool, long)"/>,
+        /// so an older-started refresh that finishes after a newer one is rejected rather than
+        /// republishing older data.
+        /// </summary>
+        public long NextRefreshGeneration() => Interlocked.Increment(ref _generationCounter);
+
+        /// <summary>
+        /// Convenience overload that reserves a fresh generation at call time (for callers that
+        /// publish immediately and don't span a long fetch, e.g. tests).
+        /// </summary>
+        public bool TryReplaceFrom(IReadOnlyCollection<AwardRow> rows, bool complete)
+            => TryReplaceFrom(rows, complete, NextRefreshGeneration());
 
         /// <summary>
         /// Publish a fresh index, but only when it is safe to do so. Returns true if published.
         /// A <paramref name="complete"/> run always publishes; a PARTIAL run publishes only when
         /// the index is currently empty (first install) — never over an existing populated index,
-        /// so a single failed ceremony query can't erase that ceremony's awards. The
-        /// currently-empty check and the swap happen under one lock, so a slow startup fetch and
-        /// a concurrent manual refresh can't race to downgrade a complete index to partial.
-        /// An empty row set never publishes.
+        /// so a single failed ceremony query can't erase that ceremony's awards. A publication
+        /// whose <paramref name="generation"/> is not newer than the last published one is also
+        /// rejected, so an older-started refresh can't overwrite a newer one. The generation check,
+        /// the currently-empty check, the version bump and the swap+persist all happen under one
+        /// lock, so concurrent startup/manual/scheduled refreshes can't race. An empty row set
+        /// never publishes.
         /// </summary>
-        public bool TryReplaceFrom(IReadOnlyCollection<AwardRow> rows, bool complete)
+        public bool TryReplaceFrom(IReadOnlyCollection<AwardRow> rows, bool complete, long generation)
         {
             ArgumentNullException.ThrowIfNull(rows);
 
@@ -133,6 +156,14 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
             AwardsIndex next;
             lock (_rebuildLock)
             {
+                if (generation <= _lastPublishedGeneration)
+                {
+                    _logger.LogWarning(
+                        "[Awards] Rejected a stale refresh (generation {Gen} <= last published {Last}); a newer refresh already won.",
+                        generation, _lastPublishedGeneration);
+                    return false;
+                }
+
                 var currentlyEmpty = _index.Version == 0 && _index.ByImdb.Count == 0 && _index.ByTmdb.Count == 0;
                 if (!complete && !currentlyEmpty)
                 {
@@ -152,6 +183,7 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
                 };
 
                 _index = next;
+                _lastPublishedGeneration = generation;
 
                 _logger.LogInformation(
                     "[Awards] Rebuilt index v{Version} ({Completeness}): {Titles} titles by IMDb, {TmdbTitles} by TMDb.",

--- a/Jellyfin.Plugin.JellyfinElevate/Services/Awards/AwardsCacheService.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/Awards/AwardsCacheService.cs
@@ -233,7 +233,7 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
                     return;
                 }
 
-                _index = new AwardsIndex
+                var loaded = new AwardsIndex
                 {
                     Version = data.Version,
                     LastModified = data.LastModified,
@@ -245,8 +245,25 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
                         ? new Dictionary<string, List<AwardEntry>>(data.ByTmdb, StringComparer.OrdinalIgnoreCase)
                         : new Dictionary<string, List<AwardEntry>>(StringComparer.OrdinalIgnoreCase)
                 };
-                _logger.LogInformation(
-                    "[Awards] Loaded {Titles} titles from disk (v{Version}).", _index.ByImdb.Count, _index.Version);
+
+                // Install under the rebuild lock and only if it's newer than what's in memory.
+                // If a manual refresh published a newer snapshot while this file read was in
+                // flight, the fresher in-memory index wins — a stale disk read never downgrades it.
+                lock (_rebuildLock)
+                {
+                    if (loaded.Version > _index.Version)
+                    {
+                        _index = loaded;
+                        _logger.LogInformation(
+                            "[Awards] Loaded {Titles} titles from disk (v{Version}).", loaded.ByImdb.Count, loaded.Version);
+                    }
+                    else
+                    {
+                        _logger.LogInformation(
+                            "[Awards] Disk cache v{OnDisk} is not newer than the in-memory index v{InMemory}; keeping memory.",
+                            loaded.Version, _index.Version);
+                    }
+                }
             }
             catch (Exception ex)
             {

--- a/Jellyfin.Plugin.JellyfinElevate/Services/Awards/AwardsCacheService.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/Awards/AwardsCacheService.cs
@@ -8,6 +8,7 @@ using Jellyfin.Plugin.JellyfinElevate.Configuration;
 using Jellyfin.Plugin.JellyfinElevate.Model.Awards;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Model.Entities;
 using Microsoft.Extensions.Logging;
@@ -229,6 +230,15 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
 
         private static IReadOnlyList<AwardEntry> LookupInIndex(AwardsIndex index, BaseItem item)
         {
+            // Awards are only tracked for Movies and Series. Restricting the lookup to those types
+            // also prevents a TMDb id-namespace collision: a Person/Episode/Season/MusicVideo TMDb
+            // id is a different namespace from a movie's and could numerically match an award-winning
+            // movie, which would otherwise surface that movie's awards on an unrelated page.
+            if (item is not Movie && item is not Series)
+            {
+                return Array.Empty<AwardEntry>();
+            }
+
             List<AwardEntry>? merged = null;
 
             var imdb = NormalizeImdb(item.GetProviderId(MetadataProvider.Imdb));

--- a/Jellyfin.Plugin.JellyfinElevate/Services/Awards/AwardsCacheService.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/Awards/AwardsCacheService.cs
@@ -1,0 +1,367 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using Jellyfin.Plugin.JellyfinElevate.Configuration;
+using Jellyfin.Plugin.JellyfinElevate.Model.Awards;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Model.Entities;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
+{
+    /// <summary>
+    /// Holds the global awards index — the set of every title that has won or been nominated
+    /// for a tracked award — keyed by external id (IMDb and TMDb) so a per-item lookup at view
+    /// time is an in-memory dictionary hit with no network call. This is what makes the feature
+    /// scale to large libraries: the index is fetched ONCE per infrequent scheduled refresh
+    /// (<c>BuildAwardsCacheTask</c>), not per item and not per page view.
+    ///
+    /// The index is an immutable snapshot swapped atomically: readers take the current reference
+    /// and read dictionaries that are never mutated after publication, so lookups need no lock.
+    /// A rebuild builds a fresh snapshot and swaps it in, then persists it to disk via
+    /// <see cref="AtomicFile"/>. On startup the last snapshot is loaded from disk, so a restart
+    /// never re-fetches from Wikidata.
+    /// </summary>
+    public sealed class AwardsCacheService
+    {
+        // Bump when the on-disk shape changes so an older cache is discarded and rebuilt
+        // instead of being deserialized into an incompatible structure.
+        private const int CurrentSchemaVersion = 1;
+
+        private readonly IApplicationPaths _applicationPaths;
+        private readonly ILogger<AwardsCacheService> _logger;
+        private readonly object _saveLock = new();
+
+        private volatile AwardsIndex _index = AwardsIndex.Empty;
+
+        public AwardsCacheService(IApplicationPaths applicationPaths, ILogger<AwardsCacheService> logger)
+        {
+            _applicationPaths = applicationPaths;
+            _logger = logger;
+        }
+
+        private string CacheFilePath =>
+            Path.Combine(_applicationPaths.PluginsPath, "configurations", "Jellyfin.Plugin.JellyfinElevate", "awards-cache.json");
+
+        /// <summary>Monotonic index version, bumped on every rebuild. 0 until the first build.</summary>
+        public long Version => _index.Version;
+
+        /// <summary>Unix-ms timestamp of the last rebuild.</summary>
+        public long LastModified => _index.LastModified;
+
+        /// <summary>Number of distinct titles carrying at least one award (by IMDb id).</summary>
+        public int TitleCount => _index.ByImdb.Count;
+
+        /// <summary>True until the first successful build/load — i.e. the index has never been populated.</summary>
+        public bool IsEmpty => _index.Version == 0 && _index.ByImdb.Count == 0 && _index.ByTmdb.Count == 0;
+
+        /// <summary>
+        /// Replace the whole index from a fresh set of provider rows. Groups rows by title,
+        /// deduplicates awards, sorts them (newest first, wins before nominations), bumps the
+        /// version, swaps the snapshot atomically, then persists to disk. A single title may be
+        /// reachable by both its IMDb and TMDb id.
+        /// </summary>
+        public void ReplaceFrom(IReadOnlyCollection<AwardRow> rows)
+        {
+            ArgumentNullException.ThrowIfNull(rows);
+
+            var byImdb = new Dictionary<string, List<AwardEntry>>(StringComparer.OrdinalIgnoreCase);
+            var byTmdb = new Dictionary<string, List<AwardEntry>>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var row in rows)
+            {
+                var entry = new AwardEntry
+                {
+                    Ceremony = row.Ceremony?.Trim() ?? string.Empty,
+                    Category = row.Category?.Trim() ?? string.Empty,
+                    Year = row.Year,
+                    Won = row.Won
+                };
+                if (entry.Ceremony.Length == 0 || entry.Category.Length == 0)
+                {
+                    continue;
+                }
+
+                var imdb = NormalizeImdb(row.ImdbId);
+                if (imdb != null)
+                {
+                    AddEntry(byImdb, imdb, entry);
+                }
+
+                var tmdbKey = NormalizeTmdbKey(row.TmdbId, row.MediaType);
+                if (tmdbKey != null)
+                {
+                    AddEntry(byTmdb, tmdbKey, entry);
+                }
+            }
+
+            DedupeAndSort(byImdb);
+            DedupeAndSort(byTmdb);
+
+            var next = new AwardsIndex
+            {
+                Version = _index.Version + 1,
+                LastModified = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                BuiltAtUtc = DateTime.UtcNow.ToString("O"),
+                ByImdb = byImdb,
+                ByTmdb = byTmdb
+            };
+
+            _index = next;
+            _logger.LogInformation(
+                "[Awards] Rebuilt index v{Version}: {Titles} titles by IMDb, {TmdbTitles} by TMDb.",
+                next.Version, byImdb.Count, byTmdb.Count);
+
+            SaveToDisk(next);
+        }
+
+        /// <summary>
+        /// Awards for a single item, resolved from its provider ids. Merges the IMDb-keyed and
+        /// TMDb-keyed lookups (a row may carry only one id), deduplicates, and returns them
+        /// newest-first. Empty when the item has no tracked awards or no external id.
+        /// </summary>
+        public IReadOnlyList<AwardEntry> LookupForItem(BaseItem item)
+        {
+            if (item == null)
+            {
+                return Array.Empty<AwardEntry>();
+            }
+
+            var index = _index;
+            List<AwardEntry>? merged = null;
+
+            var imdb = NormalizeImdb(item.GetProviderId(MetadataProvider.Imdb));
+            if (imdb != null && index.ByImdb.TryGetValue(imdb, out var byImdb))
+            {
+                merged = new List<AwardEntry>(byImdb);
+            }
+
+            var mediaType = item is Series ? "tv" : "movie";
+            var tmdbKey = NormalizeTmdbKey(item.GetProviderId(MetadataProvider.Tmdb), mediaType);
+            if (tmdbKey != null && index.ByTmdb.TryGetValue(tmdbKey, out var byTmdb))
+            {
+                if (merged == null)
+                {
+                    merged = new List<AwardEntry>(byTmdb);
+                }
+                else
+                {
+                    merged.AddRange(byTmdb);
+                }
+            }
+
+            if (merged == null || merged.Count == 0)
+            {
+                return Array.Empty<AwardEntry>();
+            }
+
+            return DedupeSorted(merged);
+        }
+
+        /// <summary>Load the last-built index from disk on startup. Leaves the index empty on any failure.</summary>
+        public void LoadFromDisk()
+        {
+            var path = CacheFilePath;
+            if (!File.Exists(path))
+            {
+                _logger.LogInformation("[Awards] No cache file found, starting empty.");
+                return;
+            }
+
+            try
+            {
+                var json = File.ReadAllText(path);
+                var data = JsonSerializer.Deserialize<AwardsCacheDiskFormat>(json);
+                if (data == null)
+                {
+                    return;
+                }
+
+                if (data.SchemaVersion != CurrentSchemaVersion)
+                {
+                    _logger.LogInformation(
+                        "[Awards] On-disk cache schema v{OnDisk} != current v{Current}; discarding and rebuilding on next refresh.",
+                        data.SchemaVersion, CurrentSchemaVersion);
+                    return;
+                }
+
+                _index = new AwardsIndex
+                {
+                    Version = data.Version,
+                    LastModified = data.LastModified,
+                    BuiltAtUtc = data.BuiltAtUtc,
+                    ByImdb = data.ByImdb != null
+                        ? new Dictionary<string, List<AwardEntry>>(data.ByImdb, StringComparer.OrdinalIgnoreCase)
+                        : new Dictionary<string, List<AwardEntry>>(StringComparer.OrdinalIgnoreCase),
+                    ByTmdb = data.ByTmdb != null
+                        ? new Dictionary<string, List<AwardEntry>>(data.ByTmdb, StringComparer.OrdinalIgnoreCase)
+                        : new Dictionary<string, List<AwardEntry>>(StringComparer.OrdinalIgnoreCase)
+                };
+                _logger.LogInformation(
+                    "[Awards] Loaded {Titles} titles from disk (v{Version}).", _index.ByImdb.Count, _index.Version);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning("[Awards] Failed to load cache from disk: {Message}", ex.Message);
+            }
+        }
+
+        private void SaveToDisk(AwardsIndex index)
+        {
+            lock (_saveLock)
+            {
+                try
+                {
+                    var dir = Path.GetDirectoryName(CacheFilePath);
+                    if (dir != null)
+                    {
+                        Directory.CreateDirectory(dir);
+                    }
+
+                    var data = new AwardsCacheDiskFormat
+                    {
+                        SchemaVersion = CurrentSchemaVersion,
+                        Version = index.Version,
+                        LastModified = index.LastModified,
+                        BuiltAtUtc = index.BuiltAtUtc,
+                        ByImdb = index.ByImdb,
+                        ByTmdb = index.ByTmdb
+                    };
+
+                    var json = JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = false });
+                    AtomicFile.WriteAllText(CacheFilePath, json);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning("[Awards] Failed to persist cache to disk: {Message}", ex.Message);
+                }
+            }
+        }
+
+        private static void AddEntry(Dictionary<string, List<AwardEntry>> map, string key, AwardEntry entry)
+        {
+            if (!map.TryGetValue(key, out var list))
+            {
+                list = new List<AwardEntry>();
+                map[key] = list;
+            }
+
+            list.Add(entry);
+        }
+
+        private static void DedupeAndSort(Dictionary<string, List<AwardEntry>> map)
+        {
+            foreach (var key in map.Keys.ToList())
+            {
+                map[key] = DedupeSorted(map[key]);
+            }
+        }
+
+        private static List<AwardEntry> DedupeSorted(IEnumerable<AwardEntry> entries)
+        {
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var result = new List<AwardEntry>();
+            foreach (var e in entries)
+            {
+                // Unit-separator delimited so distinct fields can't collide across boundaries.
+                var key = string.Join(
+                    '\u001f',
+                    e.Ceremony,
+                    e.Category,
+                    e.Year?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty,
+                    e.Won ? "1" : "0");
+                if (seen.Add(key))
+                {
+                    result.Add(e);
+                }
+            }
+
+            // Newest first; within a year wins before nominations; then ceremony/category for stability.
+            result.Sort((a, b) =>
+            {
+                var ay = a.Year ?? int.MinValue;
+                var by = b.Year ?? int.MinValue;
+                if (ay != by)
+                {
+                    return by.CompareTo(ay);
+                }
+
+                if (a.Won != b.Won)
+                {
+                    return a.Won ? -1 : 1;
+                }
+
+                var c = string.CompareOrdinal(a.Ceremony, b.Ceremony);
+                return c != 0 ? c : string.CompareOrdinal(a.Category, b.Category);
+            });
+
+            return result;
+        }
+
+        private static string? NormalizeImdb(string? imdb)
+        {
+            if (string.IsNullOrWhiteSpace(imdb))
+            {
+                return null;
+            }
+
+            var trimmed = imdb.Trim();
+            // Titles only ("tt…"); person ids ("nm…") are never a library item.
+            return trimmed.StartsWith("tt", StringComparison.OrdinalIgnoreCase) ? trimmed : null;
+        }
+
+        private static string? NormalizeTmdbKey(string? tmdbId, string? mediaType)
+        {
+            if (string.IsNullOrWhiteSpace(tmdbId))
+            {
+                return null;
+            }
+
+            var kind = string.Equals(mediaType, "tv", StringComparison.OrdinalIgnoreCase) ? "tv" : "movie";
+            return kind + ":" + tmdbId.Trim();
+        }
+
+        /// <summary>An immutable index snapshot. Dictionaries are never mutated after publication.</summary>
+        private sealed class AwardsIndex
+        {
+            public static readonly AwardsIndex Empty = new()
+            {
+                Version = 0,
+                LastModified = 0,
+                BuiltAtUtc = null,
+                ByImdb = new Dictionary<string, List<AwardEntry>>(StringComparer.OrdinalIgnoreCase),
+                ByTmdb = new Dictionary<string, List<AwardEntry>>(StringComparer.OrdinalIgnoreCase)
+            };
+
+            public long Version { get; init; }
+
+            public long LastModified { get; init; }
+
+            public string? BuiltAtUtc { get; init; }
+
+            public Dictionary<string, List<AwardEntry>> ByImdb { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+
+            public Dictionary<string, List<AwardEntry>> ByTmdb { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+        }
+
+        private sealed class AwardsCacheDiskFormat
+        {
+            public int SchemaVersion { get; set; }
+
+            public long Version { get; set; }
+
+            public long LastModified { get; set; }
+
+            public string? BuiltAtUtc { get; set; }
+
+            public Dictionary<string, List<AwardEntry>>? ByImdb { get; set; }
+
+            public Dictionary<string, List<AwardEntry>>? ByTmdb { get; set; }
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinElevate/Services/Awards/AwardsCacheService.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/Awards/AwardsCacheService.cs
@@ -79,6 +79,9 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
         /// <summary>True until the first successful build/load — i.e. the index has never been populated.</summary>
         public bool IsEmpty => _index.Version == 0 && _index.ByImdb.Count == 0 && _index.ByTmdb.Count == 0;
 
+        /// <summary>True when the current index came from a fully successful (all-ceremony) fetch.</summary>
+        public bool IsComplete => _index.Complete;
+
         /// <summary>
         /// Replace the whole index from a fresh set of provider rows, unconditionally. Groups
         /// rows by title, deduplicates awards, sorts them (newest first, wins before nominations),
@@ -247,7 +250,7 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
             var index = _index; // single consistent snapshot
             var isEmpty = index.Version == 0 && index.ByImdb.Count == 0 && index.ByTmdb.Count == 0;
             var awards = item == null ? Array.Empty<AwardEntry>() : LookupInIndex(index, item);
-            return new AwardsView(index.Version, isEmpty, awards);
+            return new AwardsView(index.Version, isEmpty, index.Complete, awards);
         }
 
         private static IReadOnlyList<AwardEntry> LookupInIndex(AwardsIndex index, BaseItem item)

--- a/Jellyfin.Plugin.JellyfinElevate/Services/Awards/AwardsCacheService.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/Awards/AwardsCacheService.cs
@@ -414,19 +414,36 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
             }
         }
 
+        private static string CategoryKey(AwardEntry e)
+            // Unit-separator delimited so distinct fields can't collide across boundaries.
+            => string.Join("\u001f", e.Ceremony, e.Category, e.Year?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty);
+
         private static List<AwardEntry> DedupeSorted(IEnumerable<AwardEntry> entries)
         {
+            var list = entries as ICollection<AwardEntry> ?? entries.ToList();
+
+            // Wikidata frequently records BOTH a win and a nomination for the same category/year
+            // (a win implies the nomination). Collapse those to just the win so the UI never shows
+            // e.g. "Best Sound Editing" as both won and nominated.
+            var wonKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var e in list)
+            {
+                if (e.Won)
+                {
+                    wonKeys.Add(CategoryKey(e));
+                }
+            }
+
             var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var result = new List<AwardEntry>();
-            foreach (var e in entries)
+            foreach (var e in list)
             {
-                // Unit-separator delimited so distinct fields can't collide across boundaries.
-                var key = string.Join(
-                    '\u001f',
-                    e.Ceremony,
-                    e.Category,
-                    e.Year?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty,
-                    e.Won ? "1" : "0");
+                if (!e.Won && wonKeys.Contains(CategoryKey(e)))
+                {
+                    continue; // a win for this category/year is present — drop the redundant nomination
+                }
+
+                var key = string.Join("\u001f", CategoryKey(e), e.Won ? "1" : "0");
                 if (seen.Add(key))
                 {
                     result.Add(e);

--- a/Jellyfin.Plugin.JellyfinElevate/Services/Awards/AwardsCacheService.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/Awards/AwardsCacheService.cs
@@ -164,8 +164,12 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
                 var currentlyEmpty = _index.Version == 0 && _index.ByImdb.Count == 0 && _index.ByTmdb.Count == 0;
                 var producesEmpty = byImdb.Count == 0 && byTmdb.Count == 0;
 
-                // Guard 1: an empty result never CLEARS an existing non-empty index (a fetch that
-                // came back empty is treated as "keep what we have", never "wipe it").
+                // Guard 1: an empty result never CLEARS an existing non-empty index — even a
+                // "complete" one. This is deliberate: an all-zero result from every ceremony query
+                // is far more likely our own ceremony QIDs/linkage having gone stale (a maintenance
+                // failure) than Wikidata genuinely dropping all film awards. Keeping the previous
+                // awards is the safer failure mode than wiping the whole index; the next refresh
+                // with corrected queries republishes real data over it.
                 if (producesEmpty && !currentlyEmpty)
                 {
                     _logger.LogWarning("[Awards] Rejected an empty rebuild over the existing index of {Titles} titles.", _index.ByImdb.Count);

--- a/Jellyfin.Plugin.JellyfinElevate/Services/Awards/AwardsCacheService.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/Awards/AwardsCacheService.cs
@@ -37,6 +37,12 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
         private readonly ILogger<AwardsCacheService> _logger;
         private readonly object _saveLock = new();
 
+        // Serializes rebuilds so the version read-modify-write and snapshot swap are atomic
+        // across concurrent callers (e.g. the first-install startup build racing a manual
+        // dashboard run of the refresh task). Reads never take this lock — they read the
+        // volatile snapshot reference directly.
+        private readonly object _rebuildLock = new();
+
         private volatile AwardsIndex _index = AwardsIndex.Empty;
 
         public AwardsCacheService(IApplicationPaths applicationPaths, ILogger<AwardsCacheService> logger)
@@ -103,21 +109,29 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
             DedupeAndSort(byImdb);
             DedupeAndSort(byTmdb);
 
-            var next = new AwardsIndex
+            // Serialize the version bump + swap + persist so two concurrent rebuilds can't both
+            // read the same old version or interleave their writes. The grouping work above is
+            // pure on locals, so it stays outside the lock.
+            AwardsIndex next;
+            lock (_rebuildLock)
             {
-                Version = _index.Version + 1,
-                LastModified = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-                BuiltAtUtc = DateTime.UtcNow.ToString("O"),
-                ByImdb = byImdb,
-                ByTmdb = byTmdb
-            };
+                next = new AwardsIndex
+                {
+                    Version = _index.Version + 1,
+                    LastModified = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    BuiltAtUtc = DateTime.UtcNow.ToString("O"),
+                    ByImdb = byImdb,
+                    ByTmdb = byTmdb
+                };
 
-            _index = next;
-            _logger.LogInformation(
-                "[Awards] Rebuilt index v{Version}: {Titles} titles by IMDb, {TmdbTitles} by TMDb.",
-                next.Version, byImdb.Count, byTmdb.Count);
+                _index = next;
 
-            SaveToDisk(next);
+                _logger.LogInformation(
+                    "[Awards] Rebuilt index v{Version}: {Titles} titles by IMDb, {TmdbTitles} by TMDb.",
+                    next.Version, byImdb.Count, byTmdb.Count);
+
+                SaveToDisk(next);
+            }
         }
 
         /// <summary>

--- a/Jellyfin.Plugin.JellyfinElevate/Services/Awards/AwardsCacheService.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/Awards/AwardsCacheService.cs
@@ -32,7 +32,7 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
     {
         // Bump when the on-disk shape changes so an older cache is discarded and rebuilt
         // instead of being deserialized into an incompatible structure.
-        private const int CurrentSchemaVersion = 1;
+        private const int CurrentSchemaVersion = 2;
 
         private readonly IApplicationPaths _applicationPaths;
         private readonly ILogger<AwardsCacheService> _logger;
@@ -49,6 +49,12 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
         // favor of a newer one — publication order follows freshness, not completion order.
         private long _generationCounter;
         private long _lastPublishedGeneration;
+
+        // Set once a refresh has published in THIS process. LoadFromDisk refuses to install a disk
+        // snapshot afterwards — an on-disk version number is meaningless across a restart (the
+        // in-memory version restarts at 0), so a fresh in-process publish must never be replaced by
+        // a stale disk read that merely has a higher persisted version.
+        private bool _publishedInProcess;
 
         private volatile AwardsIndex _index = AwardsIndex.Empty;
 
@@ -152,36 +158,51 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
             AwardsIndex next;
             lock (_rebuildLock)
             {
-                if (generation <= _lastPublishedGeneration)
-                {
-                    _logger.LogWarning(
-                        "[Awards] Rejected a stale refresh (generation {Gen} <= last published {Last}); a newer refresh already won.",
-                        generation, _lastPublishedGeneration);
-                    return false;
-                }
-
                 var currentlyEmpty = _index.Version == 0 && _index.ByImdb.Count == 0 && _index.ByTmdb.Count == 0;
                 var producesEmpty = byImdb.Count == 0 && byTmdb.Count == 0;
 
-                if (!currentlyEmpty)
+                // Guard 1: an empty result never CLEARS an existing non-empty index (a fetch that
+                // came back empty is treated as "keep what we have", never "wipe it").
+                if (producesEmpty && !currentlyEmpty)
                 {
-                    // Over an EXISTING index, only a complete AND non-empty result publishes. This
-                    // rejects a partial refresh (some queries failed) and any empty result — an
-                    // empty or partial fetch must never clear a good index.
-                    if (!complete || producesEmpty)
-                    {
-                        _logger.LogWarning(
-                            "[Awards] Rejected a {Kind} rebuild over the existing index of {Titles} titles.",
-                            !complete ? "partial" : "empty", _index.ByImdb.Count);
-                        return false;
-                    }
+                    _logger.LogWarning("[Awards] Rejected an empty rebuild over the existing index of {Titles} titles.", _index.ByImdb.Count);
+                    return false;
                 }
-                else if (producesEmpty && !complete)
+
+                // Guard 2: a partial fetch that produced nothing is not a "built" index — wait for a
+                // real result. (A COMPLETE empty result DOES publish on first install: a legitimate
+                // "built, no awards" state that clears indexEmpty.)
+                if (producesEmpty && !complete)
                 {
-                    // First install, but the fetch was partial AND produced nothing — don't mark
-                    // the index "built" yet; wait for a real result. A COMPLETE empty result DOES
-                    // publish here (a legitimate "built, no awards" state), clearing indexEmpty so
-                    // the client stops treating it as not-ready.
+                    return false;
+                }
+
+                // Precedence: does the incoming result supersede the currently published snapshot?
+                //   - a COMPLETE result supersedes a PARTIAL one regardless of generation (a
+                //     later-started partial first-build must not block a complete result — F4);
+                //   - between two results of the SAME completeness, the newer generation wins (so an
+                //     older-started refresh finishing late can't overwrite a newer one — F9);
+                //   - a PARTIAL result never supersedes a COMPLETE one.
+                bool supersedes;
+                if (complete && !_index.Complete)
+                {
+                    supersedes = true;
+                }
+                else if (complete == _index.Complete)
+                {
+                    supersedes = generation > _lastPublishedGeneration;
+                }
+                else
+                {
+                    supersedes = false;
+                }
+
+                if (!supersedes)
+                {
+                    _logger.LogWarning(
+                        "[Awards] Rejected a {Kind} rebuild (generation {Gen}); the current index is {CurKind} at generation {Last}.",
+                        complete ? "complete" : "partial", generation,
+                        _index.Complete ? "complete" : "partial", _lastPublishedGeneration);
                     return false;
                 }
 
@@ -190,12 +211,14 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
                     Version = _index.Version + 1,
                     LastModified = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
                     BuiltAtUtc = DateTime.UtcNow.ToString("O"),
+                    Complete = complete,
                     ByImdb = byImdb,
                     ByTmdb = byTmdb
                 };
 
                 _index = next;
                 _lastPublishedGeneration = generation;
+                _publishedInProcess = true;
 
                 _logger.LogInformation(
                     "[Awards] Rebuilt index v{Version} ({Completeness}): {Titles} titles by IMDb, {TmdbTitles} by TMDb.",
@@ -301,6 +324,7 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
                     Version = data.Version,
                     LastModified = data.LastModified,
                     BuiltAtUtc = data.BuiltAtUtc,
+                    Complete = data.Complete,
                     ByImdb = data.ByImdb != null
                         ? new Dictionary<string, List<AwardEntry>>(data.ByImdb, StringComparer.OrdinalIgnoreCase)
                         : new Dictionary<string, List<AwardEntry>>(StringComparer.OrdinalIgnoreCase),
@@ -309,22 +333,26 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
                         : new Dictionary<string, List<AwardEntry>>(StringComparer.OrdinalIgnoreCase)
                 };
 
-                // Install under the rebuild lock and only if it's newer than what's in memory.
-                // If a manual refresh published a newer snapshot while this file read was in
-                // flight, the fresher in-memory index wins — a stale disk read never downgrades it.
+                // Install under the rebuild lock, but only if no refresh has already published in
+                // this process. A version comparison is NOT enough: the in-memory version restarts
+                // at 0, so a fresh in-process refresh (v1) can carry a lower number than a stale disk
+                // snapshot (v5) while holding newer data — the published-in-process flag captures
+                // "an in-flight refresh already won" independent of the numeric version. The loaded
+                // generation seeds _lastPublishedGeneration to 0 so any in-session refresh supersedes.
                 lock (_rebuildLock)
                 {
-                    if (loaded.Version > _index.Version)
+                    if (_publishedInProcess)
                     {
-                        _index = loaded;
                         _logger.LogInformation(
-                            "[Awards] Loaded {Titles} titles from disk (v{Version}).", loaded.ByImdb.Count, loaded.Version);
+                            "[Awards] A refresh already published in-process; discarding the older disk snapshot (v{OnDisk}).",
+                            loaded.Version);
                     }
                     else
                     {
+                        _index = loaded;
                         _logger.LogInformation(
-                            "[Awards] Disk cache v{OnDisk} is not newer than the in-memory index v{InMemory}; keeping memory.",
-                            loaded.Version, _index.Version);
+                            "[Awards] Loaded {Titles} titles from disk (v{Version}, {Completeness}).",
+                            loaded.ByImdb.Count, loaded.Version, loaded.Complete ? "complete" : "partial");
                     }
                 }
             }
@@ -352,6 +380,7 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
                         Version = index.Version,
                         LastModified = index.LastModified,
                         BuiltAtUtc = index.BuiltAtUtc,
+                        Complete = index.Complete,
                         ByImdb = index.ByImdb,
                         ByTmdb = index.ByTmdb
                     };
@@ -457,6 +486,7 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
                 Version = 0,
                 LastModified = 0,
                 BuiltAtUtc = null,
+                Complete = false,
                 ByImdb = new Dictionary<string, List<AwardEntry>>(StringComparer.OrdinalIgnoreCase),
                 ByTmdb = new Dictionary<string, List<AwardEntry>>(StringComparer.OrdinalIgnoreCase)
             };
@@ -466,6 +496,9 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
             public long LastModified { get; init; }
 
             public string? BuiltAtUtc { get; init; }
+
+            /// <summary>Whether the snapshot came from a fully successful fetch (all ceremonies).</summary>
+            public bool Complete { get; init; }
 
             public Dictionary<string, List<AwardEntry>> ByImdb { get; init; } = new(StringComparer.OrdinalIgnoreCase);
 
@@ -481,6 +514,8 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
             public long LastModified { get; set; }
 
             public string? BuiltAtUtc { get; set; }
+
+            public bool Complete { get; set; }
 
             public Dictionary<string, List<AwardEntry>>? ByImdb { get; set; }
 

--- a/Jellyfin.Plugin.JellyfinElevate/Services/Awards/AwardsCacheService.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/Awards/AwardsCacheService.cs
@@ -112,11 +112,6 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
         {
             ArgumentNullException.ThrowIfNull(rows);
 
-            if (rows.Count == 0)
-            {
-                return false;
-            }
-
             var byImdb = new Dictionary<string, List<AwardEntry>>(StringComparer.OrdinalIgnoreCase);
             var byTmdb = new Dictionary<string, List<AwardEntry>>(StringComparer.OrdinalIgnoreCase);
 
@@ -165,11 +160,27 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
                 }
 
                 var currentlyEmpty = _index.Version == 0 && _index.ByImdb.Count == 0 && _index.ByTmdb.Count == 0;
-                if (!complete && !currentlyEmpty)
+                var producesEmpty = byImdb.Count == 0 && byTmdb.Count == 0;
+
+                if (!currentlyEmpty)
                 {
-                    _logger.LogWarning(
-                        "[Awards] Rejected a partial rebuild over the existing index of {Titles} titles (some ceremony queries failed).",
-                        _index.ByImdb.Count);
+                    // Over an EXISTING index, only a complete AND non-empty result publishes. This
+                    // rejects a partial refresh (some queries failed) and any empty result — an
+                    // empty or partial fetch must never clear a good index.
+                    if (!complete || producesEmpty)
+                    {
+                        _logger.LogWarning(
+                            "[Awards] Rejected a {Kind} rebuild over the existing index of {Titles} titles.",
+                            !complete ? "partial" : "empty", _index.ByImdb.Count);
+                        return false;
+                    }
+                }
+                else if (producesEmpty && !complete)
+                {
+                    // First install, but the fetch was partial AND produced nothing — don't mark
+                    // the index "built" yet; wait for a real result. A COMPLETE empty result DOES
+                    // publish here (a legitimate "built, no awards" state), clearing indexEmpty so
+                    // the client stops treating it as not-ready.
                     return false;
                 }
 

--- a/Jellyfin.Plugin.JellyfinElevate/Services/Awards/AwardsCacheService.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/Awards/AwardsCacheService.cs
@@ -67,14 +67,32 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
         public bool IsEmpty => _index.Version == 0 && _index.ByImdb.Count == 0 && _index.ByTmdb.Count == 0;
 
         /// <summary>
-        /// Replace the whole index from a fresh set of provider rows. Groups rows by title,
-        /// deduplicates awards, sorts them (newest first, wins before nominations), bumps the
-        /// version, swaps the snapshot atomically, then persists to disk. A single title may be
-        /// reachable by both its IMDb and TMDb id.
+        /// Replace the whole index from a fresh set of provider rows, unconditionally. Groups
+        /// rows by title, deduplicates awards, sorts them (newest first, wins before nominations),
+        /// bumps the version, swaps the snapshot atomically, then persists to disk. Prefer
+        /// <see cref="TryReplaceFrom"/> from refresh callers so a partial fetch can't clobber a
+        /// complete index; this primitive is for callers that always want to publish.
         /// </summary>
         public void ReplaceFrom(IReadOnlyCollection<AwardRow> rows)
+            => TryReplaceFrom(rows, complete: true);
+
+        /// <summary>
+        /// Publish a fresh index, but only when it is safe to do so. Returns true if published.
+        /// A <paramref name="complete"/> run always publishes; a PARTIAL run publishes only when
+        /// the index is currently empty (first install) — never over an existing populated index,
+        /// so a single failed ceremony query can't erase that ceremony's awards. The
+        /// currently-empty check and the swap happen under one lock, so a slow startup fetch and
+        /// a concurrent manual refresh can't race to downgrade a complete index to partial.
+        /// An empty row set never publishes.
+        /// </summary>
+        public bool TryReplaceFrom(IReadOnlyCollection<AwardRow> rows, bool complete)
         {
             ArgumentNullException.ThrowIfNull(rows);
+
+            if (rows.Count == 0)
+            {
+                return false;
+            }
 
             var byImdb = new Dictionary<string, List<AwardEntry>>(StringComparer.OrdinalIgnoreCase);
             var byTmdb = new Dictionary<string, List<AwardEntry>>(StringComparer.OrdinalIgnoreCase);
@@ -109,12 +127,21 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
             DedupeAndSort(byImdb);
             DedupeAndSort(byTmdb);
 
-            // Serialize the version bump + swap + persist so two concurrent rebuilds can't both
-            // read the same old version or interleave their writes. The grouping work above is
-            // pure on locals, so it stays outside the lock.
+            // The accept decision (partial vs complete over the CURRENT state) and the version
+            // bump + swap + persist all happen under one lock, so the check is atomic with the
+            // publish. The grouping work above is pure on locals, so it stays outside the lock.
             AwardsIndex next;
             lock (_rebuildLock)
             {
+                var currentlyEmpty = _index.Version == 0 && _index.ByImdb.Count == 0 && _index.ByTmdb.Count == 0;
+                if (!complete && !currentlyEmpty)
+                {
+                    _logger.LogWarning(
+                        "[Awards] Rejected a partial rebuild over the existing index of {Titles} titles (some ceremony queries failed).",
+                        _index.ByImdb.Count);
+                    return false;
+                }
+
                 next = new AwardsIndex
                 {
                     Version = _index.Version + 1,
@@ -127,11 +154,13 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
                 _index = next;
 
                 _logger.LogInformation(
-                    "[Awards] Rebuilt index v{Version}: {Titles} titles by IMDb, {TmdbTitles} by TMDb.",
-                    next.Version, byImdb.Count, byTmdb.Count);
+                    "[Awards] Rebuilt index v{Version} ({Completeness}): {Titles} titles by IMDb, {TmdbTitles} by TMDb.",
+                    next.Version, complete ? "complete" : "partial first build", byImdb.Count, byTmdb.Count);
 
                 SaveToDisk(next);
             }
+
+            return true;
         }
 
         /// <summary>

--- a/Jellyfin.Plugin.JellyfinElevate/Services/Awards/AwardsCacheService.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/Awards/AwardsCacheService.cs
@@ -178,23 +178,22 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
                 }
 
                 // Precedence: does the incoming result supersede the currently published snapshot?
+                //   - a PARTIAL result publishes ONLY onto an empty (never-built) index — a
+                //     first-install best-effort. Once ANY built snapshot exists it never publishes,
+                //     so two successive partials that each lose a different ceremony can't erase
+                //     each other's awards.
                 //   - a COMPLETE result supersedes a PARTIAL one regardless of generation (a
                 //     later-started partial first-build must not block a complete result — F4);
-                //   - between two results of the SAME completeness, the newer generation wins (so an
-                //     older-started refresh finishing late can't overwrite a newer one — F9);
-                //   - a PARTIAL result never supersedes a COMPLETE one.
+                //   - a COMPLETE result supersedes an older COMPLETE one only with a newer
+                //     generation (an older-started refresh finishing late can't overwrite it — F9).
                 bool supersedes;
-                if (complete && !_index.Complete)
+                if (complete)
                 {
-                    supersedes = true;
-                }
-                else if (complete == _index.Complete)
-                {
-                    supersedes = generation > _lastPublishedGeneration;
+                    supersedes = !_index.Complete || generation > _lastPublishedGeneration;
                 }
                 else
                 {
-                    supersedes = false;
+                    supersedes = currentlyEmpty;
                 }
 
                 if (!supersedes)

--- a/Jellyfin.Plugin.JellyfinElevate/Services/Awards/IAwardsProvider.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/Awards/IAwardsProvider.cs
@@ -7,6 +7,15 @@ using Jellyfin.Plugin.JellyfinElevate.Model.Awards;
 namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
 {
     /// <summary>
+    /// The outcome of an awards fetch: the rows collected, plus whether the run was
+    /// <see cref="Complete"/> (every sub-query succeeded). A partial run still returns the rows
+    /// it got, but the caller must NOT publish a partial run over an existing complete index —
+    /// otherwise a single timed-out ceremony query would erase all of that ceremony's awards
+    /// until a later full success.
+    /// </summary>
+    public sealed record AwardsFetchResult(IReadOnlyList<AwardRow> Rows, bool Complete);
+
+    /// <summary>
     /// Source of the global awards dataset. An implementation performs a bounded number of
     /// bulk queries (independent of library size) and returns flat <see cref="AwardRow"/>
     /// records keyed by external id; the cache service groups and indexes them. Kept as an
@@ -17,10 +26,11 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
     {
         /// <summary>
         /// Fetch every tracked award record. Reports coarse progress (0-100) and honors
-        /// cancellation. Returns whatever it could collect; a single failing sub-query must
-        /// not abort the whole run (partial data beats none). Throws only when it could not
-        /// fetch anything at all, so the caller can decide whether to keep the previous index.
+        /// cancellation. A single failing sub-query must not abort the whole run (partial data
+        /// beats none), but the result's <see cref="AwardsFetchResult.Complete"/> flag reports
+        /// whether ANY sub-query failed so the caller can avoid overwriting a good index with a
+        /// partial one. Throws only when it could not fetch anything at all.
         /// </summary>
-        Task<IReadOnlyList<AwardRow>> FetchAllAsync(IProgress<double>? progress, CancellationToken cancellationToken);
+        Task<AwardsFetchResult> FetchAllAsync(IProgress<double>? progress, CancellationToken cancellationToken);
     }
 }

--- a/Jellyfin.Plugin.JellyfinElevate/Services/Awards/IAwardsProvider.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/Awards/IAwardsProvider.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinElevate.Model.Awards;
+
+namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
+{
+    /// <summary>
+    /// Source of the global awards dataset. An implementation performs a bounded number of
+    /// bulk queries (independent of library size) and returns flat <see cref="AwardRow"/>
+    /// records keyed by external id; the cache service groups and indexes them. Kept as an
+    /// interface so the data source (Wikidata today) can be swapped or extended without
+    /// touching the cache/task/controller layers.
+    /// </summary>
+    public interface IAwardsProvider
+    {
+        /// <summary>
+        /// Fetch every tracked award record. Reports coarse progress (0-100) and honors
+        /// cancellation. Returns whatever it could collect; a single failing sub-query must
+        /// not abort the whole run (partial data beats none). Throws only when it could not
+        /// fetch anything at all, so the caller can decide whether to keep the previous index.
+        /// </summary>
+        Task<IReadOnlyList<AwardRow>> FetchAllAsync(IProgress<double>? progress, CancellationToken cancellationToken);
+    }
+}

--- a/Jellyfin.Plugin.JellyfinElevate/Services/Awards/WikidataAwardsProvider.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/Awards/WikidataAwardsProvider.cs
@@ -66,7 +66,7 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
         // Politeness gap between successive queries so a full run doesn't hammer WDQS.
         private static readonly TimeSpan InterQueryDelay = TimeSpan.FromMilliseconds(750);
 
-        public async Task<IReadOnlyList<AwardRow>> FetchAllAsync(IProgress<double>? progress, CancellationToken cancellationToken)
+        public async Task<AwardsFetchResult> FetchAllAsync(IProgress<double>? progress, CancellationToken cancellationToken)
         {
             var rows = new List<AwardRow>();
 
@@ -113,14 +113,15 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
                 succeeded, attempted, rows.Count);
 
             // Only a total wipeout (every query failed) is treated as a hard failure — the caller
-            // then keeps the previous index rather than clearing it. Any partial success returns
-            // what we have; a genuinely awards-free result set is a valid (if unlikely) answer.
+            // then keeps the previous index rather than clearing it. A partial success returns the
+            // rows collected but flags Complete=false so the caller won't publish it over a good
+            // index; a fully successful run is Complete=true.
             if (succeeded == 0 && attempted > 0)
             {
                 throw new InvalidOperationException("All Wikidata award queries failed; keeping the existing index.");
             }
 
-            return rows;
+            return new AwardsFetchResult(rows, Complete: succeeded == attempted);
         }
 
         private async Task<bool> TryRunAsync(HttpClient client, CeremonyDef ceremony, bool won, List<AwardRow> sink, CancellationToken cancellationToken)

--- a/Jellyfin.Plugin.JellyfinElevate/Services/Awards/WikidataAwardsProvider.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/Awards/WikidataAwardsProvider.cs
@@ -1,0 +1,255 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinElevate.Helpers;
+using Jellyfin.Plugin.JellyfinElevate.Model.Awards;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
+{
+    /// <summary>
+    /// Fetches the global awards dataset from the Wikidata Query Service (SPARQL). Open data,
+    /// no API key. One bounded pair of queries (wins + nominations) per ceremony — a dozen
+    /// queries total, independent of library size — each returning a few thousand rows at most.
+    ///
+    /// Wikidata models award categories' link to their ceremony inconsistently (some via
+    /// <c>instance of</c>, some via <c>part of</c>, some via <c>conferred by</c>), so each
+    /// ceremony carries its own VALUES linkage block; everything else is one shared template.
+    /// Award statements that sit on a person (acting/directing/writing) are excluded because the
+    /// query constrains the awarded entity to a film or TV series — exactly the work-level
+    /// awards a media library can badge (Best Picture, Best Film, Outstanding Series, Palme d'Or…).
+    /// </summary>
+    public sealed class WikidataAwardsProvider : IAwardsProvider
+    {
+        private const string Endpoint = "https://query.wikidata.org/sparql";
+
+        // Wikidata's user-agent policy requires a descriptive UA identifying the client and a
+        // contact/URL. https://meta.wikimedia.org/wiki/User-Agent_policy
+        private const string UserAgent =
+            "JellyfinElevate/1.0 (+https://github.com/4eh5xitv6787h645ebv/Jellyfin-Elevate; awards index) dotnet-httpclient";
+
+        // Both media roots: film (Q11424) and television series (Q5398426).
+        private const string BothRoots = "wd:Q11424 wd:Q5398426";
+        private const string FilmRoot = "wd:Q11424";
+        private const string TvRoot = "wd:Q5398426";
+
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly ILogger<WikidataAwardsProvider> _logger;
+
+        public WikidataAwardsProvider(IHttpClientFactory httpClientFactory, ILogger<WikidataAwardsProvider> logger)
+        {
+            _httpClientFactory = httpClientFactory;
+            _logger = logger;
+        }
+
+        // Per-ceremony query definitions. Only the VALUES linkage block, the type roots, and
+        // whether nominations exist differ; QIDs/linkage are verified against live Wikidata.
+        // Festivals (Cannes/Venice/Berlin) do not record nominations, so they are wins-only.
+        private static readonly IReadOnlyList<CeremonyDef> Ceremonies = new[]
+        {
+            new CeremonyDef("Academy Awards", "(wdt:P31 wd:Q19020) (wdt:P361 wd:Q19020)", Nominations: true, TypeRoots: BothRoots),
+            new CeremonyDef("Golden Globe Awards", "(wdt:P31 wd:Q1011547) (wdt:P361 wd:Q1011547)", Nominations: true, TypeRoots: BothRoots),
+            new CeremonyDef("BAFTA Awards", "(wdt:P31 wd:Q732997) (wdt:P361 wd:Q732997)", Nominations: true, TypeRoots: BothRoots),
+            new CeremonyDef("Cannes Film Festival", "(wdt:P31 wd:Q28444913) (wdt:P1027 wd:Q42369)", Nominations: false, TypeRoots: FilmRoot),
+            new CeremonyDef("Venice Film Festival", "(wdt:P1027 wd:Q49024) (wdt:P361 wd:Q108773780)", Nominations: false, TypeRoots: FilmRoot),
+            new CeremonyDef("Berlin International Film Festival", "(wdt:P1027 wd:Q130871) (wdt:P361 wd:Q130871)", Nominations: false, TypeRoots: FilmRoot),
+            new CeremonyDef("Screen Actors Guild Awards", "(wdt:P361 wd:Q268200)", Nominations: true, TypeRoots: BothRoots),
+            new CeremonyDef("Critics' Choice Awards", "(wdt:P31 wd:Q7585305) (wdt:P361 wd:Q7585305)", Nominations: true, TypeRoots: BothRoots),
+            new CeremonyDef("Primetime Emmy Awards", "(wdt:P31 wd:Q1044427) (wdt:P361 wd:Q1044427)", Nominations: true, TypeRoots: TvRoot),
+        };
+
+        // Politeness gap between successive queries so a full run doesn't hammer WDQS.
+        private static readonly TimeSpan InterQueryDelay = TimeSpan.FromMilliseconds(750);
+
+        public async Task<IReadOnlyList<AwardRow>> FetchAllAsync(IProgress<double>? progress, CancellationToken cancellationToken)
+        {
+            var rows = new List<AwardRow>();
+
+            // One "unit" per query so progress advances smoothly (wins always, noms where applicable).
+            var totalQueries = Ceremonies.Sum(c => c.Nominations ? 2 : 1);
+            var completed = 0;
+            var attempted = 0;
+            var succeeded = 0;
+
+            using var client = PluginHttpClients.CreateWikidataClient(_httpClientFactory);
+
+            foreach (var ceremony in Ceremonies)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                attempted++;
+                if (await TryRunAsync(client, ceremony, won: true, rows, cancellationToken).ConfigureAwait(false))
+                {
+                    succeeded++;
+                }
+
+                completed++;
+                progress?.Report(100.0 * completed / totalQueries);
+
+                if (ceremony.Nominations)
+                {
+                    await Task.Delay(InterQueryDelay, cancellationToken).ConfigureAwait(false);
+
+                    attempted++;
+                    if (await TryRunAsync(client, ceremony, won: false, rows, cancellationToken).ConfigureAwait(false))
+                    {
+                        succeeded++;
+                    }
+
+                    completed++;
+                    progress?.Report(100.0 * completed / totalQueries);
+                }
+
+                await Task.Delay(InterQueryDelay, cancellationToken).ConfigureAwait(false);
+            }
+
+            _logger.LogInformation(
+                "[Awards] Wikidata fetch: {Succeeded}/{Attempted} queries ok, {Rows} raw rows.",
+                succeeded, attempted, rows.Count);
+
+            // Only a total wipeout (every query failed) is treated as a hard failure — the caller
+            // then keeps the previous index rather than clearing it. Any partial success returns
+            // what we have; a genuinely awards-free result set is a valid (if unlikely) answer.
+            if (succeeded == 0 && attempted > 0)
+            {
+                throw new InvalidOperationException("All Wikidata award queries failed; keeping the existing index.");
+            }
+
+            return rows;
+        }
+
+        private async Task<bool> TryRunAsync(HttpClient client, CeremonyDef ceremony, bool won, List<AwardRow> sink, CancellationToken cancellationToken)
+        {
+            var kind = won ? "wins" : "nominations";
+            try
+            {
+                var query = BuildQuery(ceremony, won);
+                var json = await ExecuteAsync(client, query, cancellationToken).ConfigureAwait(false);
+                var before = sink.Count;
+                ParseInto(json, ceremony.Name, won, sink);
+                _logger.LogInformation("[Awards] {Ceremony} {Kind}: {Count} rows.", ceremony.Name, kind, sink.Count - before);
+                return true;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // A single ceremony/kind failing must not abort the whole run (partial data beats none).
+                _logger.LogWarning("[Awards] {Ceremony} {Kind} query failed: {Message}", ceremony.Name, kind, ex.Message);
+                return false;
+            }
+        }
+
+        private async Task<string> ExecuteAsync(HttpClient client, string sparql, CancellationToken cancellationToken)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Post, Endpoint);
+            request.Headers.TryAddWithoutValidation("User-Agent", UserAgent);
+            request.Headers.TryAddWithoutValidation("Accept", "application/sparql-results+json");
+            request.Content = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("query", sparql)
+            });
+
+            using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new HttpRequestException($"WDQS returned {(int)response.StatusCode} {response.ReasonPhrase}");
+            }
+
+            return await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        private static void ParseInto(string json, string ceremonyName, bool won, List<AwardRow> sink)
+        {
+            using var doc = JsonDocument.Parse(json);
+            if (!doc.RootElement.TryGetProperty("results", out var results)
+                || !results.TryGetProperty("bindings", out var bindings)
+                || bindings.ValueKind != JsonValueKind.Array)
+            {
+                return;
+            }
+
+            foreach (var binding in bindings.EnumerateArray())
+            {
+                var imdb = ReadValue(binding, "imdb");
+                var tmdb = ReadValue(binding, "tmdb");
+                if (imdb == null && tmdb == null)
+                {
+                    continue;
+                }
+
+                var category = ReadValue(binding, "category");
+                if (string.IsNullOrWhiteSpace(category))
+                {
+                    continue;
+                }
+
+                var mediaType = ReadValue(binding, "mediaType");
+                var yearStr = ReadValue(binding, "year");
+                int? year = null;
+                if (!string.IsNullOrEmpty(yearStr)
+                    && int.TryParse(yearStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out var y))
+                {
+                    year = y;
+                }
+
+                sink.Add(new AwardRow
+                {
+                    ImdbId = imdb,
+                    TmdbId = tmdb,
+                    MediaType = string.Equals(mediaType, "tv", StringComparison.OrdinalIgnoreCase) ? "tv" : "movie",
+                    Ceremony = ceremonyName,
+                    Category = category!,
+                    Year = year,
+                    Won = won
+                });
+            }
+        }
+
+        private static string? ReadValue(JsonElement binding, string name)
+        {
+            if (binding.TryGetProperty(name, out var node)
+                && node.TryGetProperty("value", out var value)
+                && value.ValueKind == JsonValueKind.String)
+            {
+                var s = value.GetString();
+                return string.IsNullOrWhiteSpace(s) ? null : s;
+            }
+
+            return null;
+        }
+
+        private static string BuildQuery(CeremonyDef ceremony, bool won)
+        {
+            var awardProp = won ? "P166" : "P1411";
+            // The awarded entity is constrained to a film/TV type, which auto-excludes person-level
+            // (acting/directing) statements. Category label is taken in English.
+            return
+                "SELECT DISTINCT ?imdb ?tmdb ?mediaType ?category ?year WHERE {\n" +
+                "  VALUES (?linkPred ?linkTarget) { " + ceremony.ValuesBlock + " }\n" +
+                "  ?cat ?linkPred ?linkTarget .\n" +
+                "  ?work p:" + awardProp + " ?st .\n" +
+                "  ?st ps:" + awardProp + " ?cat .\n" +
+                "  ?work wdt:P31/wdt:P279* ?typeRoot .\n" +
+                "  VALUES ?typeRoot { " + ceremony.TypeRoots + " }\n" +
+                "  BIND(IF(?typeRoot = wd:Q11424, \"movie\", \"tv\") AS ?mediaType)\n" +
+                "  OPTIONAL { ?work wdt:P345 ?imdb }\n" +
+                "  OPTIONAL { ?work wdt:P4947 ?tmdbMovie }\n" +
+                "  OPTIONAL { ?work wdt:P4983 ?tmdbTv }\n" +
+                "  BIND(COALESCE(?tmdbMovie, ?tmdbTv) AS ?tmdb)\n" +
+                "  FILTER(BOUND(?imdb) || BOUND(?tmdb))\n" +
+                "  OPTIONAL { ?st pq:P585 ?pt . BIND(YEAR(?pt) AS ?year) }\n" +
+                "  ?cat rdfs:label ?category . FILTER(LANG(?category) = \"en\")\n" +
+                "}";
+        }
+
+        private sealed record CeremonyDef(string Name, string ValuesBlock, bool Nominations, string TypeRoots);
+    }
+}

--- a/Jellyfin.Plugin.JellyfinElevate/Services/Awards/WikidataAwardsProvider.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/Awards/WikidataAwardsProvider.cs
@@ -128,7 +128,7 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
             var kind = won ? "wins" : "nominations";
             try
             {
-                var query = BuildQuery(ceremony, won);
+                var query = BuildQuery(ceremony.ValuesBlock, ceremony.TypeRoots, won);
                 var json = await ExecuteAsync(client, query, cancellationToken).ConfigureAwait(false);
                 var before = sink.Count;
                 ParseInto(json, ceremony.Name, won, sink);
@@ -166,7 +166,12 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
             return await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        private static void ParseInto(string json, string ceremonyName, bool won, List<AwardRow> sink)
+        // Test seam (Tests has InternalsVisibleTo): assert breadth + wins-only festivals
+        // without hitting the network.
+        internal static IReadOnlyList<(string Name, bool Nominations)> CeremonyMetaForTest =>
+            Ceremonies.Select(c => (c.Name, c.Nominations)).ToList();
+
+        internal static void ParseInto(string json, string ceremonyName, bool won, List<AwardRow> sink)
         {
             using var doc = JsonDocument.Parse(json);
             if (!doc.RootElement.TryGetProperty("results", out var results)
@@ -226,19 +231,19 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
             return null;
         }
 
-        private static string BuildQuery(CeremonyDef ceremony, bool won)
+        internal static string BuildQuery(string valuesBlock, string typeRoots, bool won)
         {
             var awardProp = won ? "P166" : "P1411";
             // The awarded entity is constrained to a film/TV type, which auto-excludes person-level
             // (acting/directing) statements. Category label is taken in English.
             return
                 "SELECT DISTINCT ?imdb ?tmdb ?mediaType ?category ?year WHERE {\n" +
-                "  VALUES (?linkPred ?linkTarget) { " + ceremony.ValuesBlock + " }\n" +
+                "  VALUES (?linkPred ?linkTarget) { " + valuesBlock + " }\n" +
                 "  ?cat ?linkPred ?linkTarget .\n" +
                 "  ?work p:" + awardProp + " ?st .\n" +
                 "  ?st ps:" + awardProp + " ?cat .\n" +
                 "  ?work wdt:P31/wdt:P279* ?typeRoot .\n" +
-                "  VALUES ?typeRoot { " + ceremony.TypeRoots + " }\n" +
+                "  VALUES ?typeRoot { " + typeRoots + " }\n" +
                 "  BIND(IF(?typeRoot = wd:Q11424, \"movie\", \"tv\") AS ?mediaType)\n" +
                 "  OPTIONAL { ?work wdt:P345 ?imdb }\n" +
                 "  OPTIONAL { ?work wdt:P4947 ?tmdbMovie }\n" +

--- a/Jellyfin.Plugin.JellyfinElevate/Services/Awards/WikidataAwardsProvider.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/Awards/WikidataAwardsProvider.cs
@@ -175,11 +175,16 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
         internal static void ParseInto(string json, string ceremonyName, bool won, List<AwardRow> sink)
         {
             using var doc = JsonDocument.Parse(json);
+            // A structurally valid WDQS result must expose results.bindings as an array (an empty
+            // array is legitimate — a genuine zero-row answer). Anything else (a 200 with an
+            // error/proxy payload, a truncated body) is NOT a successful query: throw so the
+            // caller counts it as a failure and does not mark the refresh Complete — otherwise a
+            // bogus "success" would erase that ceremony's awards on the next publish.
             if (!doc.RootElement.TryGetProperty("results", out var results)
                 || !results.TryGetProperty("bindings", out var bindings)
                 || bindings.ValueKind != JsonValueKind.Array)
             {
-                return;
+                throw new FormatException("WDQS response did not contain a results.bindings array.");
             }
 
             foreach (var binding in bindings.EnumerateArray())

--- a/Jellyfin.Plugin.JellyfinElevate/Services/Awards/WikidataAwardsProvider.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/Awards/WikidataAwardsProvider.cs
@@ -136,13 +136,17 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services.Awards
                 _logger.LogInformation("[Awards] {Ceremony} {Kind}: {Count} rows.", ceremony.Name, kind, sink.Count - before);
                 return true;
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
+                // Genuine caller cancellation (server shutdown / task cancel) — propagate.
                 throw;
             }
             catch (Exception ex)
             {
-                // A single ceremony/kind failing must not abort the whole run (partial data beats none).
+                // A single ceremony/kind failing must not abort the whole run (partial data beats
+                // none). This includes an HttpClient.Timeout, which surfaces as an
+                // OperationCanceledException NOT tied to our token — the filter above lets it fall
+                // through to here so one slow query is a query failure, not a whole-run abort.
                 _logger.LogWarning("[Awards] {Ceremony} {Kind} query failed: {Message}", ceremony.Name, kind, ex.Message);
                 return false;
             }

--- a/Jellyfin.Plugin.JellyfinElevate/Services/StartupService.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/StartupService.cs
@@ -117,13 +117,16 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
             try
             {
                 _logger.LogInformation("[Awards] Feature enabled and no index on disk; building the initial awards index...");
+
+                // Reserve the generation before fetching so a concurrent manual "Build Awards
+                // Cache" run started later (higher generation) wins over this slower startup build.
+                var generation = _awardsCacheService.NextRefreshGeneration();
                 var result = await _awardsProvider.FetchAllAsync(null, cancellationToken).ConfigureAwait(false);
 
                 // TryReplaceFrom publishes atomically: on first install (empty index) even a partial
-                // result is published; but if a manual "Build Awards Cache" run completed a full
-                // index while this slower fetch was in flight, a partial result here is rejected
-                // rather than downgrading the complete index.
-                if (_awardsCacheService.TryReplaceFrom(result.Rows, result.Complete))
+                // result is published; but a partial result is rejected once a complete index exists,
+                // and a stale generation is rejected once a newer refresh has published.
+                if (_awardsCacheService.TryReplaceFrom(result.Rows, result.Complete, generation))
                 {
                     _logger.LogInformation("[Awards] Initial awards index built: {0} titles.", _awardsCacheService.TitleCount);
                 }

--- a/Jellyfin.Plugin.JellyfinElevate/Services/StartupService.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/StartupService.cs
@@ -118,16 +118,18 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
             {
                 _logger.LogInformation("[Awards] Feature enabled and no index on disk; building the initial awards index...");
                 var result = await _awardsProvider.FetchAllAsync(null, cancellationToken).ConfigureAwait(false);
-                if (result.Rows.Count > 0)
+
+                // TryReplaceFrom publishes atomically: on first install (empty index) even a partial
+                // result is published; but if a manual "Build Awards Cache" run completed a full
+                // index while this slower fetch was in flight, a partial result here is rejected
+                // rather than downgrading the complete index.
+                if (_awardsCacheService.TryReplaceFrom(result.Rows, result.Complete))
                 {
-                    // First install (index empty): publish whatever we got — a partial index beats
-                    // an empty section, and the weekly task refreshes it to completeness later.
-                    _awardsCacheService.ReplaceFrom(result.Rows);
                     _logger.LogInformation("[Awards] Initial awards index built: {0} titles.", _awardsCacheService.TitleCount);
                 }
                 else
                 {
-                    _logger.LogWarning("[Awards] Initial awards fetch returned no rows; the weekly task will retry.");
+                    _logger.LogWarning("[Awards] Initial awards index not published (no rows, or a complete index already exists); the weekly task will refresh.");
                 }
             }
             catch (OperationCanceledException)

--- a/Jellyfin.Plugin.JellyfinElevate/Services/StartupService.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/StartupService.cs
@@ -20,6 +20,8 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
         private readonly TagCacheService _tagCacheService;
         private readonly TagCacheMonitor _tagCacheMonitor;
         private readonly SeerrScanTriggerService _seerrScanTriggerService;
+        private readonly Awards.AwardsCacheService _awardsCacheService;
+        private readonly Awards.IAwardsProvider _awardsProvider;
         private readonly IPluginConfigProvider _configProvider;
 
         public string Name => "Jellyfin Elevate Startup";
@@ -27,7 +29,7 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
         public string Description => "Initializes Jellyfin Elevate background services and performs necessary cleanups. The client script is injected at request time by the injection middleware.";
         public string Category => "Jellyfin Elevate";
 
-        public StartupService(ILogger<StartupService> logger, IApplicationPaths applicationPaths, AutoSeasonRequestMonitor autoSeasonRequestMonitor, AutoMovieRequestMonitor autoMovieRequestMonitor, WatchlistMonitor watchlistMonitor, TagCacheService tagCacheService, TagCacheMonitor tagCacheMonitor, SeerrScanTriggerService seerrScanTriggerService, IPluginConfigProvider configProvider)
+        public StartupService(ILogger<StartupService> logger, IApplicationPaths applicationPaths, AutoSeasonRequestMonitor autoSeasonRequestMonitor, AutoMovieRequestMonitor autoMovieRequestMonitor, WatchlistMonitor watchlistMonitor, TagCacheService tagCacheService, TagCacheMonitor tagCacheMonitor, SeerrScanTriggerService seerrScanTriggerService, Awards.AwardsCacheService awardsCacheService, Awards.IAwardsProvider awardsProvider, IPluginConfigProvider configProvider)
         {
             _logger = logger;
             _applicationPaths = applicationPaths;
@@ -37,6 +39,8 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
             _tagCacheService = tagCacheService;
             _tagCacheMonitor = tagCacheMonitor;
             _seerrScanTriggerService = seerrScanTriggerService;
+            _awardsCacheService = awardsCacheService;
+            _awardsProvider = awardsProvider;
             _configProvider = configProvider;
         }
 
@@ -81,8 +85,57 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
                     _logger.LogError($"[TagCache] Failed to initialize tag cache (tags will use batch fallback): {ex.Message}");
                 }
 
+                // Load the awards index from disk. It is rebuilt from Wikidata only on the
+                // weekly scheduled task (or a manual run), never on every startup — a restart
+                // must not re-fetch. See BuildAwardsCacheTask.
+                try
+                {
+                    _awardsCacheService.LoadFromDisk();
+                }
+                catch (System.Exception ex)
+                {
+                    _logger.LogError($"[Awards] Failed to load awards index (awards section will be empty until the next refresh): {ex.Message}");
+                }
+
                 _logger.LogInformation("Jellyfin Elevate Startup Task completed successfully.");
             }, cancellationToken);
+
+            // First install only: if the feature is enabled but the index has never been built,
+            // populate it once now so awards appear without waiting up to a week for the scheduled
+            // task. Done after the sync init block (off the tag-cache path) and outside the disk
+            // load's try/catch. A restart with an existing on-disk index skips this entirely.
+            await BuildInitialAwardsIndexIfNeededAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task BuildInitialAwardsIndexIfNeededAsync(CancellationToken cancellationToken)
+        {
+            if (_configProvider.ConfigurationOrNull?.ShowAwards != true || !_awardsCacheService.IsEmpty)
+            {
+                return;
+            }
+
+            try
+            {
+                _logger.LogInformation("[Awards] Feature enabled and no index on disk; building the initial awards index...");
+                var rows = await _awardsProvider.FetchAllAsync(null, cancellationToken).ConfigureAwait(false);
+                if (rows.Count > 0)
+                {
+                    _awardsCacheService.ReplaceFrom(rows);
+                    _logger.LogInformation("[Awards] Initial awards index built: {0} titles.", _awardsCacheService.TitleCount);
+                }
+                else
+                {
+                    _logger.LogWarning("[Awards] Initial awards fetch returned no rows; the weekly task will retry.");
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Server shutting down mid-fetch — the weekly task will build it later.
+            }
+            catch (System.Exception ex)
+            {
+                _logger.LogError($"[Awards] Initial awards index build failed (the weekly task will retry): {ex.Message}");
+            }
         }
 
         // Request-time script injection (Jellyfin 10.11 & 12).

--- a/Jellyfin.Plugin.JellyfinElevate/Services/StartupService.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/StartupService.cs
@@ -117,10 +117,12 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
             try
             {
                 _logger.LogInformation("[Awards] Feature enabled and no index on disk; building the initial awards index...");
-                var rows = await _awardsProvider.FetchAllAsync(null, cancellationToken).ConfigureAwait(false);
-                if (rows.Count > 0)
+                var result = await _awardsProvider.FetchAllAsync(null, cancellationToken).ConfigureAwait(false);
+                if (result.Rows.Count > 0)
                 {
-                    _awardsCacheService.ReplaceFrom(rows);
+                    // First install (index empty): publish whatever we got — a partial index beats
+                    // an empty section, and the weekly task refreshes it to completeness later.
+                    _awardsCacheService.ReplaceFrom(result.Rows);
                     _logger.LogInformation("[Awards] Initial awards index built: {0} titles.", _awardsCacheService.TitleCount);
                 }
                 else

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/ar.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/ar.json
@@ -698,5 +698,8 @@
   "discovery_customize_move_down": "نقل لأسفل",
   "discovery_customize_reset": "إعادة التعيين إلى الافتراضي",
   "discovery_customize_cancel": "إلغاء",
-  "discovery_customize_save": "حفظ"
+  "discovery_customize_save": "حفظ",
+  "awards_section_title": "الجوائز",
+  "awards_won": "فائز",
+  "awards_nominated": "مُرشَّح"
 }

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/bg.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/bg.json
@@ -698,5 +698,8 @@
   "discovery_customize_move_down": "Премести надолу",
   "discovery_customize_reset": "Връщане към стандартните",
   "discovery_customize_cancel": "Отказ",
-  "discovery_customize_save": "Запазване"
+  "discovery_customize_save": "Запазване",
+  "awards_section_title": "Награди",
+  "awards_won": "Победител",
+  "awards_nominated": "Номиниран"
 }

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/ca.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/ca.json
@@ -698,5 +698,8 @@
   "discovery_customize_move_down": "Mou cap avall",
   "discovery_customize_reset": "Restableix els valors predeterminats",
   "discovery_customize_cancel": "Cancel·lar",
-  "discovery_customize_save": "Desar"
+  "discovery_customize_save": "Desar",
+  "awards_section_title": "Premis",
+  "awards_won": "Guanyador",
+  "awards_nominated": "Nominat"
 }

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/cs.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/cs.json
@@ -698,5 +698,8 @@
   "discovery_customize_move_down": "Posunout dolů",
   "discovery_customize_reset": "Obnovit výchozí",
   "discovery_customize_cancel": "Zrušit",
-  "discovery_customize_save": "Uložit"
+  "discovery_customize_save": "Uložit",
+  "awards_section_title": "Ocenění",
+  "awards_won": "Vítěz",
+  "awards_nominated": "Nominace"
 }

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/da.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/da.json
@@ -698,5 +698,8 @@
   "discovery_customize_move_down": "Flyt ned",
   "discovery_customize_reset": "Nulstil til standard",
   "discovery_customize_cancel": "Annuller",
-  "discovery_customize_save": "Gem"
+  "discovery_customize_save": "Gem",
+  "awards_section_title": "Priser",
+  "awards_won": "Vinder",
+  "awards_nominated": "Nomineret"
 }

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/de.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/de.json
@@ -698,5 +698,8 @@
   "discovery_customize_move_down": "Nach unten",
   "discovery_customize_reset": "Auf Standard zurücksetzen",
   "discovery_customize_cancel": "Abbrechen",
-  "discovery_customize_save": "Speichern"
+  "discovery_customize_save": "Speichern",
+  "awards_section_title": "Auszeichnungen",
+  "awards_won": "Gewinner",
+  "awards_nominated": "Nominiert"
 }

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/en-GB.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/en-GB.json
@@ -698,5 +698,8 @@
   "discovery_customize_move_down": "Move down",
   "discovery_customize_reset": "Reset to defaults",
   "discovery_customize_cancel": "Cancel",
-  "discovery_customize_save": "Save"
+  "discovery_customize_save": "Save",
+  "awards_section_title": "Awards",
+  "awards_won": "Winner",
+  "awards_nominated": "Nominee"
 }

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/en-US.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/en-US.json
@@ -698,5 +698,8 @@
   "discovery_customize_move_down": "Move down",
   "discovery_customize_reset": "Reset to defaults",
   "discovery_customize_cancel": "Cancel",
-  "discovery_customize_save": "Save"
+  "discovery_customize_save": "Save",
+  "awards_section_title": "Awards",
+  "awards_won": "Winner",
+  "awards_nominated": "Nominee"
 }

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/en.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/en.json
@@ -698,5 +698,8 @@
   "discovery_customize_move_down": "Move down",
   "discovery_customize_reset": "Reset to defaults",
   "discovery_customize_cancel": "Cancel",
-  "discovery_customize_save": "Save"
+  "discovery_customize_save": "Save",
+  "awards_section_title": "Awards",
+  "awards_won": "Winner",
+  "awards_nominated": "Nominee"
 }

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/es.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/es.json
@@ -698,5 +698,8 @@
   "discovery_customize_move_down": "Mover abajo",
   "discovery_customize_reset": "Restablecer valores predeterminados",
   "discovery_customize_cancel": "Cancelar",
-  "discovery_customize_save": "Guardar"
+  "discovery_customize_save": "Guardar",
+  "awards_section_title": "Premios",
+  "awards_won": "Ganador",
+  "awards_nominated": "Nominado"
 }

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/fr.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/fr.json
@@ -698,5 +698,8 @@
   "discovery_customize_move_down": "Déplacer vers le bas",
   "discovery_customize_reset": "Réinitialiser par défaut",
   "discovery_customize_cancel": "Annuler",
-  "discovery_customize_save": "Enregistrer"
+  "discovery_customize_save": "Enregistrer",
+  "awards_section_title": "Récompenses",
+  "awards_won": "Lauréat",
+  "awards_nominated": "Nommé"
 }

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/he.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/he.json
@@ -698,5 +698,8 @@
   "discovery_customize_move_down": "Move down",
   "discovery_customize_reset": "איפוס לברירת מחדל",
   "discovery_customize_cancel": "Cancel",
-  "discovery_customize_save": "Save"
+  "discovery_customize_save": "Save",
+  "awards_section_title": "פרסים",
+  "awards_won": "זוכה",
+  "awards_nominated": "מועמד"
 }

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/hu.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/hu.json
@@ -698,5 +698,8 @@
   "discovery_customize_move_down": "Lefelé",
   "discovery_customize_reset": "Alapértelmezettek visszaállítása",
   "discovery_customize_cancel": "Mégsem",
-  "discovery_customize_save": "Mentés"
+  "discovery_customize_save": "Mentés",
+  "awards_section_title": "Díjak",
+  "awards_won": "Győztes",
+  "awards_nominated": "Jelölt"
 }

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/it.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/it.json
@@ -698,5 +698,8 @@
   "discovery_customize_move_down": "Sposta giù",
   "discovery_customize_reset": "Ripristina predefiniti",
   "discovery_customize_cancel": "Annulla",
-  "discovery_customize_save": "Salva"
+  "discovery_customize_save": "Salva",
+  "awards_section_title": "Premi",
+  "awards_won": "Vincitore",
+  "awards_nominated": "Candidato"
 }

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/nl.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/nl.json
@@ -698,5 +698,8 @@
   "discovery_customize_move_down": "Omlaag verplaatsen",
   "discovery_customize_reset": "Standaardwaarden herstellen",
   "discovery_customize_cancel": "Annuleren",
-  "discovery_customize_save": "Opslaan"
+  "discovery_customize_save": "Opslaan",
+  "awards_section_title": "Prijzen",
+  "awards_won": "Winnaar",
+  "awards_nominated": "Genomineerd"
 }

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/no.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/no.json
@@ -698,5 +698,8 @@
   "discovery_customize_move_down": "Flytt ned",
   "discovery_customize_reset": "Tilbakestill til standard",
   "discovery_customize_cancel": "Avbryt",
-  "discovery_customize_save": "Lagre"
+  "discovery_customize_save": "Lagre",
+  "awards_section_title": "Priser",
+  "awards_won": "Vinner",
+  "awards_nominated": "Nominert"
 }

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/pl.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/pl.json
@@ -698,5 +698,8 @@
   "discovery_customize_move_down": "Przesuń w dół",
   "discovery_customize_reset": "Przywróć domyślne",
   "discovery_customize_cancel": "Anuluj",
-  "discovery_customize_save": "Zapisz"
+  "discovery_customize_save": "Zapisz",
+  "awards_section_title": "Nagrody",
+  "awards_won": "Zwycięzca",
+  "awards_nominated": "Nominowany"
 }

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/pr.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/pr.json
@@ -698,5 +698,8 @@
   "discovery_customize_move_down": "Lower th' rigging",
   "discovery_customize_reset": "Repor predefinições",
   "discovery_customize_cancel": "Belay That",
-  "discovery_customize_save": "Set Sail"
+  "discovery_customize_save": "Set Sail",
+  "awards_section_title": "Trophies & Plunder",
+  "awards_won": "Prize Claimed",
+  "awards_nominated": "In the Runnin'"
 }

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/pt-BR.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/pt-BR.json
@@ -698,5 +698,8 @@
   "discovery_customize_move_down": "Mover para baixo",
   "discovery_customize_reset": "Restaurar padrões",
   "discovery_customize_cancel": "Cancelar",
-  "discovery_customize_save": "Salvar"
+  "discovery_customize_save": "Salvar",
+  "awards_section_title": "Prêmios",
+  "awards_won": "Vencedor",
+  "awards_nominated": "Indicado"
 }

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/pt.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/pt.json
@@ -698,5 +698,8 @@
   "discovery_customize_move_down": "Mover para baixo",
   "discovery_customize_reset": "Repor predefinições",
   "discovery_customize_cancel": "Cancelar",
-  "discovery_customize_save": "Salvar"
+  "discovery_customize_save": "Salvar",
+  "awards_section_title": "Prémios",
+  "awards_won": "Vencedor",
+  "awards_nominated": "Nomeado"
 }

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/ru.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/ru.json
@@ -698,5 +698,8 @@
   "discovery_customize_move_down": "Переместить вниз",
   "discovery_customize_reset": "Сбросить по умолчанию",
   "discovery_customize_cancel": "Отмена",
-  "discovery_customize_save": "Сохранить"
+  "discovery_customize_save": "Сохранить",
+  "awards_section_title": "Награды",
+  "awards_won": "Победитель",
+  "awards_nominated": "Номинант"
 }

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/sk.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/sk.json
@@ -698,5 +698,8 @@
   "discovery_customize_move_down": "Posunúť nadol",
   "discovery_customize_reset": "Obnoviť predvolené",
   "discovery_customize_cancel": "Zrušiť",
-  "discovery_customize_save": "Uložiť"
+  "discovery_customize_save": "Uložiť",
+  "awards_section_title": "Ocenenia",
+  "awards_won": "Víťaz",
+  "awards_nominated": "Nominácia"
 }

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/sv.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/sv.json
@@ -698,5 +698,8 @@
   "discovery_customize_move_down": "Flytta ned",
   "discovery_customize_reset": "Återställ standard",
   "discovery_customize_cancel": "Avbryt",
-  "discovery_customize_save": "Spara"
+  "discovery_customize_save": "Spara",
+  "awards_section_title": "Utmärkelser",
+  "awards_won": "Vinnare",
+  "awards_nominated": "Nominerad"
 }

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/tr.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/tr.json
@@ -698,5 +698,8 @@
   "discovery_customize_move_down": "Aşağı taşı",
   "discovery_customize_reset": "Varsayılanlara sıfırla",
   "discovery_customize_cancel": "İptal",
-  "discovery_customize_save": "Kaydet"
+  "discovery_customize_save": "Kaydet",
+  "awards_section_title": "Ödüller",
+  "awards_won": "Kazanan",
+  "awards_nominated": "Aday"
 }

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/zh-CN.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/zh-CN.json
@@ -698,5 +698,8 @@
   "discovery_customize_move_down": "下移",
   "discovery_customize_reset": "恢复默认",
   "discovery_customize_cancel": "取消",
-  "discovery_customize_save": "储存"
+  "discovery_customize_save": "储存",
+  "awards_section_title": "获奖",
+  "awards_won": "获奖者",
+  "awards_nominated": "提名"
 }

--- a/Jellyfin.Plugin.JellyfinElevate/js/locales/zh-HK.json
+++ b/Jellyfin.Plugin.JellyfinElevate/js/locales/zh-HK.json
@@ -698,5 +698,8 @@
   "discovery_customize_move_down": "下移",
   "discovery_customize_reset": "重設為預設值",
   "discovery_customize_cancel": "取消",
-  "discovery_customize_save": "儲存"
+  "discovery_customize_save": "儲存",
+  "awards_section_title": "獎項",
+  "awards_won": "得獎",
+  "awards_nominated": "提名"
 }

--- a/Jellyfin.Plugin.JellyfinElevate/js/plugin.js
+++ b/Jellyfin.Plugin.JellyfinElevate/js/plugin.js
@@ -1000,6 +1000,7 @@
             if (typeof JE.initializeArrTagLinksScript === 'function' && JE.pluginConfig?.ArrTagsShowAsLinks) JE.initializeArrTagLinksScript();
             if (typeof JE.initializeLetterboxdLinksScript === 'function' && JE.pluginConfig?.LetterboxdEnabled) JE.initializeLetterboxdLinksScript();
             if (typeof JE.initializeReviewsScript === 'function' && (JE.pluginConfig?.ShowReviews || JE.pluginConfig?.ShowUserReviews)) JE.initializeReviewsScript();
+            if (typeof JE.initializeAwardsScript === 'function' && JE.pluginConfig?.ShowAwards) JE.initializeAwardsScript();
             if (typeof JE.initializeLanguageTags === 'function' && JE.currentSettings?.languageTagsEnabled) JE.initializeLanguageTags();
             if (typeof JE.initializePeopleTags === 'function' && JE.currentSettings?.peopleTagsEnabled) JE.initializePeopleTags();
             // Initialize the unified tag pipeline AFTER all tag renderers have registered

--- a/Jellyfin.Plugin.JellyfinElevate/src/extras/awards-format.test.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/extras/awards-format.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { prettifyCategory, groupByCeremony, type AwardEntry } from './awards-format';
+
+describe('prettifyCategory', () => {
+    it('strips "<X> Award for" prefixes', () => {
+        expect(prettifyCategory('Academy Award for Best Picture', 'Academy Awards')).toBe('Best Picture');
+        expect(prettifyCategory('Primetime Emmy Award for Outstanding Drama Series', 'Primetime Emmy Awards'))
+            .toBe('Outstanding Drama Series');
+        expect(prettifyCategory('Golden Globe Award for Best Motion Picture – Drama', 'Golden Globe Awards'))
+            .toBe('Best Motion Picture – Drama');
+    });
+
+    it('strips a leading festival ceremony name for prize-style labels', () => {
+        expect(prettifyCategory('Cannes Film Festival Grand Prix', 'Cannes Film Festival')).toBe('Grand Prix');
+    });
+
+    it('leaves bare prize names untouched', () => {
+        expect(prettifyCategory("Palme d'Or", 'Cannes Film Festival')).toBe("Palme d'Or");
+        expect(prettifyCategory('Golden Lion', 'Venice Film Festival')).toBe('Golden Lion');
+    });
+
+    it('never returns an empty string', () => {
+        expect(prettifyCategory('Academy Awards', 'Academy Awards')).toBe('Academy Awards');
+        expect(prettifyCategory('', 'Academy Awards')).toBe('');
+    });
+});
+
+describe('groupByCeremony', () => {
+    const a = (ceremony: string, category: string, won = true): AwardEntry => ({ ceremony, category, won, year: 2024 });
+
+    it('groups by ceremony preserving first-seen order', () => {
+        const groups = groupByCeremony([
+            a('Academy Awards', 'Best Picture'),
+            a('BAFTA Awards', 'Best Film'),
+            a('Academy Awards', 'Best Director'),
+        ]);
+        expect(groups.map(g => g.ceremony)).toEqual(['Academy Awards', 'BAFTA Awards']);
+        expect(groups[0].entries.map(e => e.category)).toEqual(['Best Picture', 'Best Director']);
+        expect(groups[1].entries).toHaveLength(1);
+    });
+
+    it('falls back to "Awards" for a blank ceremony', () => {
+        const groups = groupByCeremony([a('', 'Some Prize')]);
+        expect(groups[0].ceremony).toBe('Awards');
+    });
+
+    it('returns an empty array for no awards', () => {
+        expect(groupByCeremony([])).toEqual([]);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinElevate/src/extras/awards-format.test.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/extras/awards-format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { prettifyCategory, groupByCeremony, type AwardEntry } from './awards-format';
+import { prettifyCategory, groupByCeremony, applyTransient, type AwardEntry, type TransientRetryState } from './awards-format';
 
 describe('prettifyCategory', () => {
     it('strips "<X> Award for" prefixes', () => {
@@ -46,5 +46,54 @@ describe('groupByCeremony', () => {
 
     it('returns an empty array for no awards', () => {
         expect(groupByCeremony([])).toEqual([]);
+    });
+});
+
+describe('applyTransient (retry budget)', () => {
+    const BASE = 2000, MAXB = 15000, COOL = 30000;
+    const fresh = (now: number, windowMs = 180000): TransientRetryState =>
+        ({ attempts: 0, windowDeadline: now + windowMs, nextAllowedAt: 0 });
+
+    it('within the window schedules a backoff retry and advances nextAllowedAt', () => {
+        const now = 1000;
+        const { state, action } = applyTransient(fresh(now), now, BASE, MAXB, COOL);
+        expect(action).toEqual({ kind: 'retry', delayMs: 2000 });
+        expect(state.attempts).toBe(1);
+        expect(state.nextAllowedAt).toBe(now + 2000);
+    });
+
+    it('backs off with attempt count and caps at maxBackoff', () => {
+        const now = 1000;
+        let s = fresh(now);
+        for (let i = 0; i < 10; i++) s = applyTransient(s, now, BASE, MAXB, COOL).state;
+        // 2000 * 10 = 20000, capped to 15000
+        const { action } = applyTransient(s, now, BASE, MAXB, COOL);
+        expect(action).toEqual({ kind: 'retry', delayMs: MAXB });
+    });
+
+    it('after the window it stops timed retries and cools down instead', () => {
+        const start = 1000;
+        const state = fresh(start, /*windowMs*/ 500); // deadline = 1500
+        const later = start + 1000; // 2000 — past the deadline
+        const res = applyTransient(state, later, BASE, MAXB, COOL);
+        expect(res.action).toEqual({ kind: 'cooldown' });
+        expect(res.state.nextAllowedAt).toBe(later + COOL);
+    });
+
+    it('never moves windowDeadline (monotonic budget — mutations cannot reset it)', () => {
+        const now = 1000;
+        const s0 = fresh(now);
+        const s1 = applyTransient(s0, now, BASE, MAXB, COOL).state;
+        const s2 = applyTransient(s1, now + 5000, BASE, MAXB, COOL).state;
+        expect(s1.windowDeadline).toBe(s0.windowDeadline);
+        expect(s2.windowDeadline).toBe(s0.windowDeadline);
+    });
+
+    it('does not mutate the input state', () => {
+        const now = 1000;
+        const s0 = fresh(now);
+        applyTransient(s0, now, BASE, MAXB, COOL);
+        expect(s0.attempts).toBe(0);
+        expect(s0.nextAllowedAt).toBe(0);
     });
 });

--- a/Jellyfin.Plugin.JellyfinElevate/src/extras/awards-format.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/extras/awards-format.ts
@@ -31,6 +31,41 @@ export function prettifyCategory(category: string, ceremony: string): string {
     return c.length > 0 ? c : category;
 }
 
+/** Transient (transport-error / index-not-ready) per-item retry budget for the Awards fetch. */
+export interface TransientRetryState {
+    /** Number of transient responses seen so far for this item (this page view). */
+    attempts: number;
+    /** Absolute time after which timed retries stop; set once per item and never moved (monotonic). */
+    windowDeadline: number;
+    /** Earliest time a fetch is allowed again — rate-limits trigger-driven retries. */
+    nextAllowedAt: number;
+}
+
+export type TransientAction =
+    | { kind: 'retry'; delayMs: number }
+    | { kind: 'cooldown' };
+
+/**
+ * Pure decision for the next transient-retry step. Increments the attempt count and, while still
+ * inside the monotonic window, asks for a capped exponential backoff retry; once the window is
+ * spent it asks for a cooldown (no more timed retries — only a rate-limited trigger-driven retry).
+ * Returns a NEW state (never mutates the input) so it is trivially testable and side-effect free.
+ */
+export function applyTransient(
+    state: TransientRetryState,
+    now: number,
+    baseDelayMs: number,
+    maxBackoffMs: number,
+    cooldownMs: number,
+): { state: TransientRetryState; action: TransientAction } {
+    const attempts = state.attempts + 1;
+    if (now < state.windowDeadline) {
+        const delayMs = Math.min(maxBackoffMs, baseDelayMs * attempts);
+        return { state: { ...state, attempts, nextAllowedAt: now + delayMs }, action: { kind: 'retry', delayMs } };
+    }
+    return { state: { ...state, attempts, nextAllowedAt: now + cooldownMs }, action: { kind: 'cooldown' } };
+}
+
 /** Groups awards by ceremony, preserving first-seen (already newest-first) order. */
 export function groupByCeremony(awards: AwardEntry[]): Array<{ ceremony: string; entries: AwardEntry[] }> {
     const order: string[] = [];

--- a/Jellyfin.Plugin.JellyfinElevate/src/extras/awards-format.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/extras/awards-format.ts
@@ -1,0 +1,49 @@
+// src/extras/awards-format.ts
+//
+// Pure, dependency-free formatting helpers for the Awards section, split out so
+// they can be unit-tested without loading the DOM/JE module graph.
+
+/** One award as returned by the server (Model/Awards/AwardEntry.cs). */
+export interface AwardEntry {
+    ceremony: string;
+    category: string;
+    year?: number | null;
+    won: boolean;
+}
+
+/**
+ * Strips the redundant ceremony prefix from a Wikidata category label so the UI shows
+ * "Best Picture" under the "Academy Awards" heading, not "Academy Award for Best Picture".
+ * Falls back to the raw label when no known shape matches.
+ */
+export function prettifyCategory(category: string, ceremony: string): string {
+    let c = (category || '').trim();
+
+    // "<anything> Award(s) for X" / "Award – X" → "X" (Oscars, Globes, BAFTA, Emmy, Critics', SAG).
+    const awardFor = c.match(/\bAwards?\s+for\s+(.+)$/i);
+    if (awardFor) {
+        c = awardFor[1].trim();
+    } else if (ceremony && c.toLowerCase().startsWith(ceremony.toLowerCase())) {
+        // Festival prizes: "Cannes Film Festival Grand Prix" → "Grand Prix".
+        c = c.slice(ceremony.length).replace(/^[\s:–-]+/, '').trim() || c;
+    }
+
+    return c.length > 0 ? c : category;
+}
+
+/** Groups awards by ceremony, preserving first-seen (already newest-first) order. */
+export function groupByCeremony(awards: AwardEntry[]): Array<{ ceremony: string; entries: AwardEntry[] }> {
+    const order: string[] = [];
+    const map = new Map<string, AwardEntry[]>();
+    for (const a of awards) {
+        const key = a.ceremony || 'Awards';
+        let list = map.get(key);
+        if (!list) {
+            list = [];
+            map.set(key, list);
+            order.push(key);
+        }
+        list.push(a);
+    }
+    return order.map(ceremony => ({ ceremony, entries: map.get(ceremony)! }));
+}

--- a/Jellyfin.Plugin.JellyfinElevate/src/extras/awards.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/extras/awards.ts
@@ -116,6 +116,11 @@ JE.initializeAwardsScript = function () {
     }
 
     async function processAwards(): Promise<void> {
+        // Fast-path bail if the admin disabled the feature since this pass was scheduled (a pending
+        // backoff timer or a queued idle callback can still call in here). The je:config-changed
+        // handler already stripped any rendered section; this stops a new one being inserted.
+        if (!JE?.pluginConfig?.ShowAwards) return;
+
         if (inFlight) {
             rerunRequested = true;
             return;
@@ -179,9 +184,10 @@ JE.initializeAwardsScript = function () {
                 return;
             }
 
-            // The user may have navigated away while the request was in flight.
+            // The user may have navigated away — or the admin disabled the feature — while the
+            // request was in flight; don't insert a section in either case.
             const stillVisible = document.querySelector<HTMLElement>('#itemDetailPage:not(.hide)');
-            if (!stillVisible || getItemIdFromUrl() !== itemId) return;
+            if (!stillVisible || getItemIdFromUrl() !== itemId || !JE?.pluginConfig?.ShowAwards) return;
             if (stillVisible.querySelector(`.${SECTION_CLASS}`)) {
                 resolved.add(itemId);
                 retry.delete(itemId);

--- a/Jellyfin.Plugin.JellyfinElevate/src/extras/awards.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/extras/awards.ts
@@ -65,6 +65,7 @@ JE.initializeAwardsScript = function () {
     const errorAttempts = new Map<string, number>();
     const notReadyAttempts = new Map<string, number>();
     const ERROR_MAX_ATTEMPTS = 3;
+    const ERROR_BASE_DELAY_MS = 2000;
     // The awards index is only ever empty transiently, during the first-install build. Retry a
     // bounded number of times with backoff so awards appear on the page that is already open
     // once the build lands, without ever caching the not-ready state as a genuine "no awards".
@@ -126,7 +127,14 @@ JE.initializeAwardsScript = function () {
             // not-ready state, NOT "no awards" — never cache it. Retry with bounded backoff so
             // the already-open page fills in once the build completes.
             if (data?.indexEmpty) {
-                scheduleNotReadyRetry(itemId);
+                const attempts = (notReadyAttempts.get(itemId) || 0) + 1;
+                if (attempts > NOT_READY_MAX_ATTEMPTS) {
+                    // The build is taking unusually long; stop probing. A later navigation re-triggers.
+                    notReadyAttempts.delete(itemId);
+                    return;
+                }
+                notReadyAttempts.set(itemId, attempts);
+                scheduleDelayedRetry(itemId, Math.min(15000, NOT_READY_BASE_DELAY_MS * attempts));
                 return;
             }
 
@@ -150,8 +158,9 @@ JE.initializeAwardsScript = function () {
             insertSection(stillVisible, section);
             processedItemIds.add(itemId);
         } catch (err) {
-            // PERF(R9): fail open — only give up on this item after repeated failures;
-            // the shared observer / nav probes retry until then. A blip never caches "no awards".
+            // PERF(R9): fail open — a transient failure schedules its own bounded, nav-guarded
+            // retry (never relying on an unrelated DOM/nav event to re-trigger), and is only given
+            // up on after ERROR_MAX_ATTEMPTS. A blip never caches "no awards".
             console.warn(`${logPrefix} failed to load awards for ${itemId}:`, err);
             const attempts = (errorAttempts.get(itemId) || 0) + 1;
             if (attempts >= ERROR_MAX_ATTEMPTS) {
@@ -159,6 +168,7 @@ JE.initializeAwardsScript = function () {
                 errorAttempts.delete(itemId);
             } else {
                 errorAttempts.set(itemId, attempts);
+                scheduleDelayedRetry(itemId, ERROR_BASE_DELAY_MS * attempts);
             }
         } finally {
             inFlight = false;
@@ -171,24 +181,15 @@ JE.initializeAwardsScript = function () {
         }
     }
 
-    // PERF(R9)/R5: bounded, nav-guarded retry while the first-install index build is in flight.
-    // Not a standing timer — it stops as soon as the item renders, the view changes, or the cap
-    // is hit; the index only starts empty once, on first install.
-    function scheduleNotReadyRetry(itemId: string): void {
-        const attempts = (notReadyAttempts.get(itemId) || 0) + 1;
-        if (attempts > NOT_READY_MAX_ATTEMPTS) {
-            // The build is taking unusually long; stop hammering. A later navigation re-triggers.
-            notReadyAttempts.delete(itemId);
-            return;
-        }
-        notReadyAttempts.set(itemId, attempts);
-        const delay = Math.min(15000, NOT_READY_BASE_DELAY_MS * attempts);
+    // PERF(R9)/R5: bounded, nav-guarded single-shot retry used by both the transport-error and
+    // index-not-ready paths. Not a standing timer — each caller caps its own attempt count, and
+    // the timer aborts if the user navigated away or the item already rendered.
+    function scheduleDelayedRetry(itemId: string, delayMs: number): void {
         window.setTimeout(() => {
-            // Abort if the user navigated away or the item already rendered.
-            if (getItemIdFromUrl() !== itemId) return;
-            if (processedItemIds.has(itemId)) return;
+            if (getItemIdFromUrl() !== itemId) return; // navigated away
+            if (processedItemIds.has(itemId)) return;   // already resolved
             schedule();
-        }, delay);
+        }, delayMs);
     }
 
     // Coalesced, idle-scheduled pass shared by every trigger (R5 — no standing timer).

--- a/Jellyfin.Plugin.JellyfinElevate/src/extras/awards.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/extras/awards.ts
@@ -159,6 +159,11 @@ JE.initializeAwardsScript = function () {
         const pending = retry.get(itemId);
         if (pending && Date.now() < pending.nextAllowedAt) return;
 
+        // PERF(R5): never fetch while the tab is hidden. A retry timer that fires in a backgrounded
+        // tab bails here (no request, no attempt consumed); the visibilitychange listener below
+        // re-runs this pass when the tab becomes visible again.
+        if (document.visibilityState === 'hidden') return;
+
         inFlight = true;
         try {
             // skipCache: the shared GET cache's 30-min TTL would otherwise pin a transient
@@ -266,6 +271,10 @@ JE.initializeAwardsScript = function () {
     // A cached-page re-show is a class flip the structural observer drops, so cover it via nav.
     onNavigate(() => { if (JE?.pluginConfig?.ShowAwards) schedule(); });
     onViewPage(() => { if (JE?.pluginConfig?.ShowAwards) schedule(); });
+    // PERF(R5): resume a retry that was skipped while the tab was hidden, once it's visible again.
+    document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible' && JE?.pluginConfig?.ShowAwards) schedule();
+    });
 
     // React to a live enable/disable toggle without a page reload. On disable, strip any rendered
     // sections and forget the resolved items so a later re-enable re-renders them; on (re-)enable,

--- a/Jellyfin.Plugin.JellyfinElevate/src/extras/awards.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/extras/awards.ts
@@ -36,6 +36,7 @@ interface ItemAwardsResponse {
     enabled: boolean;
     version: number;
     indexEmpty: boolean;
+    indexComplete: boolean;
     awards: AwardEntry[];
 }
 
@@ -181,7 +182,16 @@ JE.initializeAwardsScript = function () {
 
             const awards = Array.isArray(data?.awards) ? data.awards : [];
             if (awards.length === 0) {
-                // Genuine "no awards" (index is built) — terminal for this view.
+                // An empty list is only a GENUINE "no awards" when the index is complete. On a
+                // partial index (e.g. one ceremony query failed on first install) this item's
+                // ceremony may simply not be fetched yet, so treat it as transient and keep
+                // retrying (bounded) rather than caching "no awards" — the complete index will fill
+                // it in. `indexComplete` defaults to true for older servers without the field.
+                if (data && data.indexComplete === false) {
+                    handleTransient(itemId, NOT_READY_BASE_DELAY_MS);
+                    return;
+                }
+                // Genuine "no awards" (complete index) — terminal for this view.
                 resolved.add(itemId);
                 retry.delete(itemId);
                 return;

--- a/Jellyfin.Plugin.JellyfinElevate/src/extras/awards.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/extras/awards.ts
@@ -245,16 +245,36 @@ JE.initializeAwardsScript = function () {
     onNavigate(() => { if (JE?.pluginConfig?.ShowAwards) schedule(); });
     onViewPage(() => { if (JE?.pluginConfig?.ShowAwards) schedule(); });
 
+    // React to a live enable/disable toggle without a page reload. On disable, strip any rendered
+    // sections and forget the resolved items so a later re-enable re-renders them; on (re-)enable,
+    // clear per-item state and re-run so the current item paints. Registered once (init runs once).
+    try {
+        window.addEventListener('je:config-changed', () => {
+            if (JE?.pluginConfig?.ShowAwards) {
+                resolved.clear();
+                retry.clear();
+                schedule();
+            } else {
+                document.querySelectorAll(`.${SECTION_CLASS}`).forEach(el => el.remove());
+                resolved.clear();
+                retry.clear();
+            }
+        });
+    } catch { /* addEventListener unavailable — ignore */ }
+
     schedule();
     console.log(`${logPrefix} initialized.`);
 };
 
-// Live enable: if the admin turns Awards on while a session is open, live-config refreshes
-// JE.pluginConfig and fires je:config-changed. Register (once) then — no page reload needed.
-// A no-op when already started or still disabled.
+// Live enable from a disabled bootstrap: if the admin turns Awards on while a session is open,
+// live-config refreshes JE.pluginConfig and fires je:config-changed. Start the feature then — no
+// page reload needed. A no-op when already started or still disabled (the in-init listener above
+// then owns subsequent toggles).
 try {
-    window.addEventListener('je:config-changed', () => { JE.initializeAwardsScript?.(); });
-} catch { /* CustomEvent/addEventListener unavailable — bootstrap path still covers the enabled case */ }
+    window.addEventListener('je:config-changed', () => {
+        if (JE?.pluginConfig?.ShowAwards) JE.initializeAwardsScript?.();
+    });
+} catch { /* addEventListener unavailable — bootstrap path still covers the enabled-at-load case */ }
 
 /** Builds the whole Awards section off-DOM (R7). All dynamic text via textContent (X1). */
 function buildAwardsSection(awards: AwardEntry[]): HTMLElement {

--- a/Jellyfin.Plugin.JellyfinElevate/src/extras/awards.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/extras/awards.ts
@@ -50,13 +50,20 @@ const JE = JEBase as typeof JEBase & {
 const SECTION_CLASS = 'je-awards-section';
 const STYLE_ID = 'je-awards-styles';
 
+// Registered exactly once. Guards against double-registration when the initializer is invoked
+// both by the bootstrap loader and by the live-config re-init hook below.
+let awardsStarted = false;
+
 JE.initializeAwardsScript = function () {
     const logPrefix = '🪼 Jellyfin Elevate: Awards:';
 
+    if (awardsStarted) return;
     if (!JE?.pluginConfig?.ShowAwards) {
+        // Not started — a later admin enable (via the je:config-changed hook below) re-invokes this.
         console.log(`${logPrefix} feature disabled.`);
         return;
     }
+    awardsStarted = true;
 
     console.log(`${logPrefix} initializing...`);
 
@@ -227,12 +234,10 @@ JE.initializeAwardsScript = function () {
     }
 
     // PERF(R3): ride the shared multiplexed body observer, gated to the visible details page.
-    const subscription = onBodyMutation('je-awards', () => {
-        if (!JE?.pluginConfig?.ShowAwards) {
-            subscription.unsubscribe();
-            console.log(`${logPrefix} stopped — feature disabled.`);
-            return;
-        }
+    // The work is gated on ShowAwards at runtime (not torn down on disable) so an admin can
+    // toggle the feature off and back on live — a disabled pass is a cheap early return.
+    onBodyMutation('je-awards', () => {
+        if (!JE?.pluginConfig?.ShowAwards) return;
         if (!isDetailsPageVisible()) return;
         schedule();
     });
@@ -243,6 +248,13 @@ JE.initializeAwardsScript = function () {
     schedule();
     console.log(`${logPrefix} initialized.`);
 };
+
+// Live enable: if the admin turns Awards on while a session is open, live-config refreshes
+// JE.pluginConfig and fires je:config-changed. Register (once) then — no page reload needed.
+// A no-op when already started or still disabled.
+try {
+    window.addEventListener('je:config-changed', () => { JE.initializeAwardsScript?.(); });
+} catch { /* CustomEvent/addEventListener unavailable — bootstrap path still covers the enabled case */ }
 
 /** Builds the whole Awards section off-DOM (R7). All dynamic text via textContent (X1). */
 function buildAwardsSection(awards: AwardEntry[]): HTMLElement {

--- a/Jellyfin.Plugin.JellyfinElevate/src/extras/awards.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/extras/awards.ts
@@ -25,7 +25,7 @@
 
 import { JE as JEBase } from '../globals';
 import { ensureMaterialSymbolsFont } from '../core/ui-kit';
-import { isDetailsPageVisible, getItemIdFromUrl } from '../core/details-view';
+import { isDetailsPageVisible, getVisibleDetailsPage } from '../core/details-view';
 import { onBodyMutation } from '../core/dom-observer';
 import { onNavigate, onViewPage } from '../core/navigation';
 import { prettifyCategory, groupByCeremony, applyTransient, type AwardEntry, type TransientRetryState } from './awards-format';
@@ -126,11 +126,14 @@ JE.initializeAwardsScript = function () {
             return;
         }
 
-        const visiblePage = document.querySelector<HTMLElement>('#itemDetailPage:not(.hide)');
-        if (!visiblePage) return;
-
-        const itemId = getItemIdFromUrl();
-        if (!itemId) return;
+        // Single source of the (page, item) pair. getVisibleDetailsPage() returns null while the
+        // outgoing cached page is still visible during a details→details navigation, so we never
+        // resolve against — or inject into — the wrong page (the raw `#itemDetailPage:not(.hide)`
+        // selector can return the outgoing page mid-navigation).
+        const view = getVisibleDetailsPage();
+        if (!view) return;
+        const visiblePage = view.page;
+        const itemId = view.itemId;
 
         // Navigated to a different item — allow the new one to render and drop stale state, so a
         // genuinely new page view starts with a fresh (monotonic) retry budget.
@@ -185,9 +188,12 @@ JE.initializeAwardsScript = function () {
             }
 
             // The user may have navigated away — or the admin disabled the feature — while the
-            // request was in flight; don't insert a section in either case.
-            const stillVisible = document.querySelector<HTMLElement>('#itemDetailPage:not(.hide)');
-            if (!stillVisible || getItemIdFromUrl() !== itemId || !JE?.pluginConfig?.ShowAwards) return;
+            // request was in flight. Re-resolve the live (page, item) pair and require the SAME
+            // item AND the incoming live page before inserting, so a fast response for B can't land
+            // on A's outgoing page during a details→details navigation.
+            const after = getVisibleDetailsPage();
+            if (!after || after.itemId !== itemId || !JE?.pluginConfig?.ShowAwards) return;
+            const stillVisible = after.page;
             if (stillVisible.querySelector(`.${SECTION_CLASS}`)) {
                 resolved.add(itemId);
                 retry.delete(itemId);
@@ -220,7 +226,7 @@ JE.initializeAwardsScript = function () {
     // the timer aborts if the user navigated away or the item already rendered.
     function scheduleDelayedRetry(itemId: string, delayMs: number): void {
         window.setTimeout(() => {
-            if (getItemIdFromUrl() !== itemId) return; // navigated away
+            if (getVisibleDetailsPage()?.itemId !== itemId) return; // navigated away
             if (resolved.has(itemId)) return;           // already resolved
             schedule();
         }, delayMs);

--- a/Jellyfin.Plugin.JellyfinElevate/src/extras/awards.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/extras/awards.ts
@@ -28,7 +28,7 @@ import { ensureMaterialSymbolsFont } from '../core/ui-kit';
 import { isDetailsPageVisible, getItemIdFromUrl } from '../core/details-view';
 import { onBodyMutation } from '../core/dom-observer';
 import { onNavigate, onViewPage } from '../core/navigation';
-import { prettifyCategory, groupByCeremony, type AwardEntry } from './awards-format';
+import { prettifyCategory, groupByCeremony, applyTransient, type AwardEntry, type TransientRetryState } from './awards-format';
 import type { ApiApi, PluginConfig } from '../types/je';
 
 /** Response shape of GET /JellyfinElevate/awards/{itemId} (ItemAwardsResponse.cs). */
@@ -60,17 +60,24 @@ JE.initializeAwardsScript = function () {
 
     console.log(`${logPrefix} initializing...`);
 
-    // Per-item render dedup + fail-open retry bookkeeping (mirrors letterboxd-links).
-    const processedItemIds = new Set<string>();
-    const errorAttempts = new Map<string, number>();
-    const notReadyAttempts = new Map<string, number>();
-    const ERROR_MAX_ATTEMPTS = 3;
+    // TERMINAL per-item state: awards rendered, a genuine "no awards" answer, or the feature
+    // turned off. Never re-fetched for this page view. Distinct from the TRANSIENT retry state
+    // below, so a transport error or a not-ready index is never cached like a real answer (R9).
+    const resolved = new Set<string>();
+
+    // TRANSIENT per-item retry budget (transport errors + index-not-ready). Page-view scoped and
+    // MONOTONIC: `windowDeadline` is set once per item and never reset by a later trigger, so a
+    // mutation storm can't restart the budget; `nextAllowedAt` rate-limits fetches. Within the
+    // window we schedule timed backoff retries; after it, external triggers may still retry but
+    // only once per cooldown — so a still-down server or a long first build can't hammer, yet the
+    // open page still recovers once the server/index is ready.
+    const retry = new Map<string, TransientRetryState>();
+    const RETRY_WINDOW_MS = 3 * 60 * 1000;   // absolute per-view budget for timed retries
+    const RETRY_COOLDOWN_MS = 30 * 1000;     // min gap between post-window trigger-driven retries
+    const MAX_BACKOFF_MS = 15 * 1000;
     const ERROR_BASE_DELAY_MS = 2000;
-    // The awards index is only ever empty transiently, during the first-install build. Retry a
-    // bounded number of times with backoff so awards appear on the page that is already open
-    // once the build lands, without ever caching the not-ready state as a genuine "no awards".
-    const NOT_READY_MAX_ATTEMPTS = 8;
     const NOT_READY_BASE_DELAY_MS = 2000;
+
     let lastVisibleItemId: string | null = null;
     let inFlight = false;
     // PERF(R9)/lifecycle: if a trigger fires while a request is in flight (e.g. navigation to a
@@ -78,6 +85,28 @@ JE.initializeAwardsScript = function () {
     let rerunRequested = false;
 
     injectStyles();
+
+    function getRetry(itemId: string): TransientRetryState {
+        let r = retry.get(itemId);
+        if (!r) {
+            r = { attempts: 0, windowDeadline: Date.now() + RETRY_WINDOW_MS, nextAllowedAt: 0 };
+            retry.set(itemId, r);
+        }
+        return r;
+    }
+
+    // Unified transient handler for both the transport-error and index-not-ready paths. Never
+    // marks the item resolved; schedules a bounded timed retry while inside the window, then falls
+    // back to cooldown-gated recovery so it stays fail-open without ever hammering. The decision
+    // is the pure applyTransient() (unit-tested); this just applies its result.
+    function handleTransient(itemId: string, baseDelayMs: number): void {
+        const { state, action } = applyTransient(
+            getRetry(itemId), Date.now(), baseDelayMs, MAX_BACKOFF_MS, RETRY_COOLDOWN_MS);
+        retry.set(itemId, state);
+        if (action.kind === 'retry') {
+            scheduleDelayedRetry(itemId, action.delayMs);
+        }
+    }
 
     async function processAwards(): Promise<void> {
         if (inFlight) {
@@ -91,11 +120,11 @@ JE.initializeAwardsScript = function () {
         const itemId = getItemIdFromUrl();
         if (!itemId) return;
 
-        // Navigated to a different item — allow the new one to render and drop stale state.
+        // Navigated to a different item — allow the new one to render and drop stale state, so a
+        // genuinely new page view starts with a fresh (monotonic) retry budget.
         if (lastVisibleItemId && lastVisibleItemId !== itemId) {
-            processedItemIds.clear();
-            errorAttempts.clear();
-            notReadyAttempts.clear();
+            resolved.clear();
+            retry.clear();
         }
         lastVisibleItemId = itemId;
 
@@ -103,46 +132,43 @@ JE.initializeAwardsScript = function () {
         // three #itemDetailPage slots around) so it can't resurface against the wrong item.
         document.querySelectorAll(`#itemDetailPage.hide .${SECTION_CLASS}`).forEach(el => el.remove());
 
-        if (processedItemIds.has(itemId)) return;
+        if (resolved.has(itemId)) return;
         if (visiblePage.querySelector(`.${SECTION_CLASS}`)) {
-            processedItemIds.add(itemId);
+            resolved.add(itemId);
             return;
         }
+
+        // Cooldown gate: after the retry window is spent, external triggers (mutation/nav) may
+        // still retry, but no more than once per cooldown — a mutation storm can't hammer.
+        const pending = retry.get(itemId);
+        if (pending && Date.now() < pending.nextAllowedAt) return;
 
         inFlight = true;
         try {
             // skipCache: the shared GET cache's 30-min TTL would otherwise pin a transient
             // "index not built yet" response and hide awards for the rest of that window. This
-            // endpoint is a cheap server-side dictionary lookup, so per-view fetches are fine,
-            // and per-item dedup above already prevents repeats within a page view.
+            // endpoint is a cheap server-side dictionary lookup, so per-view fetches are fine.
             const data = await JE.core.api.plugin(`/awards/${encodeURIComponent(itemId)}`, { skipCache: true }) as ItemAwardsResponse | null;
 
             if (data && data.enabled === false) {
-                // Admin turned the feature off since bootstrap — stop retrying this view.
-                processedItemIds.add(itemId);
+                // Admin turned the feature off since bootstrap — terminal for this view.
+                resolved.add(itemId);
+                retry.delete(itemId);
                 return;
             }
 
-            // PERF(R9): the index hasn't been built yet (first install). This is a transient
-            // not-ready state, NOT "no awards" — never cache it. Retry with bounded backoff so
-            // the already-open page fills in once the build completes.
+            // PERF(R9): the index hasn't been built yet (first install). Transient not-ready
+            // state, NOT "no awards" — never cache it; retry (bounded) so the open page fills in.
             if (data?.indexEmpty) {
-                const attempts = (notReadyAttempts.get(itemId) || 0) + 1;
-                if (attempts > NOT_READY_MAX_ATTEMPTS) {
-                    // The build is taking unusually long; stop probing. A later navigation re-triggers.
-                    notReadyAttempts.delete(itemId);
-                    return;
-                }
-                notReadyAttempts.set(itemId, attempts);
-                scheduleDelayedRetry(itemId, Math.min(15000, NOT_READY_BASE_DELAY_MS * attempts));
+                handleTransient(itemId, NOT_READY_BASE_DELAY_MS);
                 return;
             }
 
             const awards = Array.isArray(data?.awards) ? data.awards : [];
-            notReadyAttempts.delete(itemId);
             if (awards.length === 0) {
-                // Genuine "no awards" (index is built) — remember it; don't re-fetch this view.
-                processedItemIds.add(itemId);
+                // Genuine "no awards" (index is built) — terminal for this view.
+                resolved.add(itemId);
+                retry.delete(itemId);
                 return;
             }
 
@@ -150,26 +176,21 @@ JE.initializeAwardsScript = function () {
             const stillVisible = document.querySelector<HTMLElement>('#itemDetailPage:not(.hide)');
             if (!stillVisible || getItemIdFromUrl() !== itemId) return;
             if (stillVisible.querySelector(`.${SECTION_CLASS}`)) {
-                processedItemIds.add(itemId);
+                resolved.add(itemId);
+                retry.delete(itemId);
                 return;
             }
 
             const section = buildAwardsSection(awards);
             insertSection(stillVisible, section);
-            processedItemIds.add(itemId);
+            resolved.add(itemId);
+            retry.delete(itemId);
         } catch (err) {
-            // PERF(R9): fail open — a transient failure schedules its own bounded, nav-guarded
-            // retry (never relying on an unrelated DOM/nav event to re-trigger), and is only given
-            // up on after ERROR_MAX_ATTEMPTS. A blip never caches "no awards".
+            // PERF(R9): fail open — a transient failure schedules a bounded, nav-guarded retry and
+            // is NEVER marked resolved, so a recovered server is picked up on the open page (within
+            // the window via a timer, after it via a cooldown-gated trigger). Never cached as "no awards".
             console.warn(`${logPrefix} failed to load awards for ${itemId}:`, err);
-            const attempts = (errorAttempts.get(itemId) || 0) + 1;
-            if (attempts >= ERROR_MAX_ATTEMPTS) {
-                processedItemIds.add(itemId);
-                errorAttempts.delete(itemId);
-            } else {
-                errorAttempts.set(itemId, attempts);
-                scheduleDelayedRetry(itemId, ERROR_BASE_DELAY_MS * attempts);
-            }
+            handleTransient(itemId, ERROR_BASE_DELAY_MS);
         } finally {
             inFlight = false;
             // A trigger that fired mid-request (or a completed request for an item that is no
@@ -187,7 +208,7 @@ JE.initializeAwardsScript = function () {
     function scheduleDelayedRetry(itemId: string, delayMs: number): void {
         window.setTimeout(() => {
             if (getItemIdFromUrl() !== itemId) return; // navigated away
-            if (processedItemIds.has(itemId)) return;   // already resolved
+            if (resolved.has(itemId)) return;           // already resolved
             schedule();
         }, delayMs);
     }

--- a/Jellyfin.Plugin.JellyfinElevate/src/extras/awards.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/extras/awards.ts
@@ -63,14 +63,26 @@ JE.initializeAwardsScript = function () {
     // Per-item render dedup + fail-open retry bookkeeping (mirrors letterboxd-links).
     const processedItemIds = new Set<string>();
     const errorAttempts = new Map<string, number>();
+    const notReadyAttempts = new Map<string, number>();
     const ERROR_MAX_ATTEMPTS = 3;
+    // The awards index is only ever empty transiently, during the first-install build. Retry a
+    // bounded number of times with backoff so awards appear on the page that is already open
+    // once the build lands, without ever caching the not-ready state as a genuine "no awards".
+    const NOT_READY_MAX_ATTEMPTS = 8;
+    const NOT_READY_BASE_DELAY_MS = 2000;
     let lastVisibleItemId: string | null = null;
     let inFlight = false;
+    // PERF(R9)/lifecycle: if a trigger fires while a request is in flight (e.g. navigation to a
+    // new item), remember to run one more pass when it finishes so the new item isn't dropped.
+    let rerunRequested = false;
 
     injectStyles();
 
     async function processAwards(): Promise<void> {
-        if (inFlight) return;
+        if (inFlight) {
+            rerunRequested = true;
+            return;
+        }
 
         const visiblePage = document.querySelector<HTMLElement>('#itemDetailPage:not(.hide)');
         if (!visiblePage) return;
@@ -82,6 +94,7 @@ JE.initializeAwardsScript = function () {
         if (lastVisibleItemId && lastVisibleItemId !== itemId) {
             processedItemIds.clear();
             errorAttempts.clear();
+            notReadyAttempts.clear();
         }
         lastVisibleItemId = itemId;
 
@@ -97,7 +110,11 @@ JE.initializeAwardsScript = function () {
 
         inFlight = true;
         try {
-            const data = await JE.core.api.plugin(`/awards/${encodeURIComponent(itemId)}`) as ItemAwardsResponse | null;
+            // skipCache: the shared GET cache's 30-min TTL would otherwise pin a transient
+            // "index not built yet" response and hide awards for the rest of that window. This
+            // endpoint is a cheap server-side dictionary lookup, so per-view fetches are fine,
+            // and per-item dedup above already prevents repeats within a page view.
+            const data = await JE.core.api.plugin(`/awards/${encodeURIComponent(itemId)}`, { skipCache: true }) as ItemAwardsResponse | null;
 
             if (data && data.enabled === false) {
                 // Admin turned the feature off since bootstrap — stop retrying this view.
@@ -105,9 +122,18 @@ JE.initializeAwardsScript = function () {
                 return;
             }
 
+            // PERF(R9): the index hasn't been built yet (first install). This is a transient
+            // not-ready state, NOT "no awards" — never cache it. Retry with bounded backoff so
+            // the already-open page fills in once the build completes.
+            if (data?.indexEmpty) {
+                scheduleNotReadyRetry(itemId);
+                return;
+            }
+
             const awards = Array.isArray(data?.awards) ? data.awards : [];
+            notReadyAttempts.delete(itemId);
             if (awards.length === 0) {
-                // Genuine "no awards" (or index not built yet) — remember it; don't re-fetch.
+                // Genuine "no awards" (index is built) — remember it; don't re-fetch this view.
                 processedItemIds.add(itemId);
                 return;
             }
@@ -136,7 +162,33 @@ JE.initializeAwardsScript = function () {
             }
         } finally {
             inFlight = false;
+            // A trigger that fired mid-request (or a completed request for an item that is no
+            // longer the visible one) — re-evaluate once so the current item isn't left unrendered.
+            if (rerunRequested) {
+                rerunRequested = false;
+                schedule();
+            }
         }
+    }
+
+    // PERF(R9)/R5: bounded, nav-guarded retry while the first-install index build is in flight.
+    // Not a standing timer — it stops as soon as the item renders, the view changes, or the cap
+    // is hit; the index only starts empty once, on first install.
+    function scheduleNotReadyRetry(itemId: string): void {
+        const attempts = (notReadyAttempts.get(itemId) || 0) + 1;
+        if (attempts > NOT_READY_MAX_ATTEMPTS) {
+            // The build is taking unusually long; stop hammering. A later navigation re-triggers.
+            notReadyAttempts.delete(itemId);
+            return;
+        }
+        notReadyAttempts.set(itemId, attempts);
+        const delay = Math.min(15000, NOT_READY_BASE_DELAY_MS * attempts);
+        window.setTimeout(() => {
+            // Abort if the user navigated away or the item already rendered.
+            if (getItemIdFromUrl() !== itemId) return;
+            if (processedItemIds.has(itemId)) return;
+            schedule();
+        }, delay);
     }
 
     // Coalesced, idle-scheduled pass shared by every trigger (R5 — no standing timer).

--- a/Jellyfin.Plugin.JellyfinElevate/src/extras/awards.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/extras/awards.ts
@@ -1,0 +1,338 @@
+// src/extras/awards.ts
+//
+// Awards — an "Awards" section on Movie and Series detail pages listing the
+// wins and nominations the title received (Oscars, Golden Globes, BAFTA,
+// Cannes, Venice, Berlin, SAG, Critics' Choice, Emmys). The data is served by
+// the plugin's /JellyfinElevate/awards/{itemId} endpoint out of a server-side
+// index the scheduled task builds from Wikidata; the client just renders it.
+// There is no external request from the browser and no per-item TMDB/Wikidata
+// call — the server resolves the item's IMDb/TMDb id against its in-memory
+// index, so even a huge library pays one cheap, cached request per detail view.
+//
+// Performance rules (docs/advanced/performance-rules.md):
+//   R3  No own body-wide observer — rides the shared JE.core.dom multiplexer
+//       via onBodyMutation, gated to the visible details page.
+//   R5  No polling — mutation + navigation + viewpage triggers only.
+//   R6  No remote assets — the trophy glyphs use the shared Material Symbols
+//       font from core/ui-kit (local asset cache), never a CDN.
+//   R7  The section is built fully off-DOM and inserted once, below the fold,
+//       only after its data is resolved — never an empty box that later grows.
+//   R9  Fail open — a transient fetch failure is retried per view (bounded),
+//       never cached like a genuine "no awards" answer.
+// Security (docs/advanced/client-security.md):
+//   X1  Every dynamic value is written via textContent (never innerHTML), so
+//       ceremony/category strings cannot open a tag or break an attribute.
+
+import { JE as JEBase } from '../globals';
+import { ensureMaterialSymbolsFont } from '../core/ui-kit';
+import { isDetailsPageVisible, getItemIdFromUrl } from '../core/details-view';
+import { onBodyMutation } from '../core/dom-observer';
+import { onNavigate, onViewPage } from '../core/navigation';
+import type { ApiApi, PluginConfig } from '../types/je';
+
+/** One award as returned by the server (Model/Awards/AwardEntry.cs). */
+interface AwardEntry {
+    ceremony: string;
+    category: string;
+    year?: number | null;
+    won: boolean;
+}
+
+/** Response shape of GET /JellyfinElevate/awards/{itemId} (ItemAwardsResponse.cs). */
+interface ItemAwardsResponse {
+    enabled: boolean;
+    version: number;
+    indexEmpty: boolean;
+    awards: AwardEntry[];
+}
+
+/** Local view of the shared namespace: the member this module owns + the core api/i18n it reads. */
+const JE = JEBase as typeof JEBase & {
+    initializeAwardsScript?: () => void;
+    pluginConfig: PluginConfig & { ShowAwards?: boolean };
+    core: { api: ApiApi };
+    t?: (key: string, params?: Record<string, unknown>) => string;
+};
+
+const SECTION_CLASS = 'je-awards-section';
+const STYLE_ID = 'je-awards-styles';
+
+JE.initializeAwardsScript = function () {
+    const logPrefix = '🪼 Jellyfin Elevate: Awards:';
+
+    if (!JE?.pluginConfig?.ShowAwards) {
+        console.log(`${logPrefix} feature disabled.`);
+        return;
+    }
+
+    console.log(`${logPrefix} initializing...`);
+
+    // Per-item render dedup + fail-open retry bookkeeping (mirrors letterboxd-links).
+    const processedItemIds = new Set<string>();
+    const errorAttempts = new Map<string, number>();
+    const ERROR_MAX_ATTEMPTS = 3;
+    let lastVisibleItemId: string | null = null;
+    let inFlight = false;
+
+    injectStyles();
+
+    async function processAwards(): Promise<void> {
+        if (inFlight) return;
+
+        const visiblePage = document.querySelector<HTMLElement>('#itemDetailPage:not(.hide)');
+        if (!visiblePage) return;
+
+        const itemId = getItemIdFromUrl();
+        if (!itemId) return;
+
+        // Navigated to a different item — allow the new one to render and drop stale state.
+        if (lastVisibleItemId && lastVisibleItemId !== itemId) {
+            processedItemIds.clear();
+            errorAttempts.clear();
+        }
+        lastVisibleItemId = itemId;
+
+        // Clean any award section left on now-hidden cached detail pages (v12 keeps up to
+        // three #itemDetailPage slots around) so it can't resurface against the wrong item.
+        document.querySelectorAll(`#itemDetailPage.hide .${SECTION_CLASS}`).forEach(el => el.remove());
+
+        if (processedItemIds.has(itemId)) return;
+        if (visiblePage.querySelector(`.${SECTION_CLASS}`)) {
+            processedItemIds.add(itemId);
+            return;
+        }
+
+        inFlight = true;
+        try {
+            const data = await JE.core.api.plugin(`/awards/${encodeURIComponent(itemId)}`) as ItemAwardsResponse | null;
+
+            if (data && data.enabled === false) {
+                // Admin turned the feature off since bootstrap — stop retrying this view.
+                processedItemIds.add(itemId);
+                return;
+            }
+
+            const awards = Array.isArray(data?.awards) ? data.awards : [];
+            if (awards.length === 0) {
+                // Genuine "no awards" (or index not built yet) — remember it; don't re-fetch.
+                processedItemIds.add(itemId);
+                return;
+            }
+
+            // The user may have navigated away while the request was in flight.
+            const stillVisible = document.querySelector<HTMLElement>('#itemDetailPage:not(.hide)');
+            if (!stillVisible || getItemIdFromUrl() !== itemId) return;
+            if (stillVisible.querySelector(`.${SECTION_CLASS}`)) {
+                processedItemIds.add(itemId);
+                return;
+            }
+
+            const section = buildAwardsSection(awards);
+            insertSection(stillVisible, section);
+            processedItemIds.add(itemId);
+        } catch (err) {
+            // PERF(R9): fail open — only give up on this item after repeated failures;
+            // the shared observer / nav probes retry until then. A blip never caches "no awards".
+            console.warn(`${logPrefix} failed to load awards for ${itemId}:`, err);
+            const attempts = (errorAttempts.get(itemId) || 0) + 1;
+            if (attempts >= ERROR_MAX_ATTEMPTS) {
+                processedItemIds.add(itemId);
+                errorAttempts.delete(itemId);
+            } else {
+                errorAttempts.set(itemId, attempts);
+            }
+        } finally {
+            inFlight = false;
+        }
+    }
+
+    // Coalesced, idle-scheduled pass shared by every trigger (R5 — no standing timer).
+    let scheduled = false;
+    function schedule(): void {
+        if (scheduled) return;
+        scheduled = true;
+        const run = () => { scheduled = false; void processAwards(); };
+        if (typeof requestIdleCallback !== 'undefined') {
+            requestIdleCallback(run, { timeout: 800 });
+        } else {
+            setTimeout(run, 100);
+        }
+    }
+
+    // PERF(R3): ride the shared multiplexed body observer, gated to the visible details page.
+    const subscription = onBodyMutation('je-awards', () => {
+        if (!JE?.pluginConfig?.ShowAwards) {
+            subscription.unsubscribe();
+            console.log(`${logPrefix} stopped — feature disabled.`);
+            return;
+        }
+        if (!isDetailsPageVisible()) return;
+        schedule();
+    });
+    // A cached-page re-show is a class flip the structural observer drops, so cover it via nav.
+    onNavigate(() => { if (JE?.pluginConfig?.ShowAwards) schedule(); });
+    onViewPage(() => { if (JE?.pluginConfig?.ShowAwards) schedule(); });
+
+    schedule();
+    console.log(`${logPrefix} initialized.`);
+};
+
+/**
+ * Strips the redundant ceremony prefix from a Wikidata category label so the UI shows
+ * "Best Picture" under the "Academy Awards" heading, not "Academy Award for Best Picture".
+ * Falls back to the raw label (kept as the chip's tooltip) when no known shape matches.
+ */
+function prettifyCategory(category: string, ceremony: string): string {
+    let c = category.trim();
+
+    // "<anything> Award(s) for X" / "Award – X" → "X" (Oscars, Globes, BAFTA, Emmy, Critics', SAG).
+    const awardFor = c.match(/\bAwards?\s+for\s+(.+)$/i);
+    if (awardFor) {
+        c = awardFor[1].trim();
+    } else if (ceremony && c.toLowerCase().startsWith(ceremony.toLowerCase())) {
+        // Festival prizes: "Cannes Film Festival Grand Prix" → "Grand Prix".
+        c = c.slice(ceremony.length).replace(/^[\s:–-]+/, '').trim() || c;
+    }
+
+    return c.length > 0 ? c : category;
+}
+
+/** Groups awards by ceremony, preserving first-seen (already newest-first) order. */
+function groupByCeremony(awards: AwardEntry[]): Array<{ ceremony: string; entries: AwardEntry[] }> {
+    const order: string[] = [];
+    const map = new Map<string, AwardEntry[]>();
+    for (const a of awards) {
+        const key = a.ceremony || 'Awards';
+        let list = map.get(key);
+        if (!list) {
+            list = [];
+            map.set(key, list);
+            order.push(key);
+        }
+        list.push(a);
+    }
+    return order.map(ceremony => ({ ceremony, entries: map.get(ceremony)! }));
+}
+
+/** Builds the whole Awards section off-DOM (R7). All dynamic text via textContent (X1). */
+function buildAwardsSection(awards: AwardEntry[]): HTMLElement {
+    ensureMaterialSymbolsFont();
+
+    const section = document.createElement('div');
+    section.className = `${SECTION_CLASS} verticalSection detailVerticalSection`;
+
+    const header = document.createElement('h2');
+    header.className = 'sectionTitle';
+    header.textContent = JE.t ? JE.t('awards_section_title') : 'Awards';
+    section.appendChild(header);
+
+    const list = document.createElement('div');
+    list.className = 'je-awards-list';
+
+    for (const group of groupByCeremony(awards)) {
+        const groupEl = document.createElement('div');
+        groupEl.className = 'je-awards-ceremony';
+
+        const name = document.createElement('div');
+        name.className = 'je-awards-ceremony-name';
+        name.textContent = group.ceremony;
+        groupEl.appendChild(name);
+
+        const chips = document.createElement('div');
+        chips.className = 'je-awards-chips';
+        for (const entry of group.entries) {
+            chips.appendChild(buildChip(entry));
+        }
+        groupEl.appendChild(chips);
+        list.appendChild(groupEl);
+    }
+
+    section.appendChild(list);
+    return section;
+}
+
+function buildChip(entry: AwardEntry): HTMLElement {
+    const chip = document.createElement('span');
+    chip.className = `je-award-chip ${entry.won ? 'je-award-won' : 'je-award-nominated'}`;
+
+    const icon = document.createElement('span');
+    icon.className = 'je-award-icon';
+    // Material Symbols ligature glyphs (rendered by the shared local font): a filled trophy
+    // for a win, an outline medal for a nomination.
+    icon.textContent = entry.won ? 'emoji_events' : 'workspace_premium';
+    icon.setAttribute('aria-hidden', 'true');
+    chip.appendChild(icon);
+
+    const label = document.createElement('span');
+    label.className = 'je-award-label';
+    label.textContent = prettifyCategory(entry.category, entry.ceremony);
+    chip.appendChild(label);
+
+    const year = Number(entry.year);
+    if (Number.isFinite(year) && year > 0) {
+        const yr = document.createElement('span');
+        yr.className = 'je-award-year';
+        yr.textContent = String(year);
+        chip.appendChild(yr);
+    }
+
+    // Full context (raw category + win/nominee) in the native tooltip.
+    const status = entry.won
+        ? (JE.t ? JE.t('awards_won') : 'Winner')
+        : (JE.t ? JE.t('awards_nominated') : 'Nominee');
+    chip.title = `${status} — ${entry.category}`;
+    return chip;
+}
+
+/**
+ * Inserts the section once (R7), below the external-links/genres area so it reads as a
+ * normal detail section. Falls back through progressively broader anchors, and finally
+ * appends to the primary detail content, so it lands somewhere sensible on both layouts.
+ */
+function insertSection(page: HTMLElement, section: HTMLElement): void {
+    const afterAnchor = page.querySelector('.itemExternalLinks')
+        || page.querySelector('.genresGroup')
+        || page.querySelector('.tagline');
+    if (afterAnchor && afterAnchor.parentNode) {
+        afterAnchor.parentNode.insertBefore(section, afterAnchor.nextSibling);
+        return;
+    }
+
+    const container = page.querySelector('.detailPagePrimaryContent')
+        || page.querySelector('.detailPageContent')
+        || page.querySelector('.detailSection')
+        || page;
+    container.appendChild(section);
+}
+
+function injectStyles(): void {
+    if (document.getElementById(STYLE_ID)) return;
+    const style = document.createElement('style');
+    style.id = STYLE_ID;
+    style.textContent = `
+        .${SECTION_CLASS} { margin: 1.5em 0; }
+        .${SECTION_CLASS} .je-awards-list { display: flex; flex-direction: column; gap: 0.9em; }
+        .${SECTION_CLASS} .je-awards-ceremony-name {
+            font-weight: 600; opacity: 0.85; margin-bottom: 0.4em; font-size: 0.95em;
+        }
+        .${SECTION_CLASS} .je-awards-chips { display: flex; flex-wrap: wrap; gap: 0.5em; }
+        .${SECTION_CLASS} .je-award-chip {
+            display: inline-flex; align-items: center; gap: 0.35em;
+            padding: 0.3em 0.7em; border-radius: 1em; font-size: 0.9em;
+            background: rgba(127, 127, 127, 0.18); white-space: nowrap; line-height: 1.4;
+        }
+        .${SECTION_CLASS} .je-award-won { background: rgba(212, 175, 55, 0.20); }
+        .${SECTION_CLASS} .je-award-nominated { opacity: 0.9; }
+        .${SECTION_CLASS} .je-award-icon {
+            font-family: 'Material Symbols Rounded';
+            font-weight: normal; font-style: normal; line-height: 1; font-size: 1.15em;
+            letter-spacing: normal; text-transform: none; display: inline-block;
+            white-space: nowrap; word-wrap: normal; direction: ltr;
+            -webkit-font-feature-settings: 'liga'; font-feature-settings: 'liga';
+            -webkit-font-smoothing: antialiased;
+        }
+        .${SECTION_CLASS} .je-award-won .je-award-icon { color: #d4af37; }
+        .${SECTION_CLASS} .je-award-year { opacity: 0.65; font-variant-numeric: tabular-nums; }
+    `;
+    document.head.appendChild(style);
+}

--- a/Jellyfin.Plugin.JellyfinElevate/src/extras/awards.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/extras/awards.ts
@@ -28,15 +28,8 @@ import { ensureMaterialSymbolsFont } from '../core/ui-kit';
 import { isDetailsPageVisible, getItemIdFromUrl } from '../core/details-view';
 import { onBodyMutation } from '../core/dom-observer';
 import { onNavigate, onViewPage } from '../core/navigation';
+import { prettifyCategory, groupByCeremony, type AwardEntry } from './awards-format';
 import type { ApiApi, PluginConfig } from '../types/je';
-
-/** One award as returned by the server (Model/Awards/AwardEntry.cs). */
-interface AwardEntry {
-    ceremony: string;
-    category: string;
-    year?: number | null;
-    won: boolean;
-}
 
 /** Response shape of GET /JellyfinElevate/awards/{itemId} (ItemAwardsResponse.cs). */
 interface ItemAwardsResponse {
@@ -176,43 +169,6 @@ JE.initializeAwardsScript = function () {
     schedule();
     console.log(`${logPrefix} initialized.`);
 };
-
-/**
- * Strips the redundant ceremony prefix from a Wikidata category label so the UI shows
- * "Best Picture" under the "Academy Awards" heading, not "Academy Award for Best Picture".
- * Falls back to the raw label (kept as the chip's tooltip) when no known shape matches.
- */
-function prettifyCategory(category: string, ceremony: string): string {
-    let c = category.trim();
-
-    // "<anything> Award(s) for X" / "Award – X" → "X" (Oscars, Globes, BAFTA, Emmy, Critics', SAG).
-    const awardFor = c.match(/\bAwards?\s+for\s+(.+)$/i);
-    if (awardFor) {
-        c = awardFor[1].trim();
-    } else if (ceremony && c.toLowerCase().startsWith(ceremony.toLowerCase())) {
-        // Festival prizes: "Cannes Film Festival Grand Prix" → "Grand Prix".
-        c = c.slice(ceremony.length).replace(/^[\s:–-]+/, '').trim() || c;
-    }
-
-    return c.length > 0 ? c : category;
-}
-
-/** Groups awards by ceremony, preserving first-seen (already newest-first) order. */
-function groupByCeremony(awards: AwardEntry[]): Array<{ ceremony: string; entries: AwardEntry[] }> {
-    const order: string[] = [];
-    const map = new Map<string, AwardEntry[]>();
-    for (const a of awards) {
-        const key = a.ceremony || 'Awards';
-        let list = map.get(key);
-        if (!list) {
-            list = [];
-            map.set(key, list);
-            order.push(key);
-        }
-        list.push(a);
-    }
-    return order.map(ceremony => ({ ceremony, entries: map.get(ceremony)! }));
-}
 
 /** Builds the whole Awards section off-DOM (R7). All dynamic text via textContent (X1). */
 function buildAwardsSection(awards: AwardEntry[]): HTMLElement {

--- a/Jellyfin.Plugin.JellyfinElevate/src/extras/index.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/extras/index.ts
@@ -8,3 +8,4 @@ import './colored-ratings';
 import './plugin-icons';
 import './theme-selector';
 import './active-streams';
+import './awards';

--- a/Jellyfin.Plugin.JellyfinElevate/src/types/je.ts
+++ b/Jellyfin.Plugin.JellyfinElevate/src/types/je.ts
@@ -30,6 +30,8 @@ export interface PluginConfig {
     AssetCacheEnabled?: boolean;
     /** Gate the in-app Approve/Decline affordance on pending Seerr requests (default true). */
     RequestApprovalsEnabled?: boolean;
+    /** Show the Awards section (Wikidata-sourced wins/nominations) on movie & series detail pages (default false). */
+    ShowAwards?: boolean;
     [key: string]: unknown;
 }
 

--- a/docs/advanced/project-structure.md
+++ b/docs/advanced/project-structure.md
@@ -108,6 +108,8 @@ Jellyfin.Plugin.JellyfinElevate/
 │   ├── ArrLinksController.cs / ArrCalendarController.cs / ArrRequestsController.cs
 │   ├── UserSettingsController.cs / HiddenContentController.cs / ReviewsController.cs
 │   ├── TagCacheController.cs / ItemInfoController.cs / BrandingController.cs
+│   ├── AwardsController.cs    # Per-item awards from the server-side index (caller-scoped lookup,
+│   │                          # no per-view network — see Services/Awards)
 │   ├── SpoilerGuardController.cs # Spoiler Guard opt-in list (series/movies/collections), Seerr
 │   │                          # pending pre-arm, and the corruption-recovery health endpoints
 │   └── ActiveStreamsController.cs / MaintenanceModeController.cs / ViewsController.cs
@@ -130,6 +132,10 @@ Jellyfin.Plugin.JellyfinElevate/
 │   │                          # ladder (authenticated token → per-user ?tag= identity marker →
 │   │                          # je-spoiler-uid cookie → session-by-IP candidates), returned with a
 │   │                          # confidence tier so consumers pick single-user vs fail-closed posture
+│   ├── Awards/                # Awards index: WikidataAwardsProvider (bulk SPARQL fetch of wins +
+│   │                          # nominations per ceremony, independent of library size), AwardsCacheService
+│   │                          # (versioned, atomically-persisted index keyed by IMDb/TMDb id; local
+│   │                          # per-item lookup). Refreshed by ScheduledTasks/BuildAwardsCacheTask (weekly)
 │   └── SpoilerGuard/          # Spoiler Guard server core: ImageBlurService (SkiaSharp Gaussian blur +
 │                              # stock-card render + pre-encoded fail-closed JPEG, cached),
 │                              # SpoilerBlurImageFilter (per-user image-byte replacement over the Image/

--- a/docs/enhanced/enhanced-features.md
+++ b/docs/enhanced/enhanced-features.md
@@ -479,6 +479,28 @@ Enable **"Show TMDB Reviews"** in **Dashboard** → **Plugins** → **Jellyfin E
 
 See [Elsewhere Features](../elsewhere/elsewhere-features.md#tmdb-reviews) for full details.
 
+### Awards
+
+Show an **Awards** section on Movie and Series detail pages listing the wins and
+nominations a title received — from the Oscars, Golden Globes, BAFTA, Cannes,
+Venice, Berlin, Screen Actors Guild, Critics' Choice and the Emmys. Awards are
+grouped by ceremony, with a trophy chip for each win and a medal chip for each
+nomination, showing the category and year.
+
+**No API key required.** The data comes from [Wikidata](https://www.wikidata.org)
+(open data). The server builds one global award index on an infrequent scheduled
+refresh and matches each item locally by its IMDb/TMDb id — so enabling this adds
+**no per-item network requests** at view time, even on very large libraries.
+
+**Setup:**
+
+1. Enable **"Show Awards"** in **Dashboard** → **Plugins** → **Jellyfin Elevate**
+   → **Awards** tab.
+2. Run the **"Build Awards Cache"** task once under **Dashboard** → **Scheduled
+   Tasks** to populate the initial index (it then refreshes weekly on its own).
+
+See [Show Awards](enhanced-settings.md#show-awards) for details.
+
 ---
 
 ## Visual Enhancements

--- a/docs/enhanced/enhanced-settings.md
+++ b/docs/enhanced/enhanced-settings.md
@@ -165,6 +165,26 @@ episodes), sourced from TMDB.
   country's release dates to prefer, falling back to US and then any region TMDB
   has for that release type.
 
+## Show Awards
+
+**Show Awards** (`ShowAwards`, admin-only) adds an **Awards** section on Movie
+and Series detail pages listing the wins and nominations the title received from
+the Oscars, Golden Globes, BAFTA, Cannes, Venice, Berlin, Screen Actors Guild,
+Critics' Choice and the Emmys.
+
+- **Admin config toggle** — enable it in the **Awards** section of the plugin
+  config page. There is no per-user override.
+- **No API key required** — the data is sourced from [Wikidata](https://www.wikidata.org)
+  (open data), not TMDB or a paid awards API.
+- **Scales to large libraries** — the server builds one global award index from
+  Wikidata and matches each item locally by its IMDb/TMDb id, so there are **no
+  per-item network requests** at view time regardless of library size.
+- **Populate + refresh** — run the **Build Awards Cache** task under **Dashboard**
+  → **Scheduled Tasks** once after enabling to build the initial index. It then
+  refreshes automatically every 7 days (award data changes rarely); you can retune
+  the cadence or run it manually from the same page. The index is saved to disk, so
+  a server restart never re-fetches.
+
 ## Home Row Filtering
 
 **Filter Continue Watching** and **Filter Next Up** (in the Hidden Content


### PR DESCRIPTION
## What & why

Implements milestone **Awards & Extended Metadata** (upstream 654): surface awards on movie and series detail pages. The original assessment assumed a paid OMDb/MDBList key and per-item lookups — unworkable for large libraries. This instead uses **Wikidata** (open data, no API key) and a **server-side index** so a library of any size pays **no per-item network cost** at view time.

An **Awards** section appears on Movie and Series detail pages, grouping **wins and nominations** by ceremony — the Oscars, Golden Globes, BAFTA, Cannes, Venice, Berlin, Screen Actors Guild, Critics' Choice and the Emmys — with a trophy chip per win and a medal chip per nomination (category + year).

## How it scales to large libraries

The server holds the *global* set of award-winning/nominated titles (a bounded index, tens of thousands of rows) built **once per refresh**, not per item. When a detail page opens, the client asks the server for that one item's awards; the server resolves the item's IMDb/TMDb provider ids and does an **in-memory dictionary lookup**. No SPARQL, no TMDB, no per-item fetch — a 200-title library and a 15,000-title library cost the same at view time.

## Implementation

- **`WikidataAwardsProvider`** — one bounded pair of SPARQL queries (wins via `award received`, nominations via `nominated for`) per ceremony, ~15 queries total independent of library size. Each ceremony carries its own verified QID + linkage block; everything else is one shared template. Person-level awards (acting/directing) are excluded by constraining the awarded entity to a film/TV type.
- **`AwardsCacheService`** — versioned, immutable-snapshot index keyed by IMDb and TMDb (movie/tv namespaced) id; atomic JSON persistence (`AtomicFile`) at `plugins/configurations/.../awards-cache.json`; loaded on startup; grouping/dedup/sort on rebuild; rebuilds serialized so concurrent refreshes stay consistent.
- **`BuildAwardsCacheTask`** — `IScheduledTask` on a 7-day interval (award data changes rarely; admin-retunable). No startup trigger — the index loads from disk on restart and is only built there on first install, so a restart never re-fetches.
- **`AwardsController`** — `[Authorize]` GET returning cached awards for an item; the item is resolved with the **caller-scoped** `GetItemById` overload (CSCTRL-4) so a non-admin can't confirm existence of items outside their libraries; bare 401/403; empty (not error) for disabled/unknown/awardless.
- **Client `src/extras/awards.ts`** — native section built off-DOM and inserted once below the external links, riding the shared body observer (R3), failing open on transient errors (R9), all dynamic text via `textContent` (X1, no `innerHTML`).
- **Config** — admin `ShowAwards` toggle (SettingDescriptors + config page + golden + `je.ts`). `awards_*` locale keys added to all 26 locales.

## Limitations / notes

- Awards attach to the **work** (Best Picture, Outstanding Series, Palme d'Or …); person-level acting/directing statuettes are intentionally not shown (a media library badges titles, not people).
- Film festivals (Cannes/Venice/Berlin) don't record nominations in Wikidata → wins only.
- First use: enable **Show Awards**, then run **Build Awards Cache** once (documented) to populate the index; it then refreshes weekly.
- Data source is Wikidata's open graph; coverage is as complete as Wikidata is.

## AI assistance

Implemented with AI assistance (Claude), including a fanned-out research pass that verified the Wikidata SPARQL model, per-ceremony QIDs/linkage and coverage counts against the live endpoint.

## Verification

- **Server:** full `dotnet test` green (773 tests), incl. 39 new awards tests — `AwardsCacheServiceTests` (grouping, win-suppresses-nomination dedup, Movie/Series-only lookup + TMDb-namespace-collision guard, publication precedence: partial-vs-complete/generation/first-install/empty, disk round-trip + version-checked load, consistent `GetAwardsView` snapshot), `AwardsControllerTests` (enable-gate, caller-scoped resolution, empty contract), `WikidataAwardsProviderTests` (win/nom query building, JSON parsing incl. malformed-response-as-failure, ceremony coverage), and `BuildAwardsCacheTaskTests` (partial/complete/first-install/empty publication). Golden config payload + config-page save-key contract regenerated for `ShowAwards`.
- **Client:** full `test:client` green (543 tests), incl. new `awards-format` tests (label prettify, ceremony grouping, and the pure `applyTransient` retry-budget: capped backoff, monotonic window, cooldown, immutability). escape/perf/leak/css/error-as-empty guard tests pass over the new module; `typecheck:src` and lint clean; bundle builds.
- **Translations:** 100% (all 26 locales) valid. **Docs:** `mkdocs build --strict` clean.
- **Live (jellyfin-12):** deployed and verified end-to-end. Enabling the feature built the index from Wikidata on startup — **5,671 award titles (index v1, complete)** across all nine ceremonies — persisted to disk. The endpoint returns correct data (Back to the Future → Oscar win "Best Sound Editing" 1986 + nominations; a test clip → empty), and the detail-page section renders natively (trophy chip for the win, medal chips for nominations, prettified categories, the redundant win/nomination collapsed). Generic E2E: 59 passed (the only failures are the pre-existing Hidden-Content baseline env failures, unrelated to awards).
- Lint: 0 new warnings (branch total equals `origin/main` exactly; the pre-existing warning-cap delta is unchanged and untouched).

## Review ledger

Codex-first adversarial review (`gpt-5.6-sol`): security/high + quality/medium + repeated state/medium rounds + one xhigh final gate. **21 findings surfaced and resolved** (each with a regression test), spanning partial-refresh data loss, concurrent-rebuild ordering, malformed-response handling, client fail-open retry semantics (terminal vs transient, monotonic budget, visibility-gating), nav-safe page resolution, caller-scoped auth (confirmed correct), and a TMDb id-namespace collision. One finding (an all-empty "complete" result clearing a populated index) was deliberately kept as-is with a documented rationale (stale ceremony QIDs are a likelier cause than real data loss, so keeping prior awards is the safer failure mode). Final state and quality medium passes are clean.
