### PR TITLE
Fix watched-state spoiler tag projections

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/TagCacheProjectionControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/TagCacheProjectionControllerTests.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Text.Json;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Controllers;
+using Jellyfin.Plugin.JellyfinCanopy.Model;
+using Jellyfin.Plugin.JellyfinCanopy.Services;
+using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
+{
+    public sealed class TagCacheProjectionControllerTests
+    {
+        [Fact]
+        public void FullSnapshot_ContentCursorIsCapturedBeforeCacheSelection()
+        {
+            using var harness = new Harness();
+            var oldId = Guid.NewGuid().ToString("N");
+            var newId = Guid.NewGuid().ToString("N");
+            harness.Cache.SeedUserAccessCacheForTest(harness.User.Id.ToString("N"), oldId, newId);
+            harness.Cache.SwapCacheAndCursorForTest(
+                new Dictionary<string, TagCacheEntry>
+                {
+                    [oldId] = new TagCacheEntry { Type = "Movie", LastUpdated = 90 }
+                },
+                version: 7,
+                lastModified: 100);
+
+            // Reproduce the reconcile boundary exactly: GetCacheForUser already
+            // captured the old dictionary, then the live cache and its cursor move.
+            harness.Cache.OnAfterUserCacheSnapshotForTest = () =>
+            {
+                harness.Cache.OnAfterUserCacheSnapshotForTest = null;
+                harness.Cache.SwapCacheAndCursorForTest(
+                    new Dictionary<string, TagCacheEntry>
+                    {
+                        [newId] = new TagCacheEntry { Type = "Movie", LastUpdated = 200 }
+                    },
+                    version: 8,
+                    lastModified: 200);
+            };
+
+            var payload = Payload(harness.Controller.GetTagCache(harness.User.Id));
+
+            Assert.Equal(7, payload.GetProperty("version").GetInt64());
+            Assert.Equal(100, payload.GetProperty("timestamp").GetInt64());
+            Assert.True(payload.GetProperty("items").TryGetProperty(oldId, out _));
+            Assert.False(payload.GetProperty("items").TryGetProperty(newId, out _));
+            Assert.Equal(8, harness.Cache.Version);
+            Assert.Equal(200, harness.Cache.LastModified);
+        }
+
+        [Fact]
+        public void LegacySinceOnlyRequest_GetsFullPersonalizedSnapshot_WhileCursorClientGetsDelta()
+        {
+            using var harness = new Harness();
+            var itemId = Guid.NewGuid().ToString("N");
+            harness.Cache.SeedUserAccessCacheForTest(harness.User.Id.ToString("N"), itemId);
+            harness.Cache.SwapCacheAndCursorForTest(
+                new Dictionary<string, TagCacheEntry>
+                {
+                    [itemId] = new TagCacheEntry { Type = "Movie", LastUpdated = 10 }
+                },
+                version: 3,
+                lastModified: 100);
+
+            // An old bundled client sends only ?since=. Since it cannot identify
+            // its watched-state revision, the safe compatibility response is full.
+            var legacy = Payload(harness.Controller.GetTagCache(harness.User.Id, since: 50));
+            Assert.False(legacy.GetProperty("projectionReset").GetBoolean());
+            Assert.Equal(1, legacy.GetProperty("count").GetInt32());
+            Assert.True(legacy.GetProperty("items").TryGetProperty(itemId, out _));
+
+            // A new client carrying both cursor halves keeps the real content delta;
+            // the old entry is correctly excluded by ?since=50.
+            var current = harness.Projection.GetDelta(
+                harness.User.Id,
+                clientEpoch: null,
+                clientRevision: null,
+                requireCursor: false);
+            var modern = Payload(harness.Controller.GetTagCache(
+                harness.User.Id,
+                since: 50,
+                projectionEpoch: current.Epoch,
+                projectionRevision: current.Revision));
+            Assert.False(modern.GetProperty("projectionReset").GetBoolean());
+            Assert.Equal(0, modern.GetProperty("count").GetInt32());
+        }
+
+        [Fact]
+        public void ProjectionOnlyWithoutCursor_ResetsWithoutSelectingSharedCache()
+        {
+            using var harness = new Harness();
+            var selections = 0;
+            harness.Cache.OnAfterUserCacheSnapshotForTest = () => selections++;
+
+            var payload = Payload(harness.Controller.GetTagCache(
+                harness.User.Id,
+                projectionOnly: true));
+
+            Assert.True(payload.GetProperty("projectionReset").GetBoolean());
+            Assert.True(payload.GetProperty("reset").GetBoolean());
+            Assert.Equal(0, payload.GetProperty("count").GetInt32());
+            Assert.Equal(0, selections);
+        }
+
+        [Fact]
+        public void EmptyRouteUserId_UsesAuthorizedEffectiveUserForProjectionIdentity()
+        {
+            using var harness = new Harness();
+            harness.Cache.SeedUserAccessCacheForTest(harness.User.Id.ToString("N"));
+            harness.UserData.RaiseUserDataSaved(
+                harness.User.Id,
+                new StubMovie { Id = Guid.NewGuid() },
+                MediaBrowser.Model.Entities.UserDataSaveReason.TogglePlayed);
+
+            // UserHelper deliberately treats Guid.Empty as "the authenticated user".
+            // Every downstream personalized operation must therefore use User.Id too.
+            var payload = Payload(harness.Controller.GetTagCache(Guid.Empty));
+
+            Assert.Equal(harness.User.Id.ToString("N"), payload.GetProperty("projectionUserId").GetString());
+            Assert.Equal(1, payload.GetProperty("projectionRevision").GetInt64());
+        }
+
+        private static JsonElement Payload(IActionResult result)
+        {
+            var ok = Assert.IsType<OkObjectResult>(result);
+            using var json = JsonDocument.Parse(JsonSerializer.Serialize(ok.Value));
+            return json.RootElement.Clone();
+        }
+
+        private sealed class Harness : IDisposable
+        {
+            private readonly string _tempDir;
+            private readonly TagCacheProjectionRevisionService _projection;
+
+            public Harness()
+            {
+                _tempDir = Path.Combine(
+                    Path.GetTempPath(),
+                    "jc-tagcache-projection-controller-" + Guid.NewGuid().ToString("N"));
+                Directory.CreateDirectory(_tempDir);
+
+                User = new User("projection-controller", "Provider", "PasswordProvider");
+                var users = new StubUserManager(User);
+                var library = new CountingLibraryManager();
+                UserData = new StubUserDataManager();
+                var appPaths = new StubAppPaths(_tempDir);
+                var config = new PluginConfiguration
+                {
+                    TagCacheServerMode = true,
+                    SpoilerBlurEnabled = false
+                };
+                var configProvider = new FakePluginConfigProvider(config);
+                var userConfig = new UserConfigurationManager(
+                    appPaths,
+                    NullLogger<UserConfigurationManager>.Instance);
+                var markers = new SpoilerIdentityService(
+                    users,
+                    NullLogger<SpoilerIdentityService>.Instance);
+                var identity = new RequestIdentityService(
+                    new CountingSessionManager(),
+                    users,
+                    markers,
+                    NullLogger<RequestIdentityService>.Instance);
+                var resolver = new SpoilerUserResolver(
+                    userConfig,
+                    library,
+                    NullLogger<SpoilerUserResolver>.Instance,
+                    identity);
+
+                Cache = new TagCacheService(
+                    library,
+                    appPaths,
+                    NullLogger<TagCacheService>.Instance);
+                _projection = new TagCacheProjectionRevisionService(
+                    UserData,
+                    NullLogger<TagCacheProjectionRevisionService>.Instance);
+                Projection = _projection;
+                Controller = new TagCacheController(
+                    new RecordingHttpClientFactory(new HttpClientHandler()),
+                    NullLogger<TagCacheController>.Instance,
+                    users,
+                    new SeerrCache(configProvider),
+                    configProvider,
+                    Cache,
+                    library,
+                    UserData,
+                    resolver,
+                    userConfig,
+                    _projection);
+                Controller.ControllerContext = new ControllerContext
+                {
+                    HttpContext = new DefaultHttpContext
+                    {
+                        User = new ClaimsPrincipal(new ClaimsIdentity(
+                            new[] { new Claim("Jellyfin-UserId", User.Id.ToString()) },
+                            "TestAuth"))
+                    }
+                };
+            }
+
+            public User User { get; }
+
+            public TagCacheService Cache { get; }
+
+            public TagCacheProjectionRevisionService Projection { get; }
+
+            public StubUserDataManager UserData { get; }
+
+            public TagCacheController Controller { get; }
+
+            public void Dispose()
+            {
+                _projection.Dispose();
+                Cache.Dispose();
+                try
+                {
+                    Directory.Delete(_tempDir, recursive: true);
+                }
+                catch
+                {
+                    // Best-effort test cleanup.
+                }
+            }
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SpoilerSeasonRatingParityTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SpoilerSeasonRatingParityTests.cs
@@ -1,0 +1,342 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Text.Json;
+using Jellyfin.Data.Enums;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Controllers;
+using Jellyfin.Plugin.JellyfinCanopy.Services;
+using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Model.Dto;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
+{
+    /// <summary>
+    /// BI-SEC-036: guarded Season rating policy must be identical across the
+    /// pre-computed tag cache, the tag-data fallback and native BaseItemDto
+    /// filtering. S0/S1 and later Seasons with any watched episode exempt only
+    /// their non-rating metadata; the guarded Series rating must never reappear.
+    /// </summary>
+    public sealed class SpoilerSeasonRatingParityTests
+    {
+        private const string SpoilerFile = "spoilerblur.json";
+
+        private static PluginConfiguration StrictConfig(bool stripRatings = true) => new()
+        {
+            SpoilerBlurEnabled = true,
+            SpoilerStripRatings = stripRatings,
+            SpoilerStripOverview = true,
+            SpoilerStripTags = true,
+            SpoilerReplaceTitle = false,
+            SpoilerOverviewPlaceholder = "Protected",
+        };
+
+        private static UserSpoilerBlur GuardedState(Guid seriesId, bool? hideRatings = null)
+        {
+            var state = new UserSpoilerBlur
+            {
+                Prefs = new SpoilerBlurUserPrefs { HideRatings = hideRatings },
+            };
+            var seriesIdN = seriesId.ToString("N");
+            state.Series[seriesIdN] = new SpoilerBlurSeriesEntry { SeriesId = seriesIdN };
+            return state;
+        }
+
+        private static SpoilerFieldStripFilter NewFilter(PluginConfiguration cfg)
+        {
+            var lib = new CountingLibraryManager();
+            var users = new StubUserManager();
+            var markers = new SpoilerIdentityService(users, NullLogger<SpoilerIdentityService>.Instance);
+            var identity = new RequestIdentityService(
+                new CountingSessionManager(), users, markers, NullLogger<RequestIdentityService>.Instance);
+            // DTO item-counts make these tests independent of live library queries.
+            var resolver = new SpoilerUserResolver(
+                userConfigManager: null!, lib, NullLogger<SpoilerUserResolver>.Instance, identity);
+            return new SpoilerFieldStripFilter(
+                resolver, lib, users, new StubUserDataManager(), new FakePluginConfigProvider(cfg));
+        }
+
+        private static BaseItemDto SeasonDto(Guid seriesId, int seasonNumber, bool anyWatched)
+            => new()
+            {
+                Id = Guid.NewGuid(),
+                Type = BaseItemKind.Season,
+                SeriesId = seriesId,
+                IndexNumber = seasonNumber,
+                Name = $"Season {seasonNumber} original",
+                Overview = "Non-rating overview remains visible for an exempt Season.",
+                Genres = new[] { "Drama" },
+                Tags = new[] { "Non-rating tag" },
+                CommunityRating = 9.8f,
+                CriticRating = 97f,
+                RecursiveItemCount = 10,
+                UserData = new UserItemDataDto
+                {
+                    Key = "season",
+                    UnplayedItemCount = anyWatched ? 9 : 10,
+                },
+            };
+
+        [Theory]
+        [InlineData(1, false, true)]
+        [InlineData(2, true, true)]
+        [InlineData(2, false, false)]
+        public void SharedDecision_PinsSeasonExemptionBoundary(
+            int seasonNumber,
+            bool anyWatched,
+            bool expectRatingOnly)
+        {
+            var decision = TagCacheService.ResolveGuardedSeasonStripDecision(seasonNumber, anyWatched);
+
+            Assert.Equal(
+                expectRatingOnly
+                    ? TagCacheService.TagStripDecision.SeasonRatingOnly
+                    : TagCacheService.TagStripDecision.Strip,
+                decision);
+        }
+
+        [Fact]
+        public void SharedDecision_MissingSeasonNumberFailsClosedEvenWhenAnyEpisodeIsWatched()
+        {
+            var decision = TagCacheService.ResolveGuardedSeasonStripDecision(
+                seasonIndexNumber: null,
+                seasonAnyWatched: true);
+
+            Assert.Equal(TagCacheService.TagStripDecision.Strip, decision);
+        }
+
+        [Fact]
+        public void SharedProjection_MarksSuppressionEvenWhenSourceRatingsAreNull()
+        {
+            var projected = TagCacheService.ProjectGuardedSeasonRatings(
+                communityRating: null,
+                criticRating: null,
+                decision: TagCacheService.TagStripDecision.SeasonRatingOnly,
+                stripRatings: true);
+
+            Assert.True(projected.Suppressed);
+            Assert.Null(projected.CommunityRating);
+            Assert.Null(projected.CriticRating);
+        }
+
+        [Fact]
+        public void FieldFilter_GuardedSeasonOne_StripsOnlyRatings()
+        {
+            var seriesId = Guid.NewGuid();
+            var cfg = StrictConfig();
+            var dto = SeasonDto(seriesId, seasonNumber: 1, anyWatched: false);
+
+            NewFilter(cfg).StripItemForTest(dto, GuardedState(seriesId), cfg);
+
+            Assert.Null(dto.CommunityRating);
+            Assert.Null(dto.CriticRating);
+            Assert.Equal("Non-rating overview remains visible for an exempt Season.", dto.Overview);
+            Assert.Equal(new[] { "Non-rating tag" }, dto.Tags);
+            Assert.Equal(new[] { "Drama" }, dto.Genres);
+            Assert.Equal("Season 1 original", dto.Name);
+        }
+
+        [Fact]
+        public void FieldFilter_GuardedSeasonTwoAnyWatched_StripsOnlyRatings()
+        {
+            var seriesId = Guid.NewGuid();
+            var cfg = StrictConfig();
+            var dto = SeasonDto(seriesId, seasonNumber: 2, anyWatched: true);
+
+            NewFilter(cfg).StripItemForTest(dto, GuardedState(seriesId), cfg);
+
+            Assert.Null(dto.CommunityRating);
+            Assert.Null(dto.CriticRating);
+            Assert.Equal("Non-rating overview remains visible for an exempt Season.", dto.Overview);
+            Assert.Equal(new[] { "Non-rating tag" }, dto.Tags);
+            Assert.Equal(new[] { "Drama" }, dto.Genres);
+        }
+
+        [Fact]
+        public void FieldFilter_GuardedSeasonTwoNoneWatched_AppliesFullConfiguredStrip()
+        {
+            var seriesId = Guid.NewGuid();
+            var cfg = StrictConfig();
+            var dto = SeasonDto(seriesId, seasonNumber: 2, anyWatched: false);
+
+            NewFilter(cfg).StripItemForTest(dto, GuardedState(seriesId), cfg);
+
+            Assert.Null(dto.CommunityRating);
+            Assert.Null(dto.CriticRating);
+            Assert.Equal("Protected", dto.Overview);
+            Assert.Empty(dto.Tags);
+        }
+
+        [Fact]
+        public void FieldFilter_AdminRatingToggleOff_PreservesExemptSeasonRatings()
+        {
+            var seriesId = Guid.NewGuid();
+            var cfg = StrictConfig(stripRatings: false);
+            var dto = SeasonDto(seriesId, seasonNumber: 1, anyWatched: false);
+
+            NewFilter(cfg).StripItemForTest(dto, GuardedState(seriesId), cfg);
+
+            Assert.Equal(9.8f, dto.CommunityRating);
+            Assert.Equal(97f, dto.CriticRating);
+        }
+
+        [Fact]
+        public void FieldFilter_HideRatingsOptOut_PreservesExemptSeasonRatings()
+        {
+            var seriesId = Guid.NewGuid();
+            var cfg = StrictConfig();
+            var dto = SeasonDto(seriesId, seasonNumber: 1, anyWatched: false);
+
+            NewFilter(cfg).StripItemForTest(dto, GuardedState(seriesId, hideRatings: false), cfg);
+
+            Assert.Equal(9.8f, dto.CommunityRating);
+            Assert.Equal(97f, dto.CriticRating);
+        }
+
+        [Fact]
+        public void GetTagData_GuardedSeasonOne_StripsRatingsAndBlocksFallbackWithoutDroppingIdentity()
+        {
+            var item = GetSeasonTagData(StrictConfig(), hideRatings: null, seasonNumber: 1);
+
+            Assert.Equal(JsonValueKind.Null, item.GetProperty("CommunityRating").ValueKind);
+            Assert.Equal(JsonValueKind.Null, item.GetProperty("CriticRating").ValueKind);
+            Assert.True(item.GetProperty("RatingSuppressed").GetBoolean());
+            Assert.NotEqual(JsonValueKind.Null, item.GetProperty("SeriesId").ValueKind);
+            Assert.Equal("Season 1 original", item.GetProperty("Name").GetString());
+            Assert.Equal("Drama", item.GetProperty("Genres")[0].GetString());
+        }
+
+        [Fact]
+        public void GetTagData_EmptyRouteUserId_UsesAuthorizedEffectiveUserPolicy()
+        {
+            var item = GetSeasonTagData(
+                StrictConfig(),
+                hideRatings: null,
+                seasonNumber: 1,
+                useEmptyRouteUserId: true);
+
+            Assert.Equal(JsonValueKind.Null, item.GetProperty("CommunityRating").ValueKind);
+            Assert.True(item.GetProperty("RatingSuppressed").GetBoolean());
+        }
+
+        [Fact]
+        public void GetTagData_GuardedSeasonTwoNoneWatched_UsesFullStub()
+        {
+            var item = GetSeasonTagData(StrictConfig(), hideRatings: null, seasonNumber: 2);
+
+            Assert.Equal(JsonValueKind.Null, item.GetProperty("CommunityRating").ValueKind);
+            Assert.Equal(JsonValueKind.Null, item.GetProperty("CriticRating").ValueKind);
+            Assert.True(item.GetProperty("RatingSuppressed").GetBoolean());
+            Assert.Equal(JsonValueKind.Null, item.GetProperty("SeriesId").ValueKind);
+            Assert.Empty(item.GetProperty("Genres").EnumerateArray());
+        }
+
+        [Theory]
+        [InlineData(false, null)]
+        [InlineData(true, false)]
+        public void GetTagData_RatingToggleOrUserOptOut_PreservesExemptSeasonRatings(
+            bool adminStripRatings,
+            bool? hideRatings)
+        {
+            var item = GetSeasonTagData(
+                StrictConfig(stripRatings: adminStripRatings),
+                hideRatings,
+                seasonNumber: 1);
+
+            Assert.Equal(9.8, item.GetProperty("CommunityRating").GetDouble(), precision: 3);
+            Assert.Equal(97, item.GetProperty("CriticRating").GetDouble(), precision: 3);
+            Assert.False(item.GetProperty("RatingSuppressed").GetBoolean());
+        }
+
+        private static JsonElement GetSeasonTagData(
+            PluginConfiguration cfg,
+            bool? hideRatings,
+            int seasonNumber,
+            bool useEmptyRouteUserId = false)
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "jc-season-rating-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+
+            var user = new User("season-rating", "Prov", "PwProv");
+            var seriesId = Guid.NewGuid();
+            var season = new StubSeason
+            {
+                Id = Guid.NewGuid(),
+                SeriesId = seriesId,
+                IndexNumber = seasonNumber,
+                Name = $"Season {seasonNumber} original",
+                Genres = new[] { "Drama" },
+                Tags = new[] { "Non-rating tag" },
+                CommunityRating = 9.8f,
+                CriticRating = 97f,
+            };
+
+            var userIdN = user.Id.ToString("N");
+            try
+            {
+                var appPaths = new StubAppPaths(dir);
+                var manager = new UserConfigurationManager(appPaths, NullLogger<UserConfigurationManager>.Instance);
+                manager.SaveUserConfiguration(userIdN, SpoilerFile, GuardedState(seriesId, hideRatings));
+                SpoilerUserResolver.InvalidateUser(userIdN);
+
+                var library = new CountingLibraryManager
+                {
+                    GetItemByIdUserHook = (id, _) => id == season.Id ? season : null,
+                    GetItemListHook = _ => Array.Empty<BaseItem>(),
+                };
+                var users = new StubUserManager(user);
+                var identity = new RequestIdentityService(
+                    new CountingSessionManager(),
+                    users,
+                    new SpoilerIdentityService(users, NullLogger<SpoilerIdentityService>.Instance),
+                    NullLogger<RequestIdentityService>.Instance);
+                var resolver = new SpoilerUserResolver(
+                    manager, library, NullLogger<SpoilerUserResolver>.Instance, identity);
+                var configProvider = new FakePluginConfigProvider(cfg);
+
+                // GetTagData does not touch the cache/revision services; null test
+                // placeholders keep this harness focused on its live fallback path.
+                var controller = new TagCacheController(
+                    new RecordingHttpClientFactory(new HttpClientHandler()),
+                    NullLogger<TagCacheController>.Instance,
+                    users,
+                    new SeerrCache(configProvider),
+                    configProvider,
+                    tagCacheService: null!,
+                    library,
+                    new StubUserDataManager(),
+                    resolver,
+                    manager,
+                    projectionRevisionService: null!);
+                var principal = new ClaimsPrincipal(new ClaimsIdentity(
+                    new[] { new Claim("Jellyfin-UserId", user.Id.ToString()) },
+                    "TestAuth"));
+                controller.ControllerContext = new ControllerContext
+                {
+                    HttpContext = new DefaultHttpContext { User = principal },
+                };
+
+                var ok = Assert.IsType<OkObjectResult>(
+                    controller.GetTagData(
+                        useEmptyRouteUserId ? Guid.Empty : user.Id,
+                        new[] { season.Id.ToString("N") }));
+                using var json = JsonDocument.Parse(JsonSerializer.Serialize(ok.Value));
+                return json.RootElement.GetProperty("Items")[0].Clone();
+            }
+            finally
+            {
+                SpoilerUserResolver.InvalidateUser(userIdN);
+                try { Directory.Delete(dir, recursive: true); } catch { /* best effort */ }
+            }
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/TagCacheProjectionRevisionTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/TagCacheProjectionRevisionTests.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.JellyfinCanopy.Model;
+using Jellyfin.Plugin.JellyfinCanopy.Services;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Model.Entities;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
+{
+    public sealed class TagCacheProjectionRevisionTests
+    {
+        private static string Key(Guid id) => id.ToString("N");
+
+        private static TagCacheProjectionRevisionService NewTracker(
+            StubUserDataManager userData,
+            int capacity = TagCacheProjectionRevisionService.DefaultJournalCapacity)
+        {
+            return new TagCacheProjectionRevisionService(
+                userData,
+                NullLogger<TagCacheProjectionRevisionService>.Instance,
+                capacity);
+        }
+
+        [Fact]
+        public void RepeatedEpisodeWatchedToggle_AdvancesRevisionAndReplaysAllDependencies()
+        {
+            var userData = new StubUserDataManager();
+            using var tracker = NewTracker(userData);
+            var userId = Guid.NewGuid();
+            var seriesId = Guid.NewGuid();
+            var seasonId = Guid.NewGuid();
+            var episode = new StubEpisode
+            {
+                Id = Guid.NewGuid(),
+                SeasonId = seasonId,
+                SeriesId = seriesId
+            };
+            var expected = new[] { Key(episode.Id), Key(seasonId), Key(seriesId) }
+                .OrderBy(static id => id, StringComparer.Ordinal)
+                .ToArray();
+
+            var initial = tracker.GetDelta(userId, null, null, requireCursor: false);
+            userData.RaiseUserDataSaved(userId, episode, UserDataSaveReason.TogglePlayed);
+
+            var first = tracker.GetDelta(userId, initial.Epoch, initial.Revision, requireCursor: true);
+            Assert.False(first.ResetRequired);
+            Assert.Equal(1, first.Revision);
+            Assert.Equal(expected, first.ItemIds);
+
+            // A repeated toggle is another authoritative transition, even though its
+            // dependency set is identical. A client on revision 1 must see it.
+            userData.RaiseUserDataSaved(userId, episode, UserDataSaveReason.TogglePlayed);
+            var second = tracker.GetDelta(userId, first.Epoch, first.Revision, requireCursor: true);
+            Assert.False(second.ResetRequired);
+            Assert.Equal(2, second.Revision);
+            Assert.Equal(expected, second.ItemIds);
+
+            // Replaying both journal records deduplicates ids without losing the
+            // latest revision boundary.
+            var aggregate = tracker.GetDelta(userId, initial.Epoch, initial.Revision, requireCursor: true);
+            Assert.Equal(2, aggregate.Revision);
+            Assert.Equal(expected, aggregate.ItemIds);
+        }
+
+        [Fact]
+        public void DependencyExpansion_CoversSeasonBoundaryAndSelfProjectedTypes()
+        {
+            var seriesId = Guid.NewGuid();
+            var season = new StubSeason { Id = Guid.NewGuid(), SeriesId = seriesId };
+            var episode = new StubEpisode
+            {
+                Id = Guid.NewGuid(),
+                SeasonId = season.Id,
+                SeriesId = seriesId
+            };
+            var movie = new StubMovie { Id = Guid.NewGuid() };
+            var series = new StubSeries { Id = seriesId };
+
+            Assert.Equal(
+                SortedKeys(episode.Id, season.Id, seriesId),
+                TagCacheProjectionRevisionService.ExpandProjectionDependencies(episode));
+            Assert.Equal(
+                SortedKeys(season.Id, seriesId),
+                TagCacheProjectionRevisionService.ExpandProjectionDependencies(season));
+            Assert.Equal(
+                new[] { Key(movie.Id) },
+                TagCacheProjectionRevisionService.ExpandProjectionDependencies(movie));
+            Assert.Equal(
+                new[] { Key(series.Id) },
+                TagCacheProjectionRevisionService.ExpandProjectionDependencies(series));
+        }
+
+        [Fact]
+        public void PerUserJournals_AreRevisionAndPayloadIsolated()
+        {
+            var userData = new StubUserDataManager();
+            using var tracker = NewTracker(userData);
+            var userA = Guid.NewGuid();
+            var userB = Guid.NewGuid();
+            var movieA = new StubMovie { Id = Guid.NewGuid() };
+            var movieB = new StubMovie { Id = Guid.NewGuid() };
+            var cursorA = tracker.GetDelta(userA, null, null, requireCursor: false);
+            var cursorB = tracker.GetDelta(userB, null, null, requireCursor: false);
+
+            userData.RaiseUserDataSaved(userA, movieA, UserDataSaveReason.TogglePlayed);
+            userData.RaiseUserDataSaved(userB, movieB, UserDataSaveReason.TogglePlayed);
+            userData.RaiseUserDataSaved(userA, movieA, UserDataSaveReason.TogglePlayed);
+
+            var deltaA = tracker.GetDelta(userA, cursorA.Epoch, cursorA.Revision, requireCursor: true);
+            var deltaB = tracker.GetDelta(userB, cursorB.Epoch, cursorB.Revision, requireCursor: true);
+            Assert.Equal(2, deltaA.Revision);
+            Assert.Equal(new[] { Key(movieA.Id) }, deltaA.ItemIds);
+            Assert.Equal(1, deltaB.Revision);
+            Assert.Equal(new[] { Key(movieB.Id) }, deltaB.ItemIds);
+
+            var caughtUpB = tracker.GetDelta(userB, deltaB.Epoch, deltaB.Revision, requireCursor: true);
+            Assert.False(caughtUpB.ResetRequired);
+            Assert.Empty(caughtUpB.ItemIds);
+            Assert.Equal(1, caughtUpB.Revision);
+        }
+
+        [Fact]
+        public void PlaybackProgress_DoesNotAdvanceProjectionRevision()
+        {
+            var userData = new StubUserDataManager();
+            using var tracker = NewTracker(userData);
+            var userId = Guid.NewGuid();
+            var initial = tracker.GetDelta(userId, null, null, requireCursor: false);
+
+            userData.RaiseUserDataSaved(
+                userId,
+                new StubMovie { Id = Guid.NewGuid() },
+                UserDataSaveReason.PlaybackProgress);
+
+            var delta = tracker.GetDelta(userId, initial.Epoch, initial.Revision, requireCursor: true);
+            Assert.False(delta.ResetRequired);
+            Assert.Equal(0, delta.Revision);
+            Assert.Empty(delta.ItemIds);
+        }
+
+        [Fact]
+        public void JournalGapAndInvalidCursors_RequireExplicitReset()
+        {
+            var userData = new StubUserDataManager();
+            using var tracker = NewTracker(userData, capacity: 2);
+            var userId = Guid.NewGuid();
+            var initial = tracker.GetDelta(userId, null, null, requireCursor: false);
+            var movies = Enumerable.Range(0, 3)
+                .Select(_ => new StubMovie { Id = Guid.NewGuid() })
+                .ToArray();
+            foreach (var movie in movies)
+            {
+                userData.RaiseUserDataSaved(userId, movie, UserDataSaveReason.TogglePlayed);
+            }
+
+            // Revision 1 is the last cursor still covered by the retained [2,3]
+            // records. Revision 0 has a gap and must force a full snapshot.
+            var covered = tracker.GetDelta(userId, initial.Epoch, clientRevision: 1, requireCursor: true);
+            Assert.False(covered.ResetRequired);
+            Assert.Equal(SortedKeys(movies[1].Id, movies[2].Id), covered.ItemIds);
+
+            AssertReset(tracker.GetDelta(userId, initial.Epoch, initial.Revision, requireCursor: true), 3);
+            AssertReset(tracker.GetDelta(userId, "different-process", 3, requireCursor: true), 3);
+            AssertReset(tracker.GetDelta(userId, initial.Epoch, 4, requireCursor: true), 3);
+            AssertReset(tracker.GetDelta(userId, initial.Epoch, -1, requireCursor: true), 3);
+            AssertReset(tracker.GetDelta(userId, initial.Epoch, null, requireCursor: true), 3);
+            AssertReset(tracker.GetDelta(userId, null, 3, requireCursor: true), 3);
+        }
+
+        [Fact]
+        public void ConstructorSubscribes_InitializeIsIdempotent_AndDisposeUnsubscribes()
+        {
+            var userData = new StubUserDataManager();
+            var tracker = new TagCacheProjectionRevisionService(
+                userData,
+                NullLogger<TagCacheProjectionRevisionService>.Instance,
+                journalCapacity: 2);
+
+            Assert.Equal(1, userData.UserDataSavedSubscriberCount);
+            tracker.Initialize();
+            tracker.Initialize();
+            Assert.Equal(1, userData.UserDataSavedSubscriberCount);
+
+            tracker.Dispose();
+            Assert.Equal(0, userData.UserDataSavedSubscriberCount);
+        }
+
+        [Fact]
+        public void ProjectionSelection_DirectlyLooksUpOnlyRequestedCachedIdsForThatUser()
+        {
+            var user = new User("projection-user", "Provider", "PasswordProvider");
+            var accessible = new StubMovie { Id = Guid.NewGuid() };
+            var inaccessible = new StubMovie { Id = Guid.NewGuid() };
+            var missing = Guid.NewGuid();
+            var lookups = new List<(Guid Id, User? User)>();
+            var library = new CountingLibraryManager
+            {
+                GetItemByIdUserHook = (id, scopedUser) =>
+                {
+                    lookups.Add((id, scopedUser));
+                    return id == accessible.Id ? accessible : null;
+                }
+            };
+            using var service = new TagCacheService(
+                library,
+                new StubAppPaths(Path.GetTempPath()),
+                NullLogger<TagCacheService>.Instance);
+            var accessibleEntry = new TagCacheEntry { Type = "Movie" };
+            service.SeedEntryForTest(Key(accessible.Id), accessibleEntry);
+            service.SeedEntryForTest(Key(inaccessible.Id), new TagCacheEntry { Type = "Movie" });
+
+            var result = service.GetCacheEntriesForUserByIds(
+                user,
+                new[]
+                {
+                    Key(accessible.Id),
+                    Key(inaccessible.Id),
+                    Key(missing),
+                    "not-an-id",
+                    Key(accessible.Id)
+                });
+
+            var selected = Assert.Single(result);
+            Assert.Equal(Key(accessible.Id), selected.Key);
+            Assert.Same(accessibleEntry, selected.Value);
+            Assert.Equal(new[] { accessible.Id, inaccessible.Id }, lookups.Select(static lookup => lookup.Id));
+            Assert.All(lookups, lookup => Assert.Same(user, lookup.User));
+        }
+
+        private static string[] SortedKeys(params Guid[] ids)
+            => ids.Select(Key).OrderBy(static id => id, StringComparer.Ordinal).ToArray();
+
+        private static void AssertReset(
+            TagCacheProjectionRevisionService.ProjectionDelta delta,
+            long expectedRevision)
+        {
+            Assert.True(delta.ResetRequired);
+            Assert.Equal(expectedRevision, delta.Revision);
+            Assert.Empty(delta.ItemIds);
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/TestDoubles/StubUserDataManager.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/TestDoubles/StubUserDataManager.cs
@@ -17,10 +17,36 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
 /// </summary>
 public sealed class StubUserDataManager : IUserDataManager
 {
+    private EventHandler<UserDataSaveEventArgs>? _userDataSaved;
+
     /// <summary>When set, backs <see cref="GetUserData(User, BaseItem)"/>.</summary>
     public Func<User, BaseItem, UserItemData?>? GetUserDataHook { get; set; }
 
-    public event EventHandler<UserDataSaveEventArgs>? UserDataSaved { add { } remove { } }
+    public event EventHandler<UserDataSaveEventArgs>? UserDataSaved
+    {
+        add => _userDataSaved += value;
+        remove => _userDataSaved -= value;
+    }
+
+    /// <summary>Live subscriber count for idempotency/disposal assertions.</summary>
+    public int UserDataSavedSubscriberCount => _userDataSaved?.GetInvocationList().Length ?? 0;
+
+    /// <summary>Raise Jellyfin's authoritative post-save event.</summary>
+    public void RaiseUserDataSaved(
+        Guid userId,
+        BaseItem item,
+        UserDataSaveReason reason,
+        UserItemData? userData = null)
+    {
+        _userDataSaved?.Invoke(this, new UserDataSaveEventArgs
+        {
+            UserId = userId,
+            Item = item,
+            SaveReason = reason,
+            UserData = userData ?? new UserItemData { Key = item.Id.ToString("N") },
+            Keys = new List<string>()
+        });
+    }
 
     public UserItemData? GetUserData(User user, BaseItem item)
         => GetUserDataHook?.Invoke(user, item);

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/TagCacheController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/TagCacheController.cs
@@ -49,11 +49,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
     [ApiController]
     public class TagCacheController : JellyfinCanopyControllerBase
     {
+        private const int MaxProjectionStabilizationPasses = 3;
+
         private readonly Services.TagCacheService _tagCacheService;
         private readonly ILibraryManager _libraryManager;
         private readonly IUserDataManager _userDataManager;
         private readonly Services.SpoilerUserResolver _spoilerResolver;
         private readonly UserConfigurationManager _userConfigurationManager;
+        private readonly Services.TagCacheProjectionRevisionService _projectionRevisionService;
 
         public TagCacheController(
             IHttpClientFactory httpClientFactory,
@@ -65,7 +68,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             ILibraryManager libraryManager,
             IUserDataManager userDataManager,
             Services.SpoilerUserResolver spoilerResolver,
-            UserConfigurationManager userConfigurationManager)
+            UserConfigurationManager userConfigurationManager,
+            Services.TagCacheProjectionRevisionService projectionRevisionService)
             : base(httpClientFactory, logger, userManager, seerrCache, configProvider)
         {
             _tagCacheService = tagCacheService;
@@ -73,12 +77,18 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             _userDataManager = userDataManager;
             _spoilerResolver = spoilerResolver;
             _userConfigurationManager = userConfigurationManager;
+            _projectionRevisionService = projectionRevisionService;
         }
 
         [HttpGet("tag-cache/{userId}")]
         [Authorize]
         [Produces("application/json")]
-        public IActionResult GetTagCache(Guid userId, [FromQuery] long? since = null)
+        public IActionResult GetTagCache(
+            Guid userId,
+            [FromQuery] long? since = null,
+            [FromQuery] string? projectionEpoch = null,
+            [FromQuery] long? projectionRevision = null,
+            [FromQuery] bool projectionOnly = false)
         {
             if (_configProvider.ConfigurationOrNull?.TagCacheServerMode != true)
             {
@@ -91,24 +101,169 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 return authorizationResult;
             }
 
-            var items = _tagCacheService.GetCacheForUser(user, since);
+            // Guid.Empty is a supported alias for the authenticated user in
+            // UserHelper. From this point onward every personalized read and cursor
+            // must use the resolved identity, not the route placeholder; otherwise
+            // accessible rows for the real user could be projected with the empty
+            // user's spoiler policy and revision journal.
+            var effectiveUserId = user.Id;
 
-            // Spoiler Guard tag-strip: when SpoilerBlur is on with any tag-relevant
-            // strip toggle, walk the cache and zero out matching fields for unwatched
-            // episodes/movies/seasons/series that are in the user's spoiler list.
-            // Needed because the JC tag-pipeline reads serverCache BEFORE GetTagData,
-            // so card overlays would still leak despite the toggle. Mirrors the
-            // per-batch strip in GetTagData. Strips a per-request CLONE only — the
-            // shared cache entry is never mutated (see TagCacheEntry.Clone()).
-            ApplyTagCacheSpoilerStrip(items, userId, user);
+            // Capture the shared-content cursor BEFORE selecting any cache rows.
+            // A reconcile can atomically swap the cache (or a flush can mutate it)
+            // while this request is being projected. Returning a later timestamp
+            // with an earlier row snapshot would make the client's next ?since=
+            // request permanently skip the intervening content change. An earlier
+            // cursor may cause one harmless duplicate delta; it cannot lose data.
+            var contentVersion = _tagCacheService.Version;
+            var contentTimestamp = _tagCacheService.LastModified;
+
+            // A projection cursor is independent from the shared content timestamp:
+            // watched state is per-user and deliberately never mutates TagCacheEntry.
+            // Incremental requests must carry both halves so a process restart or a
+            // bounded-journal gap becomes an explicit reset instead of a silent leak.
+            var hasProjectionCursorInput = projectionEpoch != null || projectionRevision.HasValue;
+            var legacySinceOnly = since.HasValue && !projectionOnly && !hasProjectionCursorInput;
+            var requireProjectionCursor = projectionOnly || hasProjectionCursorInput;
+            var projection = _projectionRevisionService.GetDelta(
+                effectiveUserId,
+                projectionEpoch,
+                projectionRevision,
+                requireProjectionCursor);
+
+            if (projection.ResetRequired)
+            {
+                // Do not fall through to GetCacheForUser: a reset response is a
+                // control message, and especially projection-only must never pay the
+                // 15k-entry access-query/cache-scan cost.
+                return ProjectionResetResponse(
+                    effectiveUserId,
+                    projection,
+                    contentVersion,
+                    contentTimestamp);
+            }
+
+            // Pre-projection clients know only ?since= and ignore the reset fields.
+            // They cannot prove which watched-state journal revisions they already
+            // hold, so the backward-safe answer is one full personalized snapshot.
+            // New clients always send epoch+revision and retain the bounded delta.
+            var contentSince = legacySinceOnly ? null : since;
+            var items = projectionOnly
+                ? new Dictionary<string, Model.TagCacheEntry>()
+                : _tagCacheService.GetCacheForUser(user, contentSince);
+            var projectionIds = new HashSet<string>(projection.ItemIds, StringComparer.Ordinal);
+            ReplaceProjectionEntries(items, user, projection.ItemIds);
+
+            // UserDataSaved can race the live strip below. Stabilize against the
+            // journal revision after each strip: when it advanced, replace every
+            // newly affected row from the shared cache and strip the whole response
+            // again using the latest user data. This prevents a response labelled R
+            // from containing a mixture read across R+1. The bounded retry fails
+            // closed with an explicit reset if watched state churn never settles.
+            var projectionStable = false;
+            for (var pass = 0; pass < MaxProjectionStabilizationPasses; pass++)
+            {
+                // Spoiler Guard tag-strip: when SpoilerBlur is on with any tag-relevant
+                // strip toggle, walk the cache and zero out matching fields for unwatched
+                // episodes/movies/seasons/series that are in the user's spoiler list.
+                // Strips a per-request CLONE only; the shared entry is never mutated.
+                ApplyTagCacheSpoilerStrip(items, effectiveUserId, user);
+
+                var afterStrip = _projectionRevisionService.GetDelta(
+                    effectiveUserId,
+                    projection.Epoch,
+                    projection.Revision,
+                    requireCursor: true);
+                if (afterStrip.ResetRequired)
+                {
+                    return ProjectionResetResponse(
+                        effectiveUserId,
+                        afterStrip,
+                        contentVersion,
+                        contentTimestamp);
+                }
+
+                if (afterStrip.Revision == projection.Revision)
+                {
+                    projection = afterStrip;
+                    projectionStable = true;
+                    break;
+                }
+
+                foreach (var itemId in afterStrip.ItemIds)
+                {
+                    projectionIds.Add(itemId);
+                }
+
+                ReplaceProjectionEntries(items, user, afterStrip.ItemIds);
+                projection = afterStrip;
+            }
+
+            if (!projectionStable)
+            {
+                var latest = _projectionRevisionService.GetDelta(
+                    effectiveUserId,
+                    projection.Epoch,
+                    projection.Revision,
+                    requireCursor: true);
+                return ProjectionResetResponse(
+                    effectiveUserId,
+                    latest,
+                    contentVersion,
+                    contentTimestamp);
+            }
 
             return Ok(new
             {
-                version = _tagCacheService.Version,
-                timestamp = _tagCacheService.LastModified,
+                version = contentVersion,
+                timestamp = contentTimestamp,
                 count = items.Count,
-                items
+                items,
+                projectionUserId = effectiveUserId.ToString("N"),
+                projectionEpoch = projection.Epoch,
+                projectionRevision = projection.Revision,
+                projectionReset = false,
+                reset = false,
+                projectionIds = projectionIds.OrderBy(static id => id, StringComparer.Ordinal).ToArray()
             });
+        }
+
+        private IActionResult ProjectionResetResponse(
+            Guid userId,
+            Services.TagCacheProjectionRevisionService.ProjectionDelta projection,
+            long contentVersion,
+            long contentTimestamp)
+        {
+            return Ok(new
+            {
+                version = contentVersion,
+                timestamp = contentTimestamp,
+                count = 0,
+                items = new Dictionary<string, Model.TagCacheEntry>(),
+                projectionUserId = userId.ToString("N"),
+                projectionEpoch = projection.Epoch,
+                projectionRevision = projection.Revision,
+                projectionReset = true,
+                reset = true,
+                projectionIds = Array.Empty<string>()
+            });
+        }
+
+        private void ReplaceProjectionEntries(
+            Dictionary<string, Model.TagCacheEntry> items,
+            JUser user,
+            string[] itemIds)
+        {
+            // Remove first so missing/inaccessible cache rows remain authoritative
+            // tombstones rather than leaving an older row in a normal content delta.
+            foreach (var itemId in itemIds)
+            {
+                items.Remove(itemId);
+            }
+
+            foreach (var (key, entry) in _tagCacheService.GetCacheEntriesForUserByIds(user, itemIds))
+            {
+                items[key] = entry;
+            }
         }
 
         // Per-user strip for the server-mode tag-cache response. The gating logic
@@ -172,7 +327,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             };
             Func<Guid, int?> seasonIndexNumber = guid =>
                 _libraryManager.GetItemById<BaseItem>(guid) is MediaBrowser.Controller.Entities.TV.Season s
-                    ? s.IndexNumber.GetValueOrDefault(int.MaxValue)
+                    ? s.IndexNumber
                     : (int?)null;
             Func<Guid, bool> seasonAnyWatched = guid =>
             {
@@ -222,6 +377,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 return authorizationResult;
             }
 
+            // Match AuthorizeUserAccess/UserHelper semantics: Guid.Empty names the
+            // authenticated user, so policy must be loaded under that resolved id.
+            var effectiveUserId = user.Id;
+
             if (ids == null || ids.Length == 0)
             {
                 return BadRequest(new { error = "ids array required" });
@@ -251,7 +410,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 // Load through the owning resolver (typed read + last-known-good +
                 // fail-closed sentinel); never null. A corrupt/unavailable policy can
                 // no longer silently disable tag stripping on this endpoint.
-                spoilerState = _spoilerResolver.LoadUserState(HttpContext, userId);
+                spoilerState = _spoilerResolver.LoadUserState(HttpContext, effectiveUserId);
                 // Empty lists = nothing to strip; treat as off — UNLESS fail-closed
                 // (policy fault, no last-known-good), which over-strips every item.
                 // Check all three dicts so a movies-only user isn't short-circuited.
@@ -290,6 +449,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
 
                 var kind = item.GetBaseItemKind();
                 var isContainer = kind == BaseItemKind.Series || kind == BaseItemKind.Season;
+                Services.TagCacheService.GuardedSeasonRatingProjection? guardedSeasonRatings = null;
 
                 // Fail-closed: the policy read faulted with no last-known-good. Return
                 // a fully-stripped Id+Type stub for EVERY item regardless of type,
@@ -511,20 +671,19 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 // it would spoil their own navigation. Movies inside opted-in collections
                 // are already handled by the Movie-stub via IsMovieInSpoilerScope.
 
-                // Season stub: for a Season of a guarded series with no watched episode
-                // and not S0/S1, return an Id+Type stub so JC tag overlays don't render
-                // on the blurred season poster. Mirrors the field-strip filter's Season
-                // strip + the image filter's HasWatchedAnyEpisodeInSeason gate.
+                // Guarded-Season projection. S0/S1 and a later Season with any
+                // watched episode keep their non-rating metadata, but ratings remain
+                // hidden because a Season card can fall back to the guarded Series'
+                // rating. A later entirely-unwatched Season still takes the full stub.
                 if (stripTagsEnabled
                     && spoilerState != null
                     && item is MediaBrowser.Controller.Entities.TV.Season spSeason
                     && spSeason.SeriesId != Guid.Empty
                     && spoilerState.Series.ContainsKey(spSeason.SeriesId.ToString("N")))
                 {
-                    var sNum = spSeason.IndexNumber.GetValueOrDefault(int.MaxValue);
-                    if (sNum > 1)
+                    bool anyWatched = false;
+                    if (spSeason.IndexNumber.HasValue && spSeason.IndexNumber.Value > 1)
                     {
-                        bool anyWatched = false;
                         try
                         {
                             foreach (var ep in spSeason.GetEpisodes(user, new MediaBrowser.Controller.Dto.DtoOptions(false), shouldIncludeMissingEpisodes: false))
@@ -541,32 +700,42 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                                 $"Spoiler Guard tag-data: season any-watched probe failed for {spSeason.Id}: {ex.Message}");
                             // Fail-CLOSED: assume not watched, proceed to stub.
                         }
+                    }
 
-                        if (!anyWatched)
+                    var seasonDecision = Services.TagCacheService.ResolveGuardedSeasonStripDecision(
+                        spSeason.IndexNumber,
+                        anyWatched);
+                    guardedSeasonRatings = Services.TagCacheService.ProjectGuardedSeasonRatings(
+                        spSeason.CommunityRating,
+                        spSeason.CriticRating,
+                        seasonDecision,
+                        spStripRatings);
+
+                    if (seasonDecision == Services.TagCacheService.TagStripDecision.Strip)
+                    {
+                        string? stubName = item.Name;
+                        if (spReplaceTitle && spSeason.IndexNumber.HasValue)
                         {
-                            string? stubName = item.Name;
-                            if (spReplaceTitle && spSeason.IndexNumber.HasValue)
-                            {
-                                stubName = $"Season {spSeason.IndexNumber.Value}";
-                            }
-                            results.Add(new
-                            {
-                                Id = item.Id,
-                                Type = kind.ToString(),
-                                Genres = spStripGenres ? Array.Empty<string>() : (spSeason.Genres ?? Array.Empty<string>()),
-                                CommunityRating = spStripRatings ? (float?)null : spSeason.CommunityRating,
-                                CriticRating = spStripRatings ? (float?)null : spSeason.CriticRating,
-                                SeriesId = spStripRatings ? (Guid?)null : spSeason.SeriesId,
-                                ProviderIds = (IDictionary<string, string>?)null,
-                                Name = stubName,
-                                Path = (string?)null,
-                                MediaStreams = (List<object>?)null,
-                                MediaSources = (List<object>?)null,
-                                FirstEpisode = (object?)null,
-                                Tags = spStripGenres ? Array.Empty<string>() : (spSeason.Tags ?? Array.Empty<string>()),
-                            });
-                            continue;
+                            stubName = $"Season {spSeason.IndexNumber.Value}";
                         }
+                        results.Add(new
+                        {
+                            Id = item.Id,
+                            Type = kind.ToString(),
+                            Genres = spStripGenres ? Array.Empty<string>() : (spSeason.Genres ?? Array.Empty<string>()),
+                            CommunityRating = guardedSeasonRatings.Value.CommunityRating,
+                            CriticRating = guardedSeasonRatings.Value.CriticRating,
+                            SeriesId = guardedSeasonRatings.Value.Suppressed ? (Guid?)null : spSeason.SeriesId,
+                            RatingSuppressed = guardedSeasonRatings.Value.Suppressed,
+                            ProviderIds = (IDictionary<string, string>?)null,
+                            Name = stubName,
+                            Path = (string?)null,
+                            MediaStreams = (List<object>?)null,
+                            MediaSources = (List<object>?)null,
+                            FirstEpisode = (object?)null,
+                            Tags = spStripGenres ? Array.Empty<string>() : (spSeason.Tags ?? Array.Empty<string>()),
+                        });
+                        continue;
                     }
                 }
 
@@ -645,9 +814,18 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                     Id = item.Id,
                     Type = kind.ToString(),
                     Genres = item.Genres,
-                    CommunityRating = item.CommunityRating,
-                    CriticRating = item.CriticRating,
+                    CommunityRating = guardedSeasonRatings.HasValue
+                        ? guardedSeasonRatings.Value.CommunityRating
+                        : item.CommunityRating,
+                    CriticRating = guardedSeasonRatings.HasValue
+                        ? guardedSeasonRatings.Value.CriticRating
+                        : item.CriticRating,
                     SeriesId = seriesId,
+                    // Keep SeriesId for genre/review identity. The explicit marker
+                    // tells the client not to reintroduce a hidden parent-Series
+                    // rating when this exempt Season's own rating fields are null.
+                    RatingSuppressed = guardedSeasonRatings.HasValue
+                        && guardedSeasonRatings.Value.Suppressed,
                     ProviderIds = item.ProviderIds,
                     Name = item.Name,
                     Path = string.IsNullOrEmpty(item.Path) ? null : System.IO.Path.GetFileName(item.Path),

--- a/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
@@ -114,6 +114,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy
             serviceCollection.AddSingleton<WatchlistMonitor>();
             serviceCollection.AddSingleton<SeerrScanTriggerService>();
             serviceCollection.AddSingleton<TagCacheService>();
+            serviceCollection.AddSingleton<TagCacheProjectionRevisionService>();
             serviceCollection.AddSingleton<TagCacheMonitor>();
             serviceCollection.AddTransient<ArrTagsSyncTask>();
             serviceCollection.AddTransient<BuildTagCacheTask>();

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/SpoilerBlurImageFilter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/SpoilerBlurImageFilter.cs
@@ -928,10 +928,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             // otherwise. Always show Season 1 (and Specials S0) as an entry
             // point.
             var season = (Season)item;
-            var seasonNum = season.IndexNumber.GetValueOrDefault(int.MaxValue);
-            if (seasonNum <= 1) return true;
-            if (HasWatchedAnyEpisodeInSeason(jUser, season)) return true;
-            return false; // blur
+            var seasonNum = season.IndexNumber;
+            var anyWatched = seasonNum.HasValue
+                && seasonNum.Value > 1
+                && HasWatchedAnyEpisodeInSeason(jUser, season);
+            var seasonDecision = TagCacheService.ResolveGuardedSeasonStripDecision(
+                seasonNum,
+                anyWatched);
+            return seasonDecision == TagCacheService.TagStripDecision.SeasonRatingOnly;
         }
 
         // Per-(user, season) "any episode watched?" probe with a short TTL

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/SpoilerFieldStripFilter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/SpoilerFieldStripFilter.cs
@@ -646,9 +646,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 // Season DTOs leak Overview right next to a blurred Season
                 // poster. Strip them too — but mirror the image filter's
                 // "S1 always shows" + "any-played => pass-through" logic
-                // so the user has an entry point.
-                var sNum = item.IndexNumber.GetValueOrDefault(int.MaxValue);
-                if (sNum <= 1) return; // Season 0 (Specials) and Season 1 always pass.
+                // so the user has an entry point. Those exemptions apply only
+                // to non-rating metadata: the Season card may carry its guarded
+                // Series' fallback rating, so the shared rating-only projection
+                // still runs before an exempt Season returns.
+                var sNum = item.IndexNumber;
 
                 // UserData.UnplayedItemCount is the simplest "any watched?"
                 // signal for a Season DTO. > 0 AND total > unplayed = some
@@ -659,7 +661,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 // helper that mirrors the image filter's logic
                 // (HasWatchedAnyEpisodeInSeason via library iteration).
                 bool seasonAnyWatched = false;
-                if (item.UserData != null
+                if (sNum.HasValue && sNum.Value > 1
+                    && item.UserData != null
                     && item.UserData.UnplayedItemCount.HasValue
                     && item.RecursiveItemCount.HasValue)
                 {
@@ -667,14 +670,40 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     var totalIndicator = item.RecursiveItemCount.Value;
                     if (totalIndicator > 0 && unplayed < totalIndicator) seasonAnyWatched = true;
                 }
-                else if (HasWatchedAnyEpisodeInSeasonServerSide(userId, item.Id))
+                else if (sNum.HasValue
+                    && sNum.Value > 1
+                    && HasWatchedAnyEpisodeInSeasonServerSide(userId, item.Id))
                 {
                     seasonAnyWatched = true;
                 }
-                // Mutate ImageTags BEFORE the watched-skip so the URL
-                // flips when the user starts the season.
-                MutateImageTagsForCacheBust(item, cfg, seasonAnyWatched, playbackPositionTicks: 0);
-                if (seasonAnyWatched) return;
+
+                var seasonDecision = TagCacheService.ResolveGuardedSeasonStripDecision(sNum, seasonAnyWatched);
+                if (seasonDecision == TagCacheService.TagStripDecision.SeasonRatingOnly)
+                {
+                    var projectedRatings = TagCacheService.ProjectGuardedSeasonRatings(
+                        item.CommunityRating,
+                        item.CriticRating,
+                        seasonDecision,
+                        ShouldStrip(cfg.SpoilerStripRatings, userState.Prefs?.HideRatings));
+                    item.CommunityRating = projectedRatings.CommunityRating;
+                    item.CriticRating = projectedRatings.CriticRating;
+
+                    // S0/S1 never transition through the any-watched boundary. Later
+                    // Seasons still need the native-image cache-bust to flip when the
+                    // first watched episode makes their non-rating metadata exempt.
+                    if (sNum.HasValue && sNum.Value > 1)
+                    {
+                        MutateImageTagsForCacheBust(item, cfg, watched: true, playbackPositionTicks: 0);
+                    }
+                    return;
+                }
+
+                // Mutate ImageTags before the full strip so the URL changes when a
+                // later watched-state update crosses the Season exemption boundary.
+                if (sNum.HasValue && sNum.Value > 1)
+                {
+                    MutateImageTagsForCacheBust(item, cfg, watched: false, playbackPositionTicks: 0);
+                }
                 ApplyStripping(item, userState, cfg, userId);
                 return;
             }

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/StartupService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/StartupService.cs
@@ -18,6 +18,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         private readonly AutoMovieRequestMonitor _autoMovieRequestMonitor;
         private readonly WatchlistMonitor _watchlistMonitor;
         private readonly TagCacheService _tagCacheService;
+        private readonly TagCacheProjectionRevisionService _tagCacheProjectionRevisionService;
         private readonly TagCacheMonitor _tagCacheMonitor;
         private readonly SeerrScanTriggerService _seerrScanTriggerService;
         private readonly IPluginConfigProvider _configProvider;
@@ -27,7 +28,17 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         public string Description => "Initializes Jellyfin Canopy background services and performs necessary cleanups. The client script is injected at request time by the injection middleware.";
         public string Category => "Jellyfin Canopy";
 
-        public StartupService(ILogger<StartupService> logger, IApplicationPaths applicationPaths, AutoSeasonRequestMonitor autoSeasonRequestMonitor, AutoMovieRequestMonitor autoMovieRequestMonitor, WatchlistMonitor watchlistMonitor, TagCacheService tagCacheService, TagCacheMonitor tagCacheMonitor, SeerrScanTriggerService seerrScanTriggerService, IPluginConfigProvider configProvider)
+        public StartupService(
+            ILogger<StartupService> logger,
+            IApplicationPaths applicationPaths,
+            AutoSeasonRequestMonitor autoSeasonRequestMonitor,
+            AutoMovieRequestMonitor autoMovieRequestMonitor,
+            WatchlistMonitor watchlistMonitor,
+            TagCacheService tagCacheService,
+            TagCacheProjectionRevisionService tagCacheProjectionRevisionService,
+            TagCacheMonitor tagCacheMonitor,
+            SeerrScanTriggerService seerrScanTriggerService,
+            IPluginConfigProvider configProvider)
         {
             _logger = logger;
             _applicationPaths = applicationPaths;
@@ -35,6 +46,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             _autoMovieRequestMonitor = autoMovieRequestMonitor;
             _watchlistMonitor = watchlistMonitor;
             _tagCacheService = tagCacheService;
+            _tagCacheProjectionRevisionService = tagCacheProjectionRevisionService;
             _tagCacheMonitor = tagCacheMonitor;
             _seerrScanTriggerService = seerrScanTriggerService;
             _configProvider = configProvider;
@@ -58,6 +70,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
 
                 // Initialize on-demand Seerr recently-added scan trigger
                 _seerrScanTriggerService.Initialize();
+
+                // Watched-state is a live per-user projection over the shared tag
+                // cache. Subscribe before loading/building the cache so no user-data
+                // transition after plugin startup can fall outside its journal.
+                _tagCacheProjectionRevisionService.Initialize();
 
                 // Load tag cache from disk. New/changed items are picked up by the
                 // monitor via Jellyfin's library scan events (ItemAdded/ItemUpdated).

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/TagCacheProjectionRevisionService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/TagCacheProjectionRevisionService.cs
@@ -1,0 +1,323 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using Jellyfin.Plugin.JellyfinCanopy.Model;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Entities;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Services
+{
+    /// <summary>
+    /// Tracks the user-specific inputs to the server tag-cache projection.
+    ///
+    /// The raw <see cref="TagCacheEntry"/> cache is shared across users, while
+    /// Spoiler Guard applies a live, per-user watched-state projection when an
+    /// endpoint serves it. A content timestamp therefore cannot describe a
+    /// watched/unwatched transition. This service gives that projection its own
+    /// process epoch, monotonically increasing per-user revision, and bounded
+    /// invalidation journal.
+    /// </summary>
+    public sealed class TagCacheProjectionRevisionService : IDisposable
+    {
+        internal const int DefaultJournalCapacity = 2048;
+
+        private sealed class ProjectionChange
+        {
+            public ProjectionChange(long revision, string[] itemIds)
+            {
+                Revision = revision;
+                ItemIds = itemIds;
+            }
+
+            public long Revision { get; }
+
+            public string[] ItemIds { get; }
+        }
+
+        private sealed class UserJournal
+        {
+            public object Gate { get; } = new();
+
+            public long Revision { get; set; }
+
+            public Queue<ProjectionChange> Changes { get; } = new();
+        }
+
+        internal sealed class ProjectionDelta
+        {
+            public ProjectionDelta(string epoch, long revision, bool resetRequired, string[] itemIds)
+            {
+                Epoch = epoch;
+                Revision = revision;
+                ResetRequired = resetRequired;
+                ItemIds = itemIds;
+            }
+
+            public string Epoch { get; }
+
+            public long Revision { get; }
+
+            public bool ResetRequired { get; }
+
+            public string[] ItemIds { get; }
+        }
+
+        private readonly IUserDataManager _userDataManager;
+        private readonly ILogger<TagCacheProjectionRevisionService> _logger;
+        private readonly int _journalCapacity;
+        private readonly string _epoch = Guid.NewGuid().ToString("N");
+        private readonly ConcurrentDictionary<Guid, UserJournal> _journals = new();
+        private readonly object _subscriptionGate = new();
+        private bool _subscribed;
+        private bool _disposed;
+
+        public TagCacheProjectionRevisionService(
+            IUserDataManager userDataManager,
+            ILogger<TagCacheProjectionRevisionService> logger)
+            : this(userDataManager, logger, DefaultJournalCapacity)
+        {
+        }
+
+        internal TagCacheProjectionRevisionService(
+            IUserDataManager userDataManager,
+            ILogger<TagCacheProjectionRevisionService> logger,
+            int journalCapacity)
+        {
+            _userDataManager = userDataManager ?? throw new ArgumentNullException(nameof(userDataManager));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            if (journalCapacity <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(journalCapacity));
+            }
+
+            _journalCapacity = journalCapacity;
+
+            // Subscribe during construction, not only from the scheduled startup
+            // task. MVC may activate TagCacheController before that task runs; DI
+            // construction must therefore establish tracking before the first
+            // tag-cache request can observe a projection cursor.
+            Initialize();
+        }
+
+        internal string Epoch => _epoch;
+
+        /// <summary>
+        /// Subscribe to Jellyfin's authoritative user-data save event. Idempotent so
+        /// a manually re-run startup task cannot register the handler twice.
+        /// </summary>
+        public void Initialize()
+        {
+            lock (_subscriptionGate)
+            {
+                ObjectDisposedException.ThrowIf(_disposed, this);
+                if (_subscribed)
+                {
+                    return;
+                }
+
+                _userDataManager.UserDataSaved += OnUserDataSaved;
+                _subscribed = true;
+            }
+
+            _logger.LogInformation("[TagCacheProjection] User-data revision tracking active (epoch {Epoch})", _epoch);
+        }
+
+        /// <summary>
+        /// Resolve changes after a client cursor. A cursor is required for any
+        /// incremental/projection-only request; a missing half, process-epoch change,
+        /// future revision, or bounded-journal gap requires an explicit full reset.
+        /// </summary>
+        internal ProjectionDelta GetDelta(
+            Guid userId,
+            string? clientEpoch,
+            long? clientRevision,
+            bool requireCursor)
+        {
+            var hasEpoch = !string.IsNullOrWhiteSpace(clientEpoch);
+            var hasRevision = clientRevision.HasValue;
+            if (requireCursor && (!hasEpoch || !hasRevision))
+            {
+                return Current(userId, resetRequired: true);
+            }
+
+            // A full snapshot has no cursor. It establishes the current identity
+            // without replaying historical invalidations (all entries are returned).
+            if (!hasEpoch && !hasRevision)
+            {
+                return Current(userId, resetRequired: false);
+            }
+
+            // A partial cursor is never authoritative.
+            if (!hasEpoch || !hasRevision || !string.Equals(clientEpoch, _epoch, StringComparison.Ordinal))
+            {
+                return Current(userId, resetRequired: true);
+            }
+
+            var requestedRevision = clientRevision!.Value;
+            if (!_journals.TryGetValue(userId, out var journal))
+            {
+                return new ProjectionDelta(
+                    _epoch,
+                    revision: 0,
+                    resetRequired: requestedRevision != 0,
+                    Array.Empty<string>());
+            }
+
+            lock (journal.Gate)
+            {
+                var currentRevision = journal.Revision;
+                if (requestedRevision < 0 || requestedRevision > currentRevision)
+                {
+                    return new ProjectionDelta(_epoch, currentRevision, resetRequired: true, Array.Empty<string>());
+                }
+
+                if (requestedRevision == currentRevision)
+                {
+                    return new ProjectionDelta(_epoch, currentRevision, resetRequired: false, Array.Empty<string>());
+                }
+
+                if (journal.Changes.Count == 0)
+                {
+                    return new ProjectionDelta(_epoch, currentRevision, resetRequired: true, Array.Empty<string>());
+                }
+
+                var earliestRetained = journal.Changes.Peek().Revision;
+                if (requestedRevision < earliestRetained - 1)
+                {
+                    return new ProjectionDelta(_epoch, currentRevision, resetRequired: true, Array.Empty<string>());
+                }
+
+                var ids = new HashSet<string>(StringComparer.Ordinal);
+                foreach (var change in journal.Changes)
+                {
+                    if (change.Revision <= requestedRevision)
+                    {
+                        continue;
+                    }
+
+                    foreach (var itemId in change.ItemIds)
+                    {
+                        ids.Add(itemId);
+                    }
+                }
+
+                return new ProjectionDelta(
+                    _epoch,
+                    currentRevision,
+                    resetRequired: false,
+                    ids.OrderBy(static id => id, StringComparer.Ordinal).ToArray());
+            }
+        }
+
+        private ProjectionDelta Current(Guid userId, bool resetRequired)
+        {
+            if (!_journals.TryGetValue(userId, out var journal))
+            {
+                return new ProjectionDelta(_epoch, revision: 0, resetRequired, Array.Empty<string>());
+            }
+
+            lock (journal.Gate)
+            {
+                return new ProjectionDelta(_epoch, journal.Revision, resetRequired, Array.Empty<string>());
+            }
+        }
+
+        private void OnUserDataSaved(object? sender, UserDataSaveEventArgs e)
+        {
+            // Match Jellyfin's native UserDataChanged publisher: progress check-ins
+            // are intentionally excluded, while TogglePlayed, PlaybackFinished,
+            // UpdateUserData, import, rating/favourite changes remain bounded to the
+            // affected item/dependants.
+            if (e == null
+                || e.UserId == Guid.Empty
+                || e.Item == null
+                || e.SaveReason == UserDataSaveReason.PlaybackProgress)
+            {
+                return;
+            }
+
+            var itemIds = ExpandProjectionDependencies(e.Item);
+            if (itemIds.Length == 0)
+            {
+                return;
+            }
+
+            var journal = _journals.GetOrAdd(e.UserId, static _ => new UserJournal());
+            lock (journal.Gate)
+            {
+                journal.Revision++;
+                journal.Changes.Enqueue(new ProjectionChange(journal.Revision, itemIds));
+                while (journal.Changes.Count > _journalCapacity)
+                {
+                    journal.Changes.Dequeue();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Expand the exact tag-cache projections whose watched/privacy decision can
+        /// change with an item. Jellyfin's native push adds only one owner/parent, so
+        /// Episode must name both Season and Series explicitly here.
+        /// </summary>
+        internal static string[] ExpandProjectionDependencies(BaseItem item)
+        {
+            var ids = new HashSet<Guid>();
+            switch (item)
+            {
+                case Episode episode:
+                    Add(episode.Id);
+                    Add(episode.SeasonId);
+                    Add(episode.SeriesId);
+                    break;
+                case Season season:
+                    Add(season.Id);
+                    Add(season.SeriesId);
+                    break;
+                case Movie movie:
+                    Add(movie.Id);
+                    break;
+                case Series series:
+                    Add(series.Id);
+                    break;
+                default:
+                    return Array.Empty<string>();
+            }
+
+            return ids
+                .Select(static id => id.ToString("N"))
+                .OrderBy(static id => id, StringComparer.Ordinal)
+                .ToArray();
+
+            void Add(Guid id)
+            {
+                if (id != Guid.Empty)
+                {
+                    ids.Add(id);
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (_subscriptionGate)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                if (_subscribed)
+                {
+                    _userDataManager.UserDataSaved -= OnUserDataSaved;
+                    _subscribed = false;
+                }
+            }
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/TagCacheService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/TagCacheService.cs
@@ -105,12 +105,30 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         // Test seams for the user-access cache invalidation contract (Tests has InternalsVisibleTo).
         internal int UserAccessCacheCount => _userAccessCache.Count;
 
-        internal void SeedUserAccessCacheForTest(string userKey)
-            => _userAccessCache[userKey] = (new HashSet<string>(), DateTime.UtcNow);
+        internal void SeedUserAccessCacheForTest(string userKey, params string[] itemIds)
+            => _userAccessCache[userKey] = (
+                new HashSet<string>(itemIds, StringComparer.Ordinal),
+                DateTime.UtcNow);
 
         internal void FlushPendingForTest() => FlushPending();
 
         internal bool ContainsKeyForTest(string key) => _cache.ContainsKey(key);
+
+        internal void SeedEntryForTest(string key, TagCacheEntry entry) => _cache[key] = entry;
+
+        // Deterministic controller-cursor race seams. A test captures the reader's
+        // dictionary, then swaps the live cache/cursor exactly where a reconcile can.
+        internal Action? OnAfterUserCacheSnapshotForTest;
+
+        internal void SwapCacheAndCursorForTest(
+            IReadOnlyDictionary<string, TagCacheEntry> entries,
+            long version,
+            long lastModified)
+        {
+            _cache = new ConcurrentDictionary<string, TagCacheEntry>(entries, StringComparer.Ordinal);
+            Interlocked.Exchange(ref _version, version);
+            Interlocked.Exchange(ref _lastModified, lastModified);
+        }
 
         // Read the live cache entry for a key (or null). Lets reconcile tests assert reference
         // identity (proving an unchanged item was reused, not re-probed) and timestamp retention.
@@ -596,6 +614,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         {
             // Capture local reference for thread safety (cache reference may be swapped)
             var cache = _cache;
+            OnAfterUserCacheSnapshotForTest?.Invoke();
             var userKey = user.Id.ToString("N");
 
             // Check user access cache
@@ -628,6 +647,51 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             return result;
         }
 
+        /// <summary>
+        /// Select a small, server-generated set of cache entries for one user without
+        /// enumerating the shared cache or materialising the user's full accessible-id
+        /// set. Missing and inaccessible ids are intentionally omitted; the controller
+        /// still returns them in <c>projectionIds</c> as deletion/access tombstones.
+        /// </summary>
+        internal Dictionary<string, TagCacheEntry> GetCacheEntriesForUserByIds(
+            JUser user,
+            IEnumerable<string> itemIds)
+        {
+            ArgumentNullException.ThrowIfNull(user);
+            ArgumentNullException.ThrowIfNull(itemIds);
+
+            // Capture the current dictionary once. A full reconcile may atomically
+            // replace _cache while this request runs, but it never mutates this
+            // captured dictionary after the swap.
+            var cache = _cache;
+            var result = new Dictionary<string, TagCacheEntry>(StringComparer.Ordinal);
+            foreach (var itemId in itemIds)
+            {
+                if (!Guid.TryParseExact(itemId, "N", out var id))
+                {
+                    continue;
+                }
+
+                var key = id.ToString("N");
+                if (result.ContainsKey(key) || !cache.TryGetValue(key, out var entry))
+                {
+                    continue;
+                }
+
+                // This overload performs Jellyfin's per-user access validation. It
+                // is O(number of projection changes), unlike GetCacheForUser's full
+                // GetItemIds query + shared-cache scan.
+                if (_libraryManager.GetItemById<BaseItem>(id, user) == null)
+                {
+                    continue;
+                }
+
+                result[key] = entry;
+            }
+
+            return result;
+        }
+
         // ── Spoiler Guard per-user tag-strip (F3) ────────────────────────────
         //
         // The JC tag pipeline reads the server cache BEFORE it fetches per-batch
@@ -650,6 +714,55 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             SeasonRatingOnly,
             /// <summary>Guarded + unwatched → full strip per the enabled toggles.</summary>
             Strip,
+        }
+
+        /// <summary>
+        /// The rating projection shared by every guarded-Season response surface.
+        /// <see cref="Suppressed"/> is deliberately independent from whether either
+        /// source rating was populated: clients must not fall back to the parent
+        /// Series when policy says ratings are hidden and the Season itself happens
+        /// to carry null ratings.
+        /// </summary>
+        internal readonly record struct GuardedSeasonRatingProjection(
+            float? CommunityRating,
+            float? CriticRating,
+            bool Suppressed);
+
+        /// <summary>
+        /// Canonical guarded-Season decision. Season 0/1 and a later Season with at
+        /// least one watched episode keep their non-rating metadata, but ratings stay
+        /// hidden because the Season card can carry the guarded Series fallback.
+        /// Missing season numbering fails closed to the full configured strip.
+        /// </summary>
+        internal static TagStripDecision ResolveGuardedSeasonStripDecision(
+            int? seasonIndexNumber,
+            bool seasonAnyWatched)
+        {
+            if (!seasonIndexNumber.HasValue)
+            {
+                return TagStripDecision.Strip;
+            }
+
+            return seasonIndexNumber.Value <= 1 || seasonAnyWatched
+                ? TagStripDecision.SeasonRatingOnly
+                : TagStripDecision.Strip;
+        }
+
+        /// <summary>
+        /// Apply the rating part of a guarded-Season decision without touching any
+        /// non-rating fields. Used by the tag cache, tag-data endpoint and native DTO
+        /// filter so their exemption behavior cannot drift again.
+        /// </summary>
+        internal static GuardedSeasonRatingProjection ProjectGuardedSeasonRatings(
+            float? communityRating,
+            float? criticRating,
+            TagStripDecision decision,
+            bool stripRatings)
+        {
+            var suppressed = stripRatings && decision != TagStripDecision.Keep;
+            return suppressed
+                ? new GuardedSeasonRatingProjection(null, null, Suppressed: true)
+                : new GuardedSeasonRatingProjection(communityRating, criticRating, Suppressed: false);
         }
 
         /// <summary>
@@ -721,14 +834,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 else if (isSeason)
                 {
                     var sNum = seasonIndexNumber(entryGuid);
-                    if (sNum.HasValue)
-                    {
-                        // S0/S1 posters always pass (their existence isn't a spoiler),
-                        // as do seasons with any watched episode — "exempt".
-                        var exempt = sNum.Value <= 1 || seasonAnyWatched(entryGuid);
-                        if (exempt) return TagStripDecision.SeasonRatingOnly;
-                    }
-                    // sNum == null (id isn't a resolvable Season) falls through to Strip.
+                    // S0/S1 posters always pass (their existence isn't a spoiler),
+                    // as do seasons with any watched episode — "exempt". Avoid the
+                    // episode walk for S0/S1, and fail closed when the Season cannot
+                    // be resolved to an index number.
+                    var anyWatched = sNum.HasValue
+                        && sNum.Value > 1
+                        && seasonAnyWatched(entryGuid);
+                    return ResolveGuardedSeasonStripDecision(sNum, anyWatched);
                 }
             }
             else
@@ -763,11 +876,16 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 // series everywhere else). Strip just the rating so it can't surface
                 // via the server tag cache. Nothing to do when ratings aren't being
                 // stripped or the entry has no rating — serve the shared instance.
-                if (stripRatings && (entry.CommunityRating != null || entry.CriticRating != null))
+                var projected = ProjectGuardedSeasonRatings(
+                    entry.CommunityRating,
+                    entry.CriticRating,
+                    decision,
+                    stripRatings);
+                if (projected.Suppressed && (entry.CommunityRating != null || entry.CriticRating != null))
                 {
                     var seasonStripped = entry.Clone();
-                    seasonStripped.CommunityRating = null;
-                    seasonStripped.CriticRating = null;
+                    seasonStripped.CommunityRating = projected.CommunityRating;
+                    seasonStripped.CriticRating = projected.CriticRating;
                     return seasonStripped;
                 }
                 return entry;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/live-config.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/live-config.test.ts
@@ -57,6 +57,21 @@ describe('config hot-reload reaction', () => {
         expect(() => emit(LIVE.CONFIG_CHANGED, {})).not.toThrow();
         await vi.waitFor(() => expect(consoleError).toHaveBeenCalled());
     });
+
+    it('rebuilds the personalized tag projection when admin spoiler policy changes', async () => {
+        JC.pluginConfig.SpoilerStripRatings = false;
+        JC.core.api = {
+            plugin: vi.fn((path: string) => path.startsWith('/public-config')
+                ? Promise.resolve({ SpoilerStripRatings: true })
+                : Promise.resolve({})),
+        } as unknown as NonNullable<typeof JC.core.api>;
+        const invalidateServerCache = vi.fn().mockResolvedValue(undefined);
+        JC.tagPipeline = { registerRenderer: vi.fn(), invalidateServerCache };
+
+        emit(LIVE.CONFIG_CHANGED, {});
+
+        await vi.waitFor(() => expect(invalidateServerCache).toHaveBeenCalledTimes(1));
+    });
 });
 describe('config hot-reload in-flight guard (CORE-9)', () => {
     afterEach(() => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/live-config.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/live-config.ts
@@ -32,6 +32,20 @@ let refreshSeq = 0;
 let lastPublicKeys: string[] = [];
 let lastPrivateKeys: string[] = [];
 
+const TAG_PROJECTION_POLICY_KEYS = [
+    'TagCacheServerMode',
+    'SpoilerBlurEnabled',
+    'SpoilerStripTags',
+    'SpoilerStripRatings',
+    'SpoilerReplaceTitle',
+    'SpoilerStripOverview',
+] as const;
+
+/** Stable snapshot of admin fields that change tag-cache privacy projection. */
+function tagProjectionPolicyFingerprint(): string {
+    return JSON.stringify(TAG_PROJECTION_POLICY_KEYS.map((key) => JC.pluginConfig?.[key]));
+}
+
 /** Prune keys that the previous payload from this source owned but the new one dropped. */
 function prunePayloadKeys(previousKeys: string[], next: object): void {
     const config = JC.pluginConfig as Record<string, unknown>;
@@ -101,6 +115,7 @@ async function refreshPluginConfig(): Promise<void> {
 
 on(LIVE.CONFIG_CHANGED, () => {
     void (async () => {
+        const previousTagPolicy = tagProjectionPolicyFingerprint();
         await refreshPluginConfig();
 
         // Let unmigrated modules and any feature reinit hooks react to the fresh
@@ -109,9 +124,16 @@ on(LIVE.CONFIG_CHANGED, () => {
             window.dispatchEvent(new CustomEvent('jc:config-changed'));
         } catch { /* CustomEvent unsupported — ignore */ }
 
-        // Tag pipeline: re-scan visible cards so tag-related toggles apply live.
+        // Policy changes alter the actual per-user cache bytes, so a rescan of
+        // already-processed cards is insufficient. Unrelated config changes retain
+        // the cheap scan path.
         try {
-            JC.tagPipeline?.scheduleScan?.();
+            if (previousTagPolicy !== tagProjectionPolicyFingerprint()
+                && JC.tagPipeline?.invalidateServerCache) {
+                await JC.tagPipeline.invalidateServerCache();
+            } else {
+                JC.tagPipeline?.scheduleScan?.();
+            }
         } catch { /* pipeline not loaded — ignore */ }
 
         console.log(`${logPrefix} plugin config hot-reloaded from server push`);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/live-rows.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/live-rows.test.ts
@@ -7,11 +7,13 @@ import './live-rows'; // registers the handlers at import
 
 describe('live rows → tag rescan', () => {
     let scheduleScan: ReturnType<typeof vi.fn>;
+    let refreshServerProjection: ReturnType<typeof vi.fn>;
 
     beforeEach(() => {
         vi.useFakeTimers();
         scheduleScan = vi.fn();
-        JC.tagPipeline = { scheduleScan } as unknown as NonNullable<typeof JC.tagPipeline>;
+        refreshServerProjection = vi.fn().mockResolvedValue(undefined);
+        JC.tagPipeline = { scheduleScan, refreshServerProjection } as unknown as NonNullable<typeof JC.tagPipeline>;
     });
 
     afterEach(() => {
@@ -30,7 +32,13 @@ describe('live rows → tag rescan', () => {
     });
 
     it('UserDataChanged also triggers a rescan', () => {
-        emit(LIVE.USER_DATA_CHANGED, { UserId: 'u1', UserDataList: [] });
+        const data = { UserId: 'u1', UserDataList: [{ ItemId: 'episode-1' }] };
+        emit(LIVE.USER_DATA_CHANGED, data);
+
+        // Privacy invalidation is dispatched synchronously; the ordinary scan
+        // remains coalesced so it cannot delay the fail-closed barrier.
+        expect(refreshServerProjection).toHaveBeenCalledWith(data);
+        expect(scheduleScan).not.toHaveBeenCalled();
         vi.advanceTimersByTime(300);
         expect(scheduleScan).toHaveBeenCalledTimes(1);
     });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/live-rows.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/live-rows.ts
@@ -10,11 +10,10 @@
 // buttons and tanstack rows in place off the same messages; this keeps JC's
 // overlays in step without a navigation or manual refresh.
 //
-// Deliberately conservative to honour the no-jank rule: it schedules a coalesced
-// tag rescan (which picks up untagged/new cards) rather than force-clearing and
-// re-rendering every existing overlay on every push — a full re-render on each
-// batched UserDataChanged would flicker. Overlays on already-tagged cards refresh
-// on the next scan/navigation.
+// Library changes keep the conservative coalesced scan. User-data changes also
+// enter the tag pipeline's synchronous fail-closed projection barrier: only the
+// pushed item ids are blanked immediately, then the server's bounded per-user
+// journal supplies the exact item/season/series closure to re-render.
 
 import { JC } from '../globals';
 import { LIVE, on } from './live';
@@ -38,11 +37,25 @@ function scheduleRescan(): void {
     }, 300);
 }
 
+function handleUserDataChanged(data: unknown): void {
+    try {
+        if (JC.tagPipeline?.refreshServerProjection) {
+            void JC.tagPipeline.refreshServerProjection(data).catch((err) => {
+                console.debug(`${logPrefix} projection refresh failed closed:`, err);
+            });
+        }
+    } catch (err) {
+        console.debug(`${logPrefix} projection invalidation skipped:`, err);
+    }
+    // Keeps batch-mode/new-card behavior and coalesces any non-projection work.
+    scheduleRescan();
+}
+
 // Items added/updated → re-tag any newly-eligible cards JC owns overlays on.
 on(LIVE.LIBRARY_CHANGED, scheduleRescan);
 
 // Watch-state / favourite / played changes → refresh watch-state-dependent
 // overlays (e.g. user-review / rating tags) to match the new state.
-on(LIVE.USER_DATA_CHANGED, scheduleRescan);
+on(LIVE.USER_DATA_CHANGED, handleUserDataChanged);
 
 console.log(`${logPrefix} initialized`);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/tag-renderer-base.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/tag-renderer-base.test.ts
@@ -11,7 +11,7 @@
 // fixture, plus a source guard that keeps the shared list container-scoped.
 
 import * as ts from 'typescript';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { JC } from '../globals';
 import { register } from './tag-renderer-base';
 import type { TagSpec } from '../types/jc';
@@ -133,5 +133,54 @@ describe('tag-renderer-base STANDARD_IGNORE_SELECTORS stay container-scoped (MIS
                 `leaf-scoped ignore selector re-introduced (ends in .card): ${sel}`,
             ).toBe(false);
         }
+    });
+});
+
+describe('tag-renderer-base projection invalidation (BI-SEC-035)', () => {
+    it('clears targeted persistent/hot values plus the overlay and tagged marker', () => {
+        const registerRenderer = vi.fn();
+        JC.tagPipeline = { registerRenderer };
+        JC.pluginConfig = { TagCacheServerMode: false };
+
+        const name = `projection-cache-${Date.now()}`;
+        const cacheKey = `jc-test-${name}`;
+        const spec: TagSpec = {
+            logPrefix: 'projection-test',
+            settingKey: 'qualityTagsEnabled',
+            containerClass: 'projection-overlay',
+            taggedAttr: 'jcProjectionTagged',
+            cache: {
+                key: cacheKey,
+                legacyPrefix: `${cacheKey}-legacy`,
+                hotBucket: `${name}-hot`,
+                saveOnUnload: false,
+            },
+            pipeline: { render: () => undefined },
+        };
+        const ctx = register(name, spec);
+        const itemId = '11111111111111111111111111111111';
+        ctx.setPersistent(itemId, { value: 'secret', timestamp: Date.now() });
+        ctx.hot?.set(itemId, { value: 'secret', timestamp: Date.now() });
+
+        const host = buildCardHost('indexPage');
+        const card = host.closest<HTMLElement>('.card')!;
+        card.dataset.jcProjectionTagged = '1';
+        const overlay = document.createElement('div');
+        overlay.className = 'projection-overlay';
+        host.appendChild(overlay);
+
+        const config = registerRenderer.mock.calls.at(-1)![1] as {
+            onServerCacheRefresh(ids: string[] | null): void;
+            invalidateCard(el: HTMLElement): void;
+        };
+        config.onServerCacheRefresh([itemId]);
+        config.invalidateCard(host);
+
+        expect(ctx.getPersistent(itemId)).toBeUndefined();
+        expect(ctx.hot!.get(itemId)).toBeUndefined();
+        expect(host.querySelector('.projection-overlay')).toBeNull();
+        expect(card.dataset.jcProjectionTagged).toBeUndefined();
+
+        localStorage.removeItem(cacheKey);
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/tag-renderer-base.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/tag-renderer-base.ts
@@ -202,6 +202,26 @@ function createTag(name: string, spec: TagSpec): TagInstance {
     }
 
     /**
+     * Drop entries whose server-side per-user projection changed. This is
+     * required even in server mode because optional localStorage/hot fallback
+     * must never replay an older unstripped value while a replacement is pending.
+     */
+    function invalidateCachedEntries(updatedIds: string[] | null): void {
+        if (updatedIds === null) {
+            state.cache = {};
+            state.hot?.clear();
+        } else {
+            for (const id of updatedIds) {
+                delete state.cache[id];
+                state.hot?.delete(id);
+            }
+        }
+        if (spec.cache && state.localStorageEnabled && JC._cacheManager) {
+            JC._cacheManager.markDirty();
+        }
+    }
+
+    /**
      * Remove legacy cache keys from previous plugin versions and honor
      * server-triggered cache clears (ClearLocalStorageTimestamp).
      */
@@ -328,9 +348,15 @@ function createTag(name: string, spec: TagSpec): TagInstance {
             renderFromServerCache: p.renderFromServerCache
                 ? (el: HTMLElement, entry: unknown, itemId: string) => p.renderFromServerCache!(ctx, el, entry, itemId)
                 : undefined,
-            onServerCacheRefresh: p.onServerCacheRefresh
-                ? (updatedIds: string[] | null) => p.onServerCacheRefresh!(ctx, updatedIds)
-                : undefined,
+            onServerCacheRefresh: (updatedIds: string[] | null) => {
+                invalidateCachedEntries(updatedIds);
+                if (p.onServerCacheRefresh) p.onServerCacheRefresh(ctx, updatedIds);
+            },
+            invalidateCard: (el: HTMLElement) => {
+                ctx.removeExistingOverlay(el);
+                const card = el.closest<HTMLElement>('.card');
+                if (card) delete card.dataset[TAGGED_ATTR];
+            },
             isEnabled: () => !!JC.currentSettings?.[spec.settingKey],
             needsFirstEpisode: !!p.needsFirstEpisode,
             needsParentSeries: !!p.needsParentSeries,

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/helpers.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/helpers.test.ts
@@ -2,8 +2,8 @@
 // getHeaderRightContainer (PERF(R4) fix: offsetParent is a forced layout read and
 // used to be re-read on every observer tick; it must now be read at most once
 // per navigation).
-import { beforeEach, describe, expect, it } from 'vitest';
-import { getHeaderRightContainer } from './helpers';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearItemCache, getHeaderRightContainer, getItemCached } from './helpers';
 import { insertHeaderTrayButton, HeaderTrayOrder } from './header-tray';
 
 /** Builds a `.headerRight` whose offsetParent getter counts layout reads. */
@@ -65,6 +65,47 @@ describe('getHeaderRightContainer per-navigation cache', () => {
 
         // Found on the next probe without requiring a navigation in between.
         expect(getHeaderRightContainer()).toBe(header);
+    });
+});
+
+describe('privacy reset item-cache invalidation (BI-SEC-035)', () => {
+    it('drops only the selected user\'s cached native DTOs', async () => {
+        const getItem = vi.spyOn(ApiClient, 'getItem').mockImplementation(
+            (userId, itemId) => Promise.resolve({ userId, itemId }),
+        );
+        const itemId = 'privacy-reset-item';
+
+        await getItemCached(itemId, { userId: 'user-a' });
+        await getItemCached(itemId, { userId: 'user-b' });
+        expect(getItem).toHaveBeenCalledTimes(2);
+
+        clearItemCache('user-a');
+        await getItemCached(itemId, { userId: 'user-a' });
+        await getItemCached(itemId, { userId: 'user-b' });
+
+        expect(getItem).toHaveBeenCalledTimes(3);
+        getItem.mockRestore();
+    });
+
+    it('does not let a retired in-flight DTO overwrite the post-reset value', async () => {
+        let resolveStale!: (value: unknown) => void;
+        const stale = new Promise<unknown>((resolve) => { resolveStale = resolve; });
+        const getItem = vi.spyOn(ApiClient, 'getItem')
+            .mockImplementationOnce(() => stale)
+            .mockResolvedValueOnce({ projection: 'fresh' });
+        const itemId = 'in-flight-privacy-reset';
+
+        const oldRequest = getItemCached(itemId, { userId: 'race-user' });
+        clearItemCache('race-user', [itemId]);
+        const freshRequest = getItemCached(itemId, { userId: 'race-user' });
+        await expect(freshRequest).resolves.toEqual({ projection: 'fresh' });
+
+        resolveStale({ projection: 'stale' });
+        await expect(oldRequest).resolves.toEqual({ projection: 'stale' });
+        await expect(getItemCached(itemId, { userId: 'race-user' }))
+            .resolves.toEqual({ projection: 'fresh' });
+        expect(getItem).toHaveBeenCalledTimes(2);
+        getItem.mockRestore();
     });
 });
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/helpers.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/helpers.ts
@@ -34,6 +34,27 @@ interface ItemCacheEntry {
 const itemCache = new Map<string, ItemCacheEntry>();
 const ITEM_CACHE_TTL_MS = 30000; // 30s -- long enough for batch prefetch to warm cache before tag systems scan
 
+/**
+ * Drop short-lived native item DTOs for one account (or every account).
+ * Privacy-policy/watch-state transitions call this before a global tag reset so
+ * a failed tag-data request cannot fall back to a pre-transition DTO.
+ */
+export function clearItemCache(userId?: string, itemIds?: string[]): void {
+    if (!userId) {
+        itemCache.clear();
+        return;
+    }
+    const prefix = `${userId}:`;
+    const selected = itemIds && itemIds.length > 0
+        ? new Set(itemIds.map((id) => id.replace(/-/g, '').toLowerCase()))
+        : null;
+    for (const key of itemCache.keys()) {
+        if (!key.startsWith(prefix)) continue;
+        const itemId = key.slice(prefix.length).replace(/-/g, '').toLowerCase();
+        if (!selected || selected.has(itemId)) itemCache.delete(key);
+    }
+}
+
 export interface GetItemCachedOptions {
     userId?: string;
     ttlMs?: number;
@@ -64,11 +85,16 @@ export async function getItemCached(itemId: string, options: GetItemCachedOption
 
     const promise = ApiClient.getItem(userId, itemId)
         .then((item) => {
-            itemCache.set(key, { item, ts: Date.now(), promise: null });
+            // A privacy reset or newer forced fetch may retire this request while
+            // it is in flight. Only the promise that still owns the key may publish.
+            if (itemCache.get(key)?.promise === promise) {
+                itemCache.set(key, { item, ts: Date.now(), promise: null });
+            }
             return item;
         })
         .catch((err: unknown) => {
-            itemCache.delete(key);
+            // Likewise, an older rejection must not delete a newer request/value.
+            if (itemCache.get(key)?.promise === promise) itemCache.delete(key);
             throw err;
         });
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/settings-tab.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/settings-tab.test.ts
@@ -6,6 +6,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const setUserPrefs = vi.fn((_next?: unknown) => Promise.resolve({}));
+const invalidateServerCache = vi.fn(() => Promise.resolve());
 let loadOkValue = true;
 
 vi.mock('./state', () => ({
@@ -29,7 +30,12 @@ async function flush(): Promise<void> { await Promise.resolve(); await Promise.r
 describe('spoiler-guard settings-tab save-guard', () => {
     beforeEach(() => {
         (JC.pluginConfig as Record<string, unknown>).SpoilerBlurEnabled = true;
+        JC.tagPipeline = {
+            registerRenderer: vi.fn(),
+            invalidateServerCache,
+        };
         setUserPrefs.mockClear();
+        invalidateServerCache.mockClear();
         loadOkValue = true;
     });
     afterEach(() => { document.body.innerHTML = ''; });
@@ -43,6 +49,7 @@ describe('spoiler-guard settings-tab save-guard', () => {
         await flush();
         expect(setUserPrefs).toHaveBeenCalledTimes(1);
         expect(setUserPrefs).toHaveBeenCalledWith({ HideRatings: false });
+        expect(invalidateServerCache).toHaveBeenCalledTimes(1);
     });
 
     it('REFUSES to save and reverts the checkbox when load failed (loadOk=false)', async () => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/settings-tab.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/settings-tab.ts
@@ -51,6 +51,13 @@ export function wireSpoilerGuardListeners(resetAutoCloseTimer: () => void): void
                 current[k] = changedBox.checked ? null : false;
             }
             await setUserPrefs(current);
+            // The server cache is a projection of these per-user preferences.
+            // A rescan cannot restore ratings/tags stripped from its existing
+            // bytes (or remove already-rendered values in the reverse direction),
+            // so rebuild the authoritative projection after any policy override.
+            if (k !== 'SkipDisableConfirm') {
+                await JC.tagPipeline?.invalidateServerCache?.();
+            }
         } catch (err) {
             console.error(`${logPrefix} saveSbPrefs failed:`, err);
             // Revert the box the user clicked so they see the change didn't stick.

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/suppression.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/suppression.test.ts
@@ -49,6 +49,7 @@ describe('shouldSuppressRatingTag', () => {
         expect(shouldSuppressRatingTag({ Type: 'Series', Id: GUARDED }, ratingCfg({ spoilerBlurEnabled: false }))).toBe(false);
         expect(shouldSuppressRatingTag({ Type: 'Series', Id: GUARDED }, ratingCfg({ stripRatings: false }))).toBe(false);
         expect(shouldSuppressRatingTag({ Type: 'Series', Id: GUARDED }, ratingCfg({ hideRatings: false }))).toBe(false);
+        expect(shouldSuppressRatingTag({ Type: 'Season', SeriesId: GUARDED }, ratingCfg({ hideRatings: false }))).toBe(false);
     });
     it('fails CLOSED on a guardable surface while state is not authoritative', () => {
         expect(shouldSuppressRatingTag({ Type: 'Series', Id: GUARDED }, ratingCfg({ loadOk: false }))).toBe(true);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/watched-refresh.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/watched-refresh.ts
@@ -11,8 +11,9 @@
 // lifecycle-tracked handle. Same outcome (image-only refresh, never a reload),
 // no global prototype patching. We deliberately do NOT trigger a full page
 // reload here: a watched flip can fire from many contexts (auto-mark on playback
-// end, batch-mark, cross-client sync) and a reload mid-flow is jarring. DOM text
-// (overview/titles/ratings) refreshes on the user's next navigation.
+// end, batch-mark, cross-client sync) and a reload mid-flow is jarring. Tag
+// overlays are refreshed independently by core/live-rows → tag-pipeline's
+// bounded per-user projection journal; this module owns image URLs only.
 
 import { register } from '../../core/lifecycle';
 import { on, LIVE } from '../../core/live';

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.test.ts
@@ -5,8 +5,17 @@
 // nested in a list row is a list row (skipped), a bare card is not, and the legacy
 // no-image `.listItemImage.cardImageContainer` variant — the one shape the modern
 // card scan selector could otherwise surface — is still caught.
-import { describe, expect, it } from 'vitest';
-import { isListViewRow } from './tag-pipeline';
+import { describe, expect, it, vi } from 'vitest';
+import { JC } from '../globals';
+import { getItemCached } from './helpers';
+import {
+    decideProjectionResponse,
+    extractUserDataChangedIds,
+    isListViewRow,
+    normalizeProjectionKey,
+    readProjectionIdentity,
+    TagProjectionDependencyIndex,
+} from './tag-pipeline';
 
 /** Build a `.cardImageContainer` nested inside a `.listItem` row. */
 function listRowImage(): HTMLElement {
@@ -52,5 +61,652 @@ describe('isListViewRow — the single list-view gate (issue 34)', () => {
 
     it('catches the legacy .listItemImage.cardImageContainer no-image variant', () => {
         expect(isListViewRow(legacyNoImageRow())).toBe(true);
+    });
+});
+
+describe('watched/privacy projection response ordering (BI-SEC-035)', () => {
+    const userA = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+    const userB = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+
+    const response = (userId: string, epoch: string, revision: number, projectionReset = false) => ({
+        projectionUserId: userId,
+        projectionEpoch: epoch,
+        projectionRevision: revision,
+        projectionReset,
+    });
+
+    it('normalizes dashed ids and binds a full response to user + epoch + revision', () => {
+        expect(normalizeProjectionKey(userA)).toBe('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+        expect(readProjectionIdentity(response(userA, 'process-1', 7))).toEqual({
+            userId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            epoch: 'process-1',
+            revision: 7,
+        });
+    });
+
+    it('rejects delayed revision N after revision N+1 was already applied', () => {
+        const current = readProjectionIdentity(response(userA, 'process-1', 11));
+        expect(decideProjectionResponse(current, response(userA, 'process-1', 10), userA)).toBe('ignore');
+        expect(decideProjectionResponse(current, response(userA, 'process-1', 12), userA)).toBe('apply');
+    });
+
+    it('never applies another user projection even when its revision is newer', () => {
+        const current = readProjectionIdentity(response(userA, 'process-1', 4));
+        expect(decideProjectionResponse(current, response(userB, 'process-1', 999), userA)).toBe('ignore');
+    });
+
+    it('requires a full reset on process epoch change or journal reset', () => {
+        const current = readProjectionIdentity(response(userA, 'old-process', 40));
+        expect(decideProjectionResponse(current, response(userA, 'new-process', 1), userA)).toBe('reset');
+        expect(decideProjectionResponse(current, response(userA, 'old-process', 41, true), userA)).toBe('reset');
+    });
+
+    it('extracts and deduplicates same-user item ids but ignores an explicit other user', () => {
+        const episode = '11111111-1111-1111-1111-111111111111';
+        const season = '22222222-2222-2222-2222-222222222222';
+        expect(extractUserDataChangedIds({
+            UserId: userA,
+            UserDataList: [{ ItemId: episode }, { ItemId: episode }, { ItemId: season }],
+        }, userA)).toEqual([
+            '11111111111111111111111111111111',
+            '22222222222222222222222222222222',
+        ]);
+        expect(extractUserDataChangedIds({
+            UserId: userB,
+            UserDataList: [{ ItemId: episode }],
+        }, userA)).toEqual([]);
+    });
+
+    it('expands Episode and Season pushes without scanning and reports incomplete relationships', () => {
+        const series = '11111111111111111111111111111111';
+        const season = '22222222222222222222222222222222';
+        const episode = '33333333333333333333333333333333';
+        const unknown = '44444444444444444444444444444444';
+        const index = new TagProjectionDependencyIndex();
+        index.replaceAll(new Map([
+            [episode, { Type: 'Episode', SeriesId: series, SeasonNumber: 2 }],
+            [series, { Type: 'Series' }],
+            [season, { Type: 'Season', SeriesId: series, SeasonNumber: 2 }],
+        ]));
+
+        const episodeExpansion = index.expand([episode]);
+        expect(episodeExpansion.complete).toBe(true);
+        expect(new Set(episodeExpansion.ids)).toEqual(new Set([episode, season, series]));
+        const seasonExpansion = index.expand([season]);
+        expect(seasonExpansion.complete).toBe(true);
+        expect(new Set(seasonExpansion.ids)).toEqual(new Set([season, series]));
+        expect(index.expand([unknown])).toEqual({ ids: [unknown], complete: false });
+
+        index.remove(season);
+        expect(index.expand([episode]).complete).toBe(false);
+        index.replace(season, { Type: 'Season', SeriesId: series, SeasonNumber: 2 });
+        expect(index.expand([episode]).complete).toBe(true);
+        index.replace(episode, { Type: 'Episode', SeriesId: series, SeasonNumber: null });
+        expect(index.expand([episode]).complete).toBe(false);
+    });
+
+    it('blanks exact Episode dependencies synchronously across overlapping native pushes', async () => {
+        document.body.innerHTML = '';
+        const episode = '11111111111111111111111111111111';
+        const siblingEpisode = '99999999999999999999999999999999';
+        const season = '22222222222222222222222222222222';
+        const series = '33333333333333333333333333333333';
+        const unrelated = '44444444444444444444444444444444';
+        const oldConfig = JC.pluginConfig;
+        JC.pluginConfig = { ...oldConfig, TagCacheServerMode: true };
+        JC._tagCachePrefetch = null;
+        const currentUser = vi.spyOn(ApiClient, 'getCurrentUserId').mockReturnValue(userA);
+        let enabled = true;
+        const requestResolvers: Array<(value: unknown) => void> = [];
+        let call = 0;
+        const ajax = vi.spyOn(ApiClient, 'ajax').mockImplementation(() => {
+            call++;
+            if (call === 1) {
+                return Promise.resolve({
+                    version: 1,
+                    timestamp: 100,
+                    items: {
+                        [episode]: { Type: 'Episode', SeriesId: series, SeasonNumber: 2, label: 'episode' },
+                        [siblingEpisode]: { Type: 'Episode', SeriesId: series, SeasonNumber: 2, label: 'sibling' },
+                        [season]: { Type: 'Season', SeriesId: series, SeasonNumber: 2, label: 'season' },
+                        [series]: { Type: 'Series', label: 'series' },
+                        [unrelated]: { Type: 'Movie', label: 'unrelated' },
+                    },
+                    projectionUserId: userA,
+                    projectionEpoch: 'process-1',
+                    projectionRevision: 1,
+                    projectionIds: [],
+                    projectionReset: false,
+                });
+            }
+            return new Promise((resolve) => { requestResolvers.push(resolve); });
+        });
+
+        JC.tagPipeline!.registerRenderer('projection-dependency-test', {
+            render: () => undefined,
+            isEnabled: () => enabled,
+            renderFromServerCache: (target: HTMLElement, entry: unknown) => {
+                const label = (entry as { label?: string }).label;
+                if (!label) return;
+                const marker = document.createElement('div');
+                marker.className = 'projection-test-secret';
+                marker.dataset.projectionLabel = label;
+                target.appendChild(marker);
+            },
+            invalidateCard: (target: HTMLElement) => {
+                target.querySelectorAll('.projection-test-secret').forEach((node) => node.remove());
+            },
+        });
+
+        const mount = (id: string, type: string): void => {
+            const image = gridCardImage();
+            const card = image.closest<HTMLElement>('.card')!;
+            card.dataset.id = id;
+            card.dataset.type = type;
+            document.body.appendChild(card);
+        };
+        mount(episode, 'Episode');
+        mount(siblingEpisode, 'Episode');
+        mount(season, 'Season');
+        mount(series, 'Series');
+        mount(unrelated, 'Movie');
+
+        await JC.tagPipeline!.invalidateServerCache?.();
+        await vi.waitFor(() => {
+            expect(document.querySelector('[data-projection-label="episode"]')).not.toBeNull();
+            expect(document.querySelector('[data-projection-label="sibling"]')).not.toBeNull();
+            expect(document.querySelector('[data-projection-label="season"]')).not.toBeNull();
+            expect(document.querySelector('[data-projection-label="series"]')).not.toBeNull();
+            expect(document.querySelector('[data-projection-label="unrelated"]')).not.toBeNull();
+        });
+
+        const pendingFirst = JC.tagPipeline!.refreshServerProjection!({
+            UserId: userA,
+            UserDataList: [{ ItemId: episode }],
+        });
+
+        // Jellyfin's native event contains only E. The local index must blank its
+        // dependent Season/Series before the server journal round trip finishes.
+        expect(document.querySelector('[data-projection-label="episode"]')).toBeNull();
+        expect(document.querySelector('[data-projection-label="season"]')).toBeNull();
+        expect(document.querySelector('[data-projection-label="series"]')).toBeNull();
+        expect(document.querySelector('[data-projection-label="sibling"]')).not.toBeNull();
+        expect(document.querySelector('[data-projection-label="unrelated"]')).not.toBeNull();
+
+        // A sibling push can overlap while E1's request is unresolved. The last
+        // authoritative relationship snapshot must remain available so this is
+        // another bounded closure, not a global blank/reset.
+        const pendingSecond = JC.tagPipeline!.refreshServerProjection!({
+            UserId: userA,
+            UserDataList: [{ ItemId: siblingEpisode }],
+        });
+        expect(document.querySelector('[data-projection-label="sibling"]')).toBeNull();
+        expect(document.querySelector('[data-projection-label="unrelated"]')).not.toBeNull();
+
+        // Cards mounted during the request are held behind the same parent gate.
+        mount(season, 'Season');
+        JC.tagPipeline!.scheduleScan?.();
+        await new Promise((resolve) => setTimeout(resolve, 220));
+        expect(document.querySelector('[data-projection-label="season"]')).toBeNull();
+        // Waiting past the longest batch debounce proves the pending gate stopped
+        // both server/local rendering and a fallback /tag-data request.
+        expect(ajax).toHaveBeenCalledTimes(3);
+
+        requestResolvers[0]({
+            version: 1,
+            timestamp: 100,
+            items: {
+                [episode]: { Type: 'Episode', SeriesId: series, SeasonNumber: 2 },
+                [season]: { Type: 'Season', SeriesId: series, SeasonNumber: 2 },
+                [series]: { Type: 'Series' },
+            },
+            projectionUserId: userA,
+            projectionEpoch: 'process-1',
+            projectionRevision: 2,
+            projectionIds: [episode, season, series],
+            projectionReset: false,
+        });
+        await pendingFirst;
+
+        requestResolvers[1]({
+            version: 1,
+            timestamp: 100,
+            items: {
+                [episode]: { Type: 'Episode', SeriesId: series, SeasonNumber: 2 },
+                [siblingEpisode]: { Type: 'Episode', SeriesId: series, SeasonNumber: 2 },
+                [season]: { Type: 'Season', SeriesId: series, SeasonNumber: 2 },
+                [series]: { Type: 'Series' },
+            },
+            projectionUserId: userA,
+            projectionEpoch: 'process-1',
+            projectionRevision: 3,
+            projectionIds: [episode, siblingEpisode, season, series],
+            projectionReset: false,
+        });
+        await pendingSecond;
+        await new Promise((resolve) => setTimeout(resolve, 30));
+
+        expect(document.querySelector('[data-projection-label="episode"]')).toBeNull();
+        expect(document.querySelector('[data-projection-label="sibling"]')).toBeNull();
+        expect(document.querySelector('[data-projection-label="season"]')).toBeNull();
+        expect(document.querySelector('[data-projection-label="series"]')).toBeNull();
+        expect(document.querySelector('[data-projection-label="unrelated"]')).not.toBeNull();
+
+        enabled = false;
+        ajax.mockRestore();
+        currentUser.mockRestore();
+        JC.pluginConfig = oldConfig;
+        document.body.innerHTML = '';
+    });
+
+    it('clears an owner-bound server projection when the active user becomes null', async () => {
+        document.body.innerHTML = '';
+        const itemId = '55555555555555555555555555555555';
+        const oldConfig = JC.pluginConfig;
+        JC.pluginConfig = { ...oldConfig, TagCacheServerMode: true };
+        JC._tagCachePrefetch = null;
+        let activeUser: string | null = userA;
+        const currentUser = vi.spyOn(ApiClient, 'getCurrentUserId').mockImplementation(() => activeUser as string);
+        const ajax = vi.spyOn(ApiClient, 'ajax').mockResolvedValue({
+            version: 1,
+            timestamp: 100,
+            items: { [itemId]: { Type: 'Movie', label: 'owner-a-secret' } },
+            projectionUserId: userA,
+            projectionEpoch: 'owner-process',
+            projectionRevision: 1,
+            projectionIds: [],
+            projectionReset: false,
+        });
+        let enabled = true;
+        const renders = vi.fn();
+        JC.tagPipeline!.registerRenderer('null-owner-projection-test', {
+            render: () => undefined,
+            isEnabled: () => enabled,
+            renderFromServerCache: (target: HTMLElement, entry: unknown) => {
+                renders();
+                if ((entry as { label?: string }).label !== 'owner-a-secret') return;
+                const marker = document.createElement('div');
+                marker.className = 'owner-a-projection-secret';
+                target.appendChild(marker);
+            },
+            invalidateCard: (target: HTMLElement) => {
+                target.querySelectorAll('.owner-a-projection-secret').forEach((node) => node.remove());
+            },
+        });
+
+        const mount = (): void => {
+            const image = gridCardImage();
+            const card = image.closest<HTMLElement>('.card')!;
+            card.dataset.id = itemId;
+            card.dataset.type = 'Movie';
+            document.body.appendChild(card);
+        };
+        mount();
+        await JC.tagPipeline!.invalidateServerCache?.();
+        await vi.waitFor(() => expect(document.querySelector('.owner-a-projection-secret')).not.toBeNull());
+        const rendersBeforeLogout = renders.mock.calls.length;
+
+        activeUser = null;
+        mount();
+        JC.tagPipeline!.scheduleScan?.();
+        await new Promise((resolve) => setTimeout(resolve, 30));
+
+        expect(document.querySelector('.owner-a-projection-secret')).toBeNull();
+        expect(renders).toHaveBeenCalledTimes(rendersBeforeLogout);
+
+        enabled = false;
+        ajax.mockRestore();
+        currentUser.mockRestore();
+        JC.pluginConfig = oldConfig;
+        document.body.innerHTML = '';
+    });
+
+    it('does not replay a warm helper DTO after an accepted projection tombstone', async () => {
+        document.body.innerHTML = '';
+        const itemId = '66666666666666666666666666666666';
+        const oldConfig = JC.pluginConfig;
+        JC.pluginConfig = { ...oldConfig, TagCacheServerMode: true };
+        JC._tagCachePrefetch = null;
+        const currentUser = vi.spyOn(ApiClient, 'getCurrentUserId').mockReturnValue(userA);
+        const getItem = vi.spyOn(ApiClient, 'getItem')
+            .mockResolvedValueOnce({ Id: itemId, Type: 'Movie', label: 'stale-helper-secret' })
+            .mockResolvedValueOnce({ Id: itemId, Type: 'Movie', label: 'fresh-helper-safe' });
+        let ajaxCall = 0;
+        const ajax = vi.spyOn(ApiClient, 'ajax').mockImplementation(() => {
+            ajaxCall++;
+            if (ajaxCall === 1) {
+                return Promise.resolve({
+                    version: 1,
+                    timestamp: 100,
+                    items: { [itemId]: { Type: 'Movie' } },
+                    projectionUserId: userA,
+                    projectionEpoch: 'helper-process',
+                    projectionRevision: 1,
+                    projectionIds: [],
+                    projectionReset: false,
+                });
+            }
+            if (ajaxCall === 2) {
+                return Promise.resolve({
+                    version: 1,
+                    timestamp: 100,
+                    items: {},
+                    projectionUserId: userA,
+                    projectionEpoch: 'helper-process',
+                    projectionRevision: 2,
+                    projectionIds: [itemId],
+                    projectionReset: false,
+                });
+            }
+            return Promise.reject(new Error('tag-data unavailable'));
+        });
+        let enabled = true;
+        const renderedLabels: string[] = [];
+        JC.tagPipeline!.registerRenderer('helper-tombstone-projection-test', {
+            isEnabled: () => enabled,
+            render: (_target: HTMLElement, item: unknown) => {
+                const label = (item as { label?: string }).label;
+                if (label) renderedLabels.push(label);
+            },
+            renderFromCache: () => false,
+        });
+
+        const image = gridCardImage();
+        const card = image.closest<HTMLElement>('.card')!;
+        card.dataset.id = itemId;
+        card.dataset.type = 'Movie';
+        document.body.appendChild(card);
+        await JC.tagPipeline!.invalidateServerCache?.();
+        await getItemCached(itemId, { userId: userA });
+        expect(getItem).toHaveBeenCalledTimes(1);
+
+        await JC.tagPipeline!.refreshServerProjection!({
+            UserId: userA,
+            UserDataList: [{ ItemId: itemId }],
+        });
+        await vi.waitFor(() => expect(getItem).toHaveBeenCalledTimes(2));
+
+        expect(renderedLabels).not.toContain('stale-helper-secret');
+        expect(renderedLabels).toContain('fresh-helper-safe');
+
+        enabled = false;
+        ajax.mockRestore();
+        getItem.mockRestore();
+        currentUser.mockRestore();
+        JC.pluginConfig = oldConfig;
+        document.body.innerHTML = '';
+    });
+
+    it('gates navigation first paint and keeps the shared content cursor behind projection-only updates', async () => {
+        document.body.innerHTML = '';
+        const itemId = '33333333333333333333333333333333';
+        const oldConfig = JC.pluginConfig;
+        const oldUi = JC.core.ui;
+        JC.pluginConfig = { ...oldConfig, TagCacheServerMode: true };
+        JC.core.ui = { injectCss: vi.fn() } as unknown as NonNullable<typeof JC.core.ui>;
+        JC._tagCachePrefetch = null;
+        const currentUser = vi.spyOn(ApiClient, 'getCurrentUserId').mockReturnValue(userA);
+
+        let call = 0;
+        const navigationResolvers: Array<(value: unknown) => void> = [];
+        const urls: string[] = [];
+        const projectedLabels: string[] = [];
+        const ajax = vi.spyOn(ApiClient, 'ajax').mockImplementation((options) => {
+            urls.push(String(options.url));
+            call++;
+            if (call === 1) {
+                return Promise.resolve({
+                    version: 1,
+                    timestamp: 100,
+                    items: { [itemId]: { label: 'initial' } },
+                    projectionUserId: userA,
+                    projectionEpoch: 'nav-process',
+                    projectionRevision: 1,
+                    projectionIds: [],
+                    projectionReset: false,
+                });
+            }
+            if (call === 2) {
+                // Projection-only carries a newer shared timestamp that must not
+                // advance the content-delta cursor because it did not fetch it.
+                return Promise.resolve({
+                    version: 1,
+                    timestamp: 200,
+                    items: { [itemId]: { label: 'watched-secret' } },
+                    projectionUserId: userA,
+                    projectionEpoch: 'nav-process',
+                    projectionRevision: 2,
+                    projectionIds: [itemId],
+                    projectionReset: false,
+                });
+            }
+            return new Promise((resolve) => { navigationResolvers.push(resolve); });
+        });
+
+        JC.tagPipeline!.registerRenderer('navigation-projection-test', {
+            render: () => undefined,
+            isEnabled: () => true,
+            renderFromServerCache: (target: HTMLElement, entry: unknown) => {
+                const label = (entry as { label?: string }).label;
+                if (label) projectedLabels.push(label);
+                if (label !== 'watched-secret') return;
+                const secret = document.createElement('div');
+                secret.className = 'navigation-projection-secret';
+                target.appendChild(secret);
+            },
+            invalidateCard: (target: HTMLElement) => {
+                target.querySelector('.navigation-projection-secret')?.remove();
+            },
+        });
+        JC.tagPipeline!.initialize?.();
+        await vi.waitFor(() => expect(ajax).toHaveBeenCalledTimes(1));
+
+        const mountCard = (): void => {
+            const image = gridCardImage();
+            const card = image.closest<HTMLElement>('.card')!;
+            card.dataset.id = itemId;
+            card.dataset.type = 'Movie';
+            document.body.appendChild(card);
+        };
+        mountCard();
+        JC.tagPipeline!.scheduleScan?.();
+        await new Promise((resolve) => setTimeout(resolve, 30));
+
+        // Local watched flip installs a sensitive projected row.
+        await JC.tagPipeline!.refreshServerProjection!({
+            UserId: userA,
+            UserDataList: [{ ItemId: itemId }],
+        });
+        await vi.waitFor(() => {
+            expect(document.querySelector('.navigation-projection-secret')).not.toBeNull();
+        });
+
+        // Simulate a missed cross-client unplay: no native push reaches this tab.
+        // Navigation must blank synchronously and hold the incoming card behind
+        // the revision request, never painting the watched-secret row first.
+        history.pushState({}, '', `/projection-nav-${Date.now()}`);
+        expect(document.querySelector('.navigation-projection-secret')).toBeNull();
+        document.body.innerHTML = '';
+        mountCard();
+        JC.tagPipeline!.scheduleScan?.();
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        expect(document.querySelector('.navigation-projection-secret')).toBeNull();
+
+        await vi.waitFor(() => expect(ajax).toHaveBeenCalledTimes(3));
+        expect(urls[2]).toContain('since=100');
+        expect(urls[2]).not.toContain('since=200');
+
+        // A second navigation supersedes the first validation. Its gate must not
+        // be released by nav A's delayed but otherwise valid r2 response.
+        history.pushState({}, '', `/projection-nav-newer-${Date.now()}`);
+        document.body.innerHTML = '';
+        mountCard();
+        JC.tagPipeline!.scheduleScan?.();
+        await vi.waitFor(() => expect(ajax).toHaveBeenCalledTimes(4));
+        expect(urls[3]).toContain('since=100');
+
+        const watchedPaints = projectedLabels.filter((label) => label === 'watched-secret').length;
+        navigationResolvers[0]({
+            version: 1,
+            timestamp: 225,
+            items: {},
+            projectionUserId: userA,
+            projectionEpoch: 'nav-process',
+            projectionRevision: 2,
+            projectionIds: [],
+            projectionReset: false,
+        });
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        expect(projectedLabels.filter((label) => label === 'watched-secret')).toHaveLength(watchedPaints);
+        expect(document.querySelector('.navigation-projection-secret')).toBeNull();
+
+        navigationResolvers[1]({
+            version: 1,
+            timestamp: 250,
+            items: { [itemId]: { label: 'stripped' } },
+            projectionUserId: userA,
+            projectionEpoch: 'nav-process',
+            projectionRevision: 3,
+            projectionIds: [itemId],
+            projectionReset: false,
+        });
+        await vi.waitFor(() => expect(projectedLabels).toContain('stripped'));
+        expect(document.querySelector('.navigation-projection-secret')).toBeNull();
+
+        ajax.mockRestore();
+        currentUser.mockRestore();
+        JC.core.ui = oldUi;
+        JC.pluginConfig = oldConfig;
+        document.body.innerHTML = '';
+    });
+
+    it('does not destroy batch caches for watched events when Spoiler Guard is off', async () => {
+        const itemId = '77777777777777777777777777777777';
+        const oldConfig = JC.pluginConfig;
+        JC.pluginConfig = {
+            ...oldConfig,
+            TagCacheServerMode: false,
+            SpoilerBlurEnabled: false,
+        };
+        const currentUser = vi.spyOn(ApiClient, 'getCurrentUserId').mockReturnValue(userA);
+        const ajax = vi.spyOn(ApiClient, 'ajax');
+
+        await JC.tagPipeline!.refreshServerProjection!({
+            UserId: userA,
+            UserDataList: [{ ItemId: itemId }],
+        });
+
+        expect(ajax).not.toHaveBeenCalled();
+        ajax.mockRestore();
+        currentUser.mockRestore();
+        JC.pluginConfig = oldConfig;
+    });
+
+    it('keeps batch-mode privacy ids blank when tag-data fails instead of replaying caches', async () => {
+        document.body.innerHTML = '';
+        const itemId = '44444444444444444444444444444444';
+        const oldConfig = JC.pluginConfig;
+        JC.pluginConfig = {
+            ...oldConfig,
+            TagCacheServerMode: false,
+            SpoilerBlurEnabled: true,
+        };
+        const currentUser = vi.spyOn(ApiClient, 'getCurrentUserId').mockReturnValue(userA);
+        const getItem = vi.spyOn(ApiClient, 'getItem');
+        const ajax = vi.spyOn(ApiClient, 'ajax').mockRejectedValue(new Error('tag-data unavailable'));
+        const renderFromCache = vi.fn((target: HTMLElement) => {
+            const secret = document.createElement('div');
+            secret.className = 'batch-cache-secret';
+            target.appendChild(secret);
+            return true;
+        });
+
+        JC.tagPipeline!.registerRenderer('batch-projection-test', {
+            render: () => undefined,
+            isEnabled: () => true,
+            renderFromCache,
+            invalidateCard: (target: HTMLElement) => {
+                target.querySelector('.batch-cache-secret')?.remove();
+            },
+        });
+
+        const image = gridCardImage();
+        const card = image.closest<HTMLElement>('.card')!;
+        card.dataset.id = itemId;
+        card.dataset.type = 'Movie';
+        document.body.appendChild(card);
+
+        await JC.tagPipeline!.invalidateServerCache?.();
+        await new Promise((resolve) => setTimeout(resolve, 250));
+
+        expect(ajax).toHaveBeenCalled();
+        expect(renderFromCache).not.toHaveBeenCalled();
+        expect(getItem).not.toHaveBeenCalled();
+        expect(document.querySelector('.batch-cache-secret')).toBeNull();
+
+        ajax.mockRestore();
+        getItem.mockRestore();
+        currentUser.mockRestore();
+        JC.pluginConfig = oldConfig;
+        document.body.innerHTML = '';
+    });
+
+    it('never paints a delayed batch response onto a recycled card element', async () => {
+        document.body.innerHTML = '';
+        const itemA = '55555555555555555555555555555555';
+        const itemB = '66666666666666666666666666666666';
+        const oldConfig = JC.pluginConfig;
+        JC.pluginConfig = {
+            ...oldConfig,
+            TagCacheServerMode: false,
+            SpoilerBlurEnabled: true,
+        };
+        const currentUser = vi.spyOn(ApiClient, 'getCurrentUserId').mockReturnValue(userA);
+        const resolvers: Array<(value: unknown) => void> = [];
+        const ajax = vi.spyOn(ApiClient, 'ajax').mockImplementation(
+            () => new Promise((resolve) => { resolvers.push(resolve); }),
+        );
+
+        JC.tagPipeline!.registerRenderer('recycled-projection-test', {
+            isEnabled: () => true,
+            render: (target: HTMLElement, rawItem: unknown) => {
+                const item = rawItem as { Id: string };
+                const marker = document.createElement('div');
+                marker.className = `recycled-item-${normalizeProjectionKey(item.Id)}`;
+                target.appendChild(marker);
+            },
+            invalidateCard: (target: HTMLElement) => {
+                target.querySelectorAll('[class^="recycled-item-"]').forEach((node) => node.remove());
+            },
+        });
+
+        const image = gridCardImage();
+        const card = image.closest<HTMLElement>('.card')!;
+        card.dataset.id = itemA;
+        card.dataset.type = 'Movie';
+        document.body.appendChild(card);
+
+        await JC.tagPipeline!.invalidateServerCache?.();
+        await vi.waitFor(() => expect(ajax).toHaveBeenCalledTimes(1));
+
+        // Reuse the exact image/target for B while A's POST is still in flight.
+        card.dataset.id = itemB;
+        JC.tagPipeline!.scheduleScan?.();
+        await new Promise((resolve) => setTimeout(resolve, 30));
+
+        resolvers[0]({ Items: [{ Id: itemA, Type: 'Movie' }] });
+        await new Promise((resolve) => setTimeout(resolve, 40));
+        expect(document.querySelector(`.recycled-item-${itemA}`)).toBeNull();
+
+        await vi.waitFor(() => expect(ajax).toHaveBeenCalledTimes(2));
+        resolvers[1]({ Items: [{ Id: itemB, Type: 'Movie' }] });
+        await vi.waitFor(() => {
+            expect(document.querySelector(`.recycled-item-${itemB}`)).not.toBeNull();
+        });
+
+        ajax.mockRestore();
+        currentUser.mockRestore();
+        JC.pluginConfig = oldConfig;
+        document.body.innerHTML = '';
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.ts
@@ -11,7 +11,7 @@
 
 import { JC } from '../globals';
 import type { TagPipelineLike } from '../types/jc';
-import { addCSS, getItemCached } from './helpers';
+import { addCSS, clearItemCache, getItemCached } from './helpers';
 import { onBodyMutation } from '../core/dom-observer';
 import { onNavigate } from '../core/navigation';
 
@@ -33,6 +33,228 @@ const logPrefix = '🪼 Jellyfin Canopy [TagPipeline]:';
 let serverCache: Map<string, any> | null = null; // Map<itemId, TagCacheEntry> loaded from server
 let serverCacheVersion = 0;
 let serverCacheTimestamp = 0;
+let serverProjection: TagProjectionIdentity | null = null;
+let serverCacheLoadGeneration = 0;
+let tagCacheOwnerUserId: string | null = null;
+
+/** Identity of one user's watched/privacy projection in one server process. */
+export interface TagProjectionIdentity {
+    userId: string;
+    epoch: string;
+    revision: number;
+}
+
+export type ProjectionResponseDecision = 'apply' | 'ignore' | 'reset';
+
+/** Normalize Jellyfin ids/cache keys for stable comparisons across dashed/N forms. */
+export function normalizeProjectionKey(value: unknown): string | null {
+    if (typeof value !== 'string') return null;
+    const normalized = value.trim().replace(/-/g, '').toLowerCase();
+    return normalized.length > 0 ? normalized : null;
+}
+
+/** Parse the server-owned projection identity carried by every tag-cache response. */
+export function readProjectionIdentity(response: any): TagProjectionIdentity | null {
+    const userId = normalizeProjectionKey(response?.projectionUserId);
+    const epoch = typeof response?.projectionEpoch === 'string'
+        ? response.projectionEpoch.trim()
+        : '';
+    const revision = Number(response?.projectionRevision);
+    if (!userId || !epoch || !Number.isSafeInteger(revision) || revision < 0) return null;
+    return { userId, epoch, revision };
+}
+
+/**
+ * Decide whether an incremental response may mutate the current per-user cache.
+ * Older revisions and other users are ignored; epoch changes require a fresh full
+ * projection because revisions are process-local and restart at server startup.
+ */
+export function decideProjectionResponse(
+    current: TagProjectionIdentity | null,
+    response: any,
+    expectedUserId: string,
+): ProjectionResponseDecision {
+    const expected = normalizeProjectionKey(expectedUserId);
+    const incoming = readProjectionIdentity(response);
+    if (!expected || !incoming || incoming.userId !== expected) return 'ignore';
+    if (response?.projectionReset === true || response?.reset === true) return 'reset';
+    if (!current || current.userId !== expected || incoming.epoch !== current.epoch) return 'reset';
+    if (incoming.revision < current.revision) return 'ignore';
+    return 'apply';
+}
+
+/** Extract the item ids carried by a native UserDataChanged payload. */
+export function extractUserDataChangedIds(data: unknown, expectedUserId: string): string[] {
+    if (!data || typeof data !== 'object') return [];
+    const payload = data as { UserId?: unknown; userId?: unknown; UserDataList?: unknown; userDataList?: unknown };
+    const eventUser = normalizeProjectionKey(payload.UserId ?? payload.userId);
+    const expected = normalizeProjectionKey(expectedUserId);
+    // Native sockets are user-scoped, but an explicit other-user payload must
+    // never evict or replace this session's projection.
+    if (eventUser && expected && eventUser !== expected) return [];
+
+    const list = payload.UserDataList ?? payload.userDataList;
+    if (!Array.isArray(list)) return [];
+    const ids = new Set<string>();
+    for (const raw of list) {
+        if (!raw || typeof raw !== 'object') continue;
+        const row = raw as { ItemId?: unknown; itemId?: unknown };
+        const id = normalizeProjectionKey(row.ItemId ?? row.itemId);
+        if (id) ids.add(id);
+    }
+    return [...ids];
+}
+
+type ProjectionDependencyMeta = {
+    type: string;
+    relationKey: string | null;
+    seriesId: string | null;
+};
+
+export type ProjectionDependencyExpansion = {
+    ids: string[];
+    /** False means the loaded snapshot could not prove the full privacy closure. */
+    complete: boolean;
+};
+
+/**
+ * Bounded in-memory dependency index built from the already-downloaded cache.
+ * It lets a native Episode push synchronously blank Episode + Season + Series
+ * before the journal round trip; no per-event full-cache scan is required.
+ */
+export class TagProjectionDependencyIndex {
+    private readonly dependencies = new Map<string, Set<string>>();
+    private readonly metadata = new Map<string, ProjectionDependencyMeta>();
+    private readonly seasonsByRelation = new Map<string, Set<string>>();
+    private readonly episodesByRelation = new Map<string, Set<string>>();
+
+    clear(): void {
+        this.dependencies.clear();
+        this.metadata.clear();
+        this.seasonsByRelation.clear();
+        this.episodesByRelation.clear();
+    }
+
+    replaceAll(entries: ReadonlyMap<string, unknown>): void {
+        this.clear();
+        // Seasons first means Episode insertion can resolve its parent in O(1).
+        for (const [id, entry] of entries) {
+            if (this.readType(entry) === 'Season') this.replace(id, entry);
+        }
+        for (const [id, entry] of entries) {
+            if (this.readType(entry) !== 'Season') this.replace(id, entry);
+        }
+    }
+
+    replace(rawId: string, entry: unknown): void {
+        const id = normalizeProjectionKey(rawId);
+        if (!id) return;
+        this.remove(id);
+
+        const type = this.readType(entry);
+        const seriesId = this.readSeriesId(entry);
+        const relationKey = seriesId ? this.readRelationKey(entry, seriesId) : null;
+        const deps = new Set<string>([id]);
+        if (seriesId) deps.add(seriesId);
+
+        if (type === 'Season' && relationKey) {
+            let seasons = this.seasonsByRelation.get(relationKey);
+            if (!seasons) {
+                seasons = new Set<string>();
+                this.seasonsByRelation.set(relationKey, seasons);
+            }
+            seasons.add(id);
+            for (const episodeId of this.episodesByRelation.get(relationKey) || []) {
+                this.dependencies.get(episodeId)?.add(id);
+            }
+        } else if (type === 'Episode' && relationKey) {
+            let episodes = this.episodesByRelation.get(relationKey);
+            if (!episodes) {
+                episodes = new Set<string>();
+                this.episodesByRelation.set(relationKey, episodes);
+            }
+            episodes.add(id);
+            for (const seasonId of this.seasonsByRelation.get(relationKey) || []) {
+                deps.add(seasonId);
+            }
+        }
+
+        this.dependencies.set(id, deps);
+        this.metadata.set(id, { type, relationKey, seriesId });
+    }
+
+    remove(rawId: string): void {
+        const id = normalizeProjectionKey(rawId);
+        if (!id) return;
+        const meta = this.metadata.get(id);
+        if (meta?.type === 'Episode' && meta.relationKey) {
+            const episodes = this.episodesByRelation.get(meta.relationKey);
+            episodes?.delete(id);
+            if (episodes?.size === 0) this.episodesByRelation.delete(meta.relationKey);
+        } else if (meta?.type === 'Season' && meta.relationKey) {
+            const seasons = this.seasonsByRelation.get(meta.relationKey);
+            seasons?.delete(id);
+            if (seasons?.size === 0) this.seasonsByRelation.delete(meta.relationKey);
+            for (const episodeId of this.episodesByRelation.get(meta.relationKey) || []) {
+                this.dependencies.get(episodeId)?.delete(id);
+            }
+        }
+        this.metadata.delete(id);
+        this.dependencies.delete(id);
+    }
+
+    expand(ids: string[]): ProjectionDependencyExpansion {
+        const expanded = new Set<string>();
+        let complete = true;
+        for (const rawId of ids) {
+            const id = normalizeProjectionKey(rawId);
+            if (!id) continue;
+            const deps = this.dependencies.get(id);
+            const meta = this.metadata.get(id);
+            if (!deps || !meta) {
+                expanded.add(id);
+                complete = false;
+                continue;
+            }
+            for (const dependency of deps) expanded.add(dependency);
+
+            if (meta.type === 'Episode') {
+                // Episode changes can alter Episode + Season + Series policy.
+                // Missing relationship metadata cannot safely degrade to self.
+                if (!meta.seriesId || !meta.relationKey
+                    || (this.seasonsByRelation.get(meta.relationKey)?.size || 0) === 0) {
+                    complete = false;
+                }
+            } else if (meta.type === 'Season') {
+                if (!meta.seriesId) complete = false;
+            } else if (meta.type !== 'Series' && meta.type !== 'Movie' && meta.type !== 'BoxSet') {
+                complete = false;
+            }
+        }
+        return { ids: [...expanded], complete };
+    }
+
+    private readType(entry: unknown): string {
+        if (!entry || typeof entry !== 'object') return '';
+        const type = (entry as { Type?: unknown }).Type;
+        return typeof type === 'string' ? type : '';
+    }
+
+    private readSeriesId(entry: unknown): string | null {
+        if (!entry || typeof entry !== 'object') return null;
+        return normalizeProjectionKey((entry as { SeriesId?: unknown }).SeriesId);
+    }
+
+    private readRelationKey(entry: unknown, seriesId: string): string | null {
+        if (!entry || typeof entry !== 'object') return null;
+        const rawSeasonNumber = (entry as { SeasonNumber?: unknown }).SeasonNumber;
+        if (rawSeasonNumber === null || rawSeasonNumber === undefined || rawSeasonNumber === '') return null;
+        const seasonNumber = Number(rawSeasonNumber);
+        return Number.isSafeInteger(seasonNumber) ? `${seriesId}:${seasonNumber}` : null;
+    }
+}
+
+const projectionDependencyIndex = new TagProjectionDependencyIndex();
 
 // ── State ──────────────────────────────────────────────────────────
 
@@ -50,6 +272,8 @@ type RendererConfig = {
     renderFromCache?: ((el: HTMLElement, itemId: string) => boolean) | null;
     renderFromServerCache?: ((el: HTMLElement, entry: any, itemId: string) => void) | null;
     onServerCacheRefresh?: ((updatedIds: string[] | null) => void) | null;
+    /** Remove this renderer's overlay + tagged marker from one card. */
+    invalidateCard?: ((el: HTMLElement) => void) | null;
     /** Whether Series/Season items need first episode data. */
     needsFirstEpisode?: boolean;
     /** Whether Season items need parent Series data. */
@@ -64,6 +288,7 @@ type RendererEntry = Required<Pick<RendererConfig, 'render' | 'isEnabled'>> & {
     renderFromCache: ((el: HTMLElement, itemId: string) => boolean) | null;
     renderFromServerCache: ((el: HTMLElement, entry: any, itemId: string) => void) | null;
     onServerCacheRefresh: ((updatedIds: string[] | null) => void) | null;
+    invalidateCard: ((el: HTMLElement) => void) | null;
     needsFirstEpisode: boolean;
     needsParentSeries: boolean;
     injectCss: (() => void) | null;
@@ -77,8 +302,26 @@ interface QueueEntry {
     itemType: string | null;
 }
 
+/** True only while a queued element/target still belongs to the captured item. */
+function queueEntryStillOwnsItem(entry: QueueEntry, itemId: string): boolean {
+    return document.contains(entry.el)
+        && entry.renderTarget.isConnected
+        && getItemId(entry.el) === itemId;
+}
+
 const renderers = new Map<string, RendererEntry>(); // name → { render, isEnabled, needsFirstEpisode, needsParentSeries }
 let processedCards = new WeakSet<Element>(); // let, not const — needs reassignment on reinit
+let renderedItemByElement = new WeakMap<Element, string>();
+const pendingProjectionIds = new Set<string>();
+// Batch-mode watched flips bypass every local/helper cache and must be satisfied
+// by a successful fresh /tag-data response before their cards can render again.
+const forceFreshProjectionIds = new Set<string>();
+// In local/batch mode, every item encountered in one privacy generation must
+// receive one successful live /tag-data response before cache reuse is allowed.
+let batchForceAllProjectionIds = false;
+const batchFreshProjectionIds = new Set<string>();
+let projectionRequestGeneration = 0;
+let projectionResetPending = JC.pluginConfig?.TagCacheServerMode === true;
 // PERF(R9): per-element failure counter — a card whose data fetch failed is
 // un-marked from processedCards (so later mutation/nav passes retry it) up to
 // this cap, then stays marked so an unreachable server isn't hammered forever.
@@ -153,6 +396,7 @@ function registerRenderer(name: string, config: RendererConfig): void {
         renderFromCache: config.renderFromCache || null,
         renderFromServerCache: config.renderFromServerCache || null,
         onServerCacheRefresh: config.onServerCacheRefresh || null,
+        invalidateCard: config.invalidateCard || null,
         isEnabled: config.isEnabled,
         needsFirstEpisode: config.needsFirstEpisode || false,
         needsParentSeries: config.needsParentSeries || false,
@@ -238,10 +482,13 @@ async function loadServerCache(): Promise<void> {
         console.log(`${logPrefix} Server cache mode disabled`);
         return;
     }
-    try {
-        const userId = ApiClient.getCurrentUserId();
-        if (!userId) return;
+    const requestedUserId = ApiClient.getCurrentUserId();
+    const requestedUserKey = normalizeProjectionKey(requestedUserId);
+    if (!requestedUserId || !requestedUserKey) return;
+    projectionResetPending = true;
+    const loadGeneration = ++serverCacheLoadGeneration;
 
+    try {
         // PERF(R7): js/plugin.js starts this fetch as soon as public config
         // lands (boot Stage 1) and parks the in-flight promise on
         // JC._tagCachePrefetch — consume it instead of starting a second
@@ -254,32 +501,105 @@ async function loadServerCache(): Promise<void> {
         if (prefetch) {
             JC._tagCachePrefetch = null;
             resp = await prefetch;
+            const prefetchedIdentity = readProjectionIdentity(resp);
+            if (!prefetchedIdentity || prefetchedIdentity.userId !== requestedUserKey) {
+                // A login switch can race the one-shot bootstrap prefetch. Never
+                // publish another account's projected cache into this session.
+                resp = null;
+            } else {
+                // The bootstrap prefetch begins before the enhanced bundle/live
+                // handlers finish loading. Validate its cursor cheaply before
+                // publication so a watched flip during bundle download cannot
+                // install a stale full snapshot.
+                try {
+                    const params = new URLSearchParams({
+                        projectionEpoch: prefetchedIdentity.epoch,
+                        projectionRevision: String(prefetchedIdentity.revision),
+                        projectionOnly: 'true',
+                    });
+                    const validation: any = await ApiClient.ajax({
+                        type: 'GET',
+                        url: ApiClient.getUrl(`/JellyfinCanopy/tag-cache/${requestedUserId}?${params.toString()}`),
+                        dataType: 'json',
+                    });
+                    const validatedIdentity = readProjectionIdentity(validation);
+                    if (decideProjectionResponse(prefetchedIdentity, validation, requestedUserId) !== 'apply'
+                        || !validatedIdentity
+                        || validatedIdentity.revision !== prefetchedIdentity.revision
+                        || normalizeIdList(validation?.projectionIds).length > 0) {
+                        resp = null;
+                    }
+                } catch {
+                    // Validation uncertainty cannot publish privacy-sensitive
+                    // prefetched bytes. Fall through to a fresh full snapshot.
+                    resp = null;
+                }
+            }
         }
         if (!resp) {
             resp = await ApiClient.ajax({
                 type: 'GET',
-                url: ApiClient.getUrl(`/JellyfinCanopy/tag-cache/${userId}`),
+                url: ApiClient.getUrl(`/JellyfinCanopy/tag-cache/${requestedUserId}`),
                 dataType: 'json'
             });
         }
 
-        if (resp && resp.items && resp.count > 0) {
-            serverCache = new Map(Object.entries(resp.items));
-            serverCacheVersion = resp.version;
-            serverCacheTimestamp = resp.timestamp;
-            console.log(`${logPrefix} Server cache loaded: ${serverCache.size} items (v${serverCacheVersion})`);
-        } else {
-            console.log(`${logPrefix} Server cache empty, using batch fallback`);
+        // A later load/reset or account switch owns the result now.
+        if (loadGeneration !== serverCacheLoadGeneration) return;
+        if (normalizeProjectionKey(ApiClient.getCurrentUserId()) !== requestedUserKey) return;
+
+        const identity = readProjectionIdentity(resp);
+        if (!identity || identity.userId !== requestedUserKey) {
+            console.warn(`${logPrefix} Server cache response lacked the expected per-user projection identity`);
+            return;
         }
+
+        const entries = new Map<string, any>();
+        if (resp?.items && typeof resp.items === 'object') {
+            for (const [rawId, entry] of Object.entries(resp.items)) {
+                const id = normalizeProjectionKey(rawId);
+                if (id) entries.set(id, entry);
+            }
+        }
+        // Drop every unscoped local/hot/DOM value before publishing the first
+        // owner-bound snapshot. Renderer isTagged() must not preserve pre-load
+        // or previous-account overlays over the authoritative projection.
+        clearRendererProjectionState(true);
+        processedCards = new WeakSet();
+        renderedItemByElement = new WeakMap();
+        projectionDependencyIndex.replaceAll(entries);
+        serverCache = entries; // an authoritative empty cache is still a loaded cache
+        serverCacheVersion = Number(resp?.version) || 0;
+        serverCacheTimestamp = Number(resp?.timestamp) || 0;
+        serverProjection = identity;
+        tagCacheOwnerUserId = identity.userId;
+        projectionResetPending = false;
+        pendingProjectionIds.clear();
+        forceFreshProjectionIds.clear();
+        console.log(
+            `${logPrefix} Server cache loaded: ${serverCache.size} items ` +
+            `(v${serverCacheVersion}, projection ${identity.revision})`,
+        );
     } catch (err) {
         console.warn(`${logPrefix} Failed to load server cache, using batch fallback:`, err);
     }
 }
 
 /**
- * Fetch incremental server cache updates since last load.
+ * Fetch incremental server cache updates since last load. A projection-only
+ * refresh asks the server journal for just watched/privacy-invalidated ids; it
+ * never walks or transfers the full shared cache during a playback event.
  */
-async function refreshServerCache(): Promise<void> {
+async function refreshServerCache(projectionOnly = false): Promise<void> {
+    if (!JC.pluginConfig?.TagCacheServerMode) return;
+    const userId = ApiClient.getCurrentUserId();
+    const userKey = normalizeProjectionKey(userId);
+    if (!userId || !userKey) return;
+
+    if (serverProjection && serverProjection.userId !== userKey) {
+        resetServerProjection(true);
+    }
+
     // If server cache was never loaded (e.g. cache was empty at startup),
     // retry the full load — the scheduled task may have built it since then
     if (!serverCache) {
@@ -291,47 +611,220 @@ async function refreshServerCache(): Promise<void> {
         }
         return;
     }
-    if (!serverCacheTimestamp) return;
+    if (!serverProjection) return;
+    // An empty/not-yet-built shared cache has no content timestamp. Navigation
+    // still has to validate the privacy cursor, but must not turn that into a
+    // full-cache request, so use the bounded journal-only shape in this case.
+    const requestProjectionOnly = projectionOnly || !serverCacheTimestamp;
+
+    const requestGeneration = projectionRequestGeneration;
+    const requestProjection = { ...serverProjection };
     try {
-        const userId = ApiClient.getCurrentUserId();
-        if (!userId) return;
+        const params = new URLSearchParams();
+        if (!requestProjectionOnly) params.set('since', String(serverCacheTimestamp));
+        params.set('projectionEpoch', requestProjection.epoch);
+        params.set('projectionRevision', String(requestProjection.revision));
+        if (requestProjectionOnly) params.set('projectionOnly', 'true');
 
         const resp: any = await ApiClient.ajax({
             type: 'GET',
-            url: ApiClient.getUrl(`/JellyfinCanopy/tag-cache/${userId}?since=${serverCacheTimestamp}`),
+            url: ApiClient.getUrl(`/JellyfinCanopy/tag-cache/${userId}?${params.toString()}`),
             dataType: 'json'
         });
 
-        if (resp && resp.items) {
-            const newEntries = Object.entries(resp.items);
-            if (newEntries.length > 0) {
-                for (const [id, entry] of newEntries) {
-                    serverCache.set(id, entry);
-                }
-                serverCacheTimestamp = resp.timestamp;
-                // Notify renderers to invalidate derived caches for updated items
-                for (const [, renderer] of renderers) {
-                    if (renderer.onServerCacheRefresh) {
-                        try { renderer.onServerCacheRefresh(newEntries.map(e => e[0])); } catch {}
-                    }
-                }
-                console.log(`${logPrefix} Server cache updated: +${newEntries.length} items`);
+        // A newer watch event, account switch, or reset supersedes this request.
+        if (requestGeneration !== projectionRequestGeneration) return;
+        if (normalizeProjectionKey(ApiClient.getCurrentUserId()) !== userKey) return;
+
+        const decision = decideProjectionResponse(serverProjection, resp, userId);
+        if (decision === 'ignore') {
+            const ignoredIdentity = readProjectionIdentity(resp);
+            // A valid delayed response is harmless because the current cursor is
+            // already newer. Malformed/other-user bytes cannot release a privacy
+            // gate and remain fail-closed.
+            if (ignoredIdentity
+                && ignoredIdentity.userId === userKey
+                && serverProjection.epoch === ignoredIdentity.epoch
+                && serverProjection.revision >= ignoredIdentity.revision) {
+                projectionResetPending = false;
+                runScan();
             }
-            // Full rebuild detected — reload everything
-            if (resp.version !== serverCacheVersion) {
-                console.log(`${logPrefix} Cache version changed, reloading full cache`);
-                await loadServerCache();
-                // Clear all derived caches on full rebuild
-                for (const [, renderer] of renderers) {
-                    if (renderer.onServerCacheRefresh) {
-                        try { renderer.onServerCacheRefresh(null); } catch {}
-                    }
-                }
+            return;
+        }
+        if (decision === 'reset') {
+            console.log(`${logPrefix} Projection epoch/journal reset, reloading one full snapshot`);
+            resetServerProjection(true);
+            await loadServerCache();
+            if (serverCache) {
+                processedCards = new WeakSet();
+                runScan();
+            }
+            return;
+        }
+
+        // A shared-cache removal/full rebuild still uses the existing version
+        // signal. Do this before mutating any projected rows.
+        if (Number(resp?.version) !== serverCacheVersion) {
+            console.log(`${logPrefix} Cache version changed, reloading full cache`);
+            resetServerProjection(true);
+            await loadServerCache();
+            if (serverCache) {
+                processedCards = new WeakSet();
+                runScan();
+            }
+            return;
+        }
+
+        const incomingIdentity = readProjectionIdentity(resp)!;
+        const projectionIds = normalizeIdList(resp?.projectionIds);
+        const newEntries: Array<[string, any]> = [];
+        if (resp?.items && typeof resp.items === 'object') {
+            for (const [rawId, entry] of Object.entries(resp.items)) {
+                const id = normalizeProjectionKey(rawId);
+                if (id) newEntries.push([id, entry]);
             }
         }
+
+        // projectionIds are authoritative invalidations/tombstones. Delete first,
+        // then merge only the rows the current per-user projection returned.
+        for (const id of projectionIds) {
+            serverCache.delete(id);
+            projectionDependencyIndex.remove(id);
+        }
+        for (const [id, entry] of newEntries) {
+            serverCache.set(id, entry);
+            projectionDependencyIndex.replace(id, entry);
+        }
+
+        const changedIds = new Set<string>(projectionIds);
+        for (const [id] of newEntries) changedIds.add(id);
+        // If a native push named an id but the journal returned no cache row
+        // (deleted/inaccessible), it remains an authoritative tombstone.
+        if (requestProjectionOnly) {
+            for (const id of pendingProjectionIds) changedIds.add(id);
+        }
+
+        serverProjection = incomingIdentity;
+        // A projection-only response carries the shared cache timestamp for
+        // context, but did not request/apply that shared content delta. Advancing
+        // the cursor here would make the next normal refresh skip unrelated
+        // library changes that landed between the two requests.
+        if (!requestProjectionOnly && Number.isFinite(Number(resp?.timestamp))) {
+            serverCacheTimestamp = Number(resp.timestamp);
+        }
+        pendingProjectionIds.clear();
+        projectionResetPending = false;
+
+        if (changedIds.size > 0) {
+            invalidateRenderedItems([...changedIds], false);
+        }
+        // Navigation cursor validation must release + rescan even when no ids
+        // changed; cards mounted while the gate was active are still unprocessed.
+        runScan();
+        console.log(
+            `${logPrefix} Server cache projection updated: ${newEntries.length} rows, ` +
+            `${projectionIds.length} invalidations (revision ${incomingIdentity.revision})`,
+        );
     } catch (err) {
+        // Fail closed: ids synchronously blanked for this request stay pending and
+        // cannot fall through to local/server caches. Navigation or the next push
+        // retries from the same cursor.
         console.warn(`${logPrefix} Failed to refresh server cache:`, err);
     }
+}
+
+function normalizeIdList(value: unknown): string[] {
+    if (!Array.isArray(value)) return [];
+    const ids = new Set<string>();
+    for (const raw of value) {
+        const id = normalizeProjectionKey(raw);
+        if (id) ids.add(id);
+    }
+    return [...ids];
+}
+
+/**
+ * Gate every mounted/new card while a bounded journal request resolves a push
+ * whose dependency closure is not present in the loaded tag-cache snapshot.
+ * The cache, cursor, and relationship index stay intact: non-taggable native
+ * events can therefore resolve with an empty O(journal) delta instead of forcing
+ * a full personalized cache download, while a failure remains globally blank.
+ */
+async function refreshUnknownServerProjection(ids: string[]): Promise<void> {
+    projectionRequestGeneration++;
+    batchGeneration++;
+    projectionResetPending = true;
+    for (const id of normalizeIdList(ids)) pendingProjectionIds.add(id);
+    for (const entry of requestQueue) processedCards.delete(entry.el);
+    requestQueue = [];
+    firstEpisodeCache.clear();
+    parentSeriesCache.clear();
+    clearRendererProjectionState(true);
+    processedCards = new WeakSet();
+    renderedItemByElement = new WeakMap();
+    await refreshServerCache(true);
+}
+
+/**
+ * Synchronous privacy barrier for UserDataChanged, followed by a bounded journal
+ * refresh. A valid other-user push is ignored; malformed current-user data forces
+ * a rare full reset rather than risking stale unstripped overlays.
+ */
+async function refreshServerProjection(data: unknown): Promise<void> {
+    const userId = ApiClient.getCurrentUserId();
+    const userKey = normalizeProjectionKey(userId);
+    if (!userId || !userKey) return;
+
+    const payload = data && typeof data === 'object'
+        ? data as { UserId?: unknown; userId?: unknown; UserDataList?: unknown; userDataList?: unknown }
+        : null;
+    const eventUser = normalizeProjectionKey(payload?.UserId ?? payload?.userId);
+    if (eventUser && eventUser !== userKey) return;
+    const serverMode = JC.pluginConfig?.TagCacheServerMode === true;
+    if (!serverMode && JC.pluginConfig?.SpoilerBlurEnabled !== true) {
+        // Watched state influences tag privacy only while Spoiler Guard is
+        // active. Avoid a full visible-card cache generation/flicker for
+        // ordinary native user-data events when both projection modes are off.
+        return;
+    }
+
+    const ids = extractUserDataChangedIds(data, userId);
+    if (ids.length === 0) {
+        // Missing ids mean we cannot identify a safe bounded subset. This is an
+        // exceptional compatibility path, not the normal playback path.
+        const visibleIds = collectVisibleProjectionIds();
+        if (!serverMode) {
+            resetServerProjection(true);
+            armBatchProjectionRefresh(visibleIds, userId);
+            return;
+        }
+        await refreshUnknownServerProjection([]);
+        return;
+    }
+
+    if (!serverMode) {
+        // Without the server journal the native payload cannot name the parent
+        // Season/Series closure. Refresh every mounted card and retire all local
+        // DTO/renderer values for this privacy generation; newly mounted cards
+        // are also forced once by batchForceAllProjectionIds.
+        const visibleIds = collectVisibleProjectionIds();
+        armBatchProjectionRefresh([...new Set([...ids, ...visibleIds])], userId);
+        return;
+    }
+
+    const expanded = projectionDependencyIndex.expand(ids);
+    if (!expanded.complete) {
+        // If the loaded cache lacks an Episode's Season/Series relationship,
+        // self-only invalidation would leave stale parent overlays visible. Gate
+        // globally until the bounded journal supplies the authoritative closure.
+        await refreshUnknownServerProjection(ids);
+        return;
+    }
+
+    projectionRequestGeneration++;
+    for (const id of expanded.ids) pendingProjectionIds.add(id);
+    invalidateRenderedItems(expanded.ids, true);
+    await refreshServerCache(true);
 }
 
 // ── Card Scanning ──────────────────────────────────────────────────
@@ -435,6 +928,146 @@ function resolveRenderTarget(el: HTMLElement): HTMLElement {
     return renderTarget;
 }
 
+/** Return an existing render target without creating a new tag host. */
+function existingRenderTarget(el: HTMLElement): HTMLElement {
+    const scalable = el.closest<HTMLElement>('.cardScalable');
+    return scalable?.querySelector<HTMLElement>('.jc-tag-host') || scalable || el;
+}
+
+/** Remove every renderer's overlay/marker from one card image. */
+function clearRenderedCard(el: HTMLElement): void {
+    const target = existingRenderTarget(el);
+    for (const [, renderer] of renderers) {
+        if (!renderer.invalidateCard) continue;
+        try { renderer.invalidateCard(target); } catch { /* fail-closed best effort continues */ }
+    }
+    processedCards.delete(el);
+    renderedItemByElement.delete(el);
+}
+
+/**
+ * Invalidate a bounded set across the projected map, renderer-derived caches,
+ * queued/in-flight tag data, and every matching visible duplicate card.
+ */
+function invalidateRenderedItems(ids: string[], evictServerRows: boolean): void {
+    const idSet = new Set(normalizeIdList(ids));
+    if (idSet.size === 0) return;
+
+    // Any pre-invalidation tag-data response is stale. Its generation checks
+    // unmark the captured cards rather than repainting them.
+    batchGeneration++;
+    requestQueue = requestQueue.filter((entry) => {
+        if (!idSet.has(entry.itemId)) return true;
+        processedCards.delete(entry.el);
+        return false;
+    });
+
+    if (evictServerRows && serverCache) {
+        for (const id of idSet) serverCache.delete(id);
+    }
+    for (const id of idSet) {
+        firstEpisodeCache.delete(id);
+        parentSeriesCache.delete(id);
+    }
+    const affected = [...idSet];
+    // The generic DTO helper is a final fallback when /tag-data fails. Retire
+    // its pre-flip rows too, including in-flight ownership, so a projection
+    // tombstone cannot fall through and repaint an old personalized DTO.
+    clearItemCache(ApiClient.getCurrentUserId(), affected);
+    for (const [, renderer] of renderers) {
+        if (!renderer.onServerCacheRefresh) continue;
+        try { renderer.onServerCacheRefresh(affected); } catch { /* continue clearing peers */ }
+    }
+
+    document.querySelectorAll<HTMLElement>('.cardImageContainer').forEach((el) => {
+        const currentItemId = getItemId(el);
+        const renderedItemId = renderedItemByElement.get(el);
+        if ((currentItemId && idSet.has(currentItemId))
+            || (renderedItemId && idSet.has(renderedItemId))) {
+            clearRenderedCard(el);
+        }
+    });
+}
+
+function clearRendererProjectionState(clearDom: boolean): void {
+    for (const [, renderer] of renderers) {
+        if (!renderer.onServerCacheRefresh) continue;
+        try { renderer.onServerCacheRefresh(null); } catch { /* clear peers even if one fails */ }
+    }
+    if (clearDom) {
+        document.querySelectorAll<HTMLElement>('.cardImageContainer').forEach(clearRenderedCard);
+    }
+}
+
+/** Start a new local privacy generation and retire every pre-generation source. */
+function beginBatchProjectionGeneration(userId: string): void {
+    batchGeneration++;
+    for (const entry of requestQueue) processedCards.delete(entry.el);
+    requestQueue = [];
+    firstEpisodeCache.clear();
+    parentSeriesCache.clear();
+    pendingProjectionIds.clear();
+    forceFreshProjectionIds.clear();
+    batchFreshProjectionIds.clear();
+    batchForceAllProjectionIds = true;
+    clearItemCache(userId);
+    clearRendererProjectionState(true);
+    processedCards = new WeakSet();
+    renderedItemByElement = new WeakMap();
+    projectionResetPending = false;
+}
+
+/** Current ids for every mounted card; resetServerProjection clears old recycled overlays. */
+function collectVisibleProjectionIds(): string[] {
+    const ids = new Set<string>();
+    document.querySelectorAll<HTMLElement>('.cardImageContainer').forEach((el) => {
+        const current = getItemId(el);
+        if (current) ids.add(current);
+    });
+    return [...ids];
+}
+
+/**
+ * Release a global batch-mode reset only into forced live tag-data requests.
+ * The helper DTO cache is user-scoped but otherwise survives renderer clears,
+ * so it must also be invalidated before any later fallback is allowed.
+ */
+function armBatchProjectionRefresh(ids: string[], userId: string): void {
+    beginBatchProjectionGeneration(userId);
+    for (const id of normalizeIdList(ids)) {
+        pendingProjectionIds.add(id);
+        forceFreshProjectionIds.add(id);
+    }
+    projectionResetPending = false;
+    runScan();
+}
+
+/** Clear all visible tag projections and all cache ownership/cursor state. */
+function resetServerProjection(clearDom: boolean): void {
+    serverCacheLoadGeneration++;
+    projectionRequestGeneration++;
+    batchGeneration++;
+    serverCache = null;
+    serverCacheVersion = 0;
+    serverCacheTimestamp = 0;
+    serverProjection = null;
+    tagCacheOwnerUserId = null;
+    projectionDependencyIndex.clear();
+    projectionResetPending = true;
+    pendingProjectionIds.clear();
+    forceFreshProjectionIds.clear();
+    batchForceAllProjectionIds = false;
+    batchFreshProjectionIds.clear();
+    for (const entry of requestQueue) processedCards.delete(entry.el);
+    requestQueue = [];
+    firstEpisodeCache.clear();
+    parentSeriesCache.clear();
+    clearItemCache();
+    clearRendererProjectionState(clearDom);
+    processedCards = new WeakSet();
+    renderedItemByElement = new WeakMap();
+}
+
 /**
  * Process a single card: skip checks, render-target resolution, cache render
  * (server cache first, then localStorage/hot cache), queueing misses for the
@@ -448,9 +1081,51 @@ function resolveRenderTarget(el: HTMLElement): HTMLElement {
  *   passes false — its tags are part of the card's first frame.
  */
 function processCard(el: HTMLElement, fadeIn: boolean): void {
-    if (processedCards.has(el)) return;
     // Skip elements no longer in the DOM (page changed)
     if (!document.contains(el)) return;
+
+    const itemId = getItemId(el);
+    if (!itemId) return;
+
+    const activeUserId = ApiClient.getCurrentUserId();
+    const activeUserKey = normalizeProjectionKey(activeUserId);
+    if (tagCacheOwnerUserId && tagCacheOwnerUserId !== activeUserKey) {
+        // Account switches can occur without a full document reload. Blank the
+        // prior owner's projection synchronously, including the transient logout
+        // state where Jellyfin reports no active user at all.
+        resetServerProjection(true);
+        if (!activeUserKey) return;
+        tagCacheOwnerUserId = activeUserKey;
+        if (JC.pluginConfig?.TagCacheServerMode) {
+            void loadServerCache().then(() => {
+                if (serverCache) runScan();
+            });
+            return;
+        }
+        batchForceAllProjectionIds = true;
+        batchFreshProjectionIds.clear();
+        clearItemCache(activeUserId);
+        projectionResetPending = false;
+    }
+    // No cache or overlay is safe to render outside a concrete user scope.
+    if (!activeUserKey) return;
+    if (!tagCacheOwnerUserId && activeUserKey) tagCacheOwnerUserId = activeUserKey;
+
+    // Virtualized/recycled card elements can survive while their data-id changes.
+    // A WeakSet alone would preserve the old item's overlays forever.
+    const renderedItemId = renderedItemByElement.get(el);
+    if (processedCards.has(el) && renderedItemId !== itemId) clearRenderedCard(el);
+    if (processedCards.has(el)) return;
+
+    const serverMode = JC.pluginConfig?.TagCacheServerMode === true;
+    const forceFresh = !serverMode
+        && (forceFreshProjectionIds.has(itemId)
+            || (batchForceAllProjectionIds && !batchFreshProjectionIds.has(itemId)));
+
+    // Server-cache mode cannot render until its projected replacement lands.
+    // Batch mode instead queues forced ids directly to the live tag-data endpoint,
+    // bypassing every cache while the same pending marker remains fail-closed.
+    if (projectionResetPending || (serverMode && pendingProjectionIds.has(itemId))) return;
 
     const card = el.closest('.card');
     if (card && card.classList.contains('jc-hidden')) return;
@@ -458,23 +1133,29 @@ function processCard(el: HTMLElement, fadeIn: boolean): void {
     // Skip contexts that should never have tags
     if (shouldSkipElement(el)) {
         processedCards.add(el);
+        renderedItemByElement.set(el, itemId);
         return;
     }
-
-    const itemId = getItemId(el);
-    if (!itemId) return;
 
     const itemType = getItemType(el);
     if (itemType && !MEDIA_TYPES.has(itemType)) {
         processedCards.add(el);
+        renderedItemByElement.set(el, itemId);
         return;
     }
 
+    if (forceFresh) {
+        pendingProjectionIds.add(itemId);
+        forceFreshProjectionIds.add(itemId);
+    }
+
     processedCards.add(el);
+    renderedItemByElement.set(el, itemId);
     const renderTarget = resolveRenderTarget(el);
 
-    // Try server cache first (all tag data pre-computed in one object)
-    const serverEntry = serverCache?.get(itemId);
+    // Try server cache first (all tag data pre-computed in one object). A watched
+    // flip in batch mode must never reuse this or any renderer-local cache.
+    const serverEntry = forceFresh ? undefined : serverCache?.get(itemId);
     if (serverEntry) {
         const renderAll = (): void => {
             for (const [, renderer] of renderers) {
@@ -486,6 +1167,11 @@ function processCard(el: HTMLElement, fadeIn: boolean): void {
         };
         if (fadeIn) withFadeIn(renderTarget, renderAll); else renderAll();
         return; // Fully rendered from server cache, skip queue
+    }
+
+    if (forceFresh) {
+        requestQueue.push({ el, renderTarget, itemId, itemType });
+        return;
     }
 
     // Fall back to localStorage/hot cache, then batch fetch for misses
@@ -564,7 +1250,11 @@ function runScan(): void {
     const elements = document.querySelectorAll<HTMLElement>('.cardImageContainer');
     const unprocessed: HTMLElement[] = [];
     for (const el of elements) {
-        if (!processedCards.has(el)) unprocessed.push(el);
+        const currentId = getItemId(el);
+        const renderedId = renderedItemByElement.get(el);
+        if (!processedCards.has(el) || (currentId !== null && currentId !== renderedId)) {
+            unprocessed.push(el);
+        }
     }
     if (unprocessed.length === 0) return;
 
@@ -659,7 +1349,8 @@ async function processQueue(): Promise<void> {
  */
 async function processBatch(batch: QueueEntry[], generation: number): Promise<void> {
     const userId = ApiClient.getCurrentUserId();
-    if (!userId) return;
+    const userKey = normalizeProjectionKey(userId);
+    if (!userId || !userKey) return;
 
     // Use arrays per ID to handle duplicate items (same movie in multiple rows)
     const elMap = new Map<string, QueueEntry[]>();
@@ -679,21 +1370,41 @@ async function processBatch(batch: QueueEntry[], generation: number): Promise<vo
             dataType: 'json'
         });
 
-        const items: any[] = response?.Items || [];
+        if (!Array.isArray(response?.Items)
+            || response.Items.some((item: unknown) => {
+                if (!item || typeof item !== 'object') return true;
+                return !normalizeProjectionKey((item as { Id?: unknown }).Id);
+            })) {
+            throw new Error('Malformed tag-data response');
+        }
+        const items: any[] = response.Items;
 
         // Abort if navigation happened while we were waiting for the API response.
         // PERF(R9): un-mark the batch's cards first — if their elements survive
         // the navigation (cached legacy page re-show), a later pass must be
         // able to pick them up again instead of seeing a hollow "processed".
-        if (generation !== batchGeneration) {
+        if (generation !== batchGeneration
+            || normalizeProjectionKey(ApiClient.getCurrentUserId()) !== userKey) {
             for (const b of batch) processedCards.delete(b.el);
+            scheduleScan();
             return;
+        }
+
+        // A successful tag-data response is authoritative even when an id is
+        // absent (deleted/inaccessible/blank). Release only this accepted batch's
+        // forced privacy ids; a later watch event changes batchGeneration and is
+        // rejected above before these sets can be touched.
+        for (const id of ids) {
+            batchFreshProjectionIds.add(id);
+            forceFreshProjectionIds.delete(id);
+            pendingProjectionIds.delete(id);
         }
 
         // Build parent series lookup for rating fallback
         const parentSeriesNeeded = new Set<string>();
         for (const item of items) {
             if ((item.Type === 'Season' || item.Type === 'Episode') && item.SeriesId &&
+                item.RatingSuppressed !== true &&
                 !item.CommunityRating && !item.CriticRating) {
                 parentSeriesNeeded.add(item.SeriesId);
             }
@@ -733,8 +1444,12 @@ async function processBatch(batch: QueueEntry[], generation: number): Promise<vo
             // meantime, un-mark instead of rendering into a stale page, so a
             // surviving card element (cached legacy re-show) gets retried rather
             // than staying marked-but-hollow.
-            if (generation !== batchGeneration) {
+            if (generation !== batchGeneration
+                || normalizeProjectionKey(ApiClient.getCurrentUserId()) !== userKey
+                || projectionResetPending
+                || pendingProjectionIds.has(itemId)) {
                 for (const entry of batchEntries) processedCards.delete(entry.el);
+                scheduleScan();
                 return;
             }
             if (!MEDIA_TYPES.has(item.Type)) return;
@@ -745,13 +1460,20 @@ async function processBatch(batch: QueueEntry[], generation: number): Promise<vo
                 const parentId = item.SeriesId.toString().replace(/-/g, '').toLowerCase();
                 parentSeries = parentSeriesMap.get(parentId) || null;
                 if ((item.Type === 'Season' || item.Type === 'Episode') &&
+                    item.RatingSuppressed !== true &&
                     !item.CommunityRating && !item.CriticRating) {
                     ratingParentSeries = parentSeries;
                 }
             }
 
             // Render to ALL cards with this ID (same item can appear in multiple rows)
+            let recycled = false;
             for (const entry of batchEntries) {
+                if (!queueEntryStillOwnsItem(entry, itemId)) {
+                    processedCards.delete(entry.el);
+                    recycled = true;
+                    continue;
+                }
                 const { renderTarget } = entry;
                 const extras = { firstEpisode, parentSeries, ratingParentSeries, renderTarget };
                 // PERF(R7): batch-fetched tags land post-paint by definition — fade them in.
@@ -766,6 +1488,7 @@ async function processBatch(batch: QueueEntry[], generation: number): Promise<vo
                     }
                 });
             }
+            if (recycled) scheduleScan();
         };
 
         // Check if ANY enabled renderer actually needs first-episode data
@@ -800,12 +1523,45 @@ async function processBatch(batch: QueueEntry[], generation: number): Promise<vo
         for (const entry of batch) {
             const { el, renderTarget, itemId } = entry;
             try {
+                if (generation !== batchGeneration
+                    || normalizeProjectionKey(ApiClient.getCurrentUserId()) !== userKey
+                    || projectionResetPending
+                    || pendingProjectionIds.has(itemId)) {
+                    processedCards.delete(el);
+                    if (generation !== batchGeneration
+                        || normalizeProjectionKey(ApiClient.getCurrentUserId()) !== userKey) {
+                        scheduleScan();
+                    }
+                    continue;
+                }
+                if (!queueEntryStillOwnsItem(entry, itemId)) {
+                    processedCards.delete(el);
+                    scheduleScan();
+                    continue;
+                }
+                // Privacy-forced ids may only be satisfied by /tag-data. The
+                // generic helper carries its own short-lived DTO cache, so using
+                // it after a batch failure could replay the pre-flip projection.
+                if (forceFreshProjectionIds.has(itemId)) {
+                    processedCards.delete(el);
+                    continue;
+                }
                 const item: any = await getItemCached(itemId, { userId });
                 if (!item || !MEDIA_TYPES.has(item.Type)) continue;
 
                 const firstEpisode = (item.Type === 'Series' || item.Type === 'Season')
                     ? await getFirstEpisode(userId, item.Id) : null;
                 const extras = { firstEpisode, parentSeries: null, ratingParentSeries: null, renderTarget };
+
+                if (generation !== batchGeneration
+                    || normalizeProjectionKey(ApiClient.getCurrentUserId()) !== userKey
+                    || projectionResetPending
+                    || pendingProjectionIds.has(itemId)
+                    || !queueEntryStillOwnsItem(entry, itemId)) {
+                    processedCards.delete(el);
+                    scheduleScan();
+                    continue;
+                }
 
                 // PERF(R7): post-paint fallback render — fade late tags in.
                 withFadeIn(renderTarget, () => {
@@ -855,6 +1611,24 @@ function buildIndicatorOffsetCSS(): string {
  * Initialize the tag pipeline: register mutation observer, navigation handler, and inject base CSS.
  */
 function initialize(): void {
+    const activeUserId = ApiClient.getCurrentUserId();
+    const activeUserKey = normalizeProjectionKey(activeUserId);
+    const serverMode = JC.pluginConfig?.TagCacheServerMode === true;
+    tagCacheOwnerUserId = activeUserKey;
+    projectionResetPending = serverMode;
+
+    // Renderer caches predate per-user ownership. Before any observer can paint,
+    // discard unscoped values in server mode and whenever Spoiler Guard is active
+    // in batch mode; otherwise a previous login/legacy entry can flash sensitive
+    // ratings while the first authoritative request is still in flight.
+    if (serverMode) {
+        clearRendererProjectionState(true);
+        processedCards = new WeakSet();
+        renderedItemByElement = new WeakMap();
+    } else if (JC.pluginConfig?.SpoilerBlurEnabled === true) {
+        beginBatchProjectionGeneration(activeUserId);
+    }
+
     // Register as body mutation subscriber at priority 0 (after hidden-content and prefetch).
     // Only trigger scans when nodes were actually added to the DOM — ignore attribute
     // changes, text changes, and hover/focus effects which cause jank if we scan on each.
@@ -887,9 +1661,22 @@ function initialize(): void {
         for (const entry of requestQueue) processedCards.delete(entry.el);
         requestQueue = [];
         firstFetchAfterNav = true; // PERF(R7): fast-track the next batch fetch
-        // Pick up any new items added since last load
-        void refreshServerCache();
-        scheduleScan();
+        if (JC.pluginConfig?.TagCacheServerMode) {
+            // A cross-client watched flip may have been missed while this tab was
+            // backgrounded. Gate before the incoming page's mutation/pre-paint
+            // scan can reuse the old projected bytes; only cursor validation may
+            // release and rescan. A network failure intentionally stays blank.
+            projectionResetPending = true;
+            projectionRequestGeneration++;
+            document.querySelectorAll<HTMLElement>('.cardImageContainer').forEach(clearRenderedCard);
+            processedCards = new WeakSet();
+            void refreshServerCache();
+        } else if (JC.pluginConfig?.SpoilerBlurEnabled === true) {
+            beginBatchProjectionGeneration(ApiClient.getCurrentUserId());
+            scheduleScan();
+        } else {
+            scheduleScan();
+        }
     });
 
     // Inject CSS containment for all tag overlay containers.
@@ -982,18 +1769,12 @@ function initialize(): void {
  */
 async function invalidateServerCache(): Promise<void> {
     try {
-        serverCache = null;
-        serverCacheVersion = 0;
-        serverCacheTimestamp = 0;
-        processedCards = new WeakSet();
-        requestQueue = [];
-        batchGeneration++;
-        firstEpisodeCache.clear();
-        parentSeriesCache.clear();
-        for (const [, renderer] of renderers) {
-            if (renderer.onServerCacheRefresh) {
-                try { renderer.onServerCacheRefresh(null); } catch { /* renderer cache clear best-effort */ }
-            }
+        const userId = ApiClient.getCurrentUserId();
+        const visibleIds = collectVisibleProjectionIds();
+        resetServerProjection(true);
+        if (!JC.pluginConfig?.TagCacheServerMode) {
+            armBatchProjectionRefresh(visibleIds, userId);
+            return;
         }
         await loadServerCache();
         processedCards = new WeakSet();
@@ -1022,6 +1803,7 @@ const tagPipelineApi = {
     },
     scheduleScan,
     invalidateServerCache,
+    refreshServerProjection,
 };
 
 // JEGlobal types tagPipeline as the narrow TagPipelineLike consumer view; the

--- a/Jellyfin.Plugin.JellyfinCanopy/src/tags/ratingtags.server-cache.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/tags/ratingtags.server-cache.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../globals';
+import type { SpoilerGuardApi, TagPipelineLike } from '../types/jc';
+import { resolveTmdbKey } from './userreviewtags';
+import './ratingtags';
+
+type RegisteredRenderer = {
+    render(el: HTMLElement, item: unknown, extras?: unknown): void;
+    renderFromCache(el: HTMLElement, itemId: string): boolean;
+    renderFromServerCache(el: HTMLElement, entry: unknown, itemId: string): void;
+};
+
+const GUARDED_SERIES = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const SEASON_ID = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+function cardHost(): { card: HTMLElement; host: HTMLElement } {
+    const card = document.createElement('div');
+    card.className = 'card';
+    const host = document.createElement('div');
+    host.className = 'jc-tag-host';
+    card.appendChild(host);
+    document.body.appendChild(card);
+    return { card, host };
+}
+
+function spoilerGuard(hideRatings: boolean): SpoilerGuardApi {
+    return {
+        init: vi.fn(),
+        addSpoilerBlurButton: vi.fn(),
+        isEnabledFor: (id: unknown) => id === GUARDED_SERIES,
+        isMovieEnabledFor: () => false,
+        isCollectionEnabledFor: () => false,
+        hasEnabledCollections: () => false,
+        fetchMovieScope: vi.fn().mockResolvedValue(null),
+        enableForSeries: vi.fn().mockResolvedValue(undefined),
+        disableForSeries: vi.fn().mockResolvedValue(undefined),
+        enableForMovie: vi.fn().mockResolvedValue(undefined),
+        disableForMovie: vi.fn().mockResolvedValue(undefined),
+        enableForCollection: vi.fn().mockResolvedValue(undefined),
+        disableForCollection: vi.fn().mockResolvedValue(undefined),
+        isTmdbEnabled: () => false,
+        enableForTmdb: vi.fn(),
+        disableForTmdb: vi.fn(),
+        whenLoaded: vi.fn().mockResolvedValue(undefined),
+        isLoadOk: () => true,
+        confirmDisableSpoiler: vi.fn().mockResolvedValue(true),
+        getUserPrefs: () => ({ HideRatings: hideRatings }),
+        setUserPrefs: vi.fn(),
+    };
+}
+
+describe('rating tag guarded-Season projection parity (BI-SEC-125)', () => {
+    let renderer: RegisteredRenderer;
+
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        JC.pluginConfig = {
+            TagCacheServerMode: true,
+            SpoilerBlurEnabled: true,
+            SpoilerStripRatings: true,
+        };
+        JC.currentSettings = { ratingTagsEnabled: true };
+        JC.spoilerGuard = spoilerGuard(true);
+        JC.tagPipeline = {
+            registerRenderer: (_name, candidate) => {
+                renderer = candidate as unknown as RegisteredRenderer;
+            },
+        } satisfies TagPipelineLike;
+        const surface = JC as typeof JC & { initializeRatingTags?: () => void };
+        surface.initializeRatingTags?.();
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+        JC.spoilerGuard = undefined;
+        const surface = JC as typeof JC & { appendUserRatingToContainer?: unknown };
+        surface.appendUserRatingToContainer = undefined;
+        JC.pluginConfig = {};
+        JC.currentSettings = {};
+    });
+
+    it('suppresses a stale non-null server-cache Season rating via preserved SeriesId', () => {
+        const { card, host } = cardHost();
+        const appendUserRating = vi.fn().mockResolvedValue(undefined);
+        const surface = JC as typeof JC & {
+            appendUserRatingToContainer?: (el: HTMLElement, item: unknown, extras?: unknown) => Promise<void>;
+        };
+        surface.appendUserRatingToContainer = appendUserRating;
+
+        renderer.renderFromServerCache(host, {
+            Type: 'Season',
+            SeriesId: GUARDED_SERIES,
+            SeriesTmdbId: '1234',
+            SeasonNumber: 1,
+            CommunityRating: 9.2,
+            CriticRating: 94,
+        }, SEASON_ID);
+
+        expect(host.querySelector('.rating-overlay-container')).toBeNull();
+        expect(card.dataset.jcRatingTagged).toBe('1');
+        expect(appendUserRating).toHaveBeenCalledTimes(1);
+        const [, syntheticItem, syntheticExtras] = appendUserRating.mock.calls[0] as unknown as [
+            HTMLElement,
+            unknown,
+            unknown,
+        ];
+        expect(resolveTmdbKey(syntheticItem, syntheticExtras)).toEqual({
+            tmdbKey: '1234:s1',
+            mediaType: 'tv',
+        });
+        surface.appendUserRatingToContainer = undefined;
+    });
+
+    it('honours the user rating-strip opt-out for the same server-cache Season', () => {
+        JC.spoilerGuard = spoilerGuard(false);
+        const { host } = cardHost();
+
+        renderer.renderFromServerCache(host, {
+            Type: 'Season',
+            SeriesId: GUARDED_SERIES,
+            CommunityRating: 9.2,
+            CriticRating: null,
+        }, SEASON_ID);
+
+        expect(host.querySelector('.rating-tag-tmdb .rating-text')?.textContent).toBe('9.2');
+    });
+
+    it('treats live tag-data RatingSuppressed as authoritative before parent fallback', () => {
+        const { card, host } = cardHost();
+
+        renderer.render(host, {
+            Id: SEASON_ID,
+            Type: 'Season',
+            SeriesId: GUARDED_SERIES,
+            RatingSuppressed: true,
+            CommunityRating: null,
+            CriticRating: null,
+        }, {
+            ratingParentSeries: { CommunityRating: 9.9, CriticRating: 99 },
+        });
+
+        expect(host.querySelector('.rating-overlay-container')).toBeNull();
+        expect(card.dataset.jcRatingTagged).toBe('1');
+    });
+
+    it('rebuilds a cached Season personal-rating key with parentSeries extras', () => {
+        const appendUserRating = vi.fn().mockResolvedValue(undefined);
+        const surface = JC as typeof JC & {
+            appendUserRatingToContainer?: (el: HTMLElement, item: unknown, extras?: unknown) => Promise<void>;
+        };
+        surface.appendUserRatingToContainer = appendUserRating;
+
+        // Populate the renderer cache while the guard is off, then prove the
+        // cache-only guarded path preserves the user's own Season review chip.
+        JC.pluginConfig = { ...JC.pluginConfig, SpoilerBlurEnabled: false };
+        const first = cardHost();
+        renderer.render(first.host, {
+            Id: SEASON_ID,
+            Type: 'Season',
+            SeriesId: GUARDED_SERIES,
+            IndexNumber: 1,
+            CommunityRating: 8.4,
+            ProviderIds: {},
+        }, {
+            parentSeries: { ProviderIds: { Tmdb: '1234' } },
+        });
+        appendUserRating.mockClear();
+
+        JC.pluginConfig = { ...JC.pluginConfig, SpoilerBlurEnabled: true };
+        const second = cardHost();
+        expect(renderer.renderFromCache(second.host, SEASON_ID)).toBe(true);
+        expect(appendUserRating).toHaveBeenCalledTimes(1);
+        const [, syntheticItem, syntheticExtras] = appendUserRating.mock.calls[0] as unknown as [
+            HTMLElement,
+            unknown,
+            unknown,
+        ];
+        expect(resolveTmdbKey(syntheticItem, syntheticExtras)).toEqual({
+            tmdbKey: '1234:s1',
+            mediaType: 'tv',
+        });
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/tags/ratingtags.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/tags/ratingtags.ts
@@ -80,15 +80,27 @@ interface RatingCacheEntry {
     sgSeriesId?: string | null;
     /** Spoiler-Guard: whether the user had played the cached item. */
     sgPlayed?: boolean;
-    // User-rating fields stashed by render(). Left UNPOPULATED by getCachedEntry
-    // (the user-rating branch in renderFromCache stays inert, matching current
-    // behavior); typed here only so that branch continues to compile.
+    // User-rating fields stashed by render() so cache-only cards can rebuild the
+    // same TMDB key without fetching the full item/parent DTO again.
     tmdbId?: string | null;
     seriesTmdbId?: string | null;
     tmdbMediaType?: string;
     seasonNumber?: number | null;
     episodeNumber?: number | null;
     parentSeasonNumber?: number | null;
+}
+
+/** Rating-related subset of a server TagCacheEntry. */
+interface ServerCacheRatingEntry {
+    Type?: string;
+    SeriesId?: string | null;
+    CommunityRating?: number | string | null;
+    CriticRating?: number | null;
+    RatingSuppressed?: boolean;
+    TmdbId?: string | null;
+    SeriesTmdbId?: string | null;
+    SeasonNumber?: number | null;
+    EpisodeNumber?: number | null;
 }
 
 /**
@@ -98,7 +110,7 @@ interface RatingCacheEntry {
  * @returns Cached rating or null.
  */
 function getCachedEntry(ctx: TagRendererContext, itemId: string): RatingCacheEntry | null {
-    const entry = (ctx.getPersistent(itemId) ?? ctx.hot?.get(itemId)) as any;
+    const entry: unknown = ctx.getPersistent(itemId) ?? ctx.hot?.get(itemId);
     if (!entry) return null;
     // Spoiler Guard: entries cached BEFORE the guard fields existed (legacy
     // string/number shorthand, or objects without sgType) carry no suppression
@@ -111,19 +123,24 @@ function getCachedEntry(ctx: TagRendererContext, itemId: string): RatingCacheEnt
         return guardOn ? null : { tmdb: String(entry), critic: null };
     }
     if (typeof entry === 'object') {
-        if (guardOn && typeof entry.sgType !== 'string') return null;
-        // Expose tmdb/critic PLUS the Spoiler-Guard fields (sgType/sgSeriesId/
-        // sgPlayed) stashed by render(). Without them, renderFromCache's
+        const cached = entry as Partial<RatingCacheEntry>;
+        if (guardOn && typeof cached.sgType !== 'string') return null;
+        // Expose ratings, personal-review identity, PLUS the Spoiler-Guard fields
+        // stashed by render(). Without them, renderFromCache's
         // suppression re-check saw Type=undefined and never suppressed, so a
-        // rating cached BEFORE the show was guarded replayed forever. (The
-        // tmdbId/seriesTmdbId user-rating fields stay intentionally unexposed —
-        // that branch's re-enable is out of scope for this fix.)
+        // rating cached BEFORE the show was guarded replayed forever.
         return {
-            tmdb: entry.tmdb ?? null,
-            critic: entry.critic ?? null,
-            sgType: entry.sgType,
-            sgSeriesId: entry.sgSeriesId ?? null,
-            sgPlayed: entry.sgPlayed === true,
+            tmdb: cached.tmdb ?? null,
+            critic: cached.critic ?? null,
+            sgType: cached.sgType,
+            sgSeriesId: cached.sgSeriesId ?? null,
+            sgPlayed: cached.sgPlayed === true,
+            tmdbId: cached.tmdbId ?? null,
+            seriesTmdbId: cached.seriesTmdbId ?? null,
+            tmdbMediaType: cached.tmdbMediaType,
+            seasonNumber: cached.seasonNumber ?? null,
+            episodeNumber: cached.episodeNumber ?? null,
+            parentSeasonNumber: cached.parentSeasonNumber ?? null,
         };
     }
     return null;
@@ -138,6 +155,55 @@ function getCachedEntry(ctx: TagRendererContext, itemId: string): RatingCacheEnt
 function setCachedEntry(ctx: TagRendererContext, itemId: string, rating: unknown): void {
     ctx.setPersistent(itemId, rating);
     ctx.hot?.set(itemId, rating);
+}
+
+/** Keep the personal/user-review chip when public ratings are suppressed. */
+function appendServerCacheUserRating(el: HTMLElement, entry: ServerCacheRatingEntry): void {
+    if (typeof JC.appendUserRatingToContainer !== 'function') return;
+    if (!entry.TmdbId && !entry.SeriesTmdbId) return;
+    const syntheticItem = {
+        Type: entry.Type,
+        ProviderIds: entry.TmdbId ? { Tmdb: entry.TmdbId } : {},
+        IndexNumber: entry.SeasonNumber,
+        ParentIndexNumber: entry.SeasonNumber,
+        // For Episode, SeasonNumber is ParentIndexNumber and EpisodeNumber is IndexNumber.
+        ...(entry.Type === 'Episode'
+            ? { ParentIndexNumber: entry.SeasonNumber, IndexNumber: entry.EpisodeNumber }
+            : {}),
+    };
+    const extras = entry.SeriesTmdbId
+        ? { parentSeries: { ProviderIds: { Tmdb: entry.SeriesTmdbId } } }
+        : null;
+    void JC.appendUserRatingToContainer(el, syntheticItem, extras);
+}
+
+/** Rebuild the real user-review resolver shape from a renderer-local cache row. */
+function appendCachedUserRating(el: HTMLElement, entry: RatingCacheEntry): boolean {
+    if (typeof JC.appendUserRatingToContainer !== 'function') return false;
+    if (!entry.tmdbId && !entry.seriesTmdbId) return false;
+
+    let type = entry.sgType;
+    if (!type) type = entry.tmdbMediaType === 'tv' ? 'Series' : 'Movie';
+    const syntheticItem: {
+        Type: string;
+        ProviderIds: { Tmdb?: string };
+        IndexNumber?: number | null;
+        ParentIndexNumber?: number | null;
+    } = {
+        Type: type,
+        ProviderIds: entry.tmdbId ? { Tmdb: entry.tmdbId } : {},
+    };
+    if (type === 'Episode') {
+        syntheticItem.IndexNumber = entry.episodeNumber;
+        syntheticItem.ParentIndexNumber = entry.parentSeasonNumber;
+    } else if (type === 'Season') {
+        syntheticItem.IndexNumber = entry.seasonNumber;
+    }
+    const extras = entry.seriesTmdbId
+        ? { parentSeries: { ProviderIds: { Tmdb: entry.seriesTmdbId } } }
+        : null;
+    void JC.appendUserRatingToContainer(el, syntheticItem, extras);
+    return true;
 }
 
 /**
@@ -284,6 +350,19 @@ const spec: TagSpec = {
 
             const itemId = item.Id;
 
+            // The live tag-data endpoint marks guarded exempt Seasons explicitly:
+            // their own ratings are null but SeriesId must remain available to the
+            // genre/review paths. Treat the marker as authoritative before every
+            // hot-cache or parent-Series fallback so neither can reintroduce the
+            // hidden series rating.
+            if (item.RatingSuppressed === true) {
+                ctx.markTagged(el);
+                if (typeof JC.appendUserRatingToContainer === 'function') {
+                    void JC.appendUserRatingToContainer(el, item, extras);
+                }
+                return;
+            }
+
             // Spoiler Guard: suppress the rating tag for guarded
             // series/seasons/unwatched-episodes. Checked BEFORE the hot-cache
             // path so a rating cached before the show was guarded can't replay
@@ -357,56 +436,38 @@ const spec: TagSpec = {
             // replay onto the card. Keep the user rating.
             if (shouldSuppressRatingTag({ Type: cached.sgType, Id: itemId, SeriesId: cached.sgSeriesId, UserData: { Played: cached.sgPlayed } })) {
                 ctx.markTagged(el);
-                if (typeof JC.appendUserRatingToContainer === 'function' && (cached.tmdbId || cached.seriesTmdbId)) {
-                    void JC.appendUserRatingToContainer(el, { Type: cached.sgType, ProviderIds: cached.tmdbId ? { Tmdb: cached.tmdbId } : {}, SeriesProviderIds: cached.seriesTmdbId ? { Tmdb: cached.seriesTmdbId } : {} });
-                }
+                appendCachedUserRating(el, cached);
                 return true;
             }
             if (cached.tmdb || cached.critic !== null) {
                 applyRatingTag(ctx, el, cached);
             }
-            if (typeof JC.appendUserRatingToContainer === 'function' && (cached.tmdbId || cached.seriesTmdbId)) {
-                const syntheticItem: any = {
-                    Type: cached.tmdbMediaType === 'tv' ? 'Series' : 'Movie',
-                    ProviderIds: cached.tmdbId ? { Tmdb: cached.tmdbId } : {},
-                    SeriesProviderIds: cached.seriesTmdbId ? { Tmdb: cached.seriesTmdbId } : {},
-                    IndexNumber: cached.seasonNumber,
-                    ParentIndexNumber: cached.parentSeasonNumber,
-                };
-                // Refine Type for Season/Episode based on available data
-                if (cached.seriesTmdbId && cached.episodeNumber != null) {
-                    syntheticItem.Type = 'Episode';
-                    syntheticItem.IndexNumber = cached.episodeNumber;
-                    syntheticItem.ParentIndexNumber = cached.parentSeasonNumber;
-                } else if (cached.seriesTmdbId && cached.seasonNumber != null) {
-                    syntheticItem.Type = 'Season';
-                    syntheticItem.IndexNumber = cached.seasonNumber;
-                }
-                void JC.appendUserRatingToContainer(el, syntheticItem);
-            }
-            return !!(cached.tmdb || cached.critic !== null);
+            const appendedUserRating = appendCachedUserRating(el, cached);
+            return !!(cached.tmdb || cached.critic !== null || appendedUserRating);
         },
-        renderFromServerCache(ctx, el, entry: any, itemId: string) {
+        renderFromServerCache(ctx, el, rawEntry: unknown, itemId: string) {
+            const entry = rawEntry as ServerCacheRatingEntry;
             if (ctx.isTagged(el)) return;
             if (ctx.shouldIgnore(el)) return;
-            // Spoiler Guard, server-cache path. The server tag-cache entry carries
-            // no Jellyfin Id / SeriesId / Played fields, only the map-key itemId
-            // (4th arg) identifies the item. So:
-            //   • Series → guard by its own id (itemId).
-            //   • Movie  → guard directly by its own id (itemId).
-            //   • Season / Episode → the parent series id isn't in the entry, so
-            //     the series guard can't be resolved here. Those rely on the
-            //     watched-aware server-side rating strip: a guarded unwatched
-            //     item arrives with null ratings and renders nothing (naturally
-            //     suppressed), while a WATCHED episode keeps its rating.
-            // Fails closed for Series/Movie while state isn't authoritative.
-            if ((entry.Type === 'Series' || entry.Type === 'Movie')
-                && shouldSuppressRatingTag({ Type: entry.Type, Id: itemId })) {
+            // Defense in depth for a stale/non-null projected row. TagCacheEntry
+            // carries SeriesId for Seasons, so client policy can suppress their
+            // series-fallback rating even before the watched revision replacement
+            // lands. Episodes deliberately rely on the server's played-aware strip:
+            // the cache entry has no Played bit, and treating all as unwatched would
+            // hide ratings from legitimately watched episodes.
+            const guardableEntry = entry.Type === 'Season'
+                ? { Type: entry.Type, Id: itemId, SeriesId: entry.SeriesId }
+                : (entry.Type === 'Series' || entry.Type === 'Movie')
+                    ? { Type: entry.Type, Id: itemId }
+                    : null;
+            if (entry.RatingSuppressed === true
+                || (guardableEntry && shouldSuppressRatingTag(guardableEntry))) {
                 ctx.markTagged(el);
+                appendServerCacheUserRating(el, entry);
                 return;
             }
             const tmdb = entry.CommunityRating != null
-                ? parseFloat(entry.CommunityRating).toFixed(1)
+                ? parseFloat(String(entry.CommunityRating)).toFixed(1)
                 : null;
             const critic = entry.CriticRating != null
                 ? normalizeCriticPercent(entry.CriticRating)
@@ -414,22 +475,7 @@ const spec: TagSpec = {
             if (tmdb || critic !== null) {
                 applyRatingTag(ctx, el, { tmdb, critic });
             }
-            if (typeof JC.appendUserRatingToContainer === 'function') {
-                // Build a synthetic item so resolveTmdbKey can derive the correct key
-                // for Movie/Series (TmdbId) and Season/Episode (SeriesTmdbId + numbers)
-                const syntheticItem = {
-                    Type: entry.Type,
-                    ProviderIds: entry.TmdbId ? { Tmdb: entry.TmdbId } : {},
-                    SeriesProviderIds: entry.SeriesTmdbId ? { Tmdb: entry.SeriesTmdbId } : {},
-                    IndexNumber: entry.SeasonNumber,
-                    ParentIndexNumber: entry.SeasonNumber,
-                    // For Episode, SeasonNumber is ParentIndexNumber and EpisodeNumber is IndexNumber
-                    ...(entry.Type === 'Episode' ? { ParentIndexNumber: entry.SeasonNumber, IndexNumber: entry.EpisodeNumber } : {})
-                };
-                if (entry.TmdbId || entry.SeriesTmdbId) {
-                    void JC.appendUserRatingToContainer(el, syntheticItem, null);
-                }
-            }
+            appendServerCacheUserRating(el, entry);
         },
     },
 };

--- a/Jellyfin.Plugin.JellyfinCanopy/src/tags/userreviewtags.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/tags/userreviewtags.ts
@@ -101,7 +101,7 @@ function appendUserRatingChip(container: HTMLElement, rating: number | null): vo
  * @param item - Jellyfin item from tag pipeline batch response.
  * @param extras - Pipeline extras containing parentSeries.
  */
-function resolveTmdbKey(item: any, extras?: any): { tmdbKey: string; mediaType: string } | null {
+export function resolveTmdbKey(item: any, extras?: any): { tmdbKey: string; mediaType: string } | null {
     const type = item.Type || '';
     if (type === 'Movie') {
         const id = item.ProviderIds?.Tmdb || item.ProviderIds?.tmdb;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/types/jc.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/types/jc.ts
@@ -475,11 +475,18 @@ export interface TagRendererApi {
 /** The unified tag pipeline (enhanced/tag-pipeline.js — legacy, loads after core). */
 export interface TagPipelineLike {
     registerRenderer(name: string, renderer: Record<string, unknown>): void;
+    /** Boot the shared observer/navigation/cache pipeline once renderers register. */
+    initialize?(): void;
     getRenderer?(name: string): { injectCss?: () => void } | undefined;
     clearProcessed?(): void;
     scheduleScan?(): void;
     /** Drop + reload the server tag cache and rescan (e.g. after a Spoiler Guard toggle). */
     invalidateServerCache?(): Promise<void>;
+    /**
+     * Synchronously blank watched/privacy-affected tags, then fetch their bounded
+     * per-user projection journal delta. Accepts native UserDataChanged.Data.
+     */
+    refreshServerProjection?(data: unknown): Promise<void>;
 }
 
 // ── live-update contracts ────────────────────────────────────────────────────


### PR DESCRIPTION
## What changed

- add a bounded per-user watched/privacy projection epoch, revision, and invalidation journal for the server tag cache
- serve exact Episode → Season → Series projection deltas and tombstones without a full shared-cache scan on playback events
- bind client projection state to user/epoch/revision and fail closed across navigation, account switches, overlapping pushes, recycled cards, failed requests, and cache fallbacks
- keep server-mode and local batch-mode tag projections fresh while retaining the official 2-CPU parity path
- suppress guarded exempt-Season ratings consistently across native DTOs, tag-data, tag-cache, images, public rating tags, and personal-rating key reconstruction
- add controller/service/parity/client regressions for the projection and Season contracts

## Why

Watched-state changes did not advance the shared content cache timestamp, so cards could retain stale Spoiler Guard overlays. Guarded exempt Seasons could also surface their parent Series rating through several response/render paths. The new projection cursor separates user-specific privacy state from shared library content and keeps every render/cache path on the same fail-closed contract.

## Validation

- .NET build: 0 warnings / 0 errors
- .NET tests: 910 / 910 passed
- client tests: 84 files / 569 tests passed
- TypeScript source type-check passed
- bundle build passed
- ESLint: 0 errors / 6547 warnings (under configured ceiling)
- `git diff --check` passed
- independent direct review plus Fable-low and Fable-medium: SHIP, no remaining blocker

Closes #96
Closes #207
