### PR TITLE
fix: make Auto-Skip E2E seed deterministic

### DIFF
--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -3,4 +3,6 @@ playwright-report/
 docker/media/
 docker/config/
 docker/cache/
+docker/seed-result.json
+docker/seed-result.json.tmp
 perf/traces/

--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -115,6 +115,18 @@ test.describe('admin authorization', () => {
         expect(state.adminFilter).toBe(false);
         expect(state.stuckSpinners).toBe(0);
 
-        assertNoRuntimeErrors(consoleErrors);
+        // Jellyfin web's own hashed host chunk can emit this exact pageerror
+        // while mounting a full standalone page. The retained CI trace for
+        // #195 attributes it to /web/49275.*.chunk.js, and the same narrow host
+        // noise is already scoped in pages-lifecycle and settings-persist.
+        // Keep every other console error and every unexpected plugin 4xx fatal.
+        const pluginErrors = consoleErrors.real().filter(
+            (text) => text !== 'pageerror: t.scrollHandler is not a function'
+        );
+        expect(pluginErrors, 'unexpected Canopy console errors').toEqual([]);
+        expect(
+            consoleErrors.unexpected4xx(),
+            'unexpected 4xx responses from plugin endpoints'
+        ).toEqual([]);
     });
 });

--- a/e2e/auto-skip.spec.ts
+++ b/e2e/auto-skip.spec.ts
@@ -4,131 +4,384 @@
 // role gating — an admin and a non-admin drive identical engine code — so one
 // perspective is sufficient.
 //
-// The dev server ships no media-segment provider, so GET /MediaSegments/{id}
-// returns empty (verified: an orphan DB row is dropped by the provider filter).
-// We therefore inject a KNOWN intro segment through the plugin's REAL fetch path
-// via route interception; everything downstream (the shipped engine's
-// timeupdate-driven skip, exact-EndTicks seek, once/seek-back guards, localized
-// toast) runs for real against real muted playback of a real long item.
-import { test, expect, loginAs, showRoute, waitForHash } from './fixtures/auth';
+// The clean seed has no media-segment provider, so GET /MediaSegments/{id}
+// returns empty. We inject one known intro through the plugin's real fetch path;
+// everything downstream (the shipped engine, real H.264/AAC playback, exact-end
+// seek, native-parity seek-back guard, and localized toast) runs for real.
+import { test, expect, loginAs, showRoute } from './fixtures/auth';
+import { api, authenticate, type Session } from './fixtures/api';
+import {
+    AUTO_SKIP_FIXTURE,
+    PLAYWRIGHT_DEVICE_PROFILE,
+    TICKS_PER_SECOND,
+    resolveAutoSkipFixture,
+    type FixtureApiClient,
+    type JellyfinItem,
+    type PlaybackInfo,
+} from '../scripts/e2e/auto-skip-fixture';
 
