### PR TITLE
fix: make secret scanning enforce (fail closed) and report, not silently pass

### DIFF
--- a/.github/secret-scan-baseline.json
+++ b/.github/secret-scan-baseline.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "Secret-scan allowlist for BI-SEC-020. Each entry accepts ONE finding by its one-way fingerprint (printed by the Security Scan job / scripts/security/secret-scan-report.js). A VERIFIED finding whose fingerprint is not listed here fails CI, so this file can never silently accept a new secret. NEVER put a raw secret here; fingerprints are SHA-256 hashes. Every entry MUST carry a reason.",
+  "allow": []
+}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -66,14 +66,18 @@ jobs:
       # Durable, actionable report surface. (This private repo has no GitHub
       # Advanced Security, so code-scanning SARIF ingest is unavailable — the
       # artifact + step summary are the report, and no job claims SARIF.)
+      #
+      # Upload ONLY the redacted report. The raw trufflehog-results.jsonl carries
+      # Raw/RawV2 match material for any real finding, so it is kept runner-local
+      # (input to the evaluator only) and never published — otherwise a real
+      # verified secret would be downloadable from the artifact for its whole
+      # retention window even after the commit is rewritten.
       - name: Upload secret-scan report
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: secret-scan-report
-          path: |
-            secret-scan-report.json
-            trufflehog-results.jsonl
+          path: secret-scan-report.json
           if-no-files-found: warn
           retention-days: 30
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -12,11 +12,16 @@ on:
 
 permissions:
   contents: read
-  security-events: write
-  actions: read
 
 jobs:
-  # Scan for secrets accidentally committed
+  # Scan the FULL git history for committed secrets. TruffleHog runs with --json
+  # (all findings, verified AND unverified) and WITHOUT --fail, so its exit code
+  # signals only whether the scanner RAN; the gate decision (fail on a verified,
+  # non-baselined finding or a scanner crash; report unverified findings) is owned
+  # by scripts/security/secret-scan-report.js so it is unit-tested and cannot be
+  # silently suppressed. Scanning full history on every event shape (push / PR /
+  # schedule) makes coverage uniform and removes the old, PR-broken
+  # `base: github.event.before` diff range.
   secret-scan:
     name: Secret Scanning
     runs-on: ubuntu-latest
@@ -31,14 +36,46 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: TruffleHog OSS
-        uses: trufflesecurity/trufflehog@30d5bb91af1a771378349dbbb0c82129392acf70
+      # Pinned to the same TruffleHog release the repo already trusts (v3.95.6).
+      - name: Run TruffleHog (full git history, JSON)
+        id: scan
+        run: |
+          set +e
+          docker run --rm -v "${{ github.workspace }}:/repo:ro" \
+            ghcr.io/trufflesecurity/trufflehog:v3.95.6 \
+            git file:///repo --json > trufflehog-results.jsonl 2> trufflehog.log
+          code=$?
+          set -e
+          echo "exit_code=${code}" >> "$GITHUB_OUTPUT"
+          echo "TruffleHog exit code: ${code}"
+          echo "----- scanner log (tail) -----"
+          tail -n 30 trufflehog.log || true
+
+      # Single decision owner: fails on a verified non-baselined finding or a
+      # scanner failure; reports unverified findings (non-blocking); writes the
+      # step summary + a machine-readable report. Never emits raw secret material.
+      - name: Evaluate findings and gate
+        run: |
+          node scripts/security/secret-scan-report.js \
+            --results trufflehog-results.jsonl \
+            --scanner-exit "${{ steps.scan.outputs.exit_code }}" \
+            --baseline .github/secret-scan-baseline.json \
+            --summary "$GITHUB_STEP_SUMMARY" \
+            --report secret-scan-report.json
+
+      # Durable, actionable report surface. (This private repo has no GitHub
+      # Advanced Security, so code-scanning SARIF ingest is unavailable — the
+      # artifact + step summary are the report, and no job claims SARIF.)
+      - name: Upload secret-scan report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          path: ./
-          base: ${{ github.event.before }}
-          head: ${{ github.sha }}
-          extra_args: --debug --only-verified
-        continue-on-error: true
+          name: secret-scan-report
+          path: |
+            secret-scan-report.json
+            trufflehog-results.jsonl
+          if-no-files-found: warn
+          retention-days: 30
 
   # Scan .NET dependencies for known vulnerabilities
   dotnet-security:
@@ -70,24 +107,3 @@ jobs:
           else
             echo "No vulnerable packages found."
           fi
-
-  # SARIF upload for GitHub Security tab
-  upload-sarif:
-    name: Upload SARIF Results
-    runs-on: ubuntu-latest
-    needs: [secret-scan, dotnet-security]
-    if: always()
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-
-      - name: Create summary
-        run: |
-          echo "## Security Scan Summary" >> $GITHUB_STEP_SUMMARY
-          echo "All security scans completed. Check individual job results for details." >> $GITHUB_STEP_SUMMARY
-# Registered for Jellyfin Elevate CI (no functional change).

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -36,13 +36,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Pinned to the same TruffleHog release the repo already trusts (v3.95.6).
+      # Pinned by IMMUTABLE DIGEST (the same v3.95.6 release the repo trusts via the
+      # TruffleHog action) — this image is the gate's root of trust, so it must not
+      # ride a mutable tag. NOTE: no verbose/--debug flag is passed, so TruffleHog's
+      # stderr (echoed below) carries only progress logs, never raw match material;
+      # keep it that way. Findings go to stdout as JSONL; --no --fail so the exit
+      # code signals only whether the scanner RAN (crash) vs found things (in JSON).
       - name: Run TruffleHog (full git history, JSON)
         id: scan
         run: |
           set +e
           docker run --rm -v "${{ github.workspace }}:/repo:ro" \
-            ghcr.io/trufflesecurity/trufflehog:v3.95.6 \
+            ghcr.io/trufflesecurity/trufflehog@sha256:96f8429082cb2d4ae73b1096dcdb2f5aa139881d97042b0c5e5fa226a392e056 \
             git file:///repo --json > trufflehog-results.jsonl 2> trufflehog.log
           code=$?
           set -e

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -42,47 +42,53 @@ jobs:
       # stderr (echoed below) carries only progress logs, never raw match material;
       # keep it that way. Findings go to stdout as JSONL; no `--fail` so the exit
       # code signals only whether the scanner RAN (crash) vs found things (in JSON).
+      # Write scanner output + report UNDER $RUNNER_TEMP, never into the PR-
+      # controlled checkout: a malicious PR could otherwise commit
+      # `results.jsonl -> /dev/null` to silently discard findings (or `-> /dev/stderr`
+      # to leak Raw into logs). The evaluator additionally rejects a non-regular /
+      # symlinked / missing results file, so this is defense-in-depth.
       - name: Run TruffleHog (full git history, JSON)
         id: scan
         run: |
           set +e
+          out="$RUNNER_TEMP/secret-scan"
+          mkdir -p "$out"
           docker run --rm -v "${{ github.workspace }}:/repo:ro" \
             ghcr.io/trufflesecurity/trufflehog@sha256:96f8429082cb2d4ae73b1096dcdb2f5aa139881d97042b0c5e5fa226a392e056 \
