### PR TITLE
Preserve Arr tags on incomplete snapshots

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Configuration/PluginConfigurationArrInstancesTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Configuration/PluginConfigurationArrInstancesTests.cs
@@ -122,6 +122,62 @@ public class PluginConfigurationArrInstancesTests
     }
 
     [Fact]
+    public void InvalidEnabledRows_AreReportedSeparatelyFromFilteredValidRows()
+    {
+        var config = NewConfig();
+        config.RadarrInstances = """
+            [
+                {"Name":"Good","Url":"http://radarr:7878","ApiKey":"key","Enabled":true},
+                {"Name":"Broken","Url":"","ApiKey":"missing-url","Enabled":true},
+                {"Name":"Disabled broken","Url":"","ApiKey":"","Enabled":false}
+            ]
+            """;
+
+        Assert.Single(config.GetEnabledRadarrInstances());
+        Assert.True(config.HasInvalidEnabledRadarrInstances());
+        Assert.False(config.IsRadarrInstancesCorrupt());
+    }
+
+    [Fact]
+    public void InvalidDisabledRows_DoNotMakeAuthoritativeSourceSetIncomplete()
+    {
+        var config = NewConfig();
+        config.SonarrInstances =
+            """[{"Name":"Disabled broken","Url":"","ApiKey":"","Enabled":false}]""";
+
+        Assert.False(config.HasInvalidEnabledSonarrInstances());
+        Assert.False(config.IsSonarrInstancesCorrupt());
+    }
+
+    [Fact]
+    public void AuthoritativeSnapshot_DoesNotReviveLegacySourceBehindStoredDisabledRows()
+    {
+        var config = NewConfig();
+        config.RadarrInstances =
+            """[{"Name":"Disabled broken","Url":"","ApiKey":"","Enabled":false}]""";
+        config.RadarrUrl = "http://legacy:7878";
+        config.RadarrApiKey = "legacy-key";
+
+        // General config migration behavior remains backward-compatible, while a destructive
+        // snapshot honors the explicit modern source set and sees no enabled sources.
+        Assert.Single(config.GetEnabledRadarrInstances());
+        Assert.Empty(config.GetEnabledRadarrInstancesForAuthoritativeSnapshot());
+    }
+
+    [Fact]
+    public void TopLevelNullInstanceJson_IsCorruptAndCannotReviveLegacySource()
+    {
+        var config = NewConfig();
+        config.SonarrInstances = "null";
+        config.SonarrUrl = "http://legacy:8989";
+        config.SonarrApiKey = "legacy-key";
+
+        Assert.True(config.IsSonarrInstancesCorrupt());
+        Assert.Empty(config.GetEnabledSonarrInstancesForAuthoritativeSnapshot());
+        Assert.Empty(config.GetSonarrInstances());
+    }
+
+    [Fact]
     public void GetRadarrInstances_MirrorsSonarrSemantics()
     {
         var config = NewConfig();

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/ScheduledTasks/ArrTagsSyncSafetyTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/ScheduledTasks/ArrTagsSyncSafetyTests.cs
@@ -1,0 +1,851 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Text;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Entities;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.ScheduledTasks;
+
+/// <summary>
+/// Regression coverage for BI-DATA-007: an incomplete Arr fetch is not an authoritative empty
+/// snapshot and must never clear previously acknowledged Jellyfin metadata.
+/// </summary>
+public sealed class ArrTagsSyncSafetyTests
+{
+    private const string RadarrOne =
+        """[{"Name":"one","Url":"http://localhost:7878","ApiKey":"key-1","Enabled":true}]""";
+
+    private static PluginConfiguration CreateConfig() => new()
+    {
+        ArrTagsSyncEnabled = true,
+        ArrTagsClearOldTags = true,
+        RadarrInstances = "[]",
+        SonarrInstances = "[]",
+    };
+
+    private static ArrTagsSyncTask CreateTask(
+        PluginConfiguration config,
+        CountingLibraryManager library,
+        HttpMessageHandler handler,
+        List<BaseItem> writes,
+        ILogger<ArrTagsSyncTask>? logger = null,
+        List<WriteObservation>? writeObservations = null,
+        Func<BaseItem, ItemUpdateType, CancellationToken, Task>? updateItem = null)
+        => new(
+            library,
+            new RecordingHttpClientFactory(handler),
+            logger ?? NullLogger<ArrTagsSyncTask>.Instance,
+            new FakePluginConfigProvider(config),
+            updateItem ?? ((item, updateType, token) =>
+            {
+                writes.Add(item);
+                writeObservations?.Add(new WriteObservation(item, updateType, token));
+                return Task.CompletedTask;
+            }));
+
+    [Fact]
+    public async Task SoleRadarrFailure_PreservesTagsWithoutLibraryScanOrWrite()
+    {
+        var config = CreateConfig();
+        config.RadarrInstances = RadarrOne;
+
+        var movie = MovieWithTmdb(100, "ordinary", "JC Arr Tag: old");
+        var scans = 0;
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = _ =>
+            {
+                scans++;
+                return new BaseItem[] { movie };
+            },
+        };
+        var handler = new RecordingHttpMessageHandler();
+        handler.AddResponse("/api/v3/tag", "boom", HttpStatusCode.InternalServerError);
+        var writes = new List<BaseItem>();
+        var logger = new CapturingLogger();
+        var progress = new SynchronousProgress<double>();
+        var task = CreateTask(config, library, handler, writes, logger);
+
+        await task.ExecuteAsync(progress, CancellationToken.None);
+
+        Assert.Equal(0, scans);
+        Assert.Empty(writes);
+        Assert.Equal(new[] { "ordinary", "JC Arr Tag: old" }, movie.Tags);
+        Assert.Single(handler.Requests);
+        Assert.Contains(logger.Entries, entry => entry.Level == LogLevel.Warning
+            && entry.Message.Contains("incomplete", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(logger.Entries, entry => entry.Level == LogLevel.Warning
+            && entry.Message.Contains("preserved", StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(100, progress.Values[^1]);
+    }
+
+    [Fact]
+    public async Task PartialRadarrFailure_DoesNotPublishSuccessfulInstanceAsAuthoritative()
+    {
+        var config = CreateConfig();
+        config.RadarrInstances = """
+            [
+              {"Name":"complete","Url":"http://localhost:7878","ApiKey":"key-1","Enabled":true},
+              {"Name":"failed","Url":"http://localhost:7879","ApiKey":"key-2","Enabled":true}
+            ]
+            """;
+
+        var movie = MovieWithTmdb(100, "ordinary", "JC Arr Tag: from-failed-instance");
+        var scans = 0;
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = _ =>
+            {
+                scans++;
+                return new BaseItem[] { movie };
+            },
+        };
+        var writes = new List<BaseItem>();
+        var handler = new StrictArrHandler();
+        handler.Add(7878, "/api/v3/tag", """[{"id":1,"label":"complete"}]""");
+        handler.Add(7878, "/api/v3/movie", """[{"id":10,"tmdbId":100,"tags":[1]}]""");
+        handler.Add(7879, "/api/v3/tag", "boom", HttpStatusCode.InternalServerError);
+        var task = CreateTask(config, library, handler, writes);
+
+        await task.ExecuteAsync(new SynchronousProgress<double>(), CancellationToken.None);
+
+        Assert.Equal(0, scans);
+        Assert.Empty(writes);
+        Assert.Contains("JC Arr Tag: from-failed-instance", movie.Tags);
+        Assert.Equal(
+            new[]
+            {
+                (7878, "/api/v3/tag"),
+                (7878, "/api/v3/movie"),
+                (7879, "/api/v3/tag"),
+            },
+            handler.Requests);
+    }
+
+    [Theory]
+    [InlineData("[{not json")]
+    [InlineData("""[{"Name":"off","Url":"http://localhost:7878","ApiKey":"key","Enabled":false}]""")]
+    public async Task CorruptOrDisabledSources_AreNoOp(string radarrInstances)
+    {
+        var config = CreateConfig();
+        config.RadarrInstances = radarrInstances;
+        var scans = 0;
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = _ =>
+            {
+                scans++;
+                return Array.Empty<BaseItem>();
+            },
+        };
+        var handler = new RecordingHttpMessageHandler();
+        var writes = new List<BaseItem>();
+        var logger = new CapturingLogger();
+        var task = CreateTask(config, library, handler, writes, logger);
+
+        await task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
+
+        Assert.Equal(0, scans);
+        Assert.Empty(writes);
+        Assert.Empty(handler.Requests);
+        if (radarrInstances.StartsWith("[{not", StringComparison.Ordinal))
+        {
+            Assert.Contains(logger.Entries, entry => entry.Level == LogLevel.Error
+                && entry.Message.Contains("corrupt", StringComparison.OrdinalIgnoreCase));
+        }
+    }
+
+    [Fact]
+    public async Task CompleteEmptySnapshot_RemovesOnlyOwnedTagsInOneWrite()
+    {
+        var config = CreateConfig();
+        config.RadarrInstances = RadarrOne;
+        var movie = MovieWithTmdb(100, "ordinary", "JC Arr Tag: old", "another");
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = _ => new BaseItem[] { movie },
+        };
+        var handler = new RecordingHttpMessageHandler();
+        handler.AddResponse("/api/v3/tag", "[]");
+        handler.AddResponse("/api/v3/movie", "[]");
+        var writes = new List<BaseItem>();
+        var observations = new List<WriteObservation>();
+        var logger = new CapturingLogger();
+        using var cts = new CancellationTokenSource();
+        var task = CreateTask(config, library, handler, writes, logger, observations);
+
+        await task.ExecuteAsync(new SynchronousProgress<double>(), cts.Token);
+
+        Assert.Same(movie, Assert.Single(writes));
+        var write = Assert.Single(observations);
+        Assert.Same(movie, write.Item);
+        Assert.Equal(ItemUpdateType.MetadataEdit, write.UpdateType);
+        Assert.Equal(cts.Token, write.Token);
+        Assert.Equal(new[] { "ordinary", "another" }, movie.Tags);
+        Assert.Contains(logger.Entries, entry => entry.Level == LogLevel.Information
+            && entry.Message.Contains("completed", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task IdenticalCompleteSnapshot_PerformsNoRepositoryWrite()
+    {
+        var config = CreateConfig();
+        config.RadarrInstances = RadarrOne;
+        var movie = MovieWithTmdb(100, "JC Arr Tag: old", "ordinary");
+        var scans = 0;
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = _ =>
+            {
+                scans++;
+                return new BaseItem[] { movie };
+            },
+        };
+        var handler = new RecordingHttpMessageHandler();
+        handler.AddResponse("/api/v3/tag", """[{"id":1,"label":"old"}]""");
+        handler.AddResponse("/api/v3/movie", """[{"id":10,"tmdbId":100,"tags":[1]}]""");
+        var writes = new List<BaseItem>();
+        var task = CreateTask(config, library, handler, writes);
+
+        await task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
+
+        Assert.Empty(writes);
+        Assert.Equal(1, scans);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal(new[] { "JC Arr Tag: old", "ordinary" }, movie.Tags);
+    }
+
+    [Fact]
+    public async Task FailedRadarrSnapshot_DoesNotBlockCompleteSonarrReconciliation()
+    {
+        var config = CreateConfig();
+        config.RadarrInstances = RadarrOne;
+        config.SonarrInstances =
+            """[{"Name":"tv","Url":"http://localhost:8989","ApiKey":"key-tv","Enabled":true}]""";
+
+        var movie = MovieWithTmdb(100, "JC Arr Tag: preserve-me");
+        var series = new StubSeries { Name = "Series", Tags = new[] { "ordinary", "JC Arr Tag: stale" } };
+        series.ProviderIds["Tvdb"] = "500";
+        var scans = 0;
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = _ =>
+            {
+                scans++;
+                return new BaseItem[] { movie, series };
+            },
+        };
+        var writes = new List<BaseItem>();
+        var handler = new StrictArrHandler();
+        handler.Add(7878, "/api/v3/tag", "boom", HttpStatusCode.ServiceUnavailable);
+        handler.Add(8989, "/api/v3/tag", """[{"id":1,"label":"fresh"}]""");
+        handler.Add(8989, "/api/v3/series", """[{"id":20,"tvdbId":500,"tags":[1]}]""");
+        var task = CreateTask(config, library, handler, writes);
+
+        await task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
+
+        Assert.Equal(1, scans);
+        Assert.Same(series, Assert.Single(writes));
+        Assert.Equal(new[] { "JC Arr Tag: preserve-me" }, movie.Tags);
+        Assert.Equal(new[] { "ordinary", "JC Arr Tag: fresh" }, series.Tags);
+        Assert.Equal(
+            new[]
+            {
+                (7878, "/api/v3/tag"),
+                (8989, "/api/v3/tag"),
+                (8989, "/api/v3/series"),
+            },
+            handler.Requests);
+    }
+
+    [Fact]
+    public async Task Cancellation_PreventsFetchAndReconciliation()
+    {
+        var config = CreateConfig();
+        config.RadarrInstances = RadarrOne;
+        var scans = 0;
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = _ =>
+            {
+                scans++;
+                return Array.Empty<BaseItem>();
+            },
+        };
+        var handler = new RecordingHttpMessageHandler();
+        var writes = new List<BaseItem>();
+        var task = CreateTask(config, library, handler, writes);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => task.ExecuteAsync(new Progress<double>(), cts.Token));
+
+        Assert.Equal(0, scans);
+        Assert.Empty(writes);
+        Assert.Empty(handler.Requests);
+    }
+
+    [Fact]
+    public async Task CancellationAfterSuccessfulInstance_DoesNotPublishAccumulatedPartialSnapshot()
+    {
+        var config = CreateConfig();
+        config.RadarrInstances = """
+            [
+              {"Name":"complete","Url":"http://localhost:7878","ApiKey":"key-1","Enabled":true},
+              {"Name":"cancel","Url":"http://localhost:7879","ApiKey":"key-2","Enabled":true}
+            ]
+            """;
+        var movie = MovieWithTmdb(100, "ordinary", "JC Arr Tag: preserve");
+        var scans = 0;
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = _ =>
+            {
+                scans++;
+                return new BaseItem[] { movie };
+            },
+        };
+        using var cts = new CancellationTokenSource();
+        var handler = new StrictArrHandler();
+        handler.Add(7878, "/api/v3/tag", """[{"id":1,"label":"complete"}]""");
+        handler.Add(7878, "/api/v3/movie", """[{"id":10,"tmdbId":100,"tags":[1]}]""");
+        handler.Add(7879, "/api/v3/tag", token =>
+        {
+            cts.Cancel();
+            return Task.FromCanceled<HttpResponseMessage>(token);
+        });
+        var writes = new List<BaseItem>();
+        var logger = new CapturingLogger();
+        var progress = new SynchronousProgress<double>();
+        var task = CreateTask(config, library, handler, writes, logger);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => task.ExecuteAsync(progress, cts.Token));
+
+        Assert.Equal(0, scans);
+        Assert.Empty(writes);
+        Assert.Equal(new[] { "ordinary", "JC Arr Tag: preserve" }, movie.Tags);
+        Assert.Equal(
+            new[]
+            {
+                (7878, "/api/v3/tag"),
+                (7878, "/api/v3/movie"),
+                (7879, "/api/v3/tag"),
+            },
+            handler.Requests);
+        Assert.DoesNotContain(100, progress.Values);
+        Assert.Contains(logger.Entries, entry => entry.Level == LogLevel.Information
+            && entry.Message.Contains("cancellation requested", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task CancellationDuringEmptyLibraryScan_DoesNotReportSuccess()
+    {
+        var config = CreateConfig();
+        config.RadarrInstances = RadarrOne;
+        using var cts = new CancellationTokenSource();
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = _ =>
+            {
+                cts.Cancel();
+                return Array.Empty<BaseItem>();
+            },
+        };
+        var handler = new StrictArrHandler();
+        handler.Add(7878, "/api/v3/tag", "[]");
+        handler.Add(7878, "/api/v3/movie", "[]");
+        var writes = new List<BaseItem>();
+        var logger = new CapturingLogger();
+        var progress = new SynchronousProgress<double>();
+        var task = CreateTask(config, library, handler, writes, logger);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => task.ExecuteAsync(progress, cts.Token));
+
+        Assert.Empty(writes);
+        Assert.DoesNotContain(100, progress.Values);
+        Assert.Contains(logger.Entries, entry => entry.Level == LogLevel.Information
+            && entry.Message.Contains("cancellation requested", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task PartialSonarrFailure_DoesNotPublishSuccessfulInstanceAsAuthoritative()
+    {
+        var config = CreateConfig();
+        config.SonarrInstances = """
+            [
+              {"Name":"complete","Url":"http://localhost:8989","ApiKey":"key-1","Enabled":true},
+              {"Name":"failed","Url":"http://localhost:8990","ApiKey":"key-2","Enabled":true}
+            ]
+            """;
+        var series = new StubSeries { Name = "Series", Tags = new[] { "ordinary", "JC Arr Tag: preserve" } };
+        series.ProviderIds[MetadataProvider.Tvdb.ToString()] = "500";
+        var scans = 0;
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = _ =>
+            {
+                scans++;
+                return new BaseItem[] { series };
+            },
+        };
+        var handler = new StrictArrHandler();
+        handler.Add(8989, "/api/v3/tag", """[{"id":1,"label":"complete"}]""");
+        handler.Add(8989, "/api/v3/series", """[{"id":20,"tvdbId":500,"tags":[1]}]""");
+        handler.Add(8990, "/api/v3/tag", "boom", HttpStatusCode.InternalServerError);
+        var writes = new List<BaseItem>();
+        var task = CreateTask(config, library, handler, writes);
+
+        await task.ExecuteAsync(new SynchronousProgress<double>(), CancellationToken.None);
+
+        Assert.Equal(0, scans);
+        Assert.Empty(writes);
+        Assert.Equal(new[] { "ordinary", "JC Arr Tag: preserve" }, series.Tags);
+        Assert.Equal(
+            new[]
+            {
+                (8989, "/api/v3/tag"),
+                (8989, "/api/v3/series"),
+                (8990, "/api/v3/tag"),
+            },
+            handler.Requests);
+    }
+
+    [Theory]
+    [InlineData("[{not json")]
+    [InlineData("[{\"Name\":\"off\",\"Url\":\"http://localhost:8989\",\"ApiKey\":\"key\",\"Enabled\":false}]")]
+    public async Task CorruptOrDisabledSonarrSources_AreNoOp(string sonarrInstances)
+    {
+        var config = CreateConfig();
+        config.SonarrInstances = sonarrInstances;
+        var scans = 0;
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = _ =>
+            {
+                scans++;
+                return Array.Empty<BaseItem>();
+            },
+        };
+        var handler = new StrictArrHandler();
+        var writes = new List<BaseItem>();
+        var task = CreateTask(config, library, handler, writes);
+
+        await task.ExecuteAsync(new SynchronousProgress<double>(), CancellationToken.None);
+
+        Assert.Equal(0, scans);
+        Assert.Empty(writes);
+        Assert.Empty(handler.Requests);
+    }
+
+    [Fact]
+    public async Task CompleteEmptySonarrSnapshot_RemovesOnlyOwnedSeriesTags()
+    {
+        var config = CreateConfig();
+        config.SonarrInstances =
+            """[{"Name":"tv","Url":"http://localhost:8989","ApiKey":"key","Enabled":true}]""";
+        var series = new StubSeries { Name = "Series", Tags = new[] { "ordinary", "JC Arr Tag: old" } };
+        series.ProviderIds[MetadataProvider.Tvdb.ToString()] = "500";
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = _ => new BaseItem[] { series },
+        };
+        var handler = new StrictArrHandler();
+        handler.Add(8989, "/api/v3/tag", "[]");
+        handler.Add(8989, "/api/v3/series", "[]");
+        var writes = new List<BaseItem>();
+        var task = CreateTask(config, library, handler, writes);
+
+        await task.ExecuteAsync(new SynchronousProgress<double>(), CancellationToken.None);
+
+        Assert.Same(series, Assert.Single(writes));
+        Assert.Equal(new[] { "ordinary" }, series.Tags);
+    }
+
+    [Fact]
+    public async Task FailedSonarrSnapshot_DoesNotBlockCompleteRadarrReconciliation()
+    {
+        var config = CreateConfig();
+        config.RadarrInstances = RadarrOne;
+        config.SonarrInstances =
+            """[{"Name":"tv","Url":"http://localhost:8989","ApiKey":"key","Enabled":true}]""";
+        var movie = MovieWithTmdb(100, "ordinary", "JC Arr Tag: stale");
+        var series = new StubSeries { Name = "Series", Tags = new[] { "JC Arr Tag: preserve" } };
+        series.ProviderIds[MetadataProvider.Tvdb.ToString()] = "500";
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = _ => new BaseItem[] { movie, series },
+        };
+        var handler = new StrictArrHandler();
+        handler.Add(7878, "/api/v3/tag", """[{"id":1,"label":"fresh"}]""");
+        handler.Add(7878, "/api/v3/movie", """[{"id":10,"tmdbId":100,"tags":[1]}]""");
+        handler.Add(8989, "/api/v3/tag", "boom", HttpStatusCode.ServiceUnavailable);
+        var writes = new List<BaseItem>();
+        var task = CreateTask(config, library, handler, writes);
+
+        await task.ExecuteAsync(new SynchronousProgress<double>(), CancellationToken.None);
+
+        Assert.Same(movie, Assert.Single(writes));
+        Assert.Equal(new[] { "ordinary", "JC Arr Tag: fresh" }, movie.Tags);
+        Assert.Equal(new[] { "JC Arr Tag: preserve" }, series.Tags);
+    }
+
+    [Fact]
+    public async Task InvalidEnabledConfigRow_MakesSuccessfulSubsetNonAuthoritative()
+    {
+        var config = CreateConfig();
+        config.RadarrInstances = """
+            [
+              {"Name":"good","Url":"http://localhost:7878","ApiKey":"key","Enabled":true},
+              {"Name":"broken","Url":"","ApiKey":"key","Enabled":true}
+            ]
+            """;
+        var movie = MovieWithTmdb(100, "JC Arr Tag: preserve");
+        var scans = 0;
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = _ =>
+            {
+                scans++;
+                return new BaseItem[] { movie };
+            },
+        };
+        var handler = new StrictArrHandler();
+        handler.Add(7878, "/api/v3/tag", """[{"id":1,"label":"good"}]""");
+        handler.Add(7878, "/api/v3/movie", """[{"id":10,"tmdbId":100,"tags":[1]}]""");
+        var writes = new List<BaseItem>();
+        var task = CreateTask(config, library, handler, writes);
+
+        await task.ExecuteAsync(new SynchronousProgress<double>(), CancellationToken.None);
+
+        Assert.Equal(0, scans);
+        Assert.Empty(writes);
+        Assert.Equal(new[] { "JC Arr Tag: preserve" }, movie.Tags);
+        Assert.Equal(new[] { (7878, "/api/v3/tag"), (7878, "/api/v3/movie") }, handler.Requests);
+    }
+
+    [Fact]
+    public async Task DisabledModernRows_DoNotReviveLegacySourceForDestructiveSync()
+    {
+        var config = CreateConfig();
+        config.RadarrInstances =
+            """[{"Name":"off","Url":"","ApiKey":"","Enabled":false}]""";
+        config.RadarrUrl = "http://localhost:7878";
+        config.RadarrApiKey = "legacy-key";
+        var scans = 0;
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = _ =>
+            {
+                scans++;
+                return Array.Empty<BaseItem>();
+            },
+        };
+        var handler = new StrictArrHandler();
+        var writes = new List<BaseItem>();
+        var task = CreateTask(config, library, handler, writes);
+
+        await task.ExecuteAsync(new SynchronousProgress<double>(), CancellationToken.None);
+
+        Assert.Equal(0, scans);
+        Assert.Empty(writes);
+        Assert.Empty(handler.Requests);
+    }
+
+    [Fact]
+    public async Task CompleteSnapshot_PreservesOwnedTagsOnLocalItemWithoutUsableProviderId()
+    {
+        var config = CreateConfig();
+        config.RadarrInstances = RadarrOne;
+        var movie = new StubMovie { Name = "Unkeyed", Tags = new[] { "ordinary", "JC Arr Tag: preserve" } };
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = _ => new BaseItem[] { movie },
+        };
+        var handler = new StrictArrHandler();
+        handler.Add(7878, "/api/v3/tag", "[]");
+        handler.Add(7878, "/api/v3/movie", "[]");
+        var writes = new List<BaseItem>();
+        var task = CreateTask(config, library, handler, writes);
+
+        await task.ExecuteAsync(new SynchronousProgress<double>(), CancellationToken.None);
+
+        Assert.Empty(writes);
+        Assert.Equal(new[] { "ordinary", "JC Arr Tag: preserve" }, movie.Tags);
+    }
+
+    [Fact]
+    public async Task UpstreamMovieWithoutCanonicalId_MakesSnapshotNonAuthoritative()
+    {
+        var config = CreateConfig();
+        config.RadarrInstances = RadarrOne;
+        var movie = MovieWithTmdb(100, "ordinary", "JC Arr Tag: preserve");
+        var scans = 0;
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = _ =>
+            {
+                scans++;
+                return new BaseItem[] { movie };
+            },
+        };
+        var handler = new StrictArrHandler();
+        handler.Add(7878, "/api/v3/tag", "[]");
+        handler.Add(7878, "/api/v3/movie", """[{"id":10,"tmdbId":0,"tags":[]}]""");
+        var writes = new List<BaseItem>();
+        var task = CreateTask(config, library, handler, writes);
+
+        await task.ExecuteAsync(new SynchronousProgress<double>(), CancellationToken.None);
+
+        Assert.Equal(0, scans);
+        Assert.Empty(writes);
+        Assert.Equal(new[] { "ordinary", "JC Arr Tag: preserve" }, movie.Tags);
+    }
+
+    [Fact]
+    public async Task CompleteSonarrSnapshot_PreservesUnmatchedLocalImdbOnlyItem()
+    {
+        var config = CreateConfig();
+        config.SonarrInstances =
+            """[{"Name":"tv","Url":"http://localhost:8989","ApiKey":"key","Enabled":true}]""";
+        var series = new StubSeries { Name = "IMDb only", Tags = new[] { "ordinary", "JC Arr Tag: preserve" } };
+        series.ProviderIds[MetadataProvider.Imdb.ToString()] = "tt500";
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = _ => new BaseItem[] { series },
+        };
+        var handler = new StrictArrHandler();
+        handler.Add(8989, "/api/v3/tag", "[]");
+        handler.Add(8989, "/api/v3/series", "[]");
+        var writes = new List<BaseItem>();
+        var task = CreateTask(config, library, handler, writes);
+
+        await task.ExecuteAsync(new SynchronousProgress<double>(), CancellationToken.None);
+
+        Assert.Empty(writes);
+        Assert.Equal(new[] { "ordinary", "JC Arr Tag: preserve" }, series.Tags);
+    }
+
+    [Fact]
+    public async Task FailedRepositoryWrite_RestoresLiveItemTagsAndRethrows()
+    {
+        var config = CreateConfig();
+        config.RadarrInstances = RadarrOne;
+        var movie = MovieWithTmdb(100, "ordinary", "JC Arr Tag: preserve");
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = _ => new BaseItem[] { movie },
+        };
+        var handler = new StrictArrHandler();
+        handler.Add(7878, "/api/v3/tag", "[]");
+        handler.Add(7878, "/api/v3/movie", "[]");
+        var writes = new List<BaseItem>();
+        var task = CreateTask(
+            config,
+            library,
+            handler,
+            writes,
+            updateItem: (_, _, _) => Task.FromException(new InvalidOperationException("write failed")));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => task.ExecuteAsync(new SynchronousProgress<double>(), CancellationToken.None));
+
+        Assert.Equal(new[] { "ordinary", "JC Arr Tag: preserve" }, movie.Tags);
+    }
+
+    [Fact]
+    public async Task CancellationDuringRepositoryWrite_RestoresLiveItemTagsAndHasNoTerminalProgress()
+    {
+        var config = CreateConfig();
+        config.RadarrInstances = RadarrOne;
+        var movie = MovieWithTmdb(100, "ordinary", "JC Arr Tag: preserve");
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = _ => new BaseItem[] { movie },
+        };
+        var handler = new StrictArrHandler();
+        handler.Add(7878, "/api/v3/tag", "[]");
+        handler.Add(7878, "/api/v3/movie", "[]");
+        using var cts = new CancellationTokenSource();
+        var writes = new List<BaseItem>();
+        var progress = new SynchronousProgress<double>();
+        var task = CreateTask(
+            config,
+            library,
+            handler,
+            writes,
+            updateItem: (_, _, token) =>
+            {
+                cts.Cancel();
+                return Task.FromCanceled(token);
+            });
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => task.ExecuteAsync(progress, cts.Token));
+
+        Assert.Equal(new[] { "ordinary", "JC Arr Tag: preserve" }, movie.Tags);
+        Assert.DoesNotContain(100, progress.Values);
+    }
+
+    [Theory]
+    [InlineData("keep\nsecond")]
+    [InlineData("keep\r\nsecond")]
+    [InlineData("keep,second")]
+    [InlineData("keep;second")]
+    public void ParseSyncFilter_AcceptsDocumentedLinesAndLegacySeparators(string configuredFilter)
+    {
+        var parsed = ArrTagsSyncTask.ParseSyncFilter(configuredFilter);
+
+        Assert.True(parsed.SetEquals(new[] { "keep", "second" }));
+    }
+
+    [Fact]
+    public async Task MultilineFilter_ReconcilesMatchingTagsWithoutClearingThemAll()
+    {
+        var config = CreateConfig();
+        config.RadarrInstances = RadarrOne;
+        config.ArrTagsSyncFilter = "keep\r\nsecond";
+        var movie = MovieWithTmdb(100, "ordinary", "JC Arr Tag: stale");
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = _ => new BaseItem[] { movie },
+        };
+        var handler = new StrictArrHandler();
+        handler.Add(7878, "/api/v3/tag",
+            """[{"id":1,"label":"keep"},{"id":2,"label":"second"},{"id":3,"label":"filtered"}]""");
+        handler.Add(7878, "/api/v3/movie", """[{"id":10,"tmdbId":100,"tags":[1,2,3]}]""");
+        var writes = new List<BaseItem>();
+        var task = CreateTask(config, library, handler, writes);
+
+        await task.ExecuteAsync(new SynchronousProgress<double>(), CancellationToken.None);
+
+        Assert.Same(movie, Assert.Single(writes));
+        Assert.Equal(new[] { "ordinary", "JC Arr Tag: keep", "JC Arr Tag: second" }, movie.Tags);
+    }
+
+    [Fact]
+    public void DesiredTags_ClearOld_UsesFilteredAuthoritativeSetWithoutTouchingOrdinaryTags()
+    {
+        var desired = ArrTagsSyncTask.BuildDesiredTags(
+            new[] { "ordinary", "JC Arr Tag: stale", "second" },
+            new[] { "keep", "filtered" },
+            "JC Arr Tag: ",
+            clearOldTags: true,
+            new HashSet<string>(new[] { "keep" }, StringComparer.OrdinalIgnoreCase));
+
+        Assert.Equal(new[] { "ordinary", "second", "JC Arr Tag: keep" }, desired);
+    }
+
+    [Fact]
+    public void TagComparison_IsOrderAndCaseInsensitiveButPreservesMultiplicity()
+    {
+        Assert.True(ArrTagsSyncTask.TagCollectionsEqual(
+            new[] { "ordinary", "JC Arr Tag: One" },
+            new[] { "jc arr tag: one", "ORDINARY" }));
+        Assert.False(ArrTagsSyncTask.TagCollectionsEqual(
+            new[] { "ordinary", "ordinary" },
+            new[] { "ordinary", "other" }));
+    }
+
+    private static StubMovie MovieWithTmdb(int tmdbId, params string[] tags)
+    {
+        var movie = new StubMovie { Name = "Movie", Tags = tags };
+        movie.ProviderIds[MetadataProvider.Tmdb.ToString()] = tmdbId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        return movie;
+    }
+
+    private sealed record WriteObservation(
+        BaseItem Item,
+        ItemUpdateType UpdateType,
+        CancellationToken Token);
+
+    private sealed class StrictArrHandler : HttpMessageHandler
+    {
+        private readonly Dictionary<(int Port, string Path), Func<CancellationToken, Task<HttpResponseMessage>>> _responses = new();
+
+        public List<(int Port, string Path)> Requests { get; } = new();
+
+        public void Add(
+            int port,
+            string path,
+            string body,
+            HttpStatusCode status = HttpStatusCode.OK)
+            => Add(port, path, _ => Respond(body, status));
+
+        public void Add(
+            int port,
+            string path,
+            Func<CancellationToken, Task<HttpResponseMessage>> response)
+            => _responses.Add((port, path), response);
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var key = (Port: request.RequestUri!.Port, Path: request.RequestUri.AbsolutePath);
+            Requests.Add(key);
+            if (!_responses.TryGetValue(key, out var response))
+            {
+                throw new InvalidOperationException($"Unexpected Arr request: {key.Port}{key.Path}");
+            }
+
+            return response(cancellationToken);
+        }
+    }
+
+    private sealed class SynchronousProgress<T> : IProgress<T>
+    {
+        public List<T> Values { get; } = new();
+
+        public void Report(T value) => Values.Add(value);
+    }
+
+    private sealed class CapturingLogger : ILogger<ArrTagsSyncTask>
+    {
+        private readonly ConcurrentQueue<LogEntry> _entries = new();
+
+        public IReadOnlyList<LogEntry> Entries => _entries.ToArray();
+
+        public IDisposable BeginScope<TState>(TState state)
+            where TState : notnull
+            => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => _entries.Enqueue(new LogEntry(logLevel, formatter(state, exception)));
+
+        private sealed class NullScope : IDisposable
+        {
+            public static NullScope Instance { get; } = new();
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+
+    private sealed record LogEntry(LogLevel Level, string Message);
+
+    private static Task<HttpResponseMessage> Respond(
+        string body,
+        HttpStatusCode status = HttpStatusCode.OK)
+        => Task.FromResult(new HttpResponseMessage(status)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json"),
+        });
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/ArrTagServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/ArrTagServiceTests.cs
@@ -18,7 +18,7 @@ public class ArrTagServiceTests
 {
     private readonly ILogger _logger = NullLogger.Instance;
 
-    private static ArrTagService CreateService(RecordingHttpMessageHandler handler, ILogger logger)
+    private static ArrTagService CreateService(HttpMessageHandler handler, ILogger logger)
         => new ArrTagService(new RecordingHttpClientFactory(handler), logger);
 
     // ─── SSRF guard ──────────────────────────────────────────────────────────
@@ -31,50 +31,60 @@ public class ArrTagServiceTests
     [InlineData("ftp://radarr.example.com")]              // non-http(s) scheme
     [InlineData("not a url")]
     [InlineData("")]
-    public async Task GetMovieTags_BlockedUrl_ReturnsEmptyWithoutAnyRequest(string url)
+    public async Task GetMovieTags_BlockedUrl_ReturnsFailedWithoutAnyRequest(string url)
     {
         var handler = new RecordingHttpMessageHandler();
         var service = CreateService(handler, _logger);
 
         var result = await service.GetMovieTagsByTmdbId(url, "key");
 
-        Assert.Empty(result);
+        Assert.False(result.IsComplete);
+        Assert.Empty(result.Value);
+        Assert.Equal("Radarr URL was rejected by the SSRF guard.", result.FailureReason);
+        if (!string.IsNullOrEmpty(url))
+        {
+            Assert.DoesNotContain(url, result.FailureReason, StringComparison.Ordinal);
+        }
+
+        Assert.DoesNotContain("key", result.FailureReason, StringComparison.Ordinal);
         Assert.Empty(handler.Requests); // guard must fire BEFORE any outbound call
     }
 
     [Fact]
-    public async Task GetSeriesTags_BlockedUrl_ReturnsEmptyWithoutAnyRequest()
+    public async Task GetSeriesTags_BlockedUrl_ReturnsFailedWithoutAnyRequest()
     {
         var handler = new RecordingHttpMessageHandler();
         var service = CreateService(handler, _logger);
 
         var result = await service.GetSeriesTagsAsync("http://169.254.169.254:8989", "key");
 
-        Assert.Empty(result.ByTvdbId);
-        Assert.Empty(result.ByImdbId);
+        Assert.False(result.IsComplete);
+        Assert.Empty(result.Value.ByTvdbId);
+        Assert.Empty(result.Value.ByImdbId);
+        Assert.Equal("Sonarr URL was rejected by the SSRF guard.", result.FailureReason);
         Assert.Empty(handler.Requests);
     }
 
     // ─── Endpoint + mapping behavior ─────────────────────────────────────────
 
     [Fact]
-    public async Task GetMovieTags_MapsLabelsByTmdbId_AndSkipsUnkeyedOrUntaggedItems()
+    public async Task GetMovieTags_MapsLabelsByTmdbId_AndSkipsUntaggedItems()
     {
         var handler = new RecordingHttpMessageHandler();
         handler.AddResponse("/api/v3/tag", """[{"id":1,"label":"alice"},{"id":2,"label":"bob"}]""");
         handler.AddResponse("/api/v3/movie", """
             [
               {"id":10,"title":"Keyed",     "tmdbId":100, "tags":[1,2]},
-              {"id":11,"title":"NoTmdb",    "tmdbId":0,   "tags":[1]},
-              {"id":12,"title":"NoTags",    "tmdbId":200, "tags":[]},
-              {"id":13,"title":"UnknownTag","tmdbId":300, "tags":[99]}
+              {"id":11,"title":"NoTags",    "tmdbId":200, "tags":[]}
             ]
             """);
         var service = CreateService(handler, _logger);
 
         var result = await service.GetMovieTagsByTmdbId("http://localhost:7878/", "api-key");
 
-        var only = Assert.Single(result);
+        Assert.True(result.IsComplete);
+        Assert.Null(result.FailureReason);
+        var only = Assert.Single(result.Value);
         Assert.Equal(100, only.Key);
         Assert.Equal(new[] { "alice", "bob" }, only.Value);
 
@@ -99,14 +109,17 @@ public class ArrTagServiceTests
 
         var result = await service.GetSeriesTagsAsync("http://localhost:8989", "api-key");
 
+        Assert.True(result.IsComplete);
+        Assert.Null(result.FailureReason);
+
         // TVDB is the canonical key: BOTH series map by TVDB, including the IMDb-less one
         // that the former IMDb-only keying silently dropped.
-        Assert.Equal(2, result.ByTvdbId.Count);
-        Assert.Equal(new[] { "alice" }, result.ByTvdbId[5000]);
-        Assert.Equal(new[] { "alice" }, result.ByTvdbId[5001]);
+        Assert.Equal(2, result.Value.ByTvdbId.Count);
+        Assert.Equal(new[] { "alice" }, result.Value.ByTvdbId[5000]);
+        Assert.Equal(new[] { "alice" }, result.Value.ByTvdbId[5001]);
 
         // The IMDb fallback map carries only the series that has an IMDb id.
-        var imdb = Assert.Single(result.ByImdbId);
+        var imdb = Assert.Single(result.Value.ByImdbId);
         Assert.Equal("tt0000001", imdb.Key);
         Assert.Equal(new[] { "alice" }, imdb.Value);
 
@@ -114,7 +127,46 @@ public class ArrTagServiceTests
     }
 
     [Fact]
-    public async Task GetMovieTags_TagEndpointFails_ReturnsEmptyAndSkipsMediaFetch()
+    public async Task GetMovieTags_DuplicateProviderIdentity_UnionsLabelsWithoutDroppingEitherEntry()
+    {
+        var handler = new RecordingHttpMessageHandler();
+        handler.AddResponse("/api/v3/tag", """[{"id":1,"label":"one"},{"id":2,"label":"two"}]""");
+        handler.AddResponse("/api/v3/movie", """
+            [
+              {"id":10,"tmdbId":100,"tags":[1]},
+              {"id":11,"tmdbId":100,"tags":[2]}
+            ]
+            """);
+        var service = CreateService(handler, _logger);
+
+        var result = await service.GetMovieTagsByTmdbId("http://localhost:7878", "key");
+
+        Assert.True(result.IsComplete);
+        Assert.Equal(new[] { "one", "two" }, Assert.Single(result.Value).Value);
+    }
+
+    [Fact]
+    public async Task GetSeriesTags_DuplicateProviderIdentity_UnionsLabelsInBothMaps()
+    {
+        var handler = new RecordingHttpMessageHandler();
+        handler.AddResponse("/api/v3/tag", """[{"id":1,"label":"one"},{"id":2,"label":"two"}]""");
+        handler.AddResponse("/api/v3/series", """
+            [
+              {"id":10,"tvdbId":500,"imdbId":"tt500","tags":[1]},
+              {"id":11,"tvdbId":500,"imdbId":"tt500","tags":[2]}
+            ]
+            """);
+        var service = CreateService(handler, _logger);
+
+        var result = await service.GetSeriesTagsAsync("http://localhost:8989", "key");
+
+        Assert.True(result.IsComplete);
+        Assert.Equal(new[] { "one", "two" }, result.Value.ByTvdbId[500]);
+        Assert.Equal(new[] { "one", "two" }, result.Value.ByImdbId["tt500"]);
+    }
+
+    [Fact]
+    public async Task GetMovieTags_TagEndpointReturns500_ReturnsFailedAndSkipsMediaFetch()
     {
         var handler = new RecordingHttpMessageHandler();
         handler.AddResponse("/api/v3/tag", "boom", HttpStatusCode.InternalServerError);
@@ -122,12 +174,29 @@ public class ArrTagServiceTests
 
         var result = await service.GetMovieTagsByTmdbId("http://localhost:7878", "key");
 
-        Assert.Empty(result);
+        Assert.False(result.IsComplete);
+        Assert.Empty(result.Value);
+        Assert.Equal("Radarr tag request returned HTTP 500.", result.FailureReason);
         Assert.Single(handler.Requests); // never reached /api/v3/movie
     }
 
     [Fact]
-    public async Task GetMovieTags_InvalidJson_ReturnsEmptyInsteadOfThrowing()
+    public async Task GetMovieTags_TagEndpointReturnsPartialContent_ReturnsFailedAndSkipsMediaFetch()
+    {
+        var handler = new RecordingHttpMessageHandler();
+        handler.AddResponse("/api/v3/tag", "[]", HttpStatusCode.PartialContent);
+        var service = CreateService(handler, _logger);
+
+        var result = await service.GetMovieTagsByTmdbId("http://localhost:7878", "key");
+
+        Assert.False(result.IsComplete);
+        Assert.Empty(result.Value);
+        Assert.Equal("Radarr tag request returned HTTP 206.", result.FailureReason);
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
+    public async Task GetMovieTags_InvalidJson_ReturnsFailedInsteadOfThrowing()
     {
         var handler = new RecordingHttpMessageHandler();
         handler.AddResponse("/api/v3/tag", "<html>not json</html>");
@@ -135,7 +204,284 @@ public class ArrTagServiceTests
 
         var result = await service.GetMovieTagsByTmdbId("http://localhost:7878", "key");
 
-        Assert.Empty(result);
+        Assert.False(result.IsComplete);
+        Assert.Empty(result.Value);
+        Assert.Equal("Radarr returned malformed JSON.", result.FailureReason);
+    }
+
+    [Fact]
+    public async Task GetMovieTags_ValidEmptyCollections_ReturnsCompleteEmptySnapshot()
+    {
+        var handler = new RecordingHttpMessageHandler();
+        handler.AddResponse("/api/v3/tag", "[]");
+        handler.AddResponse("/api/v3/movie", "[]");
+        var service = CreateService(handler, _logger);
+
+        var result = await service.GetMovieTagsByTmdbId("http://localhost:7878", "key");
+
+        Assert.True(result.IsComplete);
+        Assert.Empty(result.Value);
+        Assert.Null(result.FailureReason);
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task GetSeriesTags_ValidEmptyCollections_ReturnsCompleteEmptySnapshot()
+    {
+        var handler = new RecordingHttpMessageHandler();
+        handler.AddResponse("/api/v3/tag", "[]");
+        handler.AddResponse("/api/v3/series", "[]");
+        var service = CreateService(handler, _logger);
+
+        var result = await service.GetSeriesTagsAsync("http://localhost:8989", "key");
+
+        Assert.True(result.IsComplete);
+        Assert.Empty(result.Value.ByTvdbId);
+        Assert.Empty(result.Value.ByImdbId);
+        Assert.Null(result.FailureReason);
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task GetSeriesTags_MediaEndpointReturns500_ReturnsFailedEmptySnapshot()
+    {
+        var handler = new RecordingHttpMessageHandler();
+        handler.AddResponse("/api/v3/tag", "[]");
+        handler.AddResponse("/api/v3/series", "boom", HttpStatusCode.InternalServerError);
+        var service = CreateService(handler, _logger);
+
+        var result = await service.GetSeriesTagsAsync("http://localhost:8989", "key");
+
+        Assert.False(result.IsComplete);
+        Assert.Empty(result.Value.ByTvdbId);
+        Assert.Empty(result.Value.ByImdbId);
+        Assert.Equal("Sonarr series request returned HTTP 500.", result.FailureReason);
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task GetSeriesTags_MediaEndpointReturnsPartialContent_ReturnsFailedEmptySnapshot()
+    {
+        var handler = new RecordingHttpMessageHandler();
+        handler.AddResponse("/api/v3/tag", "[]");
+        handler.AddResponse("/api/v3/series", "[]", HttpStatusCode.PartialContent);
+        var service = CreateService(handler, _logger);
+
+        var result = await service.GetSeriesTagsAsync("http://localhost:8989", "key");
+
+        Assert.False(result.IsComplete);
+        Assert.Empty(result.Value.ByTvdbId);
+        Assert.Empty(result.Value.ByImdbId);
+        Assert.Equal("Sonarr series request returned HTTP 206.", result.FailureReason);
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Theory]
+    [InlineData("null")]
+    [InlineData("[null]")]
+    [InlineData("{}")]
+    public async Task GetMovieTags_NonCollectionJson_ReturnsFailedEmptySnapshot(string json)
+    {
+        var handler = new RecordingHttpMessageHandler();
+        handler.AddResponse("/api/v3/tag", json);
+        var service = CreateService(handler, _logger);
+
+        var result = await service.GetMovieTagsByTmdbId("http://localhost:7878", "key");
+
+        Assert.False(result.IsComplete);
+        Assert.Empty(result.Value);
+        Assert.Equal("Radarr returned malformed JSON.", result.FailureReason);
+        Assert.Single(handler.Requests);
+    }
+
+    [Theory]
+    [InlineData("[{\"id\":1}]", "Radarr returned malformed JSON.")]
+    [InlineData("[{\"id\":1,\"label\":null}]", "Radarr snapshot was inconsistent: tag entries require unique positive ids and non-blank labels.")]
+    [InlineData("[{\"id\":1,\"label\":\"\"}]", "Radarr snapshot was inconsistent: tag entries require unique positive ids and non-blank labels.")]
+    [InlineData("[{\"id\":1,\"label\":\"   \"}]", "Radarr snapshot was inconsistent: tag entries require unique positive ids and non-blank labels.")]
+    [InlineData("[{\"label\":\"missing-id\"}]", "Radarr returned malformed JSON.")]
+    [InlineData("[{\"id\":0,\"label\":\"invalid-id\"}]", "Radarr snapshot was inconsistent: tag entries require unique positive ids and non-blank labels.")]
+    public async Task GetMovieTags_InvalidTagEntry_ReturnsFailedEmptySnapshot(
+        string tagsJson,
+        string expectedFailureReason)
+    {
+        var handler = new RecordingHttpMessageHandler();
+        handler.AddResponse("/api/v3/tag", tagsJson);
+        var service = CreateService(handler, _logger);
+
+        var result = await service.GetMovieTagsByTmdbId("http://localhost:7878", "key");
+
+        Assert.False(result.IsComplete);
+        Assert.Empty(result.Value);
+        Assert.Equal(expectedFailureReason, result.FailureReason);
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
+    public async Task GetMovieTags_DuplicateTagId_ReturnsInconsistentSnapshot()
+    {
+        var handler = new RecordingHttpMessageHandler();
+        handler.AddResponse("/api/v3/tag",
+            """[{"id":1,"label":"one"},{"id":1,"label":"duplicate"}]""");
+        var service = CreateService(handler, _logger);
+
+        var result = await service.GetMovieTagsByTmdbId("http://localhost:7878", "key");
+
+        Assert.False(result.IsComplete);
+        Assert.Empty(result.Value);
+        Assert.Equal(
+            "Radarr snapshot was inconsistent: tag entries require unique positive ids and non-blank labels.",
+            result.FailureReason);
+        Assert.Single(handler.Requests);
+    }
+
+    [Theory]
+    [InlineData("[{\"id\":10,\"tmdbId\":100}]", "Radarr returned malformed JSON.")]
+    [InlineData("[{\"id\":10,\"tmdbId\":100,\"tags\":null}]", "Radarr snapshot was inconsistent: media entries require a non-null tags collection.")]
+    public async Task GetMovieTags_InvalidMediaTags_ReturnsFailedEmptySnapshot(
+        string mediaJson,
+        string expectedFailureReason)
+    {
+        var handler = new RecordingHttpMessageHandler();
+        handler.AddResponse("/api/v3/tag", "[]");
+        handler.AddResponse("/api/v3/movie", mediaJson);
+        var service = CreateService(handler, _logger);
+
+        var result = await service.GetMovieTagsByTmdbId("http://localhost:7878", "key");
+
+        Assert.False(result.IsComplete);
+        Assert.Empty(result.Value);
+        Assert.Equal(expectedFailureReason, result.FailureReason);
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task GetMovieTags_UnknownTagReference_ReturnsFailedEmptySnapshot()
+    {
+        var handler = new RecordingHttpMessageHandler();
+        handler.AddResponse("/api/v3/tag", """[{"id":1,"label":"known"}]""");
+        handler.AddResponse("/api/v3/movie", """[{"id":10,"tmdbId":100,"tags":[1,99]}]""");
+        var service = CreateService(handler, _logger);
+
+        var result = await service.GetMovieTagsByTmdbId("http://localhost:7878", "key");
+
+        Assert.False(result.IsComplete);
+        Assert.Empty(result.Value);
+        Assert.Equal(
+            "Radarr snapshot was inconsistent: media entries referenced an unknown tag id.",
+            result.FailureReason);
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Theory]
+    [InlineData("[{\"id\":10,\"tmdbId\":0,\"tags\":[1]}]")]
+    [InlineData("[{\"id\":10,\"tags\":[1]}]")]
+    [InlineData("[{\"id\":10,\"tmdbId\":0,\"tags\":[]}]")]
+    [InlineData("[{\"id\":10,\"tags\":[]}]")]
+    public async Task GetMovieTags_MovieWithoutTmdbId_ReturnsFailedEmptySnapshot(string mediaJson)
+    {
+        var handler = new RecordingHttpMessageHandler();
+        handler.AddResponse("/api/v3/tag", """[{"id":1,"label":"known"}]""");
+        handler.AddResponse("/api/v3/movie", mediaJson);
+        var service = CreateService(handler, _logger);
+
+        var result = await service.GetMovieTagsByTmdbId("http://localhost:7878", "key");
+
+        Assert.False(result.IsComplete);
+        Assert.Empty(result.Value);
+        Assert.Equal(
+            "Radarr snapshot was inconsistent: movie entries require a positive TMDB id.",
+            result.FailureReason);
+    }
+
+    [Theory]
+    [InlineData("[{\"id\":10,\"tvdbId\":0,\"imdbId\":null,\"tags\":[1]}]")]
+    [InlineData("[{\"id\":10,\"tvdbId\":0,\"imdbId\":\"tt0000010\",\"tags\":[1]}]")]
+    [InlineData("[{\"id\":10,\"tags\":[1]}]")]
+    [InlineData("[{\"id\":10,\"tvdbId\":0,\"imdbId\":\"tt0000010\",\"tags\":[]}]")]
+    [InlineData("[{\"id\":10,\"tags\":[]}]")]
+    public async Task GetSeriesTags_SeriesWithoutTvdbId_ReturnsFailedEmptySnapshot(string mediaJson)
+    {
+        var handler = new RecordingHttpMessageHandler();
+        handler.AddResponse("/api/v3/tag", """[{"id":1,"label":"known"}]""");
+        handler.AddResponse("/api/v3/series", mediaJson);
+        var service = CreateService(handler, _logger);
+
+        var result = await service.GetSeriesTagsAsync("http://localhost:8989", "key");
+
+        Assert.False(result.IsComplete);
+        Assert.Empty(result.Value.ByTvdbId);
+        Assert.Empty(result.Value.ByImdbId);
+        Assert.Equal(
+            "Sonarr snapshot was inconsistent: series entries require a positive TVDB id.",
+            result.FailureReason);
+    }
+
+    [Fact]
+    public async Task GetMovieTags_NetworkFailure_ReturnsFailedWithSafeReason()
+    {
+        var handler = new ExceptionHttpMessageHandler(new HttpRequestException("secret network detail"));
+        var service = CreateService(handler, _logger);
+
+        var result = await service.GetMovieTagsByTmdbId("http://localhost:7878", "api-secret");
+
+        Assert.False(result.IsComplete);
+        Assert.Empty(result.Value);
+        Assert.Equal("Radarr request failed.", result.FailureReason);
+        Assert.DoesNotContain("secret", result.FailureReason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task GetMovieTags_Timeout_ReturnsFailedWithSafeReason()
+    {
+        var handler = new ExceptionHttpMessageHandler(new TaskCanceledException("secret timeout detail"));
+        var service = CreateService(handler, _logger);
+
+        var result = await service.GetMovieTagsByTmdbId("http://localhost:7878", "api-secret");
+
+        Assert.False(result.IsComplete);
+        Assert.Empty(result.Value);
+        Assert.Equal("Radarr request timed out.", result.FailureReason);
+        Assert.DoesNotContain("secret", result.FailureReason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task GetMovieTags_UnexpectedFailure_ReturnsFailedWithSafeReason()
+    {
+        var handler = new ExceptionHttpMessageHandler(new InvalidOperationException("secret internal detail"));
+        var service = CreateService(handler, _logger);
+
+        var result = await service.GetMovieTagsByTmdbId("http://localhost:7878", "api-secret");
+
+        Assert.False(result.IsComplete);
+        Assert.Empty(result.Value);
+        Assert.Equal("Unexpected error while fetching Radarr tag snapshot.", result.FailureReason);
+        Assert.DoesNotContain("secret", result.FailureReason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task GetMovieTags_CallerCancellation_StillThrows()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var service = CreateService(new CancellationAwareHttpMessageHandler(), _logger);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => service.GetMovieTagsByTmdbId("http://localhost:7878", "key", cts.Token));
+    }
+
+    [Fact]
+    public async Task GetMovieTags_PreCancelledToken_StopsBeforeUrlPreflightOrRequest()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var handler = new RecordingHttpMessageHandler();
+        var service = CreateService(handler, _logger);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => service.GetMovieTagsByTmdbId("http://arr.example.test:7878", "key", cts.Token));
+
+        Assert.Empty(handler.Requests);
     }
 
     // ─── HTTP plumbing hygiene ───────────────────────────────────────────────
@@ -163,5 +509,31 @@ public class ArrTagServiceTests
         // Timeout deviation check: this service relies on the named client's
         // default (100s) rather than setting a shorter ad-hoc value.
         Assert.All(factory.CreatedClients, c => Assert.Equal(TimeSpan.FromSeconds(100), c.Timeout));
+    }
+
+    private sealed class ExceptionHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Exception _exception;
+
+        public ExceptionHttpMessageHandler(Exception exception)
+        {
+            _exception = exception;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+            => Task.FromException<HttpResponseMessage>(_exception);
+    }
+
+    private sealed class CancellationAwareHttpMessageHandler : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Configuration/PluginConfiguration.cs
@@ -892,10 +892,88 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Configuration
             return r == InstanceParseResult.Corrupt;
         }
 
+        /// <summary>
+        /// True when a non-disabled Sonarr row was discarded because it is null or lacks a URL
+        /// or API key. Fan-out readers may still use the valid rows, but destructive snapshot
+        /// consumers must not call that filtered subset authoritative.
+        /// </summary>
+        internal bool HasInvalidEnabledSonarrInstances()
+        {
+            _ = TryDeserializeInstances(SonarrInstances, out _, out var hasInvalidEnabledRows);
+            return hasInvalidEnabledRows;
+        }
+
+        /// <summary>Radarr counterpart to <see cref="HasInvalidEnabledSonarrInstances"/>.</summary>
+        internal bool HasInvalidEnabledRadarrInstances()
+        {
+            _ = TryDeserializeInstances(RadarrInstances, out _, out var hasInvalidEnabledRows);
+            return hasInvalidEnabledRows;
+        }
+
+        /// <summary>
+        /// Gets enabled Sonarr sources for a destructive snapshot. Unlike the general migration
+        /// helper, a nonempty modern array that filters to zero rows does not revive legacy fields;
+        /// those stored rows mean the admin supplied a modern source set, even when every row is
+        /// disabled or invalid.
+        /// </summary>
+        internal List<ArrInstance> GetEnabledSonarrInstancesForAuthoritativeSnapshot()
+            => GetSonarrInstancesForAuthoritativeSnapshot().Where(i => i.Enabled).ToList();
+
+        /// <summary>Radarr counterpart to <see cref="GetEnabledSonarrInstancesForAuthoritativeSnapshot"/>.</summary>
+        internal List<ArrInstance> GetEnabledRadarrInstancesForAuthoritativeSnapshot()
+            => GetRadarrInstancesForAuthoritativeSnapshot().Where(i => i.Enabled).ToList();
+
+        /// <summary>All usable Sonarr rows belonging to the authoritative source set.</summary>
+        internal List<ArrInstance> GetSonarrInstancesForAuthoritativeSnapshot()
+            => GetInstancesForAuthoritativeSnapshot(
+                SonarrInstances,
+                GetSonarrInstances);
+
+        /// <summary>All usable Radarr rows belonging to the authoritative source set.</summary>
+        internal List<ArrInstance> GetRadarrInstancesForAuthoritativeSnapshot()
+            => GetInstancesForAuthoritativeSnapshot(
+                RadarrInstances,
+                GetRadarrInstances);
+
+        private static List<ArrInstance> GetInstancesForAuthoritativeSnapshot(
+            string? storedJson,
+            Func<List<ArrInstance>> getWithLegacyFallback)
+        {
+            var parsed = TryDeserializeInstances(
+                storedJson,
+                out var parseResult,
+                out _,
+                out var hadStoredRows);
+
+            if (parseResult == InstanceParseResult.Corrupt)
+            {
+                return new List<ArrInstance>();
+            }
+
+            return hadStoredRows
+                ? parsed
+                : getWithLegacyFallback();
+        }
+
         private enum InstanceParseResult { ExplicitlyEmpty, Parsed, Corrupt }
 
         private static List<ArrInstance> TryDeserializeInstances(string? json, out InstanceParseResult result)
+            => TryDeserializeInstances(json, out result, out _);
+
+        private static List<ArrInstance> TryDeserializeInstances(
+            string? json,
+            out InstanceParseResult result,
+            out bool hasInvalidEnabledRows)
+            => TryDeserializeInstances(json, out result, out hasInvalidEnabledRows, out _);
+
+        private static List<ArrInstance> TryDeserializeInstances(
+            string? json,
+            out InstanceParseResult result,
+            out bool hasInvalidEnabledRows,
+            out bool hadStoredRows)
         {
+            hasInvalidEnabledRows = false;
+            hadStoredRows = false;
             if (string.IsNullOrWhiteSpace(json))
             {
                 result = InstanceParseResult.ExplicitlyEmpty;
@@ -909,7 +987,17 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Configuration
 
             try
             {
-                var instances = JsonSerializer.Deserialize<List<ArrInstance>>(json) ?? new List<ArrInstance>();
+                var instances = JsonSerializer.Deserialize<List<ArrInstance>>(json);
+                if (instances == null)
+                {
+                    result = InstanceParseResult.Corrupt;
+                    return new List<ArrInstance>();
+                }
+
+                hadStoredRows = instances.Count > 0;
+                hasInvalidEnabledRows = instances.Any(i => i == null
+                    || (i.Enabled
+                        && (string.IsNullOrWhiteSpace(i.Url) || string.IsNullOrWhiteSpace(i.ApiKey))));
                 // Drop null entries AND entries with empty URL or API key. System.Text.Json happily
                 // accepts `[null]` as a one-element list containing null (verified empirically);
                 // without this guard the predicate below dereferences the null and throws NRE,

--- a/Jellyfin.Plugin.JellyfinCanopy/Helpers/ArrUrlGuard.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Helpers/ArrUrlGuard.cs
@@ -92,6 +92,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers
 
         public static async Task<bool> IsAllowedUrlAsync(string? url, CancellationToken ct = default)
         {
+            ct.ThrowIfCancellationRequested();
             var sync = TrySyncChecks(url, out var host);
             if (sync.HasValue) return sync.Value;
 

--- a/Jellyfin.Plugin.JellyfinCanopy/ScheduledTasks/ArrTagsSyncTask.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/ScheduledTasks/ArrTagsSyncTask.cs
@@ -12,6 +12,7 @@ using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Tasks;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Model.Arr;
 using Jellyfin.Plugin.JellyfinCanopy.Services;
 using Jellyfin.Plugin.JellyfinCanopy.Services.Arr;
 using Microsoft.Extensions.Logging;
@@ -25,17 +26,36 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly ILogger<ArrTagsSyncTask> _logger;
         private readonly IPluginConfigProvider _configProvider;
+        private readonly Func<BaseItem, ItemUpdateType, CancellationToken, Task> _updateItem;
 
         public ArrTagsSyncTask(
             ILibraryManager libraryManager,
             IHttpClientFactory httpClientFactory,
             ILogger<ArrTagsSyncTask> logger,
             IPluginConfigProvider configProvider)
+            : this(
+                libraryManager,
+                httpClientFactory,
+                logger,
+                configProvider,
+                static (item, updateType, cancellationToken) =>
+                    item.UpdateToRepositoryAsync(updateType, cancellationToken))
+        {
+        }
+
+        /// <summary>Test seam for observing repository writes without a live Jellyfin repository.</summary>
+        internal ArrTagsSyncTask(
+            ILibraryManager libraryManager,
+            IHttpClientFactory httpClientFactory,
+            ILogger<ArrTagsSyncTask> logger,
+            IPluginConfigProvider configProvider,
+            Func<BaseItem, ItemUpdateType, CancellationToken, Task> updateItem)
         {
             _libraryManager = libraryManager;
             _httpClientFactory = httpClientFactory;
             _logger = logger;
             _configProvider = configProvider;
+            _updateItem = updateItem;
         }
 
         public string Name => "Sync Tags from *arr to Jellyfin";
@@ -63,93 +83,152 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                 return;
             }
 
+            using var cancellationRegistration = cancellationToken.Register(
+                () => _logger.LogInformation(
+                    "Arr Tags Sync cancellation requested; no incomplete snapshot will be published."));
+
             _logger.LogInformation("Starting Arr Tags Sync task...");
             progress?.Report(0);
 
             var arrTagService = new ArrTagService(_httpClientFactory, _logger);
 
             var radarrTags = new Dictionary<int, List<string>>();
+            var radarrSnapshotComplete = false;
             // Sonarr tags keyed BOTH by TVDB id (canonical) and IMDb id (fallback) so a
             // TVDB-scraped library (series without an IMDb id) still syncs.
             var sonarrTagsByTvdb = new Dictionary<int, List<string>>();
             var sonarrTagsByImdb = new Dictionary<string, List<string>>();
+            var sonarrSnapshotComplete = false;
 
             // Fetch tags from all configured Radarr instances
-            if (config.IsRadarrInstancesCorrupt())
+            var radarrConfigCorrupt = config.IsRadarrInstancesCorrupt();
+            var radarrConfigHasInvalidEnabledRows = !radarrConfigCorrupt
+                && config.HasInvalidEnabledRadarrInstances();
+            if (radarrConfigCorrupt)
             {
-                _logger.LogError("RadarrInstances config is corrupt JSON — no Radarr tags will sync this run. "
-                    + "Admin must open the Arr Links config page and reset the corrupt value.");
+                _logger.LogError("RadarrInstances config is corrupt JSON — preserving existing Radarr-owned tags. "
+                    + "Admin must open the Arr Links config page and reset the corrupt value before sync can resume.");
             }
-            var radarrInstances = config.GetEnabledRadarrInstances();
+            else if (radarrConfigHasInvalidEnabledRows)
+            {
+                _logger.LogError(
+                    "RadarrInstances contains an enabled row without a usable URL/API key — "
+                    + "preserving existing Radarr-owned tags until the row is fixed or disabled.");
+            }
+            var allAuthoritativeRadarr = radarrConfigCorrupt
+                ? new List<ArrInstance>()
+                : config.GetRadarrInstancesForAuthoritativeSnapshot();
+            var radarrInstances = allAuthoritativeRadarr.Where(i => i.Enabled).ToList();
             if (radarrInstances.Count > 0)
             {
+                radarrSnapshotComplete = !radarrConfigHasInvalidEnabledRows;
                 foreach (var instance in radarrInstances)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
                     try
                     {
                         _logger.LogInformation($"Fetching tags from Radarr instance: {instance.Name}");
-                        var instanceTags = await arrTagService.GetMovieTagsByTmdbId(instance.Url, instance.ApiKey, cancellationToken);
-                        _logger.LogInformation($"Fetched {instanceTags.Count} movie tag mappings from {instance.Name}");
-                        MergeTagMap(radarrTags, instanceTags);
+                        var result = await arrTagService.GetMovieTagsByTmdbId(instance.Url, instance.ApiKey, cancellationToken);
+                        if (!result.IsComplete)
+                        {
+                            radarrSnapshotComplete = false;
+                            _logger.LogWarning(
+                                $"Radarr tag snapshot from {instance.Name} is incomplete ({result.FailureReason}); "
+                                + "existing movie tags will be preserved.");
+                            continue;
+                        }
+
+                        _logger.LogInformation($"Fetched {result.Value.Count} movie tag mappings from {instance.Name}");
+                        MergeTagMap(radarrTags, result.Value);
                     }
                     catch (OperationCanceledException) { throw; }
                     catch (Exception ex)
                     {
+                        radarrSnapshotComplete = false;
                         _logger.LogError($"Failed to sync tags from Radarr instance {instance.Name}: {ex.Message}");
                     }
                 }
             }
             else
             {
-                var allRadarr = config.GetRadarrInstances();
-                if (allRadarr.Count > 0)
-                    _logger.LogInformation($"All {allRadarr.Count} Radarr instances are disabled — skipping Radarr sync");
+                if (allAuthoritativeRadarr.Count > 0)
+                    _logger.LogInformation($"All {allAuthoritativeRadarr.Count} Radarr instances are disabled — skipping Radarr sync");
                 else
-                    _logger.LogInformation("No Radarr instances configured, skipping Radarr sync");
+                    _logger.LogInformation("No usable enabled Radarr sources configured, skipping Radarr sync");
             }
 
             progress?.Report(25);
             cancellationToken.ThrowIfCancellationRequested();
 
             // Fetch tags from all configured Sonarr instances
-            if (config.IsSonarrInstancesCorrupt())
+            var sonarrConfigCorrupt = config.IsSonarrInstancesCorrupt();
+            var sonarrConfigHasInvalidEnabledRows = !sonarrConfigCorrupt
+                && config.HasInvalidEnabledSonarrInstances();
+            if (sonarrConfigCorrupt)
             {
-                _logger.LogError("SonarrInstances config is corrupt JSON — no Sonarr tags will sync this run. "
-                    + "Admin must open the Arr Links config page and reset the corrupt value.");
+                _logger.LogError("SonarrInstances config is corrupt JSON — preserving existing Sonarr-owned tags. "
+                    + "Admin must open the Arr Links config page and reset the corrupt value before sync can resume.");
             }
-            var sonarrInstances = config.GetEnabledSonarrInstances();
+            else if (sonarrConfigHasInvalidEnabledRows)
+            {
+                _logger.LogError(
+                    "SonarrInstances contains an enabled row without a usable URL/API key — "
+                    + "preserving existing Sonarr-owned tags until the row is fixed or disabled.");
+            }
+            var allAuthoritativeSonarr = sonarrConfigCorrupt
+                ? new List<ArrInstance>()
+                : config.GetSonarrInstancesForAuthoritativeSnapshot();
+            var sonarrInstances = allAuthoritativeSonarr.Where(i => i.Enabled).ToList();
             if (sonarrInstances.Count > 0)
             {
+                sonarrSnapshotComplete = !sonarrConfigHasInvalidEnabledRows;
                 foreach (var instance in sonarrInstances)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
                     try
                     {
                         _logger.LogInformation($"Fetching tags from Sonarr instance: {instance.Name}");
-                        var instanceMaps = await arrTagService.GetSeriesTagsAsync(instance.Url, instance.ApiKey, cancellationToken);
-                        _logger.LogInformation($"Fetched {instanceMaps.ByTvdbId.Count} series tag mappings by TVDB, {instanceMaps.ByImdbId.Count} by IMDb from {instance.Name}");
-                        MergeTagMap(sonarrTagsByTvdb, instanceMaps.ByTvdbId);
-                        MergeTagMap(sonarrTagsByImdb, instanceMaps.ByImdbId);
+                        var result = await arrTagService.GetSeriesTagsAsync(instance.Url, instance.ApiKey, cancellationToken);
+                        if (!result.IsComplete)
+                        {
+                            sonarrSnapshotComplete = false;
+                            _logger.LogWarning(
+                                $"Sonarr tag snapshot from {instance.Name} is incomplete ({result.FailureReason}); "
+                                + "existing series tags will be preserved.");
+                            continue;
+                        }
+
+                        _logger.LogInformation($"Fetched {result.Value.ByTvdbId.Count} series tag mappings by TVDB, {result.Value.ByImdbId.Count} by IMDb from {instance.Name}");
+                        MergeTagMap(sonarrTagsByTvdb, result.Value.ByTvdbId);
+                        MergeTagMap(sonarrTagsByImdb, result.Value.ByImdbId);
                     }
                     catch (OperationCanceledException) { throw; }
                     catch (Exception ex)
                     {
+                        sonarrSnapshotComplete = false;
                         _logger.LogError($"Failed to sync tags from Sonarr instance {instance.Name}: {ex.Message}");
                     }
                 }
             }
             else
             {
-                var allSonarr = config.GetSonarrInstances();
-                if (allSonarr.Count > 0)
-                    _logger.LogInformation($"All {allSonarr.Count} Sonarr instances are disabled — skipping Sonarr sync");
+                if (allAuthoritativeSonarr.Count > 0)
+                    _logger.LogInformation($"All {allAuthoritativeSonarr.Count} Sonarr instances are disabled — skipping Sonarr sync");
                 else
-                    _logger.LogInformation("No Sonarr instances configured, skipping Sonarr sync");
+                    _logger.LogInformation("No usable enabled Sonarr sources configured, skipping Sonarr sync");
             }
 
             progress?.Report(50);
             cancellationToken.ThrowIfCancellationRequested();
+
+            if (!radarrSnapshotComplete && !sonarrSnapshotComplete)
+            {
+                _logger.LogWarning(
+                    "Arr Tags Sync did not receive any complete authoritative snapshot; "
+                    + "existing Arr-owned tags were preserved and no library metadata was written.");
+                progress?.Report(100);
+                return;
+            }
 
             // Get all movies and series from Jellyfin
             var allItems = _libraryManager.GetItemList(new InternalItemsQuery
@@ -158,6 +237,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                 IsVirtualItem = false,
                 Recursive = true
             }).ToList();
+            cancellationToken.ThrowIfCancellationRequested();
 
             _logger.LogInformation($"Found {allItems.Count} items in Jellyfin library");
 
@@ -170,14 +250,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
             bool clearOldTags = config.ArrTagsClearOldTags;
 
             // Parse sync filter - if empty, sync all tags
-            var syncFilterTags = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            if (!string.IsNullOrWhiteSpace(config.ArrTagsSyncFilter))
+            var syncFilterTags = ParseSyncFilter(config.ArrTagsSyncFilter);
+            if (syncFilterTags.Count > 0)
             {
-                var filterParts = config.ArrTagsSyncFilter.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries);
-                foreach (var part in filterParts)
-                {
-                    syncFilterTags.Add(part.Trim());
-                }
                 _logger.LogInformation($"Filtering tags to sync: {string.Join(", ", syncFilterTags)}");
             }
 
@@ -186,13 +261,19 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                 cancellationToken.ThrowIfCancellationRequested();
 
                 List<string>? tagsToAdd = null;
+                var itemSnapshotComplete = false;
+                var itemHasUsableProviderId = false;
 
                 // Check if it's a movie
                 if (item is Movie movie)
                 {
+                    itemSnapshotComplete = radarrSnapshotComplete;
                     var tmdbId = movie.GetProviderId(MediaBrowser.Model.Entities.MetadataProvider.Tmdb);
-                    if (!string.IsNullOrWhiteSpace(tmdbId) && int.TryParse(tmdbId, out var tmdbIdInt))
+                    if (!string.IsNullOrWhiteSpace(tmdbId)
+                        && int.TryParse(tmdbId, out var tmdbIdInt)
+                        && tmdbIdInt > 0)
                     {
+                        itemHasUsableProviderId = true;
                         if (radarrTags.TryGetValue(tmdbIdInt, out var tags))
                         {
                             tagsToAdd = tags;
@@ -202,71 +283,62 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                 // Check if it's a series — prefer TVDB (Sonarr's canonical id), fall back to IMDb.
                 else if (item is Series series)
                 {
+                    itemSnapshotComplete = sonarrSnapshotComplete;
                     var tvdbId = series.GetProviderId(MediaBrowser.Model.Entities.MetadataProvider.Tvdb);
                     if (!string.IsNullOrWhiteSpace(tvdbId)
                         && int.TryParse(tvdbId, out var tvdbIdInt)
-                        && sonarrTagsByTvdb.TryGetValue(tvdbIdInt, out var tvdbTags))
+                        && tvdbIdInt > 0)
                     {
-                        tagsToAdd = tvdbTags;
-                    }
-                    else
-                    {
-                        var imdbId = series.GetProviderId(MediaBrowser.Model.Entities.MetadataProvider.Imdb);
-                        if (!string.IsNullOrWhiteSpace(imdbId)
-                            && sonarrTagsByImdb.TryGetValue(imdbId, out var imdbTags))
+                        itemHasUsableProviderId = true;
+                        if (sonarrTagsByTvdb.TryGetValue(tvdbIdInt, out var tvdbTags))
                         {
-                            tagsToAdd = imdbTags;
+                            tagsToAdd = tvdbTags;
                         }
                     }
+
+                    if (tagsToAdd == null)
+                    {
+                        var imdbId = series.GetProviderId(MediaBrowser.Model.Entities.MetadataProvider.Imdb);
+                        if (!string.IsNullOrWhiteSpace(imdbId))
+                        {
+                            if (sonarrTagsByImdb.TryGetValue(imdbId, out var imdbTags))
+                            {
+                                // IMDb is a matching fallback, not authoritative absence: Sonarr
+                                // may legitimately omit IMDb while TVDB remains canonical. A local
+                                // IMDb-only item is safe to reconcile only when it actually matched.
+                                itemHasUsableProviderId = true;
+                                tagsToAdd = imdbTags;
+                            }
+                        }
+                    }
+                }
+
+                if (!itemSnapshotComplete || !itemHasUsableProviderId)
+                {
+                    ReportItemProgress();
+                    continue;
                 }
 
                 var existingTags = item.Tags?.ToList() ?? new List<string>();
-                var modified = false;
-
-                // Clear old tags with the prefix if enabled
-                if (clearOldTags)
-                {
-                    var tagsToRemove = existingTags
-                        .Where(t => t.StartsWith(tagPrefix, StringComparison.OrdinalIgnoreCase))
-                        .ToList();
-
-                    if (tagsToRemove.Count > 0)
-                    {
-                        foreach (var tag in tagsToRemove)
-                        {
-                            existingTags.Remove(tag);
-                        }
-                        modified = true;
-                    }
-                }
-
-                // Add new tags if found
-                if (tagsToAdd != null && tagsToAdd.Count > 0)
-                {
-                    foreach (var tag in tagsToAdd)
-                    {
-                        // Apply sync filter - skip tags not in filter (if filter is set)
-                        if (syncFilterTags.Count > 0 && !syncFilterTags.Contains(tag))
-                        {
-                            continue;
-                        }
-
-                        var formattedTag = $"{tagPrefix}{tag}";
-
-                        // Only add if not already present
-                        if (!existingTags.Contains(formattedTag, StringComparer.OrdinalIgnoreCase))
-                        {
-                            existingTags.Add(formattedTag);
-                            modified = true;
-                        }
-                    }
-                }
+                var desiredTags = BuildDesiredTags(existingTags, tagsToAdd, tagPrefix, clearOldTags, syncFilterTags);
 
                 // Update item if modified
-                if (modified)
+                if (!TagCollectionsEqual(existingTags, desiredTags))
                 {
-                    item.Tags = existingTags.ToArray();
-                    await item.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken);
+                    var previousTags = item.Tags;
+                    item.Tags = desiredTags.ToArray();
+                    try
+                    {
+                        await _updateItem(item, ItemUpdateType.MetadataEdit, cancellationToken);
+                    }
+                    catch
+                    {
+                        // A failed repository write must not leave the live in-memory item looking
+                        // as if destructive reconciliation succeeded.
+                        item.Tags = previousTags;
+                        throw;
+                    }
+
                     updatedCount++;
                     updatedItemNames.Add(item.Name);
                     
@@ -278,9 +350,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                     }
                 }
 
-                processedItems++;
-                var currentProgress = 50 + (int)((double)processedItems / totalItems * 50);
-                progress?.Report(currentProgress);
+                ReportItemProgress();
             }
 
             // Log any remaining updated items
@@ -298,7 +368,91 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
 
             _logger.LogInformation($"Arr Tags Sync completed. Updated {updatedCount} items out of {totalItems}");
             progress?.Report(100);
+
+            void ReportItemProgress()
+            {
+                processedItems++;
+                var currentProgress = totalItems == 0
+                    ? 100
+                    : 50 + (int)((double)processedItems / totalItems * 50);
+                progress?.Report(currentProgress);
+            }
         }
+
+        /// <summary>
+        /// Parses the admin-documented one-tag-per-line format while retaining the legacy comma
+        /// and semicolon separators. Empty/whitespace-only entries never become filter values.
+        /// </summary>
+        internal static HashSet<string> ParseSyncFilter(string? configuredFilter)
+        {
+            var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (string.IsNullOrWhiteSpace(configuredFilter))
+            {
+                return result;
+            }
+
+            var parts = configuredFilter.Split(
+                new[] { ',', ';', '\r', '\n' },
+                StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            foreach (var part in parts)
+            {
+                if (part.Length > 0)
+                {
+                    result.Add(part);
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Builds the authoritative final tag collection without mutating the live item. Owned
+        /// tags are cleared only after every configured source for that media type completed; the
+        /// caller enforces that completeness gate before invoking this helper.
+        /// </summary>
+        internal static List<string> BuildDesiredTags(
+            IReadOnlyList<string> existingTags,
+            IReadOnlyList<string>? tagsToAdd,
+            string tagPrefix,
+            bool clearOldTags,
+            IReadOnlySet<string> syncFilterTags)
+        {
+            var desiredTags = clearOldTags
+                ? existingTags
+                    .Where(t => !t.StartsWith(tagPrefix, StringComparison.OrdinalIgnoreCase))
+                    .ToList()
+                : existingTags.ToList();
+
+            if (tagsToAdd == null)
+            {
+                return desiredTags;
+            }
+
+            foreach (var tag in tagsToAdd)
+            {
+                if (syncFilterTags.Count > 0 && !syncFilterTags.Contains(tag))
+                {
+                    continue;
+                }
+
+                var formattedTag = $"{tagPrefix}{tag}";
+                if (!desiredTags.Contains(formattedTag, StringComparer.OrdinalIgnoreCase))
+                {
+                    desiredTags.Add(formattedTag);
+                }
+            }
+
+            return desiredTags;
+        }
+
+        /// <summary>Order-insensitive, case-insensitive comparison that preserves multiplicity.</summary>
+        internal static bool TagCollectionsEqual(IReadOnlyList<string> left, IReadOnlyList<string> right)
+            => left.Count == right.Count
+                && left
+                    .OrderBy(t => t, StringComparer.OrdinalIgnoreCase)
+                    .SequenceEqual(
+                        right.OrderBy(t => t, StringComparer.OrdinalIgnoreCase),
+                        StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Resolves the tag prefix, defaulting only an empty/absent admin value so the write side

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Arr/ArrTagService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Arr/ArrTagService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -33,16 +34,53 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Arr
         public string? ImdbId { get; set; }
 
         [JsonPropertyName("tags")]
-        public List<int> Tags { get; set; } = new List<int>();
+        [JsonRequired]
+        public List<int>? Tags { get; set; }
     }
 
     public class ArrTag
     {
         [JsonPropertyName("id")]
+        [JsonRequired]
         public int Id { get; set; }
 
         [JsonPropertyName("label")]
-        public string Label { get; set; } = string.Empty;
+        [JsonRequired]
+        public string? Label { get; set; }
+    }
+
+    /// <summary>
+    /// A snapshot whose completeness is explicit. A failed snapshot carries an empty value
+    /// supplied by the caller so consumers cannot accidentally treat partial data as complete.
+    /// </summary>
+    /// <typeparam name="T">The snapshot value type.</typeparam>
+    public sealed class ArrSnapshotResult<T>
+    {
+        private ArrSnapshotResult(bool isComplete, T value, string? failureReason)
+        {
+            IsComplete = isComplete;
+            Value = value;
+            FailureReason = failureReason;
+        }
+
+        public bool IsComplete { get; }
+
+        public T Value { get; }
+
+        public string? FailureReason { get; }
+
+        public static ArrSnapshotResult<T> Complete(T value)
+            => new ArrSnapshotResult<T>(true, value, null);
+
+        public static ArrSnapshotResult<T> Failed(T empty, string failureReason)
+        {
+            if (string.IsNullOrWhiteSpace(failureReason))
+            {
+                throw new ArgumentException("A failure reason is required.", nameof(failureReason));
+            }
+
+            return new ArrSnapshotResult<T>(false, empty, failureReason);
+        }
     }
 
     /// <summary>
@@ -66,82 +104,121 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Arr
         /// id) and by IMDb id (fallback). Keying by IMDb alone silently synced nothing for
         /// TVDB-scraped libraries (series without an IMDb id); TVDB is the reliable key.
         /// </summary>
-        public async Task<SeriesTagMaps> GetSeriesTagsAsync(string sonarrUrl, string apiKey, CancellationToken ct = default)
+        public async Task<ArrSnapshotResult<SeriesTagMaps>> GetSeriesTagsAsync(
+            string sonarrUrl,
+            string apiKey,
+            CancellationToken ct = default)
         {
             var byTvdbId = new Dictionary<int, List<string>>();
             var byImdbId = new Dictionary<string, List<string>>();
+            var empty = new SeriesTagMaps(byTvdbId, byImdbId);
 
             var fetched = await FetchTagsAndItemsAsync(ArrType.Sonarr, sonarrUrl, apiKey, ct).ConfigureAwait(false);
-            if (fetched == null)
+            if (!fetched.IsComplete)
             {
-                return new SeriesTagMaps(byTvdbId, byImdbId);
+                return ArrSnapshotResult<SeriesTagMaps>.Failed(
+                    empty,
+                    fetched.FailureReason ?? "Sonarr snapshot fetch failed.");
             }
 
-            var (items, tagLabels) = fetched.Value;
-            foreach (var item in items)
+            try
             {
-                if (item.Tags.Count == 0)
+                foreach (var item in fetched.Value.Items)
                 {
-                    continue;
-                }
+                    ct.ThrowIfCancellationRequested();
+                    if (item.Tags == null || item.Tags.Count == 0)
+                    {
+                        continue;
+                    }
 
-                var itemTags = ResolveLabels(item, tagLabels);
-                if (itemTags.Count == 0)
-                {
-                    continue;
-                }
+                    var itemTags = ResolveLabels(item, fetched.Value.TagLabels);
+                    if (itemTags.Count == 0)
+                    {
+                        continue;
+                    }
 
-                // Separate list copies per map so a later per-instance merge can't mutate
-                // the other map's value through a shared reference.
-                if (item.TvdbId > 0)
-                {
-                    byTvdbId[item.TvdbId] = new List<string>(itemTags);
-                }
+                    // Separate list copies per map so a later per-instance merge can't mutate
+                    // the other map's value through a shared reference.
+                    if (item.TvdbId > 0)
+                    {
+                        MergeTagLabels(byTvdbId, item.TvdbId, itemTags);
+                    }
 
-                if (!string.IsNullOrEmpty(item.ImdbId))
-                {
-                    byImdbId[item.ImdbId] = new List<string>(itemTags);
+                    if (!string.IsNullOrWhiteSpace(item.ImdbId))
+                    {
+                        MergeTagLabels(byImdbId, item.ImdbId, itemTags);
+                    }
                 }
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unexpected error mapping Sonarr tag snapshot");
+                return ArrSnapshotResult<SeriesTagMaps>.Failed(
+                    new SeriesTagMaps(new Dictionary<int, List<string>>(), new Dictionary<string, List<string>>()),
+                    "Unexpected error while mapping Sonarr tag snapshot.");
             }
 
             _logger.LogInformation($"Mapped Sonarr tags for {byTvdbId.Count} series by TVDB, {byImdbId.Count} by IMDb");
-            return new SeriesTagMaps(byTvdbId, byImdbId);
+            return ArrSnapshotResult<SeriesTagMaps>.Complete(empty);
         }
 
         /// <summary>Radarr: tag labels keyed by movie TmdbId.</summary>
-        public async Task<Dictionary<int, List<string>>> GetMovieTagsByTmdbId(string radarrUrl, string apiKey, CancellationToken ct = default)
+        public async Task<ArrSnapshotResult<Dictionary<int, List<string>>>> GetMovieTagsByTmdbId(
+            string radarrUrl,
+            string apiKey,
+            CancellationToken ct = default)
         {
             var result = new Dictionary<int, List<string>>();
 
             var fetched = await FetchTagsAndItemsAsync(ArrType.Radarr, radarrUrl, apiKey, ct).ConfigureAwait(false);
-            if (fetched == null)
+            if (!fetched.IsComplete)
             {
-                return result;
+                return ArrSnapshotResult<Dictionary<int, List<string>>>.Failed(
+                    result,
+                    fetched.FailureReason ?? "Radarr snapshot fetch failed.");
             }
 
-            var (items, tagLabels) = fetched.Value;
-            foreach (var item in items)
+            try
             {
-                if (item.TmdbId > 0 && item.Tags.Count > 0)
+                foreach (var item in fetched.Value.Items)
                 {
-                    var itemTags = ResolveLabels(item, tagLabels);
-                    if (itemTags.Count > 0)
+                    ct.ThrowIfCancellationRequested();
+                    if (item.TmdbId > 0 && item.Tags != null && item.Tags.Count > 0)
                     {
-                        result[item.TmdbId] = itemTags;
+                        var itemTags = ResolveLabels(item, fetched.Value.TagLabels);
+                        if (itemTags.Count > 0)
+                        {
+                            MergeTagLabels(result, item.TmdbId, itemTags);
+                        }
                     }
                 }
             }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unexpected error mapping Radarr tag snapshot");
+                return ArrSnapshotResult<Dictionary<int, List<string>>>.Failed(
+                    new Dictionary<int, List<string>>(),
+                    "Unexpected error while mapping Radarr tag snapshot.");
+            }
 
             _logger.LogInformation($"Mapped tags for {result.Count} movies");
-            return result;
+            return ArrSnapshotResult<Dictionary<int, List<string>>>.Complete(result);
         }
 
         /// <summary>
         /// Fetches the tag label map and the full media list from one *arr instance in a
-        /// single tag + media round-trip. Returns null when the SSRF guard blocks the URL
-        /// or any fetch/parse step fails (all logged); callers degrade to empty maps.
+        /// single tag + media round-trip. Failures are returned explicitly so callers cannot
+        /// confuse an unavailable or malformed upstream with a valid empty collection.
         /// </summary>
-        private async Task<(List<ArrMediaItem> Items, Dictionary<int, string> TagLabels)?> FetchTagsAndItemsAsync(
+        private async Task<ArrSnapshotResult<FetchedArrSnapshot>> FetchTagsAndItemsAsync(
             ArrType arrType,
             string baseUrl,
             string apiKey,
@@ -153,10 +230,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Arr
 
             // SSRF guard: reject before any outbound request so scheduled-task callers
             // cannot be pointed at metadata/loopback targets via instance URL.
-            if (!Jellyfin.Plugin.JellyfinCanopy.Helpers.ArrUrlGuard.IsAllowedUrl(baseUrl))
+            if (!await Jellyfin.Plugin.JellyfinCanopy.Helpers.ArrUrlGuard
+                .IsAllowedUrlAsync(baseUrl, ct)
+                .ConfigureAwait(false))
             {
                 _logger.LogError($"Refusing to fetch {serviceName} tags — URL rejected by SSRF guard: {baseUrl}");
-                return null;
+                return FetchFailed($"{serviceName} URL was rejected by the SSRF guard.");
             }
 
             try
@@ -170,17 +249,26 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Arr
                 _logger.LogInformation($"Fetching {serviceName} tags from {baseUrl}");
                 var tagsUrl = $"{baseUrl.TrimEnd('/')}/api/v3/tag";
                 using var tagsRequest = Helpers.PluginHttpClients.BuildArrRequest(HttpMethod.Get, tagsUrl, apiKey);
-                var tagsResponse = await httpClient.SendAsync(tagsRequest, ct);
+                using var tagsResponse = await httpClient.SendAsync(tagsRequest, ct).ConfigureAwait(false);
 
-                if (!tagsResponse.IsSuccessStatusCode)
+                // Only a complete 200 response can be deletion authority. In particular, a 206
+                // array may be syntactically valid while omitting tags outside the returned range.
+                if (tagsResponse.StatusCode != HttpStatusCode.OK)
                 {
                     _logger.LogError($"Failed to fetch {serviceName} tags. Status: {tagsResponse.StatusCode}");
-                    return null;
+                    return FetchFailed($"{serviceName} tag request returned HTTP {(int)tagsResponse.StatusCode}.");
                 }
 
-                var tagsContent = await tagsResponse.Content.ReadAsStringAsync(ct);
-                var tags = JsonSerializer.Deserialize<List<ArrTag>>(tagsContent) ?? new List<ArrTag>();
-                var tagDictionary = tags.ToDictionary(t => t.Id, t => t.Label);
+                var tagsContent = await tagsResponse.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+                var tags = DeserializeCollection<ArrTag>(tagsContent);
+                if (tags.Any(tag => tag.Id <= 0 || string.IsNullOrWhiteSpace(tag.Label))
+                    || tags.Select(tag => tag.Id).Distinct().Count() != tags.Count)
+                {
+                    throw new ArrSnapshotValidationException(
+                        "tag entries require unique positive ids and non-blank labels.");
+                }
+
+                var tagDictionary = tags.ToDictionary(t => t.Id, t => t.Label!);
 
                 _logger.LogInformation($"Found {tags.Count} tags in {serviceName}");
 
@@ -188,20 +276,50 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Arr
                 _logger.LogInformation($"Fetching {serviceName} {itemNoun} from {baseUrl}");
                 var mediaUrl = $"{baseUrl.TrimEnd('/')}/api/v3/{mediaEndpoint}";
                 using var mediaRequest = Helpers.PluginHttpClients.BuildArrRequest(HttpMethod.Get, mediaUrl, apiKey);
-                var mediaResponse = await httpClient.SendAsync(mediaRequest, ct);
+                using var mediaResponse = await httpClient.SendAsync(mediaRequest, ct).ConfigureAwait(false);
 
-                if (!mediaResponse.IsSuccessStatusCode)
+                if (mediaResponse.StatusCode != HttpStatusCode.OK)
                 {
                     _logger.LogError($"Failed to fetch {serviceName} {itemNoun}. Status: {mediaResponse.StatusCode}");
-                    return null;
+                    return FetchFailed($"{serviceName} {itemNoun} request returned HTTP {(int)mediaResponse.StatusCode}.");
                 }
 
-                var mediaContent = await mediaResponse.Content.ReadAsStringAsync(ct);
-                var allItems = JsonSerializer.Deserialize<List<ArrMediaItem>>(mediaContent) ?? new List<ArrMediaItem>();
+                var mediaContent = await mediaResponse.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+                var allItems = DeserializeCollection<ArrMediaItem>(mediaContent);
+                if (allItems.Any(item => item.Tags == null))
+                {
+                    throw new ArrSnapshotValidationException(
+                        "media entries require a non-null tags collection.");
+                }
+
+                // A media response that references an id absent from the tag response is not
+                // a coherent snapshot (for example, the two endpoint reads raced a deletion).
+                // Treat it as incomplete instead of silently dropping the unresolved tag and
+                // authorizing Jellyfin metadata deletion from a partial projection.
+                if (allItems.Any(item => item.Tags!.Any(tagId => !tagDictionary.ContainsKey(tagId))))
+                {
+                    throw new ArrSnapshotValidationException(
+                        "media entries referenced an unknown tag id.");
+                }
+
+                if (arrType == ArrType.Radarr
+                    && allItems.Any(item => item.TmdbId <= 0))
+                {
+                    throw new ArrSnapshotValidationException(
+                        "movie entries require a positive TMDB id.");
+                }
+
+                if (arrType == ArrType.Sonarr
+                    && allItems.Any(item => item.TvdbId <= 0))
+                {
+                    throw new ArrSnapshotValidationException(
+                        "series entries require a positive TVDB id.");
+                }
 
                 _logger.LogInformation($"Found {allItems.Count} {itemNoun} in {serviceName}");
 
-                return (allItems, tagDictionary);
+                return ArrSnapshotResult<FetchedArrSnapshot>.Complete(
+                    new FetchedArrSnapshot(allItems, tagDictionary));
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
             {
@@ -212,28 +330,52 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Arr
             catch (HttpRequestException ex)
             {
                 _logger.LogError($"Network error fetching {serviceName} tags: {ex.Message}");
+                return FetchFailed($"{serviceName} request failed.");
             }
             catch (TaskCanceledException ex)
             {
                 _logger.LogError($"Timeout fetching {serviceName} tags: {ex.Message}");
+                return FetchFailed($"{serviceName} request timed out.");
+            }
+            catch (ArrSnapshotValidationException ex)
+            {
+                _logger.LogError($"Inconsistent {serviceName} tag snapshot: {ex.Message}");
+                return FetchFailed($"{serviceName} snapshot was inconsistent: {ex.Message}");
             }
             catch (JsonException ex)
             {
-                _logger.LogError($"Invalid JSON from {serviceName} tags endpoint: {ex.Message}");
+                _logger.LogError($"Invalid JSON in {serviceName} tag snapshot response: {ex.Message}");
+                return FetchFailed($"{serviceName} returned malformed JSON.");
             }
             catch (Exception ex)
             {
                 _logger.LogError($"Unexpected error fetching {serviceName} tags: {ex.Message}");
+                return FetchFailed($"Unexpected error while fetching {serviceName} tag snapshot.");
+            }
+        }
+
+        private static List<T> DeserializeCollection<T>(string content)
+            where T : class
+        {
+            var values = JsonSerializer.Deserialize<List<T>>(content);
+            if (values == null || values.Any(value => value == null))
+            {
+                throw new JsonException("Expected a JSON array containing non-null objects.");
             }
 
-            return null;
+            return values;
         }
+
+        private static ArrSnapshotResult<FetchedArrSnapshot> FetchFailed(string failureReason)
+            => ArrSnapshotResult<FetchedArrSnapshot>.Failed(
+                new FetchedArrSnapshot(new List<ArrMediaItem>(), new Dictionary<int, string>()),
+                failureReason);
 
         /// <summary>Resolves an item's tag ids to their labels via the fetched label map.</summary>
         private static List<string> ResolveLabels(ArrMediaItem item, Dictionary<int, string> tagLabels)
         {
             var itemTags = new List<string>();
-            foreach (var tagId in item.Tags)
+            foreach (var tagId in item.Tags ?? throw new JsonException("Arr media tags were unavailable."))
             {
                 if (tagLabels.TryGetValue(tagId, out var tagLabel))
                 {
@@ -242,6 +384,44 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Arr
             }
 
             return itemTags;
+        }
+
+        /// <summary>
+        /// Conservatively unions labels when one response repeats a provider identity. Arr should
+        /// normally enforce uniqueness, but unioning keeps either entry from becoming accidental
+        /// deletion authority while still yielding a usable snapshot.
+        /// </summary>
+        private static void MergeTagLabels<TKey>(
+            Dictionary<TKey, List<string>> destination,
+            TKey key,
+            IReadOnlyList<string> labels)
+            where TKey : notnull
+        {
+            if (!destination.TryGetValue(key, out var merged))
+            {
+                destination[key] = new List<string>(labels);
+                return;
+            }
+
+            foreach (var label in labels)
+            {
+                if (!merged.Contains(label, StringComparer.OrdinalIgnoreCase))
+                {
+                    merged.Add(label);
+                }
+            }
+        }
+
+        private sealed record FetchedArrSnapshot(
+            List<ArrMediaItem> Items,
+            Dictionary<int, string> TagLabels);
+
+        private sealed class ArrSnapshotValidationException : Exception
+        {
+            public ArrSnapshotValidationException(string message)
+                : base(message)
+            {
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- introduce an explicit complete/failed Arr snapshot result so upstream errors, partial responses, malformed/incoherent payloads, and cancellation cannot masquerade as authoritative empty data
- gate destructive reconciliation independently for Radarr and Sonarr until every enabled source for that media type completes successfully
- preserve tags for corrupt, invalid, disabled-only, or otherwise non-authoritative source sets without reviving stale legacy configuration behind modern rows
- require exact HTTP 200 snapshots, coherent tag references, and canonical provider identities; preserve unmatched local items that cannot be reconciled safely
- compute the final normalized tag set before writing, skip identical results, and restore the live item if persistence fails or is cancelled
- parse the documented newline/CRLF sync-filter format while retaining comma/semicolon compatibility
- add service, configuration, cancellation, multi-instance, cross-media, rollback, progress/logging, and task-level regression coverage

## Root cause

Fetch failures and valid empty responses were both represented as empty dictionaries. The scheduled task then treated those dictionaries as deletion authority, including after one source in a multi-instance set failed or configuration rows were silently filtered. Reconciliation also removed/re-added identical tags and wrote them unnecessarily. Separately, the UI documented one-filter-entry-per-line while the task did not split on line breaks, so a normal multiline filter could clear every owned tag.

## Impact

Existing Canopy-owned Arr tags are now preserved whenever the relevant source snapshot is incomplete or cannot be mapped safely. A genuine complete empty snapshot can still intentionally clear owned tags, ordinary Jellyfin tags remain untouched, and a complete snapshot for one media type can reconcile even if the other type fails.

## Validation

- Release build: 0 warnings, 0 errors
- Full .NET suite in the official .NET 10 SDK container: 884/884 passed
- Focused Arr/config/URL-guard regressions: passed
- `npm run test:scripts`: 126/126 passed
- `npm run typecheck` and `npm run typecheck:src`: passed
- `npm run test:client`: 548/548 passed
- `npm run test:client:coverage`: 548/548 passed
- `npm run build:bundle`: passed
- manifest validation: passed, 0 warnings
- repository lint policy: completed with 0 errors (warnings remain advisory/pre-existing)
- independent Fable 5 low-effort frozen-diff review: no blockers, zero web/GitHub requests
- two independent Codex correctness reviews: no remaining blockers

Closes #68
Closes #205
