### PR TITLE
Make maintenance recovery durable

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/MaintenanceModeControllerFailureTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/MaintenanceModeControllerFailureTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinCanopy.Controllers;
+using Jellyfin.Plugin.JellyfinCanopy.Services;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
+{
+    public sealed class MaintenanceModeControllerFailureTests : IDisposable
+    {
+        private readonly string _baseDir;
+        private readonly string _stateFilePath;
+
+        public MaintenanceModeControllerFailureTests()
+        {
+            _baseDir = Path.Combine(Path.GetTempPath(), "jc-maint-controller-" + Guid.NewGuid().ToString("N"));
+            _stateFilePath = Path.Combine(
+                _baseDir,
+                "configurations",
+                "Jellyfin.Plugin.JellyfinCanopy",
+                "maintenance-state.json");
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(_baseDir, recursive: true);
+            }
+            catch
+            {
+                // Best-effort test cleanup.
+            }
+        }
+
+        [Fact]
+        public async Task DisableFault_ReturnsStructuredConflictInsteadOfUnhandledServerError()
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(_stateFilePath)!);
+            File.WriteAllText(_stateFilePath, "{}");
+            var users = new StubUserManager();
+            using var service = CreateService(users, static (_, _) => throw new IOException("must not write"));
+            var controller = CreateController(users, service);
+
+            var result = Assert.IsType<ObjectResult>(await controller.DisableMaintenanceMode());
+
+            Assert.Equal(StatusCodes.Status409Conflict, result.StatusCode);
+            using var body = JsonDocument.Parse(JsonSerializer.Serialize(result.Value));
+            Assert.False(body.RootElement.GetProperty("success").GetBoolean());
+            Assert.Equal(MaintenancePhases.Faulted, body.RootElement.GetProperty("Phase").GetString());
+            Assert.True(body.RootElement.GetProperty("IsActive").GetBoolean());
+            Assert.False(body.RootElement.GetProperty("RecoveryAvailable").GetBoolean());
+        }
+
+        [Fact]
+        public async Task EnablePersistenceFault_ReturnsSafeServiceUnavailableAndMutatesNoAccount()
+        {
+            var users = new StubUserManager();
+            using var service = CreateService(users, static (_, _) => throw new IOException("secret-path-detail"));
+            var controller = CreateController(users, service);
+
+            var result = Assert.IsType<ObjectResult>(await controller.EnableMaintenanceMode(new MaintenanceModeRequest
+            {
+                Message = "maintenance",
+                Action = "disable_accounts"
+            }));
+
+            Assert.Equal(StatusCodes.Status503ServiceUnavailable, result.StatusCode);
+            string bodyJson = JsonSerializer.Serialize(result.Value);
+            Assert.DoesNotContain("secret-path-detail", bodyJson, StringComparison.Ordinal);
+            using var body = JsonDocument.Parse(bodyJson);
+            Assert.False(body.RootElement.GetProperty("success").GetBoolean());
+            Assert.Equal(MaintenancePhases.Inactive, body.RootElement.GetProperty("Phase").GetString());
+            Assert.False(File.Exists(_stateFilePath));
+        }
+
+        private MaintenanceModeService CreateService(StubUserManager users, Action<string, string> writer)
+            => new(
+                users,
+                new StubAppPaths(_baseDir),
+                NullLogger<MaintenanceModeService>.Instance,
+                TimeProvider.System,
+                writer);
+
+        private static MaintenanceModeController CreateController(
+            StubUserManager users,
+            MaintenanceModeService service)
+            => new(
+                null!,
+                NullLogger<MaintenanceModeController>.Instance,
+                users,
+                null!,
+                null!,
+                null!,
+                service);
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/MaintenanceModeRestoreTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/MaintenanceModeRestoreTests.cs
@@ -60,7 +60,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             await service.EnableAsync("maintenance", durationMinutes: 0, action: "disable_accounts", affectedUserIds: null);
 
             // Disable: user1's restore throws; the other two restore fine.
