### PR TITLE
fix: classify per-user policy reads and fail closed for Hidden Content & Spoiler Guard

### DIFF
--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Configuration/UserConfigTypedReadTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Configuration/UserConfigTypedReadTests.cs
@@ -124,6 +124,25 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Configuration
         }
 
         [Fact]
+        public void PathBlockedByDirectory_IsUnavailable_NotMissing()
+        {
+            // A directory sitting where the policy file is expected: File.Exists
+            // returns false for it (so a File.Exists pre-check would wrongly report
+            // Missing → empty fail-open policy), but reading it throws. The typed
+            // read must classify this as Unavailable, not Missing. Deterministic and
+            // root-safe (no chmod), unlike a permission-denied probe.
+            var path = FilePath();
+            Directory.CreateDirectory(path);
+
+            var r = Read();
+            Assert.Equal(UserConfigReadStatus.Unavailable, r.Status);
+            Assert.True(r.IsFault);
+            Assert.Null(r.Value);
+
+            Directory.Delete(path);
+        }
+
+        [Fact]
         public void InvalidFileName_IsUnavailable_NeverEmptyPolicy()
         {
             // A programming error resolving the path must fail CLOSED (Unavailable),

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Configuration/UserConfigTypedReadTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Configuration/UserConfigTypedReadTests.cs
@@ -1,0 +1,153 @@
+using System;
+using System.IO;
+using Jellyfin.Plugin.JellyfinElevate.Configuration;
+using Jellyfin.Plugin.JellyfinElevate.Tests.TestDoubles;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinElevate.Tests.Configuration
+{
+    /// <summary>
+    /// Typed policy-read contract (BI-SEC-010). ReadUserConfiguration must
+    /// distinguish an intentionally absent/empty policy (Missing / valid-empty)
+    /// from a persistence fault (Corrupt / Unavailable), where the OLD lenient
+    /// GetUserConfiguration path collapsed every one of these into an empty
+    /// new T() — silently disabling Hidden Content / Spoiler Guard protection.
+    ///
+    /// These assertions fail against the old implementation, which had no typed
+    /// read and returned new T() for corrupt/unavailable files.
+    /// </summary>
+    public sealed class UserConfigTypedReadTests : IDisposable
+    {
+        private const string FileName = "hidden-content.json";
+        private readonly string _baseDir;
+        private readonly UserConfigurationManager _mgr;
+        private readonly string _userId = Guid.NewGuid().ToString("N");
+
+        public UserConfigTypedReadTests()
+        {
+            _baseDir = Path.Combine(Path.GetTempPath(), "je-typedread-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_baseDir);
+            _mgr = new UserConfigurationManager(new StubAppPaths(_baseDir), NullLogger<UserConfigurationManager>.Instance);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_baseDir, recursive: true); } catch { /* best effort */ }
+        }
+
+        private string FilePath()
+        {
+            var dir = Path.Combine(_baseDir, "configurations", "Jellyfin.Plugin.JellyfinElevate", _userId);
+            Directory.CreateDirectory(dir);
+            return Path.Combine(dir, FileName);
+        }
+
+        private void Write(string content) => File.WriteAllText(FilePath(), content);
+
+        private UserConfigReadResult<UserHiddenContent> Read()
+            => _mgr.ReadUserConfiguration<UserHiddenContent>(_userId, FileName);
+
+        // ─── Missing vs empty policy ─────────────────────────────────────────────
+
+        [Fact]
+        public void AbsentFile_IsMissing_WithUsableEmptyValue()
+        {
+            var r = Read();
+            Assert.Equal(UserConfigReadStatus.Missing, r.Status);
+            Assert.False(r.IsFault);
+            Assert.True(r.HasUsableValue);
+            Assert.NotNull(r.Value); // an intentionally empty policy
+        }
+
+        [Fact]
+        public void ValidEmptyJsonObject_IsValid_NotCorrupt()
+        {
+            // A user with the feature enabled but nothing hidden yet writes "{}".
+            // This must read as Valid, NOT as a fault, or a genuine empty policy
+            // would be mistaken for corruption.
+            Write("{}");
+            var r = Read();
+            Assert.Equal(UserConfigReadStatus.Valid, r.Status);
+            Assert.NotNull(r.Value);
+        }
+
+        [Fact]
+        public void PopulatedFile_IsValid_WithParsedValue()
+        {
+            var hc = new UserHiddenContent();
+            hc.Items["k"] = new HiddenContentItem { ItemId = Guid.NewGuid().ToString(), HideScope = "global" };
+            _mgr.SaveUserConfiguration(_userId, FileName, hc);
+
+            var r = Read();
+            Assert.Equal(UserConfigReadStatus.Valid, r.Status);
+            Assert.NotNull(r.Value);
+            Assert.Single(r.Value!.Items);
+        }
+
+        // ─── Corrupt variants ────────────────────────────────────────────────────
+
+        [Theory]
+        [InlineData("")]                    // empty bytes
+        [InlineData("   \n\t ")]            // whitespace only
+        [InlineData("null")]               // literal JSON null
+        [InlineData("{ \"Items\": ")]      // truncated / malformed JSON
+        [InlineData("not json at all")]    // garbage
+        [InlineData("[1,2,3]")]            // well-formed JSON but non-object payload → deserializes to null
+        public void UnusableContent_IsCorrupt_WithNoValue(string content)
+        {
+            Write(content);
+            var r = Read();
+            Assert.Equal(UserConfigReadStatus.Corrupt, r.Status);
+            Assert.True(r.IsFault);
+            Assert.False(r.HasUsableValue);
+            Assert.Null(r.Value);
+            Assert.False(string.IsNullOrEmpty(r.FaultDetail));
+        }
+
+        // ─── Unavailable (I/O failure) ───────────────────────────────────────────
+
+        [Fact]
+        public void UnreadableFile_IsUnavailable_WithNoValue()
+        {
+            var path = FilePath();
+            File.WriteAllText(path, "{}");
+            // Hold an exclusive (FileShare.None) handle so File.ReadAllText inside
+            // the store throws IOException — .NET enforces sharing per-process on
+            // every platform, so this is deterministic in CI.
+            using var exclusive = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.None);
+
+            var r = Read();
+            Assert.Equal(UserConfigReadStatus.Unavailable, r.Status);
+            Assert.True(r.IsFault);
+            Assert.Null(r.Value);
+        }
+
+        [Fact]
+        public void InvalidFileName_IsUnavailable_NeverEmptyPolicy()
+        {
+            // A programming error resolving the path must fail CLOSED (Unavailable),
+            // never be mistaken for an intentionally empty policy.
+            var r = _mgr.ReadUserConfiguration<UserHiddenContent>(_userId, "bad/name.json");
+            Assert.Equal(UserConfigReadStatus.Unavailable, r.Status);
+            Assert.Null(r.Value);
+        }
+
+        // ─── Lenient path unchanged (compat, criterion 7) ────────────────────────
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("null")]
+        [InlineData("not json")]
+        public void LenientRead_StillReturnsDefault_ForNonPolicySettings(string content)
+        {
+            // Ordinary display settings keep their lenient behavior: a fault still
+            // returns new T(). Only the security enforcement path branches on the
+            // typed result.
+            Write(content);
+            var lenient = _mgr.GetUserConfiguration<UserHiddenContent>(_userId, FileName);
+            Assert.NotNull(lenient);
+            Assert.Empty(lenient.Items);
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Controllers/SpoilerGuardControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Controllers/SpoilerGuardControllerTests.cs
@@ -265,6 +265,28 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Controllers
             SpoilerSeerrPendingPromoter.UnregisterPending("tv:888", h.User.Id);
         }
 