-            git file:///repo --json > trufflehog-results.jsonl 2> trufflehog.log
+            git file:///repo --json > "$out/results.jsonl" 2> "$out/scanner.log"
           code=$?
           set -e
           echo "exit_code=${code}" >> "$GITHUB_OUTPUT"
           echo "TruffleHog exit code: ${code}"
           echo "----- scanner log (tail) -----"
-          tail -n 30 trufflehog.log || true
+          tail -n 30 "$out/scanner.log" || true
 
       # Single decision owner: fails on a verified non-baselined finding or a
-      # scanner failure; reports unverified findings (non-blocking); writes the
-      # step summary + a machine-readable report. Never emits raw secret material.
+      # scanner/output failure; reports unverified findings (non-blocking); writes
+      # the step summary + a machine-readable report. Never emits raw secret material.
       - name: Evaluate findings and gate
         run: |
           node scripts/security/secret-scan-report.js \
-            --results trufflehog-results.jsonl \
+            --results "$RUNNER_TEMP/secret-scan/results.jsonl" \
             --scanner-exit "${{ steps.scan.outputs.exit_code }}" \
             --baseline .github/secret-scan-baseline.json \
             --summary "$GITHUB_STEP_SUMMARY" \
-            --report secret-scan-report.json
+            --report "$RUNNER_TEMP/secret-scan/report.json"
 
       # Durable, actionable report surface. (This private repo has no GitHub
       # Advanced Security, so code-scanning SARIF ingest is unavailable — the
       # artifact + step summary are the report, and no job claims SARIF.)
       #
-      # Upload ONLY the redacted report. The raw trufflehog-results.jsonl carries
-      # Raw/RawV2 match material for any real finding, so it is kept runner-local
-      # (input to the evaluator only) and never published — otherwise a real
-      # verified secret would be downloadable from the artifact for its whole
-      # retention window even after the commit is rewritten.
+      # Upload ONLY the redacted report from $RUNNER_TEMP. The raw results.jsonl
+      # carries Raw/RawV2 match material for any real finding, so it is never
+      # published — otherwise a real verified secret would be downloadable from the
+      # artifact for its whole retention window even after the commit is rewritten.
       - name: Upload secret-scan report
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: secret-scan-report
-          path: secret-scan-report.json
+          path: ${{ runner.temp }}/secret-scan/report.json
           if-no-files-found: warn
           retention-days: 30
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -40,7 +40,7 @@ jobs:
       # TruffleHog action) — this image is the gate's root of trust, so it must not
       # ride a mutable tag. NOTE: no verbose/--debug flag is passed, so TruffleHog's
       # stderr (echoed below) carries only progress logs, never raw match material;
-      # keep it that way. Findings go to stdout as JSONL; --no --fail so the exit
+      # keep it that way. Findings go to stdout as JSONL; no `--fail` so the exit
       # code signals only whether the scanner RAN (crash) vs found things (in JSON).
       - name: Run TruffleHog (full git history, JSON)
         id: scan

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -76,6 +76,25 @@ We take the security of Jellyfin Elevate seriously. If you believe you have foun
 - User-provided URLs are validated before use
 - XSS protection is implemented for user-generated content
 
+## Automated Security Scanning
+
+Every push, pull request, and a daily schedule run the **Security Scan** workflow,
+which enforces (a green run is a real gate, not a formality):
+
+- **Secret scanning** — TruffleHog scans the full git history. A **verified**
+  secret finding (or a scanner failure) **fails CI**; unverified findings are
+  reported for review without blocking. Accepted findings are allowlisted by a
+  one-way fingerprint in `.github/secret-scan-baseline.json`, which cannot
+  silently accept a *new* secret. Results are published as the run's step summary
+  and a downloadable `secret-scan-report` artifact (no raw secret material is ever
+  written). This repository is private without GitHub Advanced Security, so
+  findings are not ingested into the code-scanning "Security" tab.
+- **.NET dependency audit** — `dotnet list package --vulnerable` fails CI on any
+  known-vulnerable direct or transitive package.
+
+CodeQL, Scorecard, and Dependency Review are **not** run (they require GitHub
+Advanced Security or a public repository).
+
 ## Contact
 
 For security concerns that don't constitute a vulnerability, you can:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -78,8 +78,11 @@ We take the security of Jellyfin Elevate seriously. If you believe you have foun
 
 ## Automated Security Scanning
 
-Every push, pull request, and a daily schedule run the **Security Scan** workflow,
-which enforces (a green run is a real gate, not a formality):
+The **Security Scan** workflow runs on pushes to `main`/`master`, pull requests
+targeting `main`/`master`, a daily schedule, and manual dispatch. (Version-tag
+pushes are not scanned directly; release tags are expected to point at a `main`
+commit that was already scanned on its push.) It enforces — a green run is a real
+gate, not a formality:
 
 - **Secret scanning** — TruffleHog scans the full git history. A **verified**
   secret finding (or a scanner failure) **fails CI**; unverified findings are

--- a/scripts/security/secret-scan-report.js
+++ b/scripts/security/secret-scan-report.js
@@ -73,13 +73,15 @@ function gitMeta(finding) {
     return { file: typeof git.file === 'string' ? git.file : '', line: Number(git.line) || 0 };
 }
 
-/** Stable, secret-free fingerprint: DetectorName + file + SHA-256(raw match).
- * The raw match is hashed, never stored. */
+/** Stable, secret-free fingerprint: DetectorName + file + full SHA-256(raw match).
+ * The raw match is hashed, never stored. The FULL 256-bit digest is used (not a
+ * truncation) so the baseline's per-finding key has no collision margin that a
+ * new secret could slip through. */
 function fingerprint(finding) {
     const detector = (finding && finding.DetectorName) || 'unknown';
     const { file } = gitMeta(finding);
     const raw = (finding && (finding.Raw || finding.RawV2 || finding.Redacted)) || '';
-    const hash = crypto.createHash('sha256').update(String(raw)).digest('hex').slice(0, 16);
+    const hash = crypto.createHash('sha256').update(String(raw)).digest('hex');
     return `${detector}:${file}:${hash}`;
 }
 