-const ITEM = process.env.JF_AUTOSKIP_ITEM || '14ba72cbe419e23f29d748060beef153';
-const TPS = 10_000_000;
-const START_SEC = 2;
-const END_SEC = 25;
+const OVERRIDE_ITEM_ID = process.env.JF_AUTOSKIP_ITEM || '';
+const START_SEC = AUTO_SKIP_FIXTURE.segmentStartSeconds;
+const END_SEC = AUTO_SKIP_FIXTURE.segmentEndSeconds;
+const HEBREW_AUTO_SKIP_TEXT = 'פתיח דולג אוטומטי';
+
+interface ItemList {
+    Items?: JellyfinItem[];
+}
+
+interface UserData {
+    PlaybackPositionTicks?: number;
+    PlayedPercentage?: number;
+    Played?: boolean;
+    [key: string]: unknown;
+}
+
+interface SeekRecord {
+    from: number;
+    to: number;
+}
+
+interface AutoSkipTrace {
+    lastStableTime: number;
+    seeks: SeekRecord[];
+    timeUpdates: number[];
+}
+
+function queryString(options: Record<string, unknown>): string {
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(options)) {
+        if (value !== undefined && value !== null) params.set(key, String(value));
+    }
+    return params.toString();
+}
+
+function fixtureApi(baseURL: string, session: Session): FixtureApiClient {
+    return {
+        getCurrentUserId: () => session.userId,
+        getItems: async (userId, options) =>
+            (await api<ItemList>(
+                baseURL,
+                `/Items?${queryString({ ...options, UserId: userId })}`,
+                session.token
+            )) ?? { Items: [] },
+        getItem: async (userId, itemId) => {
+            const item = await api<JellyfinItem>(
+                baseURL,
+                `/Users/${encodeURIComponent(userId)}/Items/${encodeURIComponent(itemId)}?Fields=MediaSources,Path`,
+                session.token
+            );
+            if (!item) throw new Error(`item ${itemId} returned an empty response`);
+            return item;
+        },
+        getPlaybackInfo: async (itemId, options, deviceProfile) => {
+            const info = await api<PlaybackInfo>(
+                baseURL,
+                `/Items/${encodeURIComponent(itemId)}/PlaybackInfo`,
+                session.token,
+                {
+                    method: 'POST',
+                    body: JSON.stringify({ ...options, DeviceProfile: deviceProfile }),
+                }
+            );
+            if (!info) throw new Error(`PlaybackInfo for ${itemId} returned an empty response`);
+            return info;
+        },
+    };
+}
+
+async function resetPlaybackState(
+    baseURL: string,
+    session: Session,
+    itemId: string
+): Promise<void> {
+    const path = `/UserItems/${encodeURIComponent(itemId)}/UserData?userId=${encodeURIComponent(session.userId)}`;
+    const existing = (await api<UserData>(baseURL, path, session.token)) ?? {};
+    await api<UserData>(baseURL, path, session.token, {
+        method: 'POST',
+        body: JSON.stringify({
+            ...existing,
+            PlaybackPositionTicks: 0,
+            PlayedPercentage: 0,
+            Played: false,
+        }),
+    });
+    const verified = await api<UserData>(baseURL, path, session.token);
+    const position = Number(verified?.PlaybackPositionTicks);
+    const percentage = verified?.PlayedPercentage;
+    if (!verified
+        || !Number.isFinite(position)
+        || position !== 0
+        || (percentage !== null && percentage !== undefined && Number(percentage) !== 0)
+        || verified.Played !== false) {
+        throw new Error(
+            `Auto-Skip fixture ${itemId} playback reset failed: `
+            + `PlaybackPositionTicks=${String(verified?.PlaybackPositionTicks)}, `
+            + `PlayedPercentage=${String(percentage)}, `
+            + `Played=${String(verified?.Played)}`
+        );
+    }
+}
+
+async function readTrace(page: import('playwright/test').Page): Promise<AutoSkipTrace> {
+    return page.evaluate(() => {
+        const trace = (window as unknown as { __jcAutoSkipTrace?: AutoSkipTrace }).__jcAutoSkipTrace;
+        return trace ?? { lastStableTime: -1, seeks: [], timeUpdates: [] };
+    });
+}
+
+function exactEndSeeks(trace: AutoSkipTrace): SeekRecord[] {
+    return trace.seeks.filter((seek) =>
+        seek.from >= START_SEC
+        && seek.from < END_SEC - 2
+        && Math.abs(seek.to - END_SEC) <= 0.75
+    );
+}
 
 test.describe('Auto-Skip v2 (native media segments)', () => {
-    test('skips an intro to the exact segment end, once, and never re-skips on seek-back', async ({
+    test('resolves the clean-seed item, seeks to exact end once, and ignores direct seek-back', async ({
         page,
         consoleErrors,
-    }) => {
-        await page.route('**/MediaSegments/**', (route) =>
-            route.fulfill({
+        baseURL,
+    }, testInfo) => {
+        if (!baseURL) throw new Error('Auto-Skip E2E requires a configured baseURL');
+
+        // Resolve and preflight through the server API before the browser ever
+        // navigates. This turns missing/stale/short fixtures into fast,
+        // diagnostic failures instead of a 30-second currentSrc timeout.
+        const session = await authenticate(
+            baseURL,
+            process.env.JF_ADMIN_USER || 'jc_arradmin',
+            process.env.JF_ADMIN_PASS || 'Test669Pw!x'
+        );
+        const resolved = await resolveAutoSkipFixture(fixtureApi(baseURL, session), OVERRIDE_ITEM_ID);
+        testInfo.annotations.push({
+            type: 'fixture',
+            description: `${resolved.name}: ${resolved.id}, ${resolved.durationSeconds.toFixed(1)}s, ${resolved.playbackMode}`,
+        });
+
+        // Every Playwright retry starts with zero resume state. The finally
+        // block repeats the reset so later local runs are isolated as well.
+        await resetPlaybackState(baseURL, session, resolved.id);
+
+        const requestedSegmentIds: string[] = [];
+        await page.route('**/MediaSegments/**', async (route) => {
+            const requestUrl = new URL(route.request().url());
+            const requestId = decodeURIComponent(requestUrl.pathname.split('/').pop() || '');
+            requestedSegmentIds.push(requestId);
+            if (requestId.replaceAll('-', '').toLowerCase() !== resolved.id.replaceAll('-', '').toLowerCase()) {
+                await route.continue();
+                return;
+            }
+            await route.fulfill({
                 status: 200,
                 contentType: 'application/json',
                 body: JSON.stringify({
                     Items: [
                         {
                             Id: 'e2e-intro',
-                            ItemId: ITEM,
+                            ItemId: resolved.id,
                             Type: 'Intro',
-                            StartTicks: START_SEC * TPS,
-                            EndTicks: END_SEC * TPS,
+                            StartTicks: START_SEC * TICKS_PER_SECOND,
+                            EndTicks: END_SEC * TICKS_PER_SECOND,
                         },
                     ],
                     TotalRecordCount: 1,
                     StartIndex: 0,
                 }),
-            })
-        );
+            });
+        });
 
-        await loginAs(page, 'admin', consoleErrors);
+        // Force Jellyfin's Modern layout before its first boot read. Explicit
+        // docker runs also set JF_LAYOUT_ENFORCEMENT=ForceExperimental; this
+        // client-side seed keeps the committed CI path identical.
+        await page.addInitScript((userId) => {
+            window.localStorage.setItem('layout', 'experimental');
+            window.localStorage.setItem(`${userId}-language`, 'he');
+        }, session.userId);
 
-        // Enable the intro quick-toggle the engine gates on, and record the
-        // transient auto-skip toasts (they auto-dismiss ~1.5s).
-        await page.evaluate(() => {
-            /* eslint-disable @typescript-eslint/no-explicit-any */
-            (window as any).JellyfinCanopy.currentSettings.autoSkipIntro = true;
-            (window as any).__jeToasts = [];
-            const observer = new MutationObserver((mutations) => {
-                for (const mutation of mutations) {
-                    for (const node of mutation.addedNodes) {
-                        if (node instanceof HTMLElement && node.classList.contains('jellyfin-canopy-toast')) {
-                            (window as any).__jeToasts.push(node.textContent || '');
+        try {
+            await loginAs(page, 'admin', consoleErrors);
+
+            // Prove the rendered dialect, not merely the localStorage spelling.
+            await page.waitForFunction(
+                () => {
+                    const toolbar = document.querySelector<HTMLElement>('.MuiAppBar-root .MuiToolbar-root');
+                    const legacy = document.querySelector<HTMLElement>('.headerRight');
+                    return !!toolbar && toolbar.getClientRects().length > 0
+                        && (!legacy || legacy.offsetParent === null);
+                },
+                undefined,
+                { timeout: 30_000 }
+            );
+
+            // Enable the intro quick-toggle, record transient localized toasts,
+            // and attach seek instrumentation before the video element exists.
+            await page.evaluate(() => {
+                /* eslint-disable @typescript-eslint/no-explicit-any */
+                (window as any).JellyfinCanopy.currentSettings.autoSkipIntro = true;
+                (window as any).__jeToasts = [];
+                (window as any).__jcAutoSkipTrace = { lastStableTime: 0, seeks: [], timeUpdates: [] };
+
+                const attachVideoTrace = (video: HTMLVideoElement) => {
+                    if (video.dataset.jcE2eSeekTrace === 'true') return;
+                    video.dataset.jcE2eSeekTrace = 'true';
+                    const trace = (window as any).__jcAutoSkipTrace as AutoSkipTrace;
+                    trace.lastStableTime = video.currentTime;
+                    video.addEventListener('timeupdate', () => {
+                        trace.timeUpdates.push(video.currentTime);
+                        if (!video.seeking && Number.isFinite(video.currentTime)) {
+                            trace.lastStableTime = video.currentTime;
+                        }
+                    });
+                    video.addEventListener('seeking', () => {
+                        trace.seeks.push({ from: trace.lastStableTime, to: video.currentTime });
+                    });
+                };
+
+                document.querySelectorAll<HTMLVideoElement>('video').forEach(attachVideoTrace);
+                const observer = new MutationObserver((mutations) => {
+                    for (const mutation of mutations) {
+                        for (const node of mutation.addedNodes) {
+                            if (!(node instanceof HTMLElement)) continue;
+                            if (node instanceof HTMLVideoElement) attachVideoTrace(node);
+                            node.querySelectorAll<HTMLVideoElement>('video').forEach(attachVideoTrace);
+                            if (node.classList.contains('jellyfin-canopy-toast')) {
+                                (window as any).__jeToasts.push(node.textContent || '');
+                            }
                         }
                     }
-                }
+                });
+                observer.observe(document.body, { childList: true, subtree: true });
+                /* eslint-enable @typescript-eslint/no-explicit-any */
             });
-            observer.observe(document.body, { childList: true });
-            /* eslint-enable @typescript-eslint/no-explicit-any */
-        });
+            const expectedLocalizedToast = await page.evaluate(() => {
+                const html = (window as any).JellyfinCanopy.t('toast_auto_skipped_intro') as string;
+                const host = document.createElement('div');
+                host.innerHTML = html;
+                return (host.textContent || '').trim();
+            });
+            expect(expectedLocalizedToast, 'localized toast text is not empty or a raw key').not.toBe('');
+            expect(expectedLocalizedToast, 'localized toast is not the untranslated key').not.toBe('toast_auto_skipped_intro');
+            expect(
+                expectedLocalizedToast,
+                'the forced Hebrew locale resolves the committed Auto-Skip translation'
+            ).toContain(HEBREW_AUTO_SKIP_TEXT);
 
-        // Open the item and start playback.
-        await showRoute(page, `/details?id=${ITEM}`);
-        await waitForHash(page, 'details');
-        await page.waitForTimeout(2000);
-        const clicked = await page.evaluate(() => {
-            const el = document.querySelector<HTMLElement>('.page:not(.hide) .btnPlay');
-            if (el) {
-                el.click();
-                return true;
-            }
-            return false;
-        });
-        expect(clicked, 'found and clicked the play button').toBe(true);
+            await showRoute(page, `/details?id=${resolved.id}`);
+            await page.waitForFunction(
+                (itemId) => {
+                    const route = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+                    return /details/i.test(route) && route.toLowerCase().includes(itemId.toLowerCase());
+                },
+                resolved.id,
+                { timeout: 30_000 }
+            );
 
-        // Wait for the player element, mute it, keep it playing.
-        await page.waitForFunction(
-            () => {
-                const v = document.querySelector('video');
-                return !!(v && v.currentSrc);
-            },
-            undefined,
-            { timeout: 30_000 }
-        );
-        await page.evaluate(() => {
-            const v = document.querySelector('video');
-            if (v) {
-                v.muted = true;
-                void v.play?.().catch(() => undefined);
-            }
-        });
+            const playButton = page.locator('.btnPlay:visible').first();
+            await expect(playButton, `play button for ${resolved.name} (${resolved.id})`).toBeVisible();
+            await playButton.click();
 
-        // The engine seeks to the EXACT EndTicks once playback crosses the start.
-        await page.waitForFunction(
-            (end) => {
-                const v = document.querySelector('video');
-                return !!v && v.currentTime >= end - 2;
-            },
-            END_SEC,
-            { timeout: 30_000 }
-        );
-        const afterSkip = await page.evaluate(() => document.querySelector('video')!.currentTime);
-        expect(afterSkip, 'jumped to the segment end').toBeGreaterThanOrEqual(END_SEC - 2);
-        expect(afterSkip, 'did not overshoot far past the end').toBeLessThan(END_SEC + 6);
+            await page.waitForFunction(
+                () => {
+                    const video = document.querySelector('video');
+                    return !!video?.currentSrc && video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA;
+                },
+                undefined,
+                { timeout: 30_000 }
+            );
+            await page.evaluate(() => {
+                const video = document.querySelector('video');
+                if (!video) return;
+                video.muted = true;
+                video.currentTime = 0;
+                void video.play().catch(() => undefined);
+            });
 
-        // Seek BACK into the segment — must NOT insta-re-skip.
-        await page.evaluate(() => {
-            const v = document.querySelector('video')!;
-            v.pause();
-            v.currentTime = 6;
-        });
-        await page.waitForTimeout(1500);
-        const afterSeekBack = await page.evaluate(() => document.querySelector('video')!.currentTime);
-        expect(afterSeekBack, 'stayed inside the segment, not re-skipped').toBeLessThan(END_SEC - 3);
+            // A currentTime threshold alone is vacuous: natural playback could
+            // reach 25s. Require an actual seek whose prior clock was inside the
+            // intro and whose target is the exact EndTicks boundary.
+            await expect
+                .poll(async () => exactEndSeeks(await readTrace(page)).length, {
+                    message: `actual ${START_SEC}s -> ${END_SEC}s Auto-Skip seek for ${resolved.id}`,
+                    timeout: 30_000,
+                })
+                .toBe(1);
+            const firstTrace = await readTrace(page);
+            const [firstSkip] = exactEndSeeks(firstTrace);
+            expect(firstSkip.to, 'seek target equals the segment EndTicks').toBeCloseTo(END_SEC, 1);
 
-        // The localized auto-skip toast was shown exactly once.
-        const toasts = await page.evaluate(() => (window as { __jeToasts?: string[] }).__jeToasts ?? []);
-        expect(toasts.filter((t) => /Auto-?Skipped Intro/i.test(t)).length, 'one intro toast').toBe(1);
+            expect(requestedSegmentIds.length, 'MediaSegments was requested').toBeGreaterThan(0);
+            expect(
+                requestedSegmentIds.every((id) =>
+                    id.replaceAll('-', '').toLowerCase() === resolved.id.replaceAll('-', '').toLowerCase()
+                ),
+                'every intercepted MediaSegments request used the discovered current-seed ID'
+            ).toBe(true);
 
-        // Zero real console errors. For 4xx we scope to plugin endpoints: this is
-        // the only spec that drives real media playback, whose core-server calls
-        // (session/progress reporting, trickplay, subtitle probes) legitimately
-        // 4xx in the headless test env and are outside the plugin's surface.
-        expect(consoleErrors.real(), 'unexpected console errors').toEqual([]);
-        const pluginFourxx = consoleErrors
-            .unexpected4xx()
-            .filter((r) => /\/JellyfinCanopy\//i.test(r.url));
-        expect(pluginFourxx, 'no 4xx from plugin endpoints').toEqual([]);
+            // Seek directly back INTO the segment. Native parity keeps this
+            // backward entry inert; only replaying from before Start can skip
+            // again. Keep playback paused so natural time cannot blur the proof.
+            const skipCountBeforeRewind = exactEndSeeks(firstTrace).length;
+            const timeUpdatesBeforeRewind = firstTrace.timeUpdates.length;
+            await page.evaluate(async () => {
+                const video = document.querySelector('video')!;
+                video.pause();
+                await new Promise<void>((resolve, reject) => {
+                    const timeout = window.setTimeout(
+                        () => reject(new Error('seek-back did not emit seeked within 5 seconds')),
+                        5000
+                    );
+                    video.addEventListener('seeked', () => {
+                        window.clearTimeout(timeout);
+                        resolve();
+                    }, { once: true });
+                    video.currentTime = 6;
+                });
+                // Explicitly deliver the event that drives the engine. This
+                // makes the no-re-skip assertion fail if its guard is broken,
+                // even on a browser that omits timeupdate for a paused seek.
+                video.dispatchEvent(new Event('timeupdate'));
+            });
+            await page.waitForTimeout(500);
+            const afterRewind = await page.evaluate(() => document.querySelector('video')!.currentTime);
+            expect(afterRewind, 'stayed inside the segment, not re-skipped').toBeLessThan(END_SEC - 3);
+            const rewindTrace = await readTrace(page);
+            expect(
+                rewindTrace.timeUpdates.length,
+                'the engine received a post-rewind timeupdate'
+            ).toBeGreaterThan(timeUpdatesBeforeRewind);
+            expect(
+                exactEndSeeks(rewindTrace).length,
+                'direct seek-back did not cause a second Auto-Skip seek'
+            ).toBe(skipCountBeforeRewind);
+
+            const toasts = await page.evaluate(
+                () => (window as unknown as { __jeToasts?: string[] }).__jeToasts ?? []
+            );
+            expect(
+                toasts.filter((text) => text.trim() === expectedLocalizedToast).length,
+                `one localized intro toast (${expectedLocalizedToast})`
+            ).toBe(1);
+            expect(
+                toasts.filter((text) => text.includes(HEBREW_AUTO_SKIP_TEXT)).length,
+                'the observed toast contains the independent Hebrew locale phrase'
+            ).toBe(1);
+
+            // Real media playback may legitimately produce core-server probe
+            // 4xx responses in headless Chromium; plugin endpoints may not.
+            expect(consoleErrors.real(), 'unexpected console errors').toEqual([]);
+            const pluginFourxx = consoleErrors
+                .unexpected4xx()
+                .filter((response) => /\/JellyfinCanopy\//i.test(response.url));
+            expect(pluginFourxx, 'no 4xx from plugin endpoints').toEqual([]);
+        } finally {
+            await page.evaluate(() => {
+                const video = document.querySelector('video');
+                if (!video) return;
+                video.pause();
+                video.currentTime = 0;
+            }).catch(() => undefined);
+            await resetPlaybackState(baseURL, session, resolved.id);
+        }
     });
 });

--- a/e2e/docker/compose.yml
+++ b/e2e/docker/compose.yml
@@ -7,12 +7,12 @@
 #   JF_BASE_URL=http://localhost:8100 npm run e2e
 #   docker compose -f e2e/docker/compose.yml down -v
 #
-# Image pin: 12.0-rc2 is the newest Jellyfin 12 image published; it reports
-# server version 12.0.0. Bump to the stable 12.0.0 tag once it exists.
+# The reproducible CI default remains pinned. Compatibility runs can override
+# it without editing source, for example JF_IMAGE=jellyfin/jellyfin:unstable.
 # (Do NOT use 12.0-rc1 — it hangs on the splash logo in headless Chromium.)
 services:
   jellyfin:
-    image: jellyfin/jellyfin:12.0-rc2
+    image: "${JF_IMAGE:-jellyfin/jellyfin:12.0-rc2}"
     container_name: jc-e2e-jellyfin
     # Run as the invoking user so seed.sh can clean config/cache without sudo.
     user: "${JF_UID:-1000}:${JF_GID:-1000}"

--- a/e2e/docker/seed.sh
+++ b/e2e/docker/seed.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Seed a throwaway dockerized Jellyfin 12 for the E2E suite:
 #   1. install the freshly built plugin DLL into a clean config volume,
-#   2. generate a handful of tiny valid movies + a 2×2-episode TV series with
-#      ffmpeg (testsrc2 clips),
+#   2. generate a handful of tiny valid movies, one dedicated 40-second
+#      Auto-Skip movie, and a 2×2-episode TV series with ffmpeg (testsrc2 clips),
 #   3. boot the compose stack and complete the startup wizard via the API,
 #   4. create the Movies + Shows libraries and the two test users the specs
 #      expect,
@@ -22,6 +22,8 @@
 #   SEERR_URL             a reachable Seerr URL    \
 #   SEERR_API_KEY         its API key                   > SeerrEnabled
 #   SEERR_RESPECT_PARENTAL  true|false (default true) — parental gating
+#   JF_IMAGE              compose image override (default jellyfin:12.0-rc2)
+#   JF_LAYOUT_ENFORCEMENT None|ForceExperimental|ForceLegacy (default None)
 #
 # Usage:
 #   dotnet build Jellyfin.Plugin.JellyfinCanopy/JellyfinCanopy.csproj -c Release
@@ -34,7 +36,9 @@ set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${HERE}/../.." && pwd)"
 COMPOSE="docker compose -f ${HERE}/compose.yml"
-IMAGE="jellyfin/jellyfin:12.0-rc2" # keep in sync with compose.yml
+FIXTURE_CONTRACT="${REPO_ROOT}/e2e/fixtures/media-fixtures.json"
+export JF_IMAGE="${JF_IMAGE:-jellyfin/jellyfin:12.0-rc2}"
+IMAGE="${JF_IMAGE}"
 
 export JF_PORT="${JF_PORT:-8100}"
 export JF_UID JF_GID
@@ -49,6 +53,7 @@ USER_PASS="${JF_USER_PASS:-Test669Pw!x}"
 PLUGIN_DLL="${PLUGIN_DLL:-${REPO_ROOT}/Jellyfin.Plugin.JellyfinCanopy/bin/Release/net10.0/Jellyfin.Plugin.JellyfinCanopy.dll}"
 PLUGIN_ID="9ffa12bc-f4b5-406c-ab1d-d575acbeea7b"
 CLIENT_AUTH='MediaBrowser Client="JC-E2E-Seed", Device="seed", DeviceId="jc-e2e-seed", Version="1.0.0"'
+LAYOUT_ENFORCEMENT="${JF_LAYOUT_ENFORCEMENT:-None}"
 
 log() { echo "[seed] $*"; }
 fail() { echo "[seed] ERROR: $*" >&2; exit 1; }
@@ -56,11 +61,39 @@ fail() { echo "[seed] ERROR: $*" >&2; exit 1; }
 [ -f "${PLUGIN_DLL}" ] || fail "plugin DLL not found at ${PLUGIN_DLL} — build Release first"
 command -v jq >/dev/null || fail "jq is required"
 command -v curl >/dev/null || fail "curl is required"
+[ -f "${FIXTURE_CONTRACT}" ] || fail "fixture contract not found at ${FIXTURE_CONTRACT}"
+case "${LAYOUT_ENFORCEMENT}" in
+    None|ForceExperimental|ForceLegacy) ;;
+    *) fail "JF_LAYOUT_ENFORCEMENT must be None, ForceExperimental, or ForceLegacy" ;;
+esac
+
+AUTOSKIP_NAME="$(jq -er '.autoSkip.name | select(type == "string" and length > 0)' "${FIXTURE_CONTRACT}")"
+AUTOSKIP_FILE_PREFIX="$(jq -er '.autoSkip.filePrefix | select(type == "string" and length > 0)' "${FIXTURE_CONTRACT}")"
+AUTOSKIP_DURATION="$(jq -er '.autoSkip.durationSeconds | select(type == "number" and . > 0)' "${FIXTURE_CONTRACT}")"
+AUTOSKIP_END="$(jq -er '.autoSkip.segmentEndSeconds | select(type == "number" and . > 0)' "${FIXTURE_CONTRACT}")"
+AUTOSKIP_MARGIN="$(jq -er '.autoSkip.minimumMarginSeconds | select(type == "number" and . > 0)' "${FIXTURE_CONTRACT}")"
+AUTOSKIP_MIN_DURATION="$(jq -nr --argjson end "${AUTOSKIP_END}" --argjson margin "${AUTOSKIP_MARGIN}" '$end + $margin')"
+AUTOSKIP_MIN_TICKS="$(jq -nr --argjson seconds "${AUTOSKIP_MIN_DURATION}" '$seconds * 10000000 | floor')"
+jq -en --argjson duration "${AUTOSKIP_DURATION}" --argjson minimum "${AUTOSKIP_MIN_DURATION}" \
+    '$duration >= $minimum' >/dev/null \
+    || fail "Auto-Skip fixture duration ${AUTOSKIP_DURATION}s is below required ${AUTOSKIP_MIN_DURATION}s"
+
+# A different parent path on every wiped seed produces a different Jellyfin
+# item ID. The filename and post-scan display name stay stable, and the display
+# name is the only discovery key the browser spec uses.
+SEED_NONCE="${JF_E2E_SEED_ID:-$(date -u +%Y%m%d%H%M%S%N)-$$}"
+[[ "${SEED_NONCE}" =~ ^[A-Za-z0-9._-]+$ ]] \
+    || fail "JF_E2E_SEED_ID may contain only letters, digits, dot, underscore, and dash"
+AUTOSKIP_FILENAME="${AUTOSKIP_FILE_PREFIX}.mp4"
+AUTOSKIP_RELATIVE_DIR="Movies/JC-Auto-Skip-Seed-${SEED_NONCE}"
+AUTOSKIP_RELATIVE_PATH="${AUTOSKIP_RELATIVE_DIR}/${AUTOSKIP_FILENAME}"
+AUTOSKIP_CONTAINER_PATH="/media/${AUTOSKIP_RELATIVE_PATH}"
 
 # ── 1. clean state + plugin install ─────────────────────────────────────────
 log "resetting e2e/docker state (config/cache/media)"
 ${COMPOSE} down -v --remove-orphans >/dev/null 2>&1 || true
 rm -rf "${HERE}/config" "${HERE}/cache" "${HERE}/media"
+rm -f "${HERE}/seed-result.json" "${HERE}/seed-result.json.tmp"
 mkdir -p "${HERE}/config/plugins/JellyfinCanopy_e2e" "${HERE}/cache" "${HERE}/media"
 cp "${PLUGIN_DLL}" "${HERE}/config/plugins/JellyfinCanopy_e2e/"
 log "installed plugin DLL into config/plugins/JellyfinCanopy_e2e"
@@ -88,13 +121,16 @@ fi
 # shared by both collection types would misidentify episode files as movies.
 mkdir -p "${HERE}/media/Movies" "${HERE}/media/Shows"
 
-make_clip() { # <relative-path> <tone-hz>
+make_clip() { # <relative-path> <tone-hz> [duration-seconds]
+    local duration="${3:-5}"
+    jq -en --argjson duration "${duration}" '$duration > 0' >/dev/null \
+        || fail "invalid clip duration '${duration}' for $1"
     # Tag the audio stream as English so the language-tags renderer has a real
     # language to stamp (a bare testsrc clip reports "und", which the renderer
     # skips). Genres + a community rating are added post-scan via the API below.
     run_ffmpeg \
-        -f lavfi -i "testsrc2=duration=5:size=640x360:rate=24" \
-        -f lavfi -i "sine=frequency=$2:duration=5" \
+        -f lavfi -i "testsrc2=duration=${duration}:size=640x360:rate=24" \
+        -f lavfi -i "sine=frequency=$2:duration=${duration}" \
         -c:v libx264 -preset ultrafast -pix_fmt yuv420p -c:a aac -shortest \
         -metadata:s:a:0 language=eng -y "$1"
 }
@@ -104,6 +140,9 @@ make_clip "Movies/Alpha Adventure (2021).mp4" 440
 make_clip "Movies/Beta Voyage (2022).mp4" 550
 make_clip "Movies/Gamma Quest (2023).mp4" 660
 make_clip "Movies/Delta Horizon (2024).mp4" 770
+log "generating dedicated Auto-Skip movie (${AUTOSKIP_DURATION}s, seed ${SEED_NONCE})"
+mkdir -p "${HERE}/media/${AUTOSKIP_RELATIVE_DIR}"
+make_clip "${AUTOSKIP_RELATIVE_PATH}" 880 "${AUTOSKIP_DURATION}"
 
 # ── TV: one series, 2 seasons × 2 episodes, for the Spoiler Guard specs ───────
 # Series/Season NN/… S0xE0y naming so Jellyfin's naming resolver builds the
@@ -123,11 +162,24 @@ log "starting compose stack on port ${JF_PORT}"
 ${COMPOSE} up -d
 
 log "waiting for the server to answer"
+PUBLIC_INFO=''
+SERVER_VERSION=''
 for _ in $(seq 1 60); do
-    curl -fsS -m 3 "${BASE}/System/Info/Public" >/dev/null 2>&1 && break
+    if PUBLIC_INFO="$(curl -fsS -m 3 "${BASE}/System/Info/Public" 2>/dev/null)" \
+        && SERVER_VERSION="$(printf '%s' "${PUBLIC_INFO}" \
+            | jq -er '.Version | select(type == "string" and length > 0)' 2>/dev/null)"; then
+        break
+    fi
+    PUBLIC_INFO=''
+    SERVER_VERSION=''
     sleep 3
 done
-curl -fsS -m 3 "${BASE}/System/Info/Public" >/dev/null || fail "server never came up on ${BASE}"
+[ -n "${SERVER_VERSION}" ] \
+    || fail "server never returned parseable System/Info/Public JSON on ${BASE}"
+CONTAINER_ID="$(${COMPOSE} ps -q jellyfin)"
+[ -n "${CONTAINER_ID}" ] || fail "could not resolve the Jellyfin compose container ID"
+IMAGE_ID="$(docker inspect --format '{{.Image}}' "${CONTAINER_ID}")"
+log "server version ${SERVER_VERSION}, image ${IMAGE} (${IMAGE_ID})"
 
 wizard() { # <method> <path> [json-body]
     # /System/Info/Public answers 200 slightly before the Startup API is ready,
@@ -202,6 +254,7 @@ PLUGIN_CONFIG="$(api GET "/Plugins/${PLUGIN_ID}/Configuration" \
     | jq --arg tmdb "${TMDB_API_KEY}" \
          --arg seerrUrl "${SEERR_URL}" \
          --arg seerrKey "${SEERR_API_KEY}" \
+         --arg layout "${LAYOUT_ENFORCEMENT}" \
          --argjson seerrParental "${SEERR_RESPECT_PARENTAL}" \
         '.QualityTagsEnabled = true
         | .GenreTagsEnabled = true
@@ -214,6 +267,7 @@ PLUGIN_CONFIG="$(api GET "/Plugins/${PLUGIN_ID}/Configuration" \
         | .SpoilerBlurEnabled = true
         | .ShowFileSizes = true
         | .ShowWatchProgress = true
+        | .LayoutEnforcement = $layout
         | (if $tmdb != "" then .TMDB_API_KEY = $tmdb else . end)
         | (if ($seerrUrl != "" and $seerrKey != "")
              then .SeerrUrls = $seerrUrl
@@ -222,6 +276,7 @@ PLUGIN_CONFIG="$(api GET "/Plugins/${PLUGIN_ID}/Configuration" \
                 | .SeerrRespectParentalRatings = $seerrParental
              else . end)')"
 api POST "/Plugins/${PLUGIN_ID}/Configuration" "${PLUGIN_CONFIG}" >/dev/null
+log "layout enforcement: ${LAYOUT_ENFORCEMENT}"
 
 if [ -n "${TMDB_API_KEY}" ]; then
     log "optional: TMDB configured (TmdbEnabled)"
@@ -234,15 +289,75 @@ else
     log "optional: Seerr not configured — Seerr specs will SKIP"
 fi
 
-log "waiting for the library scan to index the movies"
+log "waiting for the library scan to index all movies and the exact Auto-Skip path"
 ADMIN_ID="$(api GET /Users | jq -r --arg name "${ADMIN_USER}" '.[] | select(.Name == $name) | .Id')"
 MOVIES=0
+AUTOSKIP_SCAN_JSON=''
+AUTOSKIP_MATCH_COUNT=0
+AUTOSKIP_SCAN_TICKS=0
+AUTOSKIP_SCAN_SOURCE_COUNT=0
 for _ in $(seq 1 60); do
-    MOVIES="$(api GET "/Items?IncludeItemTypes=Movie&Recursive=true&userId=${ADMIN_ID}" | jq -r .TotalRecordCount)"
-    [ "${MOVIES}" -ge 3 ] 2>/dev/null && break
+    AUTOSKIP_SCAN_JSON="$(api GET "/Items?IncludeItemTypes=Movie&Recursive=true&userId=${ADMIN_ID}&Fields=Path,MediaSources")"
+    MOVIES="$(printf '%s' "${AUTOSKIP_SCAN_JSON}" | jq -r '.TotalRecordCount // 0')"
+    AUTOSKIP_MATCH_COUNT="$(printf '%s' "${AUTOSKIP_SCAN_JSON}" | jq -r \
+        --arg path "${AUTOSKIP_CONTAINER_PATH}" \
+        '[.Items[]? | select(.Path == $path)] | length')"
+    AUTOSKIP_SCAN_TICKS="$(printf '%s' "${AUTOSKIP_SCAN_JSON}" | jq -r \
+        --arg path "${AUTOSKIP_CONTAINER_PATH}" \
+        'first(.Items[]? | select(.Path == $path)
+            | ((.MediaSources // [] | map(.RunTimeTicks // 0) | max // 0) as $source
+               | if $source > 0 then $source else (.RunTimeTicks // 0) end)) // 0')"
+    AUTOSKIP_SCAN_SOURCE_COUNT="$(printf '%s' "${AUTOSKIP_SCAN_JSON}" | jq -r \
+        --arg path "${AUTOSKIP_CONTAINER_PATH}" \
+        'first(.Items[]? | select(.Path == $path) | (.MediaSources // [] | length)) // 0')"
+    if [ "${MOVIES}" -ge 5 ] 2>/dev/null \
+        && [ "${AUTOSKIP_MATCH_COUNT}" -eq 1 ] 2>/dev/null \
+        && [ "${AUTOSKIP_SCAN_SOURCE_COUNT}" -ge 1 ] 2>/dev/null \
+        && [ "${AUTOSKIP_SCAN_TICKS}" -ge "${AUTOSKIP_MIN_TICKS}" ] 2>/dev/null; then
+        break
+    fi
     sleep 5
 done
-[ "${MOVIES}" -ge 3 ] || fail "library scan indexed only ${MOVIES} movies"
+[ "${MOVIES}" -ge 5 ] || fail "library scan indexed only ${MOVIES} movies (expected at least 5)"
+[ "${AUTOSKIP_MATCH_COUNT}" -eq 1 ] \
+    || fail "Auto-Skip fixture '${AUTOSKIP_NAME}' (ID <missing>, duration <missing>) was not indexed at ${AUTOSKIP_CONTAINER_PATH}"
+[ "${AUTOSKIP_SCAN_SOURCE_COUNT}" -ge 1 ] 2>/dev/null \
+    || fail "Auto-Skip fixture '${AUTOSKIP_NAME}' at ${AUTOSKIP_CONTAINER_PATH} has no probed media source after the scan wait"
+[ "${AUTOSKIP_SCAN_TICKS}" -ge "${AUTOSKIP_MIN_TICKS}" ] 2>/dev/null \
+    || fail "Auto-Skip fixture '${AUTOSKIP_NAME}' at ${AUTOSKIP_CONTAINER_PATH} has ${AUTOSKIP_SCAN_TICKS} ticks; ${AUTOSKIP_MIN_TICKS} required"
+
+# Resolve by the physical path owned by this seed, validate the media metadata,
+# then apply the stable logical name used by the spec. Re-read after the update
+# so seed success cannot hide a stale/ambiguous title.
+AUTOSKIP_ID="$(printf '%s' "${AUTOSKIP_SCAN_JSON}" | jq -er \
+    --arg path "${AUTOSKIP_CONTAINER_PATH}" \
+    'first(.Items[]? | select(.Path == $path) | .Id) // empty')"
+AUTOSKIP_DTO="$(api GET "/Users/${ADMIN_ID}/Items/${AUTOSKIP_ID}?Fields=Path,MediaSources")"
+AUTOSKIP_ACTUAL_TICKS="$(printf '%s' "${AUTOSKIP_DTO}" | jq -r \
+    '(.MediaSources // [] | map(.RunTimeTicks // 0) | max // 0) as $source
+     | if $source > 0 then $source else (.RunTimeTicks // 0) end')"
+AUTOSKIP_ACTUAL_SECONDS="$(jq -nr --argjson ticks "${AUTOSKIP_ACTUAL_TICKS}" '$ticks / 10000000')"
+jq -en --argjson actual "${AUTOSKIP_ACTUAL_SECONDS}" --argjson minimum "${AUTOSKIP_MIN_DURATION}" \
+    '$actual >= $minimum' >/dev/null \
+    || fail "Auto-Skip fixture '${AUTOSKIP_NAME}' (ID ${AUTOSKIP_ID}) is ${AUTOSKIP_ACTUAL_SECONDS}s; ${AUTOSKIP_MIN_DURATION}s required"
+AUTOSKIP_PATCHED="$(printf '%s' "${AUTOSKIP_DTO}" | jq --arg name "${AUTOSKIP_NAME}" '.Name = $name')"
+api POST "/Items/${AUTOSKIP_ID}" "${AUTOSKIP_PATCHED}" >/dev/null \
+    || fail "could not apply stable name '${AUTOSKIP_NAME}' to Auto-Skip item ${AUTOSKIP_ID}"
+
+AUTOSKIP_NAMED_JSON="$(api GET "/Items?IncludeItemTypes=Movie&Recursive=true&userId=${ADMIN_ID}&Fields=Path,MediaSources")"
+AUTOSKIP_NAMED_COUNT="$(printf '%s' "${AUTOSKIP_NAMED_JSON}" | jq -r \
+    --arg name "${AUTOSKIP_NAME}" '[.Items[]? | select(.Name == $name)] | length')"
+[ "${AUTOSKIP_NAMED_COUNT}" -eq 1 ] \
+    || fail "Auto-Skip fixture '${AUTOSKIP_NAME}' is ambiguous after naming (${AUTOSKIP_NAMED_COUNT} exact matches)"
+AUTOSKIP_NAMED_ID="$(printf '%s' "${AUTOSKIP_NAMED_JSON}" | jq -er \
+    --arg name "${AUTOSKIP_NAME}" 'first(.Items[]? | select(.Name == $name) | .Id) // empty')"
+AUTOSKIP_NAMED_PATH="$(printf '%s' "${AUTOSKIP_NAMED_JSON}" | jq -er \
+    --arg name "${AUTOSKIP_NAME}" 'first(.Items[]? | select(.Name == $name) | .Path) // empty')"
+[ "${AUTOSKIP_NAMED_ID}" = "${AUTOSKIP_ID}" ] \
+    || fail "Auto-Skip fixture '${AUTOSKIP_NAME}' changed ID after metadata update (${AUTOSKIP_ID} -> ${AUTOSKIP_NAMED_ID})"
+[ "${AUTOSKIP_NAMED_PATH}" = "${AUTOSKIP_CONTAINER_PATH}" ] \
+    || fail "Auto-Skip fixture '${AUTOSKIP_NAME}' resolved to unexpected path ${AUTOSKIP_NAMED_PATH}"
+log "resolved Auto-Skip fixture: name='${AUTOSKIP_NAME}', ID=${AUTOSKIP_ID}, duration=${AUTOSKIP_ACTUAL_SECONDS}s, path=${AUTOSKIP_CONTAINER_PATH}"
 
 log "waiting for the library scan to index the test series + episodes"
 SERIES_ID=""
@@ -326,6 +441,36 @@ curl -fsS -X POST "${BASE}/UserPlayedItems/${S1E1_ID}" -H "${USER_AUTHED}" -H 'C
     || curl -fsS -X POST "${BASE}/Users/${USER_ID}/PlayedItems/${S1E1_ID}" -H "${USER_AUTHED}" -H 'Content-Type: application/json' >/dev/null \
     || fail "could not mark S01E01 played for ${USER_NAME}"
 log "marked S01E01 (${S1E1_ID}) played for ${USER_NAME}"
+
+# Machine-readable evidence for local/CI diagnostics only. The spec deliberately
+# does not read this file: it must discover the current item through Jellyfin's
+# authenticated API so a stale database ID can never become an implicit input.
+jq -n \
+    --arg seedId "${SEED_NONCE}" \
+    --arg image "${IMAGE}" \
+    --arg imageId "${IMAGE_ID}" \
+    --arg serverVersion "${SERVER_VERSION}" \
+    --arg layoutEnforcement "${LAYOUT_ENFORCEMENT}" \
+    --arg id "${AUTOSKIP_ID}" \
+    --arg name "${AUTOSKIP_NAME}" \
+    --arg path "${AUTOSKIP_CONTAINER_PATH}" \
+    --argjson durationSeconds "${AUTOSKIP_ACTUAL_SECONDS}" \
+    --argjson requiredMinimumSeconds "${AUTOSKIP_MIN_DURATION}" \
+    '{
+        seedId: $seedId,
+        image: $image,
+        imageId: $imageId,
+        serverVersion: $serverVersion,
+        layoutEnforcement: $layoutEnforcement,
+        autoSkip: {
+            id: $id,
+            name: $name,
+            path: $path,
+            durationSeconds: $durationSeconds,
+            requiredMinimumSeconds: $requiredMinimumSeconds
+        }
+    }' > "${HERE}/seed-result.json.tmp"
+mv "${HERE}/seed-result.json.tmp" "${HERE}/seed-result.json"
 
 log "ready: ${BASE} (admin=${ADMIN_USER}, user=${USER_NAME}, ${MOVIES} movies, series '${SHOW_NAME}' with ${EPISODES} episodes, Spoiler Guard enabled)"
 log "run the suite with: JF_BASE_URL=${BASE} npm run e2e"

--- a/e2e/fixtures/media-fixtures.json
+++ b/e2e/fixtures/media-fixtures.json
@@ -1,0 +1,10 @@
+{
+  "autoSkip": {
+    "name": "JC Auto-Skip E2E Fixture",
+    "filePrefix": "JC Auto-Skip E2E Fixture",
+    "durationSeconds": 40,
+    "segmentStartSeconds": 2,
+    "segmentEndSeconds": 25,
+    "minimumMarginSeconds": 10
+  }
+}

--- a/scripts/e2e/auto-skip-fixture.d.ts
+++ b/scripts/e2e/auto-skip-fixture.d.ts
@@ -1,0 +1,61 @@
+export interface AutoSkipFixtureContract {
+    name: string;
+    filePrefix: string;
+    durationSeconds: number;
+    segmentStartSeconds: number;
+    segmentEndSeconds: number;
+    minimumMarginSeconds: number;
+}
+
+export interface JellyfinItem {
+    Id?: string;
+    Name?: string;
+    RunTimeTicks?: number;
+}
+
+export interface PlaybackMediaSource {
+    Id?: string;
+    RunTimeTicks?: number;
+    SupportsDirectPlay?: boolean;
+    SupportsDirectStream?: boolean;
+    SupportsTranscoding?: boolean;
+}
+
+export interface PlaybackInfo {
+    MediaSources?: PlaybackMediaSource[];
+}
+
+export interface FixtureApiClient {
+    getCurrentUserId(): string;
+    getItems(userId: string, options: Record<string, unknown>): Promise<{ Items?: JellyfinItem[] }>;
+    getItem(userId: string, itemId: string): Promise<JellyfinItem>;
+    getPlaybackInfo(
+        itemId: string,
+        options: Record<string, unknown>,
+        deviceProfile: Record<string, unknown>
+    ): Promise<PlaybackInfo>;
+}
+
+export interface ResolvedAutoSkipFixture {
+    id: string;
+    name: string;
+    durationSeconds: number;
+    mediaSourceId: string;
+    playbackMode: 'direct-play' | 'direct-stream' | 'transcode';
+}
+
+export const AUTO_SKIP_FIXTURE: Readonly<AutoSkipFixtureContract>;
+export const PLAYWRIGHT_DEVICE_PROFILE: Readonly<Record<string, unknown>>;
+export const TICKS_PER_SECOND: number;
+export const minimumDurationSeconds: number;
+
+export function selectFixtureItem(items: JellyfinItem[], overrideId?: string): JellyfinItem;
+export function validatePlaybackInfo(
+    item: JellyfinItem,
+    playbackInfo: PlaybackInfo,
+    overrideId?: string
+): Readonly<ResolvedAutoSkipFixture>;
+export function resolveAutoSkipFixture(
+    apiClient: FixtureApiClient,
+    overrideId?: string
+): Promise<Readonly<ResolvedAutoSkipFixture>>;

--- a/scripts/e2e/auto-skip-fixture.js
+++ b/scripts/e2e/auto-skip-fixture.js
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const fixtureManifest = require('../../e2e/fixtures/media-fixtures.json');
+
+const TICKS_PER_SECOND = 10_000_000;
+
+function positiveNumber(value, label) {
+    const number = Number(value);
+    if (!Number.isFinite(number) || number <= 0) {
+        throw new Error(`Auto-Skip fixture contract has invalid ${label}: ${String(value)}`);
+    }
+    return number;
+}
+
+const manifest = fixtureManifest.autoSkip || {};
+const AUTO_SKIP_FIXTURE = Object.freeze({
+    name: String(manifest.name || '').trim(),
+    filePrefix: String(manifest.filePrefix || '').trim(),
+    durationSeconds: positiveNumber(manifest.durationSeconds, 'durationSeconds'),
+    segmentStartSeconds: positiveNumber(manifest.segmentStartSeconds, 'segmentStartSeconds'),
+    segmentEndSeconds: positiveNumber(manifest.segmentEndSeconds, 'segmentEndSeconds'),
+    minimumMarginSeconds: positiveNumber(manifest.minimumMarginSeconds, 'minimumMarginSeconds'),
+});
+
+if (!AUTO_SKIP_FIXTURE.name || !AUTO_SKIP_FIXTURE.filePrefix) {
+    throw new Error('Auto-Skip fixture contract requires a non-empty name and filePrefix');
+}
+if (AUTO_SKIP_FIXTURE.segmentStartSeconds >= AUTO_SKIP_FIXTURE.segmentEndSeconds) {
+    throw new Error('Auto-Skip fixture contract requires segmentStartSeconds < segmentEndSeconds');
+}
+
+const minimumDurationSeconds =
+    AUTO_SKIP_FIXTURE.segmentEndSeconds + AUTO_SKIP_FIXTURE.minimumMarginSeconds;
+if (AUTO_SKIP_FIXTURE.durationSeconds < minimumDurationSeconds) {
+    throw new Error(
+        `Auto-Skip fixture duration ${AUTO_SKIP_FIXTURE.durationSeconds}s is below the `
+        + `${minimumDurationSeconds}s segment-end-plus-margin requirement`
+    );
+}
+
+const PLAYWRIGHT_DEVICE_PROFILE = Object.freeze({
+    MaxStreamingBitrate: 140_000_000,
+    MaxStaticBitrate: 140_000_000,
+    MusicStreamingTranscodingBitrate: 384_000,
+    DirectPlayProfiles: [
+        {
+            Container: 'mp4,m4v',
+            AudioCodec: 'aac,mp3,opus,flac,vorbis',
+            VideoCodec: 'h264',
+            Type: 'Video',
+        },
+    ],
+    TranscodingProfiles: [
+        {
+            Container: 'ts',
+            Type: 'Video',
+            VideoCodec: 'h264',
+            AudioCodec: 'aac,mp3',
+            Protocol: 'hls',
+            Context: 'Streaming',
+        },
+    ],
+    ContainerProfiles: [],
+    CodecProfiles: [],
+    SubtitleProfiles: [],
+});
+
+function fixtureLabel(overrideId) {
+    return overrideId
+        ? `Auto-Skip fixture override ${overrideId}`
+        : `Auto-Skip fixture "${AUTO_SKIP_FIXTURE.name}"`;
+}
+
+function itemDurationLabel(item) {
+    const ticks = Number(item?.RunTimeTicks);
+    return Number.isFinite(ticks) && ticks > 0
+        ? `${(ticks / TICKS_PER_SECOND).toFixed(1)}s`
+        : '<missing>';
+}
+
+function itemDiagnostic(item, overrideId = '') {
+    const id = String(item?.Id || overrideId || '').trim() || '<missing>';
+    return `${fixtureLabel(overrideId)} (ID ${id}, duration ${itemDurationLabel(item)})`;
+}
+
+function selectFixtureItem(items, overrideId = '') {
+    const rows = Array.isArray(items) ? items : [];
+    const normalizedOverride = String(overrideId || '').trim();
+    const matches = normalizedOverride
+        ? rows.filter((item) => String(item?.Id || '') === normalizedOverride)
+        : rows.filter((item) => String(item?.Name || '').trim() === AUTO_SKIP_FIXTURE.name);
+
+    if (matches.length === 0) {
+        throw new Error(
+            `${itemDiagnostic(undefined, normalizedOverride)} was not found in the current server seed`
+        );
+    }
+    if (matches.length > 1) {
+        const details = matches.map((item) => itemDiagnostic(item, normalizedOverride)).join('; ');
+        throw new Error(
+            `${fixtureLabel(normalizedOverride)} is ambiguous (${matches.length} exact matches): ${details}`
+        );
+    }
+
+    const item = matches[0];
+    if (!String(item?.Id || '').trim()) {
+        throw new Error(`${itemDiagnostic(item, normalizedOverride)} resolved without a Jellyfin item ID`);
+    }
+    return item;
+}
+
+function sourceSupportsPlayback(source) {
+    return source?.SupportsDirectPlay === true
+        || source?.SupportsDirectStream === true
+        || source?.SupportsTranscoding === true;
+}
+
+function runtimeSeconds(item, playableSource) {
+    const sourceTicks = Number(playableSource?.RunTimeTicks);
+    const itemTicks = Number(item?.RunTimeTicks);
+    if (Number.isFinite(sourceTicks) && sourceTicks > 0) {
+        return sourceTicks / TICKS_PER_SECOND;
+    }
+    if (Number.isFinite(itemTicks) && itemTicks > 0) {
+        return itemTicks / TICKS_PER_SECOND;
+    }
+    return 0;
+}
+
+function validatePlaybackInfo(item, playbackInfo, overrideId = '') {
+    const label = fixtureLabel(String(overrideId || '').trim());
+    const mediaSources = Array.isArray(playbackInfo?.MediaSources)
+        ? playbackInfo.MediaSources
+        : [];
+    const playableSource = mediaSources.find(sourceSupportsPlayback);
+    if (!playableSource) {
+        throw new Error(
+            `${itemDiagnostic(item, String(overrideId || '').trim())} is not playable: `
+            + 'PlaybackInfo exposed no direct-play, '
+            + 'direct-stream, or transcode source'
+        );
+    }
+
+    const actualDurationSeconds = runtimeSeconds(item, playableSource);
+    if (actualDurationSeconds < minimumDurationSeconds) {
+        throw new Error(
+            `${label} (ID ${item.Id}, duration ${actualDurationSeconds.toFixed(1)}s) is too short: `
+            + `${actualDurationSeconds.toFixed(1)}s actual; `
+            + `${minimumDurationSeconds.toFixed(1)}s required `
+            + `(segment end ${AUTO_SKIP_FIXTURE.segmentEndSeconds}s + `
+            + `${AUTO_SKIP_FIXTURE.minimumMarginSeconds}s margin)`
+        );
+    }
+
+    return Object.freeze({
+        id: String(item.Id),
+        name: String(item.Name || AUTO_SKIP_FIXTURE.name),
+        durationSeconds: actualDurationSeconds,
+        mediaSourceId: String(playableSource.Id || ''),
+        playbackMode: playableSource.SupportsDirectPlay === true
+            ? 'direct-play'
+            : playableSource.SupportsDirectStream === true
+                ? 'direct-stream'
+                : 'transcode',
+    });
+}
+
+async function resolveAutoSkipFixture(apiClient, overrideId = '') {
+    if (!apiClient || typeof apiClient.getCurrentUserId !== 'function') {
+        throw new Error('Auto-Skip fixture resolution requires an authenticated Jellyfin ApiClient');
+    }
+    const userId = String(apiClient.getCurrentUserId() || '').trim();
+    if (!userId) {
+        throw new Error('Auto-Skip fixture resolution requires a signed-in Jellyfin user');
+    }
+
+    const normalizedOverride = String(overrideId || '').trim();
+    let candidates;
+    try {
+        if (normalizedOverride) {
+            candidates = [await apiClient.getItem(userId, normalizedOverride)];
+        } else {
+            const result = await apiClient.getItems(userId, {
+                IncludeItemTypes: 'Movie',
+                Recursive: true,
+                SearchTerm: AUTO_SKIP_FIXTURE.name,
+                Fields: 'MediaSources,Path',
+            });
+            candidates = result?.Items || [];
+        }
+    } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        throw new Error(
+            `${itemDiagnostic(undefined, normalizedOverride)} lookup failed before navigation: ${detail}`
+        );
+    }
+
+    const item = selectFixtureItem(candidates, normalizedOverride);
+    let playbackInfo;
+    try {
+        playbackInfo = await apiClient.getPlaybackInfo(
+            item.Id,
+            {
+                UserId: userId,
+                AutoOpenLiveStream: false,
+                MaxStreamingBitrate: PLAYWRIGHT_DEVICE_PROFILE.MaxStreamingBitrate,
+            },
+            PLAYWRIGHT_DEVICE_PROFILE
+        );
+    } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        throw new Error(
+            `${itemDiagnostic(item, normalizedOverride)} PlaybackInfo preflight failed `
+            + `before navigation: ${detail}`
+        );
+    }
+    return validatePlaybackInfo(item, playbackInfo, normalizedOverride);
+}
+
+module.exports = {
+    AUTO_SKIP_FIXTURE,
+    PLAYWRIGHT_DEVICE_PROFILE,
+    TICKS_PER_SECOND,
+    minimumDurationSeconds,
+    resolveAutoSkipFixture,
+    selectFixtureItem,
+    validatePlaybackInfo,
+};

--- a/scripts/e2e/auto-skip-fixture.test.js
+++ b/scripts/e2e/auto-skip-fixture.test.js
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+    AUTO_SKIP_FIXTURE,
+    PLAYWRIGHT_DEVICE_PROFILE,
+    TICKS_PER_SECOND,
+    minimumDurationSeconds,
+    resolveAutoSkipFixture,
+    selectFixtureItem,
+    validatePlaybackInfo,
+} = require('./auto-skip-fixture');
+
+const ROOT = path.resolve(__dirname, '../..');
+
+function item(overrides = {}) {
+    return {
+        Id: 'dynamic-id-a',
+        Name: AUTO_SKIP_FIXTURE.name,
+        RunTimeTicks: AUTO_SKIP_FIXTURE.durationSeconds * TICKS_PER_SECOND,
+        ...overrides,
+    };
+}
+
+function playbackInfo(overrides = {}) {
+    return {
+        MediaSources: [
+            {
+                Id: 'media-source-a',
+                RunTimeTicks: AUTO_SKIP_FIXTURE.durationSeconds * TICKS_PER_SECOND,
+                SupportsDirectPlay: true,
+            },
+        ],
+        ...overrides,
+    };
+}
+
+function fakeApi({ items = [item()], playback = playbackInfo(), overrideItem, failLookup } = {}) {
+    const calls = [];
+    return {
+        calls,
+        getCurrentUserId: () => 'admin-user-id',
+        getItems: async (_userId, options) => {
+            calls.push(['getItems', options]);
+            if (failLookup) throw new Error(failLookup);
+            return { Items: items };
+        },
+        getItem: async (_userId, id) => {
+            calls.push(['getItem', id]);
+            if (failLookup) throw new Error(failLookup);
+            return overrideItem || item({ Id: id, Name: 'Manually selected item' });
+        },
+        getPlaybackInfo: async (id, options, profile) => {
+            calls.push(['getPlaybackInfo', id, options, profile]);
+            return playback;
+        },
+    };
+}
+
+test('the media contract leaves a ten-second margin after the segment end', () => {
+    assert.equal(AUTO_SKIP_FIXTURE.segmentStartSeconds, 2);
+    assert.equal(AUTO_SKIP_FIXTURE.segmentEndSeconds, 25);
+    assert.equal(AUTO_SKIP_FIXTURE.minimumMarginSeconds, 10);
+    assert.equal(AUTO_SKIP_FIXTURE.durationSeconds, 40);
+    assert.ok(AUTO_SKIP_FIXTURE.segmentStartSeconds < AUTO_SKIP_FIXTURE.segmentEndSeconds);
+    assert.ok(AUTO_SKIP_FIXTURE.durationSeconds >= minimumDurationSeconds);
+});
+
+test('exact-name discovery ignores fuzzy neighbors and returns the current seed ID', () => {
+    const selected = selectFixtureItem([
+        item({ Id: 'near-1', Name: `${AUTO_SKIP_FIXTURE.name} old` }),
+        item({ Id: 'seed-run-20260713' }),
+        item({ Id: 'near-2', Name: 'Auto-Skip Fixture' }),
+    ]);
+    assert.equal(selected.Id, 'seed-run-20260713');
+});
+
+test('missing, duplicate, and blank-ID fixtures fail with immediate diagnostics', () => {
+    assert.throws(
+        () => selectFixtureItem([]),
+        /JC Auto-Skip E2E Fixture.*ID <missing>, duration <missing>.*not found/
+    );
+    assert.throws(
+        () => selectFixtureItem([item({ Id: 'a' }), item({ Id: 'b' })]),
+        /ambiguous \(2 exact matches\)/
+    );
+    assert.throws(
+        () => selectFixtureItem([item({ Id: '' })]),
+        /ID <missing>, duration 40\.0s.*without a Jellyfin item ID/
+    );
+});
+
+test('an override is selected only by its exact current ID', () => {
+    const selected = selectFixtureItem([
+        item({ Id: 'other', Name: AUTO_SKIP_FIXTURE.name }),
+        item({ Id: 'override-now', Name: 'Different title' }),
+    ], 'override-now');
+    assert.equal(selected.Id, 'override-now');
+    assert.throws(
+        () => selectFixtureItem([item({ Id: 'other' })], 'stale-id'),
+        /fixture override stale-id.*ID stale-id, duration <missing>.*not found/
+    );
+});
+
+test('too-short media fails with actual and required durations before playback', () => {
+    const short = item({ RunTimeTicks: 5 * TICKS_PER_SECOND });
+    assert.throws(
+        () => validatePlaybackInfo(short, playbackInfo({
+            MediaSources: [{
+                Id: 'short-source',
+                RunTimeTicks: 5 * TICKS_PER_SECOND,
+                SupportsDirectPlay: true,
+            }],
+        })),
+        /5\.0s actual; 35\.0s required \(segment end 25s \+ 10s margin\)/
+    );
+});
+
+test('a media item with no advertised playback path fails before navigation', () => {
+    assert.throws(
+        () => validatePlaybackInfo(item(), {
+            MediaSources: [{ Id: 'blocked', SupportsDirectPlay: false }],
+        }),
+        /ID dynamic-id-a, duration 40\.0s.*exposed no direct-play, direct-stream, or transcode source/
+    );
+});
+
+test('the selected playable source cannot borrow a longer item or alternate-source duration', () => {
+    assert.throws(
+        () => validatePlaybackInfo(item({ RunTimeTicks: 90 * TICKS_PER_SECOND }), {
+            MediaSources: [
+                {
+                    Id: 'selected-short-source',
+                    RunTimeTicks: 5 * TICKS_PER_SECOND,
+                    SupportsDirectPlay: true,
+                },
+                {
+                    Id: 'unplayable-long-source',
+                    RunTimeTicks: 90 * TICKS_PER_SECOND,
+                    SupportsDirectPlay: false,
+                    SupportsDirectStream: false,
+                    SupportsTranscoding: false,
+                },
+            ],
+        }),
+        /ID dynamic-id-a, duration 5\.0s.*5\.0s actual; 35\.0s required/
+    );
+});
+
+test('valid playback info records the dynamic ID, duration, and chosen path', () => {
+    const resolved = validatePlaybackInfo(item({ Id: 'new-seed-id' }), playbackInfo());
+    assert.deepEqual(resolved, {
+        id: 'new-seed-id',
+        name: AUTO_SKIP_FIXTURE.name,
+        durationSeconds: 40,
+        mediaSourceId: 'media-source-a',
+        playbackMode: 'direct-play',
+    });
+});
+
+test('resolver discovers by stable name and preflights PlaybackInfo before returning', async () => {
+    const api = fakeApi({
+        items: [
+            item({ Id: 'near', Name: `${AUTO_SKIP_FIXTURE.name} stale` }),
+            item({ Id: 'fresh-seed-id' }),
+        ],
+    });
+    const resolved = await resolveAutoSkipFixture(api);
+    assert.equal(resolved.id, 'fresh-seed-id');
+    assert.deepEqual(api.calls.map((call) => call[0]), ['getItems', 'getPlaybackInfo']);
+    assert.equal(api.calls[0][1].SearchTerm, AUTO_SKIP_FIXTURE.name);
+    assert.equal(api.calls[1][1], 'fresh-seed-id');
+    assert.equal(api.calls[1][2].UserId, 'admin-user-id');
+    assert.deepEqual(api.calls[1][3], PLAYWRIGHT_DEVICE_PROFILE);
+});
+
+test('resolver fetches and validates an optional override instead of trusting it', async () => {
+    const api = fakeApi();
+    const resolved = await resolveAutoSkipFixture(api, 'operator-item-id');
+    assert.equal(resolved.id, 'operator-item-id');
+    assert.deepEqual(api.calls.map((call) => call[0]), ['getItem', 'getPlaybackInfo']);
+    assert.equal(api.calls[0][1], 'operator-item-id');
+});
+
+test('lookup and PlaybackInfo errors name the phase and happen before navigation', async () => {
+    await assert.rejects(
+        resolveAutoSkipFixture(fakeApi({ failLookup: '404 missing' }), 'stale-id'),
+        /fixture override stale-id.*ID stale-id, duration <missing>.*lookup failed before navigation: 404 missing/
+    );
+
+    const api = fakeApi();
+    api.getPlaybackInfo = async () => { throw new Error('server rejected media'); };
+    await assert.rejects(
+        resolveAutoSkipFixture(api),
+        /ID dynamic-id-a, duration 40\.0s.*PlaybackInfo preflight failed before navigation: server rejected media/
+    );
+});
+
+test('seed, spec, compose, and CI consume the dynamic fixture contract', () => {
+    const seed = fs.readFileSync(path.join(ROOT, 'e2e/docker/seed.sh'), 'utf8');
+    const spec = fs.readFileSync(path.join(ROOT, 'e2e/auto-skip.spec.ts'), 'utf8');
+    const compose = fs.readFileSync(path.join(ROOT, 'e2e/docker/compose.yml'), 'utf8');
+    const workflow = fs.readFileSync(path.join(ROOT, '.github/workflows/build.yml'), 'utf8');
+
+    assert.match(seed, /media-fixtures\.json/);
+    assert.match(seed, /make_clip "\$\{AUTOSKIP_RELATIVE_PATH\}" \d+ "\$\{AUTOSKIP_DURATION\}"/);
+    assert.match(seed, /testsrc2=duration=\$\{duration\}/);
+    assert.match(seed, /sine=frequency=\$2:duration=\$\{duration\}/);
+    assert.match(seed, /seed-result\.json/);
+    assert.match(spec, /resolveAutoSkipFixture/);
+    assert.doesNotMatch(spec, /14ba72cbe419e23f29d748060beef153/);
+    assert.ok(
+        spec.indexOf('await resolveAutoSkipFixture(') < spec.indexOf('showRoute(page'),
+        'fixture preflight must appear before details navigation'
+    );
+    assert.match(compose, /image: "\$\{JF_IMAGE:-jellyfin\/jellyfin:12\.0-rc2\}"/);
+    assert.match(workflow, /npm run test:scripts/);
+});


### PR DESCRIPTION
## What changed

- add one shared Auto-Skip media contract and generate a dedicated 40-second H.264/AAC fixture on every clean seed
- vary the physical parent path per wipe, resolve the current Jellyfin ID by exact path, apply a stable logical name, and record seed/image/version evidence
- discover and preflight the fixture through authenticated Jellyfin APIs before browser navigation; validate optional overrides, playback capability, and selected-source duration
- reset and re-verify playback state before and after every attempt
- prove the actual seek from inside the intro to the exact EndTicks boundary, the discovered MediaSegments ID, guarded seek-back behavior, and a forced-Hebrew localized toast
- allow explicit image overrides while retaining the pinned CI default
- locally filter Jellyfin web's exact documented `scrollHandler is not a function` host exception in the one Hidden Content assertion exposed by the first CI run, while keeping all other console and plugin 4xx evidence fatal (#195)

## Root cause and impact

The old test fell back to an ID from an unrelated database while the clean CI seed generated only five-second movies. It therefore waited on a nonexistent/unplayable details route and retried for minutes without testing Auto-Skip. The new contract fails missing, ambiguous, stale, unplayable, or short media before navigation and exercises the real playback path against the item created in that same seed.

The first PR run proved Auto-Skip passes in CI (9.3s), then exposed a pre-existing Jellyfin-web pageerror in an unrelated Hidden Content case. Its retained trace attributes the exception to Jellyfin's hashed host chunk; two existing specs already classify that exact noise. The follow-up keeps the global runtime net strict and scopes only that exact string in the affected test.

## Validation

- two consecutive fully wiped seeds on `jellyfin/jellyfin:unstable`, `ForceExperimental`, and a 2-CPU container:
  - seed A: `a0cbad525ce962ae144e87c965ee5fc0`
  - seed B: `3ed3909edc95fe255297170e3bfdb176`
  - both focused runs passed without `JF_AUTOSKIP_ITEM` (13.2s and 19.1s)
- final hardened focused run on a third clean seed passed in 23.0s
- full live suite: 55 passed, 16 optional-integration skips, 0 failed (17.1m)
- first CI run: seed passed; Auto-Skip passed in 9.3s; 54 passed and 16 expected skips overall; only #195 failed
- 12 Auto-Skip fixture regression tests; 55 total script tests
- proof-bearing full verifier:
  - 548 client tests; 68.59% line coverage
  - 817 .NET tests; 40.46% line coverage
  - translations, syntax, typechecks, manifest, and coverage ratchets passed
  - Release build: 0 warnings, 0 errors

The remaining full-suite latency is tracked separately in #193.

Closes #74.
Closes #195.
Part of #60.
Unblocks #80.