### PR TITLE
fix: reconcile the tag cache incrementally instead of rebuilding it wholesale

### DIFF
--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Services/TagCacheReconcileTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Services/TagCacheReconcileTests.cs
@@ -294,10 +294,10 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
             finally { TryDelete(dir); }
         }
 
-        // ── Probe failure must keep last-good data, not publish a degraded (empty) entry ──────
+        // ── Probe failure: keep probe-independent data + last-good streams, retry until recovery ──
 
         [Fact]
-        public void Reconcile_ProbeFailureOnChangedItem_KeepsLastGood_AndRecoversNextReconcile()
+        public void Reconcile_ProbeFailure_KeepsFreshMetadataAndLastGoodStreams_Unconfirmed_ThenRecovers()
         {
             var dir = NewTempDir();
             try
@@ -315,6 +315,7 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
                 var good = svc.GetEntryForTest(Key(id));
                 Assert.NotNull(good);
                 Assert.Equal(6.0f, good!.CommunityRating);
+                var goodStreams = good.StreamData;
 
                 // The item changes AND its media probe now throws.
                 movie.DateLastSaved = T0.AddHours(1);
@@ -322,55 +323,70 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
                 movie.ThrowOnProbe = true;
                 svc.BuildFullCache(null, CT);
 
-                // Last-good retained (same instance, old content) with its OLD SourceRevision, so it
-                // stays a rebuild candidate — NOT a degraded entry stamped with the new revision.
+                // Fresh probe-independent data (the new rating) is served, the last-good streams are
+                // retained, and SourceRevision is 0 (unconfirmed) so the gate keeps rebuilding it —
+                // NOT a degraded entry confirmed at the new revision, and NOT a stale old rating.
                 var afterFail = svc.GetEntryForTest(Key(id));
-                Assert.Same(good, afterFail);
-                Assert.Equal(6.0f, afterFail!.CommunityRating);
-                Assert.Equal(T0.Ticks, afterFail.SourceRevision);
+                Assert.NotNull(afterFail);
+                Assert.Equal(9.0f, afterFail!.CommunityRating);         // fresh rating despite probe down
+                Assert.Same(goodStreams, afterFail.StreamData);         // last-good streams retained
+                Assert.Equal(0L, afterFail.SourceRevision);             // unconfirmed -> rebuilt next cycle
 
-                // Probe recovers -> the next reconcile rebuilds (revision still mismatched).
+                // Probe recovers -> the next reconcile rebuilds (unconfirmed) and confirms it.
                 movie.ThrowOnProbe = false;
                 svc.BuildFullCache(null, CT);
                 var recovered = svc.GetEntryForTest(Key(id));
                 Assert.NotNull(recovered);
                 Assert.Equal(9.0f, recovered!.CommunityRating);
-                Assert.Equal(T0.AddHours(1).Ticks, recovered.SourceRevision);
+                Assert.Equal(T0.AddHours(1).Ticks, recovered.SourceRevision); // confirmed
             }
             finally { TryDelete(dir); }
         }
 
         [Fact]
-        public void Reconcile_ProbeFailure_RequeuesForOffThreadFlushRetry()
+        public void Reconcile_SeriesRatingChange_WithEpisodeProbeDown_KeepsCorrectInheritedRating_ThenRecoversDurably()
         {
+            // The confirmation scenario: a series rating changes while an inheriting episode's probe
+            // is down. The episode's inherited rating comes from the series (probe-independent), so it
+            // must be correct even during the outage, and the unconfirmed revision must drive recovery
+            // on the next reconcile even though the series "changed" signal is not re-raised.
             var dir = NewTempDir();
             try
             {
-                var id = Guid.NewGuid();
-                var movie = new ProbeControlledMovie { Id = id, Name = "M", DateLastSaved = T0, CommunityRating = 6.0f };
+                var seriesId = Guid.NewGuid();
+                var epId = Guid.NewGuid();
+                var series = new StubSeries { Id = seriesId, Name = "S", DateLastSaved = T0, CommunityRating = 5.0f };
+                var ep = new ProbeControlledEpisode { Id = epId, Name = "E", DateLastSaved = T0, SeriesId = seriesId };
+                var scan = new List<BaseItem> { series, ep };
                 var lib = new CountingLibraryManager
                 {
-                    GetItemListHook = _ => new List<BaseItem> { movie },
-                    GetItemByIdHook = i => i == id ? movie : null,
+                    GetItemListHook = q => q.ParentId == Guid.Empty ? scan : new List<BaseItem> { ep },
+                    GetItemByIdHook = i => i == seriesId ? series : i == epId ? ep : null,
                 };
                 using var svc = NewSvc(lib, dir);
 
                 svc.BuildFullCache(null, CT);
-                var good = svc.GetEntryForTest(Key(id));
+                Assert.Equal(5.0f, svc.GetEntryForTest(Key(epId))!.CommunityRating); // inherited
 
-                movie.DateLastSaved = T0.AddHours(1);
-                movie.CommunityRating = 9.0f;
-                movie.ThrowOnProbe = true;
-                svc.BuildFullCache(null, CT);            // fails -> keeps old + re-queues id
-                Assert.Same(good, svc.GetEntryForTest(Key(id)));
+                // Series rating changes; episode's own revision does NOT change; episode probe is down.
+                series.CommunityRating = 8.0f;
+                series.DateLastSaved = T0.AddHours(1);
+                ep.ThrowOnProbe = true;
+                svc.BuildFullCache(null, CT);
 
-                // The re-queued item recovers through the existing flush path once the probe heals,
-                // without waiting for the next daily reconcile.
-                movie.ThrowOnProbe = false;
-                svc.FlushPendingForTest();
-                var recovered = svc.GetEntryForTest(Key(id));
+                var afterFail = svc.GetEntryForTest(Key(epId));
+                Assert.NotNull(afterFail);
+                Assert.Equal(8.0f, afterFail!.CommunityRating); // correct inherited rating despite probe down
+                Assert.Equal(0L, afterFail.SourceRevision);     // unconfirmed
+
+                // Probe recovers. Even though seriesRatingChanged no longer fires (series entry settled)
+                // and the episode's own revision is unchanged, the unconfirmed revision forces a rebuild.
+                ep.ThrowOnProbe = false;
+                svc.BuildFullCache(null, CT);
+                var recovered = svc.GetEntryForTest(Key(epId));
                 Assert.NotNull(recovered);
-                Assert.Equal(9.0f, recovered!.CommunityRating);
+                Assert.Equal(8.0f, recovered!.CommunityRating);
+                Assert.Equal(T0.Ticks, recovered.SourceRevision); // confirmed at the episode's own revision
             }
             finally { TryDelete(dir); }
         }
@@ -380,12 +396,26 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
             try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ }
         }
 
