### PR TITLE
README: from-scratch user-facing rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ Four new pages living right in Jellyfin's navigation, reorderable, native on des
 ### 🛠️ Admin superpowers
 
 - **A real settings app** — plugin settings organized into seven task-oriented areas with live search across every option, on desktop and phone.
-- **Session control** — see active streams from the header, and stop or message any session without opening the dashboard.
-- **Sonarr/Radarr in the item menu** — trigger a search, hand-pick a release (quality, size, seeders, rejection reasons — with one-tap Grab), or monitor/add items, for movies, series, seasons, and episodes.
-- **Layout enforcement** — default or force the modern Jellyfin layout across your users' devices.
+- **Session control** — see active streams from the header, and stop or message any remote-control-capable session without opening the dashboard.
+- **Sonarr/Radarr in the item menu** — trigger an automatic search on movies, series, seasons, or episodes; hand-pick a release (quality, size, seeders, rejection reasons — with one-tap Grab) for movies, seasons, and episodes; monitor/unmonitor and add missing movies or series with live download progress.
+- **Layout enforcement** — default or force the modern Jellyfin layout on your users' desktop and mobile web devices (TV-mode devices are deliberately exempt).
 - **Maintenance mode** — temporarily lock users out with a friendly banner while you work on the server.
 - **Custom branding** — your own logos, banners, login image, and favicon; plus a theme selector and deep CSS customization.
 
