### PR TITLE
Add isolated local E2E sharding

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,7 @@ jobs:
         shard: [1, 2, 3, 4]
     env:
       JF_PORT: "8100"
-      JF_BASE_URL: http://localhost:8100
+      JF_BASE_URL: http://127.0.0.1:8100
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
@@ -190,7 +190,7 @@ jobs:
 
       - name: Server logs on failure
         if: always() && (steps.seed.outcome != 'success' || steps.playwright.outcome != 'success')
-        run: docker logs jc-e2e-jellyfin --tail 200 || true
+        run: docker compose -f e2e/docker/compose.yml logs --no-color --tail 200 jellyfin || true
 
       - name: Upload traces and screenshots on failure
         if: always() && steps.playwright.outcome != 'success'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -217,12 +217,44 @@ No dev server handy? The compose stack seeds a throwaway Jellyfin 12 with the fr
 
 ```bash
 dotnet build Jellyfin.Plugin.JellyfinCanopy/JellyfinCanopy.csproj -c Release
-bash e2e/docker/seed.sh                        # boots + seeds on port 8100
-JF_BASE_URL=http://localhost:8100 npm run e2e
+bash e2e/docker/seed.sh                        # boots + seeds on loopback port 8100
+JF_BASE_URL=http://127.0.0.1:8100 npm run e2e
 docker compose -f e2e/docker/compose.yml down -v
 ```
 
 CI runs the same stack on every PR (advisory while the infrastructure earns trust).
+
+For a faster whole-suite run on a Linux development machine, use the opt-in
+local sharding runner:
+
+```bash
+npm run e2e:local                         # 4 isolated servers, 2 CPUs each
+npm run e2e:local -- --shards 6           # explicit higher parallelism
+```
+
+The runner builds the plugin once, starts one fresh Jellyfin server per native
+Playwright file shard, and keeps each server serial internally. The default
+2-CPU server quota is the official parity profile; changing it with
+`--cpus-per-server` is exploratory evidence. Four servers can use up to eight
+server CPU threads in addition to the browser and build processes, so increase
+the shard count only when current memory and CPU headroom allow it.
+
+Each server uses a random loopback port and per-run credentials. TMDB/Seerr
+environment variables are removed by default; forwarding them with
+`--allow-external-integrations` makes the run non-hermetic and can collide with
+shared external state. Results are retained under
+`e2e/test-results/local-<run-id>/`. Local sharding disables Playwright traces
+because they capture authentication arguments, deletes any retained file that
+contains a runner password, and redacts random usernames from text diagnostics.
+Still treat the directory as sensitive local-only data and do not upload or
+share it unredacted. The runner requires Linux, host `ffmpeg`, and GNU
+`setsid`/`timeout`; it tears down only its exact generated Compose projects.
+
+The single-server seed is loopback-only too. Exposing it beyond the host is a
+security-sensitive exception: it requires both `JF_BIND_ADDRESS=<numeric-ip>`
+and `JF_ALLOW_NON_LOOPBACK=true`, plus four nondefault `JF_ADMIN_USER`,
+`JF_ADMIN_PASS`, `JF_USER_NAME`, and `JF_USER_PASS` values. Never expose the
+documented test credentials to a LAN or public interface.
 
 ### Docs
 

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -989,6 +989,53 @@ below remains blocking.
 - `node scripts/new-feature.js <name>` — the paved-road scaffolder: generates a typed client module, a controller, an e2e spec stub, and a docs stub, wired into the area barrel (see `CONTRIBUTING.md`).
 - `scripts/release/` — release packaging + manifest generation/validation (see `RELEASING.md`).
 
+### Local sharded E2E
+
+`npm run e2e:local` is the opt-in fast path for running the complete dockerized
+Jellyfin 12 inventory on a Linux workstation. It builds the Release plugin once
+and fans the suite out through Playwright's native file sharding. The default is
+four independent servers with one serial browser worker and a 2-CPU Docker quota
+per server:
+
+```bash
+npm run e2e:local
+npm run e2e:local -- --shards 6
+npm run e2e:local -- --shards 4 --cpus-per-server 4  # exploratory, not parity
+```
+
+Keep 2 CPUs per server for evidence comparable with the official E2E profile.
+That quota is a ceiling, not a reservation: the four-shard default permits up to
+eight Jellyfin CPU threads, while the build, Chromium processes, and host Docker
+work consume resources outside those server quotas. The runner warns when its
+CPU plan exceeds detected logical CPUs, when current `MemAvailable` is below its
+per-shard guideline, or when the host is already using swap. Counts above four
+are deliberately explicit; reduce the count if memory pressure causes swapping.
+
+Every shard receives a random Compose project, loopback-only dynamic port,
+marker-owned state tree, and Playwright output directory. Cleanup targets those
+exact projects and reports teardown failure as a run failure; it never prunes or
+name-matches unrelated containers. The runner is Linux-only and depends on a
+host `ffmpeg` plus GNU `setsid` and `timeout` for bounded process-group shutdown.
+Each encoder is limited to two threads so media generation cannot silently use
+every host CPU outside the Jellyfin container quotas.
+
+For the single-server seed, non-loopback publication is intentionally noisy
+and exceptional. It requires `JF_BIND_ADDRESS=<numeric-ip>`,
+`JF_ALLOW_NON_LOOPBACK=true`, and nondefault values for both seeded usernames
+and passwords. Do not publish the documented test credentials outside the
+host.
+
+TMDB and Seerr variables are scrubbed for the default hermetic run. The
+`--allow-external-integrations` flag forwards them deliberately, but parallel
+shards can then rate-limit or mutate the same external service and the result is
+not parity evidence. Per-run output is retained beneath
+`e2e/test-results/local-<run-id>/`. The runner disables Playwright tracing (a
+trace can contain login arguments and tokens) and removes any retained file
+that contains one of its random passwords. Random usernames are redacted in
+text diagnostics; matching binary artifacts are removed. Other diagnostic data
+may still be sensitive, so keep artifacts local and do not upload or share them
+without inspection and redaction.
+
 ---
 
 ## Performance trace capture
@@ -1005,7 +1052,7 @@ The highest-value scenario is **`details-to-details`**: hopping from one item de
 
     ```bash
     dotnet build Jellyfin.Plugin.JellyfinCanopy/JellyfinCanopy.csproj -c Release
-    bash e2e/docker/seed.sh            # → http://localhost:8100 (admin jc_arradmin)
+    bash e2e/docker/seed.sh            # → http://127.0.0.1:8100 (admin jc_arradmin)
     # …run captures…
     docker compose -f e2e/docker/compose.yml down -v
     ```
@@ -1019,7 +1066,7 @@ The highest-value scenario is **`details-to-details`**: hopping from one item de
 ### Running
 
 ```bash
-# All scenarios, defaults (JF_BASE_URL or http://localhost:8100):
+# All scenarios, defaults (JF_BASE_URL or http://127.0.0.1:8100):
 npm run perf:trace
 
 # A subset (positional scenario names):
@@ -1040,7 +1087,7 @@ Value-taking flags (`--out`, `--latency`, `--cpu`, `--download`, `--base`, `--us
 
 | Flag | Default | Meaning |
 |------|---------|---------|
-| `--base <url>` | `JF_BASE_URL` or `http://localhost:8100` | server under test |
+| `--base <url>` | `JF_BASE_URL` or `http://127.0.0.1:8100` | server under test |
 | `--user` / `--pass` | see [Environment](#environment) | login credentials |
 | `--out <dir>` | `e2e/perf/traces` | output directory |
 | `--cpu <N>` | `1` | CPU throttle rate (`Emulation.setCPUThrottlingRate`) |
@@ -1057,7 +1104,7 @@ Matches `e2e/fixtures/auth.ts` and `e2e/docker/seed.sh`:
 
 | Var | Default | Meaning |
 |-----|---------|---------|
-| `JF_BASE_URL` | `http://localhost:8100` | server under test |
+| `JF_BASE_URL` | `http://127.0.0.1:8100` | server under test |
 | `JC_TRACE_USER` → `JF_ADMIN_USER` → `jc_arradmin` | | login user (first set wins) |
 | `JC_TRACE_PASS` → `JF_ADMIN_PASS` → `Test669Pw!x` | | login password |
 

--- a/e2e/docker/compose.yml
+++ b/e2e/docker/compose.yml
@@ -1,27 +1,46 @@
 # Throwaway Jellyfin 12 for the E2E suite (CI and local dry-runs).
 #
-# Everything lives under e2e/docker/{config,cache,media} (gitignored) and is
-# (re)created by seed.sh — never point these volumes at a real server's state.
+# By default everything lives under e2e/docker/{config,cache,media} (gitignored)
+# and is (re)created by seed.sh. The local shard runner supplies distinct
+# runner-owned bind paths — never point these volumes at a real server's state.
 #
 #   bash e2e/docker/seed.sh          # build dirs, start, wizard, users, library
-#   JF_BASE_URL=http://localhost:8100 npm run e2e
+#   JF_BASE_URL=http://127.0.0.1:8100 npm run e2e
 #   docker compose -f e2e/docker/compose.yml down -v
 #
 # The reproducible CI default remains pinned. Compatibility runs can override
 # it without editing source, for example JF_IMAGE=jellyfin/jellyfin:unstable.
 # (Do NOT use 12.0-rc1 — it hangs on the splash logo in headless Chromium.)
+# Preserve Compose's historical project name for the documented single-server
+# flow so an upgrade can tear down an older disposable stack before resetting
+# its bind-mounted state. The local shard runner always supplies a random name.
+name: "${JF_E2E_PROJECT:-docker}"
+
 services:
   jellyfin:
     image: "${JF_IMAGE:-jellyfin/jellyfin:12.0-rc2}"
-    container_name: jc-e2e-jellyfin
     # Run as the invoking user so seed.sh can clean config/cache without sudo.
     user: "${JF_UID:-1000}:${JF_GID:-1000}"
+    # Keep parity with the two-core Actions-sized environment by default. A
+    # local orchestrator can run several isolated two-core servers instead of
+    # letting one mutable server consume the whole host.
+    cpus: "${JF_CPUS:-2}"
     ports:
-      - "${JF_PORT:-8100}:8096"
+      - target: 8096
+        published: "${JF_PORT:-8100}"
+        host_ip: "${JF_BIND_ADDRESS:-127.0.0.1}"
+        protocol: tcp
     volumes:
-      - ./config:/config
-      - ./cache:/cache
-      - ./media:/media:ro
+      - type: bind
+        source: "${JF_CONFIG_DIR:-./config}"
+        target: /config
+      - type: bind
+        source: "${JF_CACHE_DIR:-./cache}"
+        target: /cache
+      - type: bind
+        source: "${JF_MEDIA_DIR:-./media}"
+        target: /media
+        read_only: true
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:8096/health"]
       interval: 5s

--- a/e2e/docker/seed.sh
+++ b/e2e/docker/seed.sh
@@ -24,32 +24,57 @@
 #   SEERR_RESPECT_PARENTAL  true|false (default true) — parental gating
 #   JF_IMAGE              compose image override (default jellyfin:12.0-rc2)
 #   JF_LAYOUT_ENFORCEMENT None|ForceExperimental|ForceLegacy (default None)
+#   JF_E2E_PROJECT        validated Compose namespace (default docker)
+#   JF_E2E_STATE_DIR      marker-owned config/cache/media root (default HERE)
+#   JF_PORT               loopback host port; 0 asks Docker for a free port
+#   JF_CPUS               Jellyfin CPU quota (default 2)
+#   JF_FFMPEG_THREADS     host encoder threads per seed (default 2)
+#   JF_BIND_ADDRESS       numeric bind address (default 127.0.0.1)
+#   JF_ALLOW_NON_LOOPBACK true explicitly permits a non-loopback bind, but only
+#                         when all four JF_* user/password values are nondefault
 #
 # Usage:
 #   dotnet build Jellyfin.Plugin.JellyfinCanopy/JellyfinCanopy.csproj -c Release
 #   bash e2e/docker/seed.sh                # default port 8100 (bare)
 #   TMDB_API_KEY=... SEERR_URL=... SEERR_API_KEY=... bash e2e/docker/seed.sh
-#   JF_BASE_URL=http://localhost:8100 npm run e2e
+#   JF_BASE_URL=http://127.0.0.1:8100 npm run e2e
 #   docker compose -f e2e/docker/compose.yml down -v
 set -euo pipefail
+umask 077
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${HERE}/../.." && pwd)"
-COMPOSE="docker compose -f ${HERE}/compose.yml"
 FIXTURE_CONTRACT="${REPO_ROOT}/e2e/fixtures/media-fixtures.json"
 export JF_IMAGE="${JF_IMAGE:-jellyfin/jellyfin:12.0-rc2}"
 IMAGE="${JF_IMAGE}"
 
+DEFAULT_ADMIN_USER="jc_arradmin"
+DEFAULT_ADMIN_PASS="Test669Pw!x"
+DEFAULT_USER_NAME="jc_arruser"
+DEFAULT_USER_PASS="Test669Pw!x"
+
+E2E_PROJECT="${JF_E2E_PROJECT:-docker}"
+if [ "${JF_E2E_STATE_DIR+x}" = x ]; then
+    STATE_INPUT="${JF_E2E_STATE_DIR}"
+    CUSTOM_STATE=1
+else
+    STATE_INPUT="${HERE}"
+    CUSTOM_STATE=0
+fi
+export JF_BIND_ADDRESS="${JF_BIND_ADDRESS:-127.0.0.1}"
+ALLOW_NON_LOOPBACK="${JF_ALLOW_NON_LOOPBACK:-false}"
 export JF_PORT="${JF_PORT:-8100}"
+export JF_CPUS="${JF_CPUS:-2}"
+export JF_FFMPEG_THREADS="${JF_FFMPEG_THREADS:-2}"
 export JF_UID JF_GID
 JF_UID="$(id -u)"
 JF_GID="$(id -g)"
 
-BASE="http://localhost:${JF_PORT}"
-ADMIN_USER="${JF_ADMIN_USER:-jc_arradmin}"
-ADMIN_PASS="${JF_ADMIN_PASS:-Test669Pw!x}"
-USER_NAME="${JF_USER_NAME:-jc_arruser}"
-USER_PASS="${JF_USER_PASS:-Test669Pw!x}"
+BASE=''
+ADMIN_USER="${JF_ADMIN_USER:-${DEFAULT_ADMIN_USER}}"
+ADMIN_PASS="${JF_ADMIN_PASS:-${DEFAULT_ADMIN_PASS}}"
+USER_NAME="${JF_USER_NAME:-${DEFAULT_USER_NAME}}"
+USER_PASS="${JF_USER_PASS:-${DEFAULT_USER_PASS}}"
 PLUGIN_DLL="${PLUGIN_DLL:-${REPO_ROOT}/Jellyfin.Plugin.JellyfinCanopy/bin/Release/net10.0/Jellyfin.Plugin.JellyfinCanopy.dll}"
 PLUGIN_ID="9ffa12bc-f4b5-406c-ab1d-d575acbeea7b"
 CLIENT_AUTH='MediaBrowser Client="JC-E2E-Seed", Device="seed", DeviceId="jc-e2e-seed", Version="1.0.0"'
@@ -62,10 +87,139 @@ fail() { echo "[seed] ERROR: $*" >&2; exit 1; }
 command -v jq >/dev/null || fail "jq is required"
 command -v curl >/dev/null || fail "curl is required"
 [ -f "${FIXTURE_CONTRACT}" ] || fail "fixture contract not found at ${FIXTURE_CONTRACT}"
+
+[[ "${E2E_PROJECT}" =~ ^[a-z0-9][a-z0-9_-]*$ ]] \
+    || fail "JF_E2E_PROJECT must start with a lowercase letter or digit and contain only lowercase letters, digits, underscore, and dash"
+[ "${#E2E_PROJECT}" -le 63 ] \
+    || fail "JF_E2E_PROJECT must be at most 63 characters"
+
+[[ "${JF_PORT}" =~ ^[0-9]+$ ]] \
+    || fail "JF_PORT must be an integer from 0 through 65535"
+[ "${#JF_PORT}" -le 5 ] \
+    || fail "JF_PORT must be an integer from 0 through 65535"
+JF_PORT="$((10#${JF_PORT}))"
+[ "${JF_PORT}" -le 65535 ] \
+    || fail "JF_PORT must be an integer from 0 through 65535"
+export JF_PORT
+
+[[ "${JF_CPUS}" =~ ^[0-9]+([.][0-9]+)?$ ]] \
+    || fail "JF_CPUS must be a positive number"
+jq -en --arg cpus "${JF_CPUS}" '$cpus | tonumber | . > 0 and . <= 64' >/dev/null \
+    || fail "JF_CPUS must be greater than 0 and at most 64"
+JF_CPUS="$(jq -nr --arg cpus "${JF_CPUS}" '$cpus | tonumber')"
+export JF_CPUS
+
+[[ "${JF_FFMPEG_THREADS}" =~ ^[0-9]+$ ]] \
+    || fail "JF_FFMPEG_THREADS must be an integer from 1 through 8"
+[ "${#JF_FFMPEG_THREADS}" -le 1 ] \
+    || fail "JF_FFMPEG_THREADS must be an integer from 1 through 8"
+JF_FFMPEG_THREADS="$((10#${JF_FFMPEG_THREADS}))"
+[ "${JF_FFMPEG_THREADS}" -ge 1 ] && [ "${JF_FFMPEG_THREADS}" -le 8 ] \
+    || fail "JF_FFMPEG_THREADS must be an integer from 1 through 8"
+export JF_FFMPEG_THREADS
+
+[[ "${JF_BIND_ADDRESS}" =~ ^[0-9A-Fa-f:.]+$ ]] \
+    || fail "JF_BIND_ADDRESS must be a numeric IPv4 or IPv6 address"
+case "${JF_BIND_ADDRESS}" in
+    127.*|::1) ;;
+    *)
+        [ "${ALLOW_NON_LOOPBACK}" = true ] \
+            || fail "non-loopback JF_BIND_ADDRESS requires JF_ALLOW_NON_LOOPBACK=true"
+        if [ "${ADMIN_USER}" = "${DEFAULT_ADMIN_USER}" ] \
+            || [ "${ADMIN_PASS}" = "${DEFAULT_ADMIN_PASS}" ] \
+            || [ "${USER_NAME}" = "${DEFAULT_USER_NAME}" ] \
+            || [ "${USER_PASS}" = "${DEFAULT_USER_PASS}" ]; then
+            fail "non-loopback binding refuses every default E2E username and password; supply a runner-scoped credential set"
+        fi
+        ;;
+esac
+[ -n "${ADMIN_USER}" ] && [ -n "${ADMIN_PASS}" ] \
+    && [ -n "${USER_NAME}" ] && [ -n "${USER_PASS}" ] \
+    || fail "seeded usernames and passwords must not be empty"
+[ "${ADMIN_USER}" != "${USER_NAME}" ] \
+    || fail "seeded admin and non-admin usernames must be distinct"
+
 case "${LAYOUT_ENFORCEMENT}" in
     None|ForceExperimental|ForceLegacy) ;;
     *) fail "JF_LAYOUT_ENFORCEMENT must be None, ForceExperimental, or ForceLegacy" ;;
 esac