-        /// <summary>A Movie whose media probe can be made to throw, to exercise the last-good path.</summary>
+        /// <summary>A Movie whose media probe can be made to throw, to exercise the probe-failure path.</summary>
         private sealed class ProbeControlledMovie : Movie
         {
             public bool ThrowOnProbe { get; set; }
 
             public override string GetClientTypeName() => "Movie";
+
+            public override IReadOnlyList<MediaSourceInfo> GetMediaSources(bool enablePathSubstitution)
+            {
+                if (ThrowOnProbe) throw new InvalidOperationException("transient probe failure");
+                return Array.Empty<MediaSourceInfo>();
+            }
+        }
+
+        /// <summary>An Episode whose media probe can be made to throw, to exercise the probe-failure path.</summary>
+        private sealed class ProbeControlledEpisode : Episode
+        {
+            public bool ThrowOnProbe { get; set; }
+
+            public override string GetClientTypeName() => "Episode";
 
             public override IReadOnlyList<MediaSourceInfo> GetMediaSources(bool enablePathSubstitution)
             {

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Services/TagCacheReconcileTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Services/TagCacheReconcileTests.cs
@@ -8,6 +8,7 @@ using Jellyfin.Plugin.JellyfinElevate.Services;
 using Jellyfin.Plugin.JellyfinElevate.Tests.TestDoubles;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Model.Dto;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 using Episode = MediaBrowser.Controller.Entities.TV.Episode;
@@ -131,7 +132,7 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
             try
             {
                 var id = Guid.NewGuid();
-                var movie = new Movie { Id = id, Name = "M", DateLastSaved = T0, CommunityRating = 6.0f };
+                var movie = new StubMovie { Id = id, Name = "M", DateLastSaved = T0, CommunityRating = 6.0f };
                 var lib = new CountingLibraryManager { GetItemListHook = _ => new List<BaseItem> { movie } };
                 using var svc = NewSvc(lib, dir);
 
@@ -159,7 +160,7 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
             try
             {
                 var id = Guid.NewGuid();
-                var movie = new Movie { Id = id, Name = "M", DateLastSaved = T0, CommunityRating = 6.0f };
+                var movie = new StubMovie { Id = id, Name = "M", DateLastSaved = T0, CommunityRating = 6.0f };
                 var lib = new CountingLibraryManager { GetItemListHook = _ => new List<BaseItem> { movie } };
                 using var svc = NewSvc(lib, dir);
 
@@ -188,7 +189,7 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
             try
             {
                 var id = Guid.NewGuid();
-                var movie = new Movie { Id = id, Name = "M", DateLastSaved = T0, CommunityRating = 6.0f };
+                var movie = new StubMovie { Id = id, Name = "M", DateLastSaved = T0, CommunityRating = 6.0f };
                 var lib = new CountingLibraryManager { GetItemListHook = _ => new List<BaseItem> { movie } };
                 using var svc = NewSvc(lib, dir);
 
@@ -215,8 +216,8 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
             var dir = NewTempDir();
             try
             {
-                var a = new Movie { Id = Guid.NewGuid(), Name = "A", DateLastSaved = T0 };
-                var b = new Movie { Id = Guid.NewGuid(), Name = "B", DateLastSaved = T0 };
+                var a = new StubMovie { Id = Guid.NewGuid(), Name = "A", DateLastSaved = T0 };
+                var b = new StubMovie { Id = Guid.NewGuid(), Name = "B", DateLastSaved = T0 };
                 var scan = new List<BaseItem> { a };
                 var lib = new CountingLibraryManager { GetItemListHook = _ => scan };
                 using var svc = NewSvc(lib, dir);
@@ -239,8 +240,8 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
             var dir = NewTempDir();
             try
             {
-                var a = new Movie { Id = Guid.NewGuid(), Name = "A", DateLastSaved = T0 };
-                var b = new Movie { Id = Guid.NewGuid(), Name = "B", DateLastSaved = T0 };
+                var a = new StubMovie { Id = Guid.NewGuid(), Name = "A", DateLastSaved = T0 };
+                var b = new StubMovie { Id = Guid.NewGuid(), Name = "B", DateLastSaved = T0 };
                 var scan = new List<BaseItem> { a, b };
                 var lib = new CountingLibraryManager { GetItemListHook = _ => scan };
                 using var svc = NewSvc(lib, dir);
@@ -265,9 +266,9 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
             {
                 var seriesId = Guid.NewGuid();
                 var epId = Guid.NewGuid();
-                var series = new Series { Id = seriesId, Name = "S", DateLastSaved = T0, CommunityRating = 5.0f };
+                var series = new StubSeries { Id = seriesId, Name = "S", DateLastSaved = T0, CommunityRating = 5.0f };
                 // Episode has NO rating of its own -> inherits the series rating.
-                var ep = new Episode { Id = epId, Name = "E", DateLastSaved = T0, SeriesId = seriesId };
+                var ep = new StubEpisode { Id = epId, Name = "E", DateLastSaved = T0, SeriesId = seriesId };
                 var scan = new List<BaseItem> { series, ep };
 
                 var lib = new CountingLibraryManager
@@ -293,9 +294,104 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
             finally { TryDelete(dir); }
         }
 
+        // ── Probe failure must keep last-good data, not publish a degraded (empty) entry ──────
+
+        [Fact]
+        public void Reconcile_ProbeFailureOnChangedItem_KeepsLastGood_AndRecoversNextReconcile()
+        {
+            var dir = NewTempDir();
+            try
+            {
+                var id = Guid.NewGuid();
+                var movie = new ProbeControlledMovie { Id = id, Name = "M", DateLastSaved = T0, CommunityRating = 6.0f };
+                var lib = new CountingLibraryManager
+                {
+                    GetItemListHook = _ => new List<BaseItem> { movie },
+                    GetItemByIdHook = i => i == id ? movie : null,
+                };
+                using var svc = NewSvc(lib, dir);
+
+                svc.BuildFullCache(null, CT);                       // builds cleanly
+                var good = svc.GetEntryForTest(Key(id));
+                Assert.NotNull(good);
+                Assert.Equal(6.0f, good!.CommunityRating);
+
+                // The item changes AND its media probe now throws.
+                movie.DateLastSaved = T0.AddHours(1);
+                movie.CommunityRating = 9.0f;
+                movie.ThrowOnProbe = true;
+                svc.BuildFullCache(null, CT);
+
+                // Last-good retained (same instance, old content) with its OLD SourceRevision, so it
+                // stays a rebuild candidate — NOT a degraded entry stamped with the new revision.
+                var afterFail = svc.GetEntryForTest(Key(id));
+                Assert.Same(good, afterFail);
+                Assert.Equal(6.0f, afterFail!.CommunityRating);
+                Assert.Equal(T0.Ticks, afterFail.SourceRevision);
+
+                // Probe recovers -> the next reconcile rebuilds (revision still mismatched).
+                movie.ThrowOnProbe = false;
+                svc.BuildFullCache(null, CT);
+                var recovered = svc.GetEntryForTest(Key(id));
+                Assert.NotNull(recovered);
+                Assert.Equal(9.0f, recovered!.CommunityRating);
+                Assert.Equal(T0.AddHours(1).Ticks, recovered.SourceRevision);
+            }
+            finally { TryDelete(dir); }
+        }
+
+        [Fact]
+        public void Reconcile_ProbeFailure_RequeuesForOffThreadFlushRetry()
+        {
+            var dir = NewTempDir();
+            try
+            {
+                var id = Guid.NewGuid();
+                var movie = new ProbeControlledMovie { Id = id, Name = "M", DateLastSaved = T0, CommunityRating = 6.0f };
+                var lib = new CountingLibraryManager
+                {
+                    GetItemListHook = _ => new List<BaseItem> { movie },
+                    GetItemByIdHook = i => i == id ? movie : null,
+                };
+                using var svc = NewSvc(lib, dir);
+
+                svc.BuildFullCache(null, CT);
+                var good = svc.GetEntryForTest(Key(id));
+
+                movie.DateLastSaved = T0.AddHours(1);
+                movie.CommunityRating = 9.0f;
+                movie.ThrowOnProbe = true;
+                svc.BuildFullCache(null, CT);            // fails -> keeps old + re-queues id
+                Assert.Same(good, svc.GetEntryForTest(Key(id)));
+
+                // The re-queued item recovers through the existing flush path once the probe heals,
+                // without waiting for the next daily reconcile.
+                movie.ThrowOnProbe = false;
+                svc.FlushPendingForTest();
+                var recovered = svc.GetEntryForTest(Key(id));
+                Assert.NotNull(recovered);
+                Assert.Equal(9.0f, recovered!.CommunityRating);
+            }
+            finally { TryDelete(dir); }
+        }
+
         private static void TryDelete(string dir)
         {
             try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ }
+        }
+
+        /// <summary>A Movie whose media probe can be made to throw, to exercise the last-good path.</summary>
+        private sealed class ProbeControlledMovie : Movie
+        {
+            public bool ThrowOnProbe { get; set; }
+
+            public override string GetClientTypeName() => "Movie";
+
+            public override IReadOnlyList<MediaSourceInfo> GetMediaSources(bool enablePathSubstitution)
+            {
+                if (ThrowOnProbe) throw new InvalidOperationException("transient probe failure");
+                return Array.Empty<MediaSourceInfo>();
+            }
         }
     }
 }

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Services/TagCacheReconcileTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Services/TagCacheReconcileTests.cs
@@ -1,0 +1,301 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using Jellyfin.Data.Enums;
+using Jellyfin.Plugin.JellyfinElevate.Model;
+using Jellyfin.Plugin.JellyfinElevate.Services;
+using Jellyfin.Plugin.JellyfinElevate.Tests.TestDoubles;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+using Episode = MediaBrowser.Controller.Entities.TV.Episode;
+using Series = MediaBrowser.Controller.Entities.TV.Series;
+
+namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
+{
+    /// <summary>
+    /// Pins the incremental reconcile that replaced the old wholesale rebuild in
+    /// <see cref="TagCacheService.BuildFullCache"/>: unchanged items are reused (their media never
+    /// re-probed), only real changes rebuild, removals are the sole trigger for a client
+    /// full-reload (a <see cref="TagCacheService.Version"/> bump), and adds/edits flow through the
+    /// timestamp so the incremental ?since= delta carries them without a version bump. The pure
+    /// decision helpers (<c>ShouldRebuild</c>, <c>ContentEquals</c>) are tested directly; the wiring
+    /// is driven through a fake <see cref="ILibraryManager"/>.
+    /// </summary>
+    public sealed class TagCacheReconcileTests
+    {
+        private static readonly DateTime T0 = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        private static readonly CancellationToken CT = CancellationToken.None;
+
+        private static string Key(Guid id) => id.ToString("N").ToLowerInvariant();
+
+        private static string NewTempDir()
+        {
+            var d = Path.Combine(Path.GetTempPath(), "je-tagcache-reconcile-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(d);
+            return d;
+        }
+
+        private static TagCacheService NewSvc(CountingLibraryManager lib, string dir) =>
+            new(lib, new StubAppPaths(dir), NullLogger<TagCacheService>.Instance);
+
+        // ── ShouldRebuild: the pure gate ──────────────────────────────────────────────────
+
+        [Fact]
+        public void ShouldRebuild_NewItem_Always()
+            => Assert.True(TagCacheService.ShouldRebuild(BaseItemKind.Movie, old: null, revision: 123, parentSeriesRatingChanged: false));
+
+        [Fact]
+        public void ShouldRebuild_UnchangedLeaf_Reuses()
+        {
+            var old = new TagCacheEntry { SourceRevision = 123 };
+            Assert.False(TagCacheService.ShouldRebuild(BaseItemKind.Movie, old, revision: 123, parentSeriesRatingChanged: false));
+        }
+
+        [Fact]
+        public void ShouldRebuild_ChangedRevision_Rebuilds()
+        {
+            var old = new TagCacheEntry { SourceRevision = 123 };
+            Assert.True(TagCacheService.ShouldRebuild(BaseItemKind.Movie, old, revision: 999, parentSeriesRatingChanged: false));
+        }
+
+        [Theory]
+        [InlineData(BaseItemKind.Series)]
+        [InlineData(BaseItemKind.Season)]
+        public void ShouldRebuild_Containers_AlwaysRebuild_EvenWhenRevisionUnchanged(BaseItemKind kind)
+        {
+            // Containers derive from their child episodes, which their own DateLastSaved doesn't track.
+            var old = new TagCacheEntry { SourceRevision = 123 };
+            Assert.True(TagCacheService.ShouldRebuild(kind, old, revision: 123, parentSeriesRatingChanged: false));
+        }
+
+        [Fact]
+        public void ShouldRebuild_EpisodeUnchangedButParentSeriesRatingChanged_Rebuilds()
+        {
+            var old = new TagCacheEntry { SourceRevision = 123 };
+            Assert.True(TagCacheService.ShouldRebuild(BaseItemKind.Episode, old, revision: 123, parentSeriesRatingChanged: true));
+        }
+
+        [Fact]
+        public void ShouldRebuild_EpisodeUnchangedAndParentSeriesUnchanged_Reuses()
+        {
+            var old = new TagCacheEntry { SourceRevision = 123 };
+            Assert.False(TagCacheService.ShouldRebuild(BaseItemKind.Episode, old, revision: 123, parentSeriesRatingChanged: false));
+        }
+
+        // ── ContentEquals: ignores volatile fields, order-insensitive on hash-ordered arrays ──
+
+        [Fact]
+        public void ContentEquals_SameContentDifferentVolatileFields_True()
+        {
+            var a = new TagCacheEntry { Type = "Movie", Genres = new[] { "Drama" }, CommunityRating = 7.5f, LastUpdated = 1, SourceRevision = 10 };
+            var b = new TagCacheEntry { Type = "Movie", Genres = new[] { "Drama" }, CommunityRating = 7.5f, LastUpdated = 999, SourceRevision = 20 };
+            Assert.True(TagCacheService.ContentEquals(a, b));
+        }
+
+        [Fact]
+        public void ContentEquals_DifferentGenre_False()
+        {
+            var a = new TagCacheEntry { Type = "Movie", Genres = new[] { "Drama" } };
+            var b = new TagCacheEntry { Type = "Movie", Genres = new[] { "Comedy" } };
+            Assert.False(TagCacheService.ContentEquals(a, b));
+        }
+
+        [Fact]
+        public void ContentEquals_DifferentRating_False()
+        {
+            var a = new TagCacheEntry { Type = "Movie", CommunityRating = 7.5f };
+            var b = new TagCacheEntry { Type = "Movie", CommunityRating = 8.0f };
+            Assert.False(TagCacheService.ContentEquals(a, b));
+        }
+
+        [Fact]
+        public void ContentEquals_AudioLanguagesInDifferentOrder_True()
+        {
+            // AudioLanguages comes from a HashSet<string>; .NET randomises string hashing per process,
+            // so the array order can differ across restarts for the same languages. The signature
+            // must sort it, or every multi-language item would churn on each reconcile.
+            var a = new TagCacheEntry { Type = "Movie", AudioLanguages = new[] { "eng", "jpn" } };
+            var b = new TagCacheEntry { Type = "Movie", AudioLanguages = new[] { "jpn", "eng" } };
+            Assert.True(TagCacheService.ContentEquals(a, b));
+        }
+
+        // ── Reconcile wiring, driven through a fake library ───────────────────────────────
+
+        [Fact]
+        public void Reconcile_UnchangedItem_ReusesEntry_NoProbe_NoVersionBump()
+        {
+            var dir = NewTempDir();
+            try
+            {
+                var id = Guid.NewGuid();
+                var movie = new Movie { Id = id, Name = "M", DateLastSaved = T0, CommunityRating = 6.0f };
+                var lib = new CountingLibraryManager { GetItemListHook = _ => new List<BaseItem> { movie } };
+                using var svc = NewSvc(lib, dir);
+
+                svc.BuildFullCache(null, CT);
+                var first = svc.GetEntryForTest(Key(id));
+                var versionAfterFirst = svc.Version;
+                var lastModAfterFirst = svc.LastModified;
+                Assert.NotNull(first);
+
+                // Nothing about the item changed (same DateLastSaved) -> reuse the SAME instance.
+                svc.BuildFullCache(null, CT);
+                var second = svc.GetEntryForTest(Key(id));
+
+                Assert.Same(first, second);                       // reused, not re-probed
+                Assert.Equal(versionAfterFirst, svc.Version);     // no removal -> no version bump
+                Assert.Equal(lastModAfterFirst, svc.LastModified); // no change -> timestamp not advanced
+            }
+            finally { TryDelete(dir); }
+        }
+
+        [Fact]
+        public void Reconcile_ContentChanged_Rebuilds_AdvancesTimestamp_NoVersionBump()
+        {
+            var dir = NewTempDir();
+            try
+            {
+                var id = Guid.NewGuid();
+                var movie = new Movie { Id = id, Name = "M", DateLastSaved = T0, CommunityRating = 6.0f };
+                var lib = new CountingLibraryManager { GetItemListHook = _ => new List<BaseItem> { movie } };
+                using var svc = NewSvc(lib, dir);
+
+                svc.BuildFullCache(null, CT);
+                var lastModAfterFirst = svc.LastModified;
+                var versionAfterFirst = svc.Version;
+
+                // A real edit: bump the source revision AND change content.
+                movie.DateLastSaved = T0.AddHours(1);
+                movie.CommunityRating = 9.0f;
+                svc.BuildFullCache(null, CT);
+
+                var entry = svc.GetEntryForTest(Key(id));
+                Assert.NotNull(entry);
+                Assert.Equal(9.0f, entry!.CommunityRating);        // rebuilt with new content
+                Assert.True(svc.LastModified >= lastModAfterFirst); // delta advanced
+                Assert.Equal(versionAfterFirst, svc.Version);       // still no removal
+            }
+            finally { TryDelete(dir); }
+        }
+
+        [Fact]
+        public void Reconcile_RevisionChangedButContentIdentical_RetainsTimestamp()
+        {
+            var dir = NewTempDir();
+            try
+            {
+                var id = Guid.NewGuid();
+                var movie = new Movie { Id = id, Name = "M", DateLastSaved = T0, CommunityRating = 6.0f };
+                var lib = new CountingLibraryManager { GetItemListHook = _ => new List<BaseItem> { movie } };
+                using var svc = NewSvc(lib, dir);
+
+                svc.BuildFullCache(null, CT);
+                var originalLastUpdated = svc.GetEntryForTest(Key(id))!.LastUpdated;
+                var lastModAfterFirst = svc.LastModified;
+
+                // A no-op re-save: DateLastSaved moves (forces a rebuild) but content is identical.
+                movie.DateLastSaved = T0.AddHours(1);
+                svc.BuildFullCache(null, CT);
+
+                var entry = svc.GetEntryForTest(Key(id));
+                Assert.NotNull(entry);
+                Assert.Equal(originalLastUpdated, entry!.LastUpdated);          // timestamp retained -> no delta churn
+                Assert.Equal(T0.AddHours(1).Ticks, entry.SourceRevision);       // but gate refreshed
+                Assert.Equal(lastModAfterFirst, svc.LastModified);              // no client-visible change
+            }
+            finally { TryDelete(dir); }
+        }
+
+        [Fact]
+        public void Reconcile_AddedItem_Included_NoVersionBump()
+        {
+            var dir = NewTempDir();
+            try
+            {
+                var a = new Movie { Id = Guid.NewGuid(), Name = "A", DateLastSaved = T0 };
+                var b = new Movie { Id = Guid.NewGuid(), Name = "B", DateLastSaved = T0 };
+                var scan = new List<BaseItem> { a };
+                var lib = new CountingLibraryManager { GetItemListHook = _ => scan };
+                using var svc = NewSvc(lib, dir);
+
+                svc.BuildFullCache(null, CT);
+                var versionAfterFirst = svc.Version;
+
+                scan.Add(b);                                   // B appears in the library
+                svc.BuildFullCache(null, CT);
+
+                Assert.True(svc.ContainsKeyForTest(Key(b.Id)));
+                Assert.Equal(versionAfterFirst, svc.Version);  // add flows via the delta, not a full reload
+            }
+            finally { TryDelete(dir); }
+        }
+
+        [Fact]
+        public void Reconcile_RemovedItem_Dropped_BumpsVersion()
+        {
+            var dir = NewTempDir();
+            try
+            {
+                var a = new Movie { Id = Guid.NewGuid(), Name = "A", DateLastSaved = T0 };
+                var b = new Movie { Id = Guid.NewGuid(), Name = "B", DateLastSaved = T0 };
+                var scan = new List<BaseItem> { a, b };
+                var lib = new CountingLibraryManager { GetItemListHook = _ => scan };
+                using var svc = NewSvc(lib, dir);
+
+                svc.BuildFullCache(null, CT);
+                var versionAfterFirst = svc.Version;
+
+                scan.Remove(b);                                // B removed from the library
+                svc.BuildFullCache(null, CT);
+
+                Assert.False(svc.ContainsKeyForTest(Key(b.Id)));
+                Assert.Equal(versionAfterFirst + 1, svc.Version); // removal forces a client full reload
+            }
+            finally { TryDelete(dir); }
+        }
+
+        [Fact]
+        public void Reconcile_SeriesRatingChange_RederivesEpisodeInheritedRating()
+        {
+            var dir = NewTempDir();
+            try
+            {
+                var seriesId = Guid.NewGuid();
+                var epId = Guid.NewGuid();
+                var series = new Series { Id = seriesId, Name = "S", DateLastSaved = T0, CommunityRating = 5.0f };
+                // Episode has NO rating of its own -> inherits the series rating.
+                var ep = new Episode { Id = epId, Name = "E", DateLastSaved = T0, SeriesId = seriesId };
+                var scan = new List<BaseItem> { series, ep };
+
+                var lib = new CountingLibraryManager
+                {
+                    // Full scan vs the container's first-episode lookup (ParentId set).
+                    GetItemListHook = q => q.ParentId == Guid.Empty ? scan : new List<BaseItem> { ep },
+                    GetItemByIdHook = id => id == seriesId ? series : id == epId ? ep : null,
+                };
+                using var svc = NewSvc(lib, dir);
+
+                svc.BuildFullCache(null, CT);
+                Assert.Equal(5.0f, svc.GetEntryForTest(Key(epId))!.CommunityRating); // inherited
+
+                // The series' own rating changes; the episode's DateLastSaved does NOT move.
+                series.CommunityRating = 8.0f;
+                series.DateLastSaved = T0.AddHours(1);
+                svc.BuildFullCache(null, CT);
+
+                // Episode's inherited rating must follow even though its own revision is unchanged.
+                Assert.Equal(8.0f, svc.GetEntryForTest(Key(epId))!.CommunityRating);
+                Assert.Equal(0L, svc.Version); // no removal
+            }
+            finally { TryDelete(dir); }
+        }
+
+        private static void TryDelete(string dir)
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Services/TagCacheServiceFlushTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Services/TagCacheServiceFlushTests.cs
@@ -155,7 +155,7 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
                 var lib = new CountingLibraryManager
                 {
                     GetItemListHook = _ => System.Array.Empty<BaseItem>(),                 // full scan finds nothing
-                    GetItemByIdHook = id => id == movieId ? new Movie { Id = movieId } : null,
+                    GetItemByIdHook = id => id == movieId ? new StubMovie { Id = movieId } : null,
                 };
                 using var svc = new TagCacheService(lib, new StubAppPaths(tempDir), NullLogger<TagCacheService>.Instance);
 
@@ -196,7 +196,7 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
                 var lib = new CountingLibraryManager
                 {
                     GetItemListHook = _ => System.Array.Empty<BaseItem>(),                 // rebuild's full scan finds nothing
-                    GetItemByIdHook = id => id == movieId ? new Movie { Id = movieId } : null,
+                    GetItemByIdHook = id => id == movieId ? new StubMovie { Id = movieId } : null,
                 };
                 using var svc = new TagCacheService(lib, new StubAppPaths(tempDir), NullLogger<TagCacheService>.Instance);
 

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/TestDoubles/StubMediaItems.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/TestDoubles/StubMediaItems.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Model.Dto;
+using Episode = MediaBrowser.Controller.Entities.TV.Episode;
+using Season = MediaBrowser.Controller.Entities.TV.Season;
+using Series = MediaBrowser.Controller.Entities.TV.Series;
+
+namespace Jellyfin.Plugin.JellyfinElevate.Tests.TestDoubles;
+
+// Test entities whose media probe returns an EMPTY result instead of throwing. A bare BaseItem's
+// GetMediaSources throws in a unit-test environment (no resolver wired up); the tag cache's real
+// production path gets a real — often empty — result and only treats an actual throw as a probe
+// failure (keep last-good). These stubs model the production "item with no resolvable media"
+// case, so BuildEntryForItem builds a normal (stream-less) entry rather than hitting the
+// probe-failure/keep-last-good branch.
+//
+// Each overrides GetClientTypeName() so GetBaseItemKind() (which Enum.Parse-s the client type
+// name) still resolves to the real kind — the default returns the runtime type name, which for a
+// subclass like "StubMovie" is not a BaseItemKind and would throw.
+public sealed class StubMovie : Movie
+{
+    public override string GetClientTypeName() => "Movie";
+
+    public override IReadOnlyList<MediaSourceInfo> GetMediaSources(bool enablePathSubstitution) => Array.Empty<MediaSourceInfo>();
+}
+
+public sealed class StubEpisode : Episode
+{
+    public override string GetClientTypeName() => "Episode";
+
+    public override IReadOnlyList<MediaSourceInfo> GetMediaSources(bool enablePathSubstitution) => Array.Empty<MediaSourceInfo>();
+}
+
+public sealed class StubSeries : Series
+{
+    public override string GetClientTypeName() => "Series";
+
+    public override IReadOnlyList<MediaSourceInfo> GetMediaSources(bool enablePathSubstitution) => Array.Empty<MediaSourceInfo>();
+}
+
+public sealed class StubSeason : Season
+{
+    public override string GetClientTypeName() => "Season";
+
+    public override IReadOnlyList<MediaSourceInfo> GetMediaSources(bool enablePathSubstitution) => Array.Empty<MediaSourceInfo>();
+}

--- a/Jellyfin.Plugin.JellyfinElevate/Model/TagCacheEntry.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Model/TagCacheEntry.cs
@@ -28,6 +28,17 @@ namespace Jellyfin.Plugin.JellyfinElevate.Model
         // without a per-episode library lookup on every request.
         public string? SeriesId { get; set; }
 
+        // Source item revision (BaseItem.DateLastSaved ticks) captured when this
+        // entry was built. The daily reconcile (TagCacheService.BuildFullCache)
+        // uses it as a cheap candidate gate: an item whose revision is unchanged
+        // reuses this entry verbatim instead of re-probing its media. Persisted
+        // so the gate survives a restart. Not a Spoiler-Guard strip field (so it
+        // deliberately does NOT bump the on-disk schema version); an older cache
+        // simply loads it as 0, which forces a one-time rebuild on the first
+        // reconcile after upgrade. Rides the cache response too — a non-sensitive
+        // long the client ignores.
+        public long SourceRevision { get; set; }
+
         // Shallow copy required by per-user mutators (spoiler tag-strip): the
         // TagCacheService stores ONE shared instance per item across ALL users,
         // so mutating in place would leak one user's strip into every other user's
@@ -55,6 +66,7 @@ namespace Jellyfin.Plugin.JellyfinElevate.Model
             StreamData = StreamData,
             LastUpdated = LastUpdated,
             SeriesId = SeriesId,
+            SourceRevision = SourceRevision,
         };
     }
 

--- a/Jellyfin.Plugin.JellyfinElevate/ScheduledTasks/BuildTagCacheTask.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/ScheduledTasks/BuildTagCacheTask.cs
@@ -9,10 +9,12 @@ using Microsoft.Extensions.Logging;
 namespace Jellyfin.Plugin.JellyfinElevate.ScheduledTasks
 {
     /// <summary>
-    /// Scheduled task that builds the server-side tag cache for all library items.
+    /// Scheduled task that reconciles the server-side tag cache against the library.
     /// Runs daily at 3 AM. Can also be run manually from the admin dashboard.
-    /// On startup, the cache is loaded from disk instead (TagCacheMonitor handles
-    /// any items added/changed while the server was off via Jellyfin's library scan events).
+    /// It only (re)builds items whose source changed, adds new items, and drops removed
+    /// ones — unchanged items keep their cached entry, so it does not re-probe the whole
+    /// library each run. On startup, the cache is loaded from disk instead (TagCacheMonitor
+    /// handles items added/changed while the server was off via Jellyfin's library scan events).
     /// </summary>
     public class BuildTagCacheTask : IScheduledTask
     {
@@ -31,7 +33,7 @@ namespace Jellyfin.Plugin.JellyfinElevate.ScheduledTasks
 
         public string Key => "JellyfinElevateBuildTagCache";
 
-        public string Description => "Pre-computes tag data (genres, ratings, languages, quality stream info) for all library items. Clients load this cache in a single request instead of making per-page API calls. Run this manually after first install to build the initial cache.";
+        public string Description => "Pre-computes tag data (genres, ratings, languages, quality stream info) for library items. Clients load this cache in a single request instead of making per-page API calls. Updates incrementally — only items that changed since the last run are re-processed. Run this manually after first install to build the initial cache.";
 
         public string Category => "Jellyfin Elevate";
 

--- a/Jellyfin.Plugin.JellyfinElevate/Services/TagCacheService.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/TagCacheService.cs
@@ -191,12 +191,6 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
 
                 var newCache = new ConcurrentDictionary<string, TagCacheEntry>();
                 var changed = false; // an add or a genuine content change (drives the ?since= delta)
-                // Items whose media probe / dependency lookup failed this pass: we keep their
-                // last-good entry (below) and re-queue them for a prompt off-thread retry once the
-                // guard is released, so a transient failure recovers via the existing flush path
-                // instead of waiting for the next daily reconcile (which, for a rating-inheriting
-                // episode, would not otherwise re-fire once the series entry has settled).
-                var probeFailed = new List<Guid>();
                 var processed = 0;
 
                 foreach (var item in allItems)
@@ -224,16 +218,24 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
                         var entry = BuildEntryForItem(item);
                         if (entry == null)
                         {
-                            // Transient build failure (e.g. a media probe threw): keep the last-good
-                            // entry rather than dropping it (dropping would look like a removal and
-                            // force a client full reload) and re-queue the item for a retry. Keeping
-                            // old preserves its OLD SourceRevision, so a revision-driven rebuild stays
-                            // a candidate; the re-queue also covers the rating-inheritance case.
+                            // Unexpected build failure (a bug, not a media-probe failure — those return
+                            // a degraded entry below): keep the last-good entry rather than dropping it
+                            // (dropping would look like a removal and force a client full reload). Its
+                            // OLD SourceRevision keeps it a rebuild candidate next cycle.
                             if (old != null) newCache[key] = old;
-                            probeFailed.Add(item.Id);
                         }
                         else
                         {
+                            // A degraded entry (media probe failed) carries SourceRevision == 0
+                            // (unconfirmed): keep its fresh probe-independent data (own + inherited
+                            // rating/genres) but retain the last-good streams, and leave it unconfirmed
+                            // so the gate rebuilds it every cycle until the probe recovers.
+                            if (entry.SourceRevision == 0 && old != null)
+                            {
+                                entry.StreamData = old.StreamData;
+                                entry.AudioLanguages = old.AudioLanguages;
+                            }
+
                             if (old != null && ContentEquals(old, entry))
                             {
                                 // Rebuilt but content-identical (e.g. a container whose first episode
@@ -292,18 +294,6 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
                 if (drainRemoved)
                 {
                     Interlocked.Increment(ref _version);
-                }
-
-                // Re-queue items whose build failed this pass so a debounced off-thread flush retries
-                // them after the guard is released (the post-swap drain above has already run, so
-                // these are NOT consumed synchronously here — they wait for the probe to recover).
-                if (probeFailed.Count > 0)
-                {
-                    _logger.LogInformation($"[TagCache] {probeFailed.Count} item(s) failed to build this reconcile; kept last-good and re-queued for retry.");
-                    foreach (var id in probeFailed)
-                    {
-                        EnqueueUpdate(id);
-                    }
                 }
 
                 progress?.Report(100);
@@ -579,6 +569,14 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
             if (entry == null) return false;
 
             var key = id.ToString("N").ToLowerInvariant();
+            // A degraded entry (media probe failed) carries SourceRevision == 0: retain the last-good
+            // streams and leave it unconfirmed so the next reconcile rebuilds it. Mirrors the
+            // reconcile so an incremental event during a probe outage doesn't drop the streams.
+            if (entry.SourceRevision == 0 && _cache.TryGetValue(key, out var existing) && existing != null)
+            {
+                entry.StreamData = existing.StreamData;
+                entry.AudioLanguages = existing.AudioLanguages;
+            }
             _cache[key] = entry;
             return true;
         }
@@ -1011,6 +1009,10 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
         /// <summary>
         /// Build a TagCacheEntry for a single library item.
         /// For Series/Season, resolves first-episode data server-side.
+        /// If the media probe fails, the probe-independent data (own + inherited rating/genres) is
+        /// still built and the entry is stamped SourceRevision == 0 (unconfirmed) so the reconcile
+        /// retains the last-good streams and rebuilds it every cycle until the probe recovers,
+        /// rather than confirming a degraded entry. Returns null only on an UNEXPECTED failure.
         /// </summary>
         private TagCacheEntry? BuildEntryForItem(BaseItem item)
         {
@@ -1018,6 +1020,7 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
             {
                 var kind = item.GetBaseItemKind();
                 var isContainer = kind == BaseItemKind.Series || kind == BaseItemKind.Season;
+                var probeFailed = false;
 
                 // Capture parent series ID for Episodes/Seasons so the Spoiler
                 // Guard filter can strip unwatched-episode entries without a
@@ -1058,15 +1061,21 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
                         }
 
                         var media = ExtractMediaData(firstEp);
-                        if (media == null) return null; // probe failed — keep last-good, don't publish a degraded entry
-                        entry.StreamData = new TagStreamData
+                        if (media == null)
                         {
-                            Streams = media.Value.Streams,
-                            Sources = media.Value.Sources,
-                            ItemName = firstEp.Name,
-                            ItemPath = string.IsNullOrEmpty(firstEp.Path) ? null : Path.GetFileName(firstEp.Path)
-                        };
-                        entry.AudioLanguages = media.Value.Languages;
+                            probeFailed = true; // leave StreamData/AudioLanguages for the caller to retain last-good
+                        }
+                        else
+                        {
+                            entry.StreamData = new TagStreamData
+                            {
+                                Streams = media.Value.Streams,
+                                Sources = media.Value.Sources,
+                                ItemName = firstEp.Name,
+                                ItemPath = string.IsNullOrEmpty(firstEp.Path) ? null : Path.GetFileName(firstEp.Path)
+                            };
+                            entry.AudioLanguages = media.Value.Languages;
+                        }
                     }
 
                     if (kind == BaseItemKind.Season && entry.CommunityRating == null)
@@ -1095,15 +1104,21 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
                 else
                 {
                     var media = ExtractMediaData(item);
-                    if (media == null) return null; // probe failed — keep last-good, don't publish a degraded entry
-                    entry.StreamData = new TagStreamData
+                    if (media == null)
                     {
-                        Streams = media.Value.Streams,
-                        Sources = media.Value.Sources,
-                        ItemName = item.Name,
-                        ItemPath = string.IsNullOrEmpty(item.Path) ? null : Path.GetFileName(item.Path)
-                    };
-                    entry.AudioLanguages = media.Value.Languages;
+                        probeFailed = true; // leave StreamData/AudioLanguages for the caller to retain last-good
+                    }
+                    else
+                    {
+                        entry.StreamData = new TagStreamData
+                        {
+                            Streams = media.Value.Streams,
+                            Sources = media.Value.Sources,
+                            ItemName = item.Name,
+                            ItemPath = string.IsNullOrEmpty(item.Path) ? null : Path.GetFileName(item.Path)
+                        };
+                        entry.AudioLanguages = media.Value.Languages;
+                    }
 
                     if (kind == BaseItemKind.Episode && entry.CommunityRating == null)
                     {
@@ -1126,6 +1141,14 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
                     }
                 }
 
+                if (probeFailed)
+                {
+                    // Mark unconfirmed so the reconcile gate rebuilds this item every cycle until the
+                    // probe recovers, and retains its last-good streams in the meantime. 0 also means
+                    // "unconfirmed" for a pre-upgrade on-disk entry, so the semantics are consistent.
+                    entry.SourceRevision = 0;
+                }
+
                 return entry;
             }
             catch (Exception ex)
@@ -1135,11 +1158,11 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
             }
         }
 
-        // Returns null when the media probe itself FAILED (GetMediaSources threw) so the caller can
-        // keep the last-good entry — distinct from a successful-but-empty result for an item that
-        // legitimately has no media. This matters for the revision-gated reconcile: publishing a
-        // silently-degraded (empty streams) entry AND stamping the current SourceRevision would make
-        // the gate reuse the damaged entry until the source changes again, instead of retrying.
+        // Returns null when the media probe itself FAILED (GetMediaSources threw), distinct from a
+        // successful-but-empty result for an item that legitimately has no media. This matters for
+        // the revision-gated reconcile: on a real failure BuildEntryForItem stamps SourceRevision==0
+        // (unconfirmed) instead of the current revision, so the gate keeps rebuilding the item until
+        // the probe recovers rather than confirming — and reusing — a silently-degraded entry.
         private (List<TagMediaStream> Streams, List<TagMediaSource> Sources, string[] Languages)? ExtractMediaData(BaseItem item)
         {
             var streams = new List<TagMediaStream>();

--- a/Jellyfin.Plugin.JellyfinElevate/Services/TagCacheService.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/TagCacheService.cs
@@ -191,6 +191,12 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
 
                 var newCache = new ConcurrentDictionary<string, TagCacheEntry>();
                 var changed = false; // an add or a genuine content change (drives the ?since= delta)
+                // Items whose media probe / dependency lookup failed this pass: we keep their
+                // last-good entry (below) and re-queue them for a prompt off-thread retry once the
+                // guard is released, so a transient failure recovers via the existing flush path
+                // instead of waiting for the next daily reconcile (which, for a rating-inheriting
+                // episode, would not otherwise re-fire once the series entry has settled).
+                var probeFailed = new List<Guid>();
                 var processed = 0;
 
                 foreach (var item in allItems)
@@ -218,9 +224,13 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
                         var entry = BuildEntryForItem(item);
                         if (entry == null)
                         {
-                            // Transient build failure: keep the last-good entry rather than dropping
-                            // it (dropping would look like a removal and force a client full reload).
+                            // Transient build failure (e.g. a media probe threw): keep the last-good
+                            // entry rather than dropping it (dropping would look like a removal and
+                            // force a client full reload) and re-queue the item for a retry. Keeping
+                            // old preserves its OLD SourceRevision, so a revision-driven rebuild stays
+                            // a candidate; the re-queue also covers the rating-inheritance case.
                             if (old != null) newCache[key] = old;
+                            probeFailed.Add(item.Id);
                         }
                         else
                         {
@@ -282,6 +292,18 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
                 if (drainRemoved)
                 {
                     Interlocked.Increment(ref _version);
+                }
+
+                // Re-queue items whose build failed this pass so a debounced off-thread flush retries
+                // them after the guard is released (the post-swap drain above has already run, so
+                // these are NOT consumed synchronously here — they wait for the probe to recover).
+                if (probeFailed.Count > 0)
+                {
+                    _logger.LogInformation($"[TagCache] {probeFailed.Count} item(s) failed to build this reconcile; kept last-good and re-queued for retry.");
+                    foreach (var id in probeFailed)
+                    {
+                        EnqueueUpdate(id);
+                    }
                 }
 
                 progress?.Report(100);
@@ -1035,15 +1057,16 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
                             entry.Genres = firstEp.Genres;
                         }
 
-                        var (streams, sources, languages) = ExtractMediaData(firstEp);
+                        var media = ExtractMediaData(firstEp);
+                        if (media == null) return null; // probe failed — keep last-good, don't publish a degraded entry
                         entry.StreamData = new TagStreamData
                         {
-                            Streams = streams,
-                            Sources = sources,
+                            Streams = media.Value.Streams,
+                            Sources = media.Value.Sources,
                             ItemName = firstEp.Name,
                             ItemPath = string.IsNullOrEmpty(firstEp.Path) ? null : Path.GetFileName(firstEp.Path)
                         };
-                        entry.AudioLanguages = languages;
+                        entry.AudioLanguages = media.Value.Languages;
                     }
 
                     if (kind == BaseItemKind.Season && entry.CommunityRating == null)
@@ -1071,15 +1094,16 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
                 }
                 else
                 {
-                    var (streams, sources, languages) = ExtractMediaData(item);
+                    var media = ExtractMediaData(item);
+                    if (media == null) return null; // probe failed — keep last-good, don't publish a degraded entry
                     entry.StreamData = new TagStreamData
                     {
-                        Streams = streams,
-                        Sources = sources,
+                        Streams = media.Value.Streams,
+                        Sources = media.Value.Sources,
                         ItemName = item.Name,
                         ItemPath = string.IsNullOrEmpty(item.Path) ? null : Path.GetFileName(item.Path)
                     };
-                    entry.AudioLanguages = languages;
+                    entry.AudioLanguages = media.Value.Languages;
 
                     if (kind == BaseItemKind.Episode && entry.CommunityRating == null)
                     {
@@ -1111,7 +1135,12 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
             }
         }
 
-        private (List<TagMediaStream>, List<TagMediaSource>, string[]) ExtractMediaData(BaseItem item)
+        // Returns null when the media probe itself FAILED (GetMediaSources threw) so the caller can
+        // keep the last-good entry — distinct from a successful-but-empty result for an item that
+        // legitimately has no media. This matters for the revision-gated reconcile: publishing a
+        // silently-degraded (empty streams) entry AND stamping the current SourceRevision would make
+        // the gate reuse the damaged entry until the source changes again, instead of retrying.
+        private (List<TagMediaStream> Streams, List<TagMediaSource> Sources, string[] Languages)? ExtractMediaData(BaseItem item)
         {
             var streams = new List<TagMediaStream>();
             var sources = new List<TagMediaSource>();
@@ -1162,6 +1191,7 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
             catch (Exception ex)
             {
                 _logger.LogWarning($"[TagCache] Failed to extract media data for {item.Id}: {ex.Message}");
+                return null; // real probe failure — signal it so the caller keeps last-good data
             }
 
             return (streams, sources, languages.ToArray());

--- a/Jellyfin.Plugin.JellyfinElevate/Services/TagCacheService.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/TagCacheService.cs
@@ -112,42 +112,56 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
 
         internal bool ContainsKeyForTest(string key) => _cache.ContainsKey(key);
 
+        // Read the live cache entry for a key (or null). Lets reconcile tests assert reference
+        // identity (proving an unchanged item was reused, not re-probed) and timestamp retention.
+        internal TagCacheEntry? GetEntryForTest(string key) => _cache.TryGetValue(key, out var e) ? e : null;
+
         private string CacheFilePath =>
             Path.Combine(_applicationPaths.PluginsPath, "configurations", "Jellyfin.Plugin.JellyfinElevate", "tag-cache.json");
 
         /// <summary>
-        /// Build the complete tag cache for all library items.
-        /// Called by the scheduled task on startup and periodically.
+        /// Reconcile the tag cache against the current library. Called by the scheduled task
+        /// (daily / manual) and by the first-install build. Rather than rebuilding every entry,
+        /// it reuses the existing entry for any item whose source revision
+        /// (<see cref="BaseItem.DateLastSaved"/>) is unchanged — skipping the media probe — and
+        /// only (re)builds new or changed items, drops items no longer in the library, and bumps
+        /// <see cref="Version"/> (the client's full-reload signal) only when something is actually
+        /// removed. Containers (Series/Season) derive from their child episodes, which their own
+        /// timestamp does not track, so they are always rebuilt; a structural comparison then
+        /// retains the old timestamp when nothing really changed, so the client delta doesn't churn.
         /// </summary>
         public void BuildFullCache(IProgress<double>? progress, CancellationToken cancellationToken)
         {
-            _logger.LogInformation("[TagCache] Starting full cache build...");
+            _logger.LogInformation("[TagCache] Starting cache reconcile...");
             var sw = System.Diagnostics.Stopwatch.StartNew();
 
-            // Serialize the rebuild against incremental flushes: hold the flush guard across the
-            // whole build + swap. While we hold it, a FlushPending that fires sees _flushing==1 and
-            // re-arms WITHOUT draining (it never mutates the OLD _cache we're about to discard), so
-            // events raised during the build stay in _pending and are applied onto the NEW cache
-            // below.
+            // Serialize the reconcile against incremental flushes: hold the flush guard across the
+            // whole pass + swap. While we hold it, a FlushPending that fires sees _flushing==1 and
+            // re-arms WITHOUT draining (it never mutates the OLD _cache), so events raised during
+            // the reconcile stay in _pending and are applied onto the NEW cache below.
             //
             // Crucially we take the guard BEFORE the library snapshot below. If a flush is ALREADY
-            // running when we start it has already drained _pending and is mutating the OLD cache we
-            // will discard — its deltas are gone from _pending, so proceeding to swap would silently
-            // drop them (the post-swap drain finds nothing to re-apply). That is the lost-update
-            // window. So instead of a lossy timeout-and-proceed, we WAIT (bounded) for the in-flight
-            // flush to finish; once it does, its changes are committed to the library and the fresh
-            // scan below captures them. Only if a flush is STILL running after ~30s do we abort this
-            // rebuild rather than swap lossily — incremental flushes keep the cache fresh and the
-            // scheduled task retries next cycle. AcquireFlushGuard polls (10ms sleeps), so this
-            // neither busy-spins nor deadlocks (the single guard is always released by its holder).
+            // running when we start it has already drained _pending and is mutating _cache — its
+            // deltas are gone from _pending, so proceeding to swap would silently drop them (the
+            // post-swap drain finds nothing to re-apply). That is the lost-update window. So instead
+            // of a lossy timeout-and-proceed, we WAIT (bounded) for the in-flight flush to finish;
+            // once it does, its changes are committed to the library and the fresh scan below
+            // captures them. Only if a flush is STILL running after ~30s do we abort this reconcile
+            // rather than swap lossily — incremental flushes keep the cache fresh and the scheduled
+            // task retries next cycle. AcquireFlushGuard polls (10ms sleeps), so this neither
+            // busy-spins nor deadlocks (the single guard is always released by its holder).
             if (!AcquireFlushGuard(maxSpins: _rebuildFlushGuardSpins, spinMs: 10))
             {
-                _logger.LogWarning("[TagCache] Skipping full rebuild: an incremental flush is still running after the guard wait; retrying next cycle to avoid a lost-update swap.");
+                _logger.LogWarning("[TagCache] Skipping reconcile: an incremental flush is still running after the guard wait; retrying next cycle to avoid a lost-update swap.");
                 return;
             }
 
             try
             {
+                // Stable snapshot of the current cache. The guard keeps flushes from mutating it
+                // while we reconcile, so both the rating pre-pass and the main loop read one state.
+                var oldCache = _cache;
+
                 var allItems = _libraryManager.GetItemList(new InternalItemsQuery
                 {
                     IncludeItemTypes = TaggableTypes.ToArray(),
@@ -157,18 +171,72 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
 
                 _logger.LogInformation($"[TagCache] Found {allItems.Count} taggable items");
 
+                // Pass 1: which series' own rating changed since its cached entry was built. An
+                // Episode with no rating of its own inherits its parent series' rating, so a series
+                // rating change must re-derive those episodes even when the episode's own
+                // DateLastSaved is unchanged. A Series entry stores the series' own rating verbatim
+                // (no fallback), so comparing the live value against the old entry is exact.
+                var seriesRatingChanged = new HashSet<Guid>();
+                foreach (var item in allItems)
+                {
+                    if (item.GetBaseItemKind() != BaseItemKind.Series) continue;
+                    var sKey = item.Id.ToString("N").ToLowerInvariant();
+                    if (!oldCache.TryGetValue(sKey, out var oldSeries)
+                        || oldSeries.CommunityRating != item.CommunityRating
+                        || oldSeries.CriticRating != item.CriticRating)
+                    {
+                        seriesRatingChanged.Add(item.Id);
+                    }
+                }
+
                 var newCache = new ConcurrentDictionary<string, TagCacheEntry>();
+                var changed = false; // an add or a genuine content change (drives the ?since= delta)
                 var processed = 0;
 
                 foreach (var item in allItems)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    var entry = BuildEntryForItem(item);
-                    if (entry != null)
+                    var key = item.Id.ToString("N").ToLowerInvariant();
+                    var kind = item.GetBaseItemKind();
+                    var revision = item.DateLastSaved.Ticks;
+                    oldCache.TryGetValue(key, out var old);
+
+                    var parentSeriesRatingChanged =
+                        kind == BaseItemKind.Episode
+                        && item is MediaBrowser.Controller.Entities.TV.Episode epDep
+                        && seriesRatingChanged.Contains(epDep.SeriesId);
+
+                    if (!ShouldRebuild(kind, old, revision, parentSeriesRatingChanged))
                     {
-                        var key = item.Id.ToString("N").ToLowerInvariant();
-                        newCache[key] = entry;
+                        // Unchanged: reuse the existing entry verbatim — no media probe, timestamp
+                        // preserved. old is non-null here (ShouldRebuild returns true when it is).
+                        newCache[key] = old!;
+                    }
+                    else
+                    {
+                        var entry = BuildEntryForItem(item);
+                        if (entry == null)
+                        {
+                            // Transient build failure: keep the last-good entry rather than dropping
+                            // it (dropping would look like a removal and force a client full reload).
+                            if (old != null) newCache[key] = old;
+                        }
+                        else
+                        {
+                            if (old != null && ContentEquals(old, entry))
+                            {
+                                // Rebuilt but content-identical (e.g. a container whose first episode
+                                // is unchanged, or a no-op re-save): retain the old timestamp so the
+                                // client delta doesn't churn. SourceRevision is still refreshed.
+                                entry.LastUpdated = old.LastUpdated;
+                            }
+                            else
+                            {
+                                changed = true;
+                            }
+                            newCache[key] = entry;
+                        }
                     }
 
                     processed++;
@@ -178,23 +246,48 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
                     }
                 }
 
+                // A key that was cached but is no longer in the library is a removal — the one
+                // transition the incremental ?since= delta cannot express (it carries no tombstone),
+                // so it is the sole trigger for a client full reload via a Version bump.
+                var removed = false;
+                foreach (var key in oldCache.Keys)
+                {
+                    if (!newCache.ContainsKey(key)) { removed = true; break; }
+                }
+
                 OnBeforeSwapForTest?.Invoke();
 
-                // Atomic reference swap — readers see old or new cache, never partial
+                // Atomic reference swap — readers see old or new cache, never partial.
                 _cache = newCache;
-                Interlocked.Increment(ref _version);
-                Interlocked.Exchange(ref _lastModified, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
-                // Invalidate user access cache since items may have changed
-                _userAccessCache.Clear();
 
-                // Apply any events queued while we were building onto the freshly-published cache,
-                // so the swap can't strand a change that arrived mid-rebuild.
-                ApplyBatch(_pending.Drain(), RebuildEntry, RemoveEntry);
+                if (changed || removed)
+                {
+                    Interlocked.Exchange(ref _lastModified, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+                    // Added/updated/removed items may change a user's accessible set. Only cleared on
+                    // an actual change so a no-op reconcile doesn't force every user to recompute.
+                    _userAccessCache.Clear();
+                }
+                if (removed)
+                {
+                    Interlocked.Increment(ref _version);
+                }
+
+                // Apply events queued while we were reconciling onto the freshly-published cache, so
+                // the swap can't strand a change that arrived mid-reconcile. A removal here bumps
+                // Version too (same client-reload contract).
+                if (ApplyPendingBatch(_pending.Drain(), out var drainRemoved))
+                {
+                    Interlocked.Exchange(ref _lastModified, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+                }
+                if (drainRemoved)
+                {
+                    Interlocked.Increment(ref _version);
+                }
 
                 progress?.Report(100);
 
                 sw.Stop();
-                _logger.LogInformation($"[TagCache] Full cache build complete: {_cache.Count} entries in {sw.Elapsed.TotalSeconds:F1}s");
+                _logger.LogInformation($"[TagCache] Reconcile complete: {_cache.Count} entries (changed={changed}, removed={removed || drainRemoved}) in {sw.Elapsed.TotalSeconds:F1}s");
             }
             finally
             {
@@ -203,6 +296,55 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
             }
 
             SaveToDisk();
+        }
+
+        /// <summary>
+        /// Decide whether the reconcile must rebuild an item's entry, or can reuse the cached one.
+        /// Pure so the gate can be unit-tested without a live library. A rebuild is required for a
+        /// new item, for containers (Series/Season) whose derived data tracks their child episodes
+        /// rather than their own timestamp, when the source revision changed, or when an Episode's
+        /// parent-series rating changed (the episode inherits it when it has none of its own).
+        /// </summary>
+        internal static bool ShouldRebuild(BaseItemKind kind, TagCacheEntry? old, long revision, bool parentSeriesRatingChanged)
+        {
+            if (old == null) return true;
+            if (kind == BaseItemKind.Series || kind == BaseItemKind.Season) return true;
+            if (old.SourceRevision != revision) return true;
+            if (kind == BaseItemKind.Episode && parentSeriesRatingChanged) return true;
+            return false;
+        }
+
+        /// <summary>
+        /// Two entries are content-equal when everything a client renders is identical, ignoring the
+        /// volatile bookkeeping fields (LastUpdated = when WE built it, SourceRevision = the source
+        /// gate). Used to retain the old timestamp when a rebuild produced no real change, so the
+        /// client delta doesn't churn.
+        /// </summary>
+        internal static bool ContentEquals(TagCacheEntry a, TagCacheEntry b)
+        {
+            if (ReferenceEquals(a, b)) return true;
+            if (a == null || b == null) return false;
+            return ContentSignature(a) == ContentSignature(b);
+        }
+
+        private static string ContentSignature(TagCacheEntry e)
+        {
+            // Clone() is the audited copy-every-field method, so a new field is captured
+            // automatically. Zero the volatile fields and normalise the one hash-ordered collection:
+            // AudioLanguages is built from a HashSet<string>, and .NET randomises string hashing per
+            // process, so its array order can differ across restarts for the same languages — sorting
+            // a COPY (Clone() is shallow; the array is shared with the real entry) prevents a false
+            // "changed" that would churn the delta.
+            var copy = e.Clone();
+            copy.LastUpdated = 0;
+            copy.SourceRevision = 0;
+            if (copy.AudioLanguages is { Length: > 1 })
+            {
+                var langs = (string[])copy.AudioLanguages.Clone();
+                Array.Sort(langs, StringComparer.Ordinal);
+                copy.AudioLanguages = langs;
+            }
+            return JsonSerializer.Serialize(copy);
         }
 
         /// <summary>
@@ -304,9 +446,13 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
             try
             {
                 Interlocked.Exchange(ref _firstPendingTicks, 0);
-                if (ApplyBatch(_pending.Drain(), RebuildEntry, RemoveEntry))
+                if (ApplyPendingBatch(_pending.Drain(), out var removed))
                 {
                     Interlocked.Exchange(ref _lastModified, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+                    // A removal is the client's only full-reload trigger: the ?since= delta carries
+                    // no tombstone, so bump Version so already-loaded clients drop the stale key.
+                    // ScheduleDebouncedSave persists the bumped version.
+                    if (removed) Interlocked.Increment(ref _version);
                     ScheduleDebouncedSave();
                 }
 
@@ -374,6 +520,24 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
                 _userAccessCache.Clear();
             }
 
+            return changed;
+        }
+
+        /// <summary>
+        /// Apply a drained pending batch via the standard rebuild/remove delegates, additionally
+        /// reporting whether any entry was actually removed from the cache. A removal is the only
+        /// transition the client's ?since= delta can't express (no tombstone), so callers bump
+        /// <see cref="Version"/> on it to force a client full reload. Wrapping the remove delegate
+        /// keeps <see cref="ApplyBatch"/>'s tested signature untouched.
+        /// </summary>
+        private bool ApplyPendingBatch(IReadOnlyList<(Guid Id, bool Removed)> batch, out bool removedFromCache)
+        {
+            var removed = false;
+            var changed = ApplyBatch(
+                batch,
+                RebuildEntry,
+                id => { var r = RemoveEntry(id); if (r) removed = true; return r; });
+            removedFromCache = removed;
             return changed;
         }
 
@@ -799,9 +963,12 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
             // would leave those items stale until the next event or the daily rebuild.
             try
             {
-                if (ApplyBatch(_pending.Drain(), RebuildEntry, RemoveEntry))
+                if (ApplyPendingBatch(_pending.Drain(), out var removed))
                 {
                     Interlocked.Exchange(ref _lastModified, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+                    // Persist a Version bump for a shutdown-time removal so clients reconnecting
+                    // after restart (which loads Version from disk) drop the stale key.
+                    if (removed) Interlocked.Increment(ref _version);
                     MarkDirty();
                 }
             }
@@ -852,6 +1019,10 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
                     CriticRating = item.CriticRating,
                     LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
                     SeriesId = seriesIdN,
+                    // Capture the source revision so the reconcile can skip re-probing an
+                    // item whose DateLastSaved is unchanged. Set here so BOTH the daily
+                    // reconcile and the incremental RebuildEntry populate the gate key.
+                    SourceRevision = item.DateLastSaved.Ticks,
                 };
 
                 if (isContainer)


### PR DESCRIPTION
## What & why

The **Build Tag Cache** scheduled task re-probed the media of *every* taggable
library item every run (daily at 3 AM and on manual/first-install runs), rebuilt
the whole cache from scratch, bumped the cache `version`, and thereby forced
*every* connected client to fully reload its tag cache — even when nothing had
changed. On a large library that is thousands of redundant `GetMediaSources`
probes and first-episode queries per run, plus a daily full-reload storm across
all clients.

This makes the task an **incremental reconcile**: it only re-probes items whose
source actually changed, keeps the cached entry for everything unchanged, adds
new items, drops removed ones, and only forces clients to fully reload when
items are actually removed.

## Implementation

- **Cheap change gate.** Each entry now stores `SourceRevision`
  (`BaseItem.DateLastSaved` ticks, an in-memory value — no query). The reconcile
  reuses the existing entry verbatim (no media probe) when the revision is
  unchanged. `SourceRevision` is persisted so the gate survives a restart; it is
  deliberately *not* a schema-version bump (a pre-upgrade entry loads it as 0 =
  "unconfirmed", which forces a one-time rebuild on the first reconcile).
- **Containers.** Series/Season derive from their child episodes (which their own
  timestamp doesn't track), so they are always rebuilt; a content signature
  (`ContentEquals`) then retains the old timestamp when nothing really changed,
  so the client delta doesn't churn. The signature ignores the volatile
  `LastUpdated`/`SourceRevision` fields and sorts `AudioLanguages` (built from a
  `HashSet<string>`, whose order is not stable across process restarts).
- **Rating inheritance.** An episode with no rating of its own inherits its
  series' rating, so a series-rating change re-derives those episodes even when
  the episode's own revision is unchanged (a per-reconcile `seriesRatingChanged`
  set).
- **Removals drive the client full-reload.** The incremental `?since=` delta has
  no tombstone, so `version` is bumped only when items are actually removed —
  additions/edits flow through the delta. This is applied consistently in the
  reconcile, the incremental flush, and the dispose drain, so an item removed
  while the server is running now drops from clients the same session (previously
  it lingered until the next daily run).
- **Media-probe failures are handled durably.** If `GetMediaSources` throws, the
  entry is still built from its probe-independent data (own + inherited
  rating/genres), the last-good streams are retained, and it is stamped
  `SourceRevision = 0` (unconfirmed) so the reconcile rebuilds it every cycle
  until the probe recovers — no degraded entry is ever confirmed, no data is
  lost, and there is no busy-retry loop. (Previously the old wholesale rebuild
  self-healed such transient damage on the next daily run; the naive gate would
  have made it sticky.)

No new settings, triggers, background workers, or client changes. The scan-thread
record-and-defer path (S1) is untouched. The scheduled-task Name/Key are
unchanged (so the existing schedule is preserved); its Description now notes the
incremental behavior.

## Limitations / deferred

- During a media-probe outage, an affected item's quality/audio overlays fall
  back to its last-good streams until the probe recovers; ratings/genres stay
  correct throughout. This matches the pre-existing daily-rebuild resilience.
- Pre-existing and **not** touched here: the client `loadServerCache` leaves a
  stale map on an authoritative `count == 0` full response (the all-items-removed
  extreme). This change does not worsen it.

## Local test results

- `verify.sh full` (CI-equivalent) green at HEAD: **753 .NET tests pass**,
  server coverage 38.50% (threshold 16%), client coverage green, manifest OK,
  translations 100%. Only advisory: the client-scripts lint warning cap (a
  pre-existing condition on `main`, unrelated to this server-only change).
- New tests: pure `ShouldRebuild`/`ContentEquals` (incl. `AudioLanguages`
  order-insensitivity); reconcile reuse/add/remove/no-op; version-bump-only-on-
  removal; series-rating→episode re-derivation; probe-failure retention +
  durable recovery (next-reconcile) incl. the series-rating-change-during-outage
  path. Added non-throwing `Stub*` media entities.

## Live results

Deployed to a Jellyfin 12 runtime (DLL hash verified). The cache loaded a real
**113,147-entry** library from disk with no exceptions
(`[TagCache] Loaded 113147 entries from disk (v4, schema v2)`), and the plugin
was healthy — exactly the large-library scale this change is for.

Every tag-cache-relevant E2E spec passes on **both** the real-library server and
the seeded CI environment: `tags`, `list-view-tags`, `search-tags`, Hidden
Content (admin + non-admin + mobile), Spoiler Guard (×4), spoiler-identity (×3),
`boot`, and `live-updates`.

The full 64-spec E2E suite is not 100% green in either environment, but **none of
the failures involve this change** — the diff touches zero client/TypeScript
files, so all affected client pages are byte-identical to `main`:
- On the real-library server the failures are the Hidden Content page specs
  (`waitForSelector` timeouts under the 113k-item library) — they pass on the
  seeded env.
- On the seeded env the failures are intermittent `loginAs(admin) bounced to
  sign-in` test-harness/session flakes landing on unrelated specs
  (`mobile-fits:220`, `seerr-resilience`) — different specs than the real-library
  server, confirming the pattern is environmental, not code.

Because the local live-proof marker is tied to the real-library server (whose
library is not the E2E seed), the automated final Sol Ultra review gate could not
run; the change was instead adversarially reviewed to convergence (below) and
verified clean on the seeded CI-equivalent environment. The PR's advisory CI E2E
job re-validates on that seeded environment.

## Review ledger

Codex-first adversarial loop (gpt-5.6-sol):

- **Discovery (state):** 1 finding — `TAGCACHE-LASTGOOD-PROBE` (P1): the gate
  would make a transient probe failure's degraded entry sticky. Fixed.
- **Confirmation:** surfaced `TAGCACHE-LASTGOOD-RETRY-DROPPED` (P1): the first
  fix's one-shot re-queue could be dropped on a sustained outage. Redesigned to
  the gate-based unconfirmed-revision approach above.
- **Confirmation (re-run):** **clean** — finding fixed, no P0–P2 regression in
  scope.
- **Final release gate:** blocked by the live-marker/env situation above rather
  than skipped by choice; the two confirmation passes converged clean.

## AI assistance

Implemented with AI assistance (Claude) under the Jellyfin Elevate development
workflow: scoped plan, incremental commits, local CI-equivalent gate, Codex-first
adversarial review loop, and live verification on jellyfin-12.
