### PR TITLE
Enforce no-reload account identity isolation

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/js/plugin.js
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/plugin.js
@@ -59,6 +59,19 @@
             forceSave() {
                 this.dirty = true;
                 this._flush();
+            },
+            // Drop an A-owned scheduled flush without unregistering the stable
+            // cache callbacks. Identity reset hooks clear/rebind the callbacks'
+            // mutable state before B is allowed to render or save.
+            cancelPending() {
+                if (this.scheduleId !== null) {
+                    try {
+                        if (typeof cancelIdleCallback === 'function') cancelIdleCallback(this.scheduleId);
+                    } catch (_) { /* not an idle-callback id */ }
+                    try { clearTimeout(this.scheduleId); } catch (_) { /* harmless */ }
+                }
+                this.scheduleId = null;
+                this.dirty = false;
             }
         },
         /**
@@ -116,6 +129,570 @@
     };
 
     const JC = window.JellyfinCanopy; // Alias for internal use
+
+    /**
+     * Create the document-lifetime identity owner. The controller is deliberately
+     * defined in this classic loader (rather than only in the later bundle):
+     * Jellyfin 12 can replace authentication before jc.bundle.js has finished
+     * loading, and invalidation must still happen synchronously in that window.
+     *
+     * @param {(change: {previous: object|null, current: object|null, epoch: number, reason: string}) => void} [finalizeTransition]
+     */
+    function createIdentitySession(finalizeTransition, diagnostics) {
+        let epoch = 0;
+        let current = null;
+        const owners = new WeakMap();
+        const resetHandlers = new Map();
+        const activateHandlers = new Map();
+        const rawUserIdsByEpoch = new Map();
+
+        const normalize = (value) => String(value ?? '').trim().replace(/-/g, '').toLowerCase();
+        const same = (a, b) => !!a && !!b
+            && a.epoch === b.epoch
+            && a.serverId === b.serverId
+            && a.userId === b.userId;
+
+        function capture() {
+            return current;
+        }
+
+        function isCurrent(context) {
+            return same(context, current);
+        }
+
+        /**
+         * Accept one host identity transition. All registered reset handlers and
+         * the loader finalizer run synchronously before this function returns.
+         */
+        function transition(serverId, userId, reason = 'unknown') {
+            const rawUserId = String(userId ?? '').trim();
+            const normalizedUserId = normalize(userId);
+            const normalizedServerId = normalizedUserId
+                ? (normalize(serverId) || 'unknown-server')
+                : '';
+
+            if ((!current && !normalizedUserId)
+                || (current
+                    && current.serverId === normalizedServerId
+                    && current.userId === normalizedUserId)) {
+                // Keep the first live raw spelling captured for this epoch. A
+                // later normalized monitor read must not erase its dashes/case.
+                if (current && rawUserId && !rawUserIdsByEpoch.has(current.epoch)) {
+                    rawUserIdsByEpoch.set(current.epoch, rawUserId);
+                }
+                return current;
+            }
+
+            const previous = current;
+            epoch += 1;
+            current = normalizedUserId
+                ? Object.freeze({ serverId: normalizedServerId, userId: normalizedUserId, epoch })
+                : null;
+            if (current) rawUserIdsByEpoch.set(epoch, rawUserId || normalizedUserId);
+            // Only the previous/current values are useful to transition cleanup.
+            for (const storedEpoch of [...rawUserIdsByEpoch.keys()]) {
+                if (storedEpoch !== previous?.epoch && storedEpoch !== current?.epoch) {
+                    rawUserIdsByEpoch.delete(storedEpoch);
+                }
+            }
+            const change = Object.freeze({ previous, current, epoch, reason: String(reason || 'unknown') });
+
+            for (const [name, handler] of [...resetHandlers.entries()]) {
+                if (epoch !== change.epoch) return current;
+                try {
+                    handler(change);
+                } catch (error) {
+                    console.error(`🪼 Jellyfin Canopy: identity reset handler "${name}" failed`, error);
+                }
+                // A reset handler may synchronously accept a newer host identity.
+                // Never continue the older handler snapshot or finalize its stale
+                // change after that nested transition has completed.
+                if (epoch !== change.epoch) return current;
+            }
+            if (epoch !== change.epoch) return current;
+            try {
+                finalizeTransition?.(change);
+            } catch (error) {
+                console.error('🪼 Jellyfin Canopy: identity transition finalizer failed', error);
+            }
+            return current;
+        }
+
+        function own(value, context = current) {
+            if (context && value !== null && (typeof value === 'object' || typeof value === 'function')) {
+                owners.set(value, context);
+            }
+            return value;
+        }
+
+        function ownerOf(value) {
+            if (value === null || (typeof value !== 'object' && typeof value !== 'function')) return null;
+            return owners.get(value) || null;
+        }
+
+        function isOwned(value, context = current) {
+            const owner = ownerOf(value);
+            return !!owner && !!context && same(owner, context);
+        }
+
+        function registerReset(name, handler) {
+            if (!name || typeof handler !== 'function') return () => {};
+            resetHandlers.set(String(name), handler);
+            return () => {
+                if (resetHandlers.get(String(name)) === handler) resetHandlers.delete(String(name));
+            };
+        }
+
+        function registerActivate(name, handler) {
+            if (!name || typeof handler !== 'function') return () => {};
+            const key = String(name);
+            const record = { handler, lastEpoch: -1, pendingEpoch: -1, pending: null };
+            activateHandlers.set(key, record);
+            return () => {
+                if (activateHandlers.get(key) === record) activateHandlers.delete(key);
+            };
+        }
+
+        async function activate(context = current) {
+            if (!isCurrent(context)) return;
+            const work = [];
+            for (const [name, record] of [...activateHandlers.entries()]) {
+                if (record.lastEpoch === context.epoch) continue;
+                if (record.pendingEpoch === context.epoch && record.pending) {
+                    work.push(record.pending);
+                    continue;
+                }
+
+                const invocation = Promise.resolve()
+                    .then(() => record.handler(context))
+                    .then(() => {
+                        // A late older invocation must not overwrite a newer
+                        // epoch that has already activated successfully.
+                        if (record.lastEpoch < context.epoch) record.lastEpoch = context.epoch;
+                    })
+                    .catch((error) => {
+                        console.error(`🪼 Jellyfin Canopy: identity activate handler "${name}" failed`, error);
+                        throw error;
+                    })
+                    .finally(() => {
+                        if (record.pending === invocation) {
+                            record.pending = null;
+                            record.pendingEpoch = -1;
+                        }
+                    });
+                record.pendingEpoch = context.epoch;
+                record.pending = invocation;
+                work.push(invocation);
+            }
+            const results = await Promise.allSettled(work);
+            let failure = null;
+            for (const result of results) {
+                if (result.status === 'rejected') {
+                    console.error('🪼 Jellyfin Canopy: identity activate handler rejected', result.reason);
+                    failure ||= result.reason instanceof Error
+                        ? result.reason
+                        : new Error('Identity activation failed', { cause: result.reason });
+                }
+            }
+            if (failure) throw failure;
+        }
+
+        function getRawUserId(context = current) {
+            if (!context) return '';
+            return rawUserIdsByEpoch.get(context.epoch) || context.userId;
+        }
+
+        return Object.freeze({
+            capture,
+            isCurrent,
+            transition,
+            own,
+            ownerOf,
+            isOwned,
+            registerReset,
+            registerActivate,
+            activate,
+            getEpoch: () => epoch,
+            getRawUserId,
+            getResetHandlerCount: () => resetHandlers.size,
+            getActivateHandlerCount: () => activateHandlers.size,
+            // Read-only loader diagnostics. The indirection lets the immutable
+            // identity surface be installed before initialization machinery is
+            // declared later in this classic script.
+            getPendingInitializationCount: () => Number(diagnostics?.getPendingInitializationCount?.() || 0),
+            getInitializationControllerCount: () => Number(diagnostics?.getInitializationControllerCount?.() || 0)
+        });
+    }
+
+    // Assigned after all loader helpers have been declared. Identity transitions
+    // can nevertheless call through this slot safely during normal host use.
+    let initializationRegistry = null;
+    const loaderDiagnostics = {
+        getPendingInitializationCount: () => initializationRegistry?.getPendingCount?.() || 0,
+        getInitializationControllerCount: () => initializationRegistry?.getControllerCount?.() || 0
+    };
+
+    function emptyUserConfig() {
+        return {
+            settings: {},
+            shortcuts: { Shortcuts: [] },
+            bookmark: { bookmarks: {} },
+            elsewhere: {},
+            hiddenContent: { items: {}, settings: {} }
+        };
+    }
+
+    /**
+     * Last synchronous phase of every identity change. Feature reset handlers
+     * run first so they can inspect/tear down their old state; only then are the
+     * shared globals replaced with owner-tagged empty state.
+     */
+    function finalizeIdentityTransition(change) {
+        // Abort and logically drain every older loader initialization before any
+        // B-owned global is published. Raw host ajax implementations sometimes
+        // ignore AbortSignal; the registry cancellation race still settles and
+        // evicts their old epoch synchronously.
+        initializationRegistry?.cancelExcept?.(change.current?.epoch ?? null, change.epoch);
+        // Jellyfin's compatibility language key is user-only. Remove A's live
+        // projection synchronously; B republishes it from a server+user scoped
+        // Canopy key after its settings file is loaded.
+        try {
+            for (const userId of identityStorageUserIdVariants(change.previous)) {
+                localStorage.removeItem(`${userId}-language`);
+            }
+        } catch (_) { /* storage can be disabled */ }
+        JC._cacheManager?.cancelPending?.();
+        JC.initialized = false;
+        JC._tagCachePrefetch = null;
+        JC.currentUser = null;
+        JC.currentSettings = undefined;
+        JC.pluginConfig = {};
+        JC.translations = {};
+        JC.pluginVersion = 'unknown';
+
+        if (JC.state) {
+            JC.state.activeShortcuts = {};
+            JC.state.removeContext = null;
+            if (JC.state.pauseScreenClickTimer != null) {
+                clearTimeout(JC.state.pauseScreenClickTimer);
+                JC.state.pauseScreenClickTimer = null;
+            }
+        }
+
+        const nextUserConfig = emptyUserConfig();
+        identity.own(nextUserConfig, change.current);
+        for (const value of Object.values(nextUserConfig)) identity.own(value, change.current);
+        JC.userConfig = nextUserConfig;
+
+        // The image filter consumes this cookie before JavaScript-backed UI can
+        // repaint. Rewrite/delete it inside the synchronous transition itself so
+        // B's first image request can never carry A's identity hint.
+        try {
+            const secure = window.location.protocol === 'https:' ? '; Secure' : '';
+            if (change.current?.userId) {
+                document.cookie = `jc-spoiler-uid=${encodeURIComponent(change.current.userId)}; path=/; SameSite=Lax${secure}`;
+            } else {
+                document.cookie = `jc-spoiler-uid=; path=/; Max-Age=0; SameSite=Lax${secure}`;
+            }
+        } catch (_) { /* cookies can be disabled */ }
+    }
+
+    const identity = createIdentitySession(finalizeIdentityTransition, loaderDiagnostics);
+    JC.identity = identity;
+    JC.core.identity = identity;
+
+    /** All compatibility-key spellings associated with one canonical owner. */
+    function identityStorageUserIdVariants(context) {
+        if (!context?.userId) return [];
+        const canonical = String(context.userId);
+        const raw = String(identity.getRawUserId?.(context) || canonical).trim();
+        const dashed = /^[0-9a-f]{32}$/i.test(canonical)
+            ? `${canonical.slice(0, 8)}-${canonical.slice(8, 12)}-${canonical.slice(12, 16)}-${canonical.slice(16, 20)}-${canonical.slice(20)}`
+            : '';
+        return [...new Set([canonical, raw, dashed].filter(Boolean))];
+    }
+
+    /** Resolve the stable server half of the canonical identity. */
+    function getClientServerId(client) {
+        if (!client) return '';
+        try {
+            const direct = typeof client.serverId === 'function' ? client.serverId() : client.serverId;
+            if (direct) return direct;
+        } catch (_) { /* try the server-info forms */ }
+        try {
+            const info = typeof client.serverInfo === 'function' ? client.serverInfo() : client._serverInfo;
+            if (info?.Id || info?.ServerId) return info.Id || info.ServerId;
+        } catch (_) { /* fall through to address */ }
+        try {
+            const address = typeof client.serverAddress === 'function'
+                ? client.serverAddress()
+                : client.getUrl?.('/');
+            if (address) return new URL(address, window.location.href).origin;
+        } catch (_) { /* unknown server is still fenced by epoch/user */ }
+        return '';
+    }
+
+    const AUTH_WRAPPED = '__jcIdentityAuthenticationWrapped';
+    let identityMonitorId = null;
+    let pendingActivation = null;
+    let apiClientPropertyHookInstalled = false;
+
+    /** Preserve the host setter exactly while bracketing it with identity work. */
+    function createAuthenticationWrapper(original, before, after, onError) {
+        return function(accessKey, userId) {
+            const beforeResult = before.call(this, accessKey, userId);
+            let result;
+            try {
+                result = original.apply(this, arguments);
+            } catch (error) {
+                // Reconcile synchronously while the host still exposes whatever
+                // authentication state its failed setter retained. Never replace
+                // the host's original exception with a reconciliation failure.
+                try { onError?.call(this, beforeResult, error, accessKey, userId); }
+                catch (_) { /* preserve the original host throw */ }
+                throw error;
+            }
+            after.call(this, beforeResult, accessKey, userId);
+            return result;
+        };
+    }
+
+    /**
+     * Replace a configurable host property with a publication fence while
+     * retaining its enumerability, configurability, getter/setter `this` value,
+     * and assignment failure behaviour. A configurable writable data property
+     * necessarily becomes an accessor, but normal host reads/writes retain the
+     * same value semantics. Non-configurable/read-only properties are left
+     * untouched so the polling bridge can remain the graceful fallback.
+     */
+    function installPropertyPublicationFence(target, propertyName, beforePublish, afterPublish) {
+        if (!target || !propertyName) return false;
+        const descriptor = Object.getOwnPropertyDescriptor(target, propertyName);
+        if (!descriptor) {
+            // Do not reserve an absent global: jellyfin-web may install it later
+            // with a descriptor whose semantics we must preserve. Readiness/monitor
+            // retries call this helper again once the real property exists.
+            return false;
+        }
+        if (!descriptor.configurable) return false;
+
+        const isData = Object.prototype.hasOwnProperty.call(descriptor, 'value');
+        if (isData && !descriptor.writable) return false;
+        if (!isData && typeof descriptor.set !== 'function') return false;
+
+        let currentValue = isData ? descriptor.value : undefined;
+        const originalGet = descriptor.get;
+        const originalSet = descriptor.set;
+        const readCurrent = function(receiver) {
+            return isData ? currentValue : originalGet?.call(receiver);
+        };
+        const runBefore = function(receiver, next, previous) {
+            try { return beforePublish?.call(receiver, next, previous); }
+            catch (_) { return undefined; }
+        };
+        const runAfter = function(receiver, next, prepared, error) {
+            try { afterPublish?.call(receiver, next, prepared, error); }
+            catch (_) { /* a fence must never break the host's assignment */ }
+        };
+
+        try {
+            Object.defineProperty(target, propertyName, {
+                configurable: descriptor.configurable,
+                enumerable: descriptor.enumerable,
+                get: function() {
+                    return readCurrent(this);
+                },
+                set: function(next) {
+                    // Match OrdinarySetWithOwnDescriptor for a writable data
+                    // property used with a different Reflect.set receiver.
+                    if (isData && this !== target) {
+                        if (this !== null && (typeof this === 'object' || typeof this === 'function')) {
+                            Object.defineProperty(this, propertyName, {
+                                configurable: true,
+                                enumerable: descriptor.enumerable,
+                                writable: true,
+                                value: next
+                            });
+                        }
+                        return;
+                    }
+
+                    const previous = readCurrent(this);
+                    const prepared = this === target
+                        ? runBefore(this, next, previous)
+                        : undefined;
+                    try {
+                        if (isData) currentValue = next;
+                        else originalSet.call(this, next);
+                    } catch (error) {
+                        if (this === target) runAfter(this, previous, prepared, error);
+                        throw error;
+                    }
+                    if (this === target) runAfter(this, readCurrent(this), prepared, null);
+                }
+            });
+            return true;
+        } catch (_) {
+            return false;
+        }
+    }
+
+    function scheduleInitializationForClient(client, context) {
+        if (!context || !identity.isCurrent(context)) return;
+        pendingActivation = { client, context };
+        pumpPendingActivation();
+    }
+
+    function pumpPendingActivation() {
+        const pending = pendingActivation;
+        if (!pending || !identity.isCurrent(pending.context)) {
+            pendingActivation = null;
+            return;
+        }
+        let liveUserId = '';
+        try { liveUserId = pending.client?.getCurrentUserId?.() || ''; } catch (_) { /* wait */ }
+        const normalizedLiveUser = String(liveUserId).replace(/-/g, '').toLowerCase();
+        const rawLiveServer = String(getClientServerId(pending.client) || '');
+        const normalizedLiveServer = rawLiveServer
+            ? rawLiveServer.trim().replace(/-/g, '').toLowerCase()
+            : 'unknown-server';
+        if (window.ApiClient !== pending.client
+            || normalizedLiveUser !== pending.context.userId
+            || normalizedLiveServer !== pending.context.serverId) return;
+        pendingActivation = null;
+        void startInitialization(pending.context, pending.client);
+    }
+
+    /** Patch the common ApiClient owner once; every server instance shares it. */
+    function installAuthenticationHook(client) {
+        if (!client) return false;
+        let owner = client;
+        while (owner && !Object.prototype.hasOwnProperty.call(owner, 'setAuthenticationInfo')) {
+            owner = Object.getPrototypeOf(owner);
+        }
+        const original = owner?.setAuthenticationInfo;
+        if (!owner || typeof original !== 'function') return false;
+        if (original[AUTH_WRAPPED]) return true;
+
+        const wrapped = createAuthenticationWrapper(
+            original,
+            function(_accessKey, userId) {
+                // Invalidate A before the host mutates its token/user. This
+                // closes the B-auth/A-snapshot window, including sync handlers.
+                return identity.transition(getClientServerId(this), userId, 'setAuthenticationInfo');
+            },
+            function(next, _accessKey, userId) {
+                if (userId && next) scheduleInitializationForClient(this, next);
+                else pendingActivation = null;
+            },
+            function(_attempted, _error) {
+                let liveUserId = '';
+                try { liveUserId = this.getCurrentUserId?.() || ''; } catch (_) { /* signed out */ }
+                const restored = identity.transition(
+                    getClientServerId(this),
+                    liveUserId,
+                    'setAuthenticationInfo-failed'
+                );
+                if (liveUserId && restored) scheduleInitializationForClient(this, restored);
+                else pendingActivation = null;
+            }
+        );
+        Object.defineProperty(wrapped, AUTH_WRAPPED, { value: true });
+        Object.defineProperty(wrapped, '__jcOriginal', { value: original });
+        try {
+            const descriptor = Object.getOwnPropertyDescriptor(owner, 'setAuthenticationInfo');
+            // A mixed accessor+value descriptor is invalid by definition. Only
+            // patch a writable/configurable data property directly; accessors use
+            // the instance fallback below.
+            if (descriptor
+                && Object.prototype.hasOwnProperty.call(descriptor, 'value')
+                && descriptor.writable !== false) {
+                Object.defineProperty(owner, 'setAuthenticationInfo', { ...descriptor, value: wrapped });
+                return true;
+            }
+        } catch (_) {
+            // Try the instance fallback below.
+        }
+        try {
+            client.setAuthenticationInfo = wrapped;
+            return client.setAuthenticationInfo === wrapped;
+        } catch (_) {
+            return false;
+        }
+    }
+
+    function prepareApiClientPublication(client) {
+        installAuthenticationHook(client);
+        let userId = '';
+        try { userId = client?.getCurrentUserId?.() || ''; } catch (_) { /* signed out */ }
+        const context = identity.transition(getClientServerId(client), userId, 'ApiClient-replacement');
+        return { client, context, userId };
+    }
+
+    function completeApiClientPublication(publishedClient, prepared, error) {
+        if (error) {
+            // An opaque host setter may reject after the pre-publication fence.
+            // Reconcile the value it actually retained without swallowing or
+            // changing the original exception.
+            try { reconcileCurrentIdentity('ApiClient-replacement-failed'); } catch (_) { /* monitor will retry */ }
+            return;
+        }
+        if (!prepared || publishedClient !== prepared.client) {
+            // An accessor may canonicalize the assigned value. Its setter was
+            // fenced against the candidate; now reconcile the effective value.
+            try { reconcileCurrentIdentity('ApiClient-replacement-effective'); } catch (_) { /* monitor will retry */ }
+            return;
+        }
+        if (prepared.context && prepared.userId) {
+            scheduleInitializationForClient(publishedClient, prepared.context);
+        } else {
+            pendingActivation = null;
+        }
+    }
+
+    function installApiClientReplacementHook() {
+        if (apiClientPropertyHookInstalled) return true;
+        apiClientPropertyHookInstalled = installPropertyPublicationFence(
+            window,
+            'ApiClient',
+            prepareApiClientPublication,
+            completeApiClientPublication
+        );
+        return apiClientPropertyHookInstalled;
+    }
+
+    function reconcileCurrentIdentity(reason = 'monitor') {
+        const client = window.ApiClient;
+        if (!client) return null;
+        installAuthenticationHook(client);
+        let userId = '';
+        try { userId = client.getCurrentUserId?.() || ''; } catch (_) { /* signed out */ }
+        const context = identity.transition(getClientServerId(client), userId, reason);
+        if (context && userId) scheduleInitializationForClient(client, context);
+        return context;
+    }
+
+    function ensureIdentityBridge() {
+        // This configurable-property path fences an already-authenticated B
+        // synchronously, before the assignment makes B globally observable.
+        // The interval below remains for non-configurable globals and foreign
+        // replacements that redefine the property descriptor entirely.
+        installApiClientReplacementHook();
+        const client = window.ApiClient;
+        if (client) installAuthenticationHook(client);
+        if (identityMonitorId === null) {
+            // Belt-and-braces for a future host that gives each server a distinct
+            // ApiClient implementation. The setter hook is the synchronous paved
+            // road; this single document-lifetime monitor installs on replacements.
+            identityMonitorId = window.setInterval(() => {
+                try {
+                    installApiClientReplacementHook();
+                    reconcileCurrentIdentity('identity-monitor');
+                    pumpPendingActivation();
+                } catch (_) { /* host is between clients */ }
+            }, 250);
+        }
+    }
 
     /**
      * Converts PascalCase object keys to camelCase recursively.
@@ -284,18 +861,22 @@
      * Loads the translation module and exposes JC.loadTranslations.
      * @returns {Promise<void>}
      */
-    async function loadTranslationsModule() {
+    let translationsModulePromise = null;
+    async function loadTranslationsModule(client = ApiClient) {
         if (typeof JC.loadTranslations === 'function') return;
-        await new Promise((resolve) => {
+        if (translationsModulePromise) return translationsModulePromise;
+        translationsModulePromise = new Promise((resolve) => {
             const script = document.createElement('script');
-            script.src = ApiClient.getUrl(`/JellyfinCanopy/dist/translations.js?v=${getScriptVersion()}`);
+            script.src = client.getUrl(`/JellyfinCanopy/dist/translations.js?v=${getScriptVersion()}`);
             script.onload = () => resolve();
             script.onerror = (e) => {
                 console.error('🪼 Jellyfin Canopy: Failed to load translations module', e);
+                translationsModulePromise = null;
                 resolve();
             };
             document.head.appendChild(script);
         });
+        await translationsModulePromise;
     }
 
     /**
@@ -315,21 +896,27 @@
      * Fetches plugin configuration and version from the server.
      * @returns {Promise<[object, string]>} A promise that resolves with config and version.
      */
-     function loadPluginData() {
-        const configPromise = ApiClient.ajax({
+     function loadPluginData(client = ApiClient, scope = null) {
+        const configRequest = client.ajax({
             type: 'GET',
-            url: ApiClient.getUrl('/JellyfinCanopy/public-config'),
-            dataType: 'json'
-        }).catch((e) => {
+            url: client.getUrl('/JellyfinCanopy/public-config'),
+            dataType: 'json',
+            signal: scope?.signal
+        });
+        const configPromise = (scope ? scope.race(configRequest) : configRequest).catch((e) => {
+            if (scope?.signal?.aborted) return {};
             console.error("🪼 Jellyfin Canopy: Failed to fetch public config", e);
             return {}; // Return empty object on error
         });
 
-        const versionPromise = ApiClient.ajax({
+        const versionRequest = client.ajax({
             type: 'GET',
-            url: ApiClient.getUrl('/JellyfinCanopy/version'),
-            dataType: 'text'
-        }).catch((e) => {
+            url: client.getUrl('/JellyfinCanopy/version'),
+            dataType: 'text',
+            signal: scope?.signal
+        });
+        const versionPromise = (scope ? scope.race(versionRequest) : versionRequest).catch((e) => {
+            if (scope?.signal?.aborted) return 'unknown';
              console.error("🪼 Jellyfin Canopy: Failed to fetch version", e);
             return 'unknown'; // Return placeholder on error
         });
@@ -344,14 +931,17 @@
      * JC.pluginConfig once that object exists.
      * @returns {Promise<object|null>} The private config, or null on failure.
      */
-    async function loadPrivateConfig() {
+    async function loadPrivateConfig(client = ApiClient, scope = null) {
         try {
-            return await ApiClient.ajax({
+            const request = client.ajax({
                 type: 'GET',
-                url: ApiClient.getUrl('/JellyfinCanopy/private-config'),
-                dataType: 'json'
+                url: client.getUrl('/JellyfinCanopy/private-config'),
+                dataType: 'json',
+                signal: scope?.signal
             });
+            return await (scope ? scope.race(request) : request);
         } catch (error) {
+            if (scope?.signal?.aborted) return null;
             console.warn('🪼 Jellyfin Canopy: Could not load private configuration. Some features may be limited.', error);
             return null; // Don't merge anything if it fails
         }
@@ -367,11 +957,13 @@
      * cache-buster, and with a sourcemap for real-file stack traces).
      * @returns {Promise<boolean>} true when the bundle loaded, false on failure.
      */
-    function loadBundle() {
-        return new Promise((resolve) => {
+    let bundleLoadPromise = null;
+    function loadBundle(client = ApiClient) {
+        if (bundleLoadPromise) return bundleLoadPromise;
+        bundleLoadPromise = new Promise((resolve) => {
             const script = document.createElement('script');
             script.async = false;
-            script.src = ApiClient.getUrl(`/JellyfinCanopy/dist/jc.bundle.js?v=${getScriptVersion()}`);
+            script.src = client.getUrl(`/JellyfinCanopy/dist/jc.bundle.js?v=${getScriptVersion()}`);
             script.onload = () => resolve(true);
             script.onerror = (e) => {
                 console.error(
@@ -382,10 +974,12 @@
                     e
                 );
                 script.remove();
+                bundleLoadPromise = null;
                 resolve(false);
             };
             document.head.appendChild(script);
         });
+        return bundleLoadPromise;
     }
 
      /**
@@ -700,9 +1294,9 @@
     let readyRetryCount = 0;
     // Cap the ApiClient-readiness poll so a login page left open unauthenticated
     // does not busy-loop (and re-parse jellyfin_credentials) forever. ~10*50ms +
-    // 590*250ms ≈ 2.5 min — generous enough for a real user typing credentials;
-    // on login Jellyfin full-reloads, discarding the loop, so this only bites the
-    // never-authenticated idle case.
+    // 590*250ms ≈ 2.5 min — generous enough for a real user typing credentials.
+    // The identity setter hook remains installed after this readiness poll stops,
+    // so a later no-reload login still starts its own epoch initialization.
     const MAX_READY_RETRIES = 600;
 
     /**
@@ -718,106 +1312,265 @@
     }
 
     /**
-     * Main initialization function.
+     * Per-epoch loader work registry. `AbortController` gives cooperative host
+     * transports a real cancellation signal; the cancellation promise also
+     * settles the logical work immediately when an older host ajax ignores it.
+     * Old entries are synchronously removed by cancelExcept(), so indefinitely
+     * held raw promises cannot grow either diagnostic map across switches.
      */
-    async function initialize() {
-        // Check for server ID mismatch - stop retrying if credentials are stale
-        if (hasServerIdMismatch()) {
-            mismatchRetryCount++;
-            if (mismatchRetryCount >= MAX_MISMATCH_RETRIES) {
-                console.warn('🪼 Jellyfin Canopy: Server ID mismatch detected - stopping to allow re-authentication');
-                JC?.hideSplashScreen?.();
-                return;
-            }
-            setTimeout(initialize, 300);
-            return;
+    function createInitializationRegistry(makeCancellationError = () => new Error('Initialization cancelled')) {
+        const workByEpoch = new Map();
+        const scopesByEpoch = new Map();
+        let cancelledThroughEpoch = 0;
+        let latestTransitionEpoch = 0;
+
+        function createScope(epoch) {
+            const controller = new AbortController();
+            let cancelled = false;
+            let cancellationError = null;
+            let rejectCancellation;
+            const cancellation = new Promise((_, reject) => { rejectCancellation = reject; });
+            const scope = {
+                epoch,
+                signal: controller.signal,
+                race(promise) {
+                    if (cancelled) return Promise.reject(cancellationError);
+                    return Promise.race([Promise.resolve(promise), cancellation]);
+                },
+                cancel() {
+                    if (cancelled) return;
+                    cancelled = true;
+                    cancellationError = makeCancellationError();
+                    controller.abort();
+                    rejectCancellation(cancellationError);
+                }
+            };
+            return scope;
         }
 
-        // Normal retry logic (no mismatch)
-        if (typeof ApiClient === 'undefined' || !ApiClient.getCurrentUserId?.()) {
-            if (readyRetryCount >= MAX_READY_RETRIES) {
-                console.warn('🪼 Jellyfin Canopy: ApiClient not ready after max retries - stopping poll');
-                JC?.hideSplashScreen?.();
-                return;
+        function start(epoch, run) {
+            if (epoch <= cancelledThroughEpoch) {
+                return Promise.reject(makeCancellationError());
             }
-            setTimeout(initialize, nextReadyPollDelay());
-            return;
+            const existing = workByEpoch.get(epoch);
+            if (existing) return existing;
+            let scope = scopesByEpoch.get(epoch);
+            if (!scope) {
+                scope = createScope(epoch);
+                scopesByEpoch.set(epoch, scope);
+            }
+            let produced;
+            try { produced = run(scope); }
+            catch (error) { produced = Promise.reject(error); }
+            const work = scope.race(produced).finally(() => {
+                if (workByEpoch.get(epoch) === work) workByEpoch.delete(epoch);
+            });
+            workByEpoch.set(epoch, work);
+            return work;
         }
 
-        // Reset mismatch counter on success
-        mismatchRetryCount = 0;
-
-        try {
-            // PERF: single parallel fetch wave. Every boot request that only
-            // needs auth/userId starts immediately instead of one-per-await —
-            // the old chain was four network round-trips deep (public config →
-            // private config → /Plugins → 5 user-settings files) even though
-            // none of those responses feed the next request.
-            const userId = ApiClient.getCurrentUserId();
-
-            // Prefetch full user object once (needed for admin check in arr-links etc.)
-            // Fire-and-forget alongside the fetch wave; result available as JC.currentUser
-            ApiClient.getCurrentUser().then(u => { JC.currentUser = u; }).catch(() => {});
-
-            const fetchPromises = [
-                ApiClient.ajax({ type: 'GET', url: ApiClient.getUrl(`/JellyfinCanopy/user-settings/${userId}/settings.json?_=${Date.now()}`), dataType: 'json' })
-                         .then(data => ({ name: 'settings', status: 'fulfilled', value: data }))
-                         .catch(e => ({ name: 'settings', status: 'rejected', reason: e })),
-                ApiClient.ajax({ type: 'GET', url: ApiClient.getUrl(`/JellyfinCanopy/user-settings/${userId}/shortcuts.json?_=${Date.now()}`), dataType: 'json' })
-                         .then(data => ({ name: 'shortcuts', status: 'fulfilled', value: data }))
-                         .catch(e => ({ name: 'shortcuts', status: 'rejected', reason: e })),
-                ApiClient.ajax({ type: 'GET', url: ApiClient.getUrl(`/JellyfinCanopy/user-settings/${userId}/bookmark.json?_=${Date.now()}`), dataType: 'json' })
-                         .then(data => ({ name: 'bookmark', status: 'fulfilled', value: data }))
-                         .catch(e => ({ name: 'bookmark', status: 'rejected', reason: e })),
-                ApiClient.ajax({ type: 'GET', url: ApiClient.getUrl(`/JellyfinCanopy/user-settings/${userId}/elsewhere.json?_=${Date.now()}`), dataType: 'json' })
-                         .then(data => ({ name: 'elsewhere', status: 'fulfilled', value: data }))
-                         .catch(e => ({ name: 'elsewhere', status: 'rejected', reason: e })),
-                ApiClient.ajax({ type: 'GET', url: ApiClient.getUrl(`/JellyfinCanopy/user-settings/${userId}/hidden-content.json?_=${Date.now()}`), dataType: 'json' })
-                         .then(data => ({ name: 'hiddenContent', status: 'fulfilled', value: data }))
-                         .catch(e => ({ name: 'hiddenContent', status: 'rejected', reason: e }))
-            ];
-            // Use allSettled to get results even if some fetches fail
-            const userSettingsPromise = Promise.allSettled(fetchPromises);
-
-            // Stage 1: Load base configs and translations
-            await loadTranslationsModule();
-            const [[config, version], translations, privateConfig] = await Promise.all([
-                loadPluginData(),
-                loadTranslations(), // Load translations first
-                loadPrivateConfig()
-            ]);
-
-            JC.pluginConfig = config && typeof config === 'object' ? config : {};
-            JC.pluginVersion = version || 'unknown';
-            JC.translations = translations || {};
-            JC.t = window.JellyfinCanopy.t; // Ensure the real function is assigned
-            // Merge the sensitive keys into the main config object
-            if (privateConfig && typeof privateConfig === 'object') {
-                Object.assign(JC.pluginConfig, privateConfig);
+        function cancelExcept(keepEpoch, transitionEpoch = keepEpoch) {
+            const transitionNumber = Number(transitionEpoch) || 0;
+            // A stale outer transition must not cancel scopes owned by a newer
+            // nested transition. Identity epochs are monotonic document-wide.
+            if (transitionNumber < latestTransitionEpoch) return;
+            latestTransitionEpoch = transitionNumber;
+            cancelledThroughEpoch = Math.max(
+                cancelledThroughEpoch,
+                keepEpoch == null ? transitionNumber : Number(keepEpoch) - 1
+            );
+            for (const [epoch, scope] of [...scopesByEpoch.entries()]) {
+                if (epoch === keepEpoch) continue;
+                if (transitionNumber && epoch > transitionNumber) continue;
+                scope.cancel();
+                scopesByEpoch.delete(epoch);
             }
+            // Evict synchronously. Each work promise will also self-check in its
+            // finally, so a late A settlement cannot delete a newer entry.
+            for (const epoch of [...workByEpoch.keys()]) {
+                if (epoch !== keepEpoch && (!transitionNumber || epoch <= transitionNumber)) {
+                    workByEpoch.delete(epoch);
+                }
+            }
+        }
 
-            // PERF(R7): warm the server tag-cache fetch NOW — its only gates are
-            // auth/userId and the TagCacheServerMode flag, which public config
-            // (this stage) just delivered. Cold-boot first tags used to wait for
-            // bundle download + full feature init before the tag pipeline even
-            // STARTED this request; handing the in-flight promise to
-            // src/enhanced/tag-pipeline.ts (which falls back to its own fetch
-            // when absent) takes the whole bundle-boot serialization out of the
-            // first-tag latency. Resolves null on failure so the pipeline's
-            // fallback path handles errors exactly as before.
-            if (JC.pluginConfig?.TagCacheServerMode) {
-                JC._tagCachePrefetch = ApiClient.ajax({
+        return Object.freeze({
+            start,
+            cancelExcept,
+            getPendingCount: () => workByEpoch.size,
+            getControllerCount: () => scopesByEpoch.size
+        });
+    }
+
+    initializationRegistry = createInitializationRegistry(identityChangedError);
+    let initializedEpoch = -1;
+    let cacheUnloadInstalled = false;
+
+    function identityChangedError() {
+        const error = new Error('Identity changed during Jellyfin Canopy initialization');
+        error.name = 'IdentityChangedError';
+        return error;
+    }
+
+    function requireCurrentIdentity(context) {
+        if (!identity.isCurrent(context)) throw identityChangedError();
+    }
+
+    function defaultUserFile(name) {
+        if (name === 'shortcuts') return { Shortcuts: [] };
+        if (name === 'bookmark') return { bookmarks: {} };
+        if (name === 'hiddenContent') return { items: {}, settings: {} };
+        return {};
+    }
+
+    /** Jellyfin host/ajax error shapes seen across web-client versions. */
+    function isNotFoundError(error) {
+        if (!error || (typeof error !== 'object' && typeof error !== 'function')) return false;
+        const candidates = [
+            error.status,
+            error.statusCode,
+            error.response?.status,
+            error.xhr?.status,
+            error.target?.status
+        ];
+        return candidates.some((value) => Number(value) === 404);
+    }
+
+    /** Fetch all five owner files once and build a local, unpublished snapshot. */
+    async function fetchUserConfig(client, context, scope) {
+        const files = [
+            ['settings', 'settings.json'],
+            ['shortcuts', 'shortcuts.json'],
+            ['bookmark', 'bookmark.json'],
+            ['elsewhere', 'elsewhere.json'],
+            ['hiddenContent', 'hidden-content.json']
+        ];
+        const results = await Promise.all(files.map(async ([name, file]) => {
+            try {
+                const request = client.ajax({
                     type: 'GET',
-                    url: ApiClient.getUrl(`/JellyfinCanopy/tag-cache/${userId}`),
-                    dataType: 'json'
-                }).catch(() => null);
+                    url: client.getUrl(`/JellyfinCanopy/user-settings/${encodeURIComponent(context.userId)}/${file}?_=${Date.now()}`),
+                    dataType: 'json',
+                    signal: scope.signal
+                });
+                const value = await scope.race(request);
+                return { name, value, missing: false };
+            } catch (reason) {
+                if (isNotFoundError(reason)) return { name, value: null, missing: true };
+                // Authentication, transport, server, cancellation, and malformed
+                // success failures must abort this initialization. Publishing a
+                // fabricated empty owner snapshot would erase real preferences.
+                throw reason;
             }
+        }));
+        requireCurrentIdentity(context);
 
-            // Check if server has triggered a translation cache clear
-            const serverTranslationClearTs = JC.pluginConfig.ClearTranslationCacheTimestamp || 0;
+        const snapshot = emptyUserConfig();
+        for (const result of results) {
+            const { name, value, missing } = result;
+            if (missing) {
+                snapshot[name] = defaultUserFile(name);
+            } else if (!value || typeof value !== 'object' || Array.isArray(value)) {
+                throw new Error(`Invalid ${name} user-settings response`);
+            } else if (name === 'bookmark') {
+                snapshot[name] = toCamelCase(value, { preserveKey: (key) => /^bm_/i.test(key) });
+            } else if (name === 'settings' || name === 'hiddenContent') {
+                snapshot[name] = toCamelCase(value);
+            } else {
+                snapshot[name] = value;
+            }
+        }
+        return snapshot;
+    }
+
+    function publishIdentitySnapshot(context, snapshot) {
+        requireCurrentIdentity(context);
+        const userConfig = identity.own(snapshot.userConfig, context);
+        for (const value of Object.values(userConfig)) identity.own(value, context);
+
+        JC.pluginConfig = identity.own(snapshot.pluginConfig, context);
+        JC.pluginVersion = snapshot.version || 'unknown';
+        JC.translations = identity.own(snapshot.translations || {}, context);
+        JC.currentUser = snapshot.currentUser ? identity.own(snapshot.currentUser, context) : null;
+        JC.userConfig = userConfig;
+        JC.t = window.JellyfinCanopy.t;
+    }
+
+    function installCacheUnloadOnce() {
+        if (cacheUnloadInstalled) return;
+        cacheUnloadInstalled = true;
+        window.addEventListener('beforeunload', () => {
+            if (identity.capture()) JC._cacheManager?.forceSave?.();
+        });
+    }
+
+    /** Stage-6 activation. Old-epoch teardown always ran before these gates. */
+    function activateFeatures(context) {
+        requireCurrentIdentity(context);
+        if (typeof JC.initializeCanopyScript === 'function') JC.initializeCanopyScript();
+        if (typeof JC.initializeElsewhereScript === 'function' && JC.pluginConfig?.ElsewhereEnabled) JC.initializeElsewhereScript();
+        if (typeof JC.initializeSeerrScript === 'function' && JC.pluginConfig?.SeerrEnabled && JC.pluginConfig?.SeerrShowSearchResults !== false) JC.initializeSeerrScript();
+        if (typeof JC.seerrIssueReporter?.initialize === 'function' && JC.pluginConfig?.SeerrEnabled && JC.pluginConfig?.SeerrShowReportButton) JC.seerrIssueReporter.initialize();
+        if (typeof JC.initializePauseScreen === 'function') JC.initializePauseScreen();
+        if (typeof JC.initializeBookmarks === 'function') JC.initializeBookmarks();
+        if (typeof JC.initializeQualityTags === 'function' && JC.currentSettings?.qualityTagsEnabled) JC.initializeQualityTags();
+        if (typeof JC.initializeGenreTags === 'function' && JC.currentSettings?.genreTagsEnabled) JC.initializeGenreTags();
+        if (typeof JC.initializeRatingTags === 'function' && JC.currentSettings?.ratingTagsEnabled) JC.initializeRatingTags();
+        if (typeof JC.initializeUserReviewTags === 'function' && JC.pluginConfig?.ShowUserReviews && JC.pluginConfig?.ShowUserRatingOnPosters && JC.currentSettings?.ratingTagsEnabled) JC.initializeUserReviewTags();
+        if (typeof JC.initializeArrLinksScript === 'function' && JC.pluginConfig?.ArrLinksEnabled) JC.initializeArrLinksScript();
+        if (typeof JC.initializeArrTagLinksScript === 'function' && JC.pluginConfig?.ArrTagsShowAsLinks) JC.initializeArrTagLinksScript();
+        if (typeof JC.initializeLetterboxdLinksScript === 'function' && JC.pluginConfig?.LetterboxdEnabled) JC.initializeLetterboxdLinksScript();
+        if (typeof JC.initializeReviewsScript === 'function' && (JC.pluginConfig?.ShowReviews || JC.pluginConfig?.ShowUserReviews)) JC.initializeReviewsScript();
+        if (typeof JC.initializeLanguageTags === 'function' && JC.currentSettings?.languageTagsEnabled) JC.initializeLanguageTags();
+        if (typeof JC.initializePeopleTags === 'function' && JC.currentSettings?.peopleTagsEnabled) JC.initializePeopleTags();
+        if (typeof JC.tagPipeline?.initialize === 'function') JC.tagPipeline.initialize();
+        if (typeof JC.initializeOsdRating === 'function') JC.initializeOsdRating();
+        if (typeof JC.initializeHiddenContent === 'function' && JC.pluginConfig?.HiddenContentEnabled) JC.initializeHiddenContent();
+        if (JC.pluginConfig?.ColoredRatingsEnabled && typeof JC.initializeColoredRatings === 'function') JC.initializeColoredRatings();
+        if (JC.pluginConfig?.ThemeSelectorEnabled && typeof JC.initializeThemeSelector === 'function') JC.initializeThemeSelector();
+        if (JC.pluginConfig?.ColoredActivityIconsEnabled && typeof JC.initializeActivityIcons === 'function') JC.initializeActivityIcons();
+        if (JC.pluginConfig?.PluginIconsEnabled && typeof JC.initializePluginIcons === 'function') JC.initializePluginIcons();
+        if (JC.pluginConfig?.ActiveStreamsEnabled && typeof JC.activeStreams?.initialize === 'function') JC.activeStreams.initialize();
+        if (typeof JC.initializePagesFramework === 'function') JC.initializePagesFramework();
+    }
+
+    async function runInitialization(context, client, scope) {
+        try {
+            requireCurrentIdentity(context);
+
+            // Start every independent owner read in one wave. Nothing is
+            // published until all values belong to this still-current epoch.
+            const userConfigPromise = fetchUserConfig(client, context, scope);
+            // A failed owner read is not equivalent to an absent owner. Let the
+            // initialization fail so the monitor retries without publishing a
+            // partial B snapshot.
+            const currentUserPromise = scope.race(client.getCurrentUser());
+            const pluginDataPromise = loadPluginData(client, scope);
+            const privateConfigPromise = loadPrivateConfig(client, scope);
+
+            await scope.race(loadTranslationsModule(client));
+            requireCurrentIdentity(context);
+            const translationsPromise = scope.race(loadTranslations());
+
+            const [userConfig, currentUser, pluginData, privateConfig, translations] = await Promise.all([
+                userConfigPromise,
+                currentUserPromise,
+                pluginDataPromise,
+                privateConfigPromise,
+                translationsPromise
+            ]);
+            requireCurrentIdentity(context);
+
+            const [publicConfig, version] = pluginData;
+            const pluginConfig = publicConfig && typeof publicConfig === 'object'
+                ? { ...publicConfig }
+                : {};
+            if (privateConfig && typeof privateConfig === 'object') Object.assign(pluginConfig, privateConfig);
+
+            let nextTranslations = translations || {};
+            const serverTranslationClearTs = pluginConfig.ClearTranslationCacheTimestamp || 0;
             const localTranslationClearTs = parseInt(localStorage.getItem('JC_translation_clear_ts') || '0', 10);
             if (serverTranslationClearTs > localTranslationClearTs) {
-                console.log(`🪼 Jellyfin Canopy: Server-triggered translation cache clear (${new Date(serverTranslationClearTs).toISOString()})`);
                 for (let i = localStorage.length - 1; i >= 0; i--) {
                     const key = localStorage.key(i);
                     if (key && (key.startsWith('JC_translation_') || key.startsWith('JC_translation_ts_'))) {
@@ -825,194 +1578,140 @@
                     }
                 }
                 localStorage.setItem('JC_translation_clear_ts', serverTranslationClearTs.toString());
-                // Reload translations with fresh data
-                JC.translations = await loadTranslations() || {};
-                JC.t = window.JellyfinCanopy.t;
+                nextTranslations = await scope.race(loadTranslations()) || {};
+                requireCurrentIdentity(context);
             }
 
-            // Inject metadata icons CSS if enabled
-            try {
-                injectMetadataIcons(!!JC.pluginConfig?.MetadataIconsEnabled);
-            } catch (e) {
-                console.warn('🪼 Jellyfin Canopy: Failed to inject Metadata icons CSS', e);
-            }
-
-            // Stage 2: Collect the user-specific settings started in the
-            // parallel fetch wave above.
-            const results = await userSettingsPromise;
-
-            JC.userConfig = { settings: {}, shortcuts: { Shortcuts: [] }, bookmark: { bookmarks: {} }, elsewhere: {}, hiddenContent: { items: {}, settings: {} } };
-            results.forEach(result => {
-                if (result.status === 'fulfilled' && result.value) {
-                    const data = result.value;
-                    if (data.status === 'fulfilled' && data.value && typeof data.value === 'object') {
-                        // *** CONVERT PASCALCASE TO CAMELCASE ***
-                        if (data.name === 'bookmark') {
-                            // Preserve the bookmark ID dictionary keys (`Bm_…`) so
-                            // the server-generated id case is not mangled to `bm_…`.
-                            JC.userConfig[data.name] = toCamelCase(data.value, { preserveKey: (k) => /^bm_/i.test(k) });
-                        } else if (data.name === 'settings' || data.name === 'hiddenContent') {
-                            JC.userConfig[data.name] = toCamelCase(data.value);
-                        } else {
-                            JC.userConfig[data.name] = data.value;
-                        }
-                    } else if (data.status === 'rejected') {
-                        if (data.name === 'shortcuts') JC.userConfig.shortcuts = { Shortcuts: [] };
-                        else if (data.name === 'bookmark') JC.userConfig.bookmark = { bookmarks: {} };
-                        else if (data.name === 'elsewhere') JC.userConfig.elsewhere = {};
-                        else if (data.name === 'hiddenContent') JC.userConfig.hiddenContent = { items: {}, settings: {} };
-                        else JC.userConfig[data.name] = {};
-                    } else {
-                        if (data.name === 'shortcuts') JC.userConfig.shortcuts = { Shortcuts: [] };
-                        else if (data.name === 'bookmark') JC.userConfig.bookmark = { bookmarks: {} };
-                        else if (data.name === 'elsewhere') JC.userConfig.elsewhere = {};
-                        else if (data.name === 'hiddenContent') JC.userConfig.hiddenContent = { items: {}, settings: {} };
-                        else JC.userConfig[data.name] = {};
-                    }
-                } else {
-                    const name = result.value?.name || result.reason?.name || '';
-                    if (name === 'shortcuts') JC.userConfig.shortcuts = { Shortcuts: [] };
-                    else if (name === 'bookmark') JC.userConfig.bookmark = { bookmarks: {} };
-                    else if (name === 'elsewhere') JC.userConfig.elsewhere = {};
-                    else if (name === 'hiddenContent') JC.userConfig.hiddenContent = { items: {}, settings: {} };
-                    else if (name) JC.userConfig[name] = {};
-                }
+            publishIdentitySnapshot(context, {
+                pluginConfig,
+                version,
+                translations: nextTranslations,
+                currentUser,
+                userConfig
             });
 
-
-            // Warm the icon fonts while the bundle is still downloading, so
-            // glyphs are ready before the first injected icon paints (see
-            // preloadIconFonts for the PERF(R1)/PERF(R6) reasoning).
-            preloadIconFonts();
-
-            // Initialize splash screen
-            if (typeof JC.initializeSplashScreen === 'function') {
-                JC.initializeSplashScreen();
+            if (pluginConfig.TagCacheServerMode) {
+                const tagCacheRequest = client.ajax({
+                    type: 'GET',
+                    url: client.getUrl(`/JellyfinCanopy/tag-cache/${encodeURIComponent(context.userId)}`),
+                    dataType: 'json',
+                    signal: scope.signal
+                });
+                JC._tagCachePrefetch = scope.race(tagCacheRequest)
+                    .then((value) => identity.isCurrent(context) ? value : null)
+                    .catch(() => null);
             }
 
-            // Stage 3: Load the client bundle (every component, one script).
-            //
-            // The entire feature tree — core layer (navigation detection,
-            // lifecycle registry, shared body observer, fetch layer, base UI
-            // primitives) plus every feature module — lives in the TypeScript
-            // tree (entry src/main.ts) and ships as a single bundle built by
-            // scripts/build-bundle.js. Import edges in src/ define execution
-            // order; there is no longer a runtime or build-time component list.
-            //
-            // One bundle for every mode. Production serves it immutable behind a
-            // versioned URL; DevMode serves the same route with no-store + a fresh
-            // cache-buster per load (getScriptVersion() returns Date.now() in dev)
-            // and the linked sourcemap keeps stack traces on real source files.
-            const bundleLoaded = await loadBundle();
+            try { injectMetadataIcons(!!pluginConfig.MetadataIconsEnabled); }
+            catch (error) { console.warn('🪼 Jellyfin Canopy: Failed to inject Metadata icons CSS', error); }
+            preloadIconFonts();
+            JC.initializeSplashScreen?.();
+
+            // The process bundle executes once per document. B reuses its module
+            // graph and only re-runs the owner activation phase below.
+            const bundleLoaded = await scope.race(loadBundle(client));
+            requireCurrentIdentity(context);
             if (!bundleLoaded) {
-                if (typeof JC.hideSplashScreen === 'function') JC.hideSplashScreen();
+                JC.hideSplashScreen?.();
                 return;
             }
-            console.log('🪼 Jellyfin Canopy: All component scripts loaded.');
 
-            // Stage 4: Initialize core settings/shortcuts using potentially defined functions
-            if (typeof JC.loadSettings === 'function' && typeof JC.initializeShortcuts === 'function') {
-                JC.currentSettings = JC.loadSettings(); // This happens AFTER config.js is loaded
-                JC.initializeShortcuts();
-            } else {
-                 console.error("🪼 Jellyfin Canopy: FATAL - config.js functions not defined after script loading.");
-                 if (typeof JC.hideSplashScreen === 'function') JC.hideSplashScreen();
-                 return;
+            if (typeof JC.loadSettings !== 'function' || typeof JC.initializeShortcuts !== 'function') {
+                throw new Error('config.js functions not defined after bundle loading');
             }
+            JC.currentSettings = identity.own(JC.loadSettings(), context);
+            JC.initializeShortcuts();
 
-            if (userId) {
-                const languageKey = `${userId}-language`;
-                // Only seed the admin's default language if the user has no language set yet.
-                // This prevents overwriting the user's own language choice on every page load.
-                if (localStorage.getItem(languageKey) === null) {
-                    const desiredLanguage = (JC.currentSettings?.displayLanguage || '').trim();
-                    if (desiredLanguage) {
-                        const normalizeLangCode = (code) => {
-                            if (!code) return '';
-                            const parts = code.split('-');
-                            if (parts.length === 1) return parts[0].toLowerCase();
-                            if (parts.length === 2) return `${parts[0].toLowerCase()}-${parts[1].toUpperCase()}`;
-                            return code;
-                        };
-                        localStorage.setItem(languageKey, normalizeLangCode(desiredLanguage));
-                    }
-                }
-            }
+            const capturedRawUserId = String(identity.getRawUserId?.(context) || context.userId).trim();
+            const normalizedRawUserId = capturedRawUserId.replace(/-/g, '').toLowerCase();
+            const compatibilityUserId = normalizedRawUserId === context.userId
+                ? capturedRawUserId
+                : context.userId;
+            const languageKey = `${compatibilityUserId}-language`;
+            const scopedLanguageKey = `jc-display-language:${context.serverId}:${context.userId}`;
+            const desiredLanguage = String(JC.currentSettings?.displayLanguage || '').trim();
+            const parts = desiredLanguage.split('-');
+            const normalizedLanguage = !desiredLanguage
+                ? ''
+                : (parts.length === 1
+                    ? parts[0].toLowerCase()
+                    : (parts.length === 2 ? `${parts[0].toLowerCase()}-${parts[1].toUpperCase()}` : desiredLanguage));
+            localStorage.setItem(scopedLanguageKey, normalizedLanguage);
+            localStorage.setItem(languageKey, normalizedLanguage);
 
-            // Stage 5: Initialize theme system first
-            if (typeof JC.themer?.init === 'function') {
-                JC.themer.init();
-                console.log('🪼 Jellyfin Canopy: Theme system initialized.');
-            }
+            if (typeof JC.themer?.init === 'function') JC.themer.init();
+            installCacheUnloadOnce();
 
-            // Register unified cache save on page unload
-            window.addEventListener('beforeunload', () => {
-                JC._cacheManager.forceSave();
-            });
+            // Bundle participants that self-wire (live socket, identity caches)
+            // activate once per epoch before the legacy Stage-6 feature calls.
+            await identity.activate(context);
+            requireCurrentIdentity(context);
+            activateFeatures(context);
+            requireCurrentIdentity(context);
 
-            // Stage 6: Initialize feature modules
-            if (typeof JC.initializeCanopyScript === 'function') JC.initializeCanopyScript();
-            if (typeof JC.initializeElsewhereScript === 'function' && JC.pluginConfig?.ElsewhereEnabled) JC.initializeElsewhereScript();
-            if (typeof JC.initializeSeerrScript === 'function' && JC.pluginConfig?.SeerrEnabled && JC.pluginConfig?.SeerrShowSearchResults !== false) JC.initializeSeerrScript();
-            if (typeof JC.seerrIssueReporter?.initialize === 'function' && JC.pluginConfig?.SeerrEnabled && JC.pluginConfig?.SeerrShowReportButton) JC.seerrIssueReporter.initialize();
-            if (typeof JC.initializePauseScreen === 'function') JC.initializePauseScreen();
-            if (typeof JC.initializeBookmarks === 'function') JC.initializeBookmarks();
-            if (typeof JC.initializeQualityTags === 'function' && JC.currentSettings?.qualityTagsEnabled) JC.initializeQualityTags();
-            if (typeof JC.initializeGenreTags === 'function' && JC.currentSettings?.genreTagsEnabled) JC.initializeGenreTags();
-            if (typeof JC.initializeRatingTags === 'function' && JC.currentSettings?.ratingTagsEnabled) JC.initializeRatingTags();
-            if (typeof JC.initializeUserReviewTags === 'function' && JC.pluginConfig?.ShowUserReviews && JC.pluginConfig?.ShowUserRatingOnPosters && JC.currentSettings?.ratingTagsEnabled) JC.initializeUserReviewTags();
-            if (typeof JC.initializeArrLinksScript === 'function' && JC.pluginConfig?.ArrLinksEnabled) JC.initializeArrLinksScript();
-            if (typeof JC.initializeArrTagLinksScript === 'function' && JC.pluginConfig?.ArrTagsShowAsLinks) JC.initializeArrTagLinksScript();
-            if (typeof JC.initializeLetterboxdLinksScript === 'function' && JC.pluginConfig?.LetterboxdEnabled) JC.initializeLetterboxdLinksScript();
-            if (typeof JC.initializeReviewsScript === 'function' && (JC.pluginConfig?.ShowReviews || JC.pluginConfig?.ShowUserReviews)) JC.initializeReviewsScript();
-            if (typeof JC.initializeLanguageTags === 'function' && JC.currentSettings?.languageTagsEnabled) JC.initializeLanguageTags();
-            if (typeof JC.initializePeopleTags === 'function' && JC.currentSettings?.peopleTagsEnabled) JC.initializePeopleTags();
-            // Initialize the unified tag pipeline AFTER all tag renderers have registered
-            if (typeof JC.tagPipeline?.initialize === 'function') JC.tagPipeline.initialize();
-            if (typeof JC.initializeOsdRating === 'function') JC.initializeOsdRating();
-            // Skip hidden content initialization when feature is disabled server-wide — JC.hiddenContent stays undefined, safely disabling all downstream consumers
-            if (typeof JC.initializeHiddenContent === 'function' && JC.pluginConfig?.HiddenContentEnabled) JC.initializeHiddenContent();
-
-            if (JC.pluginConfig?.ColoredRatingsEnabled && typeof JC.initializeColoredRatings === 'function') {
-                JC.initializeColoredRatings();
-            }
-            if (JC.pluginConfig?.ThemeSelectorEnabled && typeof JC.initializeThemeSelector === 'function') {
-                JC.initializeThemeSelector();
-            }
-            if (JC.pluginConfig?.ColoredActivityIconsEnabled && typeof JC.initializeActivityIcons === 'function') {
-                JC.initializeActivityIcons();
-            }
-            if (JC.pluginConfig?.PluginIconsEnabled && typeof JC.initializePluginIcons === 'function') {
-                JC.initializePluginIcons();
-            }
-            if (JC.pluginConfig?.ActiveStreamsEnabled && typeof JC.activeStreams?.initialize === 'function') {
-                JC.activeStreams.initialize();
-            }
-            // Pages framework: one init wires the fallback-host hooks, the
-            // entry points, and the cold-start (deep-link) adoption for ALL
-            // pages — per-page availability is gated live inside the registry.
-            if (typeof JC.initializePagesFramework === 'function') {
-                JC.initializePagesFramework();
-            }
-
-            console.log('🪼 Jellyfin Canopy: All components initialized successfully.');
-
-            // Programmatic boot-complete marker: every component script has executed
-            // and every enabled initializeX() has run. Automation (E2E) waits on this
-            // instead of racing individual JC.* properties that appear mid-boot.
+            initializedEpoch = context.epoch;
             JC.initialized = true;
-
-            // Final Stage: Hide splash screen
-            if (typeof JC.hideSplashScreen === 'function') {
-                JC.hideSplashScreen();
-            }
-
+            document.dispatchEvent(new CustomEvent('jc:identityactivated', { detail: context }));
+            JC.hideSplashScreen?.();
+            console.log(`🪼 Jellyfin Canopy: identity epoch ${context.epoch} initialized successfully.`);
         } catch (error) {
-            console.error('🪼 Jellyfin Canopy: CRITICAL INITIALIZATION FAILURE:', error);
-             if (typeof JC.hideSplashScreen === 'function') {
-                JC.hideSplashScreen();
+            if (error?.name === 'IdentityChangedError') return;
+            if (identity.isCurrent(context)) {
+                console.error('🪼 Jellyfin Canopy: CRITICAL INITIALIZATION FAILURE:', error);
+                JC.hideSplashScreen?.();
             }
         }
+    }
+
+    function startInitialization(context, client) {
+        if (!context || !identity.isCurrent(context)) return Promise.resolve();
+        if (initializedEpoch === context.epoch && JC.initialized) return Promise.resolve();
+        return initializationRegistry.start(
+            context.epoch,
+            (scope) => runInitialization(context, client, scope)
+        ).catch((error) => {
+            // Cancellation is the expected completion path for an old epoch.
+            if (error?.name === 'IdentityChangedError' || error?.name === 'AbortError') return;
+            if (identity.isCurrent(context)) {
+                console.error('🪼 Jellyfin Canopy: initialization registry failure', error);
+            }
+        });
+    }
+
+    /** Initial readiness path; subsequent sign-ins enter through the host hook. */
+    async function initialize() {
+        ensureIdentityBridge();
+        if (hasServerIdMismatch()) {
+            mismatchRetryCount++;
+            if (mismatchRetryCount >= MAX_MISMATCH_RETRIES) {
+                console.warn('🪼 Jellyfin Canopy: Server ID mismatch detected - waiting for a valid host identity');
+                JC.hideSplashScreen?.();
+                return;
+            }
+            setTimeout(initialize, 300);
+            return;
+        }
+
+        if (typeof ApiClient === 'undefined' || !ApiClient.getCurrentUserId?.()) {
+            identity.transition('', null, 'initialize-signed-out');
+            if (readyRetryCount >= MAX_READY_RETRIES) {
+                console.warn('🪼 Jellyfin Canopy: ApiClient not ready after max retries - identity hook remains active');
+                JC.hideSplashScreen?.();
+                return;
+            }
+            setTimeout(initialize, nextReadyPollDelay());
+            return;
+        }
+
+        mismatchRetryCount = 0;
+        readyRetryCount = 0;
+        const client = ApiClient;
+        const context = identity.transition(
+            getClientServerId(client),
+            client.getCurrentUserId(),
+            'initialization'
+        );
+        await startInitialization(context, client);
     }
 
     // Load splash screen immediately (before main initialization)

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/arr-globals.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/arr-globals.ts
@@ -102,7 +102,7 @@ export interface ExternalLinkOptions {
  * its runtime fallback.
  */
 export interface ArrLegacyHelpers {
-    getItemCached?: (itemId: string) => Promise<unknown>;
+    getItemCached?: (itemId: string, options?: { userId?: string }) => Promise<unknown>;
     escHtml?: (s: unknown) => string;
     createExternalLink?: (url: string, options?: ExternalLinkOptions) => HTMLAnchorElement;
     createObserver?: (

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/arr-links.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/arr-links.ts
@@ -8,7 +8,7 @@ import { createObserver } from '../core/dom-observer';
 import { resolveArrLinkBase } from './url-resolve';
 import { JC } from './arr-globals';
 import type { ExternalLinkOptions } from './arr-globals';
-import type { ApiApi, ObserverProxy } from '../types/jc';
+import type { ApiApi, IdentityContext, ObserverProxy } from '../types/jc';
 
 interface ResolvedInstance {
     name: string;
@@ -67,13 +67,69 @@ interface DropdownItem {
     tip: string;
 }
 
+let arrLinksGeneration = 0;
+let arrLinksTimer: ReturnType<typeof setTimeout> | null = null;
+let arrLinksWaitResolve: (() => void) | null = null;
+let arrLinksObserver: MutationObserver | ObserverProxy | null = null;
+let arrLinksOutsideClick: ((event: MouseEvent) => void) | null = null;
+
+function removeArrLinksUi(): void {
+    document.querySelectorAll('.arr-dropdown').forEach((node) => {
+        if (node.previousSibling?.nodeType === Node.TEXT_NODE) node.previousSibling.remove();
+        node.remove();
+    });
+    document.querySelectorAll('.arr-link').forEach((node) => {
+        if (node.previousSibling?.nodeType === Node.TEXT_NODE) node.previousSibling.remove();
+        node.remove();
+    });
+}
+
+function resetArrLinks(): void {
+    arrLinksGeneration++;
+    if (arrLinksTimer) clearTimeout(arrLinksTimer);
+    arrLinksTimer = null;
+    arrLinksWaitResolve?.();
+    arrLinksWaitResolve = null;
+    arrLinksObserver?.disconnect();
+    arrLinksObserver = null;
+    JC._arrLinksObserver = null;
+    if (arrLinksOutsideClick) document.removeEventListener('click', arrLinksOutsideClick);
+    arrLinksOutsideClick = null;
+    removeArrLinksUi();
+}
+
+function isActive(context: IdentityContext, expectedGeneration: number): boolean {
+    return arrLinksGeneration === expectedGeneration && JC.identity.isCurrent(context);
+}
+
+function waitForRetry(context: IdentityContext, expectedGeneration: number, delay: number): Promise<void> {
+    return new Promise((resolve) => {
+        const finish = (): void => {
+            if (arrLinksWaitResolve === finish) arrLinksWaitResolve = null;
+            arrLinksTimer = null;
+            resolve();
+        };
+        arrLinksWaitResolve = finish;
+        arrLinksTimer = setTimeout(finish, delay);
+        if (!isActive(context, expectedGeneration)) finish();
+    });
+}
+
 JC.initializeArrLinksScript = async function () {
     const logPrefix = '🪼 Jellyfin Canopy: Arr Links:';
+
+    resetArrLinks();
 
     if (!JC?.pluginConfig?.ArrLinksEnabled) {
         console.log(`${logPrefix} Integration disabled in plugin settings.`);
         return;
     }
+
+    const capturedIdentity = JC.identity.capture();
+    if (!capturedIdentity) return;
+    const context: IdentityContext = capturedIdentity;
+    const expectedGeneration = arrLinksGeneration;
+    const client = ApiClient;
 
     // JC.core.api is assigned by src/core/api-client.ts, which the bundle
     // executes before any arr module.
@@ -92,13 +148,15 @@ JC.initializeArrLinksScript = async function () {
         const RETRY_DELAYS_MS = [500, 1000, 2000, 4000, 8000, 8000, 8000, 8000, 8000, 8000, 8000];
         for (let i = 0; !user && i <= RETRY_DELAYS_MS.length; i++) {
             try {
-                user = await ApiClient.getCurrentUser() as typeof user;
+                user = await client.getCurrentUser() as typeof user;
+                if (!isActive(context, expectedGeneration)) return;
                 if (user) break;
             } catch {
                 // swallow error, retry
             }
             if (i < RETRY_DELAYS_MS.length) {
-                await new Promise(r => setTimeout(r, RETRY_DELAYS_MS[i]));
+                await waitForRetry(context, expectedGeneration, RETRY_DELAYS_MS[i]);
+                if (!isActive(context, expectedGeneration)) return;
             }
         }
     }
@@ -116,6 +174,7 @@ JC.initializeArrLinksScript = async function () {
         if (JC?.currentSettings && JC.currentSettings.isAdmin !== isAdmin && typeof JC.saveUserSettings === 'function') {
             JC.currentSettings.isAdmin = isAdmin;
             await JC.saveUserSettings('settings.json', JC.currentSettings);
+            if (!isActive(context, expectedGeneration)) return;
             console.log(`${logPrefix} Updated admin status in settings.json: ${isAdmin}`);
         } else if (JC?.currentSettings) {
             JC.currentSettings.isAdmin = isAdmin;
@@ -145,8 +204,6 @@ JC.initializeArrLinksScript = async function () {
     }
 
     let isAddingLinks = false; // Lock to prevent concurrent runs
-    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-    let observer: MutationObserver | ObserverProxy | null = null;
     // Cache Sonarr titleSlugs + Radarr instance matches by ID. Per-session only;
     // admin must hard-reload the web client after changing instance config for
     // this cache to drop (same constraint every other JC module has today).
@@ -423,6 +480,7 @@ JC.initializeArrLinksScript = async function () {
                 // Core throws Error('HTTP <status>') on non-OK responses, which the
                 // catch below surfaces exactly like the old !resp.ok branch did.
                 const data = await api.plugin(`/arr/series-slugs?tvdbId=${encodeURIComponent(tvdbId)}`) as ArrLookupResponse;
+                if (!isActive(context, expectedGeneration)) return [];
                 // Reset the once-per-session toast guards on successful fetch so a transient
                 // failure that has since cleared up isn't permanently silenced for real
                 // future failures.
@@ -441,6 +499,7 @@ JC.initializeArrLinksScript = async function () {
                 slugCache.set(cacheKey, results);
                 return results;
             } catch (e) {
+                if (!isActive(context, expectedGeneration)) return [];
                 surfaceGlobalFailure('Sonarr', e);
                 return [];
             }
@@ -466,6 +525,7 @@ JC.initializeArrLinksScript = async function () {
                 // Core throws Error('HTTP <status>') on non-OK responses — handled
                 // by the catch below, same as the old !resp.ok branch.
                 const data = await api.plugin(`/arr/movie-instances?tmdbId=${encodeURIComponent(tmdbId)}`) as ArrLookupResponse;
+                if (!isActive(context, expectedGeneration)) return [];
                 _toastedGlobalFailure.radarr = false;  // reset on success; see Sonarr version above
                 surfaceInstanceErrors('Radarr', data.errors);
                 const matches = Array.isArray(data.matches) ? data.matches : [];
@@ -479,12 +539,14 @@ JC.initializeArrLinksScript = async function () {
                 slugCache.set(cacheKey, results);
                 return results;
             } catch (e) {
+                if (!isActive(context, expectedGeneration)) return [];
                 surfaceGlobalFailure('Radarr', e);
                 return [];
             }
         }
 
         async function addArrLinks(): Promise<void> {
+            if (!isActive(context, expectedGeneration)) return;
             if (isAddingLinks) {
                 return;
             }
@@ -515,7 +577,8 @@ JC.initializeArrLinksScript = async function () {
             // the user already left or to a different item.
             const hashAtStart = window.location.hash;
             const isStillValidTarget = (): boolean =>
-                document.contains(anchorElement)
+                isActive(context, expectedGeneration)
+                && document.contains(anchorElement)
                 && !anchorElement.closest('#itemDetailPage.hide')
                 && window.location.hash === hashAtStart;
 
@@ -531,8 +594,8 @@ JC.initializeArrLinksScript = async function () {
                 if (!itemId) return;
 
                 const item = (JC.helpers?.getItemCached
-                    ? await JC.helpers.getItemCached(itemId)
-                    : await ApiClient.getItem(ApiClient.getCurrentUserId(), itemId)) as {
+                    ? await JC.helpers.getItemCached(itemId, { userId: context.userId })
+                    : await client.getItem(client.getCurrentUserId(), itemId)) as {
                         Type?: string;
                         Name?: string;
                         ProviderIds?: Record<string, string | undefined>;
@@ -727,6 +790,7 @@ JC.initializeArrLinksScript = async function () {
             toggle.addEventListener('click', function(e) {
                 e.preventDefault();
                 e.stopPropagation();
+                if (!isActive(context, expectedGeneration)) return;
                 document.querySelectorAll('.arr-dropdown.open').forEach(d => {
                     if (d !== wrapper) d.classList.remove('open');
                 });
@@ -776,28 +840,32 @@ JC.initializeArrLinksScript = async function () {
         }
 
         // Single delegated listener for closing all arr dropdowns on outside click.
-        document.addEventListener('click', function(e) {
+        arrLinksOutsideClick = function(e: MouseEvent) {
+            if (!isActive(context, expectedGeneration)) return;
             if (!(e.target as Element | null)?.closest('.arr-dropdown')) {
                 document.querySelectorAll('.arr-dropdown.open').forEach(d => d.classList.remove('open'));
             }
-        });
+        };
+        document.addEventListener('click', arrLinksOutsideClick);
 
-        observer = createObserver('arr-links', () => {
+        arrLinksObserver = createObserver('arr-links', () => {
+            if (!isActive(context, expectedGeneration)) return;
             if (!JC?.pluginConfig?.ArrLinksEnabled) {
-                if (observer) {
-                    observer.disconnect();
+                if (arrLinksObserver) {
+                    arrLinksObserver.disconnect();
                     console.log(`${logPrefix} Observer disconnected — feature disabled`);
                 }
                 return;
             }
 
             // Debounce to avoid excessive processing on rapid DOM changes
-            if (debounceTimer) {
-                clearTimeout(debounceTimer);
+            if (arrLinksTimer) {
+                clearTimeout(arrLinksTimer);
             }
 
-            debounceTimer = setTimeout(() => {
-                void addArrLinks();
+            arrLinksTimer = setTimeout(() => {
+                arrLinksTimer = null;
+                if (isActive(context, expectedGeneration)) void addArrLinks();
             }, 100); // Wait 100ms after last mutation before processing
         }, document.body, {
             // childList + subtree is enough — Jellyfin re-renders the detail page children
@@ -809,10 +877,12 @@ JC.initializeArrLinksScript = async function () {
         });
 
         // Store observer reference for potential cleanup
-        JC._arrLinksObserver = observer;
+        JC._arrLinksObserver = arrLinksObserver;
 
         console.log(`${logPrefix} Initialized successfully`);
     } catch (err) {
         console.error(`${logPrefix} Failed to initialize`, err);
     }
 };
+
+JC.identity.registerReset('arr-links', resetArrLinks);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/arr-tag-links.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/arr-tag-links.ts
@@ -8,21 +8,52 @@ import { onBodyMutation } from '../core/dom-observer';
 import { register as registerLifecycle } from '../core/lifecycle';
 import { onNavigate, onViewPage } from '../core/navigation';
 import { JC } from './arr-globals';
+import type { IdentityContext } from '../types/jc';
+
+const arrTagLifecycle = registerLifecycle('arr-tag-links');
+let arrTagGeneration = 0;
+let arrTagTimer: ReturnType<typeof setTimeout> | null = null;
+
+function removeArrTagLinks(): void {
+    document.querySelectorAll('.arr-tag-link').forEach((link) => {
+        if (link.previousSibling?.nodeType === Node.TEXT_NODE) link.previousSibling.remove();
+        link.remove();
+    });
+}
+
+function resetArrTagLinks(): void {
+    arrTagGeneration++;
+    if (arrTagTimer) clearTimeout(arrTagTimer);
+    arrTagTimer = null;
+    arrTagLifecycle.teardown();
+    removeArrTagLinks();
+}
+
+function isActive(context: IdentityContext, expectedGeneration: number): boolean {
+    return arrTagGeneration === expectedGeneration && JC.identity.isCurrent(context);
+}
 
 // eslint-disable-next-line @typescript-eslint/require-await -- frozen contract: initializer has always been async (plugin.js Stage 6 may rely on the Promise)
 JC.initializeArrTagLinksScript = async function () {
     const logPrefix = '🪼 Jellyfin Canopy: Arr Tag Links:';
+
+    resetArrTagLinks();
 
     if (!JC?.pluginConfig?.ArrTagsShowAsLinks) {
         console.log(`${logPrefix} Tag links display disabled in plugin settings.`);
         return;
     }
 
+    const capturedIdentity = JC.identity.capture();
+    if (!capturedIdentity) return;
+    const context: IdentityContext = capturedIdentity;
+    const expectedGeneration = arrTagGeneration;
+    const client = ApiClient;
+
     console.log(`${logPrefix} Initializing...`);
 
     let isAddingLinks = false;
     const processedItems = new Set<string>(); // Track items that have been processed
-    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
     function slugifyTagName(name: string): string {
         try {
@@ -42,6 +73,7 @@ JC.initializeArrTagLinksScript = async function () {
     }
 
     async function addTagLinks(itemId: string, externalLinksContainer: Element): Promise<void> {
+        if (!isActive(context, expectedGeneration)) return;
         if (isAddingLinks) {
             return;
         }
@@ -70,7 +102,9 @@ JC.initializeArrTagLinksScript = async function () {
         try {
             const item = (JC.helpers?.getItemCached
                 ? await JC.helpers.getItemCached(itemId)
-                : await ApiClient.getItem(ApiClient.getCurrentUserId(), itemId)) as { Tags?: string[] } | null;
+                : await client.getItem(client.getCurrentUserId(), itemId)) as { Tags?: string[] } | null;
+
+            if (!isActive(context, expectedGeneration) || !externalLinksContainer.isConnected) return;
 
             if (!item?.Tags || item.Tags.length === 0) {
                 // Mark as processed even if no tags - don't keep checking
@@ -120,7 +154,7 @@ JC.initializeArrTagLinksScript = async function () {
                 return;
             }
 
-            const serverId = (ApiClient.serverId as () => string)();
+            const serverId = (client.serverId as () => string)();
 
             relevantTags.forEach(tag => {
                 externalLinksContainer.appendChild(document.createTextNode(' '));
@@ -136,6 +170,7 @@ JC.initializeArrTagLinksScript = async function () {
 
                 link.addEventListener('click', (e) => {
                     e.preventDefault();
+                    if (!isActive(context, expectedGeneration)) return;
                     const url = `list.html?type=tag&tag=${encodeURIComponent(tag)}&serverId=${serverId}`;
                     const dashboard = (window as { Dashboard?: { navigate?: (url: string) => void } }).Dashboard;
                     if (dashboard && typeof dashboard.navigate === 'function') {
@@ -182,6 +217,7 @@ JC.initializeArrTagLinksScript = async function () {
     }
 
     function checkAndAddLinks(): void {
+        if (!isActive(context, expectedGeneration)) return;
         const visiblePage = document.querySelector('#itemDetailPage:not(.hide)');
         if (visiblePage) {
             const externalLinksContainer = visiblePage.querySelector('.itemExternalLinks');
@@ -210,36 +246,50 @@ JC.initializeArrTagLinksScript = async function () {
     // cached #itemDetailPage duplicates coexist (v12-platform.md §3) and
     // getElementById returns the lowest slot — usually an old hidden one —
     // which left this gate permanently dead after two details visits.
-    const lifecycle = registerLifecycle('arr-tag-links');
-    lifecycle.track(onBodyMutation('arr-tag-links', () => {
+    arrTagLifecycle.track(onBodyMutation('arr-tag-links', () => {
+        if (!isActive(context, expectedGeneration)) return;
         if (!JC?.pluginConfig?.ArrTagsShowAsLinks) {
             return;
         }
         if (!isDetailsPageVisible()) return;
 
         // Debounce to avoid excessive processing on rapid DOM changes
-        if (debounceTimer) {
-            clearTimeout(debounceTimer);
+        if (arrTagTimer) {
+            clearTimeout(arrTagTimer);
         }
 
-        debounceTimer = setTimeout(checkAndAddLinks, 100);
+        arrTagTimer = setTimeout(() => {
+            arrTagTimer = null;
+            checkAndAddLinks();
+        }, 100);
     }));
 
     // Also check immediately on navigation — the shared deduplicated
     // pipeline covers hashchange, popstate and pushState transitions the
     // old raw hashchange listener missed — and on viewshow, which covers
     // legacy-layout cached-page re-shows. Lifecycle-tracked for teardown.
-    lifecycle.track(onNavigate(() => {
-        if (debounceTimer) clearTimeout(debounceTimer);
-        debounceTimer = setTimeout(checkAndAddLinks, 200);
+    arrTagLifecycle.track(onNavigate(() => {
+        if (arrTagTimer) clearTimeout(arrTagTimer);
+        arrTagTimer = setTimeout(() => {
+            arrTagTimer = null;
+            checkAndAddLinks();
+        }, 200);
     }));
-    lifecycle.track(onViewPage(() => {
-        if (debounceTimer) clearTimeout(debounceTimer);
-        debounceTimer = setTimeout(checkAndAddLinks, 200);
+    arrTagLifecycle.track(onViewPage(() => {
+        if (arrTagTimer) clearTimeout(arrTagTimer);
+        arrTagTimer = setTimeout(() => {
+            arrTagTimer = null;
+            checkAndAddLinks();
+        }, 200);
     }));
 
     // Run once immediately in case were already on an item detail page
-    setTimeout(checkAndAddLinks, 500);
+    arrTagTimer = setTimeout(() => {
+        arrTagTimer = null;
+        checkAndAddLinks();
+    }, 500);
 
     console.log(`${logPrefix} Initialized successfully`);
 };
+
+JC.identity.registerReset('arr-tag-links', resetArrTagLinks);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/calendar/actions.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/calendar/actions.ts
@@ -38,6 +38,8 @@ async function loadAllDataOnce(): Promise<void> {
     // Capture THIS run's signal: a new adoption replaces activeSignal, and
     // the old run must keep honoring its own (aborted) one.
     const runSignal = activeSignal;
+    const context = JC.identity.capture();
+    if (!context || runSignal?.aborted) return;
     state.isLoading = true;
     renderPage();
 
@@ -48,15 +50,15 @@ async function loadAllDataOnce(): Promise<void> {
     // First fetch calendar events (the signal aborts the request itself on
     // drain; the helpers publish nothing once aborted)
     await fetchCalendarEvents(start, end, runSignal ?? undefined);
-    if (runSignal?.aborted) return;
+    if (runSignal?.aborted || !JC.identity.isCurrent(context)) return;
 
     // Then fetch user data for those specific events
     await fetchUserData(runSignal ?? undefined);
-    if (runSignal?.aborted) return;
+    if (runSignal?.aborted || !JC.identity.isCurrent(context)) return;
 
     if (state.activeFilters.has('Requests') || state.settings.forceOnlyRequested) {
         await ensureRequestData(runSignal ?? undefined);
-        if (runSignal?.aborted) return;
+        if (runSignal?.aborted || !JC.identity.isCurrent(context)) return;
     }
 
     state.isLoading = false;
@@ -186,6 +188,8 @@ export function toggleShowUnmonitored(): void {
  * Navigate to Jellyfin item by provider IDs
  */
 async function navigateToJellyfinItem(event: CalendarEvent, options: { preferSeries?: boolean } = {}): Promise<void> {
+    const context = JC.identity.capture();
+    if (!context) return;
     const preferSeries = !!options.preferSeries;
     const isMovie = event.type === 'Movie';
 
@@ -197,22 +201,25 @@ async function navigateToJellyfinItem(event: CalendarEvent, options: { preferSer
 
     // No need to search if itemId is already provided
     if (itemId) {
+        if (!JC.identity.isCurrent(context)) return;
         window.location.hash = `#/details?id=${itemId}`;
         return;
     }
 
     if (event.itemEpisodeId && !preferSeries) {
+        if (!JC.identity.isCurrent(context)) return;
         window.location.hash = `#/details?id=${event.itemEpisodeId}`;
         return;
     }
 
     try {
         const providerItemId = await searchFromProviders(event, { preferSeries });
-        if (providerItemId) {
+        if (providerItemId && JC.identity.isCurrent(context)) {
             window.location.hash = `#/details?id=${providerItemId}`;
             return;
         }
     } catch (error) {
+        if (!JC.identity.isCurrent(context)) return;
         console.error(`${logPrefix} Navigation failed:`, error);
     }
 }
@@ -222,6 +229,51 @@ async function navigateToJellyfinItem(event: CalendarEvent, options: { preferSer
  */
 export function handleEventClick(e: MouseEvent): void {
     const target = e.target as Element | null;
+    const ownerContainer = target?.closest<HTMLElement>('#jc-calendar-container');
+    const owner = ownerContainer ? JC.identity.ownerOf(ownerContainer) : null;
+    if (!owner || !JC.identity.isCurrent(owner)) {
+        e.preventDefault();
+        e.stopPropagation();
+        e.stopImmediatePropagation();
+        return;
+    }
+
+    const viewButton = target?.closest<HTMLElement>('[data-calendar-view]');
+    if (viewButton?.dataset.calendarView) {
+        e.preventDefault();
+        e.stopPropagation();
+        e.stopImmediatePropagation();
+        setViewMode(viewButton.dataset.calendarView);
+        return;
+    }
+
+    const shiftButton = target?.closest<HTMLElement>('[data-calendar-shift]');
+    if (shiftButton?.dataset.calendarShift) {
+        e.preventDefault();
+        e.stopPropagation();
+        e.stopImmediatePropagation();
+        shiftPeriod(shiftButton.dataset.calendarShift);
+        return;
+    }
+
+    const actionButton = target?.closest<HTMLElement>('[data-calendar-action]');
+    if (actionButton?.dataset.calendarAction) {
+        e.preventDefault();
+        e.stopPropagation();
+        e.stopImmediatePropagation();
+        if (actionButton.dataset.calendarAction === 'today') goToday();
+        if (actionButton.dataset.calendarAction === 'toggle-unmonitored') toggleShowUnmonitored();
+        return;
+    }
+
+    const legendFilter = target?.closest<HTMLElement>('[data-calendar-filter]');
+    if (legendFilter?.dataset.calendarFilter) {
+        e.preventDefault();
+        e.stopPropagation();
+        e.stopImmediatePropagation();
+        toggleFilter(legendFilter.dataset.calendarFilter);
+        return;
+    }
 
     const sidebarToggle = target?.closest('.jc-calendar-sidebar-toggle');
     if (sidebarToggle) {
@@ -304,3 +356,11 @@ export function handleEventClick(e: MouseEvent): void {
     e.stopPropagation();
     void navigateToJellyfinItem(event, { preferSeries: true });
 }
+
+JC.identity.registerReset('arr-calendar-actions', () => {
+    // The in-flight promise is allowed to settle naturally; its captured
+    // identity fences every continuation. A B adoption queues one fresh pass
+    // behind it, while stale A-only queued work is discarded synchronously.
+    activeSignal = null;
+    loadQueued = false;
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/calendar/data.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/calendar/data.identity.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../arr-globals';
+import type { ApiApi } from '../../types/jc';
+
+function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((done) => { resolve = done; });
+    return { promise, resolve };
+}
+
+function requestSnapshot(tmdbId: number): Record<string, unknown> {
+    return {
+        complete: true,
+        requests: [{ tmdbId, type: 'movie' }],
+        requestKeyCount: 1,
+    };
+}
+
+describe('Calendar identity ownership', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        localStorage.clear();
+        document.body.innerHTML = '';
+        JC.identity.transition('server-a', 'user-a', 'calendar-test-start');
+        JC.pluginConfig = { SeerrEnabled: true, CalendarFilterByLibraryAccess: true };
+        JC.currentSettings = {};
+        JC.loadSettings = () => ({});
+        JC.t = (key: string) => key;
+        JC.toast = vi.fn();
+    });
+
+    it('synchronously clears A request/user projections, drops the held snapshot, and refetches for B', async () => {
+        const heldA = deferred<unknown>();
+        const plugin = vi.fn()
+            .mockImplementationOnce(() => heldA.promise)
+            .mockResolvedValueOnce(requestSnapshot(202));
+        JC.core.api = { plugin } as unknown as ApiApi;
+        const data = await import('./data');
+
+        data.state.userDataMap.set('a-event', { isFavorite: true });
+        const first = data.ensureRequestData();
+        await vi.waitFor(() => expect(plugin).toHaveBeenCalledTimes(1));
+        expect(data.state.requestedLoading).toBe(true);
+
+        JC.identity.transition('server-a', 'user-b', 'account-switch');
+        expect(data.state.userDataMap.size).toBe(0);
+        expect(data.state.requestedItems.size).toBe(0);
+        expect(data.state.requestedLoaded).toBe(false);
+        expect(data.state.requestedLoading).toBe(false);
+
+        heldA.resolve(requestSnapshot(101));
+        await first;
+        expect(data.state.requestedItems.size).toBe(0);
+        expect(data.state.requestedLoaded).toBe(false);
+
+        await data.ensureRequestData();
+        expect(plugin).toHaveBeenCalledTimes(2);
+        expect(plugin).toHaveBeenNthCalledWith(1, '/arr/request-snapshot?userOnly=true', { signal: undefined });
+        expect(plugin).toHaveBeenNthCalledWith(2, '/arr/request-snapshot?userOnly=true', { signal: undefined });
+        expect(data.state.requestedItems).toEqual(new Set(['movie:202']));
+        expect(data.state.requestedLoaded).toBe(true);
+    });
+
+    it('does not let held A calendar or user-data responses publish after B is current', async () => {
+        const heldCalendarA = deferred<unknown>();
+        const heldUserDataA = deferred<unknown>();
+        let calendarCalls = 0;
+        let userDataCalls = 0;
+        const plugin = vi.fn((path: string) => {
+            if (path.startsWith('/arr/calendar?')) {
+                calendarCalls += 1;
+                return calendarCalls === 1
+                    ? heldCalendarA.promise
+                    : Promise.resolve({ events: [{ id: 'b-event', releaseDate: '2030-01-02T00:00:00Z' }] });
+            }
+            if (path === '/arr/calendar/user-data') {
+                userDataCalls += 1;
+                return userDataCalls === 1
+                    ? heldUserDataA.promise
+                    : Promise.resolve({ results: [{ id: 'b-event', isFavorite: true }] });
+            }
+            return Promise.reject(new Error(`Unexpected path: ${path}`));
+        });
+        JC.core.api = { plugin } as unknown as ApiApi;
+        const data = await import('./data');
+        data.state.settings.highlightFavorites = true;
+        data.state.events = [{ id: 'a-event', releaseDate: '2001-01-01T00:00:00Z' }];
+
+        const calendarA = data.fetchCalendarEvents(new Date('2030-01-01'), new Date('2030-01-31'));
+        const userDataA = data.fetchUserData();
+        await vi.waitFor(() => expect(plugin).toHaveBeenCalledTimes(2));
+
+        JC.identity.transition('server-b', 'user-b', 'server-switch');
+        expect(data.state.events).toEqual([]);
+        expect(data.state.userDataMap.size).toBe(0);
+
+        heldCalendarA.resolve({ events: [{ id: 'a-event', releaseDate: '2001-01-01T00:00:00Z' }] });
+        heldUserDataA.resolve({ results: [{ id: 'a-event', isFavorite: true }] });
+        await Promise.all([calendarA, userDataA]);
+        expect(data.state.events).toEqual([]);
+        expect(data.state.userDataMap.size).toBe(0);
+
+        await data.fetchCalendarEvents(new Date('2030-01-01'), new Date('2030-01-31'));
+        data.state.settings.highlightFavorites = true;
+        await data.fetchUserData();
+        expect(data.state.events.map((event) => event.id)).toEqual(['b-event']);
+        expect(data.state.userDataMap.get('b-event')).toEqual({ isFavorite: true, isWatched: undefined });
+    });
+
+    it('adopts the legacy show-unmonitored preference once and scopes later writes by server and user', async () => {
+        const plugin = vi.fn();
+        JC.core.api = { plugin } as unknown as ApiApi;
+        const data = await import('./data');
+        const legacyKey = 'jc.calendar.showUnmonitored';
+        const aKey = `${legacyKey}:servera:usera`;
+        const bKey = `${legacyKey}:serverb:usera`;
+        localStorage.setItem(legacyKey, 'true');
+
+        data.loadSettings();
+        expect(data.state.settings.showUnmonitored).toBe(true);
+        expect(localStorage.getItem(aKey)).toBe('true');
+        expect(localStorage.getItem(legacyKey)).toBeNull();
+
+        JC.identity.transition('server-b', 'user-a', 'same-user-server-switch');
+        data.loadSettings();
+        expect(data.state.settings.showUnmonitored).toBe(false);
+        expect(localStorage.getItem(bKey)).toBeNull();
+
+        data.setStoredShowUnmonitored(false);
+        expect(localStorage.getItem(bKey)).toBe('false');
+        JC.identity.transition('server-a', 'user-a', 'switch-back');
+        data.loadSettings();
+        expect(data.state.settings.showUnmonitored).toBe(true);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/calendar/data.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/calendar/data.ts
@@ -12,7 +12,7 @@ import { renderPage } from './render-views';
 import { getEventDateKey } from './event-date';
 import { describeFetchError } from '../../core/fetch-error';
 import { IncompleteCollectionError, readCollectionItems } from '../../core/paged-collection';
-import type { ApiApi } from '../../types/jc';
+import type { ApiApi, IdentityContext } from '../../types/jc';
 
 const logPrefix = '🪼 Jellyfin Canopy: Calendar Page:';
 
@@ -97,13 +97,37 @@ interface CalendarErrorEntry {
     reason?: string;
 }
 
-const STORAGE_KEYS = {
-    showUnmonitored: 'jc.calendar.showUnmonitored',
-};
+const LEGACY_SHOW_UNMONITORED_KEY = 'jc.calendar.showUnmonitored';
+
+function currentIdentity(): IdentityContext | null {
+    const context = JC.identity.capture();
+    return context && JC.identity.isCurrent(context) ? context : null;
+}
+
+function showUnmonitoredStorageKey(context: IdentityContext): string {
+    return `${LEGACY_SHOW_UNMONITORED_KEY}:${context.serverId}:${context.userId}`;
+}
 
 function getStoredShowUnmonitored(): boolean | null {
+    const context = currentIdentity();
+    if (!context) return null;
     try {
-        const stored = window.localStorage?.getItem(STORAGE_KEYS.showUnmonitored);
+        const storage = window.localStorage;
+        const key = showUnmonitoredStorageKey(context);
+        let stored = storage?.getItem(key);
+
+        // Upgrade the old process-global preference exactly once. It has no
+        // identity metadata, so the only safe compatibility choice is to give
+        // it to the first authenticated identity that reads it, then remove it
+        // before another account/server can inherit the same value.
+        if (stored === null) {
+            const legacy = storage?.getItem(LEGACY_SHOW_UNMONITORED_KEY);
+            if (legacy === 'true' || legacy === 'false') {
+                storage?.setItem(key, legacy);
+                stored = legacy;
+            }
+        }
+        storage?.removeItem(LEGACY_SHOW_UNMONITORED_KEY);
         if (stored === null) return null;
         return stored === 'true';
     } catch {
@@ -112,8 +136,10 @@ function getStoredShowUnmonitored(): boolean | null {
 }
 
 export function setStoredShowUnmonitored(value: boolean): void {
+    const context = currentIdentity();
+    if (!context) return;
     try {
-        window.localStorage?.setItem(STORAGE_KEYS.showUnmonitored, String(!!value));
+        window.localStorage?.setItem(showUnmonitoredStorageKey(context), String(!!value));
     } catch {
         // ignore storage errors
     }
@@ -215,6 +241,8 @@ function toLocalDayKey(date: Date): string {
  * Fetch calendar events from backend
  */
 export async function fetchCalendarEvents(startDate: Date, endDate: Date, signal?: AbortSignal): Promise<unknown> {
+    const context = currentIdentity();
+    if (!context || signal?.aborted) return null;
     try {
         const query = new URLSearchParams({
             start: startDate.toISOString(),
@@ -228,6 +256,7 @@ export async function fetchCalendarEvents(startDate: Date, endDate: Date, signal
             endDay: toLocalDayKey(endDate),
         });
         const data = await api.plugin(`/arr/calendar?${query.toString()}`, { signal }) as { events?: CalendarEvent[]; errors?: CalendarErrorEntry[] };
+        if (signal?.aborted || !JC.identity.isCurrent(context)) return null;
         state.events = (data.events || []).filter((evt) => evt && evt.releaseDate);
         state.eventsError = false;
         // Surface per-instance errors from the backend envelope so a misconfigured or
@@ -237,7 +266,7 @@ export async function fetchCalendarEvents(startDate: Date, endDate: Date, signal
     } catch (error) {
         // Teardown, not failure: the adoption drained and aborted the request.
         // No state writes, no toast — the next adoption loads fresh.
-        if (signal?.aborted) return null;
+        if (signal?.aborted || !JC.identity.isCurrent(context)) return null;
         console.error(`${logPrefix} Failed to fetch calendar events:`, error);
         state.events = [];
         // A total failure has no per-instance errors[] envelope to surface, so
@@ -297,6 +326,8 @@ function surfaceCalendarErrors(errors: CalendarErrorEntry[] | undefined): void {
  * Uses POST endpoint to only check specific calendar events, not entire library
  */
 export async function fetchUserData(signal?: AbortSignal): Promise<void> {
+    const context = currentIdentity();
+    if (!context || signal?.aborted) return;
     if (!state.settings.highlightFavorites && !state.settings.highlightWatchedSeries) {
         state.userDataMap = new Map();
         return;
@@ -327,6 +358,7 @@ export async function fetchUserData(signal?: AbortSignal): Promise<void> {
             body: { events: eventsToCheck },
             signal,
         }) as { results?: { id: string; isFavorite?: boolean; isWatched?: boolean }[] };
+        if (signal?.aborted || !JC.identity.isCurrent(context)) return;
 
         // Build Map for O(1) lookup by event ID
         state.userDataMap = new Map();
@@ -339,12 +371,14 @@ export async function fetchUserData(signal?: AbortSignal): Promise<void> {
     } catch {
         // Teardown leaves the map alone; a real error clears it (highlighting
         // is optional either way).
-        if (signal?.aborted) return;
+        if (signal?.aborted || !JC.identity.isCurrent(context)) return;
         state.userDataMap = new Map();
     }
 }
 
 async function fetchUserRequests(signal?: AbortSignal): Promise<void> {
+    const context = currentIdentity();
+    if (!context || signal?.aborted) return;
     if (!JC.pluginConfig?.SeerrEnabled) {
         state.requestedItems = new Set();
         state.requestedLoaded = true;
@@ -360,7 +394,7 @@ async function fetchUserRequests(signal?: AbortSignal): Promise<void> {
         // rows from a filtered page are not a valid next offset, so the browser
         // consumes a single explicitly-complete, self-scoped snapshot instead.
         const snapshot = await api.plugin('/arr/request-snapshot?userOnly=true', { signal });
-        if (signal?.aborted) return;
+        if (signal?.aborted || !JC.identity.isCurrent(context)) return;
         if (typeof snapshot !== 'object' || snapshot === null || Array.isArray(snapshot)) {
             throw new IncompleteCollectionError('Request snapshot was not an object.');
         }
@@ -402,7 +436,7 @@ async function fetchUserRequests(signal?: AbortSignal): Promise<void> {
         state.requestedLoaded = true;
         state.requestedError = false;
     } catch (error) {
-        if (signal?.aborted) return;
+        if (signal?.aborted || !JC.identity.isCurrent(context)) return;
         console.warn(`${logPrefix} Failed to fetch user requests:`, error);
         // Never retain an old or partial projection. Keep requestedLoaded false
         // so a later refresh or Requests-filter toggle can retry the snapshot.
@@ -413,14 +447,11 @@ async function fetchUserRequests(signal?: AbortSignal): Promise<void> {
             JC.toast('⚠ ' + esc(describeFetchError(error, JC.t?.('calendar_load_error') || 'Unable to load calendar')));
         }
     } finally {
-        if (!signal?.aborted) {
-            state.requestedLoading = false;
-            renderPage();
-        } else {
-            // Teardown: publish nothing; release the loading latch so the
-            // next adoption's ensureRequestData can run afresh.
-            state.requestedLoading = false;
-        }
+        if (!JC.identity.isCurrent(context)) return;
+        // Releasing the latch is required on same-identity page teardown so a
+        // later re-adoption can refetch. Only a live adoption may render.
+        state.requestedLoading = false;
+        if (!signal?.aborted) renderPage();
     }
 }
 
@@ -520,6 +551,8 @@ export function groupEventsByDate(events: CalendarEvent[]): Record<string, Calen
  * @returns Item ID or null if not found
  */
 export async function searchFromProviders(event: CalendarEvent, options: { preferSeries?: boolean } = {}): Promise<string | null> {
+    const context = currentIdentity();
+    if (!context) return null;
     const preferSeries = !!options.preferSeries;
     const episodeProviders: Record<string, string> = {};
     const seriesProviders: Record<string, string> = {};
@@ -542,8 +575,10 @@ export async function searchFromProviders(event: CalendarEvent, options: { prefe
 
             try {
                 const itemId = await api.plugin(`/items/by-providers?${params.toString()}`) as string | null;
+                if (!JC.identity.isCurrent(context)) return null;
                 return itemId || null;
             } catch (error) {
+                if (!JC.identity.isCurrent(context)) return null;
                 // An HTTP error (e.g. 404) means "not found" — fall through to the
                 // next provider lookup, matching the pre-core `!response.ok` path.
                 if ((error as { status?: number } | null)?.status) return null;
@@ -553,6 +588,7 @@ export async function searchFromProviders(event: CalendarEvent, options: { prefe
 
         if (hasEpisodeProviders && !preferSeries) {
             const episodeItemId = await lookup(episodeProviders);
+            if (!JC.identity.isCurrent(context)) return null;
             if (episodeItemId) return episodeItemId;
         }
 
@@ -562,7 +598,46 @@ export async function searchFromProviders(event: CalendarEvent, options: { prefe
 
         return null;
     } catch (error) {
+        if (!JC.identity.isCurrent(context)) return null;
         console.error(`${logPrefix} Provider search failed:`, error);
         return null;
     }
 }
+
+/** Drop every identity-derived projection before the transition returns. */
+function resetCalendarIdentityState(): void {
+    try { state.locationUnsubscribe?.(); } catch { /* continue synchronous reset */ }
+    Object.assign(state, {
+        events: [],
+        eventsError: false,
+        isLoading: false,
+        previousPage: null,
+        currentDate: new Date(),
+        viewMode: 'agenda',
+        rangeStart: null,
+        rangeEnd: null,
+        sidebarCollapsed: null,
+        settings: {
+            firstDayOfWeek: 'Monday',
+            timeFormat: '5pm/5:30pm',
+            highlightFavorites: false,
+            highlightWatchedSeries: false,
+            showUnmonitored: false,
+            showOnlyRequested: false,
+            forceOnlyRequested: false,
+        },
+        userDataMap: new Map<string, CalendarUserData>(),
+        activeFilters: new Set<string>(),
+        filterMatchMode: 'any',
+        filterInvert: false,
+        requestedItems: new Set<string>(),
+        requestedLoaded: false,
+        requestedLoading: false,
+        requestedError: false,
+        locationSignature: null,
+        locationUnsubscribe: null,
+    });
+    _toastedCalendarErrors.clear();
+}
+
+JC.identity.registerReset('arr-calendar-data', resetCalendarIdentityState);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/calendar/page.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/calendar/page.ts
@@ -3,7 +3,7 @@
 // Calendar page descriptor + the frozen JC.calendarPage facade. All
 // lifecycle (routing, adoption, teardown) is owned by the shared pages
 // framework; this module only knows how to render calendar content into an
-// adopted host and which actions the markup's inline handlers need.
+// adopted host and which actions its scoped delegated handler needs.
 
 import { JC } from '../arr-globals';
 import { registerPage } from '../../enhanced/pages/registry';
@@ -24,6 +24,8 @@ import {
 import type { PageContext } from '../../enhanced/pages/types';
 
 function render({ host, handle, signal }: PageContext): void {
+    const context = JC.identity.capture();
+    if (!context) return;
     injectStyles();
     loadSettings();
 
@@ -36,6 +38,7 @@ function render({ host, handle, signal }: PageContext): void {
     container.className = 'jc-interior-page-top';
     container.style.paddingLeft = '0.5em';
     container.style.paddingRight = '0.5em';
+    JC.identity.own(container, context);
     primary.appendChild(container);
     content.appendChild(primary);
     host.appendChild(content);
@@ -45,7 +48,9 @@ function render({ host, handle, signal }: PageContext): void {
     // Delegated content clicks (event cards, sidebar toggle, display-mode
     // buttons) — scoped to the adopted host and drained with it, replacing
     // the old permanent document-level listener.
-    handle.addListener(host, 'click', handleEventClick as EventListener);
+    handle.addListener(host, 'click', (event: Event) => {
+        if (JC.identity.isCurrent(context)) handleEventClick(event as MouseEvent);
+    });
 
     void loadAllData(signal);
 }
@@ -60,7 +65,7 @@ registerPage({
     render
 });
 
-/** The frozen JC.calendarPage contract (e2e + inline onclick handlers). */
+/** The frozen JC.calendarPage compatibility contract (e2e + integrations). */
 export interface CalendarPageApi {
     showPage: () => void;
     refresh: () => Promise<void>;
@@ -78,8 +83,9 @@ export interface CalendarPageApi {
     updateDisplayModeButtons: () => void;
 }
 
-// The frozen public surface (e2e + inline onclick handlers in the markup).
-// showPage delegates to the framework; content actions are unchanged.
+// The frozen public surface remains for e2e/integrations. Page markup uses the
+// adoption-owned delegated listener above so detached A controls cannot resolve
+// this live facade and act on B.
 JC.calendarPage = {
     showPage: () => { openPage('calendar'); },
     refresh: loadAllData,

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/calendar/render-views.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/calendar/render-views.ts
@@ -298,28 +298,28 @@ function renderLegend(): string {
     const showRequestsFilter = !!JC.pluginConfig?.SeerrEnabled && !state.settings.forceOnlyRequested;
     const requestsLabel = JC.t?.('requests_requests') || 'Requests';
     const requestsLegend = showRequestsFilter
-        ? `<div class="jc-calendar-legend-item ${getItemClass('Requests')}" onclick="window.JellyfinCanopy.calendarPage.toggleFilter('Requests'); event.stopPropagation();">
+        ? `<div class="jc-calendar-legend-item ${getItemClass('Requests')}" data-calendar-filter="Requests">
           <span class="material-symbols-rounded" style="color: #6f63f2; font-size: 18px;">download</span>
           <span>${requestsLabel}</span>
         </div>`
         : '';
 
     const watchlistLegend = state.settings.highlightFavorites
-        ? `<div class="jc-calendar-legend-item ${getItemClass('Watchlist')}" onclick="window.JellyfinCanopy.calendarPage.toggleFilter('Watchlist'); event.stopPropagation();">
+        ? `<div class="jc-calendar-legend-item ${getItemClass('Watchlist')}" data-calendar-filter="Watchlist">
           <span class="material-symbols-rounded" style="color: #ffd700; font-size: 18px; font-variation-settings: 'FILL' 1;">bookmark</span>
           <span>${JC.t?.('calendar_watchlist')}</span>
         </div>`
         : '';
 
     const watchedLegend = state.settings.highlightWatchedSeries
-        ? `<div class="jc-calendar-legend-item ${getItemClass('Watched')}" onclick="window.JellyfinCanopy.calendarPage.toggleFilter('Watched'); event.stopPropagation();">
+        ? `<div class="jc-calendar-legend-item ${getItemClass('Watched')}" data-calendar-filter="Watched">
           <span class="material-symbols-rounded" style="color: #64b5f6; font-size: 18px;">visibility</span>
           <span>${JC.t?.('calendar_watched')}</span>
         </div>`
         : '';
 
     const hasTwoFilters = state.activeFilters.size >= 2;
-    const unmonitoredLegend = `<div class="jc-calendar-legend-item jc-calendar-unmonitored-toggle ${state.settings.showUnmonitored ? 'active' : hasActiveFilters ? 'inactive' : ''}" onclick="window.JellyfinCanopy.calendarPage.toggleShowUnmonitored(); event.stopPropagation();" style="cursor: pointer;">
+    const unmonitoredLegend = `<div class="jc-calendar-legend-item jc-calendar-unmonitored-toggle ${state.settings.showUnmonitored ? 'active' : hasActiveFilters ? 'inactive' : ''}" data-calendar-action="toggle-unmonitored" style="cursor: pointer;">
         <span class="material-symbols-rounded" style="color: #ff9800; font-size: 18px;">${state.settings.showUnmonitored ? 'visibility' : 'visibility_off'}</span>
         <span>${JC.t?.('calendar_include_unmonitored') || 'Unmonitored'}</span>
       </div>`;
@@ -335,23 +335,23 @@ function renderLegend(): string {
     return `
       <div class="jc-calendar-legend">
         ${filterControls}
-        <div class="jc-calendar-legend-item ${getItemClass('CinemaRelease')}" onclick="window.JellyfinCanopy.calendarPage.toggleFilter('CinemaRelease'); event.stopPropagation();">
+        <div class="jc-calendar-legend-item ${getItemClass('CinemaRelease')}" data-calendar-filter="CinemaRelease">
           <span class="material-symbols-rounded" style="color: ${STATUS_COLORS.CinemaRelease}; font-size: 18px;">local_movies</span>
           <span>${JC.t?.('calendar_cinema_release')}</span>
         </div>
-        <div class="jc-calendar-legend-item ${getItemClass('DigitalRelease')}" onclick="window.JellyfinCanopy.calendarPage.toggleFilter('DigitalRelease'); event.stopPropagation();">
+        <div class="jc-calendar-legend-item ${getItemClass('DigitalRelease')}" data-calendar-filter="DigitalRelease">
           <span class="material-symbols-rounded" style="color: ${STATUS_COLORS.DigitalRelease}; font-size: 18px;">ondemand_video</span>
           <span>${JC.t?.('calendar_digital_release')}</span>
         </div>
-        <div class="jc-calendar-legend-item ${getItemClass('PhysicalRelease')}" onclick="window.JellyfinCanopy.calendarPage.toggleFilter('PhysicalRelease'); event.stopPropagation();">
+        <div class="jc-calendar-legend-item ${getItemClass('PhysicalRelease')}" data-calendar-filter="PhysicalRelease">
           <span class="material-symbols-rounded" style="color: ${STATUS_COLORS.PhysicalRelease}; font-size: 18px;">album</span>
           <span>${JC.t?.('calendar_physical_release')}</span>
         </div>
-        <div class="jc-calendar-legend-item ${getItemClass('Episode')}" onclick="window.JellyfinCanopy.calendarPage.toggleFilter('Episode'); event.stopPropagation();">
+        <div class="jc-calendar-legend-item ${getItemClass('Episode')}" data-calendar-filter="Episode">
           <span class="material-symbols-rounded" style="color: ${STATUS_COLORS.Episode}; font-size: 18px;">tv_guide</span>
           <span>${JC.t?.('calendar_episode')}</span>
         </div>
-        <div class="jc-calendar-legend-item ${getItemClass('Available')}" onclick="window.JellyfinCanopy.calendarPage.toggleFilter('Available'); event.stopPropagation();">
+        <div class="jc-calendar-legend-item ${getItemClass('Available')}" data-calendar-filter="Available">
           <span class="material-symbols-rounded" style="color: #4caf50; font-size: 18px;">check_circle</span>
           <span>${JC.t?.('seerr_btn_available') || 'Available'}</span>
         </div>
@@ -393,18 +393,18 @@ export function renderPage(): void {
         <div class="jc-calendar-actions jc-calendar-actions-center">
           <div class="jc-calendar-nav">
             <div class="jc-calendar-nav-group">
-              <button class="jc-calendar-nav-btn" onclick="window.JellyfinCanopy.calendarPage.shiftPeriod('prev'); event.stopPropagation();" aria-label="${JC.t?.('calendar_prev')}">‹</button>
-              <button class="jc-calendar-nav-btn jc-calendar-nav-today" onclick="window.JellyfinCanopy.calendarPage.goToday(); event.stopPropagation();">${JC.t?.('calendar_today')}</button>
-              <button class="jc-calendar-nav-btn" onclick="window.JellyfinCanopy.calendarPage.shiftPeriod('next'); event.stopPropagation();" aria-label="${JC.t?.('calendar_next')}">›</button>
+              <button class="jc-calendar-nav-btn" data-calendar-shift="prev" aria-label="${JC.t?.('calendar_prev')}">‹</button>
+              <button class="jc-calendar-nav-btn jc-calendar-nav-today" data-calendar-action="today">${JC.t?.('calendar_today')}</button>
+              <button class="jc-calendar-nav-btn" data-calendar-shift="next" aria-label="${JC.t?.('calendar_next')}">›</button>
             </div>
           </div>
         </div>
         <div class="jc-calendar-actions jc-calendar-actions-right">
           <div class="jc-calendar-nav">
-            <button class="jc-calendar-view-btn ${state.viewMode === 'day' ? 'active' : ''}" onclick="window.JellyfinCanopy.calendarPage.setViewMode('day'); event.stopPropagation();">${JC.t?.('calendar_day') || 'Day'}</button>
-            <button class="jc-calendar-view-btn ${state.viewMode === 'week' ? 'active' : ''}" onclick="window.JellyfinCanopy.calendarPage.setViewMode('week'); event.stopPropagation();">${JC.t?.('calendar_week')}</button>
-            <button class="jc-calendar-view-btn ${state.viewMode === 'month' ? 'active' : ''}" onclick="window.JellyfinCanopy.calendarPage.setViewMode('month'); event.stopPropagation();">${JC.t?.('calendar_month')}</button>
-            <button class="jc-calendar-view-btn ${state.viewMode === 'agenda' ? 'active' : ''}" onclick="window.JellyfinCanopy.calendarPage.setViewMode('agenda'); event.stopPropagation();">${JC.t?.('calendar_agenda')}</button>
+            <button class="jc-calendar-view-btn ${state.viewMode === 'day' ? 'active' : ''}" data-calendar-view="day">${JC.t?.('calendar_day') || 'Day'}</button>
+            <button class="jc-calendar-view-btn ${state.viewMode === 'week' ? 'active' : ''}" data-calendar-view="week">${JC.t?.('calendar_week')}</button>
+            <button class="jc-calendar-view-btn ${state.viewMode === 'month' ? 'active' : ''}" data-calendar-view="month">${JC.t?.('calendar_month')}</button>
+            <button class="jc-calendar-view-btn ${state.viewMode === 'agenda' ? 'active' : ''}" data-calendar-view="agenda">${JC.t?.('calendar_agenda')}</button>
             <div class="jc-calendar-mode-toggle ${state.viewMode === 'agenda' ? 'is-disabled' : ''}" role="group" aria-label="Display mode">
               <button type="button" class="jc-calendar-mode-btn ${state.settings.displayMode === 'list' ? 'active' : ''}" title="List" aria-label="List" data-mode="list" ${state.viewMode === 'agenda' ? 'disabled aria-disabled="true"' : ''}>
                 <span class="material-icons">view_list</span>

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/identity-controls.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/identity-controls.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from './arr-globals';
+import type { ApiApi, UserSettings } from '../types/jc';
+
+const originalApi = JC.core.api;
+const originalSave = JC.saveUserSettings;
+const originalLoad = JC.loadSettings;
+let plugin: ReturnType<typeof vi.fn>;
+
+describe('Arr page control identity ownership', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        document.body.innerHTML = '';
+        JC.identity.transition('', '', 'arr-controls-logout');
+        JC.identity.transition('server-a', 'user-a', 'arr-controls-a');
+        JC.pluginConfig = {
+            CalendarPageEnabled: true,
+            DownloadsPageEnabled: true,
+            DownloadsPagePollingEnabled: false,
+            DownloadsPageShowIssues: true,
+            SeerrEnabled: true,
+            ShowDownloadsInRequests: true,
+        };
+        plugin = vi.fn().mockResolvedValue({ requests: [], results: [], totalPages: 1 });
+        JC.core.api = { plugin } as unknown as ApiApi;
+        JC.saveUserSettings = vi.fn().mockResolvedValue(undefined);
+        JC.loadSettings = vi.fn((): UserSettings => ({}));
+    });
+
+    afterEach(() => {
+        JC.core.lifecycle?.get('arr-controls-requests')?.teardown();
+        JC.core.api = originalApi;
+        JC.saveUserSettings = originalSave;
+        JC.loadSettings = originalLoad;
+        document.body.innerHTML = '';
+        vi.restoreAllMocks();
+    });
+
+    it('keeps a retained A calendar view control from persisting B settings', async () => {
+        const { state } = await import('./calendar/data');
+        const { handleEventClick } = await import('./calendar/actions');
+        const ownerA = JC.identity.capture()!;
+        const container = document.createElement('div');
+        container.id = 'jc-calendar-container';
+        JC.identity.own(container, ownerA);
+        const staleView = document.createElement('button');
+        staleView.dataset.calendarView = 'day';
+        container.appendChild(staleView);
+        document.body.appendChild(container);
+        staleView.addEventListener('click', (event) => handleEventClick(event as MouseEvent));
+
+        JC.identity.transition('server-a', 'user-b', 'arr-controls-b');
+        const ownerB = JC.identity.capture()!;
+        JC.currentSettings = JC.identity.own({ calendarDefaultViewMode: 'month' }, ownerB);
+        state.viewMode = 'month';
+        const save = JC.saveUserSettings as ReturnType<typeof vi.fn>;
+
+        staleView.click();
+
+        expect(state.viewMode).toBe('month');
+        expect(JC.currentSettings.calendarDefaultViewMode).toBe('month');
+        expect(save).not.toHaveBeenCalled();
+        expect(staleView.getAttribute('onclick')).toBeNull();
+    });
+
+    it('routes live Requests controls through one adoption and drains retained A controls', async () => {
+        await import('../core/lifecycle');
+        await import('./requests/page');
+        const { getPage } = await import('../enhanced/pages/registry');
+        const { state } = await import('./requests/data');
+        const { renderPage } = await import('./requests/render');
+        const descriptor = getPage('downloads')!;
+        const handle = JC.core.lifecycle!.register('arr-controls-requests');
+        handle.teardown();
+        const host = document.createElement('div');
+        document.body.appendChild(host);
+        const controller = new AbortController();
+        controller.abort();
+
+        await descriptor.render({ host, handle, signal: controller.signal });
+        renderPage();
+        const liveFilter = host.querySelector<HTMLButtonElement>('[data-requests-filter="pending"]')!;
+        expect(liveFilter).not.toBeNull();
+        expect(host.querySelector('[onclick]')).toBeNull();
+
+        liveFilter.click();
+        expect(state.requestsFilter).toBe('pending');
+        await Promise.resolve();
+
+        const staleFilter = liveFilter;
+        const callsBeforeSwitch = plugin.mock.calls.length;
+        handle.teardown();
+        JC.identity.transition('server-b', 'user-a', 'arr-controls-server-switch');
+        state.requestsFilter = 'all';
+
+        staleFilter.click();
+        await Promise.resolve();
+
+        expect(state.requestsFilter).toBe('all');
+        expect(plugin).toHaveBeenCalledTimes(callsBeforeSwitch);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/requests/actions.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/requests/actions.ts
@@ -2,6 +2,7 @@
 // Requests Page — user actions: downloads tab filtering/search, request and
 // issue filter tabs and pagination (split from requests-page.js).
 
+import { JC } from '../arr-globals';
 import { fetchIssues, fetchRequests, state } from './data';
 import { renderPage } from './render';
 
@@ -9,6 +10,8 @@ import { renderPage } from './render';
  * Filter downloads by status
  */
 export function filterDownloads(status: string): void {
+    const context = JC.identity.capture();
+    if (!context || !JC.identity.isCurrent(context)) return;
     state.downloadsActiveTab = status;
     state.downloadsSearchQuery = '';
     renderPage();
@@ -18,6 +21,8 @@ export function filterDownloads(status: string): void {
  * Search downloads
  */
 export function searchDownloads(query: string): void {
+    const context = JC.identity.capture();
+    if (!context || !JC.identity.isCurrent(context)) return;
     state.downloadsSearchQuery = query;
     renderPage();
 }
@@ -26,26 +31,38 @@ export function searchDownloads(query: string): void {
  * Filter requests
  */
 export function filterRequests(filter: string): void {
+    const context = JC.identity.capture();
+    if (!context || !JC.identity.isCurrent(context)) return;
     state.requestsFilter = filter;
     state.requestsPage = 1;
-    void fetchRequests().then(() => renderPage());
+    void fetchRequests().then(() => {
+        if (JC.identity.isCurrent(context)) renderPage();
+    });
 }
 
 export function filterIssues(filter: string): void {
+    const context = JC.identity.capture();
+    if (!context || !JC.identity.isCurrent(context)) return;
     if (!filter || (filter !== 'open' && filter !== 'resolved')) return;
     if (state.issuesFilter === filter) return;
     state.issuesFilter = filter;
     state.issuesPage = 1;
-    void fetchIssues().then(() => renderPage());
+    void fetchIssues().then(() => {
+        if (JC.identity.isCurrent(context)) renderPage();
+    });
 }
 
 /**
  * Next page
  */
 export function nextPage(): void {
+    const context = JC.identity.capture();
+    if (!context || !JC.identity.isCurrent(context)) return;
     if (state.requestsPage < state.requestsTotalPages) {
         state.requestsPage++;
-        void fetchRequests().then(() => renderPage());
+        void fetchRequests().then(() => {
+            if (JC.identity.isCurrent(context)) renderPage();
+        });
     }
 }
 
@@ -53,22 +70,34 @@ export function nextPage(): void {
  * Previous page
  */
 export function prevPage(): void {
+    const context = JC.identity.capture();
+    if (!context || !JC.identity.isCurrent(context)) return;
     if (state.requestsPage > 1) {
         state.requestsPage--;
-        void fetchRequests().then(() => renderPage());
+        void fetchRequests().then(() => {
+            if (JC.identity.isCurrent(context)) renderPage();
+        });
     }
 }
 
 export function nextIssuesPage(): void {
+    const context = JC.identity.capture();
+    if (!context || !JC.identity.isCurrent(context)) return;
     if (state.issuesPage < state.issuesTotalPages) {
         state.issuesPage++;
-        void fetchIssues().then(() => renderPage());
+        void fetchIssues().then(() => {
+            if (JC.identity.isCurrent(context)) renderPage();
+        });
     }
 }
 
 export function prevIssuesPage(): void {
+    const context = JC.identity.capture();
+    if (!context || !JC.identity.isCurrent(context)) return;
     if (state.issuesPage > 1) {
         state.issuesPage--;
-        void fetchIssues().then(() => renderPage());
+        void fetchIssues().then(() => {
+            if (JC.identity.isCurrent(context)) renderPage();
+        });
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/requests/data.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/requests/data.identity.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../arr-globals';
+import type { ApiApi } from '../../types/jc';
+
+function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((done) => { resolve = done; });
+    return { promise, resolve };
+}
+
+describe('Requests page identity ownership', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        document.body.innerHTML = '';
+        JC.identity.transition('server-a', 'user-a', 'requests-test-start');
+        JC.pluginConfig = {
+            SeerrEnabled: true,
+            DownloadsPageShowIssues: true,
+        };
+        JC.toast = vi.fn();
+    });
+
+    it('drops a held A response, clears A state, and refetches for B', async () => {
+        const heldA = deferred<unknown>();
+        const plugin = vi.fn()
+            .mockImplementationOnce(() => heldA.promise)
+            .mockResolvedValueOnce({ requests: [{ id: 'b-request' }], totalPages: 1 });
+        JC.core.api = { plugin } as unknown as ApiApi;
+        const { fetchRequests, state } = await import('./data');
+
+        const first = fetchRequests();
+        await vi.waitFor(() => expect(plugin).toHaveBeenCalledTimes(1));
+        JC.identity.transition('server-a', 'user-b', 'account-switch');
+        expect(state.requests).toEqual([]);
+
+        heldA.resolve({ requests: [{ id: 'a-request' }], totalPages: 1 });
+        await first;
+        expect(state.requests).toEqual([]);
+
+        await fetchRequests();
+        expect(state.requests).toEqual([{ id: 'b-request' }]);
+        expect(plugin).toHaveBeenCalledTimes(2);
+    });
+
+    it('refuses an A-owned retained approve control after B becomes current', async () => {
+        const plugin = vi.fn().mockResolvedValue({});
+        JC.core.api = { plugin } as unknown as ApiApi;
+        const { handleRequestAction } = await import('./data');
+        const contextA = JC.identity.capture();
+        const button = document.createElement('button');
+        button.setAttribute('data-request-id', '9');
+        button.setAttribute('data-source-token', 'a-token');
+        JC.identity.own(button, contextA);
+
+        JC.identity.transition('server-a', 'user-b', 'account-switch');
+        await handleRequestAction(button, 'approve');
+
+        expect(plugin).not.toHaveBeenCalled();
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/requests/data.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/requests/data.ts
@@ -10,7 +10,7 @@
 import { JC } from '../arr-globals';
 import { renderPage } from './render';
 import { describeFetchError } from '../../core/fetch-error';
-import type { ApiApi } from '../../types/jc';
+import type { ApiApi, IdentityContext } from '../../types/jc';
 
 const logPrefix = '🪼 Jellyfin Canopy: Requests Page:';
 
@@ -186,6 +186,8 @@ export const state: RequestsPageState = {
 const issueMediaCache = new Map<string, IssueMediaDetails | null>();
 const avatarObjectUrlCache = new Map<string, string>();
 const avatarFetchPromises = new Map<string, Promise<string>>();
+const avatarAbortControllers = new Map<string, AbortController>();
+const avatarFetchTokens = new Map<string, object>();
 
 /**
  * Get API authentication headers.
@@ -211,7 +213,10 @@ export function clearAvatarObjectUrlCache(includeInFlight?: boolean): void {
     // Only clear in-flight promises on page teardown, not on re-render.
     // Clearing mid-flight would cause duplicate downloads for the same avatar.
     if (includeInFlight) {
+        avatarAbortControllers.forEach((controller) => controller.abort());
+        avatarAbortControllers.clear();
         avatarFetchPromises.clear();
+        avatarFetchTokens.clear();
     }
 }
 
@@ -269,26 +274,47 @@ async function resolveProtectedAvatarUrl(avatarUrl: string): Promise<string> {
         return avatarFetchPromises.get(avatarUrl) as Promise<string>;
     }
 
+    const context = JC.identity.capture();
+    if (!context) return '';
+    const controller = new AbortController();
+    const requestToken = {};
     const fetchPromise = (async () => {
         try {
-            const response = await fetch(ApiClient.getUrl(avatarUrl), { headers: getAuthHeaders() });
+            const response = await fetch(ApiClient.getUrl(avatarUrl), {
+                headers: getAuthHeaders(),
+                signal: controller.signal
+            });
+            if (!JC.identity.isCurrent(context)) return '';
             if (!response.ok) return '';
             const blob = await response.blob();
+            if (!JC.identity.isCurrent(context)) return '';
             const objectUrl = URL.createObjectURL(blob);
+            if (!JC.identity.isCurrent(context)) {
+                URL.revokeObjectURL(objectUrl);
+                return '';
+            }
             avatarObjectUrlCache.set(avatarUrl, objectUrl);
             return objectUrl;
         } catch {
             return '';
         } finally {
-            avatarFetchPromises.delete(avatarUrl);
+            if (avatarFetchTokens.get(avatarUrl) === requestToken) {
+                avatarFetchPromises.delete(avatarUrl);
+                avatarAbortControllers.delete(avatarUrl);
+                avatarFetchTokens.delete(avatarUrl);
+            }
         }
     })();
 
     avatarFetchPromises.set(avatarUrl, fetchPromise);
+    avatarAbortControllers.set(avatarUrl, controller);
+    avatarFetchTokens.set(avatarUrl, requestToken);
     return fetchPromise;
 }
 
 export function hydrateAvatarImages(container: HTMLElement): void {
+    const context = JC.identity.capture();
+    if (!context) return;
     const avatarImgs = container.querySelectorAll<HTMLImageElement>('img.jc-request-avatar[data-avatar-src]');
     avatarImgs.forEach((img) => {
         void (async () => {
@@ -299,7 +325,7 @@ export function hydrateAvatarImages(container: HTMLElement): void {
             }
 
             const resolvedUrl = await resolveProtectedAvatarUrl(sourceUrl);
-            if (!img.isConnected) return;
+            if (!JC.identity.isCurrent(context) || !img.isConnected) return;
 
             if (!resolvedUrl) {
                 img.style.display = 'none';
@@ -321,8 +347,11 @@ export function hydrateAvatarImages(container: HTMLElement): void {
  * Fetch download queue from backend
  */
 async function fetchDownloads(signal?: AbortSignal): Promise<unknown> {
+    const context = JC.identity.capture();
+    if (!context) return null;
     try {
         const data = await api.plugin('/arr/queue', { signal }) as { items?: DownloadItem[]; errors?: ArrErrorEntry[] };
+        if (!JC.identity.isCurrent(context)) return null;
         state.downloads = data.items || [];
         // Surface per-instance queue errors so a 401 / timeout / SSRF-reject on one
         // instance doesn't silently produce a "looks empty" downloads page.
@@ -330,7 +359,7 @@ async function fetchDownloads(signal?: AbortSignal): Promise<unknown> {
         return data;
     } catch (error) {
         // Teardown, not failure: the adoption drained and aborted the request.
-        if (signal?.aborted) return null;
+        if (signal?.aborted || !JC.identity.isCurrent(context)) return null;
         console.error(`${logPrefix} Failed to fetch downloads:`, error);
         state.downloads = [];
         // A total failure (the whole /arr/queue request rejected) has no
@@ -384,6 +413,8 @@ function surfaceDownloadsErrors(errors: ArrErrorEntry[] | undefined): void {
  * Fetch requests from backend
  */
 export async function fetchRequests(signal?: AbortSignal): Promise<unknown> {
+    const context = JC.identity.capture();
+    if (!context) return null;
     try {
         const skip = (state.requestsPage - 1) * 20;
         const filter = state.requestsFilter !== 'all' ? state.requestsFilter : '';
@@ -399,6 +430,7 @@ export async function fetchRequests(signal?: AbortSignal): Promise<unknown> {
             totalPages?: number;
             canApproveRequests?: boolean;
         };
+        if (!JC.identity.isCurrent(context)) return null;
 
         state.requests = data.requests || [];
         state.requestsTotalPages = data.totalPages || 1;
@@ -407,7 +439,7 @@ export async function fetchRequests(signal?: AbortSignal): Promise<unknown> {
 
         return data;
     } catch (error) {
-        if (signal?.aborted) return null;
+        if (signal?.aborted || !JC.identity.isCurrent(context)) return null;
         console.error(`${logPrefix} Failed to fetch requests:`, error);
         state.requests = [];
         // Distinguish a backend failure (e.g. the requests proxy's 502 when
@@ -454,25 +486,28 @@ function applyIssueMediaDetails(issue: IssueItem, details: IssueMediaDetails | n
     return issue;
 }
 
-async function fetchIssueMediaDetails(mediaType: string, tmdbId: number | string | null): Promise<IssueMediaDetails | null> {
+async function fetchIssueMediaDetails(
+    mediaType: string,
+    tmdbId: number | string | null,
+    signal: AbortSignal | undefined,
+    context: IdentityContext
+): Promise<IssueMediaDetails | null> {
     if (!mediaType || !tmdbId) return null;
+    if (!JC.identity.isCurrent(context)) return null;
     const cacheKey = `${mediaType}:${tmdbId}`;
     if (issueMediaCache.has(cacheKey)) return issueMediaCache.get(cacheKey) ?? null;
 
     const path = mediaType === 'tv'
-        ? `/JellyfinCanopy/seerr/tv/${tmdbId}`
-        : `/JellyfinCanopy/seerr/movie/${tmdbId}`;
+        ? `/seerr/tv/${tmdbId}`
+        : `/seerr/movie/${tmdbId}`;
 
     try {
-        const data = await richApiClient.ajax({
-            type: 'GET',
-            url: ApiClient.getUrl(path),
-            dataType: 'json',
-            headers: { 'X-Jellyfin-User-Id': ApiClient.getCurrentUserId() },
-        }) as IssueMediaDetails | null;
+        const data = await api.plugin(path, { signal }) as IssueMediaDetails | null;
+        if (!JC.identity.isCurrent(context)) return null;
         issueMediaCache.set(cacheKey, data || null);
         return data || null;
     } catch {
+        if (signal?.aborted || !JC.identity.isCurrent(context)) return null;
         issueMediaCache.set(cacheKey, null);
         return null;
     }
@@ -482,6 +517,8 @@ async function fetchIssueMediaDetails(mediaType: string, tmdbId: number | string
  * Fetch issues from Seerr
  */
 export async function fetchIssues(signal?: AbortSignal): Promise<unknown> {
+    const context = JC.identity.capture();
+    if (!context) return null;
     if (!JC.pluginConfig?.SeerrEnabled || !JC.pluginConfig?.DownloadsPageShowIssues) {
         state.issues = [];
         state.issuesTotalPages = 1;
@@ -494,23 +531,19 @@ export async function fetchIssues(signal?: AbortSignal): Promise<unknown> {
     try {
         const skip = (state.issuesPage - 1) * 20;
         const filter = state.issuesFilter || 'open';
-        const url = richApiClient.getUrl('/JellyfinCanopy/seerr/issue', {
-            take: 20,
-            skip: skip,
-            filter: filter,
+        const query = new URLSearchParams({
+            take: '20',
+            skip: String(skip),
+            filter,
             sort: 'added',
         });
 
-        const data = await richApiClient.ajax({
-            type: 'GET',
-            url: url,
-            dataType: 'json',
-            headers: { 'X-Jellyfin-User-Id': ApiClient.getCurrentUserId() },
-        }) as {
+        const data = await api.plugin(`/seerr/issue?${query.toString()}`, { signal }) as {
             results?: IssueItem[];
             pageInfo?: { pages?: number };
             totalPages?: number;
         } | null;
+        if (!JC.identity.isCurrent(context)) return null;
 
         let issues = data?.results || [];
         if (issues.length) {
@@ -518,7 +551,7 @@ export async function fetchIssues(signal?: AbortSignal): Promise<unknown> {
                 issues.map(async (issue) => {
                     const mediaType = getIssueMediaType(issue);
                     const tmdbId = getIssueTmdbId(issue);
-                    const details = await fetchIssueMediaDetails(mediaType, tmdbId);
+                    const details = await fetchIssueMediaDetails(mediaType, tmdbId, signal, context);
                     return applyIssueMediaDetails(issue, details, mediaType);
                 })
             );
@@ -526,13 +559,13 @@ export async function fetchIssues(signal?: AbortSignal): Promise<unknown> {
 
         // richApiClient.ajax has no abort plumbing; the drain contract is
         // still honored by refusing to publish anything post-abort.
-        if (signal?.aborted) return null;
+        if (signal?.aborted || !JC.identity.isCurrent(context)) return null;
         state.issues = issues;
         state.issuesTotalPages = data?.pageInfo?.pages || data?.totalPages || 1;
         state.issuesError = false;
         return data;
     } catch (error) {
-        if (signal?.aborted) return null;
+        if (signal?.aborted || !JC.identity.isCurrent(context)) return null;
         console.error(`${logPrefix} Failed to fetch issues:`, error);
         state.issues = [];
         state.issuesTotalPages = 1;
@@ -564,11 +597,13 @@ async function loadAllDataOnce(): Promise<void> {
     // Capture THIS run's signal: a new adoption replaces activeSignal, and
     // the old run must keep honoring its own (aborted) one.
     const runSignal = activeSignal;
+    const context = JC.identity.capture();
+    if (!context) return;
     state.isLoading = true;
     renderPage();
 
     await Promise.all([fetchDownloads(runSignal ?? undefined), fetchRequests(runSignal ?? undefined), fetchIssues(runSignal ?? undefined)]);
-    if (runSignal?.aborted) return;
+    if (runSignal?.aborted || !JC.identity.isCurrent(context)) return;
 
     state.isLoading = false;
     renderPage();
@@ -597,6 +632,9 @@ export function loadAllData(signal?: AbortSignal): Promise<void> {
 }
 
 export async function handleRequestAction(btn: HTMLButtonElement, action: 'approve' | 'decline'): Promise<void> {
+    const owner = JC.identity.ownerOf(btn);
+    const context = owner || JC.identity.capture();
+    if (!context || !JC.identity.isCurrent(context)) return;
     const requestId = btn.getAttribute('data-request-id');
     const sourceToken = btn.getAttribute('data-source-token');
     if (!requestId || !sourceToken) return;
@@ -618,6 +656,7 @@ export async function handleRequestAction(btn: HTMLButtonElement, action: 'appro
             method: 'POST',
             skipRetry: true,
         });
+        if (!JC.identity.isCurrent(context)) return;
         // Static, param-free localized strings (class (a)) — no interpolation
         // reaches toast()'s innerHTML, so no escaping is required here.
         if (typeof JC.toast === 'function') {
@@ -626,8 +665,10 @@ export async function handleRequestAction(btn: HTMLButtonElement, action: 'appro
                 : (JC.t?.('requests_declined_toast') || 'Request declined'));
         }
         await fetchRequests();
+        if (!JC.identity.isCurrent(context)) return;
         renderPage();
     } catch (err) {
+        if (!JC.identity.isCurrent(context)) return;
         console.error(`${logPrefix} Failed to ${action} request ${requestId}:`, err);
         siblingButtons.forEach((b) => { b.disabled = false; });
         if (icon) icon.textContent = action === 'approve' ? 'check' : 'close';
@@ -636,3 +677,34 @@ export async function handleRequestAction(btn: HTMLButtonElement, action: 'appro
         }
     }
 }
+
+function resetRequestsIdentityState(): void {
+    if (state.searchDebounceTimer) clearTimeout(state.searchDebounceTimer);
+    Object.assign(state, {
+        downloads: [],
+        requests: [],
+        requestsPage: 1,
+        requestsTotalPages: 1,
+        requestsFilter: 'all',
+        requestsError: false,
+        canApproveRequests: false,
+        issues: [],
+        issuesPage: 1,
+        issuesTotalPages: 1,
+        issuesError: false,
+        issuesFilter: 'open',
+        issuesPermissionDenied: undefined,
+        isLoading: false,
+        downloadsActiveTab: 'all',
+        downloadsSearchQuery: '',
+        downloadsSearchVisible: false,
+        searchDebounceTimer: null,
+    });
+    activeSignal = null;
+    loadQueued = false;
+    issueMediaCache.clear();
+    _toastedDownloadsErrors.clear();
+    clearAvatarObjectUrlCache(true);
+}
+
+JC.identity.registerReset('arr-requests-data', resetRequestsIdentityState);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/requests/page.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/requests/page.ts
@@ -3,7 +3,7 @@
 // Requests page descriptor + the frozen JC.downloadsPage facade. All
 // lifecycle (routing, adoption, teardown) is owned by the shared pages
 // framework; this module only knows how to render requests content into an
-// adopted host, which actions the markup's inline handlers need, and how to
+// adopted host, which actions its scoped delegated handlers need, and how to
 // run the poll + live-nudge for the lifetime of one adoption.
 
 import { JC } from '../arr-globals';
@@ -11,7 +11,7 @@ import { registerPage } from '../../enhanced/pages/registry';
 import { openPage } from '../../enhanced/pages/router-bridge';
 import { LIVE } from '../../core/live';
 import { injectStyles } from './styles';
-import { loadAllData } from './data';
+import { clearAvatarObjectUrlCache, loadAllData, state } from './data';
 import { handleRequestsClick, renderPage, setActiveContainer } from './render';
 import {
     filterDownloads,
@@ -84,6 +84,8 @@ function startPolling(handle: LifecycleHandle): void {
 }
 
 function render({ host, handle, signal }: PageContext): void {
+    const context = JC.identity.capture();
+    if (!context) return;
     injectStyles();
 
     const content = document.createElement('div');
@@ -93,19 +95,120 @@ function render({ host, handle, signal }: PageContext): void {
     const container = document.createElement('div');
     container.id = 'jc-downloads-container';
     container.className = 'jc-interior-page-top';
+    JC.identity.own(container, context);
     primary.appendChild(container);
     content.appendChild(primary);
     host.appendChild(content);
 
     setActiveContainer(container);
     handle.track(() => setActiveContainer(null));
+    handle.track(() => clearAvatarObjectUrlCache(true));
 
-    // Delegated card-action clicks (approve / decline / watch / view-issue /
-    // card→item) — bound ONCE per adoption on the adopted host and drained with
-    // it. Binding here (never per-render) is what guarantees a single approve
-    // POST per click; it replaces both the old permanent document-level listener
-    // and render.ts's per-render container bind-once flag.
-    handle.addListener(host, 'click', handleRequestsClick);
+    const stopOwnedEvent = (event: Event): void => {
+        event.preventDefault();
+        event.stopPropagation();
+        event.stopImmediatePropagation();
+    };
+
+    // Every page control is delegated through this adoption-owned listener.
+    // Draining it leaves detached A markup with data only: there is no inline
+    // global facade lookup that can reinterpret an A click as a B action.
+    handle.addListener(host, 'click', (event: Event) => {
+        if (!JC.identity.isCurrent(context)) {
+            stopOwnedEvent(event);
+            return;
+        }
+        const target = event.target as Element | null;
+
+        const refresh = target?.closest<HTMLElement>('.jc-refresh-btn');
+        if (refresh) {
+            stopOwnedEvent(event);
+            const icon = refresh.querySelector<HTMLElement>('.material-icons');
+            if (icon) {
+                icon.style.animation = 'spin 1s linear';
+                const timeoutId = window.setTimeout(() => {
+                    if (JC.identity.isCurrent(context)) icon.style.animation = '';
+                }, 1000);
+                handle.track({ timeoutId });
+            }
+            void loadAllData(signal);
+            return;
+        }
+
+        const downloadTab = target?.closest<HTMLElement>('.jc-downloads-tab[data-tab]');
+        if (downloadTab?.dataset.tab) {
+            stopOwnedEvent(event);
+            filterDownloads(downloadTab.dataset.tab);
+            return;
+        }
+
+        if (target?.closest('.jc-downloads-search-toggle')) {
+            stopOwnedEvent(event);
+            state.downloadsSearchVisible = !state.downloadsSearchVisible;
+            if (!state.downloadsSearchVisible) state.downloadsSearchQuery = '';
+            renderPage();
+            return;
+        }
+
+        const requestsFilter = target?.closest<HTMLElement>('[data-requests-filter]');
+        if (requestsFilter?.dataset.requestsFilter) {
+            stopOwnedEvent(event);
+            filterRequests(requestsFilter.dataset.requestsFilter);
+            return;
+        }
+
+        const requestsPage = target?.closest<HTMLElement>('[data-requests-page]')?.dataset.requestsPage;
+        if (requestsPage) {
+            stopOwnedEvent(event);
+            if (requestsPage === 'next') nextPage();
+            if (requestsPage === 'prev') prevPage();
+            return;
+        }
+
+        const issuesFilter = target?.closest<HTMLElement>('[data-issues-filter]');
+        if (issuesFilter?.dataset.issuesFilter) {
+            stopOwnedEvent(event);
+            filterIssues(issuesFilter.dataset.issuesFilter);
+            return;
+        }
+
+        const issuesPage = target?.closest<HTMLElement>('[data-issues-page]')?.dataset.issuesPage;
+        if (issuesPage) {
+            stopOwnedEvent(event);
+            if (issuesPage === 'next') nextIssuesPage();
+            if (issuesPage === 'prev') prevIssuesPage();
+            return;
+        }
+
+        handleRequestsClick(event);
+    });
+
+    handle.addListener(host, 'input', (event: Event) => {
+        if (!JC.identity.isCurrent(context)) {
+            stopOwnedEvent(event);
+            return;
+        }
+        const input = (event.target as Element | null)?.closest<HTMLInputElement>('.jc-downloads-search-input');
+        if (!input) return;
+        state.downloadsSearchQuery = input.value;
+        if (state.searchDebounceTimer) clearTimeout(state.searchDebounceTimer);
+        state.searchDebounceTimer = window.setTimeout(() => {
+            if (!JC.identity.isCurrent(context)) return;
+            const currentInput = host.querySelector<HTMLInputElement>('.jc-downloads-search-input');
+            const cursorPosition = currentInput?.selectionStart ?? 0;
+            renderPage();
+            if (!JC.identity.isCurrent(context)) return;
+            const nextInput = host.querySelector<HTMLInputElement>('.jc-downloads-search-input');
+            nextInput?.focus();
+            nextInput?.setSelectionRange(cursorPosition, cursorPosition);
+        }, 300);
+    });
+    handle.track(() => {
+        if (state.searchDebounceTimer) {
+            clearTimeout(state.searchDebounceTimer);
+            state.searchDebounceTimer = null;
+        }
+    });
 
     setupLiveNudge(handle);
 
@@ -125,7 +228,7 @@ registerPage({
     render
 });
 
-/** The frozen JC.downloadsPage contract (e2e + inline onclick handlers). */
+/** The frozen JC.downloadsPage compatibility contract (e2e + integrations). */
 export interface DownloadsPageApi {
     showPage: () => void;
     refresh: () => Promise<void>;
@@ -141,8 +244,9 @@ export interface DownloadsPageApi {
     injectStyles: () => void;
 }
 
-// The frozen public surface (e2e + inline onclick handlers in the markup).
-// showPage delegates to the framework; content actions are unchanged.
+// The frozen public surface remains for e2e/integrations. Page markup uses the
+// adoption-owned delegated handlers above, so detached A controls cannot resolve
+// this live facade and act on B.
 JC.downloadsPage = {
     showPage: () => { openPage('downloads'); },
     refresh: loadAllData,

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/requests/render.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/requests/render.ts
@@ -43,6 +43,8 @@ export function setActiveContainer(container: HTMLElement | null): void {
 export function renderPage(): void {
     const container = activeContainer;
     if (!container || !container.isConnected) return;
+    const context = JC.identity.ownerOf(container);
+    if (!context || !JC.identity.isCurrent(context)) return;
 
     let html = '';
 
@@ -163,11 +165,11 @@ export function renderPage(): void {
 
         html += `
             <div class="jc-requests-tabs">
-              <button is="emby-button" type="button" class="jc-requests-tab emby-button ${state.requestsFilter === 'all' ? 'active' : ''}" onclick="window.JellyfinCanopy.downloadsPage.filterRequests('all')">${labelAll}</button>
-              <button is="emby-button" type="button" class="jc-requests-tab emby-button ${state.requestsFilter === 'pending' ? 'active' : ''}" onclick="window.JellyfinCanopy.downloadsPage.filterRequests('pending')">${labelPending}</button>
-              <button is="emby-button" type="button" class="jc-requests-tab emby-button ${state.requestsFilter === 'processing' ? 'active' : ''}" onclick="window.JellyfinCanopy.downloadsPage.filterRequests('processing')">${labelProcessing}</button>
-              <button is="emby-button" type="button" class="jc-requests-tab emby-button ${state.requestsFilter === 'comingsoon' ? 'active' : ''}" onclick="window.JellyfinCanopy.downloadsPage.filterRequests('comingsoon')">${labelComingSoon}</button>
-              <button is="emby-button" type="button" class="jc-requests-tab emby-button ${state.requestsFilter === 'available' ? 'active' : ''}" onclick="window.JellyfinCanopy.downloadsPage.filterRequests('available')">${labelAvailable}</button>
+              <button is="emby-button" type="button" class="jc-requests-tab emby-button ${state.requestsFilter === 'all' ? 'active' : ''}" data-requests-filter="all">${labelAll}</button>
+              <button is="emby-button" type="button" class="jc-requests-tab emby-button ${state.requestsFilter === 'pending' ? 'active' : ''}" data-requests-filter="pending">${labelPending}</button>
+              <button is="emby-button" type="button" class="jc-requests-tab emby-button ${state.requestsFilter === 'processing' ? 'active' : ''}" data-requests-filter="processing">${labelProcessing}</button>
+              <button is="emby-button" type="button" class="jc-requests-tab emby-button ${state.requestsFilter === 'comingsoon' ? 'active' : ''}" data-requests-filter="comingsoon">${labelComingSoon}</button>
+              <button is="emby-button" type="button" class="jc-requests-tab emby-button ${state.requestsFilter === 'available' ? 'active' : ''}" data-requests-filter="available">${labelAvailable}</button>
             </div>
           `;
 
@@ -213,9 +215,9 @@ export function renderPage(): void {
                 if (state.requestsTotalPages > 1) {
                     html += `
                         <div class="jc-pagination">
-                            <button is="emby-button" type="button" class="emby-button" onclick="window.JellyfinCanopy.downloadsPage.prevPage()" ${state.requestsPage <= 1 ? 'disabled' : ''}><span class="material-icons">chevron_left</span></button>
+                            <button is="emby-button" type="button" class="emby-button" data-requests-page="prev" ${state.requestsPage <= 1 ? 'disabled' : ''}><span class="material-icons">chevron_left</span></button>
                             <span>${Number(state.requestsPage) || 0} / ${Number(state.requestsTotalPages) || 0}</span>
-                            <button is="emby-button" type="button" class="emby-button" onclick="window.JellyfinCanopy.downloadsPage.nextPage()" ${state.requestsPage >= state.requestsTotalPages ? 'disabled' : ''}><span class="material-icons">chevron_right</span></button>
+                            <button is="emby-button" type="button" class="emby-button" data-requests-page="next" ${state.requestsPage >= state.requestsTotalPages ? 'disabled' : ''}><span class="material-icons">chevron_right</span></button>
                         </div>
                     `;
                 }
@@ -233,8 +235,8 @@ export function renderPage(): void {
         const labelResolved = (JC.t && JC.t('seerr_issue_resolved')) || 'Resolved';
         html += `
         <div class="jc-issues-tabs">
-          <button is="emby-button" type="button" class="jc-issues-tab emby-button ${state.issuesFilter === 'open' ? 'active' : ''}" onclick="window.JellyfinCanopy.downloadsPage.filterIssues('open')">${labelOpen}</button>
-          <button is="emby-button" type="button" class="jc-issues-tab emby-button ${state.issuesFilter === 'resolved' ? 'active' : ''}" onclick="window.JellyfinCanopy.downloadsPage.filterIssues('resolved')">${labelResolved}</button>
+          <button is="emby-button" type="button" class="jc-issues-tab emby-button ${state.issuesFilter === 'open' ? 'active' : ''}" data-issues-filter="open">${labelOpen}</button>
+          <button is="emby-button" type="button" class="jc-issues-tab emby-button ${state.issuesFilter === 'resolved' ? 'active' : ''}" data-issues-filter="resolved">${labelResolved}</button>
         </div>
       `;
 
@@ -262,9 +264,9 @@ export function renderPage(): void {
             if (state.issuesTotalPages > 1) {
                 html += `
             <div class="jc-pagination">
-              <button is="emby-button" type="button" class="emby-button" onclick="window.JellyfinCanopy.downloadsPage.prevIssuesPage()" ${state.issuesPage <= 1 ? 'disabled' : ''}><span class="material-icons">chevron_left</span></button>
+              <button is="emby-button" type="button" class="emby-button" data-issues-page="prev" ${state.issuesPage <= 1 ? 'disabled' : ''}><span class="material-icons">chevron_left</span></button>
               <span>${Number(state.issuesPage) || 0} / ${Number(state.issuesTotalPages) || 0}</span>
-              <button is="emby-button" type="button" class="emby-button" onclick="window.JellyfinCanopy.downloadsPage.nextIssuesPage()" ${state.issuesPage >= state.issuesTotalPages ? 'disabled' : ''}><span class="material-icons">chevron_right</span></button>
+              <button is="emby-button" type="button" class="emby-button" data-issues-page="next" ${state.issuesPage >= state.issuesTotalPages ? 'disabled' : ''}><span class="material-icons">chevron_right</span></button>
             </div>
           `;
             }
@@ -275,86 +277,14 @@ export function renderPage(): void {
 
     clearAvatarObjectUrlCache();
     container.innerHTML = html; // existing pattern from upstream — html built from escapeHtml'd values
+    container.querySelectorAll<HTMLElement>(
+        '.jc-request-approve-btn, .jc-request-decline-btn, .jc-request-watch-btn, .jc-issue-view-btn'
+    ).forEach((control) => JC.identity.own(control, context));
     hydrateAvatarImages(container);
 
-    // Add event listener for refresh button
-    const refreshBtn = container.querySelector<HTMLElement>('.jc-refresh-btn');
-    if (refreshBtn) {
-        refreshBtn.addEventListener('click', (e) => {
-            e.preventDefault();
-
-            // Add visual feedback
-            const icon = refreshBtn.querySelector<HTMLElement>('.material-icons');
-            if (icon) {
-                icon.style.animation = 'spin 1s linear';
-                setTimeout(() => {
-                    icon.style.animation = '';
-                }, 1000);
-            }
-
-            void loadAllData();
-        });
-    }
-
-    // Add event listeners for download tabs
-    const downloadTabs = container.querySelectorAll('.jc-downloads-tab');
-    downloadTabs.forEach(tab => {
-        tab.addEventListener('click', (e) => {
-            e.preventDefault();
-            const tabName = tab.getAttribute('data-tab');
-            state.downloadsActiveTab = tabName ?? 'all';
-            renderPage();
-        });
-    });
-
-    // Add event listener for search toggle button
-    const searchToggle = container.querySelector('.jc-downloads-search-toggle');
-    if (searchToggle) {
-        searchToggle.addEventListener('click', (e) => {
-            e.preventDefault();
-            state.downloadsSearchVisible = !state.downloadsSearchVisible;
-            if (!state.downloadsSearchVisible) {
-                state.downloadsSearchQuery = '';
-            }
-            renderPage();
-        });
-    }
-
-    // Add event listener for search input with debouncing
-    const searchInput = container.querySelector<HTMLInputElement>('.jc-downloads-search-input');
-    if (searchInput) {
-        searchInput.addEventListener('input', (e) => {
-            const query = (e.target as HTMLInputElement).value;
-            state.downloadsSearchQuery = query;
-
-            // Clear existing timer
-            if (state.searchDebounceTimer) {
-                clearTimeout(state.searchDebounceTimer);
-            }
-
-            // Debounce rendering to avoid losing focus
-            state.searchDebounceTimer = setTimeout(() => {
-                const currentInput = document.querySelector<HTMLInputElement>('.jc-downloads-search-input');
-                const cursorPosition = currentInput ? currentInput.selectionStart : 0;
-
-                renderPage();
-
-                // Restore focus and cursor position
-                const newInput = document.querySelector<HTMLInputElement>('.jc-downloads-search-input');
-                if (newInput) {
-                    newInput.focus();
-                    newInput.setSelectionRange(cursorPosition, cursorPosition);
-                }
-            }, 300);
-        });
-    }
-
-    // Delegated card-action clicks are NOT bound here. renderPage() runs on
-    // initial load, every poll cycle, tab switches and search input; binding a
-    // delegated approve/decline listener per render would stack listeners and
-    // fire N approve POSTs per click. The framework descriptor (page.ts) binds
-    // handleRequestsClick ONCE per adoption on the host instead — a single
-    // listener per adoption, drained on teardown (duplicate-POST fix preserved).
+    // All controls are handled by the adoption-owned delegated listeners in
+    // page.ts. renderPage() runs repeatedly; attaching descendant listeners here
+    // would both stack work and leave detached A controls live after teardown.
 }
 
 /**
@@ -366,6 +296,14 @@ export function renderPage(): void {
  */
 export function handleRequestsClick(e: Event): void {
     const target = e.target as Element | null;
+    const ownerContainer = target?.closest<HTMLElement>('#jc-downloads-container');
+    const owner = ownerContainer ? JC.identity.ownerOf(ownerContainer) : null;
+    if (!owner || !JC.identity.isCurrent(owner)) {
+        e.preventDefault();
+        e.stopPropagation();
+        e.stopImmediatePropagation();
+        return;
+    }
     const showItem = window.Emby?.Page?.showItem as ((id: string) => void) | undefined;
 
     // Handle play/watch button clicks

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/requests/requests-error-state.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/requests/requests-error-state.test.ts
@@ -25,6 +25,7 @@ describe('requests page error state', () => {
 
     beforeEach(async () => {
         vi.resetModules();
+        document.body.innerHTML = '';
         plugin = vi.fn();
         toast = vi.fn();
         const JC = window.JellyfinCanopy as unknown as Record<string, unknown>;
@@ -48,6 +49,7 @@ describe('requests page error state', () => {
         data.state.isLoading = false;
         const container = document.createElement('div');
         document.body.appendChild(container);
+        window.JellyfinCanopy.identity.own(container);
         render.setActiveContainer(container);
         render.renderPage();
         render.setActiveContainer(null);
@@ -67,6 +69,7 @@ describe('requests page error state', () => {
         data.state.isLoading = false;
         const container = document.createElement('div');
         document.body.appendChild(container);
+        window.JellyfinCanopy.identity.own(container);
         render.setActiveContainer(container);
         render.renderPage();
         render.setActiveContainer(null);
@@ -85,5 +88,21 @@ describe('requests page error state', () => {
         expect(data.state.downloads.length).toBe(0);
         expect(toast).toHaveBeenCalledTimes(1);
         expect(String(toast.mock.calls[0][0])).toContain('downloads_load_error');
+    });
+
+    it('does not repaint a retained container owned by the previous identity', () => {
+        const container = document.createElement('div');
+        container.innerHTML = '<span>account-a-sentinel</span>';
+        document.body.appendChild(container);
+        window.JellyfinCanopy.identity.own(container);
+        render.setActiveContainer(container);
+
+        const epoch = window.JellyfinCanopy.identity.getEpoch();
+        window.JellyfinCanopy.identity.transition('requests-test-server', `requests-user-${epoch}`, 'test-account-switch');
+        render.renderPage();
+        render.setActiveContainer(null);
+
+        expect(container.innerHTML).toContain('account-a-sentinel');
+        expect(container.innerHTML).not.toContain('requests_no_requests_found');
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/search/capture.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/search/capture.ts
@@ -11,6 +11,7 @@ import { JC } from '../../globals';
 import { getItemIdFromUrl } from '../../core/details-view';
 import { setCaptured, refineCapturedType, getDetailsType, cacheDetailsType } from './state';
 import { requestInject } from './menu';
+import type { IdentityContext } from '../../types/jc';
 
 interface ItemHelpers { getItemCached?(itemId: string, options?: { userId?: string }): Promise<unknown>; }
 
@@ -30,7 +31,8 @@ function captureFromCard(cardEl: Element | null): void {
  * Details more button: only the id is knowable synchronously (from the URL). Use the prefetched
  * details type if we have it; otherwise resolve it from the item cache and re-run the injector.
  */
-function captureFromDetails(): void {
+function captureFromDetails(context: IdentityContext): void {
+    if (!JC.identity.isCurrent(context)) return;
     const itemId = getItemIdFromUrl();
     if (!itemId) { setCaptured(null); return; }
 
@@ -41,6 +43,7 @@ function captureFromDetails(): void {
     const helpers = JC.helpers as ItemHelpers | undefined;
     helpers?.getItemCached?.(itemId, { userId: ApiClient.getCurrentUserId() })
         .then((item) => {
+            if (!JC.identity.isCurrent(context)) return;
             const type = (item as { Type?: string } | null)?.Type || null;
             cacheDetailsType(itemId, type);
             refineCapturedType(itemId, type);
@@ -52,14 +55,17 @@ function captureFromDetails(): void {
 /** Wires the capture-phase listeners. Returns an unregister function for lifecycle teardown. */
 export function installCapture(track: (unregister: () => void) => void): void {
     const onMousedown = (e: Event): void => {
+        const context = JC.identity.capture();
+        if (!context) return;
         const target = e.target as Element;
         const menuButton = target.closest?.('button[data-action="menu"]');
         if (menuButton) { captureFromCard(menuButton.closest('.card[data-id]') || menuButton.closest('[data-id]')); return; }
         // Details-page overflow button (legacy + modern share the class).
-        if (target.closest?.('.btnMoreCommands')) { captureFromDetails(); }
+        if (target.closest?.('.btnMoreCommands')) { captureFromDetails(context); }
     };
 
     const onContextMenu = (e: Event): void => {
+        if (!JC.identity.capture()) return;
         const target = e.target as Element;
         if (isInsideOpenMenu(target)) return;
         const card = target.closest?.('.card[data-id]');

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/search/index.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/search/index.ts
@@ -8,10 +8,11 @@
 import { JC } from '../../globals';
 import { getItemIdFromUrl } from '../../core/details-view';
 import { LIVE, on } from '../../core/live';
-import { setAdmin, searchEnabled, cacheDetailsType, getDetailsType } from './state';
+import { setAdmin, searchEnabled, cacheDetailsType, getDetailsType, resetArrSearchState } from './state';
 import { injectArrSearchStyles } from './styles';
 import { installCapture } from './capture';
-import { requestInject, injectSearchItems } from './menu';
+import { requestInject, resetSearchItems } from './menu';
+import type { IdentityContext } from '../../types/jc';
 
 /** Public surface exposed as window.JellyfinCanopy.arrSearch. */
 export interface ArrSearchApi {
@@ -34,10 +35,11 @@ let installed = false;
 interface UserWithPolicy { Policy?: { IsAdministrator?: boolean }; }
 
 /** Resolves the caller's admin flag once (cached in currentSettings, like arr-links). */
-async function resolveAdmin(): Promise<boolean> {
+async function resolveAdmin(context: IdentityContext): Promise<boolean> {
     if (JC.currentSettings?.isAdmin === true) { setAdmin(true); return true; }
     try {
         const user = await ApiClient.getCurrentUser() as UserWithPolicy;
+        if (!JC.identity.isCurrent(context)) return false;
         const admin = user?.Policy?.IsAdministrator === true;
         setAdmin(admin);
         return admin;
@@ -49,18 +51,25 @@ async function resolveAdmin(): Promise<boolean> {
 interface ItemHelpers { getItemCached?(itemId: string, options?: { userId?: string }): Promise<unknown>; }
 
 /** Caches the current details item's type so the details "…" menu can gate without a round-trip. */
-function prefetchDetailsType(): void {
+function prefetchDetailsType(context: IdentityContext): void {
+    if (!JC.identity.isCurrent(context)) return;
     const itemId = getItemIdFromUrl();
     if (!itemId || getDetailsType(itemId)) return;
     const helpers = JC.helpers as ItemHelpers | undefined;
     helpers?.getItemCached?.(itemId, { userId: ApiClient.getCurrentUserId() })
-        .then((item) => cacheDetailsType(itemId, (item as { Type?: string } | null)?.Type || null))
+        .then((item) => {
+            if (JC.identity.isCurrent(context)) {
+                cacheDetailsType(itemId, (item as { Type?: string } | null)?.Type || null);
+            }
+        })
         .catch(() => { /* details more menu simply resolves the type on demand */ });
 }
 
 async function install(): Promise<void> {
     if (installed || !searchEnabled()) return;
-    if (!await resolveAdmin()) return; // non-admins never see the items; skip the listeners entirely
+    const context = JC.identity.capture();
+    if (!context) return;
+    if (!await resolveAdmin(context) || !JC.identity.isCurrent(context)) return; // non-admins never see the items; skip the listeners entirely
     if (installed) return; // re-entrancy guard across the await
 
     installed = true;
@@ -71,8 +80,8 @@ async function install(): Promise<void> {
     lifecycle.track(JC.core.dom!.onBodyMutation('jc-arr-search-actionsheet', () => requestInject()));
 
     // Prefetch details type on every navigation (cheap, cached).
-    lifecycle.track(JC.core.navigation!.onNavigate(() => prefetchDetailsType()));
-    prefetchDetailsType();
+    lifecycle.track(JC.core.navigation!.onNavigate(() => prefetchDetailsType(context)));
+    prefetchDetailsType(context);
 }
 
 function initialize(): void {
@@ -82,15 +91,18 @@ function initialize(): void {
 function teardown(): void {
     lifecycle.teardown();
     installed = false;
+    resetArrSearchState();
+    resetSearchItems();
 }
 
 // Always listen for config hot-reload so enabling the feature mid-session installs it, and a
 // disable is reflected immediately (the injector also reads the live flag each pass).
-lifecycle.track(on(LIVE.CONFIG_CHANGED, () => {
-    if (searchEnabled()) initialize(); else injectSearchItems();
-}));
+on(LIVE.CONFIG_CHANGED, () => {
+    if (searchEnabled()) initialize(); else teardown();
+});
 
 JC.arrSearch = { initialize, teardown };
-initialize();
+JC.identity.registerReset('arr-search', teardown);
+JC.identity.registerActivate('arr-search', () => initialize());
 
 console.log('🪼 Jellyfin Canopy: arr Search: module loaded');

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/search/interactive-modal.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/search/interactive-modal.ts
@@ -30,9 +30,11 @@ export async function openInteractiveSearch(itemId: string): Promise<void> {
     try {
         ctx = await fetchContext(itemId);
     } catch (e) {
+        if (!modal.isActive()) return;
         renderCentered(modal.body, message('error', errorMessage(e)));
         return;
     }
+    if (!modal.isActive()) return;
 
     modal.setSubtitle(headerSubtitle(ctx));
 
@@ -88,6 +90,7 @@ class ReleaseView {
     }
 
     mount(): void {
+        if (!this.modal.isActive()) return;
         this.modal.body.replaceChildren(this.buildToolbar(), this.countEl, this.listEl);
         void this.load();
     }
@@ -104,28 +107,44 @@ class ReleaseView {
                 select.appendChild(opt);
             }
             select.value = this.instanceName;
-            select.addEventListener('change', () => { this.instanceName = select.value; void this.load(); });
+            select.addEventListener('change', () => {
+                if (!this.modal.isActive()) return;
+                this.instanceName = select.value;
+                void this.load();
+            });
             bar.appendChild(labeled(JC.t!('arr_search_instance'), select));
         }
 
         const filter = el('input', 'jc-arr-filter');
         filter.type = 'search';
         filter.placeholder = JC.t!('arr_search_filter_placeholder');
-        filter.addEventListener('input', () => { this.filterText = filter.value.toLowerCase(); this.renderList(); });
+        filter.addEventListener('input', () => {
+            if (!this.modal.isActive()) return;
+            this.filterText = filter.value.toLowerCase();
+            this.renderList();
+        });
         bar.appendChild(filter);
 
         const sort = el('select', 'jc-arr-select');
         for (const [value, key] of [['default', 'arr_search_sort_default'], ['size', 'arr_search_sort_size'], ['age', 'arr_search_sort_age'], ['seeders', 'arr_search_sort_seeders'], ['score', 'arr_search_sort_score']] as const) {
             const opt = el('option'); opt.value = value; opt.textContent = JC.t!(key); sort.appendChild(opt);
         }
-        sort.addEventListener('change', () => { this.sortKey = sort.value as SortKey; this.renderList(); });
+        sort.addEventListener('change', () => {
+            if (!this.modal.isActive()) return;
+            this.sortKey = sort.value as SortKey;
+            this.renderList();
+        });
         bar.appendChild(labeled(JC.t!('arr_search_sort'), sort));
 
         const rejectLabel = el('label', 'jc-arr-check');
         const reject = el('input');
         reject.type = 'checkbox';
         reject.checked = this.hideRejected;
-        reject.addEventListener('change', () => { this.hideRejected = reject.checked; this.renderList(); });
+        reject.addEventListener('change', () => {
+            if (!this.modal.isActive()) return;
+            this.hideRejected = reject.checked;
+            this.renderList();
+        });
         rejectLabel.appendChild(reject);
         rejectLabel.appendChild(document.createTextNode(JC.t!('arr_search_hide_rejected')));
         bar.appendChild(rejectLabel);
@@ -134,19 +153,20 @@ class ReleaseView {
     }
 
     private async load(): Promise<void> {
+        if (!this.modal.isActive()) return;
         const seq = ++this.loadSeq;
         const instance = this.instanceName;
         renderCentered(this.listEl, spinner());
         this.countEl.textContent = '';
         try {
             const result = await fetchReleases(this.itemId, instance);
-            if (seq !== this.loadSeq) return; // a newer instance selection superseded this load
+            if (!this.modal.isActive() || seq !== this.loadSeq) return; // a newer instance selection superseded this load
             this.loadedInstance = instance;
             if (result.error) { renderCentered(this.listEl, message('error', result.error)); return; }
             this.releases = result.releases || [];
             this.renderList();
         } catch (e) {
-            if (seq !== this.loadSeq) return;
+            if (!this.modal.isActive() || seq !== this.loadSeq) return;
             renderCentered(this.listEl, message('error', errorMessage(e)));
         }
     }
@@ -166,6 +186,7 @@ class ReleaseView {
     }
 
     private renderList(): void {
+        if (!this.modal.isActive()) return;
         const list = this.visibleReleases();
         this.countEl.textContent = JC.t!('arr_search_release_count', { count: list.length, total: this.releases.length });
         if (list.length === 0) {
@@ -223,17 +244,19 @@ class ReleaseView {
     }
 
     private async grab(release: ArrRelease, grab: HTMLButtonElement, icon: HTMLElement): Promise<void> {
-        if (grab.disabled) return;
+        if (!this.modal.isActive() || grab.disabled) return;
         grab.disabled = true;
         icon.className = 'material-icons hourglass_empty';
         try {
             await grabRelease(this.service, this.loadedInstance, release.guid, release.indexerId);
+            if (!this.modal.isActive()) return;
             grab.classList.add('jc-arr-grabbed');
             icon.className = 'material-icons check';
             // Point the admin at the existing Downloads page for progress — never force-navigate
             // (that would yank them out of the picker mid-review) and never build a second view.
             toastSuccess(downloadsPageAvailable() ? JC.t!('arr_search_grab_sent_downloads') : JC.t!('arr_search_grab_sent'));
         } catch (e) {
+            if (!this.modal.isActive()) return;
             grab.disabled = false;
             icon.className = 'material-icons download';
             toastInfo(errorMessage(e));

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/search/manage-modal.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/search/manage-modal.ts
@@ -35,12 +35,15 @@ class ManageView {
     constructor(private modal: ArrModalHandle, private itemId: string) {}
 
     async load(): Promise<void> {
+        if (!this.modal.isActive()) return;
         this.modal.body.replaceChildren(centered(spinner()));
         try {
             const [ctx, queue] = await Promise.all([fetchContext(this.itemId), fetchStatus(this.itemId).catch(() => [])]);
+            if (!this.modal.isActive()) return;
             this.ctx = ctx;
             this.queue = queue;
         } catch (e) {
+            if (!this.modal.isActive()) return;
             this.modal.body.replaceChildren(centered(message('error', errorMessage(e))));
             return;
         }
@@ -48,6 +51,7 @@ class ManageView {
     }
 
     private render(): void {
+        if (!this.modal.isActive()) return;
         const ctx = this.ctx!;
         this.modal.setSubtitle(ctx.name || '');
 
@@ -88,6 +92,7 @@ class ManageView {
     }
 
     private renderFooter(): void {
+        if (!this.modal.isActive()) return;
         const ctx = this.ctx!;
         const footer = this.modal.footer;
         footer.replaceChildren();
@@ -99,7 +104,11 @@ class ManageView {
         }
         if (downloadsPageAvailable() && this.queue.length > 0) {
             const dl = button('download', JC.t!('arr_search_view_downloads'), 'jc-arr-btn');
-            dl.addEventListener('click', () => { navigateToDownloads(); this.modal.close(); });
+            dl.addEventListener('click', () => {
+                if (!this.modal.isActive()) return;
+                navigateToDownloads();
+                this.modal.close();
+            });
             footer.appendChild(dl);
         }
     }
@@ -154,41 +163,50 @@ class ManageView {
     }
 
     private async toggleMonitor(instanceName: string, input: HTMLInputElement): Promise<void> {
+        if (!this.modal.isActive()) return;
         const wanted = input.checked;
         input.disabled = true;
         try {
             const result = await setMonitored(this.itemId, wanted, instanceName);
+            if (!this.modal.isActive()) return;
             if (result.errors.length > 0 && result.dispatched.length === 0) throw new Error(result.errors[0].reason);
             toastSuccess(wanted ? JC.t!('arr_search_monitor_on') : JC.t!('arr_search_monitor_off'));
         } catch (e) {
+            if (!this.modal.isActive()) return;
             input.checked = !wanted; // revert
             toastError(errorMessage(e));
         } finally {
-            input.disabled = false;
+            if (this.modal.isActive()) input.disabled = false;
         }
     }
 
     private async doAutoSearch(btn: HTMLButtonElement): Promise<void> {
+        if (!this.modal.isActive()) return;
         btn.disabled = true;
         try {
             const result = await autoSearch(this.itemId);
+            if (!this.modal.isActive()) return;
             reportDispatch(result.dispatched.length, result.errors.length);
         } catch (e) {
+            if (!this.modal.isActive()) return;
             toastError(errorMessage(e));
         } finally {
-            btn.disabled = false;
+            if (this.modal.isActive()) btn.disabled = false;
         }
     }
 
     private async openAddForm(service: ArrService, instanceName: string): Promise<void> {
+        if (!this.modal.isActive()) return;
         this.modal.body.replaceChildren(centered(spinner()));
         let options: ArrAddOptions;
         try {
             options = await fetchAddOptions(service, instanceName);
         } catch (e) {
+            if (!this.modal.isActive()) return;
             this.modal.body.replaceChildren(centered(message('error', errorMessage(e))));
             return;
         }
+        if (!this.modal.isActive()) return;
         if (options.error) { this.modal.body.replaceChildren(centered(message('error', options.error))); return; }
         new AddForm(this.modal, this.itemId, service, instanceName, options, () => void this.load()).render();
     }
@@ -206,6 +224,7 @@ class AddForm {
     ) {}
 
     render(): void {
+        if (!this.modal.isActive()) return;
         const form = el('div', 'jc-arr-add-form');
         form.appendChild(el('div', 'jc-arr-section-title', JC.t!('arr_search_add_to_named', { name: this.instanceName })));
 
@@ -232,7 +251,9 @@ class AddForm {
         const footer = this.modal.footer;
         footer.replaceChildren();
         const cancel = button('arrow_back', JC.t!('arr_search_cancel'), 'jc-arr-btn');
-        cancel.addEventListener('click', () => this.onDone());
+        cancel.addEventListener('click', () => {
+            if (this.modal.isActive()) this.onDone();
+        });
         const submit = button('add', JC.t!('arr_search_add'), 'jc-arr-btn-primary');
         submit.addEventListener('click', () => void this.submit(submit, {
             qualityProfileId: Number(quality.value),
@@ -246,13 +267,16 @@ class AddForm {
     }
 
     private async submit(btn: HTMLButtonElement, values: { qualityProfileId: number; rootFolderPath: string; monitored: boolean; searchOnAdd: boolean; minimumAvailability: string | null }): Promise<void> {
+        if (!this.modal.isActive()) return;
         if (!values.qualityProfileId || !values.rootFolderPath) { toastError(JC.t!('arr_search_add_missing_fields')); return; }
         btn.disabled = true;
         try {
             await addItem({ itemId: this.itemId, instanceName: this.instanceName, ...values });
+            if (!this.modal.isActive()) return;
             toastSuccess(JC.t!('arr_search_add_success', { name: this.instanceName }));
             this.onDone();
         } catch (e) {
+            if (!this.modal.isActive()) return;
             btn.disabled = false;
             toastError(errorMessage(e));
         }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/search/menu.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/search/menu.ts
@@ -16,11 +16,21 @@ import { reportDispatch } from './manage-modal';
 import { openInteractiveSearch } from './interactive-modal';
 import { openManage } from './manage-modal';
 import type { ArrService } from './types';
+import type { IdentityContext } from '../../types/jc';
 
 const SEARCH_ID = 'jc-arr-search';
 const INTERACTIVE_ID = 'jc-arr-interactive';
 const MANAGE_ID = 'jc-arr-manage';
 const ALL_IDS = [SEARCH_ID, INTERACTIVE_ID, MANAGE_ID];
+
+/** Remove action rows stamped for the previous identity (including cached sheets). */
+export function resetSearchItems(): void {
+    if (scheduledFrame !== null) cancelAnimationFrame(scheduledFrame);
+    scheduledFrame = null;
+    for (const id of ALL_IDS) {
+        document.querySelectorAll(`[data-id="${id}"]`).forEach((node) => node.remove());
+    }
+}
 
 // Native per-item action ids present in a card OR a details action sheet (details sets play:false,
 // so we also accept edit/refresh/etc.). Their presence distinguishes a real per-item menu from a
@@ -31,13 +41,17 @@ function isPerItemSheet(scroller: HTMLElement): boolean {
     return PER_ITEM_MARKERS.some((id) => scroller.querySelector(`[data-id="${id}"]`) !== null);
 }
 
-let scheduled = false;
+let scheduledFrame: number | null = null;
 
 /** rAF-coalesced injection request (also used by the body-mutation multiplexer and the capture refine). */
 export function requestInject(): void {
-    if (scheduled) return;
-    scheduled = true;
-    requestAnimationFrame(() => { scheduled = false; injectSearchItems(); });
+    if (scheduledFrame !== null) return;
+    const context = JC.identity.capture();
+    if (!context) return;
+    scheduledFrame = requestAnimationFrame(() => {
+        scheduledFrame = null;
+        if (JC.identity.isCurrent(context)) injectSearchItems();
+    });
 }
 
 function removeExisting(scroller: HTMLElement): void {
@@ -51,6 +65,8 @@ function serviceLabel(service: ArrService): string {
 
 /** Reconciles the Search items on the currently-open action sheet. Idempotent; safe to over-call. */
 export function injectSearchItems(): void {
+    const identityContext = JC.identity.capture();
+    if (!identityContext) return;
     if (!getAdmin() || !searchEnabled()) return;
 
     const scroller = getActiveActionSheetScroller();
@@ -88,20 +104,20 @@ export function injectSearchItems(): void {
     removeExisting(scroller);
 
     const items: HTMLButtonElement[] = [];
-    items.push(makeItem(scroller, ctx.itemId, SEARCH_ID, 'search', JC.t!('arr_search_action_search', { service: serviceLabel(service) }), () => {
+    items.push(makeItem(scroller, identityContext, ctx.itemId, SEARCH_ID, 'search', JC.t!('arr_search_action_search', { service: serviceLabel(service) }), () => {
         closeOpenActionSheet();
-        void runAutoSearch(ctx.itemId);
+        void runAutoSearch(identityContext, ctx.itemId);
     }));
 
     if (supportsInteractive(ctx.type)) {
-        items.push(makeItem(scroller, ctx.itemId, INTERACTIVE_ID, 'travel_explore', JC.t!('arr_search_action_interactive'), () => {
+        items.push(makeItem(scroller, identityContext, ctx.itemId, INTERACTIVE_ID, 'travel_explore', JC.t!('arr_search_action_interactive'), () => {
             closeOpenActionSheet();
             void openInteractiveSearch(ctx.itemId);
         }));
     }
 
     if (manageEnabled()) {
-        items.push(makeItem(scroller, ctx.itemId, MANAGE_ID, 'dns', JC.t!('arr_search_action_manage', { service: serviceLabel(service) }), () => {
+        items.push(makeItem(scroller, identityContext, ctx.itemId, MANAGE_ID, 'dns', JC.t!('arr_search_action_manage', { service: serviceLabel(service) }), () => {
             closeOpenActionSheet();
             void openManage(ctx.itemId);
         }));
@@ -122,22 +138,25 @@ export function injectSearchItems(): void {
     setCaptured(null);
 }
 
-function makeItem(scroller: HTMLElement, itemId: string, dataId: string, icon: string, label: string, onClick: () => void): HTMLButtonElement {
+function makeItem(scroller: HTMLElement, context: IdentityContext, itemId: string, dataId: string, icon: string, label: string, onClick: () => void): HTMLButtonElement {
     const button = buildNativeActionSheetItem(scroller, { dataId, icon, text: label });
     button.dataset.jcItemId = itemId;
     button.addEventListener('click', (e) => {
         e.preventDefault();
         e.stopPropagation();
+        if (!JC.identity.isCurrent(context)) return;
         onClick();
     });
     return button;
 }
 
-async function runAutoSearch(itemId: string): Promise<void> {
+async function runAutoSearch(context: IdentityContext, itemId: string): Promise<void> {
     try {
         const result = await autoSearch(itemId);
+        if (!JC.identity.isCurrent(context)) return;
         reportDispatch(result.dispatched.length, result.errors.length);
     } catch (e) {
+        if (!JC.identity.isCurrent(context)) return;
         toastError(errorMessage(e));
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/search/modal.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/search/modal.identity.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+import { createArrModal } from './modal';
+
+describe('arr modal identity ownership', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        JC.identity.transition('test-server-id', 'test-user-id', 'arr-modal-test-start');
+        JC.t = (key: string) => key;
+    });
+
+    afterEach(() => {
+        JC.identity.transition('test-server-id', 'test-user-id', 'arr-modal-test-cleanup');
+        document.body.innerHTML = '';
+    });
+
+    it('closes synchronously and rejects stale publication when the account changes', () => {
+        const modal = createArrModal({ title: 'Owned by A', subtitle: 'A' });
+        const onClose = vi.fn();
+        modal.onClose(onClose);
+
+        expect(modal.isActive()).toBe(true);
+        expect(document.body.contains(modal.overlay)).toBe(true);
+
+        JC.identity.transition('test-server-id', 'user-b', 'account-switch');
+
+        expect(modal.isActive()).toBe(false);
+        expect(document.body.contains(modal.overlay)).toBe(false);
+        expect(onClose).toHaveBeenCalledTimes(1);
+
+        modal.setSubtitle('must-not-publish');
+        expect(modal.dialog.textContent).not.toContain('must-not-publish');
+        modal.close();
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/search/modal.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/search/modal.ts
@@ -8,12 +8,17 @@
 
 import { JC } from '../../globals';
 import { installModalA11y, type ModalA11yHandle } from '../../core/modal-a11y';
+import type { IdentityContext } from '../../types/jc';
 
 export interface ArrModalHandle {
     overlay: HTMLElement;
     dialog: HTMLElement;
     body: HTMLElement;
     footer: HTMLElement;
+    /** Immutable account/server epoch that owns this modal. */
+    identity: IdentityContext;
+    /** False after close or as soon as the authenticated identity changes. */
+    isActive(): boolean;
     /** Sets the header subtitle text (injection-safe). */
     setSubtitle(text: string): void;
     close(): void;
@@ -21,11 +26,15 @@ export interface ArrModalHandle {
     onClose(cb: () => void): void;
 }
 
+const openModals = new Set<ArrModalHandle>();
+
 /**
  * Builds and shows an arr modal. Closes on Escape (a11y), backdrop click and the header close
  * button. Returns handles for the caller to render into `body` and place buttons in `footer`.
  */
 export function createArrModal(opts: { title: string; subtitle?: string; icon?: string }): ArrModalHandle {
+    const identity = JC.identity.capture();
+    if (!identity) throw new Error('Cannot open an arr modal without an authenticated identity');
     const overlay = document.createElement('div');
     overlay.className = 'jc-arr-modal-overlay';
 
@@ -88,6 +97,7 @@ export function createArrModal(opts: { title: string; subtitle?: string; icon?: 
     const close = (): void => {
         if (closed) return;
         closed = true;
+        openModals.delete(handle);
         try { a11y?.release(); } catch { /* already released */ }
         overlay.remove();
         for (const cb of closeCbs) { try { cb(); } catch (e) { console.warn('🪼 Jellyfin Canopy: arr modal close cb failed', e); } }
@@ -102,13 +112,23 @@ export function createArrModal(opts: { title: string; subtitle?: string; icon?: 
         onEscape: close,
     });
 
-    return {
+    const handle: ArrModalHandle = {
         overlay,
         dialog,
         body,
         footer,
-        setSubtitle: (text: string) => { subtitleEl.textContent = text; },
+        identity,
+        isActive: () => !closed && JC.identity.isCurrent(identity),
+        setSubtitle: (text: string) => {
+            if (!closed && JC.identity.isCurrent(identity)) subtitleEl.textContent = text;
+        },
         close,
         onClose: (cb: () => void) => { closeCbs.push(cb); },
     };
+    openModals.add(handle);
+    return handle;
 }
+
+JC.identity.registerReset('arr-search-modals', () => {
+    for (const modal of Array.from(openModals)) modal.close();
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/search/state.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/search/state.ts
@@ -98,3 +98,10 @@ export function cacheDetailsType(itemId: string, type: string | null): void {
 export function getDetailsType(itemId: string): string | null {
     return detailsTypes.get(itemId) ?? null;
 }
+
+/** Drop every identity-derived decision/cache before another account activates. */
+export function resetArrSearchState(): void {
+    isAdmin = false;
+    captured = null;
+    detailsTypes.clear();
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/api-client.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/api-client.test.ts
@@ -1,9 +1,64 @@
 // Unit tests for src/core/api-client.ts — the pure retry/backoff decision
 // logic and the in-flight request deduplication.
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { calculateBackoff, deduplicatedFetch, isRetryable } from './api-client';
+import { calculateBackoff, deduplicatedFetch, fetchWithRetry, isRetryable } from './api-client';
 import { JC } from '../globals';
-import type { RetryConfig } from '../types/jc';
+import type { IdentityApi, IdentityContext, RetryConfig } from '../types/jc';
+
+const originalApiClient = ApiClient;
+const originalIdentity = (JC as typeof JC & { identity?: IdentityApi }).identity;
+const originalMaxConcurrent = JC.core.api!.manager.CONFIG.concurrency.maxConcurrent;
+
+function responseJson(value: unknown): Response {
+    const text = JSON.stringify(value);
+    return {
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(text),
+        clone() { return responseJson(value); }
+    } as unknown as Response;
+}
+
+function installApiClient(userId: string, token: string, serverId = 'server-a'): JellyfinApiClient {
+    const client = {
+        ...originalApiClient,
+        serverId: () => serverId,
+        getUrl: (path: string) => `http://jellyfin.test${path}`,
+        getCurrentUserId: () => userId,
+        accessToken: () => token
+    };
+    window.ApiClient = client;
+    (globalThis as Record<string, unknown>).ApiClient = client;
+    return client;
+}
+
+function installIdentity(
+    serverId = 'server-a',
+    userId = 'user-a',
+    epoch = 1
+): { switchTo: (nextServerId: string, nextUserId: string) => IdentityContext } {
+    let current: IdentityContext = Object.freeze({ serverId, userId, epoch });
+    const identity = {
+        capture: () => current,
+        isCurrent: (candidate: IdentityContext | null | undefined) =>
+            !!candidate
+            && candidate.serverId === current.serverId
+            && candidate.userId === current.userId
+            && candidate.epoch === current.epoch
+    } as IdentityApi;
+    JC.identity = identity;
+    JC.core.identity = identity;
+    return {
+        switchTo(nextServerId: string, nextUserId: string) {
+            current = Object.freeze({
+                serverId: nextServerId,
+                userId: nextUserId,
+                epoch: current.epoch + 1
+            });
+            return current;
+        }
+    };
+}
 
 const baseConfig: RetryConfig = {
     maxAttempts: 2,
@@ -15,6 +70,19 @@ const baseConfig: RetryConfig = {
 };
 
 afterEach(() => {
+    try { JC.core.api!.manager.abortAllRequests(); } catch { /* test cleanup */ }
+    JC.core.api!.manager.clearCache();
+    JC.core.api!.manager.CONFIG.concurrency.maxConcurrent = originalMaxConcurrent;
+    window.ApiClient = originalApiClient;
+    (globalThis as Record<string, unknown>).ApiClient = originalApiClient;
+    if (originalIdentity) {
+        JC.identity = originalIdentity;
+        JC.core.identity = originalIdentity;
+    } else {
+        delete (JC as unknown as { identity?: IdentityApi }).identity;
+        delete JC.core.identity;
+    }
+    vi.useRealTimers();
     vi.restoreAllMocks();
 });
 
@@ -76,6 +144,41 @@ describe('isRetryable', () => {
 
     it('is not retryable when neither error nor status is given', () => {
         expect(isRetryable(null, undefined)).toBe(false);
+    });
+});
+
+describe('fetchWithRetry identity guard', () => {
+    it('does not dispatch another attempt after identity becomes stale during backoff', async () => {
+        vi.useFakeTimers();
+        let identityCurrent = true;
+        const staleGuard = () => {
+            if (!identityCurrent) {
+                const error = new Error('identity stale');
+                error.name = 'AbortError';
+                throw error;
+            }
+        };
+        const retryResponse = {
+            ok: false,
+            status: 503,
+            clone: () => ({ text: () => Promise.resolve('{"retry":true}') })
+        } as unknown as Response;
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(retryResponse);
+        const pending = fetchWithRetry(
+            'http://jellyfin.test/retry-identity',
+            {},
+            { ...baseConfig, jitterFactor: 0 },
+            staleGuard
+        );
+
+        await vi.advanceTimersByTimeAsync(0);
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        const rejection = expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+
+        identityCurrent = false;
+        await vi.advanceTimersByTimeAsync(baseConfig.baseDelayMs);
+        await rejection;
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
 });
 
@@ -174,20 +277,270 @@ describe('getCached / coreFetch falsy-cache sentinel', () => {
     });
 
     it('coreFetch returns a cached falsy value without hitting the network', async () => {
+        installIdentity();
+        installApiClient('user-a', 'token-a');
         const api = JC.core.api!;
         const key = 'http://jellyfin.test/falsy-endpoint';
         const fakeResponse = {
             ok: true,
             status: 200,
-            text: () => Promise.resolve('{"network":true}'),
+            text: () => Promise.resolve('false'),
             clone() { return fakeResponse; }
         } as unknown as Response;
         const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(fakeResponse);
 
-        api.manager.setCache(key, false);
+        await expect(api.fetch(key, { cacheKey: key })).resolves.toBe(false);
+        fetchSpy.mockClear();
         const result = await api.fetch(key, { cacheKey: key });
 
         expect(result).toBe(false);
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+});
+
+describe('coreFetch identity fencing', () => {
+    it('refuses same-user authentication captured from a different server before transport', async () => {
+        installIdentity('server-b', 'shared-user');
+        installApiClient('shared-user', 'server-a-token', 'server-a');
+        const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+        await expect(JC.core.api!.jf('/Users/shared-user'))
+            .rejects.toMatchObject({ name: 'AbortError' });
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not serve an A-scoped cached response after switching to B', async () => {
+        const identity = installIdentity('server-a', 'user-a');
+        installApiClient('user-a', 'token-a');
+        const fetchSpy = vi.spyOn(globalThis, 'fetch')
+            .mockResolvedValueOnce(responseJson({ owner: 'a' }))
+            .mockResolvedValueOnce(responseJson({ owner: 'b' }));
+        const api = JC.core.api!;
+        const url = 'http://jellyfin.test/shared-cache';
+
+        await expect(api.fetch(url, { cacheKey: 'shared-cache' })).resolves.toEqual({ owner: 'a' });
+
+        identity.switchTo('server-b', 'user-b');
+        installApiClient('user-b', 'token-b', 'server-b');
+        await expect(api.fetch(url, { cacheKey: 'shared-cache' })).resolves.toEqual({ owner: 'b' });
+
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('rejects an A cache hit when logout switches identity before its promise settles', async () => {
+        const identity = installIdentity('server-a', 'user-a');
+        installApiClient('user-a', 'token-a');
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(responseJson({ owner: 'a' }));
+        const api = JC.core.api!;
+        const url = 'http://jellyfin.test/cached-before-logout';
+        await api.fetch(url, { cacheKey: 'cached-before-logout' });
+        fetchSpy.mockClear();
+
+        const cachedA = api.fetch(url, { cacheKey: 'cached-before-logout' });
+        identity.switchTo('server-b', 'user-b');
+
+        await expect(cachedA).rejects.toMatchObject({ name: 'AbortError' });
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('rejects a deferred A response after B activates and never publishes it to cache', async () => {
+        const identity = installIdentity('server-a', 'user-a');
+        installApiClient('user-a', 'token-a');
+        let resolveA!: (response: Response) => void;
+        const fetchSpy = vi.spyOn(globalThis, 'fetch')
+            .mockImplementationOnce(() => new Promise<Response>((resolve) => { resolveA = resolve; }))
+            .mockResolvedValueOnce(responseJson({ owner: 'b' }));
+        const api = JC.core.api!;
+        const url = 'http://jellyfin.test/deferred-owner';
+        const staleA = api.fetch(url, { cacheKey: 'deferred-owner', skipRetry: true });
+        await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+
+        identity.switchTo('server-b', 'user-b');
+        installApiClient('user-b', 'token-b', 'server-b');
+        api.manager.abortAllRequests();
+        resolveA(responseJson({ owner: 'a' }));
+
+        await expect(staleA).rejects.toMatchObject({ name: 'AbortError' });
+        expect(api.manager.getCached('server-a:user-a:1:deferred-owner')).toBeUndefined();
+        await expect(api.fetch(url, { cacheKey: 'deferred-owner', skipRetry: true }))
+            .resolves.toEqual({ owner: 'b' });
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('actively rejects queued A work so it never dispatches with B authentication', async () => {
+        const identity = installIdentity('server-a', 'user-a');
+        installApiClient('user-a', 'token-a');
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((
+            _url: RequestInfo | URL,
+            init?: RequestInit
+        ) =>
+            new Promise<Response>((_resolve, reject) => {
+                const rejectAbort = () => {
+                    const error = new Error('aborted');
+                    error.name = 'AbortError';
+                    reject(error);
+                };
+                if (init?.signal?.aborted) rejectAbort();
+                else init?.signal?.addEventListener('abort', rejectAbort, { once: true });
+            })
+        );
+        const api = JC.core.api!;
+        const requests = Array.from({ length: 9 }, (_, index) =>
+            api.fetch(`http://jellyfin.test/queue-${index}`, {
+                cacheKey: `queue-${index}`,
+                skipRetry: true
+            })
+        );
+        await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(8));
+
+        identity.switchTo('server-b', 'user-b');
+        installApiClient('user-b', 'token-b', 'server-b');
+        api.manager.abortAllRequests();
+
+        const results = await Promise.allSettled(requests);
+        expect(results).toHaveLength(9);
+        expect(results.every((result) => result.status === 'rejected')).toBe(true);
+        expect(fetchSpy).toHaveBeenCalledTimes(8);
+    });
+
+    it('scopes logical page-controller keys to the captured identity epoch', () => {
+        const identity = installIdentity('server-a', 'user-a');
+        const api = JC.core.api!;
+        const aSignal = api.manager.getAbortSignal('details-page');
+
+        identity.switchTo('server-b', 'user-b');
+        const bSignal = api.manager.getAbortSignal('details-page');
+
+        expect(aSignal.aborted).toBe(false);
+        expect(bSignal.aborted).toBe(false);
+        api.manager.abortAllRequests();
+        expect(aSignal.aborted).toBe(true);
+        expect(bSignal.aborted).toBe(true);
+    });
+
+    it('captures B auth headers before a B request enters the queue', async () => {
+        installIdentity('server-b', 'user-b');
+        const client = installApiClient('user-b', 'token-b', 'server-b');
+        const api = JC.core.api!;
+        api.manager.CONFIG.concurrency.maxConcurrent = 1;
+
+        let releaseBlocker!: (response: Response) => void;
+        const fetchSpy = vi.spyOn(globalThis, 'fetch')
+            .mockImplementationOnce(() => new Promise<Response>((resolve) => { releaseBlocker = resolve; }))
+            .mockResolvedValueOnce(responseJson({ ok: true }));
+
+        const blocker = api.fetch('http://jellyfin.test/blocker', {
+            auth: false,
+            skipRetry: true
+        });
+        await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+
+        const queued = api.fetch('http://jellyfin.test/auth-capture', { skipRetry: true });
+        client.getCurrentUserId = () => 'mutated-user';
+        client.accessToken = () => 'mutated-token';
+        releaseBlocker(responseJson({ released: true }));
+
+        await blocker;
+        await expect(queued).resolves.toEqual({ ok: true });
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+        const secondInit = fetchSpy.mock.calls[1]?.[1];
+        expect(secondInit?.headers).toMatchObject({
+            'X-Jellyfin-User-Id': 'user-b',
+            'Authorization': 'MediaBrowser Token="token-b"'
+        });
+    });
+
+    it('removes case-variant caller auth headers and sends only captured credentials', async () => {
+        installIdentity('server-b', 'user-b');
+        installApiClient('user-b', 'token-b', 'server-b');
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(responseJson({ ok: true }));
+
+        await JC.core.api!.fetch('http://jellyfin.test/header-merge', {
+            headers: {
+                authorization: 'MediaBrowser Token="attacker-lower"',
+                AUTHORIZATION: 'MediaBrowser Token="attacker-upper"',
+                'x-jellyfin-user-id': 'attacker-lower',
+                'X-JELLYFIN-USER-ID': 'attacker-upper',
+                'X-Caller-Header': 'preserved'
+            },
+            skipRetry: true
+        });
+
+        const initHeaders = fetchSpy.mock.calls[0]?.[1]?.headers as Record<string, string>;
+        expect(initHeaders).toMatchObject({
+            Authorization: 'MediaBrowser Token="token-b"',
+            'X-Jellyfin-User-Id': 'user-b',
+            'X-Caller-Header': 'preserved'
+        });
+        expect(Object.entries(initHeaders)
+            .filter(([key]) => key.toLowerCase() === 'authorization'))
+            .toEqual([['Authorization', 'MediaBrowser Token="token-b"']]);
+        expect(Object.entries(initHeaders)
+            .filter(([key]) => key.toLowerCase() === 'x-jellyfin-user-id'))
+            .toEqual([['X-Jellyfin-User-Id', 'user-b']]);
+    });
+
+    it('does not deduplicate another caller onto a timeout-owned transport', async () => {
+        installIdentity('server-a', 'user-a');
+        installApiClient('user-a', 'token-a', 'server-a');
+        const releases: Array<(response: Response) => void> = [];
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+            new Promise<Response>((resolve) => { releases.push(resolve); })
+        );
+        const options = { cacheKey: 'timeout-isolation', skipRetry: true } as const;
+
+        const timed = JC.core.api!.fetch('http://jellyfin.test/timeout-isolation', {
+            ...options,
+            timeoutMs: 5_000
+        });
+        await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+        const untimed = JC.core.api!.fetch('http://jellyfin.test/timeout-isolation', options);
+        await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2));
+
+        releases[0](responseJson({ transport: 'timed' }));
+        releases[1](responseJson({ transport: 'untimed' }));
+        await expect(timed).resolves.toEqual({ transport: 'timed' });
+        await expect(untimed).resolves.toEqual({ transport: 'untimed' });
+    });
+
+    it('fails closed when the canonical authenticated server is unresolved', async () => {
+        installIdentity('unknown-server', 'user-a');
+        installApiClient('user-a', 'token-a', 'unknown-server');
+        const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+        await expect(JC.core.api!.fetch('http://jellyfin.test/unresolved-server'))
+            .rejects.toMatchObject({ name: 'AbortError' });
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('accepts getUrl origin as the concrete server fallback', async () => {
+        installIdentity('http://jellyfin.test', 'user-a');
+        const getUrl = vi.fn((path: string) => `http://jellyfin.test${path}`);
+        const client = {
+            ...originalApiClient,
+            serverId: () => 'unknown-server',
+            getUrl,
+            getCurrentUserId: () => 'user-a',
+            accessToken: () => 'token-a'
+        } as JellyfinApiClient;
+        window.ApiClient = client;
+        (globalThis as Record<string, unknown>).ApiClient = client;
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(responseJson({ ok: true }));
+
+        await expect(JC.core.api!.jf('/origin-fallback', { skipRetry: true }))
+            .resolves.toEqual({ ok: true });
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect(getUrl).toHaveBeenCalledWith('/');
+    });
+
+    it('rejects authenticated work when no identity is active', async () => {
+        delete (JC as unknown as { identity?: IdentityApi }).identity;
+        delete JC.core.identity;
+        installApiClient('user-a', 'token-a');
+        const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+        await expect(JC.core.api!.fetch('http://jellyfin.test/no-identity'))
+            .rejects.toMatchObject({ name: 'AbortError' });
         expect(fetchSpy).not.toHaveBeenCalled();
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/api-client.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/api-client.ts
@@ -22,6 +22,7 @@ import type {
     ApiClientConfig,
     CoreFetchOptions,
     HttpError,
+    IdentityContext,
     RequestManagerApi,
     RequestMetric,
     RetryConfig,
@@ -61,9 +62,20 @@ const responseCache = new Map<string, { data: unknown; timestamp: number }>();
 // AbortController management per page/context
 const activeControllers = new Map<string, AbortController>();
 
+// Every coreFetch owns a controller, even when its caller did not supply one.
+// This makes document-wide navigation / identity resets able to abort all
+// active transport work rather than merely dropping its eventual result.
+const activeRequestControllers = new Set<AbortController>();
+
 // Concurrency control
 let activeCount = 0;
-const pendingQueue: Array<() => void> = [];
+interface ConcurrencyJob {
+    readonly context: IdentityContext | null;
+    start(): void;
+    cancel(error: Error): void;
+}
+const pendingQueue: ConcurrencyJob[] = [];
+const activeJobs = new Set<ConcurrencyJob>();
 
 // Metrics (debug-gated)
 const metrics = {
@@ -71,6 +83,67 @@ const metrics = {
     sections: new Map<string, SectionMetrics>(),
     requests: [] as RequestMetric[]
 };
+
+const IDENTITY_STALE_CODE = 'JC_IDENTITY_STALE';
+
+/**
+ * Abort-shaped identity error. Keeping `name === AbortError` is important:
+ * fetchWithRetry must never replay an A request after B has become current.
+ */
+function identityStaleError(message = 'Request identity is stale'): Error {
+    const error = new Error(message) as Error & { code?: string };
+    error.name = 'AbortError';
+    error.code = IDENTITY_STALE_CODE;
+    return error;
+}
+
+function snapshotIdentity(required: boolean): IdentityContext | null {
+    const captured = JC.identity?.capture?.() ?? null;
+    if (!captured) {
+        if (required) {
+            throw identityStaleError('Authenticated request requires an active Jellyfin identity');
+        }
+        return null;
+    }
+    // Do not trust a participant to retain a mutable controller-owned object.
+    // Each request carries its own immutable value snapshot.
+    return Object.freeze({
+        serverId: captured.serverId,
+        userId: captured.userId,
+        epoch: captured.epoch
+    });
+}
+
+function assertIdentityCurrent(
+    context: IdentityContext | null,
+    signal?: AbortSignal,
+    required = false
+): void {
+    if (signal?.aborted) {
+        throw identityStaleError('Request was aborted');
+    }
+    if (!context) {
+        if (required) {
+            throw identityStaleError('Authenticated request requires an active Jellyfin identity');
+        }
+        // Anonymous work may run before sign-in, but it must not publish after
+        // an authenticated owner appears.
+        if (JC.identity?.capture?.()) {
+            throw identityStaleError();
+        }
+        return;
+    }
+    if (!JC.identity?.isCurrent?.(context)) {
+        throw identityStaleError();
+    }
+}
+
+function scopedKey(key: string, context: IdentityContext | null): string {
+    const prefix = context
+        ? `${encodeURIComponent(context.serverId)}:${encodeURIComponent(context.userId)}:${context.epoch}`
+        : 'anonymous:anonymous:0';
+    return `${prefix}:${key}`;
+}
 
 /**
  * Sleep utility with jitter support
@@ -106,13 +179,16 @@ export function isRetryable(error: unknown, status?: number): boolean {
 export async function fetchWithRetry(
     url: string,
     options: RequestInit = {},
-    retryConfig: RetryConfig = CONFIG.retry
+    retryConfig: RetryConfig = CONFIG.retry,
+    requestGuard?: () => void
 ): Promise<Response> {
     const startTime = performance.now();
     let lastError: unknown;
     let lastStatus: number | undefined;
 
     for (let attempt = 1; attempt <= retryConfig.maxAttempts; attempt++) {
+        requestGuard?.();
+
         // Check time budget
         if (performance.now() - startTime > retryConfig.timeoutBudgetMs) {
             throw new Error(`Time budget exceeded (${retryConfig.timeoutBudgetMs}ms)`);
@@ -127,6 +203,7 @@ export async function fetchWithRetry(
 
         try {
             const response = await fetch(url, options);
+            requestGuard?.();
 
             if (response.ok) {
                 if (metrics.enabled) {
@@ -148,11 +225,15 @@ export async function fetchWithRetry(
             // Capture body so callers can read structured error details (e.g. quota messages).
             try {
                 const text = await response.clone().text();
+                requestGuard?.();
                 if (text) {
                     httpError.responseText = text;
                     try {
+                        requestGuard?.();
                         httpError.responseJSON = JSON.parse(text);
+                        requestGuard?.();
                     } catch (e) {
+                        if ((e as Error)?.name === 'AbortError') throw e;
                         // Body wasn't JSON (Seerr HTML challenge page, etc) — keep responseText.
                         console.debug(`${logPrefix} Error body not JSON:`, (e as Error).message);
                     }
@@ -186,6 +267,7 @@ export async function fetchWithRetry(
                 console.debug(`${logPrefix} Retry ${attempt}/${retryConfig.maxAttempts} for ${url} in ${delay}ms`);
             }
             await sleep(delay);
+            requestGuard?.();
         }
     }
 
@@ -231,30 +313,107 @@ export function deduplicatedFetch<T>(key: string, fetchFn: () => Promise<T>, sig
     return promise;
 }
 
+function drainPendingQueue(): void {
+    while (activeCount < CONFIG.concurrency.maxConcurrent && pendingQueue.length > 0) {
+        pendingQueue.shift()?.start();
+    }
+}
+
 /**
- * Execute function with concurrency limit
+ * Execute function with concurrency limit. Unlike a queue of bare wake-up
+ * callbacks, each job retains the identity captured when it was submitted and
+ * can be rejected synchronously by abortAllRequests(). A stale A job therefore
+ * cannot wake after B signs in and call its closure against B's live globals.
  */
-export async function withConcurrencyLimit<T>(fn: () => Promise<T>): Promise<T> {
-    // Wait if at capacity
-    if (activeCount >= CONFIG.concurrency.maxConcurrent) {
-        // Check queue size limit
-        if (pendingQueue.length >= CONFIG.concurrency.maxQueueSize) {
-            throw new Error('Request queue full - too many pending requests');
-        }
-        await new Promise<void>((resolve) => pendingQueue.push(resolve));
+export function withConcurrencyLimit<T>(
+    fn: () => Promise<T>,
+    context: IdentityContext | null = snapshotIdentity(false),
+    signal?: AbortSignal
+): Promise<T> {
+    if (activeCount >= CONFIG.concurrency.maxConcurrent
+        && pendingQueue.length >= CONFIG.concurrency.maxQueueSize) {
+        return Promise.reject(new Error('Request queue full - too many pending requests'));
     }
 
-    activeCount++;
-    try {
-        return await fn();
-    } finally {
-        activeCount--;
-        // Release next queued request
-        if (pendingQueue.length > 0) {
-            const next = pendingQueue.shift();
-            if (next) next();
+    return new Promise<T>((resolve, reject) => {
+        let state: 'queued' | 'active' | 'settled' | 'cancelled' = 'queued';
+        let holdsSlot = false;
+
+        const releaseSlot = (): void => {
+            if (!holdsSlot) return;
+            holdsSlot = false;
+            activeCount--;
+            activeJobs.delete(job);
+            drainPendingQueue();
+        };
+
+        const removeAbortListener = (): void => {
+            signal?.removeEventListener('abort', onAbort);
+        };
+
+        const job: ConcurrencyJob = {
+            context,
+            start(): void {
+                if (state !== 'queued') return;
+                state = 'active';
+                holdsSlot = true;
+                activeCount++;
+                activeJobs.add(job);
+
+                void (async () => {
+                    try {
+                        assertIdentityCurrent(context, signal);
+                        const value = await fn();
+                        assertIdentityCurrent(context, signal);
+                        if (state === 'active') {
+                            state = 'settled';
+                            removeAbortListener();
+                            resolve(value);
+                        }
+                    } catch (error) {
+                        if (state === 'active') {
+                            state = 'settled';
+                            removeAbortListener();
+                            reject(error instanceof Error
+                                ? error
+                                : new Error('Request failed', { cause: error }));
+                        }
+                    } finally {
+                        // cancel() may already have released this logical slot
+                        // while an abort-ignoring transport continued settling.
+                        releaseSlot();
+                    }
+                })();
+            },
+            cancel(error: Error): void {
+                if (state === 'settled' || state === 'cancelled') return;
+                state = 'cancelled';
+                removeAbortListener();
+                reject(error);
+                releaseSlot();
+            }
+        };
+
+        const onAbort = (): void => {
+            if (state === 'queued') {
+                const index = pendingQueue.indexOf(job);
+                if (index >= 0) pendingQueue.splice(index, 1);
+            }
+            job.cancel(identityStaleError('Request was aborted'));
+        };
+
+        if (signal?.aborted) {
+            job.cancel(identityStaleError('Request was aborted'));
+            return;
         }
-    }
+        signal?.addEventListener('abort', onAbort, { once: true });
+
+        if (activeCount < CONFIG.concurrency.maxConcurrent) {
+            job.start();
+        } else {
+            pendingQueue.push(job);
+        }
+    });
 }
 
 /**
@@ -262,14 +421,17 @@ export async function withConcurrencyLimit<T>(fn: () => Promise<T>): Promise<T> 
  * Automatically aborts previous request for the same key
  */
 function getAbortSignal(pageKey: string): AbortSignal {
+    const context = snapshotIdentity(false);
+    const identityPageKey = scopedKey(pageKey, context);
+
     // Abort previous controller for this key
-    const previous = activeControllers.get(pageKey);
+    const previous = activeControllers.get(identityPageKey);
     if (previous) {
         previous.abort();
     }
 
     const controller = new AbortController();
-    activeControllers.set(pageKey, controller);
+    activeControllers.set(identityPageKey, controller);
     return controller.signal;
 }
 
@@ -277,10 +439,30 @@ function getAbortSignal(pageKey: string): AbortSignal {
  * Abort all active requests (call on navigation)
  */
 function abortAllRequests(): void {
+    // Drop pending work BEFORE aborting controllers or releasing active slots.
+    // Abort listeners call cancel() synchronously, and cancel(active) drains the
+    // queue; leaving A jobs queued until later could therefore start one during
+    // the reset itself (the identity guard would stop a user switch, but a
+    // same-identity navigation abort must not dispatch it either).
+    for (const job of pendingQueue.splice(0)) {
+        job.cancel(identityStaleError('Queued request aborted'));
+    }
+
     for (const controller of activeControllers.values()) {
         controller.abort();
     }
     activeControllers.clear();
+
+    for (const controller of [...activeRequestControllers]) {
+        controller.abort();
+    }
+    activeRequestControllers.clear();
+
+    // Non-core users can call withConcurrencyLimit directly and therefore have
+    // no controller. Cancel those active logical jobs explicitly too.
+    for (const job of [...activeJobs]) {
+        job.cancel(identityStaleError('Request queue aborted'));
+    }
     inFlightRequests.clear();
 }
 
@@ -288,10 +470,16 @@ function abortAllRequests(): void {
  * Abort request for a specific page key
  */
 function abortRequest(pageKey: string): void {
-    const controller = activeControllers.get(pageKey);
+    const context = snapshotIdentity(false);
+    const identityPageKey = scopedKey(pageKey, context);
+    const controller = activeControllers.get(identityPageKey);
     if (controller) {
         controller.abort();
-        activeControllers.delete(pageKey);
+        // Do not let an old abort remove a newer controller installed under the
+        // same logical key between lookup and cleanup.
+        if (activeControllers.get(identityPageKey) === controller) {
+            activeControllers.delete(identityPageKey);
+        }
     }
 }
 
@@ -475,12 +663,70 @@ const manager: RequestManagerApi = {
  * headers are ignored). X-Jellyfin-User-Id lets the plugin's server side
  * resolve the acting user.
  */
-function authHeaders(): Record<string, string> {
+function authHeadersFor(client: JellyfinApiClient): Record<string, string> {
     return {
-        'X-Jellyfin-User-Id': ApiClient.getCurrentUserId(),
-        'Authorization': 'MediaBrowser Token="' + ApiClient.accessToken() + '"',
+        'X-Jellyfin-User-Id': client.getCurrentUserId(),
+        'Authorization': 'MediaBrowser Token="' + client.accessToken() + '"',
         'Accept': 'application/json'
     };
+}
+
+function authHeaders(): Record<string, string> {
+    return authHeadersFor(ApiClient);
+}
+
+function normalizeIdentityValue(value: string | null | undefined): string {
+    return String(value ?? '').trim().replace(/-/g, '').toLowerCase();
+}
+
+const UNKNOWN_SERVER_ID = normalizeIdentityValue('unknown-server');
+
+/** An authenticated owner must have a concrete server half, not the loader fallback. */
+function isResolvedServerId(value: string | null | undefined): boolean {
+    const normalized = normalizeIdentityValue(value);
+    return normalized !== '' && normalized !== UNKNOWN_SERVER_ID;
+}
+
+function deleteHeaderCaseInsensitive(headers: Record<string, string>, name: string): void {
+    const normalizedName = name.toLowerCase();
+    for (const key of Object.keys(headers)) {
+        if (key.toLowerCase() === normalizedName) delete headers[key];
+    }
+}
+
+function hasHeaderCaseInsensitive(headers: Record<string, string>, name: string): boolean {
+    const normalizedName = name.toLowerCase();
+    return Object.keys(headers).some((key) => key.toLowerCase() === normalizedName);
+}
+
+/** Resolve the same stable server half used by the classic identity loader. */
+function apiClientServerId(client: JellyfinApiClient): string {
+    const extended = client as JellyfinApiClient & {
+        serverId?: string | (() => string);
+        serverInfo?: { Id?: string; ServerId?: string } | (() => { Id?: string; ServerId?: string });
+        _serverInfo?: { Id?: string; ServerId?: string };
+        serverAddress?: string | (() => string);
+    };
+    try {
+        const direct = typeof extended.serverId === 'function'
+            ? extended.serverId.call(client)
+            : extended.serverId;
+        if (isResolvedServerId(direct)) return direct || '';
+    } catch { /* try server-info forms */ }
+    try {
+        const info = typeof extended.serverInfo === 'function'
+            ? extended.serverInfo.call(client)
+            : (extended.serverInfo || extended._serverInfo);
+        const fromInfo = info?.Id || info?.ServerId || '';
+        if (isResolvedServerId(fromInfo)) return fromInfo;
+    } catch { /* fall through to address */ }
+    try {
+        const address = typeof extended.serverAddress === 'function'
+            ? extended.serverAddress.call(client)
+            : (extended.serverAddress || client.getUrl('/'));
+        if (isResolvedServerId(address)) return new URL(String(address), window.location.href).origin;
+    } catch { /* unknown-server below */ }
+    return '';
 }
 
 /**
@@ -490,7 +736,11 @@ function authHeaders(): Record<string, string> {
  * @param url - Fully-qualified URL.
  * @returns Parsed JSON response ({} for empty bodies).
  */
-async function coreFetch(url: string, options: CoreFetchOptions = {}): Promise<unknown> {
+async function coreFetch(
+    url: string,
+    options: CoreFetchOptions = {},
+    requestApiClient: JellyfinApiClient = ApiClient
+): Promise<unknown> {
     const {
         method = 'GET',
         headers = {},
@@ -504,82 +754,145 @@ async function coreFetch(url: string, options: CoreFetchOptions = {}): Promise<u
     } = options;
 
     const isGet = method.toUpperCase() === 'GET';
+    const context = snapshotIdentity(auth);
+    const capturedAuthHeaders = auth
+        ? authHeadersFor(requestApiClient)
+        : { 'Accept': 'application/json' };
+    const requestHeaders: Record<string, string> = {
+        ...capturedAuthHeaders,
+        ...headers
+    };
+    if (auth) {
+        // Authentication is owned by the captured ApiClient, not by a stale
+        // caller-supplied header object. Callers needing different credentials
+        // must opt out with auth:false. Header names are case-insensitive on the
+        // wire, so remove every caller spelling before installing one canonical
+        // value; otherwise `authorization` could coexist with `Authorization`.
+        deleteHeaderCaseInsensitive(requestHeaders, 'X-Jellyfin-User-Id');
+        deleteHeaderCaseInsensitive(requestHeaders, 'Authorization');
+        requestHeaders['X-Jellyfin-User-Id'] = capturedAuthHeaders['X-Jellyfin-User-Id'];
+        requestHeaders.Authorization = capturedAuthHeaders.Authorization;
+    }
+    assertIdentityCurrent(context, signal, auth);
 
-    // Check cache first (GET only)
-    if (isGet && !skipCache && cacheKey) {
-        const cached = getCached(cacheKey);
-        if (cached !== undefined) return cached;
+    // The header and epoch must describe the same owner. This also closes the
+    // tiny synchronous window where the host has announced B but has not yet
+    // finished mutating a reused ApiClient instance's authentication fields.
+    if (auth && context
+        && normalizeIdentityValue(requestHeaders['X-Jellyfin-User-Id'])
+            !== normalizeIdentityValue(context.userId)) {
+        throw identityStaleError('ApiClient authentication does not match the captured identity');
+    }
+    if (auth && context) {
+        const requestServerId = apiClientServerId(requestApiClient);
+        if (!isResolvedServerId(context.serverId) || !isResolvedServerId(requestServerId)) {
+            throw identityStaleError('Authenticated request requires a resolved Jellyfin server identity');
+        }
+        if (normalizeIdentityValue(requestServerId) !== normalizeIdentityValue(context.serverId)) {
+            throw identityStaleError('ApiClient server does not match the captured identity');
+        }
     }
 
-    const fetchFn = async (): Promise<unknown> => {
-        const requestHeaders: Record<string, string> = {
-            ...(auth ? authHeaders() : { 'Accept': 'application/json' }),
-            ...headers
-        };
+    const identityCacheKey = cacheKey ? scopedKey(cacheKey, context) : undefined;
 
-        const init: RequestInit = { method, headers: requestHeaders };
-
-        if (body !== undefined) {
-            if (typeof body === 'string') {
-                init.body = body;
-            } else {
-                init.body = JSON.stringify(body);
-                if (!requestHeaders['Content-Type']) {
-                    requestHeaders['Content-Type'] = 'application/json';
-                }
-            }
+    // Check cache first (GET only)
+    if (isGet && !skipCache && identityCacheKey) {
+        const cached = getCached(identityCacheKey);
+        if (cached !== undefined) {
+            // Keep even a memory-cache hit asynchronous and fence its actual
+            // promise settlement. Without this yield, `const p = fetch();
+            // logout(); await p` could still deliver A data to B because no
+            // transport controller exists for abortAllRequests() to cancel.
+            await Promise.resolve();
+            assertIdentityCurrent(context, signal, auth);
+            return cached;
         }
+    }
 
-        // Per-request timeout: abort via our own controller, chained to
-        // the caller's signal so either can cancel the request.
-        let timeoutId: ReturnType<typeof setTimeout> | null = null;
-        let unchain: (() => void) | null = null;
-        if (timeoutMs && timeoutMs > 0) {
-            const controller = new AbortController();
-            if (signal) {
-                if (signal.aborted) {
-                    controller.abort();
-                } else {
-                    const onAbort = (): void => controller.abort();
-                    signal.addEventListener('abort', onAbort, { once: true });
-                    unchain = () => signal.removeEventListener('abort', onAbort);
-                }
-            }
-            timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-            init.signal = controller.signal;
-        } else if (signal) {
-            init.signal = signal;
+    // One controller exists for every request, regardless of whether the caller
+    // supplied a signal or timeout. It is registered before queueing so a reset
+    // can reject pending A work as well as active A transport.
+    const controller = new AbortController();
+    activeRequestControllers.add(controller);
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    let unchain: (() => void) | null = null;
+
+    if (signal) {
+        if (signal.aborted) {
+            controller.abort();
+        } else {
+            const onAbort = (): void => controller.abort();
+            signal.addEventListener('abort', onAbort, { once: true });
+            unchain = () => signal.removeEventListener('abort', onAbort);
         }
+    }
+    if (timeoutMs && timeoutMs > 0) {
+        timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+    }
 
-        try {
-            const response = await fetchWithRetry(
-                url,
-                init,
-                skipRetry ? { ...CONFIG.retry, maxAttempts: 1 } : undefined
-            );
-            // Tolerant JSON parse: some endpoints reply with empty bodies.
-            const text = await response.text();
-            const data: unknown = text ? JSON.parse(text) : {};
-
-            if (isGet && cacheKey) {
-                setCache(cacheKey, data);
-            }
-            return data;
-        } finally {
-            if (timeoutId) clearTimeout(timeoutId);
-            if (unchain) unchain();
-        }
+    const init: RequestInit = {
+        method,
+        headers: requestHeaders,
+        signal: controller.signal
     };
 
-    // Concurrency limit + in-flight dedup (GET with a cache key only). Forward the caller's signal:
-    // deduplicatedFetch skips dedup when a signal is present so an abortable caller gets its own
-    // request — otherwise one caller's abort could hand a rejected/aborted shared promise to the
-    // next same-key caller (e.g. a re-rendered feed re-requesting a row it just aborted).
-    return withConcurrencyLimit(() =>
-        (isGet && cacheKey)
-            ? deduplicatedFetch(cacheKey, fetchFn, signal)
-            : fetchFn()
-    );
+    if (body !== undefined) {
+        if (typeof body === 'string') {
+            init.body = body;
+        } else {
+            init.body = JSON.stringify(body);
+            if (!hasHeaderCaseInsensitive(requestHeaders, 'Content-Type')) {
+                requestHeaders['Content-Type'] = 'application/json';
+            }
+        }
+    }
+
+    const guard = (): void => assertIdentityCurrent(context, controller.signal, auth);
+
+    const fetchFn = async (): Promise<unknown> => {
+        guard();
+        const response = await fetchWithRetry(
+            url,
+            init,
+            skipRetry ? { ...CONFIG.retry, maxAttempts: 1 } : undefined,
+            guard
+        );
+        guard();
+
+        // Tolerant JSON parse: some endpoints reply with empty bodies.
+        const text = await response.text();
+        guard();
+        const data: unknown = text ? JSON.parse(text) : {};
+        guard();
+
+        if (isGet && identityCacheKey) {
+            guard();
+            setCache(identityCacheKey, data);
+        }
+        guard();
+        return data;
+    };
+
+    // Concurrency limit + in-flight dedup (GET with a cache key only). Forward an
+    // abort scope whenever the caller supplied a signal OR timeout. A timeout is
+    // caller-owned too: sharing its transport would let one caller's deadline
+    // abort an otherwise-independent waiter for the same cache key.
+    const deduplicationSignal = signal || (timeoutMs && timeoutMs > 0 ? controller.signal : undefined);
+    try {
+        const result = await withConcurrencyLimit(
+            () => (isGet && identityCacheKey)
+                ? deduplicatedFetch(identityCacheKey, fetchFn, deduplicationSignal)
+                : fetchFn(),
+            context,
+            controller.signal
+        );
+        guard();
+        return result;
+    } finally {
+        if (timeoutId) clearTimeout(timeoutId);
+        if (unchain) unchain();
+        activeRequestControllers.delete(controller);
+    }
 }
 
 /**
@@ -587,7 +900,8 @@ async function coreFetch(url: string, options: CoreFetchOptions = {}): Promise<u
  * @param path - e.g. '/Plugins'
  */
 function jf(path: string, options?: CoreFetchOptions): Promise<unknown> {
-    return coreFetch(ApiClient.getUrl(path), options);
+    const requestApiClient = ApiClient;
+    return coreFetch(requestApiClient.getUrl(path), options, requestApiClient);
 }
 
 /**

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/identity.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/identity.ts
@@ -1,0 +1,24 @@
+// src/core/identity.ts
+//
+// Bundle-side participant for the loader-owned identity controller. The
+// controller itself must live in js/plugin.js so it can intercept Jellyfin's
+// authentication setter before this bundle exists; this module connects that
+// early owner to the reusable core teardown infrastructure.
+
+import { JC } from '../globals';
+import { teardownAll } from './lifecycle';
+
+JC.identity.registerReset('core-platform', () => {
+    // Abort transport first, then remove feature resources. A promise that has
+    // already resolved is still fenced by its captured epoch in api-client.ts.
+    try { JC.core.api?.manager.abortAllRequests(); } catch { /* continue teardown */ }
+    try { JC.core.api?.manager.clearCache(); } catch { /* continue teardown */ }
+    try { teardownAll(); } catch (error) {
+        console.error('🪼 Jellyfin Canopy: identity core teardown failed', error);
+    }
+
+    // Modules may stamp ephemeral nodes that are not attached to a feature
+    // lifecycle yet. This is intentionally narrow: global shared observers and
+    // process-lifetime styles remain intact and are re-used by B.
+    document.querySelectorAll('[data-jc-identity-owned="true"]').forEach((node) => node.remove());
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/live-config.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/live-config.test.ts
@@ -72,10 +72,299 @@ describe('config hot-reload reaction', () => {
 
         await vi.waitFor(() => expect(invalidateServerCache).toHaveBeenCalledTimes(1));
     });
+
+    it('drops an A refresh continuation after the same user moves to server B', async () => {
+        const contextA = JC.identity.transition('live-server-a', 'shared-user', 'live-config-test-a')!;
+        JC.pluginConfig = {};
+        let resolvePublic: (value: unknown) => void = () => undefined;
+        const heldPublic = new Promise<unknown>((resolve) => { resolvePublic = resolve; });
+        const plugin = vi.fn((path: string) => path.startsWith('/public-config')
+            ? heldPublic
+            : Promise.resolve({}));
+        JC.core.api = { plugin } as unknown as NonNullable<typeof JC.core.api>;
+        const scheduleScan = vi.fn();
+        const invalidateServerCache = vi.fn().mockResolvedValue(undefined);
+        JC.tagPipeline = { registerRenderer: vi.fn(), scheduleScan, invalidateServerCache };
+        const domEvent = vi.fn();
+        window.addEventListener('jc:config-changed', domEvent);
+
+        emit(LIVE.CONFIG_CHANGED, {});
+        await vi.waitFor(() => expect(plugin).toHaveBeenCalledTimes(1));
+        JC.identity.transition('live-server-b', 'shared-user', 'live-config-test-b');
+        JC.pluginConfig = {};
+        resolvePublic({ Marker: 'stale-a' });
+        await new Promise((resolve) => setTimeout(resolve, 20));
+
+        expect(JC.identity.isCurrent(contextA)).toBe(false);
+        expect(JC.pluginConfig.Marker).toBeUndefined();
+        expect(domEvent).not.toHaveBeenCalled();
+        expect(scheduleScan).not.toHaveBeenCalled();
+        expect(invalidateServerCache).not.toHaveBeenCalled();
+        window.removeEventListener('jc:config-changed', domEvent);
+    });
+
+    it('does not let a synchronous DOM listener move A config work into B pipeline state', async () => {
+        const contextA = JC.identity.transition('live-dispatch-server-a', 'live-dispatch-user-a', 'live-dispatch-a')!;
+        JC.pluginConfig = { SpoilerStripRatings: false };
+        JC.core.api = {
+            plugin: vi.fn((path: string) => path.startsWith('/public-config')
+                ? Promise.resolve({ SpoilerStripRatings: true })
+                : Promise.resolve({})),
+        } as unknown as NonNullable<typeof JC.core.api>;
+        const scheduleScan = vi.fn();
+        const invalidateServerCache = vi.fn().mockResolvedValue(undefined);
+        JC.tagPipeline = { registerRenderer: vi.fn(), scheduleScan, invalidateServerCache };
+        const switchIdentity = vi.fn(() => {
+            JC.identity.transition('live-dispatch-server-b', 'live-dispatch-user-b', 'live-dispatch-b');
+        });
+        window.addEventListener('jc:config-changed', switchIdentity);
+
+        try {
+            emit(LIVE.CONFIG_CHANGED, {});
+            await vi.waitFor(() => expect(switchIdentity).toHaveBeenCalledTimes(1));
+            await Promise.resolve();
+
+            expect(JC.identity.isCurrent(contextA)).toBe(false);
+            expect(invalidateServerCache).not.toHaveBeenCalled();
+            expect(scheduleScan).not.toHaveBeenCalled();
+        } finally {
+            window.removeEventListener('jc:config-changed', switchIdentity);
+        }
+    });
 });
 describe('config hot-reload in-flight guard (CORE-9)', () => {
     afterEach(() => {
         vi.restoreAllMocks();
+    });
+
+    it('invalidates once when a newer refresh supersedes a policy-merging refresh', async () => {
+        JC.pluginConfig = { SpoilerStripRatings: false };
+        let resolveFirstPrivate: (value: unknown) => void = () => undefined;
+        const heldFirstPrivate = new Promise<unknown>((resolve) => { resolveFirstPrivate = resolve; });
+        let publicCalls = 0;
+        let privateCalls = 0;
+        const plugin = vi.fn((path: string) => {
+            if (path.startsWith('/public-config')) {
+                publicCalls += 1;
+                return Promise.resolve({ SpoilerStripRatings: true });
+            }
+            if (path.startsWith('/private-config')) {
+                privateCalls += 1;
+                return privateCalls === 1 ? heldFirstPrivate : Promise.resolve({});
+            }
+            return Promise.resolve({});
+        });
+        JC.core.api = { plugin } as unknown as NonNullable<typeof JC.core.api>;
+        const invalidateServerCache = vi.fn().mockResolvedValue(undefined);
+        const scheduleScan = vi.fn();
+        JC.tagPipeline = { registerRenderer: vi.fn(), invalidateServerCache, scheduleScan };
+
+        emit(LIVE.CONFIG_CHANGED, {}); // H1 merges the policy, then waits on private-config.
+        await vi.waitFor(() => {
+            expect(privateCalls).toBe(1);
+            expect(JC.pluginConfig.SpoilerStripRatings).toBe(true);
+        });
+
+        emit(LIVE.CONFIG_CHANGED, {}); // H2 sees the merged value and supersedes H1.
+        await vi.waitFor(() => expect(invalidateServerCache).toHaveBeenCalledTimes(1));
+        expect(publicCalls).toBe(2);
+        expect(privateCalls).toBe(2);
+        expect(scheduleScan).not.toHaveBeenCalled();
+
+        resolveFirstPrivate({});
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        expect(invalidateServerCache).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries an unchanged dirty policy after cache invalidation rejects once', async () => {
+        JC.identity.transition('live-retry-server', 'live-retry-user', 'live-config-retry-test');
+        JC.pluginConfig = { SpoilerStripRatings: false };
+        JC.core.api = {
+            plugin: vi.fn((path: string) => path.startsWith('/public-config')
+                ? Promise.resolve({ SpoilerStripRatings: true })
+                : Promise.resolve({})),
+        } as unknown as NonNullable<typeof JC.core.api>;
+        const invalidateServerCache = vi.fn()
+            .mockRejectedValueOnce(new Error('transient invalidation failure'))
+            .mockResolvedValue(undefined);
+        const scheduleScan = vi.fn();
+        JC.tagPipeline = { registerRenderer: vi.fn(), invalidateServerCache, scheduleScan };
+        const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+        emit(LIVE.CONFIG_CHANGED, {});
+        await vi.waitFor(() => expect(consoleLog).toHaveBeenCalledTimes(1));
+        expect(invalidateServerCache).toHaveBeenCalledTimes(1);
+
+        // The fetched policy is unchanged, but the failed invalidation must not
+        // have advanced the successful baseline.
+        emit(LIVE.CONFIG_CHANGED, {});
+        await vi.waitFor(() => expect(consoleLog).toHaveBeenCalledTimes(2));
+        expect(invalidateServerCache).toHaveBeenCalledTimes(2);
+
+        // Once the retry succeeds, another identical push takes the cheap path.
+        emit(LIVE.CONFIG_CHANGED, {});
+        await vi.waitFor(() => expect(scheduleScan).toHaveBeenCalledTimes(1));
+        expect(invalidateServerCache).toHaveBeenCalledTimes(2);
+    });
+
+    it('shares a pending invalidation between overlapping equivalent pushes', async () => {
+        JC.identity.transition('live-dedup-server', 'live-dedup-user', 'live-config-dedup-test');
+        JC.pluginConfig = { SpoilerStripRatings: false };
+        let privateCalls = 0;
+        JC.core.api = {
+            plugin: vi.fn((path: string) => {
+                if (path.startsWith('/public-config')) {
+                    return Promise.resolve({ SpoilerStripRatings: true });
+                }
+                privateCalls += 1;
+                return Promise.resolve({});
+            }),
+        } as unknown as NonNullable<typeof JC.core.api>;
+        let resolveInvalidation: () => void = () => undefined;
+        const heldInvalidation = new Promise<void>((resolve) => { resolveInvalidation = resolve; });
+        const invalidateServerCache = vi.fn(() => heldInvalidation);
+        const scheduleScan = vi.fn();
+        JC.tagPipeline = { registerRenderer: vi.fn(), invalidateServerCache, scheduleScan };
+        const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+        emit(LIVE.CONFIG_CHANGED, {});
+        await vi.waitFor(() => expect(invalidateServerCache).toHaveBeenCalledTimes(1));
+
+        emit(LIVE.CONFIG_CHANGED, {});
+        await vi.waitFor(() => expect(privateCalls).toBe(2));
+        expect(invalidateServerCache).toHaveBeenCalledTimes(1);
+
+        resolveInvalidation();
+        await vi.waitFor(() => expect(consoleLog).toHaveBeenCalledTimes(2));
+
+        emit(LIVE.CONFIG_CHANGED, {});
+        await vi.waitFor(() => expect(scheduleScan).toHaveBeenCalledTimes(1));
+        expect(invalidateServerCache).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not let an older invalidation completion roll back a newer policy', async () => {
+        JC.identity.transition('live-order-server', 'live-order-user', 'live-config-order-test');
+        JC.pluginConfig = { SpoilerStripRatings: false, SpoilerStripTags: false };
+        let publicCalls = 0;
+        JC.core.api = {
+            plugin: vi.fn((path: string) => {
+                if (path.startsWith('/public-config')) {
+                    publicCalls += 1;
+                    return Promise.resolve(publicCalls === 1
+                        ? { SpoilerStripRatings: true, SpoilerStripTags: false }
+                        : { SpoilerStripRatings: true, SpoilerStripTags: true });
+                }
+                return Promise.resolve({});
+            }),
+        } as unknown as NonNullable<typeof JC.core.api>;
+        let resolveOlderInvalidation: () => void = () => undefined;
+        const olderInvalidation = new Promise<void>((resolve) => { resolveOlderInvalidation = resolve; });
+        const invalidateServerCache = vi.fn()
+            .mockImplementationOnce(() => olderInvalidation)
+            .mockResolvedValue(undefined);
+        const scheduleScan = vi.fn();
+        JC.tagPipeline = { registerRenderer: vi.fn(), invalidateServerCache, scheduleScan };
+        const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+        emit(LIVE.CONFIG_CHANGED, {});
+        await vi.waitFor(() => expect(invalidateServerCache).toHaveBeenCalledTimes(1));
+
+        emit(LIVE.CONFIG_CHANGED, {});
+        await vi.waitFor(() => expect(consoleLog).toHaveBeenCalledTimes(1));
+        expect(invalidateServerCache).toHaveBeenCalledTimes(2);
+
+        resolveOlderInvalidation();
+        await vi.waitFor(() => expect(consoleLog).toHaveBeenCalledTimes(2));
+
+        emit(LIVE.CONFIG_CHANGED, {});
+        await vi.waitFor(() => expect(scheduleScan).toHaveBeenCalledTimes(1));
+        expect(invalidateServerCache).toHaveBeenCalledTimes(2);
+    });
+
+    it('starts fresh F1 work when policy observations follow F1 to F2 to F1', async () => {
+        JC.identity.transition('live-aba-server', 'live-aba-user', 'live-config-aba-test');
+        JC.pluginConfig = { SpoilerStripRatings: false, SpoilerStripTags: false };
+        const policies = [
+            { SpoilerStripRatings: true, SpoilerStripTags: false },
+            { SpoilerStripRatings: true, SpoilerStripTags: true },
+            { SpoilerStripRatings: true, SpoilerStripTags: false },
+            { SpoilerStripRatings: true, SpoilerStripTags: false },
+        ];
+        let publicCalls = 0;
+        JC.core.api = {
+            plugin: vi.fn((path: string) => path.startsWith('/public-config')
+                ? Promise.resolve(policies[Math.min(publicCalls++, policies.length - 1)])
+                : Promise.resolve({})),
+        } as unknown as NonNullable<typeof JC.core.api>;
+        let resolveFirst: () => void = () => undefined;
+        let resolveSecond: () => void = () => undefined;
+        let resolveThird: () => void = () => undefined;
+        const first = new Promise<void>((resolve) => { resolveFirst = resolve; });
+        const second = new Promise<void>((resolve) => { resolveSecond = resolve; });
+        const third = new Promise<void>((resolve) => { resolveThird = resolve; });
+        const invalidateServerCache = vi.fn()
+            .mockImplementationOnce(() => first)
+            .mockImplementationOnce(() => second)
+            .mockImplementationOnce(() => third);
+        const scheduleScan = vi.fn();
+        JC.tagPipeline = { registerRenderer: vi.fn(), invalidateServerCache, scheduleScan };
+        const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+        emit(LIVE.CONFIG_CHANGED, {});
+        await vi.waitFor(() => expect(invalidateServerCache).toHaveBeenCalledTimes(1));
+        emit(LIVE.CONFIG_CHANGED, {});
+        await vi.waitFor(() => expect(invalidateServerCache).toHaveBeenCalledTimes(2));
+        emit(LIVE.CONFIG_CHANGED, {});
+        await vi.waitFor(() => expect(invalidateServerCache).toHaveBeenCalledTimes(3));
+
+        resolveFirst();
+        resolveSecond();
+        await vi.waitFor(() => expect(consoleLog).toHaveBeenCalledTimes(2));
+        resolveThird();
+        await vi.waitFor(() => expect(consoleLog).toHaveBeenCalledTimes(3));
+
+        emit(LIVE.CONFIG_CHANGED, {});
+        await vi.waitFor(() => expect(scheduleScan).toHaveBeenCalledTimes(1));
+        expect(invalidateServerCache).toHaveBeenCalledTimes(3);
+    });
+
+    it('reasserts the successful baseline after a different policy starts invalidating', async () => {
+        JC.identity.transition('live-return-server', 'live-return-user', 'live-config-return-test');
+        JC.pluginConfig = { SpoilerStripRatings: false };
+        const policies = [
+            { SpoilerStripRatings: true },
+            { SpoilerStripRatings: false },
+            { SpoilerStripRatings: false },
+        ];
+        let publicCalls = 0;
+        JC.core.api = {
+            plugin: vi.fn((path: string) => path.startsWith('/public-config')
+                ? Promise.resolve(policies[Math.min(publicCalls++, policies.length - 1)])
+                : Promise.resolve({})),
+        } as unknown as NonNullable<typeof JC.core.api>;
+        let resolveAway: () => void = () => undefined;
+        let resolveReturn: () => void = () => undefined;
+        const away = new Promise<void>((resolve) => { resolveAway = resolve; });
+        const returned = new Promise<void>((resolve) => { resolveReturn = resolve; });
+        const invalidateServerCache = vi.fn()
+            .mockImplementationOnce(() => away)
+            .mockImplementationOnce(() => returned);
+        const scheduleScan = vi.fn();
+        JC.tagPipeline = { registerRenderer: vi.fn(), invalidateServerCache, scheduleScan };
+        const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+        emit(LIVE.CONFIG_CHANGED, {});
+        await vi.waitFor(() => expect(invalidateServerCache).toHaveBeenCalledTimes(1));
+        emit(LIVE.CONFIG_CHANGED, {});
+        await vi.waitFor(() => expect(invalidateServerCache).toHaveBeenCalledTimes(2));
+
+        resolveAway();
+        resolveReturn();
+        await vi.waitFor(() => expect(consoleLog).toHaveBeenCalledTimes(2));
+
+        emit(LIVE.CONFIG_CHANGED, {});
+        await vi.waitFor(() => expect(scheduleScan).toHaveBeenCalledTimes(1));
+        expect(invalidateServerCache).toHaveBeenCalledTimes(2);
     });
 
     it('a superseded (slower) refresh does not overwrite the newer one', async () => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/live-config.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/live-config.ts
@@ -19,7 +19,7 @@
 
 import { JC } from '../globals';
 import { LIVE, on } from './live';
-import type { PluginConfig } from '../types/jc';
+import type { IdentityContext, PluginConfig } from '../types/jc';
 
 const logPrefix = '🪼 Jellyfin Canopy: Live Config:';
 
@@ -31,6 +31,32 @@ const logPrefix = '🪼 Jellyfin Canopy: Live Config:';
 let refreshSeq = 0;
 let lastPublicKeys: string[] = [];
 let lastPrivateKeys: string[] = [];
+
+interface ConfigRefreshResult {
+    seq: number;
+    tagPolicyFingerprint: string;
+}
+
+interface TagPolicyState {
+    identityKey: string;
+    lastObservedFingerprint: string;
+    observationGeneration: number;
+    lastInvalidatedFingerprint: string;
+    lastInvalidatedGeneration: number;
+    lastInvalidatedSeq: number;
+    pendingInvalidations: Map<string, PendingTagPolicyInvalidation>;
+}
+
+interface PendingTagPolicyInvalidation {
+    observationGeneration: number;
+    maxSeq: number;
+    promise: Promise<void>;
+}
+
+// The baseline advances only after cache invalidation succeeds. A rejected
+// invalidation therefore leaves the policy dirty for the next push, while the
+// pending map lets equivalent overlapping pushes share one invalidation.
+let tagPolicyState: TagPolicyState | null = null;
 
 const TAG_PROJECTION_POLICY_KEYS = [
     'TagCacheServerMode',
@@ -46,6 +72,79 @@ function tagProjectionPolicyFingerprint(): string {
     return JSON.stringify(TAG_PROJECTION_POLICY_KEYS.map((key) => JC.pluginConfig?.[key]));
 }
 
+function identityKey(context: IdentityContext): string {
+    return `${context.serverId}:${context.userId}:${context.epoch}`;
+}
+
+function beginTagPolicyRefresh(context: IdentityContext): TagPolicyState {
+    const key = identityKey(context);
+    if (!tagPolicyState || tagPolicyState.identityKey !== key) {
+        tagPolicyState = {
+            identityKey: key,
+            // The config present when an identity becomes active is its known
+            // cache-policy baseline. Later changes advance this only after a
+            // successful invalidation.
+            lastObservedFingerprint: tagProjectionPolicyFingerprint(),
+            observationGeneration: 0,
+            lastInvalidatedFingerprint: tagProjectionPolicyFingerprint(),
+            lastInvalidatedGeneration: 0,
+            lastInvalidatedSeq: refreshSeq,
+            pendingInvalidations: new Map()
+        };
+    }
+    return tagPolicyState;
+}
+
+function observeTagPolicy(state: TagPolicyState, fingerprint: string): number {
+    if (state.lastObservedFingerprint !== fingerprint) {
+        state.lastObservedFingerprint = fingerprint;
+        state.observationGeneration += 1;
+    }
+    return state.observationGeneration;
+}
+
+async function invalidateTagPolicy(
+    state: TagPolicyState,
+    refreshed: ConfigRefreshResult,
+    observationGeneration: number,
+    invalidateServerCache: () => Promise<void>
+): Promise<void> {
+    const fingerprint = refreshed.tagPolicyFingerprint;
+    let pending = state.pendingInvalidations.get(fingerprint);
+    if (pending?.observationGeneration === observationGeneration) {
+        pending.maxSeq = Math.max(pending.maxSeq, refreshed.seq);
+    } else {
+        const next: PendingTagPolicyInvalidation = {
+            observationGeneration,
+            maxSeq: refreshed.seq,
+            promise: Promise.resolve()
+        };
+        next.promise = (async () => {
+            await invalidateServerCache();
+            // Different policy invalidations may overlap. Never let an older
+            // completion roll the successful baseline back from a newer one.
+            if (next.observationGeneration === state.observationGeneration
+                && (next.observationGeneration > state.lastInvalidatedGeneration
+                    || (next.observationGeneration === state.lastInvalidatedGeneration
+                        && next.maxSeq >= state.lastInvalidatedSeq))) {
+                state.lastInvalidatedFingerprint = fingerprint;
+                state.lastInvalidatedGeneration = next.observationGeneration;
+                state.lastInvalidatedSeq = next.maxSeq;
+            }
+        })();
+        state.pendingInvalidations.set(fingerprint, next);
+        pending = next;
+    }
+
+    try {
+        await pending.promise;
+    } finally {
+        if (state.pendingInvalidations.get(fingerprint) === pending) {
+            state.pendingInvalidations.delete(fingerprint);
+        }
+    }
+}
+
 /** Prune keys that the previous payload from this source owned but the new one dropped. */
 function prunePayloadKeys(previousKeys: string[], next: object): void {
     const config = JC.pluginConfig as Record<string, unknown>;
@@ -59,15 +158,14 @@ function prunePayloadKeys(previousKeys: string[], next: object): void {
  * Merges IN PLACE (Object.assign) to preserve the object's reference identity —
  * js/plugin.js and many modules hold JC.pluginConfig by reference, matching the
  * loader's own `Object.assign(JC.pluginConfig, privateConfig)` pattern. Guards
- * against out-of-order settle (CORE-9), prunes vanished keys per source, and
- * re-applies the delivery-flag sanitization so a hot-reload can't resurface
- * stale *UseCustomTabs/*UsePluginPages flags (INIT-1).
+ * against out-of-order settle (CORE-9) and prunes vanished keys per source.
  */
-async function refreshPluginConfig(): Promise<void> {
+async function refreshPluginConfig(context: IdentityContext): Promise<ConfigRefreshResult | null> {
+    if (!JC.identity.isCurrent(context)) return null;
     const api = JC.core.api;
     if (!api) {
         console.warn(`${logPrefix} JC.core.api unavailable — cannot refetch config.`);
-        return;
+        return null;
     }
 
     const seq = ++refreshSeq; // (CORE-9) last-initiated wins
@@ -78,65 +176,82 @@ async function refreshPluginConfig(): Promise<void> {
 
     try {
         const pub = await api.plugin(`/public-config${bust}`, { skipCache: true });
-        if (seq !== refreshSeq) return; // superseded by a newer refresh
+        if (seq !== refreshSeq || !JC.identity.isCurrent(context)) return null;
         if (pub && typeof pub === 'object') {
             prunePayloadKeys(lastPublicKeys, pub); // (CORE-9) drop vanished public keys
             Object.assign(JC.pluginConfig, pub as PluginConfig);
             lastPublicKeys = Object.keys(pub);
-            // (INIT-1/LC-1) Re-zero the stale UseCustomTabs/UsePluginPages flags
-            // IMMEDIATELY — the public payload we just merged re-wrote them to
-            // their pre-uninstall `true`. Deferring the sanitize to the end of the
-            // refresh leaves a /private-config round-trip window where a drawer
-            // rebuild would observe them true and skip re-injecting the nav item.
         }
     } catch (err) {
+        if (seq !== refreshSeq || !JC.identity.isCurrent(context)) return null;
         console.error(`${logPrefix} failed to refetch public-config:`, err);
-        return;
+        return null;
     }
 
     // Admins additionally get sensitive fields; non-admins receive {} (the
     // endpoint returns an empty object rather than 403), so this is best-effort.
     try {
         const priv = await api.plugin(`/private-config${bust}`, { skipCache: true });
-        if (seq !== refreshSeq) return;
+        if (seq !== refreshSeq || !JC.identity.isCurrent(context)) return null;
         if (priv && typeof priv === 'object') {
             prunePayloadKeys(lastPrivateKeys, priv);
             Object.assign(JC.pluginConfig, priv as Record<string, unknown>);
             lastPrivateKeys = Object.keys(priv);
         }
     } catch (err) {
+        if (seq !== refreshSeq || !JC.identity.isCurrent(context)) return null;
         console.debug(`${logPrefix} private-config not available (non-admin?):`, err);
     }
 
-    // (INIT-1) Re-force stale UseCustomTabs/UsePluginPages flags back to false for
-    // any delivery plugin that is not installed — the raw server payload we just
-    // merged still stores the pre-uninstall `true`.
+    if (seq !== refreshSeq || !JC.identity.isCurrent(context)) return null;
+    return { seq, tagPolicyFingerprint: tagProjectionPolicyFingerprint() };
 }
 
 on(LIVE.CONFIG_CHANGED, () => {
+    const context = JC.identity.capture();
+    if (!context) return;
+    const policyState = beginTagPolicyRefresh(context);
     void (async () => {
-        const previousTagPolicy = tagProjectionPolicyFingerprint();
-        await refreshPluginConfig();
+        const refreshed = await refreshPluginConfig(context);
+        if (!refreshed || refreshed.seq !== refreshSeq || !JC.identity.isCurrent(context)) return;
+
+        const observationGeneration = observeTagPolicy(
+            policyState,
+            refreshed.tagPolicyFingerprint
+        );
+        const policyChanged = policyState.lastInvalidatedFingerprint !== refreshed.tagPolicyFingerprint
+            || policyState.lastInvalidatedGeneration < observationGeneration;
 
         // Let unmigrated modules and any feature reinit hooks react to the fresh
         // config without this module having to know about each of them.
         try {
             window.dispatchEvent(new CustomEvent('jc:config-changed'));
         } catch { /* CustomEvent unsupported — ignore */ }
+        // DOM dispatch is synchronous and feature listeners are arbitrary. A
+        // listener may accept a newer host identity, so A must not continue
+        // into the now-current B pipeline after the callback stack unwinds.
+        if (!JC.identity.isCurrent(context)) return;
 
         // Policy changes alter the actual per-user cache bytes, so a rescan of
         // already-processed cards is insufficient. Unrelated config changes retain
         // the cheap scan path.
         try {
-            if (previousTagPolicy !== tagProjectionPolicyFingerprint()
-                && JC.tagPipeline?.invalidateServerCache) {
-                await JC.tagPipeline.invalidateServerCache();
+            const pipeline = JC.tagPipeline;
+            if (policyChanged && pipeline?.invalidateServerCache) {
+                await invalidateTagPolicy(
+                    policyState,
+                    refreshed,
+                    observationGeneration,
+                    () => pipeline.invalidateServerCache!()
+                );
             } else {
-                JC.tagPipeline?.scheduleScan?.();
+                pipeline?.scheduleScan?.();
             }
-        } catch { /* pipeline not loaded — ignore */ }
+        } catch { /* pipeline not loaded or invalidation failed — retry next push */ }
 
-        console.log(`${logPrefix} plugin config hot-reloaded from server push`);
+        if (JC.identity.isCurrent(context)) {
+            console.log(`${logPrefix} plugin config hot-reloaded from server push`);
+        }
     })();
 });
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/live-rows.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/live-rows.ts
@@ -26,9 +26,12 @@ const logPrefix = '🪼 Jellyfin Canopy: Live Rows:';
 let rescanTimer: ReturnType<typeof setTimeout> | null = null;
 
 function scheduleRescan(): void {
+    const context = JC.identity.capture();
+    if (!context) return;
     if (rescanTimer) return;
     rescanTimer = setTimeout(() => {
         rescanTimer = null;
+        if (!JC.identity.isCurrent(context)) return;
         try {
             JC.tagPipeline?.scheduleScan?.();
         } catch (err) {
@@ -57,5 +60,10 @@ on(LIVE.LIBRARY_CHANGED, scheduleRescan);
 // Watch-state / favourite / played changes → refresh watch-state-dependent
 // overlays (e.g. user-review / rating tags) to match the new state.
 on(LIVE.USER_DATA_CHANGED, handleUserDataChanged);
+
+JC.identity.registerReset('core-live-rows', () => {
+    if (rescanTimer) clearTimeout(rescanTimer);
+    rescanTimer = null;
+});
 
 console.log(`${logPrefix} initialized`);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/live-update.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/live-update.test.ts
@@ -74,4 +74,19 @@ describe('notifyIfNewer (one-shot toast)', () => {
         mod2.notifyIfNewer('unknown');
         expect(toast).not.toHaveBeenCalled();
     });
+
+    it('recreates exactly one initial check and interval for B', async () => {
+        const original = JC.identity.capture()!;
+        await loadWith('1.2.3.0');
+
+        const next = JC.identity.transition('server-b', 'user-b', 'live-update-test')!;
+        const afterReset = vi.getTimerCount();
+        await JC.identity.activate(next);
+        const afterActivation = vi.getTimerCount();
+        expect(afterActivation - afterReset).toBe(2);
+
+        await JC.identity.activate(next);
+        expect(vi.getTimerCount()).toBe(afterActivation);
+        JC.identity.transition(original.serverId, original.userId, 'live-update-test-restore');
+    });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/live-update.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/live-update.ts
@@ -20,6 +20,7 @@
 import { JC } from '../globals';
 import { register } from './lifecycle';
 import { LIVE, on } from './live';
+import type { IdentityContext } from '../types/jc';
 
 const logPrefix = '🪼 Jellyfin Canopy: Self-Update:';
 
@@ -87,14 +88,17 @@ export function notifyIfNewer(serverVersion: string | null | undefined): void {
  * version but register nothing. Keeps running after a notify so the heartbeat
  * never stops — notifyIfNewer itself is one-shot.
  */
-async function checkNow(): Promise<void> {
+async function checkNow(context: IdentityContext): Promise<void> {
     if (typeof ApiClient === 'undefined') return;
+    if (!JC.identity.isCurrent(context)) return;
     try {
         const res = await fetch(ApiClient.getUrl(`/JellyfinCanopy/version?_je=${Date.now()}`), {
             headers: { Authorization: `MediaBrowser Token="${ApiClient.accessToken()}"` }
         });
+        if (!JC.identity.isCurrent(context)) return;
         if (!res.ok) return;
         const serverVersion = (await res.text()).trim();
+        if (!JC.identity.isCurrent(context)) return;
         notifyIfNewer(serverVersion);
     } catch (err) {
         console.debug(`${logPrefix} version check failed:`, err);
@@ -108,18 +112,43 @@ on(LIVE.CONFIG_CHANGED, (data) => {
 });
 
 // (1) + (3): an initial check shortly after load, then a visibility-gated
-// re-check for sessions that stay open across an update. Tracked on a lifecycle
-// handle so teardownAll disposes the interval.
+// re-check for sessions that stay open across an update. Identity teardown
+// stops both and activation recreates exactly one pair for the new account.
 const handle = register('live-update');
-const initialCheck = setTimeout(() => { void checkNow(); }, 5000);
-handle.onTeardown(() => clearTimeout(initialCheck));
+let initialCheck: number | null = null;
+let recheck: number | null = null;
 
-const recheck = setInterval(() => {
-    // NOT gated on `notified`: beyond the one-shot toast, this ping is the
-    // session's live-push registry heartbeat and must outlive the notify.
-    if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return;
-    void checkNow();
-}, RECHECK_INTERVAL_MS);
-handle.track(recheck);
+function stopTimers(): void {
+    if (initialCheck !== null) {
+        clearTimeout(initialCheck);
+        initialCheck = null;
+    }
+    if (recheck !== null) {
+        clearInterval(recheck);
+        recheck = null;
+    }
+}
+
+function startTimers(context: IdentityContext): void {
+    if (!JC.identity.isCurrent(context)) return;
+    stopTimers();
+    initialCheck = window.setTimeout(() => {
+        initialCheck = null;
+        void checkNow(context);
+    }, 5000);
+    recheck = window.setInterval(() => {
+        // NOT gated on `notified`: beyond the one-shot toast, this ping is the
+        // session's live-push registry heartbeat and must outlive the notify.
+        if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return;
+        void checkNow(context);
+    }, RECHECK_INTERVAL_MS);
+}
+
+handle.onTeardown(stopTimers);
+JC.identity.registerReset('core-live-update', stopTimers);
+JC.identity.registerActivate('core-live-update', startTimers);
+
+const initialIdentity = JC.identity.capture();
+if (initialIdentity) startTimers(initialIdentity);
 
 console.log(`${logPrefix} initialized`);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/live.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/live.test.ts
@@ -8,14 +8,14 @@
 // import with a mocked subscribe.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { JC } from '../globals';
-import { dispatch, emit, getHandlerCount, LIVE, off, on } from './live';
-import { register, teardownAll } from './lifecycle';
+import { clearHandlersForTest, dispatch, emit, getHandlerCount, LIVE, off, on } from './live';
+import { teardownAll } from './lifecycle';
 import type { LiveMessage } from '../types/jc';
 
 describe('fan-out (on / emit / off)', () => {
     afterEach(() => {
         // Drain any handlers a test left registered so counts don't bleed across.
-        register('live').teardown();
+        clearHandlersForTest();
     });
 
     it('delivers an emitted event to every handler for that type', () => {
@@ -115,7 +115,7 @@ describe('fan-out (on / emit / off)', () => {
 
 describe('dispatch (SDK message → JC live event routing)', () => {
     afterEach(() => {
-        register('live').teardown();
+        clearHandlersForTest();
     });
 
     it('routes UserDataChanged to the user-data-changed event with its Data', () => {
@@ -217,7 +217,7 @@ describe('SDK-present wiring + teardown (fresh module)', () => {
         expect(h).toHaveBeenCalledWith({ ItemsAdded: ['x'] }, expect.anything());
     });
 
-    it('teardownAll disposes the SDK subscription and clears handlers', async () => {
+    it('teardownAll disposes the SDK subscription but preserves process-lifetime handlers', async () => {
         const unsub = vi.fn();
         (globalThis as { ApiClient: { subscribe?: unknown } }).ApiClient.subscribe = vi.fn(() => unsub);
 
@@ -229,7 +229,40 @@ describe('SDK-present wiring + teardown (fresh module)', () => {
         tearDownAll();
 
         expect(unsub).toHaveBeenCalledTimes(1);
-        expect(mod.getHandlerCount()).toBe(0);
+        expect(mod.getHandlerCount()).toBeGreaterThan(0);
+        mod.clearHandlersForTest();
+    });
+
+    it('unsubscribes A, ignores its queued callback, and subscribes B exactly once', async () => {
+        const callbacks: Array<(message: LiveMessage) => void> = [];
+        const unsubscribes: Array<ReturnType<typeof vi.fn>> = [];
+        const subscribe = vi.fn((_types: string[], callback: (message: LiveMessage) => void) => {
+            callbacks.push(callback);
+            const unsubscribe = vi.fn();
+            unsubscribes.push(unsubscribe);
+            return unsubscribe;
+        });
+        (globalThis as { ApiClient: { subscribe?: unknown } }).ApiClient.subscribe = subscribe;
+
+        const mod = await import('./live');
+        const handler = vi.fn();
+        mod.on(mod.LIVE.USER_DATA_CHANGED, handler);
+        const original = JC.identity.capture()!;
+
+        const next = JC.identity.transition('server-b', 'user-b', 'live-test')!;
+        expect(unsubscribes[0]).toHaveBeenCalledTimes(1);
+        callbacks[0]({ MessageType: 'UserDataChanged', Data: { UserId: original.userId } });
+        expect(handler).not.toHaveBeenCalled();
+
+        await JC.identity.activate(next);
+        await JC.identity.activate(next);
+        expect(subscribe).toHaveBeenCalledTimes(2);
+        callbacks[1]({ MessageType: 'UserDataChanged', Data: { UserId: next.userId } });
+        expect(handler).toHaveBeenCalledTimes(1);
+        expect(mod.getHandlerCount(mod.LIVE.USER_DATA_CHANGED)).toBe(1);
+
+        JC.identity.transition(original.serverId, original.userId, 'live-test-restore');
+        mod.clearHandlersForTest();
     });
 });
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/live.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/live.ts
@@ -17,7 +17,7 @@
 
 import { JC } from '../globals';
 import { register } from './lifecycle';
-import type { LiveApi, LiveHandler, LiveMessage } from '../types/jc';
+import type { IdentityContext, LiveApi, LiveHandler, LiveMessage } from '../types/jc';
 
 JC.core = JC.core || {};
 
@@ -45,6 +45,18 @@ export const LIVE = {
 
 const handlers = new Map<string, Set<LiveHandler>>();
 let sdkUnsubscribe: (() => void) | null = null;
+
+/** Dispose only the SDK socket. Process-lifetime fan-out handlers survive. */
+function unsubscribeSdk(): void {
+    if (!sdkUnsubscribe) return;
+    const unsubscribe = sdkUnsubscribe;
+    sdkUnsubscribe = null;
+    try {
+        unsubscribe();
+    } catch {
+        /* never propagate */
+    }
+}
 
 /**
  * Fan an event out to all handlers registered for `type`. Snapshots the set so
@@ -129,8 +141,9 @@ export function dispatch(message: LiveMessage): void {
  * Subscribe once to the SDK socket. Fails soft (logs a warning, leaves
  * isConnected() false) when the subscribe API is unavailable or throws.
  */
-function subscribe(): void {
+function subscribe(context: IdentityContext | null = JC.identity.capture()): void {
     if (sdkUnsubscribe) return; // already subscribed
+    if (!context || !JC.identity.isCurrent(context)) return;
     const client = typeof ApiClient !== 'undefined' ? ApiClient : undefined;
     if (!client || typeof client.subscribe !== 'function') {
         console.warn(
@@ -141,6 +154,9 @@ function subscribe(): void {
     }
     try {
         sdkUnsubscribe = client.subscribe(NATIVE_TYPES, (message) => {
+            // unsubscribe() cannot recall a callback the SDK already queued.
+            // Never fan an A message into B's process-lifetime handlers.
+            if (!JC.identity.isCurrent(context)) return;
             try {
                 dispatch(message);
             } catch (err) {
@@ -159,17 +175,21 @@ function subscribe(): void {
 // A dedicated 'live' lifecycle handle owns that teardown.
 const handle = register('live');
 subscribe();
-handle.onTeardown(() => {
-    if (sdkUnsubscribe) {
-        try {
-            sdkUnsubscribe();
-        } catch {
-            /* never propagate */
-        }
-        sdkUnsubscribe = null;
-    }
-    handlers.clear();
+handle.onTeardown(unsubscribeSdk);
+
+// Identity reset runs through core lifecycle teardown first, but this explicit
+// participant also makes the ownership rule local and safe if reset ordering
+// changes. Handlers are deliberately process-lifetime: live-config, live-rows
+// and Spoiler Guard register once when the bundle executes.
+JC.identity.registerReset('core-live', unsubscribeSdk);
+JC.identity.registerActivate('core-live', (context) => {
+    subscribe(context);
 });
+
+/** @internal Test isolation only; identity/lifecycle teardown must never call it. */
+export function clearHandlersForTest(): void {
+    handlers.clear();
+}
 
 const live: LiveApi = {
     on,

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/tag-renderer-base.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/tag-renderer-base.test.ts
@@ -184,3 +184,70 @@ describe('tag-renderer-base projection invalidation (BI-SEC-035)', () => {
         localStorage.removeItem(cacheKey);
     });
 });
+
+describe('tag-renderer-base identity ownership', () => {
+    afterEach(() => {
+        JC.identity.transition('test-server-id', 'test-user-id', 'tag-renderer-test-cleanup');
+        JC.tagPipeline = undefined;
+        JC.pluginConfig = {};
+        document.body.innerHTML = '';
+    });
+
+    it('drops A caches synchronously and rejects a retained A renderer context under B', () => {
+        const registerRenderer = vi.fn();
+        JC.tagPipeline = { registerRenderer };
+        JC.pluginConfig = { TagCacheServerMode: false };
+
+        const suffix = `${Date.now()}-${Math.random()}`;
+        const name = `identity-cache-${suffix}`;
+        const cacheKey = `jc-test-${name}`;
+        let retainedA: ReturnType<typeof register> | null = null;
+        const spec: TagSpec = {
+            logPrefix: 'identity-test',
+            settingKey: 'qualityTagsEnabled',
+            containerClass: `identity-overlay-${suffix.replaceAll('.', '-')}`,
+            taggedAttr: 'jcIdentityTestTagged',
+            cache: {
+                key: cacheKey,
+                legacyPrefix: `${cacheKey}-legacy`,
+                hotBucket: `${name}-hot`,
+                saveOnUnload: false,
+            },
+            pipeline: {
+                render(ctx) { retainedA = ctx; },
+            },
+        };
+
+        const ctxA = register(name, spec);
+        const hotA = ctxA.hot!;
+        ctxA.setPersistent('item', { value: 'A', timestamp: Date.now() });
+        hotA.set('item', { value: 'A' });
+        localStorage.setItem(cacheKey, JSON.stringify({ item: { value: 'A' } }));
+
+        const host = buildCardHost('indexPage');
+        const rendererA = registerRenderer.mock.calls.at(-1)![1] as {
+            render(el: HTMLElement, item: unknown): void;
+        };
+        rendererA.render(host, {});
+        expect(retainedA).not.toBeNull();
+
+        JC.identity.transition('server-b', `user-b-${suffix}`, 'tag-renderer-test');
+        expect(localStorage.getItem(cacheKey)).toBeNull();
+        expect(hotA.get('item')).toBeUndefined();
+        expect(ctxA.getPersistent('item')).toBeUndefined();
+
+        const ctxB = register(name, spec);
+        ctxA.setPersistent('late-public-a', { value: 'A' });
+        retainedA!.setPersistent('late-a', { value: 'A' });
+        const lateOverlay = document.createElement('div');
+        lateOverlay.className = spec.containerClass;
+        lateOverlay.appendChild(document.createElement('span'));
+        expect(retainedA!.commitOverlay(host, lateOverlay)).toBe(false);
+        expect(host.querySelector(`.${spec.containerClass}`)).toBeNull();
+        expect(ctxB.getPersistent('late-public-a')).toBeUndefined();
+        expect(ctxB.getPersistent('late-a')).toBeUndefined();
+
+        ctxB.setPersistent('item', { value: 'B' });
+        expect(ctxB.getPersistent('item')).toEqual({ value: 'B' });
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/tag-renderer-base.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/tag-renderer-base.ts
@@ -21,7 +21,13 @@
 import { JC } from '../globals';
 import { injectCss as uiInjectCss } from './ui-kit';
 import { createBoundedCache, type BoundedCache } from './bounded-cache';
-import type { TagPosition, TagRendererApi, TagRendererContext, TagSpec } from '../types/jc';
+import type {
+    IdentityContext,
+    TagPosition,
+    TagRendererApi,
+    TagRendererContext,
+    TagSpec,
+} from '../types/jc';
 
 JC.core = JC.core || {};
 
@@ -49,8 +55,10 @@ const STANDARD_IGNORE_SELECTORS: string[] = [
 
 interface TagInstance {
     ctx: TagRendererContext;
+    getContext(): TagRendererContext;
     initialize(): void;
     reinitialize(): void;
+    resetIdentity(): void;
 }
 
 /** name → tag instance */
@@ -104,6 +112,7 @@ function createTag(name: string, spec: TagSpec): TagInstance {
     const logPrefix = spec.logPrefix;
     const containerClass = spec.containerClass;
     const TAGGED_ATTR = spec.taggedAttr;
+    const ownerStorageKey = spec.cache ? `${spec.cache.key}:identity-owner` : '';
 
     const state = {
         /** persistent (localStorage-backed) cache */
@@ -115,7 +124,21 @@ function createTag(name: string, spec: TagSpec): TagInstance {
         ignoreSelectors: null as string[] | null,
         saveRegistered: false,
         unloadRegistered: false,
+        context: null as IdentityContext | null,
     };
+
+    function isContextCurrent(context: IdentityContext | null | undefined): context is IdentityContext {
+        return !!context
+            && !!state.context
+            && context.epoch === state.context.epoch
+            && context.serverId === state.context.serverId
+            && context.userId === state.context.userId
+            && JC.identity.isCurrent(context);
+    }
+
+    function ownerValue(context: IdentityContext): string {
+        return `${context.serverId}:${context.userId}`;
+    }
 
     // ── Ignore / tagged helpers ────────────────────────────────────
 
@@ -172,9 +195,29 @@ function createTag(name: string, spec: TagSpec): TagInstance {
             JC.pluginConfig?.EnableTagsLocalStorageFallback === true;
         state.cacheTtl = (JC.pluginConfig?.TagsCacheTtlDays || 30) * 24 * 60 * 60 * 1000;
         if (!spec.cache) return;
-        state.cache = state.localStorageEnabled
-            ? ((JSON.parse(localStorage.getItem(spec.cache.key) || '{}') || {}) as Record<string, unknown>)
-            : {};
+        const context = state.context;
+        if (!isContextCurrent(context)) {
+            state.cache = {};
+            state.hot?.clear();
+            return;
+        }
+        if (state.localStorageEnabled) {
+            const expectedOwner = ownerValue(context);
+            if (localStorage.getItem(ownerStorageKey) !== expectedOwner) {
+                // Legacy entries had no owner. Treat them as untrusted rather
+                // than exposing one user's projection to the next login.
+                localStorage.removeItem(spec.cache.key);
+                localStorage.setItem(ownerStorageKey, expectedOwner);
+            }
+            try {
+                state.cache = (JSON.parse(localStorage.getItem(spec.cache.key) || '{}') || {}) as Record<string, unknown>;
+            } catch {
+                state.cache = {};
+                localStorage.removeItem(spec.cache.key);
+            }
+        } else {
+            state.cache = {};
+        }
         if (spec.cache.hotBucket) {
             const Hot = (JC._hotCache = JC._hotCache || { ttl: state.cacheTtl });
             Hot[spec.cache.hotBucket] = Hot[spec.cache.hotBucket] ||
@@ -185,7 +228,8 @@ function createTag(name: string, spec: TagSpec): TagInstance {
 
     /** Persist the cache to localStorage (registered with JC._cacheManager). */
     function saveCache(): void {
-        if (!spec.cache || !state.localStorageEnabled) return;
+        const context = state.context;
+        if (!spec.cache || !state.localStorageEnabled || !isContextCurrent(context)) return;
         try {
             if (spec.cache.pruneOnSave) {
                 const now = Date.now();
@@ -195,6 +239,7 @@ function createTag(name: string, spec: TagSpec): TagInstance {
                     }
                 }
             }
+            localStorage.setItem(ownerStorageKey, ownerValue(context));
             localStorage.setItem(spec.cache.key, JSON.stringify(state.cache));
         } catch (e) {
             console.warn(`${logPrefix} Failed to save cache`, e);
@@ -264,6 +309,21 @@ function createTag(name: string, spec: TagSpec): TagInstance {
         uiInjectCss(spec.styleId, spec.buildCss(ctx));
     }
 
+    function guardedHot(context: IdentityContext): BoundedCache<string, unknown> | null {
+        if (!state.hot) return null;
+        const hot = state.hot;
+        return {
+            get: (key) => isContextCurrent(context) ? hot.get(key) : undefined,
+            set: (key, value) => { if (isContextCurrent(context)) hot.set(key, value); },
+            has: (key) => isContextCurrent(context) && hot.has(key),
+            delete: (key) => isContextCurrent(context) && hot.delete(key),
+            clear: () => { if (isContextCurrent(context)) hot.clear(); },
+            get size() { return isContextCurrent(context) ? hot.size : 0; },
+            keys: () => isContextCurrent(context) ? hot.keys() : new Map<string, unknown>().keys(),
+            values: () => isContextCurrent(context) ? hot.values() : new Map<string, unknown>().values(),
+        };
+    }
+
     // ── Context handed to spec callbacks ───────────────────────────
 
     const ctx: TagRendererContext = {
@@ -272,7 +332,10 @@ function createTag(name: string, spec: TagSpec): TagInstance {
         containerClass,
         taggedAttr: TAGGED_ATTR,
         /** shared hot cache bucket */
-        get hot() { return state.hot; },
+        get hot() {
+            const context = state.context;
+            return context && isContextCurrent(context) ? guardedHot(context) : null;
+        },
         /** cache TTL in ms */
         get cacheTtl() { return state.cacheTtl; },
         /** whether localStorage fallback is active */
@@ -280,22 +343,26 @@ function createTag(name: string, spec: TagSpec): TagInstance {
         /**
          * @returns the persistent cache entry (raw, module-defined shape)
          */
-        getPersistent(itemId: string): unknown { return state.cache[itemId]; },
+        getPersistent(itemId: string): unknown {
+            return isContextCurrent(state.context) ? state.cache[itemId] : undefined;
+        },
         /**
          * Store a persistent cache entry and schedule a save.
          */
         setPersistent(itemId: string, value: unknown): void {
+            if (!isContextCurrent(state.context)) return;
             state.cache[itemId] = value;
             if (JC._cacheManager) JC._cacheManager.markDirty();
         },
-        isTagged,
-        markTagged,
-        shouldIgnore,
-        injectCss,
+        isTagged: (el) => isContextCurrent(state.context) && isTagged(el),
+        markTagged: (el) => { if (isContextCurrent(state.context)) markTagged(el); },
+        shouldIgnore: (el) => !isContextCurrent(state.context) || shouldIgnore(el),
+        injectCss: () => { if (isContextCurrent(state.context)) injectCss(); },
         /**
          * Remove an existing overlay container from el, if present.
          */
         removeExistingOverlay(el: HTMLElement): void {
+            if (!isContextCurrent(state.context)) return;
             const existing = el.querySelector(`.${containerClass}`);
             if (existing) existing.remove();
         },
@@ -304,12 +371,47 @@ function createTag(name: string, spec: TagSpec): TagInstance {
          * @returns true if the overlay was attached
          */
         commitOverlay(el: HTMLElement, overlay: HTMLElement): boolean {
+            if (!isContextCurrent(state.context)) return false;
             if (overlay.children.length === 0) return false;
+            overlay.dataset.jcIdentityOwned = 'true';
             el.appendChild(overlay);
             markTagged(el);
             return true;
         },
     };
+
+    function scopedContext(context: IdentityContext): TagRendererContext {
+        return {
+            name,
+            logPrefix,
+            containerClass,
+            taggedAttr: TAGGED_ATTR,
+            get hot() { return guardedHot(context); },
+            get cacheTtl() { return state.cacheTtl; },
+            get localStorageEnabled() { return state.localStorageEnabled; },
+            getPersistent: (itemId) => isContextCurrent(context) ? state.cache[itemId] : undefined,
+            setPersistent: (itemId, value) => {
+                if (!isContextCurrent(context)) return;
+                state.cache[itemId] = value;
+                JC._cacheManager?.markDirty();
+            },
+            isTagged: (el) => isContextCurrent(context) && isTagged(el),
+            markTagged: (el) => { if (isContextCurrent(context)) markTagged(el); },
+            shouldIgnore: (el) => !isContextCurrent(context) || shouldIgnore(el),
+            injectCss: () => { if (isContextCurrent(context)) injectCss(); },
+            removeExistingOverlay: (el) => {
+                if (!isContextCurrent(context)) return;
+                el.querySelector(`.${containerClass}`)?.remove();
+            },
+            commitOverlay: (el, overlay) => {
+                if (!isContextCurrent(context) || overlay.children.length === 0) return false;
+                overlay.dataset.jcIdentityOwned = 'true';
+                el.appendChild(overlay);
+                markTagged(el);
+                return true;
+            },
+        };
+    }
 
     // ── Lifecycle ──────────────────────────────────────────────────
 
@@ -319,6 +421,9 @@ function createTag(name: string, spec: TagSpec): TagInstance {
      * renderer (fresh settings) without duplicating save hooks.
      */
     function initialize(): void {
+        const context = JC.identity.capture();
+        if (!context || !JC.identity.isCurrent(context)) return;
+        state.context = context;
         loadCacheSettings();
         state.ignoreSelectors = buildIgnoreSelectors();
         cleanupOldCaches();
@@ -341,18 +446,35 @@ function createTag(name: string, spec: TagSpec): TagInstance {
             return;
         }
         JC.tagPipeline.registerRenderer(name, {
-            render: (el: HTMLElement, item: unknown, extras?: unknown) => p.render(ctx, el, item, extras),
+            render: (el: HTMLElement, item: unknown, extras?: unknown) => {
+                const renderContext = state.context;
+                if (!isContextCurrent(renderContext)) return;
+                p.render(scopedContext(renderContext), el, item, extras);
+            },
             renderFromCache: p.renderFromCache
-                ? (el: HTMLElement, itemId: string) => p.renderFromCache!(ctx, el, itemId)
+                ? (el: HTMLElement, itemId: string) => {
+                    const renderContext = state.context;
+                    return isContextCurrent(renderContext)
+                        ? p.renderFromCache!(scopedContext(renderContext), el, itemId)
+                        : false;
+                }
                 : undefined,
             renderFromServerCache: p.renderFromServerCache
-                ? (el: HTMLElement, entry: unknown, itemId: string) => p.renderFromServerCache!(ctx, el, entry, itemId)
+                ? (el: HTMLElement, entry: unknown, itemId: string) => {
+                    const renderContext = state.context;
+                    if (isContextCurrent(renderContext)) {
+                        p.renderFromServerCache!(scopedContext(renderContext), el, entry, itemId);
+                    }
+                }
                 : undefined,
             onServerCacheRefresh: (updatedIds: string[] | null) => {
+                const renderContext = state.context;
+                if (!isContextCurrent(renderContext)) return;
                 invalidateCachedEntries(updatedIds);
-                if (p.onServerCacheRefresh) p.onServerCacheRefresh(ctx, updatedIds);
+                if (p.onServerCacheRefresh) p.onServerCacheRefresh(scopedContext(renderContext), updatedIds);
             },
             invalidateCard: (el: HTMLElement) => {
+                if (!isContextCurrent(state.context)) return;
                 ctx.removeExistingOverlay(el);
                 const card = el.closest<HTMLElement>('.card');
                 if (card) delete card.dataset[TAGGED_ATTR];
@@ -393,7 +515,28 @@ function createTag(name: string, spec: TagSpec): TagInstance {
         JC.tagPipeline?.scheduleScan?.();
     }
 
-    return { ctx, initialize, reinitialize };
+    function resetIdentity(): void {
+        state.context = null;
+        state.cache = {};
+        state.hot?.clear();
+        if (spec.cache) {
+            // The frozen cache key stays unchanged, but an unscoped snapshot is
+            // never allowed to survive an authenticated identity transition.
+            localStorage.removeItem(spec.cache.key);
+            localStorage.removeItem(ownerStorageKey);
+        }
+        document.querySelectorAll(`.${containerClass}`).forEach((el) => el.remove());
+        document.querySelectorAll<HTMLElement>(`[data-${toKebab(TAGGED_ATTR)}]`).forEach((el) => {
+            delete el.dataset[TAGGED_ATTR];
+        });
+    }
+
+    function getContext(): TagRendererContext {
+        const context = state.context;
+        return context && isContextCurrent(context) ? scopedContext(context) : ctx;
+    }
+
+    return { ctx, getContext, initialize, reinitialize, resetIdentity };
 }
 
 /**
@@ -417,7 +560,7 @@ function getOrCreate(name: string, spec: TagSpec): TagInstance {
 export function register(name: string, spec: TagSpec): TagRendererContext {
     const tag = getOrCreate(name, spec);
     tag.initialize();
-    return tag.ctx;
+    return tag.getContext();
 }
 
 /**
@@ -437,5 +580,9 @@ const tagRenderer: TagRendererApi = {
 };
 
 JC.core.tagRenderer = tagRenderer;
+
+JC.identity.registerReset('tag-renderer-base', () => {
+    for (const tag of tags.values()) tag.resetIdentity();
+});
 
 console.log('🪼 Jellyfin Canopy: Tag renderer core initialized');

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/ui-kit.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/ui-kit.ts
@@ -19,6 +19,17 @@ import type {
 
 JC.core = JC.core || {};
 
+const toastTimers = new Set<number>();
+
+function scheduleToastTask(callback: () => void, delay: number): void {
+    const context = JC.identity.capture();
+    const timer = window.setTimeout(() => {
+        toastTimers.delete(timer);
+        if (!context || JC.identity.isCurrent(context)) callback();
+    }, delay);
+    toastTimers.add(timer);
+}
+
 /**
  * Escapes HTML special characters to prevent XSS when interpolating into
  * HTML strings (innerHTML sinks, template literals, JC.toast, ...).
@@ -107,6 +118,7 @@ export function removeCss(id: string): boolean {
  * @param duration How long to show the toast, in ms.
  */
 export function toast(html: string, duration?: number): void {
+    const identity = JC.identity.capture();
     const ms = duration ?? (JC.CONFIG?.TOAST_DURATION || 1500);
 
     // Use the theme system to get appropriate colors
@@ -117,6 +129,7 @@ export function toast(html: string, duration?: number): void {
 
     const t = document.createElement('div');
     t.className = 'jellyfin-canopy-toast';
+    if (identity) t.dataset.jcIdentityOwned = 'true';
     Object.assign(t.style, {
         position: 'fixed',
         bottom: '20px',
@@ -138,12 +151,19 @@ export function toast(html: string, duration?: number): void {
     });
     t.innerHTML = html; // Note: the calling function should pass the localized string
     document.body.appendChild(t);
-    setTimeout(() => { t.style.transform = 'translateX(0)'; }, 10);
-    setTimeout(() => {
+    scheduleToastTask(() => { if (t.isConnected) t.style.transform = 'translateX(0)'; }, 10);
+    scheduleToastTask(() => {
+        if (!t.isConnected) return;
         t.style.transform = 'translateX(100%)';
-        setTimeout(() => t.remove(), 300);
+        scheduleToastTask(() => t.remove(), 300);
     }, ms);
 }
+
+JC.identity.registerReset('ui-toasts', () => {
+    for (const timer of toastTimers) clearTimeout(timer);
+    toastTimers.clear();
+    document.querySelectorAll('.jellyfin-canopy-toast').forEach((node) => node.remove());
+});
 
 // ── MUI component kit (v12 React/MUI markup match) ──────────────────────────
 //

--- a/Jellyfin.Plugin.JellyfinCanopy/src/discovery/customize.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/discovery/customize.ts
@@ -53,10 +53,14 @@ function defaultRowIds(genres: Map<number, string>): string[] {
  */
 export function openCustomize(mt: DiscoveryMediaType, genres: Map<number, string>, onSave: (ids: string[] | null) => void): void {
     if (activeClose) activeClose();
+    const context = JC.identity.capture();
+    if (!context) return;
     const items = buildItems(mt, genres);
 
     const overlay = document.createElement('div');
     overlay.className = 'jc-discovery-customize-overlay';
+    overlay.setAttribute('data-jc-identity-owned', 'true');
+    JC.identity.own(overlay, context);
     overlay.style.cssText = 'position:fixed;inset:0;z-index:1000001;background:rgba(0,0,0,0.75);backdrop-filter:blur(6px);display:flex;align-items:center;justify-content:center;padding:16px;';
 
     const dialog = document.createElement('div');
@@ -86,7 +90,9 @@ export function openCustomize(mt: DiscoveryMediaType, genres: Map<number, string
             cb.type = 'checkbox';
             cb.checked = item.checked;
             cb.setAttribute('aria-label', item.label);
-            cb.addEventListener('change', () => { item.checked = cb.checked; });
+            cb.addEventListener('change', () => {
+                if (JC.identity.isCurrent(context)) item.checked = cb.checked;
+            });
 
             const name = document.createElement('span');
             name.textContent = item.label;
@@ -108,11 +114,14 @@ export function openCustomize(mt: DiscoveryMediaType, genres: Map<number, string
         b.setAttribute('aria-label', label);
         b.disabled = disabled;
         b.style.cssText = `background:rgba(255,255,255,0.08);border:none;color:#fff;border-radius:4px;width:30px;height:30px;cursor:${disabled ? 'default' : 'pointer'};opacity:${disabled ? 0.3 : 1};font-size:11px;`;
-        if (!disabled) b.addEventListener('click', onClick);
+        if (!disabled) b.addEventListener('click', () => {
+            if (JC.identity.isCurrent(context)) onClick();
+        });
         return b;
     }
 
     function swap(a: number, b: number): void {
+        if (!JC.identity.isCurrent(context)) return;
         if (b < 0 || b >= items.length) return;
         [items[a], items[b]] = [items[b], items[a]];
         render();
@@ -138,12 +147,18 @@ export function openCustomize(mt: DiscoveryMediaType, genres: Map<number, string
     activeClose = close;
     cancel.addEventListener('click', close);
     overlay.addEventListener('click', (e) => { if (e.target === overlay) close(); });
-    reset.addEventListener('click', () => { clearUserRowIds(mt); close(); onSave(null); });
+    reset.addEventListener('click', () => {
+        if (!JC.identity.isCurrent(context)) return;
+        clearUserRowIds(mt);
+        close();
+        if (JC.identity.isCurrent(context)) onSave(null);
+    });
     save.addEventListener('click', () => {
+        if (!JC.identity.isCurrent(context)) return;
         const ids = items.filter((it) => it.checked).map((it) => it.id);
         setUserRowIds(mt, ids);
         close();
-        onSave(ids);
+        if (JC.identity.isCurrent(context)) onSave(ids);
     });
 
     render();
@@ -151,6 +166,8 @@ export function openCustomize(mt: DiscoveryMediaType, genres: Map<number, string
     document.body.appendChild(overlay);
     a11y = installModalA11y(dialog, { labelledBy: 'jc-discovery-customize-title', initialFocus: save, onEscape: close });
 }
+
+JC.identity.registerReset('discovery-customize', () => activeClose?.());
 
 function mkTextButton(text: string, bg: string): HTMLButtonElement {
     const b = document.createElement('button');

--- a/Jellyfin.Plugin.JellyfinCanopy/src/discovery/feed.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/discovery/feed.ts
@@ -11,11 +11,14 @@
 import { JC } from '../globals';
 import { injectCss } from '../core/ui-kit';
 import type { DiscoveryMediaType, DiscoveryRowSpec } from './rows';
+import type { IdentityContext } from '../types/jc';
 import { resolveRows, genreRowsEnabled } from './rows';
 import { fetchRow, fetchGenres } from './data';
 
 const CSS_ID = 'jc-discovery-feed-css';
 const FEED_CLASS = 'jc-discovery-feed';
+const activeControllers = new Set<AbortController>();
+const activeDestroyers = new Set<() => void>();
 
 function ensureCss(): void {
     injectCss(CSS_ID, `
@@ -57,10 +60,18 @@ function buildShelf(spec: DiscoveryRowSpec): { row: HTMLElement; itemsContainer:
 }
 
 /** Fills a shelf's cards from its data; hides the shelf if it resolves empty. */
-async function fillShelf(spec: DiscoveryRowSpec, mt: DiscoveryMediaType, row: HTMLElement, itemsContainer: HTMLElement, signal: AbortSignal): Promise<void> {
+async function fillShelf(
+    spec: DiscoveryRowSpec,
+    mt: DiscoveryMediaType,
+    row: HTMLElement,
+    itemsContainer: HTMLElement,
+    signal: AbortSignal,
+    context: IdentityContext,
+    scheduleFrame: (callback: FrameRequestCallback) => void
+): Promise<void> {
     try {
         const results = await fetchRow(spec, mt, signal);
-        if (signal.aborted) return;
+        if (signal.aborted || !JC.identity.isCurrent(context)) return;
         const fragment = JC.discoveryFilter?.createCardsFragment?.(results, { cardClass: 'overflowPortraitCard' });
         if (!fragment || fragment.childElementCount === 0) {
             row.classList.add('jc-discovery-row--empty');
@@ -68,9 +79,11 @@ async function fillShelf(spec: DiscoveryRowSpec, mt: DiscoveryMediaType, row: HT
         }
         itemsContainer.appendChild(fragment);
         // R7: content is in place before we reveal it; fade in (opacity only, no reflow).
-        requestAnimationFrame(() => itemsContainer.classList.add('jc-in'));
+        scheduleFrame(() => {
+            if (!signal.aborted && JC.identity.isCurrent(context)) itemsContainer.classList.add('jc-in');
+        });
     } catch (e) {
-        if ((e as Error)?.name === 'AbortError') return;
+        if ((e as Error)?.name === 'AbortError' || signal.aborted || !JC.identity.isCurrent(context)) return;
         row.classList.add('jc-discovery-row--empty');
     }
 }
@@ -87,12 +100,47 @@ export interface DiscoveryFeedHandle {
  */
 export async function renderFeed(container: HTMLElement, mt: DiscoveryMediaType, userRowIds: string[] | null = null): Promise<DiscoveryFeedHandle> {
     ensureCss();
+    const context = JC.identity.capture();
     const abort = new AbortController();
+    activeControllers.add(abort);
     const feed = document.createElement('div');
     feed.className = FEED_CLASS;
     feed.setAttribute('data-media-type', mt);
+    feed.setAttribute('data-jc-identity-owned', 'true');
+    if (context) JC.identity.own(feed, context);
+
+    let observer: IntersectionObserver | null = null;
+    let destroyed = false;
+    const frames = new Set<number>();
+    const scheduleFrame = (callback: FrameRequestCallback): void => {
+        const frame = requestAnimationFrame((time) => {
+            frames.delete(frame);
+            callback(time);
+        });
+        frames.add(frame);
+    };
+    const destroy = (): void => {
+        if (destroyed) return;
+        destroyed = true;
+        abort.abort();
+        activeControllers.delete(abort);
+        observer?.disconnect();
+        frames.forEach((frame) => cancelAnimationFrame(frame));
+        frames.clear();
+        activeDestroyers.delete(destroy);
+    };
+    activeDestroyers.add(destroy);
+
+    if (!context) {
+        destroy();
+        return { element: feed, destroy };
+    }
 
     const genres = await fetchGenres(mt, abort.signal);
+    if (abort.signal.aborted || !JC.identity.isCurrent(context)) {
+        destroy();
+        return { element: feed, destroy };
+    }
     let specs = resolveRows(userRowIds, genres);
     if (!userRowIds && genreRowsEnabled()) {
         // Enrich the default feed with a few real genre rows so it's rich out of the box.
@@ -107,30 +155,40 @@ export async function renderFeed(container: HTMLElement, mt: DiscoveryMediaType,
         msg.textContent = JC.t!('discovery_empty');
         feed.appendChild(msg);
         container.appendChild(feed);
-        return { element: feed, destroy: () => abort.abort() };
+        return { element: feed, destroy };
     }
 
     // Lazy-load: build every shelf shell (height reserved), fill each only when it nears the viewport.
-    const observer = new IntersectionObserver((entries) => {
+    const feedObserver = new IntersectionObserver((entries) => {
+        if (abort.signal.aborted || !JC.identity.isCurrent(context)) return;
         for (const entry of entries) {
             if (!entry.isIntersecting) continue;
             const el = entry.target as HTMLElement;
-            observer.unobserve(el);
+            feedObserver.unobserve(el);
             const spec = specs.find((s) => s.id === el.getAttribute('data-discovery-row'));
             const items = el.querySelector<HTMLElement>('.jc-discovery-row-cards');
-            if (spec && items) void fillShelf(spec, mt, el, items, abort.signal);
+            if (spec && items) void fillShelf(spec, mt, el, items, abort.signal, context, scheduleFrame);
         }
     }, { rootMargin: '400px 0px' });
+    observer = feedObserver;
 
     for (const spec of specs) {
         const { row } = buildShelf(spec);
         feed.appendChild(row);
-        observer.observe(row);
+        feedObserver.observe(row);
     }
 
     container.appendChild(feed);
     return {
         element: feed,
-        destroy: () => { abort.abort(); observer.disconnect(); },
+        destroy,
     };
 }
+
+JC.identity.registerReset('discovery-feeds', () => {
+    for (const destroy of [...activeDestroyers]) destroy();
+    for (const controller of [...activeControllers]) controller.abort();
+    activeControllers.clear();
+    document.querySelectorAll('[data-jc-identity-owned="true"].jc-discovery-feed')
+        .forEach((node) => node.remove());
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/discovery/library-tab.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/discovery/library-tab.ts
@@ -18,6 +18,7 @@ import { renderFeed, type DiscoveryFeedHandle } from './feed';
 import { fetchGenres } from './data';
 import { getUserRowIds } from './prefs';
 import { openCustomize } from './customize';
+import type { IdentityContext } from '../types/jc';
 
 interface LibraryPageDef {
     id: string;
@@ -39,6 +40,10 @@ interface PaneState {
 
 const state = new Map<string, PaneState>();
 let injectPending = false;
+let injectFrame: number | null = null;
+let initialized = false;
+let activeContext: IdentityContext | null = null;
+const lifecycle = JC.core.lifecycle!.register('discovery-library-tab');
 
 function stateFor(id: string): PaneState {
     let s = state.get(id);
@@ -98,23 +103,32 @@ function closePane(def: LibraryPageDef): void {
 }
 
 /** (Re)renders the feed into the pane's feed host using the caller's current saved row prefs. */
-async function renderFeedHost(def: LibraryPageDef): Promise<void> {
+async function renderFeedHost(def: LibraryPageDef, context: IdentityContext): Promise<void> {
+    if (!JC.identity.isCurrent(context)) return;
     const s = stateFor(def.id);
     if (!s.feedHost) return;
+    const feedHost = s.feedHost;
     s.feed?.destroy();
-    s.feedHost.textContent = '';
-    const handle = await renderFeed(s.feedHost, def.mediaType, getUserRowIds(def.mediaType));
-    if (!s.active) { handle.destroy(); return; }
+    feedHost.textContent = '';
+    const handle = await renderFeed(feedHost, def.mediaType, getUserRowIds(def.mediaType));
+    if (!JC.identity.isCurrent(context)
+        || state.get(def.id) !== s
+        || !s.active
+        || s.feedHost !== feedHost) {
+        handle.destroy();
+        return;
+    }
     s.feed = handle;
 }
 
 /** Builds the pane toolbar with the per-user "Customize" button. */
-function buildToolbar(def: LibraryPageDef): HTMLElement {
+function buildToolbar(def: LibraryPageDef, context: IdentityContext): HTMLElement {
     const toolbar = document.createElement('div');
     toolbar.className = 'jc-discovery-toolbar';
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.className = 'jc-discovery-customize-btn';
+    JC.identity.own(btn, context);
     const icon = document.createElement('span');
     icon.className = 'material-icons';
     icon.setAttribute('aria-hidden', 'true');
@@ -123,15 +137,20 @@ function buildToolbar(def: LibraryPageDef): HTMLElement {
     lbl.textContent = JC.t!('discovery_customize_button');
     btn.append(icon, lbl);
     btn.addEventListener('click', () => {
+        if (!JC.identity.isCurrent(context)) return;
         void fetchGenres(def.mediaType).then((genres) => {
-            openCustomize(def.mediaType, genres, () => { void renderFeedHost(def); });
+            if (!JC.identity.isCurrent(context) || !btn.isConnected) return;
+            openCustomize(def.mediaType, genres, () => {
+                if (JC.identity.isCurrent(context)) void renderFeedHost(def, context);
+            });
         });
     });
     toolbar.appendChild(btn);
     return toolbar;
 }
 
-async function openPane(def: LibraryPageDef): Promise<void> {
+async function openPane(def: LibraryPageDef, context: IdentityContext): Promise<void> {
+    if (!JC.identity.isCurrent(context)) return;
     const pageEl = document.querySelector<HTMLElement>(def.pageSelector);
     if (!pageEl) return;
     const s = stateFor(def.id);
@@ -139,26 +158,38 @@ async function openPane(def: LibraryPageDef): Promise<void> {
     const pane = document.createElement('div');
     pane.className = 'jc-discovery-pane';
     pane.setAttribute('data-discovery-pane', def.id);
+    pane.setAttribute('data-jc-identity-owned', 'true');
+    JC.identity.own(pane, context);
     const feedHost = document.createElement('div');
-    pane.append(buildToolbar(def), feedHost);
+    pane.append(buildToolbar(def, context), feedHost);
     pageEl.appendChild(pane);
     pageEl.classList.add('jc-discovery-active');
     s.pane = pane;
     s.feedHost = feedHost;
     s.active = true;
     document.getElementById('jc-discovery-toggle-' + def.id)?.classList.add('is-active');
-    await renderFeedHost(def);
+    await renderFeedHost(def, context);
     // If we were torn down mid-render (nav away), discard the now-orphaned pane.
-    if (!s.active) { s.feed?.destroy(); s.feed = null; pane.remove(); s.pane = null; s.feedHost = null; }
+    if (!JC.identity.isCurrent(context) || state.get(def.id) !== s || !s.active) {
+        s.feed?.destroy();
+        s.feed = null;
+        pane.remove();
+        if (state.get(def.id) === s) {
+            s.pane = null;
+            s.feedHost = null;
+        }
+    }
 }
 
-function toggle(def: LibraryPageDef): void {
+function toggle(def: LibraryPageDef, context: IdentityContext): void {
+    if (!JC.identity.isCurrent(context)) return;
     const s = stateFor(def.id);
-    if (s.active) closePane(def); else void openPane(def);
+    if (s.active) closePane(def); else void openPane(def, context);
 }
 
 /** Ensures the Discovery toggle button is in the library header tray for the given page. */
-function ensureToggle(def: LibraryPageDef): void {
+function ensureToggle(def: LibraryPageDef, context: IdentityContext): void {
+    if (!JC.identity.isCurrent(context)) return;
     const btnId = 'jc-discovery-toggle-' + def.id;
     if (document.getElementById(btnId)) return;
     const headerRight = getHeaderRightContainer();
@@ -168,14 +199,17 @@ function ensureToggle(def: LibraryPageDef): void {
         icon: 'trending_up',
         title: JC.t!('discovery_tab_title'),
         className: 'headerButton headerButtonRight paper-icon-button-light jc-discovery-toggle',
-        onClick: () => toggle(def),
+        onClick: () => toggle(def, context),
     });
+    btn.setAttribute('data-jc-identity-owned', 'true');
+    JC.identity.own(btn, context);
     if (stateFor(def.id).active) btn.classList.add('is-active');
     headerRight.insertBefore(btn, headerRight.firstChild);
     JC.core.ui!.expandIn(btn, {});
 }
 
-function inject(): void {
+function inject(context: IdentityContext): void {
+    if (!JC.identity.isCurrent(context)) return;
     if (!enabled()) return;
     const def = currentPage();
     // Tear down panes/toggles for any page we've navigated away from.
@@ -185,27 +219,54 @@ function inject(): void {
         document.getElementById('jc-discovery-toggle-' + p.id)?.remove();
     }
     if (!def) return;
-    ensureToggle(def);
+    ensureToggle(def, context);
     // Survive React re-renders: re-assert the content-hiding class, and if the pane node was blown
     // away, re-mount it.
     const s = stateFor(def.id);
     if (s.active) {
         const pageEl = document.querySelector<HTMLElement>(def.pageSelector);
         pageEl?.classList.add('jc-discovery-active');
-        if (!s.pane || !s.pane.isConnected) { s.pane = null; void openPane(def); }
+        if (!s.pane || !s.pane.isConnected) { s.pane = null; void openPane(def, context); }
     }
 }
 
-function scheduleInject(): void {
+function scheduleInject(context: IdentityContext | null = activeContext): void {
+    if (!context || !JC.identity.isCurrent(context)) return;
     if (injectPending) return;
     injectPending = true;
-    requestAnimationFrame(() => { injectPending = false; inject(); });
+    injectFrame = requestAnimationFrame(() => {
+        injectFrame = null;
+        injectPending = false;
+        if (JC.identity.isCurrent(context)) inject(context);
+    });
 }
 
 /** Wires the library-page Discovery surface. Idempotent — safe to call once at init. */
 export function initLibraryTab(): void {
+    if (initialized) return;
+    const context = JC.identity.capture();
+    if (!context) return;
+    initialized = true;
+    activeContext = context;
     ensureCss();
-    JC.core.dom!.onBodyMutation('jc-discovery-library', scheduleInject);
-    onNavigate(scheduleInject);
-    scheduleInject();
+    lifecycle.track(JC.core.dom!.onBodyMutation('jc-discovery-library', () => scheduleInject(context)));
+    lifecycle.track(onNavigate(() => scheduleInject(context)));
+    scheduleInject(context);
 }
+
+function resetLibraryTab(): void {
+    if (injectFrame !== null) cancelAnimationFrame(injectFrame);
+    injectFrame = null;
+    injectPending = false;
+    lifecycle.teardown();
+    for (const def of PAGES) closePane(def);
+    state.clear();
+    document.querySelectorAll('.jc-discovery-pane, .jc-discovery-toggle').forEach((node) => node.remove());
+    document.querySelectorAll('#moviesPage.jc-discovery-active, #tvshowsPage.jc-discovery-active')
+        .forEach((node) => node.classList.remove('jc-discovery-active'));
+    activeContext = null;
+    initialized = false;
+}
+
+JC.identity.registerReset('discovery-library-tab', resetLibraryTab);
+JC.identity.registerActivate('discovery-library-tab', () => initLibraryTab());

--- a/Jellyfin.Plugin.JellyfinCanopy/src/discovery/prefs.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/discovery/prefs.identity.test.ts
@@ -1,0 +1,24 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { JC } from '../globals';
+import { getUserRowIds, setUserRowIds } from './prefs';
+
+describe('Discovery preferences identity scope', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        JC.identity.transition('server-a', 'same-user', 'prefs-test-start');
+        ApiClient.getCurrentUserId = () => 'same-user';
+    });
+
+    it('does not replay a same-user preference on another server', () => {
+        setUserRowIds('movie', ['server-a-row']);
+        expect(getUserRowIds('movie')).toEqual(['server-a-row']);
+
+        JC.identity.transition('server-b', 'same-user', 'server-switch');
+        expect(getUserRowIds('movie')).toBeNull();
+
+        setUserRowIds('movie', ['server-b-row']);
+        expect(getUserRowIds('movie')).toEqual(['server-b-row']);
+        JC.identity.transition('server-a', 'same-user', 'server-switch-back');
+        expect(getUserRowIds('movie')).toEqual(['server-a-row']);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/discovery/prefs.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/discovery/prefs.ts
@@ -6,10 +6,30 @@
 // server-synced storage is a possible later upgrade.
 
 import type { DiscoveryMediaType } from './rows';
+import { JC } from '../globals';
 
-function storageKey(mt: DiscoveryMediaType): string {
-    const uid = (typeof ApiClient !== 'undefined' && ApiClient.getCurrentUserId?.()) || 'anon';
-    return `jc-discovery-rows:${uid}:${mt}`;
+function storageOwner(): { serverId: string; userId: string; legacyUserId: string } | null {
+    const uid = (typeof ApiClient !== 'undefined' && ApiClient.getCurrentUserId?.()) || '';
+    if (!uid) return null;
+    const normalizedUser = String(uid).replace(/-/g, '').toLowerCase();
+    const context = JC.identity?.capture?.() || null;
+    if (context && context.userId === normalizedUser) {
+        return { serverId: context.serverId, userId: normalizedUser, legacyUserId: String(uid) };
+    }
+    const extendedClient = ApiClient as unknown as { serverId?: () => unknown };
+    const rawServer = typeof extendedClient.serverId === 'function'
+        ? extendedClient.serverId()
+        : 'unknown-server';
+    const serverValue = typeof rawServer === 'string' || typeof rawServer === 'number'
+        ? String(rawServer)
+        : 'unknown-server';
+    const serverId = serverValue.replace(/-/g, '').toLowerCase();
+    return { serverId, userId: normalizedUser, legacyUserId: String(uid) };
+}
+
+function storageKey(mt: DiscoveryMediaType): string | null {
+    const owner = storageOwner();
+    return owner ? `jc-discovery-rows:${owner.serverId}:${owner.userId}:${mt}` : null;
 }
 
 /**
@@ -19,7 +39,19 @@ function storageKey(mt: DiscoveryMediaType): string {
  */
 export function getUserRowIds(mt: DiscoveryMediaType): string[] | null {
     try {
-        const raw = localStorage.getItem(storageKey(mt));
+        const key = storageKey(mt);
+        const owner = storageOwner();
+        if (!key || !owner) return null;
+        // One-time adoption of the pre-server-scope key. It can belong to only
+        // one server, so remove it immediately after assigning it to the first
+        // authenticated server that reads it.
+        const legacyKey = `jc-discovery-rows:${owner.legacyUserId}:${mt}`;
+        if (localStorage.getItem(key) === null) {
+            const legacy = localStorage.getItem(legacyKey);
+            if (legacy !== null) localStorage.setItem(key, legacy);
+        }
+        localStorage.removeItem(legacyKey);
+        const raw = localStorage.getItem(key);
         if (!raw) return null;
         const parsed: unknown = JSON.parse(raw);
         if (!Array.isArray(parsed)) return null;
@@ -29,10 +61,14 @@ export function getUserRowIds(mt: DiscoveryMediaType): string[] | null {
 
 /** Persists the user's row-id order for a media type. */
 export function setUserRowIds(mt: DiscoveryMediaType, ids: string[]): void {
-    try { localStorage.setItem(storageKey(mt), JSON.stringify(ids)); } catch { /* quota / private mode */ }
+    const key = storageKey(mt);
+    if (!key) return;
+    try { localStorage.setItem(key, JSON.stringify(ids)); } catch { /* quota / private mode */ }
 }
 
 /** Clears the user's customization so the feed reverts to the admin/default rows. */
 export function clearUserRowIds(mt: DiscoveryMediaType): void {
-    try { localStorage.removeItem(storageKey(mt)); } catch { /* ignore */ }
+    const key = storageKey(mt);
+    if (!key) return;
+    try { localStorage.removeItem(key); } catch { /* ignore */ }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/elsewhere/elsewhere.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/elsewhere/elsewhere.identity.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../globals';
+import '../enhanced/config';
+import './elsewhere';
+
+const realSaveUserSettings = JC.saveUserSettings!;
+const realCoreApi = JC.core.api;
+
+describe('Elsewhere account ownership', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        document.body.innerHTML = '';
+        JC.identity.transition('', '', 'test-logout');
+        const context = JC.identity.transition('test-server-id', 'test-user-id', 'test-login')!;
+        const elsewhere = JC.identity.own({ Region: 'US', Regions: [], Services: [] }, context);
+        JC.userConfig = JC.identity.own({ elsewhere }, context);
+        JC.pluginConfig = {
+            ElsewhereEnabled: true,
+            TmdbEnabled: true,
+            DEFAULT_REGION: 'US',
+        };
+        JC.t = (key: string) => key;
+        vi.spyOn(ApiClient, 'getCurrentUserId').mockReturnValue('test-user-id');
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            text: () => Promise.resolve('US\tUnited States'),
+        }));
+        vi.stubGlobal('requestIdleCallback', undefined);
+    });
+
+    afterEach(() => {
+        JC.saveUserSettings = realSaveUserSettings;
+        JC.core.api = realCoreApi;
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+        document.body.innerHTML = '';
+    });
+
+    it('makes a retained A modal completely inert after B becomes current', async () => {
+        const ajax = vi.spyOn(ApiClient, 'ajax').mockResolvedValue({});
+        const save = vi.fn();
+        JC.saveUserSettings = save;
+
+        (JC as typeof JC & { initializeElsewhereScript: () => void }).initializeElsewhereScript();
+        await Promise.resolve();
+        await Promise.resolve();
+        await vi.advanceTimersByTimeAsync(2_000);
+        const staleModal = document.getElementById('streaming-settings-modal')!;
+        expect(staleModal).not.toBeNull();
+        const staleSaveButton = document.getElementById('save-settings')!;
+
+        JC.identity.transition('test-server-id', 'user-b', 'account-switch');
+        vi.spyOn(ApiClient, 'getCurrentUserId').mockReturnValue('user-b');
+        vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        expect(document.getElementById('streaming-settings-modal')).toBeNull();
+        // Even if a host/client race reattaches the detached A modal, its own
+        // handlers must be inert. Relying on the central writer to reject an
+        // A-owned payload is too late: stale UI is not allowed to act as B.
+        document.body.appendChild(staleModal);
+        staleSaveButton.click();
+        await Promise.resolve();
+
+        expect(save).not.toHaveBeenCalled();
+        expect(ajax).not.toHaveBeenCalled();
+    });
+
+    it('does not let detached A search/settings controls act on B UI', async () => {
+        document.body.innerHTML = `
+            <div class="detailSectionContent">
+                <a href="https://www.themoviedb.org/movie/123">TMDB</a>
+            </div>`;
+        const fetchMock = vi.fn((input: RequestInfo | URL) => {
+            const url = input instanceof Request
+                ? input.url
+                : input instanceof URL ? input.href : input;
+            const text = url.includes('providers.txt')
+                    ? 'Netflix'
+                    : 'US\tUnited States';
+            return Promise.resolve({
+                ok: true,
+                status: 200,
+                text: () => Promise.resolve(text),
+                clone() { return this; },
+            } as unknown as Response);
+        });
+        vi.stubGlobal('fetch', fetchMock);
+        const apiFetch = vi.fn().mockResolvedValue({ results: { US: { flatrate: [] } } });
+        JC.core.api = { fetch: apiFetch } as unknown as typeof JC.core.api;
+
+        (JC as typeof JC & { initializeElsewhereScript: () => void }).initializeElsewhereScript();
+        await vi.advanceTimersByTimeAsync(2_500);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const staleSettings = document.querySelector<HTMLButtonElement>('.elsewhere-settings-button')!;
+        const staleSearch = document.querySelector<HTMLButtonElement>('.elsewhere-search-button')!;
+        expect(staleSettings).not.toBeNull();
+        expect(staleSearch).not.toBeNull();
+        const requestsBeforeSwitch = apiFetch.mock.calls.length;
+
+        JC.identity.transition('test-server-id', 'user-b', 'account-switch');
+        vi.spyOn(ApiClient, 'getCurrentUserId').mockReturnValue('user-b');
+        const bModal = document.createElement('div');
+        bModal.id = 'streaming-settings-modal';
+        bModal.style.display = 'none';
+        document.body.appendChild(bModal);
+
+        staleSettings.click();
+        staleSearch.click();
+        await Promise.resolve();
+
+        expect(bModal.style.display).toBe('none');
+        expect(staleSearch.disabled).toBe(false);
+        expect(apiFetch).toHaveBeenCalledTimes(requestsBeforeSwitch);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/elsewhere/elsewhere.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/elsewhere/elsewhere.ts
@@ -43,11 +43,80 @@ const JC = JEBase as typeof JEBase & {
     };
 };
 
+let activeElsewhereCleanup: (() => void) | null = null;
+
+function resetElsewhereIdentity(): void {
+    activeElsewhereCleanup?.();
+    activeElsewhereCleanup = null;
+    document.getElementById('streaming-settings-modal')?.remove();
+    document.querySelectorAll('.streaming-lookup-container').forEach((node) => node.remove());
+}
+
+JC.identity?.registerReset?.('elsewhere', resetElsewhereIdentity);
+
 /**
  * Initializes the Jellyfin Elsewhere script.
  * It will only run if the server reports TMDB is configured.
  */
 JC.initializeElsewhereScript = function() {
+    // Every delayed callback created by this initializer belongs to this exact
+    // account epoch. In particular, a modal left over from A must tag its fresh
+    // settings object as A-owned even if the user clicks Save after B signs in.
+    const identityContext = JC.identity?.capture?.() || null;
+    resetElsewhereIdentity();
+    let disposed = false;
+    const timeoutHandles = new Set<number>();
+    const idleHandles = new Set<number>();
+    const subscriptions: Array<() => void> = [];
+    const isInitializerCurrent = (): boolean => !disposed
+        && (!identityContext || JC.identity.isCurrent(identityContext));
+    const rejectStaleEvent = (event?: Event): boolean => {
+        if (isInitializerCurrent()) return false;
+        event?.preventDefault();
+        event?.stopImmediatePropagation();
+        return true;
+    };
+    const fenceInteractiveRoot = <T extends HTMLElement>(root: T): T => {
+        if (identityContext) JC.identity.own(root, identityContext);
+        root.dataset.jcIdentityOwned = 'true';
+        // Keep this capture fence attached to the subtree after normal teardown.
+        // A host closure can retain a detached A control; its descendant listeners
+        // and native link actions must remain inert after B becomes current.
+        for (const eventName of ['click', 'input', 'change', 'keydown']) {
+            root.addEventListener(eventName, (event) => {
+                rejectStaleEvent(event);
+            }, true);
+        }
+        return root;
+    };
+    const scheduleTimeout = (callback: () => void, delay: number): void => {
+        const handle = window.setTimeout(() => {
+            timeoutHandles.delete(handle);
+            if (isInitializerCurrent()) callback();
+        }, delay);
+        timeoutHandles.add(handle);
+    };
+    const scheduleIdle = (callback: () => void, timeout: number, fallbackDelay = timeout): void => {
+        if (typeof requestIdleCallback !== 'undefined') {
+            const handle = requestIdleCallback(() => {
+                idleHandles.delete(handle);
+                if (isInitializerCurrent()) callback();
+            }, { timeout });
+            idleHandles.add(handle);
+        } else {
+            scheduleTimeout(callback, fallbackDelay);
+        }
+    };
+    activeElsewhereCleanup = () => {
+        disposed = true;
+        for (const handle of timeoutHandles) clearTimeout(handle);
+        timeoutHandles.clear();
+        if (typeof cancelIdleCallback === 'function') {
+            for (const handle of idleHandles) cancelIdleCallback(handle);
+        }
+        idleHandles.clear();
+        for (const unsubscribe of subscriptions.splice(0)) unsubscribe();
+    };
     if (!JC.pluginConfig.ElsewhereEnabled) {
         console.log('🪼 Jellyfin Canopy: 🎬 Jellyfin Elsewhere: Feature is disabled in plugin settings.');
         return;
@@ -92,6 +161,7 @@ JC.initializeElsewhereScript = function() {
         fetch(assetUrl('elsewhere/regions.txt'))
             .then(response => response.ok ? response.text() : Promise.reject(new Error(`HTTP ${response.status}`)))
             .then(text => {
+                if (!isInitializerCurrent()) return;
                 const lines = text.trim().split('\n');
                 lines.forEach(line => {
                     if (line.startsWith('#')) return;
@@ -102,6 +172,7 @@ JC.initializeElsewhereScript = function() {
                 });
             })
             .catch(() => {
+                if (!isInitializerCurrent()) return;
                 // Fallback to hardcoded regions
                 availableRegions = {
                     'US': 'United States', 'GB': 'United Kingdom', 'IN': 'India', 'CA': 'Canada',
@@ -116,10 +187,12 @@ JC.initializeElsewhereScript = function() {
         fetch(assetUrl('elsewhere/providers.txt'))
             .then(response => response.ok ? response.text() : Promise.reject(new Error(`HTTP ${response.status}`)))
             .then(text => {
+                if (!isInitializerCurrent()) return;
                 availableProviders = text.trim().split('\n')
                     .filter(line => !line.startsWith('#') && line.trim() !== '');
             })
             .catch(() => {
+                if (!isInitializerCurrent()) return;
                 availableProviders = [
                     // Fallback to hardcoded providers
                     'Netflix', 'Amazon Prime Video', 'Disney Plus', 'HBO Max',
@@ -145,6 +218,7 @@ JC.initializeElsewhereScript = function() {
         let debounceTimer: ReturnType<typeof setTimeout> | undefined;
         // Use helpers.debounce if available for consistent behavior
         const debouncedFilter = JC.helpers?.debounce ? JC.helpers.debounce((filterText: string) => {
+            if (!isInitializerCurrent()) return;
             const value = filterText.toLowerCase();
             if (value.length === 0) {
                 dropdown.style.display = 'none';
@@ -217,7 +291,8 @@ JC.initializeElsewhereScript = function() {
                 const remove = document.createElement('span');
                 remove.textContent = '×';
                 remove.style.cssText = 'cursor: pointer; font-weight: bold; font-size: 14px;';
-                remove.onclick = () => {
+                remove.onclick = (event) => {
+                    if (rejectStaleEvent(event)) return;
                     const index = selectedValues.indexOf(value);
                     if (index > -1) {
                         selectedValues.splice(index, 1);
@@ -257,7 +332,10 @@ JC.initializeElsewhereScript = function() {
                     item.style.background = '#1a1a1a';
                 };
 
-                item.onclick = () => selectOption(option);
+                item.onclick = (event) => {
+                    if (rejectStaleEvent(event)) return;
+                    selectOption(option);
+                };
                 dropdown.appendChild(item);
             });
         }
@@ -280,6 +358,7 @@ JC.initializeElsewhereScript = function() {
         }
 
         function selectOption(option: string): void {
+            if (!isInitializerCurrent()) return;
             if (!selectedValues.includes(option)) {
                 selectedValues.push(option);
                 updateSelected();
@@ -290,13 +369,15 @@ JC.initializeElsewhereScript = function() {
             selectedIndex = -1;
         }
 
-        input.oninput = () => {
+        input.oninput = (event) => {
+            if (rejectStaleEvent(event)) return;
             if (debouncedFilter) {
                 debouncedFilter(input.value);
             } else {
                 // Fallback to manual debounce if helpers not available
                 clearTimeout(debounceTimer);
                 debounceTimer = setTimeout(() => {
+                    if (!isInitializerCurrent()) return;
                     const value = input.value.toLowerCase();
                     if (value.length === 0) {
                         dropdown.style.display = 'none';
@@ -311,6 +392,7 @@ JC.initializeElsewhereScript = function() {
         };
 
         input.onkeydown = (e) => {
+            if (rejectStaleEvent(e)) return;
             if (dropdown.style.display === 'none') return;
 
             switch (e.key) {
@@ -337,9 +419,10 @@ JC.initializeElsewhereScript = function() {
             }
         };
 
-        input.onblur = () => {
+        input.onblur = (event) => {
+            if (rejectStaleEvent(event)) return;
             // Delay hiding to allow clicks on dropdown items
-            setTimeout(() => {
+            scheduleTimeout(() => {
                 if (!dropdown.contains(document.activeElement)) {
                     dropdown.style.display = 'none';
                 }
@@ -355,7 +438,9 @@ JC.initializeElsewhereScript = function() {
     }
     // Create settings modal
     function createSettingsModal(): void {
-        const modal = document.createElement('div');
+        if (!isInitializerCurrent()) return;
+        document.getElementById('streaming-settings-modal')?.remove();
+        const modal = fenceInteractiveRoot(document.createElement('div'));
         modal.id = 'streaming-settings-modal';
         modal.style.cssText = `
             position: fixed;
@@ -436,11 +521,13 @@ JC.initializeElsewhereScript = function() {
         );
         servicesContainer.appendChild(servicesAutocomplete);
 
-        document.getElementById('cancel-settings')!.onclick = () => {
+        document.getElementById('cancel-settings')!.onclick = (event) => {
+            if (rejectStaleEvent(event)) return;
             modal.style.display = 'none';
         };
 
-        document.getElementById('save-settings')!.onclick = () => {
+        document.getElementById('save-settings')!.onclick = (event) => {
+            if (rejectStaleEvent(event)) return;
             userRegion = (document.getElementById('region-select') as HTMLSelectElement).value;
 
             // Get selected regions from autocomplete
@@ -463,16 +550,17 @@ JC.initializeElsewhereScript = function() {
 
             modal.style.display = 'none';
 
-            const elsewhereSettings = {
+            const elsewhereSettings = JC.identity.own({
                 Region: userRegion,
                 Regions: userRegions,
                 Services: userServices
-            };
+            }, identityContext);
             void JC.saveUserSettings('elsewhere.json', elsewhereSettings);
         };
 
         // Close on backdrop click
         modal.onclick = (e) => {
+            if (rejectStaleEvent(e)) return;
             if (e.target === modal) {
                 modal.style.display = 'none';
             }
@@ -541,10 +629,14 @@ JC.initializeElsewhereScript = function() {
 
     // Fetch streaming data
     function fetchStreamingData(tmdbId: string, mediaType: string, callback: (error: string | null, data?: any) => void): void {
+        if (!isInitializerCurrent()) return;
         const url = ApiClient.getUrl(`/JellyfinCanopy/tmdb/${mediaType}/${tmdbId}/watch/providers`);
         JC.core.api.fetch(url)
-            .then(data => callback(null, data))
+            .then(data => {
+                if (isInitializerCurrent()) callback(null, data);
+            })
             .catch((error: unknown) => {
+                if (!isInitializerCurrent()) return;
                 let errorMessage;
                 const errorMessageText = (error as Error).message || '';
 
@@ -775,7 +867,8 @@ JC.initializeElsewhereScript = function() {
             settingsButton.style.background = 'rgba(255, 255, 255, 0.1)';
         };
 
-        settingsButton.onclick = () => {
+        settingsButton.onclick = (event) => {
+            if (rejectStaleEvent(event)) return;
             const modal = document.getElementById('streaming-settings-modal');
             if (modal) {
                 modal.style.display = 'flex';
@@ -827,7 +920,8 @@ JC.initializeElsewhereScript = function() {
         container.appendChild(resultContainer);
 
         // Add click handler for manual lookup (multiple regions)
-        searchButton.onclick = () => {
+        searchButton.onclick = (event) => {
+            if (rejectStaleEvent(event)) return;
             searchButton.disabled = true;
             searchButton.innerHTML = '';
             const loadingIcon = createMaterialIcon('refresh', '16px');
@@ -984,7 +1078,8 @@ JC.initializeElsewhereScript = function() {
             closeButton.style.borderColor = 'rgba(255, 255, 255, 0.2)';
         };
 
-        closeButton.onclick = () => {
+        closeButton.onclick = (event) => {
+            if (rejectStaleEvent(event)) return;
             container.remove();
         };
 
@@ -1085,7 +1180,8 @@ JC.initializeElsewhereScript = function() {
             closeButton.style.borderColor = 'rgba(255, 255, 255, 0.2)';
         };
 
-        closeButton.onclick = () => {
+        closeButton.onclick = (event) => {
+            if (rejectStaleEvent(event)) return;
             container.remove();
         };
 
@@ -1108,7 +1204,9 @@ JC.initializeElsewhereScript = function() {
     // Auto-load streaming data (default region only), filling the DETACHED
     // container and signalling readiness so the caller can insert it once.
     function autoLoadStreamingData(tmdbId: string, mediaType: string, container: HTMLElement, onReady: () => void): void {
+        if (!isInitializerCurrent()) return;
         fetchStreamingData(tmdbId, mediaType, (error, data) => {
+            if (!isInitializerCurrent()) return;
             if (error) {
                 const errorDiv = document.createElement('div');
                 errorDiv.style.cssText = 'font-size: 13px; margin-top: 8px; color: #ff6b6b;';
@@ -1133,6 +1231,7 @@ JC.initializeElsewhereScript = function() {
 
     // Add buttons to detail pages
     function addStreamingLookup(): void {
+        if (!isInitializerCurrent()) return;
         const detailSections = document.querySelectorAll('.detailSectionContent');
 
         detailSections.forEach(section => {
@@ -1152,7 +1251,7 @@ JC.initializeElsewhereScript = function() {
             const tmdbId = match[2];
 
             // Create container — held OFF-DOM until its content is ready.
-            const container = document.createElement('div');
+            const container = fenceInteractiveRoot(document.createElement('div'));
             container.className = 'streaming-lookup-container';
             container.style.cssText = 'margin: 16px 0;';
 
@@ -1165,6 +1264,7 @@ JC.initializeElsewhereScript = function() {
             pendingElsewhereSections.add(section);
             autoLoadStreamingData(tmdbId, mediaType, container, () => {
                 pendingElsewhereSections.delete(section);
+                if (!isInitializerCurrent()) return;
                 if (!section.isConnected) return; // user navigated away
                 if (section.querySelector('.streaming-lookup-container')) return; // dedupe race
                 if (container.childNodes.length === 0) return; // nothing to show
@@ -1183,29 +1283,17 @@ JC.initializeElsewhereScript = function() {
     loadRegionsAndProviders();
     loadSettings();
 
-    // Use deferred initialization with requestIdleCallback
-    if (typeof requestIdleCallback !== 'undefined') {
-        requestIdleCallback(() => createSettingsModal(), { timeout: 2000 });
-    } else {
-        setTimeout(createSettingsModal, 2000);
-    }
+    scheduleIdle(createSettingsModal, 2000);
 
     // Coalesced, idle-scheduled lookup pass shared by every trigger below.
     let processingElsewhere = false;
     function scheduleStreamingLookup(): void {
-        if (processingElsewhere) return;
+        if (!isInitializerCurrent() || processingElsewhere) return;
         processingElsewhere = true;
-        if (typeof requestIdleCallback !== 'undefined') {
-            requestIdleCallback(() => {
-                addStreamingLookup();
-                processingElsewhere = false;
-            }, { timeout: 500 });
-        } else {
-            setTimeout(() => {
-                addStreamingLookup();
-                processingElsewhere = false;
-            }, 100);
-        }
+        scheduleIdle(() => {
+            addStreamingLookup();
+            processingElsewhere = false;
+        }, 500, 100);
     }
 
     // PERF(R3): this used to be a dedicated body-wide MutationObserver with
@@ -1224,19 +1312,17 @@ JC.initializeElsewhereScript = function() {
     // TMDB external link this feature anchors on only mounts when the host
     // renders item data, so with the gate dead the lookup never ran at all
     // on a slow first visit (only the too-early nav/viewshow probes fired).
-    onBodyMutation('elsewhere', () => {
+    const bodyMutation = onBodyMutation('elsewhere', () => {
+        if (!isInitializerCurrent()) return;
         if (!isDetailsPageVisible()) return;
         scheduleStreamingLookup();
     });
-    onNavigate(() => scheduleStreamingLookup());
-    onViewPage(() => scheduleStreamingLookup());
+    subscriptions.push(() => bodyMutation.unsubscribe());
+    subscriptions.push(onNavigate(() => scheduleStreamingLookup()));
+    subscriptions.push(onViewPage(() => scheduleStreamingLookup()));
 
     // Initial check
-    if (typeof requestIdleCallback !== 'undefined') {
-        requestIdleCallback(() => addStreamingLookup(), { timeout: 1000 });
-    } else {
-        setTimeout(addStreamingLookup, 1000);
-    }
+    scheduleIdle(addStreamingLookup, 1000);
 
     console.log('🪼 Jellyfin Canopy: 🎬 Jellyfin Elsewhere loaded!');
 };

--- a/Jellyfin.Plugin.JellyfinCanopy/src/elsewhere/reviews.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/elsewhere/reviews.ts
@@ -2,8 +2,8 @@
 
 import { JC as JEBase } from '../globals';
 import { ensureMaterialSymbolsFont } from '../core/ui-kit';
-import { decideReviewSuppression } from '../enhanced/spoiler-guard/suppression';
-import type { ApiApi, JELegacyHelpers, UserSettings } from '../types/jc';
+import { decideReviewSuppression, type SuppressionItem } from '../enhanced/spoiler-guard/suppression';
+import type { ApiApi, IdentityContext, JELegacyHelpers, UserSettings } from '../types/jc';
 
 /**
  * Local view of the shared namespace adding the public member this module
@@ -30,6 +30,50 @@ type ReviewsJE = typeof JEBase & {
 
 const JC = JEBase as ReviewsJE;
 
+interface ReviewItem extends SuppressionItem {
+    ProviderIds?: { Tmdb?: string | number };
+    SeriesProviderIds?: { Tmdb?: string | number };
+    IndexNumber?: number;
+    ParentIndexNumber?: number;
+}
+
+interface ReviewViewer {
+    Id?: string;
+    Policy?: { IsAdministrator?: boolean };
+}
+
+interface TmdbReview {
+    content: string;
+    author?: string;
+    created_at?: string;
+    author_details?: { rating?: number };
+}
+
+interface UserReview {
+    userId: string;
+    userName?: string;
+    content?: string;
+    rating?: number | null;
+    createdAt?: string;
+    updatedAt?: string;
+}
+
+function isTmdbReview(value: unknown): value is TmdbReview {
+    return value !== null && typeof value === 'object' && !Array.isArray(value)
+        && 'content' in value && typeof value.content === 'string';
+}
+
+function isUserReview(value: unknown): value is UserReview {
+    return value !== null && typeof value === 'object' && !Array.isArray(value)
+        && 'userId' in value && typeof value.userId === 'string';
+}
+
+function asReviewViewer(value: unknown): ReviewViewer | null {
+    return value !== null && typeof value === 'object' && !Array.isArray(value)
+        ? value
+        : null;
+}
+
 /** Dashboard global exposed by jellyfin-web (not typed in src/types/global.d.ts). */
 interface DashboardLike {
     confirm?: (text: string, title: string | undefined, callback: (confirmed: boolean) => void) => void;
@@ -48,13 +92,52 @@ export function resolveReviewByCard<T>(reviews: readonly T[], card: HTMLElement)
     return Number.isInteger(index) ? reviews[index] : undefined;
 }
 
+let reviewsGeneration = 0;
+let reviewsUnregister: (() => void) | null = null;
+const reviewsTimers = new Map<ReturnType<typeof setTimeout>, () => void>();
+
+function resetReviews(): void {
+    reviewsGeneration++;
+    reviewsUnregister?.();
+    reviewsUnregister = null;
+    for (const [timer, resolve] of reviewsTimers) {
+        clearTimeout(timer);
+        resolve();
+    }
+    reviewsTimers.clear();
+    document.querySelectorAll('.tmdb-reviews-section, .jc-review-form, .jc-review-form-placeholder, .jc-avg-user-rating-chip')
+        .forEach((node) => node.remove());
+}
+
+function reviewsActive(context: IdentityContext, expectedGeneration: number): boolean {
+    return reviewsGeneration === expectedGeneration && JC.identity.isCurrent(context);
+}
+
+function reviewsDelay(delay: number): Promise<void> {
+    return new Promise((resolve) => {
+        const finish = (): void => {
+            reviewsTimers.delete(timer);
+            resolve();
+        };
+        const timer = setTimeout(finish, delay);
+        reviewsTimers.set(timer, finish);
+    });
+}
+
 JC.initializeReviewsScript = function () {
+    resetReviews();
     const tmdbReviewsEnabled = JC.pluginConfig.ShowReviews && JC.pluginConfig.TmdbEnabled;
     const userReviewsEnabled = JC.pluginConfig.ShowUserReviews;
     if (!tmdbReviewsEnabled && !userReviewsEnabled) {
         console.log('🪼 Jellyfin Canopy: Reviews feature disabled.');
         return;
     }
+
+    const capturedIdentity = JC.identity.capture();
+    if (!capturedIdentity) return;
+    const identityContext: IdentityContext = capturedIdentity;
+    const expectedGeneration = reviewsGeneration;
+    const client = ApiClient;
 
     const logPrefix = '🪼 Jellyfin Canopy: Reviews:';
 
@@ -124,12 +207,16 @@ JC.initializeReviewsScript = function () {
         }
     }
 
-    function fetchReviews(tmdbId: string, mediaType: string): Promise<any[] | null> {
+    function fetchReviews(tmdbId: string, mediaType: string): Promise<TmdbReview[] | null> {
         const apiMediaType = mediaType === 'Series' ? 'tv' : 'movie';
         const url = `${ApiClient.getUrl(`/JellyfinCanopy/tmdb/${apiMediaType}/${tmdbId}/reviews`)}?language=en-US&page=1`;
         return JC.core.api.fetch(url)
-            .then((data: any) => data.results || [])
+            .then((data) => data !== null && typeof data === 'object' && !Array.isArray(data)
+                && 'results' in data && Array.isArray(data.results)
+                ? data.results.filter(isTmdbReview)
+                : [])
             .catch((error: unknown) => {
+                if (!reviewsActive(identityContext, expectedGeneration)) return null;
                 console.error(`${logPrefix} Failed to fetch reviews.`, error);
                 return null;
             });
@@ -138,11 +225,15 @@ JC.initializeReviewsScript = function () {
     /**
      * Fetches all user-written reviews for a TMDB item (aggregated across all users).
      */
-    function fetchUserReviews(tmdbId: string, mediaType: string): Promise<any[]> {
+    function fetchUserReviews(tmdbId: string, mediaType: string): Promise<UserReview[]> {
         // mediaType is already in API format ('movie' or 'tv') — no conversion needed
         return JC.core.api.plugin(`/reviews/${mediaType}/${tmdbId}`)
-            .then((data: any) => data.reviews || [])
+            .then((data) => data !== null && typeof data === 'object' && !Array.isArray(data)
+                && 'reviews' in data && Array.isArray(data.reviews)
+                ? data.reviews.filter(isUserReview)
+                : [])
             .catch((err: unknown) => {
+                if (!reviewsActive(identityContext, expectedGeneration)) return [];
                 console.error(`${logPrefix} Failed to fetch user reviews.`, err);
                 return [];
             });
@@ -397,7 +488,7 @@ JC.initializeReviewsScript = function () {
         return processed.join('');
     }
 
-    function createReviewElement(review: any, index: number): HTMLElement {
+    function createReviewElement(review: TmdbReview, index: number): HTMLElement {
         const REVIEW_PREVIEW_LENGTH = 350;
         const reviewCard = document.createElement('div');
         reviewCard.className = 'tmdb-review-card';
@@ -458,11 +549,11 @@ JC.initializeReviewsScript = function () {
      * when the viewer is an admin (for moderation).
      */
     function createUserReviewElement(
-        review: any,
+        review: UserReview,
         currentUserId: string,
         viewerIsAdmin: boolean,
-        onEditCallback: (review: any) => void,
-        onDeleteCallback: (review: any) => void | Promise<void>
+        onEditCallback: (review: UserReview) => void,
+        onDeleteCallback: (review: UserReview) => void | Promise<void>
     ): HTMLElement {
         const REVIEW_PREVIEW_LENGTH = 350;
         const reviewCard = document.createElement('div');
@@ -552,7 +643,7 @@ JC.initializeReviewsScript = function () {
      * @param onCancel - Called when the user cancels.
      */
     function createReviewForm(
-        existingReview: any,
+        existingReview: UserReview | null,
         onSave: (content: string, rating: number | null) => Promise<void>,
         onCancel: () => void
     ): HTMLElement {
@@ -610,6 +701,7 @@ JC.initializeReviewsScript = function () {
 
         // eslint-disable-next-line @typescript-eslint/no-misused-promises -- async click handler, matches the pre-conversion behavior
         submitBtn.addEventListener('click', async () => {
+            if (!reviewsActive(identityContext, expectedGeneration)) return;
             const content = textarea.value.trim();
             if (!content && !currentRating) {
                 errorEl.textContent = JC.t('reviews_form_error_empty');
@@ -621,6 +713,7 @@ JC.initializeReviewsScript = function () {
             try {
                 await onSave(content, currentRating || null);
             } catch (err) {
+                if (!reviewsActive(identityContext, expectedGeneration)) return;
                 errorEl.textContent = JC.t('reviews_form_error_save');
                 submitBtn.disabled = false;
                 submitBtn.innerHTML = '<span class="material-icons" aria-hidden="true">save</span>';
@@ -632,7 +725,8 @@ JC.initializeReviewsScript = function () {
         return form;
     }
 
-    function addReviewsToPage(reviews: any[] | null, userReviews: any[], contextPage: Element, tmdbId: string, tmdbMediaType: string, currentUser: any): void {
+    function addReviewsToPage(reviews: TmdbReview[] | null, userReviews: UserReview[], contextPage: Element, tmdbId: string, tmdbMediaType: string, currentUser: ReviewViewer | null): void {
+        if (!reviewsActive(identityContext, expectedGeneration) || !contextPage.isConnected) return;
         const existingSection = contextPage.querySelector('.tmdb-reviews-section');
         if (existingSection) {
             existingSection.remove();
@@ -640,7 +734,10 @@ JC.initializeReviewsScript = function () {
 
         // Inject average user rating chip next to the TMDB/RT rating chips
         if (userReviewsEnabled && userReviews.length > 0) {
-            const ratingsWithValue = userReviews.filter(r => r.rating);
+            const ratingsWithValue = userReviews.filter(
+                (review): review is UserReview & { rating: number } =>
+                    typeof review.rating === 'number' && review.rating !== 0
+            );
             if (ratingsWithValue.length > 0) {
                 const avg = ratingsWithValue.reduce((sum, r) => sum + r.rating, 0) / ratingsWithValue.length;
                 const raw = avg * 2; // convert 1-5 → raw out of 10
@@ -681,7 +778,7 @@ JC.initializeReviewsScript = function () {
         //      would see phantom admin controls, while the backend still
         //      blocks the actual delete with 403).
         // Using the live ApiClient session fixes both.
-        const currentUserId: string = (currentUser?.Id) || ApiClient.getCurrentUserId() || '';
+        const currentUserId: string = (currentUser?.Id) || identityContext.userId;
         const viewerIsAdmin = currentUser?.Policy?.IsAdministrator === true;
         const ownReview = userReviews.find(r => r.userId.replace(/-/g, '') === currentUserId.replace(/-/g, ''));
         let reviewsSection: HTMLDetailsElement;
@@ -732,6 +829,7 @@ JC.initializeReviewsScript = function () {
                     // Delete callback — routes to self-delete for own reviews,
                     // admin moderation delete for others (admin viewers only).
                     async (r) => {
+                        if (!reviewsActive(identityContext, expectedGeneration)) return;
                         const isOwn = r.userId.replace(/-/g, '') === currentUserId.replace(/-/g, '');
                         const userName = r.userName || 'user';
                         const title = isOwn
@@ -744,14 +842,17 @@ JC.initializeReviewsScript = function () {
                                 'Delete this review by {user}? This cannot be undone.',
                                 { user: userName });
                         if (!(await jcConfirm(body, title))) return;
+                        if (!reviewsActive(identityContext, expectedGeneration)) return;
                         try {
                             if (isOwn) {
                                 await deleteUserReview(tmdbId, tmdbMediaType);
                             } else {
                                 await adminDeleteUserReview(r.userId, tmdbId, tmdbMediaType);
                             }
+                            if (!reviewsActive(identityContext, expectedGeneration)) return;
                             void refreshReviews(contextPage);
                         } catch (e: any) {
+                            if (!reviewsActive(identityContext, expectedGeneration)) return;
                             // Surface the failure to the admin instead of
                             // silently failing: without this, a 403/404/500
                             // on the delete call would leave the review on
@@ -786,12 +887,14 @@ JC.initializeReviewsScript = function () {
             reviewsSection.appendChild(swipeContainer);
 
             // ── Form open/close helpers ──────────────────────────────────────
-            function openForm(existingReview: any): void {
+            function openForm(existingReview: UserReview | null): void {
+                if (!reviewsActive(identityContext, expectedGeneration)) return;
                 formPlaceholder.innerHTML = '';
                 const form = createReviewForm(
                     existingReview || null,
                     async (content, rating) => {
                         await saveUserReview(tmdbId, tmdbMediaType, content, rating);
+                        if (!reviewsActive(identityContext, expectedGeneration)) return;
                         void refreshReviews(contextPage);
                     },
                     () => { formPlaceholder.innerHTML = ''; }
@@ -804,6 +907,7 @@ JC.initializeReviewsScript = function () {
 
             if (writeBtn) {
                 writeBtn.addEventListener('click', () => {
+                    if (!reviewsActive(identityContext, expectedGeneration)) return;
                     if (formPlaceholder.querySelector('.jc-review-form')) {
                         formPlaceholder.innerHTML = '';
                     } else {
@@ -814,6 +918,7 @@ JC.initializeReviewsScript = function () {
 
             // ── Read-more toggle for TMDB reviews ─────────────────────────────
             swipeContainer.addEventListener('click', function (e) {
+                if (!reviewsActive(identityContext, expectedGeneration)) return;
                 const target = e.target as HTMLElement;
                 if (target.classList.contains('tmdb-review-toggle')) {
                     const textElement = target.parentElement!;
@@ -841,6 +946,7 @@ JC.initializeReviewsScript = function () {
 
             // Persist user's expand/collapse choice for future pages
             reviewsSection.addEventListener('toggle', function () {
+                if (!reviewsActive(identityContext, expectedGeneration)) return;
                 try {
                     if (!window.JellyfinCanopy) return;
                     const JC = window.JellyfinCanopy as ReviewsJE;
@@ -871,17 +977,20 @@ JC.initializeReviewsScript = function () {
      * Re-fetches and re-renders the review section for the current page.
      */
     async function refreshReviews(contextPage: Element): Promise<void> {
+        if (!reviewsActive(identityContext, expectedGeneration)) return;
         try {
             const itemId = new URLSearchParams(window.location.hash.split('?')[1]).get('id');
-            const userId = ApiClient.getCurrentUserId();
+            const userId = client.getCurrentUserId();
             if (!itemId || !userId) return;
 
             const item = (JC.helpers?.getItemCached
                 ? await JC.helpers.getItemCached(itemId, { userId })
-                : await ApiClient.getItem(userId, itemId)) as any;
+                : await client.getItem(userId, itemId)) as ReviewItem | null;
+            if (!reviewsActive(identityContext, expectedGeneration)) return;
             const mediaType = item?.Type;
 
             if (await shouldSuppressForSpoilerMode(item, mediaType)) {
+                if (!reviewsActive(identityContext, expectedGeneration)) return;
                 removeReviewsSection(contextPage);
                 return;
             }
@@ -903,7 +1012,8 @@ JC.initializeReviewsScript = function () {
                     let seriesTmdbId = item?.SeriesProviderIds?.Tmdb;
                     if (!seriesTmdbId && item?.SeriesId) {
                         try {
-                            const series = await ApiClient.getItem(userId, item.SeriesId) as any;
+                            const series = await client.getItem(userId, item.SeriesId) as ReviewItem | null;
+                            if (!reviewsActive(identityContext, expectedGeneration)) return;
                             seriesTmdbId = series?.ProviderIds?.Tmdb;
                         } catch (_) {}
                     }
@@ -914,7 +1024,8 @@ JC.initializeReviewsScript = function () {
                     let seriesTmdbId = item?.SeriesProviderIds?.Tmdb;
                     if (!seriesTmdbId && item?.SeriesId) {
                         try {
-                            const series = await ApiClient.getItem(userId, item.SeriesId) as any;
+                            const series = await client.getItem(userId, item.SeriesId) as ReviewItem | null;
+                            if (!reviewsActive(identityContext, expectedGeneration)) return;
                             seriesTmdbId = series?.ProviderIds?.Tmdb;
                         } catch (_) {}
                     }
@@ -932,8 +1043,10 @@ JC.initializeReviewsScript = function () {
                     ? fetchReviews(tmdbKey.split(':')[0], mediaType)
                     : Promise.resolve(null),
                 userReviewsEnabled ? fetchUserReviews(tmdbKey, apiMediaType) : Promise.resolve([]),
-                ApiClient.getCurrentUser().catch(() => null),
+                client.getCurrentUser().then(asReviewViewer).catch(() => null),
             ]);
+
+            if (!reviewsActive(identityContext, expectedGeneration)) return;
 
             const page = document.querySelector('#itemDetailPage:not(.hide)') || contextPage;
             addReviewsToPage(tmdbReviews, userReviews, page, tmdbKey, apiMediaType, currentUser);
@@ -943,6 +1056,7 @@ JC.initializeReviewsScript = function () {
                 JC.invalidateUserReviewTagCache(tmdbKey);
             }
         } catch (err) {
+            if (!reviewsActive(identityContext, expectedGeneration)) return;
             console.error(`${logPrefix} Failed to refresh reviews:`, err);
         }
     }
@@ -1143,21 +1257,25 @@ JC.initializeReviewsScript = function () {
     }
 
     async function processPage(visiblePage: Element): Promise<void> {
-        if (!visiblePage || visiblePage.querySelector('.tmdb-reviews-section')) {
+        if (!reviewsActive(identityContext, expectedGeneration)
+            || !visiblePage?.isConnected
+            || visiblePage.querySelector('.tmdb-reviews-section')) {
             return;
         }
 
         try {
             const itemId = new URLSearchParams(window.location.hash.split('?')[1]).get('id');
-            const userId = ApiClient.getCurrentUserId();
+            const userId = client.getCurrentUserId();
 
             if (itemId && userId) {
                 const item = (JC.helpers?.getItemCached
                     ? await JC.helpers.getItemCached(itemId, { userId })
-                    : await ApiClient.getItem(userId, itemId)) as any;
+                    : await client.getItem(userId, itemId)) as ReviewItem | null;
+                if (!reviewsActive(identityContext, expectedGeneration)) return;
                 const mediaType = item?.Type;
 
                 if (await shouldSuppressForSpoilerMode(item, mediaType)) {
+                    if (!reviewsActive(identityContext, expectedGeneration)) return;
                     removeReviewsSection(visiblePage);
                     return;
                 }
@@ -1180,7 +1298,8 @@ JC.initializeReviewsScript = function () {
                     let seriesTmdbId = item?.SeriesProviderIds?.Tmdb;
                     if (!seriesTmdbId && item?.SeriesId) {
                         try {
-                            const series = await ApiClient.getItem(userId, item.SeriesId) as any;
+                            const series = await client.getItem(userId, item.SeriesId) as ReviewItem | null;
+                            if (!reviewsActive(identityContext, expectedGeneration)) return;
                             seriesTmdbId = series?.ProviderIds?.Tmdb;
                         } catch (_) {}
                     }
@@ -1191,7 +1310,8 @@ JC.initializeReviewsScript = function () {
                     let seriesTmdbId = item?.SeriesProviderIds?.Tmdb;
                     if (!seriesTmdbId && item?.SeriesId) {
                         try {
-                            const series = await ApiClient.getItem(userId, item.SeriesId) as any;
+                            const series = await client.getItem(userId, item.SeriesId) as ReviewItem | null;
+                            if (!reviewsActive(identityContext, expectedGeneration)) return;
                             seriesTmdbId = series?.ProviderIds?.Tmdb;
                         } catch (_) {}
                     }
@@ -1209,12 +1329,14 @@ JC.initializeReviewsScript = function () {
                             ? fetchReviews(tmdbKey.split(':')[0], mediaType)
                             : Promise.resolve(null),
                         userReviewsEnabled ? fetchUserReviews(tmdbKey, apiMediaType) : Promise.resolve([]),
-                        ApiClient.getCurrentUser().catch(() => null),
+                        client.getCurrentUser().then(asReviewViewer).catch(() => null),
                     ]);
+                    if (!reviewsActive(identityContext, expectedGeneration)) return;
                     addReviewsToPage(tmdbReviews, userReviews, visiblePage, tmdbKey, apiMediaType, currentUser);
                 }
             }
         } catch (error) {
+            if (!reviewsActive(identityContext, expectedGeneration)) return;
             console.error(`${logPrefix} Error processing page:`, error);
         }
     }
@@ -1223,6 +1345,7 @@ JC.initializeReviewsScript = function () {
 
     // Use Emby.Page.onViewShow hook for reliable page navigation detection
     const unregister = JC.helpers.onViewPage(async (view, element, hash) => {
+        if (!reviewsActive(identityContext, expectedGeneration)) return;
         // Check if feature is still enabled
         if (!JC?.pluginConfig?.ShowReviews && !JC?.pluginConfig?.ShowUserReviews) {
             unregister();
@@ -1261,7 +1384,8 @@ JC.initializeReviewsScript = function () {
             let remainingVisibleMs = 120_000;
             let delay = 150;
             while (!visiblePage) {
-                await new Promise(resolve => setTimeout(resolve, delay));
+                await reviewsDelay(delay);
+                if (!reviewsActive(identityContext, expectedGeneration)) return;
                 if (window.location.hash !== currentHash) return; // navigated away
                 if (Date.now() >= hardDeadline) break;
                 if (document.visibilityState !== 'hidden') {
@@ -1280,4 +1404,7 @@ JC.initializeReviewsScript = function () {
         fetchItem: false,
         immediate: true // Process current page immediately on load
     });
+    reviewsUnregister = unregister;
 };
+
+JC.identity.registerReset('reviews', resetReviews);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/bookmarks.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/bookmarks.identity.test.ts
@@ -1,0 +1,391 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-return */
+
+type AnyRecord = Record<string, any>;
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+  reject(error: unknown): void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((done, fail) => {
+    resolve = done;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+}
+
+function bookmark(itemId = 'item-a', label = 'A'): AnyRecord {
+  return {
+    itemId,
+    tmdbId: 'tmdb-a',
+    tvdbId: '',
+    mediaType: 'movie',
+    name: 'Movie A',
+    timestamp: 40,
+    label,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z'
+  };
+}
+
+describe('bookmark player identity ownership', () => {
+  let JC: AnyRecord;
+  let save: ReturnType<typeof vi.fn<(fileName: string, settings: unknown) => Promise<void>>>;
+  let ajax: ReturnType<typeof vi.fn>;
+  let video: HTMLVideoElement;
+
+  async function loadModule(initialBookmarks: AnyRecord = { existing: bookmark() }): Promise<AnyRecord> {
+    vi.resetModules();
+    document.body.innerHTML = `
+      <div class="videoPlayerContainer"><video></video></div>
+      <div class="videoOsdBottom">
+        <button class="btnUserRating" data-id="item-a"></button>
+        <div class="osdPositionSliderContainer"><input class="osdPositionSlider" type="range"></div>
+        <div class="buttons focuscontainer-x"><button class="btnVideoOsdSettings"></button></div>
+      </div>
+    `;
+
+    JC = window.JellyfinCanopy;
+    JC.identity.transition('', '', 'bookmark-identity-test-logout');
+    const context = JC.identity.transition('server-a', 'user-a', 'bookmark-identity-test-a');
+    const root = JC.identity.own({ bookmarks: initialBookmarks }, context);
+    JC.userConfig = JC.identity.own({ bookmark: root }, context);
+    JC.pluginConfig = { BookmarksEnabled: true };
+    JC.t = (key: string) => key;
+    JC.escapeHtml = (value: unknown) => typeof value === 'string' ? value : '';
+    JC.isVideoPage = () => true;
+
+    save = vi.fn<(fileName: string, settings: unknown) => Promise<void>>().mockResolvedValue(undefined);
+    JC.saveUserSettings = save;
+    ajax = vi.fn().mockResolvedValue({
+      Items: [{
+        Id: 'item-a',
+        Name: 'Movie A',
+        Type: 'Movie',
+        ProviderIds: { Tmdb: 'tmdb-a' }
+      }]
+    });
+    const apiClient = {
+      getCurrentUserId: () => JC.identity.capture()?.userId || '',
+      getUrl: (path: string) => `http://jellyfin.test${path}`,
+      ajax,
+      getItem: vi.fn().mockResolvedValue({ Id: 'item-a' })
+    };
+    (globalThis as AnyRecord).ApiClient = apiClient;
+    (window as AnyRecord).ApiClient = apiClient;
+
+    video = document.querySelector('video')!;
+    Object.defineProperty(video, 'duration', { configurable: true, value: 100 });
+    video.currentTime = 5;
+
+    await import('./bookmarks');
+    return JC.bookmarks;
+  }
+
+  function switchToB(bookmarks: AnyRecord, userId = 'user-b'): AnyRecord {
+    const context = JC.identity.transition('server-b', userId, 'bookmark-identity-test-switch');
+    const root = JC.identity.own({ bookmarks }, context);
+    JC.userConfig = JC.identity.own({ bookmark: root }, context);
+    return root;
+  }
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  it('makes retained A markers, OSD buttons, and every modal control inert after a server switch', async () => {
+    const api = await loadModule();
+    await api.updateMarkers();
+    JC.initializeBookmarks();
+    await vi.waitFor(() => expect(document.getElementById('jcBookmarkBtn')).not.toBeNull());
+    await api.showModal('view');
+    await vi.waitFor(() => expect(document.querySelector('.jc-bm-player-modal-overlay')).not.toBeNull());
+
+    const marker = document.querySelector<HTMLElement>('.jc-bookmark-marker')!;
+    const osdButton = document.getElementById('jcBookmarkBtn') as HTMLButtonElement;
+    const modal = document.querySelector<HTMLElement>('.jc-bm-player-modal-overlay')!;
+    const close = modal.querySelector<HTMLButtonElement>('.jc-bookmark-modal-close')!;
+    const cancel = modal.querySelector<HTMLButtonElement>('.jc-bookmark-btn-cancel')!;
+    const submit = modal.querySelector<HTMLButtonElement>('.jc-bookmark-btn-submit')!;
+    const jump = modal.querySelector<HTMLButtonElement>('.jc-bookmark-btn-jump')!;
+    const remove = modal.querySelector<HTMLButtonElement>('.jc-bookmark-btn-delete')!;
+    await vi.waitFor(() => expect(modal.style.opacity).toBe('1'));
+
+    save.mockClear();
+    ajax.mockClear();
+    const bStore = { existing: { ...bookmark('item-b', 'B'), owner: 'b' } };
+    const bRoot = switchToB(bStore, 'user-a');
+    const retainedOpacity = modal.style.opacity;
+    video.currentTime = 5;
+
+    marker.click();
+    osdButton.click();
+    close.click();
+    cancel.click();
+    submit.click();
+    jump.click();
+    remove.click();
+    await new Promise((resolve) => setTimeout(resolve, 350));
+
+    expect(video.currentTime).toBe(5);
+    expect(save).not.toHaveBeenCalled();
+    expect(ajax).not.toHaveBeenCalled();
+    expect(bRoot.bookmarks).toBe(bStore);
+    expect(modal.style.opacity).toBe(retainedOpacity);
+    expect(document.querySelector('.jc-bm-player-modal-overlay')).toBeNull();
+    expect(document.querySelector('.jellyfin-canopy-toast')).toBeNull();
+  });
+
+  it('drops a held A modal submit without publishing B UI or markers', async () => {
+    const api = await loadModule({});
+    const heldSave = deferred<void>();
+    save.mockReturnValue(heldSave.promise);
+    const updated = vi.fn();
+    document.addEventListener('jc-bookmarks-updated', updated);
+
+    await api.showModal('add');
+    const modal = document.querySelector<HTMLElement>('.jc-bm-player-modal-overlay')!;
+    modal.querySelector<HTMLButtonElement>('.jc-bookmark-btn-submit')!.click();
+    await vi.waitFor(() => expect(save).toHaveBeenCalledTimes(1));
+
+    const bRoot = switchToB({ b: bookmark('item-b', 'B') });
+    ajax.mockClear();
+    heldSave.resolve(undefined);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(updated).not.toHaveBeenCalled();
+    expect(ajax).not.toHaveBeenCalled();
+    expect(bRoot.bookmarks).toEqual({ b: bookmark('item-b', 'B') });
+    expect(document.querySelector('.jc-bookmark-marker')).toBeNull();
+    expect(document.querySelector('.jellyfin-canopy-toast')).toBeNull();
+    document.removeEventListener('jc-bookmarks-updated', updated);
+  });
+
+  it('does not let an older same-identity item response poison the newer item cache owner', async () => {
+    const api = await loadModule({
+      one: bookmark('item-one', 'One'),
+      two: bookmark('item-two', 'Two')
+    });
+    const first = deferred<unknown>();
+    const second = deferred<unknown>();
+    ajax.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+    const rating = document.querySelector<HTMLElement>('.btnUserRating')!;
+
+    rating.dataset.id = 'item-one';
+    const firstMarkers = api.updateMarkers();
+    await vi.waitFor(() => expect(ajax).toHaveBeenCalledTimes(1));
+
+    rating.dataset.id = 'item-two';
+    const secondMarkers = api.updateMarkers();
+    await vi.waitFor(() => expect(ajax).toHaveBeenCalledTimes(2));
+
+    first.resolve({ Items: [{
+      Id: 'item-one',
+      Name: 'Movie One',
+      Type: 'Movie',
+      ProviderIds: { Tmdb: 'tmdb-one' }
+    }] });
+    await firstMarkers;
+
+    let modalSettled = false;
+    const newerModal = api.showModal('view').then(() => { modalSettled = true; });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(modalSettled).toBe(false);
+    expect(document.querySelector('.jc-bm-player-modal-overlay')).toBeNull();
+
+    second.resolve({ Items: [{
+      Id: 'item-two',
+      Name: 'Movie Two',
+      Type: 'Movie',
+      ProviderIds: { Tmdb: 'tmdb-two' }
+    }] });
+    await secondMarkers;
+    await newerModal;
+
+    expect(ajax).toHaveBeenCalledTimes(2);
+    expect(document.querySelector('.jc-bookmark-hero-subtitle')?.textContent).toBe('Movie Two');
+  });
+
+  it('drops item-one marker and modal continuations after same-identity navigation to item two', async () => {
+    const api = await loadModule({
+      one: bookmark('item-one', 'One'),
+      two: bookmark('item-two', 'Two')
+    });
+    const first = deferred<unknown>();
+    const second = deferred<unknown>();
+    ajax.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+    const rating = document.querySelector<HTMLElement>('.btnUserRating')!;
+
+    rating.dataset.id = 'item-one';
+    const staleMarkers = api.updateMarkers();
+    const staleModal = api.showModal('view');
+    await vi.waitFor(() => expect(ajax).toHaveBeenCalledTimes(1));
+
+    rating.dataset.id = 'item-two';
+    const currentMarkers = api.updateMarkers();
+    await vi.waitFor(() => expect(ajax).toHaveBeenCalledTimes(2));
+
+    first.resolve({ Items: [{
+      Id: 'item-one',
+      Name: 'Movie One',
+      Type: 'Movie',
+      ProviderIds: { Tmdb: 'tmdb-one' }
+    }] });
+    await Promise.all([staleMarkers, staleModal]);
+
+    expect(document.querySelector('.jc-bookmark-marker')).toBeNull();
+    expect(document.querySelector('.jc-bm-player-modal-overlay')).toBeNull();
+
+    second.resolve({ Items: [{
+      Id: 'item-two',
+      Name: 'Movie Two',
+      Type: 'Movie',
+      ProviderIds: { Tmdb: 'tmdb-two' }
+    }] });
+    await currentMarkers;
+
+    expect(document.querySelectorAll('.jc-bookmark-marker')).toHaveLength(1);
+    expect(document.querySelector<HTMLElement>('.jc-bookmark-marker')?.title).toContain('Two');
+    expect(document.querySelector('.jc-bm-player-modal-overlay')).toBeNull();
+  });
+
+  it('makes an already-open item-one modal and marker inert after playback advances to item two', async () => {
+    const api = await loadModule({ one: bookmark('item-a', 'One') });
+    await api.updateMarkers();
+    await api.showModal('view');
+    const rating = document.querySelector<HTMLElement>('.btnUserRating')!;
+    const marker = document.querySelector<HTMLElement>('.jc-bookmark-marker')!;
+    const modal = document.querySelector<HTMLElement>('.jc-bm-player-modal-overlay')!;
+    const submit = modal.querySelector<HTMLButtonElement>('.jc-bookmark-btn-submit')!;
+    const jump = modal.querySelector<HTMLButtonElement>('.jc-bookmark-btn-jump')!;
+    const remove = modal.querySelector<HTMLButtonElement>('.jc-bookmark-btn-delete')!;
+
+    save.mockClear();
+    ajax.mockClear();
+    rating.dataset.id = 'item-two';
+    video.currentTime = 5;
+    marker.click();
+    submit.click();
+    jump.click();
+    remove.click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(video.currentTime).toBe(5);
+    expect(save).not.toHaveBeenCalled();
+    expect(ajax).not.toHaveBeenCalled();
+    expect(JC.userConfig.bookmark.bookmarks).toEqual({ one: bookmark('item-a', 'One') });
+    expect(document.querySelector('.jellyfin-canopy-toast')).toBeNull();
+  });
+
+  it('does not save a bookmark when playback changes during its item-details fetch', async () => {
+    const api = await loadModule({});
+    const heldDetails = deferred<unknown>();
+    ajax.mockReturnValueOnce(heldDetails.promise);
+    const rating = document.querySelector<HTMLElement>('.btnUserRating')!;
+
+    const pending = api.add(12, 'Item one');
+    await vi.waitFor(() => expect(ajax).toHaveBeenCalledTimes(1));
+    rating.dataset.id = 'item-two';
+    heldDetails.resolve({ Items: [{
+      Id: 'item-a',
+      Name: 'Movie A',
+      Type: 'Movie',
+      ProviderIds: { Tmdb: 'tmdb-a' }
+    }] });
+
+    await expect(pending).resolves.toBeNull();
+    expect(save).not.toHaveBeenCalled();
+    expect(JC.userConfig.bookmark.bookmarks).toEqual({});
+  });
+
+  it('does not let a held rejected A add roll back a same-key B bookmark', async () => {
+    const api = await loadModule({});
+    const heldSave = deferred<void>();
+    save.mockReturnValue(heldSave.promise);
+    const updated = vi.fn();
+    document.addEventListener('jc-bookmarks-updated', updated);
+
+    const pending = api.add(12, 'A label');
+    await vi.waitFor(() => expect(save).toHaveBeenCalledTimes(1));
+    const aStore = save.mock.calls[0][1] as AnyRecord;
+    const generatedId = Object.keys(aStore.bookmarks)[0];
+    const bBookmark = { ...bookmark('item-b', 'B'), owner: 'b' };
+    const bRoot = switchToB({ [generatedId]: bBookmark });
+
+    heldSave.reject(new Error('stale A transport'));
+    await expect(pending).resolves.toBeNull();
+
+    expect(bRoot.bookmarks[generatedId]).toBe(bBookmark);
+    expect(updated).not.toHaveBeenCalled();
+    document.removeEventListener('jc-bookmarks-updated', updated);
+  });
+
+  it('drops a held A delete acknowledgement without touching or notifying B', async () => {
+    const api = await loadModule({ shared: bookmark() });
+    const heldSave = deferred<void>();
+    save.mockReturnValue(heldSave.promise);
+    const updated = vi.fn();
+    document.addEventListener('jc-bookmarks-updated', updated);
+
+    const pending = api.delete('shared');
+    await vi.waitFor(() => expect(save).toHaveBeenCalledTimes(1));
+    const bBookmark = { ...bookmark('item-b', 'B'), owner: 'b' };
+    const bRoot = switchToB({ shared: bBookmark });
+    heldSave.resolve(undefined);
+
+    await expect(pending).resolves.toBe(false);
+    expect(bRoot.bookmarks.shared).toBe(bBookmark);
+    expect(updated).not.toHaveBeenCalled();
+    document.removeEventListener('jc-bookmarks-updated', updated);
+  });
+
+  it('drops a held A migration removal without restoring or notifying through B', async () => {
+    const api = await loadModule({ old: bookmark('old-item', 'Old') });
+    const heldRemoval = deferred<void>();
+    save.mockResolvedValueOnce(undefined).mockReturnValueOnce(heldRemoval.promise);
+    const updated = vi.fn();
+    document.addEventListener('jc-bookmarks-updated', updated);
+
+    const pending = api.syncBookmarks(
+      [{ id: 'old', ...bookmark('old-item', 'Old') }],
+      { itemId: 'new-item', tmdbId: 'new', tvdbId: '', mediaType: 'movie', name: 'New' },
+      0,
+      ['old']
+    );
+    await vi.waitFor(() => expect(save).toHaveBeenCalledTimes(2));
+    const bBookmark = { ...bookmark('item-b', 'B'), owner: 'b' };
+    const bRoot = switchToB({ old: bBookmark });
+    heldRemoval.resolve(undefined);
+
+    await expect(pending).resolves.toEqual([]);
+    expect(bRoot.bookmarks.old).toBe(bBookmark);
+    expect(Object.keys(bRoot.bookmarks)).toEqual(['old']);
+    expect(updated).not.toHaveBeenCalled();
+    document.removeEventListener('jc-bookmarks-updated', updated);
+  });
+
+  it('stops after a synchronous update listener switches identity', async () => {
+    const api = await loadModule({});
+    const bStore = { b: bookmark('item-b', 'B') };
+    const onUpdated = vi.fn(() => { switchToB(bStore); });
+    document.addEventListener('jc-bookmarks-updated', onUpdated);
+
+    await expect(api.add(20, 'switch in listener')).resolves.toBeNull();
+
+    expect(onUpdated).toHaveBeenCalledTimes(1);
+    expect(JC.userConfig.bookmark.bookmarks).toBe(bStore);
+    document.removeEventListener('jc-bookmarks-updated', onUpdated);
+  });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/bookmarks.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/bookmarks.ts
@@ -8,21 +8,96 @@ import { escapeHtml, toast } from '../../core/ui-kit';
 import { getItemCached, debounce } from '../helpers';
 import { createObserver, disconnectObserver } from '../../core/dom-observer';
 import type { BookmarksApi } from './surface';
+import type { IdentityContext } from '../../types/jc';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-if (!JC.pluginConfig?.BookmarksEnabled) {
-  console.log('🪼 Jellyfin Canopy: Bookmarks feature is disabled');
-} else {
+// Define the surface for the document lifetime. The enabled gate is evaluated
+// on every identity activation; an A-disabled/B-enabled SPA switch must still
+// be able to start the feature without re-executing the bundle.
+{
 
   const logPrefix = '🪼 Jellyfin Canopy: Bookmarks:';
+  let bookmarkGeneration = 0;
+  const activeModalDisposers = new Map<HTMLElement, () => void>();
+  const bookmarkTimers = new Set<number>();
+  let forceCleanupBookmarks: (() => void) | null = null;
+
+  interface BookmarkIdentityCapture {
+    readonly context: Readonly<IdentityContext> | null;
+    readonly generation: number;
+  }
+
+  function captureIdentity(): BookmarkIdentityCapture {
+    const context = JC.identity.capture();
+    return Object.freeze({
+      context: context ? Object.freeze({
+        serverId: context.serverId,
+        userId: context.userId,
+        epoch: context.epoch
+      }) : null,
+      generation: bookmarkGeneration
+    });
+  }
+
+  function isIdentityCurrent(captured: BookmarkIdentityCapture): boolean {
+    return captured.generation === bookmarkGeneration && JC.identity.isCurrent(captured.context);
+  }
+
+  function scheduleIdentityTask(
+    captured: BookmarkIdentityCapture,
+    callback: () => void,
+    delay: number
+  ): number {
+    const timer = window.setTimeout(() => {
+      bookmarkTimers.delete(timer);
+      if (isIdentityCurrent(captured)) callback();
+    }, delay);
+    bookmarkTimers.add(timer);
+    return timer;
+  }
+
+  function disposeActiveModals(): void {
+    for (const dispose of [...activeModalDisposers.values()]) dispose();
+    activeModalDisposers.clear();
+  }
+
+  function bookmarkRootFor(captured: BookmarkIdentityCapture, create = false): any {
+    if (!captured.context || !isIdentityCurrent(captured)) return null;
+    const userConfig = (JC as any).userConfig;
+    if (!userConfig || typeof userConfig !== 'object') return null;
+
+    const configOwner = JC.identity.ownerOf(userConfig);
+    if (configOwner && !JC.identity.isOwned(userConfig, captured.context)) return null;
+
+    let root = userConfig.bookmark;
+    if (!root && create) {
+      root = JC.identity.own({ bookmarks: {} }, captured.context);
+      userConfig.bookmark = root;
+    }
+    if (!root || typeof root !== 'object') return null;
+
+    const rootOwner = JC.identity.ownerOf(root);
+    if (rootOwner && !JC.identity.isOwned(root, captured.context)) return null;
+    if (!root.bookmarks && create) root.bookmarks = {};
+    return root.bookmarks && typeof root.bookmarks === 'object' ? root : null;
+  }
+
+  function isBookmarkRootCurrent(captured: BookmarkIdentityCapture, root: any): boolean {
+    if (!isIdentityCurrent(captured) || (JC.userConfig as any)?.bookmark !== root) return false;
+    const owner = JC.identity.ownerOf(root);
+    return !owner || (!!captured.context && JC.identity.isOwned(root, captured.context));
+  }
 
   // Notify other views (e.g., CustomTabs library) when bookmarks change
-  function emitBookmarksUpdated(reason = 'updated'): void {
+  function emitBookmarksUpdated(captured: BookmarkIdentityCapture, reason = 'updated'): boolean {
+    if (!isIdentityCurrent(captured)) return false;
     try {
       document.dispatchEvent(new CustomEvent('jc-bookmarks-updated', { detail: { reason } }));
+      return isIdentityCurrent(captured);
     } catch (e) {
-      console.warn(`${logPrefix} Failed to emit update event`, e);
+      if (isIdentityCurrent(captured)) console.warn(`${logPrefix} Failed to emit update event`, e);
+      return false;
     }
   }
 
@@ -64,29 +139,58 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
     }
   }
 
+  /**
+   * Async player work is owned by both the account generation and the exact
+   * media item that initiated it. A same-account SPA navigation does not
+   * advance the identity epoch, so the item ID must also still match before
+   * publishing markers or a modal.
+   */
+  function isMediaItemCurrent(captured: BookmarkIdentityCapture, itemId: string): boolean {
+    return isIdentityCurrent(captured) && getCurrentItemData()?.itemId === itemId;
+  }
+
   interface ItemDetailsCache {
     itemId: string | null;
     data: any;
     pending: Promise<any> | null;
+    epoch: number;
+    requestId: number;
   }
-  const itemDetailsCache: ItemDetailsCache = { itemId: null, data: null, pending: null };
+  const itemDetailsCache: ItemDetailsCache = {
+    itemId: null,
+    data: null,
+    pending: null,
+    epoch: -1,
+    requestId: 0
+  };
 
   /**
    * Fetch full item details including TMDB/TVDB IDs (cached per item for a few seconds)
    */
   async function fetchItemDetails(itemId: string): Promise<any> {
-    if (itemDetailsCache.itemId === itemId && itemDetailsCache.data) {
+    const captured = captureIdentity();
+    const context = captured.context;
+    if (!context) return null;
+    if (itemDetailsCache.epoch === context.epoch && itemDetailsCache.itemId === itemId && itemDetailsCache.data) {
       return itemDetailsCache.data;
     }
 
-    if (itemDetailsCache.pending && itemDetailsCache.itemId === itemId) {
+    if (itemDetailsCache.epoch === context.epoch && itemDetailsCache.pending && itemDetailsCache.itemId === itemId) {
       return itemDetailsCache.pending;
     }
 
-    const fetchPromise = (async () => {
+    const requestId = itemDetailsCache.requestId + 1;
+    itemDetailsCache.itemId = itemId;
+    itemDetailsCache.data = null;
+    itemDetailsCache.epoch = context.epoch;
+    itemDetailsCache.requestId = requestId;
+
+    // Begin on the next microtask so the cache owns the request before even a
+    // synchronously-throwing host ApiClient can reach the finally block.
+    const fetchPromise = Promise.resolve().then(async () => {
       try {
-        const userId = ApiClient.getCurrentUserId?.();
-        if (!userId) return null;
+        const userId = context.userId;
+        if (!isIdentityCurrent(captured)) return null;
 
         const result: any = await ApiClient.ajax({
           type: 'GET',
@@ -98,7 +202,7 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
         });
 
         const item = result?.Items?.[0];
-        if (!item) return null;
+        if (!item || !isIdentityCurrent(captured)) return null;
 
         // For episodes/seasons, also get series TMDB/TVDB
         let sourceItem = item;
@@ -113,7 +217,7 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
               dataType: 'json'
             });
             const seriesItem = seriesResult?.Items?.[0];
-            if (seriesItem) {
+            if (seriesItem && isIdentityCurrent(captured)) {
               // Merge: use series TMDB/TVDB but keep episode info
               sourceItem = {
                 ...item,
@@ -125,6 +229,7 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
               };
             }
           } catch (e) {
+            if (!isIdentityCurrent(captured)) return null;
             console.warn(`${logPrefix} Failed to fetch series info:`, e);
           }
         }
@@ -144,17 +249,23 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
           type: item.Type
         };
 
-        itemDetailsCache.data = details;
+        if (!isIdentityCurrent(captured)) return null;
+        if (itemDetailsCache.epoch === context.epoch
+          && itemDetailsCache.requestId === requestId
+          && itemDetailsCache.itemId === itemId) {
+          itemDetailsCache.data = details;
+        }
         return details;
       } catch (e) {
+        if (!isIdentityCurrent(captured)) return null;
         console.warn(`${logPrefix} Error fetching item details:`, e);
         return null;
       } finally {
-        itemDetailsCache.pending = null;
+        if (itemDetailsCache.epoch === context.epoch
+          && itemDetailsCache.requestId === requestId) itemDetailsCache.pending = null;
       }
-    })();
+    });
 
-    itemDetailsCache.itemId = itemId;
     itemDetailsCache.pending = fetchPromise;
     return fetchPromise;
   }
@@ -207,15 +318,19 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
    * Add a new bookmark
    */
   async function addBookmark(timestamp: number, label = ''): Promise<Record<string, unknown> | null> {
+    const captured = captureIdentity();
+    if (!captured.context) return null;
     const itemData = getCurrentItemData();
     if (!itemData) {
       toast(JC.t!('toast_bookmark_no_item'), 3000);
       return null;
     }
+    const requestedItemId = itemData.itemId;
 
     // Fetch full details
-    const details = await fetchItemDetails(itemData.itemId);
-    if (!details) {
+    const details = await fetchItemDetails(requestedItemId);
+    if (!isMediaItemCurrent(captured, requestedItemId)) return null;
+    if (!details || details.itemId !== requestedItemId) {
       toast(JC.t!('toast_bookmark_fetch_failed'), 3000);
       return null;
     }
@@ -236,24 +351,22 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
       syncedFrom: ''
     };
 
-    // Initialize bookmark structure if needed
-    if (!(JC.userConfig as any).bookmark) {
-      (JC.userConfig as any).bookmark = { bookmarks: {} };
-    }
-    if (!(JC.userConfig as any).bookmark.bookmarks) {
-      (JC.userConfig as any).bookmark.bookmarks = {};
-    }
-
-    (JC.userConfig as any).bookmark.bookmarks[bookmarkId] = bookmark;
+    const root = bookmarkRootFor(captured, true);
+    if (!root || !isMediaItemCurrent(captured, requestedItemId)) return null;
+    const store = root.bookmarks;
+    store[bookmarkId] = bookmark;
 
     try {
-      await JC.saveUserSettings!('bookmark.json', (JC.userConfig as any).bookmark);
+      await JC.saveUserSettings!('bookmark.json', root);
+      if (!isBookmarkRootCurrent(captured, root)
+        || !isMediaItemCurrent(captured, requestedItemId)) return null;
       console.log(`${logPrefix} Bookmark added:`, bookmarkId, bookmark);
-      emitBookmarksUpdated('add');
+      if (!emitBookmarksUpdated(captured, 'add')) return null;
       return { id: bookmarkId, ...bookmark };
     } catch (e) {
+      if (!isBookmarkRootCurrent(captured, root)) return null;
       console.error(`${logPrefix} Failed to save bookmark:`, e);
-      delete (JC.userConfig as any).bookmark.bookmarks[bookmarkId];
+      delete store[bookmarkId];
       throw e;
     }
   }
@@ -262,20 +375,24 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
    * Update an existing bookmark
    */
   async function updateBookmark(bookmarkId: string, updates: Record<string, unknown>): Promise<boolean> {
-    if (!(JC.userConfig as any)?.bookmark?.bookmarks?.[bookmarkId]) {
+    const captured = captureIdentity();
+    if (!captured.context) return false;
+    const root = bookmarkRootFor(captured);
+    if (!root?.bookmarks?.[bookmarkId]) {
       console.warn(`${logPrefix} Bookmark not found:`, bookmarkId);
       return false;
     }
 
-    const bookmark = (JC.userConfig as any).bookmark.bookmarks[bookmarkId];
+    const bookmark = root.bookmarks[bookmarkId];
     Object.assign(bookmark, updates, { updatedAt: new Date().toISOString() });
 
     try {
-      await JC.saveUserSettings!('bookmark.json', (JC.userConfig as any).bookmark);
+      await JC.saveUserSettings!('bookmark.json', root);
+      if (!isBookmarkRootCurrent(captured, root)) return false;
       console.log(`${logPrefix} Bookmark updated:`, bookmarkId);
-      emitBookmarksUpdated('update');
-      return true;
+      return emitBookmarksUpdated(captured, 'update');
     } catch (e) {
+      if (!isBookmarkRootCurrent(captured, root)) return false;
       console.error(`${logPrefix} Failed to update bookmark:`, e);
       return false;
     }
@@ -285,19 +402,23 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
    * Delete a bookmark
    */
   async function deleteBookmark(bookmarkId: string): Promise<boolean> {
-    if (!(JC.userConfig as any)?.bookmark?.bookmarks?.[bookmarkId]) {
+    const captured = captureIdentity();
+    if (!captured.context) return false;
+    const root = bookmarkRootFor(captured);
+    if (!root?.bookmarks?.[bookmarkId]) {
       console.warn(`${logPrefix} Bookmark not found:`, bookmarkId);
       return false;
     }
 
-    delete (JC.userConfig as any).bookmark.bookmarks[bookmarkId];
+    delete root.bookmarks[bookmarkId];
 
     try {
-      await JC.saveUserSettings!('bookmark.json', (JC.userConfig as any).bookmark);
+      await JC.saveUserSettings!('bookmark.json', root);
+      if (!isBookmarkRootCurrent(captured, root)) return false;
       console.log(`${logPrefix} Bookmark deleted:`, bookmarkId);
-      emitBookmarksUpdated('delete');
-      return true;
+      return emitBookmarksUpdated(captured, 'delete');
     } catch (e) {
+      if (!isBookmarkRootCurrent(captured, root)) return false;
       console.error(`${logPrefix} Failed to delete bookmark:`, e);
       return false;
     }
@@ -319,9 +440,13 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
    *      originals — duplicates the user can retry, never data loss).
    */
   async function syncBookmarks(oldBookmarks: any[], newItemDetails: any, timeOffset = 0, removeOldIds?: string[]): Promise<any[]> {
+    const captured = captureIdentity();
+    if (!captured.context) return [];
     const synced: any[] = [];
     const now = new Date().toISOString();
-    const store = (JC.userConfig as any).bookmark.bookmarks;
+    const root = bookmarkRootFor(captured);
+    if (!root) return [];
+    const store = root.bookmarks;
 
     // 1. Write the new copies into memory.
     for (const oldBookmark of oldBookmarks) {
@@ -347,9 +472,11 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
 
     // 2. Persist + verify the new copies BEFORE removing any originals.
     try {
-      await JC.saveUserSettings!('bookmark.json', (JC.userConfig as any).bookmark);
+      await JC.saveUserSettings!('bookmark.json', root);
+      if (!isBookmarkRootCurrent(captured, root)) return [];
       console.log(`${logPrefix} Synced ${synced.length} bookmarks to new item ID`);
     } catch (e) {
+      if (!isBookmarkRootCurrent(captured, root)) return [];
       console.error(`${logPrefix} Failed to sync bookmarks:`, e);
       // Roll back the new copies we added; the originals were never touched.
       synced.forEach(bm => delete store[bm.id]);
@@ -366,18 +493,21 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
         }
       }
       try {
-        await JC.saveUserSettings!('bookmark.json', (JC.userConfig as any).bookmark);
+        await JC.saveUserSettings!('bookmark.json', root);
+        if (!isBookmarkRootCurrent(captured, root)) return [];
       } catch (e) {
+        if (!isBookmarkRootCurrent(captured, root)) return [];
         console.error(`${logPrefix} Synced new copies but could not persist removal of originals:`, e);
         // Restore the originals in memory so state matches disk (new copies +
         // originals). At worst duplicates remain — never data loss.
         Object.assign(store, removed);
-        emitBookmarksUpdated('sync');
+        if (!emitBookmarksUpdated(captured, 'sync')) return [];
         throw e;
       }
     }
 
-    emitBookmarksUpdated('sync');
+    if (!isBookmarkRootCurrent(captured, root)) return [];
+    if (!emitBookmarksUpdated(captured, 'sync')) return [];
     return synced;
   }
 
@@ -385,7 +515,11 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
    * Delete bookmarks for items that no longer exist in Jellyfin
    */
   async function cleanupOrphanedBookmarks(): Promise<{ cleaned: number; errors: number }> {
-    const allBookmarks = (JC.userConfig as any)?.bookmark?.bookmarks || {};
+    const captured = captureIdentity();
+    if (!captured.context) return { cleaned: 0, errors: 0 };
+    const root = bookmarkRootFor(captured);
+    if (!root) return { cleaned: 0, errors: 0 };
+    const allBookmarks = root.bookmarks;
     const itemIds = new Set<string>();
     const toDelete: string[] = [];
 
@@ -395,8 +529,7 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
     }
 
     // Check which items still exist
-    const userId = ApiClient.getCurrentUserId?.();
-    if (!userId) return { cleaned: 0, errors: 0 };
+    const userId = captured.context.userId;
 
     let cleaned = 0;
     let errors = 0;
@@ -404,8 +537,10 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
     for (const itemId of itemIds) {
       try {
         await getItemCached(itemId, { userId });
+        if (!isIdentityCurrent(captured)) return { cleaned, errors };
         // Item exists, keep bookmarks
       } catch (e) {
+        if (!isBookmarkRootCurrent(captured, root)) return { cleaned, errors };
         // DATA-SAFETY: only an EXPLICIT 404 (item confirmed gone) may delete a
         // bookmark. A network blip, 5xx, timeout or any other failure must NOT
         // destroy data — keep the bookmark and surface a warning instead.
@@ -425,14 +560,19 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
 
     // Delete orphaned bookmarks (confirmed 404s only)
     for (const bookmarkId of toDelete) {
+      if (!isBookmarkRootCurrent(captured, root)) return { cleaned, errors };
       try {
-        await deleteBookmark(bookmarkId);
-        cleaned++;
+        const deleted = await deleteBookmark(bookmarkId);
+        if (!isBookmarkRootCurrent(captured, root)) return { cleaned, errors };
+        if (deleted) cleaned++;
+        else errors++;
       } catch (e) {
+        if (!isBookmarkRootCurrent(captured, root)) return { cleaned, errors };
         errors++;
       }
     }
 
+    if (!isBookmarkRootCurrent(captured, root)) return { cleaned, errors };
     console.log(`${logPrefix} Cleanup: ${cleaned} orphaned bookmarks removed, ${errors} kept/failed (non-404 or delete error)`);
     return { cleaned, errors };
   }
@@ -452,10 +592,15 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
   /**
    * Create visual bookmark markers in video OSD
    */
-  function createBookmarkMarkers(video: HTMLVideoElement, bookmarksList: any[]): void {
+  function createBookmarkMarkers(
+    video: HTMLVideoElement,
+    bookmarksList: any[],
+    captured: BookmarkIdentityCapture,
+    mediaItemId: string
+  ): void {
     console.log(`${logPrefix} createBookmarkMarkers called - video:`, !!video, 'bookmarks:', bookmarksList.length);
 
-    if (!video || !bookmarksList.length) {
+    if (!captured.context || !isIdentityCurrent(captured) || !video || !bookmarksList.length) {
       console.log(`${logPrefix} Early return - no video or no bookmarks`);
       return;
     }
@@ -504,6 +649,8 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
 
       const marker = document.createElement('div');
       marker.className = 'jc-bookmark-marker';
+      marker.dataset.jcIdentityOwned = 'true';
+      marker.dataset.jcIdentityEpoch = String(captured.context!.epoch);
       marker.style.cssText = `
         position: absolute;
         left: ${percent}%;
@@ -535,12 +682,13 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
 
       // Click to jump to bookmark
       marker.addEventListener('click', (e) => {
+        if (!isMediaItemCurrent(captured, mediaItemId)) return;
         e.stopPropagation();
         video.currentTime = bookmark.timestamp;
         toast(`${JC.t!('toast_jumped_to_bookmark')}: ${formatTimestamp(bookmark.timestamp)}`, 2000);
       });
 
-      sliderContainer.appendChild(marker);
+      if (isMediaItemCurrent(captured, mediaItemId)) sliderContainer.appendChild(marker);
     });
 
     console.log(`${logPrefix} ✓ Created ${bookmarksList.length} bookmark markers`);
@@ -551,6 +699,8 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
    * Update bookmark markers for current video
    */
   async function updateBookmarkMarkersForCurrentVideo(): Promise<void> {
+    const captured = captureIdentity();
+    if (!captured.context) return;
     console.log(`${logPrefix} updateBookmarkMarkersForCurrentVideo called`);
 
     const video = document.querySelector<HTMLVideoElement>('.videoPlayerContainer video');
@@ -565,9 +715,12 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
       return;
     }
 
-    console.log(`${logPrefix} Fetching details for item:`, itemData.itemId);
-    const details = await fetchItemDetails(itemData.itemId);
-    if (!details) {
+    const requestedItemId = itemData.itemId;
+    console.log(`${logPrefix} Fetching details for item:`, requestedItemId);
+    const details = await fetchItemDetails(requestedItemId);
+    if (!details
+      || details.itemId !== requestedItemId
+      || !isMediaItemCurrent(captured, requestedItemId)) {
       console.log(`${logPrefix} Failed to fetch item details`);
       return;
     }
@@ -580,13 +733,15 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
     );
 
     console.log(`${logPrefix} Found ${bookmarksList.length} bookmarks for this item`);
-    createBookmarkMarkers(video, bookmarksList);
+    createBookmarkMarkers(video, bookmarksList, captured, requestedItemId);
   }
 
   /**
    * Show bookmark management modal
    */
   async function showBookmarkModal(mode = 'add', existingBookmark: any = null): Promise<void> {
+    const captured = captureIdentity();
+    if (!captured.context) return;
     const video = document.querySelector<HTMLVideoElement>('.videoPlayerContainer video');
     const currentTime = video?.currentTime || 0;
 
@@ -596,11 +751,14 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
       return;
     }
 
-    const details = await fetchItemDetails(itemData.itemId);
+    const requestedItemId = itemData.itemId;
+    const details = await fetchItemDetails(requestedItemId);
+    if (!isMediaItemCurrent(captured, requestedItemId)) return;
     if (!details) {
       toast(JC.t!('toast_bookmark_fetch_failed'), 3000);
       return;
     }
+    if (details.itemId !== requestedItemId) return;
 
     const { bookmarks: existingBookmarks } = findBookmarksForItem(
       details.itemId,
@@ -958,6 +1116,8 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
     // Create custom modal
     const modal = document.createElement('div');
     modal.className = 'jc-bm-player-modal-overlay';
+    modal.dataset.jcIdentityOwned = 'true';
+    modal.dataset.jcIdentityEpoch = String(captured.context.epoch);
     modal.innerHTML = `
       <div class="jc-bm-player-modal-container">
         <button class="jc-bookmark-modal-close">×</button>
@@ -972,35 +1132,78 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
       </div>
     `;
 
+    if (!isIdentityCurrent(captured)) return;
     document.body.appendChild(modal);
 
-    // Prevent keyboard shortcuts and wheel events from affecting video player
-    modal.addEventListener('keydown', (e) => e.stopPropagation());
-    modal.addEventListener('keyup', (e) => e.stopPropagation());
-    modal.addEventListener('keypress', (e) => e.stopPropagation());
-    modal.addEventListener('wheel', (e) => e.stopPropagation());
+    const modalTimers = new Set<number>();
+    let removalTimer: number | null = null;
+    let removed = false;
+    let closing = false;
 
-    const closeDialog = () => {
-      modal.style.opacity = '0';
-      setTimeout(() => {
-        modal.remove();
-        // Remove navigation listener
-        document.removeEventListener('viewshow', closeDialog);
-      }, 200);
+    const scheduleModalTask = (callback: () => void, delay: number): void => {
+      const timer = window.setTimeout(() => {
+        modalTimers.delete(timer);
+        if (isIdentityCurrent(captured) && !removed) callback();
+      }, delay);
+      modalTimers.add(timer);
     };
 
+    const removeModalNow = (): void => {
+      if (removed) return;
+      removed = true;
+      for (const timer of modalTimers) clearTimeout(timer);
+      modalTimers.clear();
+      if (removalTimer !== null) clearTimeout(removalTimer);
+      removalTimer = null;
+      document.removeEventListener('viewshow', requestClose);
+      activeModalDisposers.delete(modal);
+      modal.remove();
+    };
+
+    const disposeModal = (immediate: boolean): void => {
+      if (removed) return;
+      if (immediate) {
+        removeModalNow();
+        return;
+      }
+      if (closing) return;
+      closing = true;
+      modal.style.opacity = '0';
+      removalTimer = window.setTimeout(removeModalNow, 200);
+    };
+
+    function requestClose(): void {
+      if (!isIdentityCurrent(captured)) return;
+      disposeModal(false);
+    }
+
+    const isModalOwnerCurrent = (): boolean =>
+      isMediaItemCurrent(captured, requestedItemId);
+
+    activeModalDisposers.set(modal, () => disposeModal(true));
+
+    // Prevent keyboard shortcuts and wheel events from affecting video player
+    modal.addEventListener('keydown', (e) => { if (isIdentityCurrent(captured)) e.stopPropagation(); });
+    modal.addEventListener('keyup', (e) => { if (isIdentityCurrent(captured)) e.stopPropagation(); });
+    modal.addEventListener('keypress', (e) => { if (isIdentityCurrent(captured)) e.stopPropagation(); });
+    modal.addEventListener('wheel', (e) => { if (isIdentityCurrent(captured)) e.stopPropagation(); });
+
     // Close modal when navigating away
-    document.addEventListener('viewshow', closeDialog);
+    document.addEventListener('viewshow', requestClose);
 
     // Close button
-    modal.querySelector('.jc-bookmark-modal-close')?.addEventListener('click', closeDialog);
-    modal.querySelector('.jc-bookmark-btn-cancel')?.addEventListener('click', closeDialog);
+    modal.querySelector('.jc-bookmark-modal-close')?.addEventListener('click', requestClose);
+    modal.querySelector('.jc-bookmark-btn-cancel')?.addEventListener('click', requestClose);
     modal.addEventListener('click', (e) => {
-      if (e.target === modal) closeDialog();
+      if (isIdentityCurrent(captured) && e.target === modal) requestClose();
     });
 
     // Focus label input after modal opens
-    setTimeout(() => {
+    scheduleModalTask(() => {
+      if (!isModalOwnerCurrent()) {
+        disposeModal(true);
+        return;
+      }
       const labelInput = modal.querySelector<HTMLInputElement>('#bookmark-label');
       if (labelInput) labelInput.focus();
       modal.style.opacity = '1';
@@ -1008,21 +1211,28 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
 
     // Submit
     modal.querySelector('.jc-bookmark-btn-submit')?.addEventListener('click', () => { void (async () => {
+      if (!isModalOwnerCurrent()) return;
       const labelInput = modal.querySelector<HTMLInputElement>('#bookmark-label')!.value.trim();
 
       try {
+        let saved: boolean | Record<string, unknown> | null;
         if (isEdit) {
-          await updateBookmark(existingBookmark.id, { label: labelInput });
-           toast(JC.t!('toast_bookmark_updated'), 2000);
+          saved = await updateBookmark(existingBookmark.id, { label: labelInput });
         } else {
-          await addBookmark(timestamp, labelInput);
-           toast(JC.t!('toast_bookmark_updated'), 2000);
+          saved = await addBookmark(timestamp, labelInput);
         }
+        if (!isModalOwnerCurrent()) return;
+        if (!saved) {
+          toast(JC.t!('toast_bookmark_save_failed'), 3000);
+          return;
+        }
+        toast(JC.t!('toast_bookmark_updated'), 2000);
 
         // Refresh markers
         void updateBookmarkMarkersForCurrentVideo();
-        closeDialog();
+        requestClose();
       } catch (e) {
+        if (!isModalOwnerCurrent()) return;
         toast(JC.t!('toast_bookmark_save_failed'), 3000);
       }
     })(); });
@@ -1030,12 +1240,13 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
     // Jump to bookmark buttons
     modal.querySelectorAll<HTMLElement>('.jc-bookmark-btn-jump').forEach(btn => {
       btn.addEventListener('click', () => {
+        if (!isModalOwnerCurrent()) return;
         const bookmarkId = btn.dataset.bookmarkId;
         const bookmark = existingBookmarks.find(bm => bm.id === bookmarkId);
         if (bookmark && video) {
           video.currentTime = bookmark.timestamp;
           toast(`${JC.t!('toast_jumped_to_bookmark')}: ${formatTimestamp(bookmark.timestamp)}`, 2000);
-          closeDialog();
+          requestClose();
         }
       });
     });
@@ -1043,13 +1254,21 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
     // Delete bookmark buttons
     modal.querySelectorAll<HTMLElement>('.jc-bookmark-btn-delete').forEach(btn => {
       btn.addEventListener('click', () => { void (async () => {
+        if (!isModalOwnerCurrent()) return;
         const bookmarkId = btn.dataset.bookmarkId!;
-        await deleteBookmark(bookmarkId);
+        const deleted = await deleteBookmark(bookmarkId);
+        if (!isModalOwnerCurrent()) return;
+        if (!deleted) {
+          toast(JC.t!('toast_bookmark_save_failed'), 3000);
+          return;
+        }
         toast(JC.t!('toast_bookmark_deleted'), 2000);
         void updateBookmarkMarkersForCurrentVideo();
-        closeDialog();
+        requestClose();
         // Reopen modal to show updated list
-        setTimeout(() => { void showBookmarkModal(mode, existingBookmark); }, 300);
+        scheduleIdentityTask(captured, () => {
+          if (isModalOwnerCurrent()) void showBookmarkModal(mode, existingBookmark);
+        }, 300);
       })(); });
     });
   }
@@ -1070,7 +1289,8 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
   /**
    * Add bookmark button to the video player OSD
    */
-  function addOsdBookmarkButton(): void {
+  function addOsdBookmarkButton(captured: BookmarkIdentityCapture = captureIdentity()): void {
+    if (!captured.context || !isIdentityCurrent(captured)) return;
     // Don't add if already exists
     if (document.getElementById('jcBookmarkBtn')) return;
 
@@ -1085,15 +1305,19 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
     bookmarkBtn.id = 'jcBookmarkBtn';
     bookmarkBtn.setAttribute('is', 'paper-icon-button-light');
     bookmarkBtn.className = 'autoSize paper-icon-button-light';
+    bookmarkBtn.dataset.jcIdentityOwned = 'true';
+    bookmarkBtn.dataset.jcIdentityEpoch = String(captured.context.epoch);
     bookmarkBtn.title = JC.t!('shortcut_BookmarkCurrentTime');
     bookmarkBtn.innerHTML = '<span class="largePaperIconButton material-icons" aria-hidden="true">bookmark_add</span>';
 
     bookmarkBtn.onclick = (e) => {
+      if (!isIdentityCurrent(captured)) return;
       e.stopPropagation();
       void showBookmarkModal('add');
     };
 
     // Insert before the settings button
+    if (!isIdentityCurrent(captured)) return;
     nativeSettingsButton.parentElement!.insertBefore(bookmarkBtn, nativeSettingsButton);
     console.log(`${logPrefix} ✓ Added OSD bookmark button`);
   }
@@ -1106,11 +1330,17 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
     let cleanupFunctions: (() => void)[] = [];
 
     return function() {
+      if (!JC.pluginConfig?.BookmarksEnabled) {
+        JC.cleanupBookmarks?.();
+        return;
+      }
       // Prevent multiple initializations
       if (initialized) {
         console.log(`${logPrefix} Already initialized, skipping...`);
         return;
       }
+      const activation = captureIdentity();
+      if (!activation.context || !isIdentityCurrent(activation)) return;
       initialized = true;
 
       console.log(`${logPrefix} Initializing enhanced bookmarks...`);
@@ -1127,6 +1357,7 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
 
       // Debounced OSD injection - prevents rapid re-injection
       const debouncedOsdInjection = debounce(() => {
+        if (!isIdentityCurrent(activation)) return;
         if (!(JC as any).isVideoPage()) return;
 
         const osdBottom = document.querySelector('.videoOsdBottom');
@@ -1136,7 +1367,8 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
         // Only inject if OSD exists and we haven't already injected for this video
         if (osdBottom && video && currentOsdKey !== lastInjectedOsdKey) {
           void updateBookmarkMarkersForCurrentVideo();
-          addOsdBookmarkButton();
+          addOsdBookmarkButton(activation);
+          if (!isIdentityCurrent(activation)) return;
           lastInjectedOsdKey = currentOsdKey;
           console.log(`${logPrefix} Injected markers/button for ${currentOsdKey}`);
         }
@@ -1144,6 +1376,7 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
 
       // Managed observer: only watches when on video page
       function ensureOsdObserver(): void {
+        if (!isIdentityCurrent(activation)) return;
         if (!(JC as any).isVideoPage()) {
           disconnectObserver(osdObserverId);
           return;
@@ -1160,18 +1393,21 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
 
       // Debounced handlers for video events
       const handlePlayingEvent = debounce((e: Event) => {
+        if (!isIdentityCurrent(activation)) return;
         if ((e.target as HTMLElement).tagName === 'VIDEO' && (JC as any).isVideoPage()) {
           debouncedOsdInjection();
         }
       }, 300);
 
       const handleMetadataEvent = debounce((e: Event) => {
+        if (!isIdentityCurrent(activation)) return;
         if ((e.target as HTMLElement).tagName === 'VIDEO' && (JC as any).isVideoPage()) {
           debouncedOsdInjection();
         }
       }, 300);
 
       const handleViewShow = () => {
+        if (!isIdentityCurrent(activation)) return;
         if ((JC as any).isVideoPage()) {
           lastInjectedOsdKey = null; // Reset for new page
           ensureOsdObserver();
@@ -1201,18 +1437,45 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
         debouncedOsdInjection();
       }
 
-      // Store cleanup function globally
-      JC.cleanupBookmarks = function() {
+      const cleanupActivation = (force = false): void => {
+        if (!force && !isIdentityCurrent(activation)) return;
         cleanupFunctions.forEach(fn => fn());
         cleanupFunctions = [];
         disconnectObserver(osdObserverId);
         disconnectObserver(videoObserverId);
+        for (const timer of bookmarkTimers) clearTimeout(timer);
+        bookmarkTimers.clear();
+        disposeActiveModals();
+        document.getElementById('jcBookmarkBtn')?.remove();
+        document.querySelectorAll('.jc-bookmark-marker, .jc-bm-player-modal-overlay').forEach((node) => node.remove());
         initialized = false;
         console.log(`${logPrefix} Cleaned up`);
       };
+      const forceCleanup = (): void => cleanupActivation(true);
+      forceCleanupBookmarks = forceCleanup;
+
+      // The public cleanup is identity-owned, so a retained A function cannot
+      // tear down B. The reset hook retains the private force variant.
+      JC.cleanupBookmarks = (): void => cleanupActivation(false);
 
       console.log(`${logPrefix} ✓ Initialized`);
     };
   })();
+
+  JC.identity.registerReset('bookmarks', () => {
+    bookmarkGeneration += 1;
+    for (const timer of bookmarkTimers) clearTimeout(timer);
+    bookmarkTimers.clear();
+    disposeActiveModals();
+    itemDetailsCache.itemId = null;
+    itemDetailsCache.data = null;
+    itemDetailsCache.pending = null;
+    itemDetailsCache.epoch = -1;
+    itemDetailsCache.requestId += 1;
+    forceCleanupBookmarks?.();
+    forceCleanupBookmarks = null;
+    document.getElementById('jcBookmarkBtn')?.remove();
+    document.querySelectorAll('.jc-bookmark-marker, .jc-bm-player-modal-overlay').forEach((node) => node.remove());
+  });
 
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-identity.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+import type { ApiApi } from '../../types/jc';
+import { renderBookmarksLibrary } from './library-render';
+
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access */
+
+function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
+function bookmarkStore(): Record<string, any> {
+  return {
+    'bookmark-a': {
+      itemId: 'item-a',
+      timestamp: 42,
+      mediaType: 'movie',
+      name: 'A movie'
+    }
+  };
+}
+
+describe('bookmarks library identity ownership', () => {
+  let deleteBookmark: ReturnType<typeof vi.fn>;
+  let saveUserSettings: ReturnType<typeof vi.fn<(fileName: string, settings: unknown) => Promise<void>>>;
+  let getItem: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    JC.identity.transition('test-server-id', 'user-a', 'bookmarks-library-test-start');
+    JC.t = (key: string) => key;
+    JC.escapeHtml = (value: unknown) => typeof value === 'string' ? value : '';
+    JC.userConfig = { bookmark: { bookmarks: bookmarkStore() } };
+
+    deleteBookmark = vi.fn().mockResolvedValue(true);
+    saveUserSettings = vi.fn<(fileName: string, settings: unknown) => Promise<void>>().mockResolvedValue(undefined);
+    JC.bookmarks = {
+      delete: deleteBookmark,
+      update: vi.fn().mockResolvedValue(true),
+      cleanupOrphaned: vi.fn().mockResolvedValue({ cleaned: 0, errors: 0 }),
+      syncBookmarks: vi.fn().mockResolvedValue([]),
+    } as any;
+    JC.saveUserSettings = saveUserSettings;
+
+    getItem = vi.fn().mockResolvedValue({
+      Id: 'item-a',
+      Name: 'A movie',
+      Type: 'Movie',
+      ImageTags: {}
+    });
+    const apiClient = {
+      getCurrentUserId: () => JC.identity.capture()?.userId || '',
+      getItem,
+      getImageUrl: () => '',
+      getUrl: (path: string) => `http://jellyfin.test${path}`,
+      accessToken: () => 'token-a',
+      _deviceId: 'device-a',
+      deviceId: () => 'device-a',
+    };
+    (globalThis as any).ApiClient = apiClient;
+    (window as any).ApiClient = apiClient;
+    JC.core.api = { jf: vi.fn().mockResolvedValue([]) } as unknown as ApiApi;
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+  });
+
+  it('makes retained A delete-all and row controls inert after B becomes current', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    await renderBookmarksLibrary(container);
+
+    const deleteAll = container.querySelector<HTMLButtonElement>('.btnDeleteAllBookmarks');
+    const deleteRow = container.querySelector<HTMLButtonElement>('.btnDeleteBookmark');
+    expect(deleteAll).not.toBeNull();
+    expect(deleteRow).not.toBeNull();
+
+    JC.identity.transition('test-server-id', 'user-b', 'account-switch');
+    const bBookmarks = bookmarkStore();
+    (JC as any).userConfig = { bookmark: { bookmarks: bBookmarks } };
+
+    deleteAll!.click();
+    deleteRow!.click();
+    await Promise.resolve();
+
+    expect(window.confirm).not.toHaveBeenCalled();
+    expect(saveUserSettings).not.toHaveBeenCalled();
+    expect(deleteBookmark).not.toHaveBeenCalled();
+    expect((JC.userConfig as any).bookmark.bookmarks).toBe(bBookmarks);
+  });
+
+  it('drops a held A Sessions result before it can issue a Playing POST as B', async () => {
+    const heldSessions = deferred<unknown>();
+    const jf = vi.fn()
+      .mockImplementationOnce(() => heldSessions.promise)
+      .mockResolvedValue({});
+    JC.core.api = { jf } as unknown as ApiApi;
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    await renderBookmarksLibrary(container);
+
+    container.querySelector<HTMLButtonElement>('.btnPlayBookmark')!.click();
+    await vi.waitFor(() => expect(jf).toHaveBeenCalledTimes(1));
+    expect(jf).toHaveBeenNthCalledWith(1, '/Sessions', { skipCache: true });
+
+    JC.identity.transition('test-server-id', 'user-b', 'account-switch');
+    heldSessions.resolve([{ DeviceId: 'device-a', Id: 'session-a' }]);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(jf).toHaveBeenCalledTimes(1);
+  });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-items.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-items.ts
@@ -10,15 +10,29 @@ import { getItemCached } from '../helpers';
 import { formatTimestamp, parseTimestampInput, renderActiveBookmarks } from './library-render';
 import { findAndOfferReplacement } from './library-replacements';
 import { showOffsetAdjustmentModal } from './library-modals';
+import type { IdentityContext } from '../../types/jc';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 const logPrefix = '🪼 Jellyfin Canopy: Bookmarks Library:';
 
+const playbackTimers = new Set<number>();
+
+JC.identity.registerReset('bookmarks-library-playback', () => {
+  for (const timer of playbackTimers) window.clearTimeout(timer);
+  playbackTimers.clear();
+});
+
 /**
  * Render bookmark items with posters
  */
-export async function renderBookmarkItems(container: HTMLElement, groupedByItem: Record<string, any>, currentTab: string): Promise<void> {
+export async function renderBookmarkItems(
+  container: HTMLElement,
+  groupedByItem: Record<string, any>,
+  currentTab: string,
+  context: IdentityContext | null = JC.identity.capture()
+): Promise<void> {
+  if (!context || !JC.identity.isCurrent(context)) return;
   container.innerHTML = '';
   const apiClient: any = window.ApiClient || (window as any).ConnectionManager?.currentApiClient();
   if (!apiClient) {
@@ -26,7 +40,7 @@ export async function renderBookmarkItems(container: HTMLElement, groupedByItem:
     return;
   }
 
-  const userId = apiClient.getCurrentUserId();
+  const userId = context.userId;
   const itemPromises: Promise<any>[] = [];
 
   // Fetch all items
@@ -56,6 +70,7 @@ export async function renderBookmarkItems(container: HTMLElement, groupedByItem:
   }
 
   const results = await Promise.all(itemPromises);
+  if (!JC.identity.isCurrent(context)) return;
 
   // Apply tab filter
   const filtered = results.filter(({ group }) => {
@@ -125,7 +140,7 @@ export async function renderBookmarkItems(container: HTMLElement, groupedByItem:
           </button>
         ` : ''}
       </div>
-      <div class="jc-bookmarks-list bookmarks-list-${key}"></div>
+      <div class="jc-bookmarks-list"></div>
     `;
 
     itemCard.innerHTML = headerHtml;
@@ -135,7 +150,8 @@ export async function renderBookmarkItems(container: HTMLElement, groupedByItem:
     const findBtn = itemCard.querySelector<HTMLButtonElement>('.btnFindReplacement');
     if (findBtn) {
       findBtn.addEventListener('click', () => { void (async () => {
-        await findAndOfferReplacement(group, findBtn);
+        if (!JC.identity.isCurrent(context)) return;
+        await findAndOfferReplacement(group, findBtn, context);
       })(); });
     }
 
@@ -143,7 +159,8 @@ export async function renderBookmarkItems(container: HTMLElement, groupedByItem:
     const offsetBtn = itemCard.querySelector<HTMLElement>('.btnAdjustOffset');
     if (offsetBtn) {
       offsetBtn.addEventListener('click', () => {
-        showOffsetAdjustmentModal(group);
+        if (!JC.identity.isCurrent(context)) return;
+        showOffsetAdjustmentModal(group, context);
       });
     }
 
@@ -151,6 +168,7 @@ export async function renderBookmarkItems(container: HTMLElement, groupedByItem:
     const poster = itemCard.querySelector<HTMLElement>('.jc-bookmark-item-poster');
     if (poster) {
       poster.addEventListener('click', () => {
+        if (!JC.identity.isCurrent(context)) return;
         const itemId = poster.dataset.itemId;
         if (itemId) {
           (window.Emby?.Page as { show?: (path: string) => void } | undefined)?.show?.(`/details?id=${itemId}`);
@@ -159,7 +177,7 @@ export async function renderBookmarkItems(container: HTMLElement, groupedByItem:
     }
 
     // Render bookmarks for this item
-    const bookmarksList = itemCard.querySelector<HTMLElement>(`.bookmarks-list-${key}`);
+    const bookmarksList = itemCard.querySelector<HTMLElement>('.jc-bookmarks-list');
     if (bookmarksList) {
       group.bookmarks.forEach((bm: any) => {
         const bmEl = document.createElement('div');
@@ -247,9 +265,10 @@ export async function renderBookmarkItems(container: HTMLElement, groupedByItem:
         const playBtn = actions.querySelector<HTMLElement>('.btnPlayBookmark');
         if (playBtn) {
           playBtn.addEventListener('click', () => { void (async () => {
+            if (!JC.identity.isCurrent(context)) return;
             const itemId = playBtn.dataset.itemId!;
             const time = parseFloat(playBtn.dataset.time!);
-            await playItemAtTime(itemId, time);
+            await playItemAtTime(itemId, time, context);
           })(); });
         }
 
@@ -257,6 +276,7 @@ export async function renderBookmarkItems(container: HTMLElement, groupedByItem:
         const editBtn = actions.querySelector<HTMLButtonElement>('.btnEditBookmark');
         if (editBtn) {
           editBtn.addEventListener('click', () => {
+            if (!JC.identity.isCurrent(context)) return;
             editRow.classList.toggle('show');
             if (editRow.classList.contains('show')) {
               timeInput.focus();
@@ -265,12 +285,14 @@ export async function renderBookmarkItems(container: HTMLElement, groupedByItem:
         }
 
         cancelBtn.addEventListener('click', () => {
+          if (!JC.identity.isCurrent(context)) return;
           editRow.classList.remove('show');
           timeInput.value = formatTimestamp(bm.timestamp);
           labelInput.value = bm.label || '';
         });
 
         saveBtn.addEventListener('click', () => { void (async () => {
+          if (!JC.identity.isCurrent(context)) return;
           const parsedTime = parseTimestampInput(timeInput.value);
           if (parsedTime === null) {
             toast(JC.t!('bookmark_time_format_hint'), 3000);
@@ -284,37 +306,50 @@ export async function renderBookmarkItems(container: HTMLElement, groupedByItem:
               timestamp: parsedTime,
               label: labelInput.value.trim()
             });
+            if (!JC.identity.isCurrent(context)) return;
             if (ok) {
               toast(JC.t!('toast_bookmark_updated'), 2000);
-              renderActiveBookmarks();
+              renderActiveBookmarks(context);
             } else {
               toast(JC.t!('toast_bookmark_save_failed'), 3000);
             }
           } catch (err) {
+            if (!JC.identity.isCurrent(context)) return;
             console.error('Bookmark update failed', err);
             toast(JC.t!('toast_bookmark_save_failed'), 3000);
           } finally {
-            saveBtn.disabled = false;
-            if (editBtn) editBtn.disabled = false;
+            if (JC.identity.isCurrent(context)) {
+              saveBtn.disabled = false;
+              if (editBtn) editBtn.disabled = false;
+            }
           }
         })(); });
 
         // Delete button handler
         deleteBtn.addEventListener('click', () => { void (async () => {
+          if (!JC.identity.isCurrent(context)) return;
           const bookmarkId = deleteBtn.dataset.bookmarkId!;
-          await JC.bookmarks!.delete(bookmarkId);
-          toast(JC.t!('toast_bookmark_deleted'), 2000);
+          try {
+            await JC.bookmarks!.delete(bookmarkId);
+            if (!JC.identity.isCurrent(context)) return;
+            toast(JC.t!('toast_bookmark_deleted'), 2000);
 
-          // Re-render into the adopted host (the delete already emitted
-          // 'jc-bookmarks-updated'; this coalesces with that refresh).
-          renderActiveBookmarks();
+            // Re-render into the adopted host (the delete already emitted
+            // 'jc-bookmarks-updated'; this coalesces with that refresh).
+            renderActiveBookmarks(context);
+          } catch (error) {
+            if (!JC.identity.isCurrent(context)) return;
+            console.error('Bookmark delete failed', error);
+            toast(JC.t!('bookmark_delete_failed'), 3000);
+          }
         })(); });
 
         // Timestamp click-to-play
         const ts = info.querySelector<HTMLElement>('.jc-bm-time');
         ts?.addEventListener('click', () => { void (async () => {
+          if (!JC.identity.isCurrent(context)) return;
           const t = parseFloat(ts.dataset.time!);
-          await playItemAtTime(ts.dataset.itemId!, t);
+          await playItemAtTime(ts.dataset.itemId!, t, context);
         })(); });
       });
     }
@@ -324,7 +359,12 @@ export async function renderBookmarkItems(container: HTMLElement, groupedByItem:
 /**
  * Play item at specific time
  */
-async function playItemAtTime(itemId: string, startTime: number): Promise<void> {
+async function playItemAtTime(
+  itemId: string,
+  startTime: number,
+  context: IdentityContext | null = JC.identity.capture()
+): Promise<void> {
+  if (!context || !JC.identity.isCurrent(context)) return;
   try {
     console.log(`${logPrefix} Attempting playback: itemId=${itemId}, startTime=${startTime}`);
 
@@ -341,17 +381,17 @@ async function playItemAtTime(itemId: string, startTime: number): Promise<void> 
     console.log(`${logPrefix} Device ID: ${deviceId}`);
 
     // Query sessions to find our current session
-    const sessionsUrl = apiClient.getUrl('Sessions');
-    const sessions = await apiClient.ajax({
-      type: 'GET',
-      url: sessionsUrl,
-      dataType: 'json'
+    const sessions = await JC.core.api!.jf('/Sessions', {
+      skipCache: true
     });
+    if (!JC.identity.isCurrent(context)) return;
 
     console.log(`${logPrefix} Available sessions:`, sessions);
 
     // Find our session by device ID
-    const currentSession = sessions.find((s: any) => s.DeviceId === deviceId);
+    const currentSession = Array.isArray(sessions)
+      ? sessions.find((s: any) => s.DeviceId === deviceId)
+      : null;
 
     if (!currentSession) {
       console.warn(`${logPrefix} Could not find current session`);
@@ -368,23 +408,29 @@ async function playItemAtTime(itemId: string, startTime: number): Promise<void> 
 
     console.log(`${logPrefix} Sending playback request:`, url);
 
-    await apiClient.ajax({
-      type: 'POST',
-      url: apiClient.getUrl(url)
+    if (!JC.identity.isCurrent(context)) return;
+    await JC.core.api!.jf(`/${url}`, {
+      method: 'POST',
+      skipRetry: true
     });
+    if (!JC.identity.isCurrent(context)) return;
 
     console.log(`${logPrefix} Playback started successfully`);
     toast(JC.t!('toast_playing'), 2000);
 
     // Wait for navigation to complete, then trigger bookmark marker update
-    setTimeout(() => {
+    const timer = window.setTimeout(() => {
+      playbackTimers.delete(timer);
+      if (!JC.identity.isCurrent(context)) return;
       if ((window.JC as any)?.isVideoPage?.() && typeof window.JC?.bookmarks?.updateMarkers === 'function') {
         console.log(`${logPrefix} Triggering bookmark marker update after playback start`);
         void window.JC.bookmarks.updateMarkers();
       }
     }, 1500);
+    playbackTimers.add(timer);
 
   } catch (e) {
+    if (!JC.identity.isCurrent(context)) return;
     console.error(`${logPrefix} Failed to play item:`, e);
     toast(JC.t!('toast_playback_failed').replace('{error}', JC.escapeHtml((e as any).message || 'Unknown error')), 3000);
   }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-modals.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-modals.ts
@@ -8,13 +8,49 @@ import { JC } from '../../globals';
 import { currentPageHandle } from '../pages/fallback-host';
 import { escapeHtml, toast } from '../../core/ui-kit';
 import { formatTimestamp, renderActiveBookmarks } from './library-render';
+import type { IdentityContext } from '../../types/jc';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
+
+const modalTimers = new Set<number>();
+
+function scheduleModalTask(context: IdentityContext, callback: () => void, delay: number): void {
+  const timer = window.setTimeout(() => {
+    modalTimers.delete(timer);
+    if (JC.identity.isCurrent(context)) callback();
+  }, delay);
+  modalTimers.add(timer);
+}
+
+function ownModal(modal: HTMLElement): void {
+  modal.dataset.jcIdentityOwned = 'true';
+  modal.dataset.jcBookmarkLibraryModal = 'true';
+}
+
+function closeModal(modal: HTMLElement): void {
+  if (!modal.isConnected) return;
+  modal.style.opacity = '0';
+  const timer = window.setTimeout(() => {
+    modalTimers.delete(timer);
+    modal.remove();
+  }, 200);
+  modalTimers.add(timer);
+}
+
+JC.identity.registerReset('bookmarks-library-modals', () => {
+  for (const timer of modalTimers) window.clearTimeout(timer);
+  modalTimers.clear();
+  document.querySelectorAll('[data-jc-bookmark-library-modal="true"]').forEach((modal) => modal.remove());
+});
 
 /**
  * Show modal to adjust time offset for synced bookmarks
  */
-export function showOffsetAdjustmentModal(group: any): void {
+export function showOffsetAdjustmentModal(
+  group: any,
+  context: IdentityContext | null = JC.identity.capture()
+): void {
+  if (!context || !JC.identity.isCurrent(context)) return;
   const syncedBookmarks = group.bookmarks.filter((bm: any) => bm.syncedFrom);
   if (syncedBookmarks.length === 0) {
     toast(JC.t!('bookmark_no_synced'), 2000);
@@ -23,6 +59,7 @@ export function showOffsetAdjustmentModal(group: any): void {
 
   const modal = document.createElement('div');
   modal.className = 'jc-bm-library-modal-overlay';
+  ownModal(modal);
   modal.innerHTML = `
     <div class="jc-bm-library-modal-container" style="max-width: 550px;">
       <button class="jc-bm-library-modal-close">×</button>
@@ -72,10 +109,7 @@ export function showOffsetAdjustmentModal(group: any): void {
 
   document.body.appendChild(modal);
 
-  const closeDialog = () => {
-    modal.style.opacity = '0';
-    setTimeout(() => modal.remove(), 200);
-  };
+  const closeDialog = () => closeModal(modal);
   // Body-level modal: the page's dispose bag closes it on drain.
   currentPageHandle()?.track(closeDialog);
 
@@ -87,6 +121,7 @@ export function showOffsetAdjustmentModal(group: any): void {
 
   // Apply offset button handler
   modal.querySelector('.btnApplyOffset')?.addEventListener('click', () => { void (async () => {
+    if (!JC.identity.isCurrent(context)) return;
     const offset = parseFloat(modal.querySelector<HTMLInputElement>('#offset-adjustment-input')!.value) || 0;
 
     const btn = modal.querySelector<HTMLButtonElement>('.btnApplyOffset')!;
@@ -98,11 +133,13 @@ export function showOffsetAdjustmentModal(group: any): void {
 
       // Update each synced bookmark
       for (const bm of syncedBookmarks) {
+        if (!JC.identity.isCurrent(context)) return;
         const newTimestamp = Math.max(0, bm.timestamp + offset);
         const ok = await JC.bookmarks!.update(bm.id, {
           timestamp: newTimestamp,
           syncedFrom: '' // Clear syncedFrom to remove the icon
         });
+        if (!JC.identity.isCurrent(context)) return;
         if (ok) updatedCount++;
       }
 
@@ -115,13 +152,14 @@ export function showOffsetAdjustmentModal(group: any): void {
 
         // Refresh the adopted host (the awaited updates already resolved — no
         // blind setTimeout needed).
-        renderActiveBookmarks();
+        renderActiveBookmarks(context);
       } else {
         toast(JC.t!('bookmark_update_failed'), 3000);
         btn.disabled = false;
         btn.querySelector('span:last-child')!.textContent = JC.t!('bookmark_apply_offset');
       }
     } catch (e) {
+      if (!JC.identity.isCurrent(context)) return;
       console.error('Failed to apply offset:', e);
       toast(JC.t!('bookmark_offset_failed'), 3000);
       btn.disabled = false;
@@ -130,7 +168,7 @@ export function showOffsetAdjustmentModal(group: any): void {
   })(); });
 
   // Fade in
-  setTimeout(() => modal.style.opacity = '1', 10);
+  scheduleModalTask(context, () => { if (modal.isConnected) modal.style.opacity = '1'; }, 10);
 }
 
 /**
@@ -174,7 +212,11 @@ function findDuplicateBookmarks(bookmarks: Record<string, any>): any[] {
 /**
  * Show modal to sync duplicate bookmarks
  */
-export function showDuplicatesSyncModal(bookmarks: Record<string, any>): void {
+export function showDuplicatesSyncModal(
+  bookmarks: Record<string, any>,
+  context: IdentityContext | null = JC.identity.capture()
+): void {
+  if (!context || !JC.identity.isCurrent(context)) return;
   const duplicates = findDuplicateBookmarks(bookmarks);
 
   if (duplicates.length === 0) {
@@ -184,6 +226,7 @@ export function showDuplicatesSyncModal(bookmarks: Record<string, any>): void {
 
   const modal = document.createElement('div');
   modal.className = 'jc-bm-library-modal-overlay';
+  ownModal(modal);
   modal.style.cssText = 'position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.85); z-index: 10000; display: flex; align-items: center; justify-content: center; opacity: 0; transition: opacity 0.2s;';
   modal.innerHTML = `
     <div class="jc-bm-library-modal-container" style="max-width: 700px; background: #181818; border-radius: 12px; padding: 24px; position: relative; box-shadow: 0 8px 32px rgba(0,0,0,0.8); max-height: 85vh; overflow-y: auto;">
@@ -247,10 +290,7 @@ export function showDuplicatesSyncModal(bookmarks: Record<string, any>): void {
 
   document.body.appendChild(modal);
 
-  const closeDialog = () => {
-    modal.style.opacity = '0';
-    setTimeout(() => modal.remove(), 200);
-  };
+  const closeDialog = () => closeModal(modal);
   // Body-level modal: the page's dispose bag closes it on drain.
   currentPageHandle()?.track(closeDialog);
 
@@ -263,6 +303,7 @@ export function showDuplicatesSyncModal(bookmarks: Record<string, any>): void {
   // Adjust Offset button handlers
   modal.querySelectorAll<HTMLElement>('[data-sync-from]').forEach(btn => {
     btn.addEventListener('click', () => {
+      if (!JC.identity.isCurrent(context)) return;
       const dupIndex = parseInt(btn.dataset.dupIndex!);
       const versionIndex = parseInt(btn.dataset.syncFrom!);
       const dup = duplicates[dupIndex];
@@ -277,7 +318,7 @@ export function showDuplicatesSyncModal(bookmarks: Record<string, any>): void {
         bookmarks: bookmarksForItem,
         details: { name: dup.name }
       };
-      showOffsetAdjustmentModal(groupObj);
+      showOffsetAdjustmentModal(groupObj, context);
     });
   });
 
@@ -286,6 +327,7 @@ export function showDuplicatesSyncModal(bookmarks: Record<string, any>): void {
     if (!btn.dataset.dupIndex) return;
 
     btn.addEventListener('click', () => { void (async () => {
+      if (!JC.identity.isCurrent(context)) return;
       const dupIndex = parseInt(btn.dataset.dupIndex!);
       const dup = duplicates[dupIndex];
       const itemIds = Object.keys(dup.itemGroups);
@@ -301,6 +343,7 @@ export function showDuplicatesSyncModal(bookmarks: Record<string, any>): void {
       if (!confirm(JC.t!('bookmark_merge_confirm').replace('{count}', String(oldBookmarks.length)))) {
         return;
       }
+      if (!JC.identity.isCurrent(context)) return;
 
       btn.disabled = true;
       btn.querySelector('span:last-child')!.innerHTML = '<span class="material-icons" style="animation: spin 1s linear infinite; font-size: 18px;">refresh</span>';
@@ -317,14 +360,16 @@ export function showDuplicatesSyncModal(bookmarks: Record<string, any>): void {
 
         // Sync old bookmarks to primary
         const synced = await JC.bookmarks!.syncBookmarks(oldBookmarks, primaryDetails, 0);
+        if (!JC.identity.isCurrent(context)) return;
         toast(JC.t!('bookmark_merge_success').replace('{count}', String(synced.length)), 3000);
 
         closeDialog();
 
         // Refresh the adopted host (syncBookmarks already resolved — no blind
         // setTimeout needed).
-        renderActiveBookmarks();
+        renderActiveBookmarks(context);
       } catch (e) {
+        if (!JC.identity.isCurrent(context)) return;
         console.error('Merge failed:', e);
         toast(JC.t!('bookmark_merge_failed'), 3000);
         btn.disabled = false;
@@ -333,5 +378,5 @@ export function showDuplicatesSyncModal(bookmarks: Record<string, any>): void {
     })(); });
   });
 
-  setTimeout(() => modal.style.opacity = '1', 10);
+  scheduleModalTask(context, () => { if (modal.isConnected) modal.style.opacity = '1'; }, 10);
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-render.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-render.ts
@@ -9,10 +9,37 @@ import { JC } from '../../globals';
 import { toast } from '../../core/ui-kit';
 import { renderBookmarkItems } from './library-items';
 import { showDuplicatesSyncModal } from './library-modals';
-
-/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { IdentityContext } from '../../types/jc';
 
 const logPrefix = '🪼 Jellyfin Canopy: Bookmarks Library:';
+
+interface StoredBookmark {
+  itemId?: string;
+  tmdbId?: string;
+  tvdbId?: string;
+  mediaType?: string;
+  timestamp?: number;
+  [key: string]: unknown;
+}
+
+interface BookmarkConfig {
+  bookmarks: Record<string, StoredBookmark>;
+}
+
+interface BookmarkGroup {
+  details: StoredBookmark;
+  bookmarks: Array<StoredBookmark & { id: string }>;
+  type: string;
+}
+
+function bookmarkConfigOrEmpty(value: unknown): BookmarkConfig {
+  if (value !== null && typeof value === 'object' && !Array.isArray(value)
+      && 'bookmarks' in value && value.bookmarks !== null
+      && typeof value.bookmarks === 'object' && !Array.isArray(value.bookmarks)) {
+    return value as BookmarkConfig;
+  }
+  return { bookmarks: {} };
+}
 
 // The container the bookmarks library renders into, set by the pages-framework
 // descriptor (bookmarks/page.ts) for the lifetime of one adoption and cleared
@@ -21,16 +48,26 @@ const logPrefix = '🪼 Jellyfin Canopy: Bookmarks Library:';
 // '.sections.bookmarks' class scan that picked the LAST visible match — a
 // defect that mis-targeted stale/duplicate nodes.
 let activeContainer: HTMLElement | null = null;
+let activeContainerIdentity: IdentityContext | null = null;
 
 /** Set (or clear) the render target for the current page adoption. */
 export function setActiveContainer(container: HTMLElement | null): void {
   activeContainer = container;
+  activeContainerIdentity = container ? JC.identity.capture() : null;
 }
 
 // Coalesce bursts of refresh requests (e.g. the module's own
 // 'jc-bookmarks-updated' event plus an explicit post-write refresh in the same
 // tick) into a single render.
-let renderQueued = false;
+let renderQueueGeneration = 0;
+let queuedIdentity: IdentityContext | null = null;
+
+JC.identity.registerReset('bookmarks-library-render', () => {
+  renderQueueGeneration += 1;
+  queuedIdentity = null;
+  activeContainer = null;
+  activeContainerIdentity = null;
+});
 
 /**
  * Re-render the bookmarks library into the active container. No-op when the
@@ -38,28 +75,40 @@ let renderQueued = false;
  * entry point used by the 'jc-bookmarks-updated' event and every post-write
  * refresh — no DOM scanning, no stale-container guard.
  */
-export function renderActiveBookmarks(): void {
+export function renderActiveBookmarks(context: IdentityContext | null = JC.identity.capture()): void {
+  if (!context || !JC.identity.isCurrent(context)) return;
   if (!activeContainer || !activeContainer.isConnected) return;
-  if (renderQueued) return;
-  renderQueued = true;
+  if (!activeContainerIdentity || activeContainerIdentity.epoch !== context.epoch) return;
+  if (queuedIdentity?.epoch === context.epoch) return;
+  queuedIdentity = context;
+  const generation = ++renderQueueGeneration;
   queueMicrotask(() => {
-    renderQueued = false;
+    if (generation !== renderQueueGeneration) return;
+    queuedIdentity = null;
+    if (!JC.identity.isCurrent(context)) return;
     const container = activeContainer;
-    if (container && container.isConnected) void renderBookmarksLibrary(container);
+    if (container && container.isConnected && activeContainerIdentity?.epoch === context.epoch) {
+      void renderBookmarksLibrary(container, context);
+    }
   });
 }
 
 /**
  * Render bookmarks library content
  */
-export async function renderBookmarksLibrary(container: HTMLElement): Promise<void> {
+export async function renderBookmarksLibrary(
+  container: HTMLElement,
+  context: IdentityContext | null = JC.identity.capture()
+): Promise<void> {
+  if (!context || !JC.identity.isCurrent(context)) return;
   console.log(`${logPrefix} Rendering bookmarks library...`);
 
-  const bookmarks = (JC.userConfig as any).bookmark?.bookmarks || {};
-  const bookmarkEntries = Object.entries<any>(bookmarks);
+  const bookmarkConfig = bookmarkConfigOrEmpty(JC.userConfig?.bookmark);
+  const bookmarks = bookmarkConfig.bookmarks;
+  const bookmarkEntries = Object.entries(bookmarks);
 
   // Group by item
-  const groupedByItem: Record<string, any> = {};
+  const groupedByItem: Record<string, BookmarkGroup> = {};
   const typeCounts: Record<string, { items: number; bookmarks: number }> = {
     tv: { items: 0, bookmarks: 0 },
     movie: { items: 0, bookmarks: 0 }
@@ -85,8 +134,8 @@ export async function renderBookmarksLibrary(container: HTMLElement): Promise<vo
   }
 
   // Sort bookmarks within each group by timestamp
-  Object.values<any>(groupedByItem).forEach(group => {
-    group.bookmarks.sort((a: any, b: any) => a.timestamp - b.timestamp);
+  Object.values(groupedByItem).forEach(group => {
+    group.bookmarks.sort((a, b) => (a.timestamp ?? 0) - (b.timestamp ?? 0));
   });
 
   const totalBookmarks = bookmarkEntries.length;
@@ -144,19 +193,23 @@ export async function renderBookmarksLibrary(container: HTMLElement): Promise<vo
   const deleteAllBtn = container.querySelector<HTMLButtonElement>('.btnDeleteAllBookmarks');
 
   findDuplicatesBtn?.addEventListener('click', () => {
+    if (!JC.identity.isCurrent(context)) return;
     findDuplicatesBtn.disabled = true;
     const label = findDuplicatesBtn.querySelector('span:last-child')!;
     const origText = label.innerHTML;
     label.innerHTML = '<span class="material-icons" style="animation: spin 1s linear infinite;">refresh</span>';
 
     // Surface duplicate bookmark groups and offer merging
-    showDuplicatesSyncModal(bookmarks);
+    showDuplicatesSyncModal(bookmarks, context);
 
-    findDuplicatesBtn.disabled = false;
-    label.innerHTML = origText;
+    if (JC.identity.isCurrent(context)) {
+      findDuplicatesBtn.disabled = false;
+      label.innerHTML = origText;
+    }
   });
 
   cleanupBtn?.addEventListener('click', () => { void (async () => {
+    if (!JC.identity.isCurrent(context)) return;
     cleanupBtn.disabled = true;
     const label = cleanupBtn.querySelector('span:last-child');
     const origText = label?.innerHTML;
@@ -164,19 +217,25 @@ export async function renderBookmarksLibrary(container: HTMLElement): Promise<vo
 
     try {
       const result = await JC.bookmarks!.cleanupOrphaned();
+      if (!JC.identity.isCurrent(context)) return;
       toast(JC.t!('bookmark_cleanup_complete').replace('{count}', String(Number(result.cleaned) || 0)), 4000);
-      renderActiveBookmarks();
+      renderActiveBookmarks(context);
     } catch (error) {
+      if (!JC.identity.isCurrent(context)) return;
       console.error('Cleanup failed:', error);
       toast(JC.t!('bookmark_cleanup_failed'), 3000);
     } finally {
-      cleanupBtn.disabled = false;
-      if (label && origText) label.innerHTML = origText;
+      if (JC.identity.isCurrent(context)) {
+        cleanupBtn.disabled = false;
+        if (label && origText) label.innerHTML = origText;
+      }
     }
   })(); });
 
   deleteAllBtn?.addEventListener('click', () => { void (async () => {
+    if (!JC.identity.isCurrent(context)) return;
     if (!confirm(JC.t!('bookmark_delete_all_confirm'))) return;
+    if (!JC.identity.isCurrent(context)) return;
 
     deleteAllBtn.disabled = true;
     const label = deleteAllBtn.querySelector('span:last-child');
@@ -184,18 +243,24 @@ export async function renderBookmarksLibrary(container: HTMLElement): Promise<vo
     if (label) label.innerHTML = '<span class="material-icons" style="animation: spin 1s linear infinite;">refresh</span>';
 
     try {
-      (JC.userConfig as any).bookmark.bookmarks = {};
-      await JC.saveUserSettings!('bookmark.json', (JC.userConfig as any).bookmark);
+      // Mutate and persist the render's captured A-owned config object. Never
+      // re-read the live JC.userConfig after an authentication transition.
+      bookmarkConfig.bookmarks = {};
+      await JC.saveUserSettings!('bookmark.json', bookmarkConfig);
+      if (!JC.identity.isCurrent(context)) return;
       toast(JC.t!('bookmark_deleted_all'), 3000);
       // Direct store manipulation (no JC.bookmarks.* call) emits no update
       // event, so refresh explicitly.
-      renderActiveBookmarks();
+      renderActiveBookmarks(context);
     } catch (error) {
+      if (!JC.identity.isCurrent(context)) return;
       console.error('Delete failed:', error);
       toast(JC.t!('bookmark_delete_failed'), 3000);
     } finally {
-      deleteAllBtn.disabled = false;
-      if (label && origText) label.innerHTML = origText;
+      if (JC.identity.isCurrent(context)) {
+        deleteAllBtn.disabled = false;
+        if (label && origText) label.innerHTML = origText;
+      }
     }
   })(); });
 
@@ -203,17 +268,19 @@ export async function renderBookmarksLibrary(container: HTMLElement): Promise<vo
   if (totalBookmarks > 0) {
     const itemsContainer = container.querySelector<HTMLElement>('#bookmarks-items-container');
     if (itemsContainer) {
-      await renderBookmarkItems(itemsContainer, groupedByItem, currentTab);
+      await renderBookmarkItems(itemsContainer, groupedByItem, currentTab, context);
+      if (!JC.identity.isCurrent(context)) return;
 
       // Tab click handlers
       container.querySelectorAll<HTMLElement>('.jc-tab').forEach(btn => {
         btn.addEventListener('click', () => { void (async () => {
+          if (!JC.identity.isCurrent(context)) return;
           const tab = btn.dataset.tab!;
           container.dataset.currentTab = tab;
           container.querySelectorAll<HTMLElement>('.jc-tab').forEach(b => {
             b.classList.toggle('active', b.dataset.tab === tab);
           });
-          await renderBookmarkItems(itemsContainer, groupedByItem, tab);
+          await renderBookmarkItems(itemsContainer, groupedByItem, tab, context);
         })(); });
       });
     }
@@ -233,8 +300,8 @@ export function formatTimestamp(seconds: number): string {
   return `${m}:${s.toString().padStart(2, '0')}`;
 }
 
-function normalizeMediaType(mediaType: string): string {
-  const type = (mediaType || '').toLowerCase();
+function normalizeMediaType(mediaType: unknown): string {
+  const type = typeof mediaType === 'string' ? mediaType.toLowerCase() : '';
   if (type === 'series' || type === 'episode' || type === 'tvshow' || type === 'tv') return 'tv';
   if (type === 'movie' || type === 'film' || type === 'musicvideo') return 'movie';
   return 'other';

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-replacements.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-replacements.ts
@@ -9,17 +9,97 @@ import { currentPageHandle } from '../pages/fallback-host';
 import { escapeHtml, toast } from '../../core/ui-kit';
 import { getItemCached } from '../helpers';
 import { renderActiveBookmarks } from './library-render';
+import type { IdentityContext } from '../../types/jc';
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
+const replacementModalTimers = new Set<number>();
+
+interface StoredBookmark {
+  itemId: string;
+  tmdbId: string;
+  tvdbId: string;
+  mediaType: string;
+  name: string;
+  [key: string]: unknown;
+}
+
+interface BookmarkGroup {
+  details: StoredBookmark;
+  bookmarks: Array<StoredBookmark & { id: string }>;
+}
+
+interface JellyfinReplacementItem {
+  Id: string;
+  Name: string;
+  ProductionYear?: string | number;
+  ProviderIds?: { Tmdb?: string; Tvdb?: string };
+  ImageTags?: { Primary?: string };
+  UserData?: { Key?: string };
+}
+
+interface ImageApiClient {
+  getImageUrl(itemId: string, options: { type: string; maxWidth: number; tag?: string }): string;
+}
+
+interface ReplacementResult {
+  group: BookmarkGroup;
+  matches: JellyfinReplacementItem[];
+}
+
+function isJellyfinReplacementItem(value: unknown): value is JellyfinReplacementItem {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    && 'Id' in value && typeof value.Id === 'string'
+    && 'Name' in value && typeof value.Name === 'string';
+}
+
+function currentImageApiClient(): ImageApiClient | null {
+  const direct = window.ApiClient as unknown as Partial<ImageApiClient> | undefined;
+  if (typeof direct?.getImageUrl === 'function') return direct as ImageApiClient;
+  const manager = (window as Window & {
+    ConnectionManager?: { currentApiClient?(): ImageApiClient | null };
+  }).ConnectionManager;
+  return manager?.currentApiClient?.() ?? null;
+}
+
+function scheduleReplacementTask(context: IdentityContext, callback: () => void, delay: number): void {
+  const timer = window.setTimeout(() => {
+    replacementModalTimers.delete(timer);
+    if (JC.identity.isCurrent(context)) callback();
+  }, delay);
+  replacementModalTimers.add(timer);
+}
+
+function ownReplacementModal(modal: HTMLElement): void {
+  modal.dataset.jcIdentityOwned = 'true';
+  modal.dataset.jcBookmarkLibraryModal = 'true';
+}
+
+function closeReplacementModal(modal: HTMLElement): void {
+  if (!modal.isConnected) return;
+  modal.style.opacity = '0';
+  const timer = window.setTimeout(() => {
+    replacementModalTimers.delete(timer);
+    modal.remove();
+  }, 200);
+  replacementModalTimers.add(timer);
+}
+
+JC.identity.registerReset('bookmarks-library-replacement-modals', () => {
+  for (const timer of replacementModalTimers) window.clearTimeout(timer);
+  replacementModalTimers.clear();
+  document.querySelectorAll('[data-jc-bookmark-library-modal="true"]').forEach((modal) => modal.remove());
+});
 
 /**
  * Search Jellyfin for items matching a TMDB/TVDB ID
  */
-async function searchForReplacementItem(tmdbId: string, tvdbId: string, mediaType: string): Promise<any[] | null> {
-  const apiClient: any = window.ApiClient || (window as any).ConnectionManager?.currentApiClient();
-  if (!apiClient) return null;
-
-  const userId = apiClient.getCurrentUserId();
+async function searchForReplacementItem(
+  tmdbId: string,
+  tvdbId: string,
+  mediaType: string,
+  context: IdentityContext
+): Promise<JellyfinReplacementItem[] | null> {
+  if (!JC.identity.isCurrent(context)) return null;
+  const userId = context.userId;
 
   try {
     // Search using Jellyfin's provider ID filtering
@@ -27,20 +107,25 @@ async function searchForReplacementItem(tmdbId: string, tvdbId: string, mediaTyp
 
     // Fetch all items of this type and filter by provider ID client-side
     // This is more reliable than relying on AnyProviderIdEquals
-    const url = `Users/${userId}/Items?Recursive=true&IncludeItemTypes=${itemTypes}&SortBy=DateCreated&SortOrder=Descending&Limit=500`;
+    const url = `/Users/${userId}/Items?Recursive=true&IncludeItemTypes=${itemTypes}&SortBy=DateCreated&SortOrder=Descending&Limit=500`;
 
     // Routed through the core fetch layer (auth + JSON parse identical to the
     // former ApiClient.ajax call; failures still land in the catch below).
-    let response: any = await JC.core.api!.fetch(apiClient.getUrl(url));
+    let response: unknown = await JC.core.api!.jf(url, { skipCache: true });
+    if (!JC.identity.isCurrent(context)) return null;
 
     // Handle if response is a string (shouldn't happen but be safe)
     if (typeof response === 'string') {
-      response = JSON.parse(response);
+      response = JSON.parse(response) as unknown;
+      if (!JC.identity.isCurrent(context)) return null;
     }
 
     console.log(`🪼 Jellyfin Canopy: Bookmarks Library: API Response:`, response);
 
-    const items = response?.Items || [];
+    const items = response !== null && typeof response === 'object' && !Array.isArray(response)
+      && 'Items' in response && Array.isArray(response.Items)
+      ? response.Items.filter(isJellyfinReplacementItem)
+      : [];
     console.log(`🪼 Jellyfin Canopy: Bookmarks Library: Fetched ${items.length} total items of type ${itemTypes}`);
 
     if (!Array.isArray(items) || items.length === 0) {
@@ -50,7 +135,7 @@ async function searchForReplacementItem(tmdbId: string, tvdbId: string, mediaTyp
 
     // Filter items by matching provider IDs
     // Check both ProviderIds and UserData.Key (TMDB ID is often stored there)
-    const matches = items.filter((item: any) => {
+    const matches = items.filter((item) => {
       const providerIds = item.ProviderIds || {};
       const userData = item.UserData || {};
 
@@ -72,6 +157,7 @@ async function searchForReplacementItem(tmdbId: string, tvdbId: string, mediaTyp
     console.log(`🪼 Jellyfin Canopy: Bookmarks Library: Found ${matches.length} matches for ${tmdbId ? 'TMDB:'+tmdbId : 'TVDB:'+tvdbId}`, matches);
     return matches.length > 0 ? matches : null;
   } catch (e) {
+    if (!JC.identity.isCurrent(context)) return null;
     console.error('Failed to search for replacement:', e);
     return null;
   }
@@ -80,14 +166,21 @@ async function searchForReplacementItem(tmdbId: string, tvdbId: string, mediaTyp
 /**
  * Find replacement for orphaned item and offer migration
  */
-export async function findAndOfferReplacement(group: any, triggerBtn: HTMLButtonElement): Promise<void> {
+export async function findAndOfferReplacement(
+  group: BookmarkGroup,
+  triggerBtn: HTMLButtonElement,
+  context: IdentityContext | null = JC.identity.capture()
+): Promise<void> {
+  if (!context || !JC.identity.isCurrent(context)) return;
   triggerBtn.disabled = true;
 
   const matches = await searchForReplacementItem(
     group.details.tmdbId,
     group.details.tvdbId,
-    group.details.mediaType
+    group.details.mediaType,
+    context
   );
+  if (!JC.identity.isCurrent(context)) return;
 
   if (!matches || matches.length === 0) {
     toast(JC.t!('bookmark_no_replacement'), 3000);
@@ -95,23 +188,28 @@ export async function findAndOfferReplacement(group: any, triggerBtn: HTMLButton
     return;
   }
 
-  showReplacementSelectionModal(group, matches);
+  showReplacementSelectionModal(group, matches, context);
   triggerBtn.disabled = false;
 }
 
 /**
  * Show modal to select replacement item and migrate bookmarks
  */
-function showReplacementSelectionModal(oldGroup: any, replacementItems: any[]): void {
+function showReplacementSelectionModal(
+  oldGroup: BookmarkGroup,
+  replacementItems: JellyfinReplacementItem[],
+  context: IdentityContext
+): void {
   // These modals are reached from awaited flows (library search, orphan
   // scan): the page can drain mid-await. A modal with no live adoption to
   // own its teardown must not appear over the destination view.
-  if (!currentPageHandle()) return;
-  const apiClient: any = window.ApiClient || (window as any).ConnectionManager?.currentApiClient();
+  if (!JC.identity.isCurrent(context) || !currentPageHandle()) return;
+  const apiClient = currentImageApiClient();
   if (!apiClient) return;
 
   const modal = document.createElement('div');
   modal.className = 'jc-bm-library-modal-overlay';
+  ownReplacementModal(modal);
   modal.style.cssText = 'position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.9); z-index: 10000; display: flex; align-items: center; justify-content: center; opacity: 0; transition: opacity 0.2s;';
   modal.innerHTML = `
     <div class="jc-bm-library-modal-container jc-replacement-modal-container">
@@ -168,12 +266,9 @@ function showReplacementSelectionModal(oldGroup: any, replacementItems: any[]): 
 
   document.body.appendChild(modal);
 
-  let selectedItem: any = null;
+  let selectedItem: JellyfinReplacementItem | null = null;
 
-  const closeDialog = () => {
-    modal.style.opacity = '0';
-    setTimeout(() => modal.remove(), 200);
-  };
+  const closeDialog = () => closeReplacementModal(modal);
   // Body-level modal: the page's dispose bag closes it on drain.
   currentPageHandle()?.track(closeDialog);
 
@@ -186,6 +281,7 @@ function showReplacementSelectionModal(oldGroup: any, replacementItems: any[]): 
   // Selection handlers
   modal.querySelectorAll<HTMLElement>('.replacement-option').forEach(option => {
     option.addEventListener('click', () => {
+      if (!JC.identity.isCurrent(context)) return;
       const idx = parseInt(option.dataset.itemIndex!);
       selectedItem = replacementItems[idx];
 
@@ -207,6 +303,7 @@ function showReplacementSelectionModal(oldGroup: any, replacementItems: any[]): 
 
   // Migrate handler
   modal.querySelector('.jc-bookmark-btn-submit')?.addEventListener('click', () => { void (async () => {
+    if (!JC.identity.isCurrent(context)) return;
     if (!selectedItem) return;
 
     const btn = modal.querySelector<HTMLButtonElement>('.jc-bookmark-btn-submit')!;
@@ -215,8 +312,8 @@ function showReplacementSelectionModal(oldGroup: any, replacementItems: any[]): 
 
     try {
       // Fetch full details for new item
-      const userId = apiClient.getCurrentUserId();
-      const fullItem: any = await getItemCached(selectedItem.Id, { userId });
+      const fullItem = await getItemCached(selectedItem.Id, { userId: context.userId });
+      if (!JC.identity.isCurrent(context) || !isJellyfinReplacementItem(fullItem)) return;
 
       const newDetails = {
         itemId: fullItem.Id,
@@ -230,8 +327,9 @@ function showReplacementSelectionModal(oldGroup: any, replacementItems: any[]): 
       // originals. syncBookmarks removes the originals (by id) only after the
       // new copies are durably persisted, so a mid-flight failure keeps the
       // originals intact (the old pre-delete lost data if syncing failed).
-      const oldIds = oldGroup.bookmarks.map((bm: any) => bm.id);
+      const oldIds = oldGroup.bookmarks.map((bookmark) => bookmark.id);
       const synced = await JC.bookmarks!.syncBookmarks(oldGroup.bookmarks, newDetails, 0, oldIds);
+      if (!JC.identity.isCurrent(context)) return;
 
       toast(JC.t!('bookmark_migrated').replace('{count}', String(synced.length)).replace('{name}', JC.escapeHtml(fullItem.Name)), 4000);
 
@@ -239,8 +337,9 @@ function showReplacementSelectionModal(oldGroup: any, replacementItems: any[]): 
 
       // Refresh the adopted host (syncBookmarks already resolved — no blind
       // setTimeout needed).
-      renderActiveBookmarks();
+      renderActiveBookmarks(context);
     } catch (e) {
+      if (!JC.identity.isCurrent(context)) return;
       console.error('Migration failed:', e);
       toast(JC.t!('bookmark_migration_failed'), 3000);
       btn.disabled = false;
@@ -248,25 +347,29 @@ function showReplacementSelectionModal(oldGroup: any, replacementItems: any[]): 
     }
   })(); });
 
-  setTimeout(() => modal.style.opacity = '1', 10);
+  scheduleReplacementTask(context, () => { if (modal.isConnected) modal.style.opacity = '1'; }, 10);
 }
 
 /**
  * Find all orphaned bookmarks and offer migration
  */
-export async function findAllOrphanedAndOfferMigration(bookmarks: Record<string, any>): Promise<void> {
-  const apiClient: any = window.ApiClient || (window as any).ConnectionManager?.currentApiClient();
+export async function findAllOrphanedAndOfferMigration(
+  bookmarks: Record<string, StoredBookmark>,
+  context: IdentityContext | null = JC.identity.capture()
+): Promise<void> {
+  if (!context || !JC.identity.isCurrent(context)) return;
+  const apiClient = currentImageApiClient();
   if (!apiClient) {
     toast(JC.t!('toast_api_client_unavailable'), 3000);
     return;
   }
 
-  const userId = apiClient.getCurrentUserId();
-  const orphanedGroups: any[] = [];
+  const userId = context.userId;
+  const orphanedGroups: BookmarkGroup[] = [];
 
   // Group by item ID
-  const byItem: Record<string, any> = {};
-  for (const [id, bm] of Object.entries<any>(bookmarks)) {
+  const byItem: Record<string, BookmarkGroup> = {};
+  for (const [id, bm] of Object.entries(bookmarks)) {
     if (!byItem[bm.itemId]) {
       byItem[bm.itemId] = {
         details: bm,
@@ -277,11 +380,14 @@ export async function findAllOrphanedAndOfferMigration(bookmarks: Record<string,
   }
 
   // Check each item
-  for (const [itemId, group] of Object.entries<any>(byItem)) {
+  for (const [itemId, group] of Object.entries(byItem)) {
+    if (!JC.identity.isCurrent(context)) return;
     try {
       await getItemCached(itemId, { userId });
+      if (!JC.identity.isCurrent(context)) return;
       // Item exists, not orphaned
     } catch (e) {
+      if (!JC.identity.isCurrent(context)) return;
       // DATA-SAFETY: only an explicit 404 means the item is truly gone. A
       // transient failure must not be treated as orphaned (which would offer a
       // destructive migration); keep it and warn.
@@ -302,13 +408,16 @@ export async function findAllOrphanedAndOfferMigration(bookmarks: Record<string,
   }
 
   // Search for replacements for all orphaned items
-  const replacementResults: any[] = [];
+  const replacementResults: ReplacementResult[] = [];
   for (const group of orphanedGroups) {
+    if (!JC.identity.isCurrent(context)) return;
     const matches = await searchForReplacementItem(
       group.details.tmdbId,
       group.details.tvdbId,
-      group.details.mediaType
+      group.details.mediaType,
+      context
     );
+    if (!JC.identity.isCurrent(context)) return;
     if (matches && matches.length > 0) {
       replacementResults.push({ group, matches });
     }
@@ -320,17 +429,18 @@ export async function findAllOrphanedAndOfferMigration(bookmarks: Record<string,
   }
 
   // Show summary modal
-  showOrphanedSummaryModal(replacementResults);
+  showOrphanedSummaryModal(replacementResults, context);
 }
 
 /**
  * Show summary of all orphaned items with replacements
  */
-function showOrphanedSummaryModal(replacementResults: any[]): void {
+function showOrphanedSummaryModal(replacementResults: ReplacementResult[], context: IdentityContext): void {
   // Same delayed-flow guard as showReplacementSelectionModal.
-  if (!currentPageHandle()) return;
+  if (!JC.identity.isCurrent(context) || !currentPageHandle()) return;
   const modal = document.createElement('div');
   modal.className = 'jc-bm-library-modal-overlay';
+  ownReplacementModal(modal);
   modal.style.cssText = 'position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.85); z-index: 10000; display: flex; align-items: center; justify-content: center; opacity: 0; transition: opacity 0.2s;';
   modal.innerHTML = `
     <div class="jc-bm-library-modal-container" style="max-width: 700px; background: #181818; border-radius: 12px; padding: 24px; position: relative; box-shadow: 0 8px 32px rgba(0,0,0,0.8);">
@@ -374,10 +484,7 @@ function showOrphanedSummaryModal(replacementResults: any[]): void {
 
   document.body.appendChild(modal);
 
-  const closeDialog = () => {
-    modal.style.opacity = '0';
-    setTimeout(() => modal.remove(), 200);
-  };
+  const closeDialog = () => closeReplacementModal(modal);
   // Body-level modal: the page's dispose bag closes it on drain.
   currentPageHandle()?.track(closeDialog);
 
@@ -390,12 +497,15 @@ function showOrphanedSummaryModal(replacementResults: any[]): void {
   // Migrate button handlers
   modal.querySelectorAll<HTMLElement>('.btnMigrateOrphaned').forEach(btn => {
     btn.addEventListener('click', () => {
+      if (!JC.identity.isCurrent(context)) return;
       const idx = parseInt(btn.dataset.resultIndex!);
       const result = replacementResults[idx];
       closeDialog();
-      setTimeout(() => showReplacementSelectionModal(result.group, result.matches), 300);
+      scheduleReplacementTask(context, () => {
+        showReplacementSelectionModal(result.group, result.matches, context);
+      }, 300);
     });
   });
 
-  setTimeout(() => modal.style.opacity = '1', 10);
+  scheduleReplacementTask(context, () => { if (modal.isConnected) modal.style.opacity = '1'; }, 10);
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/config.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/config.identity.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../globals';
+import type { IdentityContext } from '../types/jc';
+import './config';
+
+const saveUserSettings = JC.saveUserSettings!;
+
+function startSession(userId = 'test-user-id', serverId = 'test-server-id'): IdentityContext {
+    JC.identity.transition('', '', 'test-logout');
+    return JC.identity.transition(serverId, userId, 'test-login')!;
+}
+
+describe('identity-owned user settings', () => {
+    beforeEach(() => {
+        startSession();
+        vi.spyOn(ApiClient, 'getCurrentUserId').mockReturnValue('test-user-id');
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        JC.pluginConfig = {};
+        JC.state!.activeShortcuts = {};
+    });
+
+    it('rejects both unowned and stale payloads before ajax', async () => {
+        const ajax = vi.spyOn(ApiClient, 'ajax').mockResolvedValue({});
+        const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        await saveUserSettings('shortcuts.json', { Shortcuts: [] });
+
+        const ownerA = JC.identity.capture()!;
+        const stale = JC.identity.own({ Shortcuts: [] }, ownerA);
+        JC.identity.transition('test-server-id', 'user-b', 'account-switch');
+        vi.spyOn(ApiClient, 'getCurrentUserId').mockReturnValue('user-b');
+        await saveUserSettings('shortcuts.json', stale);
+
+        expect(ajax).not.toHaveBeenCalled();
+        expect(error).toHaveBeenCalledTimes(2);
+    });
+
+    it('refuses a current-owned same-user snapshot when the live client belongs to another server', async () => {
+        const owner = JC.identity.capture()!;
+        const payload = JC.identity.own({ Shortcuts: [{ Name: 'A', Key: 'a' }] }, owner);
+        const liveClient = ApiClient as JellyfinApiClient & { serverId: () => string };
+        const serverId = vi.spyOn(liveClient, 'serverId').mockReturnValue('other-server-id');
+        const ajax = vi.spyOn(ApiClient, 'ajax');
+        const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        await saveUserSettings('shortcuts.json', payload);
+
+        expect(serverId).toHaveBeenCalled();
+        expect(ajax).not.toHaveBeenCalled();
+        expect(error).toHaveBeenCalledWith(
+            expect.stringContaining('live server does not own the settings'),
+        );
+    });
+
+    it('fails closed when both the owner and live client use the unresolved server fallback', async () => {
+        const owner = startSession('test-user-id', 'unknown-server');
+        const payload = JC.identity.own({ Shortcuts: [{ Name: 'A', Key: 'a' }] }, owner);
+        const liveClient = ApiClient as JellyfinApiClient & { serverId: () => string };
+        vi.spyOn(liveClient, 'serverId').mockReturnValue('unknown-server');
+        const ajax = vi.spyOn(ApiClient, 'ajax').mockResolvedValue({});
+        const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        await saveUserSettings('unresolved-server.json', payload);
+
+        expect(ajax).not.toHaveBeenCalled();
+        expect(error).toHaveBeenCalledWith(
+            expect.stringContaining('live server does not own the settings'),
+        );
+    });
+
+    it('allows a save when getUrl supplies the concrete server fallback', async () => {
+        const owner = startSession('test-user-id', 'http://jellyfin.test');
+        const payload = JC.identity.own({ Shortcuts: [{ Name: 'A', Key: 'a' }] }, owner);
+        const liveClient = ApiClient as JellyfinApiClient & { serverId: () => string };
+        vi.spyOn(liveClient, 'serverId').mockReturnValue('unknown-server');
+        const ajax = vi.spyOn(ApiClient, 'ajax').mockResolvedValue({});
+        const originalCoreApi = JC.core.api;
+        delete JC.core.api;
+
+        try {
+            await saveUserSettings('origin-fallback.json', payload);
+        } finally {
+            JC.core.api = originalCoreApi;
+        }
+
+        expect(ajax).toHaveBeenCalledTimes(1);
+        expect(ajax).toHaveBeenCalledWith(expect.objectContaining({
+            url: 'http://jellyfin.test/JellyfinCanopy/user-settings/testuserid/origin-fallback.json'
+        }));
+    });
+
+    it('does not publish an A acknowledgement into a later same-user epoch', async () => {
+        let resolvePost!: (value: unknown) => void;
+        const firstPost = new Promise((resolve) => { resolvePost = resolve; });
+        const ajax = vi.spyOn(ApiClient, 'ajax')
+            .mockReturnValueOnce(firstPost)
+            .mockResolvedValueOnce({});
+        const ownerA = JC.identity.capture()!;
+        const payloadA = JC.identity.own({ Shortcuts: [{ Name: 'Open', Key: 'o' }] }, ownerA);
+
+        const pending = saveUserSettings('shortcuts.json', payloadA);
+        expect(ajax).toHaveBeenCalledTimes(1);
+
+        const ownerB = startSession();
+        resolvePost({});
+        await pending;
+
+        const payloadB = JC.identity.own({ Shortcuts: [{ Name: 'Open', Key: 'o' }] }, ownerB);
+        await saveUserSettings('shortcuts.json', payloadB);
+
+        expect(ajax).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns a current-owned merge and excludes settings owned by A', () => {
+        const ownerA = JC.identity.capture()!;
+        const staleSettings = JC.identity.own({ accountAOnly: 'secret' }, ownerA);
+        const ownerB = JC.identity.transition('test-server-id', 'user-b', 'account-switch')!;
+        JC.userConfig = JC.identity.own({ settings: staleSettings }, ownerB);
+
+        const merged = JC.loadSettings!();
+
+        expect(merged).not.toHaveProperty('accountAOnly');
+        expect(JC.identity.isOwned(merged, ownerB)).toBe(true);
+    });
+
+    it('replaces the shortcut map so A-only keys cannot survive B init', () => {
+        JC.state!.activeShortcuts = { AccountAOnly: 'a' };
+        JC.pluginConfig = { Shortcuts: [{ Name: 'Default', Key: 'd' }] };
+        JC.userConfig = {
+            shortcuts: { Shortcuts: [{ Name: 'UserB', Key: 'b' }] },
+        };
+
+        JC.initializeShortcuts!();
+
+        expect(JC.state!.activeShortcuts).toEqual({ Default: 'd', UserB: 'b' });
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/config.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/config.ts
@@ -7,6 +7,47 @@ import { JC } from '../globals';
 import type { UserSettings } from '../types/jc';
 import { adminDefaultsView } from '../core/config-resolve';
 
+function normalizeIdentityPart(value: unknown): string {
+    if (typeof value !== 'string' && typeof value !== 'number') return '';
+    return String(value).trim().replace(/-/g, '').toLowerCase();
+}
+
+const UNKNOWN_SERVER_ID = normalizeIdentityPart('unknown-server');
+
+function isResolvedServerId(value: unknown): boolean {
+    const normalized = normalizeIdentityPart(value);
+    return normalized !== '' && normalized !== UNKNOWN_SERVER_ID;
+}
+
+function liveApiClientServerId(): string {
+    const client = ApiClient as JellyfinApiClient & {
+        serverId?: string | (() => string);
+        serverInfo?: { Id?: string; ServerId?: string } | (() => { Id?: string; ServerId?: string });
+        _serverInfo?: { Id?: string; ServerId?: string };
+        serverAddress?: string | (() => string);
+    };
+    try {
+        const direct = typeof client.serverId === 'function'
+            ? client.serverId.call(client)
+            : client.serverId;
+        if (isResolvedServerId(direct)) return String(direct);
+    } catch { /* try server-info forms */ }
+    try {
+        const info = typeof client.serverInfo === 'function'
+            ? client.serverInfo.call(client)
+            : (client.serverInfo || client._serverInfo);
+        const fromInfo = info?.Id || info?.ServerId || '';
+        if (isResolvedServerId(fromInfo)) return fromInfo;
+    } catch { /* fall through to address */ }
+    try {
+        const address = typeof client.serverAddress === 'function'
+            ? client.serverAddress.call(client)
+            : (client.serverAddress || client.getUrl('/'));
+        if (isResolvedServerId(address)) return new URL(String(address), window.location.href).origin;
+    } catch { /* unknown-server below */ }
+    return '';
+}
+
 /**
  * Constants derived from the plugin configuration.
  */
@@ -37,24 +78,47 @@ JC.state = JC.state || {
 // Per-file cache of the last JSON string successfully sent to the server.
 const _lastSavedJson: Record<string, string> = {};
 
-JC.saveUserSettings = async (fileName: string, settings: unknown): Promise<void> => {
-    if (typeof ApiClient === 'undefined' || !ApiClient.getCurrentUserId) {
-        console.error("🪼 Jellyfin Canopy: ApiClient not available");
-        return;
-    }
-    try {
-        const userId = ApiClient.getCurrentUserId();
-        if (!userId) {
-            console.error("🪼 Jellyfin Canopy: User ID not available");
-            return;
-        }
+function clearSaveDeduplication(): void {
+    for (const key of Object.keys(_lastSavedJson)) delete _lastSavedJson[key];
+}
 
+// The loader installs identity before loading the bundle. Optional chaining is
+// retained for isolated module tests which provide only the old bootstrap stub.
+JC.identity?.registerReset?.('enhanced-config-writes', clearSaveDeduplication);
+
+JC.saveUserSettings = async (fileName: string, settings: unknown): Promise<void> => {
+    try {
         // Fail LOUDLY on a no-arg / bad-fileName save instead of silently no-oping.
         // A call like saveUserSettings() serializes `undefined` and — for non-
         // settings.json files — hits the dedup guard below and returns without ever
         // POSTing, which is exactly how the pause-screen delay silently lost writes.
         if (!fileName || typeof settings === 'undefined') {
             console.error('🪼 Jellyfin Canopy: saveUserSettings called without fileName/settings', { fileName });
+            return;
+        }
+
+        const owner = JC.identity?.ownerOf?.(settings);
+        if (!owner || !JC.identity.isCurrent(owner)) {
+            console.error(`🪼 Jellyfin Canopy: Refusing to save ${fileName}; settings have no current identity owner`);
+            return;
+        }
+
+        if (typeof ApiClient === 'undefined' || typeof ApiClient.getCurrentUserId !== 'function') {
+            console.error("🪼 Jellyfin Canopy: ApiClient not available");
+            return;
+        }
+        // The authentication hook normally transitions identity before the host
+        // changes this value. Keep this independent check so a missed/foreign
+        // ApiClient replacement still cannot send A's object with B's token.
+        if (normalizeIdentityPart(ApiClient.getCurrentUserId()) !== owner.userId) {
+            console.error(`🪼 Jellyfin Canopy: Refusing to save ${fileName}; live user does not own the settings`);
+            return;
+        }
+        const liveServerId = liveApiClientServerId();
+        if (!isResolvedServerId(owner.serverId)
+            || !isResolvedServerId(liveServerId)
+            || normalizeIdentityPart(liveServerId) !== normalizeIdentityPart(owner.serverId)) {
+            console.error(`🪼 Jellyfin Canopy: Refusing to save ${fileName}; live server does not own the settings`);
             return;
         }
 
@@ -71,7 +135,7 @@ JC.saveUserSettings = async (fileName: string, settings: unknown): Promise<void>
         }
 
         const serialized = JSON.stringify(dataToSave);
-        const cacheKey = `${userId}:${fileName}`;
+        const cacheKey = `${owner.serverId}:${owner.userId}:${fileName}`;
 
         // For non-settings files, skip the POST if nothing has changed.
         // settings.json is exempt: loadSettings() merges defaults so the first
@@ -81,16 +145,41 @@ JC.saveUserSettings = async (fileName: string, settings: unknown): Promise<void>
             return; // no-op — identical to last save
         }
 
-        await ApiClient.ajax({
-            type: 'POST',
-            url: ApiClient.getUrl(`/JellyfinCanopy/user-settings/${userId}/${fileName}`),
-            data: serialized,
-            contentType: 'application/json'
-        });
+        // No await occurs between this final owner check and ajax invocation.
+        // Therefore an identity transition cannot interleave and substitute B's
+        // authentication after we have authorized A's snapshot.
+        if (!JC.identity.isCurrent(owner) || !JC.identity.isOwned(settings, owner)) return;
 
-        // Update the cache on success so subsequent identical saves are skipped
-        _lastSavedJson[cacheKey] = serialized;
+        // Production writes use the central identity-owned transport so a
+        // transition aborts both queued and active A saves before B can run.
+        // The fallback preserves isolated config-module tests/legacy embedding
+        // where the core bundle has not installed JC.core.api yet.
+        if (JC.core.api?.plugin) {
+            await JC.core.api.plugin(`/user-settings/${owner.userId}/${fileName}`, {
+                method: 'POST',
+                body: serialized,
+                headers: { 'Content-Type': 'application/json' },
+                // Retrying a non-idempotent settings write can duplicate work.
+                skipRetry: true
+            });
+        } else {
+            await ApiClient.ajax({
+                type: 'POST',
+                url: ApiClient.getUrl(`/JellyfinCanopy/user-settings/${owner.userId}/${fileName}`),
+                data: serialized,
+                contentType: 'application/json'
+            });
+        }
+
+        // A may have logged out while its request was in flight. Never publish
+        // that acknowledgement into the new epoch's deduplication state.
+        if (JC.identity.isCurrent(owner) && JC.identity.isOwned(settings, owner)) {
+            _lastSavedJson[cacheKey] = serialized;
+        }
     } catch (e) {
+        // Identity/navigation teardown intentionally aborts the old owner's
+        // transport. It is a successful fence, not a user-visible save error.
+        if ((e as Error | null)?.name === 'AbortError') return;
         console.error(`🪼 Jellyfin Canopy: Failed to save ${fileName}:`, e);
     }
 };
@@ -99,7 +188,17 @@ JC.saveUserSettings = async (fileName: string, settings: unknown): Promise<void>
  * Loads and merges settings from user config, plugin defaults, and hardcoded fallbacks.
  */
 JC.loadSettings = (): UserSettings => {
-    const userSettings: Record<string, unknown> = JC.userConfig?.settings || {};
+    const context = JC.identity?.capture?.() || null;
+    const storedSettings = JC.userConfig?.settings || {};
+    // An owner-tagged object from a prior epoch must never seed B's merged
+    // settings. During legacy/test boot (no active context), retain the old
+    // behaviour so the pure default-resolution contract remains usable.
+    const storedOwner = JC.identity?.ownerOf?.(storedSettings) || null;
+    const userSettings: Record<string, unknown> = context && storedOwner
+        && !JC.identity.isOwned(storedSettings, context)
+        ? {}
+        : storedSettings;
+    if (context && !storedOwner) JC.identity.own(userSettings, context);
     const pluginDefaults: Record<string, unknown> = JC.pluginConfig || {};
     // JC.pluginConfig is PascalCase; the merge below iterates camelCase keys, so
     // the admin tier resolves through a camelCase VIEW (ENH-4). Without this the
@@ -176,7 +275,7 @@ JC.loadSettings = (): UserSettings => {
         mergedSettings.isAdmin = userSettings.isAdmin !== undefined ? userSettings.isAdmin : undefined;
     }
 
-    return mergedSettings;
+    return JC.identity?.own?.(mergedSettings, context) || mergedSettings;
 };
 
 /** Shape of a shortcut entry in plugin/user config. */
@@ -206,6 +305,7 @@ JC.initializeShortcuts = function (): void {
           }, {})
         : {};
 
-    JC.state!.activeShortcuts = JC.state!.activeShortcuts || {};
-    Object.assign(JC.state!.activeShortcuts, defaultShortcuts, userShortcuts);
+    // Replace the map instead of merging in place: keys belonging only to A
+    // must disappear when B initializes in the same SPA document.
+    JC.state!.activeShortcuts = { ...defaultShortcuts, ...userShortcuts };
 };

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/events.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/events.identity.test.ts
@@ -1,0 +1,82 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { JC } from '../globals';
+
+describe('enhanced event process lifecycle', () => {
+    beforeAll(async () => {
+        window.Events = { on: vi.fn() } as unknown as JellyfinEvents;
+        await import('./events');
+    });
+
+    afterAll(() => {
+        JC.identity.transition('', '', 'enhanced-events-test-cleanup');
+        vi.useRealTimers();
+        document.body.innerHTML = '';
+    });
+
+    it('installs wrappers once, resolves handlers live, and cancels A work', () => {
+        vi.useFakeTimers();
+        document.body.innerHTML = '<button class="headerSearchButton"></button><input type="search">';
+        JC.identity.transition('events-server-a', 'events-user-a', 'enhanced-events-test');
+        JC.pluginConfig = {};
+        JC.currentSettings = {
+            disableAllShortcuts: false,
+            longPress2xEnabled: true,
+            removeContinueWatchingEnabled: false,
+        };
+        JC.state = { activeShortcuts: { OpenSearch: 'S' }, removeContext: null, pauseScreenClickTimer: null };
+
+        const surface = JC as unknown as Record<string, unknown>;
+        surface.injectGlobalStyles = vi.fn();
+        surface.addPluginMenuButton = vi.fn();
+        surface.applySavedStylesWhenReady = vi.fn();
+        surface.addRandomButton = vi.fn();
+        surface.addUserPreferencesLink = vi.fn();
+        surface.addOsdSettingsButton = vi.fn();
+        surface.isVideoPage = vi.fn(() => true);
+        surface.initializeAutoSkipObserver = vi.fn();
+        surface.attachSeekTracker = vi.fn();
+        surface.stopAutoSkip = vi.fn();
+        JC.t = (key: string) => key;
+
+        const aDown = vi.fn();
+        const aCancel = vi.fn();
+        surface.handleLongPressDown = aDown;
+        surface.handleLongPressCancel = aCancel;
+
+        const addListener = vi.spyOn(document, 'addEventListener');
+        JC.initializeCanopyScript!();
+        const keydownInstallCount = addListener.mock.calls.filter(([type]) => type === 'keydown').length;
+        JC.initializeCanopyScript!();
+        expect(addListener.mock.calls.filter(([type]) => type === 'keydown')).toHaveLength(keydownInstallCount);
+
+        document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, button: 0 }));
+        expect(aDown).toHaveBeenCalledTimes(1);
+
+        const panelCleanup = vi.fn();
+        const panel = document.createElement('div') as HTMLDivElement & { _identityCleanup?: () => void };
+        panel.id = 'jellyfin-canopy-panel';
+        panel._identityCleanup = panelCleanup;
+        document.body.appendChild(panel);
+
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'S', bubbles: true }));
+        const search = document.querySelector<HTMLInputElement>('input[type="search"]')!;
+        expect(document.activeElement).not.toBe(search);
+
+        JC.identity.transition('events-server-b', 'events-user-b', 'enhanced-events-test');
+        expect(aCancel).toHaveBeenCalledTimes(1);
+        expect(panelCleanup).toHaveBeenCalledTimes(1);
+
+        const bDown = vi.fn();
+        surface.handleLongPressDown = bDown;
+        surface.handleLongPressCancel = vi.fn();
+        JC.currentSettings = { disableAllShortcuts: false, longPress2xEnabled: true };
+        JC.state.activeShortcuts = {};
+        vi.runOnlyPendingTimers();
+        expect(document.activeElement).not.toBe(search);
+
+        document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, button: 0 }));
+        expect(aDown).toHaveBeenCalledTimes(1);
+        expect(bDown).toHaveBeenCalledTimes(1);
+        addListener.mockRestore();
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/events.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/events.ts
@@ -10,12 +10,26 @@ import { toast } from '../core/ui-kit';
 import { stampLayoutClass } from '../core/layout';
 import { migrateLegacyClientStorage } from './legacy-storage-migration';
 import { throttle } from './helpers';
+import type { IdentityContext } from '../types/jc';
+
+const shortcutTimers = new Set<number>();
+let actionSheetFrame: number | null = null;
+let wasVideoPage = false;
+
+function scheduleIdentityTimer(context: IdentityContext, callback: () => void, delay: number): void {
+    const timer = window.setTimeout(() => {
+        shortcutTimers.delete(timer);
+        if (JC.identity.isCurrent(context)) callback();
+    }, delay);
+    shortcutTimers.add(timer);
+}
 
 /**
  * An always-active key listener specifically for opening the panel.
  * @param e The keyboard event.
  */
 function panelKeyListener(e: KeyboardEvent): void {
+    if (!JC.identity.capture()) return;
     // INT-1: never open the panel through an open JC modal (`?` would otherwise
     // pop the panel up behind another dialog).
     if (isAnyModalOpen() || document.body.classList.contains('jc-modal-open')) return;
@@ -36,6 +50,10 @@ function panelKeyListener(e: KeyboardEvent): void {
  * @param e The keyboard event.
  */
 JC.keyListener = (e: KeyboardEvent) => {
+    const context = JC.identity.capture();
+    if (!context
+        || JC.pluginConfig?.DisableAllShortcuts
+        || JC.currentSettings?.disableAllShortcuts) return;
     // INT-1: suppress every global shortcut while any JC modal is open so a
     // configured key can't fire through the dialog and navigate the SPA away.
     if (isAnyModalOpen() || document.body.classList.contains('jc-modal-open')) return;
@@ -49,13 +67,15 @@ JC.keyListener = (e: KeyboardEvent) => {
                   (key.match(/^[a-zA-Z]$/) ? key.toUpperCase() : key);
 
     const video = document.querySelector('video');
-    const activeShortcuts = JC.state!.activeShortcuts;
+    const activeShortcuts = JC.state!.activeShortcuts || {};
 
     // --- Global Shortcuts ---
     if (combo === activeShortcuts.OpenSearch) {
         e.preventDefault();
         document.querySelector<HTMLElement>('button.headerSearchButton')?.click();
-        setTimeout(() => document.querySelector<HTMLInputElement>('input[type="search"]')?.focus(), 100);
+        scheduleIdentityTimer(context, () => {
+            document.querySelector<HTMLInputElement>('input[type="search"]')?.focus();
+        }, 100);
         toast(JC.t!('toast_search'));
     } else if (combo === activeShortcuts.GoToHome) {
         e.preventDefault();
@@ -106,7 +126,16 @@ JC.keyListener = (e: KeyboardEvent) => {
                 if (dialogContainer) dialogContainer.remove();
             } else {
                 // Stats menu is not open, open it
-                JC.openSettings!(() => document.querySelector<HTMLElement>('.actionSheetContent button[data-id="stats"]')?.click());
+                document.querySelector<HTMLElement>(
+                    '.videoOsdBottom .btnVideoOsdSettings, ' +
+                    '.videoOsdBottom button[title="Settings"], ' +
+                    '.videoOsdBottom button[aria-label="Settings"]'
+                )?.click();
+                scheduleIdentityTimer(context, () => {
+                    if (JC.identity.isCurrent(context)) {
+                        document.querySelector<HTMLElement>('.actionSheetContent button[data-id="stats"]')?.click();
+                    }
+                }, 120);
             }
             break;
         }
@@ -205,10 +234,9 @@ function setupDOMObserver(): void {
     // PERF(R8): track the video-page state across ticks so the leave-page teardown
     // (stopAutoSkip) runs once on the transition instead of on every mutation
     // batch of every non-video page.
-    let wasVideoPage = false;
-
     const runPageSpecificFunctions = () => {
-        if ((JC as any).isVideoPage()) {
+        if (!JC.identity.capture() || !JC.currentSettings) return;
+        if (JC.isVideoPage?.()) {
             wasVideoPage = true;
             (JC as any).addOsdSettingsButton();
             JC.initializeAutoSkipObserver!();
@@ -252,10 +280,9 @@ function setupDOMObserver(): void {
  * how many mutations fire, and the handlers early-return cheaply when no sheet is open.
  */
 function observeActionSheets(): void {
-    let scheduled = false;
-    const runInjection = () => {
-        scheduled = false;
-        if (!JC.currentSettings!.removeContinueWatchingEnabled) return;
+    const runInjection = (context: IdentityContext) => {
+        actionSheetFrame = null;
+        if (!JC.identity.isCurrent(context) || !JC.currentSettings?.removeContinueWatchingEnabled) return;
         if (typeof (JC as any).addRemoveButton === 'function') {
             (JC as any).addRemoveButton();
         } else {
@@ -271,9 +298,10 @@ function observeActionSheets(): void {
     createObserver(
         'action-sheets',
         () => {
-            if (scheduled) return;
-            scheduled = true;
-            requestAnimationFrame(runInjection);
+            if (actionSheetFrame !== null) return;
+            const context = JC.identity.capture();
+            if (!context) return;
+            actionSheetFrame = requestAnimationFrame(() => runInjection(context));
         },
         document.body,
         { childList: true, subtree: true }
@@ -312,7 +340,7 @@ function addContextMenuListener(): void {
 
     // Listen for three-dot menu button clicks
     document.body.addEventListener('mousedown', (e) => {
-        if (!JC.currentSettings!.removeContinueWatchingEnabled) return;
+        if (!JC.identity.capture() || !JC.currentSettings?.removeContinueWatchingEnabled) return;
 
         const menuButton = (e.target as Element).closest('button[data-action="menu"]');
         if (!menuButton) return;
@@ -323,7 +351,7 @@ function addContextMenuListener(): void {
 
     // Listen for right-click (contextmenu) / long-press on home cards
     document.body.addEventListener('contextmenu', (e) => {
-        if (!JC.currentSettings!.removeContinueWatchingEnabled) return;
+        if (!JC.identity.capture() || !JC.currentSettings?.removeContinueWatchingEnabled) return;
         if (isInsideOpenMenu(e.target as Element)) return;
 
         // Only real cards carry a removable home surface; ignore other [data-id] targets.
@@ -334,6 +362,98 @@ function addContextMenuListener(): void {
 /**
  * Initializes all event listeners for the core Jellyfin Canopy script.
  */
+let processListenersInstalled = false;
+
+function installProcessListeners(): void {
+    if (processListenersInstalled) return;
+    processListenersInstalled = true;
+
+    setupDOMObserver();
+    observeActionSheets();
+    addContextMenuListener();
+
+    // These wrappers deliberately survive account switches. They consult the
+    // current identity/settings at event time, so repeated A→B→A activation
+    // cannot stack handlers or retain an old user's feature gates.
+    document.addEventListener('keydown', panelKeyListener);
+    document.addEventListener('keydown', JC.keyListener!);
+
+    const videoPageCheck = (handlerName: string) => (e: Event) => {
+        if (!JC.identity.capture() || !JC.currentSettings?.longPress2xEnabled) return;
+        if (JC.isVideoPage?.()) {
+            // Don't interfere with clicks on OSD buttons / the pause screen overlay / Enhanced Panel
+            if (e.target && (e.target as Element).closest && (e.target as Element).closest('.osdControls, .pause-screen-active, .jellyfin-canopy-panel')) return;
+            const handler = (JC as unknown as Record<string, unknown>)[handlerName];
+            if (typeof handler === 'function') (handler as (event: Event) => void)(e);
+        }
+    };
+
+    document.addEventListener('mousedown', videoPageCheck('handleLongPressDown'), true);
+    document.addEventListener('mouseup', videoPageCheck('handleLongPressUp'), true);
+    document.addEventListener('mousemove', videoPageCheck('handleLongPressMove'), true);
+    document.addEventListener('click', videoPageCheck('handleLongPressClick'), true);
+    document.addEventListener('mouseleave', videoPageCheck('handleLongPressCancel'), true);
+    document.addEventListener('touchstart', videoPageCheck('handleLongPressDown'), { capture: true, passive: true });
+    document.addEventListener('touchmove', videoPageCheck('handleLongPressMove'), { capture: true, passive: true });
+    document.addEventListener('touchend', videoPageCheck('handleLongPressUp'), { capture: true, passive: false });
+    document.addEventListener('touchcancel', videoPageCheck('handleLongPressCancel'), { capture: true, passive: false });
+
+    // Visibility behaviour is likewise gated from the live B settings.
+    document.addEventListener('visibilitychange', () => {
+        const settings = JC.currentSettings;
+        if (!JC.identity.capture() || !settings) return;
+        const video = document.querySelector('video');
+        if (!video) return;
+
+        JC.attachSeekTracker!(video);
+
+        if (document.hidden) {
+            if (!video.paused && settings.autoPauseEnabled) {
+                video.pause();
+                video.dataset.wasPlayingBeforeHidden = 'true';
+            }
+            if (settings.autoPipEnabled && !document.pictureInPictureElement) {
+                video.requestPictureInPicture().catch(err => console.error("🪼 Jellyfin Canopy: Auto PiP Error:", err));
+            }
+        } else {
+            if (video.paused && video.dataset.wasPlayingBeforeHidden === 'true' && settings.autoResumeEnabled) {
+                void video.play();
+            }
+            delete video.dataset.wasPlayingBeforeHidden;
+            if (settings.autoPipEnabled && document.pictureInPictureElement) {
+                document.exitPictureInPicture().catch(err => console.error("🪼 Jellyfin Canopy: Auto PiP Error:", err));
+            }
+        }
+    });
+}
+
+JC.identity.registerReset('enhanced-events', () => {
+    if (JC.state) JC.state.removeContext = null;
+    wasVideoPage = false;
+    if (actionSheetFrame !== null) {
+        cancelAnimationFrame(actionSheetFrame);
+        actionSheetFrame = null;
+    }
+    for (const timer of shortcutTimers) clearTimeout(timer);
+    shortcutTimers.clear();
+    try { JC.handleLongPressCancel?.(new Event('identitychange')); } catch { /* best-effort teardown */ }
+    try { JC.stopAutoSkip?.(); } catch { /* best-effort teardown */ }
+    // These are identity-derived transient surfaces. Durable injectors rebuild
+    // them from B's settings during the next activation.
+    const panel = document.getElementById('jellyfin-canopy-panel');
+    const ownedPanel = panel as unknown as {
+        _identityCleanup?: () => void;
+        _a11y?: { release(): void };
+    } | null;
+    if (ownedPanel?._identityCleanup) ownedPanel._identityCleanup();
+    else {
+        ownedPanel?._a11y?.release();
+        panel?.remove();
+    }
+    document.getElementById('enhancedSettingsBtn')?.remove();
+    document.querySelectorAll('[data-speed-overlay="true"]').forEach((node) => node.remove());
+});
+
 JC.initializeCanopyScript = function() {
     // Rebrand migration: adopt state written by pre-2.0 "Jellyfin Elevate" builds.
     migrateLegacyClientStorage();
@@ -347,71 +467,13 @@ JC.initializeCanopyScript = function() {
     }
 
     // Initial UI setup
-    (JC as any).injectGlobalStyles();
+    JC.injectGlobalStyles?.();
     // Stamp the modern/legacy layout class on <html> now that the app has
     // booted (the header is normally rendered by this point). The stamp is
     // idempotent and self-retries on navigation until the layout resolves.
     stampLayoutClass();
-    (JC as any).addPluginMenuButton();
-    (JC as any).applySavedStylesWhenReady();
+    JC.addPluginMenuButton?.();
+    JC.applySavedStylesWhenReady?.();
 
-    // Setup persistent listeners and observers
-    setupDOMObserver();
-    observeActionSheets();
-    addContextMenuListener();
-
-    // Always listen for the panel-opening key
-    document.addEventListener('keydown', panelKeyListener);
-
-    // Conditionally listen for all other shortcuts
-    if (!JC.pluginConfig.DisableAllShortcuts) {
-        document.addEventListener('keydown', JC.keyListener!);
-    }
-
-    // Add Long Press listeners if enabled
-    if (JC.currentSettings!.longPress2xEnabled) {
-        const videoPageCheck = (handler: (e: Event) => void) => (e: Event) => {
-            if ((JC as any).isVideoPage()) {
-                // Don't interfere with clicks on OSD buttons / the pause screen overlay / Enhanced Panel
-                if (e.target && (e.target as Element).closest && (e.target as Element).closest('.osdControls, .pause-screen-active, .jellyfin-canopy-panel')) return;
-                handler(e);
-            }
-        };
-
-        document.addEventListener('mousedown', videoPageCheck(JC.handleLongPressDown!), true);
-        document.addEventListener('mouseup', videoPageCheck(JC.handleLongPressUp!), true);
-        document.addEventListener('mousemove', videoPageCheck(JC.handleLongPressMove!), true);
-        document.addEventListener('click', videoPageCheck(JC.handleLongPressClick!), true);
-        document.addEventListener('mouseleave', videoPageCheck(JC.handleLongPressCancel!), true);
-        document.addEventListener('touchstart', videoPageCheck(JC.handleLongPressDown!), { capture: true, passive: true });
-        document.addEventListener('touchmove', videoPageCheck(JC.handleLongPressMove!), { capture: true, passive: true });
-        document.addEventListener('touchend', videoPageCheck(JC.handleLongPressUp!), { capture: true, passive: false });
-        document.addEventListener('touchcancel', videoPageCheck(JC.handleLongPressCancel!), { capture: true, passive: false });
-    }
-
-    // Listeners for tab visibility (auto-pause/resume/PiP)
-    document.addEventListener('visibilitychange', () => {
-        const video = document.querySelector('video');
-        if (!video) return;
-
-        JC.attachSeekTracker!(video);
-
-        if (document.hidden) {
-            if (!video.paused && JC.currentSettings!.autoPauseEnabled) {
-                video.pause();
-                video.dataset.wasPlayingBeforeHidden = 'true';
-            }
-            if (JC.currentSettings!.autoPipEnabled && !document.pictureInPictureElement) {
-                video.requestPictureInPicture().catch(err => console.error("🪼 Jellyfin Canopy: Auto PiP Error:", err));
-            }
-        } else {
-            if (video.paused && video.dataset.wasPlayingBeforeHidden === 'true' && JC.currentSettings!.autoResumeEnabled) {
-                void video.play();
-            }
-            delete video.dataset.wasPlayingBeforeHidden;
-            if (JC.currentSettings!.autoPipEnabled && document.pictureInPictureElement) {
-                document.exitPictureInPicture().catch(err => console.error("🪼 Jellyfin Canopy: Auto PiP Error:", err));
-            }
-        }
-    });
+    installProcessListeners();
 };

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/details-media-info.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/details-media-info.identity.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+import { displayAudioLanguages, displayWatchProgress } from './details-media-info';
+
+function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((done) => { resolve = done; });
+    return { promise, resolve };
+}
+
+async function flushPromises(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+}
+
+function mountContainer(): HTMLElement {
+    const container = document.createElement('div');
+    container.className = 'itemMiscInfo itemMiscInfo-primary';
+    document.body.appendChild(container);
+    return container;
+}
+
+describe('details media-info identity lifecycle', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        document.body.innerHTML = '';
+        JC.identity.transition('details-server-a', 'details-user-a', 'details-media-test');
+        JC.currentSettings = { watchProgressMode: 'percentage' };
+        JC.t = (key: string) => key;
+    });
+
+    afterEach(() => {
+        JC.identity.transition('', '', 'details-media-test-cleanup');
+        JC.core.api = undefined;
+        vi.restoreAllMocks();
+        vi.clearAllTimers();
+        vi.useRealTimers();
+        document.body.innerHTML = '';
+    });
+
+    it('removes A chips and rejects a held A response before B DOM/cache publication', async () => {
+        const container = mountContainer();
+        const aResponse = deferred<unknown>();
+        const aPlugin = vi.fn().mockReturnValue(aResponse.promise);
+        JC.core.api = { plugin: aPlugin } as unknown as NonNullable<typeof JC.core.api>;
+
+        displayWatchProgress('shared-item', container);
+        expect(aPlugin).toHaveBeenCalledWith(
+            '/watch-progress/detailsusera/shared-item',
+            { skipCache: true },
+        );
+
+        JC.identity.transition('details-server-b', 'details-user-b', 'details-media-test');
+        JC.currentSettings = { watchProgressMode: 'percentage' };
+        expect(container.querySelector('.mediaInfoItem-watchProgress')).toBeNull();
+
+        const bPlugin = vi.fn().mockResolvedValue({
+            progress: 80,
+            totalPlaybackTicks: 80,
+            totalRuntimeTicks: 100,
+        });
+        JC.core.api = { plugin: bPlugin } as unknown as NonNullable<typeof JC.core.api>;
+        displayWatchProgress('shared-item', container);
+        await flushPromises();
+        expect(container.textContent).toContain('80%');
+
+        aResponse.resolve({ progress: 5, totalPlaybackTicks: 5, totalRuntimeTicks: 100 });
+        await flushPromises();
+
+        expect(container.textContent).toContain('80%');
+        expect(container.textContent).not.toContain('5%');
+    });
+
+    it('cancels A retry timers synchronously on transition', async () => {
+        const container = mountContainer();
+        const plugin = vi.fn().mockRejectedValue(new Error('temporary'));
+        JC.core.api = { plugin } as unknown as NonNullable<typeof JC.core.api>;
+        vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        displayWatchProgress('retry-item', container);
+        await flushPromises();
+        expect(plugin).toHaveBeenCalledTimes(1);
+
+        JC.identity.transition('details-server-b', 'details-user-b', 'details-media-test');
+        vi.advanceTimersByTime(10_000);
+
+        expect(plugin).toHaveBeenCalledTimes(1);
+        expect(container.querySelector('.mediaInfoItem-watchProgress')).toBeNull();
+    });
+
+    it('uses the captured account for audio metadata and drops A language results', async () => {
+        const container = mountContainer();
+        const aResponse = deferred<unknown>();
+        const getItem = vi.spyOn(ApiClient, 'getItem')
+            .mockReturnValueOnce(aResponse.promise)
+            .mockResolvedValueOnce({
+                Type: 'Movie',
+                MediaSources: [{ MediaStreams: [{ Type: 'Audio', Language: 'spa' }] }],
+            });
+
+        displayAudioLanguages('audio-item', container);
+        expect(getItem).toHaveBeenNthCalledWith(1, 'detailsusera', 'audio-item');
+
+        JC.identity.transition('details-server-b', 'details-user-b', 'details-media-test');
+        JC.currentSettings = {};
+        displayAudioLanguages('audio-item', container);
+        await flushPromises();
+
+        aResponse.resolve({
+            Type: 'Movie',
+            MediaSources: [{ MediaStreams: [{ Type: 'Audio', Language: 'eng' }] }],
+        });
+        await flushPromises();
+
+        expect(getItem).toHaveBeenNthCalledWith(2, 'detailsuserb', 'audio-item');
+        expect(container.querySelector('[data-lang="spa"]')).not.toBeNull();
+        expect(container.querySelector('[data-lang="eng"]')).toBeNull();
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/details-media-info.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/details-media-info.ts
@@ -8,6 +8,7 @@ import { JC } from '../../globals';
 import { flagSvgUrl } from '../../core/asset-urls';
 import { createBoundedCache } from '../../core/bounded-cache';
 import { getItemCached } from '../helpers';
+import type { IdentityContext } from '../../types/jc';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -37,6 +38,35 @@ interface WatchProgressEntry {
 const watchProgressCache = createBoundedCache<string, WatchProgressEntry & { ts: number; error?: boolean }>({ maxEntries: 500, ttlMs: WATCHPROGRESS_CACHE_TTL }); // Map<itemId, { progress, totalPlaybackTicks, totalRuntimeTicks, ts }>
 const fileSizeCache = createBoundedCache<string, { size: number | null; unavailable: boolean; ts: number; error?: boolean }>({ maxEntries: 500, ttlMs: FILESIZE_CACHE_TTL }); // Map<itemId, { size, unavailable, ts }>
 const audioLanguageCache = createBoundedCache<string, { languages: { name: string; code: string }[]; unavailable: boolean; ts: number; error?: boolean }>({ maxEntries: 500, ttlMs: LANGUAGE_CACHE_TTL }); // Map<itemId, { languages, unavailable, ts }>
+const retryTimers = new Set<number>();
+
+function isActive(context: IdentityContext, placeholder?: HTMLElement): boolean {
+    return JC.identity.isCurrent(context) && (!placeholder || placeholder.isConnected);
+}
+
+function scheduleRetry(
+    context: IdentityContext,
+    placeholder: HTMLElement,
+    callback: () => void,
+    delay: number,
+): void {
+    const timer = window.setTimeout(() => {
+        retryTimers.delete(timer);
+        if (isActive(context, placeholder)) callback();
+    }, delay);
+    retryTimers.add(timer);
+}
+
+function resetDetailsMediaInfo(): void {
+    for (const timer of retryTimers) clearTimeout(timer);
+    retryTimers.clear();
+    watchProgressCache.clear();
+    fileSizeCache.clear();
+    audioLanguageCache.clear();
+    document.querySelectorAll(
+        '.mediaInfoItem-watchProgress, .mediaInfoItem-fileSize, .mediaInfoItem-audioLanguage',
+    ).forEach((node) => node.remove());
+}
 
 /** Effective read-side TTL: transient errors expire fast (PERF(R9)), real answers keep the full TTL. */
 function effectiveTtl(entry: { error?: boolean }, normalTtl: number): number {
@@ -63,6 +93,8 @@ function formatSize(bytes: number): string {
  * @param container The DOM element to append the info to.
  */
 export function displayWatchProgress(itemId: string, container: HTMLElement): void {
+    const context = JC.identity.capture();
+    if (!context) return;
     // show itemMiscInfo if hidden like on season pages
     if (container.classList.contains('hide')) {
         container.classList.remove('hide');
@@ -106,7 +138,7 @@ export function displayWatchProgress(itemId: string, container: HTMLElement): vo
     };
 
     const persistWatchProgressMode = (mode: string): void => {
-        if (!window.JellyfinCanopy) return;
+        if (!isActive(context, placeholder) || !window.JellyfinCanopy) return;
         window.JellyfinCanopy.currentSettings = window.JellyfinCanopy.currentSettings || {};
         window.JellyfinCanopy.currentSettings.watchProgressMode = mode;
         if (typeof window.JellyfinCanopy.saveUserSettings === 'function') {
@@ -122,11 +154,11 @@ export function displayWatchProgress(itemId: string, container: HTMLElement): vo
 
     // onClick handler to toggle between percentage and time-based display
     placeholder.addEventListener('click', () => {
+        if (!isActive(context, placeholder)) return;
         const watchProgress = watchProgressCache.get(itemId);
         if (!watchProgress) return;
 
-        const div = document.querySelector(`.mediaInfoItem-watchProgress[data-item-id="${itemId}"]`)!
-            .querySelector<HTMLElement>('.mediaInfoItem-watchProgress-value');
+        const div = placeholder.querySelector<HTMLElement>('.mediaInfoItem-watchProgress-value');
         if (!div) return;
 
         const currentMode = div.dataset.type || 'percentage';
@@ -223,16 +255,19 @@ export function displayWatchProgress(itemId: string, container: HTMLElement): vo
 
     // Helper to render the 0 state
     const renderUnavailable = (): void => {
+        if (!isActive(context, placeholder)) return;
         placeholder.innerHTML = getIconSpan(0);
         placeholder.appendChild(getWatchProgressValue({ progress: 0, totalPlaybackTicks: 0, totalRuntimeTicks: 0 }));
     };
 
     const performFetch = async (attempt = 1): Promise<void> => {
+        if (!isActive(context, placeholder)) return;
         // Check cache first to avoid repeated network calls (read inside so a
         // retry sees fresh state, not values captured before the first attempt).
         const now = Date.now();
         const cached = watchProgressCache.get(itemId);
         if (cached && (now - cached.ts) < effectiveTtl(cached, WATCHPROGRESS_CACHE_TTL)) {
+            if (!isActive(context, placeholder)) return;
             if (!cached.progress) {
                 renderUnavailable();
                 return;
@@ -243,11 +278,11 @@ export function displayWatchProgress(itemId: string, container: HTMLElement): vo
         }
 
         try {
-            const itemResult: any = await ApiClient.ajax({
-                type: 'GET',
-                url: ApiClient.getUrl(`/JellyfinCanopy/watch-progress/${ApiClient.getCurrentUserId()}/${itemId}`),
-                dataType: 'json'
-            });
+            const itemResult: any = await JC.core.api!.plugin(
+                `/watch-progress/${context.userId}/${encodeURIComponent(itemId)}`,
+                { skipCache: true },
+            );
+            if (!isActive(context, placeholder)) return;
 
             const watchProgress = {
                 progress: itemResult?.progress ?? 0,
@@ -260,6 +295,7 @@ export function displayWatchProgress(itemId: string, container: HTMLElement): vo
 
             watchProgressCache.set(itemId, watchProgress);
         } catch (error) {
+            if (!isActive(context, placeholder)) return;
             console.error('🪼 Jellyfin Canopy: Error fetching watch progress for ID %s:', itemId, error);
             // PERF(R9): fail open — render the 0 state now, but remember the
             // failure only briefly (ERROR_CACHE_TTL) and retry in place while
@@ -269,11 +305,9 @@ export function displayWatchProgress(itemId: string, container: HTMLElement): vo
             renderUnavailable();
             watchProgressCache.set(itemId, { progress: 0, totalPlaybackTicks: 0, totalRuntimeTicks: 0, ts: now, error: true });
             if (attempt < FETCH_MAX_ATTEMPTS) {
-                window.setTimeout(() => {
-                    if (placeholder.isConnected) {
-                        watchProgressCache.delete(itemId);
-                        void performFetch(attempt + 1);
-                    }
+                scheduleRetry(context, placeholder, () => {
+                    watchProgressCache.delete(itemId);
+                    void performFetch(attempt + 1);
                 }, RETRY_BASE_DELAY_MS * attempt);
             }
         }
@@ -292,6 +326,8 @@ export function displayWatchProgress(itemId: string, container: HTMLElement): vo
  * @param container The DOM element to append the info to.
  */
 export function displayItemSize(itemId: string, container: HTMLElement): void {
+    const context = JC.identity.capture();
+    if (!context) return;
     const existing = container.querySelector<HTMLElement>('.mediaInfoItem-fileSize');
     if (existing) {
         // If already rendered for this itemId, do nothing
@@ -317,15 +353,18 @@ export function displayItemSize(itemId: string, container: HTMLElement): void {
 
     // Helper to render a dash (no data) but keep the element
     const renderUnavailable = (): void => {
+        if (!isActive(context, placeholder)) return;
         placeholder.innerHTML = `<span class="material-icons" style="font-size: inherit; margin-right: 0.3em;">save</span> -`;
     };
 
     const performFetch = async (attempt = 1): Promise<void> => {
+        if (!isActive(context, placeholder)) return;
         // Check cache first to avoid repeated network calls (read inside so a
         // retry sees fresh state, not values captured before the first attempt).
         const now = Date.now();
         const cached = fileSizeCache.get(itemId);
         if (cached && (now - cached.ts) < effectiveTtl(cached, FILESIZE_CACHE_TTL)) {
+            if (!isActive(context, placeholder)) return;
             if (cached.unavailable || !cached.size) {
                 renderUnavailable();
                 return;
@@ -336,11 +375,11 @@ export function displayItemSize(itemId: string, container: HTMLElement): void {
         }
 
         try {
-            const itemResult: any = await ApiClient.ajax({
-                type: 'GET',
-                url: ApiClient.getUrl(`/JellyfinCanopy/file-size/${ApiClient.getCurrentUserId()}/${itemId}`),
-                dataType: 'json'
-            });
+            const itemResult: any = await JC.core.api!.plugin(
+                `/file-size/${context.userId}/${encodeURIComponent(itemId)}`,
+                { skipCache: true },
+            );
+            if (!isActive(context, placeholder)) return;
             const totalSize = itemResult?.size ?? 0;
 
             if (totalSize > 0) {
@@ -352,6 +391,7 @@ export function displayItemSize(itemId: string, container: HTMLElement): void {
                 fileSizeCache.set(itemId, { size: null, unavailable: true, ts: now });
             }
         } catch (error) {
+            if (!isActive(context, placeholder)) return;
             console.error('🪼 Jellyfin Canopy: Error fetching item size for ID %s:', itemId, error);
             // PERF(R9): fail open — show the dash now, but only remember the
             // failure briefly (ERROR_CACHE_TTL, not the 1h data TTL) and retry
@@ -360,11 +400,9 @@ export function displayItemSize(itemId: string, container: HTMLElement): void {
             renderUnavailable();
             fileSizeCache.set(itemId, { size: null, unavailable: true, ts: now, error: true });
             if (attempt < FETCH_MAX_ATTEMPTS) {
-                window.setTimeout(() => {
-                    if (placeholder.isConnected) {
-                        fileSizeCache.delete(itemId);
-                        void performFetch(attempt + 1);
-                    }
+                scheduleRetry(context, placeholder, () => {
+                    fileSizeCache.delete(itemId);
+                    void performFetch(attempt + 1);
                 }, RETRY_BASE_DELAY_MS * attempt);
             }
         }
@@ -400,20 +438,17 @@ const languageToCountryMap: Record<string, string> = {English:"gb",eng:"gb",Japa
  * @returns The first episode item, or null when the series genuinely has none.
  */
 async function fetchFirstEpisodeForLanguage(userId: string, parentId: string): Promise<any> {
-    const response: any = await ApiClient.ajax({
-        type: 'GET',
-        url: (ApiClient as { getUrl(path: string, params?: unknown): string }).getUrl('/Items', {
-            ParentId: parentId,
-            IncludeItemTypes: 'Episode',
-            Recursive: true,
-            SortBy: 'PremiereDate',
-            SortOrder: 'Ascending',
-            Limit: 1,
-            Fields: 'MediaStreams,MediaSources',
-            userId: userId
-        }),
-        dataType: 'json'
+    const query = new URLSearchParams({
+        ParentId: parentId,
+        IncludeItemTypes: 'Episode',
+        Recursive: 'true',
+        SortBy: 'PremiereDate',
+        SortOrder: 'Ascending',
+        Limit: '1',
+        Fields: 'MediaStreams,MediaSources',
+        UserId: userId,
     });
+    const response: any = await JC.core.api!.jf(`/Items?${query.toString()}`, { skipCache: true });
     return response.Items?.[0] || null;
 }
 
@@ -423,6 +458,8 @@ async function fetchFirstEpisodeForLanguage(userId: string, parentId: string): P
  * @param container The DOM element to append the info to.
  */
 export function displayAudioLanguages(itemId: string, container: HTMLElement): void {
+    const context = JC.identity.capture();
+    if (!context) return;
     // show itemMiscInfo if hidden like on season pages
     if (container.classList.contains('hide')) {
         container.classList.remove('hide');
@@ -472,12 +509,14 @@ export function displayAudioLanguages(itemId: string, container: HTMLElement): v
 
     // Helper to render unavailable/no data with dash
     const renderUnavailable = (): void => {
+        if (!isActive(context, placeholder)) return;
         applyLangStyles(placeholder);
         placeholder.innerHTML = `<span class="material-icons" style="font-size: inherit; margin-right: 0.3em;">translate</span> -`;
     };
 
     // Helper to render language items with proper DOM elements
     const renderLanguages = (languages: { name: string; code: string }[]): void => {
+        if (!isActive(context, placeholder)) return;
         // Clear the loading indicator
         placeholder.innerHTML = '';
         placeholder.style.display = 'flex';
@@ -577,10 +616,12 @@ export function displayAudioLanguages(itemId: string, container: HTMLElement): v
     };
 
     const performFetch = async (attempt = 1): Promise<void> => {
+        if (!isActive(context, placeholder)) return;
         // Check cache first
         const now = Date.now();
         const cached = audioLanguageCache.get(itemId);
         if (cached && (now - cached.ts) < effectiveTtl(cached, LANGUAGE_CACHE_TTL)) {
+            if (!isActive(context, placeholder)) return;
             if (cached.unavailable || !cached.languages || cached.languages.length === 0) {
                 renderUnavailable();
                 return;
@@ -591,14 +632,15 @@ export function displayAudioLanguages(itemId: string, container: HTMLElement): v
         }
 
         try {
-            const userId = ApiClient.getCurrentUserId();
-            const item: any = await getItemCached(itemId, { userId });
+            const item: any = await getItemCached(itemId, { userId: context.userId });
+            if (!isActive(context, placeholder)) return;
 
             let sourceItem = item;
 
             // For Series/Season, fetch the first episode to get language info
             if (item.Type === 'Series' || item.Type === 'Season') {
-                const episode = await fetchFirstEpisodeForLanguage(userId, item.Id);
+                const episode = await fetchFirstEpisodeForLanguage(context.userId, item.Id);
+                if (!isActive(context, placeholder)) return;
                 if (episode) {
                     sourceItem = episode;
                 } else {
@@ -634,6 +676,7 @@ export function displayAudioLanguages(itemId: string, container: HTMLElement): v
                 audioLanguageCache.set(itemId, { languages: [], unavailable: true, ts: Date.now() });
             }
         } catch (error) {
+            if (!isActive(context, placeholder)) return;
             console.error('🪼 Jellyfin Canopy: Error fetching audio languages for %s:', itemId, error);
             // PERF(R9): fail open — show the dash now, remember the failure only
             // briefly (ERROR_CACHE_TTL) and retry in place while the chip is on
@@ -641,11 +684,9 @@ export function displayAudioLanguages(itemId: string, container: HTMLElement): v
             renderUnavailable();
             audioLanguageCache.set(itemId, { languages: [], unavailable: true, ts: Date.now(), error: true });
             if (attempt < FETCH_MAX_ATTEMPTS) {
-                window.setTimeout(() => {
-                    if (placeholder.isConnected) {
-                        audioLanguageCache.delete(itemId);
-                        void performFetch(attempt + 1);
-                    }
+                scheduleRetry(context, placeholder, () => {
+                    audioLanguageCache.delete(itemId);
+                    void performFetch(attempt + 1);
                 }, RETRY_BASE_DELAY_MS * attempt);
             }
         }
@@ -655,3 +696,5 @@ export function displayAudioLanguages(itemId: string, container: HTMLElement): v
     // hits fill the chip in the same task as the insertion, one reflow total.
     void performFetch();
 }
+
+JC.identity.registerReset('details-media-info', resetDetailsMediaInfo);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/details-page.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/details-page.identity.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+import { recordDetailsViewShown, resetDetailsViewTrackingForTests } from '../../core/details-view';
+
+async function flushPromises(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+}
+
+function mountDetailsPage(itemId: string): HTMLElement {
+    window.history.replaceState(null, '', `/web/index.html#/details?id=${itemId}`);
+    const page = document.createElement('div');
+    page.id = 'itemDetailPage';
+    page.className = 'page libraryPage';
+    page.innerHTML = `
+        <h1>Item</h1>
+        <div class="detailButtons"></div>
+        <div class="itemMiscInfo itemMiscInfo-primary"></div>
+    `;
+    document.body.appendChild(page);
+    recordDetailsViewShown(page);
+    return page;
+}
+
+describe('details-page identity dispatcher', () => {
+    beforeAll(async () => {
+        await import('./details-page');
+    });
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        document.body.innerHTML = '';
+        resetDetailsViewTrackingForTests();
+        JC.identity.transition('page-server-a', 'page-user-a', 'details-page-test');
+        JC.currentSettings = {};
+        JC.pluginConfig = {};
+        JC.hiddenContent = undefined;
+        JC.spoilerGuard = undefined;
+    });
+
+    afterEach(() => {
+        JC.identity.transition('', '', 'details-page-test-cleanup');
+        vi.restoreAllMocks();
+        vi.clearAllTimers();
+        vi.useRealTimers();
+        document.body.innerHTML = '';
+        resetDetailsViewTrackingForTests();
+        window.history.replaceState(null, '', '/web/index.html#/home');
+    });
+
+    it('cancels A queued dispatch and starts the visible item under B ownership', async () => {
+        mountDetailsPage('queued-item');
+        const getItem = vi.spyOn(ApiClient, 'getItem').mockResolvedValue({ Type: 'Movie' });
+        const contextA = JC.identity.capture()!;
+        await JC.identity.activate(contextA);
+
+        const contextB = JC.identity.transition('page-server-b', 'page-user-b', 'details-page-test')!;
+        JC.currentSettings = {};
+        await JC.identity.activate(contextB);
+        vi.advanceTimersByTime(100);
+        await flushPromises();
+
+        expect(getItem).toHaveBeenCalledTimes(1);
+        expect(getItem).toHaveBeenCalledWith('pageuserb', 'queued-item');
+    });
+
+    it('cancels an A item-type backoff before it can refetch under B', async () => {
+        mountDetailsPage('retry-item');
+        const getItem = vi.spyOn(ApiClient, 'getItem').mockRejectedValue(new Error('temporary'));
+        const contextA = JC.identity.capture()!;
+        await JC.identity.activate(contextA);
+        vi.advanceTimersByTime(100);
+        await flushPromises();
+        expect(getItem).toHaveBeenCalledTimes(1);
+
+        JC.identity.transition('page-server-b', 'page-user-b', 'details-page-test');
+        vi.advanceTimersByTime(10_000);
+        await flushPromises();
+
+        expect(getItem).toHaveBeenCalledTimes(1);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/details-page.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/details-page.ts
@@ -9,9 +9,10 @@ import { JC } from '../../globals';
 import { getVisibleDetailsPage, isDetailsPageVisible } from '../../core/details-view';
 import { onBodyMutation } from '../../core/dom-observer';
 import { onNavigate, onViewPage } from '../../core/navigation';
-import { debounce, getItemCached } from '../helpers';
+import { getItemCached } from '../helpers';
 import { displayWatchProgress, displayItemSize, displayAudioLanguages } from './details-media-info';
 import { displayReleaseDate } from './release-dates';
+import type { IdentityContext } from '../../types/jc';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -29,7 +30,10 @@ let itemTypeFetchInProgress: Promise<unknown> | null = null;
 // dispatcher runs may still probe while the page keeps mutating (debounced,
 // pre-existing behavior) — both stop once the type resolves or the item changes.
 let itemTypeFetchAttempts = 0;
+const itemTypeRetryTimers = new Set<number>();
 const ITEM_TYPE_FETCH_MAX_ATTEMPTS = 4;
+let detailsDispatchTimer: number | null = null;
+let detailsDispatchGeneration = 0;
 
 // Types that support file size and watch progress
 const FEATURES_SUPPORTED_TYPES = ['Episode', 'Season', 'Series', 'Movie', 'BoxSet', 'Playlist'];
@@ -46,18 +50,20 @@ const HIDE_SUPPORTED_TYPES = ['Movie', 'Series', 'Episode', 'Season'];
  * @param itemId The item's Jellyfin ID.
  * @param visiblePage The visible detail page element.
  */
-function addHideContentButton(itemId: string, visiblePage: Element): void {
+function addHideContentButton(context: IdentityContext, itemId: string, visiblePage: Element): void {
+    if (!JC.identity.isCurrent(context)) return;
     // JC.hiddenContent is another family's frozen surface (hidden-content-init),
     // read late-bound at every call site exactly like the legacy file did.
     if (!(JC as any).hiddenContent) return;
     const settings = (JC as any).hiddenContent.getSettings();
     if (!settings.enabled || !settings.showHideButtons) return;
-    const isPerson = lastDetailsItemType === 'Person';
+    const itemType = lastDetailsItemType;
+    const isPerson = itemType === 'Person';
     if (isPerson) {
         if (!settings.showButtonCast) return;
     } else {
         if (settings.showButtonDetails === false) return;
-        if (!HIDE_SUPPORTED_TYPES.includes(lastDetailsItemType as string)) return;
+        if (!HIDE_SUPPORTED_TYPES.includes(itemType as string)) return;
     }
 
     // Don't add duplicate
@@ -83,6 +89,14 @@ function addHideContentButton(itemId: string, visiblePage: Element): void {
     button.setAttribute('is', 'emby-button');
     button.className = 'button-flat detailButton emby-button jc-detail-hide-btn';
     button.type = 'button';
+    let mounted = false;
+
+    const isTargetCurrent = (): boolean => {
+        if (!JC.identity.isCurrent(context)) return false;
+        const current = getVisibleDetailsPage();
+        if (!current || current.page !== visiblePage || current.itemId !== itemId) return false;
+        return !mounted || button.isConnected;
+    };
 
     const hideLabel = JC.t!('hidden_content_hide_button') !== 'hidden_content_hide_button'
         ? JC.t!('hidden_content_hide_button')
@@ -114,26 +128,31 @@ function addHideContentButton(itemId: string, visiblePage: Element): void {
     }
 
     function setHiddenState(): void {
+        if (!isTargetCurrent()) return;
         button.classList.add('jc-already-hidden');
         button.setAttribute('aria-label', hiddenLabel);
         button.title = hiddenLabel;
         renderContent('', 'visibility_off');
 
         button.onmouseenter = () => {
+            if (!isTargetCurrent()) return;
             button.title = unhideLabel;
         };
         button.onmouseleave = () => {
+            if (!isTargetCurrent()) return;
             button.title = hiddenLabel;
         };
         button.onclick = (e) => {
             e.preventDefault();
             e.stopPropagation();
+            if (!isTargetCurrent()) return;
             (JC as any).hiddenContent.unhideItem(itemId);
             setHideState();
         };
     }
 
     function setHideState(): void {
+        if (!isTargetCurrent()) return;
         button.classList.remove('jc-already-hidden');
         button.setAttribute('aria-label', hideLabel);
         button.title = hideLabel;
@@ -143,6 +162,7 @@ function addHideContentButton(itemId: string, visiblePage: Element): void {
         button.onclick = (e) => {
             e.preventDefault();
             e.stopPropagation();
+            if (!isTargetCurrent()) return;
 
             void (async () => {
                 // Get item name from the page title
@@ -156,25 +176,28 @@ function addHideContentButton(itemId: string, visiblePage: Element): void {
                 let seasonNumber: number | null = null;
                 let episodeNumber: number | null = null;
                 try {
-                    const userId = ApiClient.getCurrentUserId();
-                    const item: any = await getItemCached(itemId, { userId });
+                    const item: any = await getItemCached(itemId, { userId: context.userId });
+                    if (!isTargetCurrent()) return;
                     tmdbId = item?.ProviderIds?.Tmdb || '';
                     seriesId = item?.SeriesId || '';
                     seriesName = item?.SeriesName || '';
                     seasonNumber = item?.ParentIndexNumber != null ? item.ParentIndexNumber : null;
                     episodeNumber = item?.IndexNumber != null ? item.IndexNumber : null;
                 } catch (err) {
+                    if (!isTargetCurrent()) return;
                     console.warn('🪼 Jellyfin Canopy: Could not fetch item metadata for hide button', err);
                 }
 
-                const isEpisode = lastDetailsItemType === 'Episode';
-                const isSeason = lastDetailsItemType === 'Season';
+                if (!isTargetCurrent()) return;
+
+                const isEpisode = itemType === 'Episode';
+                const isSeason = itemType === 'Season';
 
                 // Build base item data
                 const baseItemData = {
                     itemId,
                     name: itemName,
-                    type: lastDetailsItemType,
+                    type: itemType,
                     tmdbId,
                     seriesId,
                     seriesName,
@@ -185,19 +208,22 @@ function addHideContentButton(itemId: string, visiblePage: Element): void {
                 if (isEpisode && seriesId) {
                     // Episode on a detail page: show choice dialog
                     (JC as any).hiddenContent.confirmAndHide(baseItemData, () => {
-                        setHiddenState();
+                        if (isTargetCurrent()) setHiddenState();
                     }, {
                         showEpisodeChoice: true,
                         onChooseShow: async () => {
+                            if (!isTargetCurrent()) return;
                             // User chose to hide the entire show
                             let seriesTmdbId = '';
                             try {
-                                const userId = ApiClient.getCurrentUserId();
-                                const series: any = await ApiClient.getItem(userId, seriesId);
+                                const series: any = await ApiClient.getItem(context.userId, seriesId);
+                                if (!isTargetCurrent()) return;
                                 seriesTmdbId = series?.ProviderIds?.Tmdb || '';
                             } catch (err) {
+                                if (!isTargetCurrent()) return;
                                 console.warn('🪼 Jellyfin Canopy: Could not fetch series metadata for hide-show action', err);
                             }
+                            if (!isTargetCurrent()) return;
                             (JC as any).hiddenContent.hideItem({
                                 itemId: seriesId,
                                 name: seriesName || itemName,
@@ -211,12 +237,12 @@ function addHideContentButton(itemId: string, visiblePage: Element): void {
                 } else if (isSeason && seriesId) {
                     // Season: hide with series metadata
                     (JC as any).hiddenContent.confirmAndHide(baseItemData, () => {
-                        setHiddenState();
+                        if (isTargetCurrent()) setHiddenState();
                     });
                 } else {
                     // Movie or Series: standard hide
                     (JC as any).hiddenContent.confirmAndHide(baseItemData, () => {
-                        setHiddenState();
+                        if (isTargetCurrent()) setHiddenState();
                     });
                 }
             })();
@@ -236,9 +262,11 @@ function addHideContentButton(itemId: string, visiblePage: Element): void {
     } else {
         buttonContainer.appendChild(button);
     }
+    mounted = true;
 }
 
-const handleItemDetails = debounce(() => {
+function runHandleItemDetails(context: IdentityContext): void {
+    if (!JC.identity.isCurrent(context)) return;
     // Resolve the visible details view ONLY when it belongs to the current
     // URL's item. During a details→details push the outgoing page is still
     // the visible one when navigation callbacks fire — injecting there put
@@ -259,35 +287,50 @@ const handleItemDetails = debounce(() => {
         if (lastDetailsItemId !== itemId) {
             lastDetailsItemId = itemId;
             lastDetailsItemType = null;
+            itemTypeFetchInProgress = null;
             itemTypeFetchAttempts = 0;
+            for (const timer of itemTypeRetryTimers) clearTimeout(timer);
+            itemTypeRetryTimers.clear();
         }
 
         // Fetch item type once per item to decide applicability
         if (!lastDetailsItemType) {
             if (!itemTypeFetchInProgress) {
-                const userId = ApiClient.getCurrentUserId();
                 const fetchItemId = itemId;
-                itemTypeFetchInProgress = getItemCached(itemId, { userId })
+                const fetchPage = visiblePage;
+                const request = getItemCached(itemId, { userId: context.userId })
                     .then((item: any) => {
+                        if (itemTypeFetchInProgress !== request || !JC.identity.isCurrent(context)) return;
                         itemTypeFetchInProgress = null;
+                        const current = getVisibleDetailsPage();
+                        if (!current || current.page !== fetchPage || current.itemId !== fetchItemId) {
+                            scheduleHandleItemDetails(context);
+                            return;
+                        }
                         // The user navigated to a DIFFERENT item while this was in
                         // flight — discard the stale type (it belongs to the old
                         // item) and re-dispatch so the current item starts its own
                         // fetch instead of rendering with the wrong feature gates.
                         if (lastDetailsItemId !== fetchItemId) {
-                            handleItemDetails();
+                            scheduleHandleItemDetails(context);
                             return;
                         }
                         lastDetailsItemType = item?.Type || null;
                         itemTypeFetchAttempts = 0;
                         // Re-run once type is known to render features
-                        handleItemDetails();
+                        scheduleHandleItemDetails(context);
                     })
                     .catch(() => {
+                        if (itemTypeFetchInProgress !== request || !JC.identity.isCurrent(context)) return;
                         itemTypeFetchInProgress = null;
+                        const current = getVisibleDetailsPage();
+                        if (!current || current.page !== fetchPage || current.itemId !== fetchItemId) {
+                            scheduleHandleItemDetails(context);
+                            return;
+                        }
                         if (lastDetailsItemId !== fetchItemId) {
                             // Different item now — let it start its own fetch.
-                            handleItemDetails();
+                            scheduleHandleItemDetails(context);
                             return;
                         }
                         // PERF(R9): fail open — getItemCached drops failed entries,
@@ -298,20 +341,23 @@ const handleItemDetails = debounce(() => {
                         itemTypeFetchAttempts++;
                         if (itemTypeFetchAttempts < ITEM_TYPE_FETCH_MAX_ATTEMPTS) {
                             const delay = 1000 * Math.pow(2, itemTypeFetchAttempts - 1);
-                            window.setTimeout(() => {
-                                if (lastDetailsItemId === fetchItemId) {
-                                    handleItemDetails();
+                            const timer = window.setTimeout(() => {
+                                itemTypeRetryTimers.delete(timer);
+                                if (JC.identity.isCurrent(context) && lastDetailsItemId === fetchItemId) {
+                                    scheduleHandleItemDetails(context);
                                 }
                             }, delay);
+                            itemTypeRetryTimers.add(timer);
                         }
                     });
+                itemTypeFetchInProgress = request;
             }
             return;
         }
 
         // Add hide content button on detail pages (including Person pages)
         if ((JC as any).hiddenContent) {
-            addHideContentButton(itemId, visiblePage);
+            addHideContentButton(context, itemId, visiblePage);
         }
 
         // Spoiler Guard toggle on Series (blurs all unwatched episode images via
@@ -343,7 +389,18 @@ const handleItemDetails = debounce(() => {
     } catch (e) {
     console.warn('🪼 Jellyfin Canopy: Error in item details handler', e);
 }
-}, 100);
+}
+
+function scheduleHandleItemDetails(context = JC.identity.capture()): void {
+    if (!context || !JC.identity.isCurrent(context)) return;
+    const generation = ++detailsDispatchGeneration;
+    if (detailsDispatchTimer !== null) clearTimeout(detailsDispatchTimer);
+    detailsDispatchTimer = window.setTimeout(() => {
+        detailsDispatchTimer = null;
+        if (generation !== detailsDispatchGeneration || !JC.identity.isCurrent(context)) return;
+        runHandleItemDetails(context);
+    }, 100);
+}
 
 // PERF(R3): this used to be a dedicated body-wide MutationObserver with
 // attributes:['class','style'], firing on every hover/focus/style write on
@@ -360,7 +417,23 @@ const handleItemDetails = debounce(() => {
 // the chips when item data arrives) never ran.
 onBodyMutation('item-details-info', () => {
     if (!isDetailsPageVisible()) return;
-    handleItemDetails();
+    scheduleHandleItemDetails();
 });
-onNavigate(() => { handleItemDetails(); });
-onViewPage(() => { handleItemDetails(); });
+onNavigate(() => { scheduleHandleItemDetails(); });
+onViewPage(() => { scheduleHandleItemDetails(); });
+
+JC.identity.registerReset('details-page', () => {
+    detailsDispatchGeneration++;
+    if (detailsDispatchTimer !== null) {
+        clearTimeout(detailsDispatchTimer);
+        detailsDispatchTimer = null;
+    }
+    lastDetailsItemId = null;
+    lastDetailsItemType = null;
+    itemTypeFetchInProgress = null;
+    itemTypeFetchAttempts = 0;
+    for (const timer of itemTypeRetryTimers) clearTimeout(timer);
+    itemTypeRetryTimers.clear();
+    document.querySelectorAll('.jc-detail-hide-btn').forEach((node) => node.remove());
+});
+JC.identity.registerActivate('details-page', (context) => { scheduleHandleItemDetails(context); });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/random-button.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/random-button.ts
@@ -7,6 +7,7 @@ import { JC } from '../../globals';
 import { toast } from '../../core/ui-kit';
 import { getHeaderRightContainer } from '../helpers';
 import { insertHeaderTrayButton, HeaderTrayOrder } from '../header-tray';
+import type { IdentityContext } from '../../types/jc';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -14,8 +15,8 @@ import { insertHeaderTrayButton, HeaderTrayOrder } from '../header-tray';
  * Fetches a random item (Movie or Series) from the user's library.
  * @returns A promise that resolves to a random item or null.
  */
-async function getRandomItem(): Promise<any> {
-    const userId = ApiClient.getCurrentUserId();
+async function getRandomItem(context: IdentityContext): Promise<any> {
+    const userId = context.userId;
     if (!userId) {
         console.error("🪼 Jellyfin Canopy: User not logged in.");
         return null;
@@ -26,10 +27,20 @@ async function getRandomItem(): Promise<any> {
     if (JC.currentSettings!.randomIncludeShows) itemTypes.push('Series');
     const includeItemTypes = itemTypes.join(',');
 
-    const apiUrl = ApiClient.getUrl(`/Users/${userId}/Items?IncludeItemTypes=${includeItemTypes}&Recursive=true&SortBy=Random&Limit=100&Fields=ExternalUrls`);
+    const query = new URLSearchParams({
+        IncludeItemTypes: includeItemTypes,
+        Recursive: 'true',
+        SortBy: 'Random',
+        Limit: '100',
+        Fields: 'ExternalUrls',
+    });
 
     try {
-        const response: any = await ApiClient.ajax({ type: 'GET', url: apiUrl, dataType: 'json' });
+        const response: any = await JC.core.api!.jf(
+            `/Users/${userId}/Items?${query.toString()}`,
+            { skipCache: true },
+        );
+        if (!JC.identity.isCurrent(context)) return null;
         if (response && response.Items && response.Items.length > 0) {
             let items: any[] = response.Items;
 
@@ -56,6 +67,7 @@ async function getRandomItem(): Promise<any> {
         }
         throw new Error('No items found in selected libraries.');
     } catch (error) {
+        if (!JC.identity.isCurrent(context)) return null;
         console.error('🪼 Jellyfin Canopy: Error fetching random item:', error);
         toast(`${JC.icon!(JC.IconName!.ERROR)} ${JC.escapeHtml((error as any)?.message || 'Unknown error')}`, 2000);
         return null;
@@ -66,7 +78,8 @@ async function getRandomItem(): Promise<any> {
  * Navigates the browser to the details page of the given item.
  * @param item The item to navigate to.
  */
-function navigateToItem(item: any): void {
+function navigateToItem(context: IdentityContext, item: any): void {
+    if (!JC.identity.isCurrent(context)) return;
     if (item && item.Id) {
         const embyPage = window.Emby?.Page as { show?: (path: string) => void } | undefined;
         if (window.Emby && embyPage && typeof embyPage.show === 'function') {
@@ -94,25 +107,30 @@ function setGlyph(btn: HTMLElement, ligature: string): void {
 }
 
 /** Shared click handler: fetch a random item and navigate, with a spinner glyph. */
-function onRandomClick(randomButton: HTMLButtonElement): void {
+const randomResetTimers = new Set<number>();
+
+function onRandomClick(context: IdentityContext, randomButton: HTMLButtonElement): void {
+    if (!JC.identity.isCurrent(context)) return;
     void (async () => {
         randomButton.disabled = true;
         randomButton.classList.add('loading');
         setGlyph(randomButton, 'hourglass_empty');
 
         try {
-            const item = await getRandomItem();
-            if (item) {
-                navigateToItem(item);
+            const item = await getRandomItem(context);
+            if (item && JC.identity.isCurrent(context)) {
+                navigateToItem(context, item);
             }
         } finally {
-            setTimeout(() => {
-                if (document.getElementById(randomButton.id)) {
+            const timer = window.setTimeout(() => {
+                randomResetTimers.delete(timer);
+                if (JC.identity.isCurrent(context) && document.getElementById(randomButton.id)) {
                     randomButton.disabled = false;
                     randomButton.classList.remove('loading');
                     setGlyph(randomButton, 'casino');
                 }
             }, 500);
+            randomResetTimers.add(timer);
         }
     })();
 }
@@ -124,7 +142,7 @@ function onRandomClick(randomButton: HTMLButtonElement): void {
  * paper-icon-button-light markup so it matches that layout's own buttons.
  * @param anchor - The resolved header container (see getHeaderRightContainer).
  */
-function buildRandomButton(anchor: HTMLElement): HTMLDivElement {
+function buildRandomButton(context: IdentityContext, anchor: HTMLElement): HTMLDivElement {
     const buttonContainer = document.createElement('div');
     buttonContainer.id = 'randomItemButtonContainer';
 
@@ -152,7 +170,7 @@ function buildRandomButton(anchor: HTMLElement): HTMLDivElement {
         randomButton.appendChild(glyph);
     }
 
-    randomButton.addEventListener('click', () => onRandomClick(randomButton));
+    randomButton.addEventListener('click', () => onRandomClick(context, randomButton));
     buttonContainer.appendChild(randomButton);
     return buttonContainer;
 }
@@ -168,6 +186,8 @@ let randomButtonHandle: { run(): void; remove(): void } | null = null;
  * JC.core.dom.ensureInjected; disabling removes it.
  */
 JC.addRandomButton = (): void => {
+    const context = JC.identity.capture();
+    if (!context) return;
     if (!JC.currentSettings!.randomButtonEnabled) {
         randomButtonHandle?.remove();
         randomButtonHandle = null;
@@ -195,7 +215,8 @@ JC.addRandomButton = (): void => {
         'jc-random-button',
         () => getHeaderRightContainer(),
         (headerRight, ctx) => {
-            const container = buildRandomButton(headerRight);
+            if (!JC.identity.isCurrent(context)) return null;
+            const container = buildRandomButton(context, headerRight);
             insertHeaderTrayButton(headerRight, container, HeaderTrayOrder.randomButton);
             JC.core.ui!.expandIn(container, { instant: ctx?.prePaint === true || !firstBuild });
             firstBuild = false;
@@ -204,3 +225,12 @@ JC.addRandomButton = (): void => {
         { headerTray: true, prePaint: true }
     );
 };
+
+JC.identity.registerReset('random-button', () => {
+    for (const timer of randomResetTimers) clearTimeout(timer);
+    randomResetTimers.clear();
+    randomButtonHandle?.remove();
+    randomButtonHandle = null;
+    document.getElementById('randomItemButtonContainer')?.remove();
+});
+JC.identity.registerActivate('random-button', () => { JC.addRandomButton?.(); });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/release-dates.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/release-dates.identity.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+import type { ApiApi } from '../../types/jc';
+import { displayReleaseDate } from './release-dates';
+
+function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((done) => { resolve = done; });
+    return { promise, resolve };
+}
+
+function tmdbRelease(date: string): unknown {
+    return {
+        results: [{
+            iso_3166_1: 'US',
+            release_dates: [{ type: 3, release_date: date }],
+        }],
+    };
+}
+
+describe('release-date identity ownership', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        JC.identity.transition('test-server-id', 'user-a', 'release-date-test-start');
+        JC.pluginConfig = { DEFAULT_REGION: 'US' };
+        JC.t = (key: string) => key;
+        JC.escapeHtml = (value: unknown) => typeof value === 'string' ? value : '';
+        ApiClient.getItem = vi.fn().mockResolvedValue({ Type: 'Movie', ProviderIds: { Tmdb: '42' } });
+    });
+
+    it('drops a held A response and refetches instead of replaying it for B', async () => {
+        const heldA = deferred<unknown>();
+        const plugin = vi.fn()
+            .mockImplementationOnce(() => heldA.promise)
+            .mockResolvedValueOnce(tmdbRelease('2030-02-03'));
+        JC.core.api = { plugin } as unknown as ApiApi;
+        const container = document.createElement('div');
+        document.body.appendChild(container);
+
+        displayReleaseDate('same-item', container);
+        await vi.waitFor(() => expect(plugin).toHaveBeenCalledTimes(1));
+
+        JC.identity.transition('test-server-id', 'user-b', 'account-switch');
+        expect(container.querySelector('.mediaInfoItem-releaseDate')).toBeNull();
+        heldA.resolve(tmdbRelease('2000-01-02'));
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(container.textContent).not.toContain('2000');
+
+        displayReleaseDate('same-item', container);
+        await vi.waitFor(() => expect(plugin).toHaveBeenCalledTimes(2));
+        await vi.waitFor(() => expect(container.textContent).toContain('2030'));
+        expect(container.textContent).not.toContain('2000');
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/release-dates.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/release-dates.ts
@@ -8,8 +8,7 @@ import { JC } from '../../globals';
 import { ensureMaterialSymbolsFont } from '../../core/ui-kit';
 import { createBoundedCache } from '../../core/bounded-cache';
 import { addCSS, getItemCached } from '../helpers';
-
-/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { IdentityContext } from '../../types/jc';
 
 const RELEASEDATE_CACHE_TTL = 60 * 60 * 1000; // 1 hour
 // PERF(R9): fail open — a transient TMDB/proxy failure must not be remembered
@@ -25,10 +24,52 @@ interface ReleaseInfo {
     titleKey: string;
 }
 
+interface ReleaseDateEntry {
+    type: number;
+    release_date: string;
+}
+
+interface MovieReleaseRegion {
+    iso_3166_1: string;
+    release_dates?: ReleaseDateEntry[];
+}
+
+interface MovieReleaseResponse {
+    results?: MovieReleaseRegion[];
+}
+
+interface EpisodeAirDate {
+    air_date?: string | null;
+}
+
+interface SeriesReleaseResponse {
+    next_episode_to_air?: EpisodeAirDate | null;
+    last_episode_to_air?: EpisodeAirDate | null;
+}
+
+interface SeasonReleaseResponse {
+    episodes?: EpisodeAirDate[];
+}
+
+interface JellyfinReleaseItem {
+    Type?: string;
+    SeriesId?: string;
+    ProviderIds?: { Tmdb?: string | number };
+    SeriesProviderIds?: { Tmdb?: string | number };
+    IndexNumber?: number;
+    ParentIndexNumber?: number;
+}
+
 // Bounded + TTL-swept via core/bounded-cache (no raw growing Map): the read-side
 // `now - cached.ts < RELEASEDATE_CACHE_TTL` guard below stays for identical
 // behavior, but the util now caps size and expires entries so nothing leaks.
 const releaseDateCache = createBoundedCache<string, { infos: ReleaseInfo[]; ts: number; error?: boolean }>({ maxEntries: 300, ttlMs: RELEASEDATE_CACHE_TTL }); // Map<itemId, { infos, ts }>
+const retryTimers = new Set<number>();
+const idleCallbacks = new Set<number>();
+
+function isActive(context: IdentityContext, placeholder?: HTMLElement): boolean {
+    return JC.identity.isCurrent(context) && (!placeholder || placeholder.isConnected);
+}
 
 /**
  * Fetches a path from TMDB via the plugin's proxy endpoint. Throws on
@@ -37,12 +78,20 @@ const releaseDateCache = createBoundedCache<string, { infos: ReleaseInfo[]; ts: 
  * that gets cached for an hour.
  * @param path TMDB API path, e.g. `/movie/{id}/release_dates`.
  */
-function tmdbGet(path: string): Promise<any> {
-    const url = ApiClient.getUrl(`/JellyfinCanopy/tmdb${path}`);
-    return fetch(url, { headers: { "Authorization": `MediaBrowser Token="${ApiClient.accessToken()}"` } })
-        .then(r => r.ok ? r.json() : Promise.reject(new Error(`API Error: ${r.status}`)))
+function tmdbGet<T>(context: IdentityContext, path: string): Promise<T> {
+    return JC.core.api!.plugin(`/tmdb${path}`, { skipCache: true })
+        .then((data) => {
+            if (!JC.identity.isCurrent(context)) {
+                const error = new Error('Release-date request identity is stale');
+                error.name = 'AbortError';
+                throw error;
+            }
+            return data as T;
+        })
         .catch((error: unknown) => {
-            console.error(`🪼 Jellyfin Canopy: Release Date: TMDB request failed for ${path}`, error);
+            if (JC.identity.isCurrent(context)) {
+                console.error(`🪼 Jellyfin Canopy: Release Date: TMDB request failed for ${path}`, error);
+            }
             throw error;
         });
 }
@@ -75,7 +124,7 @@ const MOVIE_RELEASE_BUCKETS: ReleaseBucket[] = [
 ];
 
 /** Returns the earliest `release_date` among entries of the given bucket's types, or null. */
-function earliestOfBucket(releaseDates: any[], bucket: ReleaseBucket): any {
+function earliestOfBucket(releaseDates: ReleaseDateEntry[] | undefined, bucket: ReleaseBucket): ReleaseDateEntry | null {
     const matches = (releaseDates || []).filter(d => bucket.types.includes(d.type) && d.release_date);
     if (matches.length === 0) return null;
     return matches.reduce((a, b) => (a.release_date < b.release_date ? a : b));
@@ -90,9 +139,9 @@ function earliestOfBucket(releaseDates: any[], bucket: ReleaseBucket): any {
  * to one region's entry would silently drop digital/physical dates that
  * TMDB has recorded under a different country.
  */
-async function getMovieReleaseInfo(tmdbId: string): Promise<ReleaseInfo[]> {
-    const data = await tmdbGet(`/movie/${tmdbId}/release_dates`);
-    const results: any[] = data?.results;
+async function getMovieReleaseInfo(context: IdentityContext, tmdbId: string): Promise<ReleaseInfo[]> {
+    const data = await tmdbGet<MovieReleaseResponse>(context, `/movie/${tmdbId}/release_dates`);
+    const results = data.results;
     if (!Array.isArray(results) || results.length === 0) return [];
 
     const region = ((JC.pluginConfig?.DEFAULT_REGION as string) || 'US').toUpperCase();
@@ -100,10 +149,10 @@ async function getMovieReleaseInfo(tmdbId: string): Promise<ReleaseInfo[]> {
 
     const infos: ReleaseInfo[] = [];
     for (const bucket of MOVIE_RELEASE_BUCKETS) {
-        let earliest: any = null;
+        let earliest: ReleaseDateEntry | null = null;
         for (const iso of preferredOrder) {
             const entry = results.find(r => r.iso_3166_1 === iso);
-            earliest = entry && earliestOfBucket(entry.release_dates, bucket);
+            earliest = entry ? earliestOfBucket(entry.release_dates, bucket) : null;
             if (earliest) break;
         }
         if (!earliest) {
@@ -118,19 +167,20 @@ async function getMovieReleaseInfo(tmdbId: string): Promise<ReleaseInfo[]> {
 }
 
 /** Resolves the next (or, if none, most recent) episode air date for a series. */
-async function getSeriesReleaseInfo(tmdbId: string): Promise<ReleaseInfo[]> {
-    const data = await tmdbGet(`/tv/${tmdbId}`);
+async function getSeriesReleaseInfo(context: IdentityContext, tmdbId: string): Promise<ReleaseInfo[]> {
+    const data = await tmdbGet<SeriesReleaseResponse>(context, `/tv/${tmdbId}`);
     const date = data?.next_episode_to_air?.air_date || data?.last_episode_to_air?.air_date;
     return date ? [{ date, icon: 'tv_guide', titleKey: 'calendar_episode' }] : [];
 }
 
 /** Resolves the next (or, if none, most recent) episode air date within a season. */
-async function getSeasonReleaseInfo(tmdbId: string, seasonNumber: number): Promise<ReleaseInfo[]> {
-    const data = await tmdbGet(`/tv/${tmdbId}/season/${seasonNumber}`);
-    const episodes: any[] = data?.episodes;
+async function getSeasonReleaseInfo(context: IdentityContext, tmdbId: string, seasonNumber: number): Promise<ReleaseInfo[]> {
+    const data = await tmdbGet<SeasonReleaseResponse>(context, `/tv/${tmdbId}/season/${seasonNumber}`);
+    const episodes = data.episodes;
     if (!Array.isArray(episodes) || episodes.length === 0) return [];
 
-    const withDates = episodes.filter(e => e.air_date);
+    const withDates = episodes.filter((episode): episode is { air_date: string } =>
+        typeof episode.air_date === 'string' && episode.air_date.length > 0);
     if (withDates.length === 0) return [];
 
     const today = todayIso();
@@ -140,9 +190,9 @@ async function getSeasonReleaseInfo(tmdbId: string, seasonNumber: number): Promi
 }
 
 /** Resolves a single episode's air date. */
-async function getEpisodeReleaseInfo(tmdbId: string, seasonNumber: number, episodeNumber: number): Promise<ReleaseInfo[]> {
-    const data = await tmdbGet(`/tv/${tmdbId}/season/${seasonNumber}/episode/${episodeNumber}`);
-    return data?.air_date ? [{ date: data.air_date, icon: 'tv_guide', titleKey: 'calendar_episode' }] : [];
+async function getEpisodeReleaseInfo(context: IdentityContext, tmdbId: string, seasonNumber: number, episodeNumber: number): Promise<ReleaseInfo[]> {
+    const data = await tmdbGet<EpisodeAirDate>(context, `/tv/${tmdbId}/season/${seasonNumber}/episode/${episodeNumber}`);
+    return data.air_date ? [{ date: data.air_date, icon: 'tv_guide', titleKey: 'calendar_episode' }] : [];
 }
 
 /**
@@ -151,17 +201,17 @@ async function getEpisodeReleaseInfo(tmdbId: string, seasonNumber: number, episo
  * SeriesProviderIds, falling back to fetching the series item) the same
  * way reviews.js does for TMDB reviews.
  */
-async function resolveReleaseInfo(item: any, userId: string): Promise<ReleaseInfo[]> {
+async function resolveReleaseInfo(context: IdentityContext, item: JellyfinReleaseItem | null, userId: string): Promise<ReleaseInfo[]> {
     const mediaType = item?.Type;
 
     if (mediaType === 'Movie') {
         const tmdbId = item?.ProviderIds?.Tmdb;
-        return tmdbId ? getMovieReleaseInfo(tmdbId) : [];
+        return tmdbId ? getMovieReleaseInfo(context, String(tmdbId)) : [];
     }
 
     if (mediaType === 'Series') {
         const tmdbId = item?.ProviderIds?.Tmdb;
-        return tmdbId ? getSeriesReleaseInfo(tmdbId) : [];
+        return tmdbId ? getSeriesReleaseInfo(context, String(tmdbId)) : [];
     }
 
     if (mediaType === 'Season' || mediaType === 'Episode') {
@@ -170,16 +220,17 @@ async function resolveReleaseInfo(item: any, userId: string): Promise<ReleaseInf
             // PERF(R9): let a transient series-lookup failure propagate to the
             // short-TTL retry path — swallowing it here would cache "no dates"
             // for an hour on a network blip.
-            const series: any = await ApiClient.getItem(userId, item.SeriesId);
+            const series = await getItemCached(item.SeriesId, { userId }) as JellyfinReleaseItem | null;
+            if (!JC.identity.isCurrent(context)) return [];
             seriesTmdbId = series?.ProviderIds?.Tmdb;
         }
         if (!seriesTmdbId) return [];
 
         if (mediaType === 'Season') {
-            return item?.IndexNumber != null ? getSeasonReleaseInfo(seriesTmdbId, item.IndexNumber) : [];
+            return item?.IndexNumber != null ? getSeasonReleaseInfo(context, String(seriesTmdbId), item.IndexNumber) : [];
         }
         return (item?.ParentIndexNumber != null && item?.IndexNumber != null)
-            ? getEpisodeReleaseInfo(seriesTmdbId, item.ParentIndexNumber, item.IndexNumber)
+            ? getEpisodeReleaseInfo(context, String(seriesTmdbId), item.ParentIndexNumber, item.IndexNumber)
             : [];
     }
 
@@ -204,6 +255,8 @@ async function resolveReleaseInfo(item: any, userId: string): Promise<ReleaseInf
  * @param container The DOM element to append the chip to.
  */
 export function displayReleaseDate(itemId: string, container: HTMLElement): void {
+    const context = JC.identity.capture();
+    if (!context) return;
     const existing = container.querySelector<HTMLElement>('.mediaInfoItem-releaseDate');
     if (existing) {
         // Already rendered (or in flight) for this itemId — nothing to do.
@@ -213,7 +266,7 @@ export function displayReleaseDate(itemId: string, container: HTMLElement): void
 
     const cached = releaseDateCache.get(itemId);
     if (cached && (Date.now() - cached.ts) < (cached.error ? ERROR_CACHE_TTL : RELEASEDATE_CACHE_TTL)) {
-        if (cached.infos.length > 0) renderReleaseDateChip(container, itemId, cached.infos);
+        if (cached.infos.length > 0) renderReleaseDateChip(context, container, itemId, cached.infos);
         return;
     }
 
@@ -224,11 +277,14 @@ export function displayReleaseDate(itemId: string, container: HTMLElement): void
     container.appendChild(placeholder);
 
     const performFetch = async (attempt = 1): Promise<void> => {
+        if (!isActive(context, placeholder)) return;
         const now = Date.now();
         try {
-            const userId = ApiClient.getCurrentUserId();
-            const item = await getItemCached(itemId, { userId });
-            const infos = await resolveReleaseInfo(item, userId);
+            const userId = context.userId;
+            const item = await getItemCached(itemId, { userId }) as JellyfinReleaseItem | null;
+            if (!isActive(context, placeholder)) return;
+            const infos = await resolveReleaseInfo(context, item, userId);
+            if (!isActive(context, placeholder)) return;
             releaseDateCache.set(itemId, { infos, ts: now });
             // The user may have navigated away while this was in flight.
             if (!placeholder.isConnected) return;
@@ -238,6 +294,7 @@ export function displayReleaseDate(itemId: string, container: HTMLElement): void
                 placeholder.remove();
             }
         } catch (error) {
+            if (!isActive(context, placeholder)) return;
             console.error(`🪼 Jellyfin Canopy: Release Date: Error fetching release info for ${itemId}:`, error);
             // PERF(R9): fail open — a transient failure is remembered only
             // briefly (ERROR_CACHE_TTL, not the 1h answer TTL) and retried in
@@ -247,12 +304,14 @@ export function displayReleaseDate(itemId: string, container: HTMLElement): void
             // row, same as the normal slow-TMDB path.
             releaseDateCache.set(itemId, { infos: [], ts: now, error: true });
             if (attempt < FETCH_MAX_ATTEMPTS && placeholder.isConnected) {
-                window.setTimeout(() => {
-                    if (placeholder.isConnected) {
+                const timer = window.setTimeout(() => {
+                    retryTimers.delete(timer);
+                    if (isActive(context, placeholder)) {
                         releaseDateCache.delete(itemId);
                         void performFetch(attempt + 1);
                     }
                 }, RETRY_BASE_DELAY_MS * attempt);
+                retryTimers.add(timer);
             } else {
                 placeholder.remove();
             }
@@ -260,9 +319,17 @@ export function displayReleaseDate(itemId: string, container: HTMLElement): void
     };
 
     if (typeof requestIdleCallback !== 'undefined') {
-        requestIdleCallback(() => { void performFetch(); }, { timeout: 2000 });
+        const idleId = requestIdleCallback(() => {
+            idleCallbacks.delete(idleId);
+            if (isActive(context, placeholder)) void performFetch();
+        }, { timeout: 2000 });
+        idleCallbacks.add(idleId);
     } else {
-        setTimeout(() => { void performFetch(); }, 0);
+        const timer = window.setTimeout(() => {
+            retryTimers.delete(timer);
+            if (isActive(context, placeholder)) void performFetch();
+        }, 0);
+        retryTimers.add(timer);
     }
 }
 
@@ -300,14 +367,26 @@ function fillReleaseDateChip(chip: HTMLElement, infos: ReleaseInfo[]): void {
     chip.style.alignItems = 'center';
     chip.style.gap = '0.6em';
     chip.style.margin = '0 1em 0 0 !important';
-    chip.innerHTML = infos.map(info => `<span style="display: inline-flex; align-items: center;"><span class="jc-release-date-icon" style="font-size: inherit; margin-right: 0.3em;" title="${JC.t!(info.titleKey)}">${info.icon}</span>${JC.escapeHtml(formatReleaseDate(info.date))}</span>`).join('');
+    chip.innerHTML = infos.map(info => `<span style="display: inline-flex; align-items: center;"><span class="jc-release-date-icon" style="font-size: inherit; margin-right: 0.3em;" title="${JC.escapeHtml(JC.t!(info.titleKey))}">${JC.escapeHtml(info.icon)}</span>${JC.escapeHtml(formatReleaseDate(info.date))}</span>`).join('');
 }
 
 /** Creates and appends a fresh release-date chip (cache-hit path, where there's no placeholder to fill). */
-function renderReleaseDateChip(container: HTMLElement, itemId: string, infos: ReleaseInfo[]): void {
+function renderReleaseDateChip(context: IdentityContext, container: HTMLElement, itemId: string, infos: ReleaseInfo[]): void {
+    if (!JC.identity.isCurrent(context)) return;
     const chip = document.createElement('div');
     chip.className = 'mediaInfoItem mediaInfoItem-releaseDate';
     chip.dataset.itemId = itemId;
     fillReleaseDateChip(chip, infos);
     container.appendChild(chip);
 }
+
+JC.identity.registerReset('release-dates', () => {
+    for (const timer of retryTimers) clearTimeout(timer);
+    retryTimers.clear();
+    if (typeof cancelIdleCallback !== 'undefined') {
+        for (const idleId of idleCallbacks) cancelIdleCallback(idleId);
+    }
+    idleCallbacks.clear();
+    releaseDateCache.clear();
+    document.querySelectorAll('.mediaInfoItem-releaseDate').forEach((node) => node.remove());
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/remove-home.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/remove-home.identity.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+import type { ApiApi } from '../../types/jc';
+import { removeFromHomeSurface } from './remove-home';
+
+function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((done) => { resolve = done; });
+    return { promise, resolve };
+}
+
+describe('Continue Watching removal identity ownership', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        JC.identity.transition('test-server-id', 'user-a', 'remove-home-test-start');
+        JC.t = (key: string) => key;
+        JC.escapeHtml = (value: unknown) => typeof value === 'string' ? value : '';
+    });
+
+    it('drops a held A completion without mutating B UI or hidden state', async () => {
+        const held = deferred<unknown>();
+        const plugin = vi.fn(() => held.promise);
+        JC.core.api = { plugin } as unknown as ApiApi;
+        const markScopedHidden = vi.fn();
+        JC.hiddenContent = {
+            flushPendingSave: vi.fn().mockResolvedValue(undefined),
+            markScopedHidden,
+        } as unknown as NonNullable<typeof JC.hiddenContent>;
+
+        const card = document.createElement('div');
+        document.body.appendChild(card);
+        const result = removeFromHomeSurface('item-a', 'continuewatching', card);
+        await vi.waitFor(() => expect(plugin).toHaveBeenCalledTimes(1));
+
+        JC.identity.transition('test-server-id', 'user-b', 'account-switch');
+        held.resolve({});
+
+        await expect(result).resolves.toBe(false);
+        expect(card.style.display).toBe('');
+        expect(markScopedHidden).not.toHaveBeenCalled();
+    });
+
+    it('reverses an A-owned optimistic hide synchronously on transition', async () => {
+        JC.core.api = { plugin: vi.fn().mockResolvedValue({}) } as unknown as ApiApi;
+        JC.hiddenContent = {
+            flushPendingSave: vi.fn().mockResolvedValue(undefined),
+            markScopedHidden: vi.fn(),
+        } as unknown as NonNullable<typeof JC.hiddenContent>;
+        const card = document.createElement('div');
+        document.body.appendChild(card);
+
+        await expect(removeFromHomeSurface('item-a', 'continuewatching', card)).resolves.toBe(true);
+        expect(card.style.display).toBe('none');
+
+        JC.identity.transition('test-server-id', 'user-b', 'account-switch');
+        expect(card.style.display).toBe('');
+        expect(card.dataset.jcHomeRemoved).toBeUndefined();
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/remove-home.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/remove-home.ts
@@ -12,6 +12,7 @@ import {
     buildNativeActionSheetItem, setActionSheetItemIcon, getActiveActionSheetScroller,
     fitActionSheetItem, closeOpenActionSheet,
 } from '../../core/action-sheet';
+import type { IdentityContext } from '../../types/jc';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -97,12 +98,14 @@ function optimisticHideRemovedCard(itemId: string, surface: string, card?: HTMLE
     try {
         if (card && card.isConnected) {
             card.style.display = 'none';
+            card.dataset.jcHomeRemoved = '1';
             return;
         }
         // Fallback (card re-rendered/detached): hide matching cards on the same surface only.
         document.querySelectorAll<HTMLElement>(`.card[data-id="${CSS.escape(itemId)}"]`).forEach(c => {
             if (JC.detectCardSurface!(c) === surface) {
                 c.style.display = 'none';
+                c.dataset.jcHomeRemoved = '1';
             }
         });
     } catch (e) {
@@ -118,8 +121,10 @@ function optimisticHideRemovedCard(itemId: string, surface: string, card?: HTMLE
  * @param card The specific card element the action was triggered from.
  */
 export async function removeFromHomeSurface(itemId: string, surface: string, card?: HTMLElement): Promise<boolean> {
+    const context = JC.identity.capture();
+    if (!context) return false;
     const config = REMOVE_SURFACES[surface];
-    const userId = ApiClient.getCurrentUserId();
+    const userId = context.userId;
     if (!userId || !itemId || !config) {
         showNotification(JC.t!('remove_continue_watching_error'), "error");
         return false;
@@ -130,20 +135,20 @@ export async function removeFromHomeSurface(itemId: string, surface: string, car
     // don't proceed on top of stale server state.
     try {
         await (JC as any).hiddenContent?.flushPendingSave?.();
+        if (!JC.identity.isCurrent(context)) return false;
     } catch (e: any) {
+        if (!JC.identity.isCurrent(context)) return false;
         showNotification(JC.t!('remove_continue_watching_error_api', { error: JC.escapeHtml(e?.statusText || '') || JC.t!('unknown_error') }), "error");
         return false;
     }
 
     try {
-        await ApiClient.ajax({
-            type: 'POST',
-            url: ApiClient.getUrl(`/JellyfinCanopy/${config.path}/hide/${itemId}`),
-            data: '{}',
-            contentType: 'application/json',
-            dataType: 'json',
-            headers: { 'Content-Type': 'application/json' }
-        } as any);
+        await JC.core.api!.plugin(`/${config.path}/hide/${encodeURIComponent(itemId)}`, {
+            method: 'POST',
+            body: {},
+            skipRetry: true,
+        });
+        if (!JC.identity.isCurrent(context)) return false;
 
         optimisticHideRemovedCard(itemId, surface, card);
 
@@ -155,6 +160,7 @@ export async function removeFromHomeSurface(itemId: string, surface: string, car
         }
         return true;
     } catch (error: any) {
+        if (!JC.identity.isCurrent(context)) return false;
         // SEC(X1): server/API error text reaches an innerHTML-rendered toast.
         const errorMessage = JC.escapeHtml(error.responseJSON?.message
             || error.responseJSON?.Message
@@ -184,7 +190,10 @@ export function hideEmptyHomeSections(): void {
                 if (card.style.display === 'none') continue;
                 visibleCount++;
             }
-            if (visibleCount === 0) section.style.display = 'none';
+            if (visibleCount === 0) {
+                section.style.display = 'none';
+                section.dataset.jcHomeSectionHidden = '1';
+            }
         }
     } catch (err) {
         console.warn('🪼 Jellyfin Canopy: hideEmptyHomeSections failed', err);
@@ -202,7 +211,7 @@ JC.hideEmptyHomeSections = hideEmptyHomeSections;
  * @param card The source card element, for a precise optimistic hide.
  * @returns The created button element.
  */
-function createRemoveButton(scroller: HTMLElement, itemId: string, surface: string, card?: HTMLElement): HTMLButtonElement {
+function createRemoveButton(context: IdentityContext, scroller: HTMLElement, itemId: string, surface: string, card?: HTMLElement): HTMLButtonElement {
     const config = REMOVE_SURFACES[surface] || REMOVE_SURFACES.continuewatching;
     const button = buildNativeActionSheetItem(scroller, {
         dataId: 'remove-continue-watching',
@@ -216,6 +225,7 @@ function createRemoveButton(scroller: HTMLElement, itemId: string, surface: stri
     button.addEventListener('click', (e) => {
         e.preventDefault();
         e.stopPropagation();
+        if (!JC.identity.isCurrent(context)) return;
 
         void (async () => {
             const originalText = textEl.textContent;
@@ -224,6 +234,7 @@ function createRemoveButton(scroller: HTMLElement, itemId: string, surface: stri
             setActionSheetItemIcon(button, 'hourglass_empty');
 
             const success = await removeFromHomeSurface(itemId, surface, card);
+            if (!JC.identity.isCurrent(context)) return;
 
             // Restore visuals BEFORE close — a stuck sheet under odd themes is better than a stuck "Removing…" label.
             button.disabled = false;
@@ -255,6 +266,8 @@ function createRemoveButton(scroller: HTMLElement, itemId: string, surface: stri
  * The context is consumed once handled so a later sheet can't reuse it.
  */
 JC.addRemoveButton = (): void => {
+    const context = JC.identity.capture();
+    if (!context) return;
     if (!JC.currentSettings!.removeContinueWatchingEnabled) return;
 
     const scroller = getActiveActionSheetScroller();
@@ -286,10 +299,22 @@ JC.addRemoveButton = (): void => {
     }
     if (!wantSurface) { JC.state!.removeContext = null; return; }
 
-    const removeButton = createRemoveButton(scroller, ctx.itemId, wantSurface, ctx.card as HTMLElement | undefined);
+    const removeButton = createRemoveButton(context, scroller, ctx.itemId, wantSurface, ctx.card as HTMLElement | undefined);
     insertionPoint.after(removeButton);
     fitActionSheetItem(removeButton, scroller);
     // Consume the context: one menu-open yields one button; later observer fires (or an
     // unrelated sheet opened within the TTL) must not re-inject from this same context.
     JC.state!.removeContext = null;
 };
+
+JC.identity.registerReset('remove-home', () => {
+    document.querySelectorAll('[data-id="remove-continue-watching"]').forEach((node) => node.remove());
+    document.querySelectorAll<HTMLElement>('[data-jc-home-removed="1"]').forEach((card) => {
+        card.style.removeProperty('display');
+        delete card.dataset.jcHomeRemoved;
+    });
+    document.querySelectorAll<HTMLElement>('[data-jc-home-section-hidden="1"]').forEach((section) => {
+        section.style.removeProperty('display');
+        delete section.dataset.jcHomeSectionHidden;
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/remove-multiselect.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/remove-multiselect.ts
@@ -12,6 +12,7 @@ import {
     buildNativeActionSheetItem, setActionSheetItemIcon, fitActionSheetItem,
     closeOpenActionSheet, getActiveActionSheetScroller,
 } from '../../core/action-sheet';
+import type { IdentityContext } from '../../types/jc';
 
 // ── Multi-select / long-press menu ───────────────────────────────────────────
 // Touch devices have no per-item "…" button; a long-press opens Jellyfin's multi-select
@@ -61,8 +62,9 @@ let activeConfirmClose: ((result: boolean) => void) | null = null;
  * surface it will be removed from. Inline-styled so it works even when the Hidden Content
  * module (and its dialog CSS) isn't active. Resolves true to proceed, false to cancel.
  */
-function confirmMultiRemove(targets: { name: string; surface: string }[]): Promise<boolean> {
+function confirmMultiRemove(context: IdentityContext, targets: { name: string; surface: string }[]): Promise<boolean> {
     return new Promise((resolve) => {
+        if (!JC.identity.isCurrent(context)) { resolve(false); return; }
         // Cleanly tear down any confirm still open (resolve its promise + drop its listener)
         // before opening a new one, so we never orphan a pending Promise / keydown handler.
         if (activeConfirmClose) activeConfirmClose(false);
@@ -125,7 +127,7 @@ function confirmMultiRemove(targets: { name: string; surface: string }[]): Promi
         };
         activeConfirmClose = close;
         cancel.addEventListener('click', () => close(false));
-        ok.addEventListener('click', () => close(true));
+        ok.addEventListener('click', () => close(JC.identity.isCurrent(context)));
         overlay.addEventListener('click', (e) => { if (e.target === overlay) close(false); });
 
         overlay.appendChild(dialog);
@@ -146,12 +148,14 @@ function confirmMultiRemove(targets: { name: string; surface: string }[]): Promi
  * selection intact for a retry).
  * @returns how many were removed.
  */
-async function performMultiRemove(targets: { itemId: string; surface: string; card: HTMLElement }[]): Promise<number> {
+async function performMultiRemove(context: IdentityContext, targets: { itemId: string; surface: string; card: HTMLElement }[]): Promise<number> {
     let removed = 0;
     for (const t of targets) {
+        if (!JC.identity.isCurrent(context)) return removed;
         // Sequential — selections are small and this keeps the HC store writes ordered.
         if (await removeFromHomeSurface(t.itemId, t.surface, t.card)) removed++;
     }
+    if (!JC.identity.isCurrent(context)) return removed;
     if (removed > 0) {
         closeOpenActionSheet();
         exitSelectionMode();
@@ -179,7 +183,7 @@ function multiSelectRemoveLabel(targets: { surface: string }[]): string {
  * Removes every selected Continue Watching / Next Up card from its own surface.
  * @param scroller The multi-select menu's scroller.
  */
-function createMultiSelectRemoveButton(scroller: HTMLElement, targets: RemovableCardTarget[]): HTMLButtonElement {
+function createMultiSelectRemoveButton(context: IdentityContext, scroller: HTMLElement, targets: RemovableCardTarget[]): HTMLButtonElement {
     const button = buildNativeActionSheetItem(scroller, {
         dataId: 'jc-multiselect-remove',
         icon: 'visibility_off',
@@ -190,6 +194,7 @@ function createMultiSelectRemoveButton(scroller: HTMLElement, targets: Removable
     button.addEventListener('click', (e) => {
         e.preventDefault();
         e.stopPropagation();
+        if (!JC.identity.isCurrent(context)) return;
 
         void (async () => {
             // Recollect the selection at click time, not from the build-time closure: if the
@@ -201,9 +206,9 @@ function createMultiSelectRemoveButton(scroller: HTMLElement, targets: Removable
             // item and the surface it'll be removed from, so the action is never a surprise.
             if (current.length > 1) {
                 closeOpenActionSheet();
-                const confirmed = await confirmMultiRemove(current);
-                if (!confirmed) return; // selection kept so the user can adjust
-                await performMultiRemove(current);
+                const confirmed = await confirmMultiRemove(context, current);
+                if (!confirmed || !JC.identity.isCurrent(context)) return; // selection kept so the user can adjust
+                await performMultiRemove(context, current);
                 return;
             }
 
@@ -213,7 +218,8 @@ function createMultiSelectRemoveButton(scroller: HTMLElement, targets: Removable
             textEl.textContent = JC.t!('remove_button_removing');
             setActionSheetItemIcon(button, 'hourglass_empty');
 
-            await performMultiRemove(current);
+            await performMultiRemove(context, current);
+            if (!JC.identity.isCurrent(context)) return;
 
             button.disabled = false;
             textEl.textContent = originalText;
@@ -229,6 +235,8 @@ function createMultiSelectRemoveButton(scroller: HTMLElement, targets: Removable
  * least one selected card is in Continue Watching or Next Up. Idempotent per menu.
  */
 JC.addMultiSelectRemoveButton = (): void => {
+    const context = JC.identity.capture();
+    if (!context) return;
     if (!JC.currentSettings!.removeContinueWatchingEnabled) return;
 
     const scroller = getActiveActionSheetScroller();
@@ -240,7 +248,7 @@ JC.addMultiSelectRemoveButton = (): void => {
     const targets = collectSelectedRemovableCards();
     if (!targets.length) return;
 
-    const removeButton = createMultiSelectRemoveButton(scroller, targets);
+    const removeButton = createMultiSelectRemoveButton(context, scroller, targets);
     const anchor = scroller.querySelector('[data-id="refresh"]')
         || scroller.querySelector('[data-id="markunplayed"]')
         || scroller.querySelector('[data-id="markplayed"]');
@@ -251,3 +259,10 @@ JC.addMultiSelectRemoveButton = (): void => {
     }
     fitActionSheetItem(removeButton, scroller);
 };
+
+JC.identity.registerReset('remove-multiselect', () => {
+    activeConfirmClose?.(false);
+    activeConfirmClose = null;
+    document.querySelectorAll('.jc-remove-confirm-overlay, [data-id="jc-multiselect-remove"]')
+        .forEach((node) => node.remove());
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/helpers.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/helpers.test.ts
@@ -3,6 +3,7 @@
 // used to be re-read on every observer tick; it must now be read at most once
 // per navigation).
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../globals';
 import { clearItemCache, getHeaderRightContainer, getItemCached } from './helpers';
 import { insertHeaderTrayButton, HeaderTrayOrder } from './header-tray';
 
@@ -104,6 +105,25 @@ describe('privacy reset item-cache invalidation (BI-SEC-035)', () => {
         await expect(oldRequest).resolves.toEqual({ projection: 'stale' });
         await expect(getItemCached(itemId, { userId: 'race-user' }))
             .resolves.toEqual({ projection: 'fresh' });
+        expect(getItem).toHaveBeenCalledTimes(2);
+        getItem.mockRestore();
+    });
+
+    it('drops a held DTO and refetches when the same user id switches servers', async () => {
+        let resolveA!: (value: unknown) => void;
+        const heldA = new Promise<unknown>((resolve) => { resolveA = resolve; });
+        const getItem = vi.spyOn(ApiClient, 'getItem')
+            .mockImplementationOnce(() => heldA)
+            .mockResolvedValueOnce({ server: 'b' });
+
+        JC.identity.transition('server-a', 'same-user', 'helpers-server-a');
+        const requestA = getItemCached('same-item', { userId: 'same-user' });
+        JC.identity.transition('server-b', 'same-user', 'helpers-server-switch');
+        resolveA({ server: 'a' });
+
+        await expect(requestA).resolves.toBeNull();
+        await expect(getItemCached('same-item', { userId: 'same-user' }))
+            .resolves.toEqual({ server: 'b' });
         expect(getItem).toHaveBeenCalledTimes(2);
         getItem.mockRestore();
     });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/helpers.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/helpers.ts
@@ -10,7 +10,7 @@
 
 import { JC } from '../globals';
 import { onNavigate } from '../core/navigation';
-import type { NavigateCallback, ViewPageCallback, ViewPageOptions } from '../types/jc';
+import type { IdentityContext, NavigateCallback, ViewPageCallback, ViewPageOptions } from '../types/jc';
 
 // Tracks whether the MUI-toolbar button-sizing CSS fix has been injected (see
 // getHeaderRightContainer below) so it's only added once.
@@ -28,6 +28,9 @@ interface ItemCacheEntry {
     item: unknown;
     ts: number;
     promise: Promise<unknown> | null;
+    owner: IdentityContext;
+    userId: string;
+    itemId: string;
 }
 
 // Shared cache for item payloads to deduplicate cross-module ApiClient.getItem calls
@@ -44,14 +47,13 @@ export function clearItemCache(userId?: string, itemIds?: string[]): void {
         itemCache.clear();
         return;
     }
-    const prefix = `${userId}:`;
+    const normalizedUserId = userId.replace(/-/g, '').toLowerCase();
     const selected = itemIds && itemIds.length > 0
         ? new Set(itemIds.map((id) => id.replace(/-/g, '').toLowerCase()))
         : null;
-    for (const key of itemCache.keys()) {
-        if (!key.startsWith(prefix)) continue;
-        const itemId = key.slice(prefix.length).replace(/-/g, '').toLowerCase();
-        if (!selected || selected.has(itemId)) itemCache.delete(key);
+    for (const [key, entry] of itemCache) {
+        if (entry.userId !== normalizedUserId) continue;
+        if (!selected || selected.has(entry.itemId)) itemCache.delete(key);
     }
 }
 
@@ -68,13 +70,17 @@ export interface GetItemCachedOptions {
 export async function getItemCached(itemId: string, options: GetItemCachedOptions = {}): Promise<unknown> {
     if (!itemId) return null;
 
+    const context = JC.identity.capture();
+    if (!context) return null;
     const ttlMs = Number.isFinite(options.ttlMs) ? (options.ttlMs as number) : ITEM_CACHE_TTL_MS;
     const userId = options.userId || ApiClient.getCurrentUserId();
-    const key = `${userId}:${itemId}`;
+    const normalizedUserId = String(userId).replace(/-/g, '').toLowerCase();
+    const normalizedItemId = itemId.replace(/-/g, '').toLowerCase();
+    const key = `${context.serverId}:${normalizedUserId}:${normalizedItemId}`;
     const now = Date.now();
     const entry = itemCache.get(key);
 
-    if (!options.forceRefresh && entry) {
+    if (!options.forceRefresh && entry && JC.identity.isCurrent(entry.owner)) {
         if (entry.promise) {
             return entry.promise;
         }
@@ -85,22 +91,40 @@ export async function getItemCached(itemId: string, options: GetItemCachedOption
 
     const promise = ApiClient.getItem(userId, itemId)
         .then((item) => {
+            if (!JC.identity.isCurrent(context)) return null;
             // A privacy reset or newer forced fetch may retire this request while
             // it is in flight. Only the promise that still owns the key may publish.
             if (itemCache.get(key)?.promise === promise) {
-                itemCache.set(key, { item, ts: Date.now(), promise: null });
+                itemCache.set(key, {
+                    item,
+                    ts: Date.now(),
+                    promise: null,
+                    owner: context,
+                    userId: normalizedUserId,
+                    itemId: normalizedItemId
+                });
             }
             return item;
         })
         .catch((err: unknown) => {
             // Likewise, an older rejection must not delete a newer request/value.
             if (itemCache.get(key)?.promise === promise) itemCache.delete(key);
+            if (!JC.identity.isCurrent(context)) return null;
             throw err;
         });
 
-    itemCache.set(key, { item: null, ts: now, promise });
+    itemCache.set(key, {
+        item: null,
+        ts: now,
+        promise,
+        owner: context,
+        userId: normalizedUserId,
+        itemId: normalizedItemId
+    });
     return promise;
 }
+
+JC.identity.registerReset('enhanced-item-cache', () => itemCache.clear());
 
 /**
  * Debounce a function call

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content-page/admin.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content-page/admin.ts
@@ -7,7 +7,15 @@
 
 import { JC } from '../../globals';
 import { currentPageHandle } from '../pages/fallback-host';
-import { state, POSTER_MAX_WIDTH } from './state';
+import {
+    cancelPageTimeout,
+    capturePageFence,
+    isPageFenceCurrent,
+    schedulePageTimeout,
+    state,
+    POSTER_MAX_WIDTH,
+} from './state';
+import type { HiddenContentPageFence } from './state';
 import { isCssColor } from '../../core/css-safe';
 // Cross-module reference (defined in hidden-content-page/render.ts). ES-module
 // cyclic edge — only ever invoked at call time, never during module evaluation.
@@ -16,6 +24,14 @@ import { renderPage } from './render';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 const logPrefix = '🪼 Jellyfin Canopy: Hidden Content Page:';
+let activeAdminModalClose: (() => void) | null = null;
+
+function resetAdminUi(): void {
+    activeAdminModalClose?.();
+    activeAdminModalClose = null;
+}
+
+JC.identity?.registerReset?.('hidden-content-page-admin-ui', resetAdminUi);
 
 // ============================================================
 // Admin cross-user view
@@ -28,7 +44,8 @@ const logPrefix = '🪼 Jellyfin Canopy: Hidden Content Page:';
  * UX gate only — the server independently enforces admin access on every
  * admin/* endpoint, so a false positive here cannot leak another user's data.
  */
-async function resolveIsAdmin(): Promise<boolean> {
+async function resolveIsAdmin(fence: HiddenContentPageFence): Promise<boolean> {
+    if (!isPageFenceCurrent(fence)) return false;
     if (state.adminIsAdmin !== null) return state.adminIsAdmin;
     // A positive flag is trustworthy; a falsy one may simply be "not yet resolved",
     // so only short-circuit on an explicit true and otherwise verify authoritatively.
@@ -43,6 +60,7 @@ async function resolveIsAdmin(): Promise<boolean> {
     }
     try {
         const user: any = await ApiClient.getCurrentUser();
+        if (!isPageFenceCurrent(fence)) return false;
         // Authoritative result — cache it even when false.
         state.adminIsAdmin = !!(user && user.Policy && user.Policy.IsAdministrator);
         return state.adminIsAdmin;
@@ -60,6 +78,8 @@ async function resolveIsAdmin(): Promise<boolean> {
  * after the cache is invalidated (state.adminUsers reset to null). Never throws.
  */
 export async function maybeInitAdminFilter(): Promise<void> {
+    const fence = capturePageFence();
+    if (!isPageFenceCurrent(fence)) return;
     // Respect the admin config toggle: when cross-user access is disabled, never build the filter
     // (and never call the admin endpoints, which the server also refuses).
     if (JC.pluginConfig && JC.pluginConfig.HiddenContentAdmin === false) return;
@@ -69,20 +89,24 @@ export async function maybeInitAdminFilter(): Promise<void> {
     // completion must NOT repopulate adminUsers — that would defeat the fresh re-init on re-open.
     const token = state.adminLoadToken;
     try {
-        const isAdmin = await resolveIsAdmin();
+        const isAdmin = await resolveIsAdmin(fence);
+        if (!isPageFenceCurrent(fence) || token !== state.adminLoadToken) return;
         if (!isAdmin) return; // leave adminUsers null; resolveIsAdmin governs retry semantics
         const list = await (JC as any).hiddenContent.fetchHiddenContentUsers();
         // null = transient failure: leave adminUsers null so a later render retries, and do NOT
         // re-render here (re-rendering would re-enter this function and spin a fetch/render loop).
         if (list === null) return;
-        if (token !== state.adminLoadToken) return; // page left during the fetch — discard stale result
+        if (!isPageFenceCurrent(fence) || token !== state.adminLoadToken) return; // page/account left during the fetch
         state.adminUsers = list;
         // The dropdown can now be drawn from cache — repaint the current surface.
         renderPage();
     } catch (e) {
-        console.warn(`${logPrefix} admin filter init failed`, e);
+        if (isPageFenceCurrent(fence)) console.warn(`${logPrefix} admin filter init failed`, e);
     } finally {
-        state.adminUsersLoading = false;
+        // A's completion must not clear B's independent loading sentinel.
+        if (isPageFenceCurrent(fence) && token === state.adminLoadToken) {
+            state.adminUsersLoading = false;
+        }
     }
 }
 
@@ -94,6 +118,8 @@ export async function maybeInitAdminFilter(): Promise<void> {
  * @param value Selected user id (N format) or '' for own list.
  */
 export async function onAdminUserChange(value: string): Promise<void> {
+    const fence = capturePageFence();
+    if (!isPageFenceCurrent(fence)) return;
     const token = ++state.adminLoadToken;
     state.searchQuery = '';
     state.scopedOnly = false;
@@ -118,7 +144,8 @@ export async function onAdminUserChange(value: string): Promise<void> {
     renderPage();
 
     const items = await (JC as any).hiddenContent.fetchUserHiddenItemsForAdmin(value);
-    if (token !== state.adminLoadToken) return; // a newer selection superseded this one
+    if (!isPageFenceCurrent(fence) || token !== state.adminLoadToken
+        || state.selectedAdminUserId !== value) return;
     if (items === null) {
         // Load failed — surface an error (with retry) rather than a misleading empty grid. Leaving
         // adminItemsUserId null keeps adminReady false so the error branch renders.
@@ -201,8 +228,10 @@ export function createAdminViewingBadge(): HTMLElement {
  * @param key Item key (item._key || item.itemId).
  */
 export function handleUnhide(key: string): void {
+    const fence = capturePageFence();
+    if (!isPageFenceCurrent(fence)) return;
     if (state.selectedAdminUserId) {
-        if (state.adminEditMode) void adminUnhide([key]);
+        if (state.adminEditMode) void adminUnhide([key], fence);
         return; // read-only view: ignore (the control should already be stripped)
     }
     (JC as any).hiddenContent.unhideItem(key);
@@ -213,9 +242,11 @@ export function handleUnhide(key: string): void {
  * @param keys Item keys to unhide.
  */
 export function handleUnhideMany(keys: string[]): void {
+    const fence = capturePageFence();
+    if (!isPageFenceCurrent(fence)) return;
     if (!Array.isArray(keys) || keys.length === 0) return;
     if (state.selectedAdminUserId) {
-        if (state.adminEditMode) void adminUnhide(keys);
+        if (state.adminEditMode) void adminUnhide(keys, fence);
         return;
     }
     keys.forEach((k) => (JC as any).hiddenContent.unhideItem(k));
@@ -226,11 +257,12 @@ export function handleUnhideMany(keys: string[]): void {
  * repaints. Keeps the dropdown count roughly in sync without a full refetch.
  * @param keys Item keys to unhide for state.selectedAdminUserId.
  */
-async function adminUnhide(keys: string[]): Promise<void> {
+async function adminUnhide(keys: string[], fence: HiddenContentPageFence): Promise<void> {
+    if (!isPageFenceCurrent(fence)) return;
     const uid = state.selectedAdminUserId;
     if (!uid) return;
     const ok = await (JC as any).hiddenContent.adminUnhideForUser(uid, keys);
-    if (!ok) return;
+    if (!ok || !isPageFenceCurrent(fence) || state.selectedAdminUserId !== uid) return;
     const removed = new Set(keys);
     if (Array.isArray(state.adminItems)) {
         state.adminItems = state.adminItems.filter((it) => !removed.has(it._key));
@@ -250,7 +282,8 @@ async function adminUnhide(keys: string[]): Promise<void> {
  * @param result A normalized search result (library or Seerr).
  * @returns true on success.
  */
-async function adminAddItem(targetUserId: string, result: any): Promise<boolean> {
+async function adminAddItem(targetUserId: string, result: any, fence: HiddenContentPageFence): Promise<boolean> {
+    if (!isPageFenceCurrent(fence) || state.selectedAdminUserId !== targetUserId) return false;
     const item = {
         itemId: result.itemId || '',
         name: result.name || '',
@@ -267,7 +300,8 @@ async function adminAddItem(targetUserId: string, result: any): Promise<boolean>
         hiddenAt: new Date().toISOString(),
     };
     const added = await (JC as any).hiddenContent.adminHideForUser(targetUserId, [item]);
-    if (added === false) return false;
+    if (added === false || !isPageFenceCurrent(fence)
+        || state.selectedAdminUserId !== targetUserId) return false;
     // The server returns the number of items it newly added; 0 means the user already had it hidden.
     // Only update the local cache + dropdown count for a real add, so the count can't drift upward.
     const didAdd = typeof added === 'number' ? added > 0 : true;
@@ -290,16 +324,20 @@ async function adminAddItem(targetUserId: string, result: any): Promise<boolean>
  * management-panel styling.
  */
 export function openAdminAddModal(): void {
+    const fence = capturePageFence();
+    if (!isPageFenceCurrent(fence)) return;
     const uid = state.selectedAdminUserId;
     if (!uid) return;
     const userName = state.adminUserName || uid;
 
+    activeAdminModalClose?.();
     // The open overlay normally blocks re-opening, but if a stale one is somehow present, note it so
     // we don't later "restore" the page overflow to its already-locked 'hidden' value (a perma-lock).
     const hadStaleOverlay = !!document.querySelector('.jc-hidden-admin-add-overlay');
     document.querySelector('.jc-hidden-admin-add-overlay')?.remove();
     const overlay = document.createElement('div');
     overlay.className = 'jc-hidden-management-overlay jc-hidden-admin-add-overlay';
+    overlay.dataset.jcIdentityOwned = 'true';
     const panel = document.createElement('div');
     panel.className = 'jc-hidden-management-panel';
 
@@ -338,12 +376,25 @@ export function openAdminAddModal(): void {
     // can never re-save and re-apply a 'hidden' that permanently locks the page.
     const prevBodyOverflow = hadStaleOverlay ? '' : document.body.style.overflow;
     const prevHtmlOverflow = hadStaleOverlay ? '' : document.documentElement.style.overflow;
+    const pageHandle = currentPageHandle();
+    let searchTimer: number | null = null;
+    let searchToken = 0;
+    let closed = false;
+    const isModalCurrent = (): boolean => !closed && isPageFenceCurrent(fence);
     const close = (): void => {
+        if (closed) return;
+        closed = true;
+        searchToken += 1;
+        cancelPageTimeout(searchTimer);
+        searchTimer = null;
         overlay.remove();
         document.removeEventListener('keydown', esc);
         document.body.style.overflow = prevBodyOverflow;
         document.documentElement.style.overflow = prevHtmlOverflow;
+        pageHandle?.untrack(close);
+        if (activeAdminModalClose === close) activeAdminModalClose = null;
     };
+    activeAdminModalClose = close;
     const esc = (e: KeyboardEvent): void => { if (e.key === 'Escape') close(); };
     closeBtn.addEventListener('click', close);
     overlay.addEventListener('click', (e) => { if (e.target === overlay) close(); });
@@ -354,6 +405,7 @@ export function openAdminAddModal(): void {
         const alreadyHidden = (state.adminItems || []).some((i) => (i._key || i.itemId) === key);
         const card = document.createElement('div');
         card.className = 'jc-hidden-item-card';
+        card.dataset.jcIdentityOwned = 'true';
 
         const posterWrap = document.createElement('div');
         posterWrap.className = 'jc-hidden-item-poster-link';
@@ -366,12 +418,22 @@ export function openAdminAddModal(): void {
             // Library item → Jellyfin image, falling back to the TMDB poster if available.
             img.src = (ApiClient as { getUrl(path: string, params?: unknown): string }).getUrl('/Items/' + n.itemId + '/Images/Primary', { maxWidth: POSTER_MAX_WIDTH });
             img.onerror = tmdbPoster
-                ? function (this: HTMLImageElement) { this.onerror = function (this: HTMLImageElement) { this.style.display = 'none'; }; this.src = tmdbPoster; }
-                : function (this: HTMLImageElement) { this.style.display = 'none'; };
+                ? function (this: HTMLImageElement) {
+                    if (!isModalCurrent()) return;
+                    this.onerror = function (this: HTMLImageElement) {
+                        if (isModalCurrent()) this.style.display = 'none';
+                    };
+                    this.src = tmdbPoster;
+                }
+                : function (this: HTMLImageElement) {
+                    if (isModalCurrent()) this.style.display = 'none';
+                };
         } else if (tmdbPoster) {
             // Seerr-only item → TMDB poster.
             img.src = tmdbPoster;
-            img.onerror = function (this: HTMLImageElement) { this.style.display = 'none'; };
+            img.onerror = function (this: HTMLImageElement) {
+                if (isModalCurrent()) this.style.display = 'none';
+            };
         } else {
             img.style.display = 'none';
         }
@@ -399,9 +461,11 @@ export function openAdminAddModal(): void {
             btn.textContent = JC.t!('hidden_content_admin_add_hide');
             btn.addEventListener('click', () => {
                 void (async () => {
+                    if (!isModalCurrent()) return;
                     btn.disabled = true;
                     btn.textContent = JC.t!('hidden_content_admin_add_hiding');
-                    const ok = await adminAddItem(uid, n);
+                    const ok = await adminAddItem(uid, n, fence);
+                    if (!isModalCurrent()) return;
                     btn.textContent = ok ? JC.t!('hidden_content_admin_add_added') : JC.t!('hidden_content_admin_add_hide');
                     if (!ok) btn.disabled = false;
                 })();
@@ -414,15 +478,15 @@ export function openAdminAddModal(): void {
         return card;
     };
 
-    let searchTimer: number | null = null;
-    let searchToken = 0;
     const showMessage = (text: string): void => {
+        if (!isModalCurrent()) return;
         const m = document.createElement('div');
         m.className = 'jc-hidden-management-empty';
         m.textContent = text;
         grid.replaceChildren(m);
     };
     const doSearch = async (q: string): Promise<void> => {
+        if (!isModalCurrent()) return;
         const token = ++searchToken;
         const term = (q || '').trim();
         if (term.length < 2) { grid.replaceChildren(hint); return; }
@@ -433,7 +497,7 @@ export function openAdminAddModal(): void {
         // Routed through the core fetch layer (auth + JSON parse identical to the
         // former ApiClient.ajax call; any failure still resolves to []).
         const libP = JC.core.api!.fetch((ApiClient as { getUrl(path: string, params?: unknown): string }).getUrl('/Items', {
-            userId: ApiClient.getCurrentUserId(), searchTerm: term, IncludeItemTypes: 'Movie,Series',
+            userId: fence.context?.userId || ApiClient.getCurrentUserId(), searchTerm: term, IncludeItemTypes: 'Movie,Series',
             Recursive: true, Limit: 24, Fields: 'ProviderIds', ImageTypeLimit: 1, EnableImageTypes: 'Primary',
         })).then((res: any) => (res && res.Items) || []).catch(() => []);
         const seerrAPI = (JC as any).seerrAPI;
@@ -442,7 +506,7 @@ export function openAdminAddModal(): void {
             : Promise.resolve([]);
 
         const [libItems, seerrItems] = await Promise.all([libP, seerrP]);
-        if (token !== searchToken) return;
+        if (!isModalCurrent() || token !== searchToken) return;
 
         const normalized: any[] = [];
         const seenTmdb = new Set<string>();
@@ -470,8 +534,12 @@ export function openAdminAddModal(): void {
     };
 
     searchInput.addEventListener('input', () => {
-        if (searchTimer) clearTimeout(searchTimer);
-        searchTimer = window.setTimeout(() => { void doSearch(searchInput.value); }, 300);
+        if (!isModalCurrent()) return;
+        cancelPageTimeout(searchTimer);
+        searchTimer = schedulePageTimeout(() => {
+            searchTimer = null;
+            void doSearch(searchInput.value);
+        }, 300, fence);
     });
 
     document.body.style.overflow = 'hidden';
@@ -479,6 +547,6 @@ export function openAdminAddModal(): void {
     document.body.appendChild(overlay);
     // Body-level overlay with a scroll lock: register on the page's dispose
     // bag so a drain (navigation) closes it and restores the scroll owners.
-    currentPageHandle()?.track(close);
+    pageHandle?.track(close);
     searchInput.focus();
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content-page/cards.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content-page/cards.ts
@@ -6,13 +6,30 @@
 // identical; the JC.internals.hiddenContentPage bag is now real module imports.)
 
 import { JC } from '../../globals';
-import { scopeBadgeText, scopeUnhideText, showUnhideConfirmation, POSTER_MAX_WIDTH } from './state';
+import {
+    capturePageFence,
+    isPageFenceCurrent,
+    schedulePageTimeout,
+    scopeBadgeText,
+    scopeUnhideText,
+    showUnhideConfirmation,
+    POSTER_MAX_WIDTH,
+} from './state';
+import type { HiddenContentPageFence } from './state';
 import { handleUnhide, handleUnhideMany } from './admin';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 /** Delay before removing a card after unhide animation. */
 const UNHIDE_FADE_DELAY_MS = 200;
+
+function fenceLink(link: HTMLElement, fence: HiddenContentPageFence): void {
+    link.addEventListener('click', (event) => {
+        if (isPageFenceCurrent(fence)) return;
+        event.preventDefault();
+        event.stopImmediatePropagation();
+    });
+}
 
 // ============================================================
 // Rendering Functions
@@ -43,11 +60,13 @@ function formatEpisodeLabel(item: any): string {
  * @returns The poster link element.
  */
 function createGroupPoster(group: any, tmdbId: string): HTMLElement {
+    const fence = capturePageFence();
     const hasJellyfinId = !!group.seriesId;
     const hasTmdbId = !!tmdbId;
 
     const posterLink = document.createElement('a');
     posterLink.className = 'jc-hidden-group-poster-link';
+    fenceLink(posterLink, fence);
     if (hasJellyfinId) {
         posterLink.href = `#/details?id=${group.seriesId}`;
     } else if (hasTmdbId) {
@@ -60,6 +79,7 @@ function createGroupPoster(group: any, tmdbId: string): HTMLElement {
     if (hasJellyfinId) {
         img.src = `${(ApiClient as { getUrl(path: string, params?: unknown): string }).getUrl('/Items/' + group.seriesId + '/Images/Primary', { maxWidth: POSTER_MAX_WIDTH })}`;
         img.onerror = function (this: HTMLImageElement) {
+            if (!isPageFenceCurrent(fence)) return;
             // eslint-disable-next-line @typescript-eslint/no-this-alias -- nested error handlers reference the outer <img>; verbatim from the legacy code
             const self = this;
             // Signal the card that Jellyfin item is gone
@@ -69,29 +89,37 @@ function createGroupPoster(group: any, tmdbId: string): HTMLElement {
             // Item removed from Jellyfin — fall back to TMDB poster
             if (hasTmdbId && fallbackPosterPath) {
                 self.src = `https://image.tmdb.org/t/p/w${POSTER_MAX_WIDTH}${fallbackPosterPath}`;
-                self.onerror = function (this: HTMLImageElement) { this.style.display = 'none'; };
+                self.onerror = function (this: HTMLImageElement) {
+                    if (isPageFenceCurrent(fence)) this.style.display = 'none';
+                };
             } else if (hasTmdbId && (JC as any).seerrAPI) {
                 // No posterPath stored — fetch it from Seerr
-                self.onerror = function (this: HTMLImageElement) { this.style.display = 'none'; };
+                self.onerror = function (this: HTMLImageElement) {
+                    if (isPageFenceCurrent(fence)) this.style.display = 'none';
+                };
                 const mainItem = group.items[0];
                 const mediaType = (mainItem && mainItem.type === 'Series') ? 'tv' : 'movie';
                 const fetchFn = mediaType === 'tv'
                     ? (JC as any).seerrAPI.fetchTvShowDetails
                     : (JC as any).seerrAPI.fetchMovieDetails;
                 fetchFn(parseInt(tmdbId, 10)).then(function (details: any) {
+                    if (!isPageFenceCurrent(fence)) return;
                     const path = details && (details.posterPath || details.poster_path);
                     if (path) {
                         self.src = `https://image.tmdb.org/t/p/w${POSTER_MAX_WIDTH}${path}`;
                     } else {
                         self.style.display = 'none';
                     }
-                }).catch(function () { self.style.display = 'none'; });
+                }).catch(function () {
+                    if (isPageFenceCurrent(fence)) self.style.display = 'none';
+                });
             } else if (group.seriesName && (JC as any).seerrAPI && (JC as any).seerrMoreInfo) {
                 // No TMDB id stored (e.g. an episode hidden from Next Up) and the Jellyfin media is gone.
                 // Resolve the show via a Seerr search by name so the card can still open the more-info
                 // modal — instead of leaving a blank poster and a dead "#/details" link.
                 self.style.display = 'none';
                 (JC as any).seerrAPI.search(group.seriesName).then(function (res: any) {
+                    if (!isPageFenceCurrent(fence)) return;
                     const results = (res && res.results) || [];
                     const hit = results.find(function (r: any) { return r.mediaType === 'tv'; }) || results[0];
                     if (hit && hit.id) {
@@ -103,7 +131,9 @@ function createGroupPoster(group: any, tmdbId: string): HTMLElement {
                         if (p) {
                             self.src = `https://image.tmdb.org/t/p/w${POSTER_MAX_WIDTH}${p}`;
                             self.style.display = '';
-                            self.onerror = function (this: HTMLImageElement) { this.style.display = 'none'; };
+                            self.onerror = function (this: HTMLImageElement) {
+                                if (isPageFenceCurrent(fence)) this.style.display = 'none';
+                            };
                         }
                     }
                 }).catch(function () {});
@@ -113,10 +143,14 @@ function createGroupPoster(group: any, tmdbId: string): HTMLElement {
         };
     } else if (fallbackPosterPath) {
         img.src = `https://image.tmdb.org/t/p/w${POSTER_MAX_WIDTH}${fallbackPosterPath}`;
-        img.onerror = function (this: HTMLImageElement) { this.style.display = 'none'; };
+        img.onerror = function (this: HTMLImageElement) {
+            if (isPageFenceCurrent(fence)) this.style.display = 'none';
+        };
     } else if (group.items[0]?.itemId) {
         img.src = `${(ApiClient as { getUrl(path: string, params?: unknown): string }).getUrl('/Items/' + group.items[0].itemId + '/Images/Primary', { maxWidth: POSTER_MAX_WIDTH })}`;
-        img.onerror = function (this: HTMLImageElement) { this.style.display = 'none'; };
+        img.onerror = function (this: HTMLImageElement) {
+            if (isPageFenceCurrent(fence)) this.style.display = 'none';
+        };
     }
     img.alt = '';
     img.loading = 'lazy';
@@ -134,6 +168,7 @@ function createGroupPoster(group: any, tmdbId: string): HTMLElement {
  * @returns The info container element.
  */
 function createGroupInfo(group: any, mainItem: any, totalItems: number, hasEpisodes: boolean, tmdbId: string): { info: HTMLElement; nameEl: HTMLElement } {
+    const fence = capturePageFence();
     const hasJellyfinId = !!group.seriesId;
     const hasTmdbId = !!tmdbId;
 
@@ -144,6 +179,7 @@ function createGroupInfo(group: any, mainItem: any, totalItems: number, hasEpiso
         ? document.createElement('a')
         : document.createElement('div');
     nameEl.className = 'jc-hidden-group-name';
+    fenceLink(nameEl, fence);
     nameEl.textContent = group.seriesName || JC.t!('hidden_content_unknown_show');
     nameEl.title = group.seriesName || '';
     if (hasJellyfinId) {
@@ -181,6 +217,7 @@ function createGroupInfo(group: any, mainItem: any, totalItems: number, hasEpiso
  * @returns A document fragment with the detail and unhide button.
  */
 function createSingleItemDisplay(group: any, mainItem: any, hasEpisodes: boolean): DocumentFragment {
+    const fence = capturePageFence();
     const fragment = document.createDocumentFragment();
 
     if (hasEpisodes) {
@@ -189,6 +226,7 @@ function createSingleItemDisplay(group: any, mainItem: any, hasEpisodes: boolean
 
         const label = document.createElement('a');
         label.className = 'jc-hidden-group-item-label';
+        fenceLink(label, fence);
         label.textContent = formatEpisodeLabel(mainItem);
         label.title = mainItem.name || '';
         if (mainItem.itemId) {
@@ -213,14 +251,16 @@ function createSingleItemDisplay(group: any, mainItem: any, hasEpisodes: boolean
     unhideBtn.className = 'jc-hidden-group-unhide';
     unhideBtn.textContent = scopeUnhideText(mainItem.hideScope);
     unhideBtn.addEventListener('click', () => {
+        if (!isPageFenceCurrent(fence)) return;
         const itemLabel = hasEpisodes
             ? (group.seriesName || '') + ' – ' + formatEpisodeLabel(mainItem)
             : (group.seriesName || mainItem.name || 'this item');
         showUnhideConfirmation(JC.t!('hidden_content_unhide_confirm') || 'Unhide this item?', () => {
+            if (!isPageFenceCurrent(fence)) return;
             (unhideBtn.closest('.jc-hidden-group-card') as HTMLElement).style.opacity = '0.3';
-            setTimeout(() => {
+            schedulePageTimeout(() => {
                 handleUnhide(mainItem._key || mainItem.itemId);
-            }, UNHIDE_FADE_DELAY_MS);
+            }, UNHIDE_FADE_DELAY_MS, fence);
         }, itemLabel);
     });
     fragment.appendChild(unhideBtn);
@@ -237,6 +277,7 @@ function createSingleItemDisplay(group: any, mainItem: any, hasEpisodes: boolean
  * @returns A document fragment containing expand button, items list, and unhide-all.
  */
 function createExpandableItemsList(group: any, displayItems: any[], totalItems: number): DocumentFragment {
+    const fence = capturePageFence();
     const fragment = document.createDocumentFragment();
 
     // Expand/collapse button
@@ -267,6 +308,7 @@ function createExpandableItemsList(group: any, displayItems: any[], totalItems: 
 
         const label = document.createElement('a');
         label.className = 'jc-hidden-group-item-label';
+        fenceLink(label, fence);
         label.textContent = item._label;
         label.title = item.name || '';
         if (item.itemId) {
@@ -290,12 +332,14 @@ function createExpandableItemsList(group: any, displayItems: any[], totalItems: 
         unhideBtn.textContent = scopeUnhideText(item.hideScope);
         unhideBtn.addEventListener('click', (e) => {
             e.preventDefault();
+            if (!isPageFenceCurrent(fence)) return;
             const rowLabel = (group.seriesName || '') + ' – ' + formatEpisodeLabel(item);
             showUnhideConfirmation(JC.t!('hidden_content_unhide_confirm') || 'Unhide this item?', () => {
+                if (!isPageFenceCurrent(fence)) return;
                 row.style.opacity = '0.3';
-                setTimeout(() => {
+                schedulePageTimeout(() => {
                     handleUnhide(item._key || item.itemId);
-                }, UNHIDE_FADE_DELAY_MS);
+                }, UNHIDE_FADE_DELAY_MS, fence);
             }, rowLabel);
         });
         row.appendChild(unhideBtn);
@@ -309,7 +353,9 @@ function createExpandableItemsList(group: any, displayItems: any[], totalItems: 
     unhideAllBtn.className = 'jc-hidden-group-unhide-all';
     unhideAllBtn.textContent = JC.t!('hidden_content_unhide_all_show');
     unhideAllBtn.addEventListener('click', () => {
+        if (!isPageFenceCurrent(fence)) return;
         showUnhideConfirmation(JC.t!('hidden_content_unhide_all_confirm') || 'Unhide all items for this show?', () => {
+            if (!isPageFenceCurrent(fence)) return;
             handleUnhideMany(group.items.map((item: any) => item._key || item.itemId));
         }, group.seriesName || 'this show');
     });
@@ -317,6 +363,7 @@ function createExpandableItemsList(group: any, displayItems: any[], totalItems: 
 
     // Toggle expand/collapse
     expandBtn.addEventListener('click', () => {
+        if (!isPageFenceCurrent(fence)) return;
         const isExpanded = itemsList.classList.toggle('expanded');
         expandBtn.classList.toggle('expanded', isExpanded);
         unhideAllBtn.classList.toggle('expanded', isExpanded);
@@ -331,8 +378,10 @@ function createExpandableItemsList(group: any, displayItems: any[], totalItems: 
  * @returns The group card element.
  */
 export function createGroupCard(group: any): HTMLElement {
+    const fence = capturePageFence();
     const card = document.createElement('div');
     card.className = 'jc-hidden-group-card';
+    card.dataset.jcIdentityOwned = 'true';
 
     const seriesItems = group.items.filter((i: any) => i.type === 'Series');
     const episodeItems = group.items.filter((i: any) => i.type !== 'Series');
@@ -358,6 +407,10 @@ export function createGroupCard(group: any): HTMLElement {
         const posterLink = card.querySelector<HTMLElement>('.jc-hidden-group-poster-link');
         const baseMediaType = mainItem.type === 'Series' ? 'tv' : 'movie';
         const openSeerr = (e?: Event): void => {
+            if (!isPageFenceCurrent(fence)) {
+                e?.preventDefault();
+                return;
+            }
             const id = tmdbId || (posterLink && posterLink.dataset.resolvedTmdbId);
             if (!id) return;
             const mediaType = tmdbId ? baseMediaType : (posterLink!.dataset.resolvedMediaType || 'tv');
@@ -413,6 +466,7 @@ export function createGroupCard(group: any): HTMLElement {
  * @returns The section element.
  */
 export function createSection(titleKey: string, content: HTMLElement, options: { expandable?: boolean } = {}): HTMLElement {
+    const fence = capturePageFence();
     const section = document.createElement('div');
     section.className = 'jc-hidden-group-section';
 
@@ -431,6 +485,7 @@ export function createSection(titleKey: string, content: HTMLElement, options: {
         let allExpanded = false;
 
         toggleBtn.addEventListener('click', () => {
+            if (!isPageFenceCurrent(fence)) return;
             allExpanded = !allExpanded;
             toggleBtn.textContent = allExpanded
                 ? JC.t!('hidden_content_collapse_all')

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content-page/identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content-page/identity.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+import type { IdentityContext } from '../../types/jc';
+import { maybeInitAdminFilter, openAdminAddModal } from './admin';
+import { createGroupCard } from './cards';
+import { state } from './state';
+
+const originalApi = JC.core.api;
+
+function startSession(serverId = 'server-a', userId = 'user-a'): IdentityContext {
+    JC.identity.transition('', '', 'test-logout');
+    return JC.identity.transition(serverId, userId, 'test-login')!;
+}
+
+describe('hidden-content page identity lifecycle', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        document.body.innerHTML = '';
+        JC.t = (key: string) => key;
+        startSession();
+        JC.currentSettings = { isAdmin: true };
+    });
+
+    afterEach(() => {
+        JC.identity.transition('', '', 'test-cleanup');
+        JC.core.api = originalApi;
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+        document.body.innerHTML = '';
+    });
+
+    it('does not let a held A admin-list fetch publish or clear B loading state', async () => {
+        let resolveA!: (value: unknown[]) => void;
+        const heldA = new Promise<unknown[]>((resolve) => { resolveA = resolve; });
+        const fetchUsers = vi.fn()
+            .mockReturnValueOnce(heldA)
+            .mockResolvedValueOnce([{ userId: 'b-child', userName: 'B child', count: 1 }]);
+        JC.hiddenContent = { fetchHiddenContentUsers: fetchUsers } as unknown as NonNullable<typeof JC.hiddenContent>;
+
+        const loadA = maybeInitAdminFilter();
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(fetchUsers).toHaveBeenCalledTimes(1);
+
+        JC.identity.transition('server-b', 'user-b', 'account-switch');
+        JC.currentSettings = { isAdmin: true };
+        const loadB = maybeInitAdminFilter();
+        await loadB;
+        expect(state.adminUsers).toEqual([{ userId: 'b-child', userName: 'B child', count: 1 }]);
+
+        resolveA([{ userId: 'a-child', userName: 'A child', count: 9 }]);
+        await loadA;
+
+        expect(state.adminUsers).toEqual([{ userId: 'b-child', userName: 'B child', count: 1 }]);
+        expect(state.adminUsersLoading).toBe(false);
+    });
+
+    it('cancels an A unhide fade and rejects retained A controls after B activates', async () => {
+        const unhideItem = vi.fn();
+        JC.hiddenContent = { unhideItem } as unknown as NonNullable<typeof JC.hiddenContent>;
+        const card = createGroupCard({
+            seriesName: 'A show',
+            seriesId: 'series-a',
+            items: [{ _key: 'series-a', itemId: 'series-a', name: 'A show', type: 'Series' }],
+        });
+        document.body.appendChild(card);
+
+        const retainedUnhide = card.querySelector<HTMLButtonElement>('.jc-hidden-group-unhide')!;
+        retainedUnhide.click();
+        const retainedConfirm = document.querySelector<HTMLButtonElement>('.jc-hide-confirm-hide')!;
+        retainedConfirm.click();
+
+        JC.identity.transition('server-b', 'user-b', 'account-switch');
+        retainedUnhide.click();
+        retainedConfirm.click();
+        await vi.runAllTimersAsync();
+
+        expect(unhideItem).not.toHaveBeenCalled();
+        expect(document.querySelector('.jc-hide-confirm-overlay')).toBeNull();
+        expect(state.adminIsAdmin).toBeNull();
+    });
+
+    it('closes the admin add modal and discards a held A search response', async () => {
+        let resolveSearch!: (value: unknown) => void;
+        const heldSearch = new Promise((resolve) => { resolveSearch = resolve; });
+        const fetch = vi.fn().mockReturnValue(heldSearch);
+        JC.core.api = { fetch } as unknown as NonNullable<typeof JC.core.api>;
+        state.selectedAdminUserId = 'target-a';
+        state.adminUserName = 'Target A';
+        state.adminItems = [];
+
+        openAdminAddModal();
+        const retainedInput = document.querySelector<HTMLInputElement>('.jc-hidden-admin-add-overlay input')!;
+        retainedInput.value = 'Alien';
+        retainedInput.dispatchEvent(new Event('input'));
+        await vi.advanceTimersByTimeAsync(300);
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(document.body.style.overflow).toBe('hidden');
+
+        JC.identity.transition('server-b', 'user-b', 'account-switch');
+        expect(document.querySelector('.jc-hidden-admin-add-overlay')).toBeNull();
+        expect(document.body.style.overflow).toBe('');
+
+        resolveSearch({ Items: [{ Id: 'a-item', Name: 'A result', Type: 'Movie' }] });
+        await Promise.resolve();
+        await Promise.resolve();
+        retainedInput.dispatchEvent(new Event('input'));
+        await vi.runAllTimersAsync();
+
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(document.body.textContent).not.toContain('A result');
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content-page/page.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content-page/page.test.ts
@@ -72,6 +72,7 @@ describe('onHide full state reset', () => {
         state.adminUserName = 'Bob';
         state.adminUsers = [{ userId: 'user-1', userName: 'Bob', count: 3 }];
         state.adminUsersLoading = true;
+        state.adminIsAdmin = true;
         const tokenBefore = state.adminLoadToken;
 
         descriptor.onHide!();
@@ -86,6 +87,7 @@ describe('onHide full state reset', () => {
         expect(state.adminUserName).toBe('');
         expect(state.adminUsers).toBeNull();
         expect(state.adminUsersLoading).toBe(false);
+        expect(state.adminIsAdmin).toBeNull();
         // Invalidates any in-flight cross-user fetch.
         expect(state.adminLoadToken).toBe(tokenBefore + 1);
     });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content-page/page.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content-page/page.ts
@@ -15,7 +15,12 @@ import { registerPage } from '../pages/registry';
 import { openPage } from '../pages/router-bridge';
 import { injectStyles } from './styles';
 import { renderPage, setActiveContainer } from './render';
-import { state } from './state';
+import {
+    capturePageFence,
+    resetHiddenContentPageState,
+    schedulePageTimeout,
+    state,
+} from './state';
 import type { PageContext } from '../pages/types';
 
 function render({ host, handle }: PageContext): void {
@@ -23,6 +28,8 @@ function render({ host, handle }: PageContext): void {
 
     const content = document.createElement('div');
     content.setAttribute('data-role', 'content');
+    content.dataset.jcIdentityOwned = 'true';
+    content.dataset.jcHiddenPageOwner = 'true';
     const primary = document.createElement('div');
     primary.className = 'content-primary jc-hidden-content-page';
     const container = document.createElement('div');
@@ -39,6 +46,15 @@ function render({ host, handle }: PageContext): void {
 
     setActiveContainer(container);
     handle.track(() => setActiveContainer(null));
+
+    // Identity activation re-adopts a still-mounted route before Stage 6
+    // recreates JC.hiddenContent. Retry exactly once on the next task; Stage 6
+    // is synchronous after activation, and the page-owned timer drains if the
+    // route/account changes first.
+    if (!JC.hiddenContent) {
+        const fence = capturePageFence();
+        schedulePageTimeout(() => renderPage(), 0, fence);
+    }
 
     // Repaint on the user's own hidden-content changes. Registered through the
     // per-adoption dispose bag so it drains with the page — no permanent window
@@ -71,17 +87,7 @@ function render({ host, handle }: PageContext): void {
  * has been left; clearing adminUsersLoading frees the next open to re-fetch.
  */
 function onHide(): void {
-    state.searchQuery = '';
-    state.adminLoadToken++;
-    state.selectedAdminUserId = null;
-    state.adminEditMode = false;
-    state.adminItems = null;
-    state.adminItemsUserId = null;
-    state.adminLoadError = false;
-    state.adminUserName = '';
-    state.scopedOnly = false;
-    state.adminUsers = null;
-    state.adminUsersLoading = false;
+    resetHiddenContentPageState();
 }
 
 registerPage({

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content-page/render.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content-page/render.ts
@@ -8,7 +8,14 @@
 
 import { JC } from '../../globals';
 import { isCssColor } from '../../core/css-safe';
-import { state, scopeBadgeText, showUnhideConfirmation } from './state';
+import {
+    capturePageFence,
+    isPageFenceCurrent,
+    schedulePageTimeout,
+    state,
+    scopeBadgeText,
+    showUnhideConfirmation,
+} from './state';
 import {
     handleUnhide, handleUnhideMany, maybeInitAdminFilter, onAdminUserChange,
     toOpaqueColor, applyAdminThemeVars, createAdminViewingBadge,
@@ -255,8 +262,11 @@ export function setActiveContainer(container: HTMLElement | null): void {
  * DOM). Called on adoption and whenever hidden content changes.
  */
 export function renderPage(): void {
+    const fence = capturePageFence();
+    if (!isPageFenceCurrent(fence)) return;
     const container = activeContainer;
     if (!container || !container.isConnected) return;
+    if (!JC.hiddenContent) return;
 
     // Publish theme colours so the admin controls follow the active theme (Purple Haze, etc.).
     applyAdminThemeVars(container);
@@ -330,15 +340,17 @@ export function renderPage(): void {
     // defer to the next tick so the native picker fully tears down before the element is replaced.
     if (toolbar.adminUserSelect) {
         toolbar.adminUserSelect.addEventListener('change', (e) => {
+            if (!isPageFenceCurrent(fence)) return;
             const value = (e.target as HTMLSelectElement).value;
             try { (e.target as HTMLSelectElement).blur(); } catch (_) {}
-            setTimeout(function () { void onAdminUserChange(value); }, 0);
+            schedulePageTimeout(() => { void onAdminUserChange(value); }, 0, fence);
         });
     }
 
     // Wire the admin edit-mode toggle: flips read-only ↔ editable for the viewed user.
     if (toolbar.adminEditToggle) {
         toolbar.adminEditToggle.addEventListener('click', () => {
+            if (!isPageFenceCurrent(fence)) return;
             state.adminEditMode = !state.adminEditMode;
             renderPage();
         });
@@ -346,7 +358,9 @@ export function renderPage(): void {
 
     // Wire the admin "add items" button: opens the library-search modal.
     if (toolbar.adminAddBtn) {
-        toolbar.adminAddBtn.addEventListener('click', () => openAdminAddModal());
+        toolbar.adminAddBtn.addEventListener('click', () => {
+            if (isPageFenceCurrent(fence)) openAdminAddModal();
+        });
     }
 
     // Apply scoped filter — only show items hidden from Next Up / CW
@@ -374,7 +388,9 @@ export function renderPage(): void {
             // Load failed — show a retry affordance rather than a misleading "empty".
             emptyDiv.textContent = JC.t!('hidden_content_admin_load_error');
             emptyDiv.style.cursor = 'pointer';
-            emptyDiv.addEventListener('click', () => void onAdminUserChange(state.selectedAdminUserId!));
+            emptyDiv.addEventListener('click', () => {
+                if (isPageFenceCurrent(fence)) void onAdminUserChange(state.selectedAdminUserId!);
+            });
         } else if (viewingOther && !adminReady) {
             // Another user's items are still loading — show a loading hint rather than "empty".
             emptyDiv.textContent = JC.t!('hidden_content_admin_loading');
@@ -398,6 +414,7 @@ export function renderPage(): void {
 
     // Attach search handler
     toolbar.searchInput.addEventListener('input', () => {
+        if (!isPageFenceCurrent(fence)) return;
         state.searchQuery = toolbar.searchInput.value;
         renderPage();
     });
@@ -410,6 +427,7 @@ export function renderPage(): void {
 
     // Attach scoped filter toggle
     toolbar.scopedToggle.addEventListener('click', () => {
+        if (!isPageFenceCurrent(fence)) return;
         state.scopedOnly = !state.scopedOnly;
         renderPage();
 
@@ -431,7 +449,9 @@ export function renderPage(): void {
         toolbar.unhideAllBtn.style.display = 'none';
     } else {
         toolbar.unhideAllBtn.addEventListener('click', () => {
+            if (!isPageFenceCurrent(fence)) return;
             showUnhideConfirmation(JC.t!('hidden_content_clear_confirm') || 'Unhide all items?', () => {
+                if (!isPageFenceCurrent(fence)) return;
                 if (viewingOther) {
                     handleUnhideMany((state.adminItems || []).map((it) => it._key || it.itemId));
                 } else {
@@ -464,14 +484,17 @@ function stripUnhideControls(container: HTMLElement): void {
  * @param item The hidden item data.
  */
 function attachUnhideHandler(card: HTMLElement, item: any): void {
+    const fence = capturePageFence();
     const unhideBtn = card.querySelector('.jc-hidden-item-unhide');
     if (unhideBtn) {
         unhideBtn.addEventListener('click', () => {
+            if (!isPageFenceCurrent(fence)) return;
             showUnhideConfirmation(JC.t!('hidden_content_unhide_confirm') || 'Unhide this item?', () => {
+                if (!isPageFenceCurrent(fence)) return;
                 card.classList.add('jc-hidden-item-removing');
-                setTimeout(() => {
+                schedulePageTimeout(() => {
                     handleUnhide(item._key || item.itemId);
-                }, 300);
+                }, 300, fence);
             }, item.name || 'this item');
         });
     }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content-page/state.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content-page/state.ts
@@ -9,6 +9,7 @@
 
 import { JC } from '../../globals';
 import { currentPageHandle } from '../pages/fallback-host';
+import type { IdentityContext } from '../../types/jc';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -56,6 +57,76 @@ export const state: HiddenContentPageState = {
     adminLoadToken: 0,           // increments per fetch so stale responses are ignored
 };
 
+/** Owner captured by page controls, requests, and delayed UI work. */
+export interface HiddenContentPageFence {
+    readonly generation: number;
+    readonly context: IdentityContext | null;
+}
+
+let pageGeneration = 0;
+const pageTimeouts = new Set<number>();
+let activeUnhideClose: (() => void) | null = null;
+
+export function capturePageFence(): HiddenContentPageFence {
+    return {
+        generation: pageGeneration,
+        context: JC.identity?.capture?.() || null,
+    };
+}
+
+export function isPageFenceCurrent(fence: HiddenContentPageFence): boolean {
+    return fence.generation === pageGeneration
+        && (!fence.context || JC.identity.isCurrent(fence.context));
+}
+
+/** Schedule page-owned delayed work and discard it on drain/account switch. */
+export function schedulePageTimeout(
+    callback: () => void,
+    delay: number,
+    fence: HiddenContentPageFence = capturePageFence(),
+): number {
+    const handle = window.setTimeout(() => {
+        pageTimeouts.delete(handle);
+        if (isPageFenceCurrent(fence)) callback();
+    }, delay);
+    pageTimeouts.add(handle);
+    return handle;
+}
+
+export function cancelPageTimeout(handle: number | null): void {
+    if (handle == null) return;
+    clearTimeout(handle);
+    pageTimeouts.delete(handle);
+}
+
+/**
+ * Drain every identity/adoption-owned page resource and reset all view state.
+ * The generation bump fences promises that cannot be physically cancelled.
+ */
+export function resetHiddenContentPageState(): void {
+    pageGeneration += 1;
+    for (const handle of pageTimeouts) clearTimeout(handle);
+    pageTimeouts.clear();
+    activeUnhideClose?.();
+    activeUnhideClose = null;
+    document.querySelectorAll('[data-jc-hidden-page-owner="true"]').forEach((node) => node.remove());
+
+    state.searchQuery = '';
+    state.adminLoadToken += 1;
+    state.adminIsAdmin = null;
+    state.selectedAdminUserId = null;
+    state.adminEditMode = false;
+    state.adminItems = null;
+    state.adminItemsUserId = null;
+    state.adminLoadError = false;
+    state.adminUserName = '';
+    state.scopedOnly = false;
+    state.adminUsers = null;
+    state.adminUsersLoading = false;
+}
+
+JC.identity?.registerReset?.('hidden-content-page-state', resetHiddenContentPageState);
+
 export function scopeBadgeText(scope: string | undefined): string {
     const s = (scope || '').toLowerCase();
     if (s === 'continuewatching') return JC.t!('hidden_content_scope_cw_label');
@@ -82,10 +153,14 @@ export const POSTER_MAX_WIDTH = 300;
  * @param itemName Optional item name to show below the heading.
  */
 export function showUnhideConfirmation(message: string, onConfirm: () => void, itemName?: string): void {
-    document.querySelector('.jc-hide-confirm-overlay')?.remove();
+    const fence = capturePageFence();
+    if (!isPageFenceCurrent(fence)) return;
+    activeUnhideClose?.();
 
     const overlay = document.createElement('div');
     overlay.className = 'jc-hide-confirm-overlay';
+    overlay.dataset.jcIdentityOwned = 'true';
+    const pageHandle = currentPageHandle();
 
     const dialog = document.createElement('div');
     dialog.className = 'jc-hide-confirm-dialog';
@@ -103,7 +178,10 @@ export function showUnhideConfirmation(message: string, onConfirm: () => void, i
     const closeDialog = (): void => {
         overlay.remove();
         document.removeEventListener('keydown', escHandler);
+        pageHandle?.untrack(closeDialog);
+        if (activeUnhideClose === closeDialog) activeUnhideClose = null;
     };
+    activeUnhideClose = closeDialog;
 
     const buttons = document.createElement('div');
     buttons.className = 'jc-hide-confirm-buttons';
@@ -119,7 +197,7 @@ export function showUnhideConfirmation(message: string, onConfirm: () => void, i
     confirmBtn.textContent = JC.t!('hidden_content_unhide') || 'Unhide';
     confirmBtn.addEventListener('click', () => {
         closeDialog();
-        onConfirm();
+        if (isPageFenceCurrent(fence)) onConfirm();
     });
     buttons.appendChild(confirmBtn);
 
@@ -138,5 +216,5 @@ export function showUnhideConfirmation(message: string, onConfirm: () => void, i
     document.body.appendChild(overlay);
     // Body-level overlay: navigating away must never strand it — the page's
     // dispose bag closes it on drain (closeDialog is idempotent).
-    currentPageHandle()?.track(closeDialog);
+    pageHandle?.track(closeDialog);
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/buttons.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/buttons.ts
@@ -10,6 +10,40 @@ import { hiddenIdSet, getSettings, hideItem, unhideItem } from './data';
 import type { HideItemParams } from './data';
 import { getCardSurface, getCardItemId } from './filter';
 import { confirmAndHide } from './dialogs';
+import type { IdentityContext } from '../../types/jc';
+
+interface ButtonFence {
+    readonly generation: number;
+    readonly context: IdentityContext | null;
+}
+
+let buttonGeneration = 0;
+
+function captureButtonFence(): ButtonFence {
+    return { generation: buttonGeneration, context: JC.identity?.capture?.() || null };
+}
+
+function isButtonFenceCurrent(fence: ButtonFence): boolean {
+    return fence.generation === buttonGeneration
+        && (!fence.context || JC.identity.isCurrent(fence.context));
+}
+
+function removeButtonsAndRestorePosition(): void {
+    document.querySelectorAll<HTMLElement>('.jc-hide-btn').forEach((btn) => {
+        const cardBox = btn.parentElement;
+        if (cardBox && btn.dataset.jcHidePreviousPosition !== undefined) {
+            cardBox.style.position = btn.dataset.jcHidePreviousPosition;
+        }
+        btn.remove();
+    });
+}
+
+function resetButtonUi(): void {
+    buttonGeneration += 1;
+    removeButtonsAndRestorePosition();
+}
+
+JC.identity?.registerReset?.('hidden-content-buttons', resetButtonUi);
 
 // ============================================================
 // Library hide buttons
@@ -23,8 +57,12 @@ import { confirmAndHide } from './dialogs';
  * @param itemId The Jellyfin item ID.
  */
 function createLibraryHideButton(cardBox: HTMLElement, card: HTMLElement, itemId: string, isPerson: boolean): void {
+    const fence = captureButtonFence();
+    if (!isButtonFenceCurrent(fence)) return;
+    const previousPosition = cardBox.style.position;
     cardBox.style.position = 'relative';
     const btn = document.createElement('button');
+    btn.dataset.jcHidePreviousPosition = previousPosition;
 
     const hideLabel = JC.t!('hidden_content_hide_button') !== 'hidden_content_hide_button' ? JC.t!('hidden_content_hide_button') : 'Hide';
     const hiddenLabel = JC.t!('hidden_content_already_hidden') !== 'hidden_content_already_hidden' ? JC.t!('hidden_content_already_hidden') : 'Hidden';
@@ -45,6 +83,7 @@ function createLibraryHideButton(cardBox: HTMLElement, card: HTMLElement, itemId
 
     /** Configures the button for "already hidden" state — click to unhide. */
     function setHiddenState(): void {
+        if (!isButtonFenceCurrent(fence)) return;
         btn.className = 'jc-hide-btn jc-already-hidden';
         btn.title = hiddenLabel;
         renderIcon('visibility_off');
@@ -53,6 +92,7 @@ function createLibraryHideButton(cardBox: HTMLElement, card: HTMLElement, itemId
         btn.onclick = (e) => {
             e.preventDefault();
             e.stopPropagation();
+            if (!isButtonFenceCurrent(fence)) return;
             unhideItem(itemId);
             setHideState();
         };
@@ -60,6 +100,7 @@ function createLibraryHideButton(cardBox: HTMLElement, card: HTMLElement, itemId
 
     /** Configures the button for "visible" state — click to hide. */
     function setHideState(): void {
+        if (!isButtonFenceCurrent(fence)) return;
         btn.className = 'jc-hide-btn';
         btn.title = hideLabel;
         renderIcon('visibility');
@@ -69,16 +110,18 @@ function createLibraryHideButton(cardBox: HTMLElement, card: HTMLElement, itemId
             void (async () => {
                 e.preventDefault();
                 e.stopPropagation();
+                if (!isButtonFenceCurrent(fence)) return;
 
                 const cardName = card.querySelector('.cardText')?.textContent || '';
                 const surface = getCardSurface(card);
 
                 if (surface === 'nextup' || surface === 'continuewatching') {
-                    await handleScopedCardHide(card, itemId, cardName, surface, setHiddenState);
+                    await handleScopedCardHide(card, itemId, cardName, surface, setHiddenState, fence);
                 } else {
                     const itemData: HideItemParams = { itemId, name: cardName };
                     if (isPerson) itemData.type = 'Person';
                     confirmAndHide(itemData, () => {
+                        if (!isButtonFenceCurrent(fence)) return;
                         card.classList.add('jc-hidden');
                     });
                 }
@@ -103,7 +146,15 @@ function createLibraryHideButton(cardBox: HTMLElement, card: HTMLElement, itemId
  * @param surface The detected surface ('nextup' or 'continuewatching').
  * @param setHiddenState Callback to switch the button to "hidden" state.
  */
-async function handleScopedCardHide(card: HTMLElement, itemId: string, cardName: string, surface: string, setHiddenState: () => void): Promise<void> {
+async function handleScopedCardHide(
+    card: HTMLElement,
+    itemId: string,
+    cardName: string,
+    surface: string,
+    setHiddenState: () => void,
+    fence: ButtonFence,
+): Promise<void> {
+    if (!isButtonFenceCurrent(fence)) return;
     const itemData: HideItemParams = { itemId, name: cardName };
     // Pass surface through so the hideScope stays bound to the row the user clicked.
     const dialogOpts: {
@@ -116,6 +167,7 @@ async function handleScopedCardHide(card: HTMLElement, itemId: string, cardName:
     try {
         const userId = ApiClient.getCurrentUserId();
         const item: any = await getItemCached(itemId, { userId });
+        if (!isButtonFenceCurrent(fence)) return;
         const itemType = item?.Type || '';
         const seriesId = item?.SeriesId || '';
         const seriesName = item?.SeriesName || '';
@@ -131,18 +183,23 @@ async function handleScopedCardHide(card: HTMLElement, itemId: string, cardName:
         if ((itemType === 'Episode' || itemType === 'Season') && seriesId) {
             dialogOpts.showEpisodeChoice = true;
             dialogOpts.onChooseScoped = () => {
+                if (!isButtonFenceCurrent(fence)) return;
                 hideItem({ ...itemData, hideScope: surface });
                 card.classList.add('jc-hidden');
             };
             dialogOpts.onChooseShow = () => {
                 void (async () => {
+                    if (!isButtonFenceCurrent(fence)) return;
                     let seriesTmdbId = '';
                     try {
                         const series: any = await getItemCached(seriesId, { userId });
+                        if (!isButtonFenceCurrent(fence)) return;
                         seriesTmdbId = series?.ProviderIds?.Tmdb || '';
                     } catch (err) {
+                        if (!isButtonFenceCurrent(fence)) return;
                         console.warn('🪼 Jellyfin Canopy: Failed to fetch series TMDB ID', err);
                     }
+                    if (!isButtonFenceCurrent(fence)) return;
                     hideItem({
                         itemId: seriesId,
                         name: seriesName || cardName,
@@ -154,19 +211,24 @@ async function handleScopedCardHide(card: HTMLElement, itemId: string, cardName:
             };
         } else {
             dialogOpts.onChooseScoped = () => {
+                if (!isButtonFenceCurrent(fence)) return;
                 hideItem({ ...itemData, hideScope: surface });
                 card.classList.add('jc-hidden');
             };
         }
     } catch (err) {
+        if (!isButtonFenceCurrent(fence)) return;
         console.warn('🪼 Jellyfin Canopy: Failed to fetch item data for scoped hide', err);
         dialogOpts.onChooseScoped = () => {
+            if (!isButtonFenceCurrent(fence)) return;
             hideItem({ itemId, name: cardName, hideScope: surface });
             card.classList.add('jc-hidden');
         };
     }
 
+    if (!isButtonFenceCurrent(fence)) return;
     confirmAndHide(itemData, () => {
+        if (!isButtonFenceCurrent(fence)) return;
         card.classList.add('jc-hidden');
     }, dialogOpts);
 }
@@ -177,6 +239,8 @@ async function handleScopedCardHide(card: HTMLElement, itemId: string, cardName:
  * Skips cards that already have a `.jc-hide-btn` to avoid duplicates.
  */
 export function addLibraryHideButtons(): void {
+    const fence = captureButtonFence();
+    if (!isButtonFenceCurrent(fence)) return;
     const s = getSettings();
     if (!s.enabled || !s.showHideButtons) return;
     // At least one of library or cast buttons must be enabled
@@ -186,6 +250,7 @@ export function addLibraryHideButtons(): void {
 
     const cards = document.querySelectorAll<HTMLElement>('.card[data-id] .cardBox, .card[data-itemid] .cardBox');
     for (let i = 0; i < cards.length; i++) {
+        if (!isButtonFenceCurrent(fence)) return;
         const cardBox = cards[i];
         if (cardBox.querySelector('.jc-hide-btn')) continue;
 
@@ -227,8 +292,5 @@ export function addLibraryHideButtons(): void {
  * Called when the `showButtonLibrary` setting is toggled off.
  */
 export function removeLibraryHideButtons(): void {
-    const btns = document.querySelectorAll('.card[data-id] .jc-hide-btn, .card[data-itemid] .jc-hide-btn');
-    for (let i = 0; i < btns.length; i++) {
-        btns[i].remove();
-    }
+    resetButtonUi();
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/data.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/data.ts
@@ -6,6 +6,7 @@
 // (Converted from js/enhanced/hidden-content-data.js — bodies semantically identical.)
 
 import { JC } from '../../globals';
+import type { IdentityContext } from '../../types/jc';
 // Cross-module references (defined in the later-loaded
 // hidden-content-save/dialogs/filter modules) — call-time only, so the
 // import cycles are safe.
@@ -71,6 +72,49 @@ export const hiddenIdSet = new Set<string>();
 const hiddenTmdbIdSet = new Set<string>();
 let hiddenData: HiddenContentData | null = null;
 
+function emptyHiddenData(): HiddenContentData {
+    return { items: {}, settings: {} };
+}
+
+function contextFor(data: HiddenContentData): IdentityContext | null {
+    const owner = JC.identity?.ownerOf?.(data) || null;
+    return owner && JC.identity.isCurrent(owner) ? owner : null;
+}
+
+/** Publish a replacement only while its captured owner is still current. */
+function replaceHiddenData(data: HiddenContentData, context: IdentityContext): boolean {
+    if (!JC.identity.isCurrent(context)) return false;
+    const userConfig = JC.userConfig;
+    if (!userConfig) return false;
+    const configOwner = JC.identity.ownerOf(userConfig);
+    if (configOwner && !JC.identity.isOwned(userConfig, context)) return false;
+    if (!configOwner) JC.identity.own(userConfig, context);
+
+    hiddenData = JC.identity.own(data, context);
+    userConfig.hiddenContent = hiddenData;
+    return true;
+}
+
+function commitHiddenData(data: HiddenContentData, previous: HiddenContentData): boolean {
+    const context = contextFor(previous);
+    if (context) return replaceHiddenData(data, context);
+    // Preserve the legacy/test-only no-session behaviour, but fail closed when
+    // an active identity exists and the previous blob was not owned by it.
+    if (JC.identity?.capture?.()) return false;
+    hiddenData = data;
+    JC.userConfig = JC.userConfig || {};
+    JC.userConfig.hiddenContent = hiddenData;
+    return true;
+}
+
+function clearIdentityData(): void {
+    hiddenData = null;
+    hiddenIdSet.clear();
+    hiddenTmdbIdSet.clear();
+}
+
+JC.identity?.registerReset?.('hidden-content-data', clearIdentityData);
+
 // ============================================================
 // Internal helpers
 // ============================================================
@@ -80,9 +124,27 @@ let hiddenData: HiddenContentData | null = null;
  * from `JC.userConfig.hiddenContent`.
  */
 export function getHiddenData(): HiddenContentData {
-    if (!hiddenData) {
-        hiddenData = (JC.userConfig?.hiddenContent as HiddenContentData | undefined) || { items: {}, settings: {} };
+    if (hiddenData) {
+        const owner = JC.identity?.ownerOf?.(hiddenData) || null;
+        if (!owner || JC.identity.isCurrent(owner)) return hiddenData;
+        hiddenData = null;
     }
+
+    const context = JC.identity?.capture?.() || null;
+    const configured = JC.userConfig?.hiddenContent as HiddenContentData | undefined;
+    if (!context) {
+        hiddenData = configured || emptyHiddenData();
+        return hiddenData;
+    }
+
+    // Never adopt an owner-tagged object from A. Unowned values are accepted
+    // only as the freshly loaded value for the current initialization and are
+    // immediately tagged before they can reach a save path.
+    const configuredOwner = JC.identity.ownerOf(configured);
+    hiddenData = configuredOwner && !JC.identity.isOwned(configured, context)
+        ? emptyHiddenData()
+        : (configured || emptyHiddenData());
+    JC.identity.own(hiddenData, context);
     return hiddenData;
 }
 
@@ -191,18 +253,28 @@ export function emitChange(): void {
 
 // Re-fetch from server and replace local cache. Don't call immediately after a server-direct write from THIS tab — use markScopedHidden().
 export async function refresh(): Promise<boolean> {
+    const context = JC.identity?.capture?.() || null;
+    if (context && !JC.identity.isCurrent(context)) return false;
     try {
-        const userId = ApiClient.getCurrentUserId();
+        const userId = context?.userId || ApiClient.getCurrentUserId();
         if (!userId) return false;
         const fresh = await ApiClient.ajax({
             type: 'GET',
             url: ApiClient.getUrl(`/JellyfinCanopy/user-settings/${userId}/hidden-content.json?_=${Date.now()}`),
             dataType: 'json'
         });
+        if (context && !JC.identity.isCurrent(context)) return false;
         const camelCased = (typeof (JC as any).toCamelCase === 'function') ? (JC as any).toCamelCase(fresh) : fresh;
-        JC.userConfig = JC.userConfig || {};
-        JC.userConfig.hiddenContent = camelCased || { items: {}, settings: {} };
-        hiddenData = JC.userConfig.hiddenContent as HiddenContentData;
+        const next = camelCased && typeof camelCased === 'object'
+            ? camelCased as HiddenContentData
+            : emptyHiddenData();
+        if (context) {
+            if (!replaceHiddenData(next, context)) return false;
+        } else {
+            JC.userConfig = JC.userConfig || {};
+            JC.userConfig.hiddenContent = next;
+            hiddenData = next;
+        }
         rebuildSets();
         emitChange();
         return true;
@@ -279,9 +351,7 @@ export function markScopedHidden(itemId: string, scope?: string): void {
     const nextItems = { ...items, [itemId]: merged };
     if (hyphenated !== itemId) delete nextItems[hyphenated];
     if (noHyphen !== itemId) delete nextItems[noHyphen];
-    hiddenData = { ...data, items: nextItems };
-    JC.userConfig = JC.userConfig || {};
-    JC.userConfig.hiddenContent = hiddenData;
+    if (!commitHiddenData({ ...data, items: nextItems }, data)) return;
     rebuildSets();
     emitChange();
 }
@@ -361,11 +431,11 @@ export function hideItem({ itemId, name, type, tmdbId, posterPath, seriesId, ser
         hideScope: hideScope || 'global'
     };
 
-    hiddenData = {
+    const nextData: HiddenContentData = {
         ...data,
         items: { ...data.items, [key]: newItem }
     };
-    JC.userConfig!.hiddenContent = hiddenData;
+    if (!commitHiddenData(nextData, data)) return;
     rebuildSets();
     debouncedSave();
     emitChange();
@@ -396,8 +466,7 @@ export function unhideItem(itemId: string): void {
         }
     }
 
-    hiddenData = { ...data, items: newItems };
-    JC.userConfig!.hiddenContent = hiddenData;
+    if (!commitHiddenData({ ...data, items: newItems }, data)) return;
     rebuildSets();
     debouncedSave();
     emitChange();
@@ -416,11 +485,11 @@ export function unhideItem(itemId: string): void {
  */
 export function updateSettings(partial: Record<string, unknown>): void {
     const data = getHiddenData();
-    hiddenData = {
+    const nextData: HiddenContentData = {
         ...data,
         settings: { ...data.settings, ...partial }
     };
-    JC.userConfig!.hiddenContent = hiddenData;
+    if (!commitHiddenData(nextData, data)) return;
     debouncedSave();
     emitChange();
     refreshNativeCardVisibility();
@@ -515,8 +584,7 @@ export function filterRequestItems(items: any[]): any[] {
 export function unhideAll(): void {
     const oldHiddenIds = new Set(hiddenIdSet);
     const data = getHiddenData();
-    hiddenData = { ...data, items: {} };
-    JC.userConfig!.hiddenContent = hiddenData;
+    if (!commitHiddenData({ ...data, items: {} }, data)) return;
     rebuildSets();
     debouncedSave();
     emitChange();
@@ -530,6 +598,17 @@ export function unhideAll(): void {
  * that owns the hiddenData closure variable.
  */
 export function resetFromUserConfig(): void {
-    hiddenData = (JC.userConfig?.hiddenContent as HiddenContentData | undefined) || { items: {}, settings: {} };
+    const context = JC.identity?.capture?.() || null;
+    const configured = (JC.userConfig?.hiddenContent as HiddenContentData | undefined) || emptyHiddenData();
+    if (context) {
+        const owner = JC.identity.ownerOf(configured);
+        hiddenData = owner && !JC.identity.isOwned(configured, context)
+            ? emptyHiddenData()
+            : configured;
+        JC.identity.own(hiddenData, context);
+        if (JC.userConfig) JC.userConfig.hiddenContent = hiddenData;
+    } else {
+        hiddenData = configured;
+    }
     rebuildSets();
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/dialogs.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/dialogs.ts
@@ -7,6 +7,7 @@
 import { JC } from '../../globals';
 import { getSettings, hideItem, unhideItem } from './data';
 import type { HideItemParams } from './data';
+import type { IdentityContext } from '../../types/jc';
 
 /** Options customising the hide-confirmation dialog variants. */
 export interface HideDialogOptions {
@@ -27,6 +28,79 @@ const SUPPRESS_DURATION_MS = 15 * 60 * 1000;
 /** LocalStorage key for "don't ask again" suppression timestamp. */
 const SUPPRESS_STORAGE_KEY = 'jc_hide_confirm_suppressed_until';
 
+interface DialogFence {
+    readonly generation: number;
+    readonly context: IdentityContext | null;
+}
+
+let dialogGeneration = 0;
+let activeUndoClose: (() => void) | null = null;
+let activeConfirmClose: (() => void) | null = null;
+const dialogTimeouts = new Set<number>();
+const dialogFrames = new Set<number>();
+
+function captureDialogFence(): DialogFence {
+    return {
+        generation: dialogGeneration,
+        context: JC.identity?.capture?.() || null,
+    };
+}
+
+function isDialogFenceCurrent(fence: DialogFence): boolean {
+    return fence.generation === dialogGeneration
+        && (!fence.context || JC.identity.isCurrent(fence.context));
+}
+
+function scheduleDialogTimeout(callback: () => void, delay: number): number {
+    const handle = window.setTimeout(() => {
+        dialogTimeouts.delete(handle);
+        callback();
+    }, delay);
+    dialogTimeouts.add(handle);
+    return handle;
+}
+
+function cancelDialogTimeout(handle: number | null): void {
+    if (handle == null) return;
+    clearTimeout(handle);
+    dialogTimeouts.delete(handle);
+}
+
+function scheduleDialogFrame(callback: () => void): number {
+    const handle = requestAnimationFrame(() => {
+        dialogFrames.delete(handle);
+        callback();
+    });
+    dialogFrames.add(handle);
+    return handle;
+}
+
+function cancelDialogFrame(handle: number | null): void {
+    if (handle == null) return;
+    cancelAnimationFrame(handle);
+    dialogFrames.delete(handle);
+}
+
+function resetDialogUi(): void {
+    dialogGeneration += 1;
+    activeUndoClose?.();
+    activeConfirmClose?.();
+    activeUndoClose = null;
+    activeConfirmClose = null;
+    for (const handle of dialogTimeouts) clearTimeout(handle);
+    for (const handle of dialogFrames) cancelAnimationFrame(handle);
+    dialogTimeouts.clear();
+    dialogFrames.clear();
+    document.querySelectorAll('.jc-undo-toast, .jc-hide-confirm-overlay').forEach((node) => node.remove());
+}
+
+JC.identity?.registerReset?.('hidden-content-dialogs', resetDialogUi);
+
+function suppressionStorageKey(context: IdentityContext | null): string {
+    if (!context) return SUPPRESS_STORAGE_KEY;
+    return `${SUPPRESS_STORAGE_KEY}:${encodeURIComponent(context.serverId)}:${encodeURIComponent(context.userId)}`;
+}
+
 // ============================================================
 // Undo toast
 // ============================================================
@@ -38,7 +112,9 @@ const SUPPRESS_STORAGE_KEY = 'jc_hide_confirm_suppressed_until';
  * @param itemId Storage key used to unhide if the user clicks Undo.
  */
 export function showUndoToast(itemName: string, itemId: string): void {
-    document.querySelectorAll('.jc-undo-toast').forEach(el => el.remove());
+    const fence = captureDialogFence();
+    if (!isDialogFenceCurrent(fence)) return;
+    activeUndoClose?.();
 
     const themeVars = JC.themer?.getThemeVariables?.() || {};
     const toastBg = themeVars.secondaryBg || 'linear-gradient(135deg, rgba(0,0,0,0.9), rgba(40,40,40,0.9))';
@@ -47,6 +123,7 @@ export function showUndoToast(itemName: string, itemId: string): void {
 
     const toast = document.createElement('div');
     toast.className = 'jc-undo-toast';
+    toast.dataset.jcIdentityOwned = 'true';
     Object.assign(toast.style, {
         background: toastBg,
         border: toastBorder,
@@ -67,21 +144,45 @@ export function showUndoToast(itemName: string, itemId: string): void {
         borderColor: accentColor
     });
     undoBtn.textContent = JC.t!('hidden_content_undo');
-    undoBtn.addEventListener('click', () => {
-        unhideItem(itemId);
+    let frameHandle: number | null = null;
+    let dismissHandle: number | null = null;
+    let removalHandle: number | null = null;
+    const dispose = (): void => {
+        cancelDialogFrame(frameHandle);
+        cancelDialogTimeout(dismissHandle);
+        cancelDialogTimeout(removalHandle);
+        frameHandle = null;
+        dismissHandle = null;
+        removalHandle = null;
+        toast.remove();
+        if (activeUndoClose === dispose) activeUndoClose = null;
+    };
+    const dismiss = (): void => {
+        if (!isDialogFenceCurrent(fence)) {
+            dispose();
+            return;
+        }
         toast.classList.remove('jc-visible');
-        setTimeout(() => toast.remove(), 300);
+        cancelDialogTimeout(removalHandle);
+        removalHandle = scheduleDialogTimeout(dispose, 300);
+    };
+    activeUndoClose = dispose;
+
+    undoBtn.addEventListener('click', () => {
+        if (!isDialogFenceCurrent(fence)) return;
+        unhideItem(itemId);
+        dismiss();
     });
     toast.appendChild(undoBtn);
 
     document.body.appendChild(toast);
-    requestAnimationFrame(() => toast.classList.add('jc-visible'));
-
-    setTimeout(() => {
-        if (toast.parentNode) {
-            toast.classList.remove('jc-visible');
-            setTimeout(() => toast.remove(), 300);
-        }
+    frameHandle = scheduleDialogFrame(() => {
+        frameHandle = null;
+        if (isDialogFenceCurrent(fence)) toast.classList.add('jc-visible');
+    });
+    dismissHandle = scheduleDialogTimeout(() => {
+        dismissHandle = null;
+        if (toast.parentNode) dismiss();
     }, UNDO_TOAST_DURATION);
 }
 
@@ -94,10 +195,13 @@ export function showUndoToast(itemName: string, itemId: string): void {
  * (either permanently via settings or temporarily via the 15-minute timer).
  * @returns `true` if the confirmation should be skipped.
  */
-function isConfirmationSuppressed(): boolean {
+function isConfirmationSuppressed(context: IdentityContext | null): boolean {
     const settings = getSettings();
     if (settings.showHideConfirmation === false) return true;
-    const until = localStorage.getItem(SUPPRESS_STORAGE_KEY);
+    // The legacy unscoped value must never flow into an authenticated session.
+    // Removing it is safer than guessing which server/user originally owned it.
+    if (context) localStorage.removeItem(SUPPRESS_STORAGE_KEY);
+    const until = localStorage.getItem(suppressionStorageKey(context));
     if (until && new Date(until) > new Date()) return true;
     return false;
 }
@@ -244,7 +348,7 @@ function createEpisodeChoiceButtons(closeDialog: () => void, onConfirm: () => vo
  * @param onConfirm Called when the user confirms hiding.
  * @returns A document fragment containing the options and buttons.
  */
-function createStandardConfirmButtons(closeDialog: () => void, onConfirm: () => void): DocumentFragment {
+function createStandardConfirmButtons(closeDialog: () => void, onConfirm: () => void, fence: DialogFence): DocumentFragment {
     const fragment = document.createDocumentFragment();
 
     const options = document.createElement('div');
@@ -271,9 +375,13 @@ function createStandardConfirmButtons(closeDialog: () => void, onConfirm: () => 
     hideBtn.className = 'jc-hide-confirm-hide';
     hideBtn.textContent = JC.t!('hidden_content_confirm_hide');
     hideBtn.addEventListener('click', () => {
+        if (!isDialogFenceCurrent(fence)) {
+            closeDialog();
+            return;
+        }
         if (suppress15Check.checked) {
             const until = new Date(Date.now() + SUPPRESS_DURATION_MS).toISOString();
-            localStorage.setItem(SUPPRESS_STORAGE_KEY, until);
+            localStorage.setItem(suppressionStorageKey(fence.context), until);
         }
         closeDialog();
         onConfirm();
@@ -292,10 +400,13 @@ function createStandardConfirmButtons(closeDialog: () => void, onConfirm: () => 
  * @param dialogOptions Options to customize the dialog.
  */
 function showHideConfirmation(itemName: string, onConfirm: () => void, dialogOptions: HideDialogOptions = {}): void {
-    document.querySelector('.jc-hide-confirm-overlay')?.remove();
+    const fence = captureDialogFence();
+    if (!isDialogFenceCurrent(fence)) return;
+    activeConfirmClose?.();
 
     const overlay = document.createElement('div');
     overlay.className = 'jc-hide-confirm-overlay';
+    overlay.dataset.jcIdentityOwned = 'true';
 
     const dialog = document.createElement('div');
     dialog.className = 'jc-hide-confirm-dialog';
@@ -322,14 +433,26 @@ function showHideConfirmation(itemName: string, onConfirm: () => void, dialogOpt
     const closeDialog = (): void => {
         overlay.remove();
         document.removeEventListener('keydown', escHandler);
+        if (activeConfirmClose === closeDialog) activeConfirmClose = null;
+    };
+    activeConfirmClose = closeDialog;
+
+    const guard = (callback: (() => void) | undefined): (() => void) | undefined => callback
+        ? () => { if (isDialogFenceCurrent(fence)) callback(); }
+        : undefined;
+    const guardedConfirm = guard(onConfirm)!;
+    const guardedOptions: HideDialogOptions = {
+        ...dialogOptions,
+        onChooseShow: guard(dialogOptions.onChooseShow),
+        onChooseScoped: guard(dialogOptions.onChooseScoped),
     };
 
     if (hasSurface) {
-        dialog.appendChild(createSurfaceDialogButtons(closeDialog, onConfirm, dialogOptions));
+        dialog.appendChild(createSurfaceDialogButtons(closeDialog, guardedConfirm, guardedOptions));
     } else if (hasEpisodeChoice) {
-        dialog.appendChild(createEpisodeChoiceButtons(closeDialog, onConfirm, dialogOptions));
+        dialog.appendChild(createEpisodeChoiceButtons(closeDialog, guardedConfirm, guardedOptions));
     } else {
-        dialog.appendChild(createStandardConfirmButtons(closeDialog, onConfirm));
+        dialog.appendChild(createStandardConfirmButtons(closeDialog, guardedConfirm, fence));
     }
 
     overlay.appendChild(dialog);
@@ -354,13 +477,16 @@ function showHideConfirmation(itemName: string, onConfirm: () => void, dialogOpt
  * @param dialogOptions Options passed to showHideConfirmation.
  */
 export function confirmAndHide(itemData: HideItemParams, onHidden?: (() => void) | null, dialogOptions: HideDialogOptions = {}): void {
-    if (!dialogOptions.showEpisodeChoice && !dialogOptions.surface && isConfirmationSuppressed()) {
+    const fence = captureDialogFence();
+    if (!isDialogFenceCurrent(fence)) return;
+    if (!dialogOptions.showEpisodeChoice && !dialogOptions.surface && isConfirmationSuppressed(fence.context)) {
         hideItem(itemData);
-        if (onHidden) onHidden();
+        if (isDialogFenceCurrent(fence) && onHidden) onHidden();
         return;
     }
     showHideConfirmation(itemData.name || 'Item', () => {
+        if (!isDialogFenceCurrent(fence)) return;
         hideItem(itemData);
-        if (onHidden) onHidden();
+        if (isDialogFenceCurrent(fence) && onHidden) onHidden();
     }, dialogOptions);
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/filter.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/filter.ts
@@ -13,12 +13,57 @@ import { JC } from '../../globals';
 import { debounce } from '../helpers';
 import { onViewPage } from '../../core/navigation';
 import { onBodyMutation } from '../../core/dom-observer';
+import type { BodySubscriberHandle, IdentityContext } from '../../types/jc';
 import { hiddenIdSet, getSettings, shouldFilterSurface, shouldProcessNativeSurface, getHiddenData, getHiddenCount } from './data';
 import { addLibraryHideButtons } from './buttons';
 
 const parentSeriesCache = new Map<string, string | null>();
 const parentSeriesRequestMap = new Map<string, Promise<string | null>>();
-const sectionSurfaceCache = new WeakMap<Element, string | null>();
+let sectionSurfaceCache = new WeakMap<Element, string | null>();
+let filterGeneration = 0;
+let viewPageUnsubscribe: (() => void) | null = null;
+let bodyMutationHandle: BodySubscriberHandle | null = null;
+const detailRescanHandles = new Set<number>();
+
+interface FilterFence {
+    generation: number;
+    context: IdentityContext | null;
+}
+
+function captureFilterFence(): FilterFence {
+    return { generation: filterGeneration, context: JC.identity?.capture?.() || null };
+}
+
+function isFilterFenceCurrent(fence: FilterFence): boolean {
+    return fence.generation === filterGeneration
+        && (!fence.context || JC.identity.isCurrent(fence.context));
+}
+
+function clearFilterIdentityState(): void {
+    filterGeneration += 1;
+    parentSeriesCache.clear();
+    parentSeriesRequestMap.clear();
+    sectionSurfaceCache = new WeakMap<Element, string | null>();
+    viewPageUnsubscribe?.();
+    viewPageUnsubscribe = null;
+    bodyMutationHandle?.unsubscribe();
+    bodyMutationHandle = null;
+    for (const handle of detailRescanHandles) clearTimeout(handle);
+    detailRescanHandles.clear();
+
+    // Remove only visibility markers owned by this feature. Other users of the
+    // generic jc-hidden class are left untouched.
+    document.querySelectorAll<HTMLElement>(`[${HIDDEN_PARENT_ATTR}], [${HIDDEN_DIRECT_ATTR}]`).forEach((card) => {
+        card.classList.remove('jc-hidden');
+        card.removeAttribute(HIDDEN_PARENT_ATTR);
+        card.removeAttribute(HIDDEN_DIRECT_ATTR);
+    });
+    document.querySelectorAll<HTMLElement>(`[${PROCESSED_ATTR}]`).forEach((card) => {
+        card.removeAttribute(PROCESSED_ATTR);
+    });
+}
+
+JC.identity?.registerReset?.('hidden-content-filter', clearFilterIdentityState);
 
 /** Delay for first detail-page rescan (async episode loading). */
 const DETAIL_RESCAN_DELAY_MS = 500;
@@ -51,26 +96,32 @@ async function getParentSeriesId(itemId: string): Promise<string | null> {
     if (parentSeriesRequestMap.has(itemId)) {
         return parentSeriesRequestMap.get(itemId)!;
     }
+    const fence = captureFilterFence();
     const request = (async () => {
         try {
-            const userId = ApiClient.getCurrentUserId();
+            const userId = fence.context?.userId || ApiClient.getCurrentUserId();
             const item: any = await ApiClient.ajax({
                 type: 'GET',
                 url: (ApiClient as { getUrl(path: string, params?: unknown): string }).getUrl(`/Users/${userId}/Items/${itemId}`, { Fields: 'SeriesId' }),
                 dataType: 'json'
             });
+            if (!isFilterFenceCurrent(fence)) return null;
             const seriesId = item?.SeriesId || null;
             parentSeriesCache.set(itemId, seriesId);
             return seriesId;
         } catch (e) {
+            if (!isFilterFenceCurrent(fence)) return null;
             console.warn('🪼 Jellyfin Canopy: Failed to fetch parent series for', itemId, e);
             parentSeriesCache.set(itemId, null);
             return null;
-        } finally {
-            parentSeriesRequestMap.delete(itemId);
         }
     })();
     parentSeriesRequestMap.set(itemId, request);
+    void request.finally(() => {
+        if (parentSeriesRequestMap.get(itemId) === request) {
+            parentSeriesRequestMap.delete(itemId);
+        }
+    });
     return request;
 }
 
@@ -162,7 +213,9 @@ function checkAndHideByParentSeries(card: HTMLElement, itemId: string): void {
     if (!getSettings().enabled || !shouldFilterSurface(getCurrentNativeSurface())) return;
     if (hiddenIdSet.size === 0) return;
 
+    const fence = captureFilterFence();
     getParentSeriesId(itemId).then((seriesId) => {
+        if (!isFilterFenceCurrent(fence)) return;
         if (!seriesId) return;
         if (!card.isConnected) return;
         if (!getSettings().enabled || !shouldFilterSurface(getCurrentNativeSurface())) return;
@@ -189,6 +242,7 @@ async function batchCheckParentSeries(cardEntries: Array<{ card: HTMLElement; it
     if (!cardEntries || cardEntries.length === 0) return;
     if (!getSettings().enabled || !shouldFilterSurface(getCurrentNativeSurface())) return;
     if (hiddenIdSet.size === 0) return;
+    const fence = captureFilterFence();
 
     // Separate cached from uncached
     const cached: Array<{ card: HTMLElement; itemId: string; seriesId: string | null }> = [];
@@ -205,6 +259,7 @@ async function batchCheckParentSeries(cardEntries: Array<{ card: HTMLElement; it
     // Process cached entries immediately
     if (cached.length > 0) {
         requestAnimationFrame(() => {
+            if (!isFilterFenceCurrent(fence)) return;
             for (let i = 0; i < cached.length; i++) {
                 const { card, seriesId } = cached[i];
                 if (!card.isConnected || !seriesId) continue;
@@ -221,7 +276,7 @@ async function batchCheckParentSeries(cardEntries: Array<{ card: HTMLElement; it
     if (uncached.length === 0) return;
 
     const BATCH_SIZE = 50;
-    const userId = ApiClient.getCurrentUserId();
+    const userId = fence.context?.userId || ApiClient.getCurrentUserId();
 
     for (let start = 0; start < uncached.length; start += BATCH_SIZE) {
         const chunk = uncached.slice(start, start + BATCH_SIZE);
@@ -233,6 +288,7 @@ async function batchCheckParentSeries(cardEntries: Array<{ card: HTMLElement; it
                 url: (ApiClient as { getUrl(path: string, params?: unknown): string }).getUrl(`/Users/${userId}/Items`, { Ids: ids, Fields: 'SeriesId' }),
                 dataType: 'json'
             });
+            if (!isFilterFenceCurrent(fence)) return;
 
             const itemsById = new Map<string, string | null>();
             const responseItems = result?.Items || [];
@@ -251,6 +307,7 @@ async function batchCheckParentSeries(cardEntries: Array<{ card: HTMLElement; it
 
             // Batch apply hiding
             requestAnimationFrame(() => {
+                if (!isFilterFenceCurrent(fence)) return;
                 for (let i = 0; i < chunk.length; i++) {
                     const { card, itemId } = chunk[i];
                     if (!card.isConnected) continue;
@@ -263,6 +320,7 @@ async function batchCheckParentSeries(cardEntries: Array<{ card: HTMLElement; it
                 }
             });
         } catch (e) {
+            if (!isFilterFenceCurrent(fence)) return;
             console.warn('🪼 Jellyfin Canopy: Batch parent series check failed', e);
             // Fall back to individual lookups for this chunk
             for (let i = 0; i < chunk.length; i++) {
@@ -306,7 +364,9 @@ export function refreshNativeCardVisibility(): void {
         restoreNativeCardsForIds(hiddenIdSet);
         return;
     }
+    const fence = captureFilterFence();
     requestAnimationFrame(() => {
+        if (!isFilterFenceCurrent(fence)) return;
         filterAllNativeCards();
         if (typeof (JC as any).hideEmptyHomeSections === 'function') {
             (JC as any).hideEmptyHomeSections();
@@ -377,7 +437,9 @@ export function filterNativeCards(syncApply = false): void {
 
     // Batch apply visibility changes
     if (toHide.length > 0 || toShow.length > 0) {
+        const fence = captureFilterFence();
         const applyVisibility = (): void => {
+            if (!isFilterFenceCurrent(fence)) return;
             for (let i = 0; i < toHide.length; i++) toHide[i].classList.add('jc-hidden');
             for (let i = 0; i < toShow.length; i++) toShow[i].classList.remove('jc-hidden');
         };
@@ -445,7 +507,9 @@ export function filterAllNativeCards(): void {
 
     // Batch apply visibility changes
     if (toHide.length > 0 || toShow.length > 0) {
+        const fence = captureFilterFence();
         requestAnimationFrame(() => {
+            if (!isFilterFenceCurrent(fence)) return;
             for (let i = 0; i < toHide.length; i++) toHide[i].classList.add('jc-hidden');
             for (let i = 0; i < toShow.length; i++) toShow[i].classList.remove('jc-hidden');
         });
@@ -468,23 +532,36 @@ const debouncedFilterNative = debounce(() => { requestAnimationFrame(() => filte
  * filtering and button injection when new cards appear in the DOM.
  */
 export function setupNativeObserver(): void {
+    viewPageUnsubscribe?.();
+    bodyMutationHandle?.unsubscribe();
+    const setupFence = captureFilterFence();
     // Use onViewPage for page navigation — much cheaper than a body MutationObserver
-    onViewPage(() => {
+    viewPageUnsubscribe = onViewPage(() => {
+        if (!isFilterFenceCurrent(setupFence)) return;
         // Detail pages load episodes asynchronously — staggered re-scans catch late-rendered cards
         if (getCurrentNativeSurface() === 'details') {
             const rescan = (): void => {
+                if (!isFilterFenceCurrent(setupFence)) return;
                 refreshNativeCardVisibility();
                 if (getSettings().showButtonLibrary) addLibraryHideButtons();
             };
-            setTimeout(rescan, DETAIL_RESCAN_DELAY_MS);
-            setTimeout(rescan, DETAIL_FINAL_RESCAN_DELAY_MS);
+            const scheduleRescan = (delay: number): void => {
+                const handle = window.setTimeout(() => {
+                    detailRescanHandles.delete(handle);
+                    rescan();
+                }, delay);
+                detailRescanHandles.add(handle);
+            };
+            scheduleRescan(DETAIL_RESCAN_DELAY_MS);
+            scheduleRescan(DETAIL_FINAL_RESCAN_DELAY_MS);
         }
     });
 
     // Lightweight observer for card/list containers
     // Priority 10: hidden-content must run before other subscribers (tags, bookmarks, etc.)
     // so it can filter/hide cards before other modules waste time processing them
-    onBodyMutation('hidden-content', (mutations) => {
+    bodyMutationHandle = onBodyMutation('hidden-content', (mutations) => {
+        if (!isFilterFenceCurrent(setupFence)) return;
         const settings = getSettings();
         if (!settings.enabled) return;
         const shouldFilter = getHiddenCount() > 0;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/identity.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+import type { IdentityContext } from '../../types/jc';
+import { getHiddenData, hiddenIdSet, refresh, resetFromUserConfig, updateSettings } from './data';
+
+function startSession(userId = 'test-user-id'): IdentityContext {
+    JC.identity.transition('', '', 'test-logout');
+    return JC.identity.transition('test-server-id', userId, 'test-login')!;
+}
+
+function installHiddenData(
+    context: IdentityContext,
+    items: Record<string, { itemId?: string }> = {},
+): void {
+    const hiddenContent = JC.identity.own({ items, settings: {} }, context);
+    JC.userConfig = JC.identity.own({ hiddenContent }, context);
+    resetFromUserConfig();
+}
+
+describe('hidden-content identity fencing', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        const context = startSession();
+        vi.spyOn(ApiClient, 'getCurrentUserId').mockReturnValue('test-user-id');
+        installHiddenData(context, { a: { itemId: 'item-a' } });
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+        document.body.innerHTML = '';
+    });
+
+    it('cancels A debounce work synchronously on account transition', async () => {
+        const ajax = vi.spyOn(ApiClient, 'ajax').mockResolvedValue({});
+        updateSettings({ filterSearch: true });
+
+        const ownerB = JC.identity.transition('test-server-id', 'user-b', 'account-switch')!;
+        vi.spyOn(ApiClient, 'getCurrentUserId').mockReturnValue('user-b');
+        installHiddenData(ownerB, { b: { itemId: 'item-b' } });
+        await vi.advanceTimersByTimeAsync(1_000);
+
+        expect(ajax).not.toHaveBeenCalled();
+        expect(hiddenIdSet.has('item-a')).toBe(false);
+        expect(hiddenIdSet.has('item-b')).toBe(true);
+    });
+
+    it('cancels a failed A save retry ladder before its first retry', async () => {
+        const ajax = vi.spyOn(ApiClient, 'ajax').mockRejectedValue(new Error('offline'));
+        vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        updateSettings({ filterSearch: true });
+
+        await vi.advanceTimersByTimeAsync(500);
+        expect(ajax).toHaveBeenCalledTimes(1);
+
+        JC.identity.transition('test-server-id', 'user-b', 'account-switch');
+        vi.spyOn(ApiClient, 'getCurrentUserId').mockReturnValue('user-b');
+        await vi.advanceTimersByTimeAsync(30_000);
+
+        expect(ajax).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not reconcile or retry an A request that completes after B activates', async () => {
+        let resolvePost!: (value: unknown) => void;
+        const pendingPost = new Promise((resolve) => { resolvePost = resolve; });
+        const ajax = vi.spyOn(ApiClient, 'ajax').mockReturnValue(pendingPost);
+        updateSettings({ filterSearch: true });
+
+        await vi.advanceTimersByTimeAsync(500);
+        expect(ajax).toHaveBeenCalledTimes(1);
+
+        const ownerB = JC.identity.transition('test-server-id', 'user-b', 'account-switch')!;
+        vi.spyOn(ApiClient, 'getCurrentUserId').mockReturnValue('user-b');
+        installHiddenData(ownerB);
+        resolvePost({});
+        await Promise.resolve();
+        await Promise.resolve();
+        await vi.advanceTimersByTimeAsync(30_000);
+
+        expect(ajax).toHaveBeenCalledTimes(1);
+        expect(JC.identity.isOwned(getHiddenData(), ownerB)).toBe(true);
+    });
+
+    it('does not let a late A retry completion erase B retry state', async () => {
+        let rejectARetry!: (reason: unknown) => void;
+        const pendingARetry = new Promise((_resolve, reject) => { rejectARetry = reject; });
+        const ajax = vi.spyOn(ApiClient, 'ajax')
+            .mockRejectedValueOnce(new Error('A initial failure'))
+            .mockReturnValueOnce(pendingARetry)
+            .mockRejectedValueOnce(new Error('B initial failure'))
+            .mockResolvedValueOnce({});
+        vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        updateSettings({ filterSearch: true });
+
+        await vi.advanceTimersByTimeAsync(500);
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(ajax).toHaveBeenCalledTimes(2);
+
+        const ownerB = JC.identity.transition('test-server-id', 'user-b', 'account-switch')!;
+        vi.spyOn(ApiClient, 'getCurrentUserId').mockReturnValue('user-b');
+        installHiddenData(ownerB);
+        updateSettings({ filterSearch: true });
+        await vi.advanceTimersByTimeAsync(500);
+        expect(ajax).toHaveBeenCalledTimes(3);
+
+        rejectARetry(new Error('late A failure'));
+        await Promise.resolve();
+        await Promise.resolve();
+        await vi.advanceTimersByTimeAsync(1_000);
+
+        expect(ajax).toHaveBeenCalledTimes(4);
+    });
+
+    it('drops a late A refresh response instead of publishing it into B', async () => {
+        let resolveGet!: (value: unknown) => void;
+        const pendingGet = new Promise((resolve) => { resolveGet = resolve; });
+        vi.spyOn(ApiClient, 'ajax').mockReturnValue(pendingGet);
+        const pendingRefresh = refresh();
+
+        const ownerB = JC.identity.transition('test-server-id', 'user-b', 'account-switch')!;
+        vi.spyOn(ApiClient, 'getCurrentUserId').mockReturnValue('user-b');
+        installHiddenData(ownerB, { b: { itemId: 'item-b' } });
+        resolveGet({ Items: { a: { ItemId: 'item-a' } }, Settings: {} });
+
+        await expect(pendingRefresh).resolves.toBe(false);
+        expect(getHiddenData().items).toEqual({ b: { itemId: 'item-b' } });
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/init.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/init.ts
@@ -45,6 +45,15 @@ import { addLibraryHideButtons, removeLibraryHideButtons } from './buttons';
 
 /** Initial filter delay after module initialization. */
 const INIT_FILTER_DELAY_MS = 150;
+let initialFilterTimeout: number | null = null;
+
+function cancelInitialFilter(): void {
+    if (initialFilterTimeout != null) clearTimeout(initialFilterTimeout);
+    initialFilterTimeout = null;
+    JC.hiddenContent = undefined;
+}
+
+JC.identity?.registerReset?.('hidden-content-init', cancelInitialFilter);
 
 // ============================================================
 // Initialization
@@ -55,12 +64,18 @@ const INIT_FILTER_DELAY_MS = 150;
  * injects CSS, sets up the MutationObserver, and exposes the public API.
  */
 JC.initializeHiddenContent = function (): void {
+    const context = JC.identity?.capture?.() || null;
+    if (context && !JC.identity.isCurrent(context)) return;
+    cancelInitialFilter();
     resetFromUserConfig();
     injectCSS();
     setupNativeObserver();
 
     if (getHiddenCount() > 0) {
-        setTimeout(filterAllNativeCards, INIT_FILTER_DELAY_MS);
+        initialFilterTimeout = window.setTimeout(() => {
+            initialFilterTimeout = null;
+            if (!context || JC.identity.isCurrent(context)) filterAllNativeCards();
+        }, INIT_FILTER_DELAY_MS);
     }
 
     // Expose public API

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/panel.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/panel.ts
@@ -7,9 +7,53 @@
 import { JC } from '../../globals';
 import { getHiddenData, unhideItem, unhideAll } from './data';
 import type { HiddenItem } from './data';
+import type { IdentityContext } from '../../types/jc';
 
 /** Max poster width when loading images from TMDB / Jellyfin. */
 const POSTER_MAX_WIDTH = 300;
+
+interface PanelFence {
+    readonly generation: number;
+    readonly context: IdentityContext | null;
+}
+
+let panelGeneration = 0;
+let activeManagementClose: (() => void) | null = null;
+const panelTimeouts = new Set<number>();
+
+function capturePanelFence(): PanelFence {
+    return { generation: panelGeneration, context: JC.identity?.capture?.() || null };
+}
+
+function isPanelFenceCurrent(fence: PanelFence): boolean {
+    return fence.generation === panelGeneration
+        && (!fence.context || JC.identity.isCurrent(fence.context));
+}
+
+function schedulePanelTimeout(callback: () => void, delay: number, fence: PanelFence): number {
+    const handle = window.setTimeout(() => {
+        panelTimeouts.delete(handle);
+        if (isPanelFenceCurrent(fence)) callback();
+    }, delay);
+    panelTimeouts.add(handle);
+    return handle;
+}
+
+function cancelPanelTimeout(handle: number): void {
+    clearTimeout(handle);
+    panelTimeouts.delete(handle);
+}
+
+function resetPanelUi(): void {
+    panelGeneration += 1;
+    activeManagementClose?.();
+    activeManagementClose = null;
+    for (const handle of panelTimeouts) clearTimeout(handle);
+    panelTimeouts.clear();
+    document.querySelectorAll('.jc-hidden-management-overlay').forEach((node) => node.remove());
+}
+
+JC.identity?.registerReset?.('hidden-content-management-panel', resetPanelUi);
 
 // ============================================================
 // Management panel (overlay)
@@ -41,9 +85,11 @@ function createManagementHeader(count: number): HTMLElement {
  * @returns The card element.
  */
 export function createItemCard(item: HiddenItem, onNavigate?: () => void): HTMLElement {
+    const fence = capturePanelFence();
     const card = document.createElement('div');
     card.className = 'jc-hidden-item-card';
     card.dataset.itemId = item.itemId;
+    card.dataset.jcIdentityOwned = 'true';
 
     const hasJellyfinId = !!item.itemId;
     const hasTmdbId = !!item.tmdbId;
@@ -74,6 +120,7 @@ export function createItemCard(item: HiddenItem, onNavigate?: () => void): HTMLE
         img.alt = '';
         img.loading = 'lazy';
         img.onerror = () => {
+            if (!isPanelFenceCurrent(fence)) return;
             const self = img;
             // Switch card to Seerr navigation
             if (hasTmdbId && (JC as any).seerrMoreInfo) {
@@ -82,27 +129,35 @@ export function createItemCard(item: HiddenItem, onNavigate?: () => void): HTMLE
             // Item removed from Jellyfin — fall back to TMDB poster
             if (hasTmdbId && item.posterPath) {
                 self.src = `https://image.tmdb.org/t/p/w${POSTER_MAX_WIDTH}${item.posterPath}`;
-                self.onerror = function(this: HTMLImageElement) { this.style.display = 'none'; };
+                self.onerror = function(this: HTMLImageElement) {
+                    if (isPanelFenceCurrent(fence)) this.style.display = 'none';
+                };
             } else if (hasTmdbId && (JC as any).seerrAPI) {
                 // No posterPath stored — fetch it from Seerr
-                self.onerror = function(this: HTMLImageElement) { this.style.display = 'none'; };
+                self.onerror = function(this: HTMLImageElement) {
+                    if (isPanelFenceCurrent(fence)) this.style.display = 'none';
+                };
                 const fetchFn = mediaType === 'tv'
                     ? (JC as any).seerrAPI.fetchTvShowDetails
                     : (JC as any).seerrAPI.fetchMovieDetails;
                 fetchFn(parseInt(String(item.tmdbId), 10)).then(function(details: any) {
+                    if (!isPanelFenceCurrent(fence)) return;
                     const path = details && (details.posterPath || details.poster_path);
                     if (path) {
                         self.src = `https://image.tmdb.org/t/p/w${POSTER_MAX_WIDTH}${path}`;
                     } else {
                         self.style.display = 'none';
                     }
-                }).catch(function() { self.style.display = 'none'; });
+                }).catch(function() {
+                    if (isPanelFenceCurrent(fence)) self.style.display = 'none';
+                });
             } else if (item.type !== 'Person' && item.name && (JC as any).seerrAPI && (JC as any).seerrMoreInfo) {
                 // No TMDB id stored and the Jellyfin media is gone — resolve via a Seerr search
                 // so the card opens the more-info modal instead of a blank poster + dead link.
                 self.style.display = 'none';
                 const wantType = (item.type === 'Series' || item.type === 'Episode' || item.type === 'Season') ? 'tv' : 'movie';
                 (JC as any).seerrAPI.search(item.name).then(function(res: any) {
+                    if (!isPanelFenceCurrent(fence)) return;
                     const results = (res && res.results) || [];
                     const hit = results.find(function(r: any) { return r.mediaType === wantType; })
                         || results.find(function(r: any) { return r.mediaType === 'movie' || r.mediaType === 'tv'; });
@@ -114,7 +169,9 @@ export function createItemCard(item: HiddenItem, onNavigate?: () => void): HTMLE
                         if (p) {
                             self.src = `https://image.tmdb.org/t/p/w${POSTER_MAX_WIDTH}${p}`;
                             self.style.display = '';
-                            self.onerror = function(this: HTMLImageElement) { this.style.display = 'none'; };
+                            self.onerror = function(this: HTMLImageElement) {
+                                if (isPanelFenceCurrent(fence)) this.style.display = 'none';
+                            };
                         }
                     }
                 }).catch(function() {});
@@ -150,6 +207,10 @@ export function createItemCard(item: HiddenItem, onNavigate?: () => void): HTMLE
     const navigableLinks = [posterLink, nameLink];
     for (const link of navigableLinks) {
         link.addEventListener('click', (e) => {
+            if (!isPanelFenceCurrent(fence)) {
+                e.preventDefault();
+                return;
+            }
             // If item was removed from Jellyfin, fall back to the Seerr modal — using the
             // stored TMDB id, or one resolved at render time by a Seerr search.
             const removedId = (card.dataset.jellyfinRemoved === '1')
@@ -199,22 +260,30 @@ export function createItemCard(item: HiddenItem, onNavigate?: () => void): HTMLE
  * Shows all hidden items in a searchable grid with unhide actions.
  */
 export function showManagementPanel(): void {
-    document.querySelector('.jc-hidden-management-overlay')?.remove();
+    const fence = capturePanelFence();
+    if (!isPanelFenceCurrent(fence)) return;
+    activeManagementClose?.();
 
     const data = getHiddenData();
     const items = Object.entries(data.items || {}).map(([key, item]) => ({ ...item, _key: key }));
 
     const overlay = document.createElement('div');
     overlay.className = 'jc-hidden-management-overlay';
+    overlay.dataset.jcIdentityOwned = 'true';
 
     const panel = document.createElement('div');
     panel.className = 'jc-hidden-management-panel';
 
     const header = createManagementHeader(items.length);
+    const overlayTimers = new Set<number>();
     const closeOverlay = (): void => {
+        for (const handle of overlayTimers) cancelPanelTimeout(handle);
+        overlayTimers.clear();
         overlay.remove();
         document.removeEventListener('keydown', escHandler);
+        if (activeManagementClose === closeOverlay) activeManagementClose = null;
     };
+    activeManagementClose = closeOverlay;
     header.querySelector('.jc-hidden-management-close')!.addEventListener('click', closeOverlay);
     panel.appendChild(header);
 
@@ -229,6 +298,7 @@ export function showManagementPanel(): void {
      * @param filter Search text to filter by name.
      */
     function renderGrid(filter?: string): void {
+        if (!isPanelFenceCurrent(fence)) return;
         const filtered = filter
             ? items.filter(i => i.name?.toLowerCase().includes(filter.toLowerCase()))
             : items;
@@ -251,11 +321,14 @@ export function showManagementPanel(): void {
         grid.className = 'jc-hidden-management-grid';
 
         for (const item of filtered) {
-            const card = createItemCard(item, () => overlay.remove());
+            const card = createItemCard(item, closeOverlay);
 
             card.querySelector('.jc-hidden-item-unhide')!.addEventListener('click', () => {
+                if (!isPanelFenceCurrent(fence) || !overlay.isConnected) return;
                 card.classList.add('jc-hidden-item-removing');
-                setTimeout(() => {
+                const handle = schedulePanelTimeout(() => {
+                    overlayTimers.delete(handle);
+                    if (!card.isConnected || !overlay.isConnected) return;
                     unhideItem(item._key || item.itemId!);
                     card.remove();
                     const remaining = gridContainer.querySelectorAll('.jc-hidden-item-card').length;
@@ -266,7 +339,8 @@ export function showManagementPanel(): void {
                         emptyDiv.textContent = JC.t!('hidden_content_manage_empty');
                         gridContainer.replaceChildren(emptyDiv);
                     }
-                }, 300);
+                }, 300, fence);
+                overlayTimers.add(handle);
             });
 
             grid.appendChild(card);
@@ -277,10 +351,14 @@ export function showManagementPanel(): void {
 
     renderGrid();
 
-    toolbar.searchInput.addEventListener('input', () => renderGrid(toolbar.searchInput.value));
+    toolbar.searchInput.addEventListener('input', () => {
+        if (isPanelFenceCurrent(fence)) renderGrid(toolbar.searchInput.value);
+    });
 
     toolbar.unhideAllBtn.addEventListener('click', () => {
+        if (!isPanelFenceCurrent(fence) || !overlay.isConnected) return;
         if (!confirm(JC.t!('hidden_content_clear_confirm'))) return;
+        if (!isPanelFenceCurrent(fence)) return;
         unhideAll();
         const emptyDiv = document.createElement('div');
         emptyDiv.className = 'jc-hidden-management-empty';

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/save.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/save.ts
@@ -5,11 +5,36 @@
 // (Converted from js/enhanced/hidden-content-save.js — bodies semantically identical.)
 
 import { JC } from '../../globals';
+import type { IdentityContext } from '../../types/jc';
 import { toast } from '../../core/ui-kit';
 import { getHiddenData } from './data';
 import type { HiddenItem } from './data';
 
 let saveTimeout: number | null = null;
+let pendingDebounceContext: IdentityContext | null = null;
+
+class StaleHiddenContentIdentityError extends Error {
+    constructor() {
+        super('hidden-content identity is no longer current');
+    }
+}
+
+function normalizeUserId(value: unknown): string {
+    if (typeof value !== 'string' && typeof value !== 'number') return '';
+    return String(value).trim().replace(/-/g, '').toLowerCase();
+}
+
+function currentDataContext(): IdentityContext | null {
+    const data = getHiddenData();
+    const owner = JC.identity?.ownerOf?.(data) || null;
+    return owner && JC.identity.isCurrent(owner) ? owner : null;
+}
+
+function isUsableContext(context: IdentityContext | null | undefined): context is IdentityContext {
+    if (!context || !JC.identity.isCurrent(context)) return false;
+    const data = getHiddenData();
+    return JC.identity.isOwned(data, context);
+}
 
 /** Debounce interval for persisting hidden-content data. */
 const SAVE_DEBOUNCE_MS = 500;
@@ -19,20 +44,27 @@ const SAVE_DEBOUNCE_MS = 500;
  * Coalesces rapid writes (e.g. bulk-unhide) into a single save.
  */
 export function debouncedSave(): void {
+    const context = currentDataContext();
+    if (!context) return;
     if (saveTimeout) clearTimeout(saveTimeout);
+    pendingDebounceContext = context;
     saveTimeout = window.setTimeout(() => {
         void (async () => {
+            const scheduledContext = pendingDebounceContext;
             saveTimeout = null;
+            pendingDebounceContext = null;
+            if (!isUsableContext(scheduledContext)) return;
             try {
                 // Route through directSaveHiddenContent (not JC.saveUserSettings) so a successful save can
                 // reconcile against any in-flight retry and a failure can re-enter the retry ladder.
                 // JC.saveUserSettings swallows errors, which would leave a pending retry firing later and
                 // clobbering server state.
-                const sent = await directSaveHiddenContent();
-                reconcileAfterSave(sent);
+                const sent = await directSaveHiddenContent(scheduledContext);
+                reconcileAfterSave(sent, scheduledContext);
             } catch (e) {
+                if (e instanceof StaleHiddenContentIdentityError || !JC.identity.isCurrent(scheduledContext)) return;
                 console.warn('🪼 Jellyfin Canopy: debouncedSave failed; scheduling background retry', e);
-                if (pendingRetryHandle == null) scheduleFlushRetry(0);
+                if (pendingRetryHandle == null) scheduleFlushRetry(0, scheduledContext);
             }
         })();
     }, SAVE_DEBOUNCE_MS);
@@ -148,16 +180,24 @@ export async function adminHideForUser(targetUserId: string, items: HiddenItem[]
 // Direct bypass of JC.saveUserSettings (which swallows errors) so callers can react to failure.
 // Returns the JSON snapshot that was sent so the caller can compare it to current state and decide
 // whether the success acknowledgement still represents the latest local intent.
-async function directSaveHiddenContent(): Promise<string> {
-    const userId = ApiClient.getCurrentUserId();
-    if (!userId) throw new Error('no current user');
-    const snapshot = JSON.stringify(getHiddenData());
+async function directSaveHiddenContent(context: IdentityContext): Promise<string> {
+    if (!isUsableContext(context)) throw new StaleHiddenContentIdentityError();
+    if (normalizeUserId(ApiClient.getCurrentUserId()) !== context.userId) {
+        throw new StaleHiddenContentIdentityError();
+    }
+    const data = getHiddenData();
+    if (!JC.identity.isOwned(data, context)) throw new StaleHiddenContentIdentityError();
+    const snapshot = JSON.stringify(data);
+    // Keep the last identity check adjacent to invocation. No task can switch
+    // authentication between these two synchronous statements.
+    if (!JC.identity.isCurrent(context)) throw new StaleHiddenContentIdentityError();
     await ApiClient.ajax({
         type: 'POST',
-        url: ApiClient.getUrl(`/JellyfinCanopy/user-settings/${userId}/hidden-content.json`),
+        url: ApiClient.getUrl(`/JellyfinCanopy/user-settings/${context.userId}/hidden-content.json`),
         data: snapshot,
         contentType: 'application/json'
     });
+    if (!JC.identity.isCurrent(context)) throw new StaleHiddenContentIdentityError();
     return snapshot;
 }
 
@@ -166,7 +206,8 @@ async function directSaveHiddenContent(): Promise<string> {
 // - Mismatch: state moved during the await; schedule another save.
 // The retry-timer body explicitly clears RETRY_INFLIGHT before calling this so a same-state mismatch
 // doesn't leave the sentinel stuck; cancelPendingRetry refuses to clear an in-flight retry from another path.
-function reconcileAfterSave(snapshotSent: string): void {
+function reconcileAfterSave(snapshotSent: string, context: IdentityContext): void {
+    if (!isUsableContext(context)) return;
     if (snapshotSent === JSON.stringify(getHiddenData())) {
         cancelPendingRetry();
     } else {
@@ -179,6 +220,15 @@ function reconcileAfterSave(snapshotSent: string): void {
 const FLUSH_RETRY_DELAYS_MS = [1000, 5000, 15000];
 const RETRY_INFLIGHT = -1; // sentinel: retry timer fired and POST is in flight (handle no longer cancelable)
 let pendingRetryHandle: number | null = null;
+let pendingRetryContext: IdentityContext | null = null;
+
+function clearRetryStateFor(context: IdentityContext): void {
+    // A late completion from an invalidated epoch must not clear a retry that B
+    // has scheduled since the synchronous reset ran.
+    if (pendingRetryContext !== context) return;
+    pendingRetryHandle = null;
+    pendingRetryContext = null;
+}
 
 function cancelPendingRetry(): void {
     // Don't unset RETRY_INFLIGHT — the timer body whose POST is in flight needs to manage its own
@@ -186,9 +236,11 @@ function cancelPendingRetry(): void {
     if (pendingRetryHandle === RETRY_INFLIGHT) return;
     if (pendingRetryHandle != null) clearTimeout(pendingRetryHandle);
     pendingRetryHandle = null;
+    pendingRetryContext = null;
 }
 
-function scheduleFlushRetry(attempt: number): void {
+function scheduleFlushRetry(attempt: number, context: IdentityContext): void {
+    if (!isUsableContext(context)) return;
     if (attempt >= FLUSH_RETRY_DELAYS_MS.length) {
         console.error('🪼 Jellyfin Canopy: hidden-content save retries exhausted; local change may be lost on reload');
         // User-visible toast — the bulk-save endpoint is genuinely down at this point.
@@ -196,27 +248,40 @@ function scheduleFlushRetry(attempt: number): void {
             toast(JC.t!('hidden_content_save_failed_persistent'), 5000);
         } catch (_) { /* toast helper unavailable, console.error above is best-effort */ }
         pendingRetryHandle = null;
+        pendingRetryContext = null;
         return;
     }
+    pendingRetryContext = context;
     pendingRetryHandle = window.setTimeout(() => {
         void (async () => {
+            if (pendingRetryContext !== context || !isUsableContext(context)) {
+                clearRetryStateFor(context);
+                return;
+            }
             pendingRetryHandle = RETRY_INFLIGHT; // mark in-flight so a concurrent debouncedSave failure doesn't spawn a parallel ladder
             // Guard for ApiClient teardown / signed-out state during the window.
-            if (typeof ApiClient === 'undefined' || typeof ApiClient.getCurrentUserId !== 'function' || !ApiClient.getCurrentUserId()) {
+            if (typeof ApiClient === 'undefined' || typeof ApiClient.getCurrentUserId !== 'function'
+                || normalizeUserId(ApiClient.getCurrentUserId()) !== context.userId) {
                 console.error('🪼 Jellyfin Canopy: abandoning hidden-content retry; ApiClient unavailable');
                 pendingRetryHandle = null;
+                pendingRetryContext = null;
                 return;
             }
             try {
-                const sent = await directSaveHiddenContent();
+                const sent = await directSaveHiddenContent(context);
                 // Retry succeeded — clear the in-flight sentinel BEFORE reconcile so a state-mismatch
                 // reschedule via debouncedSave doesn't leave the sentinel stuck (cancelPendingRetry from
                 // other code paths intentionally refuses to clear RETRY_INFLIGHT).
                 if (pendingRetryHandle === RETRY_INFLIGHT) pendingRetryHandle = null;
-                reconcileAfterSave(sent);
+                pendingRetryContext = null;
+                reconcileAfterSave(sent, context);
             } catch (err) {
+                if (err instanceof StaleHiddenContentIdentityError || !JC.identity.isCurrent(context)) {
+                    clearRetryStateFor(context);
+                    return;
+                }
                 console.warn(`🪼 Jellyfin Canopy: hidden-content save retry ${attempt + 1} failed`, err);
-                scheduleFlushRetry(attempt + 1);
+                scheduleFlushRetry(attempt + 1, context);
             }
         })();
     }, FLUSH_RETRY_DELAYS_MS[attempt]);
@@ -226,20 +291,39 @@ function scheduleFlushRetry(attempt: number): void {
 // On failure: re-throw so the caller aborts, AND start a bounded background retry so the local mutation isn't lost.
 export async function flushPendingSave(): Promise<void> {
     if (!saveTimeout) return;
+    const context = pendingDebounceContext;
     clearTimeout(saveTimeout);
     saveTimeout = null;
+    pendingDebounceContext = null;
+    if (!isUsableContext(context)) throw new StaleHiddenContentIdentityError();
     try {
-        const sent = await directSaveHiddenContent();
-        reconcileAfterSave(sent);
+        const sent = await directSaveHiddenContent(context);
+        reconcileAfterSave(sent, context);
     } catch (e) {
+        if (e instanceof StaleHiddenContentIdentityError || !JC.identity.isCurrent(context)) throw e;
         console.warn('🪼 Jellyfin Canopy: flushPendingSave failed; scheduling background retry', e);
-        if (pendingRetryHandle == null) scheduleFlushRetry(0);
+        if (pendingRetryHandle == null) scheduleFlushRetry(0, context);
         throw e;
     }
 }
 
+function cancelAllPersistence(): void {
+    if (saveTimeout != null) clearTimeout(saveTimeout);
+    saveTimeout = null;
+    pendingDebounceContext = null;
+    if (pendingRetryHandle != null && pendingRetryHandle !== RETRY_INFLIGHT) {
+        clearTimeout(pendingRetryHandle);
+    }
+    // An in-flight ajax cannot be cancelled here, but its captured context will
+    // fail the post-await fence and therefore cannot reconcile or retry.
+    pendingRetryHandle = null;
+    pendingRetryContext = null;
+}
+
+JC.identity?.registerReset?.('hidden-content-persistence', cancelAllPersistence);
+
 // Cancel pending retries on tab teardown so a stale snapshot can't overwrite server state after navigation.
 // Only pagehide — visibilitychange fires on backgrounded tabs the user may return to within the retry window.
 try {
-    window.addEventListener('pagehide', cancelPendingRetry);
+    window.addEventListener('pagehide', cancelAllPersistence);
 } catch (_) { /* non-browser env, harmless */ }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/ui-identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/ui-identity.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+import type { IdentityContext } from '../../types/jc';
+import { addLibraryHideButtons } from './buttons';
+import { confirmAndHide, showUndoToast } from './dialogs';
+import { getHiddenData, resetFromUserConfig } from './data';
+import { showManagementPanel } from './panel';
+
+function startSession(serverId = 'server-a', userId = 'user-a'): IdentityContext {
+    JC.identity.transition('', '', 'test-logout');
+    return JC.identity.transition(serverId, userId, 'test-login')!;
+}
+
+function installHiddenData(
+    context: IdentityContext,
+    items: Record<string, { itemId?: string; name?: string; type?: string }> = {},
+    settings: Record<string, unknown> = {},
+): void {
+    const hiddenContent = JC.identity.own({ items, settings }, context);
+    JC.userConfig = JC.identity.own({ hiddenContent }, context);
+    resetFromUserConfig();
+}
+
+describe('hidden-content identity-owned UI', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        document.body.innerHTML = '';
+        localStorage.clear();
+        JC.t = (key: string) => key;
+        vi.spyOn(ApiClient, 'getCurrentUserId').mockReturnValue('usera');
+    });
+
+    afterEach(() => {
+        JC.identity.transition('', '', 'test-cleanup');
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+        document.body.innerHTML = '';
+        localStorage.clear();
+    });
+
+    it('scopes temporary confirmation suppression by both server and user', () => {
+        const ownerA = startSession('server-a', 'user-a');
+        installHiddenData(ownerA, {}, { showHideConfirmation: true });
+        localStorage.setItem('jc_hide_confirm_suppressed_until', new Date(Date.now() + 60_000).toISOString());
+
+        confirmAndHide({ itemId: 'a', name: 'A' });
+        const overlayA = document.querySelector<HTMLElement>('.jc-hide-confirm-overlay')!;
+        expect(overlayA).toBeTruthy();
+        const suppress = overlayA.querySelector<HTMLInputElement>('input[type="checkbox"]')!;
+        suppress.checked = true;
+        overlayA.querySelector<HTMLButtonElement>('.jc-hide-confirm-hide')!.click();
+
+        expect(localStorage.getItem('jc_hide_confirm_suppressed_until')).toBeNull();
+        expect(localStorage.getItem('jc_hide_confirm_suppressed_until:servera:usera')).toBeTruthy();
+
+        const ownerB = JC.identity.transition('server-b', 'user-a', 'server-switch')!;
+        installHiddenData(ownerB, {}, { showHideConfirmation: true });
+        confirmAndHide({ itemId: 'b', name: 'B' });
+
+        // Same normalized user id on another server must not inherit A's 15-minute choice.
+        expect(document.querySelector('.jc-hide-confirm-overlay')).toBeTruthy();
+    });
+
+    it('synchronously removes A overlays/buttons and makes retained controls inert', async () => {
+        const ownerA = startSession();
+        installHiddenData(ownerA, { a: { itemId: 'item-a', name: 'A', type: 'Movie' } }, {
+            enabled: true,
+            showHideButtons: true,
+            showButtonLibrary: true,
+            showButtonCast: false,
+            experimentalHideCollections: true,
+        });
+
+        showUndoToast('A', 'item-a');
+        showManagementPanel();
+        const card = document.createElement('div');
+        card.className = 'card';
+        card.dataset.id = 'item-a';
+        const cardBox = document.createElement('div');
+        cardBox.className = 'cardBox';
+        cardBox.style.position = 'absolute';
+        const text = document.createElement('div');
+        text.className = 'cardText';
+        text.textContent = 'A';
+        cardBox.appendChild(text);
+        card.appendChild(cardBox);
+        document.body.appendChild(card);
+        addLibraryHideButtons();
+
+        const retainedUndo = document.querySelector<HTMLButtonElement>('.jc-undo-btn')!;
+        const retainedPanelUnhide = document.querySelector<HTMLButtonElement>('.jc-hidden-management-overlay .jc-hidden-item-unhide')!;
+        const retainedCardButton = cardBox.querySelector<HTMLButtonElement>('.jc-hide-btn')!;
+        expect(retainedUndo).toBeTruthy();
+        expect(retainedPanelUnhide).toBeTruthy();
+        expect(retainedCardButton).toBeTruthy();
+
+        const ownerB = JC.identity.transition('server-b', 'user-b', 'account-switch')!;
+        vi.spyOn(ApiClient, 'getCurrentUserId').mockReturnValue('userb');
+        installHiddenData(ownerB, { b: { itemId: 'item-b', name: 'B', type: 'Movie' } }, {
+            enabled: true,
+            showHideButtons: true,
+            showButtonLibrary: true,
+            showButtonCast: false,
+            experimentalHideCollections: true,
+        });
+
+        expect(document.querySelector('.jc-undo-toast')).toBeNull();
+        expect(document.querySelector('.jc-hidden-management-overlay')).toBeNull();
+        expect(document.querySelector('.jc-hide-btn')).toBeNull();
+        expect(cardBox.style.position).toBe('absolute');
+
+        retainedUndo.click();
+        retainedPanelUnhide.click();
+        retainedCardButton.click();
+        await vi.runAllTimersAsync();
+
+        expect(getHiddenData().items).toEqual({ b: { itemId: 'item-b', name: 'B', type: 'Movie' } });
+        expect(card.classList.contains('jc-hidden')).toBe(false);
+
+        showUndoToast('B', 'item-b');
+        showManagementPanel();
+        addLibraryHideButtons();
+        expect(document.querySelector('.jc-undo-toast')).toBeTruthy();
+        expect(document.querySelector('.jc-hidden-management-overlay')?.textContent).toContain('B');
+        expect(cardBox.querySelector('.jc-hide-btn')).toBeTruthy();
+        expect(cardBox.querySelector('.jc-hide-btn')).not.toBe(retainedCardButton);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/language-nogithub.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/language-nogithub.test.ts
@@ -21,12 +21,9 @@ describe('language control locale source', () => {
         JC.currentSettings = {};
         JC.t = (k: string) => k;
 
-        const ajax = vi.fn((opts: { url: string }) => {
-            if (opts.url.includes('/JellyfinCanopy/locales')) return Promise.resolve(['en', 'fr', 'de']);
-            if (opts.url.includes('/Localization/Cultures')) return Promise.resolve([]);
-            return Promise.resolve({});
-        });
-        (globalThis as Record<string, any>).ApiClient.ajax = ajax;
+        const plugin = vi.fn().mockResolvedValue(['en', 'fr', 'de']);
+        const jf = vi.fn().mockResolvedValue([]);
+        JC.core.api = { plugin, jf };
 
         const fetchSpy = vi.fn((_url?: unknown) => Promise.resolve({ ok: false, json: () => Promise.resolve([]) }));
         (globalThis as Record<string, any>).fetch = fetchSpy;
@@ -38,6 +35,7 @@ describe('language control locale source', () => {
         const githubCalls = fetchSpy.mock.calls.filter((c) => String(c[0]).includes('api.github.com'));
         expect(githubCalls.length).toBe(0);
         // The server locale endpoint WAS used.
-        expect(ajax.mock.calls.some((c) => c[0].url.includes('/JellyfinCanopy/locales'))).toBe(true);
+        expect(plugin).toHaveBeenCalledWith('/locales');
+        expect(jf).toHaveBeenCalledWith('/Localization/Cultures');
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/osd-rating.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/osd-rating.identity.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../globals';
+
+function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((done) => { resolve = done; });
+    return { promise, resolve };
+}
+
+function mountPlayer(itemId = 'item-1'): void {
+    document.body.innerHTML = `
+        <div class="videoPlayerContainer">
+            <div class="videoOsdBottom">
+                <button class="btnUserRating" data-id="${itemId}"></button>
+                <span class="osdTimeText">Ends at 22:00</span>
+            </div>
+        </div>
+    `;
+}
+
+async function flushPromises(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+}
+
+describe('OSD rating identity lifecycle', () => {
+    beforeAll(async () => {
+        window.Events = { on: vi.fn() } as unknown as JellyfinEvents;
+        await import('./osd-rating');
+    });
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        document.body.innerHTML = '';
+        JC.identity.transition('osd-server-a', 'osd-user-a', 'osd-rating-test');
+        JC.pluginConfig = { ShowRatingInPlayer: true };
+        JC.isVideoPage = () => true;
+    });
+
+    afterEach(() => {
+        JC.identity.transition('', '', 'osd-rating-test-cleanup');
+        vi.clearAllTimers();
+        vi.useRealTimers();
+        document.body.innerHTML = '';
+    });
+
+    it('does not let a held A response populate B UI or cache', async () => {
+        mountPlayer();
+        const aResponse = deferred<unknown>();
+        const jf = vi.fn().mockReturnValueOnce(aResponse.promise);
+        JC.core.api = { jf } as unknown as NonNullable<typeof JC.core.api>;
+
+        JC.initializeOsdRating!();
+        await flushPromises();
+        vi.advanceTimersByTime(200);
+        expect(jf).toHaveBeenCalledTimes(1);
+
+        JC.identity.transition('osd-server-b', 'osd-user-b', 'osd-rating-test');
+        jf.mockResolvedValue({ Items: [{ CommunityRating: 8.8, CriticRating: 72 }] });
+        JC.initializeOsdRating!();
+        await flushPromises();
+        vi.advanceTimersByTime(200);
+        await flushPromises();
+
+        aResponse.resolve({ Items: [{ CommunityRating: 1.1, CriticRating: 5 }] });
+        await flushPromises();
+
+        const container = document.getElementById('jc-osd-rating-container');
+        expect(container?.textContent).toContain('8.8');
+        expect(container?.textContent).toContain('72%');
+        expect(container?.textContent).not.toContain('1.1');
+    });
+
+    it('cancels A player waits and keeps navigation subscriptions bounded', () => {
+        const baseBodyCount = JC.core.dom!.getBodySubscriberCount();
+        const baseNavCount = JC.core.navigation!.getNavCallbackCount();
+        JC.core.api = { jf: vi.fn() } as unknown as NonNullable<typeof JC.core.api>;
+
+        JC.initializeOsdRating!();
+        expect(JC.core.dom!.getBodySubscriberCount()).toBe(baseBodyCount + 1);
+        expect(JC.core.navigation!.getNavCallbackCount()).toBe(baseNavCount + 1);
+
+        JC.identity.transition('osd-server-b', 'osd-user-b', 'osd-rating-test');
+        expect(JC.core.dom!.getBodySubscriberCount()).toBe(baseBodyCount);
+        expect(JC.core.navigation!.getNavCallbackCount()).toBe(baseNavCount);
+
+        mountPlayer();
+        JC.initializeOsdRating!();
+        const activeNavCount = JC.core.navigation!.getNavCallbackCount();
+        JC.initializeOsdRating!();
+        expect(JC.core.navigation!.getNavCallbackCount()).toBe(activeNavCount);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/osd-rating.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/osd-rating.ts
@@ -4,13 +4,26 @@
 // (Converted from js/enhanced/osd-rating.js — bodies semantically identical.)
 
 import { JC } from '../globals';
-import { waitForElement } from '../core/dom-observer';
+import { onBodyMutation } from '../core/dom-observer';
 import { onNavigate } from '../core/navigation';
+import type { IdentityContext } from '../types/jc';
 
 /** Ratings resolved for one item (display-ready values). */
 interface OsdRating {
     tmdb: string | null;
     critic: number | null;
+}
+
+/** Minimal Jellyfin item projection requested by the OSD rating endpoint. */
+interface RatingItem {
+  Type?: string;
+  SeriesId?: string;
+  CommunityRating?: unknown;
+  CriticRating?: unknown;
+}
+
+interface RatingItemsResponse {
+  Items?: RatingItem[];
 }
 
 const logPrefix = '🪼 Jellyfin Canopy: OSD Rating:';
@@ -26,6 +39,23 @@ const ratingCache = new Map<string, OsdRating>();
 const pendingRatings = new Map<string, Promise<OsdRating>>();
 let scheduledUpdate: number | null = null;
 let osdObserver: MutationObserver | null = null;
+let navUnsubscribe: (() => void) | null = null;
+let generation = 0;
+
+interface AttachAttempt {
+  readonly generation: number;
+  cancel(): void;
+}
+
+let attachAttempt: AttachAttempt | null = null;
+
+function isActive(context: IdentityContext, expectedGeneration: number): boolean {
+  return generation === expectedGeneration && JC.identity.isCurrent(context);
+}
+
+function ratingKey(context: IdentityContext, itemId: string): string {
+  return `${context.serverId}:${context.userId}:${context.epoch}:${itemId}`;
+}
 
 function isEnabled(): boolean {
   // Controlled by server config; default true unless explicitly disabled
@@ -52,26 +82,33 @@ function getCurrentItemId(): string | null {
   return favBtn?.dataset?.id || null;
 }
 
-async function fetchItemRatings(userId: string, itemId: string): Promise<OsdRating> {
+async function fetchItemRatings(
+  context: IdentityContext,
+  expectedGeneration: number,
+  itemId: string
+): Promise<OsdRating> {
   try {
-    const result: any = await ApiClient.ajax({
-      type: 'GET',
-      url: (ApiClient as { getUrl(path: string, params?: unknown): string }).getUrl(`/Users/${userId}/Items`, { Ids: itemId, Fields: 'CommunityRating,CriticRating,Type' }),
-      dataType: 'json'
+    const params = new URLSearchParams({
+      Ids: itemId,
+      Fields: 'CommunityRating,CriticRating,Type'
     });
+    const result = await JC.core.api!.jf(`/Users/${context.userId}/Items?${params}`) as RatingItemsResponse;
+    if (!isActive(context, expectedGeneration)) return { tmdb: null, critic: null };
     const item = result?.Items?.[0];
     if (!item) return { tmdb: null, critic: null };
 
     let sourceItem = item;
     if ((item.Type === 'Season' || item.Type === 'Episode') && item.SeriesId && !item.CommunityRating && !item.CriticRating) {
       try {
-        const seriesResult: any = await ApiClient.ajax({
-          type: 'GET',
-          url: (ApiClient as { getUrl(path: string, params?: unknown): string }).getUrl(`/Users/${userId}/Items`, { Ids: item.SeriesId, Fields: 'CommunityRating,CriticRating,Type' }),
-          dataType: 'json'
+        const seriesParams = new URLSearchParams({
+          Ids: String(item.SeriesId),
+          Fields: 'CommunityRating,CriticRating,Type'
         });
+        const seriesResult = await JC.core.api!.jf(`/Users/${context.userId}/Items?${seriesParams}`) as RatingItemsResponse;
+        if (!isActive(context, expectedGeneration)) return { tmdb: null, critic: null };
         sourceItem = seriesResult?.Items?.[0] || item;
       } catch (e) {
+        if (!isActive(context, expectedGeneration)) return { tmdb: null, critic: null };
         console.warn(`${logPrefix} Failed to fetch series rating for ${item.Type}`, e);
       }
     }
@@ -81,6 +118,7 @@ async function fetchItemRatings(userId: string, itemId: string): Promise<OsdRati
 
     return { tmdb, critic };
   } catch (e) {
+    if (!isActive(context, expectedGeneration)) return { tmdb: null, critic: null };
     console.warn(`${logPrefix} Failed to fetch rating for ${itemId}`, e);
     return { tmdb: null, critic: null };
   }
@@ -106,6 +144,7 @@ export function ensureStyles(): void {
 
 function injectRating(osdRoot: HTMLElement, rating: OsdRating, itemId: string): void {
   if (!osdRoot || (!rating.tmdb && rating.critic === null)) return;
+  if (!osdRoot.isConnected || getCurrentItemId() !== itemId) return;
   ensureStyles();
 
   const osdTimeContainer = osdRoot.querySelector('.osdTimeText');
@@ -151,20 +190,24 @@ function injectRating(osdRoot: HTMLElement, rating: OsdRating, itemId: string): 
   osdTimeContainer.insertAdjacentElement('beforebegin', container);
 }
 
-async function updateOsdRating(): Promise<void> {
+async function updateOsdRating(
+  context = JC.identity.capture(),
+  expectedGeneration = generation
+): Promise<void> {
+  if (!context || !isActive(context, expectedGeneration)) return;
   if (!isEnabled()) {
     console.debug(`${logPrefix} Skipped - feature disabled`);
     return;
   }
-  if (!(JC as any).isVideoPage()) {
+  if (!JC.isVideoPage?.()) {
     return;
   }
   const osdRoot = document.querySelector<HTMLElement>('.videoOsdBottom');
   if (!osdRoot) return;
 
-  const userId = ApiClient.getCurrentUserId?.();
   const itemId = getCurrentItemId();
-  if (!userId || !itemId) return;
+  if (!itemId) return;
+  const key = ratingKey(context, itemId);
 
   // Skip re-injection only if the container already shows the correct item
   const existing = osdRoot.querySelector<HTMLElement>(`#${CONTAINER_ID}`);
@@ -174,45 +217,72 @@ async function updateOsdRating(): Promise<void> {
   if (existing) existing.remove();
 
   // Serve from cache if available (including null-rating to avoid refetch loops)
-  if (ratingCache.has(itemId)) {
-    const cached = ratingCache.get(itemId);
+  if (ratingCache.has(key)) {
+    const cached = ratingCache.get(key);
     if (cached && (cached.tmdb || cached.critic !== null)) injectRating(osdRoot, cached, itemId);
     return;
   }
 
   // Reuse in-flight fetch
-  if (pendingRatings.has(itemId)) {
-    const rating = await pendingRatings.get(itemId);
-    if (rating && (rating.tmdb || rating.critic !== null)) injectRating(osdRoot, rating, itemId);
+  if (pendingRatings.has(key)) {
+    const rating = await pendingRatings.get(key);
+    if (isActive(context, expectedGeneration) && rating && (rating.tmdb || rating.critic !== null)) {
+      injectRating(osdRoot, rating, itemId);
+    }
     return;
   }
 
   const promise = (async () => {
-    const rating = await fetchItemRatings(userId, itemId);
-    ratingCache.set(itemId, rating);
+    const rating = await fetchItemRatings(context, expectedGeneration, itemId);
+    if (isActive(context, expectedGeneration)) ratingCache.set(key, rating);
     return rating;
   })();
 
-  pendingRatings.set(itemId, promise);
+  pendingRatings.set(key, promise);
 
   try {
     const rating = await promise;
-    if (rating && (rating.tmdb || rating.critic !== null)) injectRating(osdRoot, rating, itemId);
+    if (isActive(context, expectedGeneration) && rating && (rating.tmdb || rating.critic !== null)) {
+      injectRating(osdRoot, rating, itemId);
+    }
   } finally {
-    pendingRatings.delete(itemId);
+    pendingRatings.delete(key);
   }
 }
 
-function scheduleUpdate(): void {
+function scheduleUpdate(context: IdentityContext, expectedGeneration: number): void {
   if (scheduledUpdate) return;
   scheduledUpdate = window.setTimeout(() => {
     scheduledUpdate = null;
-    if ((JC as any).isVideoPage()) void updateOsdRating();
+    if (isActive(context, expectedGeneration) && JC.isVideoPage?.()) {
+      void updateOsdRating(context, expectedGeneration);
+    }
   }, 200);
 }
 
-// Guards attachOsdObserver against overlapping waitForElement waits.
-let attachInFlight = false;
+function waitForPlayerContainer(attempt: AttachAttempt): Promise<Element | null> {
+  const existing = document.querySelector('.videoPlayerContainer');
+  if (existing) return Promise.resolve(existing);
+
+  return new Promise((resolve) => {
+    let settled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    let handle: { unsubscribe(): void } | null = null;
+    const settle = (element: Element | null): void => {
+      if (settled) return;
+      settled = true;
+      if (timeoutId) clearTimeout(timeoutId);
+      handle?.unsubscribe();
+      resolve(element);
+    };
+    attempt.cancel = () => settle(null);
+    handle = onBodyMutation(`osd-rating-player-${attempt.generation}`, () => {
+      const element = document.querySelector('.videoPlayerContainer');
+      if (element) settle(element);
+    });
+    timeoutId = setTimeout(() => settle(null), 20_000);
+  });
+}
 
 /**
  * Attaches the OSD observer, scoped to the player container.
@@ -222,24 +292,25 @@ let attachInFlight = false;
  * every page. It is now created lazily when a video page mounts and is torn
  * down on leave (see the onNavigate wiring in JC.initializeOsdRating).
  */
-async function attachOsdObserver(): Promise<void> {
-  if (osdObserver || attachInFlight) return;
-  attachInFlight = true;
+async function attachOsdObserver(context: IdentityContext, expectedGeneration: number): Promise<void> {
+  if (!isActive(context, expectedGeneration)) return;
+  if (osdObserver || attachAttempt) return;
+  const attempt: AttachAttempt = { generation: expectedGeneration, cancel() { /* assigned by waiter */ } };
+  attachAttempt = attempt;
   try {
     // The player container mounts shortly after navigation; wait for it via
     // the shared body observer instead of observing body ourselves.
-    const target = document.querySelector('.videoPlayerContainer')
-      || await waitForElement('.videoPlayerContainer', 20000);
+    const target = await waitForPlayerContainer(attempt);
     if (!target) return;
-    if (!(JC as any).isVideoPage()) return; // navigated away while waiting
+    if (!isActive(context, expectedGeneration) || !JC.isVideoPage?.()) return; // navigated/switched while waiting
     if (osdObserver) return;
     osdObserver = new MutationObserver(() => {
-      scheduleUpdate();
+      scheduleUpdate(context, expectedGeneration);
     });
     osdObserver.observe(target, { childList: true, subtree: true });
-    scheduleUpdate();
+    scheduleUpdate(context, expectedGeneration);
   } finally {
-    attachInFlight = false;
+    if (attachAttempt === attempt) attachAttempt = null;
   }
 }
 
@@ -255,21 +326,40 @@ function detachOsdObserver(): void {
   }
 }
 
+function reset(): void {
+  generation++;
+  detachOsdObserver();
+  navUnsubscribe?.();
+  navUnsubscribe = null;
+  attachAttempt?.cancel();
+  attachAttempt = null;
+  ratingCache.clear();
+  pendingRatings.clear();
+  document.querySelectorAll(`#${CONTAINER_ID}`).forEach((node) => node.remove());
+}
+
 JC.initializeOsdRating = function() {
+  reset();
   if (!isEnabled()) {
     console.log(`${logPrefix} Feature is disabled in settings.`);
     return;
   }
   try {
+    const context = JC.identity.capture();
+    if (!context) return;
+    const expectedGeneration = generation;
     const syncWithPage = (): void => {
-      if ((JC as any).isVideoPage()) {
-        void attachOsdObserver();
+      if (!isActive(context, expectedGeneration)) return;
+      if (JC.isVideoPage?.()) {
+        void attachOsdObserver(context, expectedGeneration);
       } else {
         detachOsdObserver();
       }
     };
-    onNavigate(syncWithPage);
+    navUnsubscribe = onNavigate(syncWithPage);
     syncWithPage(); // boot may happen while already on a video page
     console.log(`${logPrefix} Initialized successfully.`);
   } catch (e) { console.warn(`${logPrefix} Init failed`, e); }
 };
+
+JC.identity.registerReset('osd-rating', reset);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/pages/entry-points.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/pages/entry-points.identity.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+import { registerPage } from './registry';
+import { initEntryPoints } from './entry-points';
+
+describe('page entry-point identity lifecycle', () => {
+    it('removes A chrome synchronously and does not retain an A-only link for B', async () => {
+        document.body.innerHTML = '';
+        JC.identity.transition('server-a', 'user-a', 'entry-test-start');
+        let enabled = true;
+        let language = 'A';
+        JC.t = () => `Calendar ${language}`;
+        registerPage({
+            id: 'identity-entry',
+            route: '/identity-entry',
+            titleKey: 'identity_entry',
+            titleFallback: 'Identity entry',
+            icon: 'event',
+            isEnabled: () => enabled,
+            render: vi.fn(),
+        });
+        const sidebar = document.createElement('div');
+        sidebar.className = 'mainDrawer-scrollContainer';
+        Object.defineProperty(sidebar, 'offsetParent', { get: () => document.body });
+        document.body.appendChild(sidebar);
+        initEntryPoints();
+
+        const retainedA = document.getElementById('jcPageLink-identity-entry') as HTMLAnchorElement;
+        expect(retainedA.textContent).toContain('Calendar A');
+        const hashBefore = window.location.hash;
+
+        enabled = false;
+        language = 'B';
+        const contextB = JC.identity.transition('server-a', 'user-b', 'account-switch');
+        expect(document.getElementById('jcPageLink-identity-entry')).toBeNull();
+
+        await JC.identity.activate(contextB);
+        expect(document.getElementById('jcPageLink-identity-entry')).toBeNull();
+        retainedA.click();
+        expect(window.location.hash).toBe(hashBefore);
+        JC.core.dom!.removeBodySubscriber('jc-pages-entries');
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/pages/entry-points.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/pages/entry-points.ts
@@ -28,15 +28,18 @@ import { orderedPages, pageAvailable, resolvePage } from './registry';
 import { openPage } from './router-bridge';
 import { refreshCurrent } from './fallback-host';
 import type { PageDescriptor } from './types';
+import type { IdentityContext } from '../../types/jc';
 
 const PAGES_TRAY_ORDER_BASE = 30;
+let initialized = false;
 
 function pageTitle(descriptor: PageDescriptor): string {
     return JC.t?.(descriptor.titleKey) || descriptor.titleFallback;
 }
 
-function activate(descriptor: PageDescriptor, event: Event): void {
+function activate(descriptor: PageDescriptor, event: Event, context: IdentityContext): void {
     event.preventDefault();
+    if (!JC.identity.isCurrent(context)) return;
     if (resolvePage() === descriptor) {
         refreshCurrent();
         return;
@@ -85,12 +88,14 @@ function drawerLinkId(descriptor: PageDescriptor): string {
     return `jcPageLink-${descriptor.id}`;
 }
 
-function buildDrawerLink(descriptor: PageDescriptor): HTMLAnchorElement {
+function buildDrawerLink(descriptor: PageDescriptor, context: IdentityContext): HTMLAnchorElement {
     const link = document.createElement('a');
     link.setAttribute('is', 'emby-linkbutton');
     link.className = 'lnkMediaFolder navMenuOption emby-button';
     link.href = `#${descriptor.route}`;
     link.id = drawerLinkId(descriptor);
+    link.setAttribute('data-jc-identity-owned', 'true');
+    JC.identity.own(link, context);
     const icon = document.createElement('span');
     icon.className = 'material-icons navMenuOptionIcon';
     icon.setAttribute('aria-hidden', 'true');
@@ -99,12 +104,14 @@ function buildDrawerLink(descriptor: PageDescriptor): HTMLAnchorElement {
     label.className = 'sectionName navMenuOptionText';
     label.textContent = pageTitle(descriptor);
     link.append(icon, label);
-    link.addEventListener('click', (e) => activate(descriptor, e));
+    link.addEventListener('click', (e) => activate(descriptor, e, context));
     return link;
 }
 
 /** Reconcile the drawer entries with the live registry state. */
 function reconcileDrawer(): void {
+    const context = JC.identity.capture();
+    if (!context) return;
     const sidebar = getSidebarContainer();
     if (!sidebar) return;
     const section = ensureCanopySection(sidebar);
@@ -117,8 +124,12 @@ function reconcileDrawer(): void {
             continue;
         }
         let link = existing;
+        if (link && !JC.identity.isOwned(link, context)) {
+            link.remove();
+            link = null;
+        }
         if (!link) {
-            link = buildDrawerLink(descriptor);
+            link = buildDrawerLink(descriptor, context);
         }
         // Deterministic order regardless of injection timing: place each
         // entry right after the previous one (header first).
@@ -137,6 +148,8 @@ function trayButtonId(descriptor: PageDescriptor): string {
 }
 
 function reconcileTray(): void {
+    const context = JC.identity.capture();
+    if (!context) return;
     // The tray is the modern layout's surface; the legacy header has the
     // drawer instead. getHeaderRightContainer resolves per layout — on the
     // legacy layout the drawer covers discovery, so skip the tray there.
@@ -144,7 +157,11 @@ function reconcileTray(): void {
     const tray = getHeaderRightContainer();
     if (!tray) return;
     orderedPages().forEach((descriptor, index) => {
-        const existing = document.getElementById(trayButtonId(descriptor));
+        let existing = document.getElementById(trayButtonId(descriptor));
+        if (existing && !JC.identity.isOwned(existing, context)) {
+            existing.remove();
+            existing = null;
+        }
         if (!pageAvailable(descriptor)) {
             existing?.remove();
             return;
@@ -155,13 +172,15 @@ function reconcileTray(): void {
         button.type = 'button';
         button.setAttribute('is', 'paper-icon-button-light');
         button.className = 'headerButton headerButtonRight paper-icon-button-light';
+        button.setAttribute('data-jc-identity-owned', 'true');
+        JC.identity.own(button, context);
         button.title = pageTitle(descriptor);
         const icon = document.createElement('span');
         icon.className = 'material-icons';
         icon.setAttribute('aria-hidden', 'true');
         icon.textContent = descriptor.icon;
         button.appendChild(icon);
-        button.addEventListener('click', (e) => activate(descriptor, e));
+        button.addEventListener('click', (e) => activate(descriptor, e, context));
         insertHeaderTrayButton(tray, button, PAGES_TRAY_ORDER_BASE + index);
     });
 }
@@ -173,12 +192,18 @@ function prefsLinkId(descriptor: PageDescriptor): string {
 }
 
 function reconcilePrefsMenu(): void {
+    const context = JC.identity.capture();
+    if (!context) return;
     const page = document.getElementById('myPreferencesMenuPage');
     if (!page || page.classList.contains('hide')) return;
     const menuContainer = page.querySelector('.verticalSection');
     if (!menuContainer) return;
     for (const descriptor of orderedPages()) {
-        const existing = document.getElementById(prefsLinkId(descriptor));
+        let existing = document.getElementById(prefsLinkId(descriptor));
+        if (existing && !JC.identity.isOwned(existing, context)) {
+            existing.remove();
+            existing = null;
+        }
         if (!pageAvailable(descriptor)) {
             existing?.remove();
             continue;
@@ -190,6 +215,8 @@ function reconcilePrefsMenu(): void {
         link.setAttribute('data-ripple', 'false');
         link.href = `#${descriptor.route}`;
         link.className = 'listItem-border emby-button';
+        link.setAttribute('data-jc-identity-owned', 'true');
+        JC.identity.own(link, context);
         link.style.display = 'block';
         link.style.padding = '0';
         link.style.margin = '0';
@@ -206,13 +233,15 @@ function reconcilePrefsMenu(): void {
         body.appendChild(text);
         item.append(icon, body);
         link.appendChild(item);
-        link.addEventListener('click', (e) => activate(descriptor, e));
+        link.addEventListener('click', (e) => activate(descriptor, e, context));
         menuContainer.appendChild(link);
     }
 }
 
 /** Wire all surfaces off the shared observers/events (no private pollers). */
 export function initEntryPoints(): void {
+    if (initialized) return;
+    initialized = true;
     onBodyMutation('jc-pages-entries', () => {
         reconcileDrawer();
         reconcileTray();
@@ -228,3 +257,18 @@ export function initEntryPoints(): void {
     reconcileDrawer();
     reconcileTray();
 }
+
+function resetEntryPoints(): void {
+    document.querySelectorAll<HTMLElement>(
+        '[id^="jcPageLink-"], [id^="jcPageTray-"], [id^="jcPagePrefs-"]'
+    ).forEach((entry) => entry.remove());
+}
+
+function activateEntryPoints(): void {
+    reconcileDrawer();
+    reconcileTray();
+    reconcilePrefsMenu();
+}
+
+JC.identity.registerReset('pages-entry-points', resetEntryPoints);
+JC.identity.registerActivate('pages-entry-points', activateEntryPoints);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/pages/index.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/pages/index.ts
@@ -13,7 +13,7 @@
 
 import { JC } from '../../globals';
 import { installEarlyMask } from './early-mask';
-import { initFallbackHost, lateAdoptIfOnPage } from './fallback-host';
+import { drain, initFallbackHost, lateAdoptIfOnPage } from './fallback-host';
 import { initEntryPoints } from './entry-points';
 
 installEarlyMask();
@@ -34,3 +34,11 @@ export function initPagesFramework(): void {
 }
 
 JC.initializePagesFramework = initPagesFramework;
+
+// A fallback page can survive the host's no-reload login route swap. Drain it
+// synchronously before the loader replaces A's globals, then reconcile the
+// still-mounted route once B's atomic snapshot has been committed.
+JC.identity.registerReset('pages-framework', () => drain('identity-change'));
+JC.identity.registerActivate('pages-framework', () => {
+    if (initialized) lateAdoptIfOnPage();
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/pausescreen.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/pausescreen.test.ts
@@ -18,11 +18,21 @@ function initPauseScreen(): void {
     (window.JellyfinCanopy as unknown as PauseApi).initializePauseScreen();
 }
 
+function destroyPauseScreen(): void {
+    const instance = jc()._pauseScreenInstance as { destroy?: () => void } | undefined;
+    instance?.destroy?.();
+    jc()._pauseScreenInstance = undefined;
+}
+
 describe('pause-screen singleton + teardown', () => {
     beforeEach(() => {
+        // Do not discard the only handle to a previous test's shared-body
+        // subscription. A connected jsdom MutationObserver can otherwise
+        // deliver its final record after the environment has removed the
+        // global `document`, producing misleading full-suite stderr.
+        destroyPauseScreen();
         document.body.innerHTML = '';
         document.head.innerHTML = '';
-        jc()._pauseScreenInstance = undefined;
         (window.JellyfinCanopy as unknown as { t: (k: string) => string }).t = (k: string) => k;
         jc().currentSettings = { pauseScreenEnabled: true, pauseScreenDelaySeconds: 5 };
         localStorage.setItem(
@@ -32,6 +42,7 @@ describe('pause-screen singleton + teardown', () => {
     });
 
     afterEach(() => {
+        destroyPauseScreen();
         vi.restoreAllMocks();
         localStorage.clear();
     });
@@ -69,5 +80,20 @@ describe('pause-screen singleton + teardown', () => {
         expect(revokeSpy).toHaveBeenCalledWith('blob:a');
         expect(revokeSpy).toHaveBeenCalledWith('blob:b');
         expect(inst.imgBlobCache.size).toBe(0);
+    });
+
+    it('destroy releases the shared body subscription before later DOM mutations', async () => {
+        initPauseScreen();
+        const inst = jc()._pauseScreenInstance as {
+            checkForVideoChanges: () => void;
+            destroy: () => void;
+        };
+        const checkSpy = vi.spyOn(inst, 'checkForVideoChanges');
+
+        destroyPauseScreen();
+        document.body.append(document.createElement('div'));
+        await Promise.resolve();
+
+        expect(checkSpy).not.toHaveBeenCalled();
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/pausescreen.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/pausescreen.ts
@@ -6,15 +6,10 @@
 // (Converted from js/enhanced/pausescreen.js — bodies semantically identical.)
 
 import { JC } from '../globals';
-import type { BodySubscriberHandle } from '../types/jc';
+import type { BodySubscriberHandle, IdentityContext } from '../types/jc';
 import { onBodyMutation } from '../core/dom-observer';
 
 JC.initializePauseScreen = function() {
-  // Only run if the feature is enabled in the user's settings
-  if (!JC.currentSettings?.pauseScreenEnabled) {
-      console.log('🪼 Jellyfin Canopy: Custom Pause Screen is disabled.');
-      return;
-  }
   // Singleton: a prior instance (Stage-6 re-invokes this on config hot-reload /
   // account switch) must be torn down before constructing a new one, or its
   // overlay/style/document listeners stack. The boot below now retains the
@@ -25,6 +20,12 @@ JC.initializePauseScreen = function() {
       try { prevInstance.destroy(); }
       catch (e) { console.warn('🪼 Jellyfin Canopy: pause-screen destroy failed', e); }
       JC._pauseScreenInstance = undefined;
+  }
+  // Tear down A before evaluating B's gate. Otherwise A-enabled → B-disabled
+  // leaves A's overlay/listeners/token-bearing instance alive indefinitely.
+  if (!JC.currentSettings?.pauseScreenEnabled) {
+      console.log('🪼 Jellyfin Canopy: Custom Pause Screen is disabled.');
+      return;
   }
     class JellyfinPauseScreen {
       // State
@@ -39,6 +40,7 @@ JC.initializePauseScreen = function() {
       itemCache = new Map<string, { item: any; domain: string }>();
       fetchAbort: AbortController | null = null;
       observer: BodySubscriberHandle | null = null;
+      identityContext: IdentityContext | null = null;
       prevFocused: Element | null = null;
 
       // Pause screen delay state
@@ -75,6 +77,7 @@ JC.initializePauseScreen = function() {
         this.itemCache = new Map();
         this.fetchAbort = null;
         this.observer = null;
+        this.identityContext = JC.identity.capture();
         this.prevFocused = null;
 
         // Pause screen delay state
@@ -117,13 +120,16 @@ JC.initializePauseScreen = function() {
         this.setupInteractionListeners();
       }
 
+      isIdentityCurrent(): boolean {
+        return JC.identity.isCurrent(this.identityContext);
+      }
+
       getCredentials(): { token: string; userId: string } | null {
-        const creds = localStorage.getItem("jellyfin_credentials");
-        if (!creds) return null;
         try {
-          const parsed = JSON.parse(creds);
-          const server = parsed.Servers?.[0];
-          return server ? { token: server.AccessToken, userId: server.UserId } : null;
+          const context = this.identityContext;
+          if (!context || !JC.identity.isCurrent(context)) return null;
+          const token = ApiClient.accessToken?.();
+          return token ? { token, userId: context.userId } : null;
         } catch {
           return null;
         }
@@ -633,6 +639,7 @@ JC.initializePauseScreen = function() {
       }
 
       async handleVideoChange(video: HTMLVideoElement) {
+        if (!this.isIdentityCurrent()) return;
         this.clearState();
         this.currentVideo = video;
         this.cleanupListeners = this.attachVideoListeners(video);
@@ -651,6 +658,7 @@ JC.initializePauseScreen = function() {
         if (itemId) {
           this.currentItemId = itemId;
           await this.fetchItemInfo(itemId);
+          if (!this.isIdentityCurrent()) return;
         }
       }
 
@@ -748,6 +756,7 @@ JC.initializePauseScreen = function() {
       }
 
       async fetchItemInfo(itemId: string) {
+        if (!this.isIdentityCurrent()) return;
           this.clearDisplayData();
           this.fetchAbort?.abort();
           this.fetchAbort = new AbortController();
@@ -759,6 +768,7 @@ JC.initializePauseScreen = function() {
                   headers: { "Authorization": 'MediaBrowser Token="' + this.token + '"', "Accept": "application/json" },
                   signal: this.fetchAbort.signal
               });
+              if (!this.isIdentityCurrent()) return;
               record = { item: itemResp, domain: (ApiClient as any).serverAddress() };
               this.itemCache.set(itemId, record);
               }
@@ -774,10 +784,13 @@ JC.initializePauseScreen = function() {
       async fetchWithRetry(url: string, options: RequestInit, maxRetries = 2): Promise<any> {
         for (let i = 0; i <= maxRetries; i++) {
           try {
+            if (!this.isIdentityCurrent()) throw new DOMException('Identity changed', 'AbortError');
             const response = await fetch(url, options);
+            if (!this.isIdentityCurrent()) throw new DOMException('Identity changed', 'AbortError');
             if (!response.ok) throw new Error(`HTTP ${response.status}`);
             return await response.json();
           } catch (error) {
+            if ((error as Error)?.name === 'AbortError') throw error;
             if (i === maxRetries) throw error;
             await new Promise(r => setTimeout(r, 1000 * (i + 1)));
           }
@@ -785,6 +798,7 @@ JC.initializePauseScreen = function() {
       }
 
       async displayItemInfo(item: any, domain: string, itemId: string) {
+        if (!this.isIdentityCurrent()) return;
         // Details
         const year = item.ProductionYear || "";
         const rating = item.OfficialRating || "";
@@ -807,6 +821,7 @@ JC.initializePauseScreen = function() {
           this.firstAvailableBlobURL(discUrls),
           this.firstAvailableBlobURL(backdropUrls)
         ]);
+        if (!this.isIdentityCurrent()) return;
 
         if (logoURL) this.overlayLogo.src = logoURL;
         if (discURL) this.overlayDisc.src = discURL;
@@ -870,6 +885,7 @@ JC.initializePauseScreen = function() {
       // ------- Image helpers (blob cache) -------
       async firstAvailableBlobURL(urls: string[]): Promise<string | null> {
         for (const url of urls) {
+          if (!this.isIdentityCurrent()) return null;
           if (!url) continue;
           const ok = await this.probeImage(url);
           if (!ok) continue;
@@ -879,6 +895,7 @@ JC.initializePauseScreen = function() {
         return null;
       }
       async probeImage(url: string, timeoutMs = 2500): Promise<boolean> {
+        if (!this.isIdentityCurrent()) return false;
         if (this.imgProbeCache.has(url)) return this.imgProbeCache.get(url)!;
         try {
           const ctl = new AbortController();
@@ -889,6 +906,7 @@ JC.initializePauseScreen = function() {
             signal: ctl.signal
           });
           clearTimeout(t);
+          if (!this.isIdentityCurrent()) return false;
           const ok = res.ok;
           this.imgProbeCache.set(url, ok);
           return ok;
@@ -898,6 +916,7 @@ JC.initializePauseScreen = function() {
         }
       }
       async toBlobURL(url: string, timeoutMs = 5000): Promise<string | null> {
+        if (!this.isIdentityCurrent()) return null;
         if (this.imgBlobCache.has(url)) return this.imgBlobCache.get(url)!;
         try {
           const ctl = new AbortController();
@@ -907,8 +926,9 @@ JC.initializePauseScreen = function() {
             signal: ctl.signal
           });
           clearTimeout(t);
-          if (!res.ok) return null;
+          if (!res.ok || !this.isIdentityCurrent()) return null;
           const blob = await res.blob();
+          if (!this.isIdentityCurrent()) return null;
           const obj = URL.createObjectURL(blob);
           this.imgBlobCache.set(url, obj);
           return obj;
@@ -986,3 +1006,15 @@ JC.initializePauseScreen = function() {
     JC._pauseScreenInstance = new JellyfinPauseScreen();
       console.log('🪼 Jellyfin Canopy: Custom Pause Screen initialized.');
   };
+
+JC.identity.registerReset('pause-screen', () => {
+  const instance = JC._pauseScreenInstance;
+  if (instance) {
+    try { instance.destroy(); } catch { /* complete the shared reset */ }
+    JC._pauseScreenInstance = undefined;
+  }
+  if (JC.state?.pauseScreenClickTimer != null) {
+    clearTimeout(JC.state.pauseScreenClickTimer);
+    JC.state.pauseScreenClickTimer = null;
+  }
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/playback.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/playback.identity.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../globals';
+
+function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((done) => { resolve = done; });
+    return { promise, resolve };
+}
+
+async function flushPromises(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+}
+
+function mountVideo(src: string, currentTime = 10): HTMLVideoElement {
+    const video = document.createElement('video');
+    Object.defineProperty(video, 'currentSrc', { configurable: true, get: () => src });
+    Object.defineProperty(video, 'duration', { configurable: true, value: 120 });
+    video.currentTime = currentTime;
+    document.body.appendChild(video);
+    return video;
+}
+
+function fpsItem(fps: number): unknown {
+    return {
+        MediaSources: [{
+            Id: 'source-1',
+            MediaStreams: [{ Type: 'Video', RealFrameRate: fps }],
+        }],
+    };
+}
+
+describe('playback identity lifecycle', () => {
+    beforeAll(async () => {
+        await import('./playback');
+    });
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        document.body.innerHTML = '';
+        window.history.replaceState(null, '', '/web/index.html#/video');
+        JC.identity.transition('play-server-a', 'play-user-a', 'playback-test');
+        JC.currentSettings = { longPress2xEnabled: true, autoSkipIntro: true };
+        const surface = JC as unknown as Record<string, unknown>;
+        surface.state = { activeShortcuts: {}, pauseScreenClickTimer: null };
+        surface.icon = () => '';
+        surface.IconName = { FAST_FORWARD: 'fast_forward', PLAY: 'play' };
+        surface.t = (key: string) => key;
+    });
+
+    afterEach(() => {
+        JC.identity.transition('', '', 'playback-test-cleanup');
+        JC.core.api = undefined;
+        vi.restoreAllMocks();
+        vi.clearAllTimers();
+        vi.useRealTimers();
+        document.body.innerHTML = '';
+        window.history.replaceState(null, '', '/web/index.html#/home');
+    });
+
+    it('does not let a held A FPS lookup seek or overwrite B frame-step state', async () => {
+        window.history.replaceState(null, '', '/web/index.html#/video?id=item-shared');
+        const video = mountVideo('http://jellyfin.test/Videos/item-shared/stream?MediaSourceId=source-1');
+        const aResponse = deferred<unknown>();
+        const getItem = vi.spyOn(ApiClient, 'getItem')
+            .mockReturnValueOnce(aResponse.promise)
+            .mockResolvedValueOnce(fpsItem(60));
+
+        const aStep = JC.frameStep!('forward');
+        await flushPromises();
+        expect(getItem).toHaveBeenNthCalledWith(1, 'playusera', 'item-shared');
+
+        JC.identity.transition('play-server-b', 'play-user-b', 'playback-test');
+        JC.currentSettings = {};
+        const bStep = JC.frameStep!('forward');
+        await bStep;
+        expect(getItem).toHaveBeenNthCalledWith(2, 'playuserb', 'item-shared');
+        const bTime = video.currentTime;
+        expect(bTime).toBeCloseTo(10 + (1 / 60), 6);
+
+        aResponse.resolve(fpsItem(12));
+        await aStep;
+
+        expect(video.currentTime).toBeCloseTo(bTime, 8);
+        expect(document.querySelector('[data-jc-frame-overlay="true"]')?.textContent).toContain('60 fps');
+    });
+
+    it('does not share or apply FPS across a same-item media-source switch', async () => {
+        window.history.replaceState(null, '', '/web/index.html#/video?id=item-shared');
+        let src = 'http://jellyfin.test/Videos/item-shared/stream?MediaSourceId=source-1';
+        const video = document.createElement('video');
+        Object.defineProperty(video, 'currentSrc', { configurable: true, get: () => src });
+        Object.defineProperty(video, 'duration', { configurable: true, value: 120 });
+        video.currentTime = 10;
+        document.body.appendChild(video);
+        const sourceOne = deferred<unknown>();
+        const getItem = vi.spyOn(ApiClient, 'getItem')
+            .mockReturnValueOnce(sourceOne.promise)
+            .mockResolvedValueOnce({
+                MediaSources: [{
+                    Id: 'source-2',
+                    MediaStreams: [{ Type: 'Video', RealFrameRate: 50 }],
+                }],
+            });
+
+        const oldSourceStep = JC.frameStep!('forward');
+        await flushPromises();
+        src = 'http://jellyfin.test/Videos/item-shared/stream?MediaSourceId=source-2';
+        const newSourceStep = JC.frameStep!('forward');
+        await newSourceStep;
+
+        expect(getItem).toHaveBeenCalledTimes(2);
+        const newSourceTime = video.currentTime;
+        expect(newSourceTime).toBeCloseTo(10 + (1 / 50), 6);
+
+        sourceOne.resolve(fpsItem(12));
+        await oldSourceStep;
+
+        expect(video.currentTime).toBeCloseTo(newSourceTime, 8);
+        expect(document.querySelector('[data-jc-frame-overlay="true"]')?.textContent).toContain('50 fps');
+    });
+
+    it('cancels A long-press work and restores only the video A changed', () => {
+        const aVideo = mountVideo('blob:a', 5);
+        Object.defineProperty(aVideo, 'paused', { configurable: true, value: false });
+        aVideo.playbackRate = 1.25;
+
+        JC.handleLongPressDown!({ button: 0, clientX: 20, clientY: 20 } as unknown as Event);
+        vi.advanceTimersByTime(500);
+        expect(aVideo.playbackRate).toBe(2);
+        expect(document.querySelector('[data-speed-overlay="true"]')).not.toBeNull();
+
+        aVideo.remove();
+        const bVideo = mountVideo('blob:b', 5);
+        bVideo.playbackRate = 1.5;
+        JC.identity.transition('play-server-b', 'play-user-b', 'playback-test');
+        JC.currentSettings = { longPress2xEnabled: true };
+        vi.runOnlyPendingTimers();
+
+        expect(aVideo.playbackRate).toBe(1.25);
+        expect(bVideo.playbackRate).toBe(1.5);
+        expect(document.querySelector('[data-speed-overlay="true"]')).toBeNull();
+    });
+
+    it('drops A delayed settings callbacks at the synchronous transition boundary', () => {
+        document.body.innerHTML = '<div class="videoOsdBottom"><button class="btnVideoOsdSettings"></button></div>';
+        const callback = vi.fn();
+
+        JC.openSettings!(callback);
+        JC.identity.transition('play-server-b', 'play-user-b', 'playback-test');
+        vi.advanceTimersByTime(120);
+
+        expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('recreates the blob-source session resolver so A cannot seed B auto-skip', async () => {
+        window.history.replaceState(null, '', '/web/index.html#/video');
+        const video = mountVideo('blob:shared-source', 0.5);
+        (ApiClient as unknown as Record<string, unknown>).deviceId = () => 'device-1';
+        const aSessions = deferred<unknown>();
+        const aJf = vi.fn().mockReturnValue(aSessions.promise);
+        JC.core.api = { jf: aJf } as unknown as NonNullable<typeof JC.core.api>;
+
+        JC.initializeAutoSkipObserver!();
+        await flushPromises();
+        expect(aJf).toHaveBeenCalledWith(
+            '/Sessions?ControllableByUserId=playusera',
+            { skipCache: true },
+        );
+
+        JC.identity.transition('play-server-b', 'play-user-b', 'playback-test');
+        JC.currentSettings = { autoSkipIntro: true };
+        const bJf = vi.fn((path: string) => {
+            if (path.startsWith('/Sessions?')) {
+                return Promise.resolve([{ DeviceId: 'device-1', NowPlayingItem: { Id: 'item-b' } }]);
+            }
+            if (path === '/MediaSegments/item-b') {
+                return Promise.resolve({ Items: [{ Id: 'intro-b', Type: 'Intro', StartTicks: 0, EndTicks: 100_000_000 }] });
+            }
+            return Promise.resolve({ Items: [] });
+        });
+        JC.core.api = { jf: bJf } as unknown as NonNullable<typeof JC.core.api>;
+        JC.initializeAutoSkipObserver!();
+        await flushPromises();
+        video.dispatchEvent(new Event('timeupdate'));
+        await flushPromises();
+        video.dispatchEvent(new Event('timeupdate'));
+
+        expect(video.currentTime).toBe(10);
+        expect(bJf).toHaveBeenCalledWith('/MediaSegments/item-b', { skipCache: true });
+
+        aSessions.resolve([{ DeviceId: 'device-1', NowPlayingItem: { Id: 'item-a' } }]);
+        await flushPromises();
+        video.dispatchEvent(new Event('timeupdate'));
+
+        expect(bJf.mock.calls.some(([path]) => path === '/MediaSegments/item-a')).toBe(false);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/playback.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/playback.ts
@@ -8,6 +8,55 @@ import { toast } from '../core/ui-kit';
 import { createAutoSkipEngine,
     createSessionItemResolver, parseTranscodeOffsetTicksFromSrc } from './auto-skip';
 import type { AutoSkipEngine, MediaSegment, VideoLike } from './auto-skip';
+import type { IdentityContext } from '../types/jc';
+
+interface FpsStream {
+    Type?: string;
+    ReferenceFrameRate?: unknown;
+    RealFrameRate?: unknown;
+    AverageFrameRate?: unknown;
+}
+
+interface FpsMediaSource {
+    Id?: string;
+    MediaStreams?: FpsStream[];
+}
+
+interface FpsItem {
+    MediaSources?: FpsMediaSource[];
+}
+
+interface SeekTrackedVideo extends HTMLVideoElement {
+    _jeSeekTrackerAttached?: boolean;
+}
+
+interface LongPressEventData {
+    button?: number;
+    clientX?: number;
+    clientY?: number;
+    touches?: ArrayLike<{ clientX: number; clientY: number }>;
+}
+
+function longPressEventData(event: Event): LongPressEventData {
+    return event as Event & LongPressEventData;
+}
+
+const playbackTimers = new Set<number>();
+
+function schedulePlaybackTimer(context: IdentityContext, callback: () => void, delay: number): number {
+    const timer = window.setTimeout(() => {
+        playbackTimers.delete(timer);
+        if (JC.identity.isCurrent(context)) callback();
+    }, delay);
+    playbackTimers.add(timer);
+    return timer;
+}
+
+function cancelPlaybackTimer(timer: number | null): void {
+    if (timer === null) return;
+    clearTimeout(timer);
+    playbackTimers.delete(timer);
+}
 
 /**
  * Finds the currently active video element on the page.
@@ -24,8 +73,10 @@ const settingsBtn = (): HTMLElement | null => document.querySelector<HTMLElement
 );
 
 JC.openSettings = (cb: () => void) => {
+    const context = JC.identity.capture();
+    if (!context) return;
     settingsBtn()?.click();
-    setTimeout(cb, 120); // Wait for the menu to animate open
+    schedulePlaybackTimer(context, cb, 120); // Wait for the menu to animate open
 };
 
 /**
@@ -88,6 +139,7 @@ const _fpsInflight = new Map<string, Promise<number>>();
 let _frameOverlay: HTMLElement | null = null;
 let _frameOverlayHideTimer: number | null = null;
 let _frameOverlayFadeTimer: number | null = null;
+let _frameOverlayFrame: number | null = null;
 const _fallbackFpsWarned = new Set<string>();
 
 function getCurrentVideoItemId(): string | null {
@@ -102,11 +154,11 @@ function getCurrentVideoItemId(): string | null {
     }
 }
 
-function pickFps(stream: any): number | null {
+function pickFps(stream: FpsStream | null | undefined): number | null {
     if (!stream) return null;
     const candidates = [stream.ReferenceFrameRate, stream.RealFrameRate, stream.AverageFrameRate];
     for (const c of candidates) {
-        const n = parseFloat(c);
+        const n = Number(c);
         if (Number.isFinite(n) && n >= 1 && n < 1000) return n;
     }
     return null;
@@ -124,70 +176,89 @@ function getActiveMediaSourceId(video: HTMLVideoElement | null): string | null {
     }
 }
 
-async function fetchFpsForItem(itemId: string, activeMediaSourceId: string | null): Promise<number | null> {
+async function fetchFpsForItem(
+    context: IdentityContext,
+    itemId: string,
+    activeMediaSourceId: string | null,
+): Promise<number | null> {
     if (!itemId || !window.ApiClient) return null;
     try {
-        const userId = window.ApiClient.getCurrentUserId();
-        const item: any = await window.ApiClient.getItem(userId, itemId);
+        const item = await window.ApiClient.getItem(context.userId, itemId) as FpsItem | null;
+        if (!JC.identity.isCurrent(context)) return null;
         const sources = Array.isArray(item?.MediaSources) ? item.MediaSources : [];
         const ordered = activeMediaSourceId
-            ? [...sources.filter((s: any) => s.Id === activeMediaSourceId), ...sources.filter((s: any) => s.Id !== activeMediaSourceId)]
+            ? [...sources.filter((source) => source.Id === activeMediaSourceId), ...sources.filter((source) => source.Id !== activeMediaSourceId)]
             : sources;
         for (const source of ordered) {
-            const vs = source.MediaStreams?.find((s: any) => s.Type === 'Video');
+            const vs = source.MediaStreams?.find((stream) => stream.Type === 'Video');
             const fps = pickFps(vs);
             if (fps) return fps;
         }
     } catch (err) {
+        if (!JC.identity.isCurrent(context)) return null;
         console.warn('🪼 Jellyfin Canopy: frame-step fps lookup failed', err);
     }
     return null;
 }
 
-function getFpsCacheKey(itemId: string | null, video: HTMLVideoElement | null): string | null {
+function getFpsCacheKey(
+    context: IdentityContext,
+    itemId: string | null,
+    video: HTMLVideoElement | null,
+): string | null {
     if (!itemId) return null;
     const msId = getActiveMediaSourceId(video);
-    if (msId) return `${itemId}|ms:${msId}`;
+    const owner = `${context.serverId}:${context.userId}:${context.epoch}`;
+    if (msId) return `${owner}|${itemId}|ms:${msId}`;
     const src = (video?.currentSrc || video?.src || '').split('?')[0];
-    return `${itemId}|src:${src}`;
+    return `${owner}|${itemId}|src:${src}`;
 }
 
-async function resolveFps(video: HTMLVideoElement | null): Promise<number> {
+async function resolveFps(context: IdentityContext, video: HTMLVideoElement | null): Promise<number> {
+    if (!JC.identity.isCurrent(context)) return FRAME_STEP_FALLBACK_FPS;
     const itemId = getCurrentVideoItemId();
-    const cacheKey = getFpsCacheKey(itemId, video);
+    const cacheKey = getFpsCacheKey(context, itemId, video);
     if (cacheKey && _fpsCache.has(cacheKey)) return _fpsCache.get(cacheKey)!;
-    // Inflight keyed by itemId so presses before/after currentSrc populates share one fetch.
-    if (itemId && _fpsInflight.has(itemId)) return _fpsInflight.get(itemId)!;
+    // Source-aware: the same item can switch MediaSourceId while a lookup is in
+    // flight (quality/source change). Sharing that promise would apply the old
+    // source's FPS to the new stream.
+    const inflightKey = cacheKey;
+    if (inflightKey && _fpsInflight.has(inflightKey)) return _fpsInflight.get(inflightKey)!;
 
     const activeMediaSourceId = getActiveMediaSourceId(video);
+    const activeSourcePath = (video?.currentSrc || video?.src || '').split('?')[0];
     const promise = (async () => {
-        const fetched = itemId ? await fetchFpsForItem(itemId, activeMediaSourceId) : null;
+        const fetched = itemId ? await fetchFpsForItem(context, itemId, activeMediaSourceId) : null;
+        if (!JC.identity.isCurrent(context)) return FRAME_STEP_FALLBACK_FPS;
         const isReal = Number.isFinite(fetched) && (fetched as number) >= 1;
         const fps = isReal ? (fetched as number) : FRAME_STEP_FALLBACK_FPS;
         // Build write key from the source we fetched for, not getVideo() which may have swapped.
         const finalKey = itemId
             ? (activeMediaSourceId
-                ? `${itemId}|ms:${activeMediaSourceId}`
-                : `${itemId}|src:${(video?.currentSrc || video?.src || '').split('?')[0]}`)
+                ? `${context.serverId}:${context.userId}:${context.epoch}|${itemId}|ms:${activeMediaSourceId}`
+                : `${context.serverId}:${context.userId}:${context.epoch}|${itemId}|src:${activeSourcePath}`)
             : null;
         if (finalKey && isReal) _fpsCache.set(finalKey, fps);
-        if (!isReal && itemId && !_fallbackFpsWarned.has(itemId)) {
+        const warnedKey = itemId ? `${context.epoch}:${itemId}` : null;
+        if (!isReal && warnedKey && !_fallbackFpsWarned.has(warnedKey)) {
             try {
                 toast(tWithFallback(
                     'toast_frame_step_fps_fallback',
                     'ℹ Frame step using fallback {fps} fps (actual rate unknown)',
                     { fps: FRAME_STEP_FALLBACK_FPS }
                 ));
-                _fallbackFpsWarned.add(itemId);
+                _fallbackFpsWarned.add(warnedKey);
             } catch (err) {
                 console.warn('🪼 Jellyfin Canopy: frame-step fallback toast failed', err);
             }
         }
         return fps;
     })();
-    if (itemId) _fpsInflight.set(itemId, promise);
+    if (inflightKey) _fpsInflight.set(inflightKey, promise);
     try { return await promise; }
-    finally { if (itemId) _fpsInflight.delete(itemId); }
+    finally {
+        if (inflightKey && _fpsInflight.get(inflightKey) === promise) _fpsInflight.delete(inflightKey);
+    }
 }
 
 // JC.t returns the raw key on miss; tWithFallback substitutes an inline English default
@@ -217,7 +288,8 @@ function tWithFallback(key: string, fallback: string, params?: Record<string, un
     return result;
 }
 
-function showFrameOverlay(text: string): void {
+function showFrameOverlay(context: IdentityContext, text: string): void {
+    if (!JC.identity.isCurrent(context)) return;
     if (!_frameOverlay) {
         _frameOverlay = document.createElement('div');
         _frameOverlay.setAttribute('data-jc-frame-overlay', 'true');
@@ -233,17 +305,19 @@ function showFrameOverlay(text: string): void {
     }
     _frameOverlay.textContent = text;
     _frameOverlay.style.display = 'block';
-    requestAnimationFrame(() => {
-        if (_frameOverlay) _frameOverlay.style.opacity = '1';
+    if (_frameOverlayFrame !== null) cancelAnimationFrame(_frameOverlayFrame);
+    _frameOverlayFrame = requestAnimationFrame(() => {
+        _frameOverlayFrame = null;
+        if (JC.identity.isCurrent(context) && _frameOverlay) _frameOverlay.style.opacity = '1';
     });
 
-    if (_frameOverlayHideTimer) { clearTimeout(_frameOverlayHideTimer); _frameOverlayHideTimer = null; }
-    if (_frameOverlayFadeTimer) { clearTimeout(_frameOverlayFadeTimer); _frameOverlayFadeTimer = null; }
-    _frameOverlayHideTimer = window.setTimeout(() => {
+    cancelPlaybackTimer(_frameOverlayHideTimer);
+    cancelPlaybackTimer(_frameOverlayFadeTimer);
+    _frameOverlayHideTimer = schedulePlaybackTimer(context, () => {
         _frameOverlayHideTimer = null;
         if (!_frameOverlay) return;
         _frameOverlay.style.opacity = '0';
-        _frameOverlayFadeTimer = window.setTimeout(() => {
+        _frameOverlayFadeTimer = schedulePlaybackTimer(context, () => {
             _frameOverlayFadeTimer = null;
             if (_frameOverlay && _frameOverlay.style.opacity === '0') {
                 _frameOverlay.style.display = 'none';
@@ -254,24 +328,35 @@ function showFrameOverlay(text: string): void {
 
 JC.frameStep = async (direction: 'forward' | 'back') => {
   try {
+    const context = JC.identity.capture();
+    if (!context) return;
     const video = getVideo();
     if (!video) {
         toast(JC.t!('toast_no_video_found'));
         return;
     }
+    const playbackKey = getFpsCacheKey(context, getCurrentVideoItemId(), video);
     if (!video.paused) {
         try {
-            const r: any = video.pause();
+            const result: unknown = video.pause();
             // pause() returns a Promise on Chromecast/MSE/PiP; swallow rejection.
-            if (r && typeof r.catch === 'function') {
-                r.catch((err: unknown) => console.warn('🪼 Jellyfin Canopy: video.pause() rejected', err));
+            if (result instanceof Promise) {
+                void result.catch((err: unknown) => {
+                    if (JC.identity.isCurrent(context)) {
+                        console.warn('🪼 Jellyfin Canopy: video.pause() rejected', err);
+                    }
+                });
             }
         } catch (err) {
             console.warn('🪼 Jellyfin Canopy: video.pause() threw', err);
         }
     }
 
-    const fps = await resolveFps(video);
+    const fps = await resolveFps(context, video);
+    if (!JC.identity.isCurrent(context)
+        || getVideo() !== video
+        || !video.isConnected
+        || getFpsCacheKey(context, getCurrentVideoItemId(), video) !== playbackKey) return;
     const frameDuration = 1 / fps;
     const delta = direction === 'forward' ? frameDuration : -frameDuration;
     const upper = Number.isFinite(video.duration) ? video.duration : Infinity;
@@ -286,7 +371,7 @@ JC.frameStep = async (direction: 'forward' | 'back') => {
         '{arrow} Frame {frame}  ·  {fps} fps',
         { arrow, frame: frameNum, fps: fpsLabel }
     );
-    showFrameOverlay(text);
+    showFrameOverlay(context, text);
   } catch (err) {
     console.warn('🪼 Jellyfin Canopy: frameStep failed', err);
   }
@@ -300,6 +385,22 @@ JC.frameStep = async (direction: 'forward' | 'back') => {
 let _lastStablePosition: number | null = null;   // updated continuously during normal playback
 let _lastPositionBeforeSeek: number | null = null; // snapshotted at seek start
 let _jumpingBack = false;
+let _jumpingBackTimer: number | null = null;
+let _seekTracker: {
+    video: HTMLVideoElement;
+    context: IdentityContext;
+    onTimeUpdate: () => void;
+    onSeeking: () => void;
+} | null = null;
+
+function detachSeekTracker(): void {
+    if (!_seekTracker) return;
+    const { video, onTimeUpdate, onSeeking } = _seekTracker;
+    video.removeEventListener('timeupdate', onTimeUpdate);
+    video.removeEventListener('seeking', onSeeking);
+    delete (video as SeekTrackedVideo)._jeSeekTrackerAttached;
+    _seekTracker = null;
+}
 
 /**
  * Attaches timeupdate + seeking listeners to the given video element to track
@@ -308,30 +409,41 @@ let _jumpingBack = false;
  * @param video
  */
 JC.attachSeekTracker = (video: HTMLVideoElement) => {
-    if (!video || (video as any)._jeSeekTrackerAttached) return;
+    const context = JC.identity.capture();
+    if (!context || !video) return;
+    if (_seekTracker?.video === video && JC.identity.isCurrent(_seekTracker.context)) return;
+    detachSeekTracker();
 
     // Keep a rolling record of where we actually are during normal playback
-    video.addEventListener('timeupdate', () => {
+    const onTimeUpdate = () => {
+        if (!JC.identity.isCurrent(context) || getVideo() !== video) return;
         if (_jumpingBack) return;
         if (!video.seeking && Number.isFinite(video.currentTime) && video.currentTime > 0) {
             _lastStablePosition = video.currentTime;
         }
-    });
+    };
 
-    video.addEventListener('seeking', () => {
+    const onSeeking = () => {
+        if (!JC.identity.isCurrent(context) || getVideo() !== video) return;
         if (_jumpingBack) return;
         if (_lastStablePosition !== null) {
             _lastPositionBeforeSeek = _lastStablePosition;
         }
-    });
+    };
 
-    (video as any)._jeSeekTrackerAttached = true;
+    video.addEventListener('timeupdate', onTimeUpdate);
+    video.addEventListener('seeking', onSeeking);
+
+    (video as SeekTrackedVideo)._jeSeekTrackerAttached = true;
+    _seekTracker = { video, context, onTimeUpdate, onSeeking };
 };
 
 /**
  * Jumps back to the position captured just before the last seek.
  */
 JC.jumpToLastPosition = () => {
+    const context = JC.identity.capture();
+    if (!context) return;
     const video = getVideo();
     if (!video) {
         toast(JC.t!('toast_no_video_found'));
@@ -346,7 +458,11 @@ JC.jumpToLastPosition = () => {
     _jumpingBack = true;
     _lastStablePosition = null;    // reset so it re-accumulates after the jump
     video.currentTime = targetTime;
-    setTimeout(() => { _jumpingBack = false; }, 500);
+    cancelPlaybackTimer(_jumpingBackTimer);
+    _jumpingBackTimer = schedulePlaybackTimer(context, () => {
+        _jumpingBackTimer = null;
+        _jumpingBack = false;
+    }, 500);
 
     const mins = Math.floor(targetTime / 60);
     const secs = Math.floor(targetTime % 60).toString().padStart(2, '0');
@@ -379,7 +495,10 @@ JC.skipIntroOutro = () => {
  * Cycles through available subtitle tracks in the OSD menu.
  */
 JC.cycleSubtitleTrack = () => {
+    const context = JC.identity.capture();
+    if (!context) return;
     const performCycle = () => {
+        if (!JC.identity.isCurrent(context)) return;
         const allItems = document.querySelectorAll('.actionSheetContent .listItem');
         if (allItems.length === 0) {
             toast(JC.t!('toast_no_subtitles_found'));
@@ -421,7 +540,7 @@ JC.cycleSubtitleTrack = () => {
             document.body.click();
         }
         document.querySelector<HTMLElement>('button.btnSubtitles')?.click();
-        setTimeout(performCycle, 200);
+        schedulePlaybackTimer(context, performCycle, 200);
     }
 };
 
@@ -429,7 +548,10 @@ JC.cycleSubtitleTrack = () => {
  * Cycles through available audio tracks in the OSD menu.
  */
 JC.cycleAudioTrack = () => {
+    const context = JC.identity.capture();
+    if (!context) return;
     const performCycle = () => {
+        if (!JC.identity.isCurrent(context)) return;
         const audioOptions = Array.from(document.querySelectorAll('.actionSheetContent .listItem')).filter(item => item.querySelector('.listItemBodyText.actionSheetItemText'));
 
         if (audioOptions.length === 0) {
@@ -461,7 +583,7 @@ JC.cycleAudioTrack = () => {
             document.body.click();
         }
         document.querySelector<HTMLElement>('button.btnAudio')?.click();
-        setTimeout(performCycle, 200);
+        schedulePlaybackTimer(context, performCycle, 200);
     }
 };
 
@@ -471,7 +593,8 @@ const ASPECT_CYCLE_MAX_ATTEMPTS = 25;
 /**
  * Cycles through video aspect ratio modes (Auto, Cover, Fill).
  */
-const performAspectCycle = (attempts = 0) => {
+const performAspectCycle = (context: IdentityContext, attempts = 0) => {
+    if (!JC.identity.isCurrent(context)) return;
     const opts = [...document.querySelectorAll<HTMLElement>('.actionSheetContent button[data-id="auto"], .actionSheetContent button[data-id="cover"], .actionSheetContent button[data-id="fill"]')];
 
     if (!opts.length) {
@@ -479,7 +602,7 @@ const performAspectCycle = (attempts = 0) => {
         // poll forever (was an unbounded 120ms loop, leak-guard-allowlisted).
         if (attempts >= ASPECT_CYCLE_MAX_ATTEMPTS) return;
         document.querySelector<HTMLElement>('.actionSheetContent button[data-id="aspectratio"]')?.click();
-        setTimeout(() => performAspectCycle(attempts + 1), 120);
+        schedulePlaybackTimer(context, () => performAspectCycle(context, attempts + 1), 120);
         return;
     }
 
@@ -488,14 +611,16 @@ const performAspectCycle = (attempts = 0) => {
     const next = opts[(current + 1) % opts.length];
     if (next) {
         next.click();
-        toast(JC.t!('toast_aspect_ratio', { ratio: next.textContent.trim() }));
+        toast(JC.t!('toast_aspect_ratio', { ratio: JC.escapeHtml(next.textContent.trim()) }));
     }
 };
 
 // The main function called by the shortcut to start the process.
 JC.cycleAspect = () => {
+    const context = JC.identity.capture();
+    if (!context) return;
     // This opens the main settings panel ONCE and then hands off to the inner logic.
-    JC.openSettings!(performAspectCycle);
+    JC.openSettings!(() => performAspectCycle(context));
 };
 
 // --- Auto-Skip v2 (data-driven, honours native Media Segment boundaries) ---
@@ -517,14 +642,16 @@ JC.cycleAspect = () => {
  * invent settings for Recap/Preview/Commercial, which the native per-type
  * actions own (documented precedence).
  */
-function segmentTypeEnabled(type: string | undefined): boolean {
-    if (type === 'Intro') return !!JC.currentSettings!.autoSkipIntro;
-    if (type === 'Outro') return !!JC.currentSettings!.autoSkipOutro;
+function segmentTypeEnabled(context: IdentityContext, type: string | undefined): boolean {
+    if (!JC.identity.isCurrent(context)) return false;
+    if (type === 'Intro') return !!JC.currentSettings?.autoSkipIntro;
+    if (type === 'Outro') return !!JC.currentSettings?.autoSkipOutro;
     return false;
 }
 
 /** Localized toast after an auto-skip. Constant keys, no interpolation (X1 safe). */
-function autoSkipToast(seg: MediaSegment): void {
+function autoSkipToast(context: IdentityContext, seg: MediaSegment): void {
+    if (!JC.identity.isCurrent(context)) return;
     if (seg.Type === 'Intro') toast(JC.t!('toast_auto_skipped_intro'));
     else if (seg.Type === 'Outro') toast(JC.t!('toast_auto_skipped_outro'));
 }
@@ -544,18 +671,19 @@ function parseItemIdFromVideosSrc(src: string): string | null {
  * /Sessions?ControllableByUserId works for non-admins and includes the caller's
  * own session; matched by DeviceId so casts/other tabs never mislead.
  */
-async function probeNowPlayingItemId(): Promise<string | null> {
+async function probeNowPlayingItemId(context: IdentityContext): Promise<string | null> {
     try {
+        if (!JC.identity.isCurrent(context)) return null;
         const api = JC.core?.api;
         const ac = window.ApiClient;
         if (!api || typeof api.jf !== 'function' || !ac) return null;
-        const userId = typeof ac.getCurrentUserId === 'function' ? ac.getCurrentUserId() : '';
         const deviceId = typeof ac.deviceId === 'function' ? ac.deviceId() : '';
-        if (!userId || !deviceId) return null;
+        if (!context.userId || !deviceId) return null;
         const sessions = await api.jf(
-            `/Sessions?ControllableByUserId=${encodeURIComponent(userId)}`,
+            `/Sessions?ControllableByUserId=${encodeURIComponent(context.userId)}`,
             { skipCache: true }
         ) as Array<{ DeviceId?: string; NowPlayingItem?: { Id?: string } }> | undefined;
+        if (!JC.identity.isCurrent(context)) return null;
         if (!Array.isArray(sessions)) return null;
         // Same-browser tabs share a deviceId (the server usually merges them
         // into one session). If more than one playing session still matches,
@@ -567,11 +695,13 @@ async function probeNowPlayingItemId(): Promise<string | null> {
     }
 }
 
-const resolvePlayingItemId = createSessionItemResolver({
-    parseFromSrc: parseItemIdFromVideosSrc,
-    fallbackId: getCurrentVideoItemId,
-    probeNowPlayingId: probeNowPlayingItemId
-});
+function createPlayingItemResolver(context: IdentityContext): (video: VideoLike) => string | null {
+    return createSessionItemResolver({
+        parseFromSrc: parseItemIdFromVideosSrc,
+        fallbackId: getCurrentVideoItemId,
+        probeNowPlayingId: () => probeNowPlayingItemId(context)
+    });
+}
 
 /**
  * Absolute-position offset for the engine: parsed from the element's own source
@@ -583,22 +713,33 @@ function getTranscodePositionOffsetTicks(video: VideoLike): number {
 }
 
 /** Fetch the item's provider-filtered media segments via the native REST API. */
-async function fetchMediaSegments(itemId: string): Promise<MediaSegment[]> {
+async function fetchMediaSegments(context: IdentityContext, itemId: string): Promise<MediaSegment[]> {
+    if (!JC.identity.isCurrent(context)) return [];
     const api = JC.core?.api;
     if (!api || typeof api.jf !== 'function') return [];
-    const res = await api.jf(`/MediaSegments/${encodeURIComponent(itemId)}`, { skipCache: true }) as
-        { Items?: MediaSegment[] } | undefined;
-    return Array.isArray(res?.Items) ? res.Items : [];
+    try {
+        const res = await api.jf(`/MediaSegments/${encodeURIComponent(itemId)}`, { skipCache: true }) as
+            { Items?: MediaSegment[] } | undefined;
+        if (!JC.identity.isCurrent(context)) return [];
+        return Array.isArray(res?.Items) ? res.Items : [];
+    } catch (error) {
+        if (!JC.identity.isCurrent(context)) return [];
+        throw error;
+    }
 }
 
 let _autoSkipEngine: AutoSkipEngine | null = null;
-function autoSkipEngine(): AutoSkipEngine {
-    if (!_autoSkipEngine) {
+let _autoSkipContext: IdentityContext | null = null;
+function autoSkipEngine(context: IdentityContext): AutoSkipEngine {
+    if (!_autoSkipEngine || _autoSkipContext?.epoch !== context.epoch) {
+        _autoSkipEngine?.detach();
+        _autoSkipContext = context;
+        const resolvePlayingItemId = createPlayingItemResolver(context);
         _autoSkipEngine = createAutoSkipEngine({
-            shouldSkipType: segmentTypeEnabled,
-            fetchSegments: fetchMediaSegments,
+            shouldSkipType: (type) => segmentTypeEnabled(context, type),
+            fetchSegments: (itemId) => fetchMediaSegments(context, itemId),
             resolveItemId: resolvePlayingItemId,
-            onSkipped: autoSkipToast,
+            onSkipped: (segment) => autoSkipToast(context, segment),
             getPositionOffsetTicks: getTranscodePositionOffsetTicks
         });
     }
@@ -611,9 +752,11 @@ function autoSkipEngine(): AutoSkipEngine {
  * only re-checks for an item change).
  */
 JC.initializeAutoSkipObserver = () => {
+    const context = JC.identity.capture();
+    if (!context) return;
     const video = getVideo();
     if (!video) return; // catch it on a later tick once the element mounts
-    autoSkipEngine().attach(video);
+    autoSkipEngine(context).attach(video);
 };
 
 /** Tears the auto-skip engine down (video-page leave). */
@@ -632,13 +775,17 @@ const LONG_PRESS_CONFIG = {
 let pressTimer: number | null = null;
 let isLongPress = false;
 let videoElement: HTMLVideoElement | null = null;
+let pressContext: IdentityContext | null = null;
 let originalSpeed = LONG_PRESS_CONFIG.SPEED_NORMAL;
 let speedOverlay: HTMLElement | null = null;
+let speedOverlayShowTimer: number | null = null;
+let speedOverlayHideTimer: number | null = null;
 let pressStartX: number | null = null;
 let pressStartY: number | null = null;
 
 function createSpeedOverlay(): void {
-    if (speedOverlay) return;
+    if (speedOverlay?.isConnected) return;
+    speedOverlay = null;
     speedOverlay = document.createElement('div');
     speedOverlay.setAttribute('data-speed-overlay', 'true');
     speedOverlay.style.cssText = `
@@ -651,95 +798,113 @@ function createSpeedOverlay(): void {
     document.body.appendChild(speedOverlay);
 }
 
-function showOverlay(speed: number): void {
+function showOverlay(context: IdentityContext, speed: number): void {
+    if (!JC.identity.isCurrent(context)) return;
     createSpeedOverlay();
     speedOverlay!.innerHTML = `${speed}x${speed > 1 ? ' ' + JC.icon!(JC.IconName!.FAST_FORWARD) : ' ' + JC.icon!(JC.IconName!.PLAY)}`;
     speedOverlay!.style.display = 'block';
-    setTimeout(() => speedOverlay!.style.opacity = '1', 10);
+    cancelPlaybackTimer(speedOverlayShowTimer);
+    cancelPlaybackTimer(speedOverlayHideTimer);
+    speedOverlayShowTimer = schedulePlaybackTimer(context, () => {
+        speedOverlayShowTimer = null;
+        if (speedOverlay) speedOverlay.style.opacity = '1';
+    }, 10);
 }
 
-function hideOverlay(): void {
+function hideOverlay(context: IdentityContext): void {
+    if (!JC.identity.isCurrent(context)) return;
     if (speedOverlay) {
         speedOverlay.style.opacity = '0';
-        setTimeout(() => speedOverlay!.style.display = 'none', 200);
+        cancelPlaybackTimer(speedOverlayShowTimer);
+        cancelPlaybackTimer(speedOverlayHideTimer);
+        speedOverlayShowTimer = null;
+        speedOverlayHideTimer = schedulePlaybackTimer(context, () => {
+            speedOverlayHideTimer = null;
+            if (speedOverlay) speedOverlay.style.display = 'none';
+        }, 200);
     }
 }
 
-JC.handleLongPressDown = (e: any) => {
-    if (!JC.currentSettings!.longPress2xEnabled || (e.button !== undefined && e.button !== 0) || pressTimer) {
+function clearLongPressState(hideVisibleOverlay: boolean): boolean {
+    const wasLongPress = isLongPress;
+    cancelPlaybackTimer(pressTimer);
+    pressTimer = null;
+    if (wasLongPress && videoElement) videoElement.playbackRate = originalSpeed;
+    if (hideVisibleOverlay && wasLongPress && pressContext && JC.identity.isCurrent(pressContext)) {
+        hideOverlay(pressContext);
+    }
+    isLongPress = false;
+    videoElement = null;
+    pressContext = null;
+    pressStartX = null;
+    pressStartY = null;
+    return wasLongPress;
+}
+
+JC.handleLongPressDown = (e: Event) => {
+    const eventData = longPressEventData(e);
+    if (!JC.currentSettings?.longPress2xEnabled || (eventData.button !== undefined && eventData.button !== 0) || pressTimer) {
         return;
     }
+    const context = JC.identity.capture();
+    if (!context) return;
     videoElement = getVideo();
     if (!videoElement) return;
+    pressContext = context;
+    const pressedVideo = videoElement;
 
     // Store initial press position
-    pressStartX = e.clientX || e.touches?.[0]?.clientX;
-    pressStartY = e.clientY || e.touches?.[0]?.clientY;
+    pressStartX = eventData.clientX ?? eventData.touches?.[0]?.clientX ?? null;
+    pressStartY = eventData.clientY ?? eventData.touches?.[0]?.clientY ?? null;
 
     originalSpeed = videoElement.playbackRate || LONG_PRESS_CONFIG.SPEED_NORMAL;
     isLongPress = false;
 
-    pressTimer = window.setTimeout(() => {
+    const timer = schedulePlaybackTimer(context, () => {
+        if (pressTimer !== timer || videoElement !== pressedVideo || getVideo() !== pressedVideo) {
+            if (pressTimer === timer) clearLongPressState(false);
+            return;
+        }
         if (JC.state!.pauseScreenClickTimer) {
             clearTimeout(JC.state!.pauseScreenClickTimer);
             JC.state!.pauseScreenClickTimer = null;
         }
         isLongPress = true;
         // Make sure video is playing when we activate speed boost
-        if (videoElement!.paused) {
-            videoElement!.play().catch(err => console.warn("🪼 Play blocked:", err));
+        if (pressedVideo.paused) {
+            pressedVideo.play().catch((error) => {
+                if (JC.identity.isCurrent(context)) console.warn('🪼 Play blocked:', error);
+            });
         }
-        videoElement!.playbackRate = LONG_PRESS_CONFIG.SPEED_FAST;
-        showOverlay(LONG_PRESS_CONFIG.SPEED_FAST);
+        pressedVideo.playbackRate = LONG_PRESS_CONFIG.SPEED_FAST;
+        showOverlay(context, LONG_PRESS_CONFIG.SPEED_FAST);
         if (navigator.vibrate) navigator.vibrate(50);
     }, LONG_PRESS_CONFIG.DURATION);
+    pressTimer = timer;
 };
 
-JC.handleLongPressUp = (e: any) => {
+JC.handleLongPressUp = (e: Event) => {
     if (!pressTimer) return;
-    clearTimeout(pressTimer);
-    pressTimer = null;
-
-    if (isLongPress) {
-        const video = getVideo();
-        if (video) {
-            video.playbackRate = originalSpeed;
-        }
-        hideOverlay();
+    if (clearLongPressState(true)) {
         e.preventDefault();
         e.stopPropagation();
         e.stopImmediatePropagation();
     }
-    isLongPress = false;
-    pressStartX = null;
-    pressStartY = null;
 };
 
 JC.handleLongPressCancel = () => {
-    if (pressTimer) {
-        clearTimeout(pressTimer);
-        pressTimer = null;
-        if (isLongPress) {
-            const video = getVideo();
-            if (video) {
-                video.playbackRate = originalSpeed;
-            }
-            hideOverlay();
-        }
-        isLongPress = false;
-    }
-    pressStartX = null;
-    pressStartY = null;
+    clearLongPressState(true);
 };
 
 // Handle mouse movement during press to detect drag/scrub
-JC.handleLongPressMove = (e: any) => {
-    if (!pressTimer || isLongPress || !pressStartX || !pressStartY) return;
+JC.handleLongPressMove = (e: Event) => {
+    if (!pressTimer || isLongPress || pressStartX === null || pressStartY === null) return;
 
-    const currentX = e.clientX || e.touches?.[0]?.clientX;
-    const currentY = e.clientY || e.touches?.[0]?.clientY;
+    const eventData = longPressEventData(e);
+    const currentX = eventData.clientX ?? eventData.touches?.[0]?.clientX;
+    const currentY = eventData.clientY ?? eventData.touches?.[0]?.clientY;
 
-    if (currentX === null || currentY === null) return;
+    if (currentX === undefined || currentY === undefined) return;
 
     const distanceMoved = Math.sqrt(
         Math.pow(currentX - pressStartX, 2) + Math.pow(currentY - pressStartY, 2)
@@ -747,15 +912,12 @@ JC.handleLongPressMove = (e: any) => {
 
     // If user moves more than threshold, cancel the long press (likely a drag attempt)
     if (distanceMoved > LONG_PRESS_CONFIG.MOVEMENT_THRESHOLD) {
-        clearTimeout(pressTimer);
-        pressTimer = null;
-        pressStartX = null;
-        pressStartY = null;
+        clearLongPressState(false);
     }
 };
 
 // Block click events that would pause/play when doing a long press
-JC.handleLongPressClick = (e: any) => {
+JC.handleLongPressClick = (e: Event) => {
     // If long press is just completed OR user is still holding (timer active),
     // prevent the click from pausing the video
     if (isLongPress || pressTimer) {
@@ -765,3 +927,52 @@ JC.handleLongPressClick = (e: any) => {
         return;
     }
 };
+
+function resetPlaybackState(): void {
+    for (const timer of playbackTimers) clearTimeout(timer);
+    playbackTimers.clear();
+
+    _frameOverlayHideTimer = null;
+    _frameOverlayFadeTimer = null;
+    if (_frameOverlayFrame !== null) cancelAnimationFrame(_frameOverlayFrame);
+    _frameOverlayFrame = null;
+    _frameOverlay?.remove();
+    _frameOverlay = null;
+    _fpsCache.clear();
+    _fpsInflight.clear();
+    _fallbackFpsWarned.clear();
+
+    detachSeekTracker();
+    _lastStablePosition = null;
+    _lastPositionBeforeSeek = null;
+    _jumpingBack = false;
+    _jumpingBackTimer = null;
+
+    if (isLongPress && videoElement) videoElement.playbackRate = originalSpeed;
+    pressTimer = null;
+    isLongPress = false;
+    videoElement = null;
+    pressContext = null;
+    pressStartX = null;
+    pressStartY = null;
+    speedOverlayShowTimer = null;
+    speedOverlayHideTimer = null;
+    speedOverlay?.remove();
+    speedOverlay = null;
+
+    _autoSkipEngine?.detach();
+    _autoSkipEngine = null;
+    _autoSkipContext = null;
+
+    document.querySelectorAll('[data-jc-frame-overlay="true"], [data-speed-overlay="true"]')
+        .forEach((node) => node.remove());
+}
+
+JC.identity.registerReset('enhanced-playback', resetPlaybackState);
+JC.identity.registerActivate('enhanced-playback', (context) => {
+    if (!JC.identity.isCurrent(context) || !JC.isVideoPage?.()) return;
+    const video = getVideo();
+    if (!video) return;
+    JC.attachSeekTracker!(video);
+    JC.initializeAutoSkipObserver!();
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/language.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/language.ts
@@ -8,8 +8,19 @@
 import { JC } from '../../globals';
 import { toast } from '../../core/ui-kit';
 import type { PanelContext } from './panel';
+import type { IdentityContext } from '../../types/jc';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
+
+const reloadTimers = new Set<number>();
+
+function scheduleReload(context: IdentityContext, delay: number): void {
+    const timer = window.setTimeout(() => {
+        reloadTimers.delete(timer);
+        if (JC.identity.isCurrent(context)) window.location.reload();
+    }, delay);
+    reloadTimers.add(timer);
+}
 
 /**
  * Wires the language dropdown and translation-cache controls.
@@ -17,16 +28,19 @@ import type { PanelContext } from './panel';
  */
 export function wireLanguageControls(ctx: PanelContext): void {
     const { resetAutoCloseTimer } = ctx;
+    const context = JC.identity.capture();
+    if (!context) return;
 
     // --- Language Settings ---
     const displayLanguageSelect = document.getElementById('displayLanguageSelect') as HTMLSelectElement | null;
     if (displayLanguageSelect) {
         // Get current user ID for localStorage key
-        const userId = ApiClient.getCurrentUserId();
+        const userId = context.userId;
         const languageKey = `${userId}-language`;
+        const scopedLanguageKey = `jc-display-language:${context.serverId}:${context.userId}`;
 
         // Get saved language from localStorage as well
-        const localStorageLang = localStorage.getItem(languageKey);
+        const localStorageLang = localStorage.getItem(scopedLanguageKey);
         const savedLanguage = (JC.currentSettings as any).displayLanguage || localStorageLang || '';
 
         console.log('🪼 Jellyfin Canopy: Current language setting:', {
@@ -53,9 +67,10 @@ export function wireLanguageControls(ctx: PanelContext): void {
                 // leaked the client IP, and hit GitHub's 60/hr anonymous rate limit
                 // (→ 403) — dropped entirely; no replacement needed.
                 const [localeCodes, cultures]: [any, any] = await Promise.all([
-                    ApiClient.ajax({ type: 'GET', url: ApiClient.getUrl('/JellyfinCanopy/locales'), dataType: 'json' }),
-                    ApiClient.ajax({ type: 'GET', url: ApiClient.getUrl('/Localization/Cultures'), dataType: 'json' })
+                    JC.core.api!.plugin('/locales'),
+                    JC.core.api!.jf('/Localization/Cultures'),
                 ]);
+                if (!JC.identity.isCurrent(context) || !displayLanguageSelect.isConnected) return;
 
                 const cultureMap: Record<string, any> = {};
                 cultures.forEach((c: any) => {
@@ -86,8 +101,11 @@ export function wireLanguageControls(ctx: PanelContext): void {
                     displayLanguageSelect.appendChild(option);
                 });
             } catch (err) {
+                if (!JC.identity.isCurrent(context)) return;
                 console.warn('🪼 Jellyfin Canopy: Failed to load language options:', err);
             }
+
+            if (!JC.identity.isCurrent(context) || !displayLanguageSelect.isConnected) return;
 
             // Normalize saved language code with region support (e.g., zh-HK) when available
             let normalizedLanguage = '';
@@ -111,6 +129,7 @@ export function wireLanguageControls(ctx: PanelContext): void {
 
         // Save language on change
         displayLanguageSelect.addEventListener('change', (e) => { void (async () => {
+            if (!JC.identity.isCurrent(context)) return;
             const newLang = (e.target as HTMLSelectElement).value;
 
             const normalizeLangCode = (code: string) => {
@@ -129,13 +148,21 @@ export function wireLanguageControls(ctx: PanelContext): void {
 
             // Save to settings.json (use base language code)
             (JC.currentSettings as any).displayLanguage = newLang;
-            await JC.saveUserSettings!('settings.json', JC.currentSettings);
+            try {
+                await JC.saveUserSettings!('settings.json', JC.currentSettings);
+            } catch (error) {
+                if (!JC.identity.isCurrent(context)) return;
+                throw error;
+            }
+            if (!JC.identity.isCurrent(context)) return;
 
             // Save to localStorage (use the same code)
             if (fullCultureCode) {
+                localStorage.setItem(scopedLanguageKey, fullCultureCode);
                 localStorage.setItem(languageKey, fullCultureCode);
             } else {
                 // Set empty value instead of removing key
+                localStorage.setItem(scopedLanguageKey, '');
                 localStorage.setItem(languageKey, '');
             }
 
@@ -144,7 +171,7 @@ export function wireLanguageControls(ctx: PanelContext): void {
             } else {
                 toast(JC.t!('toast_language_changed'));
             }
-            setTimeout(() => window.location.reload(), 1500);
+            scheduleReload(context, 1500);
         })(); });
     }
 
@@ -152,6 +179,7 @@ export function wireLanguageControls(ctx: PanelContext): void {
     const clearTranslationCacheButton = document.getElementById('clearTranslationCacheButton');
     if (clearTranslationCacheButton) {
         clearTranslationCacheButton.addEventListener('click', () => {
+            if (!JC.identity.isCurrent(context)) return;
             const cacheKeys = [];
             const CACHE_PREFIX = 'JC_translation_';
             const CACHE_TIMESTAMP_PREFIX = 'JC_translation_ts_';
@@ -166,8 +194,13 @@ export function wireLanguageControls(ctx: PanelContext): void {
             cacheKeys.forEach(key => localStorage.removeItem(key));
 
             toast(JC.t!('toast_translation_cache_cleared', { count: cacheKeys.length }));
-            setTimeout(() => window.location.reload(), 2000);
+            scheduleReload(context, 2000);
             resetAutoCloseTimer();
         });
     }
 }
+
+JC.identity.registerReset('settings-language', () => {
+    for (const timer of reloadTimers) clearTimeout(timer);
+    reloadTimers.clear();
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/panel.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/panel.identity.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+import type { ApiApi, UserSettings } from '../../types/jc';
+
+vi.mock('../../core/modal-a11y', () => ({
+    installModalA11y: () => ({ release: vi.fn() }),
+}));
+vi.mock('./template', () => ({
+    buildPanelHtml: () => `
+        <div class="jc-panel-header"></div>
+        <button id="closeSettingsPanel" type="button">close</button>
+        <input id="retainedSettingsToggle" type="checkbox">
+    `,
+}));
+vi.mock('./shortcut-editor', () => ({ wireShortcutEditor: vi.fn() }));
+vi.mock('./hidden-content-tab', () => ({ wireHiddenContentListeners: vi.fn() }));
+vi.mock('../spoiler-guard/settings-tab', () => ({ wireSpoilerGuardListeners: vi.fn() }));
+vi.mock('./language', () => ({ wireLanguageControls: vi.fn() }));
+vi.mock('./settings', () => ({
+    wireMiscSettingsControls: vi.fn(),
+    wireSettingsListeners: (ctx: { help: HTMLElement }) => {
+        ctx.help.querySelector<HTMLInputElement>('#retainedSettingsToggle')!
+            .addEventListener('change', (event) => {
+                const canopy = window.JellyfinCanopy;
+                canopy.currentSettings!.retainedSettingsToggle =
+                    (event.target as HTMLInputElement).checked;
+                void canopy.saveUserSettings!('settings.json', canopy.currentSettings!);
+            });
+    },
+}));
+
+const originalApi = JC.core.api;
+const originalSave = JC.saveUserSettings;
+const originalLoad = JC.loadSettings;
+
+describe('settings panel retained descendant ownership', () => {
+    beforeEach(async () => {
+        document.body.innerHTML = '';
+        JC.identity.transition('', '', 'settings-panel-test-logout');
+        const ownerA = JC.identity.transition('server-a', 'user-a', 'settings-panel-test-a')!;
+        JC.pluginConfig = { Shortcuts: [] };
+        JC.userConfig = JC.identity.own({ settings: JC.identity.own({}, ownerA) }, ownerA);
+        JC.currentSettings = JC.identity.own({ retainedSettingsToggle: false }, ownerA);
+        JC.core.api = { plugin: vi.fn().mockResolvedValue({}) } as unknown as ApiApi;
+        JC.saveUserSettings = vi.fn().mockResolvedValue(undefined);
+        JC.loadSettings = vi.fn(() => JC.identity.own({ retainedSettingsToggle: false }, ownerA) as UserSettings);
+        JC.t = (key: string) => key;
+        JC.CONFIG = { ...JC.CONFIG, HELP_PANEL_AUTOCLOSE_DELAY: 60_000 };
+        JC.state = {
+            ...JC.state,
+            activeShortcuts: {},
+            removeContext: JC.state?.removeContext ?? null,
+            pauseScreenClickTimer: JC.state?.pauseScreenClickTimer ?? null,
+        };
+        JC.initializeShortcuts = vi.fn();
+        (JC as typeof JC & { toCamelCase: (value: unknown) => unknown }).toCamelCase = (value) => value;
+        (JC as typeof JC & { themer: { getThemeVariables(): Record<string, string> } }).themer = {
+            getThemeVariables: () => ({
+                panelBg: '#181818', secondaryBg: '#222', altAccent: '#333',
+                blur: '0px', textColor: '#fff', logo: '',
+            }),
+        };
+        await import('./panel');
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+        JC.core.api = originalApi;
+        JC.saveUserSettings = originalSave;
+        JC.loadSettings = originalLoad;
+        vi.restoreAllMocks();
+    });
+
+    it('keeps an A toggle inert after normal identity cleanup and B activation', async () => {
+        await JC.showEnhancedPanel!();
+        const stalePanel = document.getElementById('jellyfin-canopy-panel')!;
+        const staleToggle = stalePanel.querySelector<HTMLInputElement>('#retainedSettingsToggle')!;
+        expect(staleToggle).not.toBeNull();
+
+        const ownerB = JC.identity.transition('server-a', 'user-b', 'settings-panel-test-b')!;
+        expect(stalePanel.isConnected).toBe(false);
+        JC.currentSettings = JC.identity.own({ retainedSettingsToggle: false }, ownerB);
+        const save = JC.saveUserSettings as ReturnType<typeof vi.fn>;
+        save.mockClear();
+
+        staleToggle.checked = true;
+        staleToggle.dispatchEvent(new Event('change', { bubbles: true }));
+
+        expect(JC.currentSettings.retainedSettingsToggle).toBe(false);
+        expect(save).not.toHaveBeenCalled();
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/panel.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/panel.ts
@@ -14,6 +14,7 @@ import { wireSettingsListeners, wireMiscSettingsControls } from './settings';
 import { wireHiddenContentListeners } from './hidden-content-tab';
 import { wireSpoilerGuardListeners } from '../spoiler-guard/settings-tab';
 import { wireLanguageControls } from './language';
+import type { IdentityContext } from '../../types/jc';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -23,6 +24,9 @@ import { wireLanguageControls } from './language';
  */
 export interface PanelContext {
     help: HTMLElement;
+    identityContext: IdentityContext;
+    registerCleanup: (cleanup: () => void) => void;
+    trackTimer: (timer: number) => void;
     pluginShortcuts: any[];
     resetAutoCloseTimer: () => void;
     panelBgColor: string;
@@ -48,21 +52,32 @@ const CANOPY_GRADIENT = 'linear-gradient(135deg, #00D4FF 0%, #2F80FF 52%, #7B4CF
  * Toggles the main settings and help panel for the plugin.
  */
 JC.showEnhancedPanel = async () => {
+    const identityContext = JC.identity.capture();
+    if (!identityContext) return;
     // Refresh user settings when panel opens to ensure correct user's settings are displayed
-    const currentUserId = ApiClient.getCurrentUserId();
+    const currentUserId = identityContext.userId;
     if (currentUserId) {
         try {
             // Fetch fresh settings for the current user
-            const settingsResponse = await ApiClient.ajax({
-                type: 'GET',
-                url: ApiClient.getUrl(`/JellyfinCanopy/user-settings/${currentUserId}/settings.json?_=${Date.now()}`),
-                dataType: 'json'
-            });
+            const settingsResponse = JC.core.api?.plugin
+                ? await JC.core.api.plugin(
+                    `/user-settings/${currentUserId}/settings.json?_=${Date.now()}`,
+                    { skipCache: true }
+                )
+                : await ApiClient.ajax({
+                    type: 'GET',
+                    url: ApiClient.getUrl(`/JellyfinCanopy/user-settings/${currentUserId}/settings.json?_=${Date.now()}`),
+                    dataType: 'json'
+                });
+            if (!JC.identity.isCurrent(identityContext)) return;
 
             // Update the userConfig with fresh data
             if (settingsResponse) {
                 JC.userConfig = JC.userConfig || {};
-                JC.userConfig.settings = (window.JellyfinCanopy as any).toCamelCase(settingsResponse);
+                JC.userConfig.settings = JC.identity.own(
+                    (window.JellyfinCanopy as any).toCamelCase(settingsResponse),
+                    identityContext
+                );
 
                 // Reload current settings
                 if (typeof JC.loadSettings === 'function') {
@@ -70,9 +85,12 @@ JC.showEnhancedPanel = async () => {
                 }
             }
         } catch (e) {
+            if (!JC.identity.isCurrent(identityContext) || (e as Error)?.name === 'AbortError') return;
             console.warn("🪼 Jellyfin Canopy: Could not refresh settings for panel display:", e);
         }
     }
+
+    if (!JC.identity.isCurrent(identityContext)) return;
 
     // Re-initialize shortcuts to ensure they're populated before building the panel
     if (typeof JC.initializeShortcuts === 'function') {
@@ -87,8 +105,12 @@ JC.showEnhancedPanel = async () => {
         // keydown listener is torn down — otherwise all JC shortcuts stay
         // suppressed for the rest of the session (the normal close paths below
         // already release; this early-return branch used to skip it).
-        (existing as unknown as { _a11y?: ModalA11yHandle })._a11y?.release();
-        existing.remove();
+        const owned = existing as unknown as { _a11y?: ModalA11yHandle; _identityCleanup?: () => void };
+        if (owned._identityCleanup) owned._identityCleanup();
+        else {
+            owned._a11y?.release();
+            existing.remove();
+        }
         return;
     }
     // Get theme-appropriate styles
@@ -115,6 +137,8 @@ JC.showEnhancedPanel = async () => {
 
     const help = document.createElement('div');
     help.id = panelId;
+    help.setAttribute('data-jc-identity-owned', 'true');
+    JC.identity.own(help, identityContext);
     Object.assign(help.style, {
         position: 'fixed',
         top: '50%',
@@ -156,24 +180,58 @@ JC.showEnhancedPanel = async () => {
     let autoCloseTimer: number | null = null;
     let isMouseInside = false;
     let a11y: ModalA11yHandle | null = null;
+    let panelClosed = false;
+    let closeHelp: (ev: any) => void = () => undefined;
+    const panelTimers = new Set<number>();
+    const panelCleanupCallbacks: Array<() => void> = [];
+
+    // Every descendant listener installed by the split panel modules is
+    // authorization-gated at the panel root. This also protects a retained,
+    // detached A control that a test/extension dispatches after B becomes live.
+    const guardedEvents = [
+        'click', 'change', 'input', 'keydown', 'focus', 'blur',
+        'mousedown', 'mouseup', 'touchstart', 'touchend'
+    ];
+    const guardStalePanelEvent = (event: Event) => {
+        if (JC.identity.isCurrent(identityContext)) return;
+        event.preventDefault();
+        event.stopImmediatePropagation();
+    };
+    guardedEvents.forEach((type) => help.addEventListener(type, guardStalePanelEvent, true));
+    // Deliberately do not unregister this root fence in cleanupPanel(). The
+    // panel subtree itself is removed, so it is collectible normally; if a host
+    // or extension retains an A descendant, however, the capture listener must
+    // remain on that detached ancestry and keep its existing child handlers
+    // inert after B becomes current.
+
+    const cleanupPanel = () => {
+        if (panelClosed) return;
+        panelClosed = true;
+        if (autoCloseTimer) clearTimeout(autoCloseTimer);
+        autoCloseTimer = null;
+        for (const timer of panelTimers) clearTimeout(timer);
+        panelTimers.clear();
+        help.remove();
+        document.removeEventListener('keydown', closeHelp);
+        document.removeEventListener('mousemove', handleMouseMove);
+        document.removeEventListener('mouseup', handleMouseUp);
+        for (const cleanup of panelCleanupCallbacks.splice(0)) cleanup();
+        a11y?.release();
+        a11y = null;
+    };
 
     const resetAutoCloseTimer = () => {
+        if (!JC.identity.isCurrent(identityContext)) return;
         if (autoCloseTimer) clearTimeout(autoCloseTimer);
         autoCloseTimer = window.setTimeout(() => {
             if (!isMouseInside && document.getElementById(panelId)) {
-                help.remove();
-                document.removeEventListener('keydown', closeHelp);
-                document.removeEventListener('mousemove', handleMouseMove);
-                document.removeEventListener('mouseup', handleMouseUp);
-                // release() restores focus and drops the jc-modal-open gate that
-                // suppresses JC.keyListener — no manual re-add of the listener.
-                a11y?.release();
-                a11y = null;
+                cleanupPanel();
             }
         }, JC.CONFIG!.HELP_PANEL_AUTOCLOSE_DELAY as number);
     };
 
     const handleMouseDown = (e: MouseEvent) => {
+        if (!JC.identity.isCurrent(identityContext)) return;
         // Drag only from the header bar: the panes host interactive surfaces
         // (subtitle position grid, selects, sliders) that must own their own
         // pointer gestures — a blanket panel-drag stole them once the old
@@ -188,6 +246,7 @@ JC.showEnhancedPanel = async () => {
     };
 
     const handleMouseMove = (e: MouseEvent) => {
+        if (!JC.identity.isCurrent(identityContext)) return;
         if (isDragging) {
             help.style.left = `${e.clientX - offset.x}px`;
             help.style.top = `${e.clientY - offset.y}px`;
@@ -197,6 +256,7 @@ JC.showEnhancedPanel = async () => {
     };
 
     const handleMouseUp = () => {
+        if (!JC.identity.isCurrent(identityContext)) return;
         isDragging = false;
         help.style.cursor = 'grab';
         resetAutoCloseTimer();
@@ -215,6 +275,9 @@ JC.showEnhancedPanel = async () => {
     // (settings-panel/template.ts and the settings-panel/*.ts wiring files).
     const ctx: PanelContext = {
         help,
+        identityContext,
+        registerCleanup: (cleanup) => panelCleanupCallbacks.push(cleanup),
+        trackTimer: (timer) => panelTimers.add(timer),
         pluginShortcuts,
         resetAutoCloseTimer,
         panelBgColor,
@@ -274,7 +337,9 @@ JC.showEnhancedPanel = async () => {
                 mainColumn.inert = false;
             }
         };
-        phoneMedia.addEventListener('change', () => syncLayerFocus(false));
+        const handlePhoneMediaChange = () => syncLayerFocus(false);
+        phoneMedia.addEventListener('change', handlePhoneMediaChange);
+        panelCleanupCallbacks.push(() => phoneMedia.removeEventListener('change', handlePhoneMediaChange));
 
         const activate = (pane: HTMLElement, persist: boolean) => {
             panes.forEach(p => p.classList.toggle('active', p === pane));
@@ -345,29 +410,26 @@ JC.showEnhancedPanel = async () => {
     allDetails.forEach((details, index) => {
         details.addEventListener('toggle', () => {
             if (details.open) {
-                setTimeout(() => {
+                const timer = window.setTimeout(() => {
+                    panelTimers.delete(timer);
+                    if (panelClosed || !JC.identity.isCurrent(identityContext)) return;
                     details.scrollIntoView({ behavior: 'smooth', block: index === 0 ? 'center' : 'nearest' });
                 }, 150);
+                panelTimers.add(timer);
             }
             resetAutoCloseTimer();
         });
     });
 
     // --- Event Handlers for Settings Panel ---
-    const closeHelp = (ev: any) => {
+    closeHelp = (ev: any) => {
         if ((ev.type === 'keydown' && (ev.key === 'Escape' || ev.key === '?')) || (ev.type === 'click' && ev.target.id === 'closeSettingsPanel')) {
             // modal-a11y's Escape path invokes this with a synthetic
             // `{ type, key }` object (not a DOM event), so stopPropagation may be
             // absent — guard it. Calling it unconditionally threw a TypeError
             // here, aborting the close so Escape never dismissed the panel.
             ev.stopPropagation?.();
-            if (autoCloseTimer) clearTimeout(autoCloseTimer);
-            help.remove();
-            document.removeEventListener('keydown', closeHelp);
-            document.removeEventListener('mousemove', handleMouseMove);
-            document.removeEventListener('mouseup', handleMouseUp);
-            a11y?.release();
-            a11y = null;
+            cleanupPanel();
         }
     };
 
@@ -389,7 +451,9 @@ JC.showEnhancedPanel = async () => {
     // Stash the handle on the panel element so the toggle-close early-return
     // branch (top of this function) can release it without re-entering this
     // closure. The close paths that DO reach this closure use `a11y` directly.
-    (help as unknown as { _a11y?: ModalA11yHandle })._a11y = a11y;
+    const ownedPanel = help as unknown as { _a11y?: ModalA11yHandle; _identityCleanup?: () => void };
+    ownedPanel._a11y = a11y;
+    ownedPanel._identityCleanup = cleanupPanel;
     ctx.createToast = createToast;
 
     wireSettingsListeners(ctx);
@@ -398,3 +462,12 @@ JC.showEnhancedPanel = async () => {
     wireMiscSettingsControls(ctx);
     wireLanguageControls(ctx);
 };
+
+JC.identity.registerReset('settings-panel', () => {
+    const panel = document.getElementById('jellyfin-canopy-panel');
+    const cleanup = panel
+        ? (panel as unknown as { _identityCleanup?: () => void })._identityCleanup
+        : undefined;
+    if (cleanup) cleanup();
+    else panel?.remove();
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/release-notes.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/release-notes.identity.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+import { showReleaseNotesNotification } from './release-notes';
+
+function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((done) => { resolve = done; });
+    return { promise, resolve };
+}
+
+describe('release notes identity ownership', () => {
+    it('does not mount a held A release response after B becomes current', async () => {
+        document.body.innerHTML = '';
+        JC.identity.transition('server-a', 'user-a', 'release-notes-test-start');
+        const held = deferred<Response>();
+        const fetchMock = vi.fn(() => held.promise);
+        vi.stubGlobal('fetch', fetchMock);
+
+        const result = showReleaseNotesNotification();
+        await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+        JC.identity.transition('server-a', 'user-b', 'account-switch');
+        held.resolve({
+            ok: true,
+            json: () => Promise.resolve({ body: 'A notes', tag_name: 'A', published_at: '', html_url: '#' }),
+        } as Response);
+        await result;
+
+        expect(document.getElementById('jellyfin-release-notes-notification')).toBeNull();
+        vi.unstubAllGlobals();
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/release-notes.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/release-notes.ts
@@ -10,20 +10,33 @@ import { escapeHtml, toast } from '../../core/ui-kit';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 export const GITHUB_REPO = '4eh5xitv6787h645ebv/Jellyfin-Canopy';
+const releaseControllers = new Set<AbortController>();
+const releaseTimers = new Set<number>();
 
 /**
  * Fetches the latest GitHub release notes and displays them in a notification panel.
  */
 export async function showReleaseNotesNotification(): Promise<void> {
+    const context = JC.identity.capture();
+    if (!context) return;
+    const controller = new AbortController();
+    releaseControllers.add(controller);
     let release: any;
     try {
-        const response = await fetch(`https://api.github.com/repos/${GITHUB_REPO}/releases/latest`);
+        const response = await fetch(`https://api.github.com/repos/${GITHUB_REPO}/releases/latest`, {
+            signal: controller.signal
+        });
+        if (!JC.identity.isCurrent(context)) return;
         if (!response.ok) throw new Error('Failed to fetch release data');
         release = await response.json();
+        if (!JC.identity.isCurrent(context)) return;
     } catch (error) {
+        if (controller.signal.aborted || !JC.identity.isCurrent(context)) return;
         console.error('🪼 Jellyfin Canopy: Failed to fetch release notes:', error);
         toast(JC.icon!(JC.IconName!.ERROR) + ' Could not load release notes.');
         return;
+    } finally {
+        releaseControllers.delete(controller);
     }
 
     const notificationId = 'jellyfin-release-notes-notification';
@@ -32,6 +45,8 @@ export async function showReleaseNotesNotification(): Promise<void> {
 
     const notification = document.createElement('div');
     notification.id = notificationId;
+    notification.setAttribute('data-jc-identity-owned', 'true');
+    JC.identity.own(notification, context);
 
     // --- Release notes autoclose ---
     let autoCloseTimer: number | null = null;
@@ -41,24 +56,41 @@ export async function showReleaseNotesNotification(): Promise<void> {
     const closePanel = () => {
         if (document.getElementById(notificationId)) {
             notification.style.transform = 'translateY(-50%) translateX(100%)';
-            setTimeout(() => notification.remove(), 300);
+            const timer = window.setTimeout(() => {
+                releaseTimers.delete(timer);
+                notification.remove();
+            }, 300);
+            releaseTimers.add(timer);
         }
     };
 
     const resetAutoCloseTimer = () => {
-        if (autoCloseTimer) clearTimeout(autoCloseTimer);
+        if (autoCloseTimer) {
+            clearTimeout(autoCloseTimer);
+            releaseTimers.delete(autoCloseTimer);
+        }
         autoCloseTimer = window.setTimeout(() => {
+            releaseTimers.delete(autoCloseTimer!);
+            autoCloseTimer = null;
+            if (!JC.identity.isCurrent(context)) return;
             if (!isMouseInside) {
                 closePanel();
             }
         }, AUTOCLOSE_DELAY);
+        releaseTimers.add(autoCloseTimer);
     };
 
     notification.addEventListener('mouseenter', () => {
+        if (!JC.identity.isCurrent(context)) return;
         isMouseInside = true;
-        if (autoCloseTimer) clearTimeout(autoCloseTimer);
+        if (autoCloseTimer) {
+            clearTimeout(autoCloseTimer);
+            releaseTimers.delete(autoCloseTimer);
+            autoCloseTimer = null;
+        }
     });
     notification.addEventListener('mouseleave', () => {
+        if (!JC.identity.isCurrent(context)) return;
         isMouseInside = false;
         resetAutoCloseTimer();
     });
@@ -169,7 +201,19 @@ export async function showReleaseNotesNotification(): Promise<void> {
         `;
 
     document.body.appendChild(notification);
-    setTimeout(() => { notification.style.transform = 'translateY(-50%) translateX(0)'; }, 10);
+    const enterTimer = window.setTimeout(() => {
+        releaseTimers.delete(enterTimer);
+        if (JC.identity.isCurrent(context)) notification.style.transform = 'translateY(-50%) translateX(0)';
+    }, 10);
+    releaseTimers.add(enterTimer);
 
     resetAutoCloseTimer();
 }
+
+JC.identity.registerReset('settings-release-notes', () => {
+    for (const controller of releaseControllers) controller.abort();
+    releaseControllers.clear();
+    for (const timer of releaseTimers) clearTimeout(timer);
+    releaseTimers.clear();
+    document.getElementById('jellyfin-release-notes-notification')?.remove();
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/settings.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/settings.identity.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+import { wireSettingsListeners } from './settings';
+import type { PanelContext } from './panel';
+
+const TOGGLE_IDS = [
+    'autoPauseToggle', 'autoResumeToggle', 'autoPipToggle', 'autoSkipIntroToggle',
+    'autoSkipOutroToggle', 'randomButtonToggle', 'randomUnwatchedOnly',
+    'showWatchProgressToggle', 'showFileSizesToggle', 'showAudioLanguagesToggle',
+    'removeContinueWatchingToggle', 'qualityTagsToggle', 'genreTagsToggle',
+    'pauseScreenToggle', 'languageTagsToggle', 'ratingTagsToggle', 'peopleTagsToggle',
+    'tagsHideOnHoverToggle', 'disableCustomSubtitleStyles', 'longPress2xEnabled'
+];
+
+describe('settings panel document listener identity cleanup', () => {
+    it('cannot save B from an A subtitle drag after reset', () => {
+        document.body.innerHTML = '';
+        JC.identity.transition('server-a', 'user-a', 'settings-drag-test-start');
+        const contextA = JC.identity.capture()!;
+        for (const id of TOGGLE_IDS) {
+            const input = document.createElement('input');
+            input.id = id;
+            input.type = 'checkbox';
+            document.body.appendChild(input);
+        }
+        const grid = document.createElement('div');
+        grid.id = 'subtitlePositionGrid';
+        Object.defineProperty(grid, 'getBoundingClientRect', {
+            value: () => ({ left: 0, top: 0, width: 100, height: 100 })
+        });
+        const preview = document.createElement('div');
+        preview.id = 'subtitlePositionPreview';
+        document.body.append(grid, preview);
+
+        const cleanups: Array<() => void> = [];
+        const save = vi.fn().mockResolvedValue(undefined);
+        JC.saveUserSettings = save;
+        JC.currentSettings = {};
+        wireSettingsListeners({
+            identityContext: contextA,
+            registerCleanup: (cleanup: () => void) => cleanups.push(cleanup),
+            createToast: () => '',
+            resetAutoCloseTimer: vi.fn(),
+        } as unknown as PanelContext);
+
+        grid.dispatchEvent(new MouseEvent('mousedown', { clientX: 10, clientY: 20, bubbles: true }));
+        expect(JC.currentSettings.subtitleHorizontalPosition).toBe(10);
+
+        JC.identity.transition('server-a', 'user-b', 'account-switch');
+        cleanups.forEach((cleanup) => cleanup());
+        JC.currentSettings = {};
+        document.dispatchEvent(new MouseEvent('mousemove', { clientX: 90, clientY: 90 }));
+        document.dispatchEvent(new MouseEvent('mouseup'));
+
+        expect(JC.currentSettings.subtitleHorizontalPosition).toBeUndefined();
+        expect(JC.currentSettings.subtitleVerticalPosition).toBeUndefined();
+        expect(save).not.toHaveBeenCalled();
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/settings.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/settings.ts
@@ -6,7 +6,7 @@
 // (Converted from js/enhanced/ui-panel-settings.js — bodies semantically identical.)
 
 import { JC } from '../../globals';
-import { toast } from '../../core/ui-kit';
+import { escapeHtml, toast } from '../../core/ui-kit';
 import { showReleaseNotesNotification } from './release-notes';
 import type { PanelContext } from './panel';
 
@@ -18,7 +18,7 @@ import type { PanelContext } from './panel';
  * @param {object} ctx Shared panel context assembled in settings-panel/panel.ts.
  */
 export function wireSettingsListeners(ctx: PanelContext): void {
-    const { createToast, resetAutoCloseTimer } = ctx;
+    const { createToast, resetAutoCloseTimer, identityContext, registerCleanup } = ctx;
 
     const addSettingToggleListener = (id: string, settingKey: string, featureKey: string, requiresRefresh = false) => {
         document.getElementById(id)!.addEventListener('change', (e) => {
@@ -291,6 +291,7 @@ export function wireSettingsListeners(ctx: PanelContext): void {
 
     if (posGrid) {
         const updatePosition = (xPct: number, yPct: number) => {
+            if (!JC.identity.isCurrent(identityContext)) return;
             xPct = Math.max(2, Math.min(98, xPct));
             yPct = Math.max(2, Math.min(98, yPct));
             if (posPreview) {
@@ -315,43 +316,61 @@ export function wireSettingsListeners(ctx: PanelContext): void {
         let dragging = false;
 
         posGrid.addEventListener('mousedown', (e) => {
+            if (!JC.identity.isCurrent(identityContext)) return;
             const { x, y } = getPctFromEvent(e);
             updatePosition(x, y);
             dragging = true;
             e.preventDefault();
         });
 
-        document.addEventListener('mousemove', (e) => {
+        const handlePositionMouseMove = (e: MouseEvent) => {
+            if (!JC.identity.isCurrent(identityContext)) return;
             if (!dragging) return;
             const { x, y } = getPctFromEvent(e);
             updatePosition(x, y);
             resetAutoCloseTimer();
-        });
+        };
 
-        document.addEventListener('mouseup', () => {
+        const handlePositionMouseUp = () => {
+            if (!JC.identity.isCurrent(identityContext)) return;
             if (!dragging) return;
             dragging = false;
             void JC.saveUserSettings!('settings.json', JC.currentSettings);
-        });
+        };
 
         posGrid.addEventListener('touchstart', (e) => {
+            if (!JC.identity.isCurrent(identityContext)) return;
             const { x, y } = getPctFromEvent(e);
             updatePosition(x, y);
             dragging = true;
             e.preventDefault();
         }, { passive: false });
 
-        document.addEventListener('touchmove', (e) => {
+        const handlePositionTouchMove = (e: TouchEvent) => {
+            if (!JC.identity.isCurrent(identityContext)) return;
             if (!dragging) return;
             const { x, y } = getPctFromEvent(e);
             updatePosition(x, y);
             resetAutoCloseTimer();
-        }, { passive: true });
+        };
 
-        document.addEventListener('touchend', () => {
+        const handlePositionTouchEnd = () => {
+            if (!JC.identity.isCurrent(identityContext)) return;
             if (!dragging) return;
             dragging = false;
             void JC.saveUserSettings!('settings.json', JC.currentSettings);
+        };
+
+        document.addEventListener('mousemove', handlePositionMouseMove);
+        document.addEventListener('mouseup', handlePositionMouseUp);
+        document.addEventListener('touchmove', handlePositionTouchMove, { passive: true });
+        document.addEventListener('touchend', handlePositionTouchEnd);
+        registerCleanup(() => {
+            dragging = false;
+            document.removeEventListener('mousemove', handlePositionMouseMove);
+            document.removeEventListener('mouseup', handlePositionMouseUp);
+            document.removeEventListener('touchmove', handlePositionTouchMove);
+            document.removeEventListener('touchend', handlePositionTouchEnd);
         });
     }
 
@@ -478,7 +497,7 @@ export function wireMiscSettingsControls(ctx: PanelContext): void {
                     const fontSize = (JC as any).fontSizePresets[fontSizeIndex].size;
                     const fontFamily = (JC as any).fontFamilyPresets[fontFamilyIndex].family;
                     (JC as any).applySubtitleStyles(selectedPreset.textColor, selectedPreset.bgColor, fontSize, fontFamily, selectedPreset.textShadow);
-                    toast(JC.t!('toast_subtitle_style', { style: selectedPreset.name }));
+                    toast(JC.t!('toast_subtitle_style', { style: escapeHtml(selectedPreset.name) }));
                 } else if (type === 'font-size') {
                     (JC.currentSettings as any).selectedFontSizePresetIndex = presetIndex;
                     const fontFamilyIndex = (JC.currentSettings as any).selectedFontFamilyPresetIndex ?? 0;
@@ -492,7 +511,7 @@ export function wireMiscSettingsControls(ctx: PanelContext): void {
                         : 'none';
 
                     (JC as any).applySubtitleStyles(textColor, bgColor, selectedPreset.size, fontFamily, textShadow);
-                    toast(JC.t!('toast_subtitle_size', { size: selectedPreset.name }));
+                    toast(JC.t!('toast_subtitle_size', { size: escapeHtml(selectedPreset.name) }));
                 } else if (type === 'font-family') {
                     (JC.currentSettings as any).selectedFontFamilyPresetIndex = presetIndex;
                     const fontSizeIndex = (JC.currentSettings as any).selectedFontSizePresetIndex ?? 2;
@@ -506,7 +525,7 @@ export function wireMiscSettingsControls(ctx: PanelContext): void {
                         : 'none';
 
                     (JC as any).applySubtitleStyles(textColor, bgColor, fontSize, selectedPreset.family, textShadow);
-                    toast(JC.t!('toast_subtitle_font', { font: selectedPreset.name }));
+                    toast(JC.t!('toast_subtitle_font', { font: escapeHtml(selectedPreset.name) }));
                 }
 
                 void JC.saveUserSettings!('settings.json', JC.currentSettings);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/shortcut-editor.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/shortcut-editor.identity.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+import { wireShortcutEditor } from './shortcut-editor';
+import type { PanelContext } from './panel';
+
+describe('settings shortcut editor identity ownership', () => {
+    it('does not let a retained A key control mutate B shortcuts', () => {
+        JC.identity.transition('server-a', 'user-a', 'shortcut-test-start');
+        const contextA = JC.identity.capture()!;
+        const help = document.createElement('div');
+        help.innerHTML = '<span class="shortcut-key" data-action="play">P</span><span></span>';
+        const key = help.querySelector<HTMLElement>('.shortcut-key')!;
+        JC.pluginConfig = { DisableAllShortcuts: false };
+        JC.state = { activeShortcuts: { play: 'P' } } as unknown as NonNullable<typeof JC.state>;
+        JC.userConfig = { shortcuts: { Shortcuts: [] } };
+        const save = vi.fn().mockResolvedValue(undefined);
+        JC.saveUserSettings = save;
+        wireShortcutEditor({
+            help,
+            pluginShortcuts: [{ Name: 'play', Key: 'P' }],
+            primaryAccentColor: '#0ff',
+            kbdBackground: '#111',
+            identityContext: contextA,
+            trackTimer: vi.fn(),
+        } as unknown as PanelContext);
+
+        JC.identity.transition('server-a', 'user-b', 'account-switch');
+        const bShortcuts = { Shortcuts: [] as Array<{ Name: string; Key: string }> };
+        JC.userConfig = { shortcuts: bShortcuts };
+        key.dispatchEvent(new KeyboardEvent('keydown', { key: 'X', bubbles: true }));
+
+        expect(bShortcuts.Shortcuts).toEqual([]);
+        expect(save).not.toHaveBeenCalled();
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/shortcut-editor.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/shortcut-editor.ts
@@ -15,7 +15,8 @@ import type { PanelContext } from './panel';
  * @param {object} ctx Shared panel context assembled in settings-panel/panel.ts.
  */
 export function wireShortcutEditor(ctx: PanelContext): void {
-    const { help, pluginShortcuts, primaryAccentColor, kbdBackground } = ctx;
+    const { help, pluginShortcuts, primaryAccentColor, kbdBackground, identityContext, trackTimer } = ctx;
+    const isCurrent = () => JC.identity.isCurrent(identityContext);
 
     // --- Shortcut Key Binding Logic ---
     if (!JC.pluginConfig.DisableAllShortcuts) {
@@ -23,15 +24,17 @@ export function wireShortcutEditor(ctx: PanelContext): void {
         shortcutKeys.forEach(keyElement => {
             const getOriginalKey = () => JC.state!.activeShortcuts[keyElement.dataset.action!];
 
-            keyElement.addEventListener('click', () => keyElement.focus());
+            keyElement.addEventListener('click', () => { if (isCurrent()) keyElement.focus(); });
 
             keyElement.addEventListener('focus', () => {
+                if (!isCurrent()) return;
                 keyElement.textContent = JC.t!('panel_shortcuts_listening');
                 keyElement.style.borderColor = primaryAccentColor;
                 keyElement.style.width = '100px';
             });
 
             keyElement.addEventListener('blur', () => {
+                if (!isCurrent()) return;
                 keyElement.textContent = getOriginalKey();
                 keyElement.style.borderColor = 'transparent';
                 keyElement.style.width = 'auto';
@@ -40,6 +43,7 @@ export function wireShortcutEditor(ctx: PanelContext): void {
             keyElement.addEventListener('keydown', (e) => {
                 e.preventDefault();
                 e.stopPropagation();
+                if (!isCurrent()) return;
 
                 const labelWrapper = keyElement.nextElementSibling;
                 const action = keyElement.dataset.action!;
@@ -76,12 +80,14 @@ export function wireShortcutEditor(ctx: PanelContext): void {
                 if (existingAction && existingAction !== action) {
                     keyElement.style.background = 'rgb(255 0 0 / 60%)';
                     keyElement.classList.add('shake-error');
-                    setTimeout(() => {
+                    const timer = window.setTimeout(() => {
+                        if (!isCurrent()) return;
                         keyElement.classList.remove('shake-error');
                         if (document.activeElement === keyElement) {
                             keyElement.style.background = kbdBackground;
                         }
                     }, 500);
+                    trackTimer(timer);
                         // Reject the new keybinding and stop the function
                     return;
                 }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/detail-button.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/detail-button.identity.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    enabled: false,
+    enableForSeries: vi.fn<() => Promise<void>>(),
+    disableForSeries: vi.fn<() => Promise<void>>(),
+    confirmDisableSpoiler: vi.fn<() => Promise<boolean>>(),
+    refreshSpoilerableImages: vi.fn<() => void>(),
+}));
+
+vi.mock('./state', () => ({
+    isEnabledFor: () => mocks.enabled,
+    isMovieEnabledFor: () => mocks.enabled,
+    isCollectionEnabledFor: () => mocks.enabled,
+    enableForSeries: () => mocks.enableForSeries(),
+    disableForSeries: () => mocks.disableForSeries(),
+    enableForMovie: () => mocks.enableForSeries(),
+    disableForMovie: () => mocks.disableForSeries(),
+    enableForCollection: () => mocks.enableForSeries(),
+    disableForCollection: () => mocks.disableForSeries(),
+    getUserPrefs: () => ({}),
+    isStateLoaded: () => true,
+}));
+
+vi.mock('./dialog', () => ({
+    confirmDisableSpoiler: () => mocks.confirmDisableSpoiler(),
+}));
+
+vi.mock('./image-refresh', () => ({
+    refreshSpoilerableImages: () => mocks.refreshSpoilerableImages(),
+}));
+
+import { JC } from '../../globals';
+import { addSpoilerBlurButton } from './detail-button';
+
+function deferred(): { promise: Promise<void>; resolve(): void } {
+    let resolve!: () => void;
+    const promise = new Promise<void>((done) => { resolve = done; });
+    return { promise, resolve };
+}
+
+function renderPage(): HTMLElement {
+    document.body.innerHTML = '<div id="itemDetailPage"><div class="detailButtons"></div></div>';
+    return document.getElementById('itemDetailPage')!;
+}
+
+async function flush(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+}
+
+describe('Spoiler Guard detail button identity ownership', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        document.body.innerHTML = '';
+        JC.identity.transition('', '', 'detail-button-test-reset');
+        JC.identity.transition('server-a', 'user-a', 'detail-button-test-start');
+        (JC.pluginConfig as Record<string, unknown>).SpoilerBlurEnabled = true;
+        (JC.pluginConfig as Record<string, unknown>).SpoilerBlurStrictRefresh = false;
+        JC.t = (key: string) => key;
+        JC.toast = vi.fn();
+        JC.tagPipeline = {
+            registerRenderer: vi.fn(),
+            invalidateServerCache: vi.fn().mockResolvedValue(undefined),
+        };
+        mocks.enabled = false;
+        mocks.enableForSeries.mockReset().mockResolvedValue(undefined);
+        mocks.disableForSeries.mockReset().mockResolvedValue(undefined);
+        mocks.confirmDisableSpoiler.mockReset().mockResolvedValue(true);
+        mocks.refreshSpoilerableImages.mockClear();
+    });
+
+    afterEach(() => {
+        JC.identity.transition('', '', 'detail-button-test-cleanup');
+        vi.useRealTimers();
+        document.body.innerHTML = '';
+    });
+
+    it('removes A and drops its held completion while allowing a fresh B control', async () => {
+        const held = deferred();
+        mocks.enableForSeries.mockReturnValueOnce(held.promise);
+        const page = renderPage();
+        addSpoilerBlurButton('item-a', page, 'Series');
+        const retainedA = page.querySelector<HTMLButtonElement>('.jc-spoiler-blur-btn')!;
+        retainedA.click();
+        expect(mocks.enableForSeries).toHaveBeenCalledTimes(1);
+
+        JC.identity.transition('server-a', 'user-b', 'account-switch');
+        expect(document.querySelector('.jc-spoiler-blur-btn')).toBeNull();
+        held.resolve();
+        await flush();
+
+        expect(JC.toast).not.toHaveBeenCalled();
+        expect(mocks.refreshSpoilerableImages).not.toHaveBeenCalled();
+        retainedA.click();
+        expect(mocks.enableForSeries).toHaveBeenCalledTimes(1);
+
+        addSpoilerBlurButton('item-b', page, 'Series');
+        const buttonB = page.querySelector<HTMLButtonElement>('.jc-spoiler-blur-btn')!;
+        expect(buttonB).toBeTruthy();
+        expect(buttonB).not.toBe(retainedA);
+        buttonB.click();
+        await flush();
+
+        expect(mocks.enableForSeries).toHaveBeenCalledTimes(2);
+        expect(mocks.refreshSpoilerableImages).toHaveBeenCalledTimes(1);
+        expect(JC.toast).toHaveBeenCalledWith('spoiler_blur_enabled_toast');
+    });
+
+    it('cancels an A-owned strict-refresh reload timer synchronously', async () => {
+        (JC.pluginConfig as Record<string, unknown>).SpoilerBlurStrictRefresh = true;
+        const page = renderPage();
+        addSpoilerBlurButton('item-a', page, 'Series');
+        page.querySelector<HTMLButtonElement>('.jc-spoiler-blur-btn')!.click();
+        await flush();
+        expect(vi.getTimerCount()).toBe(1);
+
+        JC.identity.transition('server-a', 'user-b', 'account-switch');
+        expect(vi.getTimerCount()).toBe(0);
+        await vi.advanceTimersByTimeAsync(1_000);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/detail-button.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/detail-button.ts
@@ -18,6 +18,7 @@ import {
 } from './state';
 import { confirmDisableSpoiler } from './dialog';
 import { refreshSpoilerableImages } from './image-refresh';
+import type { IdentityContext } from '../../types/jc';
 
 const logPrefix = '🪼 Jellyfin Canopy [SpoilerGuard]:';
 
@@ -65,6 +66,13 @@ function placeButton(button: HTMLButtonElement, container: Element): void {
     }
 }
 
+function isLiveButton(button: HTMLButtonElement, context: IdentityContext, visiblePage?: Element): boolean {
+    return JC.identity.isCurrent(context)
+        && JC.identity.isOwned(button, context)
+        && button.isConnected
+        && (!visiblePage || visiblePage.contains(button));
+}
+
 /**
  * Insert (or refresh) the Spoiler Guard toggle on a Series / Movie / Collection
  * detail page's action row. Idempotent: re-running on the same page reuses the
@@ -74,6 +82,8 @@ function placeButton(button: HTMLButtonElement, container: Element): void {
  * @param itemType - Jellyfin item Type (Series | Movie | BoxSet).
  */
 export function addSpoilerBlurButton(itemId: string, visiblePage: Element, itemType: string): void {
+    const context = JC.identity.capture();
+    if (!context || !JC.identity.isCurrent(context)) return;
     if (JC.pluginConfig?.SpoilerBlurEnabled !== true) return;
     if (!itemId || !visiblePage) return;
     if (!isStateLoaded()) return; // wait for the initial GET attempt to settle
@@ -93,11 +103,20 @@ export function addSpoilerBlurButton(itemId: string, visiblePage: Element, itemT
 
     let existing = visiblePage.querySelector<HTMLButtonElement>('.jc-spoiler-blur-btn');
 
+    // A cached details-page element can survive an account switch. Never
+    // reuse a control whose listener closure belongs to the previous epoch.
+    if (existing && !JC.identity.isOwned(existing, context)) {
+        existing.remove();
+        existing = null;
+    }
+
     if (!existing) {
         existing = document.createElement('button');
         existing.setAttribute('is', 'emby-button');
         existing.className = 'button-flat detailButton emby-button jc-spoiler-blur-btn';
         existing.type = 'button';
+        existing.dataset.jcIdentityOwned = 'true';
+        JC.identity.own(existing, context);
         placeButton(existing, container);
         // Read itemId/kind LIVE from data-attrs at click time, not closure:
         // Jellyfin reuses #itemDetailPage across SPA navigations, so a button
@@ -105,10 +124,12 @@ export function addSpoilerBlurButton(itemId: string, visiblePage: Element, itemT
         existing.addEventListener('click', (e) => {
             e.preventDefault();
             e.stopPropagation();
+            if (!isLiveButton(existing!, context)) return;
             const liveId = existing!.getAttribute('data-jc-item-id') || '';
             const liveKind = (existing!.getAttribute('data-jc-spoiler-kind') || 'series') as SpoilerKind;
             const livePage = existing!.closest('#itemDetailPage:not(.hide)') || visiblePage;
-            onToggleClicked(existing!, liveId, liveKind, livePage);
+            if (!isLiveButton(existing!, context, livePage)) return;
+            onToggleClicked(existing!, liveId, liveKind, livePage, context);
         });
         existing.setAttribute('data-jc-item-id', itemId);
         existing.setAttribute('data-jc-spoiler-state', newState);
@@ -139,10 +160,21 @@ export function addSpoilerBlurButton(itemId: string, visiblePage: Element, itemT
 // server-side strip changes. Coalesced + debounced so a burst of watched-marks
 // triggers one reload. One-shot setTimeout (not self-rescheduling).
 let pendingReload: number | null = null;
-function scheduleFullReload(): void {
-    if (pendingReload) clearTimeout(pendingReload);
+let pendingReloadContext: IdentityContext | null = null;
+function cancelFullReload(): void {
+    if (pendingReload !== null) clearTimeout(pendingReload);
+    pendingReload = null;
+    pendingReloadContext = null;
+}
+
+function scheduleFullReload(context: IdentityContext): void {
+    cancelFullReload();
+    pendingReloadContext = context;
     pendingReload = window.setTimeout(() => {
+        const owner = pendingReloadContext;
         pendingReload = null;
+        pendingReloadContext = null;
+        if (!owner || !JC.identity.isCurrent(owner)) return;
         try { location.reload(); } catch (e) { console.warn(`${logPrefix} reload failed:`, e); }
     }, 600);
 }
@@ -151,28 +183,38 @@ function scheduleFullReload(): void {
  * Click handler: flips Spoiler Guard for this item, confirms on disable (unless
  * snoozed / SkipDisableConfirm), toasts, and refreshes images in place.
  */
-function onToggleClicked(button: HTMLButtonElement, itemId: string, kind: SpoilerKind, visiblePage: Element): void {
+function onToggleClicked(
+    button: HTMLButtonElement,
+    itemId: string,
+    kind: SpoilerKind,
+    visiblePage: Element,
+    context: IdentityContext,
+): void {
+    if (!isLiveButton(button, context, visiblePage)) return;
     if (button.disabled) return; // ignore re-entrant clicks
     const willBeEnabled = !isEnabledForKind(kind, itemId);
     // Disable up-front so rapid double-clicks can't stack confirm dialogs.
     button.disabled = true;
     if (!willBeEnabled) {
-        confirmDisableSpoiler().then((proceed) => {
-            if (proceed) performToggle(button, itemId, kind, visiblePage, willBeEnabled);
+        confirmDisableSpoiler(context).then((proceed) => {
+            if (!isLiveButton(button, context, visiblePage)) return;
+            if (proceed) performToggle(button, itemId, kind, visiblePage, willBeEnabled, context);
             else button.disabled = false;
         }, (err) => {
+            if (!isLiveButton(button, context, visiblePage)) return;
             console.warn(`${logPrefix} confirmDisableSpoiler rejected:`, err);
             button.disabled = false;
         });
         return;
     }
-    performToggle(button, itemId, kind, visiblePage, willBeEnabled);
+    performToggle(button, itemId, kind, visiblePage, willBeEnabled, context);
 }
 
 function performToggle(
     button: HTMLButtonElement, itemId: string, kind: SpoilerKind,
-    visiblePage: Element, willBeEnabled: boolean
+    visiblePage: Element, willBeEnabled: boolean, context: IdentityContext,
 ): void {
+    if (!isLiveButton(button, context, visiblePage)) return;
     let displayName = '';
     if ((kind === 'movie' || kind === 'collection') && visiblePage) {
         try {
@@ -193,6 +235,7 @@ function performToggle(
     }
 
     promise.then(() => {
+        if (!isLiveButton(button, context, visiblePage)) return;
         renderButton(button, willBeEnabled);
         button.setAttribute('data-jc-spoiler-state', willBeEnabled ? 'on' : 'off');
 
@@ -234,11 +277,17 @@ function performToggle(
         try { refreshSpoilerableImages(); }
         catch (e) { console.warn(`${logPrefix} refreshSpoilerableImages failed:`, e); }
 
-        if (JC.pluginConfig?.SpoilerBlurStrictRefresh === true) scheduleFullReload();
+        if (JC.pluginConfig?.SpoilerBlurStrictRefresh === true) scheduleFullReload(context);
     }).catch((err) => {
+        if (!isLiveButton(button, context, visiblePage)) return;
         console.error(`${logPrefix} Toggle failed:`, err);
         JC.toast?.(JC.t!('spoiler_blur_error_toast'));
     }).finally(() => {
-        button.disabled = false;
+        if (isLiveButton(button, context, visiblePage)) button.disabled = false;
     });
 }
+
+JC.identity.registerReset('spoiler-detail-controls', () => {
+    cancelFullReload();
+    document.querySelectorAll('.jc-spoiler-blur-btn').forEach((node) => node.remove());
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/dialog.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/dialog.identity.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    whenLoaded: vi.fn<() => Promise<void>>(),
+    getUserPrefs: vi.fn(() => ({ SkipDisableConfirm: false })),
+    isDisableSnoozed: vi.fn(() => false),
+    setDisableSnooze: vi.fn<() => void>(),
+}));
+
+vi.mock('./state', () => ({
+    whenLoaded: () => mocks.whenLoaded(),
+    getUserPrefs: () => mocks.getUserPrefs(),
+}));
+
+vi.mock('./snooze', () => ({
+    isDisableSnoozed: () => mocks.isDisableSnoozed(),
+    setDisableSnooze: () => mocks.setDisableSnooze(),
+}));
+
+import { JC } from '../../globals';
+import { confirmDisableSpoiler } from './dialog';
+
+function deferred(): { promise: Promise<void>; resolve(): void } {
+    let resolve!: () => void;
+    const promise = new Promise<void>((done) => { resolve = done; });
+    return { promise, resolve };
+}
+
+async function flush(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+}
+
+describe('Spoiler Guard disable-confirm identity ownership', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        JC.identity.transition('', '', 'dialog-test-reset');
+        JC.identity.transition('server-a', 'user-a', 'dialog-test-start');
+        JC.t = (key: string) => key;
+        mocks.whenLoaded.mockReset().mockResolvedValue(undefined);
+        mocks.getUserPrefs.mockClear();
+        mocks.isDisableSnoozed.mockClear();
+        mocks.setDisableSnooze.mockClear();
+    });
+
+    afterEach(() => {
+        JC.identity.transition('', '', 'dialog-test-cleanup');
+        document.body.innerHTML = '';
+    });
+
+    it('does not read B preferences or open a dialog when A whenLoaded settles late', async () => {
+        const held = deferred();
+        mocks.whenLoaded.mockReturnValueOnce(held.promise);
+        const ownerA = JC.identity.capture()!;
+
+        const result = confirmDisableSpoiler(ownerA);
+        JC.identity.transition('server-a', 'user-b', 'account-switch');
+        held.resolve();
+
+        await expect(result).resolves.toBe(false);
+        expect(mocks.getUserPrefs).not.toHaveBeenCalled();
+        expect(document.querySelector('.jc-spoiler-confirm-overlay')).toBeNull();
+    });
+
+    it('closes A synchronously and a retained confirm cannot authorize or snooze B', async () => {
+        const ownerA = JC.identity.capture()!;
+        const result = confirmDisableSpoiler(ownerA);
+        await flush();
+
+        const overlay = document.querySelector<HTMLElement>('.jc-spoiler-confirm-overlay')!;
+        const retainedConfirm = overlay.querySelector<HTMLButtonElement>('.jc-spoiler-confirm-ok')!;
+        overlay.querySelector<HTMLInputElement>('input[type="checkbox"]')!.checked = true;
+        expect(overlay).toBeTruthy();
+
+        JC.identity.transition('server-a', 'user-b', 'account-switch');
+
+        expect(document.querySelector('.jc-spoiler-confirm-overlay')).toBeNull();
+        await expect(result).resolves.toBe(false);
+        retainedConfirm.click();
+        expect(mocks.setDisableSnooze).not.toHaveBeenCalled();
+        expect(document.body.classList.contains('jc-modal-open')).toBe(false);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/dialog.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/dialog.ts
@@ -11,6 +11,7 @@ import { installModalA11y } from '../../core/modal-a11y';
 import { whenLoaded } from './state';
 import { getUserPrefs } from './state';
 import { isDisableSnoozed, setDisableSnooze } from './snooze';
+import type { IdentityContext } from '../../types/jc';
 
 const logPrefix = '🪼 Jellyfin Canopy [SpoilerGuard]:';
 
@@ -22,21 +23,46 @@ const logPrefix = '🪼 Jellyfin Canopy [SpoilerGuard]:';
  * window before loadState() resolves.
  * @returns true to proceed with the disable, false to cancel.
  */
-export function confirmDisableSpoiler(): Promise<boolean> {
+export function confirmDisableSpoiler(context: IdentityContext | null = JC.identity.capture()): Promise<boolean> {
+    if (!context || !JC.identity.isCurrent(context)) return Promise.resolve(false);
     return whenLoaded().then(() => {
+        // `whenLoaded()` may have belonged to A and settled only after B's
+        // state became current. Never read B's preferences or create a dialog
+        // on behalf of that stale A continuation.
+        if (!JC.identity.isCurrent(context)) return false;
         if (getUserPrefs().SkipDisableConfirm) return true;
         if (isDisableSnoozed()) return true;
-        return showConfirmDialog();
+        return showConfirmDialog(context);
+    }, (error) => {
+        if (JC.identity.isCurrent(context)) {
+            console.warn(`${logPrefix} disable-confirm state load failed:`, error);
+        }
+        return false;
     });
 }
 
+interface OpenConfirm {
+    finish(confirmed: boolean): void;
+}
+
+const openConfirms = new Set<OpenConfirm>();
+
 /** Builds and shows the native confirm overlay. Resolves true/false. */
-function showConfirmDialog(): Promise<boolean> {
+function showConfirmDialog(context: IdentityContext): Promise<boolean> {
+    if (!JC.identity.isCurrent(context)) return Promise.resolve(false);
     return new Promise<boolean>((resolve) => {
-        document.querySelector('.jc-spoiler-confirm-overlay')?.remove();
+        // Resolve an existing confirmation rather than merely removing its DOM
+        // and marooning its caller's promise forever.
+        for (const open of Array.from(openConfirms)) open.finish(false);
+        if (!JC.identity.isCurrent(context)) {
+            resolve(false);
+            return;
+        }
 
         const overlay = document.createElement('div');
         overlay.className = 'jc-spoiler-confirm-overlay';
+        overlay.dataset.jcIdentityOwned = 'true';
+        JC.identity.own(overlay, context);
 
         const dialog = document.createElement('div');
         dialog.className = 'jc-spoiler-confirm-dialog';
@@ -88,17 +114,22 @@ function showConfirmDialog(): Promise<boolean> {
         });
 
         let settled = false;
+        const record: OpenConfirm = { finish };
+        openConfirms.add(record);
         function finish(confirmed: boolean): void {
             if (settled) return;
             settled = true;
+            openConfirms.delete(record);
+            const isCurrent = JC.identity.isCurrent(context);
             try {
-                if (confirmed && snoozeCheck.checked) setDisableSnooze();
+                if (isCurrent && confirmed && snoozeCheck.checked) setDisableSnooze();
             } catch (e) {
-                console.warn(`${logPrefix} snooze persist failed:`, e);
+                if (isCurrent) console.warn(`${logPrefix} snooze persist failed:`, e);
             }
             a11y.release();
             overlay.remove();
-            resolve(confirmed);
+            // A retained confirmation can never authorize an operation for B.
+            resolve(isCurrent && confirmed);
         }
 
         cancelBtn.addEventListener('click', () => finish(false));
@@ -108,3 +139,10 @@ function showConfirmDialog(): Promise<boolean> {
         document.body.appendChild(overlay);
     });
 }
+
+JC.identity.registerReset('spoiler-disable-confirms', () => {
+    for (const open of Array.from(openConfirms)) open.finish(false);
+    // Defensive cleanup for an overlay removed from the registry by hostile
+    // host DOM churn before its completion callback ran.
+    document.querySelectorAll('.jc-spoiler-confirm-overlay').forEach((node) => node.remove());
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/identity.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+import {
+    primeIdentityCookieEarly,
+    resetIdentityCookie,
+} from './identity';
+
+describe('spoiler identity cookie ownership', () => {
+    afterEach(() => {
+        resetIdentityCookie();
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
+
+    it('expires A synchronously and primes B once on activation', async () => {
+        vi.useFakeTimers();
+        const interval = vi.spyOn(window, 'setInterval');
+        const original = JC.identity.capture()!;
+
+        resetIdentityCookie();
+        primeIdentityCookieEarly(original);
+        expect(document.cookie).toContain(`jc-spoiler-uid=${original.userId}`);
+
+        const next = JC.identity.transition('server-b', 'user-b', 'spoiler-cookie-test')!;
+        expect(document.cookie).not.toContain('jc-spoiler-uid=');
+
+        await JC.identity.activate(next);
+        await JC.identity.activate(next);
+        expect(document.cookie).toContain(`jc-spoiler-uid=${next.userId}`);
+        expect(interval).toHaveBeenCalledTimes(2);
+
+        JC.identity.transition(original.serverId, original.userId, 'spoiler-cookie-test-restore');
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/identity.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/identity.ts
@@ -21,17 +21,24 @@
 // refreshed on every load, so switching accounts updates it. Do NOT reintroduce
 // image-URL rewriting here.
 
+import { JC } from '../../globals';
+import type { IdentityContext } from '../../types/jc';
+
 const logPrefix = '🪼 Jellyfin Canopy [SpoilerGuard]:';
 
-/** Write the identity cookie for the current user, if one is available. */
-export function setIdentityCookie(): void {
+function clearIdentityCookie(): void {
     try {
-        const uid = (typeof ApiClient !== 'undefined' && typeof ApiClient.getCurrentUserId === 'function')
-            ? ApiClient.getCurrentUserId()
-            : null;
-        if (uid) {
-            document.cookie = `jc-spoiler-uid=${encodeURIComponent(uid)}; path=/; SameSite=Lax`;
-        }
+        document.cookie = 'jc-spoiler-uid=; path=/; SameSite=Lax; Max-Age=0';
+    } catch {
+        /* no document cookie surface */
+    }
+}
+
+/** Write the identity cookie for the captured current user, if available. */
+export function setIdentityCookie(context: IdentityContext | null = JC.identity.capture()): void {
+    try {
+        if (!context || !JC.identity.isCurrent(context)) return;
+        document.cookie = `jc-spoiler-uid=${encodeURIComponent(context.userId)}; path=/; SameSite=Lax`;
     } catch (e) {
         console.warn(`${logPrefix} identity cookie set failed:`, e);
     }
@@ -47,27 +54,52 @@ export function setIdentityCookie(): void {
 // with the new user's early image requests.
 const PRIME_INTERVAL_MS = 250;
 const PRIME_MAX_TRIES = 20;
-let primed = false;
+let primedEpoch: number | null = null;
+let primeInterval: number | null = null;
+
+function stopPriming(): void {
+    if (primeInterval !== null) {
+        clearInterval(primeInterval);
+        primeInterval = null;
+    }
+}
+
+/** Drop A's hint synchronously before any B image request can inherit it. */
+export function resetIdentityCookie(): void {
+    stopPriming();
+    primedEpoch = null;
+    clearIdentityCookie();
+}
 
 /** Write the cookie now, then retry briefly until a user id is available. */
-export function primeIdentityCookieEarly(): void {
-    if (primed) return;
-    primed = true;
-    setIdentityCookie();
+export function primeIdentityCookieEarly(context: IdentityContext | null = JC.identity.capture()): void {
+    if (!context || !JC.identity.isCurrent(context)) return;
+    if (primedEpoch === context.epoch) return;
+    stopPriming();
+    primedEpoch = context.epoch;
+    setIdentityCookie(context);
     let tries = 0;
     try {
-        const iv = setInterval(() => {
+        primeInterval = window.setInterval(() => {
+            if (!JC.identity.isCurrent(context)) {
+                stopPriming();
+                return;
+            }
             const uid = (typeof ApiClient !== 'undefined' && typeof ApiClient.getCurrentUserId === 'function')
                 ? ApiClient.getCurrentUserId()
                 : null;
-            if (uid) {
-                setIdentityCookie();
-                clearInterval(iv);
+            const normalizedUid = String(uid || '').replace(/-/g, '').toLowerCase();
+            if (normalizedUid === context.userId) {
+                setIdentityCookie(context);
+                stopPriming();
             } else if (++tries >= PRIME_MAX_TRIES) {
-                clearInterval(iv);
+                stopPriming();
             }
         }, PRIME_INTERVAL_MS);
     } catch {
         /* setInterval unavailable — init() still sets the cookie once. */
     }
 }
+
+JC.identity.registerReset('spoiler-identity-cookie', resetIdentityCookie);
+JC.identity.registerActivate('spoiler-identity-cookie', primeIdentityCookieEarly);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/index.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/index.identity.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+
+const mocks = vi.hoisted(() => ({
+    loadState: vi.fn(() => Promise.resolve()),
+    resetState: vi.fn(),
+    installWatchedRefresh: vi.fn(),
+    setIdentityCookie: vi.fn(),
+    primeIdentityCookieEarly: vi.fn(),
+    liveHandler: null as (() => void) | null,
+}));
+
+vi.mock('./state', () => ({
+    loadState: mocks.loadState,
+    resetState: mocks.resetState,
+    whenLoaded: vi.fn(),
+    isLoadOk: vi.fn(),
+    isEnabledFor: vi.fn(),
+    isMovieEnabledFor: vi.fn(),
+    isCollectionEnabledFor: vi.fn(),
+    hasEnabledCollections: vi.fn(),
+    fetchMovieScope: vi.fn(),
+    enableForSeries: vi.fn(),
+    disableForSeries: vi.fn(),
+    enableForMovie: vi.fn(),
+    disableForMovie: vi.fn(),
+    enableForCollection: vi.fn(),
+    disableForCollection: vi.fn(),
+    isTmdbEnabled: vi.fn(),
+    enableForTmdb: vi.fn(),
+    disableForTmdb: vi.fn(),
+    getUserPrefs: vi.fn(),
+    setUserPrefs: vi.fn(),
+}));
+vi.mock('./identity', () => ({
+    setIdentityCookie: mocks.setIdentityCookie,
+    primeIdentityCookieEarly: mocks.primeIdentityCookieEarly,
+}));
+vi.mock('./watched-refresh', () => ({ installWatchedRefresh: mocks.installWatchedRefresh }));
+vi.mock('./detail-button', () => ({ addSpoilerBlurButton: vi.fn() }));
+vi.mock('./dialog', () => ({ confirmDisableSpoiler: vi.fn() }));
+vi.mock('./styles', () => ({ injectSpoilerGuardCss: vi.fn() }));
+vi.mock('../../core/live', () => ({
+    LIVE: { CONFIG_CHANGED: 'config-changed' },
+    on: vi.fn((_type: string, handler: () => void) => {
+        mocks.liveHandler = handler;
+        return vi.fn();
+    }),
+}));
+
+describe('spoiler guard identity activation', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        mocks.loadState.mockClear();
+        mocks.resetState.mockClear();
+        mocks.installWatchedRefresh.mockClear();
+        mocks.setIdentityCookie.mockClear();
+        mocks.primeIdentityCookieEarly.mockClear();
+        mocks.liveHandler = null;
+        JC.pluginConfig = { SpoilerBlurEnabled: true };
+    });
+
+    it('loads once per epoch and remains dormant when B has the feature disabled', async () => {
+        const original = JC.identity.capture()!;
+        await import('./index');
+        expect(mocks.loadState).toHaveBeenCalledTimes(1);
+
+        const next = JC.identity.transition('server-b', 'user-b', 'spoiler-index-test')!;
+        JC.pluginConfig = { SpoilerBlurEnabled: false };
+        await JC.identity.activate(next);
+        await JC.identity.activate(next);
+        expect(mocks.loadState).toHaveBeenCalledTimes(1);
+
+        JC.pluginConfig = { SpoilerBlurEnabled: true };
+        mocks.liveHandler?.();
+        expect(mocks.resetState).toHaveBeenCalledTimes(1);
+        expect(mocks.loadState).toHaveBeenCalledTimes(2);
+        expect(mocks.installWatchedRefresh).toHaveBeenCalledTimes(2);
+
+        JC.identity.transition(original.serverId, original.userId, 'spoiler-index-test-restore');
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/index.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/index.ts
@@ -29,24 +29,30 @@ import { confirmDisableSpoiler } from './dialog';
 import { injectSpoilerGuardCss } from './styles';
 import { primeIdentityCookieEarly, setIdentityCookie } from './identity';
 import { installWatchedRefresh } from './watched-refresh';
+import type { IdentityContext } from '../../types/jc';
 
 const logPrefix = '🪼 Jellyfin Canopy [SpoilerGuard]:';
 
 let inited = false;
+let activeEpoch: number | null = null;
 
 /**
  * Boot the client feature. Gated on the admin master switch. Idempotent: safe
  * to re-run on LIVE.CONFIG_CHANGED (re-fetches state; the cookie / CSS / live
  * subscription install once).
  */
-function init(): void {
+function init(context: IdentityContext | null = JC.identity.capture()): void {
     if (JC.pluginConfig?.SpoilerBlurEnabled !== true) return;
-    setIdentityCookie();
+    if (!context || !JC.identity.isCurrent(context)) return;
+    setIdentityCookie(context);
+    primeIdentityCookieEarly(context);
     if (!inited) {
         inited = true;
         injectSpoilerGuardCss();
-        installWatchedRefresh();
     }
+    installWatchedRefresh();
+    if (activeEpoch === context.epoch) return;
+    activeEpoch = context.epoch;
     void loadState();
 }
 
@@ -78,12 +84,20 @@ JC.spoilerGuard = {
 // card <img> requests — with a bounded retry until ApiClient reports a user.
 primeIdentityCookieEarly();
 
+JC.identity.registerReset('spoiler-guard', () => {
+    activeEpoch = null;
+});
+JC.identity.registerActivate('spoiler-guard', (context) => {
+    init(context);
+});
+
 // Boot now, and re-boot when an admin saves config (re-init instead of reload).
 init();
 on(LIVE.CONFIG_CHANGED, () => {
     try {
         if (JC.pluginConfig?.SpoilerBlurEnabled === true) {
             resetState();
+            activeEpoch = null;
             init();
         }
     } catch (e) {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/seerr-toggle.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/seerr-toggle.identity.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    enabled: false,
+    whenLoaded: vi.fn<() => Promise<void>>(),
+    enableForTmdb: vi.fn<() => Promise<unknown>>(),
+    disableForTmdb: vi.fn<() => Promise<unknown>>(),
+    confirmDisableSpoiler: vi.fn<() => Promise<boolean>>(),
+}));
+
+vi.mock('./state', () => ({
+    isTmdbEnabled: () => mocks.enabled,
+    whenLoaded: () => mocks.whenLoaded(),
+    enableForTmdb: () => mocks.enableForTmdb(),
+    disableForTmdb: () => mocks.disableForTmdb(),
+}));
+
+vi.mock('./dialog', () => ({
+    confirmDisableSpoiler: () => mocks.confirmDisableSpoiler(),
+}));
+
+import { JC } from '../../globals';
+import { buildSeerrPendingToggle } from './seerr-toggle';
+
+function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((done) => { resolve = done; });
+    return { promise, resolve };
+}
+
+async function flush(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+}
+
+describe('Spoiler Guard Seerr control identity ownership', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        JC.identity.transition('', '', 'seerr-toggle-test-reset');
+        JC.identity.transition('server-a', 'user-a', 'seerr-toggle-test-start');
+        (JC.pluginConfig as Record<string, unknown>).SpoilerBlurEnabled = true;
+        JC.t = (key: string) => key;
+        JC.toast = vi.fn();
+        mocks.enabled = false;
+        mocks.whenLoaded.mockReset().mockResolvedValue(undefined);
+        mocks.enableForTmdb.mockReset().mockResolvedValue({ promoted: 'pending' });
+        mocks.disableForTmdb.mockReset().mockResolvedValue({});
+        mocks.confirmDisableSpoiler.mockReset().mockResolvedValue(true);
+    });
+
+    afterEach(() => {
+        JC.identity.transition('', '', 'seerr-toggle-test-cleanup');
+        document.body.innerHTML = '';
+    });
+
+    it('drops A held-load label work, removes A, and creates a distinct B control', async () => {
+        const held = deferred<void>();
+        mocks.whenLoaded.mockReturnValueOnce(held.promise);
+        const retainedA = buildSeerrPendingToggle({ id: 42, title: 'A' }, 'movie')!;
+        document.body.appendChild(retainedA);
+        expect(retainedA.textContent).toContain('spoiler_blur_pending_button_off');
+
+        JC.identity.transition('server-a', 'user-b', 'account-switch');
+        expect(document.querySelector('.jc-spoiler-pending-btn')).toBeNull();
+        mocks.enabled = true;
+        held.resolve(undefined);
+        await flush();
+
+        expect(retainedA.textContent).toContain('spoiler_blur_pending_button_off');
+        retainedA.click();
+        expect(mocks.enableForTmdb).not.toHaveBeenCalled();
+        expect(mocks.disableForTmdb).not.toHaveBeenCalled();
+
+        const buttonB = buildSeerrPendingToggle({ id: 42, title: 'B' }, 'movie')!;
+        document.body.appendChild(buttonB);
+        await flush();
+        expect(buttonB).not.toBe(retainedA);
+        expect(buttonB.textContent).toContain('spoiler_blur_pending_button_on');
+    });
+
+    it('does not let a retained A confirmation disable B state', async () => {
+        mocks.enabled = true;
+        const heldConfirm = deferred<boolean>();
+        mocks.confirmDisableSpoiler.mockReturnValueOnce(heldConfirm.promise);
+        const retainedA = buildSeerrPendingToggle({ id: 7, title: 'A' }, 'tv')!;
+        document.body.appendChild(retainedA);
+        retainedA.click();
+        expect(mocks.confirmDisableSpoiler).toHaveBeenCalledTimes(1);
+
+        JC.identity.transition('server-a', 'user-b', 'account-switch');
+        heldConfirm.resolve(true);
+        await flush();
+
+        expect(mocks.disableForTmdb).not.toHaveBeenCalled();
+        expect(JC.toast).not.toHaveBeenCalled();
+        expect(document.querySelector('.jc-spoiler-pending-btn')).toBeNull();
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/seerr-toggle.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/seerr-toggle.ts
@@ -20,6 +20,8 @@ const logPrefix = '🪼 Jellyfin Canopy [SpoilerGuard]:';
  * @param mediaType - 'tv' | 'movie'.
  */
 export function buildSeerrPendingToggle(data: any, mediaType: string): HTMLButtonElement | null { // eslint-disable-line @typescript-eslint/no-explicit-any
+    const context = JC.identity.capture();
+    if (!context || !JC.identity.isCurrent(context)) return null;
     if (JC.pluginConfig?.SpoilerBlurEnabled !== true) return null;
     if (mediaType !== 'tv' && mediaType !== 'movie') return null;
     const tmdbId = data?.id;
@@ -33,8 +35,10 @@ export function buildSeerrPendingToggle(data: any, mediaType: string): HTMLButto
     // Deliberately NOT the primary request CTA class — this is a quieter
     // secondary action with its own ghost styling.
     btn.className = 'jc-spoiler-pending-btn';
+    btn.dataset.jcIdentityOwned = 'true';
     btn.setAttribute('data-jc-tmdb-id', String(tmdbId));
     btn.setAttribute('data-jc-media-type', mediaType);
+    JC.identity.own(btn, context);
 
     const iconSpan = document.createElement('span');
     iconSpan.className = 'material-icons';
@@ -42,7 +46,14 @@ export function buildSeerrPendingToggle(data: any, mediaType: string): HTMLButto
     btn.appendChild(iconSpan);
     btn.appendChild(labelSpan);
 
+    function isOwnedButton(requireConnected = false): boolean {
+        return JC.identity.isCurrent(context)
+            && JC.identity.isOwned(btn, context)
+            && (!requireConnected || btn.isConnected);
+    }
+
     function refreshLabel(): void {
+        if (!isOwnedButton()) return;
         const enabled = isTmdbEnabled(mediaType, String(tmdbId), jellyfinMediaId);
         const label = enabled ? JC.t!('spoiler_blur_pending_button_on') : JC.t!('spoiler_blur_pending_button_off');
         btn.classList.toggle('jc-spoiler-pending-on', enabled);
@@ -55,34 +66,46 @@ export function buildSeerrPendingToggle(data: any, mediaType: string): HTMLButto
     // Cold-load fix: state may load after the modal mounts, so an initial
     // refreshLabel could read empty sets. whenLoaded resolves immediately if
     // already loaded, else awaits the in-flight load.
-    whenLoaded().then(refreshLabel).catch(() => { /* refresh best-effort */ });
+    whenLoaded().then(() => {
+        if (isOwnedButton()) refreshLabel();
+    }).catch(() => { /* refresh best-effort */ });
 
     btn.addEventListener('click', (e) => {
         e.preventDefault();
         e.stopPropagation();
+        if (!isOwnedButton(true)) return;
         if (btn.disabled) return;
         btn.disabled = true;
         const wasEnabled = isTmdbEnabled(mediaType, String(tmdbId), jellyfinMediaId);
         void (async () => {
             try {
                 if (wasEnabled) {
-                    const proceed = await confirmDisableSpoiler();
-                    if (!proceed) return;
+                    const proceed = await confirmDisableSpoiler(context);
+                    if (!isOwnedButton(true) || !proceed) return;
                     await disableForTmdb(mediaType, String(tmdbId));
+                    if (!isOwnedButton(true)) return;
                     JC.toast?.(JC.t!('spoiler_blur_pending_disabled_toast'));
                 } else {
                     await enableForTmdb(mediaType, String(tmdbId), displayName);
+                    if (!isOwnedButton(true)) return;
                     JC.toast?.(JC.t!('spoiler_blur_pending_enabled_toast'));
                 }
             } catch (err) {
+                if (!isOwnedButton(true)) return;
                 console.warn(`${logPrefix} pending toggle failed:`, err);
                 JC.toast?.(JC.t!('spoiler_blur_pending_error_toast'));
             } finally {
-                refreshLabel();
-                btn.disabled = false;
+                if (isOwnedButton(true)) {
+                    refreshLabel();
+                    btn.disabled = false;
+                }
             }
         })();
     });
 
     return btn;
 }
+
+JC.identity.registerReset('spoiler-seerr-controls', () => {
+    document.querySelectorAll('.jc-spoiler-pending-btn').forEach((node) => node.remove());
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/settings-tab.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/settings-tab.test.ts
@@ -8,9 +8,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const setUserPrefs = vi.fn((_next?: unknown) => Promise.resolve({}));
 const invalidateServerCache = vi.fn(() => Promise.resolve());
 let loadOkValue = true;
+let loadPromise: Promise<void> = Promise.resolve();
 
 vi.mock('./state', () => ({
-    whenLoaded: () => Promise.resolve(),
+    whenLoaded: () => loadPromise,
     isLoadOk: () => loadOkValue,
     getUserPrefs: () => ({}),
     setUserPrefs: (next: unknown) => setUserPrefs(next),
@@ -27,8 +28,16 @@ function renderRatingsBox(checked: boolean): HTMLInputElement {
 
 async function flush(): Promise<void> { await Promise.resolve(); await Promise.resolve(); }
 
+function deferred(): { promise: Promise<void>; resolve(): void } {
+    let resolve!: () => void;
+    const promise = new Promise<void>((done) => { resolve = done; });
+    return { promise, resolve };
+}
+
 describe('spoiler-guard settings-tab save-guard', () => {
     beforeEach(() => {
+        JC.identity.transition('', '', 'settings-test-reset');
+        JC.identity.transition('server-a', 'user-a', 'settings-test-start');
         (JC.pluginConfig as Record<string, unknown>).SpoilerBlurEnabled = true;
         JC.tagPipeline = {
             registerRenderer: vi.fn(),
@@ -37,8 +46,12 @@ describe('spoiler-guard settings-tab save-guard', () => {
         setUserPrefs.mockClear();
         invalidateServerCache.mockClear();
         loadOkValue = true;
+        loadPromise = Promise.resolve();
     });
-    afterEach(() => { document.body.innerHTML = ''; });
+    afterEach(() => {
+        JC.identity.transition('', '', 'settings-test-cleanup');
+        document.body.innerHTML = '';
+    });
 
     it('saves when the initial load succeeded', async () => {
         const box = renderRatingsBox(true);
@@ -63,5 +76,30 @@ describe('spoiler-guard settings-tab save-guard', () => {
         expect(setUserPrefs).not.toHaveBeenCalled();
         // The box the user clicked is reverted to its pre-click state.
         expect(box.checked).toBe(true);
+    });
+
+    it('drops a held A load and makes the retained checkbox inert for B', async () => {
+        const held = deferred();
+        loadPromise = held.promise;
+        const resetAutoCloseTimer = vi.fn();
+        const box = renderRatingsBox(true);
+        wireSpoilerGuardListeners(resetAutoCloseTimer);
+
+        box.checked = false;
+        box.dispatchEvent(new Event('change'));
+        expect(box.disabled).toBe(true);
+
+        JC.identity.transition('server-a', 'user-b', 'account-switch');
+        expect(box.disabled).toBe(true);
+        held.resolve();
+        await flush();
+
+        expect(setUserPrefs).not.toHaveBeenCalled();
+        expect(invalidateServerCache).not.toHaveBeenCalled();
+
+        box.dispatchEvent(new Event('change'));
+        await flush();
+        expect(setUserPrefs).not.toHaveBeenCalled();
+        expect(resetAutoCloseTimer).toHaveBeenCalledTimes(1);
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/settings-tab.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/settings-tab.ts
@@ -9,6 +9,15 @@
 
 import { JC } from '../../globals';
 import { whenLoaded, isLoadOk, getUserPrefs, setUserPrefs, type SpoilerUserPrefs } from './state';
+import type { IdentityContext } from '../../types/jc';
+
+interface SettingsBinding {
+    context: IdentityContext;
+    boxes: HTMLInputElement[];
+    cleanup(): void;
+}
+
+const settingsBindings = new Set<SettingsBinding>();
 
 const logPrefix = '🪼 Jellyfin Canopy [SpoilerGuard]:';
 
@@ -17,22 +26,37 @@ const logPrefix = '🪼 Jellyfin Canopy [SpoilerGuard]:';
  * @param resetAutoCloseTimer - Panel helper to defer the auto-close timer.
  */
 export function wireSpoilerGuardListeners(resetAutoCloseTimer: () => void): void {
+    const context = JC.identity.capture();
+    if (!context || !JC.identity.isCurrent(context)) return;
     if (JC.pluginConfig?.SpoilerBlurEnabled !== true) return;
+
+    // A normally-closed settings panel removes its DOM without notifying this
+    // module. Prune that prior binding before wiring the next panel so the
+    // synchronous reset registry stays bounded.
+    for (const binding of Array.from(settingsBindings)) {
+        if (!binding.boxes.some((box) => box.isConnected)) binding.cleanup();
+    }
 
     const boxes = Array.from(
         document.querySelectorAll<HTMLInputElement>('input[type="checkbox"][id^="sbPref"][data-pref]')
     );
     if (boxes.length === 0) return;
 
+    let active = true;
+    const isLive = (box?: HTMLInputElement): boolean => active
+        && JC.identity.isCurrent(context)
+        && (!box || box.isConnected);
     const setBoxesDisabled = (disabled: boolean): void => { for (const b of boxes) b.disabled = disabled; };
 
     const saveSbPrefs = async (changedBox: HTMLInputElement, previousChecked: boolean): Promise<void> => {
+        if (!isLive(changedBox)) return;
         setBoxesDisabled(true);
         try {
             // Avoid the cold-load race: don't write from the in-memory cache
             // until loadState() populated it, or an early toggle POSTs an
             // empty-cache payload that silently clobbers stored prefs.
             await whenLoaded();
+            if (!isLive(changedBox)) return;
             // Refuse to save when the initial GET failed — the cache is empty
             // and writing from it would clobber stored prefs.
             if (!isLoadOk()) {
@@ -50,32 +74,57 @@ export function wireSpoilerGuardListeners(resetAutoCloseTimer: () => void): void
                 // admin (null, so later admin policy flips track through).
                 current[k] = changedBox.checked ? null : false;
             }
+            if (!isLive(changedBox)) return;
             await setUserPrefs(current);
+            if (!isLive(changedBox)) return;
             // The server cache is a projection of these per-user preferences.
             // A rescan cannot restore ratings/tags stripped from its existing
             // bytes (or remove already-rendered values in the reverse direction),
             // so rebuild the authoritative projection after any policy override.
             if (k !== 'SkipDisableConfirm') {
                 await JC.tagPipeline?.invalidateServerCache?.();
+                if (!isLive(changedBox)) return;
             }
         } catch (err) {
+            if (!isLive(changedBox)) return;
             console.error(`${logPrefix} saveSbPrefs failed:`, err);
             // Revert the box the user clicked so they see the change didn't stick.
             changedBox.checked = previousChecked;
             JC.toast?.(JC.t!('spoiler_blur_error_toast'));
         } finally {
-            setBoxesDisabled(false);
+            // A's stale finally must not re-enable a retained control after B
+            // has synchronously torn the panel down.
+            if (isLive(changedBox)) setBoxesDisabled(false);
         }
     };
 
+    const listeners = new Map<HTMLInputElement, () => void>();
     for (const box of boxes) {
-        box.addEventListener('change', () => {
+        const listener = (): void => {
+            if (!isLive(box)) return;
             // .checked already flipped by the time `change` fires; negate for revert.
             const previousChecked = !box.checked;
             void saveSbPrefs(box, previousChecked);
-            resetAutoCloseTimer();
-        });
+            if (isLive(box)) resetAutoCloseTimer();
+        };
+        listeners.set(box, listener);
+        box.addEventListener('change', listener);
     }
+
+    const binding: SettingsBinding = {
+        context,
+        boxes,
+        cleanup(): void {
+            if (!active) return;
+            active = false;
+            for (const [box, listener] of listeners) {
+                box.removeEventListener('change', listener);
+                box.disabled = true;
+            }
+            settingsBindings.delete(binding);
+        },
+    };
+    settingsBindings.add(binding);
 
     // Rows render from a synchronous getUserPrefs() that may run before the
     // initial load resolves (or after it fails), defaulting every box to
@@ -84,19 +133,25 @@ export function wireSpoilerGuardListeners(resetAutoCloseTimer: () => void): void
     void (async () => {
         try {
             await whenLoaded();
+            if (!isLive()) return;
             if (!isLoadOk()) {
                 setBoxesDisabled(true);
                 return;
             }
             const loaded = getUserPrefs();
             for (const b of boxes) {
+                if (!isLive(b)) return;
                 const k = b.dataset.pref!;
                 b.checked = k === 'SkipDisableConfirm'
                     ? !!loaded[k]
                     : loaded[k] !== false; // checked = inherit; unchecked = opt-out (false)
             }
         } catch (syncErr) {
-            console.warn(`${logPrefix} pref re-sync failed:`, syncErr);
+            if (isLive()) console.warn(`${logPrefix} pref re-sync failed:`, syncErr);
         }
     })();
 }
+
+JC.identity.registerReset('spoiler-settings-controls', () => {
+    for (const binding of Array.from(settingsBindings)) binding.cleanup();
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/snooze.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/snooze.test.ts
@@ -4,10 +4,12 @@ import {
     classifySnoozeExpiry, isDisableSnoozed, setDisableSnooze,
     snoozeStorageKey, SNOOZE_MS, MAX_SNOOZE_FUTURE_MS,
 } from './snooze';
+import { JC } from '../../globals';
 
 const UID = 'test-user-id'; // the setup.ts ApiClient stub returns this
 
 afterEach(() => {
+    JC.identity.transition('test-server-id', UID, 'snooze-test-cleanup');
     localStorage.clear();
     vi.restoreAllMocks();
 });
@@ -61,6 +63,14 @@ describe('spoiler-guard/snooze', () => {
             const stored = Number(localStorage.getItem(snoozeStorageKey(UID)));
             expect(stored).toBeGreaterThanOrEqual(before + SNOOZE_MS - 50);
             expect(stored).toBeLessThanOrEqual(Date.now() + SNOOZE_MS + 50);
+        });
+
+        it('does not replay a snooze for the same user id on another server', () => {
+            setDisableSnooze();
+            expect(isDisableSnoozed()).toBe(true);
+
+            JC.identity.transition('other-server', UID, 'server-switch');
+            expect(isDisableSnoozed()).toBe(false);
         });
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/snooze.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/snooze.ts
@@ -6,6 +6,8 @@
 // unavailable (pre-init, post-logout transient) we treat the request as
 // "never snoozed; never persist" rather than collapsing into a shared bucket.
 
+import { JC } from '../../globals';
+
 const logPrefix = '🪼 Jellyfin Canopy [SpoilerGuard]:';
 
 export const SNOOZE_MS = 15 * 60 * 1000;
@@ -46,9 +48,23 @@ export function snoozeUid(): string | null {
     return null;
 }
 
-/** Per-user localStorage key for the snooze expiry. */
+/** Per-server/per-user localStorage key for the snooze expiry. */
 export function snoozeStorageKey(uid: string): string {
-    return `jc-spoiler-disable-snooze:${uid}`;
+    const normalizedUid = uid.replace(/-/g, '').toLowerCase();
+    const context = JC.identity?.capture?.() || null;
+    let serverId = context && context.userId === normalizedUid ? context.serverId : '';
+    if (!serverId) {
+        try {
+            const extendedClient = ApiClient as unknown as { serverId?: () => unknown };
+            const raw = typeof extendedClient.serverId === 'function'
+                ? extendedClient.serverId()
+                : '';
+            if (typeof raw === 'string' || typeof raw === 'number') {
+                serverId = String(raw).replace(/-/g, '').toLowerCase();
+            }
+        } catch { /* use unknown-server */ }
+    }
+    return `jc-spoiler-disable-snooze:${serverId || 'unknown-server'}:${normalizedUid}`;
 }
 
 /** True when the disable-confirm dialog is currently snoozed for this user. */
@@ -57,6 +73,12 @@ export function isDisableSnoozed(): boolean {
     if (!uid) return false;
     const key = snoozeStorageKey(uid);
     try {
+        const legacyKey = `jc-spoiler-disable-snooze:${uid}`;
+        if (localStorage.getItem(key) === null) {
+            const legacy = localStorage.getItem(legacyKey);
+            if (legacy !== null) localStorage.setItem(key, legacy);
+        }
+        localStorage.removeItem(legacyKey);
         const raw = localStorage.getItem(key);
         if (!raw) return false;
         const verdict = classifySnoozeExpiry(Number(raw), Date.now());

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/state.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/state.test.ts
@@ -1,7 +1,9 @@
 // src/enhanced/spoiler-guard/state.test.ts
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
 import {
-    applyPromoteResponse, applyRemoveResponse, type SpoilerCaches,
+    applyPromoteResponse, applyRemoveResponse, enableForSeries, isEnabledFor,
+    loadState, resetState, type SpoilerCaches,
 } from './state';
 
 function emptyCaches(): SpoilerCaches {
@@ -71,5 +73,55 @@ describe('spoiler-guard pending cache transitions', () => {
             applyRemoveResponse(c, 'movie:5', { removedFrom: 'movie', jellyfinId: 'EF-01' });
             expect(c.movies.has('ef01')).toBe(false);
         });
+    });
+});
+
+describe('spoiler-guard identity fencing', () => {
+    const originalApi = JC.core.api;
+
+    afterEach(() => {
+        JC.core.api = originalApi;
+        resetState();
+    });
+
+    it('does not publish A state after B has loaded', async () => {
+        const original = JC.identity.capture()!;
+        let resolveA!: (value: unknown) => void;
+        const plugin = vi.fn()
+            .mockImplementationOnce(() => new Promise((resolve) => { resolveA = resolve; }))
+            .mockResolvedValueOnce({ Series: { BBBB: true } });
+        JC.core.api = { plugin } as unknown as NonNullable<typeof JC.core.api>;
+
+        resetState();
+        const loadA = loadState();
+        const next = JC.identity.transition('server-b', 'user-b', 'spoiler-state-test')!;
+        const loadB = loadState();
+        await loadB;
+        expect(isEnabledFor('bbbb')).toBe(true);
+
+        resolveA({ Series: { AAAA: true } });
+        await loadA;
+        expect(isEnabledFor('aaaa')).toBe(false);
+        expect(isEnabledFor('bbbb')).toBe(true);
+
+        JC.identity.transition(original.serverId, original.userId, 'spoiler-state-test-restore');
+        void next;
+    });
+
+    it('rejects a late A mutation without changing B caches', async () => {
+        const original = JC.identity.capture()!;
+        let resolveA!: () => void;
+        JC.core.api = {
+            plugin: vi.fn(() => new Promise<void>((resolve) => { resolveA = resolve; })),
+        } as unknown as NonNullable<typeof JC.core.api>;
+
+        resetState();
+        const pending = enableForSeries('AAAA');
+        JC.identity.transition('server-b', 'user-b', 'spoiler-mutation-test');
+        resolveA();
+
+        await expect(pending).rejects.toThrow(/stale identity/i);
+        expect(isEnabledFor('aaaa')).toBe(false);
+        JC.identity.transition(original.serverId, original.userId, 'spoiler-mutation-test-restore');
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/state.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/state.ts
@@ -9,6 +9,7 @@
 
 import { JC } from '../../globals';
 import { normalizeId, pendingKey } from './ids';
+import type { IdentityContext } from '../../types/jc';
 
 const logPrefix = '🪼 Jellyfin Canopy [SpoilerGuard]:';
 
@@ -83,9 +84,36 @@ let userPrefs: SpoilerUserPrefs = {};
 let loaded = false;
 let loadOk = false;
 let statePromise: Promise<void> | null = null;
+let stateGeneration = 0;
+
+function staleIdentityError(): Error {
+    return new Error('Spoiler Guard operation belongs to a stale identity');
+}
+
+function ownsCurrentState(context: IdentityContext, generation: number): boolean {
+    return generation === stateGeneration && JC.identity.isCurrent(context);
+}
+
+/** Run one request under the current state generation and reject stale results. */
+function runOwned<T>(request: (context: IdentityContext) => Promise<T>): Promise<T> {
+    const context = JC.identity.capture();
+    if (!context || !JC.identity.isCurrent(context)) return Promise.reject(staleIdentityError());
+    const generation = stateGeneration;
+    let pending: Promise<T>;
+    try {
+        pending = request(context);
+    } catch (error) {
+        return Promise.reject(error instanceof Error ? error : new Error(String(error)));
+    }
+    return pending.then((value) => {
+        if (!ownsCurrentState(context, generation)) throw staleIdentityError();
+        return value;
+    });
+}
 
 /** Reset all in-memory state (used on re-init / account switch). */
 export function resetState(): void {
+    stateGeneration++;
     caches.series.clear();
     caches.movies.clear();
     caches.collections.clear();
@@ -100,8 +128,13 @@ export function resetState(): void {
 
 /** Fetch the user's guarded-id lists + override prefs from the server. */
 export function loadState(): Promise<void> {
+    if (statePromise) return statePromise;
+    const context = JC.identity.capture();
+    if (!context || !JC.identity.isCurrent(context)) return Promise.resolve();
+    const generation = stateGeneration;
     statePromise = JC.core.api!.plugin('/spoiler-blur/series')
         .then((data: unknown) => {
+            if (!ownsCurrentState(context, generation)) return;
             const d = (data ?? {}) as {
                 Series?: Record<string, unknown>;
                 Movies?: Record<string, unknown>;
@@ -128,6 +161,7 @@ export function loadState(): Promise<void> {
             loadOk = true;
         })
         .catch((err: unknown) => {
+            if (!ownsCurrentState(context, generation)) return;
             // Mark `loaded` so whenLoaded() unblocks, but DON'T set loadOk:
             // the cache is unreliable, so save/strip callers fail-closed.
             console.error(`${logPrefix} Failed to load spoiler-blur state; downstream consumers will fail-closed:`, err);
@@ -197,7 +231,7 @@ export function fetchMovieScope(movieId: string): Promise<MovieScopeResult | nul
     if (!n) return Promise.resolve(null);
     const hit = scopeCache.get(n);
     if (hit && Date.now() - hit.ts < SCOPE_TTL_MS) return Promise.resolve(hit.value);
-    return JC.core.api!.plugin(`/spoiler-blur/scope/movie/${encodeURIComponent(n)}`)
+    return runOwned(() => JC.core.api!.plugin(`/spoiler-blur/scope/movie/${encodeURIComponent(n)}`))
         .then((resp: unknown) => {
             const r = (resp ?? {}) as Partial<MovieScopeResult>;
             const value: MovieScopeResult = { inScope: r.inScope === true, played: r.played === true };
@@ -214,30 +248,30 @@ export function fetchMovieScope(movieId: string): Promise<MovieScopeResult | nul
 
 export function enableForSeries(seriesId: string): Promise<void> {
     const n = normalizeId(seriesId);
-    return JC.core.api!.plugin(`/spoiler-blur/series/${encodeURIComponent(n)}`, { method: 'POST' })
+    return runOwned(() => JC.core.api!.plugin(`/spoiler-blur/series/${encodeURIComponent(n)}`, { method: 'POST' }))
         .then(() => { caches.series.add(n); });
 }
 export function disableForSeries(seriesId: string): Promise<void> {
     const n = normalizeId(seriesId);
-    return JC.core.api!.plugin(`/spoiler-blur/series/${encodeURIComponent(n)}`, { method: 'DELETE' })
+    return runOwned(() => JC.core.api!.plugin(`/spoiler-blur/series/${encodeURIComponent(n)}`, { method: 'DELETE' }))
         .then(() => { caches.series.delete(n); });
 }
 export function enableForMovie(movieId: string, movieName?: string): Promise<void> {
     const n = normalizeId(movieId);
-    return JC.core.api!.plugin(`/spoiler-blur/movies/${encodeURIComponent(n)}`, {
-        method: 'POST', body: { MovieName: movieName || '' },
-    }).then(() => { caches.movies.add(n); });
+    return runOwned((context) => JC.core.api!.plugin(`/spoiler-blur/movies/${encodeURIComponent(n)}`, {
+        method: 'POST', body: JC.identity.own({ MovieName: movieName || '' }, context),
+    })).then(() => { caches.movies.add(n); });
 }
 export function disableForMovie(movieId: string): Promise<void> {
     const n = normalizeId(movieId);
-    return JC.core.api!.plugin(`/spoiler-blur/movies/${encodeURIComponent(n)}`, { method: 'DELETE' })
+    return runOwned(() => JC.core.api!.plugin(`/spoiler-blur/movies/${encodeURIComponent(n)}`, { method: 'DELETE' }))
         .then(() => { caches.movies.delete(n); });
 }
 export function enableForCollection(collectionId: string, collectionName?: string): Promise<void> {
     const n = normalizeId(collectionId);
-    return JC.core.api!.plugin(`/spoiler-blur/collections/${encodeURIComponent(n)}`, {
-        method: 'POST', body: { CollectionName: collectionName || '' },
-    }).then(() => {
+    return runOwned((context) => JC.core.api!.plugin(`/spoiler-blur/collections/${encodeURIComponent(n)}`, {
+        method: 'POST', body: JC.identity.own({ CollectionName: collectionName || '' }, context),
+    })).then(() => {
         caches.collections.add(n);
         // Collection membership changes movie scope — cached scope answers
         // (keyed by movie id only) are now stale, so drop them all.
@@ -246,7 +280,7 @@ export function enableForCollection(collectionId: string, collectionName?: strin
 }
 export function disableForCollection(collectionId: string): Promise<void> {
     const n = normalizeId(collectionId);
-    return JC.core.api!.plugin(`/spoiler-blur/collections/${encodeURIComponent(n)}`, { method: 'DELETE' })
+    return runOwned(() => JC.core.api!.plugin(`/spoiler-blur/collections/${encodeURIComponent(n)}`, { method: 'DELETE' }))
         .then(() => {
             caches.collections.delete(n);
             scopeCache.clear();
@@ -311,7 +345,7 @@ export function enableForTmdb(mediaType: string, tmdbId: string, displayName?: s
     const i = String(tmdbId || '').trim();
     if (!i || (t !== 'tv' && t !== 'movie')) return Promise.reject(new Error('invalid mediaType/tmdbId'));
     const query = displayName ? `?displayName=${encodeURIComponent(displayName)}` : '';
-    return JC.core.api!.plugin(`/spoiler-blur/pending/${t}/${encodeURIComponent(i)}${query}`, { method: 'POST' })
+    return runOwned(() => JC.core.api!.plugin(`/spoiler-blur/pending/${t}/${encodeURIComponent(i)}${query}`, { method: 'POST' }))
         .then((resp: unknown) => {
             const r = (resp ?? {}) as PromoteResponse;
             applyPromoteResponse(caches, pendingKey(t, i), r);
@@ -323,7 +357,7 @@ export function disableForTmdb(mediaType: string, tmdbId: string): Promise<Remov
     const t = String(mediaType || '').toLowerCase();
     const i = String(tmdbId || '').trim();
     if (!i || (t !== 'tv' && t !== 'movie')) return Promise.reject(new Error('invalid mediaType/tmdbId'));
-    return JC.core.api!.plugin(`/spoiler-blur/pending/${t}/${encodeURIComponent(i)}`, { method: 'DELETE' })
+    return runOwned(() => JC.core.api!.plugin(`/spoiler-blur/pending/${t}/${encodeURIComponent(i)}`, { method: 'DELETE' }))
         .then((resp: unknown) => {
             const r = (resp ?? {}) as RemoveResponse;
             applyRemoveResponse(caches, pendingKey(t, i), r);
@@ -344,10 +378,10 @@ export function getUserPrefs(): SpoilerUserPrefs {
  * server (inherit admin). Returns the saved prefs on success.
  */
 export function setUserPrefs(next: SpoilerUserPrefs): Promise<SpoilerUserPrefs> {
-    const payload = next || {};
-    return JC.core.api!.plugin('/spoiler-blur/user-prefs', {
-        method: 'POST', body: payload, skipRetry: true,
-    }).then((res: unknown) => {
+    const payload = { ...(next || {}) };
+    return runOwned((context) => JC.core.api!.plugin('/spoiler-blur/user-prefs', {
+        method: 'POST', body: JC.identity.own(payload, context), skipRetry: true,
+    })).then((res: unknown) => {
         userPrefs = { ...payload };
         const r = res as { prefs?: SpoilerUserPrefs } | undefined;
         return r?.prefs ?? userPrefs;
@@ -362,3 +396,5 @@ export function hasAnyState(): boolean {
     return caches.series.size > 0 || caches.movies.size > 0 || caches.collections.size > 0
         || caches.pendingTmdb.size > 0;
 }
+
+JC.identity.registerReset('spoiler-state', resetState);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/watched-refresh.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/watched-refresh.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+import { register } from '../../core/lifecycle';
+
+const mocks = vi.hoisted(() => ({
+    handler: null as (() => void) | null,
+    unsubscribe: vi.fn(),
+    refresh: vi.fn(),
+}));
+
+vi.mock('../../core/live', () => ({
+    LIVE: { USER_DATA_CHANGED: 'user-data-changed' },
+    on: vi.fn((_type: string, handler: () => void) => {
+        mocks.handler = handler;
+        return mocks.unsubscribe;
+    }),
+}));
+vi.mock('./state', () => ({ hasAnyState: () => true }));
+vi.mock('./image-refresh', () => ({ refreshSpoilerableImages: mocks.refresh }));
+
+describe('spoiler watched refresh identity lifecycle', () => {
+    afterEach(() => {
+        register('spoiler-guard-watched').teardown();
+        vi.clearAllTimers();
+        vi.useRealTimers();
+        mocks.handler = null;
+        mocks.unsubscribe.mockClear();
+        mocks.refresh.mockClear();
+    });
+
+    it('installs once, drops A timers, then installs one B subscription', async () => {
+        vi.useFakeTimers();
+        const original = JC.identity.capture()!;
+        const { installWatchedRefresh } = await import('./watched-refresh');
+
+        installWatchedRefresh();
+        installWatchedRefresh();
+        const handlerA = mocks.handler!;
+        handlerA();
+
+        const next = JC.identity.transition('server-b', 'user-b', 'spoiler-watched-test')!;
+        vi.advanceTimersByTime(250);
+        expect(mocks.refresh).not.toHaveBeenCalled();
+
+        register('spoiler-guard-watched').teardown();
+        expect(mocks.unsubscribe).toHaveBeenCalledTimes(1);
+        await JC.identity.activate(next);
+        installWatchedRefresh();
+        installWatchedRefresh();
+        expect(mocks.unsubscribe).toHaveBeenCalledTimes(1);
+
+        mocks.handler?.();
+        vi.advanceTimersByTime(250);
+        expect(mocks.refresh).toHaveBeenCalledTimes(1);
+        JC.identity.transition(original.serverId, original.userId, 'spoiler-watched-test-restore');
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/watched-refresh.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/watched-refresh.ts
@@ -19,16 +19,21 @@ import { register } from '../../core/lifecycle';
 import { on, LIVE } from '../../core/live';
 import { refreshSpoilerableImages } from './image-refresh';
 import { hasAnyState } from './state';
+import { JC } from '../../globals';
+import type { IdentityContext } from '../../types/jc';
 
 const REFRESH_DEBOUNCE_MS = 200;
 
 let debounceTimer: number | null = null;
+let liveUnsubscribe: (() => void) | null = null;
+const handle = register('spoiler-guard-watched');
 
 /** Debounced image-only refresh (coalesces a burst of season-mark events). */
-function scheduleRefresh(): void {
+function scheduleRefresh(context: IdentityContext): void {
     if (debounceTimer) clearTimeout(debounceTimer);
     debounceTimer = window.setTimeout(() => {
         debounceTimer = null;
+        if (!JC.identity.isCurrent(context)) return;
         try { refreshSpoilerableImages(); }
         catch (e) { console.warn('🪼 Jellyfin Canopy [SpoilerGuard]: auto-refresh after watched-flip failed:', e); }
     }, REFRESH_DEBOUNCE_MS);
@@ -41,13 +46,23 @@ function scheduleRefresh(): void {
  * reset tears them down cleanly.
  */
 export function installWatchedRefresh(): void {
-    const handle = register('spoiler-guard-watched');
-    const unsubscribe = on(LIVE.USER_DATA_CHANGED, () => {
+    if (liveUnsubscribe) return;
+    const context = JC.identity.capture();
+    if (!context || !JC.identity.isCurrent(context)) return;
+    liveUnsubscribe = on(LIVE.USER_DATA_CHANGED, () => {
+        if (!JC.identity.isCurrent(context)) return;
         if (!hasAnyState()) return;
-        scheduleRefresh();
-    });
-    handle.track(unsubscribe);
-    handle.onTeardown(() => {
-        if (debounceTimer) { clearTimeout(debounceTimer); debounceTimer = null; }
+        scheduleRefresh(context);
     });
 }
+
+// Persistent hook registered once even though the reusable lifecycle handle is
+// torn down for every identity. Activation calls installWatchedRefresh again.
+handle.onTeardown(() => {
+    if (liveUnsubscribe) {
+        liveUnsubscribe();
+        liveUnsubscribe = null;
+    }
+    if (debounceTimer) { clearTimeout(debounceTimer); debounceTimer = null; }
+});
+JC.identity.registerReset('spoiler-guard-watched', () => handle.teardown());

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/subtitles-cssinjection.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/subtitles-cssinjection.test.ts
@@ -26,7 +26,7 @@ describe('subtitles ::cue insertRule injection', () => {
     });
 
     it('falls back to a safe colour instead of injecting the payload declaration', async () => {
-        const JC = window.JellyfinCanopy as unknown as Record<string, any>;
+        const JC = window.JellyfinCanopy;
         JC.currentSettings = {
             customSubtitleTextColor: '#FFFFFFFF',
             customSubtitleBgColor: MALICIOUS,
@@ -43,7 +43,7 @@ describe('subtitles ::cue insertRule injection', () => {
         await import('./subtitles');
 
         const insertSpy = vi.spyOn(CSSStyleSheet.prototype, 'insertRule');
-        JC.applySavedStylesWhenReady();
+        JC.applySavedStylesWhenReady?.();
 
         expect(insertSpy).toHaveBeenCalled();
         const rule = String(insertSpy.mock.calls[0][0]);
@@ -52,5 +52,41 @@ describe('subtitles ::cue insertRule injection', () => {
         expect(rule).not.toContain('evil');
         // The bg colour is replaced by the transparent fallback.
         expect(rule).toContain('#00000000');
+    });
+
+    it('removes A styling and leaves B-disabled subtitles untouched', async () => {
+        const JC = window.JellyfinCanopy;
+        JC.identity.transition('server-a', 'user-a', 'subtitle-test-start');
+        JC.currentSettings = {
+            customSubtitleTextColor: '#FF0000FF',
+            customSubtitleBgColor: '#000000FF',
+            disableCustomSubtitleStyles: false,
+        };
+        document.body.appendChild(document.createElement('video'));
+        const innerA = document.createElement('div');
+        innerA.className = 'videoSubtitlesInner';
+        document.body.appendChild(innerA);
+        const clientSheet = document.createElement('style');
+        clientSheet.id = 'htmlvideoplayer-cuestyle';
+        document.head.appendChild(clientSheet);
+        await import('./subtitles');
+
+        JC.applySavedStylesWhenReady?.();
+        expect(innerA.style.getPropertyValue('color')).not.toBe('');
+        expect((document.getElementById('jc-html-videoplayer-cuestyle') as HTMLStyleElement | null)
+            ?.sheet?.cssRules.length).toBe(1);
+
+        const contextB = JC.identity.transition('server-a', 'user-b', 'account-switch');
+        expect(innerA.style.getPropertyValue('color')).toBe('');
+        expect((document.getElementById('jc-html-videoplayer-cuestyle') as HTMLStyleElement | null)
+            ?.sheet?.cssRules.length ?? 0).toBe(0);
+
+        JC.currentSettings = { disableCustomSubtitleStyles: true };
+        await JC.identity.activate(contextB);
+        const innerB = document.createElement('div');
+        innerB.className = 'videoSubtitlesInner';
+        document.body.appendChild(innerB);
+        await Promise.resolve();
+        expect(innerB.getAttribute('style')).toBeNull();
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/subtitles.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/subtitles.ts
@@ -6,7 +6,7 @@
 import { JC } from '../globals';
 import { onBodyMutation } from '../core/dom-observer';
 import { cssColorOr } from '../core/css-safe';
-import type { BodySubscriberHandle } from '../types/jc';
+import type { BodySubscriberHandle, IdentityContext } from '../types/jc';
 
 interface SubtitleStyle {
     textColor?: string;
@@ -18,6 +18,7 @@ interface SubtitleStyle {
 
 let subtitleObserver: BodySubscriberHandle | null = null;
 let currentSubtitleStyle: SubtitleStyle = {};
+let activeSubtitleContext: IdentityContext | null = null;
 
 /**
  * Preset styles for subtitles.
@@ -62,7 +63,8 @@ JC.fontFamilyPresets = [
  * center of the text, so font size changes don't shift the visual position.
  * When disableCustomSubtitleStyles is true, removes JC position overrides entirely.
  */
-function applySubtitlePosition(): void {
+function applySubtitlePosition(context: IdentityContext | null = activeSubtitleContext): void {
+    if (context && !JC.identity.isCurrent(context)) return;
     const containers = document.querySelectorAll<HTMLElement>('.videoSubtitles');
     if (!containers.length) return;
 
@@ -139,8 +141,12 @@ JC.applySubtitlePosition = applySubtitlePosition;
  * Jellyfin renders subtitles into .videoSubtitlesInner DOM elements; inline
  * !important styles win over the client's own stylesheet.
  */
-function forceApplyInlineStyles(element: HTMLElement | null): void {
-    if (!element || JC.currentSettings?.disableCustomSubtitleStyles) return;
+function forceApplyInlineStyles(
+    element: HTMLElement | null,
+    context: IdentityContext | null = activeSubtitleContext
+): void {
+    if (!element || !context || !JC.identity.isCurrent(context)
+        || JC.currentSettings?.disableCustomSubtitleStyles) return;
 
     // Apply all custom styles directly to videoSubtitlesInner
     element.style.setProperty('background-color', currentSubtitleStyle.bgColor!, 'important');
@@ -168,22 +174,23 @@ function forceApplyInlineStyles(element: HTMLElement | null): void {
 /**
  * Watches for subtitle elements and applies styles to them as they appear.
  */
-function startSubtitleObserver(): void {
+function startSubtitleObserver(context: IdentityContext): void {
     if (subtitleObserver) subtitleObserver.unsubscribe();
     subtitleObserver = onBodyMutation('subtitles', (mutations) => {
+        if (!JC.identity.isCurrent(context)) return;
         for (const mutation of mutations) {
             for (const node of mutation.addedNodes) {
                 if (node.nodeType === 1) {
                     const el = node as HTMLElement;
                     if (el.classList.contains('videoSubtitlesInner')) {
-                        forceApplyInlineStyles(el);
+                        forceApplyInlineStyles(el, context);
                     } else if (el.querySelector) {
                         const inner = el.querySelector<HTMLElement>('.videoSubtitlesInner');
-                        if (inner) forceApplyInlineStyles(inner);
+                        if (inner) forceApplyInlineStyles(inner, context);
                     }
                     // Also reapply position whenever a subtitle container appears
                     if (el.classList.contains('videoSubtitles') || el.querySelector?.('.videoSubtitles')) {
-                        applySubtitlePosition();
+                        applySubtitlePosition(context);
                     }
                 }
             }
@@ -195,6 +202,9 @@ function startSubtitleObserver(): void {
  * Main function to apply styles. It sets the desired style and starts the process.
  */
 JC.applySubtitleStyles = (textColor: string, bgColor: string, fontSize: number, fontFamily: string, textShadow: string) => {
+    const context = JC.identity.capture();
+    if (!context) return;
+    activeSubtitleContext = context;
     // THEME-6: the video-page driver re-invokes this on every ~100ms tick with
     // the same resolved style. Skip the observer teardown/re-subscribe and the
     // ::cue rewrite when nothing changed and the pipeline is already live; only
@@ -207,7 +217,7 @@ JC.applySubtitleStyles = (textColor: string, bgColor: string, fontSize: number, 
     const cueSheetLive = !!(document.getElementById('jc-html-videoplayer-cuestyle') as HTMLStyleElement | null)?.sheet?.cssRules.length;
     if (unchanged && subtitleObserver && cueSheetLive) {
         // Position is cheap + idempotent — keep it; skip the rest.
-        applySubtitlePosition();
+        applySubtitlePosition(context);
         return;
     }
 
@@ -215,13 +225,14 @@ JC.applySubtitleStyles = (textColor: string, bgColor: string, fontSize: number, 
     currentSubtitleStyle = { textColor, bgColor, fontSize, fontFamily, textShadow };
 
     // Force-apply to any subtitle elements that might already exist
-    document.querySelectorAll<HTMLElement>('.videoSubtitlesInner').forEach(forceApplyInlineStyles);
+    document.querySelectorAll<HTMLElement>('.videoSubtitlesInner')
+        .forEach((element) => forceApplyInlineStyles(element, context));
 
     // Apply position to the container
-    applySubtitlePosition();
+    applySubtitlePosition(context);
 
     // Start the observer to catch any new subtitle elements
-    startSubtitleObserver();
+    startSubtitleObserver(context);
 
     // NATIVE cue rendering path: on Jellyfin 12, .videoSubtitlesInner only
     // exists when jellyfin-web's useCustomSubtitles() is true (Firefox/
@@ -231,7 +242,7 @@ JC.applySubtitleStyles = (textColor: string, bgColor: string, fontSize: number, 
     // override there, or every JC subtitle setting silently no-ops on the
     // most common browser. Position settings cannot apply to native cues
     // (::cue supports style properties only).
-    applyNativeCueStyles();
+    applyNativeCueStyles(context);
 };
 
 /**
@@ -241,7 +252,8 @@ JC.applySubtitleStyles = (textColor: string, bgColor: string, fontSize: number, 
  * the video-page observer re-invokes the style pipeline after that, so this
  * lands even when the track is picked mid-playback.
  */
-function applyNativeCueStyles(): void {
+function applyNativeCueStyles(context: IdentityContext): void {
+    if (!JC.identity.isCurrent(context)) return;
     const clientCueSheet = document.getElementById('htmlvideoplayer-cuestyle') as HTMLStyleElement | null;
     if (!clientCueSheet?.sheet) return;
 
@@ -249,6 +261,8 @@ function applyNativeCueStyles(): void {
     if (!styleElement?.sheet) {
         styleElement = document.createElement('style');
         styleElement.id = 'jc-html-videoplayer-cuestyle';
+        styleElement.setAttribute('data-jc-identity-owned', 'true');
+        JC.identity.own(styleElement, context);
         document.head.appendChild(styleElement);
     }
 
@@ -286,11 +300,12 @@ function applyNativeCueStyles(): void {
  * When custom styles are disabled, removes all JC-injected styles cleanly.
  */
 JC.applySavedStylesWhenReady = () => {
+    const context = JC.identity.capture();
+    if (!context) return;
+    activeSubtitleContext = context;
     if (!document.querySelector('video')) {
-        if (subtitleObserver) {
-            subtitleObserver.unsubscribe();
-            subtitleObserver = null;
-        }
+        removeInjectedStyles();
+        currentSubtitleStyle = {};
         return;
     }
 
@@ -318,3 +333,12 @@ JC.applySavedStylesWhenReady = () => {
         );
     }
 };
+
+function resetSubtitleIdentity(): void {
+    activeSubtitleContext = null;
+    currentSubtitleStyle = {};
+    removeInjectedStyles();
+}
+
+JC.identity.registerReset('enhanced-subtitles', resetSubtitleIdentity);
+JC.identity.registerActivate('enhanced-subtitles', () => JC.applySavedStylesWhenReady?.());

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.test.ts
@@ -709,4 +709,101 @@ describe('watched/privacy projection response ordering (BI-SEC-035)', () => {
         JC.pluginConfig = oldConfig;
         document.body.innerHTML = '';
     });
+
+    it('fully resets A, ignores its late cache load, and activates B without duplicate wiring', async () => {
+        document.body.innerHTML = '';
+        const itemId = '88888888888888888888888888888888';
+        const originalIdentity = JC.identity.capture()!;
+        const oldConfig = JC.pluginConfig;
+        const oldUi = JC.core.ui;
+        JC.pluginConfig = { ...oldConfig, TagCacheServerMode: true, SpoilerBlurEnabled: false };
+        JC.core.ui = { injectCss: vi.fn() } as unknown as NonNullable<typeof JC.core.ui>;
+        JC._tagCachePrefetch = null;
+
+        let activeUser = userA;
+        const currentUser = vi.spyOn(ApiClient, 'getCurrentUserId').mockImplementation(() => activeUser);
+        let resolveA!: (value: unknown) => void;
+        const ajax = vi.spyOn(ApiClient, 'ajax')
+            .mockImplementationOnce(() => new Promise((resolve) => { resolveA = resolve; }))
+            .mockResolvedValueOnce({
+                version: 1,
+                timestamp: 2,
+                items: { [itemId]: { Type: 'Movie', label: 'owner-b' } },
+                projectionUserId: userB,
+                projectionEpoch: 'process-b',
+                projectionRevision: 1,
+                projectionIds: [],
+                projectionReset: false,
+            });
+
+        JC.tagPipeline!.registerRenderer('identity-switch-projection-test', {
+            render: () => undefined,
+            isEnabled: () => true,
+            renderFromServerCache: (target: HTMLElement, entry: unknown) => {
+                const marker = document.createElement('span');
+                marker.className = `identity-${String((entry as { label?: string }).label)}`;
+                target.appendChild(marker);
+            },
+            invalidateCard: (target: HTMLElement) => {
+                target.querySelectorAll('[class^="identity-owner-"]').forEach((node) => node.remove());
+            },
+        });
+
+        const image = gridCardImage();
+        const card = image.closest<HTMLElement>('.card')!;
+        card.dataset.id = itemId;
+        card.dataset.type = 'Movie';
+        const staleHost = document.createElement('div');
+        staleHost.className = 'jc-tag-host';
+        staleHost.innerHTML = '<span class="identity-owner-a"></span>';
+        card.querySelector('.cardScalable')!.appendChild(staleHost);
+        document.body.appendChild(card);
+
+        const identityA = JC.identity.transition('server-a', userA, 'tag-pipeline-a')!;
+        const activationA = JC.identity.activate(identityA);
+        // Activation handlers begin in a promise microtask in the real loader.
+        // Prove A's cache read is actually held before accepting B; otherwise B
+        // can consume the first mock response and this is not a late-A race.
+        await vi.waitFor(() => expect(ajax).toHaveBeenCalledTimes(1));
+
+        activeUser = userB;
+        const identityB = JC.identity.transition('server-b', userB, 'tag-pipeline-b')!;
+        expect(document.querySelector('.identity-owner-a')).toBeNull();
+        const subscriberCount = JC.core.dom!.getBodySubscriberCount();
+        await JC.identity.activate(identityB);
+        await vi.waitFor(() => expect(document.querySelector('.identity-owner-b')).not.toBeNull());
+
+        JC.tagPipeline!.initialize?.();
+        JC.tagPipeline!.initialize?.();
+        expect(JC.core.dom!.getBodySubscriberCount()).toBe(subscriberCount);
+        expect(ajax).toHaveBeenCalledTimes(2);
+
+        resolveA({
+            version: 1,
+            timestamp: 1,
+            items: { [itemId]: { Type: 'Movie', label: 'owner-a' } },
+            projectionUserId: userA,
+            projectionEpoch: 'process-a',
+            projectionRevision: 1,
+            projectionIds: [],
+            projectionReset: false,
+        });
+        await activationA;
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        expect(document.querySelector('.identity-owner-a')).toBeNull();
+        expect(document.querySelector('.identity-owner-b')).not.toBeNull();
+
+        JC.pluginConfig = oldConfig;
+        activeUser = originalIdentity.userId;
+        const restored = JC.identity.transition(
+            originalIdentity.serverId,
+            originalIdentity.userId,
+            'tag-pipeline-restore',
+        );
+        if (restored) await JC.identity.activate(restored);
+        JC.core.ui = oldUi;
+        ajax.mockRestore();
+        currentUser.mockRestore();
+        document.body.innerHTML = '';
+    });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.ts
@@ -10,7 +10,7 @@
 // The pipeline handles all scanning, fetching, caching, and scheduling.
 
 import { JC } from '../globals';
-import type { TagPipelineLike } from '../types/jc';
+import type { IdentityContext, TagPipelineLike } from '../types/jc';
 import { addCSS, clearItemCache, getItemCached } from './helpers';
 import { onBodyMutation } from '../core/dom-observer';
 import { onNavigate } from '../core/navigation';
@@ -325,15 +325,19 @@ let projectionResetPending = JC.pluginConfig?.TagCacheServerMode === true;
 // PERF(R9): per-element failure counter — a card whose data fetch failed is
 // un-marked from processedCards (so later mutation/nav passes retry it) up to
 // this cap, then stays marked so an unreachable server isn't hammered forever.
-const cardFetchFailures = new WeakMap<Element, number>();
+let cardFetchFailures = new WeakMap<Element, number>();
 const CARD_FETCH_MAX_FAILURES = 3;
 const firstEpisodeCache = new Map<string, Promise<any>>(); // seriesId → Promise<item|null>
 const parentSeriesCache = new Map<string, Promise<any>>(); // seriesId → Promise<item|null>
 let fetchTimer: number | null = null;
 let isProcessing = false;
+let processingGeneration = 0;
 let batchGeneration = 0; // Incremented on navigation to cancel stale in-flight batches
 let requestQueue: QueueEntry[] = []; // { el, itemId, itemType }
 let firstFetchAfterNav = true; // PERF(R7): shortens the debounce for the first batch of a navigation
+let processWired = false;
+let activeIdentityEpoch: number | null = null;
+let identityActivationGeneration = 0;
 
 // ── Pipeline-level exclusions ─────────────────────────────────────
 // Elements matching these selectors are skipped before any renderer runs.
@@ -841,6 +845,7 @@ function hasAnyEnabledRenderer(): boolean {
 }
 
 let scanScheduled = false;
+let scanScheduleGeneration = 0;
 // PERF(R8): 20 cards/chunk (was 5). Cache-resident renders are plain DOM writes;
 // the old 5-card chunks stretched a fully-cached page over many idle slices,
 // which read as tags trickling in long after the posters.
@@ -862,7 +867,9 @@ const scheduleIdle: (fn: () => void) => unknown = typeof requestIdleCallback ===
 function scheduleScan(): void {
     if (scanScheduled) return;
     scanScheduled = true;
+    const scheduledGeneration = scanScheduleGeneration;
     scheduleIdle(() => {
+        if (scheduledGeneration !== scanScheduleGeneration) return;
         scanScheduled = false;
         runScan();
     });
@@ -1066,6 +1073,33 @@ function resetServerProjection(clearDom: boolean): void {
     clearRendererProjectionState(clearDom);
     processedCards = new WeakSet();
     renderedItemByElement = new WeakMap();
+}
+
+/**
+ * Retire every identity-owned pipeline value synchronously. Renderer
+ * registrations and process wiring are bundle-lifetime and intentionally stay.
+ */
+function resetTagPipelineIdentity(): void {
+    identityActivationGeneration++;
+    activeIdentityEpoch = null;
+    if (fetchTimer !== null) {
+        clearTimeout(fetchTimer);
+        fetchTimer = null;
+    }
+    scanScheduleGeneration++;
+    scanScheduled = false;
+    scanGeneration++;
+    processingGeneration++;
+    isProcessing = false;
+    firstFetchAfterNav = true;
+    cardFetchFailures = new WeakMap<Element, number>();
+    JC._tagCachePrefetch = null;
+    resetServerProjection(true);
+    document.querySelectorAll(
+        '.jc-tag-host, .genre-overlay-container, .quality-overlay-container, ' +
+        '.language-overlay-container, .rating-overlay-container'
+    ).forEach((node) => node.remove());
+    document.body.classList.remove('jc-tags-hide-on-hover');
 }
 
 /**
@@ -1321,6 +1355,7 @@ const SERVER_BATCH_LIMIT = 200;
  */
 async function processQueue(): Promise<void> {
     if (isProcessing || requestQueue.length === 0) return;
+    const myProcessingGeneration = processingGeneration;
     isProcessing = true;
 
     try {
@@ -1333,12 +1368,16 @@ async function processQueue(): Promise<void> {
             await processBatch(batch, myGeneration);
         }
     } finally {
-        isProcessing = false;
-        // PERF(R9): cards queued while this run was in flight (a new page's
-        // scan during a stale batch — scheduleFetchIfQueued no-ops when
-        // isProcessing) would otherwise sit until the next mutation.
-        // Reschedule so the queue always drains.
-        if (requestQueue.length > 0) scheduleFetchIfQueued();
+        // Identity reset can allow B to start while an unsignalled ApiClient.ajax
+        // from A is still settling. A must not clear B's processing lock.
+        if (myProcessingGeneration === processingGeneration) {
+            isProcessing = false;
+            // PERF(R9): cards queued while this run was in flight (a new page's
+            // scan during a stale batch — scheduleFetchIfQueued no-ops when
+            // isProcessing) would otherwise sit until the next mutation.
+            // Reschedule so the queue always drains.
+            if (requestQueue.length > 0) scheduleFetchIfQueued();
+        }
     }
 }
 
@@ -1610,9 +1649,16 @@ function buildIndicatorOffsetCSS(): string {
 /**
  * Initialize the tag pipeline: register mutation observer, navigation handler, and inject base CSS.
  */
-function initialize(): void {
+async function initialize(
+    context: IdentityContext | null = JC.identity.capture(),
+): Promise<void> {
+    if (!context || !JC.identity.isCurrent(context)) return;
+    if (activeIdentityEpoch === context.epoch) return;
     const activeUserId = ApiClient.getCurrentUserId();
     const activeUserKey = normalizeProjectionKey(activeUserId);
+    if (!activeUserKey) return;
+    activeIdentityEpoch = context.epoch;
+    const activationGeneration = ++identityActivationGeneration;
     const serverMode = JC.pluginConfig?.TagCacheServerMode === true;
     tagCacheOwnerUserId = activeUserKey;
     projectionResetPending = serverMode;
@@ -1629,25 +1675,28 @@ function initialize(): void {
         beginBatchProjectionGeneration(activeUserId);
     }
 
-    // Register as body mutation subscriber at priority 0 (after hidden-content and prefetch).
-    // Only trigger scans when nodes were actually added to the DOM — ignore attribute
-    // changes, text changes, and hover/focus effects which cause jank if we scan on each.
-    onBodyMutation('tag-pipeline', (mutations) => {
-        for (let i = 0; i < mutations.length; i++) {
-            if (mutations[i].addedNodes.length > 0) {
-                // PERF(R1): cache-resident tags render synchronously in this same
-                // mutation batch — before the new cards' first paint (budget-
-                // guarded, see syncScanAddedCards). The async scan remains the
-                // catch-all for budget overflow and cache misses.
-                syncScanAddedCards(mutations);
-                scheduleScan();
-                return;
+    if (!processWired) {
+        processWired = true;
+        // Register as body mutation subscriber at priority 0 (after hidden-content and prefetch).
+        // Only trigger scans when nodes were actually added to the DOM — ignore attribute
+        // changes, text changes, and hover/focus effects which cause jank if we scan on each.
+        onBodyMutation('tag-pipeline', (mutations) => {
+            for (let i = 0; i < mutations.length; i++) {
+                if (mutations[i].addedNodes.length > 0) {
+                    // PERF(R1): cache-resident tags render synchronously in this same
+                    // mutation batch — before the new cards' first paint (budget-
+                    // guarded, see syncScanAddedCards). The async scan remains the
+                    // catch-all for budget overflow and cache misses.
+                    syncScanAddedCards(mutations);
+                    scheduleScan();
+                    return;
+                }
             }
-        }
-    }, { priority: 0 });
+        }, { priority: 0 });
 
-    // Also trigger on navigation
-    onNavigate(() => {
+        // Also trigger on navigation. This callback is process-lifetime; every
+        // branch reads the current identity/config at call time.
+        onNavigate(() => {
         // Invalidate any in-flight batch processing (don't reset isProcessing
         // directly — let stale batches finish naturally and discard results)
         batchGeneration++;
@@ -1677,7 +1726,8 @@ function initialize(): void {
         } else {
             scheduleScan();
         }
-    });
+        });
+    }
 
     // Inject CSS containment for all tag overlay containers.
     // This tells the browser these elements are independent from the rest of the
@@ -1742,6 +1792,7 @@ function initialize(): void {
         }
     `);
     // Apply the class based on current setting
+    document.body.classList.remove('jc-tags-hide-on-hover');
     if (JC.currentSettings?.tagsHideOnHover) {
         document.body.classList.add('jc-tags-hide-on-hover');
     }
@@ -1749,10 +1800,11 @@ function initialize(): void {
     // Load server cache then do initial scan.
     // Cards may have been processed during the async load (via mutation observer),
     // so clear processedCards after load to rescan with the server cache available.
-    void loadServerCache().then(() => {
-        processedCards = new WeakSet();
-        runScan();
-    });
+    await loadServerCache();
+    if (activationGeneration !== identityActivationGeneration
+        || !JC.identity.isCurrent(context)) return;
+    processedCards = new WeakSet();
+    runScan();
 
     console.log(`${logPrefix} Initialized`);
 }
@@ -1805,6 +1857,9 @@ const tagPipelineApi = {
     invalidateServerCache,
     refreshServerProjection,
 };
+
+JC.identity.registerReset('tag-pipeline', resetTagPipelineIdentity);
+JC.identity.registerActivate('tag-pipeline', (context) => initialize(context));
 
 // JEGlobal types tagPipeline as the narrow TagPipelineLike consumer view; the
 // real surface (this object) is a superset with null-able optional callbacks.

--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/active-streams.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/active-streams.identity.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+interface StreamsApi {
+    activeStreams: { initialize(): void; destroy(): void };
+}
+
+interface ControlSet {
+    elements: HTMLElement[];
+    stop: HTMLButtonElement;
+    messageSend: HTMLButtonElement;
+    broadcastSend: HTMLButtonElement;
+    messageResult: HTMLElement;
+    broadcastResult: HTMLElement;
+}
+
+const SESSION = {
+    Id: 'session-a',
+    UserId: 'user-a',
+    UserName: 'Account A viewer',
+    Client: 'Web',
+    DeviceName: 'Browser',
+    SupportsRemoteControl: true,
+    RemoteEndPoint: '127.0.0.1',
+    NowPlayingItem: {
+        Id: 'item-a',
+        Type: 'Movie',
+        Name: 'Account A movie',
+        RunTimeTicks: 12_000_000_000,
+    },
+    PlayState: { IsPaused: false, PositionTicks: 3_000_000_000, PlayMethod: 'DirectPlay' },
+    TranscodingInfo: null,
+};
+
+const api = (): StreamsApi => window.JellyfinCanopy as unknown as StreamsApi;
+const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+const click = (element: Element): void => {
+    element.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+};
+
+const originalSubscribe = ApiClient.subscribe?.bind(ApiClient);
+
+function configure(plugin: ReturnType<typeof vi.fn>, toast = vi.fn()): void {
+    const header = document.createElement('div');
+    header.className = 'identity-test-header';
+    document.body.appendChild(header);
+    const canopy = window.JellyfinCanopy as unknown as Record<string, unknown>;
+    canopy.pluginConfig = { ActiveStreamsEnabled: true, ActiveStreamsAllUsers: false };
+    canopy.currentUser = { Policy: { IsAdministrator: true } };
+    canopy.t = (key: string) => key;
+    canopy.toast = toast;
+    canopy.themer = { getThemeVariables: () => ({}) };
+    canopy.helpers = {
+        getHeaderRightContainer: () => header,
+        onBodyMutation: () => ({ unsubscribe() { /* no-op */ } }),
+    };
+    canopy.core = {
+        api: { plugin },
+        lifecycle: { register: () => ({ track: <T>(resource: T): T => resource, teardown() { /* no-op */ } }) },
+        navigation: { onNavigate: () => () => { /* no-op */ } },
+    };
+    ApiClient.subscribe = () => () => { /* no-op */ };
+}
+
+function switchIdentity(serverId: string, userId: string, reason: string): void {
+    window.JellyfinCanopy.identity.transition(serverId, userId, reason);
+}
+
+async function initializeAndOpen(): Promise<void> {
+    api().activeStreams.initialize();
+    await flush();
+    click(document.getElementById('jc-active-streams')!);
+    await flush();
+}
+
+function captureArmedControls(): ControlSet {
+    const header = document.getElementById('jc-active-streams')!;
+    const panel = document.getElementById('jc-active-streams-panel')!;
+    const card = panel.querySelector<HTMLElement>('.jc-as-card')!;
+    const stop = card.querySelector<HTMLButtonElement>('.jc-as-action-btn-stop')!;
+    const messageToggle = Array.from(card.querySelectorAll<HTMLButtonElement>('.jc-as-action-btn'))
+        .find((button) => !button.classList.contains('jc-as-action-btn-stop'))!;
+    const messageForm = card.querySelector<HTMLElement>('.jc-as-msg-form')!;
+    const messageCancel = messageForm.querySelector<HTMLButtonElement>('.jc-as-broadcast-cancel')!;
+    const messageSend = messageForm.querySelector<HTMLButtonElement>('.jc-as-broadcast-send')!;
+    const messageResult = messageForm.querySelector<HTMLElement>('.jc-as-broadcast-result')!;
+    const messagePreset = messageForm.querySelector<HTMLButtonElement>('.jc-as-preset')!;
+    const broadcastToggle = panel.querySelector<HTMLButtonElement>('.jc-as-broadcast-btn')!;
+    const broadcastForm = panel.querySelector<HTMLElement>('.jc-as-broadcast-form')!;
+    const broadcastCancel = broadcastForm.querySelector<HTMLButtonElement>('.jc-as-broadcast-cancel')!;
+    const broadcastSend = broadcastForm.querySelector<HTMLButtonElement>('.jc-as-broadcast-send')!;
+    const broadcastResult = broadcastForm.querySelector<HTMLElement>('.jc-as-broadcast-result')!;
+    const broadcastPreset = broadcastForm.querySelector<HTMLButtonElement>('.jc-as-preset')!;
+
+    // Arm/fill A controls while A is current, without issuing a request.
+    click(stop);
+    click(messageToggle);
+    messageForm.querySelector<HTMLTextAreaElement>('textarea')!.value = 'A-only direct message';
+    click(broadcastToggle);
+    broadcastForm.querySelector<HTMLTextAreaElement>('textarea')!.value = 'A-only broadcast';
+
+    return {
+        stop,
+        messageSend,
+        broadcastSend,
+        messageResult,
+        broadcastResult,
+        elements: [
+            header,
+            panel.querySelector('.jc-as-panel-close')!,
+            panel.querySelector('.jc-as-refresh-btn')!,
+            panel.querySelector('.jc-as-card-title-link')!,
+            stop,
+            messageToggle,
+            messagePreset,
+            messageCancel,
+            messageSend,
+            broadcastToggle,
+            broadcastPreset,
+            broadcastCancel,
+            broadcastSend,
+        ],
+    };
+}
+
+describe('active-streams identity-owned controls', () => {
+    beforeEach(async () => {
+        try { api().activeStreams.destroy(); } catch { /* module not loaded */ }
+        switchIdentity('', '', 'identity-test-reset');
+        vi.resetModules();
+        document.body.innerHTML = '';
+        switchIdentity('server-a', 'user-a', 'identity-test-a');
+        await import('./active-streams');
+    });
+
+    afterEach(() => {
+        try { api().activeStreams.destroy(); } catch { /* module not loaded */ }
+        switchIdentity('', '', 'identity-test-cleanup');
+        document.body.innerHTML = '';
+        if (originalSubscribe) ApiClient.subscribe = originalSubscribe;
+        else delete ApiClient.subscribe;
+        vi.restoreAllMocks();
+    });
+
+    it.each([
+        ['same server A→B', 'server-a'],
+        ['server switch A→B', 'server-b'],
+    ])('detached %s controls make zero requests and cannot mutate B panel', async (_label, nextServer) => {
+        const plugin = vi.fn((path: string) => path.endsWith('/active-streams/sessions')
+            ? Promise.resolve([SESSION])
+            : Promise.resolve({ sent: 1, skipped: 0, errors: [] }));
+        configure(plugin);
+        await initializeAndOpen();
+        const stale = captureArmedControls();
+        const aPanel = document.getElementById('jc-active-streams-panel')!;
+
+        switchIdentity(nextServer, 'user-b', 'identity-test-switch');
+        expect(aPanel.isConnected).toBe(false);
+        // Re-activate a fresh B surface in the same document.
+        const canopy = window.JellyfinCanopy as unknown as Record<string, unknown>;
+        canopy.pluginConfig = { ActiveStreamsEnabled: true, ActiveStreamsAllUsers: false };
+        canopy.currentUser = { Policy: { IsAdministrator: true } };
+        api().activeStreams.initialize();
+        await flush();
+        click(document.getElementById('jc-active-streams')!);
+        await flush();
+
+        const bPanel = document.getElementById('jc-active-streams-panel')!;
+        const beforePanel = bPanel.outerHTML;
+        const beforeHash = window.location.hash;
+        const beforeCalls = plugin.mock.calls.length;
+        for (const control of stale.elements) click(control);
+        await flush();
+
+        expect(plugin).toHaveBeenCalledTimes(beforeCalls);
+        expect(plugin.mock.calls.some(([path]) => /\/(stop|message)$|\/broadcast$/.test(String(path)))).toBe(false);
+        expect(bPanel.outerHTML).toBe(beforePanel);
+        expect(window.location.hash).toBe(beforeHash);
+    });
+
+    it('held A stop/message/broadcast continuations publish nothing after B activates', async () => {
+        const actionResolvers: Array<(value: unknown) => void> = [];
+        const toast = vi.fn();
+        const plugin = vi.fn((path: string) => {
+            if (path.endsWith('/active-streams/sessions')) return Promise.resolve([SESSION]);
+            return new Promise((resolve) => actionResolvers.push(resolve));
+        });
+        configure(plugin, toast);
+        await initializeAndOpen();
+        const stale = captureArmedControls();
+
+        click(stale.stop);
+        click(stale.messageSend);
+        click(stale.broadcastSend);
+        await flush();
+        expect(actionResolvers).toHaveLength(3);
+
+        switchIdentity('server-a', 'user-b', 'identity-test-held-switch');
+        const canopy = window.JellyfinCanopy as unknown as Record<string, unknown>;
+        canopy.pluginConfig = { ActiveStreamsEnabled: true, ActiveStreamsAllUsers: false };
+        canopy.currentUser = { Policy: { IsAdministrator: true } };
+        api().activeStreams.initialize();
+        await flush();
+        click(document.getElementById('jc-active-streams')!);
+        await flush();
+
+        const bPanel = document.getElementById('jc-active-streams-panel')!;
+        const beforePanel = bPanel.outerHTML;
+        const beforeCalls = plugin.mock.calls.length;
+        actionResolvers.forEach((resolve) => resolve({ sent: 1, skipped: 0, errors: [] }));
+        await flush();
+        await flush();
+
+        expect(plugin).toHaveBeenCalledTimes(beforeCalls);
+        expect(toast).not.toHaveBeenCalled();
+        expect(stale.messageResult.textContent).toBe('');
+        expect(stale.broadcastResult.textContent).toBe('');
+        expect(stale.stop.disabled).toBe(true);
+        expect(stale.messageSend.disabled).toBe(true);
+        expect(stale.broadcastSend.disabled).toBe(true);
+        expect(bPanel.outerHTML).toBe(beforePanel);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/active-streams.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/active-streams.ts
@@ -4,7 +4,7 @@
 import { JC as JEBase } from '../globals';
 import { describeFetchError } from '../core/fetch-error';
 import { insertHeaderTrayButton, HeaderTrayOrder } from '../enhanced/header-tray';
-import type { ApiApi, LifecycleApi, LifecycleHandle, NavigationApi, PluginConfig, UiApi } from '../types/jc';
+import type { ApiApi, IdentityContext, LifecycleApi, LifecycleHandle, NavigationApi, PluginConfig, UiApi } from '../types/jc';
 
 /**
  * Local view of the shared namespace adding the public member this module
@@ -110,6 +110,26 @@ let _visListener: (() => void) | null = null;
 let _nudgeTimer: ReturnType<typeof setTimeout> | null = null;
 // Monotonic refresh counter — see updateCounter's request-ordering guard.
 let _refreshSeq = 0;
+let _identityContext: IdentityContext | null = null;
+
+const isCurrentContext = (context: IdentityContext | null): context is IdentityContext =>
+    !!context
+    && _identityContext?.epoch === context.epoch
+    && _identityContext.serverId === context.serverId
+    && _identityContext.userId === context.userId
+    && JC.identity.isCurrent(context);
+
+/** Freeze a value snapshot even when a host/test identity implementation does not. */
+const immutableOwner = (context: IdentityContext | null): IdentityContext | null => context
+    ? Object.freeze({ serverId: context.serverId, userId: context.userId, epoch: context.epoch })
+    : null;
+
+const stampOwner = <T extends HTMLElement>(element: T, context: IdentityContext): T => {
+    element.dataset.jcIdentityEpoch = String(context.epoch);
+    element.dataset.jcIdentityServer = context.serverId;
+    element.dataset.jcIdentityUser = context.userId;
+    return element;
+};
 
 // ── Helpers ──────────────────────────────────────────────────────────────
 const ticksToTime = (ticks: number): string => {
@@ -131,7 +151,8 @@ const getAccentColor = (): string => {
     }
 };
 
-const applyThemeVars = (): void => {
+const applyThemeVars = (context?: IdentityContext): void => {
+    if (context && !isCurrentContext(context)) return;
     document.documentElement.style.setProperty('--jc-as-accent', getAccentColor());
 };
 
@@ -653,11 +674,13 @@ const isVisible = (): boolean => {
 };
 
 // ── API — uses plugin proxy so non-admins don't need Sessions permission ─
-const fetchSessions = async (): Promise<SessionView[] | null> => {
+const fetchSessions = async (context: IdentityContext): Promise<SessionView[] | null> => {
+    if (!isCurrentContext(context)) return null;
     try {
         // Core throws on non-OK responses — caught below, returning null
         // exactly like the old !resp.ok branch.
-        return await JC.core.api.plugin('/active-streams/sessions') as SessionView[];
+        const sessions = await JC.core.api.plugin('/active-streams/sessions') as SessionView[];
+        return isCurrentContext(context) ? sessions : null;
     } catch (_) {
         return null;
     }
@@ -725,7 +748,12 @@ const buildBadgeElements = (session: SessionView): HTMLElement[] => {
 };
 
 // ── Session card builder ─────────────────────────────────────────────────
-const buildSessionCard = (session: SessionView, index?: number, restore?: CardUiState): HTMLElement => {
+const buildSessionCard = (
+    session: SessionView,
+    context: IdentityContext,
+    index?: number,
+    restore?: CardUiState,
+): HTMLElement => {
     // Caller (renderPanel) only passes sessions with a NowPlayingItem.
     const item = session.NowPlayingItem as SessionNowPlaying;
     const ps: SessionPlayState = session.PlayState || {};
@@ -740,7 +768,7 @@ const buildSessionCard = (session: SessionView, index?: number, restore?: CardUi
     const dur = item.RunTimeTicks || 0;
     const pct = dur ? Math.min(100, (pos / dur) * 100).toFixed(1) : 0;
 
-    const card = document.createElement('div');
+    const card = stampOwner(document.createElement('div'), context);
     card.className = 'jc-as-card jc-as-card-with-poster';
     // Stable key + structural signature for in-place live updates — see
     // applyLiveUpdate / panelMatchesSessions.
@@ -760,7 +788,10 @@ const buildSessionCard = (session: SessionView, index?: number, restore?: CardUi
         poster.alt = '';
         poster.loading = 'lazy';
         poster.src = (ApiClient as any).getImageUrl(posterId, { type: 'Primary', tag: posterTag, height: 120, quality: 80 });
-        poster.addEventListener('error', () => { poster.replaceWith(placeholder()); });
+        poster.addEventListener('error', () => {
+            if (!isCurrentContext(context)) return;
+            poster.replaceWith(placeholder());
+        });
         card.appendChild(poster);
     } else {
         card.appendChild(placeholder());
@@ -793,6 +824,7 @@ const buildSessionCard = (session: SessionView, index?: number, restore?: CardUi
         link.textContent = title;
         link.href = '#';
         link.addEventListener('click', (e) => {
+            if (!isCurrentContext(context)) return;
             e.preventDefault();
             try {
                 if (typeof Emby !== 'undefined' && (Emby as any).Page?.showItem) {
@@ -880,6 +912,7 @@ const buildSessionCard = (session: SessionView, index?: number, restore?: CardUi
         fallback.style.display = 'none';
 
         img.addEventListener('error', () => {
+            if (!isCurrentContext(context)) return;
             img.style.display = 'none';
             fallback.style.display = 'inline';
         });
@@ -903,7 +936,7 @@ const buildSessionCard = (session: SessionView, index?: number, restore?: CardUi
     // Admin session-control actions (stop / targeted message). Only offered to
     // admins on sessions the client can actually remote-control.
     if (isAdmin() && session.SupportsRemoteControl && session.Id) {
-        main.appendChild(buildSessionActions(session, restore));
+        main.appendChild(buildSessionActions(session, context, restore));
     }
 
     // RemoteEndPoint — null for non-admins (stripped server-side)
@@ -933,7 +966,7 @@ const messagePresets = (): string[] => [
 ];
 
 /** A row of preset chips; clicking one fills the target textarea. */
-const buildPresetRow = (target: HTMLTextAreaElement): HTMLElement => {
+const buildPresetRow = (target: HTMLTextAreaElement, context: IdentityContext): HTMLElement => {
     const row = document.createElement('div');
     row.className = 'jc-as-presets';
     for (const preset of messagePresets()) {
@@ -942,6 +975,7 @@ const buildPresetRow = (target: HTMLTextAreaElement): HTMLElement => {
         chip.className = 'jc-as-preset';
         chip.textContent = preset;
         chip.addEventListener('click', (e) => {
+            if (!isCurrentContext(context)) return;
             e.stopPropagation();
             target.value = preset;
             target.focus();
@@ -952,16 +986,19 @@ const buildPresetRow = (target: HTMLTextAreaElement): HTMLElement => {
 };
 
 // ── Per-session admin actions ──────────────────────────────────────────────
-const sendSessionStop = async (sessionId: string): Promise<void> => {
+const sendSessionStop = async (sessionId: string, context: IdentityContext): Promise<void> => {
+    if (!isCurrentContext(context)) return;
     try {
         // skipRetry: stopping is not idempotent-safe to auto-repeat.
         await JC.core.api.plugin(`/active-streams/sessions/${encodeURIComponent(sessionId)}/stop`, {
             method: 'POST',
             skipRetry: true,
         });
+        if (!isCurrentContext(context)) return;
         notify(JC.t?.('session_control_stopped') || 'Stream stopped');
-        void updateCounter({ live: true });
+        void updateCounter({ live: true }, context);
     } catch (err) {
+        if (!isCurrentContext(context)) return;
         notify(JC.t?.('session_control_stop_failed') || 'Failed to stop the stream');
         console.warn(`${LOG} stop session failed:`, err);
     }
@@ -972,16 +1009,20 @@ const sendSessionMessage = async (
     text: string,
     timeoutMs: number,
     resultEl: HTMLElement,
+    context: IdentityContext,
 ): Promise<void> => {
+    if (!isCurrentContext(context)) return;
     try {
         await JC.core.api.plugin(`/active-streams/sessions/${encodeURIComponent(sessionId)}/message`, {
             method: 'POST',
             body: { text, timeoutMs },
             skipRetry: true,
         });
+        if (!isCurrentContext(context)) return;
         resultEl.className = 'jc-as-broadcast-result jc-as-broadcast-ok';
         resultEl.textContent = JC.t?.('session_control_message_sent') || 'Message sent';
     } catch (err) {
+        if (!isCurrentContext(context)) return;
         resultEl.className = 'jc-as-broadcast-result jc-as-broadcast-err';
         resultEl.textContent = JC.t?.('session_control_message_failed') || 'Failed to send message';
         console.warn(`${LOG} message session failed:`, err);
@@ -989,9 +1030,13 @@ const sendSessionMessage = async (
 };
 
 /** The stop + message action row (with an inline per-session message form). */
-const buildSessionActions = (session: SessionView, restore?: CardUiState): HTMLElement => {
+const buildSessionActions = (
+    session: SessionView,
+    context: IdentityContext,
+    restore?: CardUiState,
+): HTMLElement => {
     const sessionId = String(session.Id);
-    const wrap = document.createElement('div');
+    const wrap = stampOwner(document.createElement('div'), context);
 
     const row = document.createElement('div');
     row.className = 'jc-as-actions';
@@ -1010,6 +1055,7 @@ const buildSessionActions = (session: SessionView, restore?: CardUiState): HTMLE
 
     let confirmTimer: ReturnType<typeof setTimeout> | null = null;
     const resetStop = (): void => {
+        if (!isCurrentContext(context)) return;
         stopBtn.classList.remove('jc-as-confirming');
         stopLabel.textContent = JC.t?.('session_control_stop') || 'Stop';
         if (confirmTimer) { clearTimeout(confirmTimer); confirmTimer = null; }
@@ -1018,6 +1064,7 @@ const buildSessionActions = (session: SessionView, restore?: CardUiState): HTMLE
     // always (re)starting the 4s auto-reset timer so a restored confirm can't
     // stay armed forever.
     const armConfirm = (): void => {
+        if (!isCurrentContext(context)) return;
         stopBtn.classList.add('jc-as-confirming');
         stopLabel.textContent = JC.t?.('session_control_stop_confirm') || 'Confirm stop?';
         if (confirmTimer) clearTimeout(confirmTimer);
@@ -1025,6 +1072,7 @@ const buildSessionActions = (session: SessionView, restore?: CardUiState): HTMLE
     };
     // eslint-disable-next-line @typescript-eslint/no-misused-promises -- async click handler
     stopBtn.addEventListener('click', async (e) => {
+        if (!isCurrentContext(context)) return;
         e.stopPropagation();
         if (!stopBtn.classList.contains('jc-as-confirming')) {
             armConfirm();
@@ -1032,7 +1080,8 @@ const buildSessionActions = (session: SessionView, restore?: CardUiState): HTMLE
         }
         resetStop();
         stopBtn.disabled = true;
-        await sendSessionStop(sessionId);
+        await sendSessionStop(sessionId, context);
+        if (!isCurrentContext(context)) return;
         stopBtn.disabled = false;
     });
 
@@ -1061,7 +1110,7 @@ const buildSessionActions = (session: SessionView, restore?: CardUiState): HTMLE
     textArea.placeholder = JC.t?.('session_control_message_placeholder') || 'Message to this session…';
     textArea.maxLength = 1000;
 
-    const presets = buildPresetRow(textArea);
+    const presets = buildPresetRow(textArea, context);
 
     const resultEl = document.createElement('div');
     resultEl.className = 'jc-as-broadcast-result';
@@ -1086,27 +1135,35 @@ const buildSessionActions = (session: SessionView, restore?: CardUiState): HTMLE
     wrap.appendChild(form);
 
     const closeForm = (): void => {
+        if (!isCurrentContext(context)) return;
         msgBtn.classList.remove('jc-as-action-active');
         form.classList.remove('jc-as-msg-form-open');
         resultEl.className = 'jc-as-broadcast-result';
         resultEl.textContent = '';
     };
     msgBtn.addEventListener('click', (e) => {
+        if (!isCurrentContext(context)) return;
         e.stopPropagation();
         const open = form.classList.toggle('jc-as-msg-form-open');
         msgBtn.classList.toggle('jc-as-action-active', open);
         if (open) { resultEl.textContent = ''; resultEl.className = 'jc-as-broadcast-result'; textArea.focus(); }
     });
-    cancelBtn.addEventListener('click', (e) => { e.stopPropagation(); closeForm(); });
+    cancelBtn.addEventListener('click', (e) => {
+        if (!isCurrentContext(context)) return;
+        e.stopPropagation();
+        closeForm();
+    });
     // eslint-disable-next-line @typescript-eslint/no-misused-promises -- async click handler
     sendBtn.addEventListener('click', async (e) => {
+        if (!isCurrentContext(context)) return;
         e.stopPropagation();
         const text = textArea.value.trim();
         if (!text) { textArea.focus(); return; }
         sendBtn.disabled = true;
         resultEl.className = 'jc-as-broadcast-result';
         resultEl.textContent = '';
-        await sendSessionMessage(sessionId, text, 10000, resultEl);
+        await sendSessionMessage(sessionId, text, 10000, resultEl, context);
+        if (!isCurrentContext(context)) return;
         sendBtn.disabled = false;
     });
 
@@ -1163,7 +1220,8 @@ export const sessionSig = (s: SessionView): string => {
 const activeSessions = (sessions: SessionView[] | null): SessionView[] => (sessions || []).filter(s => s.NowPlayingItem);
 
 /** Update the panel title to reflect the current active-stream count. */
-const updatePanelTitle = (active: SessionView[]): void => {
+const updatePanelTitle = (active: SessionView[], context: IdentityContext): void => {
+    if (!isCurrentContext(context)) return;
     const titleEl = document.querySelector('#jc-active-streams-panel .jc-as-panel-title');
     if (!titleEl) return;
     if (active.length) {
@@ -1178,7 +1236,8 @@ const updatePanelTitle = (active: SessionView[]): void => {
 };
 
 /** Update (creating if needed) the "last updated" footer. */
-const updateFooter = (): void => {
+const updateFooter = (context: IdentityContext): void => {
+    if (!isCurrentContext(context)) return;
     const panel = document.getElementById('jc-active-streams-panel');
     if (!panel) return;
     let footer = panel.querySelector('.jc-as-panel-footer');
@@ -1210,7 +1269,8 @@ export const panelMatchesSessions = (sessions: SessionView[]): boolean => {
 };
 
 /** Update progress bars / play-state in place, leaving card structure intact. */
-const applyLiveUpdate = (sessions: SessionView[]): void => {
+const applyLiveUpdate = (sessions: SessionView[], context: IdentityContext): void => {
+    if (!isCurrentContext(context)) return;
     const body = document.querySelector('#jc-active-streams-panel .jc-as-panel-body');
     if (!body) return;
     const byId = new Map<string | null, Element>();
@@ -1246,8 +1306,8 @@ const applyLiveUpdate = (sessions: SessionView[]): void => {
                 : (JC.t?.('toast_playing') || 'Playing');
         }
     });
-    updatePanelTitle(active);
-    updateFooter();
+    updatePanelTitle(active, context);
+    updateFooter(context);
 };
 
 // ── Card UI-state preservation across structural rebuilds ──────────────────
@@ -1272,7 +1332,8 @@ const captureCardUiState = (body: Element): Map<string, CardUiState> => {
 };
 
 // ── Panel renderer ───────────────────────────────────────────────────────
-const renderPanel = (sessions: SessionView[] | null): void => {
+const renderPanel = (sessions: SessionView[] | null, context: IdentityContext): void => {
+    if (!isCurrentContext(context)) return;
     const panel = document.getElementById('jc-active-streams-panel');
     if (!panel) return;
 
@@ -1295,7 +1356,7 @@ const renderPanel = (sessions: SessionView[] | null): void => {
     }
 
     const active = activeSessions(sessions);
-    updatePanelTitle(active);
+    updatePanelTitle(active, context);
 
     const body = panel.querySelector('.jc-as-panel-body');
     if (!body) return;
@@ -1311,14 +1372,20 @@ const renderPanel = (sessions: SessionView[] | null): void => {
         empty.textContent = JC.t?.('active_streams_none') || 'No active streams';
         body.appendChild(empty);
     } else {
-        active.forEach((session, i) => body.appendChild(buildSessionCard(session, i, prevState.get(sessionCardKey(session, i)))));
+        active.forEach((session, i) => body.appendChild(buildSessionCard(
+            session,
+            context,
+            i,
+            prevState.get(sessionCardKey(session, i)),
+        )));
     }
 
-    updateFooter();
+    updateFooter(context);
 };
 
 // ── Counter updater ──────────────────────────────────────────────────────
-const updateHeaderButton = (sessions: SessionView[] | null): void => {
+const updateHeaderButton = (sessions: SessionView[] | null, context: IdentityContext): void => {
+    if (!isCurrentContext(context)) return;
     const btn = document.getElementById('jc-active-streams');
     if (!btn) return;
 
@@ -1367,23 +1434,29 @@ const updateHeaderButton = (sessions: SessionView[] | null): void => {
 // Fetch sessions once, then update the header badge and (if open) the panel.
 // A `live` refresh updates progress/state in place when the session set is
 // unchanged (R2/R7); a structural change rebuilds the card list.
-const updateCounter = async (opts?: { live?: boolean }): Promise<void> => {
+const updateCounter = async (
+    opts?: { live?: boolean },
+    requestedContext: IdentityContext | null = _identityContext,
+): Promise<void> => {
+    const context = requestedContext;
+    if (!isCurrentContext(context)) return;
     // Request-ordering guard: ws nudges, the fallback interval, manual refresh
     // and post-action refreshes can overlap. Drop a response that a newer
     // request has already superseded so a slow reply can't roll back the panel.
     const seq = ++_refreshSeq;
-    const sessions = await fetchSessions();
-    if (seq !== _refreshSeq) return;
+    const sessions = await fetchSessions(context);
+    if (seq !== _refreshSeq || !isCurrentContext(context)) return;
     _lastUpdated = new Date();
-    updateHeaderButton(sessions);
+    updateHeaderButton(sessions, context);
     if (!_panelOpen) return;
-    if (opts?.live && sessions && panelMatchesSessions(sessions)) applyLiveUpdate(sessions);
-    else renderPanel(sessions);
+    if (opts?.live && sessions && panelMatchesSessions(sessions)) applyLiveUpdate(sessions, context);
+    else renderPanel(sessions, context);
 };
 
 // ── Fetch on demand (no background polling) ──────────────────────────────
-const startPolling = (): void => {
-    void updateCounter(); // initial fetch only; panel open & refresh button drive updates
+const startPolling = (context: IdentityContext): void => {
+    if (!isCurrentContext(context)) return;
+    void updateCounter(undefined, context); // initial fetch only; panel open & refresh button drive updates
 };
 
 const stopPolling = (): void => {
@@ -1393,21 +1466,22 @@ const stopPolling = (): void => {
 // ── Live updates (active only while the panel is open) ─────────────────────
 // Debounced nudge: coalesce a burst of core `Sessions` websocket pushes into a
 // single live refresh. Not self-rescheduling — the timer fires once and clears.
-const nudgeLive = (): void => {
-    if (!_panelOpen || _nudgeTimer) return;
+const nudgeLive = (context: IdentityContext): void => {
+    if (!isCurrentContext(context) || !_panelOpen || _nudgeTimer) return;
     _nudgeTimer = setTimeout(() => {
         _nudgeTimer = null;
-        if (_panelOpen) void updateCounter({ live: true });
+        if (isCurrentContext(context) && _panelOpen) void updateCounter({ live: true }, context);
     }, LIVE_NUDGE_DEBOUNCE_MS);
 };
 
-const startLive = (): void => {
+const startLive = (context: IdentityContext): void => {
+    if (!isCurrentContext(context)) return;
     // Push channel: the core `Sessions` websocket message (same one the native
     // dashboard's live-sessions view subscribes to). Best-effort — fails soft
     // when the SDK socket bridge is unavailable (older hosts / jsdom).
     if (!_liveUnsub && typeof ApiClient !== 'undefined' && typeof ApiClient.subscribe === 'function') {
         try {
-            _liveUnsub = ApiClient.subscribe(['Sessions'], () => nudgeLive());
+            _liveUnsub = ApiClient.subscribe(['Sessions'], () => nudgeLive(context));
         } catch (_) {
             _liveUnsub = null;
         }
@@ -1418,15 +1492,18 @@ const startLive = (): void => {
     // its pushes plus the on-focus refresh below.
     if (!_liveUnsub && !_liveTimer) {
         _liveTimer = setInterval(() => {
+            if (!isCurrentContext(context)) return;
             if (document.visibilityState === 'hidden') return;
-            void updateCounter({ live: true });
+            void updateCounter({ live: true }, context);
         }, LIVE_FALLBACK_MS);
     }
     // Refresh immediately when the tab regains focus (the interval skipped
     // hidden ticks, so the panel could be stale on return).
     if (!_visListener) {
         _visListener = (): void => {
-            if (_panelOpen && document.visibilityState === 'visible') void updateCounter({ live: true });
+            if (isCurrentContext(context) && _panelOpen && document.visibilityState === 'visible') {
+                void updateCounter({ live: true }, context);
+            }
         };
         document.addEventListener('visibilitychange', _visListener);
     }
@@ -1440,7 +1517,8 @@ const stopLive = (): void => {
 };
 
 // Close the panel and tear down its live-update resources.
-const closePanel = (panel: HTMLElement): void => {
+const closePanel = (panel: HTMLElement, context: IdentityContext): void => {
+    if (!isCurrentContext(context)) return;
     _panelOpen = false;
     panel.classList.remove('jc-as-panel-open');
     stopLive();
@@ -1450,8 +1528,8 @@ const closePanel = (panel: HTMLElement): void => {
 let _broadcastFormOpen = false;
 let _broadcastCollapseTimer: ReturnType<typeof setTimeout> | null = null;
 
-const injectBroadcastButton = (panel: HTMLElement): void => {
-    if (!panel) return;
+const injectBroadcastButton = (panel: HTMLElement, context: IdentityContext): void => {
+    if (!isCurrentContext(context) || !panel) return;
     if (panel.querySelector('.jc-as-broadcast-btn')) return;
 
     const header = panel.querySelector('.jc-as-panel-header');
@@ -1523,7 +1601,7 @@ const injectBroadcastButton = (panel: HTMLElement): void => {
     form.appendChild(headerInput);
     form.appendChild(messageLabel);
     form.appendChild(textArea);
-    form.appendChild(buildPresetRow(textArea));
+    form.appendChild(buildPresetRow(textArea, context));
     form.appendChild(headerNote);
     form.appendChild(timeoutRow);
     form.appendChild(resultEl);
@@ -1550,17 +1628,20 @@ const injectBroadcastButton = (panel: HTMLElement): void => {
 
     // ── Event wiring ─────────────────────────────────────────────────────
     broadcastBtn.addEventListener('click', (e) => {
+        if (!isCurrentContext(context)) return;
         e.stopPropagation();
-        toggleBroadcastForm(broadcastBtn, form, resultEl, textArea, headerInput, timeoutInput);
+        toggleBroadcastForm(broadcastBtn, form, resultEl, textArea, headerInput, timeoutInput, context);
     });
 
     cancelBtn.addEventListener('click', (e) => {
+        if (!isCurrentContext(context)) return;
         e.stopPropagation();
-        collapseBroadcastForm(broadcastBtn, form, resultEl, textArea, headerInput, timeoutInput);
+        collapseBroadcastForm(broadcastBtn, form, resultEl, textArea, headerInput, timeoutInput, context);
     });
 
     // eslint-disable-next-line @typescript-eslint/no-misused-promises -- async click handler, matches the pre-conversion behavior
     sendBtn.addEventListener('click', async (e) => {
+        if (!isCurrentContext(context)) return;
         e.stopPropagation();
         const text = textArea.value.trim();
         if (!text) {
@@ -1575,19 +1656,22 @@ const injectBroadcastButton = (panel: HTMLElement): void => {
         resultEl.className = 'jc-as-broadcast-result';
         resultEl.textContent = '';
 
-        await sendBroadcast(header, text, timeoutMs, resultEl);
+        await sendBroadcast(header, text, timeoutMs, resultEl, context);
 
+        if (!isCurrentContext(context)) return;
         sendBtn.disabled = false;
 
         // Auto-collapse after 3 s
         if (_broadcastCollapseTimer) clearTimeout(_broadcastCollapseTimer);
         _broadcastCollapseTimer = setTimeout(() => {
-            collapseBroadcastForm(broadcastBtn, form, resultEl, textArea, headerInput, timeoutInput);
+            if (!isCurrentContext(context)) return;
+            collapseBroadcastForm(broadcastBtn, form, resultEl, textArea, headerInput, timeoutInput, context);
         }, 3000);
     });
 };
 
-const toggleBroadcastForm = (btn: HTMLElement, form: HTMLElement, resultEl: HTMLElement, textArea: HTMLTextAreaElement, headerInput: HTMLInputElement, timeoutInput: HTMLInputElement): void => {
+const toggleBroadcastForm = (btn: HTMLElement, form: HTMLElement, resultEl: HTMLElement, textArea: HTMLTextAreaElement, headerInput: HTMLInputElement, timeoutInput: HTMLInputElement, context: IdentityContext): void => {
+    if (!isCurrentContext(context)) return;
     _broadcastFormOpen = !_broadcastFormOpen;
     btn.classList.toggle('jc-as-broadcast-active', _broadcastFormOpen);
     form.classList.toggle('jc-as-broadcast-form-open', _broadcastFormOpen);
@@ -1601,7 +1685,8 @@ const toggleBroadcastForm = (btn: HTMLElement, form: HTMLElement, resultEl: HTML
     }
 };
 
-const collapseBroadcastForm = (btn: HTMLElement, form: HTMLElement, resultEl: HTMLElement, textArea: HTMLTextAreaElement, headerInput: HTMLInputElement, timeoutInput: HTMLInputElement): void => {
+const collapseBroadcastForm = (btn: HTMLElement, form: HTMLElement, resultEl: HTMLElement, textArea: HTMLTextAreaElement, headerInput: HTMLInputElement, timeoutInput: HTMLInputElement, context: IdentityContext): void => {
+    if (!isCurrentContext(context)) return;
     _broadcastFormOpen = false;
     btn.classList.remove('jc-as-broadcast-active');
     form.classList.remove('jc-as-broadcast-form-open');
@@ -1612,7 +1697,8 @@ const collapseBroadcastForm = (btn: HTMLElement, form: HTMLElement, resultEl: HT
     timeoutInput.value = '10';
 };
 
-const sendBroadcast = async (header: string | undefined, text: string, timeoutMs: number, resultEl: HTMLElement): Promise<void> => {
+const sendBroadcast = async (header: string | undefined, text: string, timeoutMs: number, resultEl: HTMLElement, context: IdentityContext): Promise<void> => {
+    if (!isCurrentContext(context)) return;
     try {
         // skipRetry: broadcasting is not idempotent — never auto-repeat it.
         const data = await JC.core.api.plugin('/active-streams/broadcast', {
@@ -1620,10 +1706,12 @@ const sendBroadcast = async (header: string | undefined, text: string, timeoutMs
             body: { header: header || null, text, timeoutMs },
             skipRetry: true
         }) as any;
+        if (!isCurrentContext(context)) return;
         const errNote = data.errors?.length ? ` (${data.errors.length} error${data.errors.length > 1 ? 's' : ''})` : '';
         resultEl.className = 'jc-as-broadcast-result jc-as-broadcast-ok';
         resultEl.textContent = `Sent to ${data.sent} of ${data.sent + data.skipped} sessions${errNote}`;
     } catch (err: any) {
+        if (!isCurrentContext(context)) return;
         resultEl.className = 'jc-as-broadcast-result jc-as-broadcast-err';
         if (err && err.status) {
             // HTTP error: surface a sanitized upstream message (never a raw
@@ -1636,19 +1724,21 @@ const sendBroadcast = async (header: string | undefined, text: string, timeoutMs
 };
 
 // ── Panel ────────────────────────────────────────────────────────────────
-const togglePanel = (): void => {
+const togglePanel = (context: IdentityContext): void => {
+    if (!isCurrentContext(context)) return;
     const panel = document.getElementById('jc-active-streams-panel');
     if (!panel) return;
     _panelOpen = !_panelOpen;
     panel.classList.toggle('jc-as-panel-open', _panelOpen);
-    if (_panelOpen) { void updateCounter(); startLive(); }
+    if (_panelOpen) { void updateCounter(undefined, context); startLive(context); }
     else stopLive();
 };
 
-const injectPanel = (): void => {
+const injectPanel = (context: IdentityContext): void => {
+    if (!isCurrentContext(context)) return;
     if (document.getElementById('jc-active-streams-panel')) return;
 
-    const panel = document.createElement('div');
+    const panel = stampOwner(document.createElement('div'), context);
     panel.id = 'jc-active-streams-panel';
 
     const header = document.createElement('div');
@@ -1667,8 +1757,9 @@ const injectPanel = (): void => {
     closeIcon.textContent = 'close';
     closeBtn.appendChild(closeIcon);
     closeBtn.addEventListener('click', (e) => {
+        if (!isCurrentContext(context)) return;
         e.stopPropagation();
-        closePanel(panel);
+        closePanel(panel, context);
     });
 
     header.appendChild(titleEl);
@@ -1705,39 +1796,44 @@ const injectPanel = (): void => {
     refreshIcon.textContent = 'refresh';
     refreshBtn.appendChild(refreshIcon);
     refreshBtn.addEventListener('click', (e) => {
+        if (!isCurrentContext(context)) return;
         e.stopPropagation();
         refreshBtn.classList.add('jc-as-refreshing');
-        refreshBtn.addEventListener('animationend', () => refreshBtn.classList.remove('jc-as-refreshing'), { once: true });
-        void updateCounter();
+        refreshBtn.addEventListener('animationend', () => {
+            if (isCurrentContext(context)) refreshBtn.classList.remove('jc-as-refreshing');
+        }, { once: true });
+        void updateCounter(undefined, context);
     });
     header.insertBefore(refreshBtn, closeBtn);
 
     // Inject broadcast button for admins only
     if (JC?.currentUser?.Policy?.IsAdministrator === true) {
-        injectBroadcastButton(panel);
+        injectBroadcastButton(panel, context);
     }
 
     _outsideClickListener = (e) => {
+        if (!isCurrentContext(context)) return;
         const btn = document.getElementById('jc-active-streams');
         if (_panelOpen && !panel.contains(e.target as Node) && btn && !btn.contains(e.target as Node)) {
-            closePanel(panel);
+            closePanel(panel, context);
         }
     };
     document.addEventListener('click', _outsideClickListener);
 };
 
 // ── Header button ────────────────────────────────────────────────────────
-const tryInjectHeader = (attempts = 0): void => {
+const tryInjectHeader = (attempts: number, context: IdentityContext): void => {
+    if (!isCurrentContext(context)) return;
     if (document.getElementById('jc-active-streams')) return;
     if (attempts > 20) return;
 
     const headerRight = JC.helpers.getHeaderRightContainer();
     if (!headerRight) {
-        _headerRetryTimer = setTimeout(() => tryInjectHeader(attempts + 1), 500);
+        _headerRetryTimer = setTimeout(() => tryInjectHeader(attempts + 1, context), 500);
         return;
     }
 
-    const btn = document.createElement('button');
+    const btn = stampOwner(document.createElement('button'), context);
     btn.id = 'jc-active-streams';
     btn.type = 'button';
     btn.setAttribute('is', 'paper-icon-button-light');
@@ -1755,7 +1851,11 @@ const tryInjectHeader = (attempts = 0): void => {
 
     btn.appendChild(icon);
     btn.appendChild(sup);
-    btn.addEventListener('click', (e) => { e.stopPropagation(); togglePanel(); });
+    btn.addEventListener('click', (e) => {
+        if (!isCurrentContext(context)) return;
+        e.stopPropagation();
+        togglePanel(context);
+    });
 
     insertHeaderTrayButton(headerRight, btn, HeaderTrayOrder.activeStreams);
     // PERF(R1, doctrine: reserved-space entrance + pre-paint re-mounts): the
@@ -1767,16 +1867,18 @@ const tryInjectHeader = (attempts = 0): void => {
     // its first paint — so they attach instantly with no animation.
     JC.core?.ui?.expandIn(btn, { instant: _headerInjectedOnce });
     _headerInjectedOnce = true;
-    injectPanel();
-    applyThemeVars();
-    startPolling();
+    injectPanel(context);
+    applyThemeVars(context);
+    startPolling(context);
 };
 
 // ── Observer ─────────────────────────────────────────────────────────────
-const startObserver = (): void => {
+const startObserver = (context: IdentityContext): void => {
+    if (!isCurrentContext(context)) return;
     if (_observer) return;
     const callback = (): void => {
-        if (!document.getElementById('jc-active-streams')) tryInjectHeader(0);
+        if (!isCurrentContext(context)) return;
+        if (!document.getElementById('jc-active-streams')) tryInjectHeader(0, context);
     };
     if (JC?.helpers?.onBodyMutation) {
         _observer = JC.helpers.onBodyMutation('active-streams', callback);
@@ -1797,6 +1899,11 @@ const stopObserver = (): void => {
 // ── Public API ───────────────────────────────────────────────────────────
 JC.activeStreams = {
     initialize() {
+        // Re-entry is allowed after an identity/config activation. Always drain
+        // the prior controller before evaluating the new user's visibility gate.
+        if (_observer || _pollTimer || _lifecycle || document.getElementById('jc-active-streams')) {
+            JC.activeStreams!.destroy();
+        }
         if (!JC?.pluginConfig?.ActiveStreamsEnabled) {
             return;
         }
@@ -1804,15 +1911,18 @@ JC.activeStreams = {
             console.log(`${LOG} Active Streams: skipping — not visible for this user.`);
             return;
         }
+        _identityContext = immutableOwner(JC.identity.capture());
+        if (!_identityContext) return;
+        const context = _identityContext;
         console.log(`${LOG} Active Streams: initializing.`);
         injectStyles();
-        startObserver();
-        tryInjectHeader(0);
+        startObserver(context);
+        tryInjectHeader(0, context);
         // Re-apply theme vars on every navigation (hashchange, popstate
         // and pushState — the old raw hashchange listener missed the
         // latter). Tracked via a lifecycle handle so destroy() removes it.
         _lifecycle = JC.core.lifecycle.register('active-streams');
-        _lifecycle.track(JC.core.navigation.onNavigate(() => applyThemeVars()));
+        _lifecycle.track(JC.core.navigation.onNavigate(() => applyThemeVars(context)));
     },
 
     destroy() {
@@ -1830,5 +1940,10 @@ JC.activeStreams = {
         _panelOpen = false;
         _broadcastFormOpen = false;
         _headerInjectedOnce = false; // next enable cycle re-animates its boot injection
+        _refreshSeq++;
+        _lastUpdated = null;
+        _identityContext = null;
     }
 };
+
+JC.identity.registerReset('active-streams', () => JC.activeStreams?.destroy());

--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-activity-icons.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-activity-icons.ts
@@ -2,7 +2,7 @@
 // Replaces activity icons with Material Design icons and adds colors
 
 import { JC as JEBase } from '../globals';
-import type { LifecycleApi, LifecycleHandle, NavigationApi } from '../types/jc';
+import type { IdentityContext, LifecycleApi, LifecycleHandle, NavigationApi } from '../types/jc';
 
 /**
  * Local view of the shared namespace adding the public members this module
@@ -360,8 +360,18 @@ let isProcessing = false;
 let observer: { unsubscribe(): void } | null = null;
 let lifecycle: LifecycleHandle | null = null;
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+let generation = 0;
+const originalAvatars = new WeakMap<Element, { children: Node[]; background: string; priority: string }>();
 
-function updateActivityIcons(): void {
+function isActive(context: IdentityContext, expectedGeneration: number): boolean {
+    return generation === expectedGeneration && JC.identity.isCurrent(context);
+}
+
+function updateActivityIcons(
+    context = JC.identity.capture(),
+    expectedGeneration = generation
+): void {
+    if (!context || !isActive(context, expectedGeneration)) return;
     if (isProcessing) return;
     isProcessing = true;
 
@@ -393,7 +403,17 @@ function updateActivityIcons(): void {
                     avatar.style.backgroundColor === match.color) return;
             }
 
-            avatar.innerHTML = `<span class="material-icons">${match.icon}</span>`;
+            if (!originalAvatars.has(avatar)) {
+                originalAvatars.set(avatar, {
+                    children: Array.from(avatar.childNodes, (node) => node.cloneNode(true)),
+                    background: avatar.style.getPropertyValue('background-color'),
+                    priority: avatar.style.getPropertyPriority('background-color')
+                });
+            }
+            const icon = document.createElement('span');
+            icon.className = 'material-icons';
+            icon.textContent = match.icon;
+            avatar.replaceChildren(icon);
             avatar.style.setProperty('background-color', match.color, 'important');
             avatar.setAttribute(dataAttr, 'true');
         });
@@ -402,12 +422,15 @@ function updateActivityIcons(): void {
     }
 }
 
-function debouncedUpdateActivityIcons(): void {
+function debouncedUpdateActivityIcons(context: IdentityContext, expectedGeneration: number): void {
     if (debounceTimer) clearTimeout(debounceTimer);
-    debounceTimer = setTimeout(updateActivityIcons, 100);
+    debounceTimer = setTimeout(() => {
+        debounceTimer = null;
+        updateActivityIcons(context, expectedGeneration);
+    }, 100);
 }
 
-function startMonitoring(): void {
+function startMonitoring(context: IdentityContext, expectedGeneration: number): void {
     if (observer) return;
 
     const callback = (mutations: MutationRecord[]): void => {
@@ -434,7 +457,7 @@ function startMonitoring(): void {
         });
 
         if (shouldProcess) {
-            debouncedUpdateActivityIcons();
+            debouncedUpdateActivityIcons(context, expectedGeneration);
         }
     };
 
@@ -456,13 +479,38 @@ function stopMonitoring(): void {
         lifecycle.teardown();
         lifecycle = null;
     }
+    if (debounceTimer) {
+        clearTimeout(debounceTimer);
+        debounceTimer = null;
+    }
+}
+
+function restoreOwnedUi(): void {
+    document.querySelectorAll('[data-jellyfin-canopy-activity-icon]').forEach((avatar) => {
+        const original = originalAvatars.get(avatar);
+        if (original) {
+            avatar.replaceChildren(...original.children.map((node) => node.cloneNode(true)));
+            if (original.background) {
+                (avatar as HTMLElement).style.setProperty('background-color', original.background, original.priority);
+            } else {
+                (avatar as HTMLElement).style.removeProperty('background-color');
+            }
+        }
+        avatar.removeAttribute('data-jellyfin-canopy-activity-icon');
+    });
 }
 
 function initialize(): void {
+    stopMonitoring();
+    const context = JC.identity.capture();
+    if (!context) return;
+    const expectedGeneration = ++generation;
+    isProcessing = false;
+
     // Inject CSS for Material Icons
     injectCSS();
-    updateActivityIcons();
-    startMonitoring();
+    updateActivityIcons(context, expectedGeneration);
+    startMonitoring(context, expectedGeneration);
 
     // Re-process icons when navigating to activity page or configuration
     // page. Uses the shared deduplicated navigation pipeline (covers
@@ -473,10 +521,21 @@ function initialize(): void {
         const hash = window.location.hash;
         if (hash.includes('#/dashboard/activity') || hash.includes('#/configurationpage')) {
             // Use a longer timeout to ensure page is rendered
-            setTimeout(updateActivityIcons, 300);
+            if (debounceTimer) clearTimeout(debounceTimer);
+            debounceTimer = setTimeout(() => {
+                debounceTimer = null;
+                updateActivityIcons(context, expectedGeneration);
+            }, 300);
         }
     }));
 }
 
 JC.initializeActivityIcons = initialize;
 JC.stopActivityIconsMonitoring = stopMonitoring;
+
+JC.identity.registerReset('colored-activity-icons', () => {
+    generation++;
+    isProcessing = false;
+    stopMonitoring();
+    restoreOwnedUi();
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.identity.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../globals';
+
+function switchIdentity(serverId: string, userId: string): void {
+    JC.identity.transition(serverId, userId, 'colored-ratings-test');
+}
+
+function addRating(value = 'PG-13'): HTMLElement {
+    const rating = document.createElement('span');
+    rating.className = 'mediaInfoOfficialRating';
+    rating.textContent = value;
+    document.body.appendChild(rating);
+    return rating;
+}
+
+describe('colored ratings identity lifecycle', () => {
+    beforeAll(async () => {
+        window.Events = { on: vi.fn() } as unknown as JellyfinEvents;
+        await import('./colored-ratings');
+    });
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        document.body.innerHTML = '';
+        switchIdentity('ratings-server-a', 'ratings-user-a');
+        JC.pluginConfig = { ColoredRatingsEnabled: true };
+    });
+
+    afterEach(() => {
+        JC.identity.transition('', '', 'colored-ratings-test-cleanup');
+        vi.clearAllTimers();
+        vi.useRealTimers();
+        document.body.innerHTML = '';
+    });
+
+    it('undoes A annotations and queued work when B disables the feature', () => {
+        const rating = addRating();
+        JC.initializeColoredRatings!();
+        expect(rating.getAttribute('rating')).toBe('PG-13');
+        expect(document.getElementById('jellyfin-ratings-style')).toBeTruthy();
+
+        document.dispatchEvent(new Event('visibilitychange'));
+        switchIdentity('ratings-server-b', 'ratings-user-b');
+        JC.pluginConfig = { ColoredRatingsEnabled: false };
+        JC.initializeColoredRatings!();
+        vi.runOnlyPendingTimers();
+
+        expect(rating.hasAttribute('rating')).toBe(false);
+        expect(rating.dataset.jcColoredRating).toBeUndefined();
+        expect(document.getElementById('jellyfin-ratings-style')).toBeNull();
+    });
+
+    it('keeps observer/navigation counts bounded across A to B to A', () => {
+        addRating('R');
+        JC.initializeColoredRatings!();
+        const bodyCount = JC.core.dom!.getBodySubscriberCount();
+        const navCount = JC.core.navigation!.getNavCallbackCount();
+
+        JC.initializeColoredRatings!();
+        expect(JC.core.dom!.getBodySubscriberCount()).toBe(bodyCount);
+        expect(JC.core.navigation!.getNavCallbackCount()).toBe(navCount);
+
+        switchIdentity('ratings-server-b', 'ratings-user-b');
+        JC.pluginConfig = { ColoredRatingsEnabled: true };
+        JC.initializeColoredRatings!();
+        switchIdentity('ratings-server-a', 'ratings-user-a');
+        JC.initializeColoredRatings!();
+
+        expect(JC.core.dom!.getBodySubscriberCount()).toBe(bodyCount);
+        expect(JC.core.navigation!.getNavCallbackCount()).toBe(navCount);
+        expect(document.querySelectorAll('[data-jc-colored-rating="true"]')).toHaveLength(1);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.ts
@@ -5,7 +5,7 @@ import { JC as JEBase } from '../globals';
 import { assetUrl } from '../core/asset-urls';
 import { onBodyMutation } from '../core/dom-observer';
 import { onNavigate } from '../core/navigation';
-import type { PluginConfig } from '../types/jc';
+import type { IdentityContext, PluginConfig } from '../types/jc';
 
 /**
  * Local view of the shared namespace adding the public members this module
@@ -32,6 +32,11 @@ let navUnsubscribe: (() => void) | null = null;
 let navSettleTimer: ReturnType<typeof setTimeout> | null = null;
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 let processedElements = new WeakSet<Element>();
+let generation = 0;
+
+function isActive(context: IdentityContext, expectedGeneration: number): boolean {
+    return generation === expectedGeneration && JC.identity.isCurrent(context);
+}
 
 function isFeatureEnabled(): boolean {
     return Boolean(window?.JellyfinCanopy?.pluginConfig?.ColoredRatingsEnabled);
@@ -54,11 +59,13 @@ function injectCSS(): void {
 }
 
 
-function processRatingElements(): void {
+function processRatingElements(context: IdentityContext, expectedGeneration: number): void {
+    if (!isActive(context, expectedGeneration) || !isFeatureEnabled()) return;
     try {
         const elements = document.querySelectorAll<HTMLElement>(CONFIG.targetSelector);
 
         elements.forEach((element) => {
+            if (!isActive(context, expectedGeneration)) return;
             if (processedElements.has(element)) {
                 const currentRating = element.textContent?.trim();
                 const existingRating = element.getAttribute(CONFIG.attributeName);
@@ -73,13 +80,16 @@ function processRatingElements(): void {
 
                 if (element.getAttribute(CONFIG.attributeName) !== normalizedRating) {
                     element.setAttribute(CONFIG.attributeName, normalizedRating);
+                    element.dataset.jcColoredRating = 'true';
                     processedElements.add(element);
 
                     if (!element.getAttribute('aria-label')) {
                         element.setAttribute('aria-label', `Content rated ${normalizedRating}`);
+                        element.dataset.jcColoredRatingAria = 'true';
                     }
                     if (!element.getAttribute('title')) {
                         element.setAttribute('title', `Rating: ${normalizedRating}`);
+                        element.dataset.jcColoredRatingTitle = 'true';
                     }
                 }
             }
@@ -107,11 +117,15 @@ function normalizeRating(rating: string): string {
     return ratingMappings[normalized] || rating.trim();
 }
 
-function debouncedProcess(): void {
+function debouncedProcess(context: IdentityContext, expectedGeneration: number): void {
+    if (!isActive(context, expectedGeneration)) return;
     if (debounceTimer) {
         clearTimeout(debounceTimer);
     }
-    debounceTimer = setTimeout(processRatingElements, CONFIG.debounceDelay);
+    debounceTimer = setTimeout(() => {
+        debounceTimer = null;
+        processRatingElements(context, expectedGeneration);
+    }, CONFIG.debounceDelay);
 }
 
 /**
@@ -142,7 +156,7 @@ export function mutationsTouchRatings(mutations: MutationRecord[]): boolean {
     return false;
 }
 
-function setupMutationObserver(): boolean {
+function setupMutationObserver(context: IdentityContext, expectedGeneration: number): boolean {
     if (!window.MutationObserver) return false;
 
     try {
@@ -152,8 +166,8 @@ function setupMutationObserver(): boolean {
         // only ever (re)renders via childList mutations, and the
         // per-navigation pass below covers cached-page re-shows.
         observerHandle = onBodyMutation('colored-ratings', (mutations) => {
-            if (mutationsTouchRatings(mutations)) {
-                debouncedProcess();
+            if (isActive(context, expectedGeneration) && mutationsTouchRatings(mutations)) {
+                debouncedProcess(context, expectedGeneration);
             }
         });
         return true;
@@ -163,16 +177,19 @@ function setupMutationObserver(): boolean {
     }
 }
 
-function setupNavigationWatcher(): void {
+function setupNavigationWatcher(context: IdentityContext, expectedGeneration: number): void {
     if (navUnsubscribe) return;
     // PERF(R5): replaces both the permanent 1Hz full-document polling interval and
     // the per-mutation location.href watcher — one debounced pass per
     // navigation plus a settle pass for late-arriving page content.
     navUnsubscribe = onNavigate(() => {
-        if (!isFeatureEnabled()) return;
-        debouncedProcess();
+        if (!isActive(context, expectedGeneration) || !isFeatureEnabled()) return;
+        debouncedProcess(context, expectedGeneration);
         if (navSettleTimer) clearTimeout(navSettleTimer);
-        navSettleTimer = setTimeout(processRatingElements, CONFIG.navSettleDelay);
+        navSettleTimer = setTimeout(() => {
+            navSettleTimer = null;
+            processRatingElements(context, expectedGeneration);
+        }, CONFIG.navSettleDelay);
     });
 }
 
@@ -189,8 +206,9 @@ function pausePolling(): void {
  * pause screen's rating element is colored as soon as it is shown.
  */
 function resumePolling(): void {
-    if (isFeatureEnabled()) {
-        debouncedProcess();
+    const context = JC.identity.capture();
+    if (context && isFeatureEnabled()) {
+        debouncedProcess(context, generation);
     }
 }
 
@@ -214,27 +232,52 @@ function cleanup(): void {
     processedElements = new WeakSet();
 }
 
+function reset(): void {
+    generation += 1;
+    cleanup();
+    document.querySelectorAll<HTMLElement>('[data-jc-colored-rating="true"]').forEach((element) => {
+        element.removeAttribute(CONFIG.attributeName);
+        if (element.dataset.jcColoredRatingAria === 'true') element.removeAttribute('aria-label');
+        if (element.dataset.jcColoredRatingTitle === 'true') element.removeAttribute('title');
+        delete element.dataset.jcColoredRating;
+        delete element.dataset.jcColoredRatingAria;
+        delete element.dataset.jcColoredRatingTitle;
+    });
+    document.getElementById(CONFIG.cssId)?.remove();
+}
+
 function initialize(): void {
+    reset();
     if (!isFeatureEnabled()) {
-        cleanup();
         return;
     }
-    cleanup();
+    const context = JC.identity.capture();
+    if (!context) return;
+    const expectedGeneration = generation;
     injectCSS();
-    processRatingElements();
-    setupMutationObserver();
-    setupNavigationWatcher();
+    processRatingElements(context, expectedGeneration);
+    setupMutationObserver(context, expectedGeneration);
+    setupNavigationWatcher(context, expectedGeneration);
 }
 
 if (typeof document.visibilityState !== 'undefined') {
     document.addEventListener('visibilitychange', () => {
-        if (document.visibilityState === 'visible' && isFeatureEnabled()) {
-            setTimeout(processRatingElements, 100);
+        const context = JC.identity.capture();
+        if (context && document.visibilityState === 'visible' && isFeatureEnabled()) {
+            const expectedGeneration = generation;
+            if (debounceTimer) clearTimeout(debounceTimer);
+            debounceTimer = setTimeout(() => {
+                debounceTimer = null;
+                if (isActive(context, expectedGeneration) && isFeatureEnabled()) {
+                    processRatingElements(context, expectedGeneration);
+                }
+            }, 100);
         }
     });
 }
 
 window.addEventListener('beforeunload', cleanup);
+JC.identity.registerReset('colored-ratings', reset);
 JC.initializeColoredRatings = initialize;
 // Expose pause/resume functions for pausescreen.js to control
 JC.pauseRatingsPolling = pausePolling;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/identity-lifecycle-surface.d.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/identity-lifecycle-surface.d.ts
@@ -1,0 +1,11 @@
+// JEGlobal surface owned by the identity-aware extras modules.
+import type {} from '../types/jc';
+
+declare module '../types/jc' {
+    interface JEGlobal {
+        initializeColoredRatings?: () => void;
+        pauseRatingsPolling?: () => void;
+        resumeRatingsPolling?: () => void;
+        initializeThemeSelector?: () => void;
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/plugin-icons.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/plugin-icons.ts
@@ -3,7 +3,7 @@
 
 import { JC as JEBase } from '../globals';
 import { assetUrl } from '../core/asset-urls';
-import type { LifecycleApi, LifecycleHandle, NavigationApi } from '../types/jc';
+import type { IdentityContext, LifecycleApi, LifecycleHandle, NavigationApi } from '../types/jc';
 
 /** Icon override descriptor for a built-in plugin link. */
 interface IconConfig {
@@ -57,11 +57,17 @@ function injectCSS(): void {
 let isProcessing = false;
 let observer: { unsubscribe(): void } | null = null;
 let lifecycle: LifecycleHandle | null = null;
-let customPluginsCache: CustomPlugin[] | null = null;
-let lastProcessedPluginsCount = 0;
+let customPluginsCache: { context: IdentityContext; value: CustomPlugin[] } | null = null;
+let generation = 0;
+let retryTimer: ReturnType<typeof setTimeout> | null = null;
+const replacedIcons = new WeakMap<Element, Node>();
+
+function isActive(context: IdentityContext, expectedGeneration: number): boolean {
+    return generation === expectedGeneration && JC.identity.isCurrent(context);
+}
 
 // Get custom plugins from server configuration
-async function getCustomPlugins(): Promise<CustomPlugin[]> {
+async function getCustomPlugins(context: IdentityContext, expectedGeneration: number): Promise<CustomPlugin[]> {
     // Check for test data first (used by configuration page test button)
     const testLinks = (window as { testCustomPluginLinks?: Array<{ name: string; icon: string }> }).testCustomPluginLinks;
     if (testLinks) {
@@ -75,8 +81,8 @@ async function getCustomPlugins(): Promise<CustomPlugin[]> {
     }
 
     // Return cached data if available
-    if (customPluginsCache) {
-        return customPluginsCache;
+    if (customPluginsCache && JC.identity.isCurrent(customPluginsCache.context)) {
+        return customPluginsCache.value;
     }
 
     try {
@@ -89,9 +95,11 @@ async function getCustomPlugins(): Promise<CustomPlugin[]> {
         const pluginId = '9ffa12bc-f4b5-406c-ab1d-d575acbeea7b';
         const getPluginConfiguration = ApiClient.getPluginConfiguration as (id: string) => Promise<{ CustomPluginLinks?: string }>;
         const config = await getPluginConfiguration(pluginId);
+        if (!isActive(context, expectedGeneration)) return [];
         const customLinksText = config.CustomPluginLinks || '';
-        customPluginsCache = parseCustomPluginLinks(customLinksText);
-        return customPluginsCache;
+        const value = parseCustomPluginLinks(customLinksText);
+        customPluginsCache = { context, value };
+        return value;
     } catch (e) {
         console.warn('Failed to load custom plugins from server:', e);
     }
@@ -206,13 +214,19 @@ function replacePluginIcon(selector: string, iconConfig: IconConfig): boolean {
     }
 
     if (iconElement) {
+        iconElement.setAttribute('data-jc-plugin-icon-owned', 'true');
+        replacedIcons.set(iconElement, oldIcon.cloneNode(true));
         oldIcon.replaceWith(iconElement);
         return true;
     }
     return false;
 }
 
-async function processPluginIcons(): Promise<void> {
+async function processPluginIcons(
+    context = JC.identity.capture(),
+    expectedGeneration = generation
+): Promise<void> {
+    if (!context || !isActive(context, expectedGeneration)) return;
     if (isProcessing) return;
     isProcessing = true;
 
@@ -222,9 +236,6 @@ async function processPluginIcons(): Promise<void> {
         if (!pluginsSection) {
             return;
         }
-
-        // Count current plugins to detect changes
-        const currentPluginsCount = pluginsSection.querySelectorAll('a[href*="configurationpage"]').length;
 
         // Only clean up test links to avoid flickering
         const existingTestLinks = pluginsSection.querySelectorAll('[data-jellyfin-canopy-plugin-id^="test-"]');
@@ -295,21 +306,21 @@ async function processPluginIcons(): Promise<void> {
         });
 
         // Add custom user-defined plugins
-        const customPlugins = await getCustomPlugins();
+        const customPlugins = await getCustomPlugins(context, expectedGeneration);
+        if (!isActive(context, expectedGeneration)) return;
         customPlugins.forEach(plugin => {
             createCustomPluginLink(plugin);
         });
 
-        lastProcessedPluginsCount = currentPluginsCount;
     } finally {
-        isProcessing = false;
+        if (generation === expectedGeneration) isProcessing = false;
     }
 }
 
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
 // Monitor for changes similar to KefinTweaks approach
-function startMonitoring(): void {
+function startMonitoring(context: IdentityContext, expectedGeneration: number): void {
     if (observer) return;
 
     const callback = (mutations: MutationRecord[]): void => {
@@ -343,7 +354,10 @@ function startMonitoring(): void {
         if (shouldProcess) {
             // Debounce the processing
             if (debounceTimer) clearTimeout(debounceTimer);
-            debounceTimer = setTimeout(() => { void processPluginIcons(); }, 100);
+            debounceTimer = setTimeout(() => {
+                debounceTimer = null;
+                void processPluginIcons(context, expectedGeneration);
+            }, 100);
         }
     };
 
@@ -363,6 +377,11 @@ function stopMonitoring(): void {
     }
     if (debounceTimer) {
         clearTimeout(debounceTimer);
+        debounceTimer = null;
+    }
+    if (retryTimer) {
+        clearTimeout(retryTimer);
+        retryTimer = null;
     }
     if (lifecycle) {
         lifecycle.teardown();
@@ -373,39 +392,61 @@ function stopMonitoring(): void {
 // Handle page navigation via the shared deduplicated pipeline (covers
 // hashchange, popstate and pushState navs). Tracked through a lifecycle
 // handle so stopMonitoring() can remove it.
-function setupNavigationListener(): void {
+function setupNavigationListener(context: IdentityContext, expectedGeneration: number): void {
     lifecycle = JC.core.lifecycle.register('plugin-icons');
     lifecycle.track(JC.core.navigation.onNavigate(() => {
         const hash = window.location.hash;
         // Process plugin icons when navigating to dashboard, settings, or configuration pages
         if (hash.includes('#/dashboard') || hash.includes('#/settings') || hash.includes('#/configurationpage')) {
             if (debounceTimer) clearTimeout(debounceTimer);
-            debounceTimer = setTimeout(() => { void processPluginIcons(); }, 300);
+            debounceTimer = setTimeout(() => {
+                debounceTimer = null;
+                void processPluginIcons(context, expectedGeneration);
+            }, 300);
         }
     }));
 }
 
+function restoreOwnedUi(): void {
+    document.querySelectorAll('[data-jc-plugin-icon-owned="true"]').forEach((icon) => {
+        const original = replacedIcons.get(icon);
+        if (original) icon.replaceWith(original);
+        else icon.remove();
+    });
+    document.querySelectorAll('[data-jellyfin-canopy-plugin-id]').forEach((link) => link.remove());
+}
+
 function initialize(): void {
+    stopMonitoring();
+    const context = JC.identity.capture();
+    if (!context) return;
+    const expectedGeneration = ++generation;
+    isProcessing = false;
+
     // Inject CSS for Material Icons
     injectCSS();
-    setupNavigationListener();
+    setupNavigationListener(context, expectedGeneration);
 
     // Wait for ApiClient to be available
     let retries = 0;
     const maxRetries = 10;
 
     const tryInitialize = async (): Promise<void> => {
+        if (!isActive(context, expectedGeneration)) return;
         if (typeof ApiClient !== 'undefined') {
-            await processPluginIcons();
-            startMonitoring();
+            await processPluginIcons(context, expectedGeneration);
+            if (isActive(context, expectedGeneration)) startMonitoring(context, expectedGeneration);
         } else if (retries < maxRetries) {
             retries++;
-            setTimeout(() => { void tryInitialize(); }, 500);
+            retryTimer = setTimeout(() => {
+                retryTimer = null;
+                void tryInitialize();
+            }, 500);
         } else {
             console.warn('ApiClient not available after retries, custom plugin links will not work');
             // Still set up the basic icon replacement and monitoring
-            await processPluginIcons();
-            startMonitoring();
+            await processPluginIcons(context, expectedGeneration);
+            if (isActive(context, expectedGeneration)) startMonitoring(context, expectedGeneration);
         }
     };
 
@@ -414,6 +455,14 @@ function initialize(): void {
 
 JC.initializePluginIcons = initialize;
 JC.stopPluginIconsMonitoring = stopMonitoring;
+
+JC.identity.registerReset('plugin-icons', () => {
+    generation++;
+    isProcessing = false;
+    customPluginsCache = null;
+    stopMonitoring();
+    restoreOwnedUi();
+});
 
 // Expose API for refreshing custom plugins
 JC.customPlugins = {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/theme-selector.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/theme-selector.identity.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../globals';
+
+function switchIdentity(serverId: string, userId: string): void {
+    JC.identity.transition(serverId, userId, 'theme-selector-test');
+}
+
+function mountPreferencesPage(): void {
+    document.body.innerHTML = `
+        <section class="verticalSection">
+            <div class="headerUsername"></div>
+            <a class="lnkUserProfile"></a>
+        </section>
+    `;
+}
+
+describe('theme selector identity lifecycle', () => {
+    beforeAll(async () => {
+        window.Events = { on: vi.fn() } as unknown as JellyfinEvents;
+        await import('./theme-selector');
+    });
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        localStorage.clear();
+        sessionStorage.clear();
+        document.body.className = '';
+        mountPreferencesPage();
+        switchIdentity('server-a', 'user-a');
+        JC.pluginConfig = { ThemeSelectorEnabled: true };
+    });
+
+    afterEach(() => {
+        JC.identity.transition('', '', 'theme-selector-test-cleanup');
+        vi.clearAllTimers();
+        vi.useRealTimers();
+        document.body.innerHTML = '';
+    });
+
+    it('removes A UI and rejects a detached A control after a server switch', () => {
+        JC.initializeThemeSelector!();
+        vi.advanceTimersByTime(100);
+
+        const select = document.getElementById('theme-selector-select') as HTMLSelectElement;
+        expect(select).toBeTruthy();
+        expect(JC.core.dom!.getBodySubscriberCount()).toBeGreaterThan(0);
+
+        switchIdentity('server-b', 'user-a');
+        JC.pluginConfig = { ThemeSelectorEnabled: false };
+        expect(document.getElementById('jellyfin-theme-selector')).toBeNull();
+        expect(document.body.classList.contains('theme-applying')).toBe(false);
+
+        select.value = 'Ocean';
+        select.dispatchEvent(new Event('change', { bubbles: true }));
+        vi.runOnlyPendingTimers();
+
+        expect(localStorage.getItem('jc-theme:servera:usera:customCss')).toBeNull();
+        expect(localStorage.getItem('usera-customCss')).toBeNull();
+        expect(sessionStorage.length).toBe(0);
+    });
+
+    it('keeps equal user ids on different servers isolated and bounds subscriptions', () => {
+        JC.initializeThemeSelector!();
+        vi.advanceTimersByTime(100);
+        const aSubscriberCount = JC.core.dom!.getBodySubscriberCount();
+
+        const selectA = document.getElementById('theme-selector-select') as HTMLSelectElement;
+        selectA.value = 'Aurora';
+        selectA.dispatchEvent(new Event('change', { bubbles: true }));
+        expect(localStorage.getItem('jc-theme:servera:usera:customCss')).toContain('aurora.css');
+
+        switchIdentity('server-b', 'user-a');
+        JC.pluginConfig = { ThemeSelectorEnabled: true };
+        mountPreferencesPage();
+        JC.initializeThemeSelector!();
+        vi.advanceTimersByTime(100);
+
+        const selectB = document.getElementById('theme-selector-select') as HTMLSelectElement;
+        expect(selectB.value).toBe('Default');
+        expect(localStorage.getItem('jc-theme:serverb:usera:customCss')).toBeNull();
+        expect(JC.core.dom!.getBodySubscriberCount()).toBe(aSubscriberCount);
+
+        switchIdentity('server-a', 'user-a');
+        expect(localStorage.getItem('usera-customCss')).toContain('aurora.css');
+        mountPreferencesPage();
+        JC.initializeThemeSelector!();
+        vi.advanceTimersByTime(100);
+        expect((document.getElementById('theme-selector-select') as HTMLSelectElement).value).toBe('Aurora');
+        expect(JC.core.dom!.getBodySubscriberCount()).toBe(aSubscriberCount);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/theme-selector.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/theme-selector.ts
@@ -3,6 +3,9 @@
 
 import { JC as JEBase } from '../globals';
 import { themeCssUrl } from '../core/asset-urls';
+import { onBodyMutation } from '../core/dom-observer';
+import { escapeHtml } from '../core/ui-kit';
+import type { IdentityContext } from '../types/jc';
 
 /**
  * Local view of the shared namespace adding the public member this module
@@ -10,7 +13,6 @@ import { themeCssUrl } from '../core/asset-urls';
  */
 const JC = JEBase as typeof JEBase & {
     initializeThemeSelector?: () => void;
-    helpers?: { onBodyMutation?: (id: string, cb: () => void) => { unsubscribe(): void } };
 };
 
 const THEMES: Readonly<Record<string, string>> = Object.freeze({
@@ -39,16 +41,25 @@ const INIT_DELAY = 250;
 const NOTIFICATION_DELAY = 1000;
 const DEBOUNCE_DELAY = 100;
 const TRANSITION_DURATION = 300;
+const STORAGE_PREFIX = 'jc-theme:';
+const STORAGE_MIGRATION_KEY = 'jc-theme-storage-v2-migrated';
+const LEGACY_NOTIFICATION_KEY = 'jellyfin-theme-applied';
 
 // PERF(R6): no remote assets — Jellyfish theme CSS served from the local asset
 // cache (with its logo/background image urls rewritten to local copies).
 const getThemeImport = (filename: string): string => filename ? `@import url("${themeCssUrl(filename)}");` : '';
 
-const getStorageKey = (userId: string, key: string): string => `${userId}-${key}`;
+const getStorageKey = (context: IdentityContext, key: string): string =>
+    `${STORAGE_PREFIX}${context.serverId}:${context.userId}:${key}`;
 
-const getLocalStorageValue = (userId: string, key: string, defaultValue: string | null = null): string | null => {
+// Jellyfish consumes this compatibility key while booting its stylesheet. It
+// is only a mirror of the current server-scoped value; the canonical value
+// above prevents equal user ids on two Jellyfin servers from sharing a theme.
+const getCompatibilityKey = (context: IdentityContext, key: string): string => `${context.userId}-${key}`;
+
+const getLocalStorageValue = (context: IdentityContext, key: string, defaultValue: string | null = null): string | null => {
     try {
-        const value = localStorage.getItem(getStorageKey(userId, key));
+        const value = localStorage.getItem(getStorageKey(context, key));
         return value === null ? defaultValue : value;
     } catch (e) {
         console.error('🪼 Jellyfin Canopy: Theme selector storage read error', e);
@@ -56,9 +67,12 @@ const getLocalStorageValue = (userId: string, key: string, defaultValue: string 
     }
 };
 
-const setLocalStorageValue = (userId: string, key: string, value: string): boolean => {
+const setLocalStorageValue = (context: IdentityContext, key: string, value: string): boolean => {
     try {
-        localStorage.setItem(getStorageKey(userId, key), value);
+        localStorage.setItem(getStorageKey(context, key), value);
+        if (key === 'customCss' && JC.identity.isCurrent(context)) {
+            localStorage.setItem(getCompatibilityKey(context, key), value);
+        }
         return true;
     } catch (e) {
         console.error('🪼 Jellyfin Canopy: Theme selector storage write error', e);
@@ -66,9 +80,12 @@ const setLocalStorageValue = (userId: string, key: string, value: string): boole
     }
 };
 
-const removeLocalStorageValue = (userId: string, key: string): boolean => {
+const removeLocalStorageValue = (context: IdentityContext, key: string): boolean => {
     try {
-        localStorage.removeItem(getStorageKey(userId, key));
+        localStorage.removeItem(getStorageKey(context, key));
+        if (key === 'customCss' && JC.identity.isCurrent(context)) {
+            localStorage.removeItem(getCompatibilityKey(context, key));
+        }
         return true;
     } catch (e) {
         console.error('🪼🎨Jellyfish Theme Selector : localStorage remove error:', e);
@@ -77,19 +94,19 @@ const removeLocalStorageValue = (userId: string, key: string): boolean => {
 };
 
 // --- Random Theme Functions ---
-const isRandomThemeEnabled = (userId: string): boolean => {
-    const setting = getLocalStorageValue(userId, 'randomThemeEnabled');
+const isRandomThemeEnabled = (context: IdentityContext): boolean => {
+    const setting = getLocalStorageValue(context, 'randomThemeEnabled');
     return setting === null ? RANDOM_THEME_DEFAULT : setting === 'true';
 };
 
-const setRandomThemeEnabled = (userId: string, isEnabled: boolean): void => {
-    setLocalStorageValue(userId, 'randomThemeEnabled', String(isEnabled));
+const setRandomThemeEnabled = (context: IdentityContext, isEnabled: boolean): void => {
+    setLocalStorageValue(context, 'randomThemeEnabled', String(isEnabled));
 };
 
-const getLastRandomDate = (userId: string): string | null => getLocalStorageValue(userId, 'lastRandomThemeDate');
+const getLastRandomDate = (context: IdentityContext): string | null => getLocalStorageValue(context, 'lastRandomThemeDate');
 
-const setLastRandomDate = (userId: string, date: string): void => {
-    setLocalStorageValue(userId, 'lastRandomThemeDate', date);
+const setLastRandomDate = (context: IdentityContext, date: string): void => {
+    setLocalStorageValue(context, 'lastRandomThemeDate', date);
 };
 
 const getTodayDate = (): string => new Date().toISOString().split('T')[0];
@@ -153,29 +170,52 @@ const injectCustomCss = (): void => {
 
 
 
-// --- User ID Extraction ---
-const extractUserId = (): string | null => {
-    try {
-        const userId = window.ApiClient?.getCurrentUserId?.();
-        if (userId && userId.trim() !== '') return userId;
-    } catch (e) {
-        console.error('🪼🎨Jellyfish Theme Selector :  Error extracting user ID:', e);
-    }
-    console.error('🪼🎨Jellyfish Theme Selector :  Could not extract user ID');
-    return null;
-};
-
 // --- Theme Management ---
-const getCurrentTheme = (userId: string): string => getLocalStorageValue(userId, 'customCss', '') || '';
+const getCurrentTheme = (context: IdentityContext): string => getLocalStorageValue(context, 'customCss', '') || '';
 
-const setTheme = (userId: string, themeFilename: string, themeName = 'Default'): void => {
+const setTheme = (context: IdentityContext, themeFilename: string, themeName = 'Default'): void => {
+    if (!JC.identity.isCurrent(context)) return;
     const themeValue = getThemeImport(themeFilename);
     if (themeValue) {
-        setLocalStorageValue(userId, 'customCss', themeValue);
+        setLocalStorageValue(context, 'customCss', themeValue);
         console.log(`🪼🎨Jellyfish Theme Selector :  Theme set to: ${themeName}`);
     } else {
-        removeLocalStorageValue(userId, 'customCss');
+        removeLocalStorageValue(context, 'customCss');
         console.log('🪼🎨Jellyfish Theme Selector :  Theme cleared (default)');
+    }
+};
+
+const getNotificationKey = (context: IdentityContext): string =>
+    `${LEGACY_NOTIFICATION_KEY}:${context.serverId}:${context.userId}`;
+
+/**
+ * Adopt the old user-only keys once, for the identity active during upgrade.
+ * Every later identity uses server-scoped keys exclusively. This avoids an A
+ * compatibility mirror being mistaken for B's preference when user ids happen
+ * to match across servers.
+ */
+const migrateLegacyStorageOnce = (context: IdentityContext): void => {
+    try {
+        if (localStorage.getItem(STORAGE_MIGRATION_KEY) !== 'true') {
+            for (const key of ['customCss', 'randomThemeEnabled', 'lastRandomThemeDate']) {
+                const scopedKey = getStorageKey(context, key);
+                const legacyKey = getCompatibilityKey(context, key);
+                if (localStorage.getItem(scopedKey) === null) {
+                    const legacyValue = localStorage.getItem(legacyKey);
+                    if (legacyValue !== null) localStorage.setItem(scopedKey, legacyValue);
+                }
+            }
+            localStorage.setItem(STORAGE_MIGRATION_KEY, 'true');
+        }
+
+        // Keep Jellyfish's boot-time compatibility key synchronized with the
+        // current canonical value. A missing B value removes A's old mirror.
+        const currentTheme = getCurrentTheme(context);
+        const compatibilityKey = getCompatibilityKey(context, 'customCss');
+        if (currentTheme) localStorage.setItem(compatibilityKey, currentTheme);
+        else localStorage.removeItem(compatibilityKey);
+    } catch (e) {
+        console.error('Jellyfin Canopy: Theme selector storage migration error', e);
     }
 };
 
@@ -195,12 +235,22 @@ const showNotification = (message: string): void => {
     }
 };
 
-const checkPostRefreshNotification = (): void => {
+const checkPostRefreshNotification = (context: IdentityContext, expectedGeneration: number): void => {
     try {
-        const pendingNotification = sessionStorage.getItem('jellyfin-theme-applied');
+        const notificationKey = getNotificationKey(context);
+        let pendingNotification = sessionStorage.getItem(notificationKey);
+        // Compatibility with a reload initiated by a pre-upgrade bundle. The
+        // unscoped value is consumed once and cannot survive an SPA switch.
+        if (!pendingNotification) pendingNotification = sessionStorage.getItem('jellyfin-theme-applied');
+        sessionStorage.removeItem(LEGACY_NOTIFICATION_KEY);
         if (pendingNotification) {
-            sessionStorage.removeItem('jellyfin-theme-applied');
-            setTimeout(() => showNotification(`Theme applied: ${pendingNotification}`), NOTIFICATION_DELAY);
+            sessionStorage.removeItem(notificationKey);
+            notificationTimer = window.setTimeout(() => {
+                notificationTimer = null;
+                if (isActive(context, expectedGeneration)) {
+                    showNotification(`Theme applied: ${escapeHtml(pendingNotification)}`);
+                }
+            }, NOTIFICATION_DELAY);
         }
     } catch (e) {
         console.error('🪼🎨Jellyfish Theme Selector :  Session storage error:', e);
@@ -208,12 +258,11 @@ const checkPostRefreshNotification = (): void => {
 };
 
 // --- Random Theme Logic ---
-const applyRandomThemeIfNeeded = (): void => {
-    const userId = extractUserId();
-    if (!userId || !isRandomThemeEnabled(userId)) return;
+const applyRandomThemeIfNeeded = (context: IdentityContext, expectedGeneration: number): void => {
+    if (!isActive(context, expectedGeneration) || !isRandomThemeEnabled(context)) return;
 
     const today = getTodayDate();
-    const lastDate = getLastRandomDate(userId);
+    const lastDate = getLastRandomDate(context);
 
     if (today !== lastDate) {
         console.log('🪼🎨Jellyfish Theme Selector :  New day detected! Applying a random theme.');
@@ -221,15 +270,15 @@ const applyRandomThemeIfNeeded = (): void => {
         const randomThemeName = availableThemes[Math.floor(Math.random() * availableThemes.length)];
         const randomThemeFilename = THEMES[randomThemeName];
 
-        setTheme(userId, randomThemeFilename, randomThemeName);
-        setLastRandomDate(userId, today);
+        setTheme(context, randomThemeFilename, randomThemeName);
+        setLastRandomDate(context, today);
 
         try {
-            sessionStorage.setItem('jellyfin-theme-applied', `Random Daily (${randomThemeName})`);
+            sessionStorage.setItem(getNotificationKey(context), `Random Daily (${randomThemeName})`);
         } catch (e) {
             console.error('🪼🎨Jellyfish Theme Selector :  Could not set session storage:', e);
         }
-        window.location.reload();
+        if (isActive(context, expectedGeneration)) window.location.reload();
     } else {
         console.log('🪼🎨Jellyfish Theme Selector :  Random theme already applied for today.');
     }
@@ -244,7 +293,11 @@ const createIcon = (iconName: string, className = 'material-icons'): HTMLElement
     return icon;
 };
 
-const createThemeSelect = (userId: string, currentThemeValue: string): HTMLSelectElement => {
+const createThemeSelect = (
+    context: IdentityContext,
+    expectedGeneration: number,
+    currentThemeValue: string
+): HTMLSelectElement => {
     const select = document.createElement('select');
     select.setAttribute('is', 'emby-select');
     select.className = 'emby-select-withcolor emby-select';
@@ -272,6 +325,7 @@ const createThemeSelect = (userId: string, currentThemeValue: string): HTMLSelec
     select.addEventListener('change', (e) => {
         e.preventDefault();
         e.stopPropagation();
+        if (!isActive(context, expectedGeneration)) return;
 
         const newThemeName = (e.target as HTMLSelectElement).value;
         const newThemeFilename = THEMES[newThemeName];
@@ -285,17 +339,20 @@ const createThemeSelect = (userId: string, currentThemeValue: string): HTMLSelec
         document.body.classList.add('theme-applying');
 
         // Save to localStorage
-        setTheme(userId, newThemeFilename, newThemeName);
+        setTheme(context, newThemeFilename, newThemeName);
 
         // Store notification for after reload
         try {
-            sessionStorage.setItem('jellyfin-theme-applied', newThemeName);
+            sessionStorage.setItem(getNotificationKey(context), newThemeName);
         } catch (e) {
             console.error('🪼🎨Jellyfish Theme Selector :  Session storage error:', e);
         }
 
         // Wait for fade-out transition, then reload
-        setTimeout(() => {
+        if (reloadTimer) clearTimeout(reloadTimer);
+        reloadTimer = window.setTimeout(() => {
+            reloadTimer = null;
+            if (!isActive(context, expectedGeneration)) return;
             console.log(`🪼🎨Jellyfish Theme Selector :  Reloading to apply theme: ${newThemeName}`);
             window.location.reload();
         }, TRANSITION_DURATION);
@@ -304,7 +361,7 @@ const createThemeSelect = (userId: string, currentThemeValue: string): HTMLSelec
     return select;
 };
 
-const createRandomButton = (userId: string): HTMLButtonElement => {
+const createRandomButton = (context: IdentityContext, expectedGeneration: number): HTMLButtonElement => {
     const button = document.createElement('button');
     button.setAttribute('is', 'emby-button');
     button.className = 'emby-button';
@@ -317,7 +374,7 @@ const createRandomButton = (userId: string): HTMLButtonElement => {
     text.style.fontSize = '0.85em';
 
     const updateButtonState = (): void => {
-        const isEnabled = isRandomThemeEnabled(userId);
+        const isEnabled = isRandomThemeEnabled(context);
         button.classList.toggle('active', isEnabled);
         text.textContent = isEnabled ? 'Daily' : '';
         button.setAttribute('aria-pressed', isEnabled.toString());
@@ -328,21 +385,22 @@ const createRandomButton = (userId: string): HTMLButtonElement => {
     updateButtonState();
 
     button.addEventListener('click', () => {
-        const newState = !isRandomThemeEnabled(userId);
-        setRandomThemeEnabled(userId, newState);
+        if (!isActive(context, expectedGeneration)) return;
+        const newState = !isRandomThemeEnabled(context);
+        setRandomThemeEnabled(context, newState);
         showNotification(`Random daily theme turned ${newState ? 'ON' : 'OFF'}.`);
         console.log(`🪼🎨Jellyfish Theme Selector :  Random daily theme set to: ${newState}`);
         updateButtonState();
 
         if (newState) {
-            applyRandomThemeIfNeeded();
+            applyRandomThemeIfNeeded(context, expectedGeneration);
         }
     });
 
     return button;
 };
 
-const createThemeSelector = (userId: string): HTMLElement => {
+const createThemeSelector = (context: IdentityContext, expectedGeneration: number): HTMLElement => {
     const container = document.createElement('div');
     container.className = 'theme-selector-container listItem-border';
     container.id = SELECTOR_ID;
@@ -363,9 +421,9 @@ const createThemeSelector = (userId: string): HTMLElement => {
     textLabel.id = 'theme-selector-label';
     textLabel.textContent = 'Theme';
 
-    const currentThemeValue = getCurrentTheme(userId);
-    const select = createThemeSelect(userId, currentThemeValue);
-    const randomButton = createRandomButton(userId);
+    const currentThemeValue = getCurrentTheme(context);
+    const select = createThemeSelect(context, expectedGeneration, currentThemeValue);
+    const randomButton = createRandomButton(context, expectedGeneration);
 
     contentDiv.appendChild(textLabel);
     contentDiv.appendChild(randomButton);
@@ -378,19 +436,21 @@ const createThemeSelector = (userId: string): HTMLElement => {
 };
 
 // --- DOM Injection ---
-const injectThemeSelector = (): boolean => {
+const injectThemeSelector = (context: IdentityContext, expectedGeneration: number): boolean => {
     try {
+        if (!isActive(context, expectedGeneration)) return false;
         const targetDiv = document.querySelector('.verticalSection .headerUsername');
         if (!targetDiv) return false;
 
         const parentSection = targetDiv.closest('.verticalSection');
         if (!parentSection) return false;
 
-        const userId = extractUserId();
-        if (!userId) return false;
+        if (!isActive(context, expectedGeneration)) return false;
 
         console.log('🪼🎨Jellyfish Theme Selector :  Creating theme selector element...');
-        const themeSelector = createThemeSelector(userId);
+        const themeSelector = createThemeSelector(context, expectedGeneration);
+        themeSelector.dataset.jcIdentityOwned = 'true';
+        if (!isActive(context, expectedGeneration)) return false;
         parentSection.appendChild(themeSelector);
         console.log('🪼🎨Jellyfish Theme Selector :  Successfully injected!');
         return true;
@@ -410,10 +470,40 @@ const isOnPreferencesPage = (): boolean => {
 
 // --- Initialization ---
 let observerInstance: { unsubscribe(): void } | null = null;
-let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+let initTimer: ReturnType<typeof setTimeout> | null = null;
+let notificationTimer: ReturnType<typeof setTimeout> | null = null;
+let reloadTimer: ReturnType<typeof setTimeout> | null = null;
+let generation = 0;
 
-// ~25s at 250ms: enough for a slow ApiClient boot, then give up so a login page
-// left open (never authenticates) can't busy-loop the poller for the session.
+function isActive(context: IdentityContext, expectedGeneration: number): boolean {
+    return generation === expectedGeneration && JC.identity.isCurrent(context);
+}
+
+function isFeatureEnabled(): boolean {
+    return JC.pluginConfig?.ThemeSelectorEnabled === true;
+}
+
+function cleanup(): void {
+    observerInstance?.unsubscribe();
+    observerInstance = null;
+    if (debounceTimer) clearTimeout(debounceTimer);
+    if (initTimer) clearTimeout(initTimer);
+    if (notificationTimer) clearTimeout(notificationTimer);
+    if (reloadTimer) clearTimeout(reloadTimer);
+    debounceTimer = null;
+    initTimer = null;
+    notificationTimer = null;
+    reloadTimer = null;
+    document.getElementById(SELECTOR_ID)?.remove();
+    document.body.classList.remove('theme-applying', 'theme-applied');
+}
+
+function reset(): void {
+    generation += 1;
+    cleanup();
+}
+
 // ~25s at 250ms: enough for a slow ApiClient boot, then give up so a login page
 // left open (never authenticates) can't busy-loop the poller for the session.
 const MAX_INIT_ATTEMPTS = 100;
@@ -421,20 +511,28 @@ const MAX_INIT_ATTEMPTS = 100;
 const initialize = (attempt = 0): void => {
     // Browser-only module — never reschedule in a non-DOM (SSR/test) context.
     if (typeof window === 'undefined') return;
+    if (attempt === 0) reset();
+    const context = JC.identity.capture();
+    if (!context || !isFeatureEnabled()) return;
+    const expectedGeneration = generation;
     if (typeof ApiClient === 'undefined' || typeof ApiClient.getCurrentUserId !== 'function') {
         if (attempt >= MAX_INIT_ATTEMPTS) {
             console.warn('🪼🎨Jellyfish Theme Selector :  ApiClient never became available; giving up.');
             return;
         }
         console.log('🪼🎨Jellyfish Theme Selector :  Waiting for ApiClient...');
-        setTimeout(() => initialize(attempt + 1), INIT_DELAY);
+        initTimer = window.setTimeout(() => {
+            initTimer = null;
+            if (isActive(context, expectedGeneration)) initialize(attempt + 1);
+        }, INIT_DELAY);
         return;
     }
 
     console.log('🪼🎨Jellyfish Theme Selector :  ApiClient is available. Starting persistent element monitoring.');
-    applyRandomThemeIfNeeded();
+    migrateLegacyStorageOnce(context);
+    applyRandomThemeIfNeeded(context, expectedGeneration);
     injectCustomCss();
-    checkPostRefreshNotification();
+    checkPostRefreshNotification(context, expectedGeneration);
 
     // Cleanup existing observer if present
     if (observerInstance) {
@@ -443,23 +541,37 @@ const initialize = (attempt = 0): void => {
     }
 
     const callback = (): void => {
-        clearTimeout(debounceTimer);
-        debounceTimer = setTimeout(() => {
+        if (!isActive(context, expectedGeneration) || !isFeatureEnabled()) return;
+        if (debounceTimer) clearTimeout(debounceTimer);
+        debounceTimer = window.setTimeout(() => {
+            debounceTimer = null;
+            if (!isActive(context, expectedGeneration) || !isFeatureEnabled()) return;
             const selectorExists = document.getElementById(SELECTOR_ID);
             if (isOnPreferencesPage() && !selectorExists) {
                 console.log('🪼🎨Jellyfish Theme Selector :  Preferences page detected and selector is missing. Injecting...');
-                injectThemeSelector();
+                injectThemeSelector(context, expectedGeneration);
             }
         }, DEBOUNCE_DELAY);
     };
 
-    if (JC?.helpers?.onBodyMutation) {
-        observerInstance = JC.helpers.onBodyMutation('theme-selector', callback);
-    } else {
-        const mo = new MutationObserver(callback);
-        mo.observe(document.body, { childList: true, subtree: true });
-        observerInstance = { unsubscribe() { mo.disconnect(); } };
-    }
+    observerInstance = onBodyMutation('theme-selector', callback);
+    callback();
 };
 
+JC.identity.registerReset('theme-selector', (change) => {
+    reset();
+    try {
+        if (change.previous) {
+            localStorage.removeItem(getCompatibilityKey(change.previous, 'customCss'));
+            sessionStorage.removeItem(getNotificationKey(change.previous));
+        }
+        if (change.current) {
+            const currentTheme = getCurrentTheme(change.current);
+            const compatibilityKey = getCompatibilityKey(change.current, 'customCss');
+            if (currentTheme) localStorage.setItem(compatibilityKey, currentTheme);
+            else localStorage.removeItem(compatibilityKey);
+        }
+        sessionStorage.removeItem(LEGACY_NOTIFICATION_KEY);
+    } catch { /* storage may be blocked */ }
+});
 JC.initializeThemeSelector = initialize;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/main.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/main.ts
@@ -37,6 +37,9 @@ import './core/lifecycle';
 import './core/dom-observer';
 import './core/ui-kit';
 import './core/api-client';
+// Connect the loader-owned identity epoch to core request/lifecycle teardown
+// only after both owners above have installed their public surfaces.
+import './core/identity';
 import './core/tag-renderer-base';
 // Pages framework: imported before the feature barrels so the early 404-mask
 // installs at parse time and the registry exists before descriptors register.

--- a/Jellyfin.Plugin.JellyfinCanopy/src/others/letterboxd-links.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/others/letterboxd-links.ts
@@ -5,7 +5,7 @@ import { assetUrl } from '../core/asset-urls';
 import { isDetailsPageVisible } from '../core/details-view';
 import { onBodyMutation } from '../core/dom-observer';
 import { onNavigate, onViewPage } from '../core/navigation';
-import type { JELegacyHelpers, PluginConfig } from '../types/jc';
+import type { IdentityContext, JELegacyHelpers, PluginConfig } from '../types/jc';
 
 /** Options accepted by helpers.createExternalLink (and its local fallback). */
 interface ExternalLinkOptions {
@@ -24,18 +24,61 @@ const JC = JEBase as typeof JEBase & {
     pluginConfig: PluginConfig & { LetterboxdEnabled?: boolean; ShowLetterboxdLinkAsText?: boolean };
     helpers: JELegacyHelpers & {
         createExternalLink?: (url: string, options?: ExternalLinkOptions) => HTMLAnchorElement;
-        getItemCached?: (itemId: string) => Promise<unknown>;
+        getItemCached?: (itemId: string, options?: { userId?: string }) => Promise<unknown>;
     };
 };
+
+let letterboxdGeneration = 0;
+let letterboxdBodySubscription: { unsubscribe(): void } | null = null;
+let letterboxdNavUnsubscribe: (() => void) | null = null;
+let letterboxdViewUnsubscribe: (() => void) | null = null;
+const letterboxdTimers = new Set<ReturnType<typeof setTimeout>>();
+const letterboxdIdleJobs = new Set<number>();
+
+function removeLetterboxdLinks(): void {
+    document.querySelectorAll('.letterboxd-link').forEach((link) => {
+        if (link.previousSibling?.nodeType === Node.TEXT_NODE) link.previousSibling.remove();
+        link.remove();
+    });
+}
+
+function resetLetterboxd(): void {
+    letterboxdGeneration++;
+    letterboxdBodySubscription?.unsubscribe();
+    letterboxdBodySubscription = null;
+    letterboxdNavUnsubscribe?.();
+    letterboxdNavUnsubscribe = null;
+    letterboxdViewUnsubscribe?.();
+    letterboxdViewUnsubscribe = null;
+    for (const timer of letterboxdTimers) clearTimeout(timer);
+    letterboxdTimers.clear();
+    if (typeof cancelIdleCallback === 'function') {
+        for (const job of letterboxdIdleJobs) cancelIdleCallback(job);
+    }
+    letterboxdIdleJobs.clear();
+    removeLetterboxdLinks();
+}
+
+function isActive(context: IdentityContext, expectedGeneration: number): boolean {
+    return letterboxdGeneration === expectedGeneration && JC.identity.isCurrent(context);
+}
 
 // eslint-disable-next-line @typescript-eslint/require-await -- public initializer kept async to preserve its Promise-returning contract
 JC.initializeLetterboxdLinksScript = async function () {
     const logPrefix = '🪼 Jellyfin Canopy: Letterboxd Links:';
 
+    resetLetterboxd();
+
     if (!JC?.pluginConfig?.LetterboxdEnabled) {
         console.log(`${logPrefix} Integration disabled in plugin settings.`);
         return;
     }
+
+    const capturedIdentity = JC.identity.capture();
+    if (!capturedIdentity) return;
+    const context: IdentityContext = capturedIdentity;
+    const expectedGeneration = letterboxdGeneration;
+    const client = ApiClient;
 
     console.log(`${logPrefix} Initializing...`);
 
@@ -112,6 +155,7 @@ JC.initializeLetterboxdLinksScript = async function () {
     }
 
     async function addLetterboxdLinks(): Promise<void> {
+        if (!isActive(context, expectedGeneration)) return;
         if (isAddingLinks) {
             return;
         }
@@ -151,8 +195,9 @@ JC.initializeLetterboxdLinksScript = async function () {
         isAddingLinks = true;
         try {
             const item = (JC.helpers?.getItemCached
-                ? await JC.helpers.getItemCached(itemId)
-                : await ApiClient.getItem(ApiClient.getCurrentUserId(), itemId)) as any;
+                ? await JC.helpers.getItemCached(itemId, { userId: context.userId })
+                : await client.getItem(client.getCurrentUserId(), itemId)) as any;
+            if (!isActive(context, expectedGeneration) || !anchorElement.isConnected) return;
             if (!item?.Type) {
                 processedItemIds.add(itemId);
                 return;
@@ -191,6 +236,7 @@ JC.initializeLetterboxdLinksScript = async function () {
             anchorElement.appendChild(createLinkButton("Letterboxd", letterboxdUrl, "letterboxd-link-icon"));
             processedItemIds.add(itemId);
         } catch (err) {
+            if (!isActive(context, expectedGeneration)) return;
             console.error(`${logPrefix} Error adding Letterboxd link:`, err);
             // PERF(R9): fail open — only poison the processed set after repeated
             // failures; the shared body observer / nav probes retry until then.
@@ -220,18 +266,25 @@ JC.initializeLetterboxdLinksScript = async function () {
     // Coalesced, idle-scheduled lookup pass shared by every trigger below.
     let processingLetterboxd = false;
     function scheduleLetterboxdLinks(): void {
+        if (!isActive(context, expectedGeneration)) return;
         if (processingLetterboxd) return;
         processingLetterboxd = true;
         if (typeof requestIdleCallback !== 'undefined') {
-            requestIdleCallback(() => {
+            const job = requestIdleCallback(() => {
+                letterboxdIdleJobs.delete(job);
+                if (!isActive(context, expectedGeneration)) return;
                 void addLetterboxdLinks();
                 processingLetterboxd = false;
             }, { timeout: 500 });
+            letterboxdIdleJobs.add(job);
         } else {
-            setTimeout(() => {
+            const timer = setTimeout(() => {
+                letterboxdTimers.delete(timer);
+                if (!isActive(context, expectedGeneration)) return;
                 void addLetterboxdLinks();
                 processingLetterboxd = false;
             }, 100);
+            letterboxdTimers.add(timer);
         }
     }
 
@@ -248,27 +301,39 @@ JC.initializeLetterboxdLinksScript = async function () {
     // cached #itemDetailPage duplicates coexist (v12-platform.md §3) and
     // getElementById returns the lowest slot — usually an old hidden one —
     // which left this gate permanently dead after two details visits.
-    const letterboxdSubscription = onBodyMutation('letterboxd-links', () => {
+    letterboxdBodySubscription = onBodyMutation('letterboxd-links', () => {
+        if (!isActive(context, expectedGeneration)) return;
         if (!JC?.pluginConfig?.LetterboxdEnabled) {
-            letterboxdSubscription.unsubscribe();
+            letterboxdBodySubscription?.unsubscribe();
+            letterboxdBodySubscription = null;
             console.log(`${logPrefix} Stopped - feature disabled`);
             return;
         }
         if (!isDetailsPageVisible()) return;
         scheduleLetterboxdLinks();
     });
-    onNavigate(() => {
+    letterboxdNavUnsubscribe = onNavigate(() => {
+        if (!isActive(context, expectedGeneration)) return;
         if (JC?.pluginConfig?.LetterboxdEnabled) scheduleLetterboxdLinks();
     });
-    onViewPage(() => {
+    letterboxdViewUnsubscribe = onViewPage(() => {
+        if (!isActive(context, expectedGeneration)) return;
         if (JC?.pluginConfig?.LetterboxdEnabled) scheduleLetterboxdLinks();
     });
 
     // Initial check
     if (typeof requestIdleCallback !== 'undefined') {
-        requestIdleCallback(() => { void addLetterboxdLinks(); }, { timeout: 1000 });
+        const job = requestIdleCallback(() => {
+            letterboxdIdleJobs.delete(job);
+            if (isActive(context, expectedGeneration)) void addLetterboxdLinks();
+        }, { timeout: 1000 });
+        letterboxdIdleJobs.add(job);
     } else {
-        setTimeout(() => { void addLetterboxdLinks(); }, 500);
+        const timer = setTimeout(() => {
+            letterboxdTimers.delete(timer);
+            if (isActive(context, expectedGeneration)) void addLetterboxdLinks();
+        }, 500);
+        letterboxdTimers.add(timer);
     }
 
     try {
@@ -277,3 +342,5 @@ JC.initializeLetterboxdLinksScript = async function () {
         console.error(`${logPrefix} Failed to initialize`, err);
     }
 };
+
+JC.identity.registerReset('letterboxd-links', resetLetterboxd);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/api.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/api.identity.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../globals';
+
+describe('Seerr API identity-owned caches and issue writes', () => {
+    let originalIdentity = JC.identity.capture()!;
+    let fetchMock: ReturnType<typeof vi.fn>;
+    let pluginMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(async () => {
+        vi.resetModules();
+        originalIdentity = JC.identity.capture()!;
+        fetchMock = vi.fn();
+        pluginMock = vi.fn();
+        JC.core.api = {
+            fetch: fetchMock,
+            plugin: pluginMock,
+        } as unknown as NonNullable<typeof JC.core.api>;
+        JC.pluginConfig = { SeerrEnable4KRequests: true };
+        JC.escapeHtml = (value: unknown) => String(value);
+        JC.toast = vi.fn();
+        await import('./api');
+    });
+
+    afterEach(() => {
+        JC.identity.transition(
+            originalIdentity.serverId,
+            originalIdentity.userId,
+            'seerr-api-test-restore',
+        );
+    });
+
+    it('rejects A status and override results while caching B only', async () => {
+        let resolveStatusA!: (value: unknown) => void;
+        let resolveRulesA!: (value: unknown) => void;
+        fetchMock
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises -- deferred request fixture
+            .mockImplementationOnce(() => new Promise((resolve) => { resolveStatusA = resolve; }))
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises -- deferred request fixture
+            .mockImplementationOnce(() => new Promise((resolve) => { resolveRulesA = resolve; }))
+            .mockResolvedValueOnce({ active: true, userFound: true, canRequest4kMovie: false })
+            .mockResolvedValueOnce([{ id: 'rule-b' }]);
+
+        const statusA = JC.seerrAPI!.checkUserStatus();
+        const rulesA = JC.seerrAPI!.fetchOverrideRules();
+        JC.identity.transition('server-b', 'user-b', 'seerr-api-race');
+
+        const statusB = await JC.seerrAPI!.checkUserStatus();
+        const rulesB = await JC.seerrAPI!.fetchOverrideRules();
+        expect(statusB.canRequest4kMovie).toBe(false);
+        expect(rulesB).toEqual([{ id: 'rule-b' }]);
+
+        resolveStatusA({ active: true, userFound: true, canRequest4kMovie: true });
+        resolveRulesA([{ id: 'rule-a' }]);
+        await expect(statusA).rejects.toThrow(/stale identity/i);
+        await expect(rulesA).rejects.toThrow(/stale identity/i);
+        expect(JC.seerrAPI!.canRequest4k('movie')).toBe(false);
+        expect(await JC.seerrAPI!.fetchOverrideRules()).toEqual([{ id: 'rule-b' }]);
+    });
+
+    it('does not issue an A report POST after its media lookup resolves under B', async () => {
+        let resolveLookup!: (value: unknown) => void;
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises -- deferred request fixture
+        fetchMock.mockImplementationOnce(() => new Promise((resolve) => { resolveLookup = resolve; }));
+
+        const pending = JC.seerrAPI!.reportIssue('42', 'movie', '1', 'bad video');
+        JC.identity.transition('server-b', 'user-b', 'seerr-issue-write-race');
+        resolveLookup({ mediaInfo: { id: 99 } });
+
+        await expect(pending).rejects.toThrow(/stale identity/i);
+        expect(pluginMock).not.toHaveBeenCalled();
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/api.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/api.ts
@@ -2,6 +2,7 @@
 import { JC } from '../globals';
 import { describeFetchError } from '../core/fetch-error';
 import { isSafeLinkBase } from '../core/url-safe';
+import type { IdentityContext } from '../types/jc';
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- legacy Seerr payload shapes; typed incrementally */
 
@@ -10,8 +11,8 @@ import { isSafeLinkBase } from '../core/url-safe';
  * legacy Seerr payloads — typed loosely until the typed-model phase.
  */
 export interface SeerrApi {
-    checkUserStatus: () => Promise<any>;
-    surfaceUserStatusBanner: (status: any) => void;
+    checkUserStatus: () => Promise<SeerrUserStatus>;
+    surfaceUserStatusBanner: (status: SeerrUserStatus) => void;
     clearUserStatusCache: () => void;
     search: (query: string, page?: number, options?: any) => Promise<any>;
     fetchMovieCollection: (tmdbId: any) => Promise<any>;
@@ -19,7 +20,7 @@ export interface SeerrApi {
     fetchTvShowDetails: (tmdbId: any, options?: any) => Promise<any>;
     fetchTvSeasonDetails: (tmdbId: any, seasonNumber: any) => Promise<any>;
     fetchTmdbTvDetails: (tmdbId: any) => Promise<any>;
-    fetchOverrideRules: () => Promise<any[]>;
+    fetchOverrideRules: () => Promise<SeerrOverrideRule[]>;
     getCurrentSeerrUserId: () => Promise<string | null>;
     evaluateOverrideRules: (mediaData: any, mediaType: any, is4k?: boolean) => Promise<any>;
     requestMedia: (tmdbId: any, mediaType: any, advancedSettings?: any, is4k?: boolean, mediaData?: any) => Promise<any>;
@@ -47,6 +48,20 @@ export interface SeerrApi {
      * resolves. The single source of truth for every 4K UI gate.
      */
     canRequest4k: (mediaType: any) => boolean;
+}
+
+export interface SeerrUserStatus {
+    active: boolean;
+    userFound: boolean;
+    reason?: string;
+    message?: string;
+    seerrUserId?: string | number | null;
+    canRequest4kMovie?: boolean;
+    canRequest4kTv?: boolean;
+}
+
+export interface SeerrOverrideRule {
+    [key: string]: any;
 }
 
 /**
@@ -102,8 +117,9 @@ const api = {} as SeerrApi;
 // sections to disappear for the entire SPA session after a single transient
 // error. Now we keep success results for the SPA session but only cache
 // negatives for 60 seconds so transient blips recover automatically.
-let cachedUserStatus: any = null;
+let cachedUserStatus: SeerrUserStatus | null = null;
 let cachedUserStatusAt = 0;
+let cachedUserStatusEpoch: number | null = null;
 const NEGATIVE_USER_STATUS_TTL_MS = 60 * 1000;
 // PERF(R9): a TRANSIENT transport failure (no answer from the server at all)
 // is remembered even more briefly than a genuine negative answer — one blip
@@ -113,9 +129,35 @@ const ERROR_USER_STATUS_TTL_MS = 10 * 1000;
 let cachedUserStatusTtl = NEGATIVE_USER_STATUS_TTL_MS;
 
 // Cache for override rules
-let cachedOverrideRules: any[] | null = null;
+let cachedOverrideRules: SeerrOverrideRule[] | null = null;
 let overrideRulesCachedAt = 0;
+let overrideRulesEpoch: number | null = null;
 const OVERRIDE_RULES_TTL = 5 * 60 * 1000; // 5 minutes
+
+function identityChangedError(): Error {
+    return new Error('Seerr operation belongs to a stale identity');
+}
+
+function captureIdentity(): IdentityContext {
+    const context = JC.identity.capture();
+    if (!context || !JC.identity.isCurrent(context)) throw identityChangedError();
+    return context;
+}
+
+function assertCurrentIdentity(context: IdentityContext): void {
+    if (!JC.identity.isCurrent(context)) throw identityChangedError();
+}
+
+function resetIdentityCaches(): void {
+    cachedUserStatus = null;
+    cachedUserStatusAt = 0;
+    cachedUserStatusEpoch = null;
+    cachedUserStatusTtl = NEGATIVE_USER_STATUS_TTL_MS;
+    cachedOverrideRules = null;
+    overrideRulesCachedAt = 0;
+    overrideRulesEpoch = null;
+    delete window.__JE_userStatusBannerShown;
+}
 
 /**
  * Internal fetch helper — delegates to the shared core API client, which
@@ -225,7 +267,8 @@ function emitMediaRequested(tmdbId: any, mediaType: any, is4k = false): void {
  * @returns {Promise<{active: boolean, userFound: boolean}>}
  */
 api.checkUserStatus = async function() {
-    if (cachedUserStatus !== null) {
+    const context = captureIdentity();
+    if (cachedUserStatus !== null && cachedUserStatusEpoch === context.epoch) {
         // Successful result is sticky for the SPA session.
         if (cachedUserStatus.active && cachedUserStatus.userFound) {
             return cachedUserStatus;
@@ -239,27 +282,38 @@ api.checkUserStatus = async function() {
     }
 
     try {
-        const status = await get('/user-status', { skipCache: true });
+        const status = await get('/user-status', { skipCache: true }) as unknown as SeerrUserStatus;
+        assertCurrentIdentity(context);
         cachedUserStatus = status;
         cachedUserStatusAt = Date.now();
+        cachedUserStatusEpoch = context.epoch;
         cachedUserStatusTtl = NEGATIVE_USER_STATUS_TTL_MS;
         // Surface the typed reason as a banner so users aren't left staring
         // at silently-hidden discovery sections.
         api.surfaceUserStatusBanner(status);
         return status;
-    } catch (error: any) {
+    } catch (error: unknown) {
+        assertCurrentIdentity(context);
         console.warn(`${logPrefix} Status check failed:`, error);
+        const errorShape = error && typeof error === 'object'
+            ? error as { responseJSON?: unknown }
+            : null;
+        const response = errorShape?.responseJSON && typeof errorShape.responseJSON === 'object'
+            ? errorShape.responseJSON as { code?: unknown; message?: unknown }
+            : undefined;
+        const responseCode = typeof response?.code === 'string' ? response.code : null;
         const fallback = {
             active: false,
             userFound: false,
-            reason: error?.responseJSON?.code || 'unreachable',
-            message: error?.responseJSON?.message
-        };
+            reason: responseCode || 'unreachable',
+            message: typeof response?.message === 'string' ? response.message : undefined
+        } satisfies SeerrUserStatus;
         cachedUserStatus = fallback;
         cachedUserStatusAt = Date.now();
+        cachedUserStatusEpoch = context.epoch;
         // PERF(R9): a typed business answer keeps the normal negative TTL; a
         // bare transport failure (nothing came back) expires fast.
-        cachedUserStatusTtl = error?.responseJSON?.code ? NEGATIVE_USER_STATUS_TTL_MS : ERROR_USER_STATUS_TTL_MS;
+        cachedUserStatusTtl = responseCode ? NEGATIVE_USER_STATUS_TTL_MS : ERROR_USER_STATUS_TTL_MS;
         api.surfaceUserStatusBanner(fallback);
         return fallback;
     }
@@ -275,8 +329,10 @@ api.surfaceUserStatusBanner = function(status) {
         if (!status || (status.active && status.userFound)) return;
         if (status.reason === 'disabled') return;
         // Don't double-surface within a single session.
-        if (window.__JE_userStatusBannerShown === status.reason) return;
-        window.__JE_userStatusBannerShown = status.reason;
+        const reason = status.reason || 'unknown';
+        const bannerKey = `${JC.identity.getEpoch()}:${reason}`;
+        if (window.__JE_userStatusBannerShown === bannerKey) return;
+        window.__JE_userStatusBannerShown = bannerKey;
 
         const reasons: Record<string, string> = {
             blocked: 'Your administrator has disabled Seerr for your account.',
@@ -288,7 +344,7 @@ api.surfaceUserStatusBanner = function(status) {
         // from SeerrHttpHelper.ToResponseShape, which uses UserMessage
         // (plain English, no URLs / cf-ray / proxy product names). Still
         // HTML-escape it before insertion as defence-in-depth.
-        const rawMsg = status.message || reasons[status.reason] || 'Seerr is unavailable right now.';
+        const rawMsg = status.message || reasons[reason] || 'Seerr is unavailable right now.';
         const msg = (typeof JC !== 'undefined' && typeof JC.escapeHtml === 'function')
             ? JC.escapeHtml(rawMsg)
             : String(rawMsg).replace(/[&<>"']/g, function(c){return ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#039;'} as Record<string, string>)[c];});
@@ -311,6 +367,7 @@ api.surfaceUserStatusBanner = function(status) {
 api.clearUserStatusCache = function() {
     cachedUserStatus = null;
     cachedUserStatusAt = 0;
+    cachedUserStatusEpoch = null;
 };
 
 /**
@@ -329,18 +386,17 @@ api.canRequest4k = function(mediaType) {
         : !!JC.pluginConfig.SeerrEnable4KRequests;
     if (!adminEnabled) return false;
 
-    const status = cachedUserStatus as {
-        active?: boolean;
-        userFound?: boolean;
-        canRequest4kMovie?: boolean;
-        canRequest4kTv?: boolean;
-    } | null;
-    if (!status || !status.active || !status.userFound) {
+    const status = cachedUserStatus;
+    const context = JC.identity.capture();
+    if (!context || cachedUserStatusEpoch !== context.epoch
+        || !status || !status.active || !status.userFound) {
         // Capability not resolved yet — hide for now rather than showing an option
         // the server may reject. Callers resolve status before rendering, so this
         // path is belt-and-suspenders; the fire-and-forget fetch just guards against
         // a stray early call leaving the capability permanently unresolved.
-        if (cachedUserStatus === null) { void api.checkUserStatus(); }
+        if (cachedUserStatus === null || cachedUserStatusEpoch !== context?.epoch) {
+            void api.checkUserStatus().catch(() => undefined);
+        }
         return false;
     }
     return isTv ? !!status.canRequest4kTv : !!status.canRequest4kMovie;
@@ -487,17 +543,24 @@ api.fetchTmdbTvDetails = async function(tmdbId) {
  * @returns {Promise<Array>}
  */
 api.fetchOverrideRules = async function() {
-    if (cachedOverrideRules !== null && Date.now() - overrideRulesCachedAt < OVERRIDE_RULES_TTL) {
+    const context = captureIdentity();
+    if (cachedOverrideRules !== null && overrideRulesEpoch === context.epoch
+        && Date.now() - overrideRulesCachedAt < OVERRIDE_RULES_TTL) {
         return cachedOverrideRules;
     }
     try {
         const rules = await get('/overrideRule');
-        cachedOverrideRules = Array.isArray(rules) ? rules : [];
+        assertCurrentIdentity(context);
+        cachedOverrideRules = Array.isArray(rules)
+            ? rules as SeerrOverrideRule[]
+            : [];
         overrideRulesCachedAt = Date.now();
+        overrideRulesEpoch = context.epoch;
         return cachedOverrideRules;
     } catch (error: any) {
+        assertCurrentIdentity(context);
         console.error(`${logPrefix} Failed to fetch override rules:`, error);
-        return cachedOverrideRules || [];
+        return overrideRulesEpoch === context.epoch ? (cachedOverrideRules || []) : [];
     }
 };
 
@@ -648,37 +711,43 @@ api.evaluateOverrideRules = async function(mediaData, mediaType, is4k = false) {
  * @returns {Promise<any>}
  */
 api.requestMedia = async function(tmdbId, mediaType, advancedSettings = {}, is4k = false, mediaData = null) {
+    const context = captureIdentity();
     // Apply override rules if no advanced settings are provided and media data is available
     if (Object.keys(advancedSettings).length === 0 && mediaData) {
         const overrideSettings = await api.evaluateOverrideRules(mediaData, mediaType, is4k);
+        assertCurrentIdentity(context);
         if (overrideSettings) {
             console.debug(`${logPrefix} Applying override rule settings:`, overrideSettings);
             advancedSettings = { ...overrideSettings };
         }
     }
 
-    const body = {
-        mediaType,
-        mediaId: parseInt(tmdbId),
-        ...advancedSettings,
+    const body = JC.identity.own({
+        mediaType: mediaType as unknown,
+        mediaId: Number.parseInt(String(tmdbId), 10),
+        ...(advancedSettings as unknown as Record<string, unknown>),
         ...(mediaType === 'tv' ? { seasons: 'all' } : {}),
         ...(is4k ? { is4k: true } : {})
-    };
+    } satisfies Record<string, unknown>, context);
 
     const result = await post('/request', body);
+    assertCurrentIdentity(context);
 
     // Add to watchlist after successful request
     if (result) {
         invalidateRequestCaches(tmdbId, mediaType);
         emitMediaRequested(tmdbId, mediaType, is4k);
+        assertCurrentIdentity(context);
         try {
             await api.addToWatchlist(tmdbId, mediaType);
+            assertCurrentIdentity(context);
         } catch (error: any) {
             // Don't fail the request if watchlist addition fails
             console.warn(`${logPrefix} Failed to add to watchlist:`, error);
         }
     }
 
+    assertCurrentIdentity(context);
     return result;
 };
 
@@ -692,36 +761,42 @@ api.requestMedia = async function(tmdbId, mediaType, advancedSettings = {}, is4k
  * @returns {Promise<any>}
  */
 api.requestTvSeasons = async function(tmdbId, seasonNumbers, advancedSettings = {}, mediaData = null, is4k = false) {
+    const context = captureIdentity();
     // Apply override rules if no advanced settings are provided and media data is available
     if (Object.keys(advancedSettings).length === 0 && mediaData) {
         const overrideSettings = await api.evaluateOverrideRules(mediaData, 'tv', is4k);
+        assertCurrentIdentity(context);
         if (overrideSettings) {
             console.debug(`${logPrefix} Applying override rule settings for TV seasons:`, overrideSettings);
             advancedSettings = { ...overrideSettings };
         }
     }
 
-    const body = {
+    const body = JC.identity.own({
         mediaType: 'tv',
-        mediaId: parseInt(tmdbId),
-        seasons: seasonNumbers,
-        ...advancedSettings,
+        mediaId: Number.parseInt(String(tmdbId), 10),
+        seasons: seasonNumbers as unknown,
+        ...(advancedSettings as unknown as Record<string, unknown>),
         ...(is4k ? { is4k: true } : {})
-    };
+    } satisfies Record<string, unknown>, context);
     const result = await post('/request', body);
+    assertCurrentIdentity(context);
 
     // Add to watchlist after successful request
     if (result) {
         invalidateRequestCaches(tmdbId, 'tv');
         emitMediaRequested(tmdbId, 'tv', is4k);
+        assertCurrentIdentity(context);
         try {
             await api.addToWatchlist(tmdbId, 'tv');
+            assertCurrentIdentity(context);
         } catch (error: any) {
             // Don't fail the request if watchlist addition fails
             console.warn(`${logPrefix} Failed to add to watchlist:`, error);
         }
     }
 
+    assertCurrentIdentity(context);
     return result;
 };
 
@@ -736,6 +811,7 @@ api.requestTvSeasons = async function(tmdbId, seasonNumbers, advancedSettings = 
  * @returns {Promise<{pageInfo?: object, results: Array}>}
  */
 api.fetchIssuesForMedia = async function(tmdbId, mediaType, options = {}) {
+    const context = captureIdentity();
     const { take = 20, skip = 0, filter = 'open', sort = 'added' } = options;
     try {
         const query = new URLSearchParams({
@@ -746,6 +822,7 @@ api.fetchIssuesForMedia = async function(tmdbId, mediaType, options = {}) {
         });
 
         const res = await get(`/issue?${query.toString()}`);
+        assertCurrentIdentity(context);
         const issues = res && Array.isArray(res.results) ? res.results : [];
 
         const filtered = issues.filter((issue: any) => {
@@ -757,6 +834,7 @@ api.fetchIssuesForMedia = async function(tmdbId, mediaType, options = {}) {
 
         return { ...res, results: filtered };
     } catch (error: any) {
+        assertCurrentIdentity(context);
         console.error(`${logPrefix} Failed to fetch issues for ${mediaType} ${tmdbId}:`, error);
         return { results: [] };
     }
@@ -768,10 +846,13 @@ api.fetchIssuesForMedia = async function(tmdbId, mediaType, options = {}) {
  * @returns {Promise<object|null>}
  */
 api.fetchIssueById = async function(issueId) {
+    const context = captureIdentity();
     try {
         const res = await get(`/issue/${issueId}`);
+        assertCurrentIdentity(context);
         return res || null;
     } catch (error: any) {
+        assertCurrentIdentity(context);
         console.warn(`${logPrefix} Failed to fetch issue ${issueId}:`, error);
         return null;
     }
@@ -910,6 +991,7 @@ api.addToWatchlist = async function(tmdbId, mediaType) {
 // parses the numeric value and forwards it to Seerr.
 
 api.reportIssue = async function(mediaId, mediaType, problemType, message = '', problemSeason = 0, problemEpisode = 0) {
+    const context = captureIdentity();
     try {
         // problemType is now a numeric issue type (1, 2, 3, or 4) from the form
         const issueType = parseInt(problemType) || 4;
@@ -922,6 +1004,7 @@ api.reportIssue = async function(mediaId, mediaType, problemType, message = '', 
         } else if (mediaType === 'tv') {
             apiResult = await get(`/tv/${mediaId}`);
         }
+        assertCurrentIdentity(context);
 
         const internalId = apiResult && apiResult.mediaInfo && apiResult.mediaInfo.id;
         if (!internalId) {
@@ -929,19 +1012,21 @@ api.reportIssue = async function(mediaId, mediaType, problemType, message = '', 
         }
         console.debug(`${logPrefix} Retrieved internal media id for issue report:`, internalId);
 
-        const body = {
+        const body = JC.identity.own({
             mediaId: parseInt(internalId),
             issueType: issueType,
             problemSeason: parseInt(problemSeason) || 0,
             problemEpisode: parseInt(problemEpisode) || 0,
             message: message || ''
-        };
+        }, context);
 
         console.debug(`${logPrefix} Sending issue report with body:`, body);
         const result = await post('/issue', body);
+        assertCurrentIdentity(context);
         console.debug(`${logPrefix} Issue reported for Seerr media ID ${internalId} (TMDB ${mediaId}, ${mediaType}): ${problemType}`);
         return result;
     } catch (error: any) {
+        assertCurrentIdentity(context);
         console.error(`${logPrefix} Failed to report issue for TMDB ID ${mediaId}:`, error);
         throw error;
     }
@@ -1060,3 +1145,4 @@ api.resolveSeerrBaseUrl = function() {
 
 // Expose the API module on the global JC object
 JC.seerrAPI = api;
+JC.identity.registerReset('seerr-api', resetIdentityCaches);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/base.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/base.identity.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+
+function deferred(): { promise: Promise<void>; resolve(): void } {
+    let resolve!: () => void;
+    const promise = new Promise<void>((done) => { resolve = done; });
+    return { promise, resolve };
+}
+
+describe('Seerr discovery controller identity lifecycle', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        JC.identity.transition('server-a', 'user-a', 'discovery-base-test-start');
+        JC.pluginConfig = {};
+    });
+
+    it('removes A synchronously, drops held A, and renders B on activation', async () => {
+        const heldA = deferred();
+        let call = 0;
+        await import('./base');
+        const controller = JC.discoveryBase!.createDiscovery({
+            key: 'identity-test',
+            mode: 'one-shot',
+            logLabel: 'Identity Test',
+            configKey: 'IdentityTestEnabled',
+            getIdFromUrl: () => 'same-item',
+            renderOneShot: vi.fn(async ({ signal }: { signal: AbortSignal }) => {
+                call++;
+                if (call === 1) await heldA.promise;
+                if (signal.aborted) return false;
+                const section = document.createElement('div');
+                section.className = 'seerr-identity-test-discovery-section';
+                section.textContent = call === 1 ? 'account-a' : 'account-b';
+                document.body.appendChild(section);
+                return true;
+            }),
+        });
+
+        const staleSection = document.createElement('div');
+        staleSection.className = 'seerr-identity-test-discovery-section';
+        staleSection.textContent = 'visible-a';
+        document.body.appendChild(staleSection);
+        const first = controller.render();
+        await vi.waitFor(() => expect(call).toBe(1));
+
+        const contextB = JC.identity.transition('server-a', 'user-b', 'account-switch');
+        expect(document.querySelector('.seerr-identity-test-discovery-section')).toBeNull();
+        heldA.resolve();
+        await first;
+        expect(document.body.textContent).not.toContain('account-a');
+
+        await JC.identity.activate(contextB);
+        await vi.waitFor(() => expect(call).toBe(2));
+        await vi.waitFor(() => expect(document.body.textContent).toContain('account-b'));
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/base.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/base.ts
@@ -20,6 +20,7 @@
 //
 // Public surface: JC.discoveryBase { createDiscovery, idFromDetailUrl, idFromListParam }.
 import { JC } from '../../globals';
+import type { IdentityContext } from '../../types/jc';
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- legacy Seerr payload + spec shapes; typed incrementally */
 
@@ -32,9 +33,42 @@ export interface DiscoveryController {
     start: () => void;
 }
 
+interface DiscoveryResolveContext {
+    id: string;
+    signal: AbortSignal;
+}
+
+interface DiscoveryOneShotContext extends DiscoveryResolveContext {
+    pageKey: string;
+    waitForPageReady: (signal?: AbortSignal) => Promise<HTMLElement | null>;
+}
+
+export interface DiscoverySpec {
+    key: string;
+    mode: 'dual-feed' | 'client-paged' | 'one-shot';
+    logLabel: string;
+    configKey: string;
+    defaultEnabled?: boolean;
+    getIdFromUrl: () => string | null;
+    pageKey?: (id: string) => string;
+    resolveFeeds?: (context: DiscoveryResolveContext) => Promise<{
+        tvId?: number | null;
+        movieId?: number | null;
+        title: string;
+    } | null>;
+    buildDiscoverPath?: (kind: 'tv' | 'movie', id: number) => string;
+    resolveItems?: (context: DiscoveryResolveContext) => Promise<{
+        items: any[];
+        title: string;
+    } | null>;
+    renderOneShot?: (context: DiscoveryOneShotContext) => Promise<boolean | undefined>;
+    pageSize?: number;
+    onCleanup?: () => void;
+}
+
 /** Shared discovery chassis (JC.discoveryBase). */
 export interface DiscoveryBaseApi {
-    createDiscovery: (spec: any) => DiscoveryController;
+    createDiscovery: (spec: DiscoverySpec) => DiscoveryController;
     idFromDetailUrl: () => string | null;
     idFromListParam: (param: string) => () => string | null;
 }
@@ -119,7 +153,7 @@ function idFromListParam(param: string): () => string | null {
  * @param {DiscoverySpec} spec
  * @returns {{initialize: () => void, cleanup: () => void, render: () => Promise<void>, handlePageNavigation: () => void, start: () => void}}
  */
-function createDiscovery(spec: any): DiscoveryController {
+function createDiscovery(spec: DiscoverySpec): DiscoveryController {
     const key = spec.key;
     const logPrefix = `🪼 Jellyfin Canopy: ${spec.logLabel}:`;
     const sectionSelector = `.seerr-${key}-discovery-section`;
@@ -139,6 +173,10 @@ function createDiscovery(spec: any): DiscoveryController {
     let currentAbortController: AbortController | null = null;
     /** @type {string|null} */
     let currentRenderingPageKey: string | null = null;
+    let renderGeneration = 0;
+    let initialized = false;
+    let started = false;
+    const renderFrames = new Set<number>();
 
     // ---- Pagination state (dual-feed + client-paged) --------------------
     let isLoading = false;
@@ -203,7 +241,7 @@ function createDiscovery(spec: any): DiscoveryController {
             const sortBy = kind === 'tv'
                 ? (JC.discoveryFilter?.getTvSortMode(key) || '')
                 : (JC.discoveryFilter?.getSortMode(key) || '');
-            let path = `${spec.buildDiscoverPath(kind, feedId)}?page=${page}`;
+            let path = `${spec.buildDiscoverPath!(kind, feedId)}?page=${page}`;
             if (sortBy) path += `&sortBy=${encodeURIComponent(sortBy)}`;
             const response = await fetchWithManagedRequest(path, { signal });
             if (signal?.aborted) {
@@ -675,11 +713,16 @@ function createDiscovery(spec: any): DiscoveryController {
      * @param {AbortSignal} signal
      * @param {string} pageKey
      */
-    async function renderDualFeed(id: string, signal: AbortSignal, pageKey: string): Promise<void> {
+    async function renderDualFeed(
+        id: string,
+        signal: AbortSignal,
+        pageKey: string,
+        context: IdentityContext
+    ): Promise<void> {
         const pageReadyPromise = waitForPageReady(signal);
 
-        const resolved = await spec.resolveFeeds({ id, signal });
-        if (signal.aborted) return;
+        const resolved = await spec.resolveFeeds!({ id, signal });
+        if (signal.aborted || !JC.identity.isCurrent(context)) return;
         if (!resolved || (!resolved.tvId && !resolved.movieId)) return;
 
         // Reset pagination state
@@ -718,7 +761,7 @@ function createDiscovery(spec: any): DiscoveryController {
             pageReadyPromise
         ]);
 
-        if (signal.aborted) return;
+        if (signal.aborted || !JC.identity.isCurrent(context)) return;
 
         // Process results
         fetchResults.forEach((r: any) => {
@@ -758,7 +801,14 @@ function createDiscovery(spec: any): DiscoveryController {
         const existing = document.querySelector(sectionSelector);
         if (existing) existing.remove();
 
-        const section = createSectionContainer(resolved.title, hasBoth, handleFilterChange, handleSortChange);
+        const section = createSectionContainer(
+            resolved.title,
+            hasBoth,
+            (mode) => { if (JC.identity.isCurrent(context)) handleFilterChange(mode); },
+            () => JC.identity.isCurrent(context) ? handleSortChange() : undefined
+        );
+        section.setAttribute('data-jc-identity-owned', 'true');
+        JC.identity.own(section, context);
         const itemsContainer = section.querySelector('.itemsContainer')!;
 
         const fragment = createCardsFragment(displayResults);
@@ -795,9 +845,14 @@ function createDiscovery(spec: any): DiscoveryController {
      * @param {AbortSignal} signal
      * @param {string} pageKey
      */
-    async function renderClientPaged(id: string, signal: AbortSignal, pageKey: string): Promise<void> {
-        const resolved = await spec.resolveItems({ id, signal });
-        if (signal.aborted) return;
+    async function renderClientPaged(
+        id: string,
+        signal: AbortSignal,
+        pageKey: string,
+        context: IdentityContext
+    ): Promise<void> {
+        const resolved = await spec.resolveItems!({ id, signal });
+        if (signal.aborted || !JC.identity.isCurrent(context)) return;
         if (!resolved || !resolved.items || resolved.items.length === 0) return;
 
         // Store all results for filter switching
@@ -823,7 +878,7 @@ function createDiscovery(spec: any): DiscoveryController {
 
         // Wait for page content
         const detailSection = await waitForPageReady(signal);
-        if (signal.aborted) return;
+        if (signal.aborted || !JC.identity.isCurrent(context)) return;
 
         if (!detailSection) {
             console.debug(`${logPrefix} Could not find detail section to insert into`);
@@ -835,7 +890,14 @@ function createDiscovery(spec: any): DiscoveryController {
         if (existing) existing.remove();
 
         // Create and insert section
-        const section = createSectionContainer(resolved.title, hasBoth, handleFilterChange, handleSortChange);
+        const section = createSectionContainer(
+            resolved.title,
+            hasBoth,
+            (mode) => { if (JC.identity.isCurrent(context)) handleFilterChange(mode); },
+            () => JC.identity.isCurrent(context) ? handleSortChange() : undefined
+        );
+        section.setAttribute('data-jc-identity-owned', 'true');
+        JC.identity.own(section, context);
         const itemsContainer = section.querySelector('.itemsContainer')!;
 
         // Seed first page and let seamless scroll load the rest.
@@ -873,6 +935,8 @@ function createDiscovery(spec: any): DiscoveryController {
      * error handling.
      */
     async function render(): Promise<void> {
+        const context = JC.identity.capture();
+        if (!context) return;
         const id = spec.getIdFromUrl();
         if (!id) return;
 
@@ -888,6 +952,7 @@ function createDiscovery(spec: any): DiscoveryController {
 
         // Set rendering key before potentially aborting
         currentRenderingPageKey = pageKey;
+        const generation = ++renderGeneration;
 
         // Cancel any previous requests (for different pages)
         if (currentAbortController) {
@@ -903,18 +968,23 @@ function createDiscovery(spec: any): DiscoveryController {
 
         try {
             if (isDualFeed) {
-                await renderDualFeed(id, signal, pageKey);
+                await renderDualFeed(id, signal, pageKey, context);
             } else if (isClientPaged) {
-                await renderClientPaged(id, signal, pageKey);
+                await renderClientPaged(id, signal, pageKey, context);
             } else {
-                const rendered = await spec.renderOneShot({
+                const rendered = await spec.renderOneShot!({
                     id,
                     pageKey,
                     signal,
                     waitForPageReady
                 });
-                if (signal.aborted) return;
+                if (signal.aborted || !JC.identity.isCurrent(context)) return;
                 if (rendered) {
+                    const section = document.querySelector<HTMLElement>(sectionSelector);
+                    if (section) {
+                        section.setAttribute('data-jc-identity-owned', 'true');
+                        JC.identity.own(section, context);
+                    }
                     // Mark as processed
                     processedPages.add(pageKey);
 
@@ -933,12 +1003,13 @@ function createDiscovery(spec: any): DiscoveryController {
             console.error(`${logPrefix} Error rendering ${key} discovery:`, error);
         } finally {
             // Clear rendering key after completion (success, abort, or failure)
-            currentRenderingPageKey = null;
+            if (renderGeneration === generation) currentRenderingPageKey = null;
         }
     }
 
     /** Cleanup function — aborts in-flight requests and resets state. */
     function cleanup() {
+        renderGeneration++;
         if (currentAbortController) {
             currentAbortController.abort();
             currentAbortController = null;
@@ -961,6 +1032,9 @@ function createDiscovery(spec: any): DiscoveryController {
         renderedCount = 0;
 
         currentRenderingPageKey = null;
+        for (const frame of renderFrames) cancelAnimationFrame(frame);
+        renderFrames.clear();
+        document.querySelectorAll(sectionSelector).forEach((section) => section.remove());
 
         // Clear cached results
         cachedTvResults = [];
@@ -985,14 +1059,22 @@ function createDiscovery(spec: any): DiscoveryController {
 
     /** Handles page navigation — renders when the URL matches the module. */
     function handlePageNavigation() {
+        const context = JC.identity.capture();
+        if (!context) return;
         const id = spec.getIdFromUrl();
         if (id) {
-            requestAnimationFrame(() => { void render(); });
+            const frame = requestAnimationFrame(() => {
+                renderFrames.delete(frame);
+                if (JC.identity.isCurrent(context)) void render();
+            });
+            renderFrames.add(frame);
         }
     }
 
     /** Initialize navigation listeners + lifecycle teardown wiring. */
     function initialize() {
+        if (initialized) return;
+        initialized = true;
         // Lifecycle: run cleanup() on EVERY navigation — hashchange, popstate
         // AND the pushState transitions the old raw hashchange listener
         // missed. Registration order matters: the teardown wiring is
@@ -1009,12 +1091,17 @@ function createDiscovery(spec: any): DiscoveryController {
 
     /** Run initialize now, or on DOMContentLoaded if still loading. */
     function start() {
+        if (started) return;
+        started = true;
         if (document.readyState === 'loading') {
             document.addEventListener('DOMContentLoaded', initialize);
         } else {
             initialize();
         }
     }
+
+    JC.identity.registerReset(`seerr-${key}-discovery`, cleanup);
+    JC.identity.registerActivate(`seerr-${key}-discovery`, () => handlePageNavigation());
 
     return { initialize, cleanup, render, handlePageNavigation, start };
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/filter-utils.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/filter-utils.identity.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+
+describe('discovery managed request identity paving', () => {
+    let jf: ReturnType<typeof vi.fn>;
+    let getCached: ReturnType<typeof vi.fn>;
+    let setCache: ReturnType<typeof vi.fn>;
+    let fetchWithRetry: ReturnType<typeof vi.fn>;
+
+    beforeEach(async () => {
+        vi.resetModules();
+        jf = vi.fn().mockResolvedValue({ results: ['current'] });
+        getCached = vi.fn();
+        setCache = vi.fn();
+        fetchWithRetry = vi.fn();
+        JC.core.api = {
+            jf,
+        } as unknown as NonNullable<typeof JC.core.api>;
+        JC.requestManager = {
+            getCached,
+            setCache,
+            fetchWithRetry,
+        } as unknown as NonNullable<typeof JC.requestManager>;
+        await import('./filter-utils');
+    });
+
+    it('delegates parsing, cache publication, and identity fencing to core API', async () => {
+        const signal = new AbortController().signal;
+        const result: unknown = await JC.discoveryFilter!.fetchWithManagedRequest(
+            '/JellyfinCanopy/tmdb/genres/movie',
+            'genre',
+            { signal },
+        );
+
+        expect(result).toEqual({ results: ['current'] });
+        expect(jf).toHaveBeenCalledWith(
+            '/JellyfinCanopy/tmdb/genres/movie',
+            {
+                signal,
+                cacheKey: 'genre:/JellyfinCanopy/tmdb/genres/movie',
+            },
+        );
+        expect(getCached).not.toHaveBeenCalled();
+        expect(setCache).not.toHaveBeenCalled();
+        expect(fetchWithRetry).not.toHaveBeenCalled();
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/filter-utils.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/filter-utils.ts
@@ -23,12 +23,16 @@ export interface DiscoveryFilterApi {
     createFilterControl: (moduleName: string, onFilterChange: (mode: string) => void) => HTMLElement;
     createSortControl: (moduleName: string, onSortChange: (sort: string) => void | Promise<void>) => HTMLElement;
     createSectionHeader: (title: string, moduleName: string, showFilter: boolean, onFilterChange: (mode: string) => void, onSortChange?: (sort: string) => void | Promise<void>) => HTMLElement;
-    fetchWithManagedRequest: (path: string, cachePrefix: string, options?: any) => Promise<any>;
+    fetchWithManagedRequest: (path: string, cachePrefix: string, options?: ManagedRequestOptions) => Promise<any>;
     createCardsFragment: (results: any[], options?: any) => DocumentFragment;
     waitForPageReady: (signal?: AbortSignal, options?: any) => Promise<any>;
     setupInfiniteScroll: (state: any, sectionSelector: string, loadMoreFn: () => Promise<void>, hasMoreCheck: () => boolean, isLoadingCheck: () => boolean) => void;
     cleanupScrollObserver: (state: any) => void;
     applyFilterVisibility: (container: HTMLElement | null, mode: string) => void;
+}
+
+interface ManagedRequestOptions {
+    signal?: AbortSignal;
 }
 
 declare module '../../types/jc' {
@@ -46,6 +50,11 @@ const FILTER_MODES = {
 };
 const runtimeFilterModes = new Map<string, string>();
 const runtimeSortModes = new Map<string, string>();
+
+JC.identity.registerReset('seerr-discovery-filter', () => {
+    runtimeFilterModes.clear();
+    runtimeSortModes.clear();
+});
 
 const SORT_OPTIONS = [
     { value: '', label: 'Popular' },
@@ -378,42 +387,19 @@ function createSectionHeader(title: string, moduleName: string, showFilter: bool
  * @param {object} [options] - Fetch options including signal
  * @returns {Promise<any>}
  */
-async function fetchWithManagedRequest(path: string, cachePrefix: string, options: any = {}): Promise<any> {
-    const url = ApiClient.getUrl(path);
+async function fetchWithManagedRequest(
+    path: string,
+    cachePrefix: string,
+    options: ManagedRequestOptions = {}
+): Promise<any> {
     const { signal } = options;
-
-    const requestManager = JC.requestManager;
-    if (requestManager) {
-        const cacheKey = `${cachePrefix}:${path}`;
-        const cached = requestManager.getCached(cacheKey);
-        if (cached) return cached;
-
-        const fetchFn = async () => {
-            const response = await requestManager.fetchWithRetry(url, {
-                method: 'GET',
-                headers: {
-                    'X-Jellyfin-User-Id': ApiClient.getCurrentUserId(),
-                    'Authorization': 'MediaBrowser Token="' + ApiClient.accessToken() + '"',
-                    'Accept': 'application/json'
-                },
-                signal
-            });
-            const data = await response.json();
-            requestManager.setCache(cacheKey, data);
-            return data;
-        };
-
-        return requestManager.withConcurrencyLimit(() =>
-            requestManager.deduplicatedFetch(cacheKey, fetchFn)
-        );
-    }
-
-    // Fallback to ApiClient.ajax
-    return ApiClient.ajax({
-        type: 'GET',
-        url: url,
-        headers: { 'X-Jellyfin-User-Id': ApiClient.getCurrentUserId() },
-        dataType: 'json'
+    // The core paved road owns auth, per-identity cache keys, parsing fences,
+    // abort-on-transition, dedup and concurrency. Calling manager primitives
+    // directly here previously allowed an unsignalled A response to parse and
+    // setCache after B had become current.
+    return JC.core.api!.jf(path, {
+        signal,
+        cacheKey: `${cachePrefix}:${path}`,
     });
 }
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/genre.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/genre.ts
@@ -163,7 +163,11 @@ const discovery = JC.discoveryBase!.createDiscovery({
     resolveFeeds,
     buildDiscoverPath: (kind: string, id: number) => kind === 'tv'
         ? `/JellyfinCanopy/seerr/discover/tv/genre/${id}`
-        : `/JellyfinCanopy/seerr/discover/movies/genre/${id}`
+        : `/JellyfinCanopy/seerr/discover/movies/genre/${id}`,
+    onCleanup: () => {
+        genreInfoCache.clear();
+        tmdbGenreCache = null;
+    }
 });
 
 discovery.start();

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/network.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/network.ts
@@ -227,7 +227,11 @@ const discovery = JC.discoveryBase!.createDiscovery({
     resolveFeeds,
     buildDiscoverPath: (kind: string, id: number) => kind === 'tv'
         ? `/JellyfinCanopy/seerr/discover/tv/network/${id}`
-        : `/JellyfinCanopy/seerr/discover/movies/studio/${id}`
+        : `/JellyfinCanopy/seerr/discover/movies/studio/${id}`,
+    onCleanup: () => {
+        networkIdCache.clear();
+        studioInfoCache.clear();
+    }
 });
 
 discovery.start();

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/person.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/person.ts
@@ -215,7 +215,11 @@ const discovery = JC.discoveryBase!.createDiscovery({
     configKey: 'SeerrShowPersonDiscovery',
     getIdFromUrl: JC.discoveryBase!.idFromDetailUrl,
     pageSize: 40,
-    resolveItems
+    resolveItems,
+    onCleanup: () => {
+        personIdCache.clear();
+        personInfoCache.clear();
+    }
 });
 
 discovery.start();

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/tag.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/tag.ts
@@ -108,7 +108,8 @@ const discovery = JC.discoveryBase!.createDiscovery({
     resolveFeeds,
     buildDiscoverPath: (kind: string, id: number) => kind === 'tv'
         ? `/JellyfinCanopy/seerr/discover/tv/keyword/${id}`
-        : `/JellyfinCanopy/seerr/discover/movies/keyword/${id}`
+        : `/JellyfinCanopy/seerr/discover/movies/keyword/${id}`,
+    onCleanup: () => keywordIdCache.clear()
 });
 
 discovery.start();

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/issue-reporter.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/issue-reporter.identity.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../globals';
+
+describe('Seerr issue reporter identity fencing', () => {
+    let originalIdentity = JC.identity.capture()!;
+
+    beforeEach(async () => {
+        vi.resetModules();
+        originalIdentity = JC.identity.capture()!;
+        JC.pluginConfig = { SeerrShowIssueIndicator: true };
+        JC.t = (key: string) => key;
+        JC.escapeHtml = (value: unknown) => String(value);
+        JC.toast = vi.fn();
+        await import('./issue-reporter');
+    });
+
+    afterEach(() => {
+        JC.identity.transition(
+            originalIdentity.serverId,
+            originalIdentity.userId,
+            'issue-reporter-test-restore',
+        );
+        document.body.innerHTML = '';
+    });
+
+    it('removes A button synchronously and ignores its late issue indicator', async () => {
+        let resolveIssues!: (value: unknown) => void;
+        JC.seerrAPI = {
+            fetchIssuesForMedia: vi.fn(() => new Promise((resolve) => { resolveIssues = resolve; })),
+        } as unknown as NonNullable<typeof JC.seerrAPI>;
+        const button = document.createElement('button');
+        document.body.appendChild(button);
+
+        const pending = JC.seerrIssueReporter!.applyIssueIndicator(button, '42', 'movie');
+        JC.identity.transition('server-b', 'user-b', 'issue-indicator-race');
+        expect(button.isConnected).toBe(false);
+
+        resolveIssues({ results: [{ id: 1 }] });
+        await pending;
+        expect(button.querySelector('.seerr-issue-count-badge')).toBeNull();
+        expect(button.classList.contains('has-open-issues')).toBe(false);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/issue-reporter.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/issue-reporter.ts
@@ -1,5 +1,6 @@
 // src/seerr/issue-reporter.ts
 import { JC } from '../globals';
+import type { IdentityContext } from '../types/jc';
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- legacy Seerr payload shapes; typed incrementally */
 
@@ -10,9 +11,9 @@ export interface SeerrIssueReporterApi {
     createReportButton: (container: any, tmdbId: any, itemName: string, mediaType: string, backdropUrl?: string | null, item?: any) => HTMLButtonElement | null;
     createUnavailableButton: (container: any, itemName: string, mediaType: string, reason?: string) => HTMLButtonElement | null;
     getTmdbIdFallback: (itemName: string, mediaType: string, item: any) => Promise<string | null>;
-    applyIssueIndicator: (button: any, tmdbId: any, mediaType: string, prefetched?: Promise<any> | null) => Promise<void>;
+    applyIssueIndicator: (button: HTMLElement, tmdbId: any, mediaType: string, prefetched?: Promise<any> | null) => Promise<void>;
     tryAddButton: () => Promise<boolean>;
-    initialize: () => Promise<void>;
+    initialize: () => void | Promise<void>;
 }
 
 declare module '../types/jc' {
@@ -28,6 +29,43 @@ const escapeHtml = JC.escapeHtml;
 
 // Cache for user permission to report
 let cachedUserCanReport: string | null = null;
+let cachedUserCanReportEpoch: number | null = null;
+let reporterListenerInstalled = false;
+let reporterViewGeneration = 0;
+let reporterInitialTimer: number | null = null;
+
+function captureReporterIdentity(): IdentityContext {
+    const context = JC.identity.capture();
+    if (!context || !JC.identity.isCurrent(context)) {
+        throw new Error('Issue reporter operation belongs to a stale identity');
+    }
+    return context;
+}
+
+function isReporterIdentityCurrent(context: IdentityContext): boolean {
+    return JC.identity.isCurrent(context);
+}
+
+function ownReporterElement<T extends HTMLElement>(element: T, context: IdentityContext): T {
+    JC.identity.own(element, context);
+    element.dataset.jcIdentityOwned = 'true';
+    return element;
+}
+
+function resetIssueReporterIdentity(): void {
+    cachedUserCanReport = null;
+    cachedUserCanReportEpoch = null;
+    reporterViewGeneration++;
+    if (reporterInitialTimer !== null) {
+        clearTimeout(reporterInitialTimer);
+        reporterInitialTimer = null;
+    }
+    document.querySelectorAll(
+        '[data-jc-identity-owned="true"], .seerr-report-issue-icon, .seerr-report-unavailable-icon, ' +
+        '.seerr-season-modal[data-jc-identity-owned="true"]'
+    ).forEach((node) => node.remove());
+    document.body.classList.remove('seerr-modal-is-open');
+}
 
 /**
  * Issue type definitions matching Seerr's 4 core issue types
@@ -47,11 +85,24 @@ const getIssueTypes = () => [
  * @returns {Promise<string>}
  */
 issueReporter.checkReportingAvailability = async function (item) {
+    const context = captureReporterIdentity();
     try {
         // Check Seerr status first
-        const statusUrl = ApiClient.getUrl('/JellyfinCanopy/seerr/status');
-        const statusRes: any = await ApiClient.ajax({ type: 'GET', url: statusUrl, dataType: 'json' });
-        const seerrActive = statusRes && statusRes.active === true;
+        let seerrActive: boolean;
+        if (cachedUserCanReportEpoch === context.epoch && cachedUserCanReport !== null) {
+            seerrActive = cachedUserCanReport === 'available';
+        } else {
+            const statusUrl = ApiClient.getUrl('/JellyfinCanopy/seerr/status');
+            const statusRes = await ApiClient.ajax({
+                type: 'GET',
+                url: statusUrl,
+                dataType: 'json'
+            }) as { active?: boolean } | null;
+            if (!isReporterIdentityCurrent(context)) throw new Error('stale identity');
+            seerrActive = statusRes?.active === true;
+            cachedUserCanReport = seerrActive ? 'available' : 'no-seerr';
+            cachedUserCanReportEpoch = context.epoch;
+        }
 
         // Resolve TMDB ID: direct, parent (for Season/Episode), or fallback search
         let tmdbId = item && (item.ProviderIds?.Tmdb || item.ProviderIds?.['Tmdb']);
@@ -66,6 +117,7 @@ issueReporter.checkReportingAvailability = async function (item) {
                     const parentItem: any = JC.helpers?.getItemCached
                         ? await JC.helpers.getItemCached(parentId, { userId })
                         : await ApiClient.getItem(userId, parentId);
+                    if (!isReporterIdentityCurrent(context)) throw new Error('stale identity');
                     tmdbId = parentItem?.ProviderIds?.Tmdb || parentItem?.ProviderIds?.['Tmdb'] || null;
                     if (tmdbId) {
                         console.debug(`${logPrefix} Availability check resolved TMDB via parent: ${tmdbId}`);
@@ -88,9 +140,11 @@ issueReporter.checkReportingAvailability = async function (item) {
         // Both available
         return 'available';
     } catch (error: any) {
+        if (!isReporterIdentityCurrent(context)) throw error;
         console.debug(`${logPrefix} Error checking reporting availability:`, error);
         // On error, assume available and let the actual request fail if needed
         cachedUserCanReport = 'available';
+        cachedUserCanReportEpoch = context.epoch;
         return 'available';
     }
 };
@@ -103,6 +157,8 @@ issueReporter.checkReportingAvailability = async function (item) {
  * @param {string} backdropUrl - Optional backdrop image URL (full URL from Jellyfin or TMDB)
  */
 issueReporter.showReportModal = function (tmdbId, itemName, mediaType, backdropUrl = null, item: any = null) {
+    const context = JC.identity.capture();
+    if (!context || !JC.identity.isCurrent(context)) return;
     // Create the form HTML
     const ISSUE_TYPES = getIssueTypes();
     const formHtml = `
@@ -165,6 +221,7 @@ issueReporter.showReportModal = function (tmdbId, itemName, mediaType, backdropU
         backdropUrl: backdropUrl,
         buttonText: JC.t!('seerr_report_issue_submit'),
         onSave: async (modalEl, button, closeModal) => {
+            if (!isReporterIdentityCurrent(context) || !modalEl.isConnected) return;
             const issueType = modalEl.querySelector<HTMLInputElement>('input[name="issue-type"]:checked')?.value;
             const message = modalEl.querySelector<HTMLTextAreaElement>('#issue-message')!.value;
 
@@ -192,6 +249,7 @@ issueReporter.showReportModal = function (tmdbId, itemName, mediaType, backdropU
 
                 // Pass only the contents of the description box to the API
                 const result = await JC.seerrAPI!.reportIssue(tmdbId, mediaType, issueType, message, problemSeason, problemEpisode);
+                if (!isReporterIdentityCurrent(context) || !modalEl.isConnected) return;
 
                 if (result) {
                     JC.toast!(JC.t!('seerr_report_issue_success'), 3000);
@@ -201,6 +259,7 @@ issueReporter.showReportModal = function (tmdbId, itemName, mediaType, backdropU
                     throw new Error('No response from API');
                 }
             } catch (error: any) {
+                if (!isReporterIdentityCurrent(context) || !modalEl.isConnected) return;
                 console.error(`${logPrefix} Error reporting issue:`, error);
                 const errorMsg = error?.message || error?.toString() || '';
                 if (error?.status === 403) {
@@ -216,6 +275,8 @@ issueReporter.showReportModal = function (tmdbId, itemName, mediaType, backdropU
         }
     });
 
+    ownReporterElement(modalElement, context);
+
     show();
 
     // Load existing issues/comments for this item
@@ -224,7 +285,9 @@ issueReporter.showReportModal = function (tmdbId, itemName, mediaType, backdropU
         const loadingEl = modalElement.querySelector('#seerr-issues-loading');
 
         const renderEmpty = (msg = JC.t!('seerr_no_issues_yet')) => {
-            if (bodyEl) bodyEl.innerHTML = `<div class="seerr-issues-empty">${msg}</div>`;
+            if (bodyEl && isReporterIdentityCurrent(context) && modalElement.isConnected) {
+                bodyEl.innerHTML = `<div class="seerr-issues-empty">${msg}</div>`;
+            }
         };
 
         const issueTypeLabels: Record<string | number, string> = {
@@ -253,6 +316,7 @@ issueReporter.showReportModal = function (tmdbId, itemName, mediaType, backdropU
         try {
             if (loadingEl) loadingEl.textContent = JC.t!('seerr_loading_issues');
             const res = await JC.seerrAPI!.fetchIssuesForMedia(tmdbId, mediaType, { take: 50, filter: 'all' });
+            if (!isReporterIdentityCurrent(context) || !modalElement.isConnected) return;
             let issues = res?.results || [];
 
             if (!issues.length) {
@@ -266,6 +330,7 @@ issueReporter.showReportModal = function (tmdbId, itemName, mediaType, backdropU
                     return full || issue;
                 } catch (_: any) { return issue; }
             }));
+            if (!isReporterIdentityCurrent(context) || !modalElement.isConnected) return;
 
             issues = enriched;
 
@@ -337,9 +402,12 @@ issueReporter.showReportModal = function (tmdbId, itemName, mediaType, backdropU
                     `;
                 }).join('');
 
-            if (bodyEl) bodyEl.innerHTML = sections;
+            if (bodyEl && isReporterIdentityCurrent(context) && modalElement.isConnected) {
+                bodyEl.innerHTML = sections;
+            }
 
         } catch (err: any) {
+            if (!isReporterIdentityCurrent(context) || !modalElement.isConnected) return;
             console.error(`${logPrefix} Failed to load existing issues:`, err);
             renderEmpty(JC.t!('seerr_load_issues_error'));
         }
@@ -349,6 +417,7 @@ issueReporter.showReportModal = function (tmdbId, itemName, mediaType, backdropU
     if (mediaType === 'tv') {
         void (async () => {
             try {
+                if (!isReporterIdentityCurrent(context) || !modalElement.isConnected) return;
                 const placeholder = modalElement.querySelector('#seerr-tv-controls-placeholder');
                 if (!placeholder) return;
 
@@ -407,6 +476,7 @@ issueReporter.showReportModal = function (tmdbId, itemName, mediaType, backdropU
                             }),
                             dataType: 'json'
                         });
+                        if (!isReporterIdentityCurrent(context) || !modalElement.isConnected) return;
 
                         const seasonsList = seasonsRes?.Items || [];
                         normalized = seasonsList.map((s: any) => ({
@@ -430,6 +500,7 @@ issueReporter.showReportModal = function (tmdbId, itemName, mediaType, backdropU
                                     }),
                                     dataType: 'json'
                                 });
+                                if (!isReporterIdentityCurrent(context) || !modalElement.isConnected) return;
                                 const eps = epsRes?.Items || [];
                                 s.episodes = eps.map((ep: any) => ({ episodeNumber: parseInt(ep.IndexNumber || ep.ParentIndexNumber || ep.Index || 0) || 0, title: ep.Name || ep.Title || '' }));
                             } catch (e: any) {
@@ -570,7 +641,9 @@ issueReporter.createReportButton = function (container, tmdbId, itemName, mediaT
         return null;
     }
 
-    const button = document.createElement('button');
+    const context = JC.identity.capture();
+    if (!context || !JC.identity.isCurrent(context)) return null;
+    const button = ownReporterElement(document.createElement('button'), context);
     button.setAttribute('is', 'emby-button');
     button.className = 'button-flat detailButton emby-button seerr-report-issue-icon';
     button.type = 'button';
@@ -585,6 +658,7 @@ issueReporter.createReportButton = function (container, tmdbId, itemName, mediaT
     button.addEventListener('click', (e: MouseEvent) => {
         e.preventDefault();
         e.stopPropagation();
+        if (!isReporterIdentityCurrent(context)) return;
         issueReporter.showReportModal(tmdbId, itemName, mediaType, backdropUrl, item);
     });
 
@@ -600,7 +674,9 @@ issueReporter.createReportButton = function (container, tmdbId, itemName, mediaT
 issueReporter.createUnavailableButton = function (container, itemName, mediaType, reason = 'unavailable') {
     if (!container) return null;
 
-    const button = document.createElement('button');
+    const context = JC.identity.capture();
+    if (!context || !JC.identity.isCurrent(context)) return null;
+    const button = ownReporterElement(document.createElement('button'), context);
     button.setAttribute('is', 'emby-button');
     button.className = 'button-flat detailButton emby-button seerr-report-unavailable-icon';
     button.type = 'button';
@@ -635,6 +711,7 @@ issueReporter.createUnavailableButton = function (container, itemName, mediaType
     button.addEventListener('click', (e: MouseEvent) => {
         e.preventDefault();
         e.stopPropagation();
+        if (!isReporterIdentityCurrent(context)) return;
         if (reason === 'no-tmdb') {
             JC.toast!('TMDB ID not found for this item', 4000);
         } else if (reason === 'no-seerr') {
@@ -656,6 +733,8 @@ issueReporter.createUnavailableButton = function (container, itemName, mediaType
  * Uses OMDB API or other methods to find TMDB ID
  */
 issueReporter.getTmdbIdFallback = async function (itemName, mediaType, item) {
+    const context = JC.identity.capture();
+    if (!context || !JC.identity.isCurrent(context)) return null;
     try {
         console.debug(`${logPrefix} Attempting fallback TMDB lookup for ${itemName}`);
 
@@ -712,6 +791,7 @@ issueReporter.getTmdbIdFallback = async function (itemName, mediaType, item) {
                 if (imdbId) {
                     console.debug(`${logPrefix} Trying Seerr search by IMDB ID: ${imdbId}`);
                     const res = await JC.seerrAPI.search(imdbId);
+                    if (!isReporterIdentityCurrent(context)) return null;
                     if (res && Array.isArray(res.results) && res.results.length > 0) {
                         // Prefer a result with matching mediaType
                         const match = res.results.find((r: any) => (r.mediaType === mediaType || (mediaType === 'tv' && r.mediaType === 'tv') || (mediaType === 'movie' && r.mediaType === 'movie')) && r.id);
@@ -732,6 +812,7 @@ issueReporter.getTmdbIdFallback = async function (itemName, mediaType, item) {
                 const titleQuery = `${item.Name}${year ? ' ' + year : ''}`;
                 console.debug(`${logPrefix} Trying Seerr search by title: "${titleQuery}"`);
                 const res2 = await JC.seerrAPI.search(titleQuery);
+                if (!isReporterIdentityCurrent(context)) return null;
                 if (res2 && Array.isArray(res2.results) && res2.results.length > 0) {
                     // Try to find best match: exact title and same year
                     const exact = res2.results.find((r: any) => {
@@ -775,10 +856,14 @@ issueReporter.getTmdbIdFallback = async function (itemName, mediaType, item) {
  */
 issueReporter.applyIssueIndicator = async function (button, tmdbId, mediaType, prefetched = null) {
     if (!JC.pluginConfig?.SeerrShowIssueIndicator) return;
+    const context = JC.identity.capture();
+    if (!context || !JC.identity.isCurrent(context)) return;
+    ownReporterElement(button, context);
     try {
         const result = prefetched
             ? await prefetched
             : await JC.seerrAPI!.fetchIssuesForMedia(tmdbId, mediaType, { take: 50, filter: 'open' });
+        if (!isReporterIdentityCurrent(context) || !button.isConnected) return;
         const openIssues = result?.results || [];
         if (openIssues.length === 0) return;
 
@@ -824,6 +909,8 @@ issueReporter.applyIssueIndicator = async function (button, tmdbId, mediaType, p
  * Attempts to add the report issue button to the current detail page
  */
 issueReporter.tryAddButton = async function () {
+    const context = JC.identity.capture();
+    if (!context || !JC.identity.isCurrent(context)) return false;
     const itemDetailPage = document.querySelector('#itemDetailPage:not(.hide)');
     if (!itemDetailPage) {
         return false;
@@ -870,6 +957,7 @@ issueReporter.tryAddButton = async function () {
         const item: any = JC.helpers?.getItemCached
             ? await JC.helpers.getItemCached(itemId, { userId })
             : await ApiClient.getItem(userId, itemId);
+        if (!isReporterIdentityCurrent(context)) return false;
         if (!item) {
             console.debug(`${logPrefix} Could not fetch item data`);
             return false;
@@ -914,6 +1002,7 @@ issueReporter.tryAddButton = async function () {
 
         // Check if reporting is available (item has TMDB ID and Seerr configured)
         const availability = await issueReporter.checkReportingAvailability(item);
+        if (!isReporterIdentityCurrent(context)) return false;
 
         // If services not available, show unavailable button — except when the
         // item itself simply has no TMDB ID (e.g. MusicVideo, or any other type
@@ -969,7 +1058,7 @@ issueReporter.tryAddButton = async function () {
                     // Stale-navigation guard (same as the active-button insert):
                     // don't pin the old item's disabled button onto a new page.
                     const currentUnavailItemId = new URLSearchParams(window.location.hash.split('?')[1]).get('id');
-                    if (currentUnavailItemId !== itemId) {
+                    if (!isReporterIdentityCurrent(context) || currentUnavailItemId !== itemId) {
                         console.debug(`${logPrefix} Item changed during async work (${itemId} -> ${currentUnavailItemId}), discarding stale unavailable button`);
                         return false;
                     }
@@ -1005,6 +1094,7 @@ issueReporter.tryAddButton = async function () {
                         const parentItem: any = JC.helpers?.getItemCached
                             ? await JC.helpers.getItemCached(parentId, { userId: userId2 })
                             : await ApiClient.getItem(userId2, parentId);
+                        if (!isReporterIdentityCurrent(context)) return false;
                         if (parentItem) {
                             const parentTmdb = parentItem.ProviderIds?.Tmdb;
                             if (parentTmdb) {
@@ -1023,6 +1113,7 @@ issueReporter.tryAddButton = async function () {
         if (!tmdbId) {
             console.debug(`${logPrefix} No direct TMDB ID found for ${item.Name}, trying fallback...`);
             tmdbId = await issueReporter.getTmdbIdFallback(item.Name, mediaType, item);
+            if (!isReporterIdentityCurrent(context)) return false;
 
             if (!tmdbId) {
                 // No TMDB ID for this item, and the fallback search couldn't find one
@@ -1119,7 +1210,7 @@ issueReporter.tryAddButton = async function () {
             // page (and its dedup would block the correct button). Verify the
             // URL still points at the item this call resolved.
             const currentItemId = new URLSearchParams(window.location.hash.split('?')[1]).get('id');
-            if (currentItemId !== itemId) {
+            if (!isReporterIdentityCurrent(context) || currentItemId !== itemId) {
                 console.debug(`${logPrefix} Item changed during async work (${itemId} -> ${currentItemId}), discarding stale button`);
                 return false;
             }
@@ -1148,91 +1239,49 @@ issueReporter.tryAddButton = async function () {
     return false;
 };
 
-/**
- * Initializes issue reporter on item detail pages
- */
-issueReporter.initialize = async function () {
+/** One bounded retry chain for the current view and identity. */
+async function handleReporterView(context: IdentityContext): Promise<void> {
+    const generation = ++reporterViewGeneration;
+    const retryDelaysMs = [100, 500, 1000, 2000, 4000];
+    for (const delay of retryDelaysMs) {
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        if (generation !== reporterViewGeneration || !isReporterIdentityCurrent(context)) return;
+        if (!JC.pluginConfig?.SeerrEnabled || !JC.pluginConfig?.SeerrShowReportButton) return;
+        try {
+            if (await issueReporter.tryAddButton()) return;
+        } catch (error: any) {
+            if (!isReporterIdentityCurrent(context)) return;
+            console.warn(`${logPrefix} Error in viewShow handler:`, error);
+        }
+    }
+}
+
+/** Initializes one process-lifetime listener; activation only schedules B's pass. */
+issueReporter.initialize = function () {
     if (!JC.pluginConfig?.SeerrEnabled || !JC.pluginConfig?.SeerrShowReportButton) {
         console.debug(`${logPrefix} Seerr integration or report-button feature disabled, skipping initialization`);
         return;
     }
-
+    const context = captureReporterIdentity();
     JC.seerrUI?.addMainStyles?.();
 
-    console.log(`${logPrefix} Initializing... (verifying Seerr status)`);
-
-    /** One status probe: 'active' | 'inactive' (a real server answer) | 'error' (transient). */
-    const verifyStatus = async (): Promise<'active' | 'inactive' | 'error'> => {
-        try {
-            const statusUrl = ApiClient.getUrl('/JellyfinCanopy/seerr/status');
-            const statusRes: any = await ApiClient.ajax({ type: 'GET', url: statusUrl, dataType: 'json' });
-            return statusRes && statusRes.active ? 'active' : 'inactive';
-        } catch (e: any) {
-            console.warn(`${logPrefix} Seerr status probe failed:`, e);
-            return 'error';
-        }
-    };
-
-    // PERF(R9): fail open — the old one-shot check disabled the report button
-    // for the ENTIRE session (until a hard reload) on a single transient
-    // failure at boot. Only a genuine "inactive" answer from the server skips
-    // init; transient errors retry with backoff and, if still failing, fall
-    // through to lazy re-verification on each view below.
-    let statusVerified = false;
-    const STATUS_RETRY_DELAYS_MS = [2000, 5000, 10000];
-    for (let i = 0; ; i++) {
-        const status = await verifyStatus();
-        if (status === 'active') { statusVerified = true; break; }
-        if (status === 'inactive') {
-            console.debug(`${logPrefix} Seerr status check returned inactive, skipping reporter init`);
-            return;
-        }
-        if (i >= STATUS_RETRY_DELAYS_MS.length) {
-            console.warn(`${logPrefix} Could not verify Seerr status at boot; will re-verify lazily per view`);
-            break;
-        }
-        await new Promise(r => setTimeout(r, STATUS_RETRY_DELAYS_MS[i]));
+    if (!reporterListenerInstalled) {
+        reporterListenerInstalled = true;
+        document.addEventListener('viewshow', () => {
+            const current = JC.identity.capture();
+            if (current) void handleReporterView(current);
+        });
     }
 
-    // Distinguishes view generations so a retry chain from a previous view
-    // stops as soon as a new view shows (and chains never stack up).
-    let viewGeneration = 0;
+    if (reporterInitialTimer !== null) clearTimeout(reporterInitialTimer);
+    reporterInitialTimer = window.setTimeout(() => {
+        reporterInitialTimer = null;
+        if (isReporterIdentityCurrent(context)) void handleReporterView(context);
+    }, 500);
 
-    const handleViewShow = async () => {
-        const generation = ++viewGeneration;
-        // PERF(R9): fail open — the old single 100ms shot lost the button
-        // whenever the page or its button row mounted later than that (routine
-        // on slow servers/connections). Bounded backoff retries instead,
-        // abandoned the moment another view shows; the synchronous dedup in
-        // tryAddButton keeps double-fires idempotent.
-        const RETRY_DELAYS_MS = [100, 500, 1000, 2000, 4000];
-        for (const delay of RETRY_DELAYS_MS) {
-            await new Promise(r => setTimeout(r, delay));
-            if (generation !== viewGeneration) return;
-            try {
-                if (!statusVerified) {
-                    const status = await verifyStatus();
-                    if (status === 'inactive') return;
-                    if (status === 'error') continue; // transient — try again next round
-                    statusVerified = true;
-                }
-                if (generation !== viewGeneration) return;
-                if (await issueReporter.tryAddButton()) return;
-            } catch (error: any) {
-                console.warn(`${logPrefix} Error in viewShow handler:`, error);
-            }
-        }
-    };
-
-    // Listen for Jellyfin's page navigation events
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises -- legacy async listener; errors handled inside
-    document.addEventListener('viewshow', handleViewShow);
-
-    // Also try on initial load
-    setTimeout(handleViewShow, 500);
-
-    console.log(`${logPrefix} ✓ Initialized issue reporter with viewshow listener`);
+    console.log(`${logPrefix} ✓ Initialized issue reporter with one viewshow listener`);
 };
 
 // Expose the module on the global JC object
 JC.seerrIssueReporter = issueReporter;
+JC.identity.registerReset('seerr-issue-reporter', resetIssueReporterIdentity);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/item-details.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/item-details.ts
@@ -4,6 +4,7 @@
 // Series detail pages when the show has unrequested seasons in Seerr.
 import { JC } from '../globals';
 import { getItemIdFromUrl, getVisibleDetailsPage } from '../core/details-view';
+import type { IdentityContext } from '../types/jc';
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- legacy Seerr payload shapes; typed incrementally */
 
@@ -23,6 +24,11 @@ const REQUEST_MORE_BTN_CLASS = 'jc-series-request-more-btn';
 // check (and vice versa) when the user navigates between detail pages.
 let currentAbortController: AbortController | null = null;
 let requestMoreAbortController: AbortController | null = null;
+const pendingFrames = new Set<number>();
+
+function isCurrent(context: IdentityContext | null, signal?: AbortSignal): context is IdentityContext {
+    return !!context && !signal?.aborted && JC.identity.isCurrent(context);
+}
 
 /**
  * Gets the TMDB ID from a Jellyfin item
@@ -30,20 +36,20 @@ let requestMoreAbortController: AbortController | null = null;
  * @param {AbortSignal} [signal] - Optional abort signal
  * @returns {Promise<{tmdbId: number|null, type: string|null}>}
  */
-async function getTmdbIdFromItem(itemId: string, signal?: AbortSignal): Promise<{ tmdbId: number | null; type: string | null }> {
+async function getTmdbIdFromItem(itemId: string, context: IdentityContext, signal?: AbortSignal): Promise<{ tmdbId: number | null; type: string | null }> {
     try {
         // Check for abort before making request
         if (signal?.aborted) {
             throw new DOMException('Aborted', 'AbortError');
         }
 
-        const userId = ApiClient.getCurrentUserId();
+        const userId = context.userId;
         const item: any = JC.helpers?.getItemCached
             ? await JC.helpers.getItemCached(itemId, { userId })
             : await ApiClient.getItem(userId, itemId);
 
         // Check for abort after request
-        if (signal?.aborted) {
+        if (!isCurrent(context, signal)) {
             throw new DOMException('Aborted', 'AbortError');
         }
 
@@ -180,7 +186,8 @@ function waitForDetailPageReady(itemId: string, signal?: AbortSignal): Promise<a
  * @param {string} title - Section title (already translated)
  * @returns {HTMLElement} - Section element
  */
-function createSeerrSection(results: any[], title: string): HTMLElement | null {
+function createSeerrSection(results: any[], title: string, context: IdentityContext): HTMLElement | null {
+    if (!isCurrent(context)) return null;
     if (!results || results.length === 0) {
         return null;
     }
@@ -202,6 +209,8 @@ function createSeerrSection(results: any[], title: string): HTMLElement | null {
 
     const section = document.createElement('div');
     section.className = 'verticalSection emby-scroller-container seerr-details-section';
+    section.dataset.jcIdentityOwned = 'true';
+    JC.identity.own(section, context);
     section.setAttribute('data-seerr-section', 'true');
 
     const titleElement = document.createElement('h2');
@@ -270,6 +279,8 @@ function createSeerrSection(results: any[], title: string): HTMLElement | null {
  * @param {string} itemId - Jellyfin item ID
  */
 async function renderSimilarAndRecommended(itemId: string) {
+    const context = JC.identity.capture();
+    if (!context) return;
     // Prevent duplicate renders (check only - add after success)
     if (processedItems.has(itemId)) {
         return;
@@ -299,7 +310,7 @@ async function renderSimilarAndRecommended(itemId: string) {
 
         // Check if Seerr is active
         const status = await JC.seerrAPI!.checkUserStatus();
-        if (signal.aborted) return;
+        if (!isCurrent(context, signal)) return;
 
         if (!status || !status.active) {
             console.debug(`${logPrefix} Seerr is not active, skipping`);
@@ -307,8 +318,8 @@ async function renderSimilarAndRecommended(itemId: string) {
         }
 
         // Get TMDB ID and type
-        const { tmdbId, type } = await getTmdbIdFromItem(itemId, signal);
-        if (signal.aborted) return;
+        const { tmdbId, type } = await getTmdbIdFromItem(itemId, context, signal);
+        if (!isCurrent(context, signal)) return;
 
         if (!tmdbId || !type) {
             console.debug(`${logPrefix} No valid TMDB ID found for item, skipping`);
@@ -347,7 +358,7 @@ async function renderSimilarAndRecommended(itemId: string) {
             waitForDetailPageReady(itemId, signal)
         ]);
 
-        if (signal.aborted) return;
+        if (!isCurrent(context, signal)) return;
 
         const similarResults = similarData?.results || [];
         const recommendedResults = recommendedData?.results || [];
@@ -387,7 +398,7 @@ async function renderSimilarAndRecommended(itemId: string) {
         }
 
         // Final abort check before DOM manipulation
-        if (signal.aborted) return;
+        if (!isCurrent(context, signal)) return;
 
         // Remove any existing Seerr sections to avoid duplicates
         detailPageContent.querySelectorAll('.seerr-details-section').forEach((el: Element) => el.remove());
@@ -400,7 +411,8 @@ async function renderSimilarAndRecommended(itemId: string) {
             const recommendedTitle = JC.t ? (JC.t('seerr_recommended_title') || 'Recommended') : 'Recommended';
             const recommendedSection = createSeerrSection(
                 filteredRecommendedResults.slice(0, 20),
-                recommendedTitle
+                recommendedTitle,
+                context
             );
             if (recommendedSection) {
                 moreLikeThisSection.after(recommendedSection);
@@ -412,7 +424,8 @@ async function renderSimilarAndRecommended(itemId: string) {
             const similarTitle = JC.t ? (JC.t('seerr_similar_title') || 'Similar') : 'Similar';
             const similarSection = createSeerrSection(
                 filteredSimilarResults.slice(0, 20),
-                similarTitle
+                similarTitle,
+                context
             );
             if (similarSection) {
                 const lastSeerrSection = detailPageContent.querySelector('.seerr-details-section:last-of-type');
@@ -579,7 +592,7 @@ function waitForChecker(signal?: AbortSignal): Promise<any> {
  * @param {object} tvDetails - TV show details from Seerr
  * @returns {HTMLButtonElement}
  */
-function buildSeriesRequestMoreButton(tvDetails: any): HTMLButtonElement {
+function buildSeriesRequestMoreButton(tvDetails: any, context: IdentityContext): HTMLButtonElement {
     // Defensive: i18n table may not be initialized yet on first navigation;
     // match the fallback pattern used elsewhere in this file.
     const labelText = (JC.t && JC.t('seerr_btn_request_more')) || 'Request More';
@@ -587,6 +600,8 @@ function buildSeriesRequestMoreButton(tvDetails: any): HTMLButtonElement {
     const button = document.createElement('button');
     button.type = 'button';
     button.className = `seerr-request-button seerr-button-request ${REQUEST_MORE_BTN_CLASS}`;
+    button.dataset.jcIdentityOwned = 'true';
+    JC.identity.own(button, context);
     button.title = labelText;
     // Inline overrides so the button sits comfortably next to the h2 text
     // without inheriting the heading's font size or block layout.
@@ -613,6 +628,7 @@ function buildSeriesRequestMoreButton(tvDetails: any): HTMLButtonElement {
     button.addEventListener('click', (e: MouseEvent) => {
         e.preventDefault();
         e.stopPropagation();
+        if (!isCurrent(context)) return;
         if (JC.seerrUI?.showSeasonSelectionModal) {
             JC.seerrUI.showSeasonSelectionModal(
                 tvDetails.id,
@@ -634,6 +650,8 @@ function buildSeriesRequestMoreButton(tvDetails: any): HTMLButtonElement {
  * @param {string} itemId - Jellyfin item ID
  */
 async function renderSeriesRequestMoreButton(itemId: string) {
+    const context = JC.identity.capture();
+    if (!context) return;
     if (processedRequestMoreItems.has(itemId)) return;
 
     // Cancel any in-flight Request More check from a previous navigation.
@@ -648,15 +666,19 @@ async function renderSeriesRequestMoreButton(itemId: string) {
         if (JC.pluginConfig?.SeerrShowRequestMoreOnSeries === false) return;
 
         const status = await JC.seerrAPI!.checkUserStatus();
-        if (signal.aborted) return;
+        if (!isCurrent(context, signal)) return;
         if (!status?.active) return;
 
-        const { tmdbId, type } = await getTmdbIdFromItem(itemId, signal);
-        if (signal.aborted) return;
+        const { tmdbId, type } = await getTmdbIdFromItem(itemId, context, signal);
+        if (!isCurrent(context, signal)) return;
         if (!tmdbId || type !== 'tv') return;
 
-        const tvDetails = await JC.seerrAPI!.fetchTvShowDetails(tmdbId);
-        if (signal.aborted) return;
+        const tvDetails = await JC.seerrAPI!.fetchTvShowDetails(tmdbId, { signal }) as unknown as {
+            name?: string;
+            title?: string;
+            [key: string]: any;
+        };
+        if (!isCurrent(context, signal)) return;
         if (!tvDetails) return;
 
         // PERF(R7): resolve the Seasons heading in parallel with the checker and
@@ -667,8 +689,10 @@ async function renderSeriesRequestMoreButton(itemId: string) {
         // heading's first painted state, and the later button append displaces
         // nothing but trailing free space.
         const headingPromise = waitForSeasonsHeading(itemId, signal);
-        void headingPromise.then((h: any) => {
-            if (h && !signal.aborted) h.classList.add('jc-series-request-more-heading');
+        void headingPromise.then((heading: unknown) => {
+            if (heading instanceof HTMLElement && isCurrent(context, signal)) {
+                heading.classList.add('jc-series-request-more-heading');
+            }
         });
 
         // Wait for the checker to become available — the Seerr
@@ -678,13 +702,13 @@ async function renderSeriesRequestMoreButton(itemId: string) {
         // where the button would otherwise never appear until the user
         // navigates away and back.
         const checker = await waitForChecker(signal);
-        if (signal.aborted) return;
+        if (!isCurrent(context, signal)) return;
         if (!checker) {
             console.warn(`${requestMoreLogPrefix} checkForUnrequestedSeasons unavailable after 3s, skipping`);
             return;
         }
         const hasUnrequested = await checker(tvDetails);
-        if (signal.aborted) return;
+        if (!isCurrent(context, signal)) return;
         if (!hasUnrequested) {
             // Dedupe negative results too. Each call to checker() runs an
             // HTTP request to /JellyfinCanopy/seerr/request, so we
@@ -696,7 +720,7 @@ async function renderSeriesRequestMoreButton(itemId: string) {
         }
 
         const heading = await headingPromise;
-        if (signal.aborted) return;
+        if (!isCurrent(context, signal)) return;
         if (!heading) {
             console.debug(`${requestMoreLogPrefix} Seasons heading not found, skipping`);
             return;
@@ -712,7 +736,7 @@ async function renderSeriesRequestMoreButton(itemId: string) {
         // headingPromise above). PERF(R7): appending at the heading's flow end
         // displaces nothing but trailing free space — single insert, content
         // fully built (no empty-shell insert).
-        const button = buildSeriesRequestMoreButton(tvDetails);
+        const button = buildSeriesRequestMoreButton(tvDetails, context);
         heading.appendChild(button);
 
         processedRequestMoreItems.add(itemId);
@@ -730,6 +754,8 @@ async function renderSeriesRequestMoreButton(itemId: string) {
  * Handles item details page navigation
  */
 function handleItemDetailsPage() {
+    const context = JC.identity.capture();
+    if (!context) return;
     // Details route on either layout: the legacy layout keeps it in the hash
     // (#/details?id=X), the modern layout in the path + search
     // (/web/details?id=X with an empty hash). The old hash-only check meant
@@ -742,12 +768,17 @@ function handleItemDetailsPage() {
 
     const itemId = getItemIdFromUrl();
     if (itemId) {
+        for (const pending of pendingFrames) cancelAnimationFrame(pending);
+        pendingFrames.clear();
         // Use requestAnimationFrame instead of fixed timeout
         // This ensures we're in sync with the rendering cycle
-        requestAnimationFrame(() => {
+        const frame = requestAnimationFrame(() => {
+            pendingFrames.delete(frame);
+            if (!isCurrent(context)) return;
             void renderSimilarAndRecommended(itemId);
             void renderSeriesRequestMoreButton(itemId);
         });
+        pendingFrames.add(frame);
     }
 }
 
@@ -755,6 +786,8 @@ function handleItemDetailsPage() {
  * Cleanup function for navigation
  */
 function cleanup() {
+    for (const frame of pendingFrames) cancelAnimationFrame(frame);
+    pendingFrames.clear();
     // Abort any in-flight requests
     if (currentAbortController) {
         currentAbortController.abort();
@@ -767,6 +800,10 @@ function cleanup() {
     // Clear processed items caches
     processedItems.clear();
     processedRequestMoreItems.clear();
+    document.querySelectorAll('.seerr-details-section, .' + REQUEST_MORE_BTN_CLASS).forEach((node) => node.remove());
+    document.querySelectorAll('.jc-series-request-more-heading').forEach((node) => {
+        node.classList.remove('jc-series-request-more-heading');
+    });
 }
 
 /**
@@ -816,3 +853,8 @@ if (document.readyState === 'loading') {
 } else {
     initialize();
 }
+
+JC.identity.registerReset('seerr-item-details-identity', cleanup);
+JC.identity.registerActivate('seerr-item-details-identity', () => {
+    handleItemDetailsPage();
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/modal.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/modal.identity.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../globals';
+
+describe('Seerr request modal identity ownership', () => {
+    beforeAll(async () => {
+        JC.t = (key: string) => key;
+        await import('./modal');
+    });
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        document.body.replaceChildren();
+        JC.identity.transition('modal-server-a', 'modal-user-a', 'test setup');
+    });
+
+    afterEach(() => {
+        vi.clearAllTimers();
+        vi.useRealTimers();
+    });
+
+    it('synchronously removes A and makes a retained A primary control inert', () => {
+        const onSave = vi.fn();
+        const handle = JC.seerrModal!.create({
+            title: 'A title',
+            subtitle: 'A subtitle',
+            bodyHtml: '<div>body</div>',
+            onSave,
+        });
+        handle.show();
+
+        const retainedPrimary = handle.modalElement.querySelector<HTMLButtonElement>('.seerr-modal-button-primary')!;
+        expect(handle.modalElement.isConnected).toBe(true);
+
+        JC.identity.transition('modal-server-b', 'modal-user-b', 'account switch');
+
+        expect(handle.modalElement.isConnected).toBe(false);
+        expect(document.body.classList.contains('seerr-modal-is-open')).toBe(false);
+        retainedPrimary.click();
+        vi.runAllTimers();
+        expect(onSave).not.toHaveBeenCalled();
+        expect(handle.modalElement.classList.contains('show')).toBe(false);
+    });
+
+    it('cancels advanced-option polling before it can publish A data under B', () => {
+        const handle = JC.seerrModal!.create({
+            title: 'A title',
+            subtitle: 'A subtitle',
+            bodyHtml: JC.seerrModal!.createAdvancedOptionsHTML('movie'),
+            onSave: vi.fn(),
+        });
+        handle.show();
+        JC.seerrModal!.populateAdvancedOptions(handle.modalElement, {
+            servers: [{ id: 1, name: 'A server', qualityProfiles: [], rootFolders: [] }],
+            tags: [],
+        }, 'movie');
+
+        const retainedSelect = handle.modalElement.querySelector<HTMLSelectElement>('#movie-server')!;
+        JC.identity.transition('modal-server-b2', 'modal-user-b2', 'account switch');
+        vi.advanceTimersByTime(10_000);
+
+        expect(retainedSelect.options).toHaveLength(0);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/modal.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/modal.ts
@@ -39,6 +39,9 @@ declare module '../types/jc' {
 
 const logPrefix = '🪼 Jellyfin Canopy: Seerr Modal:';
 const modal = {} as SeerrModalApi;
+type ManagedModal = SeerrModalHandle & { destroy: () => void };
+type IdentityCleanupElement = HTMLElement & { _jcIdentityCleanups?: Set<() => void> };
+const activeModals = new Set<ManagedModal>();
 
 const escapeHtml = JC.escapeHtml;
 
@@ -56,8 +59,11 @@ const escapeHtml = JC.escapeHtml;
  * @returns {object} - An object with methods to show and close the modal.
  */
 modal.create = function({ title, subtitle, bodyHtml, backdropPath, backdropUrl, onSave, onClose, buttonText }) {
-    const modalElement = document.createElement('div');
+    const identity = JC.identity.capture();
+    const modalElement = document.createElement('div') as IdentityCleanupElement;
     modalElement.className = 'seerr-season-modal';
+    modalElement.dataset.jcIdentityOwned = 'true';
+    JC.identity.own(modalElement, identity);
     modalElement.setAttribute('role', 'dialog');
     modalElement.setAttribute('aria-modal', 'true');
     modalElement.setAttribute('tabindex', '-1');
@@ -126,7 +132,15 @@ modal.create = function({ title, subtitle, bodyHtml, backdropPath, backdropUrl, 
     // restored it, and never counted toward the jc-modal-open shortcut gate).
     let a11y: ModalA11yHandle | null = null;
 
+    let isClosing = false;
+    let showTimer: ReturnType<typeof setTimeout> | null = null;
+    let removeTimer: ReturnType<typeof setTimeout> | null = null;
+    const cleanups = new Set<() => void>();
+    modalElement._jcIdentityCleanups = cleanups;
+    const isCurrent = () => !!identity && JC.identity.isCurrent(identity) && !isClosing;
+
     const show = () => {
+        if (!isCurrent() || document.body.contains(modalElement)) return;
         document.body.appendChild(modalElement);
         document.body.classList.add('seerr-modal-is-open');
         // Add a state to history to handle back button for closing
@@ -137,14 +151,34 @@ modal.create = function({ title, subtitle, bodyHtml, backdropPath, backdropUrl, 
             initialFocus: () => modalElement.querySelector<HTMLElement>('button:not([disabled]), select, input'),
             onEscape: () => history.back(), // keep the history-based close mechanism
         });
-        setTimeout(() => { modalElement.classList.add('show'); }, 10);
+        showTimer = setTimeout(() => {
+            showTimer = null;
+            if (isCurrent() && document.body.contains(modalElement)) modalElement.classList.add('show');
+        }, 10);
     };
 
-    let isClosing = false;
+    const finishClose = () => {
+        if (document.body.contains(modalElement)) modalElement.remove();
+        activeModals.delete(handle);
+        if (activeModals.size === 0) document.body.classList.remove('seerr-modal-is-open');
+    };
 
-    const close = () => {
+    const closeInternal = (immediate: boolean) => {
         if (isClosing) return;
         isClosing = true;
+
+        if (showTimer !== null) {
+            clearTimeout(showTimer);
+            showTimer = null;
+        }
+        if (removeTimer !== null) {
+            clearTimeout(removeTimer);
+            removeTimer = null;
+        }
+        for (const cleanup of cleanups) {
+            try { cleanup(); } catch { /* continue closing */ }
+        }
+        cleanups.clear();
 
         if (typeof onClose === 'function') {
             try {
@@ -158,23 +192,30 @@ modal.create = function({ title, subtitle, bodyHtml, backdropPath, backdropUrl, 
         a11y?.release(); // restores focus to the trigger + lifts the shortcut gate
         a11y = null;
         modalElement.classList.remove('show');
-        document.body.classList.remove('seerr-modal-is-open');
-        setTimeout(() => {
-            if (document.body.contains(modalElement)) {
-                document.body.removeChild(modalElement);
-            }
-            isClosing = false;
-        }, 300);
+        if (immediate) {
+            finishClose();
+        } else {
+            removeTimer = setTimeout(() => {
+                removeTimer = null;
+                finishClose();
+            }, 300);
+        }
     };
+    const close = () => closeInternal(false);
 
     // Event listeners for closing the modal
-    cancelBtn.addEventListener('click', () => history.back());
-    modalElement.addEventListener('click', (e: MouseEvent) => { if (e.target === modalElement) history.back(); });
+    cancelBtn.addEventListener('click', () => { if (isCurrent()) history.back(); });
+    modalElement.addEventListener('click', (e: MouseEvent) => { if (isCurrent() && e.target === modalElement) history.back(); });
 
     // Event listener for the primary action button
-    primaryBtn.addEventListener('click', () => { void onSave(modalElement, primaryBtn, close); });
+    primaryBtn.addEventListener('click', () => {
+        if (!isCurrent()) return;
+        void onSave(modalElement, primaryBtn, close);
+    });
 
-    return { modalElement, show, close };
+    const handle: ManagedModal = { modalElement, show, close, destroy: () => closeInternal(true) };
+    activeModals.add(handle);
+    return handle;
 };
 
 /**
@@ -213,6 +254,10 @@ modal.createAdvancedOptionsHTML = function(idPrefix) {
  * @param {string} idPrefix - The prefix ('movie' or 'tv') used for the element IDs.
  */
 modal.populateAdvancedOptions = function(modalElement, data, idPrefix) {
+    const identity = JC.identity.ownerOf(modalElement) || JC.identity.capture();
+    const isCurrent = () => !!identity
+        && JC.identity.isCurrent(identity)
+        && document.body.contains(modalElement);
     // Backend failed to load server options: show an error note instead of
     // polling for selects that will only ever be populated with empty
     // placeholders — three empty dropdowns look like a valid config (W4-ERR-5).
@@ -228,6 +273,10 @@ modal.populateAdvancedOptions = function(modalElement, data, idPrefix) {
     let attempts = 0;
     const maxAttempts = 50; // 5 seconds
     const interval = setInterval(() => {
+        if (!isCurrent()) {
+            clearInterval(interval);
+            return;
+        }
         const serverSelect = modalElement.querySelector<HTMLSelectElement>(`#${idPrefix}-server`);
         const qualitySelect = modalElement.querySelector<HTMLSelectElement>(`#${idPrefix}-quality`);
         const folderSelect = modalElement.querySelector<HTMLSelectElement>(`#${idPrefix}-folder`);
@@ -283,7 +332,13 @@ modal.populateAdvancedOptions = function(modalElement, data, idPrefix) {
             }
         }
     }, 100);
+    const cleanups = (modalElement as IdentityCleanupElement)._jcIdentityCleanups;
+    cleanups?.add(() => clearInterval(interval));
 };
+
+JC.identity.registerReset('seerr-request-modal', () => {
+    for (const active of [...activeModals]) active.destroy();
+});
 
 // Expose the modal module on the global JC object
 JC.seerrModal = modal;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/more-info-modal/actions-tv.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/more-info-modal/actions-tv.ts
@@ -2,6 +2,7 @@
 // TV request buttons: season request split-button, 4K variants and
 // the "Request More" button.
 import { JC } from '../../globals';
+import type { IdentityContext } from '../../types/jc';
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- legacy Seerr payload + DOM shapes; typed incrementally */
 /* eslint-disable @typescript-eslint/no-misused-promises, @typescript-eslint/require-await -- legacy async event listeners with fire-and-forget bodies; semantics preserved verbatim */
@@ -9,6 +10,43 @@ import { JC } from '../../globals';
 
 import { internal } from './internal';
 const DisplayStatus = JC.seerrStatus!.DISPLAY;
+interface ActionModal extends HTMLElement {
+    _actionCleanups?: Set<() => void>;
+}
+
+const state: {
+    currentModal: ActionModal | null;
+    identity: IdentityContext | null;
+    openGeneration: number;
+} = internal.state;
+
+function isLiveNode(node?: Node | null): boolean {
+    return !!state.identity
+        && JC.identity.isCurrent(state.identity)
+        && !!state.currentModal
+        && state.currentModal.isConnected
+        && (!node || (state.currentModal.contains(node)
+            && (!JC.identity.ownerOf(node) || JC.identity.isOwned(node, state.identity))));
+}
+
+function ownControl<T extends Node>(node: T): T {
+    return JC.identity.own(node, state.identity);
+}
+
+function trackModalCleanup(cleanup: () => void): void {
+    state.currentModal?._actionCleanups?.add(cleanup);
+}
+
+function scheduleModalFrame(callback: () => void): void {
+    const cleanups = state.currentModal?._actionCleanups;
+    let frame = 0;
+    const cancel = () => cancelAnimationFrame(frame);
+    frame = requestAnimationFrame(() => {
+        cleanups?.delete(cancel);
+        callback();
+    });
+    cleanups?.add(cancel);
+}
 
 /**
  * Render request/4K actions and download progress inside the modal.
@@ -37,12 +75,14 @@ if (show4kOption) {
     buttonGroup.className = 'seerr-button-group jc-more-info-button-group';
 
     const mainButton = document.createElement('button');
+    ownControl(mainButton);
     mainButton.className = 'seerr-request-button seerr-split-main seerr-button-request';
     mainButton.innerHTML = `${JC.seerrUIIcons?.request || '<span class="material-icons">download</span>'}<span>${JC.t!('seerr_btn_request')}</span>`;
     mainButton.dataset.tmdbId = data.id;
     mainButton.dataset.mediaType = 'tv';
 
     const arrowButton = document.createElement('button');
+    ownControl(arrowButton);
     arrowButton.className = 'seerr-split-arrow';
     arrowButton.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path fill-rule="evenodd" d="M12.53 16.28a.75.75 0 01-1.06 0l-7.5-7.5a.75.75 0 011.06-1.06L12 14.69l6.97-6.97a.75.75 0 111.06 1.06l-7.5 7.5z" clip-rule="evenodd" /></svg>';
     arrowButton.title = JC.t!('seerr_btn_request_4k') || 'Request in 4K';
@@ -52,6 +92,7 @@ if (show4kOption) {
     mainButton.addEventListener('click', async (e: any) => {
         e.preventDefault();
         e.stopPropagation();
+        if (!isLiveNode(mainButton)) return;
         if (JC.seerrUI?.showSeasonSelectionModal) {
             JC.seerrUI.showSeasonSelectionModal(data.id, 'tv', data.title || data.name, data, false);
         }
@@ -65,6 +106,7 @@ if (show4kOption) {
             document.removeEventListener('click', handleDocClick, true);
         }
     };
+    trackModalCleanup(close4k);
     const handleDocClick = (ev: any) => {
         if (!open4k) return;
         if (!open4k.contains(ev.target) && !arrowButton.contains(ev.target)) {
@@ -75,6 +117,7 @@ if (show4kOption) {
     arrowButton.addEventListener('click', (e: any) => {
         e.preventDefault();
         e.stopPropagation();
+        if (!isLiveNode(arrowButton)) return;
         if (open4k) {
             close4k();
             return;
@@ -83,6 +126,7 @@ if (show4kOption) {
         const menu = document.createElement('div');
         menu.className = 'jc-4k-popup';
         const option = document.createElement('button');
+        ownControl(option);
         option.className = 'jc-4k-popup-item';
 
         const tvPopupDs4k = JC.seerrStatus!.resolveDisplayStatus(status4k, false);
@@ -104,6 +148,7 @@ if (show4kOption) {
             option.addEventListener('click', async (ev: any) => {
                 ev.preventDefault();
                 ev.stopPropagation();
+                if (!isLiveNode(arrowButton)) return;
                 close4k();
                 if (JC.seerrUI?.showSeasonSelectionModal) {
                     JC.seerrUI.showSeasonSelectionModal(data.id, 'tv', data.title || data.name, data, true);
@@ -112,12 +157,16 @@ if (show4kOption) {
         }
 
         menu.appendChild(option);
+        menu.dataset.jcIdentityOwned = 'true';
+        JC.identity.own(menu, state.identity);
         document.body.appendChild(menu);
         const rect = arrowButton.getBoundingClientRect();
         menu.style.position = 'fixed';
         menu.style.left = `${rect.left}px`;
         menu.style.top = `${rect.bottom + 6}px`;
-        requestAnimationFrame(() => menu.classList.add('show'));
+        scheduleModalFrame(() => {
+            if (isLiveNode(arrowButton) && open4k === menu) menu.classList.add('show');
+        });
         open4k = menu;
         document.addEventListener('click', handleDocClick, true);
     });
@@ -129,11 +178,13 @@ if (show4kOption) {
 }
 
 const requestButton = document.createElement('button');
+ownControl(requestButton);
 requestButton.className = 'seerr-request-button seerr-button-request';
 requestButton.innerHTML = `${JC.seerrUIIcons?.request || '<span class="material-icons">download</span>'}<span>${JC.t!('seerr_btn_request')}</span>`;
 requestButton.addEventListener('click', async (e: any) => {
     e.preventDefault();
     e.stopPropagation();
+    if (!isLiveNode(requestButton)) return;
 
     // TV always shows season selection modal
     if (JC.seerrUI?.showSeasonSelectionModal) {
@@ -147,11 +198,13 @@ return container;
 
 function buildSingleTv4kButton(data: any) {
 const button = document.createElement('button');
+ownControl(button);
 button.className = 'seerr-request-button seerr-button-request';
 button.innerHTML = `${JC.seerrUIIcons?.request || '<span class="material-icons">download</span>'}<span>${JC.t!('seerr_btn_request_4k') || 'Request in 4K'}</span>`;
 button.addEventListener('click', async (e: any) => {
     e.preventDefault();
     e.stopPropagation();
+    if (!isLiveNode(button)) return;
     if (JC.seerrUI?.showSeasonSelectionModal) {
         JC.seerrUI.showSeasonSelectionModal(data.id, 'tv', data.title || data.name, data, true);
     }
@@ -171,6 +224,7 @@ if (show4kOption) {
     buttonGroup.className = 'seerr-button-group jc-more-info-button-group';
 
     const mainButton = document.createElement('button');
+    ownControl(mainButton);
     mainButton.className = 'seerr-request-button seerr-split-main seerr-button-request';
     mainButton.innerHTML = `${JC.seerrUIIcons?.request || '<span class="material-icons">download</span>'}<span>${JC.t!('seerr_btn_request_more') || 'Request More'}</span>`;
     mainButton.dataset.tmdbId = data.id;
@@ -178,12 +232,14 @@ if (show4kOption) {
     mainButton.addEventListener('click', async (e: any) => {
         e.preventDefault();
         e.stopPropagation();
+        if (!isLiveNode(mainButton)) return;
         if (JC.seerrUI?.showSeasonSelectionModal) {
             JC.seerrUI.showSeasonSelectionModal(data.id, 'tv', data.title || data.name, data, false);
         }
     });
 
     const arrowButton = document.createElement('button');
+    ownControl(arrowButton);
     arrowButton.className = 'seerr-split-arrow';
     arrowButton.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path fill-rule="evenodd" d="M12.53 16.28a.75.75 0 01-1.06 0l-7.5-7.5a.75.75 0 011.06-1.06L12 14.69l6.97-6.97a.75.75 0 111.06 1.06l-7.5 7.5z" clip-rule="evenodd" /></svg>';
     arrowButton.title = JC.t!('seerr_btn_request_4k') || 'Request in 4K';
@@ -196,6 +252,7 @@ if (show4kOption) {
             document.removeEventListener('click', handleDocClick, true);
         }
     };
+    trackModalCleanup(close4k);
     const handleDocClick = (ev: any) => {
         if (!open4k) return;
         if (!open4k.contains(ev.target) && !arrowButton.contains(ev.target)) {
@@ -206,6 +263,7 @@ if (show4kOption) {
     arrowButton.addEventListener('click', (e: any) => {
         e.preventDefault();
         e.stopPropagation();
+        if (!isLiveNode(arrowButton)) return;
         if (open4k) {
             close4k();
             return;
@@ -214,6 +272,7 @@ if (show4kOption) {
         const menu = document.createElement('div');
         menu.className = 'jc-4k-popup';
         const option = document.createElement('button');
+        ownControl(option);
         option.className = 'jc-4k-popup-item';
         option.textContent = JC.t!('seerr_btn_request_4k') || 'Request in 4K';
 
@@ -226,6 +285,7 @@ if (show4kOption) {
             option.addEventListener('click', async (ev: any) => {
                 ev.preventDefault();
                 ev.stopPropagation();
+                if (!isLiveNode(arrowButton)) return;
                 close4k();
                 if (JC.seerrUI?.showSeasonSelectionModal) {
                     JC.seerrUI.showSeasonSelectionModal(data.id, 'tv', data.title || data.name, data, true);
@@ -234,12 +294,16 @@ if (show4kOption) {
         }
 
         menu.appendChild(option);
+        menu.dataset.jcIdentityOwned = 'true';
+        JC.identity.own(menu, state.identity);
         document.body.appendChild(menu);
         const rect = arrowButton.getBoundingClientRect();
         menu.style.position = 'fixed';
         menu.style.left = `${rect.left}px`;
         menu.style.top = `${rect.bottom + 6}px`;
-        requestAnimationFrame(() => menu.classList.add('show'));
+        scheduleModalFrame(() => {
+            if (isLiveNode(arrowButton) && open4k === menu) menu.classList.add('show');
+        });
         open4k = menu;
         document.addEventListener('click', handleDocClick, true);
     });
@@ -251,11 +315,13 @@ if (show4kOption) {
 }
 
 const requestButton = document.createElement('button');
+ownControl(requestButton);
 requestButton.className = 'seerr-request-button seerr-button-request';
 requestButton.innerHTML = `${JC.seerrUIIcons?.request || '<span class="material-icons">download</span>'}<span>${JC.t!('seerr_btn_request_more') || 'Request More'}</span>`;
 requestButton.addEventListener('click', async (e: any) => {
     e.preventDefault();
     e.stopPropagation();
+    if (!isLiveNode(requestButton)) return;
 
     // Show season selection modal for partially available shows
     if (JC.seerrUI?.showSeasonSelectionModal) {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/more-info-modal/actions.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/more-info-modal/actions.ts
@@ -2,6 +2,7 @@
 // Action-area rendering: movie request buttons, requested chips, quota chip
 // and the renderActions orchestrator for the action/chip/download mounts.
 import { JC } from '../../globals';
+import type { IdentityContext } from '../../types/jc';
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- legacy Seerr payload + DOM shapes; typed incrementally */
 /* eslint-disable @typescript-eslint/no-misused-promises -- legacy async event listeners with fire-and-forget bodies; semantics preserved verbatim */
@@ -9,18 +10,56 @@ import { JC } from '../../globals';
 
 import { internal } from './internal';
 import { buildSeerrPendingToggle } from '../../enhanced/spoiler-guard/seerr-toggle';
-const state = internal.state;
+interface ActionModal extends HTMLElement {
+    _actionCleanups?: Set<() => void>;
+}
+
+const state: {
+    currentModal: ActionModal | null;
+    identity: IdentityContext | null;
+    openGeneration: number;
+} = internal.state;
 const logPrefix = '🪼 Jellyfin Canopy: Seerr More Info:';
 const escapeHtml = JC.escapeHtml;
 const DisplayStatus = JC.seerrStatus!.DISPLAY;
 
+function isLiveNode(node?: Node | null): boolean {
+    return !!state.identity
+        && JC.identity.isCurrent(state.identity)
+        && !!state.currentModal
+        && state.currentModal.isConnected
+        && (!node || (state.currentModal.contains(node)
+            && (!JC.identity.ownerOf(node) || JC.identity.isOwned(node, state.identity))));
+}
+
+function ownControl<T extends Node>(node: T): T {
+    return JC.identity.own(node, state.identity);
+}
+
+function trackModalCleanup(cleanup: () => void): void {
+    state.currentModal?._actionCleanups?.add(cleanup);
+}
+
+function scheduleModalFrame(callback: () => void): void {
+    const cleanups = state.currentModal?._actionCleanups;
+    let frame = 0;
+    const cancel = () => cancelAnimationFrame(frame);
+    frame = requestAnimationFrame(() => {
+        cleanups?.delete(cancel);
+        callback();
+    });
+    cleanups?.add(cancel);
+}
+
 function buildSingle4kButton(data: any) {
 const button = document.createElement('button');
+ownControl(button);
 button.className = 'seerr-request-button seerr-button-request';
 button.innerHTML = `${JC.seerrUIIcons?.request || '<span class="material-icons">download</span>'}<span>${JC.t!('seerr_btn_request_4k') || 'Request in 4K'}</span>`;
 button.addEventListener('click', async (e: any) => {
     e.preventDefault();
     e.stopPropagation();
+    if (!isLiveNode(button)) return;
     if (JC.pluginConfig.SeerrShowAdvanced) {
         window.JellyfinCanopy?.seerrUI?.showMovieRequestModal?.(data.id, data.title || data.name, data, true);
         return;
@@ -29,11 +68,14 @@ button.addEventListener('click', async (e: any) => {
     button.innerHTML = `<span>${JC.t!('seerr_btn_requesting')}</span><span class="seerr-button-spinner"></span>`;
     try {
         await JC.seerrAPI!.requestMedia(data.id, 'movie', { is4k: true }, false, data);
+        if (!isLiveNode(button)) return;
         mountRequestedChip(data, 'movie', true);
     } catch (error: any) {
+        if (!isLiveNode(button)) return;
         // Quota errors get a themed dialog; restore button to idle.
         if (JC.seerrUI?.isQuotaError?.(error)) {
             await JC.seerrUI.showQuotaErrorDialog(error, 'movie');
+            if (!isLiveNode(button)) return;
             button.disabled = false;
             button.innerHTML = `${JC.seerrUIIcons?.request || '<span class="material-icons">download</span>'}<span>${JC.t!('seerr_btn_request_4k') || 'Request in 4K'}</span>`;
             return;
@@ -64,12 +106,14 @@ if (show4kOption) {
     buttonGroup.className = 'seerr-button-group jc-more-info-button-group';
 
     const mainButton = document.createElement('button');
+    ownControl(mainButton);
     mainButton.className = 'seerr-request-button seerr-split-main seerr-button-request';
     mainButton.innerHTML = `${JC.seerrUIIcons?.request || '<span class="material-icons">download</span>'}<span>${JC.t!('seerr_btn_request')}</span>`;
     mainButton.dataset.tmdbId = data.id;
     mainButton.dataset.mediaType = 'movie';
 
     const arrowButton = document.createElement('button');
+    ownControl(arrowButton);
     arrowButton.className = 'seerr-split-arrow';
     arrowButton.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path fill-rule="evenodd" d="M12.53 16.28a.75.75 0 01-1.06 0l-7.5-7.5a.75.75 0 011.06-1.06L12 14.69l6.97-6.97a.75.75 0 111.06 1.06l-7.5 7.5z" clip-rule="evenodd" /></svg>';
     arrowButton.title = 'Request in 4K';
@@ -79,6 +123,7 @@ if (show4kOption) {
     mainButton.addEventListener('click', async (e: any) => {
         e.preventDefault();
         e.stopPropagation();
+        if (!isLiveNode(mainButton)) return;
         if (JC.pluginConfig.SeerrShowAdvanced) {
             window.JellyfinCanopy?.seerrUI?.showMovieRequestModal?.(data.id, data.title || data.name, data, false);
             return;
@@ -87,11 +132,14 @@ if (show4kOption) {
         mainButton.innerHTML = `<span>${JC.t!('seerr_btn_requesting')}</span><span class="seerr-button-spinner"></span>`;
         try {
             const response = await JC.seerrAPI!.requestMedia(data.id, 'movie', {}, false, data);
+            if (!isLiveNode(mainButton)) return;
             mountRequestedChip(data, 'movie', false, response);
         } catch (error: any) {
+            if (!isLiveNode(mainButton)) return;
             // Quota errors get a themed dialog; restore button to idle.
             if (JC.seerrUI?.isQuotaError?.(error)) {
                 await JC.seerrUI.showQuotaErrorDialog(error, 'movie');
+                if (!isLiveNode(mainButton)) return;
                 mainButton.disabled = false;
                 mainButton.innerHTML = `${JC.seerrUIIcons?.request || '<span class="material-icons">download</span>'}<span>${JC.t!('seerr_btn_request')}</span>`;
                 return;
@@ -113,6 +161,7 @@ const close4k = () => {
         document.removeEventListener('click', handleDocClick, true);
     }
 };
+trackModalCleanup(close4k);
 const handleDocClick = (ev: any) => {
     if (!open4k) return;
     if (!open4k.contains(ev.target) && !arrowButton.contains(ev.target)) {
@@ -123,13 +172,15 @@ const handleDocClick = (ev: any) => {
     arrowButton.addEventListener('click', (e: any) => {
     e.preventDefault();
     e.stopPropagation();
+    if (!isLiveNode(arrowButton)) return;
     if (open4k) {
         close4k();
         return;
     }
     const menu = document.createElement('div');
     menu.className = 'jc-4k-popup';
-    const option = document.createElement('button');
+        const option = document.createElement('button');
+        ownControl(option);
     option.className = 'jc-4k-popup-item';
 
     const moviePopupDs4k = JC.seerrStatus!.resolveDisplayStatus(status4k, false);
@@ -151,6 +202,7 @@ const handleDocClick = (ev: any) => {
         option.addEventListener('click', async (ev: any) => {
             ev.preventDefault();
             ev.stopPropagation();
+            if (!isLiveNode(arrowButton)) return;
             if (JC.pluginConfig.SeerrShowAdvanced) {
                 close4k();
                 window.JellyfinCanopy?.seerrUI?.showMovieRequestModal?.(data.id, data.title || data.name, data, true);
@@ -160,12 +212,15 @@ const handleDocClick = (ev: any) => {
             option.textContent = JC.t!('seerr_btn_requesting');
             try {
                 const response = await JC.seerrAPI!.requestMedia(data.id, 'movie', { is4k: true }, false, data);
+                if (!isLiveNode(arrowButton)) return;
                 mountRequestedChip(data, 'movie', true, response);
                 close4k();
             } catch (error: any) {
+                if (!isLiveNode(arrowButton)) return;
                 // Quota errors get a themed dialog; restore option to idle.
                 if (JC.seerrUI?.isQuotaError?.(error)) {
                     await JC.seerrUI.showQuotaErrorDialog(error, 'movie');
+                    if (!isLiveNode(arrowButton)) return;
                     option.disabled = false;
                     option.textContent = 'Request in 4K';
                     return;
@@ -177,12 +232,16 @@ const handleDocClick = (ev: any) => {
     }
 
     menu.appendChild(option);
+    menu.dataset.jcIdentityOwned = 'true';
+    JC.identity.own(menu, state.identity);
     document.body.appendChild(menu);
     const rect = arrowButton.getBoundingClientRect();
     menu.style.position = 'fixed';
     menu.style.left = `${rect.left}px`;
     menu.style.top = `${rect.bottom + 6}px`;
-    requestAnimationFrame(() => menu.classList.add('show'));
+    scheduleModalFrame(() => {
+        if (isLiveNode(arrowButton) && open4k === menu) menu.classList.add('show');
+    });
     open4k = menu;
     document.addEventListener('click', handleDocClick, true);
 });
@@ -192,11 +251,13 @@ const handleDocClick = (ev: any) => {
     container.appendChild(buttonGroup);
 } else {
     const requestButton = document.createElement('button');
+    ownControl(requestButton);
     requestButton.className = 'seerr-request-button seerr-button-request';
     requestButton.innerHTML = `${JC.seerrUIIcons?.request || '<span class="material-icons">download</span>'}<span>${JC.t!('seerr_btn_request')}</span>`;
     requestButton.addEventListener('click', async (e: any) => {
         e.preventDefault();
         e.stopPropagation();
+        if (!isLiveNode(requestButton)) return;
         if (JC.pluginConfig.SeerrShowAdvanced) {
             window.JellyfinCanopy?.seerrUI?.showMovieRequestModal?.(data.id, data.title || data.name, data, false);
             return;
@@ -205,11 +266,14 @@ const handleDocClick = (ev: any) => {
         requestButton.innerHTML = `<span>${JC.t!('seerr_btn_requesting')}</span><span class="seerr-button-spinner"></span>`;
         try {
             await JC.seerrAPI!.requestMedia(data.id, 'movie', {}, false, data);
+            if (!isLiveNode(requestButton)) return;
             mountRequestedChip(data, 'movie', false);
         } catch (error: any) {
+            if (!isLiveNode(requestButton)) return;
             // Quota errors get a themed dialog; restore button to idle.
             if (JC.seerrUI?.isQuotaError?.(error)) {
                 await JC.seerrUI.showQuotaErrorDialog(error, 'movie');
+                if (!isLiveNode(requestButton)) return;
                 requestButton.disabled = false;
                 requestButton.innerHTML = `${JC.seerrUIIcons?.request || '<span class="material-icons">download</span>'}<span>${JC.t!('seerr_btn_request')}</span>`;
                 return;
@@ -227,6 +291,7 @@ return container;
 }
 
 function mountRequestedChip(data: any, mediaType: any, is4k: any, response: any = null) {
+if (!isLiveNode()) return;
 const mediaInfo = data.mediaInfo = data.mediaInfo || {};
 if (mediaType === 'movie') {
     if (is4k) {
@@ -252,13 +317,15 @@ renderActions(data, mediaType);
 // Token guards against stale chip insertion when the user navigates between items.
 let _quotaRenderToken = 0;
 
-async function maybeRenderMoreInfoQuotaChip(actionMount: any, mediaType: any) {
-if (!actionMount) return;
+async function maybeRenderMoreInfoQuotaChip(actionMount: HTMLElement | null, mediaType: any) {
+if (!actionMount || !isLiveNode(actionMount)) return;
+const identity = state.identity;
 const myToken = ++_quotaRenderToken;
 actionMount.dataset.quotaRenderToken = String(myToken);
 
 try {
     const quota = await JC.seerrAPI?.fetchUserQuota?.();
+    if (!identity || !JC.identity.isCurrent(identity) || !isLiveNode(actionMount)) return;
     if (!actionMount.isConnected) return;
     if (actionMount.dataset.quotaRenderToken !== String(myToken)) return;
 
@@ -273,11 +340,15 @@ try {
 }
 
 function renderActions(data: any, mediaType: any) {
-if (!state.currentModal) return;
+if (!state.currentModal || !isLiveNode()) return;
+for (const cleanup of state.currentModal._actionCleanups || []) {
+    try { cleanup(); } catch { /* continue rendering */ }
+}
+state.currentModal._actionCleanups?.clear?.();
 
-const actionMount = state.currentModal.querySelector('[data-mount="jc-actions"]');
-const chipMount = state.currentModal.querySelector('[data-mount="jc-status-chip"]');
-const downloadsMount = state.currentModal.querySelector('[data-mount="jc-downloads"]');
+const actionMount = state.currentModal.querySelector<HTMLElement>('[data-mount="jc-actions"]');
+const chipMount = state.currentModal.querySelector<HTMLElement>('[data-mount="jc-status-chip"]');
+const downloadsMount = state.currentModal.querySelector<HTMLElement>('[data-mount="jc-downloads"]');
 if (actionMount) actionMount.innerHTML = '';
 if (chipMount) chipMount.innerHTML = '';
 if (downloadsMount) downloadsMount.innerHTML = '';
@@ -286,7 +357,7 @@ if (downloadsMount) downloadsMount.innerHTML = '';
 // primary Request CTA, independent of request status (pre-arm before request,
 // or register intent on a title someone else requested). Its own mount so the
 // actionMount.innerHTML resets above don't wipe it.
-const secondaryMount = state.currentModal.querySelector('[data-mount="jc-secondary-actions"]');
+const secondaryMount = state.currentModal.querySelector<HTMLElement>('[data-mount="jc-secondary-actions"]');
 if (secondaryMount) {
     secondaryMount.innerHTML = '';
     try {
@@ -415,6 +486,7 @@ if (mediaType === 'movie') {
             return;
         }
         void internal.checkForUnrequestedSeasons(data).then((hasUnrequestedSeasons: any) => {
+            if (!isLiveNode(actionMount)) return;
             if (hasUnrequestedSeasons && actionMount) {
                 const requestMoreButton = internal.buildTvRequestMoreButton(data, show4kTv, canRequest4k);
                 if (requestMoreButton) actionMount.appendChild(requestMoreButton);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/more-info-modal/init.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/more-info-modal/init.identity.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+import { internal } from './internal';
+
+function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((res) => { resolve = res; });
+    return { promise, resolve };
+}
+
+function openMoreInfo(tmdbId: number, mediaType: 'movie' | 'tv'): Promise<void> {
+    return (JC.seerrMoreInfo as {
+        open: (id: number, type: 'movie' | 'tv') => Promise<void>;
+    }).open(tmdbId, mediaType);
+}
+
+describe('Seerr more-info modal identity ownership', () => {
+    beforeAll(async () => {
+        JC.t = (key: string) => key;
+        internal.buildModalContent = () => `
+            <div class="modal-overlay"><div class="modal-container">
+                <h1 id="jc-more-info-title">title</h1>
+                <button class="modal-refresh">refresh</button>
+                <button class="modal-close">close</button>
+                <button class="jc-collection-card-button" data-collection-id="7" data-collection-name="A">collection</button>
+                <div data-mount="ratings"></div>
+            </div></div>`;
+        internal.renderActions = vi.fn();
+        internal.enrichSeasonCardsWithJellyfinLinks = vi.fn();
+        internal.backfillSeasonMetadata = vi.fn();
+        internal.fetchRatings = vi.fn().mockResolvedValue(null);
+        internal.buildRatingLogos = vi.fn(() => '');
+        internal.showError = vi.fn();
+        JC.seerrUI = { showCollectionRequestModal: vi.fn() };
+        await import('./init');
+    });
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        document.body.replaceChildren();
+        JC.identity.transition('info-server-a', `info-user-a-${Math.random()}`, 'test setup');
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.clearAllTimers();
+        vi.useRealTimers();
+    });
+
+    it('drops held A detail data after B becomes current', async () => {
+        const held = deferred<{ id: number; title: string }>();
+        internal.fetchMediaDetails = vi.fn(() => held.promise);
+
+        const opening = openMoreInfo(41, 'movie');
+        JC.identity.transition('info-server-b', 'info-user-b', 'account switch');
+        held.resolve({ id: 41, title: 'A title' });
+        await opening;
+
+        expect(document.querySelector('.jc-more-info-modal')).toBeNull();
+        expect(internal.renderActions).not.toHaveBeenCalled();
+        expect(internal.showError).not.toHaveBeenCalled();
+    });
+
+    it('removes an open A modal synchronously and makes retained actions inert', async () => {
+        internal.fetchMediaDetails = vi.fn().mockResolvedValue({ id: 42, title: 'A title' });
+        await openMoreInfo(42, 'movie');
+        const retainedModal = document.querySelector<HTMLElement>('.jc-more-info-modal')!;
+        const retainedCollection = retainedModal.querySelector<HTMLButtonElement>('.jc-collection-card-button')!;
+
+        JC.identity.transition('info-server-b2', 'info-user-b2', 'account switch');
+        retainedCollection.click();
+        vi.runAllTimers();
+
+        expect(retainedModal.isConnected).toBe(false);
+        expect(JC.seerrUI!.showCollectionRequestModal).not.toHaveBeenCalled();
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/more-info-modal/init.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/more-info-modal/init.ts
@@ -2,15 +2,37 @@
 // Public surface + orchestration for the Seerr more-info modal:
 // open/close, modal lifecycle, refresh and navigation cleanup.
 import { JC } from '../../globals';
-import { installModalA11y } from '../../core/modal-a11y';
+import { installModalA11y, type ModalA11yHandle } from '../../core/modal-a11y';
+import type { IdentityContext } from '../../types/jc';
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- legacy Seerr payload + DOM shapes; typed incrementally */
 /* eslint-disable @typescript-eslint/no-misused-promises -- legacy async event listeners with fire-and-forget bodies; semantics preserved verbatim */
 
 
-const moreInfoModal: any = JC.seerrMoreInfo = JC.seerrMoreInfo || {};
+interface MoreInfoModalElement extends HTMLDivElement {
+    _identityCleanups: Set<() => void>;
+    _actionCleanups: Set<() => void>;
+    _cleanupTvListener?: () => void;
+    _a11y?: ModalA11yHandle;
+    _activationTimer?: ReturnType<typeof setTimeout>;
+    _removeTimer?: ReturnType<typeof setTimeout>;
+    _isClosing?: boolean;
+}
+
+interface MoreInfoModalApi {
+    open: (tmdbId: any, mediaType: any) => Promise<void>;
+    close: (immediate?: boolean) => void;
+    checkForUnrequestedSeasons?: (data: any) => Promise<boolean>;
+}
+
+const moreInfoModal = (JC.seerrMoreInfo || {}) as MoreInfoModalApi;
+JC.seerrMoreInfo = moreInfoModal;
 import { internal } from './internal';
-const state = internal.state;
+const state: {
+    currentModal: MoreInfoModalElement | null;
+    identity: IdentityContext | null;
+    openGeneration: number;
+} = internal.state;
 const logPrefix = '🪼 Jellyfin Canopy: Seerr More Info:';
 
 /**
@@ -19,16 +41,21 @@ const logPrefix = '🪼 Jellyfin Canopy: Seerr More Info:';
  * @param {string} mediaType - 'movie' or 'tv'
  */
 moreInfoModal.open = async function (tmdbId: any, mediaType: any) {
+const identity = JC.identity.capture();
+if (!identity || !JC.identity.isCurrent(identity)) return;
+const generation = ++state.openGeneration;
+const isCurrent = () => generation === state.openGeneration && JC.identity.isCurrent(identity);
 try {
     // Fetch details first so the modal can open immediately
     const data = await internal.fetchMediaDetails(tmdbId, mediaType);
+    if (!isCurrent()) return;
     if (!data) {
         internal.showError('Failed to load media information');
         return;
     }
 
     // Render modal immediately
-    showModal(data, mediaType);
+    showModal(data, mediaType, identity, generation);
 
     // For TV shows, backfill missing season metadata (poster, overview, airDate) from TMDB/episodes
     if (mediaType === 'tv' && data.seasons?.some((s: any) => s.episodeCount > 0 && (!s.airDate || !s.posterPath))) {
@@ -38,6 +65,7 @@ try {
     // Fetch ratings in the background and populate when ready
     internal.fetchRatings(tmdbId, mediaType)
         .then((ratings: any) => {
+            if (!isCurrent()) return;
             // Modal might have been closed or replaced; ensure we're updating the correct one
             if (!state.currentModal) return;
             const modalTmdbId = state.currentModal?.dataset?.tmdbId;
@@ -52,10 +80,12 @@ try {
             }
         })
         .catch((error: any) => {
+            if (!isCurrent()) return;
             console.error(`${logPrefix} Failed to fetch ratings for TMDB ID ${tmdbId}:`, error);
             // Silently fail; modal is already shown without ratings
         });
 } catch (error: any) {
+    if (!isCurrent()) return;
     console.error('Error opening more info modal:', error);
     internal.showError('Failed to load media information');
 }
@@ -64,7 +94,18 @@ try {
 /**
  * Refresh modal data and update displays
  */
-async function refreshModalData(data: any, mediaType: any, modal: any, refreshBtn: any) {
+async function refreshModalData(
+    data: any,
+    mediaType: any,
+    modal: MoreInfoModalElement,
+    refreshBtn: HTMLButtonElement
+) {
+const identity = JC.identity.ownerOf(modal);
+const isCurrent = () => !!identity
+    && JC.identity.isCurrent(identity)
+    && state.currentModal === modal
+    && modal.isConnected;
+if (!isCurrent()) return;
 try {
     // Show loading state on button
     refreshBtn.classList.add('loading');
@@ -72,6 +113,7 @@ try {
 
     // Fetch fresh data
     const freshData = await internal.fetchMediaDetails(data.id, mediaType);
+    if (!isCurrent()) return;
     if (!freshData) {
         internal.showError('Failed to refresh media information');
         refreshBtn.classList.remove('loading');
@@ -92,6 +134,7 @@ try {
     refreshBtn.disabled = false;
 
 } catch (error: any) {
+    if (!isCurrent()) return;
     console.error('Error refreshing modal data:', error);
     internal.showError('Failed to refresh modal data');
     refreshBtn.classList.remove('loading');
@@ -102,31 +145,39 @@ try {
 /**
  * Show the modal with media information
  */
-function showModal(data: any, mediaType: any) {
+function showModal(data: any, mediaType: any, identity: IdentityContext, generation: number) {
+if (!JC.identity.isCurrent(identity) || generation !== state.openGeneration) return;
 // Close existing modal if any
-moreInfoModal.close();
+moreInfoModal.close(true);
 
-const modal = document.createElement('div');
+const modal = document.createElement('div') as MoreInfoModalElement;
 modal.className = 'jc-more-info-modal';
+modal.dataset.jcIdentityOwned = 'true';
+JC.identity.own(modal, identity);
 modal.innerHTML = internal.buildModalContent(data, mediaType);
 // Tag modal so async updates only apply to the current item
 modal.dataset.tmdbId = String(data.id || '');
 modal.dataset.mediaType = mediaType;
+modal._identityCleanups = new Set<() => void>();
+modal._actionCleanups = new Set<() => void>();
 
 // Add event listeners
 modal.addEventListener('click', (e: any) => {
+    if (!JC.identity.isCurrent(identity) || state.currentModal !== modal) return;
     if (e.target === modal || e.target.classList.contains('modal-overlay')) {
         moreInfoModal.close();
     }
 });
 
 // Refresh button handler
-const refreshBtn = modal.querySelector('.modal-refresh');
+const refreshBtn = modal.querySelector<HTMLButtonElement>('.modal-refresh');
 if (refreshBtn) {
     refreshBtn.addEventListener('click', async (e: any) => {
         e.preventDefault();
         e.stopPropagation();
-        await refreshModalData(data, mediaType, modal, refreshBtn);
+        if (JC.identity.isCurrent(identity) && state.currentModal === modal) {
+            await refreshModalData(data, mediaType, modal, refreshBtn);
+        }
     });
 }
 
@@ -136,7 +187,7 @@ if (closeBtn) {
     closeBtn.addEventListener('click', (e: any) => {
         e.preventDefault();
         e.stopPropagation();
-        moreInfoModal.close();
+        if (JC.identity.isCurrent(identity) && state.currentModal === modal) moreInfoModal.close();
     });
 }
 
@@ -146,6 +197,7 @@ if (collectionBtn) {
     collectionBtn.addEventListener('click', (e: any) => {
         e.preventDefault();
         e.stopPropagation();
+        if (!JC.identity.isCurrent(identity) || state.currentModal !== modal) return;
         const collectionId = parseInt(collectionBtn.dataset.collectionId || "", 10);
         const collectionName = collectionBtn.dataset.collectionName;
         if (collectionId && collectionName) {
@@ -156,11 +208,12 @@ if (collectionBtn) {
 
 document.body.appendChild(modal);
 state.currentModal = modal;
+state.identity = identity;
 
 // Accessible dialog: role/aria, focus trap + restore, Escape, and the
 // jc-modal-open gate that suppresses JC global shortcuts while open (A11Y-1 /
 // INT-1). Replaces the former hand-rolled Escape-only keydown listener.
-(modal as any)._a11y = installModalA11y(modal, {
+modal._a11y = installModalA11y(modal, {
     labelledBy: 'jc-more-info-title',
     onEscape: () => moreInfoModal.close(),
 });
@@ -174,11 +227,13 @@ if (mediaType === 'tv') {
 // Listen for TV season requests to update status
 if (mediaType === 'tv') {
     const handleTvRequest = async (e: any) => {
+        if (!JC.identity.isCurrent(identity) || state.currentModal !== modal) return;
         if (!e.detail?.tmdbId || String(e.detail.tmdbId) !== String(data.id)) return;
 
         try {
             // Refresh details to pull latest status/progress
             const fresh = await internal.fetchMediaDetails(data.id, 'tv');
+            if (!JC.identity.isCurrent(identity) || state.currentModal !== modal) return;
             if (fresh?.mediaInfo) {
                 data.mediaInfo = fresh.mediaInfo;
             } else {
@@ -187,45 +242,65 @@ if (mediaType === 'tv') {
                 mediaInfo.status = mediaInfo.status || 2;
             }
         } catch (_: any) {
+            if (!JC.identity.isCurrent(identity) || state.currentModal !== modal) return;
             const mediaInfo = data.mediaInfo || (data.mediaInfo = {});
             mediaInfo.status = mediaInfo.status || 2;
         }
 
+        if (!JC.identity.isCurrent(identity) || state.currentModal !== modal) return;
         internal.renderActions(data, mediaType);
         internal.enrichSeasonCardsWithJellyfinLinks(data, modal);
     };
     document.addEventListener('seerr-tv-requested', handleTvRequest);
-    (modal as any)._cleanupTvListener = () => document.removeEventListener('seerr-tv-requested', handleTvRequest);
+    modal._cleanupTvListener = () => document.removeEventListener('seerr-tv-requested', handleTvRequest);
 }
 
 // Trigger animation
-setTimeout(() => modal.classList.add('active'), 10);
+const activationTimer = setTimeout(() => {
+    if (JC.identity.isCurrent(identity) && state.currentModal === modal) modal.classList.add('active');
+}, 10);
+modal._activationTimer = activationTimer;
 }
 
 /**
  * Close the modal
  */
-moreInfoModal.close = function () {
-if (state.currentModal) {
-    if (state.currentModal._isClosing) return;
-    state.currentModal._isClosing = true;
+moreInfoModal.close = function (immediate = false) {
+const target = state.currentModal;
+if (target) {
+    if (target._isClosing && !immediate) return;
+    target._isClosing = true;
+
+    if (target._activationTimer) clearTimeout(target._activationTimer);
+    if (target._removeTimer) clearTimeout(target._removeTimer);
+    for (const cleanup of target._identityCleanups || []) {
+        try { cleanup(); } catch { /* continue closing */ }
+    }
+    target._identityCleanups?.clear?.();
+    for (const cleanup of target._actionCleanups || []) {
+        try { cleanup(); } catch { /* continue closing */ }
+    }
+    target._actionCleanups?.clear?.();
 
     // Clean up TV request listener if exists
-    if (state.currentModal._cleanupTvListener) {
-        state.currentModal._cleanupTvListener();
+    if (target._cleanupTvListener) {
+        target._cleanupTvListener();
     }
     // Release the a11y handle now (before the 300ms removal) so focus restores
     // immediately and the jc-modal-open gate lifts.
-    if (state.currentModal._a11y) {
-        state.currentModal._a11y.release();
+    if (target._a11y) {
+        target._a11y.release();
     }
-    state.currentModal.classList.remove('active');
-    setTimeout(() => {
-        if (document.body.contains(state.currentModal)) {
-            document.body.removeChild(state.currentModal);
+    target.classList.remove('active');
+    const finish = () => {
+        target.remove();
+        if (state.currentModal === target) {
+            state.currentModal = null;
+            state.identity = null;
         }
-        state.currentModal = null;
-    }, 300);
+    };
+    if (immediate) finish();
+    else target._removeTimer = setTimeout(finish, 300);
 }
 }
 
@@ -234,6 +309,11 @@ document.addEventListener('viewshow', function () {
     if (state.currentModal) {
         moreInfoModal.close();
     }
+});
+
+JC.identity.registerReset('seerr-more-info-modal', () => {
+    state.openGeneration += 1;
+    moreInfoModal.close(true);
 });
 
 // Expose helpers used by other modules (e.g., item-details.js for the

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/more-info-modal/internal.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/more-info-modal/internal.ts
@@ -11,9 +11,15 @@
 
 /** The shared more-info modal helper bag (was JC.internals.moreInfoModal). */
 export interface MoreInfoModalInternal {
-    state: { currentModal: any };
+    state: {
+        currentModal: any;
+        identity: import('../../types/jc').IdentityContext | null;
+        openGeneration: number;
+    };
     [key: string]: any;
 }
 
 /** Singleton shared across the more-info-modal-* modules. */
-export const internal: MoreInfoModalInternal = { state: { currentModal: null } };
+export const internal: MoreInfoModalInternal = {
+    state: { currentModal: null, identity: null, openGeneration: 0 }
+};

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/more-info-modal/seasons.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/more-info-modal/seasons.ts
@@ -2,12 +2,17 @@
 // Season-level logic: metadata backfill from TMDB, Jellyfin season links,
 // availability chips, unrequested-season detection and the seasons section.
 import { JC } from '../../globals';
+import type { IdentityContext } from '../../types/jc';
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- legacy Seerr payload + DOM shapes; typed incrementally */
 
 
 import { internal } from './internal';
-const state = internal.state;
+const state: {
+    currentModal: HTMLElement | null;
+    identity: IdentityContext | null;
+    openGeneration: number;
+} = internal.state;
 const logPrefix = '🪼 Jellyfin Canopy: Seerr More Info:';
 const escapeHtml = JC.escapeHtml;
 const MediaStatus = JC.seerrStatus!.MEDIA;
@@ -38,6 +43,13 @@ return Number.isInteger(normalized) && normalized >= 0 ? normalized : null;
 async function backfillSeasonMetadata(tmdbId: any, data: any) {
 try {
     if (!state.currentModal || !data?.seasons) return;
+    const modal = state.currentModal;
+    const identity = JC.identity.ownerOf(modal);
+    const isCurrent = () => !!identity
+        && JC.identity.isCurrent(identity)
+        && state.currentModal === modal
+        && modal.isConnected;
+    if (!isCurrent()) return;
 
     const api = JC.seerrAPI;
     const seasonsMissingData = data.seasons.filter((s: any) => s.episodeCount > 0 && (!s.airDate || !s.posterPath || !s.overview));
@@ -57,6 +69,7 @@ try {
         : [];
 
     const [tmdbData, ...episodeResults] = await Promise.all([tmdbPromise, ...episodePromises]);
+    if (!isCurrent()) return;
 
     // Build TMDB season lookup
     const tmdbMap: any = {};
@@ -73,12 +86,12 @@ try {
     });
 
     // Bail if modal was closed/replaced during async fetch
-    if (!state.currentModal || String(state.currentModal.dataset?.tmdbId) !== String(tmdbId)) return;
+    if (!isCurrent() || String(modal.dataset?.tmdbId) !== String(tmdbId)) return;
 
     // Update each season card in the DOM
     data.seasons.forEach((season: any) => {
         const sNum = season.seasonNumber;
-        const card = state.currentModal.querySelector(`.season-card[data-season-number="${CSS.escape(String(sNum))}"]`);
+        const card = modal.querySelector(`.season-card[data-season-number="${CSS.escape(String(sNum))}"]`);
         if (!card) return;
 
         const tmdbSeason = tmdbMap[sNum];
@@ -196,20 +209,25 @@ return `<div class="season-links">${pills.join('')}</div>`;
 }
 
 async function fetchJellyfinSeasonMap(seriesId: any) {
-const userId = ApiClient.getCurrentUserId?.();
-if (!userId || !seriesId) return {};
+const identity = JC.identity.capture();
+if (!identity || !seriesId) return {};
 
 try {
-    const response: any = await ApiClient.ajax({
-        type: 'GET',
-        url: ApiClient.getUrl(`/Users/${userId}/Items`, {
-            ParentId: seriesId,
-            IncludeItemTypes: 'Season',
-            Recursive: false,
-            Fields: 'ParentIndexNumber,IndexNumber,Name'
-        }),
-        dataType: 'json'
+    const query = new URLSearchParams({
+        ParentId: String(seriesId),
+        IncludeItemTypes: 'Season',
+        Recursive: 'false',
+        Fields: 'ParentIndexNumber,IndexNumber,Name'
     });
+    const path = `/Users/${encodeURIComponent(identity.userId)}/Items?${query.toString()}`;
+    const response: any = JC.core.api
+        ? await JC.core.api.jf(path)
+        : await ApiClient.ajax({
+            type: 'GET',
+            url: ApiClient.getUrl(`/Users/${identity.userId}/Items`, Object.fromEntries(query)),
+            dataType: 'json'
+        });
+    if (!JC.identity.isCurrent(identity)) return {};
 
     const map: any = {};
     const items = Array.isArray(response?.Items) ? response.Items : [];
@@ -226,8 +244,17 @@ try {
 }
 }
 
-async function enrichSeasonCardsWithJellyfinLinks(data: any, modal: any = state.currentModal) {
+async function enrichSeasonCardsWithJellyfinLinks(
+    data: any,
+    modal: HTMLElement | null = state.currentModal
+) {
 if (!modal || data?.mediaType === 'movie') return;
+const identity = JC.identity.ownerOf(modal);
+const isCurrent = () => !!identity
+    && JC.identity.isCurrent(identity)
+    && state.currentModal === modal
+    && modal.isConnected;
+if (!isCurrent()) return;
 
 const cards = modal.querySelectorAll('[data-season-number]');
 if (!cards.length) return;
@@ -237,6 +264,7 @@ if (!seriesId) return;
 
 if (!data._jellyfinSeasonIdMap) {
     data._jellyfinSeasonIdMap = await fetchJellyfinSeasonMap(seriesId);
+    if (!isCurrent()) return;
 }
 
 cards.forEach((card: any) => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/seerr.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/seerr.identity.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../globals';
+
+describe('Seerr search identity lifecycle', () => {
+    let originalIdentity = JC.identity.capture()!;
+    let resolveSearch!: (value: unknown) => void;
+    let renderResults: ReturnType<typeof vi.fn>;
+    let bodyUnsubscribes: Array<ReturnType<typeof vi.fn>>;
+    let navUnsubscribes: Array<ReturnType<typeof vi.fn>>;
+
+    beforeEach(async () => {
+        vi.useFakeTimers();
+        vi.resetModules();
+        originalIdentity = JC.identity.capture()!;
+        document.body.innerHTML = `
+            <div id="searchPage">
+                <input id="searchTextInput" value="identity query">
+                <div class="searchResults"></div>
+            </div>`;
+        JC.pluginConfig = {
+            SeerrEnabled: true,
+            SeerrShowSearchResults: true,
+            SeerrShowGenreDiscovery: false,
+        };
+        renderResults = vi.fn();
+        bodyUnsubscribes = [];
+        navUnsubscribes = [];
+        JC.seerrAPI = {
+            checkUserStatus: vi.fn().mockResolvedValue({ active: true, userFound: true }),
+            search: vi.fn(() => new Promise((resolve) => { resolveSearch = resolve; })),
+            requestMedia: vi.fn(),
+            addCollections: vi.fn((results: unknown[]) => Promise.resolve(results)),
+        } as unknown as NonNullable<typeof JC.seerrAPI>;
+        JC.seerrUI = {
+            addMainStyles: vi.fn(),
+            addSeasonModalStyles: vi.fn(),
+            updateSeerrIcon: vi.fn(),
+            renderSeerrResults: renderResults,
+            showMovieRequestModal: vi.fn(),
+            showSeasonSelectionModal: vi.fn(),
+            showCollectionRequestModal: vi.fn(),
+            hideHoverPopover: vi.fn(),
+            toggleHoverPopoverLock: vi.fn(),
+            updateSeerrResults: vi.fn(),
+            createSeerrCard: vi.fn(() => document.createElement('div')),
+            icons: {},
+        };
+        JC.seamlessScroll = {
+            createDeduplicator: () => ({ filter: (rows: unknown[]) => rows, clear: vi.fn() }),
+            cleanupInfiniteScroll: vi.fn(),
+            setupInfiniteScroll: vi.fn(),
+        } as unknown as NonNullable<typeof JC.seamlessScroll>;
+        JC.helpers = {
+            onBodyMutation: vi.fn(() => {
+                const unsubscribe = vi.fn();
+                bodyUnsubscribes.push(unsubscribe);
+                return { unsubscribe, disconnect: unsubscribe };
+            }),
+            onNavigate: vi.fn(() => {
+                const unsubscribe = vi.fn();
+                navUnsubscribes.push(unsubscribe);
+                return unsubscribe;
+            }),
+        };
+        JC.t = (key: string) => key;
+        JC.toast = vi.fn();
+        await import('./seerr');
+    });
+
+    afterEach(() => {
+        JC.identity.transition(
+            originalIdentity.serverId,
+            originalIdentity.userId,
+            'seerr-search-test-restore',
+        );
+        vi.clearAllTimers();
+        vi.useRealTimers();
+        document.body.innerHTML = '';
+    });
+
+    it('replaces same-epoch wiring and rejects a late A search after B-disabled reset', async () => {
+        const initialize = JC.initializeSeerrScript as unknown as () => void;
+        initialize();
+        await vi.advanceTimersByTimeAsync(0);
+        initialize();
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(bodyUnsubscribes).toHaveLength(2);
+        expect(navUnsubscribes).toHaveLength(2);
+        expect(bodyUnsubscribes[0]).toHaveBeenCalledTimes(1);
+        expect(navUnsubscribes[0]).toHaveBeenCalledTimes(1);
+        expect(bodyUnsubscribes[1]).not.toHaveBeenCalled();
+        expect(navUnsubscribes[1]).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(300);
+        expect(JC.seerrAPI!.search).toHaveBeenCalledTimes(1);
+
+        JC.pluginConfig = { SeerrEnabled: false, SeerrShowSearchResults: false };
+        JC.identity.transition('server-b', 'user-b', 'seerr-search-race');
+        expect(bodyUnsubscribes[1]).toHaveBeenCalledTimes(1);
+        expect(navUnsubscribes[1]).toHaveBeenCalledTimes(1);
+
+        resolveSearch({ results: [{ id: 1 }], page: 1, totalPages: 1 });
+        await vi.advanceTimersByTimeAsync(0);
+        expect(renderResults).not.toHaveBeenCalled();
+        expect(document.querySelector('.seerr-section')).toBeNull();
+
+        document.dispatchEvent(new CustomEvent('seerr-manual-refresh'));
+        await vi.advanceTimersByTimeAsync(500);
+        expect(JC.seerrAPI!.search).toHaveBeenCalledTimes(1);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/seerr.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/seerr.ts
@@ -1,12 +1,81 @@
 // src/seerr/seerr.ts
 import { JC } from '../globals';
+import type { IdentityContext } from '../types/jc';
 
+interface SeerrSearchRuntime {
+    context: IdentityContext;
+    cleanups: Array<() => void>;
+    timers: Set<number>;
+    cleanupState?: () => void;
+}
+
+interface SeerrUserStatus {
+    active: boolean;
+    userFound: boolean;
+}
+
+function asElement(target: EventTarget | null): Element | null {
+    return target instanceof Element ? target : null;
+}
+
+function hasUnsubscribe(value: unknown): value is { unsubscribe: () => void } {
+    if (!value || typeof value !== 'object' || !('unsubscribe' in value)) return false;
+    return typeof (value as { unsubscribe?: unknown }).unsubscribe === 'function';
+}
+
+let activeRuntime: SeerrSearchRuntime | null = null;
+
+function runtimeIsCurrent(runtime: SeerrSearchRuntime): boolean {
+    return activeRuntime === runtime && JC.identity.isCurrent(runtime.context);
+}
+
+function scheduleRuntime(runtime: SeerrSearchRuntime, fn: () => void, delay: number): number {
+    const timer = window.setTimeout(() => {
+        runtime.timers.delete(timer);
+        if (runtimeIsCurrent(runtime)) fn();
+    }, delay);
+    runtime.timers.add(timer);
+    return timer;
+}
+
+function listenRuntime(
+    runtime: SeerrSearchRuntime,
+    target: EventTarget,
+    type: string,
+    listener: EventListener,
+    options?: boolean | AddEventListenerOptions,
+): void {
+    target.addEventListener(type, listener, options);
+    runtime.cleanups.push(() => target.removeEventListener(type, listener, options));
+}
+
+function resetSeerrSearchIdentity(): void {
+    const resultsUi = JC.seerrUI as { resetResultsIdentity?: () => void } | undefined;
+    resultsUi?.resetResultsIdentity?.();
+    const runtime = activeRuntime;
+    activeRuntime = null;
+    if (runtime) {
+        for (const timer of runtime.timers) clearTimeout(timer);
+        runtime.timers.clear();
+        try { runtime.cleanupState?.(); } catch { /* continue */ }
+        for (const cleanup of runtime.cleanups.splice(0).reverse()) {
+            try { cleanup(); } catch { /* continue */ }
+        }
+    }
+    document.querySelectorAll(
+        '.seerr-section, .seerr-4k-popup, #seerr-placeholder, .seerr-season-modal'
+    ).forEach((node) => node.remove());
+    document.querySelectorAll('.section-hidden').forEach((node) => node.classList.remove('section-hidden'));
+}
+
+JC.identity.registerReset('seerr-search', resetSeerrSearchIdentity);
 
 /**
  * Main initialization function for Seerr search integration.
  * This function sets up the state, observers, and event listeners.
  */
 JC.initializeSeerrScript = function() {
+    resetSeerrSearchIdentity();
     // Early exit if Seerr integration or search results are disabled in plugin settings
     if (!JC.pluginConfig.SeerrEnabled) {
         console.log('🪼 Jellyfin Canopy: Seerr Search: Integration is disabled in plugin settings.');
@@ -17,6 +86,12 @@ JC.initializeSeerrScript = function() {
         return;
     }
 
+    const context = JC.identity.capture();
+    if (!context || !JC.identity.isCurrent(context)) return;
+    const runtime: SeerrSearchRuntime = { context, cleanups: [], timers: new Set<number>() };
+    activeRuntime = runtime;
+    const isCurrent = (): boolean => runtimeIsCurrent(runtime);
+
     const logPrefix = '🪼 Jellyfin Canopy: Seerr:';
     const escapeHtml = JC.escapeHtml;
     console.log(`${logPrefix} Initializing...`);
@@ -25,11 +100,11 @@ JC.initializeSeerrScript = function() {
     // STATE MANAGEMENT VARIABLES
     // ================================
     let lastProcessedQuery: string | null = null;
-    let debounceTimeout: any = null;
+    let debounceTimeout: number | null = null;
     let isSeerrActive = false;
     let seerrUserFound = false;
     let isSeerrOnlyMode = false;
-    let hiddenSections: any[] = [];
+    let hiddenSections: Element[] = [];
     let seerrOriginalPosition: HTMLElement | null = null;
 
     // Infinite scroll pagination state
@@ -39,6 +114,8 @@ JC.initializeSeerrScript = function() {
     let searchHasMore = false;
     const searchScrollState: any = {};
     let searchDeduplicator: any = null;
+    let pageObserverInitialized = false;
+    const wiredAlphaPickers = new WeakSet<Element>();
 
 
     // Destructure modules for easy access
@@ -49,6 +126,20 @@ JC.initializeSeerrScript = function() {
         showCollectionRequestModal, hideHoverPopover, toggleHoverPopoverLock, updateSeerrResults,
         createSeerrCard
     } = JC.seerrUI!;
+    const hideRuntimePopover = hideHoverPopover as unknown as () => void;
+    const setRuntimePopoverLock = toggleHoverPopoverLock as unknown as (locked?: boolean) => void;
+
+    runtime.cleanupState = () => {
+        if (debounceTimeout !== null) {
+            clearTimeout(debounceTimeout);
+            debounceTimeout = null;
+        }
+        JC.seamlessScroll?.cleanupInfiniteScroll(searchScrollState);
+        hiddenSections.forEach((section) => section.classList.remove('section-hidden'));
+        seerrOriginalPosition?.remove();
+        hiddenSections = [];
+        seerrOriginalPosition = null;
+    };
 
     /**
      * Toggles between showing all search results vs only Seerr results.
@@ -121,11 +212,13 @@ JC.initializeSeerrScript = function() {
      * @param {string} query The search query.
      */
     async function fetchAndRenderResults(query: string, options: any = {}) {
+        if (!isCurrent()) return;
         const { skipCache = false } = options;
         resetSearchPagination();
         searchDeduplicator = JC.seamlessScroll?.createDeduplicator() || null;
 
         const data = await search(query, 1, { skipCache });
+        if (!isCurrent() || lastProcessedQuery !== query) return;
         let results = data.results || [];
         searchCurrentPage = data.page || 1;
         searchTotalPages = data.totalPages || 1;
@@ -139,7 +232,7 @@ JC.initializeSeerrScript = function() {
 
             // Enrich with collections in the background, then re-render
             prepareResultsWithCollections(results).then((enrichedResults: any[]) => {
-                if (lastProcessedQuery !== query) return;
+                if (!isCurrent() || lastProcessedQuery !== query) return;
                 if (JC.hiddenContent) enrichedResults = JC.hiddenContent.filterSeerrResults(enrichedResults, 'search');
                 if (enrichedResults.length > results.length) {
                     renderSeerrResults(enrichedResults, query, isSeerrOnlyMode, isSeerrActive, seerrUserFound);
@@ -162,14 +255,14 @@ JC.initializeSeerrScript = function() {
      * @param {string} query The current search query.
      */
     async function loadMoreSearchResults(query: string) {
-        if (searchIsLoading || !searchHasMore || lastProcessedQuery !== query) return;
+        if (!isCurrent() || searchIsLoading || !searchHasMore || lastProcessedQuery !== query) return;
 
         searchIsLoading = true;
         const nextPage = searchCurrentPage + 1;
 
         try {
             const data = await search(query, nextPage);
-            if (lastProcessedQuery !== query) return; // query changed during fetch
+            if (!isCurrent() || lastProcessedQuery !== query) return; // query/identity changed during fetch
 
             let results = data.results || [];
             searchCurrentPage = data.page || nextPage;
@@ -191,6 +284,7 @@ JC.initializeSeerrScript = function() {
                 }
             }
         } catch (error: any) {
+            if (!isCurrent()) return;
             if (error.name !== 'AbortError') {
                 console.warn(`${logPrefix} Failed to load more search results:`, error);
                 // Roll back page on failure
@@ -198,7 +292,7 @@ JC.initializeSeerrScript = function() {
             }
             throw error; // Re-throw for seamlessScroll retry handling
         } finally {
-            searchIsLoading = false;
+            if (isCurrent()) searchIsLoading = false;
         }
     }
 
@@ -224,6 +318,7 @@ JC.initializeSeerrScript = function() {
      * @returns {Promise<Array>} Enriched results including collections and badges.
      */
     async function prepareResultsWithCollections(rawResults: any[]) {
+        if (!isCurrent()) return [];
         let results = rawResults || [];
         if (JC.pluginConfig.ShowCollectionsInSearch === false) {
             return results;
@@ -231,6 +326,7 @@ JC.initializeSeerrScript = function() {
 
         try {
             results = await JC.seerrAPI!.addCollections(results);
+            if (!isCurrent()) return [];
         } catch (e: any) {
             console.debug(`${logPrefix} Collection addition failed:`, e);
         }
@@ -282,6 +378,7 @@ JC.initializeSeerrScript = function() {
      */
     // Manual refresh handler
     async function manualRefreshSeerrData(query: string | null) {
+        if (!isCurrent()) return;
         const section = document.querySelector('.seerr-section');
         const itemsContainer = section?.querySelector('.itemsContainer');
         if (!query || !itemsContainer) return;
@@ -292,7 +389,9 @@ JC.initializeSeerrScript = function() {
             searchDeduplicator = JC.seamlessScroll?.createDeduplicator() || null;
 
             const data = await search(query, 1);
+            if (!isCurrent() || lastProcessedQuery !== query) return;
             let results = await prepareResultsWithCollections(data.results || []);
+            if (!isCurrent() || lastProcessedQuery !== query) return;
             if (JC.hiddenContent) results = JC.hiddenContent.filterSeerrResults(results, 'search');
 
             searchCurrentPage = data.page || 1;
@@ -311,6 +410,7 @@ JC.initializeSeerrScript = function() {
                 setupSearchInfiniteScroll(query);
             }
         } catch (error: any) {
+            if (!isCurrent()) return;
             console.warn(`${logPrefix} Failed to refresh Seerr data:`, error);
         }
     }
@@ -319,14 +419,18 @@ JC.initializeSeerrScript = function() {
      * Sets up DOM observation for search page changes.
      */
     function initializePageObserver() {
+        if (pageObserverInitialized || !isCurrent()) return;
+        pageObserverInitialized = true;
         const handleSearch = () => {
+            if (!isCurrent()) return;
             const searchInput = document.querySelector<HTMLInputElement>('#searchPage #searchTextInput');
             const isSearchPage = searchInput !== null;
             const currentQuery = isSearchPage ? searchInput.value : null;
 
             if (isSearchPage && currentQuery?.trim()) {
-                clearTimeout(debounceTimeout);
-                debounceTimeout = setTimeout(() => {
+                if (debounceTimeout !== null) clearTimeout(debounceTimeout);
+                debounceTimeout = scheduleRuntime(runtime, () => {
+                    debounceTimeout = null;
                     if (!isSeerrActive) {
                         document.querySelectorAll('.seerr-section').forEach(el => el.remove());
                         return;
@@ -346,7 +450,8 @@ JC.initializeSeerrScript = function() {
                     void fetchAndRenderResults(latestQuery);
                 }, 300);
             } else {
-                clearTimeout(debounceTimeout);
+                if (debounceTimeout !== null) clearTimeout(debounceTimeout);
+                debounceTimeout = null;
                 lastProcessedQuery = null;
                 isSeerrOnlyMode = false;
                 resetSearchPagination();
@@ -365,6 +470,7 @@ JC.initializeSeerrScript = function() {
         let lastIconState: string | null = null;
 
         function tryAttachSearchListener() {
+            if (!isCurrent()) return;
             // PERF(R8): this runs on every structural body-mutation batch — gate on
             // a cheap search-page probe first, and only touch the icon when its
             // state changed or the icon got detached (page rebuild). The old
@@ -382,15 +488,17 @@ JC.initializeSeerrScript = function() {
             const searchInput = searchPage.querySelector<HTMLInputElement>('#searchTextInput');
             if (searchInput && !searchInput.dataset.seerrListener) {
                 console.debug(`${logPrefix} Search input found, attaching listener.`);
-                searchInput.addEventListener('input', handleSearch);
+                listenRuntime(runtime, searchInput, 'input', handleSearch);
                 searchInput.dataset.seerrListener = 'true';
+                runtime.cleanups.push(() => { delete searchInput.dataset.seerrListener; });
 
                 // Add a click listener for the alphabet picker
                 const alphaPicker = document.querySelector('.alphaPicker');
-                if (alphaPicker) {
-                    alphaPicker.addEventListener('click', () => {
+                if (alphaPicker && !wiredAlphaPickers.has(alphaPicker)) {
+                    wiredAlphaPickers.add(alphaPicker);
+                    listenRuntime(runtime, alphaPicker, 'click', () => {
                         // Use a short delay to ensure the input value has updated before we read it
-                        setTimeout(handleSearch, 100);
+                        scheduleRuntime(runtime, handleSearch, 100);
                     });
                 }
 
@@ -400,13 +508,18 @@ JC.initializeSeerrScript = function() {
         }
 
         // Listen for manual refresh events from the UI
-        document.addEventListener('seerr-manual-refresh', function(e) {
+        const handleManualRefresh = () => {
+            if (!isCurrent()) return;
             const searchInput = document.querySelector<HTMLInputElement>('#searchPage #searchTextInput');
             const query = searchInput ? searchInput.value : null;
             void manualRefreshSeerrData(query);
-        });
+        };
+        listenRuntime(runtime, document, 'seerr-manual-refresh', handleManualRefresh);
 
-        JC.helpers!.onBodyMutation!('seerr-search-listener', tryAttachSearchListener);
+        const bodyHandle: unknown = JC.helpers!.onBodyMutation!('seerr-search-listener', tryAttachSearchListener);
+        if (hasUnsubscribe(bodyHandle)) {
+            runtime.cleanups.push(() => bodyHandle.unsubscribe());
+        }
 
         // Immediately check if the search page is already rendered (handles the
         // case where the observer was set up after the search page loaded, e.g.
@@ -418,14 +531,17 @@ JC.initializeSeerrScript = function() {
         // Uses the shared jc:navigate event (from helpers.js) which already
         // patches pushState/replaceState, plus popstate and hashchange.
         if (JC.helpers?.onNavigate) {
-            JC.helpers.onNavigate(() => setTimeout(tryAttachSearchListener, 200));
+            const unsubscribe = JC.helpers.onNavigate(() => {
+                scheduleRuntime(runtime, tryAttachSearchListener, 200);
+            });
+            if (typeof unsubscribe === 'function') runtime.cleanups.push(unsubscribe);
         } else {
             // Fallback if helpers.js hasn't loaded yet — may double-fire with
             // onNavigate if helpers loads later, but tryAttachSearchListener is
             // idempotent (guarded by dataset.seerrListener) so this is safe.
-            const onNav = () => setTimeout(tryAttachSearchListener, 200);
-            window.addEventListener('popstate', onNav);
-            window.addEventListener('hashchange', onNav);
+            const onNav = () => { scheduleRuntime(runtime, tryAttachSearchListener, 200); };
+            listenRuntime(runtime, window, 'popstate', onNav);
+            listenRuntime(runtime, window, 'hashchange', onNav);
         }
     }
 
@@ -437,9 +553,19 @@ JC.initializeSeerrScript = function() {
         const timeout = 20000;
 
         const checkForUser = async () => {
+            if (!isCurrent()) return;
             if (ApiClient.getCurrentUserId() && ApiClient.accessToken()) {
                 console.log(`${logPrefix} User session found. Initializing...`);
-                const status = await checkUserStatus();
+                let status: SeerrUserStatus;
+                try {
+                    status = await checkUserStatus();
+                } catch (error) {
+                    if (!isCurrent()) return;
+                    console.warn(`${logPrefix} User status check failed; keeping page observer retryable:`, error);
+                    initializePageObserver();
+                    return;
+                }
+                if (!isCurrent()) return;
                 isSeerrActive = status.active;
                 seerrUserFound = status.userFound;
                 console.debug(`${logPrefix} Status: active=${isSeerrActive}, userFound=${seerrUserFound}`);
@@ -450,13 +576,15 @@ JC.initializeSeerrScript = function() {
                     Promise.all([
                         JC.discoveryFilter?.fetchWithManagedRequest?.('/JellyfinCanopy/tmdb/genres/tv', 'genre', {})?.catch(() => {}),
                         JC.discoveryFilter?.fetchWithManagedRequest?.('/JellyfinCanopy/tmdb/genres/movie', 'genre', {})?.catch(() => {})
-                    ]).catch(() => {});
+                    ]).then(() => {
+                        if (!isCurrent()) return;
+                    }).catch(() => {});
                 }
             } else if (Date.now() - startTime > timeout) {
                 console.warn(`${logPrefix} Timed out waiting for user session. Features may be limited.`);
                 initializePageObserver();
             } else {
-                setTimeout(checkForUser, 300);
+                scheduleRuntime(runtime, () => { void checkForUser(); }, 300);
             }
         };
         void checkForUser();
@@ -471,24 +599,30 @@ JC.initializeSeerrScript = function() {
     waitForUserAndInitialize();
 
     // Hide popover when touching outside request buttons or scrolling
-    document.addEventListener('touchstart', (e: any) => {
-        if (!e.target.closest('.seerr-request-button')) {
-            toggleHoverPopoverLock(false);
-            hideHoverPopover();
+    listenRuntime(runtime, document, 'touchstart', (event: Event) => {
+        if (!isCurrent()) return;
+        if (!asElement(event.target)?.closest('.seerr-request-button')) {
+            setRuntimePopoverLock(false);
+            hideRuntimePopover();
         }
     }, { passive: true });
-    document.addEventListener('scroll', () => hideHoverPopover(), true);
+    listenRuntime(runtime, document, 'scroll', () => {
+        if (isCurrent()) hideRuntimePopover();
+    }, true);
 
     // Remove touch overlay when touching outside cards
-    document.body.addEventListener('touchstart', (e: any) => {
-        if (!e.target.closest('.seerr-card')) {
+    listenRuntime(runtime, document.body, 'touchstart', (event: Event) => {
+        if (!isCurrent()) return;
+        if (!asElement(event.target)?.closest('.seerr-card')) {
             document.querySelectorAll('.seerr-card.is-touch').forEach(card => card.classList.remove('is-touch'));
         }
     }, { passive: true });
 
     // Close 4K popup when clicking outside
-    document.body.addEventListener('click', (e: any) => {
-        if (!e.target.closest('.seerr-button-group') && !e.target.closest('.seerr-4k-popup')) {
+    listenRuntime(runtime, document.body, 'click', (event: Event) => {
+        if (!isCurrent()) return;
+        const target = asElement(event.target);
+        if (!target?.closest('.seerr-button-group') && !target?.closest('.seerr-4k-popup')) {
             const popup = document.querySelector('.seerr-4k-popup');
             if (popup) popup.remove();
         }
@@ -496,10 +630,15 @@ JC.initializeSeerrScript = function() {
 
     // Main click handler for request buttons and 4K popup items
     // eslint-disable-next-line @typescript-eslint/no-misused-promises -- legacy async listener; errors are handled inside the handler
-    document.body.addEventListener('click', async function(event: any) {
+    const handleRequestClick = async function(event: Event) {
+        if (!isCurrent()) return;
+        const target = asElement(event.target);
+        if (!target) return;
         // Handle 4K popup item clicks
-        if (event.target.closest('.seerr-4k-popup-item')) {
-            const item = event.target.closest('.seerr-4k-popup-item');
+        if (target.closest('.seerr-4k-popup-item')) {
+            const item = target.closest<HTMLButtonElement>('.seerr-4k-popup-item');
+            if (!item) return;
+            if (!JC.identity.isOwned(item, runtime.context)) return;
             const action = item.dataset.action;
             const tmdbId = item.dataset.tmdbId;
             const mediaType = String(item.dataset.mediaType || 'movie').toLowerCase();
@@ -510,8 +649,8 @@ JC.initializeSeerrScript = function() {
                 item.innerHTML = `<span>Requesting...</span><span class="seerr-button-spinner"></span>`;
 
                 // Find the original item data from the card
-                const card = event.target.closest('.seerr-card');
-                const button = card?.querySelector('.seerr-request-button');
+                const card = target.closest<HTMLElement>('.seerr-card');
+                const button = card?.querySelector<HTMLButtonElement>('.seerr-request-button');
                 const searchResultItem = button?.dataset.searchResultItem ? JSON.parse(button.dataset.searchResultItem) : null;
                 const titleText = card?.querySelector('.cardText-first bdi')?.textContent
                     || searchResultItem?.name
@@ -533,6 +672,7 @@ JC.initializeSeerrScript = function() {
                         showMovieRequestModal(tmdbId, titleText, searchResultItem, true);
                     } else {
                         const response = await requestMedia(tmdbId, 'movie', {}, true, searchResultItem); // true for 4K, pass searchResultItem for override rules
+                        if (!isCurrent()) return;
                         console.debug(`${logPrefix} Seerr 4K request response:`, response);
                         if (searchResultItem) {
                             if (!searchResultItem.mediaInfo) searchResultItem.mediaInfo = {};
@@ -544,10 +684,13 @@ JC.initializeSeerrScript = function() {
                         // Refresh the results to update the UI
                         const query = new URLSearchParams(window.location.hash.split('?')[1])?.get('query');
                         if (query) {
-                            setTimeout(() => fetchAndRenderResults(query, { skipCache: true }), 1000);
+                            scheduleRuntime(runtime, () => {
+                                void fetchAndRenderResults(query, { skipCache: true });
+                            }, 1000);
                         }
                     }
                 } catch (error: any) {
+                    if (!isCurrent()) return;
                     // Quota errors get a themed dialog with usage + reset info.
                     if (JC.seerrUI?.isQuotaError?.(error)) {
                         await JC.seerrUI.showQuotaErrorDialog(error, 'movie');
@@ -568,14 +711,17 @@ JC.initializeSeerrScript = function() {
             return;
         }
 
-        const button = event.target.closest('.seerr-request-button');
+        const button = target.closest<HTMLButtonElement>('.seerr-request-button');
         if (!button || button.disabled) return;
+        const ownerNode = button.closest('.seerr-card') || button;
+        if (!JC.identity.isOwned(button, runtime.context)
+            && !JC.identity.isOwned(ownerNode, runtime.context)) return;
 
         const mediaType = button.dataset.mediaType;
         const tmdbId = button.dataset.tmdbId;
         const collectionId = button.dataset.collectionId;
         const searchResultItem = button.dataset.searchResultItem ? JSON.parse(button.dataset.searchResultItem) : null;
-        const card = button.closest('.seerr-card');
+        const card = button.closest<HTMLElement>('.seerr-card');
         const titleText = card?.querySelector('.cardText-first bdi')?.textContent
             || searchResultItem?.name
             || searchResultItem?.title
@@ -601,10 +747,12 @@ JC.initializeSeerrScript = function() {
                 button.innerHTML = `<span>${JC.t!('seerr_btn_requesting')}</span><span class="seerr-button-spinner"></span>`;
                 try {
                     await requestMedia(tmdbId, mediaType, {}, false, searchResultItem); // Pass searchResultItem for override rules
+                    if (!isCurrent() || !button.isConnected) return;
                     button.innerHTML = `<span>${JC.t!('seerr_btn_requested')}</span>${JC.seerrUI!.icons.requested}`;
                     button.classList.remove('seerr-button-request');
                     button.classList.add('seerr-button-pending');
                 } catch (error: any) {
+                    if (!isCurrent() || !button.isConnected) return;
                     button.disabled = false;
                     // Quota errors get a themed dialog; restore button to idle.
                     if (JC.seerrUI?.isQuotaError?.(error)) {
@@ -626,6 +774,9 @@ JC.initializeSeerrScript = function() {
                 }
             }
         }
+    };
+    listenRuntime(runtime, document.body, 'click', (event: Event) => {
+        void handleRequestClick(event);
     });
 
     console.log(`${logPrefix} Initialization complete.`);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/badges.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/badges.ts
@@ -63,8 +63,16 @@ function setStatusBadge(card: any, item: any) {
  * @param {string} mediaType - The type of media, either 'movie' or 'tv'.
  * @returns {Promise<void>} A promise that resolves when the icons have been fetched and added, or if the process fails.
  */
-async function fetchProviderIcons(container: any, tmdbId: any, mediaType: any) {
+async function fetchProviderIcons(container: HTMLElement | null, tmdbId: any, mediaType: any) {
     if (!container || !tmdbId || !mediaType) return;
+    const card = container.closest('.seerr-card');
+    const identity = JC.identity.ownerOf(card) || JC.identity.capture();
+    const isCurrent = () => !!identity
+        && JC.identity.isCurrent(identity)
+        && !!card
+        && JC.identity.isOwned(card, identity)
+        && container.isConnected;
+    if (!isCurrent()) return;
 
     // Early exit if TMDB is not configured - prevents slow/failing API calls
     if (!JC.pluginConfig?.TmdbEnabled) {
@@ -79,6 +87,7 @@ async function fetchProviderIcons(container: any, tmdbId: any, mediaType: any) {
         // Routed through the core API client (auth headers, retry, dedup);
         // non-OK responses throw and land in the catch below.
         const data: any = await JC.core.api!.plugin(`/tmdb/${mediaType}/${tmdbId}/watch/providers`);
+        if (!isCurrent()) return;
         let providers = data.results?.[DEFAULT_REGION]?.flatrate;
 
         if (providers && providers.length > 0) {
@@ -150,12 +159,15 @@ function addCollectionMembershipBadge(card: any, item: any) {
     const imageContainer = card.querySelector('.cardImageContainer');
     if (!imageContainer) return;
     const badge = document.createElement('div');
+    const identity = JC.identity.ownerOf(card) || JC.identity.capture();
+    JC.identity.own(badge, identity);
     badge.className = 'seerr-collection-badge';
     badge.innerHTML = `<span class="material-icons">collections</span><span>${escapeHtml(item.collection.name) || JC.t!('seerr_card_badge_collection')}</span>`; // collection name escaped
     badge.title = `Part of ${item.collection.name || 'collection'}`;
     badge.addEventListener('click', (e: any) => {
         e.preventDefault();
         e.stopPropagation();
+        if (!identity || !JC.identity.isCurrent(identity) || !JC.identity.isOwned(card, identity)) return;
         ui.showCollectionRequestModal(item.collection.id, item.collection.name, item);
     });
     imageContainer.appendChild(badge);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/buttons.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/buttons.ts
@@ -1,6 +1,7 @@
 // src/seerr/ui/buttons.ts
 // Request-button configuration for movie/TV/collection cards.
 import { JC } from '../../globals';
+import type { IdentityContext } from '../../types/jc';
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- legacy Seerr payload + DOM shapes; typed incrementally */
 
@@ -12,6 +13,20 @@ const MediaStatus = JC.seerrStatus!.MEDIA;
 const DisplayStatus = JC.seerrStatus!.DISPLAY;
 const icons = internal.icons; // requires ui/icons.ts to be loaded first
 
+function resolveIdentity(node: unknown): IdentityContext | null {
+    const element = node instanceof Element ? node : null;
+    return JC.identity.ownerOf(node)
+        || JC.identity.ownerOf(element?.closest('.seerr-card'))
+        || JC.identity.capture();
+}
+
+function isLive(node: unknown, identity: IdentityContext | null | undefined): boolean {
+    const card = node instanceof Element ? node.closest('.seerr-card') : null;
+    return !!identity
+        && JC.identity.isCurrent(identity)
+        && (JC.identity.isOwned(node, identity) || (!!card && JC.identity.isOwned(card, identity)));
+}
+
 /**
  * Configures the request button based on item status and type.
  * @param {HTMLElement} button - Button element to configure.
@@ -20,6 +35,8 @@ const icons = internal.icons; // requires ui/icons.ts to be loaded first
  * @param {boolean} seerrUserFound - If the current user is linked.
  */
 function configureRequestButton(button: any, item: any, isSeerrActive: any, seerrUserFound: any) {
+    const identity = resolveIdentity(button);
+    JC.identity.own(button, identity);
     if (!isSeerrActive) {
         button.innerHTML = `<span>${JC.t!('seerr_btn_offline')}</span>${icons.cloud_off}`;
         button.disabled = true;
@@ -69,6 +86,8 @@ function configureCollectionButton(button: any, item: any) {
  * @param {Object} item - Media item data.
  */
 function configureTvShowButton(button: any, overallStatus: any, seasonAnalysis: any, item: any) {
+    const identity = resolveIdentity(button);
+    JC.identity.own(button, identity);
     const setButton = (text: any, icon: any, className: any, disabled: any = false, summary: any = seasonAnalysis?.statusSummary) => {
         button.innerHTML = `${icon || ''}<span>${text}</span>`;
         if (summary) button.innerHTML += `<div class="seerr-season-summary">${summary}</div>`;
@@ -97,14 +116,17 @@ function configureTvShowButton(button: any, overallStatus: any, seasonAnalysis: 
     if (show4KOption && !button.closest('.seerr-button-group')) {
         const buttonGroup = document.createElement('div');
         buttonGroup.className = 'seerr-button-group';
+        JC.identity.own(buttonGroup, identity);
 
         const mainButton = button.cloneNode(true);
+        JC.identity.own(mainButton, identity);
         mainButton.classList.add('seerr-split-main');
         mainButton.dataset.tmdbId = item.id;
         mainButton.dataset.mediaType = 'tv';
         mainButton.dataset.searchResultItem = JSON.stringify(item);
 
         const arrowButton = document.createElement('button');
+        JC.identity.own(arrowButton, identity);
         arrowButton.className = 'seerr-split-arrow';
         arrowButton.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path fill-rule="evenodd" d="M12.53 16.28a.75.75 0 01-1.06 0l-7.5-7.5a.75.75 0 011.06-1.06L12 14.69l6.97-6.97a.75.75 0 111.06 1.06l-7.5 7.5z" clip-rule="evenodd" /></svg>';
         arrowButton.dataset.tmdbId = item.id;
@@ -128,6 +150,7 @@ function configureTvShowButton(button: any, overallStatus: any, seasonAnalysis: 
 
         arrowButton.addEventListener('click', (e: any) => {
             e.stopPropagation();
+            if (!isLive(arrowButton, identity)) return;
             if (state.active4KPopup && state.active4KPopup.parentElement === buttonGroup) {
                 internal.hide4KPopup();
             } else {
@@ -143,6 +166,8 @@ function configureTvShowButton(button: any, overallStatus: any, seasonAnalysis: 
  * @param {Object} item - Movie item data.
  */
 function configureMovieButton(button: any, item: any) {
+    const identity = resolveIdentity(button);
+    JC.identity.own(button, identity);
     button.dataset.searchResultItem = JSON.stringify(item);
     const status = item.mediaInfo ? item.mediaInfo.status : 1;
     const status4k = item.mediaInfo ? item.mediaInfo.status4k : 1;
@@ -162,6 +187,7 @@ function configureMovieButton(button: any, item: any) {
         // Create button group
         const buttonGroup = document.createElement('div');
         buttonGroup.className = 'seerr-button-group';
+        JC.identity.own(buttonGroup, identity);
 
         const hasMainDownloads = item.mediaInfo?.downloadStatus?.length > 0 || item.mediaInfo?.downloadStatus4k?.length > 0;
         const mainDisplayStatus = JC.seerrStatus!.resolveDisplayStatus(status, hasMainDownloads);
@@ -171,6 +197,7 @@ function configureMovieButton(button: any, item: any) {
 
         // Main button
         const mainButton = document.createElement('button');
+        JC.identity.own(mainButton, identity);
         mainButton.className = `seerr-request-button seerr-split-main ${mainButtonClass}`;
         mainButton.disabled = mainButtonDisabled;
         mainButton.innerHTML = `${mainButtonIcon}<span>${mainButtonText}</span>${mainShowSpinner ? '<span class="seerr-button-spinner"></span>' : ''}`;
@@ -183,6 +210,7 @@ function configureMovieButton(button: any, item: any) {
         }
 
         const arrowButton = document.createElement('button');
+        JC.identity.own(arrowButton, identity);
         arrowButton.className = 'seerr-split-arrow';
         arrowButton.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path fill-rule="evenodd" d="M12.53 16.28a.75.75 0 01-1.06 0l-7.5-7.5a.75.75 0 011.06-1.06L12 14.69l6.97-6.97a.75.75 0 111.06 1.06l-7.5 7.5z" clip-rule="evenodd" /></svg>';
         arrowButton.dataset.tmdbId = item.id;
@@ -208,6 +236,7 @@ function configureMovieButton(button: any, item: any) {
             // eslint-disable-next-line @typescript-eslint/no-misused-promises -- legacy async listener; errors handled inside
             mainButton.addEventListener('click', async (e: any) => {
                 e.stopPropagation();
+                if (!isLive(mainButton, identity)) return;
                 if (JC.pluginConfig.SeerrShowAdvanced) {
                     ui.showMovieRequestModal(item.id, item.title || item.name, item, false);
                 } else {
@@ -215,16 +244,19 @@ function configureMovieButton(button: any, item: any) {
                     mainButton.innerHTML = `<span>${JC.t!('seerr_btn_requesting')}</span><span class="seerr-button-spinner"></span>`;
                     try {
                         await JC.seerrAPI!.requestMedia(item.id, 'movie', {}, false, item);
+                        if (!isLive(mainButton, identity)) return;
                         if (!item.mediaInfo) item.mediaInfo = {};
                         item.mediaInfo.status = 3;
                         mainButton.innerHTML = `<span>${JC.t!('seerr_btn_requested')}</span>${icons.requested}`;
                         mainButton.classList.remove('seerr-button-request');
                         mainButton.classList.add('seerr-button-pending');
                     } catch (error: any) {
+                        if (!isLive(mainButton, identity)) return;
                         mainButton.disabled = false;
                         // Quota errors get a themed dialog; restore button to idle.
                         if (ui.isQuotaError && ui.isQuotaError(error)) {
                             await ui.showQuotaErrorDialog(error, 'movie');
+                            if (!isLive(mainButton, identity)) return;
                             mainButton.innerHTML = `${icons.request}<span>${JC.t!('seerr_btn_request')}</span>`;
                             return;
                         }
@@ -248,6 +280,7 @@ function configureMovieButton(button: any, item: any) {
 
         arrowButton.addEventListener('click', (e: any) => {
             e.stopPropagation();
+            if (!isLive(arrowButton, identity)) return;
             if (state.active4KPopup && state.active4KPopup.parentElement === buttonGroup) {
                 internal.hide4KPopup();
             } else {
@@ -275,6 +308,7 @@ function configureMovieButton(button: any, item: any) {
         button.addEventListener('click', async (e: any) => {
             e.preventDefault();
             e.stopPropagation();
+            if (!isLive(button, identity)) return;
             if (JC.pluginConfig.SeerrShowAdvanced) {
                 ui.showMovieRequestModal(item.id, item.title || item.name, item, false);
             } else {
@@ -282,16 +316,19 @@ function configureMovieButton(button: any, item: any) {
                 button.innerHTML = `<span>${JC.t!('seerr_btn_requesting')}</span><span class="seerr-button-spinner"></span>`;
                 try {
                     await JC.seerrAPI!.requestMedia(item.id, 'movie', {}, false, item);
+                    if (!isLive(button, identity)) return;
                     if (!item.mediaInfo) item.mediaInfo = {};
                     item.mediaInfo.status = 3;
                     button.innerHTML = `<span>${JC.t!('seerr_btn_requested')}</span>${icons.requested}`;
                     button.classList.remove('seerr-button-request');
                     button.classList.add('seerr-button-pending');
                 } catch (error: any) {
+                    if (!isLive(button, identity)) return;
                     button.disabled = false;
                     // Quota errors get a themed dialog; restore button to idle.
                     if (ui.isQuotaError && ui.isQuotaError(error)) {
                         await ui.showQuotaErrorDialog(error, 'movie');
+                        if (!isLive(button, identity)) return;
                         button.innerHTML = `${icons.request}<span>${JC.t!('seerr_btn_request')}</span>`;
                         return;
                     }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/cards.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/cards.identity.test.ts
@@ -1,0 +1,65 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+import { internal, ui } from './internal';
+
+describe('Seerr card identity ownership', () => {
+    const open = vi.fn();
+    const cardSurfaces = JC as unknown as {
+        seerrStatus: {
+            MEDIA: { AVAILABLE: number; PARTIALLY_AVAILABLE: number };
+            effectiveMediaStatus: (status: number) => number;
+        };
+        seerrMoreInfo: { open: typeof open };
+    };
+
+    beforeAll(async () => {
+        internal.icons = { star: '' };
+        internal.setStatusBadge = vi.fn();
+        internal.configureRequestButton = vi.fn();
+        internal.addMediaTypeBadge = vi.fn();
+        internal.addCollectionMembershipBadge = vi.fn();
+        internal.fetchProviderIcons = vi.fn();
+        internal.analyzeSeasonStatuses = vi.fn(() => null);
+        cardSurfaces.seerrStatus = {
+            MEDIA: { AVAILABLE: 5, PARTIALLY_AVAILABLE: 4 },
+            effectiveMediaStatus: (status: number) => status || 1,
+        };
+        JC.seerrAPI = {
+            resolveSeerrBaseUrl: () => 'https://seerr.test'
+        } as unknown as NonNullable<typeof JC.seerrAPI>;
+        JC.pluginConfig = { SeerrUseMoreInfoModal: true, ShowElsewhereOnSeerr: false };
+        JC.t = (key: string) => key;
+        cardSurfaces.seerrMoreInfo = { open };
+        await import('./cards');
+    });
+
+    beforeEach(() => {
+        document.body.replaceChildren();
+        open.mockClear();
+        JC.identity.transition('card-server-a', `card-user-a-${Math.random()}`, 'test setup');
+    });
+
+    it('removes A cards synchronously and retained direct controls cannot open under B', () => {
+        const createCard = ui.createSeerrCard as unknown as (
+            item: { id: number; mediaType: string; title: string; overview: string },
+            active: boolean,
+            userFound: boolean
+        ) => HTMLElement;
+        const card = createCard({
+            id: 123,
+            mediaType: 'movie',
+            title: 'A movie',
+            overview: 'A overview',
+        }, true, true);
+        document.body.appendChild(card);
+        const retainedPoster = card.querySelector<HTMLElement>('.seerr-poster-image')!;
+        const retainedTitle = card.querySelector<HTMLElement>('.seerr-more-info-link')!;
+
+        JC.identity.transition('card-server-b', 'card-user-b', 'account switch');
+        retainedPoster.click();
+        retainedTitle.click();
+
+        expect(card.isConnected).toBe(false);
+        expect(open).not.toHaveBeenCalled();
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/cards.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/cards.ts
@@ -12,6 +12,8 @@ import { ui, internal } from './internal';
 const MediaStatus = JC.seerrStatus!.MEDIA;
 const icons = internal.icons; // requires ui/icons.ts to be loaded first
 const escapeHtml = JC.escapeHtml;
+const cardTimers = new Set<ReturnType<typeof setTimeout>>();
+const outsideOverviewCleanups = new Set<() => void>();
 
 /**
  * Creates an individual Seerr result card.
@@ -21,6 +23,8 @@ const escapeHtml = JC.escapeHtml;
  * @returns {HTMLElement} - Card element.
  */
 function createSeerrCard(item: any, isSeerrActive: any, seerrUserFound: any) {
+    const identity = JC.identity.capture();
+    const isCurrent = () => !!identity && JC.identity.isCurrent(identity);
     const year = item.releaseDate?.substring(0, 4) || item.firstAirDate?.substring(0, 4) || 'N/A';
     // validate posterPath before interpolating into a CSS
     // url() context. Anything other than a leading-slash relative path
@@ -69,6 +73,8 @@ function createSeerrCard(item: any, isSeerrActive: any, seerrUserFound: any) {
 
     const card = document.createElement('div');
     card.className = `card overflowPortraitCard card-hoverable card-withuserdata seerr-card${isAvailable ? ' seerr-card-in-library' : ''}`;
+    card.dataset.jcIdentityOwned = 'true';
+    JC.identity.own(card, identity);
     card.innerHTML = `
         <div class="cardBox cardBox-bottompadded">
             <div class="cardScalable">
@@ -111,11 +117,12 @@ function createSeerrCard(item: any, isSeerrActive: any, seerrUserFound: any) {
     if (imageContainer && cardScalable) {
         imageContainer.classList.remove('itemAction');
 
-        let overview: any = null;
-        let button: any = null;
+        let overview: HTMLElement | null = null;
+        let button: HTMLButtonElement | null = null;
 
         // Create the overview element
         const createOverview = () => {
+            if (!isCurrent()) return;
             overview = document.createElement('div');
             overview.className = 'seerr-overview';
             overview.style.cursor = 'pointer';
@@ -130,19 +137,27 @@ function createSeerrCard(item: any, isSeerrActive: any, seerrUserFound: any) {
             `;
 
             cardScalable.appendChild(overview);
-            button = overview.querySelector('.seerr-request-button');
+            button = overview.querySelector<HTMLButtonElement>('.seerr-request-button');
+            if (!button) return;
+            JC.identity.own(button, identity);
             internal.configureRequestButton(button, item, isSeerrActive, seerrUserFound);
 
             // Click handler on overview to open modal
-            overview.addEventListener('click', (e: any) => {
-                if (e.target.closest('.seerr-request-button')) {
+            overview.addEventListener('click', (event: MouseEvent) => {
+                if (!isCurrent()) {
+                    event.preventDefault();
+                    event.stopPropagation();
                     return;
                 }
-                if (e.target.closest('.seerr-overview-link')) {
+                const target = event.target instanceof Element ? event.target : null;
+                if (target?.closest('.seerr-request-button')) {
                     return;
                 }
-                e.preventDefault();
-                e.stopPropagation();
+                if (target?.closest('.seerr-overview-link')) {
+                    return;
+                }
+                event.preventDefault();
+                event.stopPropagation();
 
                 if (item.mediaType === 'collection') {
                     ui.showCollectionRequestModal(item.id, item.name || item.title, item);
@@ -164,10 +179,15 @@ function createSeerrCard(item: any, isSeerrActive: any, seerrUserFound: any) {
                 button = null;
             }
             document.removeEventListener('click', handleOutsideClick);
+            outsideOverviewCleanups.delete(removeOverview);
         };
 
         // Helper to close overview if clicked outside
         const handleOutsideClick = (evt: any) => {
+            if (!isCurrent()) {
+                removeOverview();
+                return;
+            }
             if (!card.contains(evt.target)) {
                 removeOverview();
             }
@@ -175,6 +195,7 @@ function createSeerrCard(item: any, isSeerrActive: any, seerrUserFound: any) {
 
         // Desktop: hover to show/hide overview
         cardScalable.addEventListener('mouseenter', () => {
+            if (!isCurrent()) return;
             if (!overview) {
                 createOverview();
             }
@@ -188,6 +209,7 @@ function createSeerrCard(item: any, isSeerrActive: any, seerrUserFound: any) {
 
         // Use touchstart for mobile to create overview (prevents touchend from immediately opening modal)
         imageContainer.addEventListener('touchstart', (e: any) => {
+            if (!isCurrent()) return;
             if (e.target.closest('.seerr-overview') || e.target.closest('.seerr-request-button')) {
                 return;
             }
@@ -195,14 +217,20 @@ function createSeerrCard(item: any, isSeerrActive: any, seerrUserFound: any) {
             if (!overview) {
                 e.preventDefault();
                 createOverview();
-                setTimeout(() => {
-                    document.addEventListener('click', handleOutsideClick);
+                const timer = setTimeout(() => {
+                    cardTimers.delete(timer);
+                    if (isCurrent()) {
+                        document.addEventListener('click', handleOutsideClick);
+                        outsideOverviewCleanups.add(removeOverview);
+                    }
                 }, 0);
+                cardTimers.add(timer);
             }
         }, { passive: false });
 
         // Desktop: use click event
         imageContainer.addEventListener('click', (e: any) => {
+            if (!isCurrent()) return;
             // Skip if touch device (touchstart already handled it)
             if (e.type === 'click' && 'ontouchstart' in window) {
                 return;
@@ -216,16 +244,22 @@ function createSeerrCard(item: any, isSeerrActive: any, seerrUserFound: any) {
                 e.preventDefault();
                 e.stopPropagation();
                 createOverview();
-                setTimeout(() => {
-                    document.addEventListener('click', handleOutsideClick);
+                const timer = setTimeout(() => {
+                    cardTimers.delete(timer);
+                    if (isCurrent()) {
+                        document.addEventListener('click', handleOutsideClick);
+                        outsideOverviewCleanups.add(removeOverview);
+                    }
                 }, 0);
+                cardTimers.add(timer);
             }
         });
 
         imageContainer.setAttribute('tabindex', '0');
-        imageContainer.addEventListener('keydown', (e: any) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
+        imageContainer.addEventListener('keydown', (event: KeyboardEvent) => {
+            if (!isCurrent()) return;
+            if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
                 if (!overview) {
                     createOverview();
                 } else {
@@ -233,6 +267,7 @@ function createSeerrCard(item: any, isSeerrActive: any, seerrUserFound: any) {
                 }
             }
         });
+
     }
     internal.addMediaTypeBadge(card, item);
     // If movie belongs to a collection, show a collection badge that opens the modal
@@ -242,9 +277,10 @@ function createSeerrCard(item: any, isSeerrActive: any, seerrUserFound: any) {
     const posterImage = card.querySelector<HTMLElement>('.seerr-poster-image');
     if (posterImage && useMoreInfoModal && JC.seerrMoreInfo) {
         posterImage.style.cursor = 'pointer';
-        posterImage.addEventListener('click', (e: any) => {
-            e.preventDefault();
-            e.stopPropagation();
+        posterImage.addEventListener('click', (event: MouseEvent) => {
+            if (!isCurrent()) return;
+            event.preventDefault();
+            event.stopPropagation();
             const tmdbId = parseInt(item.id);
             const mediaType = item.mediaType;
             if (tmdbId && mediaType) {
@@ -256,7 +292,11 @@ function createSeerrCard(item: any, isSeerrActive: any, seerrUserFound: any) {
     // Add click handler for the title link
     const moreInfoLink = card.querySelector<HTMLElement>('.seerr-more-info-link');
     if (moreInfoLink) {
-        moreInfoLink.addEventListener('click', (e: any) => {
+        moreInfoLink.addEventListener('click', (event: MouseEvent) => {
+            if (!isCurrent()) {
+                event.preventDefault();
+                return;
+            }
             // Check if this is a library item (href already set to jellyfin item)
             const href = moreInfoLink.getAttribute('href');
             const isLibraryLink = href && href.startsWith('#!/details?id=');
@@ -269,16 +309,16 @@ function createSeerrCard(item: any, isSeerrActive: any, seerrUserFound: any) {
 
             // If collection, open collection modal
             if (item.mediaType === 'collection') {
-                e.preventDefault();
-                e.stopPropagation();
+                event.preventDefault();
+                event.stopPropagation();
                 ui.showCollectionRequestModal(item.id, item.name || item.title, item);
                 return;
             }
 
             // If using modal, prevent default and open modal
             if (useMoreInfoModal && JC.seerrMoreInfo) {
-                e.preventDefault();
-                e.stopPropagation();
+                event.preventDefault();
+                event.stopPropagation();
                 const tmdbId = parseInt(moreInfoLink.dataset.tmdbId || "");
                 const mediaType = moreInfoLink.dataset.mediaType;
                 if (tmdbId && mediaType) {
@@ -288,7 +328,8 @@ function createSeerrCard(item: any, isSeerrActive: any, seerrUserFound: any) {
             }
 
             // For external Seerr links the <a> has is="emby-linkbutton" — let default run.
-            const isPlainLeftClick = e.button === 0 && !e.ctrlKey && !e.metaKey && !e.shiftKey && !e.altKey;
+            const isPlainLeftClick = event.button === 0
+                && !event.ctrlKey && !event.metaKey && !event.shiftKey && !event.altKey;
             if (isExternalSeerrLink && isPlainLeftClick) {
                 return;
             }
@@ -338,6 +379,7 @@ function createSeerrCard(item: any, isSeerrActive: any, seerrUserFound: any) {
                 hideBtn.onclick = (e: any) => {
                     e.preventDefault();
                     e.stopPropagation();
+                    if (!isCurrent()) return;
                     JC.hiddenContent?.unhideItem(unhideKey);
                     setHideState();
                 };
@@ -355,6 +397,7 @@ function createSeerrCard(item: any, isSeerrActive: any, seerrUserFound: any) {
                 hideBtn.onclick = (e: any) => {
                     e.preventDefault();
                     e.stopPropagation();
+                    if (!isCurrent()) return;
                     // The hide button is only added when hidden-content is enabled,
                     // so JC.hiddenContent is present here; optional-chain to satisfy
                     // the type without changing behavior.
@@ -385,3 +428,11 @@ function createSeerrCard(item: any, isSeerrActive: any, seerrUserFound: any) {
 ui.createSeerrCard = createSeerrCard;
 
 internal.createSeerrCard = createSeerrCard;
+
+JC.identity.registerReset('seerr-cards', () => {
+    for (const timer of cardTimers) clearTimeout(timer);
+    cardTimers.clear();
+    for (const cleanup of [...outsideOverviewCleanups]) cleanup();
+    outsideOverviewCleanups.clear();
+    document.querySelectorAll('.seerr-card[data-jc-identity-owned="true"]').forEach((card) => card.remove());
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/popover.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/popover.ts
@@ -11,6 +11,17 @@ const DisplayStatus = JC.seerrStatus!.DISPLAY;
 const state = internal.state;
 const escapeHtml = JC.escapeHtml;
 const icons = internal.icons; // requires ui-icons.js to be loaded first
+const popupTimers = new Set<ReturnType<typeof setTimeout>>();
+
+function hoverPopoverElement(): HTMLElement | null {
+    const value: unknown = state.seerrHoverPopover;
+    return value instanceof HTMLElement ? value : null;
+}
+
+function active4KPopupElement(): HTMLElement | null {
+    const value: unknown = state.active4KPopup;
+    return value instanceof HTMLElement ? value : null;
+}
 
 // ================================
 // DOWNLOAD PROGRESS POPOVER SYSTEM
@@ -21,12 +32,23 @@ const icons = internal.icons; // requires ui-icons.js to be loaded first
  * Used for showing download progress on hover/focus.
  */
 function ensureHoverPopover() {
-    if (!state.seerrHoverPopover) {
-        state.seerrHoverPopover = document.createElement('div');
-        state.seerrHoverPopover.className = 'seerr-hover-popover';
-        document.body.appendChild(state.seerrHoverPopover);
+    const identity = JC.identity.capture();
+    if (!identity) return null;
+    let popover = hoverPopoverElement();
+    if (popover && !JC.identity.isOwned(popover, identity)) {
+        popover.remove();
+        state.seerrHoverPopover = null;
+        popover = null;
     }
-    return state.seerrHoverPopover;
+    if (!popover) {
+        popover = document.createElement('div');
+        popover.className = 'seerr-hover-popover';
+        popover.dataset.jcIdentityOwned = 'true';
+        JC.identity.own(popover, identity);
+        document.body.appendChild(popover);
+        state.seerrHoverPopover = popover;
+    }
+    return popover;
 }
 
 /**
@@ -80,6 +102,7 @@ function fillHoverPopover(item: any) {
     }
 
     const popover = ensureHoverPopover();
+    if (!popover) return null;
     let popoverHTML = '';
 
     allDownloads.forEach((downloadStatus: any) => {
@@ -145,14 +168,16 @@ function positionHoverPopover(element: any, x: any, y: any) {
 /**
  * Hides the hover popover (respects mobile lock).
  */
-ui.hideHoverPopover = function () {
-    if (state.seerrHoverPopover && !state.seerrHoverLock) {
-        state.seerrHoverPopover.classList.remove('show');
-        delete state.seerrHoverPopover.dataset.tmdbId;
-        delete state.seerrHoverPopover.dataset.clientX;
-        delete state.seerrHoverPopover.dataset.clientY;
+function hideHoverPopover(): void {
+    const popover = hoverPopoverElement();
+    if (popover && !state.seerrHoverLock) {
+        popover.classList.remove('show');
+        delete popover.dataset.tmdbId;
+        delete popover.dataset.clientX;
+        delete popover.dataset.clientY;
     }
-};
+}
+ui.hideHoverPopover = hideHoverPopover;
 
 /**
  * Toggles the lock state for the hover popover, used for mobile tap interactions.
@@ -188,8 +213,9 @@ function createInlineProgress(downloadStatus: any) {
  * Hides any active 4K popup menu.
  */
 function hide4KPopup() {
-    if (state.active4KPopup) {
-        state.active4KPopup.remove();
+    const popup = active4KPopupElement();
+    if (popup) {
+        popup.remove();
         state.active4KPopup = null;
     }
 }
@@ -199,17 +225,23 @@ function hide4KPopup() {
  * @param {HTMLElement} buttonGroup - The split button container.
  * @param {Object} item - Media item data.
  */
-function show4KPopup(buttonGroup: any, item: any) {
+function show4KPopup(buttonGroup: HTMLElement, item: any) {
+    const identity = JC.identity.capture();
+    const ownerNode = buttonGroup.closest('.seerr-card') || buttonGroup;
+    if (!identity || !JC.identity.isCurrent(identity) || !JC.identity.isOwned(ownerNode, identity)) return;
     hide4KPopup();
 
     const popup = document.createElement('div');
     popup.className = 'seerr-4k-popup';
+    popup.dataset.jcIdentityOwned = 'true';
+    JC.identity.own(popup, identity);
 
     const status4k = item.mediaInfo ? item.mediaInfo.status4k : 1;
 
     // Create 4K button
     const request4KBtn = document.createElement('button');
     request4KBtn.className = 'seerr-4k-popup-item';
+    JC.identity.own(request4KBtn, identity);
 
     const popupDs4k = JC.seerrStatus!.resolveDisplayStatus(status4k, false);
     if (popupDs4k === DisplayStatus.AVAILABLE) {
@@ -243,9 +275,11 @@ function show4KPopup(buttonGroup: any, item: any) {
     popup.style.top = `${rect.bottom + 4}px`;
     popup.style.width = `${rect.width}px`;
 
-    setTimeout(() => {
-        popup.classList.add('show');
+    const timer = setTimeout(() => {
+        popupTimers.delete(timer);
+        if (JC.identity.isCurrent(identity) && state.active4KPopup === popup) popup.classList.add('show');
     }, 10);
+    popupTimers.add(timer);
 }
 
 /**
@@ -253,8 +287,12 @@ function show4KPopup(buttonGroup: any, item: any) {
  * @param {HTMLElement} button - Button element.
  * @param {Object} item - Media item with download status.
  */
-function addDownloadProgressHover(button: any, item: any) {
+function addDownloadProgressHover(button: HTMLElement, item: any) {
+    const identity = JC.identity.capture();
+    if (identity) JC.identity.own(button, identity);
+    const isCurrent = () => !!identity && JC.identity.isCurrent(identity) && JC.identity.isOwned(button, identity);
     const showPopover = (e: any) => {
+        if (!isCurrent()) return;
         const popover = fillHoverPopover(item);
         if (popover) {
             const clientX = e.clientX || (e.target.getBoundingClientRect().right);
@@ -269,19 +307,24 @@ function addDownloadProgressHover(button: any, item: any) {
 
     button.addEventListener('mouseenter', showPopover);
     button.addEventListener('mousemove', (e: any) => {
+        if (!isCurrent()) return;
         if (state.seerrHoverPopover?.classList.contains('show') && !state.seerrHoverLock) {
             state.seerrHoverPopover.dataset.clientX = e.clientX;
             state.seerrHoverPopover.dataset.clientY = e.clientY;
             positionHoverPopover(state.seerrHoverPopover, e.clientX, e.clientY);
         }
     });
-    button.addEventListener('mouseleave', ui.hideHoverPopover);
+    button.addEventListener('mouseleave', () => {
+        if (isCurrent()) hideHoverPopover();
+    });
     button.addEventListener('focus', showPopover);
     button.addEventListener('blur', () => {
+        if (!isCurrent()) return;
         ui.toggleHoverPopoverLock(false);
-        ui.hideHoverPopover();
+        hideHoverPopover();
     });
     button.addEventListener('touchstart', (e: any) => {
+        if (!isCurrent()) return;
         e.preventDefault();
         const popover = fillHoverPopover(item);
         if (popover) {
@@ -293,8 +336,8 @@ function addDownloadProgressHover(button: any, item: any) {
                 positionHoverPopover(popover, clientX, clientY);
                 popover.classList.add('show');
                 popover.dataset.tmdbId = item.id;
-                popover.dataset.clientX = clientX;
-                popover.dataset.clientY = clientY;
+                popover.dataset.clientX = String(clientX);
+                popover.dataset.clientY = String(clientY);
             } else {
                 popover.classList.remove('show');
             }
@@ -311,3 +354,13 @@ internal.createInlineProgress = createInlineProgress;
 internal.hide4KPopup = hide4KPopup;
 internal.show4KPopup = show4KPopup;
 internal.addDownloadProgressHover = addDownloadProgressHover;
+
+JC.identity.registerReset('seerr-popovers', () => {
+    for (const timer of popupTimers) clearTimeout(timer);
+    popupTimers.clear();
+    hoverPopoverElement()?.remove();
+    active4KPopupElement()?.remove();
+    state.seerrHoverPopover = null;
+    state.active4KPopup = null;
+    state.seerrHoverLock = false;
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/request-modals.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/request-modals.ts
@@ -12,6 +12,7 @@ const MediaStatus = JC.seerrStatus!.MEDIA;
 const logPrefix = '🪼 Jellyfin Canopy: Seerr UI:';
 const escapeHtml = JC.escapeHtml;
 const icons = internal.icons; // requires ui-icons.js to be loaded first
+type IdentityCleanupElement = HTMLElement & { _jcIdentityCleanups?: Set<() => void> };
 
 /**
  * Shows the advanced request modal for movies.
@@ -20,6 +21,8 @@ const icons = internal.icons; // requires ui-icons.js to be loaded first
  * @param {Object|null} searchResultItem - Original search result data.
  */
 ui.showMovieRequestModal = async function (tmdbId: any, title: any, searchResultItem: any, is4k: any = false) {
+    const identity = JC.identity.capture();
+    if (!identity || !JC.identity.isCurrent(identity)) return;
     const { create, createAdvancedOptionsHTML, populateAdvancedOptions } = JC.seerrModal!;
     const { requestMedia, fetchAdvancedRequestData, fetchUserQuota } = JC.seerrAPI!;
 
@@ -29,12 +32,14 @@ ui.showMovieRequestModal = async function (tmdbId: any, title: any, searchResult
         subtitle: title,
         bodyHtml,
         backdropPath: searchResultItem?.backdropPath,
-        onSave: async (modalEl: any, requestBtn: any, closeFn: any) => {
-            const serverSelect = modalEl.querySelector('#movie-server');
-            const qualitySelect = modalEl.querySelector('#movie-quality');
-            const folderSelect = modalEl.querySelector('#movie-folder');
+        onSave: async (modalEl: HTMLElement, requestBtn: HTMLButtonElement, closeFn: () => void) => {
+            const isCurrent = () => JC.identity.isCurrent(identity) && modalEl.isConnected;
+            if (!isCurrent()) return;
+            const serverSelect = modalEl.querySelector<HTMLSelectElement>('#movie-server');
+            const qualitySelect = modalEl.querySelector<HTMLSelectElement>('#movie-quality');
+            const folderSelect = modalEl.querySelector<HTMLSelectElement>('#movie-folder');
 
-            if (!serverSelect.value || !qualitySelect.value || !folderSelect.value) {
+            if (!serverSelect?.value || !qualitySelect?.value || !folderSelect?.value) {
                 JC.toast!(JC.t!('seerr_modal_toast_options_missing'), 3000);
                 return;
             }
@@ -45,15 +50,19 @@ ui.showMovieRequestModal = async function (tmdbId: any, title: any, searchResult
 
             try {
                 await requestMedia(tmdbId, 'movie', settings, is4k, searchResultItem);
+                if (!isCurrent()) return;
                 // Manually update the original button on the card
-                const originalButton = document.querySelector(`.seerr-request-button[data-tmdb-id="${tmdbId}"]`);
-                if (originalButton) {
+                const originalButton = document.querySelector<HTMLButtonElement>(
+                    `.seerr-request-button[data-tmdb-id="${tmdbId}"]`
+                );
+                if (originalButton && JC.identity.isOwned(originalButton, identity)) {
                     originalButton.innerHTML = `<span>${JC.t!('seerr_btn_requested')}</span>${icons.requested}`;
                     originalButton.classList.remove('seerr-button-request');
                     originalButton.classList.add('seerr-button-pending');
                 }
                 closeFn();
             } catch (error: any) {
+                if (!isCurrent()) return;
                 await internal.handleRequestError(error, 'movie', requestBtn, JC.t!('seerr_modal_request'));
             }
         }
@@ -64,6 +73,7 @@ ui.showMovieRequestModal = async function (tmdbId: any, title: any, searchResult
     const bodyEl = modalElement.querySelector('.seerr-modal-body');
     if (bodyEl) {
         fetchUserQuota().then((quota: any) => {
+            if (!JC.identity.isCurrent(identity)) return;
             const chip = internal.buildQuotaChip(quota, 'movie');
             if (chip && document.body.contains(modalElement)) {
                 bodyEl.insertBefore(chip, bodyEl.firstChild);
@@ -73,8 +83,10 @@ ui.showMovieRequestModal = async function (tmdbId: any, title: any, searchResult
 
     try {
         const data = await fetchAdvancedRequestData('movie');
+        if (!JC.identity.isCurrent(identity) || !modalElement.isConnected) return;
         populateAdvancedOptions(modalElement, data, 'movie');
     } catch (error: any) {
+        if (!JC.identity.isCurrent(identity) || !modalElement.isConnected) return;
         console.error(`${logPrefix} Failed to load advanced options:`, error);
         JC.toast!(JC.t!('seerr_err_load_server_options'), 3000);
     }
@@ -128,6 +140,8 @@ function describeCollectionRowStatus(status: number, hasActiveDownloads: boolean
  * @param {object} searchResultItem - Optional search result item data.
  */
 ui.showCollectionRequestModal = async function (collectionId: any, collectionName: any, searchResultItem: any = null) {
+    const identity = JC.identity.capture();
+    if (!identity || !JC.identity.isCurrent(identity)) return;
     const { create, createAdvancedOptionsHTML, populateAdvancedOptions } = JC.seerrModal!;
     const { fetchCollectionDetails, requestMedia, fetchAdvancedRequestData } = JC.seerrAPI!;
 
@@ -135,7 +149,9 @@ ui.showCollectionRequestModal = async function (collectionId: any, collectionNam
     let collectionDetails;
     try {
         collectionDetails = await fetchCollectionDetails(collectionId);
+        if (!JC.identity.isCurrent(identity)) return;
     } catch (error: any) {
+        if (!JC.identity.isCurrent(identity)) return;
         JC.toast!(JC.t!('seerr_toast_collection_fetch_failed'), 4000);
         return;
     }
@@ -222,17 +238,23 @@ ui.showCollectionRequestModal = async function (collectionId: any, collectionNam
         bodyHtml,
         backdropPath: collectionDetails.backdrop_path || collectionDetails.backdropPath,
         buttonText: JC.t!('seerr_modal_request_selected_movies') || 'Request Selected Movies',
-        onSave: async (modalEl: any, requestBtn: any, closeFn: any) => {
+        onSave: async (
+            modalEl: IdentityCleanupElement,
+            requestBtn: HTMLButtonElement,
+            closeFn: () => void
+        ) => {
+            const isCurrent = () => JC.identity.isCurrent(identity) && modalEl.isConnected;
+            if (!isCurrent()) return;
             requestBtn.disabled = true;
             requestBtn.innerHTML = `${JC.t!('seerr_modal_requesting') || 'Requesting'}<span class="seerr-button-spinner"></span>`;
 
-            const is4k = !!(modalEl.querySelector('#seerr-collection-4k') as HTMLInputElement | null)?.checked;
+            const is4k = !!modalEl.querySelector<HTMLInputElement>('#seerr-collection-4k')?.checked;
 
             let settings = {};
             if (showAdvanced) {
-                const server = modalEl.querySelector('#movie-server').value;
-                const quality = modalEl.querySelector('#movie-quality').value;
-                const folder = modalEl.querySelector('#movie-folder').value;
+                const server = modalEl.querySelector<HTMLSelectElement>('#movie-server')?.value;
+                const quality = modalEl.querySelector<HTMLSelectElement>('#movie-quality')?.value;
+                const folder = modalEl.querySelector<HTMLSelectElement>('#movie-folder')?.value;
                 if (!server || !quality || !folder) {
                     JC.toast!(JC.t!('seerr_modal_toast_options_missing') || 'Please select all options', 3000);
                     requestBtn.disabled = false;
@@ -243,8 +265,9 @@ ui.showCollectionRequestModal = async function (collectionId: any, collectionNam
             }
 
             try {
-                const selectedMovies = Array.from(modalEl.querySelectorAll('.seerr-collection-movie-row .seerr-collection-checkbox:checked:not(:disabled)'))
-                    .map((cb: any) => parseInt(cb.dataset.tmdbId));
+                const selectedMovies = Array.from(modalEl.querySelectorAll<HTMLInputElement>(
+                    '.seerr-collection-movie-row .seerr-collection-checkbox:checked:not(:disabled)'
+                )).map((checkbox) => Number.parseInt(checkbox.dataset.tmdbId || '', 10));
 
                 if (selectedMovies.length === 0) {
                     JC.toast!(JC.t!('seerr_modal_toast_select_movie') || 'Please select at least one movie', 3000);
@@ -257,8 +280,10 @@ ui.showCollectionRequestModal = async function (collectionId: any, collectionNam
                 let otherFailures = 0;
                 let quotaHitError: any = null;
                 for (const tmdbId of selectedMovies) {
+                    if (!isCurrent()) return;
                     try {
                         await requestMedia(tmdbId, 'movie', settings, is4k, searchResultItem);
+                        if (!isCurrent()) return;
                         successCount++;
                     } catch (error: any) {
                         // Once quota is hit every remaining request will also fail — break.
@@ -281,11 +306,13 @@ ui.showCollectionRequestModal = async function (collectionId: any, collectionNam
                 JC.toast!(toastText, 4000);
                 if (quotaHitError) {
                     await ui.showQuotaErrorDialog(quotaHitError, 'movie');
+                    if (!isCurrent()) return;
                 }
                 closeFn();
 
                 // Refresh search results
-                setTimeout(() => {
+                const refreshTimer = setTimeout(() => {
+                    if (!JC.identity.isCurrent(identity)) return;
                     const query = new URLSearchParams(window.location.hash.split('?')[1])?.get('query');
                     if (query) {
                         const mainController = JC.seerr;
@@ -294,7 +321,9 @@ ui.showCollectionRequestModal = async function (collectionId: any, collectionNam
                         }
                     }
                 }, 1000);
+                modalEl._jcIdentityCleanups?.add(() => clearTimeout(refreshTimer));
             } catch (error: any) {
+                if (!isCurrent()) return;
                 JC.toast!(JC.t!('seerr_modal_toast_request_fail') || 'Request failed', 4000);
                 requestBtn.disabled = false;
                 requestBtn.textContent = JC.t!('seerr_modal_request_selected_movies') || 'Request Selected Movies';
@@ -306,12 +335,15 @@ ui.showCollectionRequestModal = async function (collectionId: any, collectionNam
     if (showAdvanced) {
         try {
             const advancedData = await fetchAdvancedRequestData('movie');
+            if (!JC.identity.isCurrent(identity)) return;
             populateAdvancedOptions(modalInstance.modalElement, advancedData, 'movie');
         } catch (error: any) {
+            if (!JC.identity.isCurrent(identity)) return;
             console.error('Failed to load advanced options:', error);
         }
     }
 
+    if (!JC.identity.isCurrent(identity)) return;
     modalInstance.show();
 
     // Add Select All checkbox functionality
@@ -327,6 +359,7 @@ ui.showCollectionRequestModal = async function (collectionId: any, collectionNam
         };
 
         selectAllCheckbox.addEventListener('change', () => {
+            if (!JC.identity.isCurrent(identity)) return;
             const allCheckboxes = movieList.querySelectorAll('.seerr-collection-movie-row .seerr-collection-checkbox:not(:disabled)');
             allCheckboxes.forEach((checkbox: any) => {
                 checkbox.checked = selectAllCheckbox.checked;
@@ -334,6 +367,7 @@ ui.showCollectionRequestModal = async function (collectionId: any, collectionNam
         });
 
         movieList.addEventListener('change', (e: any) => {
+            if (!JC.identity.isCurrent(identity)) return;
             if (e.target.classList.contains('seerr-collection-checkbox') && e.target.id !== 'seerr-select-all-movies') {
                 updateSelectAllState();
             }
@@ -344,6 +378,7 @@ ui.showCollectionRequestModal = async function (collectionId: any, collectionNam
         const fourKToggle = modalInstance.modalElement.querySelector<HTMLInputElement>('#seerr-collection-4k');
         if (fourKToggle) {
             fourKToggle.addEventListener('change', () => {
+                if (!JC.identity.isCurrent(identity)) return;
                 const is4k = fourKToggle.checked;
                 movieList.querySelectorAll<HTMLElement>('.seerr-collection-movie-row').forEach((row) => {
                     const checkbox = row.querySelector<HTMLInputElement>('.seerr-collection-checkbox');

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/results.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/results.identity.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+
+describe('Seerr results identity placement', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        vi.useFakeTimers();
+        document.body.innerHTML = '<div id="searchPage"></div>';
+        JC.identity.transition('server-a', 'user-a', 'seerr-results-test-start');
+        JC.t = (key: string) => key;
+        JC.seerrStatus = { MEDIA: {} } as NonNullable<typeof JC.seerrStatus>;
+        JC.seerrUI = {};
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        document.body.innerHTML = '';
+    });
+
+    it('cancels A detached placement so it cannot insert into B', async () => {
+        await import('./results');
+        JC.seerrUI!.renderSeerrResults([], 'account-a', false, true, true);
+        expect(document.querySelector('.seerr-section')).toBeNull();
+
+        JC.identity.transition('server-a', 'user-b', 'account-switch');
+        const anchor = document.createElement('div');
+        anchor.className = 'verticalSection';
+        anchor.innerHTML = '<h2 class="sectionTitle">Movies</h2>';
+        document.getElementById('searchPage')!.appendChild(anchor);
+        await vi.advanceTimersByTimeAsync(1500);
+
+        expect(document.querySelector('.seerr-section')).toBeNull();
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/results.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/results.ts
@@ -171,9 +171,21 @@ function analyzeSeasonStatuses(seasons: any) {
 // PERF(R7): pending detached-placement watcher for the Seerr section. A newer
 // render supersedes (cancels) it so a stale keystroke never inserts late.
 let pendingSectionPlacement: { cancel: () => void } | null = null;
+const sectionTimers = new Set<number>();
 // How long to hold the built section detached waiting for the native
 // Movies/Shows sections before falling back to the results container.
 const SECTION_PLACEMENT_TIMEOUT_MS = 1000;
+
+/** Cancel detached placement/timers owned by the previous search identity. */
+export function resetSeerrResultsIdentity(): void {
+    pendingSectionPlacement?.cancel();
+    pendingSectionPlacement = null;
+    for (const timer of sectionTimers) clearTimeout(timer);
+    sectionTimers.clear();
+}
+
+ui.resetResultsIdentity = resetSeerrResultsIdentity;
+JC.identity.registerReset('seerr-results-placement', resetSeerrResultsIdentity);
 
 /**
  * Renders Seerr search results into the search page with improved placement logic.
@@ -184,6 +196,8 @@ const SECTION_PLACEMENT_TIMEOUT_MS = 1000;
  * @param {boolean} seerrUserFound - If the current user is linked.
  */
 ui.renderSeerrResults = function (results: any, query: any, isSeerrOnlyMode: any, isSeerrActive: any, seerrUserFound: any) {
+    const context = JC.identity.capture();
+    if (!context) return;
     console.log(`${logPrefix} Rendering results for query: "${query}"`);
     const searchPage = document.querySelector('#searchPage')!;
     if (!searchPage) {
@@ -193,12 +207,9 @@ ui.renderSeerrResults = function (results: any, query: any, isSeerrOnlyMode: any
 
     // A newer render supersedes any still-detached section from the previous
     // keystroke — cancel its placement watcher so it never inserts late.
-    if (pendingSectionPlacement) {
-        pendingSectionPlacement.cancel();
-        pendingSectionPlacement = null;
-    }
+    resetSeerrResultsIdentity();
 
-    const sectionToInject = createSeerrSection(results, isSeerrOnlyMode, isSeerrActive, seerrUserFound);
+    const sectionToInject = createSeerrSection(results, isSeerrOnlyMode, isSeerrActive, seerrUserFound, context);
 
     // PERF(R7): per-keystroke re-render PATCHES the existing section in place —
     // one replaceChildren() swap inside the same container node — instead of
@@ -207,14 +218,19 @@ ui.renderSeerrResults = function (results: any, query: any, isSeerrOnlyMode: any
     // only the mount strategy changed.
     const oldSection = searchPage.querySelector('.seerr-section');
     if (oldSection) {
-        oldSection.replaceChildren(...Array.from(sectionToInject.childNodes));
-        // Keep the localized no-results message in sync (the full-render path
-        // does this at placement time).
-        const noResultsMessage = searchPage.querySelector('.noItemsMessage');
-        if (noResultsMessage) {
-            noResultsMessage.textContent = JC.t!('seerr_no_results_jellyfin', { query });
+        const owner = JC.identity.ownerOf(oldSection);
+        if (owner && !JC.identity.isCurrent(owner)) {
+            oldSection.remove();
+        } else {
+            oldSection.replaceChildren(...Array.from(sectionToInject.childNodes));
+            // Keep the localized no-results message in sync (the full-render path
+            // does this at placement time).
+            const noResultsMessage = searchPage.querySelector('.noItemsMessage');
+            if (noResultsMessage) {
+                noResultsMessage.textContent = JC.t!('seerr_no_results_jellyfin', { query });
+            }
+            return;
         }
-        return;
     }
 
     const primarySectionKeywords = ['movies', 'shows', 'film', 'serier', 'filme', 'serien', 'películas', 'series', 'films', 'séries', 'serie tv'];
@@ -240,6 +256,7 @@ ui.renderSeerrResults = function (results: any, query: any, isSeerrOnlyMode: any
      * @returns {boolean} True if the section was inserted.
      */
     function tryPlaceAtAnchor() {
+        if (!JC.identity.isCurrent(context) || !searchPage.isConnected) return false;
         const noResultsMessage = searchPage.querySelector('.noItemsMessage');
         if (noResultsMessage) {
             noResultsMessage.textContent = JC.t!('seerr_no_results_jellyfin', { query });
@@ -266,6 +283,10 @@ ui.renderSeerrResults = function (results: any, query: any, isSeerrOnlyMode: any
 
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
     const observer = new MutationObserver(() => {
+        if (!JC.identity.isCurrent(context)) {
+            resetSeerrResultsIdentity();
+            return;
+        }
         if (searchPage.querySelector('.noItemsMessage') || findLastPrimarySection()) {
             cancel();
             pendingSectionPlacement = null;
@@ -274,7 +295,11 @@ ui.renderSeerrResults = function (results: any, query: any, isSeerrOnlyMode: any
     });
     const cancel = () => {
         observer.disconnect();
-        if (timeoutId) clearTimeout(timeoutId);
+        if (timeoutId) {
+            clearTimeout(timeoutId);
+            sectionTimers.delete(Number(timeoutId));
+            timeoutId = null;
+        }
     };
     pendingSectionPlacement = { cancel };
     observer.observe(searchPage, { childList: true, subtree: true });
@@ -284,6 +309,7 @@ ui.renderSeerrResults = function (results: any, query: any, isSeerrOnlyMode: any
     timeoutId = setTimeout(() => {
         cancel();
         pendingSectionPlacement = null;
+        if (!JC.identity.isCurrent(context) || !searchPage.isConnected) return;
         const resultsContainer = searchPage.querySelector('.searchResults, [class*="searchResults"], .padded-top.padded-bottom-page');
         if (resultsContainer) {
             resultsContainer.appendChild(sectionToInject);
@@ -291,6 +317,7 @@ ui.renderSeerrResults = function (results: any, query: any, isSeerrOnlyMode: any
             searchPage.appendChild(sectionToInject);
         }
     }, SECTION_PLACEMENT_TIMEOUT_MS);
+    sectionTimers.add(Number(timeoutId));
 };
 
 /**
@@ -301,10 +328,18 @@ ui.renderSeerrResults = function (results: any, query: any, isSeerrOnlyMode: any
  * @param {boolean} seerrUserFound - If the current user is linked.
  * @returns {HTMLElement} - Section element.
  */
-function createSeerrSection(results: any = [], isSeerrOnlyMode: any, isSeerrActive: any, seerrUserFound: any) {
+function createSeerrSection(
+    results: any = [],
+    isSeerrOnlyMode: any,
+    isSeerrActive: any,
+    seerrUserFound: any,
+    context = JC.identity.capture()
+) {
     const section = document.createElement('div');
     section.className = 'verticalSection emby-scroller-container seerr-section';
     section.setAttribute('data-seerr-section', 'true');
+    section.setAttribute('data-jc-identity-owned', 'true');
+    if (context) JC.identity.own(section, context);
 
     const title = document.createElement('h2');
     title.className = 'sectionTitle sectionTitle-cards focuscontainer-x padded-left padded-right';
@@ -330,8 +365,13 @@ function createSeerrSection(results: any = [], isSeerrOnlyMode: any, isSeerrActi
     refreshBtn.addEventListener('click', function (e: any) {
         e.preventDefault();
         e.stopPropagation();
+        if (!context || !JC.identity.isCurrent(context)) return;
         icon.style.transform = 'rotate(360deg)';
-        setTimeout(() => { icon.style.transform = ''; }, 500);
+        const timer = window.setTimeout(() => {
+            sectionTimers.delete(timer);
+            if (JC.identity.isCurrent(context)) icon.style.transform = '';
+        }, 500);
+        sectionTimers.add(timer);
         document.dispatchEvent(new CustomEvent('seerr-manual-refresh'));
     });
     title.appendChild(refreshBtn);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/season-modal.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/season-modal.ts
@@ -11,6 +11,7 @@ const escapeHtml = JC.escapeHtml;
 let refreshModalTimer: ReturnType<typeof setTimeout> | null = null;
 let refreshModalAbortController: AbortController | null = null;
 let refreshModalGeneration = 0;
+type IdentityCleanupElement = HTMLElement & { _jcIdentityCleanups?: Set<() => void> };
 
 function cancelSeasonModalRefresh(): void {
     refreshModalGeneration += 1;
@@ -33,9 +34,12 @@ function cancelSeasonModalRefresh(): void {
  */
 ui.showSeasonSelectionModal = async function (tmdbId: any, mediaType: any, showTitle: any, searchResultItem: any = null, is4k: any = false) {
     if (mediaType !== 'tv') return;
+    const identity = JC.identity.capture();
+    if (!identity || !JC.identity.isCurrent(identity)) return;
     cancelSeasonModalRefresh();
     const modalGeneration = refreshModalGeneration;
-    const isCurrentGeneration = () => modalGeneration === refreshModalGeneration;
+    const isCurrentGeneration = () => modalGeneration === refreshModalGeneration
+        && JC.identity.isCurrent(identity);
 
 
     const { create, createAdvancedOptionsHTML, populateAdvancedOptions } = JC.seerrModal!;
@@ -107,6 +111,8 @@ ui.showSeasonSelectionModal = async function (tmdbId: any, mediaType: any, showT
             if (isCurrentGeneration()) cancelSeasonModalRefresh();
         },
         onSave: async (modalEl: any, requestBtn: any, closeFn: any) => {
+            const liveModal = modalEl as IdentityCleanupElement;
+            if (!isCurrentGeneration() || !liveModal.isConnected) return;
             requestBtn.disabled = true;
             requestBtn.innerHTML = `${JC.t!('seerr_modal_requesting')}<span class="seerr-button-spinner"></span>`;
 
@@ -148,6 +154,7 @@ ui.showSeasonSelectionModal = async function (tmdbId: any, mediaType: any, showT
                         return;
                     }
                     await requestTvSeasons(tmdbId, selectedSeasons, settings, searchResultItem, is4k);
+                    if (!isCurrentGeneration() || !liveModal.isConnected) return;
                     JC.toast!(JC.t!('seerr_modal_toast_request_success', { count: selectedSeasons.length, title: JC.escapeHtml(resolvedShowTitle) }), 4000);
                 } else {
                     // Partial requests disabled: request all non-special seasons to avoid locking specials
@@ -160,6 +167,7 @@ ui.showSeasonSelectionModal = async function (tmdbId: any, mediaType: any, showT
                     } else {
                         await requestMedia(tmdbId, 'tv', settings, is4k, searchResultItem);
                     }
+                    if (!isCurrentGeneration() || !liveModal.isConnected) return;
 
                     JC.toast!(JC.t!('seerr_modal_toast_request_success', { count: 'all', title: JC.escapeHtml(resolvedShowTitle) }), 4000);
                 }
@@ -171,7 +179,8 @@ ui.showSeasonSelectionModal = async function (tmdbId: any, mediaType: any, showT
                 internal.markCardRequested(tmdbId, 'tv', is4k);
 
                 closeFn();
-                setTimeout(() => {
+                const resultsRefreshTimer = setTimeout(() => {
+                    if (!isCurrentGeneration()) return;
                     const query = new URLSearchParams(window.location.hash.split('?')[1])?.get('query');
                     if (query) {
                         const mainController = JC.seerr;
@@ -180,7 +189,9 @@ ui.showSeasonSelectionModal = async function (tmdbId: any, mediaType: any, showT
                         }
                     }
                 }, 1000);
+                liveModal._jcIdentityCleanups?.add(() => clearTimeout(resultsRefreshTimer));
             } catch (error: any) {
+                if (!isCurrentGeneration() || !liveModal.isConnected) return;
                 const resetLabel = is4k
                     ? (JC.t!('seerr_btn_request_4k') || 'Request in 4K')
                     : (partialRequestsEnabled ? JC.t!('seerr_modal_request_selected') : JC.t!('seerr_modal_request'));
@@ -201,6 +212,7 @@ ui.showSeasonSelectionModal = async function (tmdbId: any, mediaType: any, showT
     const tvBodyEl = modalInstance.modalElement.querySelector('.seerr-modal-body');
     if (tvBodyEl) {
         JC.seerrAPI?.fetchUserQuota?.().then((quota: any) => {
+            if (!isCurrentGeneration()) return;
             const chip = internal.buildQuotaChip(quota, 'tv');
             if (chip && document.body.contains(modalInstance.modalElement)) {
                 tvBodyEl.insertBefore(chip, tvBodyEl.firstChild);
@@ -240,6 +252,7 @@ ui.showSeasonSelectionModal = async function (tmdbId: any, mediaType: any, showT
         // Primary: fetch first episode air date from each season (Seerr/TheTVDB has these)
         const seasonFetches = seasonsNeedingDates.map((s: any) =>
             fetchTvSeasonDetails(tmdbId, s.seasonNumber).then((detail: any) => {
+                if (!isCurrentGeneration()) return;
                 const firstEp = detail?.episodes?.[0];
                 if (firstEp?.airDate && isValidDate(firstEp.airDate)) {
                     airDateCache[s.seasonNumber] = firstEp.airDate;
@@ -250,6 +263,7 @@ ui.showSeasonSelectionModal = async function (tmdbId: any, mediaType: any, showT
         // Fallback: also try TMDB for any gaps (runs in parallel)
         const tmdbFetch = JC.pluginConfig?.TmdbEnabled
             ? fetchTmdbTvDetails(tmdbId).then((tmdbData: any) => {
+                if (!isCurrentGeneration()) return;
                 if (!tmdbData?.seasons) return;
                 tmdbData.seasons.forEach((s: any) => {
                     const date = s.air_date || '';
@@ -288,6 +302,7 @@ ui.showSeasonSelectionModal = async function (tmdbId: any, mediaType: any, showT
 
             // Handle Select All checkbox click — only toggles regular seasons, not Specials
             selectAllCheckbox.addEventListener('change', () => {
+                if (!isCurrentGeneration()) return;
                 const allSeasonCheckboxes = seasonList.querySelectorAll(regularSeasonSelector);
                 allSeasonCheckboxes.forEach((checkbox: any) => {
                     checkbox.checked = selectAllCheckbox.checked;
@@ -296,6 +311,7 @@ ui.showSeasonSelectionModal = async function (tmdbId: any, mediaType: any, showT
 
             // Add change listeners to individual season checkboxes
             seasonList.addEventListener('change', (e: any) => {
+                if (!isCurrentGeneration()) return;
                 if (e.target.classList.contains('seerr-season-checkbox') && e.target.id !== 'seerr-select-all-seasons') {
                     updateSelectAllState();
                 }
@@ -363,6 +379,8 @@ ui.showSeasonSelectionModal = async function (tmdbId: any, mediaType: any, showT
         }
     }
 };
+
+JC.identity.registerReset('seerr-season-modal', cancelSeasonModalRefresh);
 
 function invalidateSeasonRequestState(seasonListElement: any): void {
     if (!seasonListElement) return;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.identity.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../globals';
+import './peopletags';
+
+function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((done) => { resolve = done; });
+    return { promise, resolve };
+}
+
+function mountPersonCard(personId: string): HTMLElement {
+    document.body.innerHTML = `
+        <div id="itemDetailPage">
+            <div id="castCollapsible">
+                <div class="personCard" data-id="${personId}">
+                    <div class="cardScalable"></div>
+                </div>
+            </div>
+        </div>`;
+    return document.querySelector<HTMLElement>('.personCard')!;
+}
+
+const surface = JC as typeof JC & { initializePeopleTags?: () => void };
+
+describe('people tags identity lifecycle', () => {
+    const originalApi = JC.core.api;
+    const originalHelpers = JC.helpers;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        document.body.innerHTML = '';
+        localStorage.clear();
+        JC.identity.transition('people-server-a', `people-user-a-${Date.now()}`, 'people-test-a');
+        JC.currentSettings = { peopleTagsEnabled: true };
+        JC.pluginConfig = { TagsCacheTtlDays: 7 };
+    });
+
+    afterEach(() => {
+        JC.identity.transition('test-server-id', 'test-user-id', 'people-test-cleanup');
+        JC.core.api = originalApi;
+        JC.helpers = originalHelpers;
+        JC.currentSettings = {};
+        JC.pluginConfig = {};
+        document.body.innerHTML = '';
+        localStorage.clear();
+        vi.useRealTimers();
+    });
+
+    it('disconnects A, rejects its late response, and starts one clean B observer', async () => {
+        const callbacks: MutationCallback[] = [];
+        const disconnects: ReturnType<typeof vi.fn>[] = [];
+        JC.helpers = {
+            ...originalHelpers,
+            createObserver: vi.fn((_id, callback) => {
+                callbacks.push(callback);
+                const disconnect = vi.fn();
+                disconnects.push(disconnect);
+                return { disconnect };
+            }),
+        };
+
+        const responseA = deferred<any>();
+        const plugin = vi.fn()
+            .mockReturnValueOnce(responseA.promise)
+            .mockResolvedValueOnce({ currentAge: 44, birthPlace: 'Perth, Australia' });
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+
+        window.location.hash = '#/details?id=item-a';
+        const cardA = mountPersonCard('person-a');
+        localStorage.setItem('JellyfinCanopy-peopleTagsCache', JSON.stringify({ secret: 'A' }));
+        surface.initializePeopleTags!();
+        expect(callbacks).toHaveLength(1);
+
+        callbacks[0]([{ addedNodes: [document.createElement('div')] }] as unknown as MutationRecord[], {} as MutationObserver);
+        await vi.advanceTimersByTimeAsync(100);
+        expect(plugin).toHaveBeenCalledTimes(1);
+
+        JC.identity.transition('people-server-b', 'people-user-b', 'people-test-b');
+        expect(disconnects[0]).toHaveBeenCalledTimes(1);
+        expect(localStorage.getItem('JellyfinCanopy-peopleTagsCache')).toBeNull();
+
+        responseA.resolve({ currentAge: 99, birthPlace: 'A-only place' });
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(cardA.querySelector('.jc-people-age-container')).toBeNull();
+        expect(cardA.querySelector('.jc-people-place-banner')).toBeNull();
+
+        // Even if a queued copy of A's observer callback is delivered, its
+        // captured epoch keeps it dormant.
+        callbacks[0]([{ addedNodes: [document.createElement('div')] }] as unknown as MutationRecord[], {} as MutationObserver);
+        await vi.advanceTimersByTimeAsync(100);
+        expect(plugin).toHaveBeenCalledTimes(1);
+
+        window.location.hash = '#/details?id=item-b';
+        const cardB = mountPersonCard('person-b');
+        surface.initializePeopleTags!();
+        expect(callbacks).toHaveLength(2);
+        callbacks[1]([{ addedNodes: [document.createElement('div')] }] as unknown as MutationRecord[], {} as MutationObserver);
+        await vi.advanceTimersByTimeAsync(100);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(plugin).toHaveBeenCalledTimes(2);
+        expect(cardB.querySelector('.jc-people-age-text')?.textContent).toBe('44y');
+        expect(cardB.querySelector('.jc-people-place-text')?.textContent).toBe('Perth, Australia');
+        expect(cardB.querySelector('.jc-people-age-container')?.getAttribute('data-jc-identity-owned')).toBe('true');
+    });
+
+    it('retains the current owner cache across a same-identity reinitialization', () => {
+        const disconnect = vi.fn();
+        JC.helpers = {
+            ...originalHelpers,
+            createObserver: vi.fn(() => ({ disconnect })),
+        };
+        const context = JC.identity.capture()!;
+        const cache = JSON.stringify({ 'person-a-item-a': { currentAge: 40 } });
+        localStorage.setItem('JellyfinCanopy-peopleTagsCacheIdentityOwner', `${context.serverId}:${context.userId}`);
+        localStorage.setItem('JellyfinCanopy-peopleTagsCache', cache);
+        localStorage.setItem('JellyfinCanopy-peopleTagsCacheTimestamp', JSON.stringify({ 'person-a-item-a': Date.now() }));
+
+        surface.initializePeopleTags!();
+        surface.initializePeopleTags!();
+
+        expect(disconnect).toHaveBeenCalledTimes(1);
+        expect(localStorage.getItem('JellyfinCanopy-peopleTagsCache')).toBe(cache);
+        expect(localStorage.getItem('JellyfinCanopy-peopleTagsCacheIdentityOwner')).toBe(
+            `${context.serverId}:${context.userId}`,
+        );
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.ts
@@ -8,8 +8,28 @@
 
 import { JC as JEBase } from '../globals';
 import { flagPngUrl } from '../core/asset-urls';
+import { createBoundedCache, type BoundedCache } from '../core/bounded-cache';
 import { ensureMaterialSymbolsFont, injectCss } from '../core/ui-kit';
-import type { JELegacyHelpers, PluginConfig, UserSettings } from '../types/jc';
+import type { ApiApi, JELegacyHelpers, PluginConfig, UserSettings } from '../types/jc';
+
+interface PersonData {
+    isDeceased?: boolean;
+    ageAtDeath?: number | null;
+    currentAge?: number | null;
+    ageAtItemRelease?: number | null;
+    birthPlace?: string | null;
+}
+
+function parseRecord<T>(raw: string): Record<string, T> {
+    const parsed: unknown = JSON.parse(raw);
+    return parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? parsed as Record<string, T>
+        : {};
+}
+
+function isPersonData(value: unknown): value is PersonData {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
 
 /**
  * Local view of the shared namespace adding the public member this module
@@ -20,11 +40,30 @@ const JC = JEBase as typeof JEBase & {
     initializePeopleTags?: () => void;
     currentSettings: UserSettings & { peopleTagsEnabled?: boolean };
     pluginConfig: PluginConfig;
+    core: { api: ApiApi };
     helpers: JELegacyHelpers & {
-        debounce<T extends (...args: any[]) => void>(fn: T, wait: number): T;
-        createObserver(id: string, cb: MutationCallback, target: Node, config: MutationObserverInit): unknown;
+        createObserver(
+            id: string,
+            cb: MutationCallback,
+            target: Node,
+            config: MutationObserverInit
+        ): { disconnect?: () => void; unsubscribe?: () => void };
     };
 };
+
+let activePeopleTagsCleanup: ((clearPersistent: boolean) => void) | null = null;
+
+function teardownPeopleTags(clearPersistent: boolean): void {
+    const cleanup = activePeopleTagsCleanup;
+    activePeopleTagsCleanup = null;
+    try { cleanup?.(clearPersistent); } catch { /* continue */ }
+    document.querySelectorAll('.jc-people-age-container, .jc-people-place-banner').forEach((node) => node.remove());
+    document.querySelectorAll('.jc-deceased-poster').forEach((node) => node.classList.remove('jc-deceased-poster'));
+}
+
+function resetPeopleTagsIdentity(): void {
+    teardownPeopleTags(true);
+}
 
 /**
  * Effective people-tags cache TTL in milliseconds, derived from the
@@ -39,15 +78,34 @@ export function peopleTagsCacheTtlMs(cfg: PluginConfig | null | undefined): numb
 }
 
 JC.initializePeopleTags = function() {
+    // A same-user settings reinitialization should replace observers/timers
+    // without throwing away that user's valid persistent cache.
+    teardownPeopleTags(false);
     if (!JC.currentSettings.peopleTagsEnabled) {
         console.log('🪼 Jellyfin Canopy: People Tags: Feature is disabled in settings.');
         return;
     }
 
+    const context = JC.identity.capture();
+    if (!context || !JC.identity.isCurrent(context)) return;
+    const isCurrent = (): boolean => JC.identity.isCurrent(context);
+    const timers = new Set<number>();
+    let observerHandle: { disconnect?: () => void; unsubscribe?: () => void } | null = null;
+
     const logPrefix = '🪼 Jellyfin Canopy: People Tags:';
     const CACHE_KEY = 'JellyfinCanopy-peopleTagsCache';
     const CACHE_TIMESTAMP_KEY = 'JellyfinCanopy-peopleTagsCacheTimestamp';
+    const CACHE_OWNER_KEY = 'JellyfinCanopy-peopleTagsCacheIdentityOwner';
     const CACHE_TTL = peopleTagsCacheTtlMs(JC.pluginConfig);
+
+    const schedule = (fn: () => void, delay: number): number => {
+        const timer = window.setTimeout(() => {
+            timers.delete(timer);
+            if (isCurrent()) fn();
+        }, delay);
+        timers.add(timer);
+        return timer;
+    };
 
     // Country mapping dictionary
     const COUNTRY_MAP: Record<string, string> = {
@@ -99,18 +157,53 @@ JC.initializePeopleTags = function() {
         'Papua New Guinea': 'PG', 'Fiji': 'FJ', 'Samoa': 'WS', 'Tonga': 'TO'
     };
 
-    const peopleCache: Record<string, any> = JSON.parse(localStorage.getItem(CACHE_KEY) || '{}');
-    const peopleCacheTimestamp: Record<string, number> = JSON.parse(localStorage.getItem(CACHE_TIMESTAMP_KEY) || '{}');
+    const expectedCacheOwner = `${context.serverId}:${context.userId}`;
+    if (localStorage.getItem(CACHE_OWNER_KEY) !== expectedCacheOwner) {
+        // Older builds stored an unowned cache. It cannot safely be replayed
+        // after login as a different Jellyfin user.
+        localStorage.removeItem(CACHE_KEY);
+        localStorage.removeItem(CACHE_TIMESTAMP_KEY);
+        localStorage.setItem(CACHE_OWNER_KEY, expectedCacheOwner);
+    }
+    let peopleCache: Record<string, PersonData> = {};
+    let peopleCacheTimestamp: Record<string, number> = {};
+    try {
+        peopleCache = parseRecord<PersonData>(localStorage.getItem(CACHE_KEY) || '{}');
+        peopleCacheTimestamp = parseRecord<number>(localStorage.getItem(CACHE_TIMESTAMP_KEY) || '{}');
+    } catch {
+        localStorage.removeItem(CACHE_KEY);
+        localStorage.removeItem(CACHE_TIMESTAMP_KEY);
+    }
     const Hot = (JC._hotCache = JC._hotCache || { ttl: CACHE_TTL });
-    // Local handle keeps the shared bucket usable under HotCache's wide index
-    // type (Map | number | undefined) — same object as Hot.peopleTags.
-    const hotPeopleTags = (Hot.peopleTags = Hot.peopleTags || new Map()) as Map<string, { data: any; timestamp: number }>;
+    const previousHot = Hot.peopleTags as BoundedCache<string, unknown> | undefined;
+    previousHot?.clear?.();
+    const hotPeopleTags = createBoundedCache<string, { data: PersonData; timestamp: number }>({
+        maxEntries: 1000,
+        ttlMs: CACHE_TTL,
+    });
+    Hot.peopleTags = hotPeopleTags;
 
     let processedCastMembers = new WeakSet<Element>();
     let processedPersonIds = new Set<string>();
     let lastProcessedItemId: string | null = null;
     let peopleTagsComplete = false; // Set true after all cast members tagged for current item
     let isProcessing = false;
+
+    activePeopleTagsCleanup = (clearPersistent) => {
+        for (const timer of timers) clearTimeout(timer);
+        timers.clear();
+        if (observerHandle?.unsubscribe) observerHandle.unsubscribe();
+        else observerHandle?.disconnect?.();
+        observerHandle = null;
+        hotPeopleTags.clear();
+        peopleCache = {};
+        peopleCacheTimestamp = {};
+        if (clearPersistent) {
+            localStorage.removeItem(CACHE_KEY);
+            localStorage.removeItem(CACHE_TIMESTAMP_KEY);
+            localStorage.removeItem(CACHE_OWNER_KEY);
+        }
+    };
 
     // Styles for deceased indicators, overlay positioning, and material-symbols-rounded font.
     // Shared @font-face lives in core/ui-kit (local asset cache), not here.
@@ -195,14 +288,15 @@ JC.initializePeopleTags = function() {
      * @param personId
      * @param itemId (optional, for calculating age at release)
      */
-    async function getPersonInfo(personId: string, itemId: string | null = null): Promise<any> {
+    async function getPersonInfo(personId: string, itemId: string | null = null): Promise<PersonData | null> {
+        if (!isCurrent()) return null;
         const cacheKey = itemId ? `${personId}-${itemId}` : personId;
         const now = Date.now();
 
         // Check in-memory cache first
         if (hotPeopleTags.has(cacheKey)) {
             const cached = hotPeopleTags.get(cacheKey)!;
-            if (now - cached.timestamp < CACHE_TTL) {
+            if (isCurrent() && now - cached.timestamp < CACHE_TTL) {
                 return cached.data;
             }
         }
@@ -210,7 +304,9 @@ JC.initializePeopleTags = function() {
         // Check localStorage cache
         if (peopleCache[cacheKey] && peopleCacheTimestamp[cacheKey]) {
             if (now - peopleCacheTimestamp[cacheKey] < CACHE_TTL) {
-                const data = peopleCache[cacheKey];
+                if (!isCurrent()) return null;
+                const data = JC.identity.own(peopleCache[cacheKey], context);
+                peopleCache[cacheKey] = data;
                 hotPeopleTags.set(cacheKey, { data, timestamp: now });
                 return data;
             }
@@ -218,27 +314,28 @@ JC.initializePeopleTags = function() {
 
         // Fetch from backend
         try {
-            const queryString = itemId ? `?itemId=${itemId}` : '';
-            const url = ApiClient.getUrl(`/JellyfinCanopy/person/${personId}${queryString}`);
-            const data = await ApiClient.ajax({
-                type: 'GET',
-                url: url,
-                dataType: 'json'
-            }) as any;
+            const queryString = itemId ? `?itemId=${encodeURIComponent(itemId)}` : '';
+            const data = await JC.core.api.plugin(`/person/${encodeURIComponent(personId)}${queryString}`, {
+                cacheKey: `people-tags:${cacheKey}`,
+            });
+            if (!isCurrent()) return null;
 
-            if (data) {
+            if (isPersonData(data)) {
                 // Cache it
-                peopleCache[cacheKey] = data;
+                const ownedData = JC.identity.own(data, context);
+                peopleCache[cacheKey] = ownedData;
                 peopleCacheTimestamp[cacheKey] = now;
-                hotPeopleTags.set(cacheKey, { data, timestamp: now });
+                hotPeopleTags.set(cacheKey, { data: ownedData, timestamp: now });
 
+                if (!isCurrent()) return null;
+                localStorage.setItem(CACHE_OWNER_KEY, expectedCacheOwner);
                 localStorage.setItem(CACHE_KEY, JSON.stringify(peopleCache));
                 localStorage.setItem(CACHE_TIMESTAMP_KEY, JSON.stringify(peopleCacheTimestamp));
 
-                return data;
+                return ownedData;
             }
         } catch (error) {
-            console.warn(`${logPrefix} Failed to fetch person info for ${personId}:`, error);
+            if (isCurrent()) console.warn(`${logPrefix} Failed to fetch person info for ${personId}:`, error);
         }
 
         return null;
@@ -285,10 +382,12 @@ JC.initializePeopleTags = function() {
      * Create people tag chips in top-left corner and birthplace banner at bottom
      * @returns Object with ageContainer and placeContainer elements
      */
-    function createPeopleTag(personData: any): { ageContainer: HTMLElement; placeContainer: HTMLElement } {
+    function createPeopleTag(personData: PersonData): { ageContainer: HTMLElement; placeContainer: HTMLElement } {
         // Age chips container (top-left)
         const ageContainer = document.createElement('div');
         ageContainer.className = 'jc-people-age-container';
+        ageContainer.dataset.jcIdentityOwned = 'true';
+        JC.identity.own(ageContainer, context);
         ageContainer.style.cssText = `
             position: absolute;
             top: 8px;
@@ -316,6 +415,8 @@ JC.initializePeopleTags = function() {
         // Birthplace banner (bottom of card)
         const placeContainer = document.createElement('div');
         placeContainer.className = 'jc-people-place-banner';
+        placeContainer.dataset.jcIdentityOwned = 'true';
+        JC.identity.own(placeContainer, context);
         placeContainer.style.cssText = `
             position: absolute;
             bottom: 0;
@@ -369,6 +470,7 @@ JC.initializePeopleTags = function() {
      * @param currentItemId - Current item ID from URL
      */
     async function processSingleCollapsible(collapsibleSelector: string, currentItemId: string): Promise<void> {
+        if (!isCurrent()) return;
         const collapsible = document.querySelector(`#itemDetailPage:not(.hide) ${collapsibleSelector}`);
         if (!collapsible) return;
 
@@ -378,6 +480,7 @@ JC.initializePeopleTags = function() {
         console.debug(`${logPrefix} Found ${castCards.length} cast members in ${collapsibleSelector}`);
 
         for (const card of castCards) {
+            if (!isCurrent()) return;
             if (processedCastMembers.has(card)) continue;
             processedCastMembers.add(card);
 
@@ -391,6 +494,8 @@ JC.initializePeopleTags = function() {
 
             try {
                 const personData = await getPersonInfo(personId, currentItemId);
+                const liveItemId = new URLSearchParams(window.location.hash.split('?')[1]).get('id');
+                if (!isCurrent() || liveItemId !== currentItemId || !card.isConnected) return;
                 if (!personData) {
                     continue;
                 }
@@ -420,6 +525,7 @@ JC.initializePeopleTags = function() {
 
                 // Create and append age chips (top-left) and place banner (bottom)
                 const tags = createPeopleTag(personData);
+                if (!isCurrent() || !cardScalable.isConnected) return;
                 if (tags.ageContainer.children.length > 0) {
                     cardScalable.appendChild(tags.ageContainer);
                 }
@@ -437,7 +543,7 @@ JC.initializePeopleTags = function() {
      * Process cast and guest cast members in the current view
      */
     async function processCastMembers(): Promise<void> {
-        if (isProcessing) return;
+        if (!isCurrent() || isProcessing) return;
         isProcessing = true;
 
         try {
@@ -453,12 +559,13 @@ JC.initializePeopleTags = function() {
 
             // Process both cast and guest cast sections
             await processSingleCollapsible('#castCollapsible', currentItemId);
+            if (!isCurrent()) return;
             await processSingleCollapsible('#guestCastCollapsible', currentItemId);
 
         } catch (error) {
-            console.error(`${logPrefix} Error in processCastMembers:`, error);
+            if (isCurrent()) console.error(`${logPrefix} Error in processCastMembers:`, error);
         } finally {
-            isProcessing = false;
+            if (isCurrent()) isProcessing = false;
         }
     }
 
@@ -468,8 +575,11 @@ JC.initializePeopleTags = function() {
     function initialize(): void {
         console.debug(`${logPrefix} Initializing with managed observer pattern`);
 
-        // Handle item details page display with debounced observer (same pattern as features.js)
-        const handlePeopleTags = JC.helpers.debounce(() => {
+        // Handle item details page display with an identity-owned debounce.
+        // A helper-owned timeout cannot be cancelled synchronously on logout.
+        let debounceTimer: number | null = null;
+        const runPeopleTags = () => {
+            if (!isCurrent()) return;
             const castSection = document.querySelector('#itemDetailPage:not(.hide) #castCollapsible');
             const guestCastSection = document.querySelector('#itemDetailPage:not(.hide) #guestCastCollapsible');
 
@@ -499,8 +609,9 @@ JC.initializePeopleTags = function() {
                 // navigations don't mark the wrong item as done.
                 const processingItemId = itemId;
                 void processCastMembers().then(() => {
-                    setTimeout(() => {
-                        if (lastProcessedItemId === processingItemId) {
+                    if (!isCurrent()) return;
+                    schedule(() => {
+                        if (isCurrent() && lastProcessedItemId === processingItemId) {
                             peopleTagsComplete = true;
                         }
                     }, 2000);
@@ -508,15 +619,26 @@ JC.initializePeopleTags = function() {
             } catch (e) {
                 // Ignore errors (likely not on an item page)
             }
-        }, 100);
+        };
+        const handlePeopleTags = () => {
+            if (!isCurrent()) return;
+            if (debounceTimer !== null) {
+                clearTimeout(debounceTimer);
+                timers.delete(debounceTimer);
+            }
+            debounceTimer = schedule(() => {
+                debounceTimer = null;
+                runPeopleTags();
+            }, 100);
+        };
 
         // Create managed observer for people tags.
         // Only watches childList (not attributes) to avoid firing on every hover
         // class/style change. Cast sections appear via childList mutations.
-        JC.helpers.createObserver(
+        observerHandle = JC.helpers.createObserver(
             'people-tags',
             (mutations) => {
-                if (!JC.currentSettings?.peopleTagsEnabled) return;
+                if (!isCurrent() || !JC.currentSettings?.peopleTagsEnabled) return;
 
                 // Reset completion flag when navigating to a different item
                 // (must happen BEFORE the peopleTagsComplete check)
@@ -560,3 +682,5 @@ JC.initializePeopleTags = function() {
 
     initialize();
 };
+
+JC.identity.registerReset('people-tags', resetPeopleTagsIdentity);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/tags/userreviewtags.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/tags/userreviewtags.identity.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../globals';
+import './userreviewtags';
+
+function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((done) => { resolve = done; });
+    return { promise, resolve };
+}
+
+const surface = JC as typeof JC & {
+    appendUserRatingToContainer?: (container: HTMLElement, item: unknown) => Promise<void>;
+};
+
+describe('user review tag identity ownership', () => {
+    const originalApi = JC.core.api;
+
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        JC.identity.transition('review-server-a', `review-user-a-${Date.now()}`, 'review-test-a');
+        JC.pluginConfig = {
+            ShowUserReviews: true,
+            ShowUserRatingOnPosters: true,
+            ShowUserRatingDash: true,
+        };
+        JC.currentSettings = { ratingTagsEnabled: true };
+    });
+
+    afterEach(() => {
+        JC.core.api = originalApi;
+        JC.pluginConfig = {};
+        JC.currentSettings = {};
+        document.body.innerHTML = '';
+    });
+
+    it('does not cache or append a delayed A review after B becomes current', async () => {
+        const responseA = deferred<any>();
+        const responseB = deferred<any>();
+        const plugin = vi.fn()
+            .mockReturnValueOnce(responseA.promise)
+            .mockReturnValueOnce(responseB.promise);
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+
+        const item = { Type: 'Movie', ProviderIds: { Tmdb: '123' } };
+        const containerA = document.createElement('div');
+        containerA.className = 'cardImageContainer';
+        document.body.appendChild(containerA);
+
+        const appendA = surface.appendUserRatingToContainer!(containerA, item);
+        expect(plugin).toHaveBeenCalledTimes(1);
+
+        JC.identity.transition('review-server-b', 'review-user-b', 'review-test-b');
+        const containerB = document.createElement('div');
+        containerB.className = 'cardImageContainer';
+        document.body.appendChild(containerB);
+        const appendB = surface.appendUserRatingToContainer!(containerB, item);
+        expect(plugin).toHaveBeenCalledTimes(2);
+
+        responseA.resolve({ reviews: [{ rating: 1 }] });
+        await appendA;
+        expect(containerA.querySelector('.jc-userreview-tag')).toBeNull();
+        expect(containerB.querySelector('.jc-userreview-tag')).toBeNull();
+
+        responseB.resolve({ reviews: [{ rating: 4 }] });
+        await appendB;
+        expect(containerB.querySelector('.jc-userreview-tag .rating-text')?.textContent).toBe('8');
+        expect(containerB.querySelector('.jc-userreview-tag')?.getAttribute('data-jc-identity-owned')).toBe('true');
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/tags/userreviewtags.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/tags/userreviewtags.ts
@@ -6,7 +6,7 @@
 
 import { JC as JEBase } from '../globals';
 import { ensureMaterialSymbolsFont, injectCss } from '../core/ui-kit';
-import type { ApiApi } from '../types/jc';
+import type { ApiApi, IdentityContext } from '../types/jc';
 
 /**
  * Local view of the shared namespace adding the public members this module
@@ -25,7 +25,17 @@ const logPrefix = '🪼 Jellyfin Canopy: User Review Tags:';
 // Per-session cache: tmdbKey → rating (1-5 or null)
 const _reviewCache = new Map<string, number | null>();
 // In-flight deduplication
-const _inFlight = new Map<string, Promise<number | null>>();
+const _inFlight = new Map<string, { context: IdentityContext; promise: Promise<number | null> }>();
+
+function isCurrent(context: IdentityContext | null | undefined): context is IdentityContext {
+    return !!context && JC.identity.isCurrent(context);
+}
+
+function resetUserReviewTagsIdentity(): void {
+    _reviewCache.clear();
+    _inFlight.clear();
+    document.querySelectorAll('.jc-userreview-tag').forEach((node) => node.remove());
+}
 
 /**
  * Fetch the average rating across all users for a given tmdbKey.
@@ -33,14 +43,19 @@ const _inFlight = new Map<string, Promise<number | null>>();
  */
 async function fetchUserRating(tmdbKey: string, mediaType: string): Promise<number | null> {
     if (!JC.pluginConfig?.ShowUserReviews) return null;
+    const context = JC.identity.capture();
+    if (!isCurrent(context)) return null;
     if (_reviewCache.has(tmdbKey)) return _reviewCache.get(tmdbKey)!;
-    if (_inFlight.has(tmdbKey)) return _inFlight.get(tmdbKey)!;
+    const existing = _inFlight.get(tmdbKey);
+    if (existing && isCurrent(existing.context)) return existing.promise;
 
+    const record = { context, promise: null as unknown as Promise<number | null> };
     const promise = (async (): Promise<number | null> => {
         try {
             // Core throws on non-OK responses, which lands in the catch below —
             // same "cache null, return null" outcome as the old !response.ok branch.
             const data = await JC.core.api.plugin(`/reviews/${mediaType}/${tmdbKey}`) as any;
+            if (!isCurrent(context)) return null;
             const rated = (data.reviews || []).filter((r: any) => r.rating);
             if (rated.length === 0) {
                 _reviewCache.set(tmdbKey, null);
@@ -51,14 +66,15 @@ async function fetchUserRating(tmdbKey: string, mediaType: string): Promise<numb
             _reviewCache.set(tmdbKey, avg);
             return avg;
         } catch (e) {
-            _reviewCache.set(tmdbKey, null);
+            if (isCurrent(context)) _reviewCache.set(tmdbKey, null);
             return null;
         } finally {
-            _inFlight.delete(tmdbKey);
+            if (_inFlight.get(tmdbKey) === record) _inFlight.delete(tmdbKey);
         }
     })();
 
-    _inFlight.set(tmdbKey, promise);
+    record.promise = promise;
+    _inFlight.set(tmdbKey, record);
     return promise;
 }
 
@@ -67,7 +83,12 @@ async function fetchUserRating(tmdbKey: string, mediaType: string): Promise<numb
  * Uses the same .rating-tag + .rating-tag-critic structure as the tomato chip,
  * with a material icon instead of the SVG background.
  */
-function appendUserRatingChip(container: HTMLElement, rating: number | null): void {
+function appendUserRatingChip(
+    container: HTMLElement,
+    rating: number | null,
+    context: IdentityContext,
+): void {
+    if (!isCurrent(context)) return;
     container.querySelector('.jc-userreview-tag')?.remove();
 
     const showDash = JC.pluginConfig?.ShowUserRatingDash !== false;
@@ -81,6 +102,8 @@ function appendUserRatingChip(container: HTMLElement, rating: number | null): vo
 
     const tag = document.createElement('div');
     tag.className = 'rating-tag rating-tag-critic jc-userreview-tag';
+    tag.dataset.jcIdentityOwned = 'true';
+    JC.identity.own(tag, context);
 
     const icon = document.createElement('span');
     icon.className = 'jc-userreview-icon';
@@ -180,12 +203,15 @@ JC.appendUserRatingToContainer = async function(containerOrEl: HTMLElement, item
     if (!JC.pluginConfig?.ShowUserReviews) return;
     if (!JC.pluginConfig?.ShowUserRatingOnPosters) return;
     if (!JC.currentSettings?.ratingTagsEnabled) return;
+    const context = JC.identity.capture();
+    if (!isCurrent(context)) return;
 
     const resolved = resolveTmdbKey(item, extras);
     if (!resolved) return;
 
     const { tmdbKey, mediaType } = resolved;
     const rating = await fetchUserRating(tmdbKey, mediaType);
+    if (!isCurrent(context)) return;
 
     if (rating === null && JC.pluginConfig?.ShowUserRatingDash === false) return;
 
@@ -196,12 +222,14 @@ JC.appendUserRatingToContainer = async function(containerOrEl: HTMLElement, item
         if (!overlay) {
             overlay = document.createElement('div');
             overlay.className = 'rating-overlay-container';
+            overlay.dataset.jcIdentityOwned = 'true';
+            JC.identity.own(overlay, context);
             containerOrEl.appendChild(overlay);
         }
         container = overlay;
     }
 
-    appendUserRatingChip(container, rating);
+    appendUserRatingChip(container, rating, context);
 };
 
 /**
@@ -211,3 +239,5 @@ JC.invalidateUserReviewTagCache = function(tmdbKey?: string) {
     if (tmdbKey) _reviewCache.delete(tmdbKey);
     else _reviewCache.clear();
 };
+
+JC.identity.registerReset('user-review-tags', resetUserReviewTagsIdentity);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/test/escape-guard.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/test/escape-guard.test.ts
@@ -181,48 +181,6 @@ const ALLOWLIST: AllowlistEntry[] = [
         why: 'pre-built HTML from formatFutureReleaseDate\'s { isHtml, text } payload — the template that constructs it is itself scanned in render-helpers.ts',
     },
     {
-        file: 'enhanced/bookmarks/library-items.ts',
-        expr: 'key',
-        line: 128,
-        why: 'Object.entries key over bookmark groups (server item ids); used symmetrically as a class fragment (L128) and querySelector (L162) — escaping one side would desync them',
-    },
-    {
-        file: 'enhanced/features/release-dates.ts',
-        expr: 'info.titleKey',
-        line: 303,
-        why: 'ReleaseInfo entries are built by this module: titleKey is a fixed translation key literal',
-    },
-    {
-        file: 'enhanced/features/release-dates.ts',
-        expr: 'info.icon',
-        line: 303,
-        why: 'ReleaseInfo entries are built by this module: icon is a Material Symbols glyph name literal',
-    },
-    {
-        file: 'enhanced/playback.ts',
-        expr: 'next.textContent',
-        line: 491,
-        why: 'label of the host client\'s own aspect-ratio OSD menu item (jellyfin-web UI string, not media metadata)',
-    },
-    {
-        file: 'enhanced/settings-panel/settings.ts',
-        expr: 'selectedPreset.name',
-        line: 481,
-        why: 'name of a plugin-defined subtitle preset (subtitlePresets table in the legacy js/ tree) shown in the style toast',
-    },
-    {
-        file: 'enhanced/settings-panel/settings.ts',
-        expr: 'selectedPreset.name',
-        line: 495,
-        why: 'name of a plugin-defined font-size preset (fontSizePresets table in the legacy js/ tree) shown in the size toast',
-    },
-    {
-        file: 'enhanced/settings-panel/settings.ts',
-        expr: 'selectedPreset.name',
-        line: 509,
-        why: 'name of a plugin-defined font-family preset (fontFamilyPresets table in the legacy js/ tree) shown in the font toast',
-    },
-    {
         file: 'enhanced/settings-panel/template.ts',
         expr: 'preset.size',
         line: 53,
@@ -233,12 +191,6 @@ const ALLOWLIST: AllowlistEntry[] = [
         expr: 'preset.family',
         line: 55,
         why: 'plugin-defined font-family preset tables (legacy js/ tree) — fixed font-family literals',
-    },
-    {
-        file: 'extras/theme-selector.ts',
-        expr: 'sessionStorage.getItem(\'jellyfin-theme-applied\')',
-        line: 200,
-        why: 'round-trip of this module\'s own sessionStorage value — a theme name from the plugin theme table, persisted across the reload it triggers',
     },
 ];
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/test/plugin-loader.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/test/plugin-loader.test.ts
@@ -6,7 +6,7 @@
 // interpolation; the case-transform and genre-tag helpers are extracted and
 // evaluated so their real behaviour is asserted.
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import * as ts from 'typescript';
 
 const TEST_FILE_PATH = decodeURIComponent(new URL(import.meta.url).pathname);
@@ -34,9 +34,586 @@ type ResolveFactory = (
     jc: { pluginConfig?: Record<string, unknown> },
 ) => (userSettings: Record<string, unknown>) => boolean;
 
+type IdentityContext = Readonly<{ serverId: string; userId: string; epoch: number }>;
+type IdentityChange = Readonly<{
+    previous: IdentityContext | null;
+    current: IdentityContext | null;
+    epoch: number;
+    reason: string;
+}>;
+type IdentitySession = {
+    capture(): IdentityContext | null;
+    isCurrent(context: IdentityContext | null): boolean;
+    transition(serverId: unknown, userId: unknown, reason?: string): IdentityContext | null;
+    own<T>(value: T, context?: IdentityContext | null): T;
+    ownerOf(value: unknown): IdentityContext | null;
+    isOwned(value: unknown, context?: IdentityContext | null): boolean;
+    registerReset(name: string, handler: (change: IdentityChange) => void): () => void;
+    registerActivate(name: string, handler: (context: IdentityContext) => void | Promise<void>): () => void;
+    activate(context?: IdentityContext | null): Promise<void>;
+    getEpoch(): number;
+    getRawUserId(context?: IdentityContext | null): string;
+    getPendingInitializationCount(): number;
+    getInitializationControllerCount(): number;
+};
+
+type InitializationScope = {
+    epoch: number;
+    signal: AbortSignal;
+    race<T>(promise: PromiseLike<T> | T): Promise<T>;
+    cancel(): void;
+};
+type InitializationRegistry = {
+    start<T>(epoch: number, run: (scope: InitializationScope) => PromiseLike<T> | T): Promise<T>;
+    cancelExcept(epoch: number | null, transitionEpoch?: number | null): void;
+    getPendingCount(): number;
+    getControllerCount(): number;
+};
+
 describe('plugin.js loader guards', () => {
     it('loaded the loader source', () => {
         expect(SRC.length).toBeGreaterThan(0);
+    });
+
+    it('owns one immutable server/user epoch and resets synchronously on every real transition', () => {
+        const source = extractFunctionSource('createIdentitySession');
+        expect(source, 'createIdentitySession not found').toBeTruthy();
+        const create = eval(`(${source})`) as (
+            finalizer?: (change: IdentityChange) => void,
+        ) => IdentitySession;
+        const order: string[] = [];
+        const session = create((change) => order.push(`final:${change.epoch}`));
+        session.registerReset('probe', (change) => order.push(`reset:${change.epoch}`));
+
+        const a = session.transition('server-a', 'user-a', 'initial')!;
+        expect(Object.isFrozen(a)).toBe(true);
+        expect(a).toEqual({ serverId: 'servera', userId: 'usera', epoch: 1 });
+        expect(order).toEqual(['reset:1', 'final:1']);
+
+        // A duplicate host event for the same identity is a strict no-op.
+        expect(session.transition('server-a', 'user-a', 'duplicate')).toBe(a);
+        expect(session.getEpoch()).toBe(1);
+        expect(order).toEqual(['reset:1', 'final:1']);
+
+        // Server identity is part of the owner even when the user id matches.
+        const otherServer = session.transition('server-b', 'user-a', 'server-switch')!;
+        expect(otherServer.epoch).toBe(2);
+        expect(session.isCurrent(a)).toBe(false);
+        expect(order.slice(-2)).toEqual(['reset:2', 'final:2']);
+
+        expect(session.transition('server-b', null, 'logout')).toBeNull();
+        expect(session.getEpoch()).toBe(3);
+        expect(order.slice(-2)).toEqual(['reset:3', 'final:3']);
+    });
+
+    it('stops an outer transition when a reset handler accepts a newer nested identity', () => {
+        const source = extractFunctionSource('createIdentitySession');
+        const create = eval(`(${source})`) as (
+            finalizer?: (change: IdentityChange) => void,
+        ) => IdentitySession;
+        const order: string[] = [];
+        const session = create((change) => order.push(`final:${change.current?.userId || 'none'}`));
+        session.registerReset('nested', (change) => {
+            order.push(`nested:${change.current?.userId || 'none'}`);
+            if (change.current?.userId === 'b') session.transition('server', 'c', 'nested-newer');
+        });
+        session.registerReset('later', (change) => order.push(`later:${change.current?.userId || 'none'}`));
+        session.transition('server', 'a', 'initial');
+        order.length = 0;
+
+        const result = session.transition('server', 'b', 'outer');
+
+        expect(result?.userId).toBe('c');
+        expect(order).toEqual([
+            'nested:b',
+            'nested:c',
+            'later:c',
+            'final:c',
+        ]);
+        expect(order).not.toContain('later:b');
+        expect(order).not.toContain('final:b');
+    });
+
+    it('rejects prior-epoch object ownership and activates each participant once per epoch', async () => {
+        const source = extractFunctionSource('createIdentitySession');
+        const create = eval(`(${source})`) as () => IdentitySession;
+        const session = create();
+        const activate = vi.fn();
+        session.registerActivate('probe', activate);
+
+        const a = session.transition('s', 'a')!;
+        const aSettings = session.own({ marker: 'A' }, a);
+        expect(session.isOwned(aSettings)).toBe(true);
+        await session.activate(a);
+        await session.activate(a);
+        expect(activate).toHaveBeenCalledTimes(1);
+
+        const b = session.transition('s', 'b')!;
+        expect(session.isOwned(aSettings)).toBe(false);
+        expect(session.ownerOf(aSettings)).toBe(a);
+        expect(session.isCurrent(a)).toBe(false);
+        const bSettings = session.own({ marker: 'B' }, b);
+        expect(session.isOwned(bSettings)).toBe(true);
+        await session.activate(b);
+        expect(activate).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries failed activation handlers while successful peers stay once per epoch', async () => {
+        const source = extractFunctionSource('createIdentitySession');
+        const create = eval(`(${source})`) as () => IdentitySession;
+        const session = create();
+        const context = session.transition('server', 'user')!;
+        const successful = vi.fn().mockResolvedValue(undefined);
+        const flaky = vi.fn()
+            .mockRejectedValueOnce(new Error('first activation failed'))
+            .mockResolvedValue(undefined);
+        const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        session.registerActivate('successful', successful);
+        session.registerActivate('flaky', flaky);
+
+        await expect(session.activate(context)).rejects.toThrow('first activation failed');
+        expect(successful).toHaveBeenCalledTimes(1);
+        expect(flaky).toHaveBeenCalledTimes(1);
+
+        await expect(session.activate(context)).resolves.toBeUndefined();
+        await expect(session.activate(context)).resolves.toBeUndefined();
+        expect(successful).toHaveBeenCalledTimes(1);
+        expect(flaky).toHaveBeenCalledTimes(2);
+        expect(error).toHaveBeenCalled();
+    });
+
+    it('retains the captured raw user id without changing the canonical context shape', () => {
+        const source = extractFunctionSource('createIdentitySession');
+        const create = eval(`(${source})`) as () => IdentitySession;
+        const session = create();
+        const raw = 'AABBCCDD-EEFF-0011-2233-445566778899';
+        const context = session.transition('server', raw)!;
+
+        expect(context).toEqual({
+            serverId: 'server',
+            userId: 'aabbccddeeff00112233445566778899',
+            epoch: 1,
+        });
+        expect(session.getRawUserId(context)).toBe(raw);
+        session.transition('server', context.userId, 'normalized-monitor-duplicate');
+        expect(session.getRawUserId(context)).toBe(raw);
+    });
+
+    it('publishes read-only bounded initialization diagnostics through the identity surface', () => {
+        const source = extractFunctionSource('createIdentitySession');
+        const create = eval(`(${source})`) as (
+            finalizer?: (change: IdentityChange) => void,
+            diagnostics?: {
+                getPendingInitializationCount(): number;
+                getInitializationControllerCount(): number;
+            },
+        ) => IdentitySession;
+        let pending = 2;
+        let controllers = 1;
+        const session = create(undefined, {
+            getPendingInitializationCount: () => pending,
+            getInitializationControllerCount: () => controllers,
+        });
+
+        expect(session.getPendingInitializationCount()).toBe(2);
+        expect(session.getInitializationControllerCount()).toBe(1);
+        pending = 0;
+        controllers = 0;
+        expect(session.getPendingInitializationCount()).toBe(0);
+        expect(session.getInitializationControllerCount()).toBe(0);
+        expect(Object.isFrozen(session)).toBe(true);
+    });
+
+    it('invalidates synchronously before the host authentication setter mutates credentials', () => {
+        const source = extractFunctionSource('createAuthenticationWrapper');
+        expect(source, 'createAuthenticationWrapper not found').toBeTruthy();
+        type Host = { userId: string };
+        type Setter = (this: Host, token: string | null, userId: string | null) => string;
+        const create = eval(`(${source})`) as (
+            original: Setter,
+            before: Setter,
+            after: (this: Host, beforeResult: string, token: string | null, userId: string | null) => void,
+        ) => Setter;
+        const order: string[] = [];
+        const host = { userId: 'A' };
+        const wrapped = create(
+            function(_token, userId) {
+                order.push(`host:${this.userId}->${userId}`);
+                this.userId = userId || '';
+                return 'host-result';
+            },
+            function(_token, userId) {
+                order.push(`invalidate:${this.userId}->${userId}`);
+                return 'epoch-B';
+            },
+            function(epoch) { order.push(`activate:${epoch}:${this.userId}`); },
+        );
+
+        expect(wrapped.call(host, 'token-B', 'B')).toBe('host-result');
+        expect(order).toEqual([
+            'invalidate:A->B',
+            'host:A->B',
+            'activate:epoch-B:B',
+        ]);
+    });
+
+    it('reconciles authentication synchronously and preserves the host setter throw', () => {
+        const source = extractFunctionSource('createAuthenticationWrapper');
+        type Host = { userId: string };
+        type Setter = (this: Host, token: string | null, userId: string | null) => string;
+        const create = eval(`(${source})`) as (
+            original: Setter,
+            before: Setter,
+            after: (this: Host) => void,
+            onError: (
+                this: Host,
+                beforeResult: string,
+                error: Error,
+                token: string | null,
+                userId: string | null,
+            ) => void,
+        ) => Setter;
+        const order: string[] = [];
+        const host = { userId: 'A' };
+        const hostError = new Error('host rejected credentials');
+        let canonicalIdentity = 'A';
+        const after = vi.fn();
+        const wrapped = create(
+            function() {
+                order.push(`host-throws:visible=${this.userId}`);
+                throw hostError;
+            },
+            function(_token, userId) {
+                canonicalIdentity = userId || '';
+                order.push(`transition:${canonicalIdentity}:visible=${this.userId}`);
+                return canonicalIdentity;
+            },
+            after,
+            function(_attempted, error) {
+                expect(error).toBe(hostError);
+                canonicalIdentity = this.userId;
+                order.push(`rollback:${canonicalIdentity}`);
+            },
+        );
+
+        expect(() => wrapped.call(host, 'token-B', 'B')).toThrow(hostError);
+        expect(canonicalIdentity).toBe('A');
+        expect(after).not.toHaveBeenCalled();
+        expect(order).toEqual([
+            'transition:B:visible=A',
+            'host-throws:visible=A',
+            'rollback:A',
+        ]);
+    });
+
+    it('fences a configurable ApiClient replacement before B is globally observable', () => {
+        const source = extractFunctionSource('installPropertyPublicationFence');
+        expect(source, 'installPropertyPublicationFence not found').toBeTruthy();
+        type Client = { id: string; authenticationHookInstalled?: boolean };
+        type Host = { ApiClient: Client };
+        const install = eval(`(${source})`) as (
+            target: Host,
+            propertyName: 'ApiClient',
+            before: (next: Client, previous: Client) => unknown,
+            after: (next: Client, prepared: unknown, error: unknown) => void,
+        ) => boolean;
+        const clientA: Client = { id: 'A' };
+        const clientB: Client = { id: 'B' };
+        const host = {} as Host;
+        Object.defineProperty(host, 'ApiClient', {
+            configurable: true,
+            enumerable: false,
+            writable: true,
+            value: clientA,
+        });
+        const order: string[] = [];
+
+        expect(install(
+            host,
+            'ApiClient',
+            (next) => {
+                next.authenticationHookInstalled = true;
+                order.push(`hook:${next.id}`);
+                order.push(`transition:${next.id}:visible=${host.ApiClient.id}`);
+                return `epoch-${next.id}`;
+            },
+            (next, epoch) => order.push(`schedule:${String(epoch)}:visible=${host.ApiClient.id}:${next.id}`),
+        )).toBe(true);
+
+        host.ApiClient = clientB;
+        expect(clientB.authenticationHookInstalled).toBe(true);
+        expect(order).toEqual([
+            'hook:B',
+            'transition:B:visible=A',
+            'schedule:epoch-B:visible=B:B',
+        ]);
+        expect(host.ApiClient).toBe(clientB);
+        const descriptor = Object.getOwnPropertyDescriptor(host, 'ApiClient');
+        expect(descriptor).toMatchObject({ configurable: true, enumerable: false });
+
+        // A different Reflect.set receiver keeps ordinary data-property semantics
+        // and does not replace/fence the actual window-owned value.
+        const receiver = {} as Host;
+        const clientC: Client = { id: 'C' };
+        expect(Reflect.set(host, 'ApiClient', clientC, receiver)).toBe(true);
+        expect(receiver.ApiClient).toBe(clientC);
+        expect(host.ApiClient).toBe(clientB);
+        expect(order).toHaveLength(3);
+    });
+
+    it('leaves a non-configurable ApiClient property untouched for monitor fallback', () => {
+        const source = extractFunctionSource('installPropertyPublicationFence');
+        const install = eval(`(${source})`) as (
+            target: Record<string, unknown>,
+            propertyName: string,
+            before: () => void,
+            after: () => void,
+        ) => boolean;
+        const before = vi.fn();
+        const after = vi.fn();
+        const host: Record<string, unknown> = {};
+        Object.defineProperty(host, 'ApiClient', {
+            configurable: false,
+            enumerable: true,
+            writable: true,
+            value: 'A',
+        });
+
+        expect(install(host, 'ApiClient', before, after)).toBe(false);
+        host.ApiClient = 'B';
+        expect(host.ApiClient).toBe('B');
+        expect(before).not.toHaveBeenCalled();
+        expect(after).not.toHaveBeenCalled();
+    });
+
+    it('does not reserve an absent ApiClient global and can hook it after the host installs it', () => {
+        const source = extractFunctionSource('installPropertyPublicationFence');
+        const install = eval(`(${source})`) as (
+            target: Record<string, unknown>,
+            propertyName: string,
+            before: (next: unknown) => unknown,
+            after: (next: unknown) => void,
+        ) => boolean;
+        const host: Record<string, unknown> = {};
+        const before = vi.fn((next: unknown) => next);
+        const after = vi.fn();
+
+        expect(install(host, 'ApiClient', before, after)).toBe(false);
+        expect(Object.prototype.hasOwnProperty.call(host, 'ApiClient')).toBe(false);
+
+        Object.defineProperty(host, 'ApiClient', {
+            configurable: true,
+            enumerable: true,
+            writable: true,
+            value: 'host-A',
+        });
+        expect(install(host, 'ApiClient', before, after)).toBe(true);
+        host.ApiClient = 'host-B';
+        expect(host.ApiClient).toBe('host-B');
+        expect(before).toHaveBeenCalledWith('host-B', 'host-A');
+        expect(after).toHaveBeenCalled();
+    });
+
+    it('installs B authentication fencing before transition and schedules only after publication', () => {
+        const prepare = extractFunctionSource('prepareApiClientPublication') || '';
+        const complete = extractFunctionSource('completeApiClientPublication') || '';
+        expect(prepare.indexOf('installAuthenticationHook(client)')).toBeGreaterThanOrEqual(0);
+        expect(prepare.indexOf('identity.transition(')).toBeGreaterThan(prepare.indexOf('installAuthenticationHook(client)'));
+        expect(complete).toContain('scheduleInitializationForClient(publishedClient, prepared.context)');
+    });
+
+    it('drains repeated held initialization epochs synchronously and keeps controllers bounded', async () => {
+        const source = extractFunctionSource('createInitializationRegistry');
+        expect(source, 'createInitializationRegistry not found').toBeTruthy();
+        const create = eval(`(${source})`) as (
+            makeCancellationError: () => Error,
+        ) => InitializationRegistry;
+        const registry = create(() => {
+            const error = new Error('identity changed');
+            error.name = 'IdentityChangedError';
+            return error;
+        });
+        const signals: AbortSignal[] = [];
+        const settlements: Array<Promise<string>> = [];
+
+        for (let epoch = 1; epoch <= 32; epoch++) {
+            const held = registry.start(epoch, (scope) => {
+                signals.push(scope.signal);
+                return new Promise<never>(() => { /* host ignores AbortSignal forever */ });
+            });
+            settlements.push(held.then(
+                () => 'resolved',
+                (error: Error) => error.name,
+            ));
+            expect(registry.getPendingCount()).toBe(1);
+            expect(registry.getControllerCount()).toBe(1);
+
+            registry.cancelExcept(epoch + 1);
+            expect(registry.getPendingCount()).toBe(0);
+            expect(registry.getControllerCount()).toBe(0);
+            expect(signals.at(-1)?.aborted).toBe(true);
+
+            const staleRun = vi.fn(() => Promise.resolve('stale'));
+            await expect(registry.start(epoch, staleRun))
+                .rejects.toMatchObject({ name: 'IdentityChangedError' });
+            expect(staleRun).not.toHaveBeenCalled();
+            expect(registry.getPendingCount()).toBe(0);
+            expect(registry.getControllerCount()).toBe(0);
+        }
+
+        await expect(Promise.all(settlements)).resolves.toEqual(
+            Array.from({ length: 32 }, () => 'IdentityChangedError'),
+        );
+    });
+
+    it('ignores a stale cancellation after a newer registry transition', async () => {
+        const source = extractFunctionSource('createInitializationRegistry');
+        const create = eval(`(${source})`) as (
+            makeCancellationError: () => Error,
+        ) => InitializationRegistry;
+        const registry = create(() => {
+            const error = new Error('identity changed');
+            error.name = 'IdentityChangedError';
+            return error;
+        });
+        let signal!: AbortSignal;
+        const held = registry.start(3, (scope) => {
+            signal = scope.signal;
+            return new Promise<never>(() => { /* held */ });
+        });
+
+        registry.cancelExcept(3, 3);
+        registry.cancelExcept(2, 2);
+        expect(signal.aborted).toBe(false);
+        expect(registry.getPendingCount()).toBe(1);
+        expect(registry.getControllerCount()).toBe(1);
+
+        registry.cancelExcept(null, 4);
+        await expect(held).rejects.toMatchObject({ name: 'IdentityChangedError' });
+        expect(signal.aborted).toBe(true);
+        expect(registry.getPendingCount()).toBe(0);
+        expect(registry.getControllerCount()).toBe(0);
+    });
+
+    it('recognizes only genuine 404 host error shapes as a missing user file', () => {
+        const source = extractFunctionSource('isNotFoundError');
+        expect(source, 'isNotFoundError not found').toBeTruthy();
+        const isNotFound = eval(`(${source})`) as (error: unknown) => boolean;
+
+        expect(isNotFound({ status: 404 })).toBe(true);
+        expect(isNotFound({ statusCode: '404' })).toBe(true);
+        expect(isNotFound({ response: { status: 404 } })).toBe(true);
+        expect(isNotFound({ xhr: { status: 404 } })).toBe(true);
+        expect(isNotFound({ target: { status: 404 } })).toBe(true);
+        expect(isNotFound({ status: 401 })).toBe(false);
+        expect(isNotFound({ status: 503 })).toBe(false);
+        expect(isNotFound(new TypeError('network failed'))).toBe(false);
+    });
+
+    it('fails a five-file owner read on transient errors but defaults a genuine 404', async () => {
+        const fetchSource = extractFunctionSource('fetchUserConfig');
+        const notFoundSource = extractFunctionSource('isNotFoundError');
+        expect(fetchSource, 'fetchUserConfig not found').toBeTruthy();
+        expect(notFoundSource, 'isNotFoundError not found').toBeTruthy();
+        type AjaxOptions = { url: string };
+        type LoaderClient = {
+            getUrl(path: string): string;
+            ajax(options: AjaxOptions): Promise<unknown>;
+        };
+        type LoaderScope = {
+            signal: AbortSignal;
+            race<T>(promise: PromiseLike<T> | T): Promise<T>;
+        };
+        type FetchUserConfig = (
+            client: LoaderClient,
+            context: IdentityContext,
+            scope: LoaderScope,
+        ) => Promise<Record<string, unknown>>;
+        const isNotFound = eval(`(${notFoundSource})`) as (error: unknown) => boolean;
+        const makeFetch = eval(
+            '(function(isNotFoundError, requireCurrentIdentity, emptyUserConfig, defaultUserFile, toCamelCase) {'
+            + 'async ' + fetchSource
+            + '; return fetchUserConfig; })',
+        ) as (
+            isNotFoundError: (error: unknown) => boolean,
+            requireCurrentIdentity: (context: IdentityContext) => void,
+            emptyUserConfig: () => Record<string, unknown>,
+            defaultUserFile: (name: string) => Record<string, unknown>,
+            toCamelCase: (value: unknown) => unknown,
+        ) => FetchUserConfig;
+        const fetchUserConfig = makeFetch(
+            isNotFound,
+            () => undefined,
+            () => ({ settings: {}, shortcuts: {}, bookmark: {}, elsewhere: {}, hiddenContent: {} }),
+            (name) => name === 'shortcuts' ? { Shortcuts: [] } : {},
+            (value) => value,
+        );
+        const controller = new AbortController();
+        const scope: LoaderScope = {
+            signal: controller.signal,
+            race: <T>(promise: PromiseLike<T> | T) => Promise.resolve(promise),
+        };
+        const context = { serverId: 'server', userId: 'user/id', epoch: 1 };
+        const transientError = Object.assign(new Error('temporary server failure'), { status: 503 });
+        const transientAjax = vi.fn((options: AjaxOptions) => options.url.includes('settings.json')
+            ? Promise.reject(transientError)
+            : Promise.resolve({}));
+
+        await expect(fetchUserConfig({ getUrl: (path) => path, ajax: transientAjax }, context, scope))
+            .rejects.toBe(transientError);
+        expect(transientAjax).toHaveBeenCalledTimes(5);
+
+        const malformedAjax = vi.fn((options: AjaxOptions) => options.url.includes('settings.json')
+            ? Promise.resolve(null)
+            : Promise.resolve({}));
+        await expect(fetchUserConfig({ getUrl: (path) => path, ajax: malformedAjax }, context, scope))
+            .rejects.toThrow('Invalid settings user-settings response');
+        expect(malformedAjax).toHaveBeenCalledTimes(5);
+
+        const missingError = Object.assign(new Error('missing'), { status: 404 });
+        const missingAjax = vi.fn((options: AjaxOptions) => options.url.includes('shortcuts.json')
+            ? Promise.reject(missingError)
+            : Promise.resolve({}));
+        const snapshot = await fetchUserConfig({ getUrl: (path) => path, ajax: missingAjax }, context, scope);
+
+        expect(missingAjax).toHaveBeenCalledTimes(5);
+        expect(snapshot.shortcuts).toEqual({ Shortcuts: [] });
+        for (const [options] of missingAjax.mock.calls) {
+            expect(options.url).toContain('/user-settings/user%2Fid/');
+        }
+    });
+
+    it('does not downgrade current-user failure and encodes every loader user path', () => {
+        const run = extractFunctionSource('runInitialization') || '';
+        const fetchUser = extractFunctionSource('fetchUserConfig') || '';
+        expect(run).toContain('scope.race(client.getCurrentUser())');
+        expect(run).not.toContain('scope.race(client.getCurrentUser()).catch');
+        expect(fetchUser).toContain('encodeURIComponent(context.userId)');
+        expect(SRC).toContain('/tag-cache/${encodeURIComponent(context.userId)}');
+    });
+
+    it('cleans raw/canonical/dashed language keys and uses Secure cookies only on HTTPS', () => {
+        const variantsSource = extractFunctionSource('identityStorageUserIdVariants');
+        expect(variantsSource, 'identityStorageUserIdVariants not found').toBeTruthy();
+        const raw = 'AABBCCDD-EEFF-0011-2233-445566778899';
+        const context = {
+            serverId: 'server',
+            userId: 'aabbccddeeff00112233445566778899',
+            epoch: 1,
+        };
+        const makeVariants = eval(
+            `(function(identity) { ${variantsSource}; return identityStorageUserIdVariants; })`,
+        ) as (identity: { getRawUserId(): string }) => (context: IdentityContext) => string[];
+        const variants = makeVariants({ getRawUserId: () => raw })(context);
+
+        expect(variants).toEqual(expect.arrayContaining([
+            context.userId,
+            raw,
+            'aabbccdd-eeff-0011-2233-445566778899',
+        ]));
+        expect(SRC).toContain('const compatibilityUserId = normalizedRawUserId === context.userId');
+        expect(SRC).toContain("window.location.protocol === 'https:' ? '; Secure' : ''");
+        expect(SRC).toContain('SameSite=Lax${secure}');
     });
 
     // LOADER-1 — the stale-credential give-up branches called
@@ -44,7 +621,7 @@ describe('plugin.js loader guards', () => {
     // never hid. Every give-up must use the module-local `JC` alias.
     it('splash-hide give-ups use the local JC alias, not window.JC (LOADER-1)', () => {
         expect(SRC).not.toContain('window.JC?.hideSplashScreen');
-        expect(SRC).toContain('JC?.hideSplashScreen?.();');
+        expect(SRC).toContain('JC.hideSplashScreen?.();');
     });
 
     // LOADER-7 — the boot placeholder seeded `bookmarks: { Bookmarks: {} }`

--- a/Jellyfin.Plugin.JellyfinCanopy/src/test/setup-identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/test/setup-identity.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../globals';
+
+const unregister: Array<() => void> = [];
+
+afterEach(() => {
+    for (const dispose of unregister.splice(0)) dispose();
+});
+
+describe('shared test identity activation contract', () => {
+    it('retries a failed handler and memoizes only its successful attempt', async () => {
+        const context = JC.identity.transition('setup-server', 'setup-retry-user', 'setup-retry')!;
+        const flaky = vi.fn()
+            .mockRejectedValueOnce(new Error('first activation failed'))
+            .mockResolvedValue(undefined);
+        unregister.push(JC.identity.registerActivate('setup-retry-probe', flaky));
+
+        await expect(JC.identity.activate(context)).rejects.toThrow('first activation failed');
+        await expect(JC.identity.activate(context)).resolves.toBeUndefined();
+        await expect(JC.identity.activate(context)).resolves.toBeUndefined();
+
+        expect(flaky).toHaveBeenCalledTimes(2);
+    });
+
+    it('deduplicates concurrent activation for the same handler and epoch', async () => {
+        const context = JC.identity.transition('setup-server', 'setup-pending-user', 'setup-pending')!;
+        let release: (() => void) | undefined;
+        const held = new Promise<void>((resolve) => { release = resolve; });
+        const handler = vi.fn(() => held);
+        unregister.push(JC.identity.registerActivate('setup-pending-probe', handler));
+
+        const first = JC.identity.activate(context);
+        const second = JC.identity.activate(context);
+        await Promise.resolve();
+        expect(handler).toHaveBeenCalledTimes(1);
+
+        release?.();
+        await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined]);
+        expect(handler).toHaveBeenCalledTimes(1);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/test/setup.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/test/setup.ts
@@ -4,10 +4,121 @@
 // bundle loads — the window.JellyfinCanopy bootstrap namespace and the
 // jellyfin-web globals the core modules touch at import time.
 
-import type { JEGlobal } from '../types/jc';
+import type { IdentityApi, IdentityChange, IdentityContext, JEGlobal } from '../types/jc';
+
+let testIdentity: IdentityContext | null = Object.freeze({
+    serverId: 'test-server-id',
+    userId: 'test-user-id',
+    epoch: 1,
+});
+let testEpoch = 1;
+const owners = new WeakMap<object, IdentityContext>();
+const resetHandlers = new Map<string, (change: IdentityChange) => void>();
+interface TestActivateRecord {
+    fn: (context: IdentityContext) => void | Promise<void>;
+    epoch: number;
+    pendingEpoch: number;
+    pending: Promise<void> | null;
+}
+const activateHandlers = new Map<string, TestActivateRecord>();
+const coerceString: (value?: unknown) => string = String;
+
+const identity: IdentityApi = {
+    capture: () => testIdentity,
+    isCurrent: (context) => !!context && !!testIdentity
+        && context.epoch === testIdentity.epoch
+        && context.serverId === testIdentity.serverId
+        && context.userId === testIdentity.userId,
+    transition(serverId, userId, reason = 'test') {
+        const nextUser = coerceString(userId ?? '').replace(/-/g, '').toLowerCase();
+        const nextServer = nextUser
+            ? (coerceString(serverId ?? '').replace(/-/g, '').toLowerCase() || 'unknown-server')
+            : '';
+        if ((!testIdentity && !nextUser)
+            || (testIdentity?.serverId === nextServer && testIdentity?.userId === nextUser)) return testIdentity;
+        const previous = testIdentity;
+        testEpoch += 1;
+        testIdentity = nextUser ? Object.freeze({ serverId: nextServer, userId: nextUser, epoch: testEpoch }) : null;
+        const change = { previous, current: testIdentity, epoch: testEpoch, reason };
+        for (const handler of resetHandlers.values()) handler(change);
+        return testIdentity;
+    },
+    own<T>(value: T, context = testIdentity): T {
+        if (context && value !== null && (typeof value === 'object' || typeof value === 'function')) {
+            owners.set(value, context);
+        }
+        return value;
+    },
+    ownerOf(value) {
+        return value !== null && (typeof value === 'object' || typeof value === 'function')
+            ? owners.get(value) || null
+            : null;
+    },
+    isOwned(value, context = testIdentity) {
+        const owner = this.ownerOf(value);
+        return !!owner && !!context && owner.epoch === context.epoch
+            && owner.serverId === context.serverId && owner.userId === context.userId;
+    },
+    registerReset(name, handler) {
+        resetHandlers.set(name, handler);
+        return () => { if (resetHandlers.get(name) === handler) resetHandlers.delete(name); };
+    },
+    registerActivate(name, handler) {
+        const record: TestActivateRecord = {
+            fn: handler,
+            epoch: -1,
+            pendingEpoch: -1,
+            pending: null,
+        };
+        activateHandlers.set(name, record);
+        return () => { if (activateHandlers.get(name) === record) activateHandlers.delete(name); };
+    },
+    async activate(context = testIdentity) {
+        if (!context || !this.isCurrent(context)) return;
+        const work: Promise<void>[] = [];
+        for (const record of activateHandlers.values()) {
+            if (record.epoch === context.epoch) continue;
+            if (record.pendingEpoch === context.epoch && record.pending) {
+                work.push(record.pending);
+                continue;
+            }
+
+            const invocation = Promise.resolve()
+                .then(() => record.fn(context))
+                .then(() => {
+                    // Match the loader contract: a failed handler remains
+                    // retryable, and late older success cannot replace newer.
+                    if (record.epoch < context.epoch) record.epoch = context.epoch;
+                })
+                .finally(() => {
+                    if (record.pending === invocation) {
+                        record.pending = null;
+                        record.pendingEpoch = -1;
+                    }
+                });
+            record.pendingEpoch = context.epoch;
+            record.pending = invocation;
+            work.push(invocation);
+        }
+
+        const results = await Promise.allSettled(work);
+        const failure = results.find((result): result is PromiseRejectedResult => result.status === 'rejected');
+        if (failure) {
+            throw failure.reason instanceof Error
+                ? failure.reason
+                : new Error('Test identity activation failed', { cause: failure.reason });
+        }
+    },
+    getEpoch: () => testEpoch,
+    getResetHandlerCount: () => resetHandlers.size,
+    getActivateHandlerCount: () => activateHandlers.size,
+    getPendingInitializationCount: () => 0,
+    getInitializationControllerCount: () => 0,
+};
 
 const bootstrapJE = {
-    core: {},
+    core: { identity },
+    identity,
     pluginConfig: {},
     translations: {},
     pluginVersion: 'test',
@@ -22,6 +133,7 @@ window.Emby = { Page: {} };
 
 // Minimal ApiClient: only what the core modules call at import/test time.
 const apiClientStub = {
+    serverId: () => 'test-server-id',
     getUrl: (path: string) => `http://jellyfin.test${path}`,
     getCurrentUserId: () => 'test-user-id',
     accessToken: () => 'test-token',

--- a/Jellyfin.Plugin.JellyfinCanopy/src/types/jc.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/types/jc.ts
@@ -47,6 +47,8 @@ export interface CacheManager {
     unregister(saveCallback: () => void): void;
     markDirty(): void;
     forceSave(): void;
+    /** Cancel a scheduled identity-owned flush without dropping stable callbacks. */
+    cancelPending(): void;
 }
 
 /**
@@ -74,6 +76,50 @@ export interface HotCache {
 }
 
 // ── Core surface contracts (frozen until the facade phase) ─────────────────
+
+/** Immutable owner of one authenticated Jellyfin client epoch. */
+export interface IdentityContext {
+    readonly serverId: string;
+    readonly userId: string;
+    readonly epoch: number;
+}
+
+/** Synchronous transition delivered to identity reset participants. */
+export interface IdentityChange {
+    readonly previous: IdentityContext | null;
+    readonly current: IdentityContext | null;
+    readonly epoch: number;
+    readonly reason: string;
+}
+
+/**
+ * Document-lifetime identity controller created by js/plugin.js before the
+ * bundle loads. Objects that can later be persisted are explicitly owner-tagged
+ * so an A snapshot cannot be serialized under B's live authentication.
+ */
+export interface IdentityApi {
+    capture(): IdentityContext | null;
+    isCurrent(context: IdentityContext | null | undefined): boolean;
+    transition(serverId: unknown, userId: unknown, reason?: string): IdentityContext | null;
+    own<T>(value: T, context?: IdentityContext | null): T;
+    ownerOf(value: unknown): IdentityContext | null;
+    isOwned(value: unknown, context?: IdentityContext | null): boolean;
+    registerReset(name: string, handler: (change: IdentityChange) => void): () => void;
+    registerActivate(
+        name: string,
+        handler: (context: IdentityContext) => void | Promise<void>
+    ): () => void;
+    activate(context?: IdentityContext | null): Promise<void>;
+    getEpoch(): number;
+    /** Raw dashed/cased host user id captured for compatibility storage keys. */
+    getRawUserId?(context?: IdentityContext | null): string;
+    getResetHandlerCount(): number;
+    getActivateHandlerCount(): number;
+    /** Loader work still logically awaiting completion for the current epoch. */
+    getPendingInitializationCount(): number;
+    /** Abort scopes retained by the loader (bounded to the current epoch). */
+    getInitializationControllerCount(): number;
+}
 
 export type NavigateCallback = (event?: Event) => void;
 
@@ -530,6 +576,7 @@ export interface LiveApi {
 // ── The JC global ───────────────────────────────────────────────────────────
 
 export interface JECore {
+    identity?: IdentityApi;
     navigation?: NavigationApi;
     lifecycle?: LifecycleApi;
     dom?: DomApi;
@@ -561,6 +608,8 @@ export interface JELegacyHelpers {
  */
 export interface JEGlobal extends JellyfinCanopyPublicApi {
     core: JECore;
+    /** Canonical account/server/epoch owner installed by the classic loader. */
+    identity: IdentityApi;
     pluginConfig: PluginConfig;
     currentSettings?: UserSettings;
     translations: Record<string, string>;

--- a/e2e/account-switch.spec.ts
+++ b/e2e/account-switch.spec.ts
@@ -1,0 +1,863 @@
+// No-reload account switching (BI-CLIENT-006).
+//
+// This is deliberately one long browser-document flow. `loginAs` is allowed to
+// perform the initial authenticated boot; after that point the test never calls
+// page.goto/page.reload. Every transition uses Jellyfin 12's own logout and
+// authentication APIs, followed by its SPA router. A document marker +
+// performance.timeOrigin make an accidental hard navigation a first-class
+// assertion failure rather than an invisible shortcut.
+import {
+    test,
+    expect,
+    loginAs,
+    assertNoRuntimeErrors,
+    USERS,
+    type ConsoleErrors,
+} from './fixtures/auth';
+import type { Page, Request, Route } from 'playwright/test';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const USER_FILES = [
+    'settings.json',
+    'shortcuts.json',
+    'bookmark.json',
+    'elsewhere.json',
+    'hidden-content.json',
+] as const;
+
+const ACCOUNT_SWITCH_PATH = /\/JellyfinCanopy\/user-settings\/([^/?]+)\/([^/?]+)(?:\?|$)/i;
+const EXPECTED_IDENTITY_ABORT =
+    /Failed to save settings\.json.*(?:IdentityStaleError|AbortError|identity|Request was aborted)/i;
+// Jellyfin Web's TanStack query layer logs its own cancellation stack when
+// Dashboard.logout() revokes the active query client. Scope this to the exact
+// host bundle; a CancelledError with any Canopy frame remains a failure.
+const HOST_LOGOUT_NOISE =
+    /CancelledError[\s\S]*node_modules\.%40tanstack\.query-core\.bundle\.js/i;
+
+type Segment =
+    | 'a-save'
+    | 'logout-a1'
+    | 'b1'
+    | 'logout-b1'
+    | 'a2'
+    | 'logout-a2'
+    | 'b2';
+
+type BSegment = Extract<Segment, 'b1' | 'b2'>;
+
+interface DocumentIdentity {
+    marker: string;
+    timeOrigin: number;
+}
+
+interface LoginResult {
+    userId: string;
+    token: string;
+}
+
+interface IdentitySnapshot {
+    serverId: string;
+    userId: string;
+    epoch: number;
+}
+
+interface Diagnostics {
+    resetHandlers: number;
+    activateHandlers: number;
+    pendingInitializations: number;
+    initializationControllers: number;
+    lifecycleFeatures: string[];
+    liveHandlers: number;
+    viewHandlers: number;
+    navigationCallbacks: number;
+    domObservers: number;
+    bodySubscribers: number;
+    duplicatePluginIds: string[];
+}
+
+interface UserFileRequest {
+    segment: Segment;
+    method: string;
+    userId: string;
+    file: string;
+    authorization: string;
+    explicitUserId: string;
+    postData: string;
+}
+
+function bPayloadSentinel(segment: BSegment, file: (typeof USER_FILES)[number]): string {
+    return `jc-e2e-${segment}-${file}-owner-payload`;
+}
+
+/**
+ * Minimal valid server-file shapes. The synthetic marker is deliberately part
+ * of each response payload: owner WeakMap stamps alone cannot make these five
+ * independent values appear in the published snapshot.
+ */
+function bUserFilePayload(
+    segment: BSegment,
+    file: (typeof USER_FILES)[number]
+): Record<string, unknown> {
+    const accountSwitchOwnerSentinel = bPayloadSentinel(segment, file);
+    switch (file) {
+        case 'shortcuts.json':
+            return { Shortcuts: [], accountSwitchOwnerSentinel };
+        case 'bookmark.json':
+            return { Bookmarks: {}, accountSwitchOwnerSentinel };
+        case 'hidden-content.json':
+            return { Items: {}, Settings: {}, accountSwitchOwnerSentinel };
+        default:
+            return { accountSwitchOwnerSentinel };
+    }
+}
+
+function expectedBPayloadSentinels(segment: BSegment): Record<string, string> {
+    return Object.fromEntries(USER_FILES.map((file) => [file, bPayloadSentinel(segment, file)]));
+}
+
+function normalizeIdentityPart(value: unknown): string {
+    return String(value ?? '').trim().replace(/-/g, '').toLowerCase();
+}
+
+function parseUserFileRequest(request: Request, segment: Segment): UserFileRequest | null {
+    const match = new URL(request.url()).pathname.match(ACCOUNT_SWITCH_PATH);
+    if (!match) return null;
+    const headers = request.headers();
+    return {
+        segment,
+        method: request.method().toUpperCase(),
+        userId: normalizeIdentityPart(decodeURIComponent(match[1])),
+        file: decodeURIComponent(match[2]).toLowerCase(),
+        authorization: headers.authorization || '',
+        explicitUserId: normalizeIdentityPart(headers['x-jellyfin-user-id'] || ''),
+        postData: request.postData() || '',
+    };
+}
+
+function authorizationToken(authorization: string): string {
+    return authorization.match(/\bToken="([^"]+)"/i)?.[1] || '';
+}
+
+async function withDeadline<T>(promise: Promise<T>, label: string, timeoutMs = 15_000): Promise<T> {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    try {
+        return await Promise.race([
+            promise,
+            new Promise<T>((_resolve, reject) => {
+                timeoutId = setTimeout(
+                    () => reject(new Error(`${label} was not intercepted within ${timeoutMs}ms`)),
+                    timeoutMs
+                );
+            }),
+        ]);
+    } finally {
+        if (timeoutId) clearTimeout(timeoutId);
+    }
+}
+
+async function installDocumentIdentity(page: Page): Promise<DocumentIdentity> {
+    return page.evaluate(() => {
+        const identity = {
+            marker: `jc-account-switch-${typeof crypto.randomUUID === 'function'
+                ? crypto.randomUUID()
+                : `${Date.now()}-${Math.random().toString(16).slice(2)}`}`,
+            timeOrigin: performance.timeOrigin,
+        };
+        (window as any).__jcAccountSwitchDocument = identity;
+        (window as any).__jcActivatedEpochs = [];
+        document.addEventListener('jc:identityactivated', (event: Event) => {
+            const epoch = Number((event as CustomEvent).detail?.epoch);
+            if (Number.isFinite(epoch)) (window as any).__jcActivatedEpochs.push(epoch);
+        });
+        return identity;
+    });
+}
+
+async function expectSameDocument(page: Page, expected: DocumentIdentity): Promise<void> {
+    const actual = await page.evaluate(() => ({
+        marker: (window as any).__jcAccountSwitchDocument?.marker || '',
+        timeOrigin: performance.timeOrigin,
+    }));
+    expect(actual, 'account switches must retain the original browser document').toEqual(expected);
+}
+
+async function currentIdentity(page: Page): Promise<IdentitySnapshot> {
+    return page.evaluate(() => {
+        const current = (window as any).JellyfinCanopy?.identity?.capture?.();
+        if (!current) throw new Error('Jellyfin Canopy has no active identity');
+        return { serverId: current.serverId, userId: current.userId, epoch: current.epoch };
+    });
+}
+
+async function readDiagnostics(page: Page): Promise<Diagnostics> {
+    return page.evaluate(() => {
+        const JC = (window as any).JellyfinCanopy;
+        const counts = new Map<string, number>();
+        for (const node of document.querySelectorAll<HTMLElement>('[id]')) {
+            const id = node.id;
+            if (!id.startsWith('jc-') && !id.startsWith('jellyfin-canopy')) continue;
+            counts.set(id, (counts.get(id) || 0) + 1);
+        }
+        return {
+            resetHandlers: JC.identity.getResetHandlerCount(),
+            activateHandlers: JC.identity.getActivateHandlerCount(),
+            pendingInitializations: JC.identity.getPendingInitializationCount(),
+            initializationControllers: JC.identity.getInitializationControllerCount(),
+            lifecycleFeatures: [...(JC.core.lifecycle?.getFeatures?.() || [])].sort(),
+            liveHandlers: Number(JC.core.live?.getHandlerCount?.() || 0),
+            viewHandlers: Number(JC.core.navigation?.getViewHandlerCount?.() || 0),
+            navigationCallbacks: Number(JC.core.navigation?.getNavCallbackCount?.() || 0),
+            domObservers: Number(JC.core.dom?.getObserverCount?.() || 0),
+            bodySubscribers: Number(JC.core.dom?.getBodySubscriberCount?.() || 0),
+            duplicatePluginIds: [...counts.entries()]
+                .filter(([, count]) => count > 1)
+                .map(([id]) => id)
+                .sort(),
+        };
+    });
+}
+
+/**
+ * Log out through the real host API and wait for the synchronous JC null-owner
+ * transition plus the host's signed-out route. No hard navigation fallback is
+ * permitted here: if Jellyfin replaces the document, the marker assertion
+ * below fails.
+ */
+async function spaLogout(page: Page, documentIdentity: DocumentIdentity): Promise<number> {
+    await page.waitForFunction(
+        () => typeof (window as any).Dashboard?.logout === 'function',
+        undefined,
+        { timeout: 30_000 }
+    );
+    await page.evaluate(() => {
+        const state = ((window as any).__jcLogoutState = { done: false, error: '' });
+        try {
+            Promise.resolve((window as any).Dashboard.logout()).then(
+                () => { state.done = true; },
+                (error: unknown) => {
+                    state.error = String((error as Error)?.message || error);
+                    state.done = true;
+                }
+            );
+        } catch (error) {
+            state.error = String((error as Error)?.message || error);
+            state.done = true;
+        }
+    });
+
+    await page.waitForFunction(() => {
+        const JC = (window as any).JellyfinCanopy;
+        const userId = String((window as any).ApiClient?.getCurrentUserId?.() || '').trim();
+        return !JC?.identity?.capture?.() && !userId;
+    }, undefined, { timeout: 30_000 });
+    await page.waitForFunction(
+        () => /login|selectserver/i.test(`${window.location.pathname}${window.location.hash}`),
+        undefined,
+        { timeout: 30_000 }
+    );
+    await page.waitForFunction(
+        () => (window as any).__jcLogoutState?.done === true,
+        undefined,
+        { timeout: 30_000 }
+    );
+
+    const signedOut = await page.evaluate(() => {
+        const JC = (window as any).JellyfinCanopy;
+        return {
+            error: (window as any).__jcLogoutState?.error || '',
+            epoch: Number(JC.identity.getEpoch()),
+            cookie: document.cookie,
+            initialized: JC.initialized === true,
+            pendingInitializations: Number(JC.identity.getPendingInitializationCount()),
+            initializationControllers: Number(JC.identity.getInitializationControllerCount()),
+        };
+    });
+    expect(signedOut.error, 'Dashboard.logout() must complete without error').toBe('');
+    expect(signedOut.cookie, 'the spoiler identity cookie is removed synchronously on logout')
+        .not.toMatch(/(?:^|;\s*)jc-spoiler-uid=/i);
+    expect(signedOut.initialized, 'signed-out state cannot remain initialized as the prior user').toBe(false);
+    expect(
+        signedOut.pendingInitializations,
+        'identity transition synchronously drains prior initialization work'
+    ).toBe(0);
+    expect(
+        signedOut.initializationControllers,
+        'signed-out state retains no prior initialization controller'
+    ).toBe(0);
+    await expectSameDocument(page, documentIdentity);
+    return signedOut.epoch;
+}
+
+/** Authenticate on the current host client, without waiting for JC boot. */
+async function beginSpaLogin(
+    page: Page,
+    role: keyof typeof USERS,
+    documentIdentity: DocumentIdentity
+): Promise<LoginResult> {
+    await page.waitForFunction(
+        () => typeof (window as any).ApiClient?.authenticateUserByName === 'function',
+        undefined,
+        { timeout: 30_000 }
+    );
+    const result = await page.evaluate(async (credentials) => {
+        const apiClient = (window as any).ApiClient;
+        const authentication = await apiClient.authenticateUserByName(
+            credentials.username,
+            credentials.password
+        );
+        return {
+            userId: String(
+                authentication?.User?.Id
+                || authentication?.UserId
+                || apiClient.getCurrentUserId?.()
+                || ''
+            ).trim(),
+            // Never infer the new epoch's token from ApiClient: on a broken
+            // auth handoff that fallback could still expose the prior session.
+            token: String(authentication?.AccessToken || ''),
+        };
+    }, USERS[role]);
+    expect(result.userId, `${role} authentication returns a user ID`).not.toBe('');
+    expect(result.token, `${role} authentication returns an access token`).not.toBe('');
+
+    await page.waitForFunction((expectedUserId) => {
+        const expected = String(expectedUserId).replace(/-/g, '').toLowerCase();
+        const live = String((window as any).ApiClient?.getCurrentUserId?.() || '')
+            .replace(/-/g, '').toLowerCase();
+        const owned = String((window as any).JellyfinCanopy?.identity?.capture?.()?.userId || '')
+            .replace(/-/g, '').toLowerCase();
+        return live === expected && owned === expected;
+    }, result.userId, { timeout: 30_000 });
+    await expectSameDocument(page, documentIdentity);
+    return result;
+}
+
+/** Finish the owner boot and route within the existing Jellyfin SPA. */
+async function finishSpaLogin(
+    page: Page,
+    login: LoginResult,
+    documentIdentity: DocumentIdentity
+): Promise<IdentitySnapshot> {
+    await page.waitForFunction((expectedUserId) => {
+        const JC = (window as any).JellyfinCanopy;
+        const expected = String(expectedUserId).replace(/-/g, '').toLowerCase();
+        const context = JC?.identity?.capture?.();
+        const live = String((window as any).ApiClient?.getCurrentUserId?.() || '')
+            .replace(/-/g, '').toLowerCase();
+        return JC?.initialized === true
+            && context?.userId === expected
+            && live === expected
+            && !!JC.currentSettings
+            && !!JC.currentUser;
+    }, login.userId, { timeout: 60_000 });
+
+    // Never await Emby.Page.show(): Jellyfin 12 can leave its promise pending
+    // on parameter-only navigation. The hash/visible-page condition is the
+    // supported completion signal.
+    await page.evaluate(() => { void (window as any).Emby.Page.show('/home'); });
+    await page.waitForFunction(
+        () => window.location.hash.includes('/home')
+            && !!document.querySelector('#indexPage:not(.hide)'),
+        undefined,
+        { timeout: 30_000 }
+    );
+    await expectSameDocument(page, documentIdentity);
+    return currentIdentity(page);
+}
+
+async function assertOwnerState(
+    page: Page,
+    expectedUserId: string,
+    expectedSegment: BSegment
+): Promise<void> {
+    const state = await page.evaluate((rawExpected) => {
+        const normalize = (value: unknown): string =>
+            String(value ?? '').trim().replace(/-/g, '').toLowerCase();
+        const expected = normalize(rawExpected);
+        const JC = (window as any).JellyfinCanopy;
+        const context = JC.identity.capture();
+        const owner = (value: unknown): string => normalize(JC.identity.ownerOf(value)?.userId);
+        const five = ['settings', 'shortcuts', 'bookmark', 'elsewhere', 'hiddenContent'];
+        const cookie = document.cookie.split(';')
+            .map((part) => part.trim())
+            .find((part) => part.startsWith('jc-spoiler-uid='))
+            ?.slice('jc-spoiler-uid='.length) || '';
+
+        return {
+            expected,
+            contextUser: normalize(context?.userId),
+            liveUser: normalize((window as any).ApiClient?.getCurrentUserId?.()),
+            currentUser: normalize(JC.currentUser?.Id),
+            cookieUser: normalize(decodeURIComponent(cookie)),
+            rootOwners: [
+                owner(JC.pluginConfig),
+                owner(JC.translations),
+                owner(JC.currentUser),
+                owner(JC.userConfig),
+                owner(JC.currentSettings),
+            ],
+            fileOwners: five.map((key) => owner(JC.userConfig?.[key])),
+            payloadSentinels: {
+                'settings.json': JC.userConfig?.settings?.accountSwitchOwnerSentinel,
+                'shortcuts.json': JC.userConfig?.shortcuts?.accountSwitchOwnerSentinel,
+                'bookmark.json': JC.userConfig?.bookmark?.accountSwitchOwnerSentinel,
+                'elsewhere.json': JC.userConfig?.elsewhere?.accountSwitchOwnerSentinel,
+                'hidden-content.json': JC.userConfig?.hiddenContent?.accountSwitchOwnerSentinel,
+            },
+            currentSettingsSentinel: JC.currentSettings?.accountSwitchOwnerSentinel,
+            frozenContext: Object.isFrozen(context),
+            initialized: JC.initialized === true,
+            staleSnapshotCurrent: JC.identity.isOwned((window as any).__jcASettingsSnapshot),
+            staleSnapshotPublished: JC.currentSettings === (window as any).__jcASettingsSnapshot,
+            staleFetchPublished:
+                JC.currentSettings?.accountSwitchRaceSentinel === 'from-held-a-fetch'
+                || JC.userConfig?.settings?.accountSwitchRaceSentinel === 'from-held-a-fetch',
+            staleCache: JC.core.api.manager.getCached('jc-e2e-account-switch-a-only'),
+            oldPanelConnected: !!(window as any).__jcASettingsPanel?.isConnected,
+        };
+    }, expectedUserId);
+
+    expect(state.contextUser).toBe(state.expected);
+    expect(state.liveUser).toBe(state.expected);
+    expect(state.currentUser).toBe(state.expected);
+    expect(state.cookieUser, 'spoiler cookie belongs to the current user').toBe(state.expected);
+    expect(state.rootOwners, 'all published root snapshots are B-owned')
+        .toEqual(Array(5).fill(state.expected));
+    expect(state.fileOwners, 'all five user-file snapshots are B-owned')
+        .toEqual(Array(5).fill(state.expected));
+    const expectedPayloads = expectedBPayloadSentinels(expectedSegment);
+    expect(
+        state.payloadSentinels,
+        `${expectedSegment}: all five published snapshots contain only this segment's payloads`
+    ).toEqual(expectedPayloads);
+    expect(
+        state.currentSettingsSentinel,
+        `${expectedSegment}: merged currentSettings comes from this segment's settings payload`
+    ).toBe(expectedPayloads['settings.json']);
+    expect(state.frozenContext, 'canonical identity is immutable').toBe(true);
+    expect(state.initialized).toBe(true);
+    expect(state.staleSnapshotCurrent, 'A-owned settings cannot become current under B').toBe(false);
+    expect(state.staleSnapshotPublished, 'A settings object cannot be published under B').toBe(false);
+    expect(state.staleFetchPublished, 'late A fetch data cannot publish into B').toBe(false);
+    expect(state.staleCache, 'identity reset clears the A-only core cache entry').toBeUndefined();
+    expect(state.oldPanelConnected, 'the prior-user settings panel is detached').toBe(false);
+}
+
+function expectFiveFilesOnce(
+    requests: UserFileRequest[],
+    epochName: 'b1' | 'b2',
+    expectedUserId: string,
+    expectedToken: string
+): void {
+    const expected = normalizeIdentityPart(expectedUserId);
+    const reads = requests.filter((request) =>
+        request.method === 'GET'
+        && request.userId === expected
+        && authorizationToken(request.authorization) === expectedToken
+        && USER_FILES.includes(request.file as (typeof USER_FILES)[number])
+    );
+    const counts = Object.fromEntries(USER_FILES.map((file) => [
+        file,
+        reads.filter((request) => request.file === file).length,
+    ]));
+    expect(counts, `${epochName}: each owner file is fetched exactly once`).toEqual(
+        Object.fromEntries(USER_FILES.map((file) => [file, 1]))
+    );
+}
+
+function expectRequestOwnership(
+    requests: UserFileRequest[],
+    expectedBySegment: Record<Segment, { userId: string; token: string } | null>
+): void {
+    expect(requests.length, 'the switch flow captured user-file traffic').toBeGreaterThan(0);
+    for (const [segment, expectedOwner] of Object.entries(expectedBySegment) as [
+        Segment,
+        { userId: string; token: string } | null,
+    ][]) {
+        const segmentRequests = requests.filter((request) => request.segment === segment);
+        if (!expectedOwner) {
+            expect(
+                segmentRequests.map(({ method, userId, file }) => ({ method, userId, file })),
+                `${segment}: logout dispatches no user-file requests`
+            ).toEqual([]);
+            continue;
+        }
+
+        const expectedUserId = normalizeIdentityPart(expectedOwner.userId);
+        for (const request of segmentRequests) {
+            expect(
+                request.userId,
+                `${segment} ${request.method} ${request.file} uses this epoch's owner path`
+            ).toBe(expectedUserId);
+            expect(
+                authorizationToken(request.authorization),
+                `${segment} ${request.method} ${request.file} uses this epoch's exact token`
+            ).toBe(expectedOwner.token);
+            if (request.explicitUserId) {
+                expect(
+                    request.explicitUserId,
+                    `${segment} ${request.method} ${request.file} has a matching explicit user ID`
+                ).toBe(expectedUserId);
+            }
+        }
+    }
+}
+
+function isExpectedHostLogout4xx(response: { url: string; status: number }): boolean {
+    if (response.url.includes('/JellyfinCanopy/')) return false;
+    if (response.status === 401) return true;
+    return response.status === 400 && /\/SyncPlay\/List(?:\?|$)/i.test(response.url);
+}
+
+function assertOnlyHostLogoutNoise(consoleErrors: ConsoleErrors, label: string): void {
+    const failed = consoleErrors.unexpected4xx();
+    const syncPlay400 = failed.some((response) =>
+        response.status === 400 && /\/SyncPlay\/List(?:\?|$)/i.test(response.url));
+    expect(
+        consoleErrors.real().filter((text) =>
+            !HOST_LOGOUT_NOISE.test(text)
+            && !(syncPlay400 && /Failed to load resource:.*status of 400 \(Bad Request\)/i.test(text))
+        ),
+        `${label}: no errors beyond Jellyfin Web's own logout cancellation`
+    ).toEqual([]);
+    expect(
+        failed.filter((response) => !isExpectedHostLogout4xx(response)),
+        `${label}: no plugin 4xx or unexpected host 4xx responses`
+    ).toEqual([]);
+}
+
+test.describe('no-reload account identity switching', () => {
+    test('A → logout → B and repeated B → A → B isolate every owner epoch', async ({
+        page,
+        consoleErrors,
+    }) => {
+        test.slow();
+        await loginAs(page, 'admin', consoleErrors);
+        const documentIdentity = await installDocumentIdentity(page);
+        const a1 = await currentIdentity(page);
+        const a1Token = await page.evaluate(() => String((window as any).ApiClient.accessToken()));
+        expect(a1.userId).not.toBe('');
+        expect(a1Token).not.toBe('');
+
+        // Give teardown a concrete A-owned UI node and cache entry to remove.
+        await page.evaluate(() => {
+            const JC = (window as any).JellyfinCanopy;
+            JC.core.api.manager.setCache('jc-e2e-account-switch-a-only', {
+                owner: JC.identity.capture()?.userId,
+            });
+            JC.showEnhancedPanel();
+        });
+        const aPanel = page.locator('#jellyfin-canopy-panel');
+        await expect(aPanel).toBeVisible({ timeout: 15_000 });
+        await page.evaluate(() => {
+            (window as any).__jcASettingsPanel = document.querySelector('#jellyfin-canopy-panel');
+        });
+        assertNoRuntimeErrors(consoleErrors);
+        // Everything collected from this point until the transport abort is
+        // the deliberately induced A-save race, and nothing else.
+        consoleErrors.reset();
+
+        let segment: Segment = 'a-save';
+        const requests: UserFileRequest[] = [];
+        page.on('request', (request) => {
+            const parsed = parseUserFileRequest(request, segment);
+            if (parsed) requests.push(parsed);
+        });
+
+        let releaseHeldSave!: () => void;
+        const heldSaveRelease = new Promise<void>((resolve) => { releaseHeldSave = resolve; });
+        let resolveHeldSaveSeen!: () => void;
+        const heldSaveSeen = new Promise<void>((resolve) => { resolveHeldSaveSeen = resolve; });
+        let heldSaveHandled = false;
+        let heldSaveAttempts = 0;
+        let heldSaveRouteFinished!: () => void;
+        const heldSaveFinished = new Promise<void>((resolve) => { heldSaveRouteFinished = resolve; });
+
+        let holdA2Fetch = false;
+        let releaseHeldFetch!: () => void;
+        const heldFetchRelease = new Promise<void>((resolve) => { releaseHeldFetch = resolve; });
+        let resolveHeldFetchSeen!: () => void;
+        const heldFetchSeen = new Promise<void>((resolve) => { resolveHeldFetchSeen = resolve; });
+        let heldFetchHandled = false;
+        let heldFetchRouteFinished!: () => void;
+        const heldFetchFinished = new Promise<void>((resolve) => { heldFetchRouteFinished = resolve; });
+
+        // If an earlier assertion fails, do not strand an intercepted request
+        // while Playwright tears the page down.
+        page.on('close', () => {
+            releaseHeldSave();
+            releaseHeldFetch();
+        });
+
+        const aId = normalizeIdentityPart(a1.userId);
+        await page.route('**/JellyfinCanopy/user-settings/**', async (route: Route) => {
+            const request = route.request();
+            const parsed = parseUserFileRequest(request, segment);
+            if (!parsed) {
+                await route.continue();
+                return;
+            }
+
+            if (parsed.method === 'POST'
+                && parsed.userId === aId
+                && parsed.file === 'settings.json'
+                && /AccountSwitchRaceSentinel/i.test(parsed.postData)) {
+                heldSaveAttempts++;
+                if (heldSaveHandled) {
+                    // A retry/duplicate is itself a failure, but never forward
+                    // its sentinel payload into the shared Jellyfin fixture.
+                    await route.fulfill({ status: 204, body: '' });
+                    return;
+                }
+                heldSaveHandled = true;
+                resolveHeldSaveSeen();
+                await heldSaveRelease;
+                try {
+                    // Fulfil locally after B is live. If the identity reset
+                    // already aborted the fetch this rejects harmlessly; if it
+                    // did not, the response still cannot mutate server state.
+                    await route.fulfill({ status: 204, body: '' });
+                } catch { /* an aborted route is the expected path */ }
+                heldSaveRouteFinished();
+                return;
+            }
+
+            if (holdA2Fetch
+                && !heldFetchHandled
+                && parsed.method === 'GET'
+                && parsed.userId === aId
+                && parsed.file === 'settings.json') {
+                heldFetchHandled = true;
+                resolveHeldFetchSeen();
+                await heldFetchRelease;
+                try {
+                    await route.fulfill({
+                        status: 200,
+                        contentType: 'application/json',
+                        body: JSON.stringify({
+                            AccountSwitchRaceSentinel: 'from-held-a-fetch',
+                        }),
+                    });
+                } catch { /* a host/client abort is also safe */ }
+                heldFetchRouteFinished();
+                return;
+            }
+
+            if ((segment === 'b1' || segment === 'b2')
+                && parsed.method === 'GET'
+                && USER_FILES.includes(parsed.file as (typeof USER_FILES)[number])) {
+                const file = parsed.file as (typeof USER_FILES)[number];
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify(bUserFilePayload(segment, file)),
+                });
+                return;
+            }
+
+            await route.continue();
+        });
+
+        // Begin a real settings write from A and stop it at the network edge.
+        // The central request owner must settle/abort it during logout, before
+        // this test releases the intercepted route under B.
+        await page.evaluate(() => {
+            const JC = (window as any).JellyfinCanopy;
+            const owner = JC.identity.capture();
+            const originalPluginFetch = JC.core.api.plugin;
+            const observedPluginFetch = function(path: string, options: any): Promise<unknown> {
+                const transport = originalPluginFetch.call(JC.core.api, path, options);
+                if (/\/user-settings\/.+\/settings\.json$/i.test(path)
+                    && /AccountSwitchRaceSentinel/i.test(String(options?.body || ''))) {
+                    (window as any).__jcHeldSaveTransportOutcome = 'pending';
+                    void transport.then(
+                        () => { (window as any).__jcHeldSaveTransportOutcome = 'resolved'; },
+                        (error: unknown) => {
+                            (window as any).__jcHeldSaveTransportOutcome =
+                                `rejected:${String((error as Error)?.name || error)}`;
+                        }
+                    );
+                }
+                return transport;
+            };
+            JC.core.api.plugin = observedPluginFetch;
+            (window as any).__jcRestoreObservedPluginFetch = () => {
+                if (JC.core.api.plugin === observedPluginFetch) {
+                    JC.core.api.plugin = originalPluginFetch;
+                }
+            };
+
+            const snapshot = JC.identity.own({
+                ...JC.currentSettings,
+                accountSwitchRaceSentinel: 'held-a-save',
+            }, owner);
+            (window as any).__jcASettingsSnapshot = snapshot;
+            (window as any).__jcHeldSaveOutcome = 'pending';
+            void JC.saveUserSettings('settings.json', snapshot).then(
+                () => { (window as any).__jcHeldSaveOutcome = 'settled'; },
+                (error: unknown) => {
+                    (window as any).__jcHeldSaveOutcome = `rejected:${String((error as Error)?.name || error)}`;
+                }
+            );
+        });
+        try {
+            await withDeadline(heldSaveSeen, 'held A settings POST');
+        } catch (error) {
+            const outcome = await page.evaluate(() => ({
+                save: (window as any).__jcHeldSaveOutcome,
+                transport: (window as any).__jcHeldSaveTransportOutcome,
+            }));
+            const tail = requests.slice(-5)
+                .map(({ segment: ownerSegment, method, userId, file }) =>
+                    ({ segment: ownerSegment, method, userId, file }));
+            throw new Error(`${String((error as Error).message)}; outcome=${JSON.stringify(outcome)}; requests=${JSON.stringify(tail)}`);
+        }
+
+        segment = 'logout-a1';
+        const logoutA1Epoch = await spaLogout(page, documentIdentity);
+        expect(logoutA1Epoch).toBeGreaterThan(a1.epoch);
+
+        await page.waitForFunction(
+            () => String((window as any).__jcHeldSaveTransportOutcome || '').startsWith('rejected:'),
+            undefined,
+            { timeout: 10_000 }
+        );
+        const heldTransportOutcome = await page.evaluate(() => {
+            (window as any).__jcRestoreObservedPluginFetch?.();
+            return String((window as any).__jcHeldSaveTransportOutcome || '');
+        });
+        expect(
+            heldTransportOutcome,
+            'identity reset rejects the still-held central save transport'
+        ).toMatch(/^rejected:(?:AbortError|IdentityStaleError)$/);
+
+        await page.waitForFunction(
+            () => (window as any).__jcHeldSaveOutcome !== 'pending',
+            undefined,
+            { timeout: 10_000 }
+        );
+        expect(heldSaveAttempts, 'the held A save dispatches exactly once').toBe(1);
+        expect(
+            consoleErrors.all.filter((text) =>
+                /Failed to save settings\.json/i.test(text)
+                && !EXPECTED_IDENTITY_ABORT.test(text)
+            ),
+            'the induced save race reports only the expected identity abort'
+        ).toEqual([]);
+        assertOnlyHostLogoutNoise(consoleErrors, 'A1 logout / held-save abort');
+        consoleErrors.reset();
+
+        segment = 'b1';
+        const b1Login = await beginSpaLogin(page, 'user', documentIdentity);
+        const b1 = await finishSpaLogin(page, b1Login, documentIdentity);
+        expect(b1.userId).toBe(normalizeIdentityPart(b1Login.userId));
+        expect(b1.userId === a1.userId, 'A and B must be distinct seeded accounts').toBe(false);
+        expect(b1.serverId).toBe(a1.serverId);
+        expect(b1.epoch).toBeGreaterThan(logoutA1Epoch);
+
+        releaseHeldSave();
+        await heldSaveFinished;
+
+        expectFiveFilesOnce(requests, 'b1', b1.userId, b1Login.token);
+        await assertOwnerState(page, b1.userId, 'b1');
+        const b1Diagnostics = await readDiagnostics(page);
+        expect(b1Diagnostics.duplicatePluginIds, 'B1 has no duplicate plugin UI IDs').toEqual([]);
+        expect(b1Diagnostics.pendingInitializations, 'B1 initialization work is fully drained').toBe(0);
+        expect(
+            b1Diagnostics.initializationControllers,
+            'B1 retains at most its one current-epoch initialization controller'
+        ).toBeLessThanOrEqual(1);
+
+        // Repeat the switch, but hold one of A's five loader reads so A can
+        // authenticate without ever publishing a complete owner snapshot.
+        assertNoRuntimeErrors(consoleErrors);
+        consoleErrors.reset();
+        segment = 'logout-b1';
+        const logoutB1Epoch = await spaLogout(page, documentIdentity);
+        expect(logoutB1Epoch).toBeGreaterThan(b1.epoch);
+        assertOnlyHostLogoutNoise(consoleErrors, 'B1 logout');
+        consoleErrors.reset();
+
+        holdA2Fetch = true;
+        segment = 'a2';
+        const a2Login = await beginSpaLogin(page, 'admin', documentIdentity);
+        try {
+            await withDeadline(heldFetchSeen, 'held A loader settings GET');
+        } catch (error) {
+            const state = await page.evaluate(() => ({
+                identity: (window as any).JellyfinCanopy?.identity?.capture?.(),
+                initialized: (window as any).JellyfinCanopy?.initialized,
+            }));
+            const tail = requests.slice(-5)
+                .map(({ segment: ownerSegment, method, userId, file }) =>
+                    ({ segment: ownerSegment, method, userId, file }));
+            throw new Error(`${String((error as Error).message)}; state=${JSON.stringify(state)}; requests=${JSON.stringify(tail)}`);
+        }
+        const a2 = await currentIdentity(page);
+        expect(a2.userId).toBe(aId);
+        expect(a2.epoch).toBeGreaterThan(logoutB1Epoch);
+        const a2Pending = await page.evaluate(() => ({
+            initialized: (window as any).JellyfinCanopy.initialized === true,
+            cookie: document.cookie,
+        }));
+        expect(a2Pending.initialized, 'held A fetch keeps A from publishing/activating').toBe(false);
+        expect(a2Pending.cookie).toMatch(
+            new RegExp(`(?:^|;\\s*)jc-spoiler-uid=${aId}(?:;|$)`, 'i')
+        );
+
+        assertNoRuntimeErrors(consoleErrors);
+        consoleErrors.reset();
+        segment = 'logout-a2';
+        const logoutA2Epoch = await spaLogout(page, documentIdentity);
+        expect(logoutA2Epoch).toBeGreaterThan(a2.epoch);
+        assertOnlyHostLogoutNoise(consoleErrors, 'A2 logout / held-loader abort');
+        consoleErrors.reset();
+
+        segment = 'b2';
+        const b2Login = await beginSpaLogin(page, 'user', documentIdentity);
+        const b2 = await finishSpaLogin(page, b2Login, documentIdentity);
+        expect(b2.userId).toBe(normalizeIdentityPart(b2Login.userId));
+        expect(b2Login.token === b1Login.token, 'B2 must be a fresh authenticated session').toBe(false);
+        expect(b2.serverId).toBe(a1.serverId);
+        expect(b2.epoch).toBeGreaterThan(logoutA2Epoch);
+        expectFiveFilesOnce(requests, 'b2', b2.userId, b2Login.token);
+
+        // Only now let the old A settings response reach its abandoned
+        // initialization promise. Two animation frames provide a deterministic
+        // browser task/microtask drain before checking that it stayed fenced.
+        releaseHeldFetch();
+        await heldFetchFinished;
+        await page.evaluate(() => new Promise<void>((resolve) => {
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+        }));
+
+        await assertOwnerState(page, b2.userId, 'b2');
+        const activatedEpochs = await page.evaluate(
+            () => [...((window as any).__jcActivatedEpochs || [])] as number[]
+        );
+        expect(activatedEpochs, 'the incomplete held A2 epoch never activates').not.toContain(a2.epoch);
+        expect(activatedEpochs.filter((epoch) => epoch === b1.epoch)).toHaveLength(1);
+        expect(activatedEpochs.filter((epoch) => epoch === b2.epoch)).toHaveLength(1);
+
+        const b2Diagnostics = await readDiagnostics(page);
+        expect(b2Diagnostics.duplicatePluginIds, 'B2 has no duplicate plugin UI IDs').toEqual([]);
+        expect(b2Diagnostics, 'repeating B → A → B does not grow handlers or lifecycle registrations')
+            .toEqual(b1Diagnostics);
+
+        expectRequestOwnership(
+            requests,
+            {
+                'a-save': { userId: a1.userId, token: a1Token },
+                'logout-a1': null,
+                b1: { userId: b1.userId, token: b1Login.token },
+                'logout-b1': null,
+                a2: { userId: a2.userId, token: a2Login.token },
+                'logout-a2': null,
+                b2: { userId: b2.userId, token: b2Login.token },
+            }
+        );
+        await expectSameDocument(page, documentIdentity);
+        assertNoRuntimeErrors(consoleErrors);
+    });
+});

--- a/e2e/settings-persist.spec.ts
+++ b/e2e/settings-persist.spec.ts
@@ -37,6 +37,19 @@ function settingsSaved(page: any): Promise<unknown> {
     );
 }
 
+/** Update and save the loader-owned settings object, matching the real panel. */
+async function saveDelay(page: any, value: number): Promise<void> {
+    await page.evaluate(async (nextValue: number) => {
+        const JC = (window as any).JellyfinCanopy;
+        const settings = JC.currentSettings;
+        if (!settings || !JC.identity?.isOwned?.(settings)) {
+            throw new Error('current settings are not owned by the active identity');
+        }
+        settings.pauseScreenDelaySeconds = nextValue;
+        await JC.saveUserSettings('settings.json', settings);
+    }, value);
+}
+
 test.describe('per-user settings persistence', () => {
     test('a per-user setting persists across reload (write → persist → reload → re-read)', async ({ page, consoleErrors }) => {
         await loginAs(page, 'user', consoleErrors);
@@ -49,10 +62,7 @@ test.describe('per-user settings persistence', () => {
             // settings.json — and wait for the POST to actually resolve.
             await Promise.all([
                 settingsSaved(page),
-                page.evaluate(async (value: number) => {
-                    const JC = (window as any).JellyfinCanopy;
-                    await JC.saveUserSettings('settings.json', { ...JC.currentSettings, pauseScreenDelaySeconds: value });
-                }, target),
+                saveDelay(page, target),
             ]);
 
             await page.reload({ waitUntil: 'domcontentloaded' });
@@ -62,10 +72,7 @@ test.describe('per-user settings persistence', () => {
         } finally {
             await Promise.all([
                 settingsSaved(page).catch(() => { /* restore is best effort */ }),
-                page.evaluate(async (value: number) => {
-                    const JC = (window as any).JellyfinCanopy;
-                    await JC.saveUserSettings('settings.json', { ...JC.currentSettings, pauseScreenDelaySeconds: value });
-                }, original),
+                saveDelay(page, original),
             ]);
         }
         assertNoRuntimeErrors(consoleErrors);
@@ -115,10 +122,7 @@ test.describe('per-user settings persistence', () => {
         } finally {
             await Promise.all([
                 settingsSaved(page).catch(() => { /* best effort */ }),
-                page.evaluate(async (value: number) => {
-                    const JC = (window as any).JellyfinCanopy;
-                    await JC.saveUserSettings('settings.json', { ...JC.currentSettings, pauseScreenDelaySeconds: value });
-                }, original),
+                saveDelay(page, original),
             ]);
         }
         assertNoRuntimeErrors(consoleErrors);


### PR DESCRIPTION
## Summary

Enforce strict no-reload account and server identity isolation across the loader, core transport/config pipeline, retained UI controls, and Dockerized Jellyfin 12 acceptance coverage.

## What changed

- make loader transitions reentrant, failure-aware, retryable, and fail closed on uncertain owner state
- bind authenticated requests, live-config projections, and deduplication to the active identity epoch
- fence retained Bookmark, Elsewhere, Arr, Active Streams, and Settings controls against stale account/media ownership
- handle live-config overlap, failure retry, A-B-A policy races, and synchronous config-change transitions
- strengthen account-switch E2E diagnostics and exact symmetric request-ownership assertions
- add local optional four-shard Docker E2E mode while retaining the official 2-CPU parity profile

## Validation

- client suites: 360/360; tests: 799/799
- script tests: 135/135
- TypeScript typechecks: passed
- lint: 0 errors (warnings remain below the enforced cap)
- syntax, translations, bundle, and Release .NET build: passed
- Dockerized Jellyfin 12 RC2 official 2-CPU parity: clean first-attempt pass
- focused live-config/bookmark/identity acceptance suites: passed
- independent Fable medium-effort final review: APPROVED

A separately tracked native Jellyfin logout flake remains open as #232; this PR does not weaken the strict E2E error net.

Closes #67
Closes #213
Closes #214
Closes #215
Closes #216
Closes #217
Closes #218
Closes #219
Closes #220
Closes #221
Closes #222
Closes #223
Closes #224
Closes #225
Closes #226
Closes #227
Closes #228
Closes #229
Closes #230
Closes #231
Closes #234