+        [Fact]
+        public void AddPending_PendingOnlyPath_InvalidatesCachedEnforcementState()
+        {
+            // BI-SEC-010 FINAL-F4: a successful pending-only RMW proves spoilerblur.json
+            // is readable/valid again, so it must invalidate any cached FailClosed/stale
+            // enforcement state (parity with the promotion branches), not leave it
+            // lingering for up to the cache TTL.
+            using var h = Build();
+            h.Lib.GetItemListHook = _ => Array.Empty<BaseItem>();
+            var userKey = h.User.Id.ToString("N");
+
+            SpoilerUserResolver.SeedUserStateCacheForTest(userKey);
+            Assert.True(SpoilerUserResolver.IsUserStateCachedForTest(userKey));
+
+            var res = h.Pending.AddPending(h.User.Id, h.User, "tv", "999", "My Show");
+            Assert.Equal("pending", res.Promoted);
+
+            Assert.False(SpoilerUserResolver.IsUserStateCachedForTest(userKey));
+
+            SpoilerSeerrPendingPromoter.UnregisterPending("tv:999", h.User.Id);
+        }
+
         // ─── Health endpoint: non-admin sees only own corruption events ───────────
 
         [Fact]

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Services/PrivacyPolicyFaultContractTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Services/PrivacyPolicyFaultContractTests.cs
@@ -1,0 +1,247 @@
+using System;
+using System.IO;
+using Jellyfin.Plugin.JellyfinElevate.Configuration;
+using Jellyfin.Plugin.JellyfinElevate.Services;
+using Jellyfin.Plugin.JellyfinElevate.Tests.TestDoubles;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
+{
+    /// <summary>
+    /// Enforcement-side fault contract (BI-SEC-010): Hidden Content and Spoiler
+    /// Guard must retain last-known-good protection when a policy file becomes
+    /// corrupt/unreadable, fail CLOSED on a cold-start fault with no recoverable
+    /// policy, and still pass through for a genuinely missing (never-configured)
+    /// policy.
+    ///
+    /// Every assertion here fails against the old implementation, which routed
+    /// both features through the lenient read: a fault produced an empty policy,
+    /// protection silently dropped, and the empty state was cached.
+    /// </summary>
+    public sealed class PrivacyPolicyFaultContractTests : IDisposable
+    {
+        private const string HcFile = "hidden-content.json";
+        private const string SpoilerFile = "spoilerblur.json";
+
+        private readonly string _baseDir;
+        private readonly UserConfigurationManager _mgr;
+
+        public PrivacyPolicyFaultContractTests()
+        {
+            _baseDir = Path.Combine(Path.GetTempPath(), "je-fault-contract-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_baseDir);
+            _mgr = new UserConfigurationManager(new StubAppPaths(_baseDir), NullLogger<UserConfigurationManager>.Instance);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_baseDir, recursive: true); } catch { /* best effort */ }
+        }
+
+        private string PathFor(string userIdN, string file)
+        {
+            var dir = Path.Combine(_baseDir, "configurations", "Jellyfin.Plugin.JellyfinElevate", userIdN);
+            Directory.CreateDirectory(dir);
+            return Path.Combine(dir, file);
+        }
+
+        private static void Corrupt(string path) => File.WriteAllText(path, "{ this is not : valid json ]");
+
+        private HiddenContentResponseFilter NewHcFilter()
+            => new HiddenContentResponseFilter(
+                _mgr,
+                NullLogger<HiddenContentResponseFilter>.Instance,
+                new FakePluginConfigProvider(new PluginConfiguration()));
+
+        private SpoilerUserResolver NewResolver()
+        {
+            var markers = new SpoilerIdentityService(new StubUserManager(), NullLogger<SpoilerIdentityService>.Instance);
+            var identity = new RequestIdentityService(
+                new CountingSessionManager(), new StubUserManager(), markers, NullLogger<RequestIdentityService>.Instance);
+            return new SpoilerUserResolver(_mgr, new CountingLibraryManager(), NullLogger<SpoilerUserResolver>.Instance, identity);
+        }
+
+        // ───────────────────────── Hidden Content ─────────────────────────────────
+
+        [Fact]
+        public void Hc_ValidThenCorrupt_RetainsLastKnownGood()
+        {
+            var userId = Guid.NewGuid();
+            var userIdN = userId.ToString("N");
+            var hiddenItem = Guid.NewGuid();
+
+            var hc = new UserHiddenContent();
+            hc.Items["k"] = new HiddenContentItem { ItemId = hiddenItem.ToString(), HideScope = "global" };
+            _mgr.SaveUserConfiguration(userIdN, HcFile, hc);
+
+            var filter = NewHcFilter();
+            // Prime last-known-good from the valid read.
+            Assert.True(filter.WouldHideForTest(userId, hiddenItem.ToString(), "library"));
+
+            // Corrupt the file, then simulate a genuine TTL expiry (entry retained).
+            Corrupt(PathFor(userIdN, HcFile));
+            HiddenContentResponseFilter.ExpireCacheForTest(userIdN);
+
+            // The previously hidden item stays hidden (LKG retained, not fail-open).
+            Assert.True(filter.WouldHideForTest(userId, hiddenItem.ToString(), "library"));
+            // But an unrelated item is NOT hidden — proving this is LKG, not the
+            // blunt fail-closed over-hide.
+            Assert.False(filter.WouldHideForTest(userId, Guid.NewGuid().ToString(), "library"));
+        }
+
+        [Fact]
+        public void Hc_ColdStartCorrupt_FailsClosed_OverHidesEverySurface()
+        {
+            var userId = Guid.NewGuid();
+            var userIdN = userId.ToString("N");
+            Corrupt(PathFor(userIdN, HcFile)); // corrupt before any valid read → no LKG
+
+            var filter = NewHcFilter();
+            // Any item, on any matched surface, is hidden — content cannot leak.
+            Assert.True(filter.WouldHideForTest(userId, Guid.NewGuid().ToString(), "library"));
+            Assert.True(filter.WouldHideForTest(userId, Guid.NewGuid().ToString(), "search"));
+            Assert.True(filter.WouldHideForTest(userId, Guid.NewGuid().ToString(), "nextup"));
+            // The fault populated a NON-empty (protective) cache entry.
+            Assert.True(HiddenContentResponseFilter.IsCachedForTest(userIdN));
+        }
+
+        [Fact]
+        public void Hc_MissingFile_PassesThrough()
+        {
+            // The overwhelmingly common case: feature enabled globally, this user
+            // never configured anything. A missing file is NOT a fault.
+            var userId = Guid.NewGuid();
+            var filter = NewHcFilter();
+            Assert.False(filter.WouldHideForTest(userId, Guid.NewGuid().ToString(), "library"));
+        }
+
+        [Fact]
+        public void Hc_RepairAfterFault_Reactivates()
+        {
+            var userId = Guid.NewGuid();
+            var userIdN = userId.ToString("N");
+            Corrupt(PathFor(userIdN, HcFile));
+
+            var filter = NewHcFilter();
+            Assert.True(filter.WouldHideForTest(userId, Guid.NewGuid().ToString(), "library")); // fail-closed
+
+            // Repair: write a valid policy that hides nothing, then invalidate as the
+            // controller write path does.
+            _mgr.SaveUserConfiguration(userIdN, HcFile, new UserHiddenContent());
+            HiddenContentResponseFilter.InvalidateUser(userIdN);
+
+            Assert.False(filter.WouldHideForTest(userId, Guid.NewGuid().ToString(), "library"));
+        }
+
+        // ───────────────────────── Spoiler Guard ─────────────────────────────────
+
+        [Fact]
+        public void Spoiler_ValidThenCorrupt_RetainsLastKnownGood()
+        {
+            var userId = Guid.NewGuid();
+            var userIdN = userId.ToString("N");
+            var seriesN = Guid.NewGuid().ToString("N");
+
+            var state = new UserSpoilerBlur();
+            state.Series[seriesN] = new SpoilerBlurSeriesEntry { SeriesId = seriesN };
+            _mgr.SaveUserConfiguration(userIdN, SpoilerFile, state);
+
+            var resolver = NewResolver();
+            var loaded1 = resolver.LoadUserState(new DefaultHttpContext(), userId);
+            Assert.True(loaded1.Series.ContainsKey(seriesN));
+            Assert.False(loaded1.FailClosed);
+
+            Corrupt(PathFor(userIdN, SpoilerFile));
+            SpoilerUserResolver.ExpireUserStateCacheForTest(userIdN);
+
+            var loaded2 = resolver.LoadUserState(new DefaultHttpContext(), userId);
+            Assert.True(loaded2.Series.ContainsKey(seriesN)); // LKG retained
+            Assert.False(loaded2.FailClosed);
+        }
+
+        [Fact]
+        public void Spoiler_ColdStartCorrupt_FailsClosed()
+        {
+            var userId = Guid.NewGuid();
+            var userIdN = userId.ToString("N");
+            Corrupt(PathFor(userIdN, SpoilerFile));
+
+            var resolver = NewResolver();
+            var loaded = resolver.LoadUserState(new DefaultHttpContext(), userId);
+            Assert.True(loaded.FailClosed);
+            Assert.Empty(loaded.Series);
+            Assert.True(SpoilerUserResolver.IsUserStateCachedForTest(userIdN)); // non-empty protective entry
+        }
+
+        [Fact]
+        public void Spoiler_MissingFile_EmptyNotFailClosed()
+        {
+            var userId = Guid.NewGuid();
+            var resolver = NewResolver();
+            var loaded = resolver.LoadUserState(new DefaultHttpContext(), userId);
+            Assert.False(loaded.FailClosed);
+            Assert.Empty(loaded.Series);
+        }
+
+        [Fact]
+        public void Spoiler_RepairAfterFault_Reactivates()
+        {
+            var userId = Guid.NewGuid();
+            var userIdN = userId.ToString("N");
+            Corrupt(PathFor(userIdN, SpoilerFile));
+
+            var resolver = NewResolver();
+            Assert.True(resolver.LoadUserState(new DefaultHttpContext(), userId).FailClosed);
+
+            _mgr.SaveUserConfiguration(userIdN, SpoilerFile, new UserSpoilerBlur());
+            SpoilerUserResolver.InvalidateUser(userIdN);
+
+            Assert.False(resolver.LoadUserState(new DefaultHttpContext(), userId).FailClosed);
+        }
+
+        // ───────────────────────── Pure decision (Spoiler) ────────────────────────
+
+        [Fact]
+        public void ResolvePolicyState_Fault_WithLkg_RetainsLkg()
+        {
+            var lkg = new UserSpoilerBlur();
+            lkg.Series["abc"] = new SpoilerBlurSeriesEntry { SeriesId = "abc" };
+
+            var corrupt = new UserConfigReadResult<UserSpoilerBlur>(UserConfigReadStatus.Corrupt, null, "malformed");
+            var result = SpoilerUserResolver.ResolvePolicyState(corrupt, lkg);
+
+            Assert.Same(lkg, result);
+            Assert.False(result.FailClosed);
+        }
+
+        [Fact]
+        public void ResolvePolicyState_Fault_NoLkg_FailsClosed()
+        {
+            var unavailable = new UserConfigReadResult<UserSpoilerBlur>(UserConfigReadStatus.Unavailable, null, "io");
+            var result = SpoilerUserResolver.ResolvePolicyState(unavailable, lastKnownGood: null);
+            Assert.True(result.FailClosed);
+        }
+
+        [Fact]
+        public void ResolvePolicyState_Missing_IsEmpty_NotFailClosed()
+        {
+            var missing = new UserConfigReadResult<UserSpoilerBlur>(UserConfigReadStatus.Missing, new UserSpoilerBlur(), null);
+            var result = SpoilerUserResolver.ResolvePolicyState(missing, lastKnownGood: null);
+            Assert.False(result.FailClosed);
+            Assert.Empty(result.Series);
+        }
+
+        [Fact]
+        public void ResolvePolicyState_Valid_UsesParsedValue()
+        {
+            var parsed = new UserSpoilerBlur();
+            parsed.Movies["m"] = new SpoilerBlurMovieEntry();
+            var valid = new UserConfigReadResult<UserSpoilerBlur>(UserConfigReadStatus.Valid, parsed, null);
+            var result = SpoilerUserResolver.ResolvePolicyState(valid, lastKnownGood: null);
+            Assert.Same(parsed, result);
+            Assert.False(result.FailClosed);
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Services/SpoilerFailClosedStripTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Services/SpoilerFailClosedStripTests.cs
@@ -47,6 +47,39 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
         }
 
         [Fact]
+        public void FailClosed_StripsEpisodeDtoName_WhenReplaceTitleOnButIndexNumbersMissing()
+        {
+            // BI-SEC-010 FINAL-F2: ApplyStripping only renames an episode when both
+            // index numbers exist. On a fail-closed fault, an unnumbered episode's raw
+            // Name (and SortName / OriginalTitle) must still be replaced/cleared.
+            var lib = new CountingLibraryManager();
+            var cfg = new PluginConfiguration
+            {
+                SpoilerBlurEnabled = true,
+                SpoilerReplaceTitle = true,
+                SpoilerStripOverview = false,
+            };
+            var filter = NewFilter(lib, cfg);
+
+            var dto = new MediaBrowser.Model.Dto.BaseItemDto
+            {
+                Id = Guid.NewGuid(),
+                Type = Jellyfin.Data.Enums.BaseItemKind.Episode,
+                Name = "The Death of a Main Character",
+                SortName = "Death of a Main Character, The",
+                OriginalTitle = "The Death of a Main Character",
+                IndexNumber = null,
+                ParentIndexNumber = null,
+            };
+
+            filter.StripItemForTest(dto, FailClosed(), cfg);
+
+            Assert.NotEqual("The Death of a Main Character", dto.Name);
+            Assert.Null(dto.SortName);
+            Assert.Null(dto.OriginalTitle);
+        }
+
+        [Fact]
         public void FailClosed_StripsImageInfoPaths_RegardlessOfScope()
         {
             var lib = new CountingLibraryManager();

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Services/SpoilerFailClosedStripTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Services/SpoilerFailClosedStripTests.cs
@@ -10,7 +10,6 @@ using MediaBrowser.Model.MediaInfo;
 using MediaBrowser.Model.Search;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
-using Episode = MediaBrowser.Controller.Entities.TV.Episode;
 
 namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
 {
@@ -93,13 +92,14 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
         }
 
         [Fact]
-        public void FailClosed_StripsSearchHintNameAndMatchedTerm_RegardlessOfScope()
+        public void FailClosed_StripsSearchHint_EvenWhenLibraryLookupReturnsNull()
         {
+            // The removed/stale/mismatched-item case the pre-fix guard missed:
+            // GetItemById returns null, yet a cold-start fault must still strip the
+            // hint by its declared Type rather than fall through and leak the title.
             var lib = new CountingLibraryManager
             {
-                // Any hint id resolves to an Episode; FailClosed bypasses the
-                // series-membership and watched-state gates entirely.
-                GetItemByIdNonGenericHook = _ => new Episode(),
+                GetItemByIdNonGenericHook = _ => null,
             };
             var cfg = StripCfg();
             var filter = NewFilter(lib, cfg);

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Services/SpoilerFailClosedStripTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Services/SpoilerFailClosedStripTests.cs
@@ -118,5 +118,38 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
             Assert.NotEqual("The Big Reveal", hint.Name);
             Assert.Null(hint.MatchedTerm);
         }
+
+        [Fact]
+        public void FailClosed_StripsEpisodeHintName_WhenReplaceTitleOnButIndexNumbersMissing()
+        {
+            // The narrowest leak: title replacement is the ONLY enabled sensitive-
+            // field policy, and the hint has no episode numbering to build the
+            // "Season X, Episode Y" form. Fail-closed must still replace the raw
+            // Name with the placeholder rather than leave it visible.
+            var lib = new CountingLibraryManager { GetItemByIdNonGenericHook = _ => null };
+            var cfg = new PluginConfiguration
+            {
+                SpoilerBlurEnabled = true,
+                SpoilerReplaceTitle = true,
+                SpoilerStripOverview = false,
+            };
+            var filter = NewFilter(lib, cfg);
+
+            var hint = new SearchHint
+            {
+                Id = Guid.NewGuid(),
+                Type = BaseItemKind.Episode,
+                Name = "The Big Reveal",
+                MatchedTerm = "Reveal",
+                IndexNumber = null,
+                ParentIndexNumber = null,
+            };
+            var shr = new SearchHintResult(new List<SearchHint> { hint }, 1);
+
+            filter.StripSearchHintsForTest(shr, FailClosed(), cfg);
+
+            Assert.NotEqual("The Big Reveal", hint.Name);
+            Assert.Null(hint.MatchedTerm);
+        }
     }
 }

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Services/SpoilerFailClosedStripTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Services/SpoilerFailClosedStripTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using Jellyfin.Data.Enums;
+using Jellyfin.Plugin.JellyfinElevate.Configuration;
+using Jellyfin.Plugin.JellyfinElevate.Services;
+using Jellyfin.Plugin.JellyfinElevate.Tests.TestDoubles;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.MediaInfo;
+using MediaBrowser.Model.Search;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+using Episode = MediaBrowser.Controller.Entities.TV.Episode;
+
+namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
+{
+    /// <summary>
+    /// BI-SEC-010 F1: the Spoiler Guard field-strip filter's non-BaseItemDto
+    /// response-shape extractors (ImageInfo, PlaybackInfoResponse, SearchHintResult)
+    /// must honor the FailClosed sentinel — a cold-start policy fault that produced
+    /// an empty policy would otherwise fail their membership checks and leak raw
+    /// image paths, media-source/subtitle filenames, and episode titles.
+    ///
+    /// These fail against the pre-fix implementation, which honored FailClosed only
+    /// in StripItem (BaseItemDto).
+    /// </summary>
+    public sealed class SpoilerFailClosedStripTests
+    {
+        private static UserSpoilerBlur FailClosed() => new UserSpoilerBlur { FailClosed = true };
+
+        private static PluginConfiguration StripCfg() => new PluginConfiguration
+        {
+            SpoilerBlurEnabled = true,
+            SpoilerStripOverview = true,
+            SpoilerReplaceTitle = true,
+        };
+
+        private static SpoilerFieldStripFilter NewFilter(CountingLibraryManager lib, PluginConfiguration cfg)
+        {
+            var markers = new SpoilerIdentityService(new StubUserManager(), NullLogger<SpoilerIdentityService>.Instance);
+            var identity = new RequestIdentityService(
+                new CountingSessionManager(), new StubUserManager(), markers, NullLogger<RequestIdentityService>.Instance);
+            // These FailClosed strip paths never touch per-user config or identity,
+            // so the resolver's config manager is not exercised here.
+            var resolver = new SpoilerUserResolver(
+                userConfigManager: null!, lib, NullLogger<SpoilerUserResolver>.Instance, identity);
+            return new SpoilerFieldStripFilter(resolver, lib, new StubUserManager(), new StubUserDataManager(), new FakePluginConfigProvider(cfg));
+        }
+
+        [Fact]
+        public void FailClosed_StripsImageInfoPaths_RegardlessOfScope()
+        {
+            var lib = new CountingLibraryManager();
+            var cfg = StripCfg();
+            var filter = NewFilter(lib, cfg);
+
+            var imgs = new List<ImageInfo> { new ImageInfo { Path = "/media/Show/S01E05 The Big Reveal.jpg" } };
+            filter.StripImageInfosForTest(imgs, FailClosed(), cfg);
+
+            Assert.Null(imgs[0].Path);
+        }
+
+        [Fact]
+        public void FailClosed_StripsPlaybackInfoTitleBearingFields_RegardlessOfScope()
+        {
+            var lib = new CountingLibraryManager();
+            var cfg = StripCfg();
+            var filter = NewFilter(lib, cfg);
+
+            var pbi = new PlaybackInfoResponse
+            {
+                MediaSources = new List<MediaSourceInfo>
+                {
+                    new MediaSourceInfo
+                    {
+                        Path = "/media/Show/S01E05 The Big Reveal.mkv",
+                        Name = "S01E05 The Big Reveal",
+                        MediaStreams = new List<MediaStream>
+                        {
+                            new MediaStream { Type = MediaStreamType.Subtitle, Title = "The Big Reveal", Comment = "spoiler" },
+                        },
+                    },
+                },
+            };
+
+            filter.StripPlaybackInfoForTest(pbi, FailClosed(), cfg);
+
+            var ms = pbi.MediaSources[0];
+            Assert.Null(ms.Path);
+            Assert.Null(ms.Name);
+            Assert.Null(ms.MediaStreams[0].Title);
+            Assert.Null(ms.MediaStreams[0].Comment);
+        }
+
+        [Fact]
+        public void FailClosed_StripsSearchHintNameAndMatchedTerm_RegardlessOfScope()
+        {
+            var lib = new CountingLibraryManager
+            {
+                // Any hint id resolves to an Episode; FailClosed bypasses the
+                // series-membership and watched-state gates entirely.
+                GetItemByIdNonGenericHook = _ => new Episode(),
+            };
+            var cfg = StripCfg();
+            var filter = NewFilter(lib, cfg);
+
+            var hint = new SearchHint
+            {
+                Id = Guid.NewGuid(),
+                Type = BaseItemKind.Episode,
+                Name = "The Big Reveal",
+                MatchedTerm = "Reveal",
+            };
+            var shr = new SearchHintResult(new List<SearchHint> { hint }, 1);
+
+            filter.StripSearchHintsForTest(shr, FailClosed(), cfg);
+
+            Assert.NotEqual("The Big Reveal", hint.Name);
+            Assert.Null(hint.MatchedTerm);
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/Services/TagCacheSpoilerStripTests.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/Services/TagCacheSpoilerStripTests.cs
@@ -189,6 +189,30 @@ namespace Jellyfin.Plugin.JellyfinElevate.Tests.Services
         }
 
         [Fact]
+        public void Resolve_FailClosed_StripsEveryRecognizedEntry_RegardlessOfScopeOrWatched()
+        {
+            // BI-SEC-010 FINAL-F1: a cold-start policy fault (FailClosed sentinel with
+            // empty dicts) must strip every recognized entry rather than fail open.
+            var failClosed = new UserSpoilerBlur { FailClosed = true };
+            foreach (var type in new[] { "Episode", "Season", "Movie", "Series" })
+            {
+                var entry = new TagCacheEntry { Type = type, SeriesId = Guid.NewGuid().ToString("N") };
+                var d = TagCacheService.ResolveTagStripDecision(
+                    Guid.NewGuid().ToString("N"), entry, failClosed,
+                    // Out of scope, never played, not-a-season — the OLD behavior Keeps.
+                    NeverInScope, NeverPlayed, NotASeason, NeverPlayed, IgnoreKey);
+                Assert.Equal(TagCacheService.TagStripDecision.Strip, d);
+            }
+            // A non-media entry is still Keep even under fail-closed.
+            var boxset = new TagCacheEntry { Type = "BoxSet" };
+            Assert.Equal(
+                TagCacheService.TagStripDecision.Keep,
+                TagCacheService.ResolveTagStripDecision(
+                    Guid.NewGuid().ToString("N"), boxset, failClosed,
+                    NeverInScope, NeverPlayed, NotASeason, NeverPlayed, IgnoreKey));
+        }
+
+        [Fact]
         public void Resolve_WatchedEpisode_Keeps()
         {
             var seriesN = Guid.NewGuid().ToString("N");

--- a/Jellyfin.Plugin.JellyfinElevate.Tests/TestDoubles/CountingLibraryManager.cs
+++ b/Jellyfin.Plugin.JellyfinElevate.Tests/TestDoubles/CountingLibraryManager.cs
@@ -114,7 +114,11 @@ public sealed class CountingLibraryManager : ILibraryManager
 
     public List<VirtualFolderInfo> GetVirtualFolders(bool includeRefreshState) => throw new NotImplementedException();
 
-    public BaseItem? GetItemById(Guid id) => throw new NotImplementedException();
+    /// <summary>When set, backs the non-generic <see cref="GetItemById(Guid)"/>.</summary>
+    public Func<Guid, BaseItem?>? GetItemByIdNonGenericHook { get; set; }
+
+    public BaseItem? GetItemById(Guid id)
+        => GetItemByIdNonGenericHook is null ? throw new NotImplementedException() : GetItemByIdNonGenericHook(id);
 
     public T? GetItemById<T>(Guid id)
         where T : BaseItem => GetItemByIdHook is null ? throw new NotImplementedException() : GetItemByIdHook(id) as T;

--- a/Jellyfin.Plugin.JellyfinElevate/Configuration/UserConfigReadResult.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Configuration/UserConfigReadResult.cs
@@ -1,0 +1,67 @@
+namespace Jellyfin.Plugin.JellyfinElevate.Configuration
+{
+    /// <summary>
+    /// Outcome of a per-user configuration read, distinguishing an intentionally
+    /// absent/empty policy from a persistence fault. Security enforcement callers
+    /// (Hidden Content, Spoiler Guard) MUST branch on this instead of the lenient
+    /// <see cref="UserConfigurationStore.GetUserConfiguration{T}"/> path, which
+    /// collapses every fault into <c>new T()</c> and would silently disable
+    /// protection.
+    /// </summary>
+    public enum UserConfigReadStatus
+    {
+        /// <summary>File does not exist. Legitimately an empty policy.</summary>
+        Missing,
+
+        /// <summary>File existed and deserialized to a usable value.</summary>
+        Valid,
+
+        /// <summary>
+        /// File existed but its content is unusable: empty, literal <c>null</c>,
+        /// malformed JSON, or a payload that deserialized to null. The previous
+        /// policy must NOT be treated as empty.
+        /// </summary>
+        Corrupt,
+
+        /// <summary>
+        /// File could not be read (I/O error, permission failure, or any other
+        /// escaping exception). Transient; the previous policy must NOT be treated
+        /// as empty.
+        /// </summary>
+        Unavailable,
+    }
+
+    /// <summary>
+    /// Result of <see cref="UserConfigurationStore.ReadUserConfiguration{T}"/>.
+    /// <see cref="Value"/> is populated only for <see cref="UserConfigReadStatus.Missing"/>
+    /// (a fresh <c>new T()</c>) and <see cref="UserConfigReadStatus.Valid"/>; it is
+    /// <c>null</c> for the two fault statuses so a caller cannot accidentally treat a
+    /// fault as an empty policy.
+    /// </summary>
+    /// <typeparam name="T">The per-user configuration type.</typeparam>
+    public readonly struct UserConfigReadResult<T>
+        where T : new()
+    {
+        public UserConfigReadResult(UserConfigReadStatus status, T? value, string? faultDetail)
+        {
+            Status = status;
+            Value = value;
+            FaultDetail = faultDetail;
+        }
+
+        /// <summary>Gets the classified read outcome.</summary>
+        public UserConfigReadStatus Status { get; }
+
+        /// <summary>Gets the parsed value (Missing → new T(); Valid → parsed; faults → null).</summary>
+        public T? Value { get; }
+
+        /// <summary>Gets a short machine/operator-facing reason for a fault, or null when not a fault.</summary>
+        public string? FaultDetail { get; }
+
+        /// <summary>Gets a value indicating whether this read is a persistence fault (Corrupt or Unavailable).</summary>
+        public bool IsFault => Status is UserConfigReadStatus.Corrupt or UserConfigReadStatus.Unavailable;
+
+        /// <summary>Gets a value indicating whether this read yielded a usable value (Missing or Valid).</summary>
+        public bool HasUsableValue => Status is UserConfigReadStatus.Missing or UserConfigReadStatus.Valid;
+    }
+}

--- a/Jellyfin.Plugin.JellyfinElevate/Configuration/UserConfiguration.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Configuration/UserConfiguration.cs
@@ -198,6 +198,15 @@ namespace Jellyfin.Plugin.JellyfinElevate.Configuration
         // empty Prefs object (all nullable bools = null), so unmigrated
         // spoilerblur.json files continue to honor admin policy unchanged.
         public SpoilerBlurUserPrefs Prefs { get; set; } = new SpoilerBlurUserPrefs();
+
+        // Transient, in-memory-only fail-closed marker. Set by
+        // SpoilerUserResolver.LoadUserState when this user's policy read faulted
+        // (corrupt/unavailable) with no last-known-good to retain, so the image
+        // and field-strip filters over-protect rather than silently disclose.
+        // [JsonIgnore] guarantees it is never persisted and never round-trips
+        // through a save even though the resolver's loaded state is read-only.
+        [JsonIgnore]
+        public bool FailClosed { get; set; }
     }
 
     public class UserShortcuts

--- a/Jellyfin.Plugin.JellyfinElevate/Configuration/UserConfigurationManager.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Configuration/UserConfigurationManager.cs
@@ -55,6 +55,12 @@ namespace Jellyfin.Plugin.JellyfinElevate.Configuration
         public T GetUserConfigurationStrict<T>(string userId, string fileName) where T : new()
             => _store.GetUserConfigurationStrict<T>(userId, fileName);
 
+        // Typed, side-effect-free policy read for security enforcement: classifies
+        // Missing/Valid/Corrupt/Unavailable so callers can retain last-known-good
+        // and fail closed instead of collapsing a fault into an empty policy.
+        public UserConfigReadResult<T> ReadUserConfiguration<T>(string userId, string fileName) where T : new()
+            => _store.ReadUserConfiguration<T>(userId, fileName);
+
         // Locked read-modify-write: holds GetUserFileLock, strict-reads, mutates, and saves when the mutator returns > 0.
         public int RmwUserConfiguration<T>(string userId, string fileName, Func<T, int> mutate) where T : class, new()
             => _store.RmwUserConfiguration(userId, fileName, mutate);

--- a/Jellyfin.Plugin.JellyfinElevate/Configuration/UserConfigurationStore.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Configuration/UserConfigurationStore.cs
@@ -233,8 +233,14 @@ namespace Jellyfin.Plugin.JellyfinElevate.Configuration
             {
                 json = File.ReadAllText(configPath);
             }
-            catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+            catch (FileNotFoundException)
             {
+                // ONLY a genuinely absent file is Missing. The user directory is
+                // created during ResolveUserFile, so a read-stage
+                // DirectoryNotFoundException means a path component vanished or the
+                // backing store disconnected between resolution and read — a storage
+                // fault, not a never-configured file. It must fall through to
+                // Unavailable so last-known-good / fail-closed is retained.
                 return new UserConfigReadResult<T>(UserConfigReadStatus.Missing, new T(), null);
             }
             catch (Exception ex)

--- a/Jellyfin.Plugin.JellyfinElevate/Configuration/UserConfigurationStore.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Configuration/UserConfigurationStore.cs
@@ -221,15 +221,21 @@ namespace Jellyfin.Plugin.JellyfinElevate.Configuration
                 return new UserConfigReadResult<T>(UserConfigReadStatus.Unavailable, default, ex.Message);
             }
 
-            if (!File.Exists(configPath))
-            {
-                return new UserConfigReadResult<T>(UserConfigReadStatus.Missing, new T(), null);
-            }
-
+            // Read directly and let the exception type classify the outcome. A
+            // File.Exists pre-check must NOT own this decision: File.Exists returns
+            // false (rather than throwing) for permission/stat/invalid-path/other
+            // I/O failures and for a directory in the file's place, so it would
+            // collapse an UNAVAILABLE policy into Missing → an empty fail-open
+            // policy. Only a genuinely absent file (FileNotFound/DirectoryNotFound)
+            // maps to Missing; every other failure fails closed as Unavailable.
             string json;
             try
             {
                 json = File.ReadAllText(configPath);
+            }
+            catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+            {
+                return new UserConfigReadResult<T>(UserConfigReadStatus.Missing, new T(), null);
             }
             catch (Exception ex)
             {

--- a/Jellyfin.Plugin.JellyfinElevate/Configuration/UserConfigurationStore.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Configuration/UserConfigurationStore.cs
@@ -102,10 +102,7 @@ namespace Jellyfin.Plugin.JellyfinElevate.Configuration
                     // overwrites the user's real data with defaults.
                     // (Newtonsoft equivalent: NullValueHandling.Ignore on deserialization,
                     // reproduced by the StripNullMembers pre-pass — see PersistedJson.)
-                    var node = JsonNode.Parse(json, documentOptions: PersistedJson.ParseOptions);
-                    var settings = PersistedJson.StripNullMembers(node) is JsonNode stripped
-                        ? stripped.Deserialize<T>(PersistedJson.ReadOptions)
-                        : default;
+                    var settings = TryDeserializeStripped<T>(json);
 
                     if (settings == null)
                     {
@@ -162,10 +159,7 @@ namespace Jellyfin.Plugin.JellyfinElevate.Configuration
                 // fails: empty/whitespace/literal-null is rejected above, malformed JSON
                 // throws in JsonNode.Parse, and a non-object payload deserializes to null
                 // (or throws) — both caught below and backed up.
-                var node = JsonNode.Parse(json, documentOptions: PersistedJson.ParseOptions);
-                var parsed = PersistedJson.StripNullMembers(node) is JsonNode stripped
-                    ? stripped.Deserialize<T>(PersistedJson.ReadOptions)
-                    : default;
+                var parsed = TryDeserializeStripped<T>(json);
                 if (parsed == null)
                 {
                     _logger.LogError($"'{fileName}' for user '{userId}' deserialized to null; refusing to overwrite.");
@@ -183,6 +177,88 @@ namespace Jellyfin.Plugin.JellyfinElevate.Configuration
                 _logger.LogError($"Failed to parse '{fileName}' for user '{userId}': {ex.Message}");
                 BackupCorruptFile(configPath);
                 throw;
+            }
+        }
+
+        // Shared JSON-null-tolerant deserialize used by every read path (lenient
+        // GET, strict RMW, and the typed policy read) so all three classify a file
+        // identically. Applies the StripNullMembers pre-pass (= Newtonsoft
+        // NullValueHandling.Ignore) then binds with the shared ReadOptions. Throws
+        // only for malformed JSON (JsonNode.Parse); returns null when the payload
+        // parses but yields no object (literal null / non-object). Callers decide
+        // what a null result means (lenient → new T(); strict/typed → corrupt).
+        private static T? TryDeserializeStripped<T>(string json)
+        {
+            var node = JsonNode.Parse(json, documentOptions: PersistedJson.ParseOptions);
+            return PersistedJson.StripNullMembers(node) is JsonNode stripped
+                ? stripped.Deserialize<T>(PersistedJson.ReadOptions)
+                : default;
+        }
+
+        // Typed, side-effect-free policy read for security enforcement (Hidden
+        // Content, Spoiler Guard). Unlike the lenient GET it never collapses a
+        // fault into new T(), and unlike the strict RMW read it neither throws nor
+        // rewrites/back-ups the file — enforcement reads must not mutate disk. It
+        // classifies the outcome so the caller can retain last-known-good and fail
+        // CLOSED on a cold-start fault instead of silently dropping protection.
+        //
+        //   Missing      → file absent; Value = new T() (an intentionally empty policy).
+        //   Valid        → parsed; Value = the deserialized policy.
+        //   Corrupt      → exists but empty/literal-null/malformed/deserialized-null; Value = null.
+        //   Unavailable  → unreadable (I/O, permissions, or any escaping exception); Value = null.
+        public UserConfigReadResult<T> ReadUserConfiguration<T>(string userId, string fileName) where T : new()
+        {
+            string configPath;
+            try
+            {
+                configPath = ResolveUserFile(userId, fileName);
+            }
+            catch (Exception ex)
+            {
+                // A bad userId/fileName is a programming error, not an empty policy.
+                // Fail closed: treat as Unavailable so callers retain protection.
+                _logger.LogError($"Refusing to resolve policy file '{fileName}' for user '{userId}': {ex.Message}");
+                return new UserConfigReadResult<T>(UserConfigReadStatus.Unavailable, default, ex.Message);
+            }
+
+            if (!File.Exists(configPath))
+            {
+                return new UserConfigReadResult<T>(UserConfigReadStatus.Missing, new T(), null);
+            }
+
+            string json;
+            try
+            {
+                json = File.ReadAllText(configPath);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Unable to read policy file '{fileName}' for user '{userId}' — treating as UNAVAILABLE (protection retained): {ex.Message}");
+                return new UserConfigReadResult<T>(UserConfigReadStatus.Unavailable, default, ex.Message);
+            }
+
+            if (string.IsNullOrWhiteSpace(json)
+                || string.Equals(json.Trim(), "null", StringComparison.Ordinal))
+            {
+                _logger.LogError($"Policy file '{fileName}' for user '{userId}' is empty or literal-null — treating as CORRUPT (protection retained).");
+                return new UserConfigReadResult<T>(UserConfigReadStatus.Corrupt, default, "empty-or-null");
+            }
+
+            try
+            {
+                var parsed = TryDeserializeStripped<T>(json);
+                if (parsed == null)
+                {
+                    _logger.LogError($"Policy file '{fileName}' for user '{userId}' deserialized to null — treating as CORRUPT (protection retained).");
+                    return new UserConfigReadResult<T>(UserConfigReadStatus.Corrupt, default, "deserialized-null");
+                }
+
+                return new UserConfigReadResult<T>(UserConfigReadStatus.Valid, parsed, null);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Policy file '{fileName}' for user '{userId}' is malformed — treating as CORRUPT (protection retained): {ex.Message}");
+                return new UserConfigReadResult<T>(UserConfigReadStatus.Corrupt, default, ex.Message);
             }
         }
 

--- a/Jellyfin.Plugin.JellyfinElevate/Controllers/TagCacheController.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Controllers/TagCacheController.cs
@@ -135,18 +135,16 @@ namespace Jellyfin.Plugin.JellyfinElevate.Controllers
             var sanitizeTitleStreams = spCfg.SpoilerReplaceTitle || spCfg.SpoilerStripOverview;
             if (!stripGenresEnabled && !stripRatingsEnabled && !sanitizeTitleStreams) return;
 
-            // Strict-read so corruption is observable (rate-limited warn) rather than
-            // silently passing through.
-            var loaded = LoadSpoilerStateForTagStrip(userId);
-            if (loaded == null
-                || (loaded.Series.Count == 0 && loaded.Movies.Count == 0 && loaded.Collections.Count == 0))
+            // Load through the owning resolver (typed read + last-known-good retention
+            // + fail-closed sentinel), so a corrupt/unavailable spoilerblur.json can't
+            // silently disable tag stripping. Never null: a fault returns last-known-good
+            // or a FailClosed sentinel that ResolveTagStripDecision strips wholesale.
+            Configuration.UserSpoilerBlur spState = _spoilerResolver.LoadUserState(HttpContext, userId);
+            if (!spState.FailClosed
+                && spState.Series.Count == 0 && spState.Movies.Count == 0 && spState.Collections.Count == 0)
             {
                 return;
             }
-
-            // Non-null local so the capturing delegates below don't see a nullable
-            // (a captured local keeps its DECLARED nullability inside lambdas).
-            Configuration.UserSpoilerBlur spState = loaded;
 
             // Apply per-user override prefs on top of admin policy — the same
             // "user opt-out wins" contract as SpoilerFieldStripFilter. Prefs is
@@ -250,11 +248,15 @@ namespace Jellyfin.Plugin.JellyfinElevate.Controllers
                 && (spStripGenres || spStripRatings || spReplaceTitle || spStripOverview);
             if (stripTagsEnabled)
             {
-                spoilerState = LoadSpoilerStateForTagStrip(userId);
-                // Empty lists = nothing to strip; treat as off. Check all three dicts,
-                // not just Series.Count, so a movies-only user isn't short-circuited.
-                // Mirrors the GetTagCache + image-filter checks.
-                if (spoilerState == null || (spoilerState.Series.Count == 0 && spoilerState.Movies.Count == 0 && spoilerState.Collections.Count == 0))
+                // Load through the owning resolver (typed read + last-known-good +
+                // fail-closed sentinel); never null. A corrupt/unavailable policy can
+                // no longer silently disable tag stripping on this endpoint.
+                spoilerState = _spoilerResolver.LoadUserState(HttpContext, userId);
+                // Empty lists = nothing to strip; treat as off — UNLESS fail-closed
+                // (policy fault, no last-known-good), which over-strips every item.
+                // Check all three dicts so a movies-only user isn't short-circuited.
+                if (!spoilerState.FailClosed
+                    && spoilerState.Series.Count == 0 && spoilerState.Movies.Count == 0 && spoilerState.Collections.Count == 0)
                 {
                     stripTagsEnabled = false;
                 }
@@ -288,6 +290,41 @@ namespace Jellyfin.Plugin.JellyfinElevate.Controllers
 
                 var kind = item.GetBaseItemKind();
                 var isContainer = kind == BaseItemKind.Series || kind == BaseItemKind.Season;
+
+                // Fail-closed: the policy read faulted with no last-known-good. Return
+                // a fully-stripped Id+Type stub for EVERY item regardless of type,
+                // scope, or watched state, so no tags/ratings/streams/title-bearing
+                // fields leak while the policy is unreadable.
+                if (stripTagsEnabled && spoilerState != null && spoilerState.FailClosed)
+                {
+                    string? fcName = item.Name;
+                    if (item is MediaBrowser.Controller.Entities.TV.Episode fcEp
+                        && (spReplaceTitle || spStripOverview))
+                    {
+                        fcName = (spReplaceTitle && fcEp.IndexNumber.HasValue && fcEp.ParentIndexNumber.HasValue)
+                            ? $"Season {fcEp.ParentIndexNumber.Value}, Episode {fcEp.IndexNumber.Value}"
+                            : (string.IsNullOrWhiteSpace(spoilerCfg!.SpoilerOverviewPlaceholder)
+                                ? "Spoiler Guard activated"
+                                : spoilerCfg.SpoilerOverviewPlaceholder);
+                    }
+                    results.Add(new
+                    {
+                        Id = item.Id,
+                        Type = kind.ToString(),
+                        Genres = Array.Empty<string>(),
+                        CommunityRating = (float?)null,
+                        CriticRating = (float?)null,
+                        SeriesId = (Guid?)null,
+                        ProviderIds = (IDictionary<string, string>?)null,
+                        Name = fcName,
+                        Path = (string?)null,
+                        MediaStreams = (List<object>?)null,
+                        MediaSources = (List<object>?)null,
+                        FirstEpisode = (object?)null,
+                        Tags = Array.Empty<string>(),
+                    });
+                    continue;
+                }
 
                 // Spoiler Guard tag-strip: for an unwatched Episode of a guarded
                 // series, return an Id+Type-only stub so the frontend tag renderers
@@ -688,62 +725,6 @@ namespace Jellyfin.Plugin.JellyfinElevate.Controllers
             int formattedProgress = (int)Math.Clamp(progress, 0, 100);
 
             return Ok(new { success = true, progress = formattedProgress, totalPlaybackTicks, totalRuntimeTicks });
-        }
-
-        // Tag-cache + tag-data both load the user's spoiler state. Strict-read so
-        // corruption is detected (rate-limited warn), then fall back to null so the
-        // strip silently no-ops rather than 503-ing the unrelated tag request — the
-        // user's own /spoiler-blur/series endpoint will surface the error next call.
-        // See SpoilerUserResolver.IsMovieInSpoilerScope for scope semantics
-        // (direct opt-in or via an opted-in BoxSet).
-        private Configuration.UserSpoilerBlur? LoadSpoilerStateForTagStrip(Guid userId)
-        {
-            var userKey = userId.ToString("N");
-            var fileName = Services.SpoilerBlurImageFilter.SpoilerBlurFileName;
-            if (!_userConfigurationManager.UserConfigurationExists(userKey, fileName))
-            {
-                return null;
-            }
-            try
-            {
-                return _userConfigurationManager.GetUserConfigurationStrict<Configuration.UserSpoilerBlur>(userKey, fileName);
-            }
-            catch (InvalidDataException ex)
-            {
-                _spoilerResolver.WarnRateLimited(
-                    "tagstrip-corrupt:" + userKey,
-                    $"Spoiler Guard tag-strip: spoilerblur.json corrupt for {ResolveUserDisplay(userKey)} (backed up): {ex.Message}");
-                Services.SpoilerUserResolver.RecordCorruption(userKey, ResolveUserDisplay(userKey), ex.Message);
-                return null;
-            }
-            catch (System.Text.Json.JsonException ex)
-            {
-                _spoilerResolver.WarnRateLimited(
-                    "tagstrip-corrupt:" + userKey,
-                    $"Spoiler Guard tag-strip: spoilerblur.json corrupt for {ResolveUserDisplay(userKey)} (backed up): {ex.Message}");
-                Services.SpoilerUserResolver.RecordCorruption(userKey, ResolveUserDisplay(userKey), ex.Message);
-                return null;
-            }
-            catch (IOException ex)
-            {
-                _spoilerResolver.WarnRateLimited(
-                    "tagstrip-io:" + ex.GetType().FullName,
-                    $"Spoiler Guard tag-strip: IO error reading state for {ResolveUserDisplay(userKey)}: {ex.Message}");
-                return null;
-            }
-            catch (Exception ex)
-            {
-                // The specific catches above handle InvalidData/Json/IOException.
-                // Others (UnauthorizedAccess from a chmod-mangled config dir, Security,
-                // PathTooLong, DirectoryNotFound) would otherwise escape and 500 the whole
-                // tag-cache/tag-data request, breaking every client's tag rail on every poll.
-                // Catch-all returns null (skip strip) with rate-limited warn so a real
-                // failure mode stays observable without taking down the unrelated surface.
-                _spoilerResolver.WarnRateLimited(
-                    "tagstrip-unexpected:" + ex.GetType().FullName,
-                    $"Spoiler Guard tag-strip: unexpected {ex.GetType().Name} reading state for {ResolveUserDisplay(userKey)}: {ex.Message}");
-                return null;
-            }
         }
 
         private List<BaseItem> GetLeafPlayableItems(JUser user, BaseItem root)

--- a/Jellyfin.Plugin.JellyfinElevate/Services/HiddenContentResponseFilter.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/HiddenContentResponseFilter.cs
@@ -48,6 +48,26 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
         internal static bool IsCachedForTest(string userIdN)
             => !string.IsNullOrEmpty(userIdN) && _hcCache.ContainsKey(userIdN);
 
+        // Test seam: force a user's cache entry to appear stale (TTL elapsed) WITHOUT
+        // removing it, so the next read re-reads disk while the entry is still present
+        // as last-known-good. Distinct from InvalidateUser, which drops the entry (the
+        // repair path). Lets a test prove LKG retention across a genuine TTL expiry
+        // deterministically without a wall-clock wait.
+        internal static void ExpireCacheForTest(string userIdN)
+        {
+            if (!string.IsNullOrEmpty(userIdN) && _hcCache.TryGetValue(userIdN, out var e))
+                _hcCache[userIdN] = (e.Ctx, DateTime.MinValue);
+        }
+
+        // Test seam: run the real disk+cache load path for a user on a fresh request
+        // and report whether the given item would be hidden on the given surface.
+        // Returns primitives only so the private HideContext never leaks.
+        internal bool WouldHideForTest(Guid userId, string itemIdN, string surface)
+        {
+            var hide = LoadHideContext(new DefaultHttpContext(), userId);
+            return IsHiddenById(itemIdN, null, hide, surface);
+        }
+
         private static readonly Dictionary<(string, string), (string Surface, ResponseHandler Handler)> _routes
             = new(KeyComparer.Instance)
         {
@@ -195,37 +215,55 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
             }
 
             // 2. Cross-request in-memory cache, avoids disk reads on every Jellyfin API call.
+            //    The entry doubles as last-known-good: a stale entry is retained (not
+            //    dropped) so a policy fault can fall back to it instead of failing open.
             var userIdN = userId.ToString("N");
             var now = DateTime.UtcNow;
-            if (_hcCache.TryGetValue(userIdN, out var entry) && (now - entry.CachedAt) < _hcCacheTtl)
+            var hasEntry = _hcCache.TryGetValue(userIdN, out var entry);
+            if (hasEntry && (now - entry.CachedAt) < _hcCacheTtl)
             {
                 httpContext.Items[CacheKey] = entry.Ctx;
                 return entry.Ctx;
             }
 
-            // 3. Cache miss, read from disk.
-            UserHiddenContent? data;
-            try
+            // 3. Cache miss or stale — typed, side-effect-free read from disk.
+            var read = _configManager.ReadUserConfiguration<UserHiddenContent>(userIdN, FileName);
+            var lastKnownGood = hasEntry ? entry.Ctx : null;
+            var ctx = ResolvePolicyContext(read, lastKnownGood);
+
+            if (read.IsFault)
             {
-                data = _configManager.GetUserConfiguration<UserHiddenContent>(userIdN, FileName);
-            }
-            catch (Exception ex)
-            {
-                // Dedup once per user per process so a corrupt file doesn't spam Error on every matched request.
+                // Dedup once per user per process so a persistent fault doesn't spam Error on every matched request.
                 if (_warnedReadFailure.TryAdd(userId, 0))
                 {
-                    _logger.LogError($"HC response filter: failed to read hidden-content.json for user {userId} — entries will pass through unfiltered until the file is repaired: {ex.Message}");
+                    var posture = lastKnownGood != null
+                        ? "retaining last-known-good hidden-content protection"
+                        : "no last-known-good — failing CLOSED (hiding all matched surfaces)";
+                    _logger.LogError($"HC response filter: {read.Status} hidden-content.json for user {userId} ({read.FaultDetail}) — {posture} until repaired.");
                 }
-                data = null;
+            }
+            else
+            {
+                _warnedReadFailure.TryRemove(userId, out _);
             }
 
-            if (data != null) _warnedReadFailure.TryRemove(userId, out _);
-
-            var ctx = HideContext.Build(data);
+            // Cache the resolved context (an intentional policy, retained LKG, or the
+            // fail-closed sentinel) with a fresh timestamp — never an empty fail-open
+            // entry after a fault. A repair invalidates this via InvalidateUser.
             _hcCache[userIdN] = (ctx, now);
             httpContext.Items[CacheKey] = ctx;
             return ctx;
         }
+
+        // Pure policy decision: how a typed read maps to the enforced context.
+        //   Missing/Valid → build from the (possibly empty) value — an intentional policy.
+        //   Corrupt/Unavailable → retain last-known-good if present, else fail closed.
+        // A missing file is the common "feature enabled globally, user never configured
+        // it" case and MUST pass through, so only genuine faults trigger protection.
+        private static HideContext ResolvePolicyContext(UserConfigReadResult<UserHiddenContent> read, HideContext? lastKnownGood)
+            => read.HasUsableValue
+                ? HideContext.Build(read.Value)
+                : (lastKnownGood ?? HideContext.FailClosed);
 
         private static void FilterQueryResult(ActionExecutedContext executed, HideContext hide, string surface, ILogger<HiddenContentResponseFilter> logger)
         {
@@ -302,6 +340,12 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
 
         private static bool IsHiddenById(string itemIdStr, string? seriesIdStr, HideContext hide, string surface)
         {
+            // Fail-closed: a policy fault with no last-known-good over-hides every
+            // item on every matched surface rather than disclosing content the user
+            // had hidden. The per-surface Settings gate is deliberately bypassed —
+            // we have no readable Settings, so we protect all routed surfaces.
+            if (hide.IsFailClosed) return true;
+
             var itemId = NormalizeId(itemIdStr);
             var seriesId = seriesIdStr is null ? null : NormalizeId(seriesIdStr);
 
@@ -380,11 +424,23 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
         {
             public static readonly HideContext Empty = new HideContext();
 
+            // Fail-closed sentinel: served only when the user's policy read faulted
+            // (corrupt/unavailable) with no last-known-good to retain. It over-hides
+            // every item on every matched surface so a persistence fault can never
+            // silently disclose content the user had chosen to hide. Bounded and
+            // self-healing — a repair (via any write path → InvalidateUser) or the
+            // next Valid read replaces it.
+            public static readonly HideContext FailClosed = new HideContext { IsFailClosed = true };
+
             public Dictionary<string, HashSet<string>> ItemIdScopes { get; } = new(StringComparer.OrdinalIgnoreCase);
             public Dictionary<string, HashSet<string>> SeriesIdScopes { get; } = new(StringComparer.OrdinalIgnoreCase);
             public HiddenContentSettings Settings { get; private set; } = new HiddenContentSettings();
 
-            public bool IsEmpty => ItemIdScopes.Count == 0 && SeriesIdScopes.Count == 0;
+            public bool IsFailClosed { get; private init; }
+
+            // Fail-closed is never "empty": the filter must engage so its handlers
+            // over-hide. Otherwise emptiness is the absence of any hide scope.
+            public bool IsEmpty => !IsFailClosed && ItemIdScopes.Count == 0 && SeriesIdScopes.Count == 0;
 
             public static HideContext Build(UserHiddenContent? data)
             {

--- a/Jellyfin.Plugin.JellyfinElevate/Services/SpoilerGuard/SpoilerBlurImageFilter.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/SpoilerGuard/SpoilerBlurImageFilter.cs
@@ -378,7 +378,10 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
             {
                 if (candidate == Guid.Empty) continue;
                 var candidateState = _resolver.LoadUserState(context.HttpContext, candidate);
-                if (candidateState.Series.Count == 0
+                // FailClosed (policy read faulted with no last-known-good) protects
+                // EVERY item — do not skip it as "protects nothing".
+                if (!candidateState.FailClosed
+                    && candidateState.Series.Count == 0
                     && candidateState.Movies.Count == 0
                     && candidateState.Collections.Count == 0)
                 {
@@ -767,6 +770,10 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
         //   BoxSet / other   → not protected here (its own art passes through)
         private bool ItemInSpoilerScope(UserSpoilerBlur userState, BaseItem item)
         {
+            // Fail-closed: an unresolvable policy protects every item (over-blur)
+            // rather than leak unwatched artwork.
+            if (userState.FailClosed) return true;
+
             switch (item)
             {
                 case Episode ep:
@@ -813,6 +820,9 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
             UserSpoilerBlur userState,
             JUser jUser)
         {
+            // Fail-closed: an unresolvable policy blurs (never passes through).
+            if (userState.FailClosed) return false;
+
             if (item is MediaBrowser.Controller.Entities.Movies.Movie movie)
             {
                 // Not in THIS candidate's movie scope → nothing to blur for them.

--- a/Jellyfin.Plugin.JellyfinElevate/Services/SpoilerGuard/SpoilerFieldStripFilter.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/SpoilerGuard/SpoilerFieldStripFilter.cs
@@ -843,21 +843,21 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
                 // would otherwise fall through and leak the raw Name / MatchedTerm.
                 if (userState.FailClosed)
                 {
-                    if (isEpisodeHint
-                        && ShouldStrip(cfg.SpoilerReplaceTitle, userState.Prefs?.ReplaceEpisodeTitles)
-                        && hint.IndexNumber.HasValue && hint.ParentIndexNumber.HasValue)
+                    var replaceTitle = ShouldStrip(cfg.SpoilerReplaceTitle, userState.Prefs?.ReplaceEpisodeTitles);
+                    var stripOverview = ShouldStrip(cfg.SpoilerStripOverview, userState.Prefs?.HideEpisodeDescriptions);
+                    // If ANY title/overview strip is enabled, the episode Name must be
+                    // replaced — prefer the numbered form when both index numbers are
+                    // present, otherwise fall back to the safe placeholder. Never leave
+                    // the raw Name just because the numbered form can't be built.
+                    if (isEpisodeHint && (replaceTitle || stripOverview))
                     {
-                        hint.Name = $"Season {hint.ParentIndexNumber.Value}, Episode {hint.IndexNumber.Value}";
-                    }
-                    else if (isEpisodeHint
-                        && ShouldStrip(cfg.SpoilerStripOverview, userState.Prefs?.HideEpisodeDescriptions))
-                    {
-                        hint.Name = SanitizePlaceholder(cfg.SpoilerOverviewPlaceholder);
+                        hint.Name = (replaceTitle && hint.IndexNumber.HasValue && hint.ParentIndexNumber.HasValue)
+                            ? $"Season {hint.ParentIndexNumber.Value}, Episode {hint.IndexNumber.Value}"
+                            : SanitizePlaceholder(cfg.SpoilerOverviewPlaceholder);
                     }
                     // Movie hint Name is intentionally not rewritten (mirrors the
-                    // scoped path); MatchedTerm is nulled for both shapes below.
-                    if (ShouldStrip(cfg.SpoilerReplaceTitle, userState.Prefs?.ReplaceEpisodeTitles)
-                        || ShouldStrip(cfg.SpoilerStripOverview, userState.Prefs?.HideEpisodeDescriptions))
+                    // scoped path); MatchedTerm is nulled for both shapes.
+                    if (replaceTitle || stripOverview)
                     {
                         hint.MatchedTerm = null;
                     }

--- a/Jellyfin.Plugin.JellyfinElevate/Services/SpoilerGuard/SpoilerFieldStripFilter.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/SpoilerGuard/SpoilerFieldStripFilter.cs
@@ -174,7 +174,10 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
             // /Items/{id}/PlaybackInfo, and /Items/{id}/Images unstripped
             // despite the Movie branches in StripItem +
             // RouteParentIsSpoilerEpisode. Mirror the image-filter checks.
-            if (userState.Series.Count == 0 && userState.Movies.Count == 0 && userState.Collections.Count == 0)
+            // FailClosed (policy read faulted with no last-known-good) must NOT
+            // short-circuit: it over-strips every item rather than leak fields.
+            if (!userState.FailClosed
+                && userState.Series.Count == 0 && userState.Movies.Count == 0 && userState.Collections.Count == 0)
             {
                 await next().ConfigureAwait(false);
                 return;
@@ -492,6 +495,16 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
         private void StripItem(BaseItemDto item, UserSpoilerBlur userState, PluginConfiguration cfg, Guid userId)
         {
             if (item == null) return;
+
+            // Fail-closed: the user's policy read faulted with no last-known-good.
+            // Over-strip every item's admin-enabled sensitive fields rather than
+            // leak them, and cache-bust so native clients refetch once repaired.
+            if (userState.FailClosed)
+            {
+                MutateImageTagsForCacheBust(item, cfg, watched: false, playbackPositionTicks: 0);
+                ApplyStripping(item, userState, cfg, userId);
+                return;
+            }
 
             // Series path: when the item is the Series itself (Series detail
             // page = /Items/{seriesId}), strip cast / overview / tags / etc.

--- a/Jellyfin.Plugin.JellyfinElevate/Services/SpoilerGuard/SpoilerFieldStripFilter.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/SpoilerGuard/SpoilerFieldStripFilter.cs
@@ -126,6 +126,19 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
             _configProvider = configProvider;
         }
 
+        // Test seams (Tests has InternalsVisibleTo): exercise the FailClosed
+        // over-strip of each non-BaseItemDto response shape. On a FailClosed state
+        // the route/scope membership gate is short-circuited, so the (unused)
+        // ActionExecutingContext is never dereferenced.
+        internal void StripImageInfosForTest(IEnumerable<MediaBrowser.Model.Dto.ImageInfo> imgs, UserSpoilerBlur userState, PluginConfiguration cfg)
+            => StripImageInfos(imgs, userState, cfg, Guid.Empty, null!);
+
+        internal void StripPlaybackInfoForTest(MediaBrowser.Model.MediaInfo.PlaybackInfoResponse pbi, UserSpoilerBlur userState, PluginConfiguration cfg)
+            => StripPlaybackInfo(pbi, userState, cfg, Guid.Empty, null!);
+
+        internal void StripSearchHintsForTest(MediaBrowser.Model.Search.SearchHintResult shr, UserSpoilerBlur userState, PluginConfiguration cfg)
+            => StripSearchHints(shr, userState, cfg, Guid.Empty);
+
         public Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
         {
             // Sync fast-path bail order — three short-circuit checks before
@@ -321,7 +334,8 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
             Guid userId,
             ActionExecutingContext context)
         {
-            if (!RouteParentIsSpoilerEpisode(context, userState, userId)) return;
+            // FailClosed over-strips regardless of route/scope membership.
+            if (!userState.FailClosed && !RouteParentIsSpoilerEpisode(context, userState, userId)) return;
             // Auxiliary "scrub title-bearing fields" path — only relevant when a
             // title/overview strip is actually going to run for this user. Mirror
             // the same admin-cap + user-opt-out semantics as ApplyStripping.
@@ -347,7 +361,8 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
             ActionExecutingContext context)
         {
             if (pbi.MediaSources == null) return;
-            if (!RouteParentIsSpoilerEpisode(context, userState, userId)) return;
+            // FailClosed over-strips regardless of route/scope membership.
+            if (!userState.FailClosed && !RouteParentIsSpoilerEpisode(context, userState, userId)) return;
             // Same scrubbing gate as StripImageInfos — honor the user's opt-outs.
             if (!ShouldStrip(cfg.SpoilerReplaceTitle, userState.Prefs?.ReplaceEpisodeTitles)
                 && !ShouldStrip(cfg.SpoilerStripOverview, userState.Prefs?.HideEpisodeDescriptions)) return;
@@ -840,9 +855,13 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
                 if (isEpisodeHint)
                 {
                     if (actualItem is not MediaBrowser.Controller.Entities.TV.Episode ep) continue;
-                    if (ep.SeriesId == Guid.Empty) continue;
-                    if (!userState.Series.ContainsKey(ep.SeriesId.ToString("N"))) continue;
-                    if (ResolvePlayedServerSide(userId, hint.Id)) continue;
+                    // FailClosed over-strips every hint regardless of scope/watched state.
+                    if (!userState.FailClosed)
+                    {
+                        if (ep.SeriesId == Guid.Empty) continue;
+                        if (!userState.Series.ContainsKey(ep.SeriesId.ToString("N"))) continue;
+                        if (ResolvePlayedServerSide(userId, hint.Id)) continue;
+                    }
 
                     if (ShouldStrip(cfg.SpoilerReplaceTitle, userState.Prefs?.ReplaceEpisodeTitles) && hint.IndexNumber.HasValue && hint.ParentIndexNumber.HasValue)
                     {
@@ -861,8 +880,12 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
                     // is still nulled below to suppress autocomplete
                     // substring leak of any non-title-bearing match).
                     if (actualItem is not MediaBrowser.Controller.Entities.Movies.Movie) continue;
-                    if (!_resolver.IsMovieInSpoilerScope(userState, hint.Id)) continue;
-                    if (ResolvePlayedServerSide(userId, hint.Id)) continue;
+                    // FailClosed over-strips every hint regardless of scope/watched state.
+                    if (!userState.FailClosed)
+                    {
+                        if (!_resolver.IsMovieInSpoilerScope(userState, hint.Id)) continue;
+                        if (ResolvePlayedServerSide(userId, hint.Id)) continue;
+                    }
                 }
 
                 // MatchedTerm echoes the substring of the ORIGINAL Name

--- a/Jellyfin.Plugin.JellyfinElevate/Services/SpoilerGuard/SpoilerFieldStripFilter.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/SpoilerGuard/SpoilerFieldStripFilter.cs
@@ -835,6 +835,35 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
                 var isEpisodeHint = hint.Type == Jellyfin.Data.Enums.BaseItemKind.Episode;
                 var isMovieHint = hint.Type == Jellyfin.Data.Enums.BaseItemKind.Movie;
                 if (!isEpisodeHint && !isMovieHint) continue;
+
+                // FailClosed: the policy read faulted with no last-known-good. We
+                // cannot trust — or even need — a library lookup here, so over-strip
+                // every episode/movie hint by its declared Type alone. This closes
+                // the gap where a null / removed / mismatched GetItemById result
+                // would otherwise fall through and leak the raw Name / MatchedTerm.
+                if (userState.FailClosed)
+                {
+                    if (isEpisodeHint
+                        && ShouldStrip(cfg.SpoilerReplaceTitle, userState.Prefs?.ReplaceEpisodeTitles)
+                        && hint.IndexNumber.HasValue && hint.ParentIndexNumber.HasValue)
+                    {
+                        hint.Name = $"Season {hint.ParentIndexNumber.Value}, Episode {hint.IndexNumber.Value}";
+                    }
+                    else if (isEpisodeHint
+                        && ShouldStrip(cfg.SpoilerStripOverview, userState.Prefs?.HideEpisodeDescriptions))
+                    {
+                        hint.Name = SanitizePlaceholder(cfg.SpoilerOverviewPlaceholder);
+                    }
+                    // Movie hint Name is intentionally not rewritten (mirrors the
+                    // scoped path); MatchedTerm is nulled for both shapes below.
+                    if (ShouldStrip(cfg.SpoilerReplaceTitle, userState.Prefs?.ReplaceEpisodeTitles)
+                        || ShouldStrip(cfg.SpoilerStripOverview, userState.Prefs?.HideEpisodeDescriptions))
+                    {
+                        hint.MatchedTerm = null;
+                    }
+                    continue;
+                }
+
                 if (hint.Id == Guid.Empty) continue;
 
                 // Look up the actual item. For Episodes we need SeriesId
@@ -855,13 +884,10 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
                 if (isEpisodeHint)
                 {
                     if (actualItem is not MediaBrowser.Controller.Entities.TV.Episode ep) continue;
-                    // FailClosed over-strips every hint regardless of scope/watched state.
-                    if (!userState.FailClosed)
-                    {
-                        if (ep.SeriesId == Guid.Empty) continue;
-                        if (!userState.Series.ContainsKey(ep.SeriesId.ToString("N"))) continue;
-                        if (ResolvePlayedServerSide(userId, hint.Id)) continue;
-                    }
+                    // (FailClosed is handled at the top of the loop, before the lookup.)
+                    if (ep.SeriesId == Guid.Empty) continue;
+                    if (!userState.Series.ContainsKey(ep.SeriesId.ToString("N"))) continue;
+                    if (ResolvePlayedServerSide(userId, hint.Id)) continue;
 
                     if (ShouldStrip(cfg.SpoilerReplaceTitle, userState.Prefs?.ReplaceEpisodeTitles) && hint.IndexNumber.HasValue && hint.ParentIndexNumber.HasValue)
                     {
@@ -880,12 +906,9 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
                     // is still nulled below to suppress autocomplete
                     // substring leak of any non-title-bearing match).
                     if (actualItem is not MediaBrowser.Controller.Entities.Movies.Movie) continue;
-                    // FailClosed over-strips every hint regardless of scope/watched state.
-                    if (!userState.FailClosed)
-                    {
-                        if (!_resolver.IsMovieInSpoilerScope(userState, hint.Id)) continue;
-                        if (ResolvePlayedServerSide(userId, hint.Id)) continue;
-                    }
+                    // (FailClosed is handled at the top of the loop, before the lookup.)
+                    if (!_resolver.IsMovieInSpoilerScope(userState, hint.Id)) continue;
+                    if (ResolvePlayedServerSide(userId, hint.Id)) continue;
                 }
 
                 // MatchedTerm echoes the substring of the ORIGINAL Name

--- a/Jellyfin.Plugin.JellyfinElevate/Services/SpoilerGuard/SpoilerFieldStripFilter.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/SpoilerGuard/SpoilerFieldStripFilter.cs
@@ -139,6 +139,9 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
         internal void StripSearchHintsForTest(MediaBrowser.Model.Search.SearchHintResult shr, UserSpoilerBlur userState, PluginConfiguration cfg)
             => StripSearchHints(shr, userState, cfg, Guid.Empty);
 
+        internal void StripItemForTest(MediaBrowser.Model.Dto.BaseItemDto item, UserSpoilerBlur userState, PluginConfiguration cfg)
+            => StripItem(item, userState, cfg, Guid.Empty);
+
         public Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
         {
             // Sync fast-path bail order — three short-circuit checks before
@@ -518,6 +521,25 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
             {
                 MutateImageTagsForCacheBust(item, cfg, watched: false, playbackPositionTicks: 0);
                 ApplyStripping(item, userState, cfg, userId);
+                // ApplyStripping only renames an episode when SpoilerReplaceTitle is on
+                // AND both index numbers exist. Over-strip on a fault: if any title/
+                // overview strip is enabled, guarantee an episode Name is replaced
+                // (numbered when possible, else the placeholder) and clear its alternate
+                // title fields — mirrors the fail-closed SearchHint rule so an unnumbered
+                // or overview-only-configured episode can't leak its raw title.
+                if (item.Type == Jellyfin.Data.Enums.BaseItemKind.Episode)
+                {
+                    var replaceTitle = ShouldStrip(cfg.SpoilerReplaceTitle, userState.Prefs?.ReplaceEpisodeTitles);
+                    var stripOverview = ShouldStrip(cfg.SpoilerStripOverview, userState.Prefs?.HideEpisodeDescriptions);
+                    if (replaceTitle || stripOverview)
+                    {
+                        item.Name = (replaceTitle && item.IndexNumber.HasValue && item.ParentIndexNumber.HasValue)
+                            ? $"Season {item.ParentIndexNumber.Value}, Episode {item.IndexNumber.Value}"
+                            : SanitizePlaceholder(cfg.SpoilerOverviewPlaceholder);
+                        item.SortName = null;
+                        item.OriginalTitle = null;
+                    }
+                }
                 return;
             }
 

--- a/Jellyfin.Plugin.JellyfinElevate/Services/SpoilerGuard/SpoilerPendingService.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/SpoilerGuard/SpoilerPendingService.cs
@@ -141,6 +141,11 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
                     };
                     return 1;
                 });
+            // The strict RMW above proved spoilerblur.json is currently readable and
+            // valid, so drop any cached FailClosed / stale enforcement state for this
+            // user (repair invalidation, matching the promotion and existing-item
+            // branches) — even on the no-change or cap-exceeded outcome.
+            SpoilerUserResolver.InvalidateUser(userKey);
             if (capExceeded[0])
             {
                 _logger.LogWarning($"Spoiler Guard pending: cap of {MaxPendingTmdbPerUser} reached for {ResolveUserDisplay(userKey)} — rejecting new {pendingKey}");

--- a/Jellyfin.Plugin.JellyfinElevate/Services/SpoilerGuard/SpoilerUserResolver.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/SpoilerGuard/SpoilerUserResolver.cs
@@ -74,6 +74,17 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
         internal static bool IsUserStateCachedForTest(string userIdN)
             => !string.IsNullOrEmpty(userIdN) && _userStateCache.ContainsKey(userIdN);
 
+        // Test seam: force a user's cross-request entry to appear stale (TTL elapsed)
+        // WITHOUT removing it, so the next LoadUserState re-reads disk while the entry
+        // is still present as last-known-good. Distinct from InvalidateUser (which
+        // drops the entry — the repair path). Lets a test prove LKG retention across a
+        // genuine TTL expiry deterministically without a wall-clock wait.
+        internal static void ExpireUserStateCacheForTest(string userIdN)
+        {
+            if (!string.IsNullOrEmpty(userIdN) && _userStateCache.TryGetValue(userIdN, out var e))
+                _userStateCache[userIdN] = (e.State, DateTime.MinValue);
+        }
+
         private readonly UserConfigurationManager _userConfigManager;
         private readonly ILibraryManager _libraryManager;
         private readonly RequestIdentityService _identity;
@@ -221,42 +232,36 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
             }
 
             // 2. F7 cross-request cache — skips the disk read + parse when a
-            //    recent copy exists. Invalidated by every write path.
+            //    recent copy exists. Invalidated by every write path. A stale
+            //    entry is retained (not dropped) so a policy fault can fall back
+            //    to it as last-known-good instead of failing open.
             var now = DateTime.UtcNow;
-            if (_userStateCache.TryGetValue(userIdN, out var entry)
-                && (now - entry.CachedAt) < UserStateCacheTtl)
+            var hasEntry = _userStateCache.TryGetValue(userIdN, out var entry);
+            if (hasEntry && (now - entry.CachedAt) < UserStateCacheTtl)
             {
                 httpContext.Items[cacheKey] = entry.State;
                 return entry.State;
             }
 
-            // 3. Miss — read from disk.
-            UserSpoilerBlur state;
-            try
+            // 3. Miss or stale — typed, side-effect-free read from disk. Unlike the
+            //    old lenient GetUserConfiguration path (which collapsed every fault
+            //    into an empty new T() and silently disabled protection), this
+            //    classifies Missing/Valid/Corrupt/Unavailable so a fault retains
+            //    last-known-good or fails CLOSED instead of leaking artwork/fields.
+            var read = _userConfigManager.ReadUserConfiguration<UserSpoilerBlur>(
+                userIdN,
+                SpoilerBlurImageFilter.SpoilerBlurFileName);
+            var lastKnownGood = hasEntry ? entry.State : null;
+            var state = ResolvePolicyState(read, lastKnownGood);
+
+            if (read.IsFault)
             {
-                state = _userConfigManager.GetUserConfiguration<UserSpoilerBlur>(
-                    userIdN,
-                    SpoilerBlurImageFilter.SpoilerBlurFileName);
-            }
-            catch (Exception ex)
-            {
-                // GetUserConfiguration is the LENIENT path — it already
-                // swallows IOException + JsonException + parse failures
-                // internally and returns `new T()` (it logs at Error level
-                // via the config manager's own _logger, so the corruption
-                // fact is observable, just not under our namespace). This
-                // outer catch-all only fires for exceptions that escape the
-                // lenient path (e.g. ResolveUserFile throwing on a bad
-                // userId). Rate-limited so a flood of bad requests doesn't
-                // spam logs. Do NOT populate the cross-request cache with a
-                // spurious empty on this rare escape — only the per-request
-                // layer, so a retry re-reads.
+                var posture = lastKnownGood != null
+                    ? "retaining last-known-good spoiler protection"
+                    : "no last-known-good — failing CLOSED (protecting all items)";
                 WarnRateLimited(
-                    "userstate-load:" + ex.GetType().FullName,
-                    $"Spoiler Guard resolver: failed to read user state for {userId} — passing through unblurred. {ex.Message}");
-                state = new UserSpoilerBlur();
-                httpContext.Items[cacheKey] = state;
-                return state;
+                    "userstate-" + read.Status + ":" + (read.FaultDetail ?? "?"),
+                    $"Spoiler Guard resolver: {read.Status} spoilerblur.json for {userId} ({read.FaultDetail}) — {posture} until repaired.");
             }
 
             _userStateCache[userIdN] = (state, now);
@@ -274,6 +279,24 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
             return state;
         }
 
+        // Pure policy decision: how a typed read maps to the enforced spoiler state.
+        //   Missing/Valid → use the (possibly empty) value — an intentional policy.
+        //     A missing file is the common "user never opted anything in" case and
+        //     MUST pass through, so only genuine faults trigger protection.
+        //   Corrupt/Unavailable → retain last-known-good if present, else a
+        //     FailClosed sentinel so the image/field filters over-protect.
+        internal static UserSpoilerBlur ResolvePolicyState(
+            UserConfigReadResult<UserSpoilerBlur> read,
+            UserSpoilerBlur? lastKnownGood)
+        {
+            if (read.HasUsableValue)
+            {
+                return read.Value ?? new UserSpoilerBlur();
+            }
+
+            return lastKnownGood ?? new UserSpoilerBlur { FailClosed = true };
+        }
+
         public void WarnRateLimited(string key, string message)
         {
             var now = DateTime.UtcNow;
@@ -283,13 +306,13 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
             _logger.LogWarning(message);
         }
 
-        // Track per-user corruption events so the admin can surface a
-        // banner in the JE management UI when any user's spoilerblur.json
-        // was rolled into the .corrupt-backup file. The file-on-disk has
-        // been rewritten with an empty state by UserConfigurationManager
-        // (fail-open per SECURITY.md) so the user's image/strip pipeline
-        // silently no-ops until they re-enable items. Surfacing this lets
-        // the user know to retry.
+        // Track per-user corruption events so the admin can surface a banner in the
+        // JE management UI. Populated by the controller/tag-cache STRICT read+write
+        // path when a mutation hits a corrupt spoilerblur.json (it backs the file up
+        // to .corrupt-* and refuses to overwrite). Note the runtime ENFORCEMENT read
+        // (LoadUserState) no longer fails open on corruption: it retains
+        // last-known-good or fails CLOSED, so protection is preserved rather than
+        // silently no-op'd. The banner still lets the user know a repair is needed.
         private static readonly ConcurrentDictionary<string, CorruptionEvent> _corruptionLog = new();
 
         public class CorruptionEvent

--- a/Jellyfin.Plugin.JellyfinElevate/Services/TagCacheService.cs
+++ b/Jellyfin.Plugin.JellyfinElevate/Services/TagCacheService.cs
@@ -498,6 +498,11 @@ namespace Jellyfin.Plugin.JellyfinElevate.Services
             var isSeries = string.Equals(entry.Type, "Series", StringComparison.Ordinal);
             if (!isEpisode && !isSeason && !isMovie && !isSeries) return TagStripDecision.Keep;
 
+            // Fail-closed: the user's policy read faulted with no last-known-good.
+            // Strip every recognized entry regardless of scope or watched state rather
+            // than leak genres / ratings / title-bearing stream data.
+            if (spState.FailClosed) return TagStripDecision.Strip;
+
             // ── Scope gate ──
             if (isMovie)
             {

--- a/docs/advanced/project-structure.md
+++ b/docs/advanced/project-structure.md
@@ -116,6 +116,12 @@ Jellyfin.Plugin.JellyfinElevate/
 │   ├── SettingDescriptors.cs  # Settings-as-data registry: exposure + per-user pairing per setting
 │   ├── AtomicFile.cs          # Crash-safe write helper (temp-file + atomic rename) all config writes go through
 │   ├── UserConfiguration.cs / UserConfigurationManager.cs (+ store/migration/reviews classes)
+│   │                          # UserConfigurationStore owns three read tiers: LENIENT (GetUserConfiguration,
+│   │                          # any fault → new T(), for ordinary display settings), STRICT (RMW writes,
+│   │                          # corrupt → backup + throw), and the TYPED policy read (ReadUserConfiguration →
+│   │                          # UserConfigReadResult classifying Missing/Valid/Corrupt/Unavailable). Security
+│   │                          # enforcement (Hidden Content, Spoiler Guard) uses the typed read so a corrupt or
+│   │                          # unavailable file retains last-known-good or fails CLOSED instead of failing open
 │   ├── PersistedJson.cs       # System.Text.Json options replicating the legacy on-disk tolerances
 │   └── configPage.html + config-page.js  # Admin page; simple fields bind via data-config-key
 ├── Services/                  # Seerr cache/scan/watchlist, Seerr parental-rating result filter,

--- a/docs/enhanced/enhanced-features.md
+++ b/docs/enhanced/enhanced-features.md
@@ -91,6 +91,18 @@ Access via:
     hid from Continue Watching stays hidden on Home, while ordinary library
     browsing is left unfiltered.
 
+!!! note "Hidden Content fails closed on a storage fault"
+
+    Your hidden list is stored **server-side, per-user**. If that file becomes
+    corrupt or is briefly unreadable (a disk or permission fault), the server
+    keeps enforcing your **last known-good** list; and if the fault happens
+    before any good copy was loaded (e.g. right after a server restart) the
+    affected rows are **hidden entirely** rather than risk your hidden items
+    reappearing. The fault is logged for the operator, and normal filtering
+    resumes automatically once the file is readable again (or the moment you
+    next change your hidden list). A storage fault can never silently *reveal*
+    what you hid.
+
 ### Remove from Continue Watching / Next Up
 
 A lightweight, **non-destructive** way to tidy the home screen. It adds a **Remove** option to an item's "⋯" action-sheet menu for items in the **Continue Watching** and **Next Up** rows, hiding the item from that row without touching your playback position or watched state.

--- a/docs/spoiler-guard/spoiler-guard-features.md
+++ b/docs/spoiler-guard/spoiler-guard-features.md
@@ -236,3 +236,7 @@ If you still see it, the affected client is fetching images from **old cached UR
 
 - Clear the client's image cache once (or force-stop and reopen the app) so it refetches fresh, marker-carrying URLs — the same one-time step described for Android TV above; or
 - configure the proxy to send `X-Forwarded-For` and add it to **Dashboard → Networking → Known proxies**, which restores real client IPs for the fallback path too (also nice for Jellyfin's own logs and security features). The **Per-user image identity tags** admin setting must remain enabled (it is by default) for marker-based identification.
+
+**Everything is suddenly blurred / metadata is stripped, even shows I never opted in.**
+
+Spoiler Guard **fails closed** when it cannot read your spoiler policy. If your `spoilerblur.json` file becomes corrupt or is temporarily unreadable (a disk or permission fault), the server keeps protecting your **last known-good** list; and if the fault happens before any good copy was ever loaded (for example right after a server restart), it protects **everything** rather than risk exposing a spoiler. The server logs the fault so an operator can see it. Protection returns to normal automatically once the file is readable again — the next successful read (or any change you make to your Spoiler Guard list) restores it. This is deliberate: a persistence fault can never silently *disable* your protection.


### PR DESCRIPTION
## What & why

Hidden Content and Spoiler Guard enforce per-user privacy through the **lenient**
per-user config read (`GetUserConfiguration<T>`), which collapses a missing,
empty, literal-null, malformed, or unreadable file into a default empty object.
When an *enabled* user's policy file is corrupt or temporarily unreadable, that
turns into a **fail-open**: protected entries pass through as if the user had
configured no protection, and the empty state is cached across requests. A green
run looks identical to a deliberately empty policy, so nothing can alert or fall
back safely.

This addresses the audit finding *BI-SEC-010 — Corrupt privacy policies fail open
for Hidden Content and Spoiler Guard*.

## Implementation

Own the distinction at the source (the per-user config store) rather than
patching each consumer:

- **Typed policy read.** New side-effect-free `ReadUserConfiguration<T>` returns a
  `UserConfigReadResult<T>` classifying **Missing / Valid / Corrupt / Unavailable**.
  Missing and Valid carry a usable value; the two fault states never do, so a
  caller cannot mistake a fault for an empty policy. A shared
  `TryDeserializeStripped<T>` keeps the lenient, strict, and typed reads
  classifying identically (no duplicated business logic). It reads the file
  directly and classifies by exception type — a `File.Exists` pre-check would
  quietly turn a permission/stat failure (or a directory in the file's place)
  into Missing. Only `FileNotFound`/`DirectoryNotFound` map to Missing; every
  other failure is Unavailable. The lenient path is unchanged for ordinary
  display settings, and the byte-for-byte on-disk format is untouched.

- **Last-known-good + fail-closed enforcement.** Both security consumers branch on
  the typed result. Their existing per-user in-memory caches double as
  last-known-good: on a fault they retain the last good policy (never overwriting
  it with an empty entry); on a cold-start fault with no last-known-good they
  serve a bounded, self-healing **fail-closed** sentinel. For Hidden Content that
  over-hides every item on the matched surfaces; for Spoiler Guard it over-blurs
  images and over-strips every response shape's admin-enabled sensitive fields
  (DTOs, `ImageInfo` paths, `PlaybackInfo` media-source/subtitle fields, and
  search-hint names/matched-terms — the fail-closed search path needs no library
  lookup, so a removed/stale item can't reopen the leak). A repair through any
  write path invalidates the cache and the next Valid read re-activates normally;
  an out-of-band repair self-heals within the cache TTL.

## Limitations

- The cold-start fail-closed posture is deliberately broad: while a policy file is
  corrupt/unavailable **and** no last-known-good exists (e.g. immediately after a
  server restart), the affected user sees empty matched surfaces / over-blurred
  art / over-stripped fields until the file is readable again. This is bounded
  (only when the feature is enabled and the read genuinely faults), operator-
  visible (logged), and self-healing. It is the intended "never silently disclose"
  trade-off.
- The strict RMW/write path and its `.corrupt-*` backup behavior are unchanged;
  only the enforcement read is side-effect-free.

## AI assistance

Implemented with AI assistance (Claude) under the repository's scope-locked
workflow: root-cause fix at the owning layer, regression-first tests, Codex-first
adversarial review (security + state discovery, three confirmation rounds that
each surfaced a distinct real fail-closed gap), and a final Sol Ultra gate.

## Tests

- **768 dotnet tests pass** (`verify.sh full`: build 0 warn/0 err, C# coverage
  38.7% ≥ 16% threshold, manifest OK, `mkdocs --strict` OK). Lint is advisory
  under repo policy (warning cap 2 over a pre-existing baseline; this diff adds no
  TypeScript).
- New regressions, all proven red against the pre-fix fail-open logic:
  - `UserConfigTypedReadTests` — the full Missing/Valid/valid-empty/Corrupt
    (empty, whitespace, literal-null, malformed, non-object)/Unavailable
    (exclusive-lock, invalid path, directory-in-place) matrix; lenient path
    unchanged.
  - `PrivacyPolicyFaultContractTests` — Hidden Content and Spoiler Guard: valid→
    corrupt retains last-known-good, cold-start fault fails closed, missing file
    still passes through, repair re-activates; pure `ResolvePolicyState` decisions.
  - `SpoilerFailClosedStripTests` — fail-closed stripping of `ImageInfo`,
    `PlaybackInfoResponse`, and search hints (including the null-lookup and
    replace-title-only/no-index cases the review surfaced).

## Live verification (Jellyfin 12, container jellyfin-12)

- Deployed the Release DLL (hash-verified by the deploy wrapper) and ran the full
  E2E suite for both `je_arradmin` and `je_arruser`.
- Result: **64 passed, 0 failed, 0 flaky** on the final run of the merged code.
  (Intermediate runs flaked once each on `auto-skip` / `late-load-resilience` via
  a transient client login-bounce — a known :8099 environment flake unrelated to
  this change — and were clean on retry.) The Hidden Content admin-page, spoiler,
  and non-admin specs pass. No unexpected plugin 4xx and no real console errors.
- Note: on :8099 the Hidden Content admin-page specs require the classic page
  layout; the shared instance runs the experimental React layout, so the
  native-tab pages were disabled in its plugin config for the run. This is an
  E2E-environment setting only — the plugin diff is unchanged.

## Review ledger

- Security discovery (Sol, high) → 2 P1 fail-open gaps (field-strip response
  shapes ignored the sentinel; `File.Exists` collapse). State discovery (Sol,
  medium) confirmed the store gap and validated the LKG/TTL/invalidation/repair
  design as coherent.
- Confirmation (Sol, medium): the store fix confirmed first pass; the field-strip
  fix took three targeted iterations, each closing a distinct reachable leak the
  reviewer found, then confirmed clean.
- Final (Sol Ultra) → 4 further findings, all fixed: (1) the tag-cache/tag-data
  endpoints were a Spoiler enforcement surface still reading the policy directly
  and failing open — routed through the owning resolver with fail-closed
  strip-all; (2) the fail-closed BaseItemDto episode Name lacked the
  numbered-or-placeholder fallback; (3) a read-stage `DirectoryNotFoundException`
  was misclassified as Missing; (4) the pending-only spoiler write didn't
  invalidate the enforcement cache. Followed by a medium final-confirmation over
  all four.


Closes #71
