### PR TITLE
ci: shard dockerized Jellyfin E2E

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,16 +121,27 @@ jobs:
   # (e2e/docker/): boot, tags, panel, navigation survival, live updates and the
   # admin authz matrix, straight from the committed Playwright suite.
   #
-  # NEW INFRASTRUCTURE — continue-on-error keeps this job advisory while it
-  # earns trust (media generation + first-boot seeding + real-browser playback
-  # have more moving parts than the other jobs). Once it has proven reliable
-  # across a stretch of PRs, drop the continue-on-error line to make it a
-  # required check.
-  e2e:
-    name: E2E (dockerized Jellyfin 12)
+  # Each shard owns a fresh Jellyfin server. Specs remain serial within that
+  # server; only independent seeded environments run concurrently. The stable
+  # aggregate job below preserves the existing check name and rejects missing,
+  # stale, or failed shard markers.
+  #
+  # NEW INFRASTRUCTURE — continue-on-error keeps the shard and aggregate jobs
+  # advisory while this lane earns trust. Once it has proven reliable, remove
+  # both continue-on-error lines and require only the stable aggregate check.
+  e2e_shard:
+    name: E2E shard ${{ matrix.shard }}/4 (dockerized Jellyfin 12)
     runs-on: ubuntu-latest
     continue-on-error: true
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        shard: [1, 2, 3, 4]
+    env:
+      JF_PORT: "8100"
+      JF_BASE_URL: http://localhost:8100
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
@@ -168,24 +179,23 @@ jobs:
       # built plugin DLL, completes the startup wizard, creates the library +
       # test users and waits for the scan (see e2e/docker/seed.sh).
       - name: Seed dockerized Jellyfin
+        id: seed
         run: bash e2e/docker/seed.sh
-        env:
-          JF_PORT: "8100"
 
-      - name: Run E2E suite
-        run: npm run e2e
-        env:
-          JF_BASE_URL: http://localhost:8100
+      - name: Run E2E shard ${{ matrix.shard }}/4
+        id: playwright
+        timeout-minutes: 15
+        run: npm run e2e -- --shard=${{ matrix.shard }}/4
 
       - name: Server logs on failure
-        if: failure()
+        if: always() && (steps.seed.outcome != 'success' || steps.playwright.outcome != 'success')
         run: docker logs jc-e2e-jellyfin --tail 200 || true
 
       - name: Upload traces and screenshots on failure
-        if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: always() && steps.playwright.outcome != 'success'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: e2e-test-results
+          name: e2e-test-results-${{ github.run_id }}-${{ github.run_attempt }}-shard-${{ matrix.shard }}-of-4
           path: e2e/test-results/
           retention-days: 7
           if-no-files-found: ignore
@@ -193,6 +203,76 @@ jobs:
       - name: Tear down
         if: always()
         run: docker compose -f e2e/docker/compose.yml down -v || true
+
+      - name: Record shard result
+        if: always()
+        env:
+          SEED_OUTCOME: ${{ steps.seed.outcome }}
+          TEST_OUTCOME: ${{ steps.playwright.outcome }}
+        run: |
+          node scripts/e2e/shard-result.js write \
+            --output "${RUNNER_TEMP}/jc-e2e-shard-results/shard-${{ matrix.shard }}.json" \
+            --shard "${{ matrix.shard }}" \
+            --total 4 \
+            --sha "${GITHUB_SHA}" \
+            --run-id "${GITHUB_RUN_ID}" \
+            --run-attempt "${GITHUB_RUN_ATTEMPT}" \
+            --seed-outcome "${SEED_OUTCOME:-skipped}" \
+            --test-outcome "${TEST_OUTCOME:-skipped}"
+
+      - name: Upload shard result
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-status-${{ github.run_id }}-${{ github.run_attempt }}-shard-${{ matrix.shard }}-of-4
+          path: ${{ runner.temp }}/jc-e2e-shard-results/shard-${{ matrix.shard }}.json
+          retention-days: 7
+          if-no-files-found: error
+
+  e2e:
+    name: E2E (dockerized Jellyfin 12)
+    needs: e2e_shard
+    if: always() && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 5
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+
+      - name: Download current-attempt shard results
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: e2e-status-${{ github.run_id }}-${{ github.run_attempt }}-shard-*-of-4
+          path: ${{ runner.temp }}/jc-e2e-shard-results
+          merge-multiple: true
+
+      - name: Require shard artifact download
+        if: always()
+        env:
+          DOWNLOAD_OUTCOME: ${{ steps.download.outcome }}
+        run: test "${DOWNLOAD_OUTCOME}" = success
+
+      - name: Aggregate shard results
+        if: always()
+        run: |
+          node scripts/e2e/shard-result.js aggregate \
+            --directory "${RUNNER_TEMP}/jc-e2e-shard-results" \
+            --total 4 \
+            --sha "${GITHUB_SHA}" \
+            --run-id "${GITHUB_RUN_ID}" \
+            --run-attempt "${GITHUB_RUN_ATTEMPT}"
 
   manifest:
     name: Manifest validation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,8 @@ jobs:
   # Each shard owns a fresh Jellyfin server. Specs remain serial within that
   # server; only independent seeded environments run concurrently. The stable
   # aggregate job below preserves the existing check name and rejects missing,
-  # stale, or failed shard markers.
+  # stale, duplicate, or failed shard markers. On a failed-jobs rerun it can
+  # reuse successful markers from prior attempts of the same run and commit.
   #
   # NEW INFRASTRUCTURE — continue-on-error keeps the shard and aggregate jobs
   # advisory while this lane earns trust. Once it has proven reliable, remove
@@ -236,6 +237,9 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     timeout-minutes: 5
+    permissions:
+      actions: read
+      contents: read
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
@@ -249,14 +253,20 @@ jobs:
         with:
           node-version: 22
 
-      - name: Download current-attempt shard results
+      - name: Download same-run shard results
         id: download
         continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: e2e-status-${{ github.run_id }}-${{ github.run_attempt }}-shard-*-of-4
+          # Force the run-scoped REST listing so a partial rerun can see marker
+          # artifacts retained from prior attempts of this same workflow run.
+          github-token: ${{ github.token }}
+          run-id: ${{ github.run_id }}
+          pattern: e2e-status-${{ github.run_id }}-*-shard-*-of-4
           path: ${{ runner.temp }}/jc-e2e-shard-results
-          merge-multiple: true
+          # Each attempt reuses shard-N.json; separate artifact directories
+          # prevent prior and current attempts from overwriting one another.
+          merge-multiple: false
 
       - name: Require shard artifact download
         if: always()

--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -5,13 +5,29 @@
 // a valid non-admin token -> bare 403 with an EMPTY body; missing/garbage
 // token -> 401. Client code branches on status alone, so the specs pin both
 // the codes and the empty-body shape.
-import { test, expect, loginAs, USERS, assertNoRuntimeErrors } from './fixtures/auth';
+import { test, expect, loginAs, USERS, type ConsoleErrors } from './fixtures/auth';
 import { apiRaw, authenticate } from './fixtures/api';
 import { isKnownHiddenContentHostNoise } from '../scripts/e2e/jellyfin-host-noise';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 const ADMIN_ENDPOINT = '/JellyfinCanopy/admin/hidden-content-users';