@@ -157,9 +157,9 @@ Four new pages living right in Jellyfin's navigation, reorderable, native on des
 > **Jellyfin 12 required.** On Jellyfin 10.11, use the original [Jellyfin Enhanced](https://github.com/n00bcodr/Jellyfin-Enhanced) instead.
 
 > [!TIP]
-> **Highly recommended:** install the [File Transformation plugin](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation) to avoid permission issues on all installation types (Docker, Windows, Linux, etc.).
+> If you also use plugins that write to the web folder (such as [Plugin Pages](https://github.com/IAmParadox27/jellyfin-plugin-pages) or [Custom Tabs](https://github.com/IAmParadox27/jellyfin-plugin-custom-tabs)), or you've switched Canopy to its legacy on-disk injection fallback, the [File Transformation plugin](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation) avoids the file-permission issues those setups can hit. Canopy's default request-time injection doesn't need it.
 
-Optional integrations — connect what you use, skip what you don't: **Seerr** (requests & discovery), **Sonarr / Radarr / Bazarr** (calendar, queue, item-menu search), a **media-segment provider** like Intro Skipper (auto-skip), and a free **TMDB API key** (Elsewhere, reviews & ratings).
+Optional integrations — connect what you use, skip what you don't: **Seerr** (requests & discovery), **Sonarr / Radarr / Bazarr** (calendar, queue, item-menu search), a **media-segment provider** like Intro Skipper (auto-skip), and a free **TMDB API key** (Elsewhere, TMDB reviews, release dates, richer cast info).
 
 → Step-by-step: [Getting Started](https://4eh5xitv6787h645ebv.github.io/Jellyfin-Canopy/getting-started/)
 
@@ -220,7 +220,7 @@ Jellyfin Canopy is developed **entirely with AI** (agentic coding tools driving 
 
 - 🐛 [Report issues](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues)
 - 💡 [Suggest features](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/discussions)
-- 🌍 Help translate — Canopy ships in 26 languages and every string is translatable
+- 🌍 Help translate — Canopy ships 26 synchronized language catalogs, and better translations are always welcome
 
 Developers: [CONTRIBUTING.md](CONTRIBUTING.md) has the workflow, quality gates, and the paved road for new features.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   <a href='https://www.buymeacoffee.com/n00bcodr' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png' border='0' alt='Buy Me a Coffee' /></a>
 </p>
 
-**Jellyfin Canopy is one plugin that turns a Jellyfin 12 server into a complete home-theater experience** — smarter playback, a built-in discovery and request flow, family-safe viewing, beautiful posters, and real admin superpowers. Install it once on the server and it lights up everywhere the Jellyfin web interface runs: browsers, the official mobile apps, and desktop apps. Nothing to install on your users' devices, nothing for them to configure — though almost everything can be personalized per user if they want to.
+**Jellyfin Canopy is one plugin that turns a Jellyfin 12 server into a complete home-theater experience** — smarter playback, a built-in discovery and request flow, family-safe viewing, beautiful posters, and real admin superpowers. Install it once on the server and it works everywhere the Jellyfin web interface runs: browsers, the official mobile apps, and desktop apps — nothing to install on your users' devices. The core experience lights up immediately; the bigger feature areas are opt-in, and a few connect to services you may already run (Seerr, Sonarr/Radarr, TMDB) — you enable what you want from one settings page, and almost everything can then be personalized per user.
 
 <br>
 
@@ -26,7 +26,7 @@
 
 - **It feels native.** Every button, panel, and page is built to look and behave like Jellyfin itself — no janky overlays, no popped-in widgets, both light and dark themes.
 - **Your whole household benefits.** Features work per user: everyone gets their own settings, their own discovery feed, their own hidden titles, their own spoiler protection.
-- **Admins stay in control.** Every user-facing option has an admin default, and the redesigned settings app makes hundreds of options easy to find with built-in search.
+- **Admins stay in control.** Nearly every per-user toggle has an admin-set default, and the redesigned settings app makes hundreds of options easy to find with built-in search.
 - **It replaces half a dozen browser tabs.** Requesting new media, approving requests, kicking a stream, grabbing a stubborn release from Sonarr — all without leaving Jellyfin.
 
 <br>
@@ -60,7 +60,7 @@ Connect [Seerr](https://github.com/seerr-team/seerr) once, and Jellyfin's own se
 - **Approve in-app** — admins (or trusted users) approve or decline pending requests with one tap.
 - **Auto-requests** — automatically request the next season as you finish one, or the next movie in a collection.
 - **Report issues** — users flag playback problems directly to Seerr from the item page.
-- **Watchlist sync** — keep your Seerr and Jellyfin watchlists in step, in either direction.
+- **Watchlist sync** — keep your Seerr and Jellyfin watchlists in step (Jellyfin → Seerr out of the box; the reverse direction needs the [KefinTweaks plugin](https://github.com/ranaldsgift/KefinTweaks) for Jellyfin watchlist support).
 
 → Setup & details: [Discover & Request](https://4eh5xitv6787h645ebv.github.io/Jellyfin-Canopy/discover/)
 
@@ -151,7 +151,7 @@ Four new pages living right in Jellyfin's navigation, reorderable, native on des
    https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/main/manifest.json
    ```
 3. Back in the **Catalog**, find **Jellyfin Canopy** and click **Install**
-4. **Restart** your Jellyfin server — done. Users get the goodies immediately; you'll find the admin settings under **Dashboard → Plugins → Jellyfin Canopy**.
+4. **Restart** your Jellyfin server, then open **Dashboard → Plugins → Jellyfin Canopy** to switch on the feature areas you want — the [Getting Started guide](https://4eh5xitv6787h645ebv.github.io/Jellyfin-Canopy/getting-started/) walks the first-run setup step by step.
 
 > [!IMPORTANT]
 > **Jellyfin 12 required.** On Jellyfin 10.11, use the original [Jellyfin Enhanced](https://github.com/n00bcodr/Jellyfin-Enhanced) instead.

--- a/README.md
+++ b/README.md
@@ -6,41 +6,144 @@
   </picture>
 </p>
 
+<h3 align="center"><em>Grow your Jellyfin.</em></h3>
+
 <p align="center">
   <img src="https://img.shields.io/badge/Jellyfin%20Version-12-AA5CC3?logo=jellyfin&logoColor=00A4DC&labelColor=black" alt="Jellyfin Version">
   <img src="https://img.shields.io/badge/License-GPL--3.0-00A4DC?labelColor=black" alt="License">
+  <img src="https://img.shields.io/badge/Languages-26-2F80FF?labelColor=black" alt="26 Languages">
   <img src="https://img.shields.io/badge/Development-100%25%20AI-AA5CC3?labelColor=black" alt="100% AI Development">
   <br><br>
   <a href='https://ko-fi.com/G2G51TIZF0' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://storage.ko-fi.com/cdn/kofi1.png?v=6' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
   <a href='https://www.buymeacoffee.com/n00bcodr' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png' border='0' alt='Buy Me a Coffee' /></a>
 </p>
 
-**Jellyfin Canopy is an independent fork and extensive modernization of [Jellyfin Enhanced](https://github.com/n00bcodr/Jellyfin-Enhanced), providing an integrated suite of playback, discovery, customization and media-management features for Jellyfin 12.**
+**Jellyfin Canopy is one plugin that turns a Jellyfin 12 server into a complete home-theater experience** — smarter playback, a built-in discovery and request flow, family-safe viewing, beautiful posters, and real admin superpowers. Install it once on the server and it lights up everywhere the Jellyfin web interface runs: browsers, the official mobile apps, and desktop apps. Nothing to install on your users' devices, nothing for them to configure — though almost everything can be personalized per user if they want to.
 
 <br>
 
-## 🙏 Origins & Credit
+## 🌟 Why Canopy?
 
-This project **would not exist** without [n00bcodr](https://github.com/n00bcodr) and his outstanding work on [Jellyfin Enhanced](https://github.com/n00bcodr/Jellyfin-Enhanced). Every feature here stands on that foundation — years of ideas, design, community building, and polish that made Jellyfin Enhanced the essential enhancement suite for Jellyfin.
-
-Jellyfin Canopy exists because the two projects chose different paths, not because of any shortcoming in the original. (Until version 2.0 this project was published as **Jellyfin Elevate** — same plugin, same plugin ID; existing installs upgrade in place.)
-
-- **Jellyfin Enhanced** continues to serve Jellyfin 10.11 — stable, proven, and actively maintained by its original author.
-- **Jellyfin Canopy** is a ground-up modernization targeting **Jellyfin 12 only**: a strict-TypeScript ES-module client, policy-based server auth, push-driven live updates, a committed Playwright e2e suite, and enforced performance rules.
-
-If you appreciate this project, please support the original author — **all donation links in this repository intentionally point to n00bcodr**:
-
-- ☕ [Ko-Fi](https://ko-fi.com/n00bcodr) ⦁ ☕ [Buy Me a Coffee](https://www.buymeacoffee.com/n00bcodr) ⦁ ⭐ [Star Jellyfin Enhanced](https://github.com/n00bcodr/Jellyfin-Enhanced)
-
-## 🤖 100% AI Development
-
-Jellyfin Canopy is developed **entirely with AI** (agentic coding tools driving design, implementation, testing, and review), directed and curated by a human maintainer. Every change still has to pass the project's full gate suite — strict TypeScript type-checking, lint, unit tests with coverage ratchets, golden snapshot tests, a real end-to-end Playwright suite against a live Jellyfin 12 server, and multi-pass adversarial code review — before it lands.
+- **It feels native.** Every button, panel, and page is built to look and behave like Jellyfin itself — no janky overlays, no popped-in widgets, both light and dark themes.
+- **Your whole household benefits.** Features work per user: everyone gets their own settings, their own discovery feed, their own hidden titles, their own spoiler protection.
+- **Admins stay in control.** Every user-facing option has an admin default, and the redesigned settings app makes hundreds of options easy to find with built-in search.
+- **It replaces half a dozen browser tabs.** Requesting new media, approving requests, kicking a stream, grabbing a stubborn release from Sonarr — all without leaving Jellyfin.
 
 <br>
 
-## 🚀 Quick Start
+## ✨ What it does
 
-### Installation
+### 🎬 A better way to watch
+
+- **Auto-Skip intros & outros** — precise, segment-based skipping for true binge mode (works with Intro Skipper or any media-segment provider).
+- **Custom pause screen** — pause and get a beautiful overlay with artwork and media info instead of a frozen frame.
+- **Keyboard shortcuts** — a full hotkey suite for navigation and playback, fully remappable per user.
+- **Bookmarks** — save moments with visual markers on the timeline and jump back to them any time, from their own Bookmarks page.
+- **Subtitle styling** — pick your own subtitle colors, size, and background.
+- **Random button** — one tap to rediscover something you forgot your library had.
+
+→ Full tour: [The Enhanced Experience](https://4eh5xitv6787h645ebv.github.io/Jellyfin-Canopy/enhanced/)
+
+### 🧭 Find your next favorite
+
+- **Discovery feed** — a Discover button inside your Movies and TV libraries opens shelves of Trending, Popular, Upcoming, Top Rated, and by-genre picks. Every card shows whether you already have it, and can request it if you don't. Each user customizes their own rows.
+- **Elsewhere** — see which streaming services carry a title, right on its detail page.
+- **Reviews** — read TMDB community reviews, and let your own users write and rate their reviews (1–5★, with admin moderation).
+
+→ Full tour: [Discover & Request](https://4eh5xitv6787h645ebv.github.io/Jellyfin-Canopy/discover/)
+
+### 🤝 Request without leaving Jellyfin
+
+Connect [Seerr](https://github.com/seerr-team/seerr) once, and Jellyfin's own search becomes a request machine:
+
+- **Search & request** anything — including titles you don't have yet — straight from Jellyfin search, with 4K and collection requests where your setup supports them.
+- **Approve in-app** — admins (or trusted users) approve or decline pending requests with one tap.
+- **Auto-requests** — automatically request the next season as you finish one, or the next movie in a collection.
+- **Report issues** — users flag playback problems directly to Seerr from the item page.
+- **Watchlist sync** — keep your Seerr and Jellyfin watchlists in step, in either direction.
+
+→ Setup & details: [Discover & Request](https://4eh5xitv6787h645ebv.github.io/Jellyfin-Canopy/discover/)
+
+### 👨‍👩‍👧 Family-safe by design
+
+- **Parental controls that follow the user everywhere** — Jellyfin's age ratings *and* tag-based block/allow rules are enforced on every discovery and request surface too, server-side, so restricted accounts never even see what they shouldn't request.
+- **Spoiler Guard** — opt-in, per-user protection that blurs images and hides episode titles and descriptions for anything you haven't watched yet — enforced by the server on every device, including TV apps.
+- **Hidden content** — any user can hide titles from their own library views, search, and discovery; a management panel handles search, unhide, and bulk actions, and admins can review any user's hidden list.
+
+→ Details: [Spoiler Guard](https://4eh5xitv6787h645ebv.github.io/Jellyfin-Canopy/spoiler-guard/) · [The Enhanced Experience](https://4eh5xitv6787h645ebv.github.io/Jellyfin-Canopy/enhanced/)
+
+### 🏷️ Posters that tell you more
+
+At-a-glance badges on your library cards — each family individually toggleable:
+
+- **Quality** (4K, HDR, Atmos…), **genre icons**, **audio-language flags**, **TMDB / Rotten Tomatoes ratings**, and **cast info** (age, birthplace) on people cards.
+
+→ Details: [The Enhanced Experience](https://4eh5xitv6787h645ebv.github.io/Jellyfin-Canopy/enhanced/)
+
+### 📄 Pages that feel built-in
+
+Four new pages living right in Jellyfin's navigation, reorderable, native on desktop and mobile:
+
+- **Calendar** — upcoming episodes and releases from Sonarr/Radarr.
+- **Requests** — request status and the live download queue.
+- **Bookmarks** — every saved moment across your library.
+- **Hidden Content** — manage everything you've hidden.
+
+→ Details: [Sonarr & Radarr](https://4eh5xitv6787h645ebv.github.io/Jellyfin-Canopy/sonarr-radarr/)
+
+### 🛠️ Admin superpowers
+
+- **A real settings app** — plugin settings organized into seven task-oriented areas with live search across every option, on desktop and phone.
+- **Session control** — see active streams from the header, and stop or message any session without opening the dashboard.
+- **Sonarr/Radarr in the item menu** — trigger a search, hand-pick a release (quality, size, seeders, rejection reasons — with one-tap Grab), or monitor/add items, for movies, series, seasons, and episodes.
+- **Layout enforcement** — default or force the modern Jellyfin layout across your users' devices.
+- **Maintenance mode** — temporarily lock users out with a friendly banner while you work on the server.
+- **Custom branding** — your own logos, banners, login image, and favicon; plus a theme selector and deep CSS customization.
+
+→ Details: [Customization](https://4eh5xitv6787h645ebv.github.io/Jellyfin-Canopy/customization/) · [Reference](https://4eh5xitv6787h645ebv.github.io/Jellyfin-Canopy/reference/)
+
+<br>
+
+## 📸 Screenshots
+
+<table>
+  <tr>
+    <th>Settings panel</th>
+    <th>Shortcuts</th>
+  </tr>
+  <tr>
+    <td><img src="docs/images/enhanced-panel-settings.png" width="400" /></td>
+    <td><img src="docs/images/enhanced-panel-shortcuts.png" width="400" /></td>
+  </tr>
+  <tr>
+    <th>Pause screen</th>
+    <th>Elsewhere</th>
+  </tr>
+  <tr>
+    <td><img src="docs/images/pausescreen.png" width="400" /></td>
+    <td><img src="docs/images/elsewhere.png" width="400" /></td>
+  </tr>
+  <tr>
+    <th>Search & request (Seerr)</th>
+    <th>Ratings on posters</th>
+  </tr>
+  <tr>
+    <td><img src="docs/images/jellyseerr.png" width="400" /></td>
+    <td><img src="docs/images/ratings.png" width="400" /></td>
+  </tr>
+  <tr>
+    <th>Calendar page</th>
+    <th>Active streams</th>
+  </tr>
+  <tr>
+    <td><img src="docs/images/calendar-page.png" width="400" /></td>
+    <td><img src="docs/images/active-stream.png" width="400" /></td>
+  </tr>
+</table>
+
+<br>
+
+## 🚀 Get started
 
 1. In Jellyfin, go to **Dashboard** → **Plugins** → **Catalog**
 2. Click the gear icon (⚙️ **Manage Repositories**), click **➕**, and add the repository:
@@ -48,92 +151,36 @@ Jellyfin Canopy is developed **entirely with AI** (agentic coding tools driving 
    https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/main/manifest.json
    ```
 3. Back in the **Catalog**, find **Jellyfin Canopy** and click **Install**
-4. **Restart** your Jellyfin server
+4. **Restart** your Jellyfin server — done. Users get the goodies immediately; you'll find the admin settings under **Dashboard → Plugins → Jellyfin Canopy**.
 
 > [!IMPORTANT]
-> **Jellyfin 12 Required** — Jellyfin Canopy only supports Jellyfin 12. Jellyfin 10.11 users should use the original [Jellyfin Enhanced](https://github.com/n00bcodr/Jellyfin-Enhanced) plugin.
+> **Jellyfin 12 required.** On Jellyfin 10.11, use the original [Jellyfin Enhanced](https://github.com/n00bcodr/Jellyfin-Enhanced) instead.
 
 > [!TIP]
-> **Highly Recommended:** Install the [File Transformation plugin](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation) to avoid permission issues on all installation types (Docker, Windows, Linux, etc.).
+> **Highly recommended:** install the [File Transformation plugin](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation) to avoid permission issues on all installation types (Docker, Windows, Linux, etc.).
 
-<br>
+Optional integrations — connect what you use, skip what you don't: **Seerr** (requests & discovery), **Sonarr / Radarr / Bazarr** (calendar, queue, item-menu search), a **media-segment provider** like Intro Skipper (auto-skip), and a free **TMDB API key** (Elsewhere, reviews & ratings).
 
-## ✨ Feature Highlights
-
-### 🎬 Playback
-- **Advanced Keyboard Shortcuts** - Comprehensive hotkeys for navigation and playback
-- **Smart Bookmarks** - Save and jump to timestamps with visual markers
-- **Custom Pause Screen** - Beautiful overlay with media info
-- **Auto-Skip Intros/Outros** - Seamless binge-watching (requires media segments — e.g. the Intro Skipper plugin or any other segment provider)
-- **Custom Subtitle Colors** - Full color customization with alpha support
-
-### 🙈 Content Management
-- **Hidden Content System** - Per-user content hiding with server-side storage
-- **Granular Filtering** - Control visibility across library, discovery, search, and more
-- **Management Panel** - Search, unhide, and bulk operations
-- **Spoiler Guard** - Per-user opt-in blur and metadata stripping for unwatched content, enforced server-side on every client
-
-### 🪼 Seerr Integration
-- **Search & Request** - Request media directly from Jellyfin search
-- **Item Details** - Recommendations and similar items on detail pages
-- **Discovery Pages** - Browse by genre, network, person, or tag
-- **Auto Requests** - Auto-request the next season or the next movie in a collection
-- **Issue Reporting** - Report problems directly to Seerr
-- **Watchlist Sync** - Auto-sync with Jellyfin watchlist
-
-### 🧭 Discovery Feed
-- **Rows of Cards** - Customizable Trending, Popular, Upcoming, Top Rated, and genre rows inside your Movies & TV Shows libraries, opened from a **Discovery** button in the library toolbar
-- **Inline Requests** - Every card carries an availability badge and a one-tap Seerr request (Seerr-backed)
-- **Per-User Customization** - Choose which rows appear and reorder them, on top of the admin defaults
-
-### 🔗 *arr Integration
-- **Quick Links** - Jump to Sonarr, Radarr, Bazarr pages (admin only)
-- **Search & Interactive Search** - Trigger an *arr search or pick a release by hand from the item menu; Monitor/Add (admin only)
-- **Tag Links** - Display and filter *arr tags
-- **Calendar View** - Upcoming releases from Sonarr/Radarr
-- **Requests Page** - Monitor download queue and status
-
-### 🏷️ Visual Enhancements
-- **Quality Tags** - 4K, HDR, Atmos, and more on posters
-- **Genre Tags** - Themed icons for instant genre identification
-- **Language Tags** - Country flags for available audio languages
-- **Rating Tags** - TMDB and Rotten Tomatoes ratings at a glance
-- **People Tags** - Age and birthplace info for cast members
-
-### 🔍 Discovery
-- **Elsewhere Integration** - See where media is available to stream
-- **TMDB Reviews** - Display user reviews from TMDB
-- **User Reviews** - Users write and rate 1–5★ reviews, with admin moderation
-- **Random Button** - Discover content in your library
-
-### 🎨 Customization
-- **Custom Branding** - Upload your own logos, banners, and favicon
-- **Theme Selector** - Choose from multiple color variants
-- **Extensive CSS Options** - Customize every visual element
-- **Active Streams Widget** - Live session monitor with admin Stop, Message, and Broadcast controls
-- **Maintenance Mode** - Temporarily lock users out with a login banner and in-session notice (admin)
-- **Multi-language Support** - Available in 26 languages
+→ Step-by-step: [Getting Started](https://4eh5xitv6787h645ebv.github.io/Jellyfin-Canopy/getting-started/)
 
 <br>
 
 ## 📚 Documentation
 
-Full documentation lives in [`docs/`](docs/) and is published at [https://4eh5xitv6787h645ebv.github.io/Jellyfin-Canopy/](https://4eh5xitv6787h645ebv.github.io/Jellyfin-Canopy/) (available once the repository is public).
+Everything above, in depth — every setting explained, with screenshots:
 
-<br>
+| | |
+|---|---|
+| [Getting Started](https://4eh5xitv6787h645ebv.github.io/Jellyfin-Canopy/getting-started/) | Installation, first-run setup, integrations |
+| [The Enhanced Experience](https://4eh5xitv6787h645ebv.github.io/Jellyfin-Canopy/enhanced/) | Playback, shortcuts, tags, pages, hidden content |
+| [Discover & Request](https://4eh5xitv6787h645ebv.github.io/Jellyfin-Canopy/discover/) | Seerr setup, discovery feed, requests, reviews |
+| [Sonarr & Radarr](https://4eh5xitv6787h645ebv.github.io/Jellyfin-Canopy/sonarr-radarr/) | Calendar, requests page, item-menu search |
+| [Spoiler Guard](https://4eh5xitv6787h645ebv.github.io/Jellyfin-Canopy/spoiler-guard/) | Per-user unwatched-content protection |
+| [Customization](https://4eh5xitv6787h645ebv.github.io/Jellyfin-Canopy/customization/) | Branding, themes, CSS, login image |
+| [Reference](https://4eh5xitv6787h645ebv.github.io/Jellyfin-Canopy/reference/) | Every admin & user setting, catalogued |
+| [Help & Community](https://4eh5xitv6787h645ebv.github.io/Jellyfin-Canopy/help/) | Troubleshooting and FAQs |
 
-## 🏗️ Project Structure
-
-One C# project (server) plus one TypeScript module tree (client), shipped as a single client bundle:
-
-- **`Jellyfin.Plugin.JellyfinCanopy/src/`** — the client: strict TypeScript ES modules organized by area (`core/`, `enhanced/`, `jellyseerr/`, `arr/`, `tags/`, `elsewhere/`, `extras/`, `others/`), bundled by esbuild into `dist/jc.bundle.js` on every build. `src/facade.ts` types the frozen public `window.JellyfinCanopy` surface.
-- **`Jellyfin.Plugin.JellyfinCanopy/js/`** — the loader (`plugin.js`), the translation files (`locales/`), and ambient type declarations (`core/globals.d.ts`); all feature code lives in `src/`.
-- **`Jellyfin.Plugin.JellyfinCanopy/`** (C#) — `Controllers/` (one per feature area, policy-based auth), `Configuration/` (settings registry + admin page), `Services/` (integrations, live-update pushes). Targets Jellyfin 12 / net10.0 only.
-- **`Jellyfin.Plugin.JellyfinCanopy.Tests/`** — xUnit tests incl. golden snapshots pinning the config payload and on-disk user-data formats.
-- **`e2e/`** — committed Playwright suite + dockerized seeded Jellyfin 12.
-- **`docs/`** — the documentation site (MkDocs).
-
-How to add a feature: [CONTRIBUTING.md](CONTRIBUTING.md)
+*(The documentation site goes live with the repository; the same pages are always browsable in [`docs/`](docs/).)*
 
 <br>
 
@@ -145,67 +192,55 @@ How to add a feature: [CONTRIBUTING.md](CONTRIBUTING.md)
 | Android App | ✅ Full | Official app with embedded web UI |
 | iOS App | ✅ Full | Official app with embedded web UI |
 | Desktop Apps | ✅ Full | Jellyfin Desktop v3.0.0+ (currently unreleased) |
-| Android TV | ❌ Not Supported, but auto-season, movie requests work | Native app, no web UI |
-| Third-party Apps | ❌ Not Supported, but auto-season, movie requests work | Depends on embedded web UI |
+| Android TV | ⚠️ Partial | Native app (no web UI) — server-side features like Spoiler Guard and auto-requests still apply |
+| Third-party Apps | ⚠️ Partial | Depends on embedded web UI — server-side features still apply |
 
 <br>
 
-## 📸 Screenshots
+## 🙏 Origins & credit
 
-<table>
-  <tr>
-    <th>Shortcuts</th>
-    <th>Settings</th>
-  </tr>
-  <tr>
-    <td><img src="docs/images/enhanced-panel-shortcuts.png" width="400" /></td>
-    <td><img src="docs/images/enhanced-panel-settings.png" width="400" /></td>
-  </tr>
-  <tr>
-    <th>Pause Screen</th>
-    <th>Elsewhere</th>
-  </tr>
-  <tr>
-    <td><img src="docs/images/pausescreen.png" width="400" /></td>
-    <td><img src="docs/images/elsewhere.png" width="400" /></td>
-  </tr>
-  <tr>
-    <th>Seerr</th>
-    <th>Ratings</th>
-  </tr>
-  <tr>
-    <td><img src="docs/images/jellyseerr.png" width="400" /></td>
-    <td><img src="docs/images/ratings.png" width="400" /></td>
-  </tr>
-</table>
+This project **would not exist** without [n00bcodr](https://github.com/n00bcodr) and his outstanding work on [Jellyfin Enhanced](https://github.com/n00bcodr/Jellyfin-Enhanced). Every feature here stands on that foundation — years of ideas, design, community building, and polish that made Jellyfin Enhanced the essential enhancement suite for Jellyfin.
+
+Jellyfin Canopy is an independent fork that exists because the two projects chose different paths, not because of any shortcoming in the original:
+
+- **Jellyfin Enhanced** continues to serve Jellyfin 10.11 — stable, proven, and actively maintained by its original author.
+- **Jellyfin Canopy** is a ground-up modernization targeting **Jellyfin 12 only**. *(Until version 2.0 it was published as **Jellyfin Elevate** — same plugin, same plugin ID; existing installs upgrade in place.)*
+
+If you appreciate this project, please support the original author — **all donation links in this repository intentionally point to n00bcodr**:
+
+- ☕ [Ko-Fi](https://ko-fi.com/n00bcodr) ⦁ ☕ [Buy Me a Coffee](https://www.buymeacoffee.com/n00bcodr) ⦁ ⭐ [Star Jellyfin Enhanced](https://github.com/n00bcodr/Jellyfin-Enhanced)
+
+## 🤖 100% AI development
+
+Jellyfin Canopy is developed **entirely with AI** (agentic coding tools driving design, implementation, testing, and review), directed and curated by a human maintainer. Every change must pass a full quality gate — type checks, unit tests with coverage floors, a real end-to-end browser suite against a live Jellyfin 12 server, and multi-pass adversarial code review — before it lands. Curious how? See the [Developer Guide](https://4eh5xitv6787h645ebv.github.io/Jellyfin-Canopy/developers/).
 
 <br>
 
 ## 🌍 Contributing
 
-- 🐛 [Report Issues](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues)
-- 💡 [Feature Requests](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/discussions)
-- 🌍 Translations: locale JSON files live in `Jellyfin.Plugin.JellyfinCanopy/js/locales/` — PRs welcome (all 26 locales must stay in sync; `npm run validate-translations` must pass)
+- 🐛 [Report issues](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues)
+- 💡 [Suggest features](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/discussions)
+- 🌍 Help translate — Canopy ships in 26 languages and every string is translatable
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow, gates, and the paved road for new features.
+Developers: [CONTRIBUTING.md](CONTRIBUTING.md) has the workflow, quality gates, and the paved road for new features.
 
 <br>
 
-## 🎯 Related Projects
+## 🎯 Related projects
 
 By [n00bcodr](https://github.com/n00bcodr), the original author of Jellyfin Enhanced:
 
-- [Jellyfin-Enhanced](https://github.com/n00bcodr/Jellyfin-Enhanced) - The original project this fork is built on (Jellyfin 10.11)
-- [Jellyfin-Tweaks](https://github.com/n00bcodr/JellyfinTweaks) - Additional tweaks plugin
-- [Jellyfin-JavaScript-Injector](https://github.com/n00bcodr/Jellyfin-JavaScript-Injector) - Custom script injection
-- [Jellyfish](https://github.com/n00bcodr/Jellyfish/) - Custom Jellyfin theme
+- [Jellyfin-Enhanced](https://github.com/n00bcodr/Jellyfin-Enhanced) — the original project this fork is built on (Jellyfin 10.11)
+- [Jellyfin-Tweaks](https://github.com/n00bcodr/JellyfinTweaks) — additional tweaks plugin
+- [Jellyfin-JavaScript-Injector](https://github.com/n00bcodr/Jellyfin-JavaScript-Injector) — custom script injection
+- [Jellyfish](https://github.com/n00bcodr/Jellyfish/) — custom Jellyfin theme
 
 Recommended plugins:
 
-- [File Transformation](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation) - Safe file modifications
-- [Custom Tabs](https://github.com/IAmParadox27/jellyfin-plugin-custom-tabs) - Custom navigation tabs
-- [Plugin Pages](https://github.com/IAmParadox27/jellyfin-plugin-pages) - Helps Plugins create custom pages for settings and info
-- [Kefin Tweaks](https://github.com/ranaldsgift/KefinTweaks) - Watchlist and more
+- [File Transformation](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation) — safe file modifications
+- [Custom Tabs](https://github.com/IAmParadox27/jellyfin-plugin-custom-tabs) — custom navigation tabs
+- [Plugin Pages](https://github.com/IAmParadox27/jellyfin-plugin-pages) — helps plugins create custom pages
+- [Kefin Tweaks](https://github.com/ranaldsgift/KefinTweaks) — watchlist and more
 
 <br>
 


### PR DESCRIPTION
# README: from-scratch user-facing rewrite

## What / why

The previous README mixed the user pitch with developer internals. This is a complete rewrite aimed at prospective users: what the plugin is and what it does for them, in plain language, with the technical depth linked out to the documentation site instead of inlined.

- Plain-language pitch and a "Why Canopy?" section up top.
- The feature catalog reorganized by what the user is trying to do (watching, discovering, requesting, family safety, poster badges, built-in pages, admin tools), each section ending in a link to its docs page.
- Expanded screenshot gallery (8 shots including the Calendar page and Active Streams).
- Friendlier get-started: the four install steps, then a first-run pointer and the optional integrations (Seerr, arrs, segment provider, TMDB key) spelled out with what each unlocks.
- A per-topic documentation table replacing the single docs link.
- Developer internals (project structure) removed — CONTRIBUTING.md and the Developer Guide own them.
- Retained deliberately: origins & credit to n00bcodr (donation links still point at him), the 100% AI development disclosure, compatibility table, related projects, license, and the install repository URL.
- Compatibility rows for Android TV / third-party apps now say which server-side features still apply (Spoiler Guard, auto-requests) instead of a bare "not supported".

## Accuracy

Every feature claim was cross-checked against the canonical docs and the merged history; nothing from open PRs is advertised. The review loop tightened nine claims to match documented behavior: the default-install promise, watchlist sync direction (KefinTweaks dependency), admin-defaults scope, the File Transformation tip (scoped to web-folder-writing setups; the default request-time injection doesn't need it), TMDB-key-backed features, session-control scope (remote-control-capable sessions), arr action scope per item type, the layout-enforcement TV-mode exemption, and the translation claim.

## Verification

- `verify.sh docs` green (strict mkdocs + docs checks) at HEAD.
- All referenced images exist in-repo; all docs links target published site paths from the mkdocs nav.

## Review ledger

- Discovery (general): 3 findings (default-install claim, watchlist dependency, admin-default overstatement) — confirmed, fixed, confirmation clean.
- Final (Sol, xhigh): 6 findings (File Transformation default, TMDB rating dependency, session-control scope, arr action scope, layout device scope, i18n overclaim) — confirmed, fixed, final-confirmation clean across all six.

## AI assistance

Written with AI assistance (Claude); claims verified against the documentation and merge history, and gated through the repository's docs verification and Codex review loop.