@@ -97,7 +99,13 @@ function loadBaseline(baselineObj) {
     }
     const set = new Set();
     for (const entry of baselineObj.allow) {
-        if (entry && typeof entry.fingerprint === 'string' && entry.fingerprint.trim() !== '') {
+        // An allowlist entry is honored ONLY when it has both a non-empty
+        // fingerprint AND a non-empty reason. A reason-less entry is ignored (so
+        // that finding is NOT allowlisted and still fails) — the documented
+        // "every entry must carry a reason" governance rule, enforced.
+        if (entry
+            && typeof entry.fingerprint === 'string' && entry.fingerprint.trim() !== ''
+            && typeof entry.reason === 'string' && entry.reason.trim() !== '') {
             set.add(entry.fingerprint.trim());
         }
     }

--- a/scripts/security/secret-scan-report.js
+++ b/scripts/security/secret-scan-report.js
@@ -102,6 +102,21 @@ function isVerified(finding) {
     return finding && finding.Verified === true;
 }
 
+/** Redact any raw-secret occurrence from a string that will be DISPLAYED (the Git
+ * path is scanner-controlled and can itself contain the secret, e.g. a file named
+ * `leak-<token>.txt`). Only reasonably-long secret values are substituted so
+ * ordinary path components aren't mangled; the original value is used solely
+ * inside the one-way fingerprint, never in the report/summary/artifact. */
+function redactSecrets(text, secrets) {
+    let out = String(text == null ? '' : text);
+    for (const s of secrets) {
+        if (typeof s === 'string' && s.length >= 6) {
+            out = out.split(s).join('<redacted-secret>');
+        }
+    }
+    return out;
+}
+
 /** Baseline is { allow: [{ fingerprint, reason, ... }] }. Returns a Set of
  * allowlisted fingerprints. A malformed baseline yields an empty set AND is
  * flagged so the caller can fail closed rather than trust an unreadable
@@ -144,7 +159,12 @@ function evaluate({ findings, parseErrors, scannerExitCode, baseline, baselineMa
             existing.verified = existing.verified || verified;
             existing.hasRawIdentity = existing.hasRawIdentity || rawId;
         } else {
-            byFp.set(fp, { detector: f.DetectorName || 'unknown', file, line, verified, fingerprint: fp, hasRawIdentity: rawId });
+            // Redact any secret material out of the DISPLAYED path before it is
+            // stored on the item (which is serialized into the report/summary/
+            // artifact). The unredacted path is only ever fed to fingerprint().
+            const rawSecrets = [f && f.Raw, f && f.RawV2];
+            const safeFile = redactSecrets(file, rawSecrets);
+            byFp.set(fp, { detector: redactSecrets(f.DetectorName || 'unknown', rawSecrets), file: safeFile, line, verified, fingerprint: fp, hasRawIdentity: rawId });
         }
     }
 

--- a/scripts/security/secret-scan-report.js
+++ b/scripts/security/secret-scan-report.js
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+
+/**
+ * Secret-scan gate + reporter (BI-SEC-020).
+ *
+ * The Security Scan workflow runs the TruffleHog CLI over the full git history
+ * with `--json` (all findings, verified AND unverified) and NO `--fail`, so its
+ * exit code reflects only whether the scanner RAN — not whether it found
+ * anything. This script is the single decision owner: it reads that JSONL, the
+ * scanner's exit code, and a committed baseline/allowlist, then decides pass/fail
+ * and writes a truthful, durable report (a GitHub step summary + a machine-
+ * readable report JSON, both uploaded as an artifact — this private repo has no
+ * GitHub Advanced Security, so a code-scanning SARIF surface is unavailable).
+ *
+ * Policy (fail CLOSED — any ambiguity blocks):
+ *   - scanner exited non-zero (crash / tool failure)            -> FAIL
+ *   - the results file is unparseable (malformed JSON lines)    -> FAIL
+ *   - any non-baselined VERIFIED finding                        -> FAIL
+ *   - non-baselined UNVERIFIED findings                         -> report, NON-blocking
+ *   - clean (no non-baselined verified findings, scanner ok)    -> PASS
+ *
+ * A new verified secret whose fingerprint is not in the baseline still fails, so
+ * the baseline can never silently accept a NEW secret.
+ *
+ * Never persists a raw secret: a finding's fingerprint is a one-way SHA-256 of
+ * the raw match (with detector + path for readability); the report shows only the
+ * detector, path/line, verified flag, and fingerprint — no secret material.
+ *
+ * Run via `npm run test:scripts` (unit) or as the workflow step:
+ *   node scripts/security/secret-scan-report.js \
+ *     --results trufflehog-results.jsonl --scanner-exit "$CODE" \
+ *     --baseline .github/secret-scan-baseline.json \
+ *     --summary "$GITHUB_STEP_SUMMARY" --report secret-scan-report.json
+ */
+
+'use strict';
+
+const fs = require('fs');
+const crypto = require('crypto');
+
+/** Parse TruffleHog JSONL. Blank lines are skipped; a non-blank line that is not
+ * valid JSON is a parse error (the caller fails closed). Non-finding objects
+ * (TruffleHog also emits log/info lines in some modes) are ignored: a finding is
+ * an object carrying a DetectorName. */
+function parseResults(text) {
+    const findings = [];
+    let parseErrors = 0;
+    const lines = String(text == null ? '' : text).split(/\r?\n/);
+    for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed === '') continue;
+        let obj;
+        try {
+            obj = JSON.parse(trimmed);
+        } catch {
+            parseErrors++;
+            continue;
+        }
+        if (obj && typeof obj === 'object' && typeof obj.DetectorName === 'string') {
+            findings.push(obj);
+        }
+    }
+    return { findings, parseErrors };
+}
+
+/** Git source metadata (file/line) for a finding, tolerating shape drift. */
+function gitMeta(finding) {
+    const git = finding
+        && finding.SourceMetadata
+        && finding.SourceMetadata.Data
+        && finding.SourceMetadata.Data.Git;
+    if (!git || typeof git !== 'object') return { file: '', line: 0 };
+    return { file: typeof git.file === 'string' ? git.file : '', line: Number(git.line) || 0 };
+}
+
+/** Stable, secret-free fingerprint: DetectorName + file + SHA-256(raw match).
+ * The raw match is hashed, never stored. */
+function fingerprint(finding) {
+    const detector = (finding && finding.DetectorName) || 'unknown';
+    const { file } = gitMeta(finding);
+    const raw = (finding && (finding.Raw || finding.RawV2 || finding.Redacted)) || '';
+    const hash = crypto.createHash('sha256').update(String(raw)).digest('hex').slice(0, 16);
+    return `${detector}:${file}:${hash}`;
+}
+
+function isVerified(finding) {
+    return finding && finding.Verified === true;
+}
+
+/** Baseline is { allow: [{ fingerprint, reason, ... }] }. Returns a Set of
+ * allowlisted fingerprints. A malformed baseline yields an empty set AND is
+ * flagged so the caller can fail closed rather than trust an unreadable
+ * allowlist. */
+function loadBaseline(baselineObj) {
+    if (!baselineObj || typeof baselineObj !== 'object' || !Array.isArray(baselineObj.allow)) {
+        return { set: new Set(), malformed: baselineObj != null };
+    }
+    const set = new Set();
+    for (const entry of baselineObj.allow) {
+        if (entry && typeof entry.fingerprint === 'string' && entry.fingerprint.trim() !== '') {
+            set.add(entry.fingerprint.trim());
+        }
+    }
+    return { set, malformed: false };
+}
+
+/**
+ * Core decision. Returns a structured result; the caller renders + sets exit code.
+ */
+function evaluate({ findings, parseErrors, scannerExitCode, baseline, baselineMalformed }) {
+    const seen = new Set();
+    const verifiedNew = [];
+    const unverifiedNew = [];
+    const baselinedHits = [];
+
+    for (const f of findings) {
+        const fp = fingerprint(f);
+        if (seen.has(fp)) continue; // de-dupe identical matches across commits
+        seen.add(fp);
+        const { file, line } = gitMeta(f);
+        const item = { detector: f.DetectorName || 'unknown', file, line, verified: isVerified(f), fingerprint: fp };
+        if (baseline.has(fp)) {
+            baselinedHits.push(item);
+        } else if (item.verified) {
+            verifiedNew.push(item);
+        } else {
+            unverifiedNew.push(item);
+        }
+    }
+
+    const reasons = [];
+    if (scannerExitCode !== 0) reasons.push(`scanner exited with code ${scannerExitCode} (tool failure)`);
+    if (parseErrors > 0) reasons.push(`${parseErrors} unparseable scanner output line(s)`);
+    if (baselineMalformed) reasons.push('baseline allowlist is malformed');
+    if (verifiedNew.length > 0) reasons.push(`${verifiedNew.length} verified secret finding(s) not in the baseline`);
+
+    return {
+        shouldFail: reasons.length > 0,
+        reasons,
+        verifiedNew,
+        unverifiedNew,
+        baselinedHits,
+        scannerExitCode,
+        parseErrors,
+    };
+}
+
+function renderSummary(result) {
+    const L = [];
+    L.push('## 🔐 Secret scan');
+    L.push('');
+    if (result.shouldFail) {
+        L.push('**Result: ❌ FAILED**');
+        L.push('');
+        for (const r of result.reasons) L.push(`- ${r}`);
+    } else {
+        L.push('**Result: ✅ passed**');
+    }
+    L.push('');
+    L.push(`- Verified (new): **${result.verifiedNew.length}**`);
+    L.push(`- Unverified (new, non-blocking): **${result.unverifiedNew.length}**`);
+    L.push(`- Baselined (allowlisted): **${result.baselinedHits.length}**`);
+    const list = (title, items) => {
+        if (items.length === 0) return;
+        L.push('');
+        L.push(`### ${title}`);
+        for (const i of items) {
+            L.push(`- \`${i.detector}\` at \`${i.file || '(no path)'}\`${i.line ? `:${i.line}` : ''} — fingerprint \`${i.fingerprint}\``);
+        }
+    };
+    list('Verified secrets (blocking)', result.verifiedNew);
+    list('Unverified findings (review; non-blocking)', result.unverifiedNew);
+    L.push('');
+    L.push('_Fingerprints are one-way hashes; no secret material is shown. To accept a finding, add its fingerprint (with a reason) to `.github/secret-scan-baseline.json`._');
+    return L.join('\n') + '\n';
+}
+
+function buildReport(result) {
+    return {
+        result: result.shouldFail ? 'failed' : 'passed',
+        reasons: result.reasons,
+        scannerExitCode: result.scannerExitCode,
+        parseErrors: result.parseErrors,
+        counts: {
+            verifiedNew: result.verifiedNew.length,
+            unverifiedNew: result.unverifiedNew.length,
+            baselined: result.baselinedHits.length,
+        },
+        // Redacted-by-construction: fingerprints only, never raw/redacted secrets.
+        verifiedNew: result.verifiedNew,
+        unverifiedNew: result.unverifiedNew,
+        baselinedHits: result.baselinedHits,
+    };
+}
+
+function parseArgs(argv) {
+    const args = {};
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i];
+        if (a.startsWith('--')) args[a.slice(2)] = argv[++i];
+    }
+    return args;
+}
+
+function readFileSafe(path) {
+    try {
+        return { text: fs.readFileSync(path, 'utf8'), missing: false };
+    } catch {
+        return { text: '', missing: true };
+    }
+}
+
+function main(argv) {
+    const args = parseArgs(argv);
+    const scannerExitCode = Number.parseInt(args['scanner-exit'], 10);
+    // A non-numeric scanner exit is itself a fault (the workflow always passes it).
+    const exitCode = Number.isFinite(scannerExitCode) ? scannerExitCode : 1;
+
+    const resultsRead = readFileSafe(args.results);
+    // A missing results file with a clean scanner exit means "no findings emitted";
+    // with a non-zero exit it is a scanner failure (handled by exitCode below).
+    const { findings, parseErrors } = parseResults(resultsRead.text);
+
+    let baselineObj = { allow: [] };
+    let baselineReadFailed = false;
+    if (args.baseline) {
+        const b = readFileSafe(args.baseline);
+        if (b.missing) {
+            baselineObj = { allow: [] }; // no baseline file == empty allowlist (still fails on new verified)
+        } else {
+            try {
+                baselineObj = JSON.parse(b.text);
+            } catch {
+                baselineReadFailed = true; // unreadable baseline -> fail closed
+            }
+        }
+    }
+    const { set: baseline, malformed } = loadBaseline(baselineObj);
+
+    const result = evaluate({
+        findings,
+        parseErrors,
+        scannerExitCode: exitCode,
+        baseline,
+        baselineMalformed: malformed || baselineReadFailed,
+    });
+
+    const summary = renderSummary(result);
+    const report = buildReport(result);
+
+    if (args.summary) {
+        try { fs.appendFileSync(args.summary, summary); } catch { /* summary is best-effort */ }
+    }
+    if (args.report) {
+        try { fs.writeFileSync(args.report, JSON.stringify(report, null, 2) + '\n'); } catch { /* best-effort */ }
+    }
+    // Always echo the summary so the raw log is self-contained.
+    process.stdout.write(summary);
+
+    return result.shouldFail ? 1 : 0;
+}
+
+module.exports = {
+    parseResults,
+    gitMeta,
+    fingerprint,
+    isVerified,
+    loadBaseline,
+    evaluate,
+    renderSummary,
+    buildReport,
+    main,
+};
+
+if (require.main === module) {
+    process.exit(main(process.argv.slice(2)));
+}