+
+# Resolve the state root without following a caller-controlled symlink chain.
+# The default source-adjacent state remains compatible with the documented
+# single-server flow. A custom state root is claimed by an exact marker before
+# any known child is removed, and reuse requires the same project/path marker.
+if (( CUSTOM_STATE == 1 )); then
+    command -v realpath >/dev/null \
+        || fail "custom JF_E2E_STATE_DIR requires GNU realpath"
+    realpath -ms -- . >/dev/null 2>&1 \
+        || fail "custom JF_E2E_STATE_DIR requires GNU realpath with -m and -s"
+    stat -c '%u' -- . >/dev/null 2>&1 \
+        || fail "custom JF_E2E_STATE_DIR requires GNU stat with -c"
+    if [[ "${STATE_INPUT}" != /* ]]; then
+        STATE_INPUT="${REPO_ROOT}/${STATE_INPUT}"
+    fi
+    STATE_LEXICAL="$(realpath -ms -- "${STATE_INPUT}")"
+    STATE_DIR="$(realpath -m -- "${STATE_INPUT}")"
+    [ "${STATE_LEXICAL}" = "${STATE_DIR}" ] \
+        || fail "JF_E2E_STATE_DIR must not contain or traverse symbolic links"
+else
+    STATE_DIR="${HERE}"
+fi
+[[ "${STATE_DIR}" != *:* && "${STATE_DIR}" != *$'\n'* ]] \
+    || fail "JF_E2E_STATE_DIR must not contain colon or newline characters"
+[ "${STATE_DIR}" != / ] \
+    || fail "JF_E2E_STATE_DIR must not be the filesystem root"
+if [ "${STATE_DIR}" = "${REPO_ROOT}" ] || [[ "${REPO_ROOT}" == "${STATE_DIR}/"* ]]; then
+    fail "JF_E2E_STATE_DIR must not be the repository root or one of its parents"
+fi
+
+STATE_MARKER="${STATE_DIR}/.jc-e2e-state-v1"
+EXPECTED_MARKER="$(printf 'Jellyfin Canopy E2E state v1\nproject=%s\nstate=%s' "${E2E_PROJECT}" "${STATE_DIR}")"
+if (( CUSTOM_STATE == 1 )); then
+    if [ -e "${STATE_DIR}" ] && [ ! -d "${STATE_DIR}" ]; then
+        fail "custom JF_E2E_STATE_DIR exists but is not a directory: ${STATE_DIR}"
+    fi
+    if [ ! -e "${STATE_DIR}" ]; then
+        mkdir -m 700 -p -- "${STATE_DIR}"
+    fi
+    [ ! -L "${STATE_DIR}" ] \
+        || fail "custom JF_E2E_STATE_DIR must not be a symbolic link"
+    [ "$(stat -c '%u' -- "${STATE_DIR}")" = "${JF_UID}" ] \
+        || fail "custom JF_E2E_STATE_DIR must be owned by uid ${JF_UID}"
+
+    if [ -e "${STATE_MARKER}" ]; then
+        [ -f "${STATE_MARKER}" ] && [ ! -L "${STATE_MARKER}" ] \
+            || fail "custom E2E state marker must be a regular non-symlink file"
+        [ "$(stat -c '%u' -- "${STATE_MARKER}")" = "${JF_UID}" ] \
+            || fail "custom E2E state marker must be owned by uid ${JF_UID}"
+        [ "$(cat -- "${STATE_MARKER}")" = "${EXPECTED_MARKER}" ] \
+            || fail "custom JF_E2E_STATE_DIR marker belongs to another path or Compose project"
+    else
+        FIRST_STATE_ENTRY="$(find "${STATE_DIR}" -mindepth 1 -maxdepth 1 -print -quit)"
+        [ -z "${FIRST_STATE_ENTRY}" ] \
+            || fail "custom JF_E2E_STATE_DIR must be empty before its ownership marker is created"
+        if ! (set -o noclobber; printf '%s\n' "${EXPECTED_MARKER}" > "${STATE_MARKER}") 2>/dev/null; then
+            [ -f "${STATE_MARKER}" ] && [ ! -L "${STATE_MARKER}" ] \
+                && [ "$(cat -- "${STATE_MARKER}")" = "${EXPECTED_MARKER}" ] \
+                || fail "could not claim custom JF_E2E_STATE_DIR safely"
+        fi
+    fi
+fi
+
+CONFIG_DIR="${STATE_DIR}/config"
+CACHE_DIR="${STATE_DIR}/cache"
+MEDIA_DIR="${STATE_DIR}/media"
+SEED_RESULT="${STATE_DIR}/seed-result.json"
+SEED_RESULT_TMP="${STATE_DIR}/seed-result.json.tmp"
+for OWNED_PATH in "${CONFIG_DIR}" "${CACHE_DIR}" "${MEDIA_DIR}" "${SEED_RESULT}" "${SEED_RESULT_TMP}"; do
+    [ ! -L "${OWNED_PATH}" ] \
+        || fail "refusing to reset symlinked E2E state path: ${OWNED_PATH}"
+done
+export JF_CONFIG_DIR="${CONFIG_DIR}"
+export JF_CACHE_DIR="${CACHE_DIR}"
+export JF_MEDIA_DIR="${MEDIA_DIR}"
+export JF_E2E_PROJECT="${E2E_PROJECT}"
+COMPOSE=(docker compose --project-name "${E2E_PROJECT}" --file "${HERE}/compose.yml")
 
 AUTOSKIP_NAME="$(jq -er '.autoSkip.name | select(type == "string" and length > 0)' "${FIXTURE_CONTRACT}")"
 AUTOSKIP_FILE_PREFIX="$(jq -er '.autoSkip.filePrefix | select(type == "string" and length > 0)' "${FIXTURE_CONTRACT}")"
@@ -90,17 +244,19 @@ AUTOSKIP_RELATIVE_PATH="${AUTOSKIP_RELATIVE_DIR}/${AUTOSKIP_FILENAME}"
 AUTOSKIP_CONTAINER_PATH="/media/${AUTOSKIP_RELATIVE_PATH}"
 
 # ── 1. clean state + plugin install ─────────────────────────────────────────
-log "resetting e2e/docker state (config/cache/media)"
-${COMPOSE} down -v --remove-orphans >/dev/null 2>&1 || true
-rm -rf "${HERE}/config" "${HERE}/cache" "${HERE}/media"
-rm -f "${HERE}/seed-result.json" "${HERE}/seed-result.json.tmp"
-mkdir -p "${HERE}/config/plugins/JellyfinCanopy_e2e" "${HERE}/cache" "${HERE}/media"
-cp "${PLUGIN_DLL}" "${HERE}/config/plugins/JellyfinCanopy_e2e/"
-log "installed plugin DLL into config/plugins/JellyfinCanopy_e2e"
+log "resetting project ${E2E_PROJECT} state under ${STATE_DIR} (config/cache/media)"
+if ! "${COMPOSE[@]}" down -v --remove-orphans >/dev/null 2>&1; then
+    fail "could not tear down Compose project ${E2E_PROJECT}; refusing to reset its state"
+fi
+rm -rf -- "${CONFIG_DIR}" "${CACHE_DIR}" "${MEDIA_DIR}"
+rm -f -- "${SEED_RESULT}" "${SEED_RESULT_TMP}"
+mkdir -p -- "${CONFIG_DIR}/plugins/JellyfinCanopy_e2e" "${CACHE_DIR}" "${MEDIA_DIR}"
+cp -- "${PLUGIN_DLL}" "${CONFIG_DIR}/plugins/JellyfinCanopy_e2e/"
+log "installed plugin DLL into the isolated config volume"
 
 # ── 2. tiny valid media (h264/aac so the Playwright Chromium can play them) ──
 if command -v ffmpeg >/dev/null; then
-    run_ffmpeg() { (cd "${HERE}/media" && ffmpeg -hide_banner -loglevel error "$@"); }
+    run_ffmpeg() { (cd "${MEDIA_DIR}" && ffmpeg -hide_banner -loglevel error "$@"); }
 else
     log "no host ffmpeg — using jellyfin-ffmpeg from ${IMAGE}"
     docker pull -q "${IMAGE}" >/dev/null
@@ -109,9 +265,9 @@ else
     # The first attempt's stderr is silenced so a wrong-path miss doesn't spam
     # a docker error per clip; the fallback stays loud for real failures.
     run_ffmpeg() {
-        docker run --rm -u "${JF_UID}:${JF_GID}" -v "${HERE}/media:/media" -w /media \
+        docker run --rm -u "${JF_UID}:${JF_GID}" -v "${MEDIA_DIR}:/media" -w /media \
             --entrypoint /usr/lib/jellyfin-ffmpeg/ffmpeg "${IMAGE}" -hide_banner -loglevel error "$@" 2>/dev/null \
-        || docker run --rm -u "${JF_UID}:${JF_GID}" -v "${HERE}/media:/media" -w /media \
+        || docker run --rm -u "${JF_UID}:${JF_GID}" -v "${MEDIA_DIR}:/media" -w /media \
             --entrypoint /usr/lib/jellyfin/ffmpeg "${IMAGE}" -hide_banner -loglevel error "$@"
     }
 fi
@@ -119,7 +275,7 @@ fi
 # Movies and Shows live in dedicated subfolders so the recursive Movies-library
 # scan never descends into the TV tree (and vice-versa) — a single /media root
 # shared by both collection types would misidentify episode files as movies.
-mkdir -p "${HERE}/media/Movies" "${HERE}/media/Shows"
+mkdir -p "${MEDIA_DIR}/Movies" "${MEDIA_DIR}/Shows"
 
 make_clip() { # <relative-path> <tone-hz> [duration-seconds]
     local duration="${3:-5}"
@@ -132,6 +288,7 @@ make_clip() { # <relative-path> <tone-hz> [duration-seconds]
         -f lavfi -i "testsrc2=duration=${duration}:size=640x360:rate=24" \
         -f lavfi -i "sine=frequency=$2:duration=${duration}" \
         -c:v libx264 -preset ultrafast -pix_fmt yuv420p -c:a aac -shortest \
+        -threads "${JF_FFMPEG_THREADS}" \
         -metadata:s:a:0 language=eng -y "$1"
 }
 
@@ -141,7 +298,7 @@ make_clip "Movies/Beta Voyage (2022).mp4" 550
 make_clip "Movies/Gamma Quest (2023).mp4" 660
 make_clip "Movies/Delta Horizon (2024).mp4" 770
 log "generating dedicated Auto-Skip movie (${AUTOSKIP_DURATION}s, seed ${SEED_NONCE})"
-mkdir -p "${HERE}/media/${AUTOSKIP_RELATIVE_DIR}"
+mkdir -p "${MEDIA_DIR}/${AUTOSKIP_RELATIVE_DIR}"
 make_clip "${AUTOSKIP_RELATIVE_PATH}" 880 "${AUTOSKIP_DURATION}"
 
 # ── TV: one series, 2 seasons × 2 episodes, for the Spoiler Guard specs ───────
@@ -151,15 +308,35 @@ make_clip "${AUTOSKIP_RELATIVE_PATH}" 880 "${AUTOSKIP_DURATION}"
 # filter has something to replace with "Season X, Episode Y".
 SHOW_NAME="Guard Test Show"
 log "generating test series '${SHOW_NAME}' (2 seasons × 2 episodes)"
-mkdir -p "${HERE}/media/Shows/${SHOW_NAME}/Season 01" "${HERE}/media/Shows/${SHOW_NAME}/Season 02"
+mkdir -p "${MEDIA_DIR}/Shows/${SHOW_NAME}/Season 01" "${MEDIA_DIR}/Shows/${SHOW_NAME}/Season 02"
 make_clip "Shows/${SHOW_NAME}/Season 01/${SHOW_NAME} S01E01.mp4" 480
 make_clip "Shows/${SHOW_NAME}/Season 01/${SHOW_NAME} S01E02.mp4" 500
 make_clip "Shows/${SHOW_NAME}/Season 02/${SHOW_NAME} S02E01.mp4" 520
 make_clip "Shows/${SHOW_NAME}/Season 02/${SHOW_NAME} S02E02.mp4" 540
 
 # ── 3. boot + startup wizard ─────────────────────────────────────────────────
-log "starting compose stack on port ${JF_PORT}"
-${COMPOSE} up -d
+log "starting Compose project ${E2E_PROJECT} on ${JF_BIND_ADDRESS}:${JF_PORT} with ${JF_CPUS} Jellyfin CPUs"
+"${COMPOSE[@]}" up -d
+
+CONTAINER_ID="$("${COMPOSE[@]}" ps -q jellyfin)"
+[ -n "${CONTAINER_ID}" ] || fail "could not resolve the Jellyfin Compose container ID"
+PORT_BINDINGS="$(docker inspect --format '{{json (index .NetworkSettings.Ports "8096/tcp")}}' "${CONTAINER_ID}")"
+PUBLISHED_PORT="$(printf '%s' "${PORT_BINDINGS}" | jq -er \
+    'select(type == "array" and length == 1) | .[0].HostPort | select(test("^[0-9]+$"))')" \
+    || fail "Jellyfin container did not publish exactly one numeric host port"
+PUBLISHED_ADDRESS="$(printf '%s' "${PORT_BINDINGS}" | jq -er \
+    'select(type == "array" and length == 1) | .[0].HostIp | select(type == "string" and length > 0)')" \
+    || fail "Jellyfin container did not publish exactly one host address"
+[ "${PUBLISHED_ADDRESS}" = "${JF_BIND_ADDRESS}" ] \
+    || fail "Docker published Jellyfin on ${PUBLISHED_ADDRESS}, expected ${JF_BIND_ADDRESS}"
+if [ "${JF_PORT}" -ne 0 ] && [ "${PUBLISHED_PORT}" -ne "${JF_PORT}" ]; then
+    fail "Docker published Jellyfin on port ${PUBLISHED_PORT}, expected ${JF_PORT}"
+fi
+case "${PUBLISHED_ADDRESS}" in
+    *:*) BASE="http://[${PUBLISHED_ADDRESS}]:${PUBLISHED_PORT}" ;;
+    0.0.0.0) BASE="http://127.0.0.1:${PUBLISHED_PORT}" ;;
+    *) BASE="http://${PUBLISHED_ADDRESS}:${PUBLISHED_PORT}" ;;
+esac
 
 log "waiting for the server to answer"
 PUBLIC_INFO=''
@@ -176,8 +353,6 @@ for _ in $(seq 1 60); do
 done
 [ -n "${SERVER_VERSION}" ] \
     || fail "server never returned parseable System/Info/Public JSON on ${BASE}"
-CONTAINER_ID="$(${COMPOSE} ps -q jellyfin)"
-[ -n "${CONTAINER_ID}" ] || fail "could not resolve the Jellyfin compose container ID"
 IMAGE_ID="$(docker inspect --format '{{.Image}}' "${CONTAINER_ID}")"
 log "server version ${SERVER_VERSION}, image ${IMAGE} (${IMAGE_ID})"
 
@@ -200,16 +375,18 @@ wizard() { # <method> <path> [json-body]
 log "completing the startup wizard"
 wizard POST /Startup/Configuration '{"UICulture":"en-US","MetadataCountryCode":"US","PreferredMetadataLanguage":"en"}'
 wizard GET /Startup/User >/dev/null
-wizard POST /Startup/User "{\"Name\":\"${ADMIN_USER}\",\"Password\":\"${ADMIN_PASS}\"}"
+wizard POST /Startup/User "$(jq -nc --arg name "${ADMIN_USER}" --arg password "${ADMIN_PASS}" \
+    '{Name: $name, Password: $password}')"
 wizard POST /Startup/RemoteAccess '{"EnableRemoteAccess":true,"EnableAutomaticPortMapping":false}'
 wizard POST /Startup/Complete
 
 # ── 4. admin token, library, second user ─────────────────────────────────────
-log "authenticating ${ADMIN_USER}"
+log "authenticating the seeded admin"
 TOKEN="$(curl -fsS -X POST "${BASE}/Users/AuthenticateByName" \
     -H "Authorization: ${CLIENT_AUTH}" -H 'Content-Type: application/json' \
-    -d "{\"Username\":\"${ADMIN_USER}\",\"Pw\":\"${ADMIN_PASS}\"}" | jq -r .AccessToken)"
-[ -n "${TOKEN}" ] && [ "${TOKEN}" != "null" ] || fail "could not authenticate ${ADMIN_USER}"
+    -d "$(jq -nc --arg username "${ADMIN_USER}" --arg password "${ADMIN_PASS}" \
+        '{Username: $username, Pw: $password}')" | jq -r .AccessToken)"
+[ -n "${TOKEN}" ] && [ "${TOKEN}" != "null" ] || fail "could not authenticate the seeded admin"
 AUTHED="Authorization: ${CLIENT_AUTH}, Token=\"${TOKEN}\""
 
 api() { # <method> <path> [json-body]
@@ -233,8 +410,9 @@ log "creating the Shows library"
 api POST "/Library/VirtualFolders?name=Shows&collectionType=tvshows&paths=%2Fmedia%2FShows&refreshLibrary=true" \
     '{"LibraryOptions":{"EnableRealtimeMonitor":false}}'
 
-log "creating user ${USER_NAME}"
-api POST /Users/New "{\"Name\":\"${USER_NAME}\",\"Password\":\"${USER_PASS}\"}" >/dev/null
+log "creating the seeded non-admin user"
+api POST /Users/New "$(jq -nc --arg name "${USER_NAME}" --arg password "${USER_PASS}" \
+    '{Name: $name, Password: $password}')" >/dev/null
 
 # ── 5. plugin feature flags (+ optional TMDB/Seerr) + scan wait ──────────────
 log "enabling the plugin features the specs exercise"
@@ -424,12 +602,13 @@ log "updated titles + overviews on ${e} episodes of '${SHOW_NAME}'"
 # The specs assert a WATCHED episode's real title survives while UNWATCHED ones
 # are stripped, and that per-user isolation holds — so exactly one episode must
 # be watched for jc_arruser (and left untouched for the admin).
-log "marking S01E01 played for ${USER_NAME}"
+log "marking S01E01 played for the seeded non-admin user"
 USER_ID="$(api GET /Users | jq -r --arg name "${USER_NAME}" '.[] | select(.Name == $name) | .Id')"
 USER_TOKEN="$(curl -fsS -X POST "${BASE}/Users/AuthenticateByName" \
     -H "Authorization: ${CLIENT_AUTH}" -H 'Content-Type: application/json' \
-    -d "{\"Username\":\"${USER_NAME}\",\"Pw\":\"${USER_PASS}\"}" | jq -r .AccessToken)"
-[ -n "${USER_TOKEN}" ] && [ "${USER_TOKEN}" != "null" ] || fail "could not authenticate ${USER_NAME}"
+    -d "$(jq -nc --arg username "${USER_NAME}" --arg password "${USER_PASS}" \
+        '{Username: $username, Pw: $password}')" | jq -r .AccessToken)"
+[ -n "${USER_TOKEN}" ] && [ "${USER_TOKEN}" != "null" ] || fail "could not authenticate the seeded non-admin user"
 USER_AUTHED="Authorization: ${CLIENT_AUTH}, Token=\"${USER_TOKEN}\""
 S1E1_ID="$(printf '%s' "${EP_JSON}" \
     | jq -r 'first(.Items[]? | select(.ParentIndexNumber == 1 and .IndexNumber == 1) | .Id) // empty')"
@@ -439,18 +618,22 @@ S1E1_ID="$(printf '%s' "${EP_JSON}" \
 # kept as a fallback for older builds).
 curl -fsS -X POST "${BASE}/UserPlayedItems/${S1E1_ID}" -H "${USER_AUTHED}" -H 'Content-Type: application/json' >/dev/null 2>&1 \
     || curl -fsS -X POST "${BASE}/Users/${USER_ID}/PlayedItems/${S1E1_ID}" -H "${USER_AUTHED}" -H 'Content-Type: application/json' >/dev/null \
-    || fail "could not mark S01E01 played for ${USER_NAME}"
-log "marked S01E01 (${S1E1_ID}) played for ${USER_NAME}"
+    || fail "could not mark S01E01 played for the seeded non-admin user"
+log "marked S01E01 (${S1E1_ID}) played for the seeded non-admin user"
 
 # Machine-readable evidence for local/CI diagnostics only. The spec deliberately
 # does not read this file: it must discover the current item through Jellyfin's
 # authenticated API so a stale database ID can never become an implicit input.
 jq -n \
     --arg seedId "${SEED_NONCE}" \
+    --arg baseUrl "${BASE}" \
+    --arg project "${E2E_PROJECT}" \
     --arg image "${IMAGE}" \
     --arg imageId "${IMAGE_ID}" \
     --arg serverVersion "${SERVER_VERSION}" \
     --arg layoutEnforcement "${LAYOUT_ENFORCEMENT}" \
+    --argjson port "${PUBLISHED_PORT}" \
+    --argjson cpus "${JF_CPUS}" \
     --arg id "${AUTOSKIP_ID}" \
     --arg name "${AUTOSKIP_NAME}" \
     --arg path "${AUTOSKIP_CONTAINER_PATH}" \
@@ -458,6 +641,10 @@ jq -n \
     --argjson requiredMinimumSeconds "${AUTOSKIP_MIN_DURATION}" \
     '{
         seedId: $seedId,
+        baseUrl: $baseUrl,
+        port: $port,
+        project: $project,
+        cpus: $cpus,
         image: $image,
         imageId: $imageId,
         serverVersion: $serverVersion,
@@ -469,8 +656,8 @@ jq -n \
             durationSeconds: $durationSeconds,
             requiredMinimumSeconds: $requiredMinimumSeconds
         }
-    }' > "${HERE}/seed-result.json.tmp"
-mv "${HERE}/seed-result.json.tmp" "${HERE}/seed-result.json"
+    }' > "${SEED_RESULT_TMP}"
+mv -- "${SEED_RESULT_TMP}" "${SEED_RESULT}"
 
-log "ready: ${BASE} (admin=${ADMIN_USER}, user=${USER_NAME}, ${MOVIES} movies, series '${SHOW_NAME}' with ${EPISODES} episodes, Spoiler Guard enabled)"
+log "ready: ${BASE} (project=${E2E_PROJECT}, cpus=${JF_CPUS}, ${MOVIES} movies, series '${SHOW_NAME}' with ${EPISODES} episodes, Spoiler Guard enabled)"
 log "run the suite with: JF_BASE_URL=${BASE} npm run e2e"

--- a/e2e/perf/capture-traces.js
+++ b/e2e/perf/capture-traces.js
@@ -28,7 +28,7 @@
  *
  * Usage (needs a resolvable `playwright` — the e2e suite's NODE_PATH convention):
  *   NODE_PATH=/path/with/playwright node e2e/perf/capture-traces.js \
- *     [scenario ...] [--base http://localhost:8100] \
+ *     [scenario ...] [--base http://127.0.0.1:8100] \
  *     [--user jc_arradmin --pass '...'] [--out e2e/perf/traces] \
  *     [--cpu 4] [--latency 300] [--download 1500] [--headed] [--list]
  *
@@ -38,7 +38,7 @@
  *   npm run perf:trace -- --list                            # list scenarios
  *
  * Env (matches e2e/fixtures/auth.ts + e2e/docker/seed.sh):
- *   JF_BASE_URL   server under test        (default http://localhost:8100)
+ *   JF_BASE_URL   server under test        (default http://127.0.0.1:8100)
  *   JC_TRACE_USER / JC_TRACE_PASS          trace login (falls back to the e2e
  *   JF_ADMIN_USER / JF_ADMIN_PASS          suite's admin env, then jc_arradmin)
  *
@@ -70,7 +70,7 @@ try {
 
 function parseArgs(argv) {
     const args = {
-        base: process.env.JF_BASE_URL || 'http://localhost:8100',
+        base: process.env.JF_BASE_URL || 'http://127.0.0.1:8100',
         user: process.env.JC_TRACE_USER || process.env.JF_ADMIN_USER || 'jc_arradmin',
         pass: process.env.JC_TRACE_PASS || process.env.JF_ADMIN_PASS || 'Test669Pw!x',
         out: path.join(__dirname, 'traces'),

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -14,9 +14,12 @@
 // (favorites, plugin config) and every spec restores what it touches.
 import { defineConfig } from 'playwright/test';
 
+const outputDir = process.env.JF_E2E_OUTPUT_DIR?.trim() || `${__dirname}/test-results`;
+const trace = process.env.JF_E2E_TRACE === 'off' ? 'off' : 'retain-on-failure';
+
 export default defineConfig({
     testDir: __dirname,
-    outputDir: `${__dirname}/test-results`,
+    outputDir,
     timeout: 180_000,
     expect: { timeout: 30_000 },
     retries: 1,
@@ -27,6 +30,6 @@ export default defineConfig({
         baseURL: process.env.JF_BASE_URL || 'http://localhost:8099',
         viewport: { width: 1440, height: 900 },
         screenshot: 'only-on-failure',
-        trace: 'retain-on-failure',
+        trace,
     },
 });

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "validate-translations": "node scripts/validate-translations.js validate",
     "test:scripts": "node --test \"scripts/**/*.test.js\"",
     "e2e": "playwright test --config e2e/playwright.config.ts",
+    "e2e:local": "bash scripts/e2e/run-local-shards.sh",
     "e2e:headed": "playwright test --config e2e/playwright.config.ts --headed",
     "perf:trace": "node e2e/perf/capture-traces.js"
   },

--- a/scripts/e2e/docker-isolation.test.js
+++ b/scripts/e2e/docker-isolation.test.js
@@ -1,0 +1,318 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const ROOT = path.resolve(__dirname, '../..');
+const COMPOSE_FILE = path.join(ROOT, 'e2e/docker/compose.yml');
+const SEED_FILE = path.join(ROOT, 'e2e/docker/seed.sh');
+const PLAYWRIGHT_FILE = path.join(ROOT, 'e2e/playwright.config.ts');
+const compose = fs.readFileSync(COMPOSE_FILE, 'utf8');
+const seed = fs.readFileSync(SEED_FILE, 'utf8');
+const playwright = fs.readFileSync(PLAYWRIGHT_FILE, 'utf8');
+
+function seedPrerequisitesAvailable() {
+    return ['bash', 'curl', 'jq', 'realpath'].every(
+        (command) => spawnSync(command, ['--version'], { encoding: 'utf8' }).status === 0
+    );
+}
+
+function runSeed(overrides = {}) {
+    const env = { ...process.env };
+    for (const name of [
+        'JF_ADMIN_USER',
+        'JF_ADMIN_PASS',
+        'JF_USER_NAME',
+        'JF_USER_PASS',
+        'JF_ALLOW_NON_LOOPBACK',
+        'JF_BIND_ADDRESS',
+        'JF_CPUS',
+        'JF_E2E_PROJECT',
+        'JF_E2E_SEED_ID',
+        'JF_E2E_STATE_DIR',
+        'JF_FFMPEG_THREADS',
+        'JF_IMAGE',
+        'JF_LAYOUT_ENFORCEMENT',
+        'JF_PORT',
+    ]) {
+        delete env[name];
+    }
+    Object.assign(env, { PLUGIN_DLL: '/bin/true', ...overrides });
+    return spawnSync('bash', [SEED_FILE], {
+        cwd: ROOT,
+        encoding: 'utf8',
+        env,
+    });
+}
+
+test('Compose isolates names, state, loopback publication, and the two-CPU default', () => {
+    assert.match(compose, /name: "\$\{JF_E2E_PROJECT:-docker\}"/);
+    assert.doesNotMatch(compose, /^\s*container_name:/m);
+    assert.match(compose, /cpus: "\$\{JF_CPUS:-2\}"/);
+    assert.match(compose, /published: "\$\{JF_PORT:-8100\}"/);
+    assert.match(compose, /host_ip: "\$\{JF_BIND_ADDRESS:-127\.0\.0\.1\}"/);
+    assert.doesNotMatch(compose, /^\s*-\s*["']?(?:\d+|\$\{[^}]*PORT[^}]*\}):\d+/m);
+    assert.match(compose, /source: "\$\{JF_CONFIG_DIR:-\.\/config\}"/);
+    assert.match(compose, /source: "\$\{JF_CACHE_DIR:-\.\/cache\}"/);
+    assert.match(compose, /source: "\$\{JF_MEDIA_DIR:-\.\/media\}"/);
+});
+
+test('seed owns one validated Compose project through an argument array', () => {
+    assert.match(seed, /E2E_PROJECT="\$\{JF_E2E_PROJECT:-docker\}"/);
+    assert.match(seed, /\^\[a-z0-9\]\[a-z0-9_-\]\*\$/);
+    assert.match(
+        seed,
+        /COMPOSE=\(docker compose --project-name "\$\{E2E_PROJECT\}" --file "\$\{HERE\}\/compose\.yml"\)/
+    );
+    assert.match(seed, /"\$\{COMPOSE\[@\]\}" down -v --remove-orphans/);
+    assert.match(seed, /"\$\{COMPOSE\[@\]\}" up -d/);
+    assert.match(seed, /refusing to reset its state/);
+    assert.doesNotMatch(seed, /down -v --remove-orphans[^\n]*\|\| true/);
+    assert.doesNotMatch(seed, /COMPOSE="docker compose/);
+    assert.doesNotMatch(seed, /\$\{COMPOSE\} (?:up|down)/);
+    assert.ok(
+        seed.indexOf('JF_E2E_SEED_ID may contain only')
+            < seed.indexOf('down -v --remove-orphans'),
+        'seed id validation must remain before destructive reset'
+    );
+});
+
+test('custom state is marker-owned and deletion is limited to known non-symlink children', () => {
+    assert.match(seed, /STATE_LEXICAL="\$\(realpath -ms/);
+    assert.match(seed, /STATE_DIR="\$\(realpath -m/);
+    assert.match(seed, /must not contain or traverse symbolic links/);
+    assert.match(seed, /STATE_MARKER="\$\{STATE_DIR\}\/\.jc-e2e-state-v1"/);
+    assert.match(seed, /marker belongs to another path or Compose project/);
+    assert.match(seed, /must be empty before its ownership marker is created/);
+    assert.match(seed, /refusing to reset symlinked E2E state path/);
+    assert.match(
+        seed,
+        /rm -rf -- "\$\{CONFIG_DIR\}" "\$\{CACHE_DIR\}" "\$\{MEDIA_DIR\}"/
+    );
+    assert.doesNotMatch(seed, /rm -rf --? "?\$\{STATE_DIR\}/);
+    assert.doesNotMatch(seed, /rm -rf "\$\{HERE\}/);
+});
+
+test('non-loopback publication is explicit and rejects the documented credentials', () => {
+    assert.match(seed, /JF_BIND_ADDRESS="\$\{JF_BIND_ADDRESS:-127\.0\.0\.1\}"/);
+    assert.match(seed, /JF_ALLOW_NON_LOOPBACK:-false/);
+    assert.match(seed, /non-loopback JF_BIND_ADDRESS requires JF_ALLOW_NON_LOOPBACK=true/);
+    assert.match(seed, /non-loopback binding refuses every default E2E username and password/);
+    assert.doesNotMatch(seed, /authenticating \$\{ADMIN_USER\}/);
+    assert.doesNotMatch(seed, /admin=\$\{ADMIN_USER\}/);
+    assert.doesNotMatch(seed, /user=\$\{USER_NAME\}/);
+});
+
+test('port zero is discovered from the owned container and recorded without credentials', () => {
+    assert.match(seed, /JF_PORT must be an integer from 0 through 65535/);
+    assert.match(seed, /docker inspect --format '\{\{json \(index \.NetworkSettings\.Ports "8096\/tcp"\)\}\}'/);
+    assert.match(seed, /PUBLISHED_PORT=/);
+    assert.match(seed, /--arg baseUrl "\$\{BASE\}"/);
+    assert.match(seed, /--arg project "\$\{E2E_PROJECT\}"/);
+    assert.match(seed, /--argjson port "\$\{PUBLISHED_PORT\}"/);
+    assert.match(seed, /--argjson cpus "\$\{JF_CPUS\}"/);
+
+    const resultBuilder = seed.slice(seed.lastIndexOf('jq -n \\\n'));
+    assert.ok(resultBuilder.length > 0, 'seed result builder must exist');
+    assert.doesNotMatch(resultBuilder, /ADMIN_(?:USER|PASS)|USER_(?:NAME|PASS)|TOKEN/);
+});
+
+test('Playwright output can be unique per local shard while retaining the old default', () => {
+    assert.match(
+        playwright,
+        /process\.env\.JF_E2E_OUTPUT_DIR\?\.trim\(\) \|\| `\$\{__dirname\}\/test-results`/
+    );
+    assert.match(playwright, /outputDir,/);
+    assert.match(playwright, /JF_E2E_TRACE === 'off' \? 'off' : 'retain-on-failure'/);
+    assert.match(playwright, /trace,/);
+    assert.doesNotMatch(playwright, /outputDir: `\$\{__dirname\}\/test-results`/);
+});
+
+test('custom-state GNU tooling does not gate the portable default seed path', () => {
+    const customBranch = seed.indexOf('if (( CUSTOM_STATE == 1 )); then');
+    assert.ok(customBranch >= 0);
+    assert.ok(seed.indexOf('command -v realpath', customBranch) > customBranch);
+    assert.ok(seed.indexOf("stat -c '%u' -- .", customBranch) > customBranch);
+    assert.match(seed, /else\n {4}STATE_DIR="\$\{HERE\}"\nfi/);
+});
+
+test('seed rejects unsafe namespaces and exposure before invoking Compose', (t) => {
+    if (!seedPrerequisitesAvailable()) {
+        t.skip('seed validation prerequisites are unavailable');
+        return;
+    }
+
+    const invalidProject = runSeed({ JF_E2E_PROJECT: 'BAD/project' });
+    assert.notEqual(invalidProject.status, 0);
+    assert.match(invalidProject.stderr, /JF_E2E_PROJECT must start/);
+
+    const exposedDefaults = runSeed({ JF_BIND_ADDRESS: '0.0.0.0' });
+    assert.notEqual(exposedDefaults.status, 0);
+    assert.match(exposedDefaults.stderr, /requires JF_ALLOW_NON_LOOPBACK=true/);
+
+    const exposedOptInDefaults = runSeed({
+        JF_BIND_ADDRESS: '0.0.0.0',
+        JF_ALLOW_NON_LOOPBACK: 'true',
+    });
+    assert.notEqual(exposedOptInDefaults.status, 0);
+    assert.match(exposedOptInDefaults.stderr, /refuses every default E2E username and password/);
+
+    const exposedScopedCredentials = runSeed({
+        JF_BIND_ADDRESS: '0.0.0.0',
+        JF_ALLOW_NON_LOOPBACK: 'true',
+        JF_ADMIN_USER: 'scoped-admin',
+        JF_ADMIN_PASS: 'scoped-admin-password',
+        JF_USER_NAME: 'scoped-user',
+        JF_USER_PASS: 'scoped-user-password',
+        JF_E2E_SEED_ID: 'invalid/after-exposure-check',
+    });
+    assert.notEqual(exposedScopedCredentials.status, 0);
+    assert.match(exposedScopedCredentials.stderr, /JF_E2E_SEED_ID may contain only/);
+    assert.doesNotMatch(exposedScopedCredentials.stderr, /JF_ALLOW_NON_LOOPBACK|refuses every default/);
+
+    const rootState = runSeed({ JF_E2E_STATE_DIR: '/' });
+    assert.notEqual(rootState.status, 0);
+    assert.match(rootState.stderr, /must not be the filesystem root/);
+});
+
+test('custom state claim is exact and symlink paths fail closed', (t) => {
+    if (!seedPrerequisitesAvailable()) {
+        t.skip('seed validation prerequisites are unavailable');
+        return;
+    }
+
+    const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'jc-e2e-seed-contract-'));
+    try {
+        const state = path.join(parent, 'owned-state');
+        const claim = runSeed({
+            JF_E2E_PROJECT: 'jc-contract-owned',
+            JF_E2E_STATE_DIR: state,
+            JF_E2E_SEED_ID: 'invalid/after-claim',
+        });
+        assert.notEqual(claim.status, 0);
+        assert.match(claim.stderr, /JF_E2E_SEED_ID may contain only/);
+        assert.equal(
+            fs.readFileSync(path.join(state, '.jc-e2e-state-v1'), 'utf8'),
+            `Jellyfin Canopy E2E state v1\nproject=jc-contract-owned\nstate=${state}\n`
+        );
+
+        const wrongProject = runSeed({
+            JF_E2E_PROJECT: 'jc-contract-other',
+            JF_E2E_STATE_DIR: state,
+            JF_E2E_SEED_ID: 'still-invalid',
+        });
+        assert.notEqual(wrongProject.status, 0);
+        assert.match(wrongProject.stderr, /marker belongs to another path or Compose project/);
+
+        const target = path.join(parent, 'symlink-target');
+        const linked = path.join(parent, 'symlink-state');
+        fs.mkdirSync(target);
+        fs.symlinkSync(target, linked, 'dir');
+        const symlinked = runSeed({
+            JF_E2E_PROJECT: 'jc-contract-link',
+            JF_E2E_STATE_DIR: linked,
+        });
+        assert.notEqual(symlinked.status, 0);
+        assert.match(symlinked.stderr, /must not contain or traverse symbolic links/);
+    } finally {
+        fs.rmSync(parent, { recursive: true, force: true });
+    }
+});
+
+test('seed refuses to delete state when exact Compose teardown fails', (t) => {
+    if (!seedPrerequisitesAvailable()) {
+        t.skip('seed validation prerequisites are unavailable');
+        return;
+    }
+
+    const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'jc-e2e-down-contract-'));
+    try {
+        const state = path.join(parent, 'owned-state');
+        const project = 'jc-contract-down-failure';
+        const claim = runSeed({
+            JF_E2E_PROJECT: project,
+            JF_E2E_STATE_DIR: state,
+            JF_E2E_SEED_ID: 'invalid/after-claim',
+        });
+        assert.notEqual(claim.status, 0);
+        assert.match(claim.stderr, /JF_E2E_SEED_ID may contain only/);
+
+        const config = path.join(state, 'config');
+        const sentinel = path.join(config, 'must-survive');
+        fs.mkdirSync(config);
+        fs.writeFileSync(sentinel, 'owned state\n');
+
+        const bin = path.join(parent, 'bin');
+        fs.mkdirSync(bin);
+        fs.writeFileSync(path.join(bin, 'docker'), '#!/usr/bin/env bash\nexit 7\n', {
+            mode: 0o700,
+        });
+        const failed = runSeed({
+            JF_E2E_PROJECT: project,
+            JF_E2E_STATE_DIR: state,
+            JF_E2E_SEED_ID: 'valid-seed-id',
+            PATH: `${bin}:${process.env.PATH}`,
+        });
+        assert.notEqual(failed.status, 0);
+        assert.match(failed.stderr, /could not tear down Compose project/);
+        assert.equal(fs.readFileSync(sentinel, 'utf8'), 'owned state\n');
+    } finally {
+        fs.rmSync(parent, { recursive: true, force: true });
+    }
+});
+
+test('rendered Compose config keeps an ephemeral custom shard isolated', (t) => {
+    const available = spawnSync('docker', ['compose', 'version'], { encoding: 'utf8' });
+    if (available.status !== 0) {
+        t.skip('docker compose is unavailable');
+        return;
+    }
+
+    const state = fs.mkdtempSync(path.join(os.tmpdir(), 'jc-e2e-compose-contract-'));
+    try {
+        const env = {
+            ...process.env,
+            JF_E2E_PROJECT: 'jc-contract-shard-7',
+            JF_PORT: '0',
+            JF_CPUS: '2',
+            JF_BIND_ADDRESS: '127.0.0.1',
+            JF_CONFIG_DIR: path.join(state, 'config'),
+            JF_CACHE_DIR: path.join(state, 'cache'),
+            JF_MEDIA_DIR: path.join(state, 'media'),
+        };
+        const rendered = spawnSync(
+            'docker',
+            ['compose', '--project-name', env.JF_E2E_PROJECT, '-f', COMPOSE_FILE, 'config', '--format', 'json'],
+            { encoding: 'utf8', env }
+        );
+        assert.equal(rendered.status, 0, rendered.stderr || rendered.stdout);
+        const config = JSON.parse(rendered.stdout);
+        const service = config.services.jellyfin;
+        assert.equal(config.name, 'jc-contract-shard-7');
+        assert.equal(service.container_name, undefined);
+        assert.equal(service.cpus, 2);
+        assert.deepEqual(service.ports, [{
+            mode: 'ingress',
+            host_ip: '127.0.0.1',
+            target: 8096,
+            published: '0',
+            protocol: 'tcp',
+        }]);
+        assert.deepEqual(
+            service.volumes.map(({ source, target, read_only }) => ({ source, target, read_only: !!read_only })),
+            [
+                { source: path.join(state, 'config'), target: '/config', read_only: false },
+                { source: path.join(state, 'cache'), target: '/cache', read_only: false },
+                { source: path.join(state, 'media'), target: '/media', read_only: true },
+            ]
+        );
+    } finally {
+        fs.rmSync(state, { recursive: true, force: true });
+    }
+});

--- a/scripts/e2e/local-shards.test.js
+++ b/scripts/e2e/local-shards.test.js
@@ -1,0 +1,566 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const test = require('node:test');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const SCRIPT = path.join(__dirname, 'run-local-shards.sh');
+const source = fs.readFileSync(SCRIPT, 'utf8');
+const packageJson = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+
+function runSourced(command, env = {}) {
+    return spawnSync('bash', ['-c', `source "$1"; ${command}`, 'bash', SCRIPT], {
+        cwd: ROOT,
+        env: { ...process.env, ...env },
+        encoding: 'utf8',
+    });
+}
+
+function discoverTests(shard) {
+    const args = ['run', 'e2e', '--', '--list'];
+    if (shard) args.push(`--shard=${shard}`);
+    const result = spawnSync('npm', args, {
+        cwd: ROOT,
+        encoding: 'utf8',
+        maxBuffer: 8 * 1024 * 1024,
+        timeout: 60_000,
+    });
+    const tests = (result.stdout || '')
+        .split(/\r?\n/)
+        .filter((line) => /^\s+.+\.spec\.ts:\d+:\d+ › /.test(line))
+        .map((line) => line.trim());
+    return { ...result, tests };
+}
+
+function discoveryUnavailable(result) {
+    const output = `${result.stdout || ''}\n${result.stderr || ''}`;
+    return result.error?.code === 'ENOENT'
+        || result.error?.code === 'ETIMEDOUT'
+        || !!result.signal
+        || (result.status === 127 && /playwright.*not found/i.test(output));
+}
+
+test('package exposes the opt-in local E2E command', () => {
+    assert.equal(packageJson.scripts['e2e:local'], 'bash scripts/e2e/run-local-shards.sh');
+});
+
+test('parser defaults to four 2-CPU shards and accepts bounded exploratory overrides', () => {
+    const defaults = runSourced("parse_args; printf '%s %s %s' \"$SHARDS\" \"$CPUS_PER_SERVER\" \"$ALLOW_EXTERNAL_INTEGRATIONS\"");
+    assert.equal(defaults.status, 0, defaults.stderr);
+    assert.equal(defaults.stdout, '4 2 0');
+
+    const overridden = runSourced("parse_args --shards=16 --cpus-per-server 8 --allow-external-integrations; printf '%s %s %s' \"$SHARDS\" \"$CPUS_PER_SERVER\" \"$ALLOW_EXTERNAL_INTEGRATIONS\"");
+    assert.equal(overridden.status, 0, overridden.stderr);
+    assert.equal(overridden.stdout, '16 8 1');
+});
+
+test('parser rejects missing, malformed and out-of-range resource values', () => {
+    for (const args of [
+        'parse_args --shards',
+        'parse_args --shards 0',
+        'parse_args --shards 17',
+        'parse_args --shards nope',
+        'parse_args --cpus-per-server 0',
+        'parse_args --cpus-per-server 65',
+        'parse_args --cpus-per-server 2.5',
+    ]) {
+        const result = runSourced(args);
+        assert.equal(result.status, 2, `${args}\nstdout: ${result.stdout}\nstderr: ${result.stderr}`);
+    }
+});
+
+test('external integration secrets are removed unless the explicit flag is present', () => {
+    const scrubbed = runSourced(
+        "sanitize_external_environment; printf '%s %s %s' \"${TMDB_API_KEY-unset}\" \"${SEERR_URL-unset}\" \"$SAFE_VALUE\"",
+        { TMDB_API_KEY: 'tmdb-secret', SEERR_URL: 'https://seerr.invalid', SAFE_VALUE: 'kept' }
+    );
+    assert.equal(scrubbed.status, 0, scrubbed.stderr);
+    assert.equal(scrubbed.stdout, 'unset unset kept');
+
+    const allowed = runSourced(
+        "parse_args --allow-external-integrations; sanitize_external_environment; printf '%s %s' \"$TMDB_API_KEY\" \"$SEERR_URL\"",
+        { TMDB_API_KEY: 'tmdb-secret', SEERR_URL: 'https://seerr.invalid' }
+    );
+    assert.equal(allowed.status, 0, allowed.stderr);
+    assert.equal(allowed.stdout, 'tmdb-secret https://seerr.invalid');
+});
+
+test('every shard gets isolated Docker, state, port, CPU and browser coordinates', () => {
+    assert.match(source, /umask 077/);
+    assert.match(source, /\/dev\/urandom/);
+    assert.match(source, /mktemp -d/);
+    assert.match(source, /STATE_ROOT="\$\(realpath -e -- "\$\{STATE_ROOT\}"\)"/);
+    assert.match(source, /\.jc-local-e2e-owner/);
+    assert.match(source, /PROJECTS\[shard\]="jc-e2e-\$\{RUN_ID\}-s\$\{shard\}"/);
+    assert.match(source, /STATE_DIRS\[shard\]="\$\{STATE_ROOT\}\/shard-\$\{shard\}"/);
+    assert.match(source, /RESULT_DIRS\[shard\]="\$\{RESULT_ROOT\}\/shard-\$\{shard\}"/);
+    for (const coordinate of [
+        'JF_E2E_PROJECT=',
+        'JF_E2E_STATE_DIR=',
+        'JF_BIND_ADDRESS=127.0.0.1',
+        'JF_PORT=0',
+        'JF_CPUS=',
+        'JF_E2E_OUTPUT_DIR=',
+    ]) {
+        assert.ok(source.includes(coordinate), `runner lost ${coordinate}`);
+    }
+    assert.match(source, /--output="\$\{output_dir\}"/);
+    assert.match(source, /JF_ADMIN_USER="\$\{ADMIN_USER\}"/);
+    assert.match(source, /JF_ADMIN_PASS="\$\{ADMIN_PASS\}"/);
+});
+
+test('seed evidence is bound back to the expected loopback project and CPU quota', () => {
+    for (const field of ['.baseUrl', '.port', '.project', '.cpus']) {
+        assert.ok(source.includes(field), `seed-result validation lost ${field}`);
+    }
+    assert.match(source, /"\$\{project\}" == "\$\{PROJECTS\[shard\]\}"/);
+    assert.match(source, /"\$\{cpus\}" == "\$\{CPUS_PER_SERVER\}"/);
+    assert.match(source, /"\$\{base_url\}" == "http:\/\/127\.0\.0\.1:\$\{port\}"/);
+});
+
+test('runner builds once, uses native file shards and waits for every phase', () => {
+    assert.equal((source.match(/dotnet build/g) || []).length, 1);
+    assert.match(source, /exec setsid --wait npm --prefix "\$\{REPO_ROOT\}" run e2e/);
+    assert.match(source, /--shard="\$\{shard\}\/\$\{SHARDS\}"/);
+
+    const main = source.slice(source.indexOf('main() {'));
+    const orderedSteps = [
+        'build_plugin_once',
+        'start_seed_jobs',
+        'wait_for_seed_jobs',
+        'start_test_jobs',
+        'wait_for_test_jobs',
+        'write_shard_markers',
+        'write_summary',
+    ];
+    let previous = -1;
+    for (const step of orderedSteps) {
+        const position = main.indexOf(step);
+        assert.ok(position > previous, `${step} is missing or out of order`);
+        previous = position;
+    }
+    assert.match(source, /exec setsid --wait bash "\$\{SEED_SCRIPT\}"/);
+    assert.doesNotMatch(source, /setsid env/);
+    assert.match(source, /export JF_E2E_TRACE=off/);
+});
+
+test('native four- and six-shard discovery is an exact duplicate-free inventory union', (t) => {
+    const unsharded = discoverTests();
+    if (discoveryUnavailable(unsharded)) {
+        t.skip('Playwright discovery is unavailable or timed out');
+        return;
+    }
+    assert.equal(unsharded.status, 0, unsharded.stderr || unsharded.stdout);
+    assert.ok(unsharded.tests.length > 0, 'unsharded discovery returned no tests');
+    const expected = [...unsharded.tests].sort();
+
+    for (const total of [4, 6]) {
+        const combined = [];
+        for (let shard = 1; shard <= total; shard += 1) {
+            const discovered = discoverTests(`${shard}/${total}`);
+            if (discoveryUnavailable(discovered)) {
+                t.skip(`Playwright discovery timed out for shard ${shard}/${total}`);
+                return;
+            }
+            assert.equal(discovered.status, 0, discovered.stderr || discovered.stdout);
+            combined.push(...discovered.tests);
+        }
+        assert.equal(combined.length, expected.length, `${total}-shard test count drifted`);
+        assert.equal(
+            new Set(combined).size,
+            combined.length,
+            `${total}-shard discovery contained duplicates`
+        );
+        assert.deepEqual([...combined].sort(), expected, `${total}-shard union was incomplete`);
+    }
+});
+
+test('signals and exit clean only generated projects while retaining diagnostics', () => {
+    assert.match(source, /trap 'cleanup' EXIT/);
+    assert.match(source, /trap 'handle_signal 130 INT' INT/);
+    assert.match(source, /trap 'handle_signal 143 TERM' TERM/);
+    assert.match(source, /trap '' INT TERM/);
+    assert.match(source, /kill -0 -- "-\$\{pid\}"/);
+    assert.match(source, /kill -TERM -- "-\$\{pid\}"/);
+    assert.match(source, /JF_CONFIG_DIR="\$\{STATE_DIRS\[shard\]\}\/config"/);
+    assert.match(source, /JF_CACHE_DIR="\$\{STATE_DIRS\[shard\]\}\/cache"/);
+    assert.match(source, /JF_MEDIA_DIR="\$\{STATE_DIRS\[shard\]\}\/media"/);
+    assert.match(source, /\(\( down_status == 0 && marker_status == 0 \)\)/);
+    assert.match(source, /cleanup_failed != 0 && original_status == 0/);
+    assert.match(source, /retaining state after cleanup failure/);
+    assert.match(source, /runner ownership marker is missing, unreadable or mismatched/);
+    assert.match(source, /elif ! rm -rf -- "\$\{STATE_ROOT\}"/);
+    assert.match(source, /down -v --remove-orphans --timeout 10/);
+    assert.match(source, /retrying once/);
+    assert.match(source, /manual recovery: docker compose --project-name/);
+    assert.match(source, /RESULT_ROOT="\$\{REPO_ROOT\}\/e2e\/test-results\/local-\$\{RUN_ID\}"/);
+    assert.doesNotMatch(source, /docker\s+(system|container|volume)\s+prune/);
+    assert.doesNotMatch(source, /docker\s+(rm|kill|stop)\b/);
+});
+
+test('test wait collects every shard after one fails', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'jc-local-wait-contract-'));
+    try {
+        const command = [
+            'source "$1"',
+            'SHARDS=2',
+            'RESULT_DIRS[1]="$2/shard-1"',
+            'RESULT_DIRS[2]="$2/shard-2"',
+            'mkdir -p "${RESULT_DIRS[1]}" "${RESULT_DIRS[2]}"',
+            "setsid --wait bash -c 'exit 7' & TEST_PIDS[1]=$!",
+            "setsid --wait bash -c 'sleep 0.2; : > \"$1\"' bash \"$2/completed\" & TEST_PIDS[2]=$!",
+            'wait_for_test_jobs',
+            '[[ "${TEST_STATUS[1]}" -eq 7 ]]',
+            '[[ "${TEST_STATUS[2]}" -eq 0 ]]',
+            '[[ -f "$2/completed" ]]',
+        ].join('\n');
+        const result = spawnSync('bash', ['-c', command, 'bash', SCRIPT, root], {
+            cwd: ROOT,
+            encoding: 'utf8',
+        });
+        assert.equal(result.status, 0, `stdout: ${result.stdout}\nstderr: ${result.stderr}`);
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test('termination finds a shard process group after its tracked leader exits', () => {
+    const command = [
+        'source "$1"',
+        "leader=''",
+        'cleanup_group() {',
+        '  [[ "$leader" =~ ^[1-9][0-9]*$ ]] || return 0',
+        '  kill -KILL -- "-$leader" >/dev/null 2>&1 || true',
+        '}',
+        'trap cleanup_group EXIT',
+        "setsid --wait bash -c 'sleep 30 & wait' &",
+        'leader=$!',
+        'SEED_PIDS[1]=$leader',
+        'for _ in {1..50}; do kill -0 -- "-$leader" 2>/dev/null && break; sleep 0.02; done',
+        'kill -KILL "$leader"',
+        'wait "$leader" 2>/dev/null || true',
+        'kill -0 -- "-$leader" 2>/dev/null',
+        'terminate_active_jobs',
+        '! kill -0 -- "-$leader" 2>/dev/null',
+    ].join('\n');
+    const result = spawnSync('bash', ['-c', command, 'bash', SCRIPT], {
+        cwd: ROOT,
+        encoding: 'utf8',
+        timeout: 10_000,
+    });
+    assert.equal(result.status, 0, `stdout: ${result.stdout}\nstderr: ${result.stderr}`);
+});
+
+for (const [signal, expected] of [['INT', 130], ['TERM', 143]]) {
+    test(`${signal} delivery preserves its exit code through owned cleanup`, () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), `jc-local-${signal.toLowerCase()}-`));
+        try {
+            const command = [
+                'source "$1"',
+                'RUN_ID=signal-contract',
+                'SHARDS=1',
+                'STATE_ROOT="$2/state"',
+                'RESULT_ROOT="$2/results"',
+                'mkdir -p "$STATE_ROOT" "$RESULT_ROOT"',
+                "printf '%s\\n' \"$RUN_ID\" > \"$STATE_ROOT/.jc-local-e2e-owner\"",
+                "trap 'cleanup' EXIT",
+                "trap 'handle_signal 130 INT' INT",
+                "trap 'handle_signal 143 TERM' TERM",
+                `kill -${signal} $$`,
+                'exit 99',
+            ].join('\n');
+            const result = spawnSync('bash', ['-c', command, 'bash', SCRIPT, root], {
+                cwd: ROOT,
+                encoding: 'utf8',
+            });
+            assert.equal(result.status, expected, `stdout: ${result.stdout}\nstderr: ${result.stderr}`);
+            assert.equal(fs.existsSync(path.join(root, 'state')), false);
+            assert.equal(
+                fs.existsSync(path.join(root, 'results', 'credential-scrub-summary.txt')),
+                true
+            );
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+}
+
+test('launcher keeps runner passwords out of the tracked process argv', (t) => {
+    if (!fs.existsSync('/proc/self/cmdline') || spawnSync('setsid', ['--version']).status !== 0) {
+        t.skip('Linux procfs and GNU setsid are required');
+        return;
+    }
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'jc-local-argv-contract-'));
+    try {
+        const fakeSeed = path.join(root, 'fake-seed.sh');
+        fs.writeFileSync(fakeSeed, '#!/usr/bin/env bash\nsleep 30\n', { mode: 0o700 });
+        const command = [
+            'source "$1"',
+            'SHARDS=1',
+            'RUN_ID=argv-contract',
+            'CPUS_PER_SERVER=2',
+            'PROJECTS[1]=argv-contract-s1',
+            'STATE_DIRS[1]="$2/state"',
+            'RESULT_DIRS[1]="$2/results"',
+            'mkdir -p "${STATE_DIRS[1]}" "${RESULT_DIRS[1]}"',
+            'SEED_SCRIPT="$2/fake-seed.sh"',
+            'PLUGIN_DLL=/bin/true',
+            'ADMIN_USER=argv_admin',
+            'ADMIN_PASS=argv-secret-admin',
+            'USER_NAME=argv_user',
+            'USER_PASS=argv-secret-user',
+            'trap terminate_active_jobs EXIT',
+            'start_seed_jobs >/dev/null',
+            'pid="${SEED_PIDS[1]}"',
+            'for _ in {1..50}; do',
+            '  cmdline="$(tr "\\0" " " < "/proc/$pid/cmdline")"',
+            '  [[ "$cmdline" == *fake-seed.sh* ]] && break',
+            '  sleep 0.02',
+            'done',
+            '[[ "$cmdline" == *fake-seed.sh* ]]',
+            '[[ "$cmdline" != *"$ADMIN_PASS"* ]]',
+            '[[ "$cmdline" != *"$USER_PASS"* ]]',
+            'terminate_active_jobs',
+            'SEED_PIDS[1]=""',
+        ].join('\n');
+        const result = spawnSync('bash', ['-c', command, 'bash', SCRIPT, root], {
+            cwd: ROOT,
+            encoding: 'utf8',
+            timeout: 10_000,
+        });
+        assert.equal(result.status, 0, `stdout: ${result.stdout}\nstderr: ${result.stderr}`);
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test('retained passwords are deleted while username-only diagnostics are redacted', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'jc-local-scrub-contract-'));
+    try {
+        const sensitive = path.join(root, 'playwright.log');
+        const usernameOnly = path.join(root, 'jellyfin.log');
+        const safe = path.join(root, 'safe.log');
+        fs.writeFileSync(sensitive, 'failure included scrub-secret-admin\n');
+        fs.writeFileSync(usernameOnly, 'authentication succeeded for scrub_admin\n');
+        fs.writeFileSync(safe, 'ordinary diagnostics\n');
+        const command = [
+            'source "$1"',
+            'RESULT_ROOT="$2"',
+            'ADMIN_USER=scrub_admin',
+            'ADMIN_PASS=scrub-secret-admin',
+            'USER_NAME=scrub_user',
+            'USER_PASS=scrub-secret-user',
+            'scrub_runner_credentials',
+        ].join('\n');
+        const result = spawnSync('bash', ['-c', command, 'bash', SCRIPT, root], {
+            cwd: ROOT,
+            encoding: 'utf8',
+        });
+        assert.equal(result.status, 0, `stdout: ${result.stdout}\nstderr: ${result.stderr}`);
+        assert.equal(fs.existsSync(sensitive), false);
+        assert.equal(fs.existsSync(usernameOnly), true);
+        assert.equal(fs.existsSync(safe), true);
+        assert.equal(
+            fs.readFileSync(usernameOnly, 'utf8'),
+            'authentication succeeded for [REDACTED-RUNNER-USER]\n'
+        );
+        const summary = fs.readFileSync(path.join(root, 'credential-scrub-summary.txt'), 'utf8');
+        assert.match(summary, /removed playwright\.log/);
+        assert.match(summary, /redacted jellyfin\.log/);
+        assert.doesNotMatch(summary, /scrub-secret/);
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test('state cleanup requires an exact owner marker and reports removal failures', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'jc-local-state-cleanup-'));
+
+    function runCleanup(stateDir, runId, setup = '') {
+        return spawnSync(
+            'bash',
+            [
+                '-c',
+                [
+                    'source "$1"',
+                    'RUN_ID="$3"',
+                    'STATE_ROOT="$2"',
+                    'SHARDS=1',
+                    setup,
+                    'cleanup',
+                ].filter(Boolean).join('\n'),
+                'bash',
+                SCRIPT,
+                stateDir,
+                runId,
+            ],
+            { cwd: ROOT, encoding: 'utf8' }
+        );
+    }
+
+    try {
+        const owned = path.join(root, 'owned');
+        fs.mkdirSync(owned);
+        fs.writeFileSync(path.join(owned, '.jc-local-e2e-owner'), 'owned-run\n');
+        const removed = runCleanup(owned, 'owned-run');
+        assert.equal(removed.status, 0, removed.stderr);
+        assert.equal(fs.existsSync(owned), false);
+
+        const mismatched = path.join(root, 'mismatched');
+        fs.mkdirSync(mismatched);
+        fs.writeFileSync(path.join(mismatched, '.jc-local-e2e-owner'), 'different-run\n');
+        const retained = runCleanup(mismatched, 'expected-run');
+        assert.equal(retained.status, 1, retained.stderr);
+        assert.equal(fs.existsSync(mismatched), true);
+        assert.match(retained.stderr, /ownership marker is missing, unreadable or mismatched/);
+
+        const rmFailure = path.join(root, 'rm-failure');
+        fs.mkdirSync(rmFailure);
+        fs.writeFileSync(path.join(rmFailure, '.jc-local-e2e-owner'), 'rm-run\n');
+        const failedRemoval = runCleanup(rmFailure, 'rm-run', 'rm() { return 9; }');
+        assert.equal(failedRemoval.status, 1, failedRemoval.stderr);
+        assert.equal(fs.existsSync(rmFailure), true);
+        assert.match(failedRemoval.stderr, /could not fully remove runner-owned state/);
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test('a Docker down failure is recorded and fails shard cleanup', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'jc-local-cleanup-contract-'));
+    const bin = path.join(root, 'bin');
+    const resultDir = path.join(root, 'results', 'shard-1');
+    const stateDir = path.join(root, 'state', 'shard-1');
+    fs.mkdirSync(bin, { recursive: true });
+    fs.mkdirSync(resultDir, { recursive: true });
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(
+        path.join(bin, 'timeout'),
+        '#!/usr/bin/env bash\n[[ "$1" == --signal=* ]] && shift\nshift\nexec "$@"\n',
+        { mode: 0o700 }
+    );
+    fs.writeFileSync(
+        path.join(bin, 'docker'),
+        '#!/usr/bin/env bash\ncase " $* " in *" down "*) exit 7 ;; *" logs "*) echo fake-log; exit 0 ;; *) exit 0 ;; esac\n',
+        { mode: 0o700 }
+    );
+
+    try {
+        const command = [
+            'source "$1"',
+            'RUN_ID=cleanup-contract',
+            'SHARDS=1',
+            'CPUS_PER_SERVER=2',
+            'PROJECTS[1]=cleanup-contract-s1',
+            'STATE_DIRS[1]="$2"',
+            'RESULT_DIRS[1]="$3"',
+            'collect_and_teardown_shard 1',
+        ].join('\n');
+        const result = spawnSync(
+            'bash',
+            ['-c', command, 'bash', SCRIPT, stateDir, resultDir],
+            {
+                cwd: ROOT,
+                env: { ...process.env, PATH: `${bin}:${process.env.PATH}` },
+                encoding: 'utf8',
+            }
+        );
+        assert.equal(result.status, 1, `stdout: ${result.stdout}\nstderr: ${result.stderr}`);
+        const marker = JSON.parse(
+            fs.readFileSync(path.join(resultDir, 'cleanup-result.json'), 'utf8')
+        );
+        assert.equal(marker.logsExit, 0);
+        assert.equal(marker.downExit, 7);
+        assert.match(
+            fs.readFileSync(path.join(resultDir, 'cleanup.log'), 'utf8'),
+            /retrying once/
+        );
+        assert.equal(fs.existsSync(path.join(resultDir, 'cleanup-result.json.tmp')), false);
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test('result markers and aggregate summary are atomic and exact-N', () => {
+    assert.match(source, /local marker="\$\{RESULT_DIRS\[shard\]\}\/shard-result\.json"/);
+    assert.match(source, /local marker_tmp="\$\{marker\}\.tmp"/);
+    assert.match(source, /mv "\$\{marker_tmp\}" "\$\{marker\}"/);
+    assert.match(source, /expected exactly \$\{SHARDS\} shard result markers/);
+    assert.match(source, /summary\.txt\.tmp/);
+    assert.match(source, /mv "\$\{summary_tmp\}" "\$\{summary\}"/);
+
+    const resultRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'jc-local-shard-summary-'));
+    try {
+        const setup = [
+            'SHARDS=2',
+            'CPUS_PER_SERVER=2',
+            'RUN_ID=contract-run',
+            'RESULT_ROOT="$2"',
+            'for shard in 1 2; do',
+            '  PROJECTS[$shard]="contract-s${shard}"',
+            '  RESULT_DIRS[$shard]="$2/shard-${shard}"',
+            '  BASE_URLS[$shard]="http://127.0.0.1:$((8100 + shard))"',
+            '  SEED_STATUS[$shard]=0',
+            '  TEST_STATUS[$shard]=0',
+            '  mkdir -p "${RESULT_DIRS[$shard]}"',
+            'done',
+            'write_shard_markers',
+        ].join('\n');
+
+        const complete = spawnSync(
+            'bash',
+            ['-c', `source "$1"; ${setup}; write_summary >/dev/null`, 'bash', SCRIPT, resultRoot],
+            { cwd: ROOT, encoding: 'utf8' }
+        );
+        assert.equal(complete.status, 0, complete.stderr);
+        assert.equal(fs.existsSync(path.join(resultRoot, 'summary.txt.tmp')), false);
+        assert.equal(fs.existsSync(path.join(resultRoot, 'summary.txt')), true);
+
+        const missing = spawnSync(
+            'bash',
+            [
+                '-c',
+                `source "$1"; ${setup}; rm "$2/shard-2/shard-result.json"; write_summary >/dev/null`,
+                'bash',
+                SCRIPT,
+                resultRoot,
+            ],
+            { cwd: ROOT, encoding: 'utf8' }
+        );
+        assert.equal(missing.status, 1, `stdout: ${missing.stdout}\nstderr: ${missing.stderr}`);
+    } finally {
+        fs.rmSync(resultRoot, { recursive: true, force: true });
+    }
+});
+
+test('resource plan guards CPU, MemAvailable and existing swap pressure', () => {
+    assert.match(source, /MEMORY_MIB_PER_SHARD_WARNING=2048/);
+    assert.match(source, /MemAvailable:/);
+    assert.match(source, /SwapTotal:/);
+    assert.match(source, /SwapFree:/);
+    assert.match(source, /parallel E2E may increase swap pressure/);
+    assert.match(source, /Linux-only and requires host ffmpeg plus GNU setsid and timeout/);
+    assert.match(source, /sensitive local-only artifacts/);
+    assert.match(source, /become unusable after successful teardown/);
+});
+
+test('runner-created shard state directories begin empty for seed ownership claims', () => {
+    assert.match(
+        source,
+        /mkdir -p "\$\{STATE_DIRS\[shard\]\}" "\$\{RESULT_DIRS\[shard\]\}\/playwright"/
+    );
+    const initialization = source.slice(
+        source.indexOf('initialize_run() {'),
+        source.indexOf('sanitize_external_environment() {')
+    );
+    assert.doesNotMatch(initialization, /STATE_DIRS\[shard\].*\.jc-e2e-state-v1/);
+});
+
+test('shell source is syntactically valid', () => {
+    const result = spawnSync('bash', ['-n', SCRIPT], { cwd: ROOT, encoding: 'utf8' });
+    assert.equal(result.status, 0, result.stderr);
+});

--- a/scripts/e2e/run-local-shards.sh
+++ b/scripts/e2e/run-local-shards.sh
@@ -1,0 +1,819 @@
+#!/usr/bin/env bash
+# Run the dockerized Jellyfin E2E suite across isolated local Playwright shards.
+#
+# This is deliberately opt-in. Each shard owns a fresh Compose project, dynamic
+# loopback port, state tree and Playwright output directory. Stateful specs stay
+# serial inside their server; concurrency exists only between clean servers.
+set -uo pipefail
+
+umask 077
+
+MIN_SHARDS=1
+MAX_SHARDS=16
+MAX_CPUS_PER_SERVER=64
+MEMORY_MIB_PER_SHARD_WARNING=2048
+SHARDS=4
+CPUS_PER_SERVER=2
+ALLOW_EXTERNAL_INTEGRATIONS=0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SEED_SCRIPT="${REPO_ROOT}/e2e/docker/seed.sh"
+COMPOSE_FILE="${REPO_ROOT}/e2e/docker/compose.yml"
+PROJECT_FILE="${REPO_ROOT}/Jellyfin.Plugin.JellyfinCanopy/JellyfinCanopy.csproj"
+PLUGIN_DLL="${REPO_ROOT}/Jellyfin.Plugin.JellyfinCanopy/bin/Release/net10.0/Jellyfin.Plugin.JellyfinCanopy.dll"
+
+RUN_ID=''
+STATE_ROOT=''
+RESULT_ROOT=''
+ADMIN_USER=''
+ADMIN_PASS=''
+USER_NAME=''
+USER_PASS=''
+CLEANUP_STARTED=0
+
+declare -a PROJECTS=()
+declare -a STATE_DIRS=()
+declare -a RESULT_DIRS=()
+declare -a BASE_URLS=()
+declare -a SEED_PIDS=()
+declare -a TEST_PIDS=()
+declare -a SEED_STATUS=()
+declare -a TEST_STATUS=()
+declare -a CLEANUP_STATUS=()
+
+log() {
+    printf '[local-e2e] %s\n' "$*"
+}
+
+warn() {
+    printf '[local-e2e] WARNING: %s\n' "$*" >&2
+}
+
+die() {
+    printf '[local-e2e] ERROR: %s\n' "$*" >&2
+    exit 2
+}
+
+usage() {
+    cat <<'EOF'
+Usage: npm run e2e:local -- [options]
+
+Run the complete Playwright inventory across isolated local Jellyfin servers.
+
+Options:
+  --shards N                    Native Playwright shard count (1..16; default 4)
+  --cpus-per-server N           CPU quota for each Jellyfin server (1..64; default 2)
+  --allow-external-integrations Forward TMDB_* and SEERR_* environment variables
+  -h, --help                    Show this help
+
+The 2-CPU default is the official local parity profile. Higher CPU quotas are
+exploratory and make timing evidence less comparable to constrained runners.
+Results and logs are retained under e2e/test-results/local-<run-id>/.
+Treat retained failure logs, screenshots and results as sensitive local-only artifacts.
+Runner credentials are random per run and become unusable after successful teardown.
+Playwright traces are disabled; password-bearing files are removed and random
+usernames are redacted from text diagnostics before the runner exits.
+
+This runner is Linux-only and requires host ffmpeg plus GNU setsid and timeout
+for process-group signal handling and bounded Docker cleanup.
+EOF
+}
+
+require_option_value() {
+    local option="$1"
+    local count="$2"
+    (( count >= 2 )) || die "${option} requires a value"
+}
+
+parse_args() {
+    while (( $# > 0 )); do
+        case "$1" in
+            --shards)
+                require_option_value "$1" "$#"
+                SHARDS="$2"
+                shift 2
+                ;;
+            --shards=*)
+                SHARDS="${1#*=}"
+                shift
+                ;;
+            --cpus-per-server)
+                require_option_value "$1" "$#"
+                CPUS_PER_SERVER="$2"
+                shift 2
+                ;;
+            --cpus-per-server=*)
+                CPUS_PER_SERVER="${1#*=}"
+                shift
+                ;;
+            --allow-external-integrations)
+                ALLOW_EXTERNAL_INTEGRATIONS=1
+                shift
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            *)
+                die "unknown option: $1"
+                ;;
+        esac
+    done
+
+    [[ "${SHARDS}" =~ ^[0-9]+$ ]] || die "--shards must be an integer from ${MIN_SHARDS} to ${MAX_SHARDS}"
+    SHARDS=$((10#${SHARDS}))
+    (( SHARDS >= MIN_SHARDS && SHARDS <= MAX_SHARDS )) \
+        || die "--shards must be an integer from ${MIN_SHARDS} to ${MAX_SHARDS}"
+
+    [[ "${CPUS_PER_SERVER}" =~ ^[0-9]+$ ]] \
+        || die "--cpus-per-server must be an integer from 1 to ${MAX_CPUS_PER_SERVER}"
+    CPUS_PER_SERVER=$((10#${CPUS_PER_SERVER}))
+    (( CPUS_PER_SERVER >= 1 && CPUS_PER_SERVER <= MAX_CPUS_PER_SERVER )) \
+        || die "--cpus-per-server must be an integer from 1 to ${MAX_CPUS_PER_SERVER}"
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+preflight() {
+    local command_name
+    for command_name in awk cat date docker dotnet ffmpeg find grep jq mktemp npm od realpath sed setsid stat timeout tr uname; do
+        require_command "${command_name}"
+    done
+    [[ "$(uname -s)" == Linux ]] || die "local sharding is Linux-only (GNU setsid/timeout are required)"
+    [[ -f "${SEED_SCRIPT}" ]] || die "seed script not found: ${SEED_SCRIPT}"
+    [[ -f "${COMPOSE_FILE}" ]] || die "Compose file not found: ${COMPOSE_FILE}"
+    [[ -f "${PROJECT_FILE}" ]] || die "plugin project not found: ${PROJECT_FILE}"
+    docker compose version >/dev/null 2>&1 || die "Docker Compose v2 is required"
+    docker info >/dev/null 2>&1 || die "Docker daemon is unavailable"
+}
+
+random_hex() {
+    local byte_count="$1"
+    od -An -N "${byte_count}" -tx1 /dev/urandom | tr -d ' \n'
+}
+
+initialize_run() {
+    local timestamp token attempt
+    timestamp="$(date -u +%Y%m%dt%H%M%Sz)"
+    mkdir -p "${REPO_ROOT}/e2e/test-results" \
+        || die "could not create the local E2E result parent"
+
+    for attempt in 1 2 3 4 5; do
+        token="$(random_hex 6)" || die "could not generate a random run id"
+        [[ "${#token}" -eq 12 ]] || die "random run id generation returned incomplete data"
+        RUN_ID="${timestamp}-${token}"
+        RESULT_ROOT="${REPO_ROOT}/e2e/test-results/local-${RUN_ID}"
+        if mkdir "${RESULT_ROOT}" 2>/dev/null; then
+            break
+        fi
+        RUN_ID=''
+    done
+    [[ -n "${RUN_ID}" ]] || die "could not allocate a unique result directory"
+
+    STATE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/jc-e2e-${RUN_ID}.XXXXXX")" \
+        || die "could not allocate an isolated state root"
+    STATE_ROOT="$(realpath -e -- "${STATE_ROOT}")" \
+        || die "could not canonicalize the isolated state root"
+    printf '%s\n' "${RUN_ID}" > "${STATE_ROOT}/.jc-local-e2e-owner" \
+        || die "could not write the runner ownership marker"
+
+    local credential_token username_token
+    credential_token="$(random_hex 12)" || die "could not generate runner credentials"
+    [[ "${#credential_token}" -eq 24 ]] \
+        || die "runner credential generation returned incomplete data"
+    username_token="$(random_hex 8)" || die "could not generate runner usernames"
+    [[ "${#username_token}" -eq 16 ]] \
+        || die "runner username generation returned incomplete data"
+    ADMIN_USER="jc_admin_${username_token}"
+    USER_NAME="jc_user_${username_token}"
+    ADMIN_PASS="Jc-${credential_token}-A9!"
+    USER_PASS="Jc-$(random_hex 12)-U9!" || die "could not generate runner credentials"
+    [[ "${#USER_PASS}" -eq 31 ]] \
+        || die "runner credential generation returned incomplete data"
+
+    local shard
+    for (( shard = 1; shard <= SHARDS; shard++ )); do
+        PROJECTS[shard]="jc-e2e-${RUN_ID}-s${shard}"
+        STATE_DIRS[shard]="${STATE_ROOT}/shard-${shard}"
+        RESULT_DIRS[shard]="${RESULT_ROOT}/shard-${shard}"
+        SEED_STATUS[shard]=125
+        TEST_STATUS[shard]=125
+        mkdir -p "${STATE_DIRS[shard]}" "${RESULT_DIRS[shard]}/playwright" \
+            || die "could not allocate state/results for shard ${shard}"
+    done
+}
+
+sanitize_external_environment() {
+    (( ALLOW_EXTERNAL_INTEGRATIONS == 0 )) || return 0
+
+    local name
+    while IFS= read -r name; do
+        unset "${name}"
+    done < <(compgen -A variable TMDB_; compgen -A variable SEERR_)
+}
+
+host_cpu_count() {
+    local count=''
+    count="$(getconf _NPROCESSORS_ONLN 2>/dev/null || true)"
+    if [[ ! "${count}" =~ ^[1-9][0-9]*$ ]] && command -v nproc >/dev/null 2>&1; then
+        count="$(nproc 2>/dev/null || true)"
+    fi
+    [[ "${count}" =~ ^[1-9][0-9]*$ ]] && printf '%s\n' "${count}"
+}
+
+host_memory_mib() {
+    [[ -r /proc/meminfo ]] || return 0
+    awk '$1 == "MemAvailable:" { print int($2 / 1024); exit }' /proc/meminfo 2>/dev/null || true
+}
+
+host_swap_used_mib() {
+    [[ -r /proc/meminfo ]] || return 0
+    awk '
+        $1 == "SwapTotal:" { total = $2 }
+        $1 == "SwapFree:" { free = $2 }
+        END { if (total > free) print int((total - free) / 1024) }
+    ' /proc/meminfo 2>/dev/null || true
+}
+
+print_resource_plan() {
+    local total_cpus host_cpus available_mib planned_mib swap_used_mib
+    total_cpus=$((SHARDS * CPUS_PER_SERVER))
+    host_cpus="$(host_cpu_count)"
+    available_mib="$(host_memory_mib)"
+    planned_mib=$((SHARDS * MEMORY_MIB_PER_SHARD_WARNING))
+    swap_used_mib="$(host_swap_used_mib)"
+
+    log "plan: ${SHARDS} isolated server(s) x ${CPUS_PER_SERVER} CPU(s) = ${total_cpus} maximum Jellyfin server CPU threads"
+    log "the build, Chromium and bounded host ffmpeg work run outside those server quotas"
+    log "memory guard: ${planned_mib} MiB suggested available (${MEMORY_MIB_PER_SHARD_WARNING} MiB per server/browser shard)"
+    if (( CPUS_PER_SERVER != 2 )); then
+        warn "${CPUS_PER_SERVER} CPUs/server is exploratory; official parity evidence uses exactly 2"
+    fi
+    if (( SHARDS > 4 )); then
+        warn "${SHARDS} shards start ${SHARDS} complete Jellyfin servers; monitor memory as well as CPU"
+    fi
+    if [[ -n "${host_cpus}" ]] && (( total_cpus > host_cpus )); then
+        warn "planned CPU quota (${total_cpus}) exceeds ${host_cpus} detected logical host CPUs"
+    fi
+    if [[ "${available_mib}" =~ ^[0-9]+$ ]] && (( available_mib < planned_mib )); then
+        warn "only ${available_mib} MiB MemAvailable; ${planned_mib} MiB is suggested for ${SHARDS} server/browser shards"
+    fi
+    if [[ "${swap_used_mib}" =~ ^[1-9][0-9]*$ ]]; then
+        warn "host already has ${swap_used_mib} MiB of swap in use; parallel E2E may increase swap pressure"
+    fi
+    if (( ALLOW_EXTERNAL_INTEGRATIONS == 1 )); then
+        warn "external TMDB/Seerr integration variables are explicitly enabled for this run"
+    else
+        log "external TMDB_* and SEERR_* variables are removed from the runner environment"
+    fi
+}
+
+terminate_active_jobs() {
+    local pid attempt alive
+    for pid in "${SEED_PIDS[@]:-}" "${TEST_PIDS[@]:-}"; do
+        [[ "${pid}" =~ ^[1-9][0-9]*$ ]] || continue
+        if kill -0 -- "-${pid}" >/dev/null 2>&1; then
+            kill -TERM -- "-${pid}" >/dev/null 2>&1 || true
+        fi
+    done
+
+    for (( attempt = 1; attempt <= 20; attempt++ )); do
+        alive=0
+        for pid in "${SEED_PIDS[@]:-}" "${TEST_PIDS[@]:-}"; do
+            [[ "${pid}" =~ ^[1-9][0-9]*$ ]] || continue
+            if kill -0 -- "-${pid}" >/dev/null 2>&1; then
+                alive=1
+            fi
+        done
+        (( alive == 1 )) || break
+        sleep 0.1
+    done
+
+    for pid in "${SEED_PIDS[@]:-}" "${TEST_PIDS[@]:-}"; do
+        [[ "${pid}" =~ ^[1-9][0-9]*$ ]] || continue
+        if kill -0 -- "-${pid}" >/dev/null 2>&1; then
+            kill -KILL -- "-${pid}" >/dev/null 2>&1 || true
+        fi
+        wait "${pid}" >/dev/null 2>&1 || true
+    done
+}
+
+collect_and_teardown_shard() {
+    local shard="$1"
+    local result_dir="${RESULT_DIRS[shard]}"
+    local cleanup_tmp="${result_dir}/cleanup-result.json.tmp"
+    local cleanup_result="${result_dir}/cleanup-result.json"
+    local logs_status down_status marker_status=0
+
+    timeout --signal=KILL 20s env \
+        JF_E2E_PROJECT="${PROJECTS[shard]}" \
+        JF_E2E_STATE_DIR="${STATE_DIRS[shard]}" \
+        JF_CONFIG_DIR="${STATE_DIRS[shard]}/config" \
+        JF_CACHE_DIR="${STATE_DIRS[shard]}/cache" \
+        JF_MEDIA_DIR="${STATE_DIRS[shard]}/media" \
+        JF_BIND_ADDRESS=127.0.0.1 \
+        JF_PORT=0 \
+        JF_CPUS="${CPUS_PER_SERVER}" \
+        docker compose -f "${COMPOSE_FILE}" --project-name "${PROJECTS[shard]}" \
+        logs --no-color jellyfin \
+        > "${result_dir}/jellyfin.log" 2>&1
+    logs_status=$?
+
+    run_compose_down() {
+        timeout --signal=KILL 30s env \
+            JF_E2E_PROJECT="${PROJECTS[shard]}" \
+            JF_E2E_STATE_DIR="${STATE_DIRS[shard]}" \
+            JF_CONFIG_DIR="${STATE_DIRS[shard]}/config" \
+            JF_CACHE_DIR="${STATE_DIRS[shard]}/cache" \
+            JF_MEDIA_DIR="${STATE_DIRS[shard]}/media" \
+            JF_BIND_ADDRESS=127.0.0.1 \
+            JF_PORT=0 \
+            JF_CPUS="${CPUS_PER_SERVER}" \
+            docker compose -f "${COMPOSE_FILE}" --project-name "${PROJECTS[shard]}" \
+            down -v --remove-orphans --timeout 10
+    }
+    run_compose_down >> "${result_dir}/cleanup.log" 2>&1
+    down_status=$?
+    if (( down_status != 0 )); then
+        printf 'first Compose teardown exited %s; retrying once\n' "${down_status}" \
+            >> "${result_dir}/cleanup.log"
+        run_compose_down >> "${result_dir}/cleanup.log" 2>&1
+        down_status=$?
+    fi
+
+    jq -n \
+        --arg runId "${RUN_ID}" \
+        --arg project "${PROJECTS[shard]}" \
+        --argjson shard "${shard}" \
+        --argjson total "${SHARDS}" \
+        --argjson logsExit "${logs_status}" \
+        --argjson downExit "${down_status}" \
+        '{
+            runId: $runId,
+            shard: $shard,
+            total: $total,
+            project: $project,
+            logsExit: $logsExit,
+            downExit: $downExit
+        }' > "${cleanup_tmp}" \
+        && mv "${cleanup_tmp}" "${cleanup_result}" \
+        || marker_status=1
+
+    (( down_status == 0 && marker_status == 0 ))
+}
+
+write_cleanup_summary_atomic() {
+    local summary_tmp="${RESULT_ROOT}/cleanup-summary.txt.tmp"
+    local summary="${RESULT_ROOT}/cleanup-summary.txt"
+    local shard cleanup_result logs_status down_status result_dir
+
+    {
+        printf 'Cleanup results for local Jellyfin E2E run %s\n' "${RUN_ID}"
+        printf '\n%-10s %-12s %-12s %s\n' 'Shard' 'Logs exit' 'Down exit' 'Marker'
+        for (( shard = 1; shard <= SHARDS; shard++ )); do
+            result_dir="${RESULT_DIRS[shard]:-}"
+            cleanup_result="${result_dir}/cleanup-result.json"
+            if [[ -n "${result_dir}" && -f "${cleanup_result}" ]]; then
+                logs_status="$(jq -r '.logsExit' "${cleanup_result}" 2>/dev/null || printf invalid)"
+                down_status="$(jq -r '.downExit' "${cleanup_result}" 2>/dev/null || printf invalid)"
+                printf '%-10s %-12s %-12s %s\n' \
+                    "${shard}/${SHARDS}" "${logs_status}" "${down_status}" "${cleanup_result}"
+            else
+                printf '%-10s %-12s %-12s %s\n' \
+                    "${shard}/${SHARDS}" 'missing' 'missing' 'missing'
+            fi
+        done
+    } > "${summary_tmp}" && mv "${summary_tmp}" "${summary}"
+}
+
+scrub_runner_credentials() {
+    local file password username status password_found username_found
+    local removed=0 redacted=0 redacted_tmp
+    local summary_tmp="${RESULT_ROOT}/credential-scrub-summary.txt.tmp"
+    local summary="${RESULT_ROOT}/credential-scrub-summary.txt"
+    local file_list="${RESULT_ROOT}/.credential-scrub-files.tmp"
+    local -a passwords=("${ADMIN_PASS}" "${USER_PASS}")
+    local -a usernames=("${ADMIN_USER}" "${USER_NAME}")
+    local -a sed_args=()
+
+    for username in "${usernames[@]}"; do
+        [[ -n "${username}" ]] || continue
+        sed_args+=(-e "s|${username}|[REDACTED-RUNNER-USER]|g")
+    done
+
+    : > "${summary_tmp}" || return 1
+    find "${RESULT_ROOT}" -type f -print0 > "${file_list}" || return 1
+    while IFS= read -r -d '' file; do
+        [[ "${file}" != "${summary_tmp}" && "${file}" != "${file_list}" ]] || continue
+        password_found=0
+        for password in "${passwords[@]}"; do
+            [[ -n "${password}" ]] || continue
+            if LC_ALL=C grep -aFq -- "${password}" "${file}"; then
+                password_found=1
+                break
+            else
+                status=$?
+                (( status == 1 )) || return 1
+            fi
+        done
+        if (( password_found == 1 )); then
+            printf 'removed %s\n' "${file#"${RESULT_ROOT}/"}" >> "${summary_tmp}" \
+                || return 1
+            rm -f -- "${file}" || return 1
+            removed=$((removed + 1))
+            continue
+        fi
+
+        username_found=0
+        for username in "${usernames[@]}"; do
+            [[ -n "${username}" ]] || continue
+            if LC_ALL=C grep -aFq -- "${username}" "${file}"; then
+                username_found=1
+                break
+            else
+                status=$?
+                (( status == 1 )) || return 1
+            fi
+        done
+        if (( username_found == 1 )); then
+            if LC_ALL=C grep -Iq . "${file}"; then
+                redacted_tmp="${file}.redacted.tmp"
+                if ! LC_ALL=C sed "${sed_args[@]}" -- "${file}" > "${redacted_tmp}"; then
+                    rm -f -- "${redacted_tmp}" "${file}"
+                    return 1
+                fi
+                mv -- "${redacted_tmp}" "${file}" || {
+                    rm -f -- "${redacted_tmp}" "${file}"
+                    return 1
+                }
+                printf 'redacted %s\n' "${file#"${RESULT_ROOT}/"}" >> "${summary_tmp}" \
+                    || return 1
+                redacted=$((redacted + 1))
+            else
+                printf 'removed-binary %s\n' "${file#"${RESULT_ROOT}/"}" \
+                    >> "${summary_tmp}" || return 1
+                rm -f -- "${file}" || return 1
+                removed=$((removed + 1))
+            fi
+        fi
+    done < "${file_list}"
+    rm -f -- "${file_list}" || return 1
+    if (( removed == 0 && redacted == 0 )); then
+        printf 'No retained file contained a runner username or password.\n' \
+            >> "${summary_tmp}" || return 1
+    elif (( removed > 0 )); then
+        warn "removed ${removed} retained artifact(s) containing a runner password or binary username"
+    fi
+    if (( redacted > 0 )); then
+        log "redacted runner usernames from ${redacted} retained diagnostic artifact(s)"
+    fi
+    mv "${summary_tmp}" "${summary}"
+}
+
+cleanup() {
+    local original_status=$?
+    (( CLEANUP_STARTED == 0 )) || return
+    CLEANUP_STARTED=1
+    trap - EXIT
+    trap '' INT TERM
+
+    terminate_active_jobs
+
+    if [[ -n "${RESULT_ROOT}" ]]; then
+        log "collecting server logs and tearing down runner-owned Compose projects"
+    fi
+
+    local shard result_dir cleanup_failed=0
+    local -a cleanup_pids=()
+    for (( shard = 1; shard <= SHARDS; shard++ )); do
+        [[ -n "${PROJECTS[shard]:-}" ]] || continue
+        result_dir="${RESULT_DIRS[shard]}"
+        mkdir -p "${result_dir}"
+        collect_and_teardown_shard "${shard}" &
+        cleanup_pids[shard]=$!
+    done
+    for (( shard = 1; shard <= SHARDS; shard++ )); do
+        [[ -n "${cleanup_pids[shard]:-}" ]] || continue
+        if wait "${cleanup_pids[shard]}"; then
+            CLEANUP_STATUS[shard]=0
+        else
+            CLEANUP_STATUS[shard]=$?
+            cleanup_failed=1
+            warn "cleanup failed for shard ${shard}/${SHARDS}; see ${RESULT_DIRS[shard]}/cleanup.log"
+            warn "manual recovery: docker compose --project-name '${PROJECTS[shard]}' --file '${COMPOSE_FILE}' down -v --remove-orphans"
+        fi
+    done
+    if (( ${#cleanup_pids[@]} > 0 )); then
+        write_cleanup_summary_atomic || cleanup_failed=1
+    fi
+    if [[ -n "${RESULT_ROOT}" ]]; then
+        scrub_runner_credentials || {
+            cleanup_failed=1
+            warn "could not verify retained artifacts are free of runner credentials"
+        }
+    fi
+
+    if [[ -n "${STATE_ROOT}" ]]; then
+        local owner_marker="${STATE_ROOT}/.jc-local-e2e-owner"
+        local owner_value=''
+        if [[ ! -f "${owner_marker}" ]] \
+            || ! owner_value="$(cat -- "${owner_marker}" 2>/dev/null)" \
+            || [[ "${owner_value}" != "${RUN_ID}" ]]; then
+            cleanup_failed=1
+            warn "retaining state because the runner ownership marker is missing, unreadable or mismatched: ${STATE_ROOT}"
+        elif (( cleanup_failed != 0 )); then
+            warn "retaining state after cleanup failure: ${STATE_ROOT}"
+        elif ! rm -rf -- "${STATE_ROOT}"; then
+            cleanup_failed=1
+            warn "could not fully remove runner-owned state: ${STATE_ROOT}"
+        fi
+    fi
+
+    if [[ -n "${RESULT_ROOT}" ]]; then
+        log "retained results: ${RESULT_ROOT}"
+    fi
+    if (( cleanup_failed != 0 && original_status == 0 )); then
+        original_status=1
+    fi
+    exit "${original_status}"
+}
+
+handle_signal() {
+    local exit_code="$1"
+    local signal_name="$2"
+    warn "received ${signal_name}; stopping runner-owned shard processes"
+    exit "${exit_code}"
+}
+
+build_plugin_once() {
+    log "building the Release plugin once for all shards"
+    (
+        cd "${REPO_ROOT}"
+        dotnet build "${PROJECT_FILE}" -c Release
+    ) 2>&1 | tee "${RESULT_ROOT}/build.log"
+    local build_status=${PIPESTATUS[0]}
+    (( build_status == 0 )) || return "${build_status}"
+    [[ -f "${PLUGIN_DLL}" ]] || {
+        warn "build succeeded but plugin DLL is missing: ${PLUGIN_DLL}"
+        return 1
+    }
+}
+
+start_seed_jobs() {
+    local shard
+    log "starting ${SHARDS} isolated seed jobs in parallel"
+    for (( shard = 1; shard <= SHARDS; shard++ )); do
+        (
+            export JF_E2E_PROJECT="${PROJECTS[shard]}"
+            export JF_E2E_STATE_DIR="${STATE_DIRS[shard]}"
+            export JF_BIND_ADDRESS=127.0.0.1
+            export JF_PORT=0
+            export JF_CPUS="${CPUS_PER_SERVER}"
+            export JF_FFMPEG_THREADS=2
+            export JF_E2E_SEED_ID="${RUN_ID}-shard-${shard}"
+            export JF_ADMIN_USER="${ADMIN_USER}"
+            export JF_ADMIN_PASS="${ADMIN_PASS}"
+            export JF_USER_NAME="${USER_NAME}"
+            export JF_USER_PASS="${USER_PASS}"
+            export PLUGIN_DLL="${PLUGIN_DLL}"
+            exec setsid --wait bash "${SEED_SCRIPT}"
+        ) > "${RESULT_DIRS[shard]}/seed.log" 2>&1 &
+        SEED_PIDS[shard]=$!
+        log "seed shard ${shard}/${SHARDS} started (project ${PROJECTS[shard]})"
+    done
+}
+
+validate_seed_result() {
+    local shard="$1"
+    local result_file="${STATE_DIRS[shard]}/seed-result.json"
+    local base_url port project cpus
+
+    [[ -f "${result_file}" ]] || {
+        warn "shard ${shard} did not write ${result_file}"
+        return 1
+    }
+    cp "${result_file}" "${RESULT_DIRS[shard]}/seed-result.json"
+
+    base_url="$(jq -er '.baseUrl | select(type == "string" and length > 0)' "${result_file}" 2>/dev/null)" || return 1
+    port="$(jq -er '.port | tostring' "${result_file}" 2>/dev/null)" || return 1
+    project="$(jq -er '.project | select(type == "string" and length > 0)' "${result_file}" 2>/dev/null)" || return 1
+    cpus="$(jq -er '.cpus | tostring' "${result_file}" 2>/dev/null)" || return 1
+
+    [[ "${port}" =~ ^[1-9][0-9]*$ ]] && (( port <= 65535 )) || return 1
+    [[ "${project}" == "${PROJECTS[shard]}" ]] || return 1
+    [[ "${cpus}" == "${CPUS_PER_SERVER}" ]] || return 1
+    [[ "${base_url}" == "http://127.0.0.1:${port}" ]] || return 1
+
+    BASE_URLS[shard]="${base_url}"
+}
+
+wait_for_seed_jobs() {
+    local shard pid status
+    for (( shard = 1; shard <= SHARDS; shard++ )); do
+        pid="${SEED_PIDS[shard]}"
+        if wait "${pid}"; then
+            status=0
+        else
+            status=$?
+        fi
+        SEED_PIDS[shard]=''
+
+        if (( status == 0 )) && validate_seed_result "${shard}"; then
+            SEED_STATUS[shard]=0
+            log "seed shard ${shard}/${SHARDS} ready at ${BASE_URLS[shard]}"
+        else
+            (( status != 0 )) || status=1
+            SEED_STATUS[shard]="${status}"
+            warn "seed shard ${shard}/${SHARDS} failed (exit ${status}); see ${RESULT_DIRS[shard]}/seed.log"
+        fi
+    done
+}
+
+start_test_jobs() {
+    local shard output_dir
+    log "starting Playwright for every successfully seeded shard"
+    for (( shard = 1; shard <= SHARDS; shard++ )); do
+        (( SEED_STATUS[shard] == 0 )) || continue
+        output_dir="${RESULT_DIRS[shard]}/playwright"
+        (
+            export JF_BASE_URL="${BASE_URLS[shard]}"
+            export JF_ADMIN_USER="${ADMIN_USER}"
+            export JF_ADMIN_PASS="${ADMIN_PASS}"
+            export JF_USER_NAME="${USER_NAME}"
+            export JF_USER_PASS="${USER_PASS}"
+            export JF_E2E_PROJECT="${PROJECTS[shard]}"
+            export JF_E2E_STATE_DIR="${STATE_DIRS[shard]}"
+            export JF_E2E_OUTPUT_DIR="${output_dir}"
+            export JF_E2E_TRACE=off
+            exec setsid --wait npm --prefix "${REPO_ROOT}" run e2e -- \
+                --shard="${shard}/${SHARDS}" --output="${output_dir}"
+        ) > "${RESULT_DIRS[shard]}/playwright.log" 2>&1 &
+        TEST_PIDS[shard]=$!
+        log "test shard ${shard}/${SHARDS} started"
+    done
+}
+
+wait_for_test_jobs() {
+    local shard pid status
+    for (( shard = 1; shard <= SHARDS; shard++ )); do
+        pid="${TEST_PIDS[shard]:-}"
+        if [[ -z "${pid}" ]]; then
+            TEST_STATUS[shard]=125
+            continue
+        fi
+        if wait "${pid}"; then
+            status=0
+        else
+            status=$?
+        fi
+        TEST_PIDS[shard]=''
+        TEST_STATUS[shard]="${status}"
+        if (( status == 0 )); then
+            log "test shard ${shard}/${SHARDS} passed"
+        else
+            warn "test shard ${shard}/${SHARDS} failed (exit ${status}); see ${RESULT_DIRS[shard]}/playwright.log"
+        fi
+    done
+}
+
+write_shard_marker() {
+    local shard="$1"
+    local marker="${RESULT_DIRS[shard]}/shard-result.json"
+    local marker_tmp="${marker}.tmp"
+
+    jq -n \
+        --arg runId "${RUN_ID}" \
+        --arg project "${PROJECTS[shard]}" \
+        --arg baseUrl "${BASE_URLS[shard]:-}" \
+        --argjson shard "${shard}" \
+        --argjson total "${SHARDS}" \
+        --argjson cpusPerServer "${CPUS_PER_SERVER}" \
+        --argjson seedExit "${SEED_STATUS[shard]}" \
+        --argjson testExit "${TEST_STATUS[shard]}" \
+        '{
+            runId: $runId,
+            shard: $shard,
+            total: $total,
+            project: $project,
+            baseUrl: $baseUrl,
+            cpusPerServer: $cpusPerServer,
+            seedExit: $seedExit,
+            testExit: $testExit
+        }' > "${marker_tmp}" \
+        && mv "${marker_tmp}" "${marker}"
+}
+
+write_shard_markers() {
+    local shard failed=0
+    for (( shard = 1; shard <= SHARDS; shard++ )); do
+        if ! write_shard_marker "${shard}"; then
+            failed=1
+            warn "could not write atomic result marker for shard ${shard}/${SHARDS}"
+        fi
+    done
+    return "${failed}"
+}
+
+validate_shard_markers() {
+    local shard marker
+    local -a markers=()
+    mapfile -t markers < <(
+        find "${RESULT_ROOT}" -mindepth 2 -maxdepth 2 -type f -name shard-result.json -print
+    )
+    if (( ${#markers[@]} != SHARDS )); then
+        warn "expected exactly ${SHARDS} shard result markers, found ${#markers[@]}"
+        return 1
+    fi
+
+    for (( shard = 1; shard <= SHARDS; shard++ )); do
+        marker="${RESULT_DIRS[shard]}/shard-result.json"
+        [[ -f "${marker}" ]] || {
+            warn "missing shard result marker: ${marker}"
+            return 1
+        }
+        jq -e \
+            --arg runId "${RUN_ID}" \
+            --arg project "${PROJECTS[shard]}" \
+            --argjson shard "${shard}" \
+            --argjson total "${SHARDS}" \
+            --argjson cpusPerServer "${CPUS_PER_SERVER}" \
+            --argjson seedExit "${SEED_STATUS[shard]}" \
+            --argjson testExit "${TEST_STATUS[shard]}" \
+            '.runId == $runId
+             and .project == $project
+             and .shard == $shard
+             and .total == $total
+             and .cpusPerServer == $cpusPerServer
+             and .seedExit == $seedExit
+             and .testExit == $testExit' \
+            "${marker}" >/dev/null || {
+                warn "invalid or stale shard result marker: ${marker}"
+                return 1
+            }
+    done
+}
+
+write_summary() {
+    local overall=0 shard test_display
+    local summary_tmp="${RESULT_ROOT}/summary.txt.tmp"
+    local summary="${RESULT_ROOT}/summary.txt"
+    validate_shard_markers || overall=1
+    for (( shard = 1; shard <= SHARDS; shard++ )); do
+        if (( SEED_STATUS[shard] != 0 || TEST_STATUS[shard] != 0 )); then
+            overall=1
+        fi
+    done
+
+    {
+        printf 'Local Jellyfin E2E run %s\n' "${RUN_ID}"
+        printf 'Shards: %s; CPUs/server: %s; maximum Jellyfin server CPU threads: %s\n' \
+            "${SHARDS}" "${CPUS_PER_SERVER}" "$((SHARDS * CPUS_PER_SERVER))"
+        printf '\n%-10s %-10s %-10s %s\n' 'Shard' 'Seed' 'Tests' 'Base URL'
+        for (( shard = 1; shard <= SHARDS; shard++ )); do
+            test_display="${TEST_STATUS[shard]}"
+            if (( SEED_STATUS[shard] != 0 )); then
+                test_display='not-run'
+            fi
+            printf '%-10s %-10s %-10s %s\n' \
+                "${shard}/${SHARDS}" "${SEED_STATUS[shard]}" "${test_display}" "${BASE_URLS[shard]:-—}"
+        done
+    } > "${summary_tmp}" && mv "${summary_tmp}" "${summary}" || overall=1
+    [[ -f "${summary}" ]] && cat "${summary}"
+    return "${overall}"
+}
+
+main() {
+    parse_args "$@"
+    preflight
+    # Job-control process groups would make setsid fork away from the PID we
+    # track. Disable them so each --wait process owns the exact negative PGID.
+    set +m
+    trap 'cleanup' EXIT
+    trap 'handle_signal 130 INT' INT
+    trap 'handle_signal 143 TERM' TERM
+    initialize_run
+
+    sanitize_external_environment
+    print_resource_plan
+    log "run id: ${RUN_ID}"
+    log "results: ${RESULT_ROOT}"
+
+    build_plugin_once || {
+        warn "plugin build failed; no shard servers were started"
+        return 1
+    }
+
+    start_seed_jobs
+    wait_for_seed_jobs
+    start_test_jobs
+    wait_for_test_jobs
+    write_shard_markers || true
+    write_summary
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/scripts/e2e/workflow-sharding.test.js
+++ b/scripts/e2e/workflow-sharding.test.js
@@ -22,6 +22,7 @@ test('E2E uses four native file shards with one fresh serial server each', () =>
 
     assert.match(shard, /strategy:\n\s+fail-fast: false\n\s+max-parallel: 4/);
     assert.match(shard, /matrix:\n\s+shard: \[1, 2, 3, 4\]/);
+    assert.match(shard, /JF_BASE_URL: http:\/\/127\.0\.0\.1:8100/);
     assert.match(shard, /id: seed\n\s+run: bash e2e\/docker\/seed\.sh/);
     assert.match(
         shard,
@@ -29,6 +30,11 @@ test('E2E uses four native file shards with one fresh serial server each', () =>
     );
     assert.doesNotMatch(shard, /npm run e2e[^\n]*(--grep|\.spec\.ts)/);
     assert.match(shard, /name: Tear down\n\s+if: always\(\)/);
+    assert.match(
+        shard,
+        /name: Server logs on failure[\s\S]*docker compose -f e2e\/docker\/compose\.yml logs --no-color --tail 200 jellyfin/
+    );
+    assert.doesNotMatch(shard, /docker logs jc-e2e-jellyfin/);
 
     assert.match(playwrightConfig, /workers:\s*1/);
     assert.match(playwrightConfig, /fullyParallel:\s*false/);


### PR DESCRIPTION
## Summary

- add an optional local sharded E2E runner (4 shards by default, configurable up to 16)
- keep each Jellyfin server at the official 2-CPU parity limit by default
- isolate Compose projects, ports, state, credentials, Playwright outputs, and cleanup per shard
- bind disposable Jellyfin servers to loopback by default and fail closed for unsafe non-loopback credentials
- preserve the historical single-server Compose project while making its limits and paths configurable
- document local resource sizing, artifact sensitivity, and exploratory overrides

Closes #201.
Closes #202.
Coordinates with #203 for the independently tracked login-recovery flakes observed during live validation.

## Verification

- `npm run test:scripts`: 126/126 passing
- `npm run typecheck:src`: passing
- `npm run build:bundle`: passing (184 modules)
- changed/new JavaScript strict ESLint: 0 warnings, 0 errors
- repository lint: 0 errors (6,576 existing advisory warnings, within the established cap)
- strict MkDocs build: passing
- shell syntax and `git diff --check`: passing
- independent Fable 5 review completed; all actionable findings fixed and revalidated

## Live Docker evidence

Final four-shard run `20260713t183339z-43f7b10fcc0a` completed in about 3m22s:

- four isolated Jellyfin servers, each reporting `NanoCpus=2000000000`
- loopback-only dynamic ports `32772`–`32775`
- all seed, test, and cleanup phases exited 0
- 52 clean passes, 16 skips, and 3 advisory flaky passes (tracked in #203)
- exact 41-container host inventory unchanged before/after
- server logs retained with generated usernames redacted
- no generated credentials or trace archives remained in artifacts
- about 13 GiB host memory remained available during the run

## Security and compatibility

- credentials are passed through a private environment, not process arguments
- final artifacts delete password-bearing files and redact generated usernames
- cleanup is constrained by ownership markers and exact Compose project names
- external integrations are scrubbed unless explicitly enabled
- the historical default Compose project remains `docker`, avoiding unsafe state migration for existing users