-            await service.DisableAsync();
+            await Assert.ThrowsAsync<InvalidOperationException>(() => service.DisableAsync());
 
             Assert.True(File.Exists(_stateFilePath));
             var state = JsonSerializer.Deserialize<MaintenanceState>(
@@ -69,6 +69,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
 
             // The failed user's record survives so a retry/restart can still re-enable them...
             Assert.True(state.IsActive);
+            Assert.Equal(MaintenancePhases.RestoreFailed, state.Phase);
             Assert.Equal(new[] { failUser.Id.ToString() }, state.AccountDisabledUserIds.ToArray());
 
             // ...and the two successfully-restored users' records are cleared.

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/MaintenanceModeStateMachineTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/MaintenanceModeStateMachineTests.cs
@@ -1,0 +1,554 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Data.Events;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Services;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Users;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
+{
+    public sealed class MaintenanceModeStateMachineTests : IDisposable
+    {
+        private readonly string _baseDir;
+        private readonly string _stateFilePath;
+        private readonly string _recoveryFilePath;
+
+        public MaintenanceModeStateMachineTests()
+        {
+            _baseDir = Path.Combine(Path.GetTempPath(), "jc-maint-state-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_baseDir);
+            _stateFilePath = Path.Combine(
+                _baseDir,
+                "configurations",
+                "Jellyfin.Plugin.JellyfinCanopy",
+                "maintenance-state.json");
+            _recoveryFilePath = _stateFilePath + ".recovery";
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(_baseDir, recursive: true);
+            }
+            catch
+            {
+                // Best-effort test cleanup.
+            }
+        }
+
+        [Fact]
+        public async Task CorruptPrimary_ReportsFaulted_AndRestoresFromRecoveryLedger()
+        {
+            var user = NewUser("recoverable");
+            var users = new StateMachineUserManager(user);
+            using (var first = CreateService(users))
+            {
+                await first.EnableAsync("maintenance", 0, "disable_accounts", null);
+            }
+
+            Assert.True(users.Policy(user.Id).IsDisabled);
+            // Syntactically valid truncation is more dangerous than malformed JSON: without
+            // strict shape validation it deserializes to a fresh IsActive=false object and can
+            // overwrite the only complete recovery ledger.
+            File.WriteAllText(_stateFilePath, "{\"IsActive\":false}");
+
+            using var restarted = CreateService(users);
+            var faulted = restarted.GetStatus();
+            Assert.Equal(MaintenancePhases.Faulted, faulted.Phase);
+            Assert.True(faulted.IsActive);
+            Assert.True(faulted.RecoveryAvailable);
+            Assert.Equal(MaintenancePhases.Active, faulted.RecoveryPhase);
+            Assert.Equal(new[] { user.Id.ToString() }, faulted.AccountDisabledUserIds);
+
+            await restarted.DisableAsync();
+
+            Assert.False(users.Policy(user.Id).IsDisabled);
+            Assert.Equal(MaintenancePhases.Inactive, restarted.GetStatus().Phase);
+            Assert.Equal(MaintenancePhases.Inactive, ReadState(_stateFilePath).Phase);
+        }
+
+        [Fact]
+        public async Task CorruptPrimaryAndRecovery_StayFaulted_AndRefuseMutation()
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(_stateFilePath)!);
+            File.WriteAllText(_stateFilePath, "{}");
+            File.WriteAllText(_recoveryFilePath, "{\"IsActive\":false}");
+
+            var primaryBytes = File.ReadAllBytes(_stateFilePath);
+            var recoveryBytes = File.ReadAllBytes(_recoveryFilePath);
+            using var service = CreateService(new StateMachineUserManager());
+
+            var status = service.GetStatus();
+            Assert.Equal(MaintenancePhases.Faulted, status.Phase);
+            Assert.True(status.IsActive);
+            Assert.False(status.RecoveryAvailable);
+            await Assert.ThrowsAsync<InvalidOperationException>(() => service.DisableAsync());
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                service.EnableAsync("replacement", 0, "disable_accounts", null));
+            Assert.Equal(primaryBytes, File.ReadAllBytes(_stateFilePath));
+            Assert.Equal(recoveryBytes, File.ReadAllBytes(_recoveryFilePath));
+        }
+
+        [Fact]
+        public async Task ExpiryRunsWithoutPolling_AndOneHundredStatusReadsObserveSingleFlightRestore()
+        {
+            var now = new DateTimeOffset(2026, 7, 14, 12, 0, 0, TimeSpan.Zero);
+            var clock = new ManualTimeProvider(now);
+            var user = NewUser("blocked-restore");
+            var users = new StateMachineUserManager(user) { BlockRestores = true };
+            using var service = CreateService(users, clock);
+            await service.StartAsync(CancellationToken.None);
+            await service.EnableAsync("maintenance", 1, "disable_accounts", null);
+
+            clock.Advance(TimeSpan.FromMinutes(1));
+            await users.RestoreStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            for (int i = 0; i < 100; i++)
+            {
+                var status = service.GetStatus();
+                Assert.True(status.IsActive);
+                Assert.Equal(MaintenancePhases.Restoring, status.Phase);
+            }
+
+            clock.Advance(TimeSpan.FromHours(1));
+            Assert.Equal(1, users.RestoreCalls);
+            users.ReleaseRestores();
+            await service.WaitForBackgroundRestoreAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Equal(1, users.RestoreCalls);
+            Assert.False(users.Policy(user.Id).IsDisabled);
+            Assert.Equal(MaintenancePhases.Inactive, service.GetStatus().Phase);
+        }
+
+        [Fact]
+        public async Task RestoreFailure_IsDurableRetainsOnlyUnresolvedIds_AndDoesNotRetryAutomatically()
+        {
+            var now = new DateTimeOffset(2026, 7, 14, 12, 0, 0, TimeSpan.Zero);
+            var clock = new ManualTimeProvider(now);
+            var good = NewUser("good");
+            var failed = NewUser("failed");
+            var users = new StateMachineUserManager(good, failed);
+            users.FailRestoreFor.Add(failed.Id);
+            using var service = CreateService(users, clock);
+            await service.StartAsync(CancellationToken.None);
+            await service.EnableAsync("maintenance", 1, "disable_accounts", null);
+
+            clock.Advance(TimeSpan.FromMinutes(1));
+            await service.WaitForBackgroundRestoreAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+            var status = service.GetStatus();
+            Assert.Equal(MaintenancePhases.RestoreFailed, status.Phase);
+            Assert.True(status.IsActive);
+            Assert.Equal(new[] { failed.Id.ToString() }, status.AccountDisabledUserIds);
+            Assert.Equal(MaintenancePhases.RestoreFailed, ReadState(_stateFilePath).Phase);
+            Assert.Equal(new[] { failed.Id.ToString() }, ReadState(_recoveryFilePath).AccountDisabledUserIds);
+            Assert.False(users.Policy(good.Id).IsDisabled);
+            Assert.True(users.Policy(failed.Id).IsDisabled);
+
+            int callsAfterFailure = users.RestoreCalls;
+            clock.Advance(TimeSpan.FromDays(7));
+            Assert.Equal(callsAfterFailure, users.RestoreCalls);
+        }
+
+        [Fact]
+        public async Task ExpiryThatQueuedBehindAnExtension_DoesNotCancelTheNewDeadlineOrRestoreEarly()
+        {
+            var now = new DateTimeOffset(2026, 7, 14, 12, 0, 0, TimeSpan.Zero);
+            var clock = new ManualTimeProvider(now);
+            var user = NewUser("extended");
+            var users = new StateMachineUserManager(user);
+            using var extensionWriterEntered = new ManualResetEventSlim();
+            using var releaseExtensionWriter = new ManualResetEventSlim();
+            bool blockExtendedActiveWrite = false;
+
+            void BlockingWriter(string path, string json)
+            {
+                var state = JsonSerializer.Deserialize<MaintenanceState>(json, PersistedJson.ReadOptions)!;
+                if (blockExtendedActiveWrite &&
+                    path == _recoveryFilePath &&
+                    state.Phase == MaintenancePhases.Active)
+                {
+                    blockExtendedActiveWrite = false;
+                    extensionWriterEntered.Set();
+                    releaseExtensionWriter.Wait(TimeSpan.FromSeconds(5));
+                }
+
+                AtomicFile.WriteAllText(path, json);
+            }
+
+            using var service = CreateService(users, clock, BlockingWriter);
+            await service.StartAsync(CancellationToken.None);
+            await service.EnableAsync("maintenance", 1, "disable_accounts", null);
+            blockExtendedActiveWrite = true;
+
+            var extension = Task.Run(() =>
+                service.EnableAsync("extended", 10, "disable_accounts", null));
+            Assert.True(extensionWriterEntered.Wait(TimeSpan.FromSeconds(5)));
+
+            // The old timer fires while the extension owns the state gate. Its queued recovery
+            // must re-read the later EndsAt after it wins the gate, not act like a manual disable.
+            clock.Advance(TimeSpan.FromMinutes(1));
+            var staleScheduledRecovery = service.WaitForBackgroundRestoreAsync();
+            Assert.False(staleScheduledRecovery.IsCompleted);
+            releaseExtensionWriter.Set();
+            await extension.WaitAsync(TimeSpan.FromSeconds(5));
+            await staleScheduledRecovery.WaitAsync(TimeSpan.FromSeconds(5));
+
+            var status = service.GetStatus();
+            Assert.Equal(MaintenancePhases.Active, status.Phase);
+            Assert.True(status.EndsAt > clock.GetUtcNow().UtcDateTime);
+            Assert.True(users.Policy(user.Id).IsDisabled);
+            Assert.Equal(0, users.RestoreCalls);
+        }
+
+        [Fact]
+        public async Task StopCancellation_DoesNotHangOnBlockedRestore_AndRecoveryCanFinishSafely()
+        {
+            var clock = new ManualTimeProvider(new DateTimeOffset(2026, 7, 14, 12, 0, 0, TimeSpan.Zero));
+            var user = NewUser("shutdown");
+            var users = new StateMachineUserManager(user) { BlockRestores = true };
+            using var service = CreateService(users, clock);
+            await service.StartAsync(CancellationToken.None);
+            await service.EnableAsync("maintenance", 1, "disable_accounts", null);
+            clock.Advance(TimeSpan.FromMinutes(1));
+            await users.RestoreStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            using var cancelled = new CancellationTokenSource();
+            cancelled.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => service.StopAsync(cancelled.Token));
+            Assert.Equal(MaintenancePhases.Restoring, service.GetStatus().Phase);
+
+            users.ReleaseRestores();
+            await service.WaitForBackgroundRestoreAsync().WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal(MaintenancePhases.Inactive, service.GetStatus().Phase);
+        }
+
+        [Fact]
+        public async Task MissingAndNullPolicyUsersRemainRecoverable_ButConfirmedDeletedUserIsRetired()
+        {
+            var transientMissing = NewUser("transient");
+            var nullPolicy = NewUser("null-policy");
+            var deletedId = Guid.NewGuid();
+            var users = new StateMachineUserManager(transientMissing, nullPolicy);
+            users.ReturnNullFromLookupFor.Add(transientMissing.Id);
+            users.ReturnNullPolicyFor.Add(nullPolicy.Id);
+            SeedState(new MaintenanceState
+            {
+                Phase = MaintenancePhases.Active,
+                IsActive = true,
+                Message = "maintenance",
+                StartedAt = DateTime.UtcNow,
+                AccountDisabledUserIds = new List<string>
+                {
+                    transientMissing.Id.ToString(),
+                    nullPolicy.Id.ToString(),
+                    deletedId.ToString()
+                },
+                RecoveryAvailable = true
+            });
+
+            using var service = CreateService(users);
+            await Assert.ThrowsAsync<InvalidOperationException>(() => service.DisableAsync());
+
+            var persisted = ReadState(_stateFilePath);
+            Assert.Equal(MaintenancePhases.RestoreFailed, persisted.Phase);
+            Assert.Contains(transientMissing.Id.ToString(), persisted.AccountDisabledUserIds);
+            Assert.Contains(nullPolicy.Id.ToString(), persisted.AccountDisabledUserIds);
+            Assert.DoesNotContain(deletedId.ToString(), persisted.AccountDisabledUserIds);
+        }
+
+        [Fact]
+        public async Task FinalOutcomeWriteFailure_PersistsRestoreFailedWithCompleteLedger()
+        {
+            var user = NewUser("final-write");
+            var users = new StateMachineUserManager(user);
+            bool failInactivePrimaryOnce = true;
+            void WriteWithOneShotFailure(string path, string json)
+            {
+                var phase = JsonSerializer.Deserialize<MaintenanceState>(json, PersistedJson.ReadOptions)?.Phase;
+                if (path == _stateFilePath && phase == MaintenancePhases.Inactive && failInactivePrimaryOnce)
+                {
+                    failInactivePrimaryOnce = false;
+                    throw new IOException("injected final primary failure");
+                }
+
+                AtomicFile.WriteAllText(path, json);
+            }
+
+            using var service = CreateService(users, TimeProvider.System, WriteWithOneShotFailure);
+            await service.EnableAsync("maintenance", 0, "disable_accounts", null);
+            await Assert.ThrowsAsync<IOException>(() => service.DisableAsync());
+
+            Assert.False(users.Policy(user.Id).IsDisabled);
+            var primary = ReadState(_stateFilePath);
+            var recovery = ReadState(_recoveryFilePath);
+            Assert.Equal(MaintenancePhases.RestoreFailed, primary.Phase);
+            Assert.Equal(MaintenancePhases.RestoreFailed, recovery.Phase);
+            Assert.Equal(new[] { user.Id.ToString() }, primary.AccountDisabledUserIds);
+            Assert.Equal(primary.AccountDisabledUserIds, recovery.AccountDisabledUserIds);
+        }
+
+        [Fact]
+        public async Task RestartDuringRestoring_ResumesOneDeterministicRecovery()
+        {
+            var clock = new ManualTimeProvider(new DateTimeOffset(2026, 7, 14, 12, 0, 0, TimeSpan.Zero));
+            var user = NewUser("restart");
+            var users = new StateMachineUserManager(user);
+            users.Policy(user.Id).IsDisabled = true;
+            SeedState(new MaintenanceState
+            {
+                Phase = MaintenancePhases.Restoring,
+                IsActive = true,
+                Message = "maintenance",
+                StartedAt = clock.GetUtcNow().UtcDateTime,
+                AccountDisabledUserIds = new List<string> { user.Id.ToString() },
+                RecoveryAvailable = true
+            });
+
+            using var service = CreateService(users, clock);
+            await service.StartAsync(CancellationToken.None);
+            clock.Advance(TimeSpan.Zero);
+            await service.WaitForBackgroundRestoreAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Equal(1, users.RestoreCalls);
+            Assert.False(users.Policy(user.Id).IsDisabled);
+            Assert.Equal(MaintenancePhases.Inactive, service.GetStatus().Phase);
+        }
+
+        private MaintenanceModeService CreateService(
+            StateMachineUserManager users,
+            TimeProvider? timeProvider = null,
+            Action<string, string>? writer = null)
+            => new(
+                users,
+                new StubAppPaths(_baseDir),
+                NullLogger<MaintenanceModeService>.Instance,
+                timeProvider ?? TimeProvider.System,
+                writer ?? AtomicFile.WriteAllText);
+
+        private void SeedState(MaintenanceState state)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(_stateFilePath)!);
+            var json = JsonSerializer.Serialize(state, PersistedJson.WriteOptions);
+            AtomicFile.WriteAllText(_stateFilePath, json);
+            AtomicFile.WriteAllText(_recoveryFilePath, json);
+        }
+
+        private static MaintenanceState ReadState(string path)
+            => JsonSerializer.Deserialize<MaintenanceState>(File.ReadAllText(path), PersistedJson.ReadOptions)!;
+
+        private static User NewUser(string name) => new(name, "Prov", "PwProv");
+
+        private sealed class StateMachineUserManager : IUserManager
+        {
+            private readonly Dictionary<Guid, User> _users;
+            private readonly Dictionary<Guid, UserPolicy> _policies;
+            private readonly TaskCompletionSource _releaseRestores = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public StateMachineUserManager(params User[] users)
+            {
+                _users = users.ToDictionary(user => user.Id);
+                _policies = users.ToDictionary(
+                    user => user.Id,
+                    _ => new UserPolicy { IsDisabled = false, EnableRemoteAccess = true });
+            }
+
+            public bool BlockRestores { get; set; }
+            public int RestoreCalls { get; private set; }
+            public HashSet<Guid> FailRestoreFor { get; } = new();
+            public HashSet<Guid> ReturnNullFromLookupFor { get; } = new();
+            public HashSet<Guid> ReturnNullPolicyFor { get; } = new();
+            public TaskCompletionSource RestoreStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public event EventHandler<GenericEventArgs<User>> OnUserUpdated { add { } remove { } }
+
+            public UserPolicy Policy(Guid id) => _policies[id];
+
+            public void ReleaseRestores() => _releaseRestores.TrySetResult();
+
+            public IEnumerable<User> GetUsers() => _users.Values;
+
+            public User? GetUserById(Guid id)
+                => ReturnNullFromLookupFor.Contains(id) ? null : _users.GetValueOrDefault(id);
+
+            public UserDto GetUserDto(User user, string? remoteEndPoint = null)
+                => new()
+                {
+                    Policy = ReturnNullPolicyFor.Contains(user.Id)
+                        ? null
+                        : new UserPolicy
+                        {
+                            IsDisabled = _policies[user.Id].IsDisabled,
+                            EnableRemoteAccess = _policies[user.Id].EnableRemoteAccess
+                        }
+                };
+
+            public async Task UpdatePolicyAsync(Guid userId, UserPolicy policy)
+            {
+                bool restoring = !policy.IsDisabled && _policies[userId].IsDisabled;
+                if (restoring)
+                {
+                    RestoreCalls++;
+                    RestoreStarted.TrySetResult();
+                    if (BlockRestores)
+                    {
+                        await _releaseRestores.Task.ConfigureAwait(false);
+                    }
+
+                    if (FailRestoreFor.Contains(userId))
+                    {
+                        throw new InvalidOperationException("injected restore failure");
+                    }
+                }
+
+                _policies[userId] = new UserPolicy
+                {
+                    IsDisabled = policy.IsDisabled,
+                    EnableRemoteAccess = policy.EnableRemoteAccess
+                };
+            }
+
+            public IEnumerable<Guid> GetUsersIds() => _users.Keys;
+            public Task InitializeAsync() => Task.CompletedTask;
+            public User? GetFirstUser() => _users.Values.FirstOrDefault();
+            public User? GetUserByName(string name) => _users.Values.FirstOrDefault(user => user.Username == name);
+            public Task RenameUser(Guid userId, string oldName, string newName) => throw new NotImplementedException();
+            public Task UpdateUserAsync(User user) => throw new NotImplementedException();
+            public Task<User> CreateUserAsync(string name) => throw new NotImplementedException();
+            public Task DeleteUserAsync(Guid userId) => throw new NotImplementedException();
+            public Task ResetPassword(Guid userId) => throw new NotImplementedException();
+            public Task ChangePassword(Guid userId, string newPassword) => throw new NotImplementedException();
+            public Task<User?> AuthenticateUser(string username, string password, string remoteEndPoint, bool isUserSession) => throw new NotImplementedException();
+            public Task<ForgotPasswordResult> StartForgotPasswordProcess(string enteredUsername, bool isInNetwork) => throw new NotImplementedException();
+            public Task<PinRedeemResult> RedeemPasswordResetPin(string pin) => throw new NotImplementedException();
+            public NameIdPair[] GetAuthenticationProviders() => Array.Empty<NameIdPair>();
+            public NameIdPair[] GetPasswordResetProviders() => Array.Empty<NameIdPair>();
+            public Task UpdateConfigurationAsync(Guid userId, UserConfiguration config) => throw new NotImplementedException();
+            public Task ClearProfileImageAsync(User user) => throw new NotImplementedException();
+        }
+
+        private sealed class ManualTimeProvider : TimeProvider
+        {
+            private readonly object _sync = new();
+            private readonly List<ManualTimer> _timers = new();
+            private DateTimeOffset _now;
+
+            public ManualTimeProvider(DateTimeOffset now)
+            {
+                _now = now;
+            }
+
+            public override DateTimeOffset GetUtcNow()
+            {
+                lock (_sync)
+                {
+                    return _now;
+                }
+            }
+
+            public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+            {
+                var timer = new ManualTimer(this, callback, state, dueTime, period);
+                lock (_sync)
+                {
+                    _timers.Add(timer);
+                }
+
+                return timer;
+            }
+
+            public void Advance(TimeSpan amount)
+            {
+                List<ManualTimer> due;
+                lock (_sync)
+                {
+                    _now = _now.Add(amount);
+                    due = _timers.Where(timer => timer.IsDue(_now)).ToList();
+                }
+
+                foreach (var timer in due)
+                {
+                    timer.Fire();
+                }
+            }
+
+            private sealed class ManualTimer : ITimer
+            {
+                private readonly ManualTimeProvider _owner;
+                private readonly TimerCallback _callback;
+                private readonly object? _state;
+                private TimeSpan _period;
+                private DateTimeOffset _dueAt;
+                private bool _disposed;
+
+                public ManualTimer(
+                    ManualTimeProvider owner,
+                    TimerCallback callback,
+                    object? state,
+                    TimeSpan dueTime,
+                    TimeSpan period)
+                {
+                    _owner = owner;
+                    _callback = callback;
+                    _state = state;
+                    _period = period;
+                    _dueAt = owner.GetUtcNow().Add(dueTime);
+                }
+
+                public bool IsDue(DateTimeOffset now) => !_disposed && _dueAt <= now;
+
+                public void Fire()
+                {
+                    if (_disposed)
+                    {
+                        return;
+                    }
+
+                    if (_period == Timeout.InfiniteTimeSpan)
+                    {
+                        _disposed = true;
+                    }
+                    else
+                    {
+                        _dueAt = _dueAt.Add(_period);
+                    }
+
+                    _callback(_state);
+                }
+
+                public bool Change(TimeSpan dueTime, TimeSpan period)
+                {
+                    if (_disposed)
+                    {
+                        return false;
+                    }
+
+                    _period = period;
+                    _dueAt = _owner.GetUtcNow().Add(dueTime);
+                    return true;
+                }
+
+                public void Dispose() => _disposed = true;
+
+                public ValueTask DisposeAsync()
+                {
+                    Dispose();
+                    return ValueTask.CompletedTask;
+                }
+            }
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Snapshots/UserFiles/maintenance-state.write.updated.json
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Snapshots/UserFiles/maintenance-state.write.updated.json
@@ -1,4 +1,6 @@
 {
+  "SchemaVersion": 2,
+  "Phase": "Active",
   "IsActive": true,
   "Message": "Wartung aktualisiert — 更新",
   "Action": "both",
@@ -7,5 +9,8 @@
   "AccountDisabledUserIds": [
     "3f2504e04f8941d39a0c0305e82c3301"
   ],
-  "RemoteDisabledUserIds": []
+  "RemoteDisabledUserIds": [],
+  "FailureReason": null,
+  "RecoveryAvailable": true,
+  "RecoveryPhase": null
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/MaintenanceModeController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/MaintenanceModeController.cs
@@ -76,13 +76,17 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             var state = _maintenanceModeService.GetStatus();
             return Ok(new
             {
+                state.Phase,
                 state.IsActive,
                 state.Message,
                 state.Action,
                 state.StartedAt,
                 state.EndsAt,
                 AccountDisabledCount = state.AccountDisabledUserIds.Count,
-                RemoteDisabledCount  = state.RemoteDisabledUserIds.Count
+                RemoteDisabledCount = state.RemoteDisabledUserIds.Count,
+                state.FailureReason,
+                state.RecoveryAvailable,
+                state.RecoveryPhase
             });
         }
 
@@ -90,20 +94,61 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
         [HttpPost("MaintenanceMode/Enable")]
         public async Task<IActionResult> EnableMaintenanceMode([FromBody] MaintenanceModeRequest request)
         {
-            await _maintenanceModeService.EnableAsync(
-                request.Message ?? string.Empty,
-                request.DurationMinutes,
-                request.Action ?? "disable_accounts",
-                request.AffectedUserIds).ConfigureAwait(false);
-            return Ok(new { success = true });
+            try
+            {
+                await _maintenanceModeService.EnableAsync(
+                    request.Message ?? string.Empty,
+                    request.DurationMinutes,
+                    request.Action ?? "disable_accounts",
+                    request.AffectedUserIds).ConfigureAwait(false);
+                return Ok(new { success = true });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return MaintenanceFailure(StatusCodes.Status409Conflict, ex.Message);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                _logger.LogError(ex, "[Maintenance] Could not persist the enable transition.");
+                return MaintenanceFailure(
+                    StatusCodes.Status503ServiceUnavailable,
+                    "Maintenance state could not be persisted; no account changes were authorized.");
+            }
         }
 
         [Authorize(Policy = Policies.RequiresElevation)]
         [HttpPost("MaintenanceMode/Disable")]
         public async Task<IActionResult> DisableMaintenanceMode()
         {
-            await _maintenanceModeService.DisableAsync().ConfigureAwait(false);
-            return Ok(new { success = true });
+            try
+            {
+                await _maintenanceModeService.DisableAsync().ConfigureAwait(false);
+                return Ok(new { success = true });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return MaintenanceFailure(StatusCodes.Status409Conflict, ex.Message);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                _logger.LogError(ex, "[Maintenance] Could not persist the disable transition.");
+                return MaintenanceFailure(
+                    StatusCodes.Status503ServiceUnavailable,
+                    "Account recovery ran, but its durable outcome could not be committed. The recovery ledger was retained.");
+            }
+        }
+
+        private IActionResult MaintenanceFailure(int statusCode, string message)
+        {
+            var state = _maintenanceModeService.GetStatus();
+            return StatusCode(statusCode, new
+            {
+                success = false,
+                error = message,
+                state.Phase,
+                state.IsActive,
+                state.RecoveryAvailable
+            });
         }
 
         [Authorize(Policy = Policies.RequiresElevation)]

--- a/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
@@ -132,6 +132,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy
             // (Resume, Items, Latest, NextUp, Upcoming, Suggestions, SearchHints). Same filter handles "Remove from
             // Continue Watching" via HideScope=continuewatching in hidden-content.json.
             serviceCollection.AddSingleton<MaintenanceModeService>();
+            serviceCollection.AddHostedService(serviceProvider => serviceProvider.GetRequiredService<MaintenanceModeService>());
             serviceCollection.AddSingleton<HiddenContentResponseFilter>();
             serviceCollection.AddScoped<IEventConsumer<PlaybackStartEventArgs>, ContinueWatchingPlaybackConsumer>();
             serviceCollection.AddHostedService<ContinueWatchingLibraryHook>();

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/MaintenanceModeService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/MaintenanceModeService.cs
@@ -2,20 +2,32 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Enums;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Library;
-using System.Text.Json;
-using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.JellyfinCanopy.Services
 {
+    public static class MaintenancePhases
+    {
+        public const string Inactive = "Inactive";
+        public const string Active = "Active";
+        public const string Restoring = "Restoring";
+        public const string RestoreFailed = "RestoreFailed";
+        public const string Faulted = "Faulted";
+    }
+
     public class MaintenanceState
     {
+        public int SchemaVersion { get; set; } = 2;
+        public string Phase { get; set; } = string.Empty;
         public bool IsActive { get; set; }
         public string Message { get; set; } = string.Empty;
         /// <summary>"disable_accounts" | "disable_remote" | "both"</summary>
@@ -26,67 +38,146 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         public List<string> AccountDisabledUserIds { get; set; } = new();
         /// <summary>Users whose remote access was disabled by maintenance mode.</summary>
         public List<string> RemoteDisabledUserIds { get; set; } = new();
+        /// <summary>A safe, admin-facing description of a durable recovery fault.</summary>
+        public string? FailureReason { get; set; }
+        /// <summary>Whether the durable state contains enough evidence to attempt account recovery.</summary>
+        public bool RecoveryAvailable { get; set; }
+        /// <summary>The last-known-good phase recovered when the primary file is unreadable.</summary>
+        public string? RecoveryPhase { get; set; }
     }
 
-    public class MaintenanceModeService
+    /// <summary>
+    /// Owns the complete maintenance-mode state machine. The primary file and its recovery
+    /// snapshot are written before user policies are changed, and expiry is driven by one hosted
+    /// timer rather than status polling.
+    /// </summary>
+    public sealed class MaintenanceModeService : IHostedService, IDisposable
     {
         private readonly IUserManager _userManager;
         private readonly ILogger<MaintenanceModeService> _logger;
         private readonly string _stateFilePath;
-        // Async-compatible mutual exclusion: the enable/disable state transitions
-        // (LoadState → decide → per-user UpdatePolicyAsync → SaveState) span awaits, so a
-        // plain lock won't do. This singleton holds one gate; leaving it undisposed for the
-        // app-lifetime singleton is intentional (matches the plugin's other singletons).
+        private readonly string _recoveryFilePath;
+        private readonly TimeProvider _timeProvider;
+        private readonly Action<string, string> _writeAllText;
         private readonly SemaphoreSlim _stateGate = new(1, 1);
+        private readonly object _stateSync = new();
+        private readonly object _timerSync = new();
+        private MaintenanceState _state;
+        private ITimer? _expiryTimer;
+        private Task _backgroundRestoreTask = Task.CompletedTask;
+        private bool _started;
+        private bool _stopping;
+        private bool _disposed;
 
-        public MaintenanceModeService(IUserManager userManager, IApplicationPaths appPaths, ILogger<MaintenanceModeService> logger)
+        public MaintenanceModeService(
+            IUserManager userManager,
+            IApplicationPaths appPaths,
+            ILogger<MaintenanceModeService> logger)
+            : this(userManager, appPaths, logger, TimeProvider.System, AtomicFile.WriteAllText)
+        {
+        }
+
+        internal MaintenanceModeService(
+            IUserManager userManager,
+            IApplicationPaths appPaths,
+            ILogger<MaintenanceModeService> logger,
+            TimeProvider timeProvider,
+            Action<string, string> writeAllText)
         {
             _userManager = userManager;
             _logger = logger;
+            _timeProvider = timeProvider;
+            _writeAllText = writeAllText;
             var dir = Path.Combine(appPaths.PluginsPath, "configurations", "Jellyfin.Plugin.JellyfinCanopy");
             Directory.CreateDirectory(dir);
             _stateFilePath = Path.Combine(dir, "maintenance-state.json");
+            _recoveryFilePath = _stateFilePath + ".recovery";
+            _state = LoadInitialState();
         }
 
         public MaintenanceState GetStatus()
         {
-            var state = LoadState();
-            if (state.IsActive && state.EndsAt.HasValue && DateTime.UtcNow >= state.EndsAt.Value)
+            lock (_stateSync)
             {
-                _ = Task.Run(() => DisableAsync());
-                return new MaintenanceState { IsActive = false };
+                return CloneState(_state);
             }
-            return state;
+        }
+
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            await _stateGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                lock (_timerSync)
+                {
+                    ObjectDisposedException.ThrowIf(_disposed, this);
+                    _started = true;
+                    _stopping = false;
+                }
+
+                ScheduleExpiry(GetStatus());
+            }
+            finally
+            {
+                _stateGate.Release();
+            }
+        }
+
+        public async Task StopAsync(CancellationToken cancellationToken)
+        {
+            Task background;
+            lock (_timerSync)
+            {
+                _stopping = true;
+                _started = false;
+                _expiryTimer?.Dispose();
+                _expiryTimer = null;
+                background = _backgroundRestoreTask;
+            }
+
+            // A restore that has already changed account policy must finish its durable state
+            // transition. Abandoning it at host shutdown would recreate the stranded-account bug.
+            if (!background.IsCompleted)
+            {
+                _logger.LogInformation("[Maintenance] Waiting for the in-flight recovery transition during shutdown.");
+                await background.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
         }
 
         /// <param name="action">"disable_accounts" | "disable_remote" | "both"</param>
         /// <param name="affectedUserIds">Specific user IDs to affect; null or empty = all non-admin users.</param>
         public async Task EnableAsync(string message, int durationMinutes, string action, List<string>? affectedUserIds)
         {
-            // Serialize the whole read-decide-apply-write transition so two concurrent
-            // EnableAsync calls (or an EnableAsync racing the auto-expiry DisableAsync)
-            // can't both proceed off the same stale state — which would double-apply user
-            // policy changes and clobber the AccountDisabled/RemoteDisabled restore lists.
             await _stateGate.WaitAsync().ConfigureAwait(false);
             try
             {
-                var currentState = LoadState();
-                if (currentState.IsActive)
+                var currentState = GetStatus();
+                if (string.Equals(currentState.Phase, MaintenancePhases.Faulted, StringComparison.Ordinal) ||
+                    string.Equals(currentState.Phase, MaintenancePhases.Restoring, StringComparison.Ordinal) ||
+                    string.Equals(currentState.Phase, MaintenancePhases.RestoreFailed, StringComparison.Ordinal))
                 {
-                    // Already active — just update message/duration; do not re-apply user changes.
-                    // A failed save throws (SaveState no longer swallows) so the caller sees the
-                    // failure rather than a false success.
+                    throw new InvalidOperationException(
+                        $"Maintenance mode cannot be enabled while recovery is {currentState.Phase}. " +
+                        "Complete or repair the existing recovery state first.");
+                }
+
+                if (string.Equals(currentState.Phase, MaintenancePhases.Active, StringComparison.Ordinal))
+                {
                     currentState.Message = message ?? string.Empty;
-                    currentState.EndsAt = durationMinutes > 0 ? DateTime.UtcNow.AddMinutes(durationMinutes) : null;
+                    currentState.EndsAt = durationMinutes > 0 ? UtcNow().AddMinutes(durationMinutes) : null;
+                    currentState.FailureReason = null;
+                    currentState.RecoveryAvailable = true;
+                    currentState.RecoveryPhase = null;
                     SaveState(currentState);
+                    PublishState(currentState);
+                    ScheduleExpiry(currentState);
                     _logger.LogInformation("[Maintenance] Message/duration updated (already active).");
                     return;
                 }
 
                 bool doAccounts = action == "disable_accounts" || action == "both";
-                bool doRemote   = action == "disable_remote"   || action == "both";
+                bool doRemote = action == "disable_remote" || action == "both";
 
-                // Build the target user set: all non-admin users, filtered to the selection
                 var allNonAdmin = _userManager.GetUsers()
                     .Where(u => !u.HasPermission(PermissionKind.IsAdministrator))
                     .ToList();
@@ -99,79 +190,84 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 else
                 {
                     var idSet = affectedUserIds
-                        .Select(s => Guid.TryParse(s, out var g) ? g : Guid.Empty)
-                        .Where(g => g != Guid.Empty)
+                        .Select(s => Guid.TryParse(s, out var parsed) ? parsed : Guid.Empty)
+                        .Where(id => id != Guid.Empty)
                         .ToHashSet();
                     targetUsers = allNonAdmin.Where(u => idSet.Contains(u.Id));
                 }
 
-                // Pass 1 — plan the mutations WITHOUT touching any account. Resolve each user's
-                // current policy and record only the users we would actually change (accounts not
-                // already disabled / remote not already off). This set IS the restore list.
                 var plan = new List<(Guid Id, string Username, MediaBrowser.Model.Users.UserPolicy Policy, bool DisableAccount, bool DisableRemote)>();
                 foreach (var user in targetUsers)
                 {
-                    try
+                    var dto = _userManager.GetUserDto(user, string.Empty);
+                    if (dto.Policy == null)
                     {
-                        var dto = _userManager.GetUserDto(user, string.Empty);
-                        if (dto.Policy == null) continue;
-
-                        bool disableAccount = doAccounts && !dto.Policy.IsDisabled;
-                        bool disableRemote  = doRemote  && dto.Policy.EnableRemoteAccess;
-                        if (disableAccount || disableRemote)
-                        {
-                            plan.Add((user.Id, user.Username, dto.Policy, disableAccount, disableRemote));
-                        }
+                        throw new InvalidOperationException($"Cannot read the policy for maintenance target '{user.Username}'.");
                     }
-                    catch (Exception ex)
+
+                    bool disableAccount = doAccounts && !dto.Policy.IsDisabled;
+                    bool disableRemote = doRemote && dto.Policy.EnableRemoteAccess;
+                    if (disableAccount || disableRemote)
                     {
-                        _logger.LogError($"[Maintenance] Failed to read policy for user '{user.Username}': {ex.Message}");
+                        plan.Add((user.Id, user.Username, dto.Policy, disableAccount, disableRemote));
                     }
                 }
 
-                var accountDisabled = plan.Where(p => p.DisableAccount).Select(p => p.Id.ToString()).ToList();
-                var remoteDisabled  = plan.Where(p => p.DisableRemote).Select(p => p.Id.ToString()).ToList();
-
+                var now = UtcNow();
                 var newState = new MaintenanceState
                 {
+                    SchemaVersion = 2,
+                    Phase = MaintenancePhases.Active,
                     IsActive = true,
-                    Message  = message ?? string.Empty,
-                    Action   = action ?? "disable_accounts",
-                    StartedAt = DateTime.UtcNow,
-                    EndsAt   = durationMinutes > 0 ? DateTime.UtcNow.AddMinutes(durationMinutes) : null,
-                    AccountDisabledUserIds = accountDisabled,
-                    RemoteDisabledUserIds  = remoteDisabled
+                    Message = message ?? string.Empty,
+                    Action = action ?? "disable_accounts",
+                    StartedAt = now,
+                    EndsAt = durationMinutes > 0 ? now.AddMinutes(durationMinutes) : null,
+                    AccountDisabledUserIds = plan.Where(p => p.DisableAccount).Select(p => p.Id.ToString()).ToList(),
+                    RemoteDisabledUserIds = plan.Where(p => p.DisableRemote).Select(p => p.Id.ToString()).ToList(),
+                    RecoveryAvailable = true
                 };
 
-                // Persist the restore intent DURABLY *before* mutating a single account. If this
-                // throws we abort with every account still untouched — we never disable users
-                // without a recoverable record of how to restore them. (Previously the save ran
-                // AFTER disabling and silently swallowed failures, stranding disabled accounts
-                // with no restore list.)
+                // Both the recovery snapshot and the primary intent exist before the first account
+                // mutation. A failed write aborts the request with every account untouched.
                 SaveState(newState);
+                PublishState(newState);
 
-                // Pass 2 — apply the planned mutations. The restore list is already on disk, so a
-                // crash mid-loop leaves a recoverable (still-active) state: the next disable restores
-                // every listed user, and re-enabling an account we never got to touch is a no-op.
                 foreach (var (id, username, policy, disableAccount, disableRemote) in plan)
                 {
                     try
                     {
-                        if (disableAccount) policy.IsDisabled = true;
-                        if (disableRemote)  policy.EnableRemoteAccess = false;
+                        if (disableAccount)
+                        {
+                            policy.IsDisabled = true;
+                        }
+
+                        if (disableRemote)
+                        {
+                            policy.EnableRemoteAccess = false;
+                        }
+
                         await _userManager.UpdatePolicyAsync(id, policy).ConfigureAwait(false);
-                        _logger.LogInformation($"[Maintenance] Updated user '{username}'" +
-                            $"{(disableAccount ? " (account disabled)" : "")}" +
-                            $"{(disableRemote ? " (remote disabled)" : "")}");
+                        _logger.LogInformation(
+                            "[Maintenance] Updated user '{Username}' (account={DisableAccount}, remote={DisableRemote}).",
+                            username,
+                            disableAccount,
+                            disableRemote);
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogError($"[Maintenance] Failed to update user '{username}': {ex.Message}");
+                        // The durable restore intent deliberately retains this user. A retry can
+                        // safely re-enable a policy even when this enable mutation never landed.
+                        _logger.LogError(ex, "[Maintenance] Failed to update user '{Username}'.", username);
                     }
                 }
 
-                _logger.LogInformation($"[Maintenance] Mode enabled. Action={action}, " +
-                    $"AccountsDisabled={accountDisabled.Count}, RemoteDisabled={remoteDisabled.Count}");
+                ScheduleExpiry(newState);
+                _logger.LogInformation(
+                    "[Maintenance] Mode enabled. Action={Action}, AccountsDisabled={AccountsDisabled}, RemoteDisabled={RemoteDisabled}.",
+                    action,
+                    newState.AccountDisabledUserIds.Count,
+                    newState.RemoteDisabledUserIds.Count);
             }
             finally
             {
@@ -179,103 +275,125 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             }
         }
 
-        public async Task DisableAsync()
+        public Task DisableAsync() => DisableCoreAsync(scheduledExpiry: false);
+
+        internal Task WaitForBackgroundRestoreAsync()
         {
-            // Hold the gate across the WHOLE transition — including the restore loop — so a
-            // concurrent EnableAsync can't interleave with an in-flight restore and re-toggle the
-            // same accounts. A SemaphoreSlim is async-compatible, so spanning the awaits is fine.
+            lock (_timerSync)
+            {
+                return _backgroundRestoreTask;
+            }
+        }
+
+        private async Task DisableCoreAsync(bool scheduledExpiry)
+        {
             await _stateGate.WaitAsync().ConfigureAwait(false);
             try
             {
-                var state = LoadState();
-                if (!state.IsActive)
+                var state = GetStatus();
+                if (string.Equals(state.Phase, MaintenancePhases.Inactive, StringComparison.Ordinal))
                 {
                     _logger.LogInformation("[Maintenance] Already inactive — skipping disable.");
                     return;
                 }
 
-                // Collect all unique user IDs that need updating
-                var allIds = state.AccountDisabledUserIds
-                    .Union(state.RemoteDisabledUserIds)
-                    .Distinct()
-                    .ToList();
-
-                var accountSet = new HashSet<string>(state.AccountDisabledUserIds);
-                var remoteSet  = new HashSet<string>(state.RemoteDisabledUserIds);
-
-                // Restore users FIRST, while the durable state still holds the full restore list.
-                // Previously we wrote IsActive=false (which also clears the restore list) BEFORE
-                // restoring, so a crash mid-restore left an inactive state with an empty list and
-                // stranded the still-disabled accounts. Now the state stays active-with-list until
-                // every restore has been applied.
-                //
-                // Track the users whose restore actually THREW: their UpdatePolicyAsync failed, so
-                // they are still disabled/remote-blocked. We must NOT clear their restore record
-                // below — that would strand them with nothing to restore from — so they stay in the
-                // persisted (still-active) list for a later retry / restart.
-                var failedIds = new HashSet<string>();
-                foreach (var idStr in allIds)
+                if (string.Equals(state.Phase, MaintenancePhases.Faulted, StringComparison.Ordinal) &&
+                    !state.RecoveryAvailable)
                 {
-                    if (!Guid.TryParse(idStr, out var userId)) continue;
+                    throw new InvalidOperationException(
+                        "Maintenance state is faulted and no recovery ledger is available. " +
+                        "Repair the state file and restart Jellyfin before changing account policies.");
+                }
+
+                if (scheduledExpiry && !ScheduledRecoveryIsStillDue(state))
+                {
+                    // The old timer may have fired while an admin extension held _stateGate.
+                    // That extension owns the replacement timer; leave it intact and do not
+                    // convert a stale callback into an unconditional manual disable.
+                    _logger.LogInformation("[Maintenance] Ignoring stale scheduled recovery after the maintenance deadline changed.");
+                    return;
+                }
+
+                CancelExpiry();
+                var restoringState = CloneState(state);
+                restoringState.SchemaVersion = 2;
+                restoringState.Phase = MaintenancePhases.Restoring;
+                restoringState.IsActive = true;
+                restoringState.EndsAt = null;
+                restoringState.FailureReason = null;
+                restoringState.RecoveryAvailable = true;
+                restoringState.RecoveryPhase = null;
+                SaveState(restoringState);
+                PublishState(restoringState);
+
+                var accountIds = ParseIds(restoringState.AccountDisabledUserIds, out var invalidAccountIds);
+                var remoteIds = ParseIds(restoringState.RemoteDisabledUserIds, out var invalidRemoteIds);
+                var unresolvedIds = new HashSet<Guid>();
+                var allIds = accountIds.Union(remoteIds).ToList();
+
+                foreach (var userId in allIds)
+                {
                     try
                     {
                         var user = _userManager.GetUserById(userId);
-                        if (user == null) continue;
+                        if (user == null)
+                        {
+                            if (IsConfirmedDeleted(userId))
+                            {
+                                _logger.LogInformation("[Maintenance] Retiring deleted user {UserId} from the restore ledger.", userId);
+                            }
+                            else
+                            {
+                                unresolvedIds.Add(userId);
+                                _logger.LogWarning("[Maintenance] User {UserId} could not be resolved; retaining the restore record.", userId);
+                            }
+
+                            continue;
+                        }
 
                         var dto = _userManager.GetUserDto(user, string.Empty);
-                        if (dto.Policy == null) continue;
+                        if (dto.Policy == null)
+                        {
+                            unresolvedIds.Add(userId);
+                            _logger.LogWarning("[Maintenance] User {UserId} has no readable policy; retaining the restore record.", userId);
+                            continue;
+                        }
 
-                        if (accountSet.Contains(idStr)) dto.Policy.IsDisabled = false;
-                        if (remoteSet.Contains(idStr))  dto.Policy.EnableRemoteAccess = true;
+                        if (accountIds.Contains(userId))
+                        {
+                            dto.Policy.IsDisabled = false;
+                        }
+
+                        if (remoteIds.Contains(userId))
+                        {
+                            dto.Policy.EnableRemoteAccess = true;
+                        }
 
                         await _userManager.UpdatePolicyAsync(userId, dto.Policy).ConfigureAwait(false);
-                        _logger.LogInformation($"[Maintenance] Restored user '{user.Username}'");
+                        _logger.LogInformation("[Maintenance] Restored user '{Username}'.", user.Username);
                     }
                     catch (Exception ex)
                     {
-                        failedIds.Add(idStr);
-                        _logger.LogError($"[Maintenance] Failed to restore user {idStr}: {ex.Message}");
+                        unresolvedIds.Add(userId);
+                        _logger.LogError(ex, "[Maintenance] Failed to restore user {UserId}; retaining the restore record.", userId);
                     }
                 }
 
-                // Clear the restore records ONLY for the users we actually restored. If every restore
-                // succeeded the state is fully cleared (IsActive=false). If some threw, keep those
-                // users — and only those — in a still-active state so the next disable / a restart
-                // retries them (IsDisabled=false / EnableRemoteAccess=true is idempotent). A failed
-                // restore therefore never drops the record that would let us recover the user.
-                MaintenanceState clearedState;
-                if (failedIds.Count == 0)
+                bool hasInvalidIds = invalidAccountIds.Count > 0 || invalidRemoteIds.Count > 0;
+                if (unresolvedIds.Count > 0 || hasInvalidIds)
                 {
-                    clearedState = new MaintenanceState { IsActive = false };
-                    _logger.LogInformation("[Maintenance] Mode disabled.");
-                }
-                else
-                {
-                    clearedState = new MaintenanceState
-                    {
-                        IsActive = true,
-                        Message = state.Message,
-                        Action = state.Action,
-                        StartedAt = state.StartedAt,
-                        EndsAt = state.EndsAt,
-                        AccountDisabledUserIds = state.AccountDisabledUserIds.Where(failedIds.Contains).ToList(),
-                        RemoteDisabledUserIds = state.RemoteDisabledUserIds.Where(failedIds.Contains).ToList()
-                    };
-                    _logger.LogWarning($"[Maintenance] Mode disable incomplete: {failedIds.Count} user(s) could not be restored and stay in the restore list for a later retry.");
+                    var failedState = CreateRestoreFailedState(
+                        restoringState,
+                        restoringState.AccountDisabledUserIds.Where(id => IsUnresolved(id, unresolvedIds, invalidAccountIds)).ToList(),
+                        restoringState.RemoteDisabledUserIds.Where(id => IsUnresolved(id, unresolvedIds, invalidRemoteIds)).ToList(),
+                        "One or more maintenance account records could not be restored. Retry explicitly after correcting the user-policy fault.");
+                    PersistOutcomeOrFallback(failedState, restoringState);
+                    throw new InvalidOperationException(failedState.FailureReason);
                 }
 
-                // Persist the outcome durably. If this write fails the state stays as it was on disk
-                // (full restore list, still active) and the next disable simply restores again
-                // (idempotent), so a failure here is self-healing rather than stranding disabled
-                // accounts.
-                try
-                {
-                    SaveState(clearedState);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError($"[Maintenance] Failed to persist cleared state (restores already applied; will retry on next disable): {ex.Message}");
-                }
+                var inactiveState = CreateInactiveState();
+                PersistOutcomeOrFallback(inactiveState, restoringState);
+                _logger.LogInformation("[Maintenance] Mode disabled.");
             }
             finally
             {
@@ -283,31 +401,453 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             }
         }
 
-        private MaintenanceState LoadState()
+        private void PersistOutcomeOrFallback(MaintenanceState outcome, MaintenanceState restoringState)
         {
             try
             {
-                if (!File.Exists(_stateFilePath)) return new MaintenanceState();
-                var json = File.ReadAllText(_stateFilePath);
-                // Newtonsoft equivalent: JsonConvert.DeserializeObject<MaintenanceState>(json).
-                return JsonSerializer.Deserialize<MaintenanceState>(json, PersistedJson.ReadOptions) ?? new MaintenanceState();
+                SaveState(outcome);
+                PublishState(outcome);
+            }
+            catch (Exception outcomeException)
+            {
+                var fallback = CreateRestoreFailedState(
+                    restoringState,
+                    restoringState.AccountDisabledUserIds.ToList(),
+                    restoringState.RemoteDisabledUserIds.ToList(),
+                    "Account restoration ran, but its final durable state could not be committed. The complete recovery ledger was retained for an explicit retry.");
+                try
+                {
+                    SaveState(fallback);
+                    PublishState(fallback);
+                }
+                catch (Exception fallbackException)
+                {
+                    restoringState.FailureReason = fallback.FailureReason;
+                    PublishState(restoringState);
+                    _logger.LogCritical(
+                        fallbackException,
+                        "[Maintenance] Failed to persist both the recovery outcome and durable RestoreFailed fallback.");
+                }
+
+                throw new IOException(fallback.FailureReason, outcomeException);
+            }
+        }
+
+        private bool IsConfirmedDeleted(Guid userId)
+        {
+            try
+            {
+                // GetUserById returning null alone is not deletion proof: database/provider faults
+                // can surface the same way. A successful authoritative user enumeration that omits
+                // the id is the explicit retirement evidence.
+                return _userManager.GetUsers().All(user => user.Id != userId);
             }
             catch (Exception ex)
             {
-                _logger.LogError($"[Maintenance] Failed to load state: {ex.Message}");
-                return new MaintenanceState();
+                _logger.LogWarning(ex, "[Maintenance] Could not confirm whether missing user {UserId} was deleted.", userId);
+                return false;
+            }
+        }
+
+        private void ScheduleExpiry(MaintenanceState state)
+        {
+            lock (_timerSync)
+            {
+                _expiryTimer?.Dispose();
+                _expiryTimer = null;
+                if (!_started || _stopping || _disposed)
+                {
+                    return;
+                }
+
+                string effectivePhase = string.Equals(state.Phase, MaintenancePhases.Faulted, StringComparison.Ordinal)
+                    ? state.RecoveryPhase ?? string.Empty
+                    : state.Phase;
+                TimeSpan? due = null;
+                if (string.Equals(effectivePhase, MaintenancePhases.Restoring, StringComparison.Ordinal))
+                {
+                    due = TimeSpan.Zero;
+                }
+                else if (string.Equals(effectivePhase, MaintenancePhases.Active, StringComparison.Ordinal) && state.EndsAt.HasValue)
+                {
+                    due = state.EndsAt.Value - UtcNow();
+                    if (due < TimeSpan.Zero)
+                    {
+                        due = TimeSpan.Zero;
+                    }
+                }
+
+                if (due.HasValue)
+                {
+                    _expiryTimer = _timeProvider.CreateTimer(OnExpiryTimer, null, due.Value, Timeout.InfiniteTimeSpan);
+                }
+            }
+        }
+
+        private void CancelExpiry()
+        {
+            lock (_timerSync)
+            {
+                _expiryTimer?.Dispose();
+                _expiryTimer = null;
+            }
+        }
+
+        private void OnExpiryTimer(object? state)
+        {
+            lock (_timerSync)
+            {
+                _expiryTimer?.Dispose();
+                _expiryTimer = null;
+                if (_stopping || _disposed || !_backgroundRestoreTask.IsCompleted)
+                {
+                    return;
+                }
+
+                _backgroundRestoreTask = RunScheduledRestoreAsync();
+            }
+        }
+
+        private async Task RunScheduledRestoreAsync()
+        {
+            try
+            {
+                await DisableCoreAsync(scheduledExpiry: true).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // There is deliberately no automatic retry loop. RestoreFailed is durable and an
+                // admin can retry explicitly after fixing the underlying policy/persistence fault.
+                _logger.LogError(ex, "[Maintenance] Scheduled recovery stopped; no automatic retry will be queued.");
+            }
+        }
+
+        private bool ScheduledRecoveryIsStillDue(MaintenanceState state)
+        {
+            string effectivePhase = string.Equals(state.Phase, MaintenancePhases.Faulted, StringComparison.Ordinal)
+                ? state.RecoveryPhase ?? string.Empty
+                : state.Phase;
+            if (string.Equals(effectivePhase, MaintenancePhases.Restoring, StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            return string.Equals(effectivePhase, MaintenancePhases.Active, StringComparison.Ordinal) &&
+                state.EndsAt.HasValue &&
+                UtcNow() >= state.EndsAt.Value;
+        }
+
+        private MaintenanceState LoadInitialState()
+        {
+            var primary = TryReadState(_stateFilePath);
+            if (primary.State != null)
+            {
+                TryRefreshRecoverySnapshot(primary.State);
+                return primary.State;
+            }
+
+            var recovery = TryReadState(_recoveryFilePath);
+            if (recovery.State != null)
+            {
+                var recovered = CloneState(recovery.State);
+                recovered.Phase = MaintenancePhases.Faulted;
+                recovered.IsActive = true;
+                recovered.FailureReason =
+                    "The primary maintenance state is unreadable. A last-known-good recovery ledger is available; disable maintenance to restore it, or repair the primary file and restart Jellyfin.";
+                recovered.RecoveryAvailable = true;
+                recovered.RecoveryPhase = recovery.State.Phase;
+                _logger.LogError(
+                    "[Maintenance] Primary state could not be read ({PrimaryFailure}); using the recovery ledger in Faulted state.",
+                    primary.Failure ?? "missing");
+                return recovered;
+            }
+
+            if (!primary.ArtifactExists && !recovery.ArtifactExists)
+            {
+                return CreateInactiveState();
+            }
+
+            _logger.LogCritical(
+                "[Maintenance] Neither the primary state nor its recovery snapshot is readable. Account recovery is blocked until the files are repaired.");
+            return new MaintenanceState
+            {
+                SchemaVersion = 2,
+                Phase = MaintenancePhases.Faulted,
+                IsActive = true,
+                FailureReason =
+                    "Maintenance state is unreadable and no valid recovery ledger is available. Repair the state files and restart Jellyfin; account mutation is blocked.",
+                RecoveryAvailable = false
+            };
+        }
+
+        private StateReadResult TryReadState(string path)
+        {
+            bool artifactExists = File.Exists(path) || Directory.Exists(path);
+            if (!artifactExists)
+            {
+                return new StateReadResult(null, false, "missing");
+            }
+
+            try
+            {
+                var json = File.ReadAllText(path);
+                using var document = JsonDocument.Parse(json, PersistedJson.ParseOptions);
+                if (document.RootElement.ValueKind != JsonValueKind.Object)
+                {
+                    throw new InvalidDataException("The maintenance state root is not an object.");
+                }
+
+                ValidatePersistedShape(document.RootElement);
+                var state = JsonSerializer.Deserialize<MaintenanceState>(json, PersistedJson.ReadOptions)
+                    ?? throw new InvalidDataException("The maintenance state is empty.");
+                if (HasProperty(document.RootElement, nameof(MaintenanceState.SchemaVersion)) && state.SchemaVersion != 2)
+                {
+                    throw new InvalidDataException($"Unsupported maintenance state schema version {state.SchemaVersion}.");
+                }
+
+                if (HasProperty(document.RootElement, nameof(MaintenanceState.Phase)))
+                {
+                    bool phaseIsInactive = string.Equals(state.Phase, MaintenancePhases.Inactive, StringComparison.Ordinal);
+                    if (phaseIsInactive == state.IsActive)
+                    {
+                        throw new InvalidDataException("The persisted maintenance phase and IsActive flag disagree.");
+                    }
+                }
+
+                NormalizeAndValidateState(state);
+                return new StateReadResult(state, true, null);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "[Maintenance] Failed to load state artifact {StateArtifact}.", Path.GetFileName(path));
+                return new StateReadResult(null, true, ex.GetType().Name);
+            }
+        }
+
+        private void TryRefreshRecoverySnapshot(MaintenanceState state)
+        {
+            try
+            {
+                var json = JsonSerializer.Serialize(state, PersistedJson.WriteOptions);
+                _writeAllText(_recoveryFilePath, json);
+            }
+            catch (Exception ex)
+            {
+                // The next state mutation writes recovery first and therefore fails closed. A
+                // readable primary remains truthful in the meantime.
+                _logger.LogError(ex, "[Maintenance] Could not refresh the recovery snapshot; future mutations will fail closed.");
             }
         }
 
         private void SaveState(MaintenanceState state)
         {
-            // Intentionally does NOT swallow write failures. The enable path persists the restore
-            // intent BEFORE mutating accounts and must be able to abort the whole transition when
-            // the save fails — a lost state save would otherwise strand disabled users with no
-            // restore list. Callers that can tolerate a save failure (the disable-path final clear)
-            // catch this explicitly.
-            // Newtonsoft equivalent: JsonConvert.SerializeObject(state, Formatting.Indented).
-            AtomicFile.WriteAllText(_stateFilePath, JsonSerializer.Serialize(state, PersistedJson.WriteOptions));
+            NormalizeAndValidateState(state);
+            var json = JsonSerializer.Serialize(state, PersistedJson.WriteOptions);
+            // Recovery first, primary second. If either write fails, callers do not publish the
+            // proposed transition or begin the policy mutations it was meant to authorize.
+            _writeAllText(_recoveryFilePath, json);
+            _writeAllText(_stateFilePath, json);
         }
+
+        private void PublishState(MaintenanceState state)
+        {
+            lock (_stateSync)
+            {
+                _state = CloneState(state);
+            }
+        }
+
+        private static void NormalizeAndValidateState(MaintenanceState state)
+        {
+            state.AccountDisabledUserIds ??= new List<string>();
+            state.RemoteDisabledUserIds ??= new List<string>();
+            state.Message ??= string.Empty;
+            state.Action ??= "disable_accounts";
+            if (string.IsNullOrWhiteSpace(state.Phase))
+            {
+                state.Phase = state.IsActive ? MaintenancePhases.Active : MaintenancePhases.Inactive;
+            }
+
+            if (state.Phase != MaintenancePhases.Inactive &&
+                state.Phase != MaintenancePhases.Active &&
+                state.Phase != MaintenancePhases.Restoring &&
+                state.Phase != MaintenancePhases.RestoreFailed &&
+                state.Phase != MaintenancePhases.Faulted)
+            {
+                throw new InvalidDataException($"Unknown maintenance phase '{state.Phase}'.");
+            }
+
+            if (state.Phase == MaintenancePhases.Inactive)
+            {
+                if (state.AccountDisabledUserIds.Count != 0 || state.RemoteDisabledUserIds.Count != 0)
+                {
+                    throw new InvalidDataException("Inactive maintenance state cannot retain recovery records.");
+                }
+
+                state.IsActive = false;
+                state.RecoveryAvailable = false;
+                state.RecoveryPhase = null;
+            }
+            else
+            {
+                state.IsActive = true;
+                if (state.Phase != MaintenancePhases.Faulted)
+                {
+                    state.RecoveryAvailable = true;
+                    state.RecoveryPhase = null;
+                }
+            }
+
+            state.SchemaVersion = Math.Max(state.SchemaVersion, 2);
+        }
+
+        private static MaintenanceState CreateInactiveState()
+            => new()
+            {
+                SchemaVersion = 2,
+                Phase = MaintenancePhases.Inactive,
+                IsActive = false,
+                RecoveryAvailable = false
+            };
+
+        private static MaintenanceState CreateRestoreFailedState(
+            MaintenanceState source,
+            List<string> accountIds,
+            List<string> remoteIds,
+            string failureReason)
+            => new()
+            {
+                SchemaVersion = 2,
+                Phase = MaintenancePhases.RestoreFailed,
+                IsActive = true,
+                Message = source.Message,
+                Action = source.Action,
+                StartedAt = source.StartedAt,
+                EndsAt = null,
+                AccountDisabledUserIds = accountIds,
+                RemoteDisabledUserIds = remoteIds,
+                FailureReason = failureReason,
+                RecoveryAvailable = true
+            };
+
+        private static HashSet<Guid> ParseIds(IEnumerable<string> values, out HashSet<string> invalid)
+        {
+            var parsed = new HashSet<Guid>();
+            invalid = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var value in values)
+            {
+                if (Guid.TryParse(value, out var id))
+                {
+                    parsed.Add(id);
+                }
+                else
+                {
+                    invalid.Add(value);
+                }
+            }
+
+            return parsed;
+        }
+
+        private static bool IsUnresolved(string value, HashSet<Guid> unresolvedIds, HashSet<string> invalidIds)
+            => invalidIds.Contains(value) || (Guid.TryParse(value, out var id) && unresolvedIds.Contains(id));
+
+        private static bool HasProperty(JsonElement element, string name)
+            => element.EnumerateObject().Any(property => string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase));
+
+        private static void ValidatePersistedShape(JsonElement element)
+        {
+            string[] legacyRequired =
+            {
+                nameof(MaintenanceState.IsActive),
+                nameof(MaintenanceState.Message),
+                nameof(MaintenanceState.Action),
+                nameof(MaintenanceState.StartedAt),
+                nameof(MaintenanceState.EndsAt),
+                nameof(MaintenanceState.AccountDisabledUserIds),
+                nameof(MaintenanceState.RemoteDisabledUserIds)
+            };
+            foreach (var property in legacyRequired)
+            {
+                if (!HasProperty(element, property))
+                {
+                    throw new InvalidDataException($"The maintenance state is missing required property '{property}'.");
+                }
+            }
+
+            if (GetProperty(element, nameof(MaintenanceState.AccountDisabledUserIds)).ValueKind != JsonValueKind.Array ||
+                GetProperty(element, nameof(MaintenanceState.RemoteDisabledUserIds)).ValueKind != JsonValueKind.Array)
+            {
+                throw new InvalidDataException("Maintenance recovery ledgers must be JSON arrays.");
+            }
+
+            bool versioned = HasProperty(element, nameof(MaintenanceState.SchemaVersion));
+            string[] versionedRequired =
+            {
+                nameof(MaintenanceState.Phase),
+                nameof(MaintenanceState.FailureReason),
+                nameof(MaintenanceState.RecoveryAvailable),
+                nameof(MaintenanceState.RecoveryPhase)
+            };
+            if (versioned && versionedRequired.Any(property => !HasProperty(element, property)))
+            {
+                throw new InvalidDataException("The versioned maintenance state is incomplete.");
+            }
+        }
+
+        private static JsonElement GetProperty(JsonElement element, string name)
+        {
+            foreach (var property in element.EnumerateObject())
+            {
+                if (string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase))
+                {
+                    return property.Value;
+                }
+            }
+
+            throw new InvalidDataException($"The maintenance state is missing required property '{name}'.");
+        }
+
+        private static MaintenanceState CloneState(MaintenanceState state)
+            => new()
+            {
+                SchemaVersion = state.SchemaVersion,
+                Phase = state.Phase,
+                IsActive = state.IsActive,
+                Message = state.Message,
+                Action = state.Action,
+                StartedAt = state.StartedAt,
+                EndsAt = state.EndsAt,
+                AccountDisabledUserIds = state.AccountDisabledUserIds.ToList(),
+                RemoteDisabledUserIds = state.RemoteDisabledUserIds.ToList(),
+                FailureReason = state.FailureReason,
+                RecoveryAvailable = state.RecoveryAvailable,
+                RecoveryPhase = state.RecoveryPhase
+            };
+
+        private DateTime UtcNow() => _timeProvider.GetUtcNow().UtcDateTime;
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            lock (_timerSync)
+            {
+                _disposed = true;
+                _stopping = true;
+                _expiryTimer?.Dispose();
+                _expiryTimer = null;
+            }
+
+            // SemaphoreSlim has no unmanaged resource. Do not dispose it here: if host shutdown
+            // cancellation stopped waiting in StopAsync, an already-durable recovery transition
+            // may still need to release the gate and finish safely in the background.
+            GC.SuppressFinalize(this);
+        }
+
+        private sealed record StateReadResult(MaintenanceState? State, bool ArtifactExists, string? Failure);
     }
 }