--- a/scripts/security/secret-scan-report.js
+++ b/scripts/security/secret-scan-report.js
@@ -73,16 +73,28 @@ function gitMeta(finding) {
     return { file: typeof git.file === 'string' ? git.file : '', line: Number(git.line) || 0 };
 }
 
-/** Stable, secret-free fingerprint: DetectorName + file + full SHA-256(raw match).
- * The raw match is hashed, never stored. The FULL 256-bit digest is used (not a
- * truncation) so the baseline's per-finding key has no collision margin that a
- * new secret could slip through. */
+/** Whether a finding carries usable raw identity (at least one of Raw/RawV2).
+ * A verified finding without it cannot be safely fingerprinted for allowlisting. */
+function hasRawIdentity(finding) {
+    return !!(finding && ((typeof finding.Raw === 'string' && finding.Raw !== '')
+        || (typeof finding.RawV2 === 'string' && finding.RawV2 !== '')));
+}
+
+/** Fully-opaque, secret-free fingerprint: a single SHA-256 over a length-delimited
+ * canonical tuple of (DetectorName, file, Raw, RawV2). Both raw fields are folded
+ * in (composite detectors put distinct credential parts in each), and the whole
+ * digest is used (no truncation). Because the file path is folded INTO the hash
+ * rather than concatenated in the clear, a filename that itself contains secret
+ * material is not exposed by the fingerprint. */
 function fingerprint(finding) {
     const detector = (finding && finding.DetectorName) || 'unknown';
     const { file } = gitMeta(finding);
-    const raw = (finding && (finding.Raw || finding.RawV2 || finding.Redacted)) || '';
-    const hash = crypto.createHash('sha256').update(String(raw)).digest('hex');
-    return `${detector}:${file}:${hash}`;
+    const raw = (finding && typeof finding.Raw === 'string') ? finding.Raw : '';
+    const rawV2 = (finding && typeof finding.RawV2 === 'string') ? finding.RawV2 : '';
+    const canonical = [detector, file, raw, rawV2]
+        .map((s) => `${Buffer.byteLength(String(s), 'utf8')}:${s}`)
+        .join('|');
+    return crypto.createHash('sha256').update(canonical, 'utf8').digest('hex');
 }
 
 function isVerified(finding) {
@@ -116,18 +128,34 @@ function loadBaseline(baselineObj) {
  * Core decision. Returns a structured result; the caller renders + sets exit code.
  */
 function evaluate({ findings, parseErrors, scannerExitCode, baseline, baselineMalformed }) {
-    const seen = new Set();
+    // Aggregate by fingerprint BEFORE classifying, and make verification MONOTONIC:
+    // if any record for a fingerprint is verified, the aggregate is verified. This
+    // prevents an unverified-first / verified-second ordering from dropping the
+    // verified occurrence.
+    const byFp = new Map();
+    for (const f of findings) {
+        const fp = fingerprint(f);
+        const { file, line } = gitMeta(f);
+        const verified = isVerified(f);
+        const rawId = hasRawIdentity(f);
+        const existing = byFp.get(fp);
+        if (existing) {
+            existing.verified = existing.verified || verified;
+            existing.hasRawIdentity = existing.hasRawIdentity || rawId;
+        } else {
+            byFp.set(fp, { detector: f.DetectorName || 'unknown', file, line, verified, fingerprint: fp, hasRawIdentity: rawId });
+        }
+    }
+
     const verifiedNew = [];
     const unverifiedNew = [];
     const baselinedHits = [];
-
-    for (const f of findings) {
-        const fp = fingerprint(f);
-        if (seen.has(fp)) continue; // de-dupe identical matches across commits
-        seen.add(fp);
-        const { file, line } = gitMeta(f);
-        const item = { detector: f.DetectorName || 'unknown', file, line, verified: isVerified(f), fingerprint: fp };
-        if (baseline.has(fp)) {
+    for (const item of byFp.values()) {
+        // A verified finding without raw identity (no Raw/RawV2) cannot be safely
+        // allowlisted by content, so it is never treated as baselined — it always
+        // blocks.
+        const baselinable = item.hasRawIdentity;
+        if (baselinable && baseline.has(item.fingerprint)) {
             baselinedHits.push(item);
         } else if (item.verified) {
             verifiedNew.push(item);
@@ -224,9 +252,22 @@ function main(argv) {
     // A non-numeric scanner exit is itself a fault (the workflow always passes it).
     const exitCode = Number.isFinite(scannerExitCode) ? scannerExitCode : 1;
 
-    const resultsRead = readFileSafe(args.results);
-    // A missing results file with a clean scanner exit means "no findings emitted";
-    // with a non-zero exit it is a scanner failure (handled by exitCode below).
+    // The results path MUST be a real, regular file the workflow just wrote — not a
+    // symlink or special file. A malicious PR could commit e.g.
+    // `results.jsonl -> /dev/null` inside the checkout to silently discard the
+    // scanner's findings (or `-> /dev/stderr` to leak Raw into logs). The workflow
+    // now writes under $RUNNER_TEMP (outside the PR checkout), and this is
+    // defense-in-depth: anything but a regular file — or a missing file — fails
+    // closed, since with the redirect a regular file is always created.
+    let resultsFault = null;
+    try {
+        const st = fs.lstatSync(args.results);
+        if (st.isSymbolicLink()) resultsFault = 'scanner results path is a symlink (rejected)';
+        else if (!st.isFile()) resultsFault = 'scanner results path is not a regular file';
+    } catch {
+        resultsFault = 'scanner results file is missing';
+    }
+    const resultsRead = resultsFault ? { text: '', missing: true } : readFileSafe(args.results);
     const { findings, parseErrors } = parseResults(resultsRead.text);
 
     let baselineObj = { allow: [] };
@@ -252,6 +293,12 @@ function main(argv) {
         baseline,
         baselineMalformed: malformed || baselineReadFailed,
     });
+
+    // A tampered/absent results file fails closed regardless of the finding set.
+    if (resultsFault) {
+        result.reasons.unshift(resultsFault);
+        result.shouldFail = true;
+    }
 
     const summary = renderSummary(result);
     const report = buildReport(result);

--- a/scripts/security/secret-scan-report.js
+++ b/scripts/security/secret-scan-report.js
@@ -110,7 +110,11 @@ function isVerified(finding) {
 function redactSecrets(text, secrets) {
     let out = String(text == null ? '' : text);
     for (const s of secrets) {
-        if (typeof s === 'string' && s.length >= 6) {
+        // Redact ANY non-empty raw value (no length threshold — a short verified
+        // secret must not leak either); over-redaction of a path is fail-closed.
+        // The empty-string guard is required: splitting on '' would insert the
+        // marker between every character.
+        if (typeof s === 'string' && s.length >= 1) {
             out = out.split(s).join('<redacted-secret>');
         }
     }

--- a/scripts/security/secret-scan-report.js
+++ b/scripts/security/secret-scan-report.js
@@ -26,11 +26,12 @@
  * the raw match (with detector + path for readability); the report shows only the
  * detector, path/line, verified flag, and fingerprint — no secret material.
  *
- * Run via `npm run test:scripts` (unit) or as the workflow step:
+ * Run via `npm run test:scripts` (unit) or as the workflow step (results/report
+ * live under $RUNNER_TEMP, outside the PR-controlled checkout):
  *   node scripts/security/secret-scan-report.js \
- *     --results trufflehog-results.jsonl --scanner-exit "$CODE" \
+ *     --results "$RUNNER_TEMP/secret-scan/results.jsonl" --scanner-exit "$CODE" \
  *     --baseline .github/secret-scan-baseline.json \
- *     --summary "$GITHUB_STEP_SUMMARY" --report secret-scan-report.json
+ *     --summary "$GITHUB_STEP_SUMMARY" --report "$RUNNER_TEMP/secret-scan/report.json"
  */
 
 'use strict';

--- a/scripts/security/secret-scan-report.test.js
+++ b/scripts/security/secret-scan-report.test.js
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+
+/**
+ * Unit tests for the secret-scan gate (BI-SEC-020). node:test + node:assert,
+ * matching the scripts' CommonJS convention. Run with `npm run test:scripts`.
+ *
+ * Every acceptance case from the issue is exercised as a fast local test so the
+ * gate's decision logic is pinned without a live TruffleHog run:
+ *   clean, verified-finding, unverified-only, baselined, NEW-verified-not-covered,
+ *   scanner-failure, malformed-output, non-numeric scanner exit; plus the
+ *   never-leak-a-raw-secret invariant.
+ */
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const S = require('./secret-scan-report.js');
+
+const RAW_SECRET = 'AKIAIOSFODNN7EXAMPLEXYZ';
+
+function findingLine({ detector = 'AWS', file = 'src/config.cs', line = 12, verified = false, raw = RAW_SECRET } = {}) {
+    return JSON.stringify({
+        DetectorName: detector,
+        Verified: verified,
+        Raw: raw,
+        RawV2: raw,
+        Redacted: raw.slice(0, 4) + '...REDACTED',
+        SourceMetadata: { Data: { Git: { file, line, commit: 'deadbeef' } } },
+    });
+}
+
+function evalJsonl(jsonl, { scannerExitCode = 0, baselineFps = [] } = {}) {
+    const { findings, parseErrors } = S.parseResults(jsonl);
+    const { set } = S.loadBaseline({ allow: baselineFps.map((fp) => ({ fingerprint: fp, reason: 't' })) });
+    return S.evaluate({ findings, parseErrors, scannerExitCode, baseline: set, baselineMalformed: false });
+}
+
+test('clean scan (no findings, scanner ok) passes', () => {
+    const r = evalJsonl('', { scannerExitCode: 0 });
+    assert.strictEqual(r.shouldFail, false);
+    assert.strictEqual(r.verifiedNew.length, 0);
+});
+
+test('a verified, non-baselined finding fails', () => {
+    const r = evalJsonl(findingLine({ verified: true }), { scannerExitCode: 0 });
+    assert.strictEqual(r.shouldFail, true);
+    assert.strictEqual(r.verifiedNew.length, 1);
+    assert.match(r.reasons.join(' '), /verified secret/i);
+});
+
+test('unverified-only findings are reported but NON-blocking', () => {
+    const r = evalJsonl(findingLine({ verified: false }), { scannerExitCode: 0 });
+    assert.strictEqual(r.shouldFail, false);
+    assert.strictEqual(r.unverifiedNew.length, 1);
+});
+
+test('a verified finding whose fingerprint is baselined passes', () => {
+    const fp = S.fingerprint(JSON.parse(findingLine({ verified: true })));
+    const r = evalJsonl(findingLine({ verified: true }), { scannerExitCode: 0, baselineFps: [fp] });
+    assert.strictEqual(r.shouldFail, false);
+    assert.strictEqual(r.baselinedHits.length, 1);
+    assert.strictEqual(r.verifiedNew.length, 0);
+});
+
+test('a NEW verified finding is NOT accepted by a non-empty baseline (no silent accept)', () => {
+    // Baseline covers a DIFFERENT secret; a brand-new verified secret must still fail.
+    const otherFp = S.fingerprint(JSON.parse(findingLine({ verified: true, raw: 'OLDACCEPTEDSECRET1' })));
+    const r = evalJsonl(findingLine({ verified: true, raw: 'BRANDNEWSECRET2' }), { scannerExitCode: 0, baselineFps: [otherFp] });
+    assert.strictEqual(r.shouldFail, true);
+    assert.strictEqual(r.verifiedNew.length, 1);
+});
+
+test('a scanner crash (non-zero exit) fails visibly even with no findings', () => {
+    const r = evalJsonl('', { scannerExitCode: 2 });
+    assert.strictEqual(r.shouldFail, true);
+    assert.match(r.reasons.join(' '), /tool failure|exited/i);
+});
+
+test('malformed scanner output fails closed', () => {
+    const r = evalJsonl('{ not valid json\n' + findingLine({ verified: false }), { scannerExitCode: 0 });
+    assert.strictEqual(r.shouldFail, true);
+    assert.match(r.reasons.join(' '), /unparseable/i);
+});
+
+test('a malformed baseline fails closed', () => {
+    const { set, malformed } = S.loadBaseline({ allow: 'not-an-array' });
+    const r = S.evaluate({ findings: [], parseErrors: 0, scannerExitCode: 0, baseline: set, baselineMalformed: malformed });
+    assert.strictEqual(r.shouldFail, true);
+});
+
+test('fingerprint is stable and never contains the raw secret', () => {
+    const f = JSON.parse(findingLine({ verified: true }));
+    const fp1 = S.fingerprint(f);
+    const fp2 = S.fingerprint(JSON.parse(findingLine({ verified: true })));
+    assert.strictEqual(fp1, fp2);
+    assert.ok(!fp1.includes(RAW_SECRET), 'fingerprint must not embed the raw secret');
+});
+
+test('report + summary never contain the raw secret', () => {
+    const r = evalJsonl(findingLine({ verified: true }), { scannerExitCode: 0 });
+    const summary = S.renderSummary(r);
+    const report = JSON.stringify(S.buildReport(r));
+    assert.ok(!summary.includes(RAW_SECRET), 'summary leaks the raw secret');
+    assert.ok(!report.includes(RAW_SECRET), 'report leaks the raw secret');
+});
+
+// ── main() integration via temp files: exit code + written report ────────────
+
+function withTmp(fn) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'je-secretscan-'));
+    try { return fn(dir); } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+}
+
+test('main() exits 1 on a verified finding and writes a leak-free report', () => {
+    withTmp((dir) => {
+        const results = path.join(dir, 'r.jsonl');
+        const report = path.join(dir, 'report.json');
+        const summary = path.join(dir, 'summary.md');
+        fs.writeFileSync(results, findingLine({ verified: true }) + '\n');
+        fs.writeFileSync(path.join(dir, 'baseline.json'), JSON.stringify({ allow: [] }));
+        const code = S.main(['--results', results, '--scanner-exit', '0',
+            '--baseline', path.join(dir, 'baseline.json'), '--report', report, '--summary', summary]);
+        assert.strictEqual(code, 1);
+        const written = fs.readFileSync(report, 'utf8');
+        assert.match(written, /"result": "failed"/);
+        assert.ok(!written.includes(RAW_SECRET));
+        assert.ok(fs.readFileSync(summary, 'utf8').length > 0);
+    });
+});
+
+test('main() exits 0 on a clean scan', () => {
+    withTmp((dir) => {
+        const results = path.join(dir, 'r.jsonl');
+        fs.writeFileSync(results, '');
+        const code = S.main(['--results', results, '--scanner-exit', '0']);
+        assert.strictEqual(code, 0);
+    });
+});
+
+test('main() fails closed when scanner-exit is non-numeric', () => {
+    withTmp((dir) => {
+        const results = path.join(dir, 'r.jsonl');
+        fs.writeFileSync(results, '');
+        const code = S.main(['--results', results, '--scanner-exit', 'weird']);
+        assert.strictEqual(code, 1);
+    });
+});

--- a/scripts/security/secret-scan-report.test.js
+++ b/scripts/security/secret-scan-report.test.js
@@ -23,13 +23,13 @@ const S = require('./secret-scan-report.js');
 
 const RAW_SECRET = 'AKIAIOSFODNN7EXAMPLEXYZ';
 
-function findingLine({ detector = 'AWS', file = 'src/config.cs', line = 12, verified = false, raw = RAW_SECRET } = {}) {
+function findingLine({ detector = 'AWS', file = 'src/config.cs', line = 12, verified = false, raw = RAW_SECRET, rawV2 = undefined } = {}) {
     return JSON.stringify({
         DetectorName: detector,
         Verified: verified,
         Raw: raw,
-        RawV2: raw,
-        Redacted: raw.slice(0, 4) + '...REDACTED',
+        RawV2: rawV2 === undefined ? raw : rawV2,
+        Redacted: String(raw).slice(0, 4) + '...REDACTED',
         SourceMetadata: { Data: { Git: { file, line, commit: 'deadbeef' } } },
     });
 }
@@ -71,6 +71,34 @@ test('a NEW verified finding is NOT accepted by a non-empty baseline (no silent 
     // Baseline covers a DIFFERENT secret; a brand-new verified secret must still fail.
     const otherFp = S.fingerprint(JSON.parse(findingLine({ verified: true, raw: 'OLDACCEPTEDSECRET1' })));
     const r = evalJsonl(findingLine({ verified: true, raw: 'BRANDNEWSECRET2' }), { scannerExitCode: 0, baselineFps: [otherFp] });
+    assert.strictEqual(r.shouldFail, true);
+    assert.strictEqual(r.verifiedNew.length, 1);
+});
+
+test('a verified duplicate AFTER an unverified one still fails (monotonic verification)', () => {
+    // BI-SEC-020-VERIFIED-DEDUPE: same fingerprint, unverified first then verified.
+    const jsonl = findingLine({ verified: false }) + '\n' + findingLine({ verified: true });
+    const r = evalJsonl(jsonl, { scannerExitCode: 0 });
+    assert.strictEqual(r.shouldFail, true);
+    assert.strictEqual(r.verifiedNew.length, 1);
+    assert.strictEqual(r.unverifiedNew.length, 0);
+});
+
+test('same Raw but different RawV2 are distinct findings (composite detector)', () => {
+    // BI-SEC-020-INCOMPLETE-FINGERPRINT: only the RawV2 differs; the newer verified
+    // secret must NOT be absorbed by a baseline entry for the older one.
+    const oldFp = S.fingerprint(JSON.parse(findingLine({ verified: true, raw: 'SHARED', rawV2: 'OLDSECRET' })));
+    const newLine = findingLine({ verified: true, raw: 'SHARED', rawV2: 'NEWSECRET' });
+    assert.notStrictEqual(S.fingerprint(JSON.parse(newLine)), oldFp);
+    const r = evalJsonl(newLine, { scannerExitCode: 0, baselineFps: [oldFp] });
+    assert.strictEqual(r.shouldFail, true);
+    assert.strictEqual(r.verifiedNew.length, 1);
+});
+
+test('a verified finding with no raw identity is non-baselinable (always blocks)', () => {
+    const line = JSON.stringify({ DetectorName: 'X', Verified: true, Raw: '', RawV2: '', SourceMetadata: { Data: { Git: { file: 'f', line: 1 } } } });
+    const fp = S.fingerprint(JSON.parse(line));
+    const r = evalJsonl(line, { scannerExitCode: 0, baselineFps: [fp] });
     assert.strictEqual(r.shouldFail, true);
     assert.strictEqual(r.verifiedNew.length, 1);
 });
@@ -165,6 +193,25 @@ test('main() exits 0 on a clean scan', () => {
         fs.writeFileSync(results, '');
         const code = S.main(['--results', results, '--scanner-exit', '0']);
         assert.strictEqual(code, 0);
+    });
+});
+
+test('main() fails closed when the results path is a symlink', () => {
+    // BI-SEC-020-UNTRUSTED-SCAN-OUTPUT: a planted symlink must not be honored.
+    withTmp((dir) => {
+        const real = path.join(dir, 'real.jsonl');
+        fs.writeFileSync(real, ''); // empty => would otherwise be "clean"
+        const link = path.join(dir, 'results.jsonl');
+        fs.symlinkSync(real, link);
+        const code = S.main(['--results', link, '--scanner-exit', '0']);
+        assert.strictEqual(code, 1);
+    });
+});
+
+test('main() fails closed when the results file is missing', () => {
+    withTmp((dir) => {
+        const code = S.main(['--results', path.join(dir, 'nope.jsonl'), '--scanner-exit', '0']);
+        assert.strictEqual(code, 1);
     });
 });
 

--- a/scripts/security/secret-scan-report.test.js
+++ b/scripts/security/secret-scan-report.test.js
@@ -133,6 +133,21 @@ test('main() exits 1 on a verified finding and writes a leak-free report', () =>
     });
 });
 
+test('the uploaded report (only artifact) stays leak-free when scanner output has Raw/RawV2', () => {
+    // BI-SEC-020-RAW-ARTIFACT: only secret-scan-report.json is published; the raw
+    // trufflehog JSONL (which carries Raw/RawV2) is kept runner-local. Prove the
+    // published report never contains that material even when the input does.
+    withTmp((dir) => {
+        const results = path.join(dir, 'r.jsonl');
+        const report = path.join(dir, 'secret-scan-report.json');
+        fs.writeFileSync(results, findingLine({ verified: true }) + '\n' + findingLine({ verified: false, raw: 'ANOTHERRAWSECRET3' }) + '\n');
+        S.main(['--results', results, '--scanner-exit', '0', '--report', report]);
+        const written = fs.readFileSync(report, 'utf8');
+        assert.ok(!written.includes(RAW_SECRET), 'published report leaks a verified raw secret');
+        assert.ok(!written.includes('ANOTHERRAWSECRET3'), 'published report leaks an unverified raw secret');
+    });
+});
+
 test('main() exits 0 on a clean scan', () => {
     withTmp((dir) => {
         const results = path.join(dir, 'r.jsonl');

--- a/scripts/security/secret-scan-report.test.js
+++ b/scripts/security/secret-scan-report.test.js
@@ -151,6 +151,15 @@ test('a secret in the Git FILE PATH is redacted from report + summary (still blo
     assert.ok(!report.includes(RAW_SECRET), 'report leaks the secret via the file path');
 });
 
+test('a SHORT secret in the file path is also redacted (no length threshold)', () => {
+    // BI-SEC-020-PATH-LEAK follow-up: a short verified secret must not leak either.
+    const shortSecret = 'abcde';
+    const r = evalJsonl(findingLine({ verified: true, raw: shortSecret, file: `leak-${shortSecret}.txt` }), { scannerExitCode: 0 });
+    assert.strictEqual(r.shouldFail, true);
+    const combined = S.renderSummary(r) + JSON.stringify(S.buildReport(r));
+    assert.ok(!combined.includes(`leak-${shortSecret}`), 'short secret leaked via the file path');
+});
+
 test('report + summary never contain the raw secret', () => {
     const r = evalJsonl(findingLine({ verified: true }), { scannerExitCode: 0 });
     const summary = S.renderSummary(r);

--- a/scripts/security/secret-scan-report.test.js
+++ b/scripts/security/secret-scan-report.test.js
@@ -140,6 +140,17 @@ test('fingerprint is stable and never contains the raw secret', () => {
     assert.ok(!fp1.includes(RAW_SECRET), 'fingerprint must not embed the raw secret');
 });
 
+test('a secret in the Git FILE PATH is redacted from report + summary (still blocks)', () => {
+    // BI-SEC-020-PATH-LEAK: a verified secret committed in a file named after
+    // itself must not leak via the displayed path in the report/summary/artifact.
+    const r = evalJsonl(findingLine({ verified: true, file: `secrets/leak-${RAW_SECRET}.txt` }), { scannerExitCode: 0 });
+    assert.strictEqual(r.shouldFail, true);
+    const summary = S.renderSummary(r);
+    const report = JSON.stringify(S.buildReport(r));
+    assert.ok(!summary.includes(RAW_SECRET), 'summary leaks the secret via the file path');
+    assert.ok(!report.includes(RAW_SECRET), 'report leaks the secret via the file path');
+});
+
 test('report + summary never contain the raw secret', () => {
     const r = evalJsonl(findingLine({ verified: true }), { scannerExitCode: 0 });
     const summary = S.renderSummary(r);

--- a/scripts/security/secret-scan-report.test.js
+++ b/scripts/security/secret-scan-report.test.js
@@ -87,6 +87,17 @@ test('malformed scanner output fails closed', () => {
     assert.match(r.reasons.join(' '), /unparseable/i);
 });
 
+test('a baseline entry WITHOUT a reason does not allowlist (still fails)', () => {
+    const fp = S.fingerprint(JSON.parse(findingLine({ verified: true })));
+    // Same fingerprint, but the entry has no reason -> must NOT be honored.
+    const { set } = S.loadBaseline({ allow: [{ fingerprint: fp }] });
+    assert.strictEqual(set.has(fp), false);
+    const { findings, parseErrors } = S.parseResults(findingLine({ verified: true }));
+    const r = S.evaluate({ findings, parseErrors, scannerExitCode: 0, baseline: set, baselineMalformed: false });
+    assert.strictEqual(r.shouldFail, true);
+    assert.strictEqual(r.verifiedNew.length, 1);
+});
+
 test('a malformed baseline fails closed', () => {
     const { set, malformed } = S.loadBaseline({ allow: 'not-an-array' });
     const r = S.evaluate({ findings: [], parseErrors: 0, scannerExitCode: 0, baseline: set, baselineMalformed: malformed });


### PR DESCRIPTION
## What & why

The Security Scan workflow could not fail CI for a leaked secret, so a green run
was not evidence the repository is clean. The TruffleHog step had
`continue-on-error: true` (a verified secret or a scanner crash was swallowed), it
scanned only `--only-verified` (unverified/private detector classes were dropped
with no policy), its PR diff range (`github.event.before`) is unset on
`pull_request` events, and a job named "Upload SARIF Results" produced no SARIF.

This addresses the audit finding *BI-SEC-020 — Secret scanning cannot fail and
produces no SARIF*.

## Implementation

Turn the scan into a real, fail-closed gate whose decision logic is unit-tested:

- **Scan** — TruffleHog (pinned to the same v3.95.6 the repo already trusts) runs
  over the **full git history** on every event shape with `--json` (verified and
  unverified) and no `--fail`, so its exit code reports only whether the scanner
  ran. Full-history scanning removes the PR-broken `github.event.before` range and
  makes coverage uniform.
- **Gate + report** — a new decision owner, `scripts/security/secret-scan-report.js`,
  reads that JSONL, the scanner exit code, and a committed baseline, and fails
  **closed**: a scanner crash, unparseable output, a malformed baseline, or any
  **verified** finding whose one-way fingerprint is not allowlisted fails the job.
  **Unverified** findings are reported (step summary + artifact) without blocking —
  the explicit policy for that detector class.
- **Baseline** — `.github/secret-scan-baseline.json` allowlists accepted findings
  by SHA-256 fingerprint, so it can never silently accept a *new* secret; a new
  verified finding still fails even when the baseline is non-empty.
- **No secret persistence** — fingerprints are one-way hashes; the report/summary
  contain only detector, path/line, verified flag, and fingerprint. Only the
  redacted `secret-scan-report.json` is uploaded as an artifact; the raw TruffleHog
  JSONL stays runner-local so a real finding is never downloadable.
- **Report surface** — the false "Upload SARIF Results" job and the unused
  `security-events` permission are removed. This private repo has no GitHub
  Advanced Security, so the artifact + step summary are the report and nothing
  claims SARIF. `SECURITY.md` now documents exactly the controls that run.
- The `.NET Security Audit` job is unchanged.

## Limitations

- Findings are not ingested into the code-scanning "Security" tab (that needs
  GitHub Advanced Security / a public repo); the durable artifact + step summary
  are the report surface, as the audit finding explicitly permits.
- The TruffleHog CLI invocation itself (Docker image + flags) is exercised only in
  CI; the gate's decision logic is fully unit-tested locally.

## AI assistance

Implemented with AI assistance (Claude): root-cause fix, regression-first tests,
and multiple rounds of independent adversarial review that surfaced and fixed
several fail-open paths before publication (see the review ledger).

## Tests

- **`npm run test:scripts`: 20 new cases** for the gate — clean, verified finding
  (fails), unverified-only (reports, non-blocking), baselined (passes), a NEW
  verified finding not covered by a non-empty baseline (fails), scanner crash
  (fails), malformed output (fails closed), malformed baseline (fails closed),
  non-numeric scanner exit (fails closed), and leak-free report/summary invariants.
- Full gate green @ `verify.sh full`: 768 .NET tests + all script tests, coverage,
  manifest, and `mkdocs --strict` OK. No plugin runtime change → no deploy/E2E.

## Review ledger

- Security discovery (Sol, high) → 1 P1: the artifact uploaded the raw TruffleHog
  JSONL (raw secret material downloadable for the retention window). Fixed by
  publishing only the redacted report; regression added. Confirmation (Sol,
  medium): clean.
- Independent adversarial finals then surfaced further fail-opens, all fixed:
  the scanner image was pinned by a mutable tag (now an immutable digest — which
  also fixed a wrong ref: the Docker tag is `3.95.6`, not the action's `v3.95.6`);
  a PR could hijack the scanner output via a committed symlink (output now written
  under `$RUNNER_TEMP`, and a missing/symlinked/non-regular results file fails
  closed); the de-dup dropped a verified duplicate that followed an unverified one
  (now aggregates by fingerprint with monotonic verification); and the fingerprint
  ignored `RawV2` when `Raw` was set (now a length-delimited canonical tuple of
  detector/file/Raw/RawV2, with the path folded into the hash). Plus P3 hardening
  (baseline `reason` enforced) and a docs-coverage correction.

Closes #81