+
+/**
+ * Entering the standalone Hidden Content page can trip two exact Jellyfin-web
+ * host races for either role. The predicate stays narrow, and plugin 4xx
+ * responses remain unfiltered.
+ */
+function assertNoHiddenContentRuntimeErrors(consoleErrors: ConsoleErrors): void {
+    const pluginErrors = consoleErrors.real().filter(
+        (text) => !isKnownHiddenContentHostNoise(text)
+    );
+    expect(pluginErrors, 'unexpected Canopy console errors').toEqual([]);
+    expect(
+        consoleErrors.unexpected4xx(),
+        'unexpected 4xx responses from plugin endpoints'
+    ).toEqual([]);
+}
 
 test.describe('admin authorization', () => {
     test('authz matrix: 200 admin / 403 empty non-admin / 401 anonymous', async ({ baseURL }) => {
@@ -80,7 +96,7 @@ test.describe('admin authorization', () => {
             // "View own" + at least the seeded user.
             expect(optionCount).toBeGreaterThan(1);
 
-            assertNoRuntimeErrors(consoleErrors);
+            assertNoHiddenContentRuntimeErrors(consoleErrors);
         } finally {
             // Leave the user's hidden-content store as found.
             await apiRaw(
@@ -116,18 +132,6 @@ test.describe('admin authorization', () => {
         expect(state.adminFilter).toBe(false);
         expect(state.stuckSpinners).toBe(0);
 
-        // Jellyfin web's own hashed host chunks can emit two proven errors
-        // while replacing Home with a full standalone page. Retained CI traces
-        // attribute them to /web chunks (#195/#198); the predicate requires the
-        // exact scroll message or the exact Home signature plus both host URLs.
-        // Keep every other console error and every unexpected plugin 4xx fatal.
-        const pluginErrors = consoleErrors.real().filter(
-            (text) => !isKnownHiddenContentHostNoise(text)
-        );
-        expect(pluginErrors, 'unexpected Canopy console errors').toEqual([]);
-        expect(
-            consoleErrors.unexpected4xx(),
-            'unexpected 4xx responses from plugin endpoints'
-        ).toEqual([]);
+        assertNoHiddenContentRuntimeErrors(consoleErrors);
     });
 });

--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -7,6 +7,7 @@
 // the codes and the empty-body shape.
 import { test, expect, loginAs, USERS, assertNoRuntimeErrors } from './fixtures/auth';
 import { apiRaw, authenticate } from './fixtures/api';
+import { isKnownHiddenContentHostNoise } from '../scripts/e2e/jellyfin-host-noise';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -115,13 +116,13 @@ test.describe('admin authorization', () => {
         expect(state.adminFilter).toBe(false);
         expect(state.stuckSpinners).toBe(0);
 
-        // Jellyfin web's own hashed host chunk can emit this exact pageerror
-        // while mounting a full standalone page. The retained CI trace for
-        // #195 attributes it to /web/49275.*.chunk.js, and the same narrow host
-        // noise is already scoped in pages-lifecycle and settings-persist.
+        // Jellyfin web's own hashed host chunks can emit two proven errors
+        // while replacing Home with a full standalone page. Retained CI traces
+        // attribute them to /web chunks (#195/#198); the predicate requires the
+        // exact scroll message or the exact Home signature plus both host URLs.
         // Keep every other console error and every unexpected plugin 4xx fatal.
         const pluginErrors = consoleErrors.real().filter(
-            (text) => text !== 'pageerror: t.scrollHandler is not a function'
+            (text) => !isKnownHiddenContentHostNoise(text)
         );
         expect(pluginErrors, 'unexpected Canopy console errors').toEqual([]);
         expect(

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -6,6 +6,15 @@
 // reload so the app boots authenticated, then wait for the plugin's
 // window.JellyfinCanopy.initialized === true flag.
 import { test as base, expect, type Page } from 'playwright/test';
+import {
+    CURRENT_USER_TIMEOUT_MS,
+    FAST_BOUNCE_TIMEOUT_MS,
+    PLUGIN_INIT_TIMEOUT_MS,
+    waitForSessionDecision,
+    type AuthSessionDecision,
+    type AuthSessionPhase,
+    type AuthSessionSnapshot,
+} from '../../scripts/e2e/auth-session-state';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -145,78 +154,53 @@ export function assertNoRuntimeErrors(consoleErrors: ConsoleErrors): void {
     ).toEqual([]);
 }
 
-/** True when the stored credentials carry a signed-in server session. */
-async function hasStoredSession(page: Page): Promise<boolean> {
+/** Read only session metadata; access tokens never leave the browser. */
+async function readAuthSession(page: Page): Promise<AuthSessionSnapshot> {
     return page.evaluate(() => {
+        let credentialsMalformed = false;
+        let storedSessions: Array<{ userId: string; hasToken: boolean }> = [];
         try {
             const raw = window.localStorage.getItem('jellyfin_credentials');
             const credentials = raw ? JSON.parse(raw) : null;
-            return !!credentials?.Servers?.some((server: any) => server.AccessToken && server.UserId);
+            storedSessions = Array.isArray(credentials?.Servers)
+                ? credentials.Servers.map((server: any) => ({
+                    userId: String(server?.UserId || '').trim(),
+                    hasToken: !!server?.AccessToken,
+                }))
+                : [];
         } catch {
-            return false;
+            credentialsMalformed = true;
         }
+        return {
+            route: window.location.hash || window.location.pathname,
+            currentUserId: String((window as any).ApiClient?.getCurrentUserId?.() || '').trim(),
+            pluginInitialized: (window as any).JellyfinCanopy?.initialized === true,
+            storedSessions,
+            credentialsMalformed,
+        };
     });
 }
 
-/** One full login attempt. Returns false when the boot bounced to sign-in. */
-async function attemptLogin(
+type LoginPhase = AuthSessionPhase | 'home-route';
+
+interface LoginAttemptResult {
+    ok: boolean;
+    phase: LoginPhase;
+    diagnostic: string;
+}
+
+function failedDecision(decision: AuthSessionDecision, timedOut = false): LoginAttemptResult {
+    return {
+        ok: false,
+        phase: decision.phase,
+        diagnostic: `${timedOut ? 'timed out: ' : ''}${decision.diagnostic}`,
+    };
+}
+
+async function finishAuthenticatedLogin(
     page: Page,
-    username: string,
-    password: string,
-    consoleErrors?: ConsoleErrors
-): Promise<boolean> {
-    await page.goto('/web/', { waitUntil: 'domcontentloaded' });
-    await page.waitForFunction(
-        () => typeof (window as any).ApiClient?.authenticateUserByName === 'function',
-        undefined,
-        { timeout: 60_000 }
-    );
-    await page.evaluate(async (credentials) => {
-        await (window as any).ApiClient.authenticateUserByName(credentials.username, credentials.password);
-    }, { username, password });
-
-    // authenticateUserByName resolves BEFORE the credential store finishes
-    // persisting the session — reloading immediately races it. Wait for the
-    // stored token first.
-    await page.waitForFunction(() => {
-        try {
-            const raw = window.localStorage.getItem('jellyfin_credentials');
-            const credentials = raw ? JSON.parse(raw) : null;
-            return !!credentials?.Servers?.some((server: any) => server.AccessToken && server.UserId);
-        } catch {
-            return false;
-        }
-    }, undefined, { timeout: 30_000 });
-
-    await page.reload({ waitUntil: 'domcontentloaded' });
-
-    // Everything before this point is boot noise from the unauthenticated app.
-    consoleErrors?.reset();
-
-    // The stored session intermittently gets clobbered across the reload
-    // (the app boots back to "Please sign in" and the plugin, unable to load
-    // user settings, never initializes). Detect that early and let the caller
-    // retry the whole attempt instead of timing out.
-    const initialized = await page
-        .waitForFunction(
-            () => (window as any).JellyfinCanopy?.initialized === true,
-            undefined,
-            { timeout: 60_000 }
-        )
-        .then(() => true, () => false);
-    if (!initialized || !(await hasStoredSession(page))) return false;
-
-    // JC initializes on the sign-in page too — prove this is an authenticated
-    // session, not a raced login bounced back to "Please sign in".
-    const authenticated = await page
-        .waitForFunction(
-            () => !!(window as any).ApiClient?.getCurrentUserId?.(),
-            undefined,
-            { timeout: 15_000 }
-        )
-        .then(() => true, () => false);
-    if (!authenticated) return false;
-
+    expectedUserId: string
+): Promise<LoginAttemptResult> {
     // The reload can restore onto the /login route it was on when we
     // authenticated (the session is valid — the app just kept the URL).
     // Route to home explicitly so every spec starts from the same place.
@@ -226,13 +210,146 @@ async function attemptLogin(
     if (onAuthPage) {
         await showRoute(page, '/home');
     }
-    return page
+
+    const homeReached = await page
         .waitForFunction(
             (expected) => window.location.hash.includes(expected),
             '/home',
             { timeout: 30_000 }
         )
         .then(() => true, () => false);
+    if (!homeReached) {
+        return {
+            ok: false,
+            phase: 'home-route',
+            diagnostic: `authenticated as ${expectedUserId}, but Jellyfin did not reach /home `
+                + `(route=${await page.evaluate(() => window.location.hash || window.location.pathname)})`,
+        };
+    }
+    return {
+        ok: true,
+        phase: 'home-route',
+        diagnostic: `authenticated as ${expectedUserId} and reached /home`,
+    };
+}
+
+/** One full login attempt with phase-specific bounce diagnostics. */
+async function attemptLogin(
+    page: Page,
+    username: string,
+    password: string,
+    consoleErrors?: ConsoleErrors
+): Promise<LoginAttemptResult> {
+    await page.goto('/web/', { waitUntil: 'domcontentloaded' });
+    await page.waitForFunction(
+        () => typeof (window as any).ApiClient?.authenticateUserByName === 'function',
+        undefined,
+        { timeout: 60_000 }
+    );
+    const expectedUserId = await page.evaluate(async (credentials) => {
+        const apiClient = (window as any).ApiClient;
+        const authenticationResult = await apiClient.authenticateUserByName(
+            credentials.username,
+            credentials.password
+        );
+        // Jellyfin returns AuthenticationResult.User.Id. Keep the ApiClient
+        // fallback for web-client builds that resolve without returning the
+        // result object, but never infer identity from the requested role.
+        return String(
+            authenticationResult?.User?.Id
+            || authenticationResult?.UserId
+            || apiClient.getCurrentUserId?.()
+            || ''
+        ).trim();
+    }, { username, password });
+    if (!expectedUserId) {
+        throw new Error(`authenticateUserByName(${username}) did not expose an authenticated user ID`);
+    }
+
+    // authenticateUserByName resolves BEFORE the credential store finishes
+    // persisting the session — reloading immediately races it. Wait for the
+    // token belonging to the exact authenticated user first.
+    await page.waitForFunction((expected) => {
+        try {
+            const raw = window.localStorage.getItem('jellyfin_credentials');
+            const credentials = raw ? JSON.parse(raw) : null;
+            return !!credentials?.Servers?.some(
+                (server: any) => server.AccessToken && String(server.UserId || '') === expected
+            );
+        } catch {
+            return false;
+        }
+    }, expectedUserId, { timeout: 30_000 });
+
+    await page.reload({ waitUntil: 'domcontentloaded' });
+
+    // Everything before this point is boot noise from the unauthenticated app.
+    consoleErrors?.reset();
+
+    // Fast path: a login/selectserver route with no persisted token and no
+    // current user is a definite bounce. A matching stored token stays pending
+    // here, so a genuinely slow authenticated plugin boot is never retried.
+    const fastDecision = await waitForSessionDecision(
+        () => readAuthSession(page),
+        expectedUserId,
+        {
+            timeoutMs: FAST_BOUNCE_TIMEOUT_MS,
+            stopOnPendingPhases: ['current-user'],
+        }
+    );
+    if (fastDecision.outcome === 'authenticated') {
+        return finishAuthenticatedLogin(page, expectedUserId);
+    }
+    if (fastDecision.outcome !== 'pending') {
+        return failedDecision(fastDecision);
+    }
+
+    let currentUserDecision = fastDecision;
+    if (fastDecision.phase !== 'current-user') {
+        // Keep the established full 60-second plugin allowance after the fast
+        // probe. The poll still exits immediately if the session later becomes
+        // a definite bounce, stale credentials, or the wrong user.
+        const pluginDecision = await waitForSessionDecision(
+            () => readAuthSession(page),
+            expectedUserId,
+            {
+                timeoutMs: PLUGIN_INIT_TIMEOUT_MS,
+                stopOnPendingPhases: ['current-user'],
+            }
+        );
+        if (pluginDecision.outcome === 'authenticated') {
+            return finishAuthenticatedLogin(page, expectedUserId);
+        }
+        if (pluginDecision.outcome !== 'pending') {
+            return failedDecision(pluginDecision);
+        }
+        if (pluginDecision.timedOut) {
+            return failedDecision({
+                ...pluginDecision,
+                phase: pluginDecision.phase === 'post-reload-session'
+                    ? 'post-reload-session'
+                    : 'plugin-init',
+            }, true);
+        }
+        currentUserDecision = pluginDecision;
+    }
+
+    // JC can initialize just before ApiClient exposes the current user. Keep
+    // the previous independent 15-second allowance, and require the exact ID
+    // returned by authenticateUserByName rather than accepting any user.
+    if (currentUserDecision.phase === 'current-user') {
+        const authenticatedDecision = await waitForSessionDecision(
+            () => readAuthSession(page),
+            expectedUserId,
+            { timeoutMs: CURRENT_USER_TIMEOUT_MS }
+        );
+        if (authenticatedDecision.outcome === 'authenticated') {
+            return finishAuthenticatedLogin(page, expectedUserId);
+        }
+        return failedDecision(authenticatedDecision, authenticatedDecision.timedOut);
+    }
+
+    return failedDecision(currentUserDecision, currentUserDecision.timedOut);
 }
 
 /**
@@ -243,11 +360,22 @@ async function attemptLogin(
 export async function loginAs(page: Page, role: Role, consoleErrors?: ConsoleErrors): Promise<void> {
     const { username, password } = USERS[role];
     const maxAttempts = 3;
+    let lastFailure: LoginAttemptResult | undefined;
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-        if (await attemptLogin(page, username, password, consoleErrors)) return;
-        console.log(`loginAs(${role}): attempt ${attempt}/${maxAttempts} bounced to sign-in, retrying`);
+        const result = await attemptLogin(page, username, password, consoleErrors);
+        if (result.ok) return;
+        lastFailure = result;
+        const retry = attempt < maxAttempts ? '; retrying' : '';
+        console.log(
+            `loginAs(${role}): attempt ${attempt}/${maxAttempts} `
+            + `[${result.phase}] ${result.diagnostic}${retry}`
+        );
     }
-    throw new Error(`loginAs(${role}): failed after ${maxAttempts} attempts`);
+    throw new Error(
+        `loginAs(${role}): failed after ${maxAttempts} attempts `
+        + `[${lastFailure?.phase || 'post-reload-session'}] `
+        + `${lastFailure?.diagnostic || 'unknown login failure'}`
+    );
 }
 
 /**

--- a/e2e/fixtures/spoiler-state.ts
+++ b/e2e/fixtures/spoiler-state.ts
@@ -1,0 +1,52 @@
+import { api, type Session } from './api';
+import {
+    applyGuardRestorePlan,
+    type GuardRestorePlan,
+} from '../../scripts/e2e/spoiler-guard-restore';
+
+/** Read the complete state so cleanup can preserve the target entry's metadata. */
+export async function getSpoilerState(
+    baseURL: string,
+    session: Session
+): Promise<Record<string, unknown>> {
+    const state = await api<Record<string, unknown>>(
+        baseURL,
+        `/JellyfinCanopy/user-settings/${session.userId}/spoilerblur.json`,
+        session.token
+    );
+    if (!state) throw new Error(`spoilerblur.json for ${session.userId} returned an empty body`);
+    return state;
+}
+
+/** Restore one target entry into the latest state without rolling back unrelated fields. */
+export async function restoreSeriesGuard(
+    baseURL: string,
+    session: Session,
+    plan: GuardRestorePlan
+): Promise<void> {
+    const latest = await getSpoilerState(baseURL, session);
+    await api(
+        baseURL,
+        `/JellyfinCanopy/user-settings/${session.userId}/spoilerblur.json`,
+        session.token,
+        {
+            method: 'POST',
+            body: JSON.stringify(applyGuardRestorePlan(latest, plan)),
+        }
+    );
+}
+
+/** Attempt every independent restore and expose cleanup failures after all finish. */
+export async function restoreSeriesGuards(
+    baseURL: string,
+    entries: Array<{ session: Session; plan: GuardRestorePlan }>
+): Promise<void> {
+    const results = await Promise.allSettled(
+        entries.map(({ session, plan }) => restoreSeriesGuard(baseURL, session, plan))
+    );
+    const failures = results
+        .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
+        .map((result) => result.reason);
+    if (failures.length === 1) throw failures[0];
+    if (failures.length > 1) throw new AggregateError(failures, 'multiple Spoiler Guard restores failed');
+}

--- a/e2e/session-control.spec.ts
+++ b/e2e/session-control.spec.ts
@@ -35,8 +35,13 @@ async function writePluginConfig(
 // supersede (close) the arruser's playing session before we could observe it.
 const STREAM_CLIENT = 'MediaBrowser Client="JC-E2E", Device="jc-e2e-sc", DeviceId="jc-e2e-sc-stream", Version="1.0.0"';
 
-/** Report a movie as playing for jc_arruser on its own device; return its name. */
-async function startUserPlayback(baseURL: string): Promise<string> {
+interface UserPlayback {
+    itemName: string;
+    stop(): Promise<void>;
+}
+
+/** Report a movie as playing for jc_arruser on its own device. */
+async function startUserPlayback(baseURL: string): Promise<UserPlayback> {
     const authRes = await fetch(`${baseURL}/Users/AuthenticateByName`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: STREAM_CLIENT },
@@ -48,18 +53,39 @@ async function startUserPlayback(baseURL: string): Promise<string> {
     const call = (path: string, init: RequestInit = {}): Promise<Response> =>
         fetch(`${baseURL}${path}`, { ...init, headers: { Authorization: streamAuth, 'Content-Type': 'application/json', ...(init.headers || {}) } });
 
-    const items = (await (await call(`/Users/${auth.User.Id}/Items?IncludeItemTypes=Movie&Recursive=true&Limit=1`)).json()) as { Items?: Array<{ Id: string; Name: string }> };
+    const itemsResponse = await call(`/Users/${auth.User.Id}/Items?IncludeItemTypes=Movie&Recursive=true&Limit=1`);
+    if (!itemsResponse.ok) throw new Error(`stream items -> ${itemsResponse.status}`);
+    const items = (await itemsResponse.json()) as { Items?: Array<{ Id: string; Name: string }> };
     const item = items?.Items?.[0];
     if (!item) throw new Error('no movie available to play');
-    await call('/Sessions/Capabilities/Full', {
+    const capabilities = await call('/Sessions/Capabilities/Full', {
         method: 'POST',
         body: JSON.stringify({ PlayableMediaTypes: ['Video'], SupportedCommands: ['DisplayMessage', 'PlayState'], SupportsMediaControl: true }),
     });
-    await call('/Sessions/Playing', {
+    if (!capabilities.ok) throw new Error(`stream capabilities -> ${capabilities.status}`);
+    const playing = await call('/Sessions/Playing', {
         method: 'POST',
         body: JSON.stringify({ ItemId: item.Id, PlayMethod: 'DirectPlay', CanSeek: true, PositionTicks: 0 }),
     });
-    return item.Name;
+    if (!playing.ok) throw new Error(`stream playing -> ${playing.status}`);
+
+    let stopped = false;
+    return {
+        itemName: item.Name,
+        stop: async () => {
+            if (stopped) return;
+            // The fixture has no live controller to act on a remote Stop
+            // command. Report stopped through Jellyfin core using the same
+            // authenticated device that reported Playing. Failed=true avoids
+            // mutating the seed user's playback state during cleanup.
+            const response = await call('/Sessions/Playing/Stopped', {
+                method: 'POST',
+                body: JSON.stringify({ ItemId: item.Id, PositionTicks: 0, Failed: true }),
+            });
+            if (!response.ok) throw new Error(`stream cleanup -> ${response.status}`);
+            stopped = true;
+        },
+    };
 }
 
 test.describe('session control', () => {
@@ -91,57 +117,76 @@ test.describe('session control', () => {
     });
 
     test('admin sees the live session and can stop / message it', async ({ page, consoleErrors, baseURL }) => {
-        const itemName = await startUserPlayback(baseURL!);
+        const playback = await startUserPlayback(baseURL!);
+        const itemName = playback.itemName;
+        let primaryFailure: unknown;
 
-        // The plugin surface reports the session with the fields the client needs.
-        const sessions = await api<Array<any>>(baseURL!, '/JellyfinCanopy/active-streams/sessions', admin!.token);
-        const target = (sessions || []).find((s) => s?.NowPlayingItem?.Name === itemName);
-        expect(target, 'admin session list includes the played item').toBeTruthy();
-        expect(typeof target.Id).toBe('string');
-        expect('SupportsRemoteControl' in target).toBe(true);
+        try {
+            // The plugin surface reports the session with the fields the client needs.
+            const sessions = await api<Array<any>>(baseURL!, '/JellyfinCanopy/active-streams/sessions', admin!.token);
+            const target = (sessions || []).find((s) => s?.NowPlayingItem?.Name === itemName);
+            expect(target, 'admin session list includes the played item').toBeTruthy();
+            expect(typeof target.Id).toBe('string');
+            expect('SupportsRemoteControl' in target).toBe(true);
 
-        // The admin UI renders the session panel with a card for that stream.
-        await loginAs(page, 'admin', consoleErrors);
-        await page.waitForFunction(
-            () => (window as any).JellyfinCanopy?.initialized === true
-                && (window as any).JellyfinCanopy?.pluginConfig?.ActiveStreamsEnabled === true,
-            undefined,
-            { timeout: 60_000 },
-        );
-        const widget = page.locator('#jc-active-streams');
-        await expect(widget).toBeVisible({ timeout: 30_000 });
-        await widget.click();
-        const card = page.locator('#jc-active-streams-panel .jc-as-card').first();
-        await expect(card).toBeVisible({ timeout: 15_000 });
-        await expect(card).toContainText(itemName);
+            // The admin UI renders the session panel with a card for that stream.
+            await loginAs(page, 'admin', consoleErrors);
+            await page.waitForFunction(
+                () => (window as any).JellyfinCanopy?.initialized === true
+                    && (window as any).JellyfinCanopy?.pluginConfig?.ActiveStreamsEnabled === true,
+                undefined,
+                { timeout: 60_000 },
+            );
+            const widget = page.locator('#jc-active-streams');
+            await expect(widget).toBeVisible({ timeout: 30_000 });
+            await widget.click();
+            const card = page.locator('#jc-active-streams-panel .jc-as-card').first();
+            await expect(card).toBeVisible({ timeout: 15_000 });
+            await expect(card).toContainText(itemName);
 
-        // Session-control endpoints act on that session (admin-gated).
-        //
-        // NOTE: this asserts ENDPOINT-LEVEL success only. The streamed session is
-        // a REST-reported fixture with no live client attached (it reports
-        // SupportsRemoteControl=false), so the message is accepted and dispatched
-        // by the core but has no client to render it — we deliberately do NOT
-        // claim on-screen delivery here. Real client rendering of the core
-        // message dialog is out of scope for this fixture; the per-card compose /
-        // send UI is covered by the unit tests.
-        const msg = await apiRaw(baseURL!, `/JellyfinCanopy/active-streams/sessions/${target.Id}/message`, admin!.token, {
-            method: 'POST',
-            body: JSON.stringify({ text: 'Please pause your stream', timeoutMs: 5000 }),
-        });
-        expect(msg.status, 'admin message endpoint accepts the request → 200').toBe(200);
+            // Session-control endpoints act on that session (admin-gated).
+            //
+            // NOTE: this asserts ENDPOINT-LEVEL success only. The streamed session is
+            // a REST-reported fixture with no live client attached (it reports
+            // SupportsRemoteControl=false), so the message is accepted and dispatched
+            // by the core but has no client to render it — we deliberately do NOT
+            // claim on-screen delivery here. Real client rendering of the core
+            // message dialog is out of scope for this fixture; the per-card compose /
+            // send UI is covered by the unit tests.
+            const msg = await apiRaw(baseURL!, `/JellyfinCanopy/active-streams/sessions/${target.Id}/message`, admin!.token, {
+                method: 'POST',
+                body: JSON.stringify({ text: 'Please pause your stream', timeoutMs: 5000 }),
+            });
+            expect(msg.status, 'admin message endpoint accepts the request → 200').toBe(200);
 
-        const stop = await apiRaw(baseURL!, `/JellyfinCanopy/active-streams/sessions/${target.Id}/stop`, admin!.token, {
-            method: 'POST',
-        });
-        expect(stop.status, 'admin stop → 200').toBe(200);
-        expect((await stop.json()).stopped).toBe(true);
+            const stop = await apiRaw(baseURL!, `/JellyfinCanopy/active-streams/sessions/${target.Id}/stop`, admin!.token, {
+                method: 'POST',
+            });
+            expect(stop.status, 'admin stop → 200').toBe(200);
+            expect((await stop.json()).stopped).toBe(true);
 
-        // The played user has no profile image, so the session card's avatar
-        // <img> 404s and falls back to the person icon (handled by its onerror).
-        // Scope that benign 404 locally — mirrors settings-persist.spec.ts.
-        const AVATAR_404 = /\/Users\/[^/]+\/Images\/Primary/i;
-        expect(consoleErrors.real().filter((t) => !AVATAR_404.test(t)), 'unexpected console errors').toEqual([]);
-        expect(consoleErrors.unexpected4xx().filter((r) => !AVATAR_404.test(r.url)), 'unexpected 4xx').toEqual([]);
+            // The played user has no profile image, so the session card's avatar
+            // <img> 404s and falls back to the person icon (handled by its onerror).
+            // Scope that benign 404 locally — mirrors settings-persist.spec.ts.
+            const AVATAR_404 = /\/Users\/[^/]+\/Images\/Primary/i;
+            expect(consoleErrors.real().filter((t) => !AVATAR_404.test(t)), 'unexpected console errors').toEqual([]);
+            expect(consoleErrors.unexpected4xx().filter((r) => !AVATAR_404.test(r.url)), 'unexpected 4xx').toEqual([]);
+        } catch (error) {
+            primaryFailure = error;
+            throw error;
+        } finally {
+            try {
+                await playback.stop();
+            } catch (cleanupFailure) {
+                if (primaryFailure) {
+                    throw new AggregateError(
+                        [primaryFailure, cleanupFailure],
+                        'session-control assertion and playback cleanup both failed'
+                    );
+                }
+                throw cleanupFailure;
+            }
+        }
     });
 
     test('non-admin gets no session surface and is forbidden from controls', async ({ page, consoleErrors, baseURL }) => {

--- a/e2e/session-control.spec.ts
+++ b/e2e/session-control.spec.ts
@@ -12,18 +12,20 @@
 // unit tests; here we drive the endpoints directly to assert their effect and
 // the admin/non-admin gate.
 import { test, expect, loginAs, assertNoRuntimeErrors, USERS } from './fixtures/auth';
-import { api, apiRaw, authenticate, PLUGIN_ID } from './fixtures/api';
+import { api, apiRaw, authenticate, PLUGIN_ID, type Session } from './fixtures/api';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 const CONFIG_PATH = `/Plugins/${PLUGIN_ID}/Configuration`;
 
-async function enableActiveStreams(baseURL: string): Promise<void> {
-    const admin = await authenticate(baseURL, USERS.admin.username, USERS.admin.password);
-    const config = await api<Record<string, unknown>>(baseURL, CONFIG_PATH, admin.token);
+async function writePluginConfig(
+    baseURL: string,
+    admin: Session,
+    config: Record<string, unknown>
+): Promise<void> {
     await api(baseURL, CONFIG_PATH, admin.token, {
         method: 'POST',
-        body: JSON.stringify({ ...config, ActiveStreamsEnabled: true, ActiveStreamsAllUsers: false }),
+        body: JSON.stringify(config),
     });
 }
 
@@ -61,14 +63,38 @@ async function startUserPlayback(baseURL: string): Promise<string> {
 }
 
 test.describe('session control', () => {
+    let admin: Session | undefined;
+    let originalConfig: Record<string, unknown> | undefined;
+
+    test.beforeAll(async ({ baseURL }) => {
+        // Capture before the first mutation. Playwright re-runs beforeAll /
+        // afterAll when a retry gets a fresh worker, so every worker restores
+        // the exact configuration it found rather than a hand-picked subset.
+        admin = await authenticate(baseURL!, USERS.admin.username, USERS.admin.password);
+        const config = await api<Record<string, unknown>>(baseURL!, CONFIG_PATH, admin.token);
+        expect(config, 'plugin configuration must be readable').toBeTruthy();
+        originalConfig = config!;
+
+        await writePluginConfig(baseURL!, admin, {
+            ...originalConfig,
+            ActiveStreamsEnabled: true,
+            ActiveStreamsAllUsers: false,
+        });
+    });
+
+    test.afterAll(async ({ baseURL }) => {
+        // If setup reached the mutation, both values are present. Do not hide a
+        // failed restore: a cleanup error must fail the file instead of leaking
+        // state silently into the next spec on this shard.
+        if (!admin || !originalConfig) return;
+        await writePluginConfig(baseURL!, admin, originalConfig);
+    });
+
     test('admin sees the live session and can stop / message it', async ({ page, consoleErrors, baseURL }) => {
-        await enableActiveStreams(baseURL!);
         const itemName = await startUserPlayback(baseURL!);
 
-        const admin = await authenticate(baseURL!, USERS.admin.username, USERS.admin.password);
-
         // The plugin surface reports the session with the fields the client needs.
-        const sessions = await api<Array<any>>(baseURL!, '/JellyfinCanopy/active-streams/sessions', admin.token);
+        const sessions = await api<Array<any>>(baseURL!, '/JellyfinCanopy/active-streams/sessions', admin!.token);
         const target = (sessions || []).find((s) => s?.NowPlayingItem?.Name === itemName);
         expect(target, 'admin session list includes the played item').toBeTruthy();
         expect(typeof target.Id).toBe('string');
@@ -98,13 +124,13 @@ test.describe('session control', () => {
         // claim on-screen delivery here. Real client rendering of the core
         // message dialog is out of scope for this fixture; the per-card compose /
         // send UI is covered by the unit tests.
-        const msg = await apiRaw(baseURL!, `/JellyfinCanopy/active-streams/sessions/${target.Id}/message`, admin.token, {
+        const msg = await apiRaw(baseURL!, `/JellyfinCanopy/active-streams/sessions/${target.Id}/message`, admin!.token, {
             method: 'POST',
             body: JSON.stringify({ text: 'Please pause your stream', timeoutMs: 5000 }),
         });
         expect(msg.status, 'admin message endpoint accepts the request → 200').toBe(200);
 
-        const stop = await apiRaw(baseURL!, `/JellyfinCanopy/active-streams/sessions/${target.Id}/stop`, admin.token, {
+        const stop = await apiRaw(baseURL!, `/JellyfinCanopy/active-streams/sessions/${target.Id}/stop`, admin!.token, {
             method: 'POST',
         });
         expect(stop.status, 'admin stop → 200').toBe(200);
@@ -119,8 +145,6 @@ test.describe('session control', () => {
     });
 
     test('non-admin gets no session surface and is forbidden from controls', async ({ page, consoleErrors, baseURL }) => {
-        await enableActiveStreams(baseURL!); // enabled, but AllUsers off
-
         // No widget for a non-admin when "show to non-admins" is off.
         await loginAs(page, 'user', consoleErrors);
         await page.waitForFunction(
@@ -131,12 +155,16 @@ test.describe('session control', () => {
         await expect(page.locator('#jc-active-streams')).toHaveCount(0);
 
         // Every session-control endpoint is forbidden for a non-admin token.
-        const user = await authenticate(baseURL!, USERS.user.username, USERS.user.password);
-        const list = await apiRaw(baseURL!, '/JellyfinCanopy/active-streams/sessions', user.token);
+        // Reuse the browser's authenticated token instead of issuing another
+        // AuthenticateByName on fixtures/api's shared REST device id. Besides
+        // avoiding login churn, this keeps the admin cleanup session intact.
+        const userToken = await page.evaluate(() => (window as any).ApiClient?.accessToken?.() as string | undefined);
+        expect(userToken, 'the signed-in non-admin session exposes an access token').toBeTruthy();
+        const list = await apiRaw(baseURL!, '/JellyfinCanopy/active-streams/sessions', userToken);
         expect(list.status, 'non-admin sessions list → 403').toBe(403);
-        const stop = await apiRaw(baseURL!, '/JellyfinCanopy/active-streams/sessions/anything/stop', user.token, { method: 'POST' });
+        const stop = await apiRaw(baseURL!, '/JellyfinCanopy/active-streams/sessions/anything/stop', userToken, { method: 'POST' });
         expect(stop.status, 'non-admin stop → 403').toBe(403);
-        const msg = await apiRaw(baseURL!, '/JellyfinCanopy/active-streams/sessions/anything/message', user.token, {
+        const msg = await apiRaw(baseURL!, '/JellyfinCanopy/active-streams/sessions/anything/message', userToken, {
             method: 'POST',
             body: JSON.stringify({ text: 'x' }),
         });

--- a/e2e/spoiler-guard.spec.ts
+++ b/e2e/spoiler-guard.spec.ts
@@ -19,10 +19,11 @@
 //      override checkbox persists through GET /spoiler-blur/user-prefs
 //
 // Every test asserts a clean console/net and restores ALL state it changes
-// (guard off, prefs back) in a finally block, even on failure.
+// (guard to its prior value, prefs back) in a finally block, even on failure.
 import { test, expect, loginAs, assertNoRuntimeErrors } from './fixtures/auth';
-import { authenticate, api, apiRaw, type Session } from './fixtures/api';
+import { authenticate, api, type Session } from './fixtures/api';
 import type { Page } from 'playwright/test';
+import { createGuardRestorePlan } from '../scripts/e2e/spoiler-guard-restore';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -134,7 +135,7 @@ async function pickTarget(user: Session): Promise<Target | null> {
 
 /** Set (POST) or clear (DELETE) the series guard for a user, server-side. */
 async function setSeriesGuard(user: Session, seriesId: string, on: boolean): Promise<void> {
-    await apiRaw(
+    await api(
         BASE,
         `/JellyfinCanopy/spoiler-blur/series/${norm(seriesId)}`,
         user.token,
@@ -231,9 +232,13 @@ test.describe('Spoiler Guard', () => {
         test.skip(!target, 'no series with an unwatched episode available on the target server');
         const t = target!;
 
-        // Start from a known-OFF baseline before boot so the client caches "off".
-        await setSeriesGuard(user, t.seriesId, false);
+        const plan = createGuardRestorePlan(
+            (await guardedSeriesIds(user)).has(norm(t.seriesId)),
+            false
+        );
         try {
+            // Start from a known-OFF baseline before boot so the client caches "off".
+            await setSeriesGuard(user, t.seriesId, plan.requiredGuarded);
             await loginAs(page, 'user', consoleErrors);
             await openDetailWithButton(page, t.seriesId);
 
@@ -272,7 +277,7 @@ test.describe('Spoiler Guard', () => {
 
             assertNoSpoilerRuntimeErrors(consoleErrors);
         } finally {
-            await setSeriesGuard(user, t.seriesId, false);
+            await setSeriesGuard(user, t.seriesId, plan.restoreGuarded);
         }
     });
 
@@ -281,9 +286,13 @@ test.describe('Spoiler Guard', () => {
         test.skip(!target, 'no series with an unwatched episode available on the target server');
         const t = target!;
 
-        // Enable server-side BEFORE boot so the button loads in the ON state.
-        await setSeriesGuard(user, t.seriesId, true);
+        const plan = createGuardRestorePlan(
+            (await guardedSeriesIds(user)).has(norm(t.seriesId)),
+            true
+        );
         try {
+            // Enable server-side BEFORE boot so the button loads in the ON state.
+            await setSeriesGuard(user, t.seriesId, plan.requiredGuarded);
             await loginAs(page, 'user', consoleErrors);
             await openDetailWithButton(page, t.seriesId);
 
@@ -312,7 +321,7 @@ test.describe('Spoiler Guard', () => {
 
             assertNoSpoilerRuntimeErrors(consoleErrors);
         } finally {
-            await setSeriesGuard(user, t.seriesId, false);
+            await setSeriesGuard(user, t.seriesId, plan.restoreGuarded);
         }
     });
 
@@ -325,9 +334,13 @@ test.describe('Spoiler Guard', () => {
         const adminReal = (await listEpisodes(admin, t.seriesId)).find((e) => e.id === t.unwatched.id);
         expect(adminReal, 'admin can see the target episode').toBeTruthy();
 
-        // Guard the series for the NON-admin only.
-        await setSeriesGuard(user, t.seriesId, true);
+        const plan = createGuardRestorePlan(
+            (await guardedSeriesIds(user)).has(norm(t.seriesId)),
+            true
+        );
         try {
+            // Guard the series for the NON-admin only.
+            await setSeriesGuard(user, t.seriesId, plan.requiredGuarded);
             // Boot a clean non-admin session purely to prove no console/net errors
             // while the user is guarded (the isolation itself is asserted via API).
             await loginAs(page, 'user', consoleErrors);
@@ -346,7 +359,7 @@ test.describe('Spoiler Guard', () => {
 
             assertNoRuntimeErrors(consoleErrors);
         } finally {
-            await setSeriesGuard(user, t.seriesId, false);
+            await setSeriesGuard(user, t.seriesId, plan.restoreGuarded);
         }
     });
 

--- a/e2e/spoiler-guard.spec.ts
+++ b/e2e/spoiler-guard.spec.ts
@@ -24,6 +24,11 @@ import { test, expect, loginAs, assertNoRuntimeErrors } from './fixtures/auth';
 import { authenticate, api, type Session } from './fixtures/api';
 import type { Page } from 'playwright/test';
 import { createGuardRestorePlan } from '../scripts/e2e/spoiler-guard-restore';
+import {
+    getSpoilerState,
+    restoreSeriesGuard,
+    restoreSeriesGuards,
+} from './fixtures/spoiler-state';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -233,7 +238,8 @@ test.describe('Spoiler Guard', () => {
         const t = target!;
 
         const plan = createGuardRestorePlan(
-            (await guardedSeriesIds(user)).has(norm(t.seriesId)),
+            await getSpoilerState(BASE, user),
+            t.seriesId,
             false
         );
         try {
@@ -277,7 +283,7 @@ test.describe('Spoiler Guard', () => {
 
             assertNoSpoilerRuntimeErrors(consoleErrors);
         } finally {
-            await setSeriesGuard(user, t.seriesId, plan.restoreGuarded);
+            await restoreSeriesGuard(BASE, user, plan);
         }
     });
 
@@ -287,7 +293,8 @@ test.describe('Spoiler Guard', () => {
         const t = target!;
 
         const plan = createGuardRestorePlan(
-            (await guardedSeriesIds(user)).has(norm(t.seriesId)),
+            await getSpoilerState(BASE, user),
+            t.seriesId,
             true
         );
         try {
@@ -321,7 +328,7 @@ test.describe('Spoiler Guard', () => {
 
             assertNoSpoilerRuntimeErrors(consoleErrors);
         } finally {
-            await setSeriesGuard(user, t.seriesId, plan.restoreGuarded);
+            await restoreSeriesGuard(BASE, user, plan);
         }
     });
 
@@ -330,22 +337,29 @@ test.describe('Spoiler Guard', () => {
         test.skip(!target, 'no series with an unwatched episode available on the target server');
         const t = target!;
 
-        // Capture the admin's real (never-guarded) title up front.
-        const adminReal = (await listEpisodes(admin, t.seriesId)).find((e) => e.id === t.unwatched.id);
-        expect(adminReal, 'admin can see the target episode').toBeTruthy();
-
-        const plan = createGuardRestorePlan(
-            (await guardedSeriesIds(user)).has(norm(t.seriesId)),
-            true
-        );
+        const [userState, adminState] = await Promise.all([
+            getSpoilerState(BASE, user),
+            getSpoilerState(BASE, admin),
+        ]);
+        const userPlan = createGuardRestorePlan(userState, t.seriesId, true);
+        const adminPlan = createGuardRestorePlan(adminState, t.seriesId, false);
         try {
-            // Guard the series for the NON-admin only.
-            await setSeriesGuard(user, t.seriesId, plan.requiredGuarded);
+            // Establish both sides explicitly: the user is guarded and the
+            // admin is not, regardless of either account's pre-test state.
+            await setSeriesGuard(admin, t.seriesId, adminPlan.requiredGuarded);
+            await setSeriesGuard(user, t.seriesId, userPlan.requiredGuarded);
+
+            const adminReal = (await listEpisodes(admin, t.seriesId))
+                .find((e) => e.id === t.unwatched.id);
+            expect(adminReal, 'admin can see the target episode').toBeTruthy();
             // Boot a clean non-admin session purely to prove no console/net errors
             // while the user is guarded (the isolation itself is asserted via API).
             await loginAs(page, 'user', consoleErrors);
 
             // The user's API view is stripped …
+            expect(await guardedSeriesIds(user), 'the user has guard state for this series').toContain(
+                norm(t.seriesId)
+            );
             const userEp = (await listEpisodes(user, t.seriesId)).find((e) => e.id === t.unwatched.id);
             expect(userEp!.name, 'the guarded user sees a stripped title').toMatch(STRIPPED_NAME);
 
@@ -359,7 +373,10 @@ test.describe('Spoiler Guard', () => {
 
             assertNoRuntimeErrors(consoleErrors);
         } finally {
-            await setSeriesGuard(user, t.seriesId, plan.restoreGuarded);
+            await restoreSeriesGuards(BASE, [
+                { session: user, plan: userPlan },
+                { session: admin, plan: adminPlan },
+            ]);
         }
     });
 

--- a/e2e/spoiler-identity-tags.spec.ts
+++ b/e2e/spoiler-identity-tags.spec.ts
@@ -18,6 +18,10 @@ import { test, expect } from './fixtures/auth';
 import { USERS } from './fixtures/auth';
 import { authenticate, api, authHeader, type Session } from './fixtures/api';
 import { createGuardRestorePlan } from '../scripts/e2e/spoiler-guard-restore';
+import {
+    getSpoilerState,
+    restoreSeriesGuards,
+} from './fixtures/spoiler-state';
 
 const BASE = process.env.JF_BASE_URL || 'http://localhost:8099';
 
@@ -137,13 +141,20 @@ test.describe('spoiler guard identity tags (reverse-proxy-safe attribution)', ()
         test.skip(!enabled, 'SpoilerBlurEnabled is off on the target server');
         test.skip(!target, 'no unwatched episode with a Primary image found');
 
-        const plan = createGuardRestorePlan(
-            await seriesIsGuarded(admin, target!.seriesId),
-            true
-        );
+        const [adminState, userState] = await Promise.all([
+            getSpoilerState(BASE, admin),
+            getSpoilerState(BASE, user),
+        ]);
+        const adminPlan = createGuardRestorePlan(adminState, target!.seriesId, true);
+        const userPlan = createGuardRestorePlan(userState, target!.seriesId, false);
         try {
-            // Guard the series for the ADMIN only (POST enables, DELETE disables).
-            await setSeriesGuard(admin, target!.seriesId, plan.requiredGuarded);
+            // Establish both sides explicitly: only the admin is guarded,
+            // regardless of either account's pre-test state.
+            await setSeriesGuard(user, target!.seriesId, userPlan.requiredGuarded);
+            await setSeriesGuard(admin, target!.seriesId, adminPlan.requiredGuarded);
+            expect(await seriesIsGuarded(admin, target!.seriesId), 'admin target is guarded').toBe(true);
+            expect(await seriesIsGuarded(user, target!.seriesId), 'user target is unguarded').toBe(false);
+
             // Tags must be re-read AFTER guarding: the strip filter adds its
             // sb- cache-bust prefix for the guarding user.
             const adminTag = await primaryTagFor(admin, target!.episodeId);
@@ -173,7 +184,10 @@ test.describe('spoiler guard identity tags (reverse-proxy-safe attribution)', ()
                 true
             );
         } finally {
-            await setSeriesGuard(admin, target!.seriesId, plan.restoreGuarded);
+            await restoreSeriesGuards(BASE, [
+                { session: admin, plan: adminPlan },
+                { session: user, plan: userPlan },
+            ]);
         }
     });
 

--- a/e2e/spoiler-identity-tags.spec.ts
+++ b/e2e/spoiler-identity-tags.spec.ts
@@ -17,11 +17,17 @@
 import { test, expect } from './fixtures/auth';
 import { USERS } from './fixtures/auth';
 import { authenticate, api, authHeader, type Session } from './fixtures/api';
+import { createGuardRestorePlan } from '../scripts/e2e/spoiler-guard-restore';
 
 const BASE = process.env.JF_BASE_URL || 'http://localhost:8099';
 
 // SpoilerIdentityService.MarkerSentinel + MarkerHexLength on the server.
 const MARKER = /-jeu[0-9a-f]{12}$/;
+
+/** Normalize a Jellyfin id to the form used by the guard-state response. */
+function norm(id: string): string {
+    return id.replace(/-/g, '').toLowerCase();
+}
 
 interface Target {
     seriesId: string;
@@ -50,6 +56,23 @@ async function primaryTagFor(session: Session, episodeId: string): Promise<strin
     const tag = dto?.ImageTags?.Primary;
     expect(tag, 'target episode lost its Primary image tag').toBeTruthy();
     return tag as string;
+}
+
+/** Whether one user's exact target series is currently guarded. */
+async function seriesIsGuarded(session: Session, seriesId: string): Promise<boolean> {
+    const state = await api<{ Series?: Record<string, unknown> }>(
+        BASE,
+        '/JellyfinCanopy/spoiler-blur/series',
+        session.token
+    );
+    return Object.keys(state?.Series ?? {}).some((id) => norm(id) === norm(seriesId));
+}
+
+/** Set the target series guard and surface any non-success response. */
+async function setSeriesGuard(session: Session, seriesId: string, guarded: boolean): Promise<void> {
+    await api(BASE, `/JellyfinCanopy/spoiler-blur/series/${seriesId}`, session.token, {
+        method: guarded ? 'POST' : 'DELETE',
+    });
 }
 
 test.describe('spoiler guard identity tags (reverse-proxy-safe attribution)', () => {
@@ -114,11 +137,13 @@ test.describe('spoiler guard identity tags (reverse-proxy-safe attribution)', ()
         test.skip(!enabled, 'SpoilerBlurEnabled is off on the target server');
         test.skip(!target, 'no unwatched episode with a Primary image found');
 
-        // Guard the series for the ADMIN only (POST enables, DELETE disables).
-        await api(BASE, `/JellyfinCanopy/spoiler-blur/series/${target!.seriesId}`, admin.token, {
-            method: 'POST',
-        });
+        const plan = createGuardRestorePlan(
+            await seriesIsGuarded(admin, target!.seriesId),
+            true
+        );
         try {
+            // Guard the series for the ADMIN only (POST enables, DELETE disables).
+            await setSeriesGuard(admin, target!.seriesId, plan.requiredGuarded);
             // Tags must be re-read AFTER guarding: the strip filter adds its
             // sb- cache-bust prefix for the guarding user.
             const adminTag = await primaryTagFor(admin, target!.episodeId);
@@ -148,9 +173,7 @@ test.describe('spoiler guard identity tags (reverse-proxy-safe attribution)', ()
                 true
             );
         } finally {
-            await api(BASE, `/JellyfinCanopy/spoiler-blur/series/${target!.seriesId}`, admin.token, {
-                method: 'DELETE',
-            }).catch(() => undefined);
+            await setSeriesGuard(admin, target!.seriesId, plan.restoreGuarded);
         }
     });
 

--- a/scripts/e2e/auth-session-state.d.ts
+++ b/scripts/e2e/auth-session-state.d.ts
@@ -1,0 +1,59 @@
+export type AuthSessionPhase =
+    | 'post-reload-session'
+    | 'plugin-init'
+    | 'current-user';
+
+export type AuthSessionOutcome =
+    | 'authenticated'
+    | 'definite-bounce'
+    | 'pending'
+    | 'wrong-user'
+    | 'stale-credentials';
+
+export interface StoredSessionSummary {
+    userId: string;
+    hasToken: boolean;
+}
+
+export interface AuthSessionSnapshot {
+    route: string;
+    currentUserId: string;
+    pluginInitialized: boolean;
+    storedSessions: StoredSessionSummary[];
+    credentialsMalformed?: boolean;
+}
+
+export interface AuthSessionDecision {
+    outcome: AuthSessionOutcome;
+    phase: AuthSessionPhase;
+    diagnostic: string;
+}
+
+export interface WaitOptions {
+    timeoutMs: number;
+    pollIntervalMs?: number;
+    now?: () => number;
+    sleep?: (delayMs: number) => Promise<void>;
+    stopOnPendingPhases?: AuthSessionPhase[];
+}
+
+export interface WaitResult extends AuthSessionDecision {
+    elapsedMs: number;
+    timedOut: boolean;
+}
+
+export const FAST_BOUNCE_TIMEOUT_MS: 8000;
+export const PLUGIN_INIT_TIMEOUT_MS: 60000;
+export const CURRENT_USER_TIMEOUT_MS: 15000;
+export const SESSION_POLL_INTERVAL_MS: 100;
+
+export function classifyAuthSession(
+    snapshot: AuthSessionSnapshot,
+    expectedUserId: string
+): AuthSessionDecision;
+
+export function waitForSessionDecision(
+    readSnapshot: () => Promise<AuthSessionSnapshot>,
+    expectedUserId: string,
+    options: WaitOptions
+): Promise<WaitResult>;

--- a/scripts/e2e/auth-session-state.js
+++ b/scripts/e2e/auth-session-state.js
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+
+// @ts-check
+'use strict';
+
+// A bounced Jellyfin login is unambiguous once the client is on an auth route
+// with neither a persisted token nor a current user. Keep this window well
+// below the plugin's real boot allowance so the common retry path is cheap
+// without treating a slow, credentialed boot as a bounce.
+const FAST_BOUNCE_TIMEOUT_MS = 8_000;
+const PLUGIN_INIT_TIMEOUT_MS = 60_000;
+const CURRENT_USER_TIMEOUT_MS = 15_000;
+const SESSION_POLL_INTERVAL_MS = 100;
+
+/** @param {unknown} value */
+function id(value) {
+    return String(value || '').trim();
+}
+
+/**
+ * Classify one post-reload Jellyfin session snapshot without browser or clock
+ * dependencies. Tokens never leave the browser; callers report only whether a
+ * server entry had one and which user ID it belonged to.
+ *
+ * @param {import('./auth-session-state').AuthSessionSnapshot} snapshot
+ * @param {string} expectedUserId
+ * @returns {import('./auth-session-state').AuthSessionDecision}
+ */
+function classifyAuthSession(snapshot, expectedUserId) {
+    const expected = id(expectedUserId);
+    if (!expected) throw new Error('auth session classification requires an expected user ID');
+
+    const route = id(snapshot?.route) || '<empty>';
+    const currentUserId = id(snapshot?.currentUserId);
+    const storedUserIds = (Array.isArray(snapshot?.storedSessions)
+        ? snapshot.storedSessions
+        : [])
+        .filter((session) => session?.hasToken === true && id(session?.userId))
+        .map((session) => id(session.userId));
+    const hasExpectedStoredSession = storedUserIds.includes(expected);
+    const onAuthRoute = /login|selectserver/i.test(route);
+    const pluginInitialized = snapshot?.pluginInitialized === true;
+    const malformed = snapshot?.credentialsMalformed === true
+        ? '; stored credentials are malformed'
+        : '';
+    const context = `expected=${expected}, current=${currentUserId || '<none>'}, `
+        + `stored=${storedUserIds.join(',') || '<none>'}, route=${route}, `
+        + `plugin=${pluginInitialized ? 'ready' : 'pending'}${malformed}`;
+
+    if (currentUserId && currentUserId !== expected) {
+        return {
+            outcome: 'wrong-user',
+            phase: 'current-user',
+            diagnostic: `authenticated as the wrong Jellyfin user (${context})`,
+        };
+    }
+
+    if (storedUserIds.length > 0 && !hasExpectedStoredSession) {
+        return {
+            outcome: 'stale-credentials',
+            phase: 'post-reload-session',
+            diagnostic: `persisted credentials do not belong to the requested user (${context})`,
+        };
+    }
+
+    if (onAuthRoute && storedUserIds.length === 0 && !currentUserId) {
+        return {
+            outcome: 'definite-bounce',
+            phase: 'post-reload-session',
+            diagnostic: `reload landed on an authentication route without a session (${context})`,
+        };
+    }
+
+    if (!hasExpectedStoredSession) {
+        return {
+            outcome: 'pending',
+            phase: 'post-reload-session',
+            diagnostic: `waiting for the requested persisted session (${context})`,
+        };
+    }
+
+    if (!pluginInitialized) {
+        return {
+            outcome: 'pending',
+            phase: 'plugin-init',
+            diagnostic: `stored session is valid while the plugin initializes (${context})`,
+        };
+    }
+
+    if (!currentUserId) {
+        return {
+            outcome: 'pending',
+            phase: 'current-user',
+            diagnostic: `plugin initialized before Jellyfin exposed the current user (${context})`,
+        };
+    }
+
+    return {
+        outcome: 'authenticated',
+        phase: 'current-user',
+        diagnostic: `authenticated session matches the requested user (${context})`,
+    };
+}
+
+/**
+ * Poll a pure snapshot reader until classification is terminal, a requested
+ * pending phase is reached, or the supplied deadline expires. Injectable time
+ * makes the retry bounds deterministic in unit tests.
+ *
+ * @param {() => Promise<import('./auth-session-state').AuthSessionSnapshot>} readSnapshot
+ * @param {string} expectedUserId
+ * @param {import('./auth-session-state').WaitOptions} options
+ * @returns {Promise<import('./auth-session-state').WaitResult>}
+ */
+async function waitForSessionDecision(readSnapshot, expectedUserId, options) {
+    if (typeof readSnapshot !== 'function') {
+        throw new Error('auth session wait requires a snapshot reader');
+    }
+
+    const timeoutMs = Number(options?.timeoutMs);
+    if (!Number.isFinite(timeoutMs) || timeoutMs < 0) {
+        throw new Error(`auth session wait has invalid timeout: ${String(options?.timeoutMs)}`);
+    }
+    const pollIntervalMs = Number(options?.pollIntervalMs ?? SESSION_POLL_INTERVAL_MS);
+    if (!Number.isFinite(pollIntervalMs) || pollIntervalMs <= 0) {
+        throw new Error(`auth session wait has invalid poll interval: ${String(pollIntervalMs)}`);
+    }
+
+    const now = options?.now || Date.now;
+    const sleep = options?.sleep || ((delayMs) => new Promise((resolve) => {
+        setTimeout(resolve, delayMs);
+    }));
+    const stopOnPendingPhases = new Set(options?.stopOnPendingPhases || []);
+    const startedAt = now();
+
+    while (true) {
+        const decision = classifyAuthSession(await readSnapshot(), expectedUserId);
+        const elapsedMs = Math.max(0, now() - startedAt);
+        if (decision.outcome !== 'pending' || stopOnPendingPhases.has(decision.phase)) {
+            return { ...decision, elapsedMs, timedOut: false };
+        }
+        if (elapsedMs >= timeoutMs) {
+            return { ...decision, elapsedMs, timedOut: true };
+        }
+        await sleep(Math.min(pollIntervalMs, timeoutMs - elapsedMs));
+    }
+}
+
+module.exports = {
+    CURRENT_USER_TIMEOUT_MS,
+    FAST_BOUNCE_TIMEOUT_MS,
+    PLUGIN_INIT_TIMEOUT_MS,
+    SESSION_POLL_INTERVAL_MS,
+    classifyAuthSession,
+    waitForSessionDecision,
+};

--- a/scripts/e2e/auth-session-state.test.js
+++ b/scripts/e2e/auth-session-state.test.js
@@ -142,6 +142,44 @@ test('the plugin phase still receives the full sixty-second allowance', async ()
     assert.equal(result.elapsedMs, 60_000);
 });
 
+test('phase handoff stops immediately once plugin initialization reaches current-user', async () => {
+    const clock = fakeClock();
+    const result = await waitForSessionDecision(async () => snapshot({
+        currentUserId: '',
+    }), EXPECTED_USER_ID, {
+        timeoutMs: PLUGIN_INIT_TIMEOUT_MS,
+        stopOnPendingPhases: ['current-user'],
+        now: clock.now,
+        sleep: clock.sleep,
+    });
+
+    assert.equal(result.outcome, 'pending');
+    assert.equal(result.phase, 'current-user');
+    assert.equal(result.timedOut, false);
+    assert.equal(result.elapsedMs, 0);
+    assert.equal(clock.elapsed(), 0);
+});
+
+test('the current-user phase receives its independent fifteen-second allowance', async () => {
+    const clock = fakeClock();
+    const result = await waitForSessionDecision(async () => snapshot({
+        currentUserId: clock.elapsed() >= CURRENT_USER_TIMEOUT_MS - 100
+            ? EXPECTED_USER_ID
+            : '',
+    }), EXPECTED_USER_ID, {
+        timeoutMs: CURRENT_USER_TIMEOUT_MS,
+        pollIntervalMs: 100,
+        now: clock.now,
+        sleep: clock.sleep,
+    });
+
+    assert.equal(result.outcome, 'authenticated');
+    assert.equal(result.phase, 'current-user');
+    assert.equal(result.timedOut, false);
+    assert.equal(result.elapsedMs, CURRENT_USER_TIMEOUT_MS - 100);
+    assert.equal(clock.elapsed(), CURRENT_USER_TIMEOUT_MS - 100);
+});
+
 test('auth.ts retains the full phase timeouts and captures the login result user', () => {
     const source = fs.readFileSync(path.join(ROOT, 'e2e/fixtures/auth.ts'), 'utf8');
 
@@ -150,6 +188,7 @@ test('auth.ts retains the full phase timeouts and captures the login result user
     assert.match(source, /timeoutMs: FAST_BOUNCE_TIMEOUT_MS/);
     assert.match(source, /timeoutMs: PLUGIN_INIT_TIMEOUT_MS/);
     assert.match(source, /timeoutMs: CURRENT_USER_TIMEOUT_MS/);
+    assert.match(source, /stopOnPendingPhases: \['current-user'\]/);
     assert.match(source, /authenticationResult\?\.User\?\.Id/);
     assert.match(source, /expectedUserId/);
     assert.match(source, /consoleErrors\?\.reset\(\)/);

--- a/scripts/e2e/auth-session-state.test.js
+++ b/scripts/e2e/auth-session-state.test.js
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+    CURRENT_USER_TIMEOUT_MS,
+    FAST_BOUNCE_TIMEOUT_MS,
+    PLUGIN_INIT_TIMEOUT_MS,
+    classifyAuthSession,
+    waitForSessionDecision,
+} = require('./auth-session-state');
+
+const ROOT = path.resolve(__dirname, '../..');
+const EXPECTED_USER_ID = 'admin-user-id';
+
+function snapshot(overrides = {}) {
+    return {
+        route: '#/home',
+        currentUserId: EXPECTED_USER_ID,
+        pluginInitialized: true,
+        storedSessions: [{ userId: EXPECTED_USER_ID, hasToken: true }],
+        ...overrides,
+    };
+}
+
+function fakeClock() {
+    let elapsedMs = 0;
+    return {
+        now: () => elapsedMs,
+        sleep: async (delayMs) => { elapsedMs += delayMs; },
+        elapsed: () => elapsedMs,
+    };
+}
+
+test('matching stored and current users classify as authenticated', () => {
+    const result = classifyAuthSession(snapshot(), EXPECTED_USER_ID);
+    assert.equal(result.outcome, 'authenticated');
+    assert.equal(result.phase, 'current-user');
+    assert.match(result.diagnostic, /expected=admin-user-id, current=admin-user-id/);
+});
+
+test('an auth route without a token or current user is a definite bounce', () => {
+    const result = classifyAuthSession(snapshot({
+        route: '#/login.html',
+        currentUserId: '',
+        pluginInitialized: false,
+        storedSessions: [],
+    }), EXPECTED_USER_ID);
+    assert.equal(result.outcome, 'definite-bounce');
+    assert.equal(result.phase, 'post-reload-session');
+});
+
+test('stored credentials keep a genuinely slow plugin boot pending', () => {
+    const result = classifyAuthSession(snapshot({
+        route: '#/login.html',
+        currentUserId: '',
+        pluginInitialized: false,
+    }), EXPECTED_USER_ID);
+    assert.equal(result.outcome, 'pending');
+    assert.equal(result.phase, 'plugin-init');
+    assert.match(result.diagnostic, /stored session is valid/);
+});
+
+test('a different current user is rejected even when the expected token exists', () => {
+    const result = classifyAuthSession(snapshot({ currentUserId: 'other-user-id' }), EXPECTED_USER_ID);
+    assert.equal(result.outcome, 'wrong-user');
+    assert.equal(result.phase, 'current-user');
+    assert.match(result.diagnostic, /wrong Jellyfin user/);
+});
+
+test('a token for only another user is classified as stale credentials', () => {
+    const result = classifyAuthSession(snapshot({
+        route: '#/login.html',
+        currentUserId: '',
+        pluginInitialized: false,
+        storedSessions: [{ userId: 'old-user-id', hasToken: true }],
+    }), EXPECTED_USER_ID);
+    assert.equal(result.outcome, 'stale-credentials');
+    assert.equal(result.phase, 'post-reload-session');
+});
+
+test('the injected clock bounds definite-bounce detection below ten seconds', async () => {
+    const clock = fakeClock();
+    const result = await waitForSessionDecision(async () => snapshot({
+        route: clock.elapsed() >= FAST_BOUNCE_TIMEOUT_MS - 100
+            ? '#/selectserver.html'
+            : '#/loading.html',
+        currentUserId: '',
+        pluginInitialized: false,
+        storedSessions: [],
+    }), EXPECTED_USER_ID, {
+        timeoutMs: FAST_BOUNCE_TIMEOUT_MS,
+        now: clock.now,
+        sleep: clock.sleep,
+    });
+
+    assert.equal(result.outcome, 'definite-bounce');
+    assert.equal(result.timedOut, false);
+    assert.equal(result.elapsedMs, FAST_BOUNCE_TIMEOUT_MS - 100);
+    assert.ok(result.elapsedMs <= 10_000);
+    assert.ok(FAST_BOUNCE_TIMEOUT_MS <= 10_000);
+});
+
+test('the fast probe expires without misclassifying a credentialed slow boot', async () => {
+    const clock = fakeClock();
+    const result = await waitForSessionDecision(async () => snapshot({
+        currentUserId: '',
+        pluginInitialized: false,
+    }), EXPECTED_USER_ID, {
+        timeoutMs: FAST_BOUNCE_TIMEOUT_MS,
+        pollIntervalMs: 1_000,
+        now: clock.now,
+        sleep: clock.sleep,
+    });
+
+    assert.equal(result.outcome, 'pending');
+    assert.equal(result.phase, 'plugin-init');
+    assert.equal(result.timedOut, true);
+    assert.equal(clock.elapsed(), FAST_BOUNCE_TIMEOUT_MS);
+});
+
+test('the plugin phase still receives the full sixty-second allowance', async () => {
+    const clock = fakeClock();
+    const result = await waitForSessionDecision(async () => snapshot({
+        currentUserId: '',
+        pluginInitialized: false,
+    }), EXPECTED_USER_ID, {
+        timeoutMs: PLUGIN_INIT_TIMEOUT_MS,
+        pollIntervalMs: 1_000,
+        now: clock.now,
+        sleep: clock.sleep,
+    });
+
+    assert.equal(result.outcome, 'pending');
+    assert.equal(result.phase, 'plugin-init');
+    assert.equal(result.timedOut, true);
+    assert.equal(result.elapsedMs, 60_000);
+});
+
+test('auth.ts retains the full phase timeouts and captures the login result user', () => {
+    const source = fs.readFileSync(path.join(ROOT, 'e2e/fixtures/auth.ts'), 'utf8');
+
+    assert.equal(PLUGIN_INIT_TIMEOUT_MS, 60_000);
+    assert.equal(CURRENT_USER_TIMEOUT_MS, 15_000);
+    assert.match(source, /timeoutMs: FAST_BOUNCE_TIMEOUT_MS/);
+    assert.match(source, /timeoutMs: PLUGIN_INIT_TIMEOUT_MS/);
+    assert.match(source, /timeoutMs: CURRENT_USER_TIMEOUT_MS/);
+    assert.match(source, /authenticationResult\?\.User\?\.Id/);
+    assert.match(source, /expectedUserId/);
+    assert.match(source, /consoleErrors\?\.reset\(\)/);
+});

--- a/scripts/e2e/jellyfin-host-noise.d.ts
+++ b/scripts/e2e/jellyfin-host-noise.d.ts
@@ -1,0 +1,4 @@
+export const SCROLL_HANDLER_ERROR: 'pageerror: t.scrollHandler is not a function';
+export const HOME_TAB_PREFIX: "[Home] failed to get tab controller TypeError: Cannot read properties of undefined (reading 'querySelector')";
+
+export function isKnownHiddenContentHostNoise(text: string): boolean;

--- a/scripts/e2e/jellyfin-host-noise.js
+++ b/scripts/e2e/jellyfin-host-noise.js
@@ -5,6 +5,7 @@ const SCROLL_HANDLER_ERROR = 'pageerror: t.scrollHandler is not a function';
 const HOME_TAB_PREFIX = "[Home] failed to get tab controller TypeError: Cannot read properties of undefined (reading 'querySelector')";
 const HOME_TAB_CHUNK = /\/web\/hometab\.[A-Za-z0-9]+\.chunk\.js:\d+:\d+/;
 const HOME_CHUNK = /\/web\/home\.[A-Za-z0-9]+\.chunk\.js:\d+:\d+/;
+const CANOPY_STACK_FRAME = /(?:^|\n)[^\n]*(?:\bJellyfinCanopy\b|\/JellyfinCanopy(?:\/|[?#]))/i;
 
 /**
  * Exact Jellyfin-web host errors observed while the standalone Hidden Content
@@ -17,7 +18,8 @@ function isKnownHiddenContentHostNoise(text) {
     if (text === SCROLL_HANDLER_ERROR) return true;
     return text.startsWith(HOME_TAB_PREFIX)
         && HOME_TAB_CHUNK.test(text)
-        && HOME_CHUNK.test(text);
+        && HOME_CHUNK.test(text)
+        && !CANOPY_STACK_FRAME.test(text);
 }
 
 module.exports = {

--- a/scripts/e2e/jellyfin-host-noise.js
+++ b/scripts/e2e/jellyfin-host-noise.js
@@ -1,0 +1,27 @@
+// @ts-check
+'use strict';
+
+const SCROLL_HANDLER_ERROR = 'pageerror: t.scrollHandler is not a function';
+const HOME_TAB_PREFIX = "[Home] failed to get tab controller TypeError: Cannot read properties of undefined (reading 'querySelector')";
+const HOME_TAB_CHUNK = /\/web\/hometab\.[A-Za-z0-9]+\.chunk\.js:\d+:\d+/;
+const HOME_CHUNK = /\/web\/home\.[A-Za-z0-9]+\.chunk\.js:\d+:\d+/;
+
+/**
+ * Exact Jellyfin-web host errors observed while the standalone Hidden Content
+ * page replaces the home view. This deliberately does not accept a generic
+ * querySelector error or a Canopy stack: every other runtime error stays fatal.
+ *
+ * @param {string} text
+ */
+function isKnownHiddenContentHostNoise(text) {
+    if (text === SCROLL_HANDLER_ERROR) return true;
+    return text.startsWith(HOME_TAB_PREFIX)
+        && HOME_TAB_CHUNK.test(text)
+        && HOME_CHUNK.test(text);
+}
+
+module.exports = {
+    HOME_TAB_PREFIX,
+    SCROLL_HANDLER_ERROR,
+    isKnownHiddenContentHostNoise,
+};

--- a/scripts/e2e/jellyfin-host-noise.test.js
+++ b/scripts/e2e/jellyfin-host-noise.test.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+    HOME_TAB_PREFIX,
+    SCROLL_HANDLER_ERROR,
+    isKnownHiddenContentHostNoise,
+} = require('./jellyfin-host-noise');
+
+const OBSERVED_HOME_RACE = `${HOME_TAB_PREFIX}\n`
+    + '    at new e (http://localhost:8100/web/hometab.2be9340f81cc7f0987ef.chunk.js:1:1173)\n'
+    + '    at http://localhost:8100/web/home.ea733a1f3e4e4f7bee3b.chunk.js:1:2950';
+
+test('accepts only the exact observed scroll-handler host message', () => {
+    assert.equal(isKnownHiddenContentHostNoise(SCROLL_HANDLER_ERROR), true);
+    assert.equal(isKnownHiddenContentHostNoise(`${SCROLL_HANDLER_ERROR} extra`), false);
+    assert.equal(isKnownHiddenContentHostNoise('t.scrollHandler is not a function'), false);
+});
+
+test('accepts the observed Home race only with both Jellyfin host chunks', () => {
+    assert.equal(isKnownHiddenContentHostNoise(OBSERVED_HOME_RACE), true);
+    assert.equal(
+        isKnownHiddenContentHostNoise(OBSERVED_HOME_RACE.replace('/web/hometab.', '/JellyfinCanopy/hometab.')),
+        false
+    );
+    assert.equal(
+        isKnownHiddenContentHostNoise(OBSERVED_HOME_RACE.replace('/web/home.', '/JellyfinCanopy/home.')),
+        false
+    );
+});
+
+test('a different Home, querySelector, or Canopy error remains fatal', () => {
+    assert.equal(
+        isKnownHiddenContentHostNoise(OBSERVED_HOME_RACE.replace("reading 'querySelector'", "reading 'remove'")),
+        false
+    );
+    assert.equal(
+        isKnownHiddenContentHostNoise('[Home] failed to get tab controller Error: Canopy failed'),
+        false
+    );
+    assert.equal(
+        isKnownHiddenContentHostNoise("TypeError: Cannot read properties of undefined (reading 'querySelector')"),
+        false
+    );
+});

--- a/scripts/e2e/jellyfin-host-noise.test.js
+++ b/scripts/e2e/jellyfin-host-noise.test.js
@@ -31,6 +31,27 @@ test('accepts the observed Home race only with both Jellyfin host chunks', () =>
     );
 });
 
+test('rejects a mixed Home race stack containing a Canopy plugin frame', () => {
+    assert.equal(
+        isKnownHiddenContentHostNoise(
+            `${OBSERVED_HOME_RACE}\n    at renderHiddenContent (http://localhost:8100/JellyfinCanopy/dist/jc.bundle.js?v=1:4:20)`
+        ),
+        false
+    );
+    assert.equal(
+        isKnownHiddenContentHostNoise(
+            `${OBSERVED_HOME_RACE}\n    at JellyfinCanopy.show (http://localhost:8100/JellyfinCanopy/script?v=1:8:15)`
+        ),
+        false
+    );
+    assert.equal(
+        isKnownHiddenContentHostNoise(
+            `${OBSERVED_HOME_RACE}\nrenderHiddenContent@http://localhost:8100/JellyfinCanopy/dist/jc.bundle.js:4:20`
+        ),
+        false
+    );
+});
+
 test('a different Home, querySelector, or Canopy error remains fatal', () => {
     assert.equal(
         isKnownHiddenContentHostNoise(OBSERVED_HOME_RACE.replace("reading 'querySelector'", "reading 'remove'")),

--- a/scripts/e2e/jellyfin-host-noise.test.js
+++ b/scripts/e2e/jellyfin-host-noise.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
 const test = require('node:test');
 
 const {
@@ -8,6 +10,8 @@ const {
     SCROLL_HANDLER_ERROR,
     isKnownHiddenContentHostNoise,
 } = require('./jellyfin-host-noise');
+
+const ROOT = path.resolve(__dirname, '../..');
 
 const OBSERVED_HOME_RACE = `${HOME_TAB_PREFIX}\n`
     + '    at new e (http://localhost:8100/web/hometab.2be9340f81cc7f0987ef.chunk.js:1:1173)\n'
@@ -65,4 +69,14 @@ test('a different Home, querySelector, or Canopy error remains fatal', () => {
         isKnownHiddenContentHostNoise("TypeError: Cannot read properties of undefined (reading 'querySelector')"),
         false
     );
+});
+
+test('both admin and non-admin Hidden Content paths use the strict host-noise assertion', () => {
+    const source = fs.readFileSync(path.join(ROOT, 'e2e/admin.spec.ts'), 'utf8');
+    const assertionCalls = source.match(/assertNoHiddenContentRuntimeErrors\(consoleErrors\);/g) ?? [];
+
+    assert.equal(assertionCalls.length, 2);
+    assert.match(source, /!isKnownHiddenContentHostNoise\(text\)/);
+    assert.match(source, /consoleErrors\.unexpected4xx\(\)/);
+    assert.doesNotMatch(source, /assertNoRuntimeErrors/);
 });

--- a/scripts/e2e/session-control-hygiene.test.js
+++ b/scripts/e2e/session-control-hygiene.test.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const source = fs.readFileSync(path.join(ROOT, 'e2e/session-control.spec.ts'), 'utf8');
+
+function sliceBetween(start, end) {
+    const from = source.indexOf(start);
+    const to = source.indexOf(end, from + start.length);
+    assert.notEqual(from, -1, `missing source marker: ${start}`);
+    assert.notEqual(to, -1, `missing source marker: ${end}`);
+    return source.slice(from, to);
+}
+
+test('session-control captures the original configuration before enabling its flags', () => {
+    const setup = sliceBetween('test.beforeAll(', 'test.afterAll(');
+    const read = setup.indexOf('const config = await api<Record<string, unknown>>');
+    const capture = setup.indexOf('originalConfig = config!;');
+    const write = setup.indexOf('await writePluginConfig(baseURL!, admin, {');
+
+    assert.ok(read >= 0, 'beforeAll must read the plugin configuration');
+    assert.ok(capture > read, 'beforeAll must retain the configuration it read');
+    assert.ok(write > capture, 'the exact original must be captured before the first write');
+    assert.match(setup, /ActiveStreamsEnabled:\s*true/);
+    assert.match(setup, /ActiveStreamsAllUsers:\s*false/);
+});
+
+test('session-control afterAll restores the exact snapshot and exposes cleanup failures', () => {
+    const writer = sliceBetween('async function writePluginConfig(', '// A DISTINCT device');
+    const cleanup = sliceBetween('test.afterAll(', "test('admin sees");
+
+    assert.match(writer, /body:\s*JSON\.stringify\(config\)/);
+    assert.match(cleanup, /await writePluginConfig\(baseURL!, admin, originalConfig\);/);
+    assert.doesNotMatch(writer, /\.catch\s*\(/, 'the configuration write must reject on failure');
+    assert.doesNotMatch(cleanup, /\.catch\s*\(/, 'afterAll must not swallow a restore failure');
+});
+
+test('session-control has no per-test configuration setup left behind', () => {
+    assert.doesNotMatch(source, /enableActiveStreams/);
+    assert.equal(
+        (source.match(/await writePluginConfig\(/g) ?? []).length,
+        2,
+        'configuration writes belong only in beforeAll and afterAll'
+    );
+});

--- a/scripts/e2e/session-control-hygiene.test.js
+++ b/scripts/e2e/session-control-hygiene.test.js
@@ -47,3 +47,22 @@ test('session-control has no per-test configuration setup left behind', () => {
         'configuration writes belong only in beforeAll and afterAll'
     );
 });
+
+test('session-control always clears its synthetic playback through Jellyfin core', () => {
+    const fixture = sliceBetween('async function startUserPlayback(', "test.describe('session control'");
+    const adminTest = sliceBetween("test('admin sees", "test('non-admin gets");
+    const tryIndex = adminTest.indexOf('try {');
+    const finallyIndex = adminTest.indexOf('} finally {');
+    const cleanupIndex = adminTest.indexOf('await playback.stop();');
+
+    assert.match(fixture, /\/Sessions\/Playing\/Stopped/);
+    assert.match(fixture, /Failed:\s*true/);
+    assert.doesNotMatch(fixture, /JellyfinCanopy\/active-streams\/sessions\/.+\/stop/);
+    assert.ok(tryIndex >= 0, 'admin assertions must be guarded by try/finally');
+    assert.ok(finallyIndex > tryIndex, 'playback cleanup must live in finally');
+    assert.ok(cleanupIndex > finallyIndex, 'finally must await the playback cleanup');
+    assert.match(adminTest, /expect\(stop\.status, 'admin stop → 200'\)\.toBe\(200\)/);
+    assert.match(adminTest, /primaryFailure\s*=\s*error/);
+    assert.match(adminTest, /new AggregateError\(\s*\[primaryFailure, cleanupFailure\]/);
+    assert.match(adminTest, /throw cleanupFailure/);
+});

--- a/scripts/e2e/shard-result.js
+++ b/scripts/e2e/shard-result.js
@@ -216,6 +216,7 @@ function aggregateMarkers(entries, expectedValues, initialErrors = []) {
     const expected = expectedRun(expectedValues);
     const errors = [...initialErrors];
     const byShard = new Map();
+    const latestByShard = new Map();
 
     for (const entry of entries) {
         const label = entry.file || 'shard marker';
@@ -227,30 +228,31 @@ function aggregateMarkers(entries, expectedValues, initialErrors = []) {
             continue;
         }
 
-        let currentAttempt = true;
+        let eligible = true;
         if (marker.total !== expected.total) {
             errors.push(
                 `${label}: shard total ${marker.total} does not match expected ${expected.total}`
             );
-            currentAttempt = false;
+            eligible = false;
         }
         if (marker.headSha !== expected.headSha) {
             errors.push(
                 `${label}: head SHA ${marker.headSha} does not match expected ${expected.headSha}`
             );
-            currentAttempt = false;
+            eligible = false;
         }
         if (marker.runId !== expected.runId) {
             errors.push(`${label}: run ID ${marker.runId} does not match expected ${expected.runId}`);
-            currentAttempt = false;
+            eligible = false;
         }
-        if (marker.runAttempt !== expected.runAttempt) {
+        if (marker.runAttempt > expected.runAttempt) {
             errors.push(
-                `${label}: run attempt ${marker.runAttempt} does not match expected ${expected.runAttempt}`
+                `${label}: run attempt ${marker.runAttempt} is newer than current attempt `
+                + `${expected.runAttempt}`
             );
-            currentAttempt = false;
+            eligible = false;
         }
-        if (!currentAttempt || marker.shard > expected.total) {
+        if (!eligible || marker.shard > expected.total) {
             continue;
         }
 
@@ -262,21 +264,45 @@ function aggregateMarkers(entries, expectedValues, initialErrors = []) {
     for (let shard = 1; shard <= expected.total; shard += 1) {
         const markers = byShard.get(shard) || [];
         if (markers.length === 0) {
-            errors.push(`Missing current-attempt marker for shard ${shard} of ${expected.total}`);
+            errors.push(
+                `Missing valid marker for shard ${shard} of ${expected.total} at or before `
+                + `run attempt ${expected.runAttempt}`
+            );
             continue;
         }
-        if (markers.length > 1) {
-            errors.push(
-                `Duplicate current-attempt markers for shard ${shard} of ${expected.total}: `
-                + markers.map((entry) => entry.file || '<memory>').join(', ')
-            );
+
+        const markersByAttempt = new Map();
+        for (const entry of markers) {
+            const attemptMarkers = markersByAttempt.get(entry.marker.runAttempt) || [];
+            attemptMarkers.push(entry);
+            markersByAttempt.set(entry.marker.runAttempt, attemptMarkers);
         }
-        for (const { marker } of markers) {
+
+        for (const [attempt, attemptMarkers] of markersByAttempt) {
+            if (attemptMarkers.length > 1) {
+                errors.push(
+                    `Duplicate markers for shard ${shard} of ${expected.total} in run attempt `
+                    + `${attempt}: `
+                    + attemptMarkers.map((entry) => entry.file || '<memory>').join(', ')
+                );
+            }
+        }
+
+        const latestAttempt = Math.max(...markersByAttempt.keys());
+        const latestMarkers = markersByAttempt.get(latestAttempt);
+        latestByShard.set(shard, latestMarkers);
+        for (const { marker } of latestMarkers) {
             if (marker.seedOutcome !== 'success') {
-                errors.push(`Shard ${shard} seed outcome is ${marker.seedOutcome}, not success`);
+                errors.push(
+                    `Shard ${shard} newest seed outcome (attempt ${latestAttempt}) is `
+                    + `${marker.seedOutcome}, not success`
+                );
             }
             if (marker.testOutcome !== 'success') {
-                errors.push(`Shard ${shard} test outcome is ${marker.testOutcome}, not success`);
+                errors.push(
+                    `Shard ${shard} newest test outcome (attempt ${latestAttempt}) is `
+                    + `${marker.testOutcome}, not success`
+                );
             }
         }
     }
@@ -285,6 +311,7 @@ function aggregateMarkers(entries, expectedValues, initialErrors = []) {
         ok: errors.length === 0,
         expected,
         byShard,
+        latestByShard,
         errors,
     };
 }
@@ -311,13 +338,22 @@ function renderSummary(result) {
     ];
     for (let shard = 1; shard <= result.expected.total; shard += 1) {
         const entries = result.byShard.get(shard) || [];
-        if (entries.length === 0) {
+        const latestEntries = result.latestByShard.get(shard) || [];
+        if (latestEntries.length === 0) {
             lines.push(`| ${shard} / ${result.expected.total} | — | — | Missing |`);
             continue;
         }
-        const seeds = entries.map(({ marker }) => marker.seedOutcome).join(', ');
-        const tests = entries.map(({ marker }) => marker.testOutcome).join(', ');
-        const markerStatus = entries.length === 1 ? 'Current attempt' : `Duplicate (${entries.length})`;
+        const latestAttempt = latestEntries[0].marker.runAttempt;
+        const seeds = latestEntries.map(({ marker }) => marker.seedOutcome).join(', ');
+        const tests = latestEntries.map(({ marker }) => marker.testOutcome).join(', ');
+        const attempts = [...new Set(entries.map(({ marker }) => marker.runAttempt))]
+            .sort((left, right) => left - right);
+        let markerStatus = `Attempt ${latestAttempt}`;
+        if (latestEntries.length > 1) {
+            markerStatus = `Duplicate attempt ${latestAttempt} (${latestEntries.length})`;
+        } else if (attempts.length > 1) {
+            markerStatus += ` selected (history: ${attempts.join(', ')})`;
+        }
         lines.push(
             `| ${shard} / ${result.expected.total} | ${markdownCell(seeds)} | `
             + `${markdownCell(tests)} | ${markerStatus} |`

--- a/scripts/e2e/shard-result.js
+++ b/scripts/e2e/shard-result.js
@@ -1,0 +1,463 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SCHEMA_VERSION = 1;
+const SHA_PATTERN = /^[0-9a-f]{40}$/i;
+const POSITIVE_DECIMAL_PATTERN = /^[1-9][0-9]*$/;
+const OUTCOMES = new Set(['success', 'failure', 'cancelled', 'skipped']);
+const MARKER_KEYS = [
+    'version',
+    'shard',
+    'total',
+    'headSha',
+    'runId',
+    'runAttempt',
+    'seedOutcome',
+    'testOutcome',
+    'createdAt',
+];
+
+function plainObject(value, label) {
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+        throw new Error(`${label} must be a JSON object`);
+    }
+    return value;
+}
+
+function exactKeys(value, expected, label) {
+    const actual = Object.keys(value).sort();
+    const wanted = [...expected].sort();
+    if (actual.length !== wanted.length || actual.some((key, index) => key !== wanted[index])) {
+        throw new Error(
+            `${label} must contain exactly these fields: ${wanted.join(', ')}`
+        );
+    }
+}
+
+function positiveInteger(value, label) {
+    const number = typeof value === 'number' ? value : Number(value);
+    if (!Number.isSafeInteger(number) || number < 1) {
+        throw new Error(`${label} must be a positive integer; received ${JSON.stringify(value)}`);
+    }
+    return number;
+}
+
+function runId(value, label = 'run ID') {
+    const normalized = String(value ?? '').trim();
+    if (!POSITIVE_DECIMAL_PATTERN.test(normalized)) {
+        throw new Error(`${label} must be a positive decimal integer; received ${JSON.stringify(value)}`);
+    }
+    return normalized;
+}
+
+function headSha(value, label = 'head SHA') {
+    const normalized = String(value ?? '').trim().toLowerCase();
+    if (!SHA_PATTERN.test(normalized)) {
+        throw new Error(`${label} must be a full 40-character hexadecimal commit SHA`);
+    }
+    return normalized;
+}
+
+function outcome(value, label) {
+    if (typeof value !== 'string' || !OUTCOMES.has(value)) {
+        throw new Error(
+            `${label} must be one of ${[...OUTCOMES].join(', ')}; received ${JSON.stringify(value)}`
+        );
+    }
+    return value;
+}
+
+function timestamp(value, label = 'createdAt') {
+    if (typeof value !== 'string') {
+        throw new Error(`${label} must be an ISO-8601 UTC timestamp`);
+    }
+    const parsed = new Date(value);
+    if (!Number.isFinite(parsed.getTime()) || parsed.toISOString() !== value) {
+        throw new Error(`${label} must be an ISO-8601 UTC timestamp`);
+    }
+    return value;
+}
+
+function validateCoordinates(shard, total) {
+    const normalizedTotal = positiveInteger(total, 'shard total');
+    const normalizedShard = positiveInteger(shard, 'shard index');
+    if (normalizedShard > normalizedTotal) {
+        throw new Error(
+            `shard index ${normalizedShard} is out of range for ${normalizedTotal} total shards`
+        );
+    }
+    return { shard: normalizedShard, total: normalizedTotal };
+}
+
+function createMarker(values, now = new Date()) {
+    const coordinates = validateCoordinates(values.shard, values.total);
+    if (!(now instanceof Date) || !Number.isFinite(now.getTime())) {
+        throw new Error('marker clock must be a valid Date');
+    }
+    return {
+        version: SCHEMA_VERSION,
+        ...coordinates,
+        headSha: headSha(values.headSha),
+        runId: runId(values.runId),
+        runAttempt: positiveInteger(values.runAttempt, 'run attempt'),
+        seedOutcome: outcome(values.seedOutcome, 'seed outcome'),
+        testOutcome: outcome(values.testOutcome, 'test outcome'),
+        createdAt: now.toISOString(),
+    };
+}
+
+function validateMarker(value, label = 'shard marker') {
+    const marker = plainObject(value, label);
+    exactKeys(marker, MARKER_KEYS, label);
+    if (marker.version !== SCHEMA_VERSION) {
+        throw new Error(`${label} has unsupported schema version ${JSON.stringify(marker.version)}`);
+    }
+    const coordinates = validateCoordinates(marker.shard, marker.total);
+    return {
+        version: SCHEMA_VERSION,
+        ...coordinates,
+        headSha: headSha(marker.headSha, `${label} head SHA`),
+        runId: runId(marker.runId, `${label} run ID`),
+        runAttempt: positiveInteger(marker.runAttempt, `${label} run attempt`),
+        seedOutcome: outcome(marker.seedOutcome, `${label} seed outcome`),
+        testOutcome: outcome(marker.testOutcome, `${label} test outcome`),
+        createdAt: timestamp(marker.createdAt, `${label} createdAt`),
+    };
+}
+
+function expectedRun(values) {
+    return {
+        total: positiveInteger(values.total, 'expected shard total'),
+        headSha: headSha(values.headSha, 'expected head SHA'),
+        runId: runId(values.runId, 'expected run ID'),
+        runAttempt: positiveInteger(values.runAttempt, 'expected run attempt'),
+    };
+}
+
+function atomicWriteJson(outputFile, value) {
+    const destination = path.resolve(outputFile);
+    const directory = path.dirname(destination);
+    fs.mkdirSync(directory, { recursive: true });
+    const temporary = path.join(
+        directory,
+        `.${path.basename(destination)}.${process.pid}.${Date.now()}.tmp`
+    );
+    try {
+        fs.writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, {
+            encoding: 'utf8',
+            flag: 'wx',
+            mode: 0o600,
+        });
+        fs.renameSync(temporary, destination);
+    } catch (error) {
+        try {
+            fs.unlinkSync(temporary);
+        } catch {
+            // The temporary file may not have been created or may already have been renamed.
+        }
+        throw error;
+    }
+    return destination;
+}
+
+function writeMarker(outputFile, values, now) {
+    const marker = createMarker(values, now);
+    atomicWriteJson(outputFile, marker);
+    return marker;
+}
+
+function collectJsonFiles(directory) {
+    const files = [];
+    function visit(current) {
+        const entries = fs.readdirSync(current, { withFileTypes: true })
+            .sort((left, right) => left.name.localeCompare(right.name));
+        for (const entry of entries) {
+            const fullPath = path.join(current, entry.name);
+            if (entry.isDirectory()) {
+                visit(fullPath);
+            } else if (entry.isFile() && entry.name.endsWith('.json')) {
+                files.push(fullPath);
+            }
+        }
+    }
+    visit(path.resolve(directory));
+    return files;
+}
+
+function readMarkerEntries(directory) {
+    const entries = [];
+    const errors = [];
+    let files;
+    try {
+        files = collectJsonFiles(directory);
+    } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        return { entries, errors: [`Could not read marker directory: ${detail}`] };
+    }
+    for (const file of files) {
+        let value;
+        try {
+            value = JSON.parse(fs.readFileSync(file, 'utf8'));
+        } catch (error) {
+            const detail = error instanceof Error ? error.message : String(error);
+            errors.push(`${file}: invalid marker JSON: ${detail}`);
+            continue;
+        }
+        entries.push({ file, value });
+    }
+    return { entries, errors };
+}
+
+function aggregateMarkers(entries, expectedValues, initialErrors = []) {
+    const expected = expectedRun(expectedValues);
+    const errors = [...initialErrors];
+    const byShard = new Map();
+
+    for (const entry of entries) {
+        const label = entry.file || 'shard marker';
+        let marker;
+        try {
+            marker = validateMarker(entry.value, label);
+        } catch (error) {
+            errors.push(error instanceof Error ? error.message : String(error));
+            continue;
+        }
+
+        let currentAttempt = true;
+        if (marker.total !== expected.total) {
+            errors.push(
+                `${label}: shard total ${marker.total} does not match expected ${expected.total}`
+            );
+            currentAttempt = false;
+        }
+        if (marker.headSha !== expected.headSha) {
+            errors.push(
+                `${label}: head SHA ${marker.headSha} does not match expected ${expected.headSha}`
+            );
+            currentAttempt = false;
+        }
+        if (marker.runId !== expected.runId) {
+            errors.push(`${label}: run ID ${marker.runId} does not match expected ${expected.runId}`);
+            currentAttempt = false;
+        }
+        if (marker.runAttempt !== expected.runAttempt) {
+            errors.push(
+                `${label}: run attempt ${marker.runAttempt} does not match expected ${expected.runAttempt}`
+            );
+            currentAttempt = false;
+        }
+        if (!currentAttempt || marker.shard > expected.total) {
+            continue;
+        }
+
+        const markers = byShard.get(marker.shard) || [];
+        markers.push({ file: entry.file || '', marker });
+        byShard.set(marker.shard, markers);
+    }
+
+    for (let shard = 1; shard <= expected.total; shard += 1) {
+        const markers = byShard.get(shard) || [];
+        if (markers.length === 0) {
+            errors.push(`Missing current-attempt marker for shard ${shard} of ${expected.total}`);
+            continue;
+        }
+        if (markers.length > 1) {
+            errors.push(
+                `Duplicate current-attempt markers for shard ${shard} of ${expected.total}: `
+                + markers.map((entry) => entry.file || '<memory>').join(', ')
+            );
+        }
+        for (const { marker } of markers) {
+            if (marker.seedOutcome !== 'success') {
+                errors.push(`Shard ${shard} seed outcome is ${marker.seedOutcome}, not success`);
+            }
+            if (marker.testOutcome !== 'success') {
+                errors.push(`Shard ${shard} test outcome is ${marker.testOutcome}, not success`);
+            }
+        }
+    }
+
+    return {
+        ok: errors.length === 0,
+        expected,
+        byShard,
+        errors,
+    };
+}
+
+function aggregateDirectory(directory, expectedValues) {
+    const read = readMarkerEntries(directory);
+    return aggregateMarkers(read.entries, expectedValues, read.errors);
+}
+
+function markdownCell(value) {
+    return String(value).replaceAll('|', '\\|').replaceAll('\n', ' ');
+}
+
+function renderSummary(result) {
+    const status = result.ok ? '✅ Passed' : '❌ Failed';
+    const lines = [
+        '### Dockerized Jellyfin E2E shard results',
+        '',
+        `**${status}** — run ${result.expected.runId}, attempt ${result.expected.runAttempt}, `
+            + `commit \`${result.expected.headSha}\``,
+        '',
+        '| Shard | Seed | Tests | Marker |',
+        '| ---: | :---: | :---: | --- |',
+    ];
+    for (let shard = 1; shard <= result.expected.total; shard += 1) {
+        const entries = result.byShard.get(shard) || [];
+        if (entries.length === 0) {
+            lines.push(`| ${shard} / ${result.expected.total} | — | — | Missing |`);
+            continue;
+        }
+        const seeds = entries.map(({ marker }) => marker.seedOutcome).join(', ');
+        const tests = entries.map(({ marker }) => marker.testOutcome).join(', ');
+        const markerStatus = entries.length === 1 ? 'Current attempt' : `Duplicate (${entries.length})`;
+        lines.push(
+            `| ${shard} / ${result.expected.total} | ${markdownCell(seeds)} | `
+            + `${markdownCell(tests)} | ${markerStatus} |`
+        );
+    }
+    if (result.errors.length > 0) {
+        lines.push('', '#### Validation errors', '');
+        for (const error of result.errors) {
+            lines.push(`- ${markdownCell(error)}`);
+        }
+    }
+    lines.push('');
+    return `${lines.join('\n')}\n`;
+}
+
+function appendSummary(summaryFile, result) {
+    fs.appendFileSync(summaryFile, renderSummary(result), 'utf8');
+}
+
+function parseOptions(argumentsList, allowed) {
+    const options = {};
+    for (let index = 0; index < argumentsList.length; index += 2) {
+        const flag = argumentsList[index];
+        const value = argumentsList[index + 1];
+        if (!flag?.startsWith('--') || value === undefined || value.startsWith('--')) {
+            throw new Error(`Expected --name value arguments; received ${JSON.stringify(flag)}`);
+        }
+        const name = flag.slice(2);
+        if (!allowed.has(name)) {
+            throw new Error(`Unknown option ${flag}`);
+        }
+        if (Object.hasOwn(options, name)) {
+            throw new Error(`Option ${flag} was provided more than once`);
+        }
+        options[name] = value;
+    }
+    for (const name of allowed) {
+        if (!Object.hasOwn(options, name)) {
+            throw new Error(`Missing required option --${name}`);
+        }
+    }
+    return options;
+}
+
+function cliValues(options) {
+    return {
+        shard: options.shard,
+        total: options.total,
+        headSha: options.sha,
+        runId: options['run-id'],
+        runAttempt: options['run-attempt'],
+        seedOutcome: options['seed-outcome'],
+        testOutcome: options['test-outcome'],
+    };
+}
+
+function cliExpected(options) {
+    return {
+        total: options.total,
+        headSha: options.sha,
+        runId: options['run-id'],
+        runAttempt: options['run-attempt'],
+    };
+}
+
+function usage() {
+    return [
+        'Usage:',
+        '  node scripts/e2e/shard-result.js write --output FILE --shard N --total N',
+        '    --sha SHA --run-id ID --run-attempt N --seed-outcome OUTCOME --test-outcome OUTCOME',
+        '  node scripts/e2e/shard-result.js aggregate --directory DIR --total N',
+        '    --sha SHA --run-id ID --run-attempt N',
+    ].join('\n');
+}
+
+function main(argv = process.argv.slice(2), env = process.env) {
+    const [command, ...rest] = argv;
+    if (command === 'write') {
+        const options = parseOptions(rest, new Set([
+            'output',
+            'shard',
+            'total',
+            'sha',
+            'run-id',
+            'run-attempt',
+            'seed-outcome',
+            'test-outcome',
+        ]));
+        const marker = writeMarker(options.output, cliValues(options));
+        console.log(
+            `Wrote E2E shard ${marker.shard}/${marker.total} result for `
+            + `run ${marker.runId} attempt ${marker.runAttempt} to ${path.resolve(options.output)}`
+        );
+        return 0;
+    }
+    if (command === 'aggregate') {
+        const options = parseOptions(rest, new Set([
+            'directory',
+            'total',
+            'sha',
+            'run-id',
+            'run-attempt',
+        ]));
+        const result = aggregateDirectory(options.directory, cliExpected(options));
+        if (env.GITHUB_STEP_SUMMARY) {
+            appendSummary(env.GITHUB_STEP_SUMMARY, result);
+        }
+        if (!result.ok) {
+            for (const error of result.errors) {
+                console.error(`E2E shard result error: ${error}`);
+            }
+            return 1;
+        }
+        console.log(
+            `Validated ${result.expected.total} E2E shard results for `
+            + `run ${result.expected.runId} attempt ${result.expected.runAttempt}`
+        );
+        return 0;
+    }
+    throw new Error(`${usage()}\n\nUnknown command ${JSON.stringify(command)}`);
+}
+
+if (require.main === module) {
+    try {
+        process.exitCode = main();
+    } catch (error) {
+        console.error(error instanceof Error ? error.message : String(error));
+        process.exitCode = 1;
+    }
+}
+
+module.exports = {
+    SCHEMA_VERSION,
+    aggregateDirectory,
+    aggregateMarkers,
+    appendSummary,
+    createMarker,
+    main,
+    readMarkerEntries,
+    renderSummary,
+    validateMarker,
+    writeMarker,
+};

--- a/scripts/e2e/shard-result.test.js
+++ b/scripts/e2e/shard-result.test.js
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const {
+    aggregateDirectory,
+    aggregateMarkers,
+    createMarker,
+    renderSummary,
+    validateMarker,
+    writeMarker,
+} = require('./shard-result');
+
+const SCRIPT = path.join(__dirname, 'shard-result.js');
+const HEAD_SHA = 'a'.repeat(40);
+const OTHER_SHA = 'b'.repeat(40);
+const EXPECTED = Object.freeze({
+    total: 4,
+    headSha: HEAD_SHA,
+    runId: '9876543210',
+    runAttempt: 2,
+});
+const CREATED_AT = new Date('2026-07-14T00:00:00.000Z');
+
+function marker(shard, overrides = {}) {
+    return createMarker({
+        shard,
+        total: EXPECTED.total,
+        headSha: EXPECTED.headSha,
+        runId: EXPECTED.runId,
+        runAttempt: EXPECTED.runAttempt,
+        seedOutcome: 'success',
+        testOutcome: 'success',
+        ...overrides,
+    }, CREATED_AT);
+}
+
+function entry(shard, overrides = {}, suffix = '') {
+    return {
+        file: `/results/shard-${shard}${suffix}.json`,
+        value: marker(shard, overrides),
+    };
+}
+
+function temporaryDirectory(t) {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'canopy-shard-result-'));
+    t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+    return directory;
+}
+
+function runCli(args, env = {}) {
+    return spawnSync(process.execPath, [SCRIPT, ...args], {
+        encoding: 'utf8',
+        env: { ...process.env, ...env },
+    });
+}
+
+function aggregateArguments(directory) {
+    return [
+        'aggregate',
+        '--directory', directory,
+        '--total', String(EXPECTED.total),
+        '--sha', EXPECTED.headSha,
+        '--run-id', EXPECTED.runId,
+        '--run-attempt', String(EXPECTED.runAttempt),
+    ];
+}
+
+test('write CLI atomically creates a strictly validated current-attempt marker', (t) => {
+    const directory = temporaryDirectory(t);
+    const output = path.join(directory, 'nested', 'shard-2.json');
+    const result = runCli([
+        'write',
+        '--output', output,
+        '--shard', '2',
+        '--total', '4',
+        '--sha', HEAD_SHA,
+        '--run-id', EXPECTED.runId,
+        '--run-attempt', '2',
+        '--seed-outcome', 'success',
+        '--test-outcome', 'success',
+    ]);
+
+    assert.equal(result.status, 0, result.stderr);
+    const written = validateMarker(JSON.parse(fs.readFileSync(output, 'utf8')));
+    assert.equal(written.shard, 2);
+    assert.equal(written.total, 4);
+    assert.equal(written.headSha, HEAD_SHA);
+    assert.equal(written.runId, EXPECTED.runId);
+    assert.equal(written.runAttempt, 2);
+    assert.equal(written.seedOutcome, 'success');
+    assert.equal(written.testOutcome, 'success');
+    assert.deepEqual(fs.readdirSync(path.dirname(output)), ['shard-2.json']);
+});
+
+test('all-success markers aggregate and the CLI appends a readable step summary', (t) => {
+    const directory = temporaryDirectory(t);
+    for (let shard = 1; shard <= EXPECTED.total; shard += 1) {
+        writeMarker(path.join(directory, `shard-${shard}.json`), {
+            ...marker(shard),
+        }, CREATED_AT);
+    }
+    const direct = aggregateDirectory(directory, EXPECTED);
+    assert.equal(direct.ok, true, direct.errors.join('\n'));
+    assert.match(renderSummary(direct), /✅ Passed/);
+
+    const summary = path.join(directory, 'step-summary.md');
+    fs.writeFileSync(summary, 'Existing summary\n', 'utf8');
+    const cli = runCli(aggregateArguments(directory), { GITHUB_STEP_SUMMARY: summary });
+    assert.equal(cli.status, 0, cli.stderr);
+    const summaryText = fs.readFileSync(summary, 'utf8');
+    assert.match(summaryText, /^Existing summary/m);
+    assert.match(summaryText, /Dockerized Jellyfin E2E shard results/);
+    assert.match(summaryText, /\| 4 \/ 4 \| success \| success \| Current attempt \|/);
+});
+
+test('a failed seed or test outcome fails aggregation and the aggregate CLI exits nonzero', (t) => {
+    const directory = temporaryDirectory(t);
+    const entries = [
+        entry(1),
+        entry(2, { seedOutcome: 'failure' }),
+        entry(3, { testOutcome: 'cancelled' }),
+        entry(4),
+    ];
+    for (const { file, value } of entries) {
+        fs.writeFileSync(path.join(directory, path.basename(file)), JSON.stringify(value));
+    }
+
+    const result = aggregateDirectory(directory, EXPECTED);
+    assert.equal(result.ok, false);
+    assert.match(result.errors.join('\n'), /Shard 2 seed outcome is failure/);
+    assert.match(result.errors.join('\n'), /Shard 3 test outcome is cancelled/);
+    const cli = runCli(aggregateArguments(directory));
+    assert.equal(cli.status, 1);
+    assert.match(cli.stderr, /E2E shard result error/);
+});
+
+test('a missing shard fails exact 1-through-N validation', () => {
+    const result = aggregateMarkers([entry(1), entry(2), entry(4)], EXPECTED);
+    assert.equal(result.ok, false);
+    assert.match(result.errors.join('\n'), /Missing current-attempt marker for shard 3 of 4/);
+});
+
+test('duplicate shard markers fail even when every outcome succeeded', () => {
+    const result = aggregateMarkers([
+        entry(1),
+        entry(2),
+        entry(2, {}, '-copy'),
+        entry(3),
+        entry(4),
+    ], EXPECTED);
+    assert.equal(result.ok, false);
+    assert.match(result.errors.join('\n'), /Duplicate current-attempt markers for shard 2 of 4/);
+    assert.match(renderSummary(result), /Duplicate \(2\)/);
+});
+
+test('a stale run attempt is rejected and cannot satisfy the expected shard', () => {
+    const result = aggregateMarkers([
+        entry(1),
+        entry(2, { runAttempt: 1 }),
+        entry(3),
+        entry(4),
+    ], EXPECTED);
+    assert.equal(result.ok, false);
+    assert.match(result.errors.join('\n'), /run attempt 1 does not match expected 2/);
+    assert.match(result.errors.join('\n'), /Missing current-attempt marker for shard 2 of 4/);
+});
+
+test('a marker for a different head SHA is rejected as stale', () => {
+    const result = aggregateMarkers([
+        entry(1),
+        entry(2),
+        entry(3, { headSha: OTHER_SHA }),
+        entry(4),
+    ], EXPECTED);
+    assert.equal(result.ok, false);
+    assert.match(result.errors.join('\n'), new RegExp(`head SHA ${OTHER_SHA} does not match`));
+    assert.match(result.errors.join('\n'), /Missing current-attempt marker for shard 3 of 4/);
+});
+
+test('malformed JSON, malformed fields, and out-of-range coordinates are rejected', (t) => {
+    const directory = temporaryDirectory(t);
+    fs.writeFileSync(path.join(directory, 'broken.json'), '{ not JSON', 'utf8');
+    const malformed = marker(1);
+    malformed.unexpected = true;
+    fs.writeFileSync(path.join(directory, 'extra-field.json'), JSON.stringify(malformed), 'utf8');
+
+    const result = aggregateDirectory(directory, EXPECTED);
+    assert.equal(result.ok, false);
+    assert.match(result.errors.join('\n'), /invalid marker JSON/);
+    assert.match(result.errors.join('\n'), /must contain exactly these fields/);
+    assert.throws(() => marker(0), /shard index must be a positive integer/);
+    assert.throws(() => marker(5), /shard index 5 is out of range for 4 total shards/);
+    assert.throws(
+        () => marker(1, { headSha: 'not-a-sha' }),
+        /full 40-character hexadecimal commit SHA/
+    );
+    assert.throws(
+        () => marker(1, { seedOutcome: 'unknown' }),
+        /seed outcome must be one of/
+    );
+});

--- a/scripts/e2e/shard-result.test.js
+++ b/scripts/e2e/shard-result.test.js
@@ -118,7 +118,7 @@ test('all-success markers aggregate and the CLI appends a readable step summary'
     const summaryText = fs.readFileSync(summary, 'utf8');
     assert.match(summaryText, /^Existing summary/m);
     assert.match(summaryText, /Dockerized Jellyfin E2E shard results/);
-    assert.match(summaryText, /\| 4 \/ 4 \| success \| success \| Current attempt \|/);
+    assert.match(summaryText, /\| 4 \/ 4 \| success \| success \| Attempt 2 \|/);
 });
 
 test('a failed seed or test outcome fails aggregation and the aggregate CLI exits nonzero', (t) => {
@@ -135,8 +135,8 @@ test('a failed seed or test outcome fails aggregation and the aggregate CLI exit
 
     const result = aggregateDirectory(directory, EXPECTED);
     assert.equal(result.ok, false);
-    assert.match(result.errors.join('\n'), /Shard 2 seed outcome is failure/);
-    assert.match(result.errors.join('\n'), /Shard 3 test outcome is cancelled/);
+    assert.match(result.errors.join('\n'), /Shard 2 newest seed outcome \(attempt 2\) is failure/);
+    assert.match(result.errors.join('\n'), /Shard 3 newest test outcome \(attempt 2\) is cancelled/);
     const cli = runCli(aggregateArguments(directory));
     assert.equal(cli.status, 1);
     assert.match(cli.stderr, /E2E shard result error/);
@@ -145,7 +145,7 @@ test('a failed seed or test outcome fails aggregation and the aggregate CLI exit
 test('a missing shard fails exact 1-through-N validation', () => {
     const result = aggregateMarkers([entry(1), entry(2), entry(4)], EXPECTED);
     assert.equal(result.ok, false);
-    assert.match(result.errors.join('\n'), /Missing current-attempt marker for shard 3 of 4/);
+    assert.match(result.errors.join('\n'), /Missing valid marker for shard 3 of 4/);
 });
 
 test('duplicate shard markers fail even when every outcome succeeded', () => {
@@ -157,20 +157,74 @@ test('duplicate shard markers fail even when every outcome succeeded', () => {
         entry(4),
     ], EXPECTED);
     assert.equal(result.ok, false);
-    assert.match(result.errors.join('\n'), /Duplicate current-attempt markers for shard 2 of 4/);
-    assert.match(renderSummary(result), /Duplicate \(2\)/);
+    assert.match(result.errors.join('\n'), /Duplicate markers for shard 2 of 4 in run attempt 2/);
+    assert.match(renderSummary(result), /Duplicate attempt 2 \(2\)/);
 });
 
-test('a stale run attempt is rejected and cannot satisfy the expected shard', () => {
+test('a failed shard recovered on attempt 2 reuses nested attempt-1 artifacts', (t) => {
+    const directory = temporaryDirectory(t);
+    const entries = [
+        entry(1, { runAttempt: 1, testOutcome: 'failure' }),
+        entry(1, { runAttempt: 2 }),
+        entry(2, { runAttempt: 1 }),
+        entry(3, { runAttempt: 1 }),
+        entry(4, { runAttempt: 1 }),
+    ];
+    entries.forEach(({ value }, index) => {
+        const artifactDirectory = path.join(directory, `attempt-artifact-${index + 1}`);
+        fs.mkdirSync(artifactDirectory);
+        fs.writeFileSync(
+            path.join(artifactDirectory, `shard-${value.shard}.json`),
+            JSON.stringify(value),
+            'utf8'
+        );
+    });
+
+    const result = aggregateDirectory(directory, EXPECTED);
+    assert.equal(result.ok, true, result.errors.join('\n'));
+    assert.equal(result.latestByShard.get(1)[0].marker.runAttempt, 2);
+    assert.equal(result.latestByShard.get(2)[0].marker.runAttempt, 1);
+    assert.match(renderSummary(result), /Attempt 2 selected \(history: 1, 2\)/);
+});
+
+test('a duplicate in an older attempt remains fatal after a newer successful retry', () => {
+    const result = aggregateMarkers([
+        entry(1, { runAttempt: 1 }, '-attempt-1-a'),
+        entry(1, { runAttempt: 1 }, '-attempt-1-b'),
+        entry(1, { runAttempt: 2 }, '-attempt-2'),
+        entry(2, { runAttempt: 1 }),
+        entry(3, { runAttempt: 1 }),
+        entry(4, { runAttempt: 1 }),
+    ], EXPECTED);
+    assert.equal(result.ok, false);
+    assert.match(result.errors.join('\n'), /Duplicate markers for shard 1 of 4 in run attempt 1/);
+});
+
+test('a failed newest shard marker is not hidden by an older success', () => {
+    const result = aggregateMarkers([
+        entry(1, { runAttempt: 1 }, '-attempt-1'),
+        entry(1, { runAttempt: 2, testOutcome: 'failure' }, '-attempt-2'),
+        entry(2, { runAttempt: 1 }),
+        entry(3, { runAttempt: 1 }),
+        entry(4, { runAttempt: 1 }),
+    ], EXPECTED);
+    assert.equal(result.ok, false);
+    assert.match(
+        result.errors.join('\n'),
+        /Shard 1 newest test outcome \(attempt 2\) is failure/
+    );
+});
+
+test('a future run attempt is rejected and cannot satisfy the expected shard', () => {
     const result = aggregateMarkers([
         entry(1),
-        entry(2, { runAttempt: 1 }),
+        entry(2, { runAttempt: 3 }),
         entry(3),
         entry(4),
     ], EXPECTED);
     assert.equal(result.ok, false);
-    assert.match(result.errors.join('\n'), /run attempt 1 does not match expected 2/);
-    assert.match(result.errors.join('\n'), /Missing current-attempt marker for shard 2 of 4/);
+    assert.match(result.errors.join('\n'), /run attempt 3 is newer than current attempt 2/);
+    assert.match(result.errors.join('\n'), /Missing valid marker for shard 2 of 4/);
 });
 
 test('a marker for a different head SHA is rejected as stale', () => {
@@ -182,7 +236,19 @@ test('a marker for a different head SHA is rejected as stale', () => {
     ], EXPECTED);
     assert.equal(result.ok, false);
     assert.match(result.errors.join('\n'), new RegExp(`head SHA ${OTHER_SHA} does not match`));
-    assert.match(result.errors.join('\n'), /Missing current-attempt marker for shard 3 of 4/);
+    assert.match(result.errors.join('\n'), /Missing valid marker for shard 3 of 4/);
+});
+
+test('a marker from a different run is rejected even when its SHA and outcome match', () => {
+    const result = aggregateMarkers([
+        entry(1),
+        entry(2, { runId: '1234567890' }),
+        entry(3),
+        entry(4),
+    ], EXPECTED);
+    assert.equal(result.ok, false);
+    assert.match(result.errors.join('\n'), /run ID 1234567890 does not match expected 9876543210/);
+    assert.match(result.errors.join('\n'), /Missing valid marker for shard 2 of 4/);
 });
 
 test('malformed JSON, malformed fields, and out-of-range coordinates are rejected', (t) => {

--- a/scripts/e2e/spoiler-guard-restore.d.ts
+++ b/scripts/e2e/spoiler-guard-restore.d.ts
@@ -1,0 +1,9 @@
+export interface GuardRestorePlan {
+    readonly requiredGuarded: boolean;
+    readonly restoreGuarded: boolean;
+}
+
+export function createGuardRestorePlan(
+    initiallyGuarded: boolean,
+    requiredGuarded: boolean
+): Readonly<GuardRestorePlan>;

--- a/scripts/e2e/spoiler-guard-restore.d.ts
+++ b/scripts/e2e/spoiler-guard-restore.d.ts
@@ -1,9 +1,17 @@
 export interface GuardRestorePlan {
     readonly requiredGuarded: boolean;
-    readonly restoreGuarded: boolean;
+    readonly normalizedSeriesId: string;
+    readonly originalKey: string | null;
+    readonly originalEntry: Readonly<Record<string, unknown>> | null;
 }
 
 export function createGuardRestorePlan(
-    initiallyGuarded: boolean,
+    initialState: Record<string, unknown>,
+    seriesId: string,
     requiredGuarded: boolean
 ): Readonly<GuardRestorePlan>;
+
+export function applyGuardRestorePlan(
+    currentState: Record<string, unknown>,
+    plan: Readonly<GuardRestorePlan>
+): Record<string, unknown>;

--- a/scripts/e2e/spoiler-guard-restore.js
+++ b/scripts/e2e/spoiler-guard-restore.js
@@ -2,19 +2,102 @@
 
 'use strict';
 
-/**
- * Keep a stateful Spoiler Guard E2E assertion explicit about both the state it
- * needs and the exact state it must restore when the assertion finishes.
- */
-function createGuardRestorePlan(initiallyGuarded, requiredGuarded) {
-    if (typeof initiallyGuarded !== 'boolean' || typeof requiredGuarded !== 'boolean') {
-        throw new TypeError('Spoiler Guard restore plans require boolean states');
+/** @param {unknown} value @param {string} label */
+function jsonObject(value, label) {
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+        throw new TypeError(`${label} must be a JSON object`);
     }
+    return /** @type {Record<string, unknown>} */ (value);
+}
+
+/** @param {Record<string, unknown>} value */
+function cloneJsonObject(value) {
+    return /** @type {Record<string, unknown>} */ (JSON.parse(JSON.stringify(value)));
+}
+
+/** @param {unknown} value */
+function normalizeSeriesId(value) {
+    if (typeof value !== 'string' || value.trim() === '') {
+        throw new TypeError('Spoiler Guard restore plans require a series id');
+    }
+    return value.replace(/-/g, '').toLowerCase();
+}
+
+/** @param {Record<string, unknown>} state */
+function seriesEntries(state) {
+    if (state.Series == null) return {};
+    return jsonObject(state.Series, 'Spoiler Guard Series');
+}
+
+/**
+ * Snapshot the target's complete entry before an E2E assertion changes it.
+ * A boolean is not enough: deleting and re-adding an existing entry replaces
+ * its EnabledAt timestamp and may discard future metadata fields.
+ *
+ * @param {Record<string, unknown>} initialState
+ * @param {string} seriesId
+ * @param {boolean} requiredGuarded
+ */
+function createGuardRestorePlan(initialState, seriesId, requiredGuarded) {
+    const state = jsonObject(initialState, 'Spoiler Guard state');
+    if (typeof requiredGuarded !== 'boolean') {
+        throw new TypeError('Spoiler Guard restore plans require a boolean target state');
+    }
+
+    const normalizedSeriesId = normalizeSeriesId(seriesId);
+    const matches = Object.entries(seriesEntries(state))
+        .filter(([key]) => normalizeSeriesId(key) === normalizedSeriesId);
+    if (matches.length > 1) {
+        throw new Error(`Spoiler Guard state has duplicate entries for series ${seriesId}`);
+    }
+
+    const [match] = matches;
+    const originalKey = match?.[0] ?? null;
+    const originalEntry = match
+        ? cloneJsonObject(jsonObject(match[1], `Spoiler Guard entry ${match[0]}`))
+        : null;
 
     return Object.freeze({
         requiredGuarded,
-        restoreGuarded: initiallyGuarded,
+        normalizedSeriesId,
+        originalKey,
+        originalEntry: originalEntry ? Object.freeze(originalEntry) : null,
     });
 }
 
-module.exports = { createGuardRestorePlan };
+/**
+ * Merge the snapshotted target entry into the latest server state. Unrelated
+ * series and every non-Series field come from the latest read, so cleanup does
+ * not roll back changes outside the E2E target.
+ *
+ * @param {Record<string, unknown>} currentState
+ * @param {{
+ *   normalizedSeriesId: string,
+ *   originalKey: string | null,
+ *   originalEntry: Readonly<Record<string, unknown>> | null
+ * }} plan
+ */
+function applyGuardRestorePlan(currentState, plan) {
+    const state = cloneJsonObject(jsonObject(currentState, 'current Spoiler Guard state'));
+    const normalizedSeriesId = normalizeSeriesId(plan?.normalizedSeriesId);
+    if ((plan.originalKey === null) !== (plan.originalEntry === null)) {
+        throw new TypeError('Spoiler Guard restore plan entry and key must both be present or absent');
+    }
+
+    const restoredSeries = { ...seriesEntries(state) };
+    for (const key of Object.keys(restoredSeries)) {
+        if (normalizeSeriesId(key) === normalizedSeriesId) delete restoredSeries[key];
+    }
+    if (plan.originalKey !== null && plan.originalEntry !== null) {
+        if (normalizeSeriesId(plan.originalKey) !== normalizedSeriesId) {
+            throw new TypeError('Spoiler Guard restore plan key does not match its series id');
+        }
+        restoredSeries[plan.originalKey] = cloneJsonObject(
+            jsonObject(plan.originalEntry, `Spoiler Guard entry ${plan.originalKey}`)
+        );
+    }
+    state.Series = restoredSeries;
+    return state;
+}
+
+module.exports = { applyGuardRestorePlan, createGuardRestorePlan };

--- a/scripts/e2e/spoiler-guard-restore.js
+++ b/scripts/e2e/spoiler-guard-restore.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+'use strict';
+
+/**
+ * Keep a stateful Spoiler Guard E2E assertion explicit about both the state it
+ * needs and the exact state it must restore when the assertion finishes.
+ */
+function createGuardRestorePlan(initiallyGuarded, requiredGuarded) {
+    if (typeof initiallyGuarded !== 'boolean' || typeof requiredGuarded !== 'boolean') {
+        throw new TypeError('Spoiler Guard restore plans require boolean states');
+    }
+
+    return Object.freeze({
+        requiredGuarded,
+        restoreGuarded: initiallyGuarded,
+    });
+}
+
+module.exports = { createGuardRestorePlan };

--- a/scripts/e2e/spoiler-guard-restore.test.js
+++ b/scripts/e2e/spoiler-guard-restore.test.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createGuardRestorePlan } = require('./spoiler-guard-restore');
+
+test('Spoiler Guard restore plans preserve both initially-ON and initially-OFF state', async (t) => {
+    await t.test('initially ON restores ON after an OFF-required assertion', () => {
+        assert.deepEqual(createGuardRestorePlan(true, false), {
+            requiredGuarded: false,
+            restoreGuarded: true,
+        });
+    });
+
+    await t.test('initially OFF restores OFF after an ON-required assertion', () => {
+        assert.deepEqual(createGuardRestorePlan(false, true), {
+            requiredGuarded: true,
+            restoreGuarded: false,
+        });
+    });
+});
+
+test('Spoiler Guard restore plans reject unknown state instead of guessing', () => {
+    assert.throws(() => createGuardRestorePlan(undefined, true), /require boolean states/);
+    assert.throws(() => createGuardRestorePlan(false, 'true'), /require boolean states/);
+});

--- a/scripts/e2e/spoiler-guard-restore.test.js
+++ b/scripts/e2e/spoiler-guard-restore.test.js
@@ -5,25 +5,98 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const { createGuardRestorePlan } = require('./spoiler-guard-restore');
+const { applyGuardRestorePlan, createGuardRestorePlan } = require('./spoiler-guard-restore');
 
-test('Spoiler Guard restore plans preserve both initially-ON and initially-OFF state', async (t) => {
-    await t.test('initially ON restores ON after an OFF-required assertion', () => {
-        assert.deepEqual(createGuardRestorePlan(true, false), {
-            requiredGuarded: false,
-            restoreGuarded: true,
-        });
+const TARGET_DASHED = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const TARGET_N = 'aaaaaaaabbbbccccddddeeeeeeeeeeee';
+
+test('Spoiler Guard restore plans preserve an initially-ON entry byte-for-byte', () => {
+    const original = {
+        Series: {
+            [TARGET_N]: {
+                SeriesId: TARGET_N,
+                SeriesName: 'Original Name',
+                EnabledAt: '2024-01-02T03:04:05.0000000Z',
+                FutureMetadata: { source: 'pre-existing' },
+            },
+            untouched: { SeriesId: 'untouched', EnabledAt: 'old' },
+        },
+        Movies: { movie: { MovieId: 'movie' } },
+        Prefs: { HideTags: false },
+    };
+    const plan = createGuardRestorePlan(original, TARGET_DASHED, false);
+    assert.deepEqual(plan, {
+        requiredGuarded: false,
+        normalizedSeriesId: TARGET_N,
+        originalKey: TARGET_N,
+        originalEntry: original.Series[TARGET_N],
     });
 
-    await t.test('initially OFF restores OFF after an ON-required assertion', () => {
-        assert.deepEqual(createGuardRestorePlan(false, true), {
-            requiredGuarded: true,
-            restoreGuarded: false,
-        });
+    const current = {
+        Series: {
+            [TARGET_N]: {
+                SeriesId: TARGET_N,
+                SeriesName: 'Recreated Name',
+                EnabledAt: '2026-07-14T00:00:00.0000000Z',
+            },
+            untouched: { SeriesId: 'untouched', EnabledAt: 'new' },
+        },
+        Movies: { addedDuringTest: { MovieId: 'addedDuringTest' } },
+        Prefs: { HideTags: true },
+    };
+    assert.deepEqual(applyGuardRestorePlan(current, plan), {
+        Series: {
+            [TARGET_N]: original.Series[TARGET_N],
+            untouched: { SeriesId: 'untouched', EnabledAt: 'new' },
+        },
+        Movies: current.Movies,
+        Prefs: current.Prefs,
     });
 });
 
-test('Spoiler Guard restore plans reject unknown state instead of guessing', () => {
-    assert.throws(() => createGuardRestorePlan(undefined, true), /require boolean states/);
-    assert.throws(() => createGuardRestorePlan(false, 'true'), /require boolean states/);
+test('Spoiler Guard restore plans remove a test-created initially-OFF entry', () => {
+    const plan = createGuardRestorePlan({ Series: {} }, TARGET_DASHED, true);
+    assert.deepEqual(plan, {
+        requiredGuarded: true,
+        normalizedSeriesId: TARGET_N,
+        originalKey: null,
+        originalEntry: null,
+    });
+    assert.deepEqual(
+        applyGuardRestorePlan({
+            Series: {
+                [TARGET_N.toUpperCase()]: { SeriesId: TARGET_N, EnabledAt: 'test' },
+                other: { SeriesId: 'other' },
+            },
+            PendingTmdb: { 'tv:42': { TmdbId: '42' } },
+        }, plan),
+        {
+            Series: { other: { SeriesId: 'other' } },
+            PendingTmdb: { 'tv:42': { TmdbId: '42' } },
+        }
+    );
+});
+
+test('Spoiler Guard restore plans reject ambiguous or malformed state', () => {
+    assert.throws(() => createGuardRestorePlan(undefined, TARGET_N, true), /state must be a JSON object/);
+    assert.throws(() => createGuardRestorePlan({}, '', true), /require a series id/);
+    assert.throws(() => createGuardRestorePlan({}, TARGET_N, 'true'), /boolean target state/);
+    assert.throws(
+        () => createGuardRestorePlan({
+            Series: {
+                [TARGET_N]: {},
+                [TARGET_N.toUpperCase()]: {},
+            },
+        }, TARGET_N, true),
+        /duplicate entries/
+    );
+    assert.throws(
+        () => applyGuardRestorePlan({}, {
+            requiredGuarded: false,
+            normalizedSeriesId: TARGET_N,
+            originalKey: TARGET_N,
+            originalEntry: null,
+        }),
+        /entry and key must both/
+    );
 });

--- a/scripts/e2e/workflow-sharding.test.js
+++ b/scripts/e2e/workflow-sharding.test.js
@@ -61,17 +61,21 @@ test('every shard reports current-attempt evidence under unique artifact names',
     assert.doesNotMatch(shard, /jc-e2e-shard-results[^\n]*e2e\/test-results/);
 });
 
-test('stable advisory aggregate rejects failed, stale, or missing shard evidence', () => {
+test('stable advisory aggregate reuses same-run attempts and rejects invalid shard evidence', () => {
     const aggregate = jobBlock('e2e', 'manifest');
 
     assert.match(aggregate, /name: E2E \(dockerized Jellyfin 12\)/);
     assert.match(aggregate, /needs: e2e_shard/);
     assert.match(aggregate, /if: always\(\)/);
     assert.match(aggregate, /continue-on-error: true/);
+    assert.match(aggregate, /permissions:\n\s+actions: read\n\s+contents: read/);
+    assert.match(aggregate, /github-token: \$\{\{ github\.token \}\}/);
+    assert.match(aggregate, /run-id: \$\{\{ github\.run_id \}\}/);
     assert.match(
         aggregate,
-        /pattern: e2e-status-\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}-shard-\*-of-4/
+        /pattern: e2e-status-\$\{\{ github\.run_id \}\}-\*-shard-\*-of-4/
     );
+    assert.match(aggregate, /merge-multiple: false/);
     assert.match(aggregate, /scripts\/e2e\/shard-result\.js aggregate/);
     for (const argument of ['--total 4', '--sha', '--run-id', '--run-attempt']) {
         assert.ok(aggregate.includes(argument), `aggregate lost ${argument}`);

--- a/scripts/e2e/workflow-sharding.test.js
+++ b/scripts/e2e/workflow-sharding.test.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const workflow = fs.readFileSync(path.join(ROOT, '.github/workflows/build.yml'), 'utf8');
+const playwrightConfig = fs.readFileSync(path.join(ROOT, 'e2e/playwright.config.ts'), 'utf8');
+
+function jobBlock(start, end) {
+    const from = workflow.indexOf(`  ${start}:`);
+    const to = workflow.indexOf(`\n  ${end}:`, from + 1);
+    assert.notEqual(from, -1, `missing ${start} job`);
+    assert.notEqual(to, -1, `missing job after ${start}`);
+    return workflow.slice(from, to);
+}
+
+test('E2E uses four native file shards with one fresh serial server each', () => {
+    const shard = jobBlock('e2e_shard', 'e2e');
+
+    assert.match(shard, /strategy:\n\s+fail-fast: false\n\s+max-parallel: 4/);
+    assert.match(shard, /matrix:\n\s+shard: \[1, 2, 3, 4\]/);
+    assert.match(shard, /id: seed\n\s+run: bash e2e\/docker\/seed\.sh/);
+    assert.match(
+        shard,
+        /id: playwright\n\s+timeout-minutes: 15\n\s+run: npm run e2e -- --shard=\$\{\{ matrix\.shard \}\}\/4/
+    );
+    assert.doesNotMatch(shard, /npm run e2e[^\n]*(--grep|\.spec\.ts)/);
+    assert.match(shard, /name: Tear down\n\s+if: always\(\)/);
+
+    assert.match(playwrightConfig, /workers:\s*1/);
+    assert.match(playwrightConfig, /fullyParallel:\s*false/);
+});
+
+test('every shard reports current-attempt evidence under unique artifact names', () => {
+    const shard = jobBlock('e2e_shard', 'e2e');
+
+    assert.match(shard, /scripts\/e2e\/shard-result\.js write/);
+    for (const argument of [
+        '--shard',
+        '--total 4',
+        '--sha',
+        '--run-id',
+        '--run-attempt',
+        '--seed-outcome',
+        '--test-outcome',
+    ]) {
+        assert.ok(shard.includes(argument), `shard marker lost ${argument}`);
+    }
+    assert.match(
+        shard,
+        /name: e2e-status-\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}-shard-\$\{\{ matrix\.shard \}\}-of-4/
+    );
+    assert.match(
+        shard,
+        /name: e2e-test-results-\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}-shard-\$\{\{ matrix\.shard \}\}-of-4/
+    );
+    assert.match(shard, /if-no-files-found: error/);
+    assert.doesNotMatch(shard, /jc-e2e-shard-results[^\n]*e2e\/test-results/);
+});
+
+test('stable advisory aggregate rejects failed, stale, or missing shard evidence', () => {
+    const aggregate = jobBlock('e2e', 'manifest');
+
+    assert.match(aggregate, /name: E2E \(dockerized Jellyfin 12\)/);
+    assert.match(aggregate, /needs: e2e_shard/);
+    assert.match(aggregate, /if: always\(\)/);
+    assert.match(aggregate, /continue-on-error: true/);
+    assert.match(
+        aggregate,
+        /pattern: e2e-status-\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}-shard-\*-of-4/
+    );
+    assert.match(aggregate, /scripts\/e2e\/shard-result\.js aggregate/);
+    for (const argument of ['--total 4', '--sha', '--run-id', '--run-attempt']) {
+        assert.ok(aggregate.includes(argument), `aggregate lost ${argument}`);
+    }
+});
+
+test('new artifact actions are immutable Node-24-native pins', () => {
+    const e2eJobs = workflow.slice(
+        workflow.indexOf('  e2e_shard:'),
+        workflow.indexOf('\n  manifest:')
+    );
+    assert.match(
+        e2eJobs,
+        /actions\/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7\.0\.1/
+    );
+    assert.match(
+        e2eJobs,
+        /actions\/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8\.0\.1/
+    );
+});

--- a/scripts/verify.test.js
+++ b/scripts/verify.test.js
@@ -169,7 +169,7 @@ test('a non-lint failure propagates and prevents the next workflow-like gate', (
 test('CI and release share the verifier while every non-lint workflow gate stays blocking', () => {
     const build = fs.readFileSync(path.join(ROOT, '.github/workflows/build.yml'), 'utf8');
     const release = fs.readFileSync(path.join(ROOT, '.github/workflows/release.yml'), 'utf8');
-    const client = build.slice(build.indexOf('  client-scripts:'), build.indexOf('  e2e:'));
+    const client = build.slice(build.indexOf('  client-scripts:'), build.indexOf('  e2e_shard:'));
 
     for (const [name, source] of [['build client job', client], ['release workflow', release]]) {
         assert.match(source, /name: ESLint \(advisory — reported in summary\)/, `${name} lacks the advisory step name`);


### PR DESCRIPTION
## Outcome

Cuts the dockerized Jellyfin 12 feedback path by running four native Playwright file shards on four independently seeded servers, while preserving the stable `E2E (dockerized Jellyfin 12)` check name through a strict aggregate job.

The prior clean baseline took 12.7 minutes inside Playwright and 14m38s for the job. Two live four-runner PR runs now complete the lane in approximately 4m08s–4m13s (slowest shard 3m54s–3m55s plus a 13s–19s aggregate): about **71–72% less wall time, or 3.5× faster**. The final run completed all 71 tests without a Playwright retry.

## Changes

- Split E2E into four native `--shard=N/4` matrix jobs, each with its own clean Jellyfin server; specs remain serial within each server.
- Keep the lane advisory during its trust period and retain the existing stable aggregate check name.
- Upload strict per-shard markers and reject missing, duplicate, stale SHA/run, future-attempt, or failed newest evidence.
- Support partial failed-job reruns by selecting the newest valid marker per shard across attempts in the same run.
- Detect definite Jellyfin auth bounces immediately while preserving the full 60-second plugin and independent 15-second current-user allowances and requiring the exact authenticated user.
- Restore exact plugin/Spoiler Guard state, including existing guard-entry metadata, and always clear synthetic session playback.
- Scope the known Jellyfin Home-tab race narrowly for both roles; mixed Canopy/host stacks remain fatal.
- Use immutable Node-24-native artifact action pins. Existing setup/hardening action migration remains owned by #192.

## Verification

Final committed SHA: `4629ca326d364e7d5be3a41dc5b06d151a450000`.

- `je12 verify full`: 94/94 script tests; 817/817 .NET tests; build 0 warnings / 0 errors
- client line coverage 68.59% (47% ratchet); plugin line coverage 40.46% (16% ratchet)
- 71 Playwright tests discovered across 30 files; shard distribution 18/19/17/17 with complete, duplicate-free union
- local Jellyfin 12.0.0 `unstable`, forced Modern layout, 2-CPU server: 55 passed, 15 expected skips, 1 recovered known host flake, 0 terminal failures in 5m55s
- post-run state: 0 synthetic playback sessions, Active Streams restored to `false/false`, both users' Spoiler Guard state restored exactly
- GitHub Build & Test run [29269890571](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/actions/runs/29269890571): all checks green; shards 3m41s / 3m54s / 3m14s / 2m52s; final totals 55 passed + 16 expected skips, **0 flaky and 0 failed**
- stable aggregate check passed in 19s after finding and validating exactly four same-run, same-SHA shard artifacts
- Security Scan run [29269890478](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/actions/runs/29269890478): green

Closes #193.
Closes #196.
Closes #197.
Closes #198.
Closes #199.
Part of #60.
Coordinates with #80 and #192.