### PR DESCRIPTION
## What changed

- model maintenance recovery as explicit durable `Inactive`, `Active`, `Restoring`, `RestoreFailed`, and `Faulted` phases
- preserve a recovery snapshot beside the primary state and fail closed on corrupt or truncated JSON
- run duration expiry from a hosted timer independently of status polling, with single-flight restoration and extension-safe scheduling
- retain unresolved users while retiring only users proven deleted by an authoritative enumeration
- expose truthful structured maintenance status and safe 409/503 controller responses
- add focused corruption, restart, persistence-failure, concurrency, timer, shutdown, and controller regressions

## Why

The old implementation could translate unreadable state into clean inactivity, strand disabled accounts, report expiry before restoration completed, and rely on an administrator polling status to trigger expiry. It also discarded some unresolved restore records.

The durable state and its recovery ledger are now the source of truth. Recovery stays observable and retryable until account restoration and the final state write both succeed.

Fixes #70

## Validation

- Debug build: 0 warnings, 0 errors
- focused maintenance tests: 15/15
- full Debug server tests: 1,211/1,211
- full Release server tests with coverage: 1,211/1,211
- coverage check: 58.68% lines (threshold 16%)
- client tests: 136 files, 799 tests
- script tests: 145/145
- typecheck, source typecheck, syntax, translations, targeted format verification, and diff check
- lint: 0 errors (pre-existing advisory warnings only)
- Jellyfin 12.0.0-rc2 Docker runtime proof at the official 2-CPU quota: maintenance blocked the selected account, expired with no status polling, restored authentication, and persisted both primary and recovery snapshots as `Inactive`
- two independent Fable-low reviews; final review approved with no blocker or high-severity findings

During validation, a separate client-test teardown race was reproduced and tracked as #236.
