### PR TITLE
Enforce the public release catalog contract

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -350,6 +350,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -361,4 +363,23 @@ jobs:
       # No dependencies needed; the validator is a self-contained Node script.
       - name: Validate manifest.json
         run: node scripts/release/validate-manifest.js manifest.json
+
+      # Syntax and checksum shape are not enough: Jellyfin has no GitHub
+      # credentials, so each new or changed asset must work anonymously.
+      # Frozen history stays out of unrelated PRs' live-network dependency.
+      - name: Verify public catalog and release assets
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          args=(
+            manifest.json
+            --manifest-url
+            https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/main/manifest.json
+          )
+          if [[ "$BASE_SHA" =~ ^[0-9a-f]{40}$ ]] \
+              && git cat-file -e "${BASE_SHA}:manifest.json" 2>/dev/null; then
+            git show "${BASE_SHA}:manifest.json" > "$RUNNER_TEMP/base-manifest.json"
+            args+=(--base-manifest "$RUNNER_TEMP/base-manifest.json")
+          fi
+          node scripts/release/verify-manifest-remote.js "${args[@]}"
 # Registered for Jellyfin Canopy CI (no functional change).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,9 @@ name: Release
 #      naming of the existing release assets),
 #   4. creates the GitHub Release (or attaches assets to a pre-drafted one,
 #      reusing its body as the changelog),
-#   5. regenerates manifest.json via scripts/release/update-manifest.js
+#   5. regenerates manifest.json via scripts/release/update-manifest.js,
+#      publishes the release asset, then proves the catalog and exact ZIP are
+#      anonymously downloadable/checksum-valid before opening the manifest PR
 #      (MD5 checksums from the real ZIPs, monotonic version guard) and opens
 #      a PR with the change — manifest.json is never pushed directly.
 #
@@ -118,6 +120,12 @@ jobs:
       - name: Validate current manifest
         run: node scripts/release/validate-manifest.js manifest.json
 
+      - name: Verify current public catalog
+        run: >-
+          node scripts/release/verify-manifest-remote.js manifest.json
+          --manifest-url
+          https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/main/manifest.json
+
       # ---- Build & package. The tag is the single source of truth for ----
       # ---- the version: it is stamped into the assemblies at build    ----
       # ---- time, never committed back into the csproj.                ----
@@ -173,6 +181,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          cp manifest.json "$RUNNER_TEMP/manifest-before-release.json"
           node scripts/release/update-manifest.js \
             --manifest manifest.json \
             --tag "$GITHUB_REF_NAME" \
@@ -206,6 +215,17 @@ jobs:
               --title "v$VERSION" \
               --notes-file changelog.txt
           fi
+
+      # A published GitHub release can still be unreachable to Jellyfin when
+      # the repository is private, the asset path is wrong, or GitHub redirects
+      # anonymous callers to authentication. Do not even open the manifest PR
+      # until the exact newly generated sourceUrl passes the public contract.
+      - name: Verify anonymous catalog contract before manifest PR
+        run: >-
+          node scripts/release/verify-manifest-remote.js manifest.json
+          --base-manifest "$RUNNER_TEMP/manifest-before-release.json"
+          --manifest-url
+          https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/main/manifest.json
 
       # The manifest lands via PR, not a direct push: a human reviews the
       # generated entry before every installed plugin starts seeing it.

--- a/Jellyfin.Plugin.JellyfinCanopy/src/test/build-scripts.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/test/build-scripts.test.ts
@@ -10,6 +10,7 @@
 import * as ts from 'typescript';
 import { afterAll, describe, expect, it } from 'vitest';
 import { verifyChecksums } from '../../../scripts/release/validate-manifest.js';
+import { writeZipFixture } from '../../../scripts/lib/zip-test-fixture.js';
 import { measurePackage } from '../../../scripts/check-dotnet-coverage.js';
 
 // Repo-root-relative temp dir. `tmp/` is gitignored, so leftovers never dirty
@@ -21,14 +22,13 @@ const REPO_ROOT = TEST_FILE_PATH.replace(
 );
 const TMP_DIR = REPO_ROOT + 'tmp';
 
-// content 'jc-checksum-fixture' → this uppercase MD5 (verified out-of-band).
-const FIXTURE_CONTENT = 'jc-checksum-fixture';
-const FIXTURE_MD5 = '6B369C7C96C67731E9AEC5E6157D1CF9';
 const FIXTURE_ZIP = 'jc-checksum-fixture.zip';
 const FIXTURE_PATH = `${TMP_DIR}/${FIXTURE_ZIP}`;
 
 if (!ts.sys.directoryExists(TMP_DIR)) ts.sys.createDirectory(TMP_DIR);
-ts.sys.writeFile(FIXTURE_PATH, FIXTURE_CONTENT);
+const FIXTURE_MD5 = writeZipFixture(FIXTURE_PATH, [
+    { name: 'JellyfinCanopy.dll', data: 'jc-checksum-fixture' },
+]);
 
 afterAll(() => {
     if (ts.sys.fileExists(FIXTURE_PATH)) ts.sys.deleteFile?.(FIXTURE_PATH);

--- a/scripts/lib/zip-layout.js
+++ b/scripts/lib/zip-layout.js
@@ -1,0 +1,178 @@
+'use strict';
+
+// @ts-check
+
+const zlib = require('node:zlib');
+
+const MAX_UNCOMPRESSED_DLL_BYTES = 128 * 1024 * 1024;
+
+/** @param {Buffer} bytes */
+function crc32(bytes) {
+    let crc = 0xffffffff;
+    for (const byte of bytes) {
+        crc ^= byte;
+        for (let bit = 0; bit < 8; bit++) {
+            crc = (crc >>> 1) ^ ((crc & 1) ? 0xedb88320 : 0);
+        }
+    }
+    return (crc ^ 0xffffffff) >>> 0;
+}
+
+/**
+ * Derives the assembly filename from the release ZIP convention.
+ * @param {string} zipName
+ * @param {string} targetAbi
+ * @returns {string | null}
+ */
+function expectedDllFromZipName(zipName, targetAbi) {
+    const abi = targetAbi.split('.').slice(0, 3).join('.');
+    const suffix = `_${abi}.zip`;
+    return abi && zipName.endsWith(suffix)
+        ? `${zipName.slice(0, -suffix.length)}.dll`
+        : null;
+}
+
+/**
+ * Reads a ZIP central directory without extracting untrusted content and
+ * enforces Jellyfin's plugin-package contract: exactly one DLL at the root.
+ * @param {Buffer} bytes
+ * @param {string | null} [expectedDll]
+ * @returns {{ok: boolean, entries: string[], error?: string}}
+ */
+function inspectZipLayout(bytes, expectedDll = null) {
+    const eocdSignature = 0x06054b50;
+    const centralSignature = 0x02014b50;
+    const minimumEocd = 22;
+    const searchStart = Math.max(0, bytes.length - 65_557);
+    let eocd = -1;
+
+    for (let offset = bytes.length - minimumEocd; offset >= searchStart; offset--) {
+        if (bytes.readUInt32LE(offset) === eocdSignature) {
+            eocd = offset;
+            break;
+        }
+    }
+    if (eocd < 0) return { ok: false, entries: [], error: 'not a readable ZIP (EOCD missing)' };
+
+    const disk = bytes.readUInt16LE(eocd + 4);
+    const centralDisk = bytes.readUInt16LE(eocd + 6);
+    const entriesOnDisk = bytes.readUInt16LE(eocd + 8);
+    const entryCount = bytes.readUInt16LE(eocd + 10);
+    const centralSize = bytes.readUInt32LE(eocd + 12);
+    const centralOffset = bytes.readUInt32LE(eocd + 16);
+    const commentLength = bytes.readUInt16LE(eocd + 20);
+    if (eocd + minimumEocd + commentLength !== bytes.length) {
+        return { ok: false, entries: [], error: 'ZIP end record does not match the file length' };
+    }
+    if (disk !== 0 || centralDisk !== 0 || entriesOnDisk !== entryCount) {
+        return { ok: false, entries: [], error: 'multi-disk ZIPs are not supported' };
+    }
+    if (entryCount === 0 || entryCount === 0xffff
+        || centralSize === 0xffffffff || centralOffset === 0xffffffff) {
+        return { ok: false, entries: [], error: 'empty or ZIP64 package is not allowed' };
+    }
+    if (centralOffset + centralSize > eocd || centralOffset > bytes.length) {
+        return { ok: false, entries: [], error: 'central directory is out of bounds' };
+    }
+
+    const entries = [];
+    let cursor = centralOffset;
+    for (let index = 0; index < entryCount; index++) {
+        if (cursor + 46 > bytes.length || bytes.readUInt32LE(cursor) !== centralSignature) {
+            return { ok: false, entries, error: 'central directory entry is truncated or invalid' };
+        }
+        const nameLength = bytes.readUInt16LE(cursor + 28);
+        const extraLength = bytes.readUInt16LE(cursor + 30);
+        const entryCommentLength = bytes.readUInt16LE(cursor + 32);
+        const flags = bytes.readUInt16LE(cursor + 8);
+        const compressionMethod = bytes.readUInt16LE(cursor + 10);
+        const expectedCrc = bytes.readUInt32LE(cursor + 16);
+        const compressedSize = bytes.readUInt32LE(cursor + 20);
+        const uncompressedSize = bytes.readUInt32LE(cursor + 24);
+        const localOffset = bytes.readUInt32LE(cursor + 42);
+        const next = cursor + 46 + nameLength + extraLength + entryCommentLength;
+        if (nameLength === 0 || next > bytes.length || next > centralOffset + centralSize) {
+            return { ok: false, entries, error: 'central directory filename is out of bounds' };
+        }
+        const name = bytes.subarray(cursor + 46, cursor + 46 + nameLength).toString('utf8');
+        if (name.includes('\0')) {
+            return { ok: false, entries, error: 'ZIP filename contains a NUL byte' };
+        }
+        if ((flags & 0x0001) !== 0) {
+            return { ok: false, entries, error: 'encrypted ZIP entries are not allowed' };
+        }
+        if (compressionMethod !== 0 && compressionMethod !== 8) {
+            return { ok: false, entries, error: `unsupported ZIP compression method ${compressionMethod}` };
+        }
+        if (uncompressedSize > MAX_UNCOMPRESSED_DLL_BYTES) {
+            return {
+                ok: false,
+                entries,
+                error: `uncompressed DLL exceeds ${MAX_UNCOMPRESSED_DLL_BYTES} bytes`,
+            };
+        }
+        if (localOffset + 30 > centralOffset || bytes.readUInt32LE(localOffset) !== 0x04034b50) {
+            return { ok: false, entries, error: 'local ZIP header is missing or out of bounds' };
+        }
+        const localNameLength = bytes.readUInt16LE(localOffset + 26);
+        const localExtraLength = bytes.readUInt16LE(localOffset + 28);
+        const localMethod = bytes.readUInt16LE(localOffset + 8);
+        const dataOffset = localOffset + 30 + localNameLength + localExtraLength;
+        if (dataOffset + compressedSize > centralOffset) {
+            return { ok: false, entries, error: 'compressed ZIP data is out of bounds' };
+        }
+        const localName = bytes.subarray(localOffset + 30, localOffset + 30 + localNameLength).toString('utf8');
+        if (localName !== name) {
+            return { ok: false, entries, error: 'local and central ZIP filenames disagree' };
+        }
+        if (localMethod !== compressionMethod) {
+            return { ok: false, entries, error: 'local and central ZIP compression methods disagree' };
+        }
+        const compressed = bytes.subarray(dataOffset, dataOffset + compressedSize);
+        let uncompressed;
+        try {
+            uncompressed = compressionMethod === 0
+                ? compressed
+                : zlib.inflateRawSync(compressed, { maxOutputLength: MAX_UNCOMPRESSED_DLL_BYTES });
+        } catch (error) {
+            return {
+                ok: false,
+                entries,
+                error: `DLL data cannot be decompressed: ${error instanceof Error ? error.message : String(error)}`,
+            };
+        }
+        if (uncompressed.length !== uncompressedSize) {
+            return { ok: false, entries, error: 'uncompressed DLL size does not match the ZIP directory' };
+        }
+        if (crc32(uncompressed) !== expectedCrc) {
+            return { ok: false, entries, error: 'DLL CRC does not match the ZIP directory' };
+        }
+        entries.push(name);
+        cursor = next;
+    }
+    if (cursor !== centralOffset + centralSize) {
+        return { ok: false, entries, error: 'central directory size does not match its entries' };
+    }
+
+    const exactRootDll = entries.length === 1
+        && !entries[0].includes('/')
+        && !entries[0].includes('\\')
+        && /^[^/\\]+\.dll$/i.test(entries[0]);
+    if (!exactRootDll) {
+        return {
+            ok: false,
+            entries,
+            error: `expected exactly one root DLL, found: ${entries.join(', ') || '(none)'}`,
+        };
+    }
+    if (expectedDll !== null && entries[0] !== expectedDll) {
+        return {
+            ok: false,
+            entries,
+            error: `expected root DLL ${expectedDll}, found ${entries[0]}`,
+        };
+    }
+    return { ok: true, entries };
+}
+
+module.exports = { expectedDllFromZipName, inspectZipLayout };

--- a/scripts/lib/zip-test-fixture.d.ts
+++ b/scripts/lib/zip-test-fixture.d.ts
@@ -1,0 +1,9 @@
+// Type surface for the zero-dependency ZIP fixture helper used by both Node
+// and strict TypeScript test suites.
+
+export interface ZipFixtureFile {
+    name: string;
+    data?: string;
+}
+
+export function writeZipFixture(fixturePath: string, files: ZipFixtureFile[]): string;

--- a/scripts/lib/zip-test-fixture.js
+++ b/scripts/lib/zip-test-fixture.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+
+/** @param {Buffer} bytes */
+function crc32(bytes) {
+    let crc = 0xffffffff;
+    for (const byte of bytes) {
+        crc ^= byte;
+        for (let bit = 0; bit < 8; bit++) {
+            crc = (crc >>> 1) ^ ((crc & 1) ? 0xedb88320 : 0);
+        }
+    }
+    return (crc ^ 0xffffffff) >>> 0;
+}
+
+/**
+ * Builds a small, standards-compliant stored ZIP without external tools.
+ * @param {{name: string, data?: string | Buffer}[]} files
+ */
+function makeZip(files) {
+    const locals = [];
+    const centrals = [];
+    let offset = 0;
+
+    for (const file of files) {
+        const name = Buffer.from(file.name, 'utf8');
+        const data = Buffer.from(file.data || 'fixture');
+        const checksum = crc32(data);
+
+        const local = Buffer.alloc(30);
+        local.writeUInt32LE(0x04034b50, 0);
+        local.writeUInt16LE(20, 4);
+        local.writeUInt16LE(0x0800, 6);
+        local.writeUInt16LE(0, 8);
+        local.writeUInt32LE(checksum, 14);
+        local.writeUInt32LE(data.length, 18);
+        local.writeUInt32LE(data.length, 22);
+        local.writeUInt16LE(name.length, 26);
+        locals.push(local, name, data);
+
+        const central = Buffer.alloc(46);
+        central.writeUInt32LE(0x02014b50, 0);
+        central.writeUInt16LE(20, 4);
+        central.writeUInt16LE(20, 6);
+        central.writeUInt16LE(0x0800, 8);
+        central.writeUInt16LE(0, 10);
+        central.writeUInt32LE(checksum, 16);
+        central.writeUInt32LE(data.length, 20);
+        central.writeUInt32LE(data.length, 24);
+        central.writeUInt16LE(name.length, 28);
+        central.writeUInt32LE(offset, 42);
+        centrals.push(central, name);
+        offset += local.length + name.length + data.length;
+    }
+
+    const centralBytes = Buffer.concat(centrals);
+    const eocd = Buffer.alloc(22);
+    eocd.writeUInt32LE(0x06054b50, 0);
+    eocd.writeUInt16LE(files.length, 8);
+    eocd.writeUInt16LE(files.length, 10);
+    eocd.writeUInt32LE(centralBytes.length, 12);
+    eocd.writeUInt32LE(offset, 16);
+    return Buffer.concat([...locals, centralBytes, eocd]);
+}
+
+/** @param {Buffer} bytes */
+function checksum(bytes) {
+    return crypto.createHash('md5').update(bytes).digest('hex').toUpperCase();
+}
+
+/**
+ * @param {string} fixturePath
+ * @param {{name: string, data?: string | Buffer}[]} files
+ */
+function writeZipFixture(fixturePath, files) {
+    const bytes = makeZip(files);
+    fs.writeFileSync(fixturePath, bytes);
+    return checksum(bytes);
+}
+
+module.exports = { checksum, makeZip, writeZipFixture };

--- a/scripts/release/validate-manifest.js
+++ b/scripts/release/validate-manifest.js
@@ -34,10 +34,10 @@
  *   node scripts/release/validate-manifest.js [path/to/manifest.json]
  *   node scripts/release/validate-manifest.js manifest.json --assets-dir dist
  *
- * With --assets-dir the checksum of every entry whose zip is present under that
- * directory is re-verified against the actual bytes (checksum CORRECTNESS, not
- * just format); entries without a local asset are skipped. Without the flag the
- * run is format-only (the CI-on-PR path, where the zips aren't present).
+ * With --assets-dir each newly built zip is matched to the newest manifest
+ * entry carrying its stable per-ABI filename, then its checksum and exact
+ * one-root-DLL layout are verified. Entries without a local asset are skipped.
+ * Without the flag the run is format-only.
  *
  * Also exports validateManifest(data) and verifyChecksums(data, assetsDir) for
  * reuse by update-manifest.js and the tests.
@@ -47,6 +47,7 @@ const fs = require('fs');
 const path = require('path');
 
 const { computeZipChecksum } = require('../lib/md5.js');
+const { expectedDllFromZipName, inspectZipLayout } = require('../lib/zip-layout.js');
 
 const VERSION_RE = /^\d+\.\d+\.\d+\.\d+$/;
 const GUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -98,6 +99,10 @@ function validateManifest(data) {
         }
         if (typeof plugin.guid !== 'string' || !GUID_RE.test(plugin.guid)) {
             errors.push(`${where}: "guid" must be a UUID`);
+        }
+        if (plugin.imageUrl !== undefined
+            && (typeof plugin.imageUrl !== 'string' || !plugin.imageUrl.startsWith('https://'))) {
+            errors.push(`${where}: "imageUrl" must be an HTTPS URL when present`);
         }
         // An empty array is valid: it is the pre-first-release state of a fresh
         // repo (the release workflow prepends the first entry). Only a missing
@@ -199,12 +204,14 @@ function entryZipName(entry) {
 }
 
 /**
- * Verify each version entry's checksum against the ACTUAL asset bytes, for any
- * asset present under assetsDir. This closes the gap validateManifest leaves —
+ * Verify each newly built asset's checksum and one-root-DLL layout against the
+ * newest matching manifest entry. This closes the gap validateManifest leaves —
  * it only checks the checksum FORMAT, so a well-formed but wrong MD5 (a
  * hand-edited manifest, or a zip rebuilt after generation) would still ship and
  * brick in-app updates. Entries whose asset is not present locally (frozen
- * history; CI-on-PR has no zips) are skipped, not errored.
+ * history; CI-on-PR has no zips) are skipped, not errored. Historical entries
+ * can legitimately reuse the stable per-ABI filename at a different tag, so a
+ * local asset is checked once against the newest entry carrying that name.
  * @param {unknown} data Parsed manifest.
  * @param {string} assetsDir Directory that may hold the release zips.
  * @returns {{ errors: string[] }}
@@ -213,21 +220,35 @@ function verifyChecksums(data, assetsDir) {
     const errors = [];
     if (!Array.isArray(data)) return { errors };
 
+    // Release filenames are intentionally stable per target ABI, so multiple
+    // historical entries can point at different tags carrying the same name.
+    // dist/ contains only the newly built asset: validate it against the first
+    // (newest) matching manifest entry, never against frozen older checksums.
+    const verifiedZipNames = new Set();
+
     data.forEach((plugin, pi) => {
         if (typeof plugin !== 'object' || plugin === null || !Array.isArray(plugin.versions)) return;
         plugin.versions.forEach((entry, vi) => {
             const at = `plugin[${pi}].versions[${vi}]`;
             const zipName = entryZipName(entry);
-            if (zipName === null) return;
+            if (zipName === null || verifiedZipNames.has(zipName)) return;
 
             const assetPath = path.join(assetsDir, zipName);
             if (!fs.existsSync(assetPath)) return; // frozen history — no local asset to verify
+            verifiedZipNames.add(zipName);
 
             const actual = computeZipChecksum(assetPath);
             if (typeof entry.checksum === 'string' && entry.checksum.toUpperCase() !== actual) {
                 errors.push(
                     `${at}: checksum ${entry.checksum} does not match ${zipName} (actual ${actual})`
                 );
+            }
+            const expectedDll = typeof entry.targetAbi === 'string'
+                ? expectedDllFromZipName(zipName, entry.targetAbi)
+                : null;
+            const layout = inspectZipLayout(fs.readFileSync(assetPath), expectedDll);
+            if (!layout.ok) {
+                errors.push(`${at}: ${zipName} ${layout.error}`);
             }
         });
     });
@@ -277,7 +298,8 @@ function main() {
     const { errors, warnings } = validateManifest(data);
 
     // Opt-in: when --assets-dir is passed (the release path, after packaging),
-    // verify checksum CORRECTNESS against the actual zips, not just format.
+    // verify checksum CORRECTNESS and exact root-DLL layout against the actual
+    // new zips, not just manifest field format.
     if (assetsDir) {
         const { errors: checksumErrors } = verifyChecksums(data, assetsDir);
         errors.push(...checksumErrors);

--- a/scripts/release/verify-manifest-remote.js
+++ b/scripts/release/verify-manifest-remote.js
@@ -1,0 +1,473 @@
+#!/usr/bin/env node
+'use strict';
+
+// @ts-check
+
+/**
+ * Verifies the public, unauthenticated Jellyfin plugin-catalog contract.
+ *
+ * Local manifest validation cannot prove that Jellyfin can download an asset:
+ * private GitHub repositories return a credential-shaped 404 and draft release
+ * assets are not available at their advertised URL. This verifier deliberately
+ * sends no Authorization or Cookie header, follows only bounded public
+ * redirects, downloads each advertised ZIP with a hard byte limit, verifies its
+ * MD5, and requires an exact one-root-DLL package layout.
+ */
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const http = require('node:http');
+const https = require('node:https');
+const path = require('node:path');
+const { URL } = require('node:url');
+
+const { validateManifest } = require('./validate-manifest.js');
+const { expectedDllFromZipName, inspectZipLayout } = require('../lib/zip-layout.js');
+
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_MANIFEST_BYTES = 4 * 1024 * 1024;
+const DEFAULT_MAX_IMAGE_BYTES = 8 * 1024 * 1024;
+const DEFAULT_MAX_ASSET_BYTES = 64 * 1024 * 1024;
+const MAX_REDIRECTS = 5;
+const USER_AGENT = 'Jellyfin-Canopy-public-catalog-verifier/1.0';
+
+class RemoteVerificationError extends Error {
+    /** @param {string} message */
+    constructor(message) {
+        super(message);
+        this.name = 'RemoteVerificationError';
+    }
+}
+
+/** @param {URL} url */
+function isLoopback(url) {
+    return url.hostname === '127.0.0.1' || url.hostname === 'localhost' || url.hostname === '::1';
+}
+
+/** @param {URL} url */
+function isAuthenticationUrl(url) {
+    return /(^|\/)(?:login|signin|oauth|session)(?:\/|$)/i.test(url.pathname)
+        || /(?:^|[?&])(?:return_to|redirect_uri)=/i.test(`${url.pathname}${url.search}`);
+}
+
+/**
+ * @typedef {object} RequestOptions
+ * @property {number} [timeoutMs]
+ * @property {number} [maxBytes]
+ * @property {boolean} [allowInsecureLocalhost]
+ */
+
+/**
+ * Performs one HTTP request without credentials or automatic redirects.
+ * @param {URL} url
+ * @param {Required<RequestOptions>} options
+ * @returns {Promise<{status: number, location: string | undefined, body: Buffer}>}
+ */
+function requestOnce(url, options) {
+    return new Promise((resolve, reject) => {
+        const transport = url.protocol === 'https:' ? https : http;
+        let settled = false;
+        let deadline;
+        const fail = (error) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(deadline);
+            reject(error);
+        };
+        const succeed = (value) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(deadline);
+            resolve(value);
+        };
+
+        const request = transport.get(url, {
+            headers: {
+                Accept: 'application/json, application/zip, application/octet-stream;q=0.9, */*;q=0.1',
+                'User-Agent': USER_AGENT,
+            },
+        }, response => {
+            const status = response.statusCode || 0;
+            const location = response.headers.location;
+
+            if (REDIRECT_STATUSES.has(status)) {
+                response.resume();
+                succeed({ status, location, body: Buffer.alloc(0) });
+                return;
+            }
+            if (status !== 200) {
+                response.resume();
+                succeed({ status, location, body: Buffer.alloc(0) });
+                return;
+            }
+
+            const contentLength = Number(response.headers['content-length']);
+            if (Number.isFinite(contentLength) && contentLength > options.maxBytes) {
+                response.resume();
+                fail(new RemoteVerificationError(
+                    `response declares ${contentLength} bytes, above the ${options.maxBytes}-byte limit`
+                ));
+                return;
+            }
+
+            const chunks = [];
+            let total = 0;
+            response.on('data', chunk => {
+                total += chunk.length;
+                if (total > options.maxBytes) {
+                    request.destroy();
+                    fail(new RemoteVerificationError(
+                        `response exceeded the ${options.maxBytes}-byte limit while downloading`
+                    ));
+                    return;
+                }
+                chunks.push(chunk);
+            });
+            response.on('end', () => {
+                succeed({ status, location, body: Buffer.concat(chunks) });
+            });
+            response.on('error', fail);
+        });
+
+        // An absolute deadline, not a socket-idle timeout: a peer that trickles
+        // one byte at a time cannot hold the release gate open indefinitely.
+        deadline = setTimeout(() => {
+            request.destroy();
+            fail(new RemoteVerificationError(`request timed out after ${options.timeoutMs}ms`));
+        }, options.timeoutMs);
+        request.on('error', error => fail(new RemoteVerificationError(error.message)));
+    });
+}
+
+/**
+ * Downloads bytes through a bounded public redirect chain.
+ * @param {string} rawUrl
+ * @param {RequestOptions} [requestOptions]
+ * @returns {Promise<{body: Buffer, finalUrl: string}>}
+ */
+async function downloadPublicBytes(rawUrl, requestOptions = {}) {
+    const options = {
+        timeoutMs: requestOptions.timeoutMs || DEFAULT_TIMEOUT_MS,
+        maxBytes: requestOptions.maxBytes || DEFAULT_MAX_ASSET_BYTES,
+        allowInsecureLocalhost: requestOptions.allowInsecureLocalhost || false,
+    };
+
+    let current;
+    try {
+        current = new URL(rawUrl);
+    } catch {
+        throw new RemoteVerificationError(`invalid URL: ${rawUrl}`);
+    }
+
+    for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects++) {
+        const allowedProtocol = current.protocol === 'https:'
+            || (options.allowInsecureLocalhost && current.protocol === 'http:' && isLoopback(current));
+        if (!allowedProtocol) {
+            throw new RemoteVerificationError(`refusing non-HTTPS URL: ${current.href}`);
+        }
+        if (isAuthenticationUrl(current)) {
+            throw new RemoteVerificationError(`redirected to an authentication endpoint: ${current.href}`);
+        }
+
+        const response = await requestOnce(current, options);
+        if (REDIRECT_STATUSES.has(response.status)) {
+            if (!response.location) {
+                throw new RemoteVerificationError(`HTTP ${response.status} redirect has no Location header`);
+            }
+            if (redirects === MAX_REDIRECTS) {
+                throw new RemoteVerificationError(`exceeded ${MAX_REDIRECTS} redirects`);
+            }
+            current = new URL(response.location, current);
+            continue;
+        }
+        if (response.status !== 200) {
+            throw new RemoteVerificationError(`anonymous GET returned HTTP ${response.status}`);
+        }
+        return { body: response.body, finalUrl: current.href };
+    }
+
+    throw new RemoteVerificationError('redirect limit exhausted');
+}
+
+/**
+ * @typedef {object} VerifyOptions
+ * @property {number} [timeoutMs]
+ * @property {number} [maxAssetBytes]
+ * @property {boolean} [allowInsecureLocalhost]
+ */
+
+/**
+ * Downloads and verifies every advertised sourceUrl in a parsed manifest.
+ * @param {unknown} data
+ * @param {VerifyOptions} [options]
+ * @returns {Promise<{errors: string[], verified: {at: string, url: string, bytes: number, dll: string}[]}>}
+ */
+async function verifyManifestSources(data, options = {}) {
+    const errors = [];
+    const verified = [];
+    if (!Array.isArray(data)) return { errors: ['manifest must be an array'], verified };
+
+    /** @type {Map<string, Promise<{body: Buffer, finalUrl: string}>>} */
+    const downloads = new Map();
+    for (let pluginIndex = 0; pluginIndex < data.length; pluginIndex++) {
+        const plugin = data[pluginIndex];
+        if (typeof plugin !== 'object' || plugin === null || !Array.isArray(plugin.versions)) continue;
+        for (let versionIndex = 0; versionIndex < plugin.versions.length; versionIndex++) {
+            const entry = plugin.versions[versionIndex];
+            const at = `plugin[${pluginIndex}].versions[${versionIndex}]`;
+            if (typeof entry !== 'object' || entry === null || typeof entry.sourceUrl !== 'string') continue;
+            try {
+                let pending = downloads.get(entry.sourceUrl);
+                if (!pending) {
+                    pending = downloadPublicBytes(entry.sourceUrl, {
+                        timeoutMs: options.timeoutMs,
+                        maxBytes: options.maxAssetBytes || DEFAULT_MAX_ASSET_BYTES,
+                        allowInsecureLocalhost: options.allowInsecureLocalhost,
+                    });
+                    downloads.set(entry.sourceUrl, pending);
+                }
+                const { body } = await pending;
+                const checksum = crypto.createHash('md5').update(body).digest('hex').toUpperCase();
+                if (checksum !== entry.checksum) {
+                    errors.push(`${at}: downloaded checksum ${checksum} does not match ${entry.checksum}`);
+                    continue;
+                }
+                const zipName = decodeURIComponent(new URL(entry.sourceUrl).pathname.split('/').pop() || '');
+                const expectedDll = typeof entry.targetAbi === 'string'
+                    ? expectedDllFromZipName(zipName, entry.targetAbi)
+                    : null;
+                const layout = inspectZipLayout(body, expectedDll);
+                if (!layout.ok) {
+                    errors.push(`${at}: ${layout.error}`);
+                    continue;
+                }
+                verified.push({ at, url: entry.sourceUrl, bytes: body.length, dll: layout.entries[0] });
+            } catch (error) {
+                errors.push(`${at}: ${error instanceof Error ? error.message : String(error)}`);
+            }
+        }
+    }
+    return { errors, verified };
+}
+
+/** @param {Buffer} bytes */
+function hasRecognizedImageSignature(bytes) {
+    return (bytes.length >= 8 && bytes.subarray(0, 8).equals(Buffer.from('89504e470d0a1a0a', 'hex')))
+        || (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff)
+        || (bytes.length >= 6 && (bytes.subarray(0, 6).toString('ascii') === 'GIF87a'
+            || bytes.subarray(0, 6).toString('ascii') === 'GIF89a'))
+        || (bytes.length >= 12 && bytes.subarray(0, 4).toString('ascii') === 'RIFF'
+            && bytes.subarray(8, 12).toString('ascii') === 'WEBP')
+        || /^\s*<svg(?:\s|>)/i.test(bytes.subarray(0, 512).toString('utf8'));
+}
+
+/**
+ * Verifies each advertised plugin image without credentials.
+ * @param {unknown} data
+ * @param {VerifyOptions} [options]
+ * @returns {Promise<{errors: string[], verified: {at: string, url: string, bytes: number}[]}>}
+ */
+async function verifyManifestImages(data, options = {}) {
+    const errors = [];
+    const verified = [];
+    if (!Array.isArray(data)) return { errors: ['manifest must be an array'], verified };
+
+    for (let pluginIndex = 0; pluginIndex < data.length; pluginIndex++) {
+        const plugin = data[pluginIndex];
+        if (typeof plugin !== 'object' || plugin === null || typeof plugin.imageUrl !== 'string') continue;
+        const at = `plugin[${pluginIndex}].imageUrl`;
+        try {
+            const { body } = await downloadPublicBytes(plugin.imageUrl, {
+                timeoutMs: options.timeoutMs,
+                maxBytes: options.maxAssetBytes || DEFAULT_MAX_IMAGE_BYTES,
+                allowInsecureLocalhost: options.allowInsecureLocalhost,
+            });
+            if (!hasRecognizedImageSignature(body)) {
+                errors.push(`${at}: downloaded bytes are not a recognized PNG, JPEG, GIF, WebP, or SVG image`);
+                continue;
+            }
+            verified.push({ at, url: plugin.imageUrl, bytes: body.length });
+        } catch (error) {
+            errors.push(`${at}: ${error instanceof Error ? error.message : String(error)}`);
+        }
+    }
+    return { errors, verified };
+}
+
+/**
+ * Selects entries whose public bytes contract is new or changed relative to a
+ * base manifest. Frozen historical entries stay locally shape-validated but do
+ * not add live-network dependencies to every unrelated pull request.
+ * @param {unknown} data
+ * @param {unknown} baseData
+ * @returns {unknown}
+ */
+function selectChangedEntries(data, baseData) {
+    if (!Array.isArray(data) || !Array.isArray(baseData)) return data;
+
+    const baseEntries = new Map();
+    const basePlugins = new Map();
+    for (const plugin of baseData) {
+        if (typeof plugin !== 'object' || plugin === null || !Array.isArray(plugin.versions)) continue;
+        basePlugins.set(plugin.guid, plugin);
+        for (const entry of plugin.versions) {
+            if (typeof entry !== 'object' || entry === null) continue;
+            const key = `${plugin.guid}|${entry.version}|${entry.targetAbi}`;
+            baseEntries.set(key, `${entry.sourceUrl}|${entry.checksum}`);
+        }
+    }
+
+    return data.map(plugin => {
+        if (typeof plugin !== 'object' || plugin === null || !Array.isArray(plugin.versions)) return plugin;
+        const selected = {
+            ...plugin,
+            versions: plugin.versions.filter(entry => {
+                if (typeof entry !== 'object' || entry === null) return true;
+                const key = `${plugin.guid}|${entry.version}|${entry.targetAbi}`;
+                return baseEntries.get(key) !== `${entry.sourceUrl}|${entry.checksum}`;
+            }),
+        };
+        const basePlugin = basePlugins.get(plugin.guid);
+        if (basePlugin && basePlugin.imageUrl === plugin.imageUrl) delete selected.imageUrl;
+        return selected;
+    });
+}
+
+/**
+ * Proves that the documented catalog itself is anonymously readable and valid.
+ * @param {string} manifestUrl
+ * @param {RequestOptions} [options]
+ * @returns {Promise<{errors: string[], entryCount: number}>}
+ */
+async function verifyManifestEndpoint(manifestUrl, options = {}) {
+    try {
+        const { body } = await downloadPublicBytes(manifestUrl, {
+            ...options,
+            maxBytes: options.maxBytes || DEFAULT_MAX_MANIFEST_BYTES,
+        });
+        const parsed = JSON.parse(body.toString('utf8'));
+        const { errors } = validateManifest(parsed);
+        const entryCount = Array.isArray(parsed)
+            ? parsed.reduce((count, plugin) => count + (Array.isArray(plugin?.versions) ? plugin.versions.length : 0), 0)
+            : 0;
+        return { errors: errors.map(error => `public manifest: ${error}`), entryCount };
+    } catch (error) {
+        return {
+            errors: [`public manifest: ${error instanceof Error ? error.message : String(error)}`],
+            entryCount: 0,
+        };
+    }
+}
+
+/** @param {string[]} argv */
+function parseCliArgs(argv) {
+    let manifestPath = null;
+    let manifestUrl = null;
+    let baseManifestPath = null;
+    for (let index = 0; index < argv.length; index++) {
+        const argument = argv[index];
+        if (argument === '--manifest-url') {
+            manifestUrl = argv[++index];
+            if (!manifestUrl) throw new Error('--manifest-url requires a URL');
+        } else if (argument === '--base-manifest') {
+            baseManifestPath = argv[++index];
+            if (!baseManifestPath) throw new Error('--base-manifest requires a file path');
+        } else if (argument.startsWith('-')) {
+            throw new Error(`unknown option: ${argument}`);
+        } else if (manifestPath === null) {
+            manifestPath = argument;
+        } else {
+            throw new Error(`unexpected argument: ${argument}`);
+        }
+    }
+    return {
+        manifestPath: manifestPath || path.join(__dirname, '..', '..', 'manifest.json'),
+        manifestUrl,
+        baseManifestPath,
+    };
+}
+
+async function main() {
+    let options;
+    try {
+        options = parseCliArgs(process.argv.slice(2));
+    } catch (error) {
+        console.error(`error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exitCode = 1;
+        return;
+    }
+
+    let data;
+    try {
+        data = JSON.parse(fs.readFileSync(options.manifestPath, 'utf8'));
+    } catch (error) {
+        console.error(`error: cannot read ${options.manifestPath}: ${error instanceof Error ? error.message : String(error)}`);
+        process.exitCode = 1;
+        return;
+    }
+
+    const local = validateManifest(data);
+    const errors = [...local.errors];
+    let sourceData = data;
+    if (errors.length === 0 && options.baseManifestPath) {
+        try {
+            const baseData = JSON.parse(fs.readFileSync(options.baseManifestPath, 'utf8'));
+            const baseValidation = validateManifest(baseData);
+            if (baseValidation.errors.length > 0) {
+                errors.push(...baseValidation.errors.map(error => `base manifest: ${error}`));
+            } else {
+                sourceData = selectChangedEntries(data, baseData);
+            }
+        } catch (error) {
+            errors.push(`base manifest: ${error instanceof Error ? error.message : String(error)}`);
+        }
+    }
+    let publicEntries = null;
+    if (errors.length === 0 && options.manifestUrl) {
+        const endpoint = await verifyManifestEndpoint(options.manifestUrl);
+        errors.push(...endpoint.errors);
+        publicEntries = endpoint.entryCount;
+    }
+
+    let verified = [];
+    let verifiedImages = [];
+    if (errors.length === 0) {
+        const images = await verifyManifestImages(sourceData);
+        errors.push(...images.errors);
+        verifiedImages = images.verified;
+        const sources = await verifyManifestSources(sourceData);
+        errors.push(...sources.errors);
+        verified = sources.verified;
+    }
+
+    for (const error of errors) console.error(`error: ${error}`);
+    if (errors.length > 0) {
+        console.error(`\npublic catalog verification failed with ${errors.length} error(s)`);
+        process.exitCode = 1;
+        return;
+    }
+
+    const endpointSummary = publicEntries === null ? '' : `; public manifest has ${publicEntries} entries`;
+    console.log(
+        `public catalog: OK (${verified.length} source asset(s), `
+        + `${verifiedImages.length} image(s) verified${endpointSummary})`
+    );
+    for (const item of verified) {
+        console.log(`  ${item.at}: ${item.bytes} bytes, ${item.dll}`);
+    }
+}
+
+if (require.main === module) {
+    void main();
+}
+
+module.exports = {
+    RemoteVerificationError,
+    downloadPublicBytes,
+    inspectZipLayout,
+    selectChangedEntries,
+    verifyManifestImages,
+    verifyManifestEndpoint,
+    verifyManifestSources,
+};

--- a/scripts/release/verify-manifest-remote.test.js
+++ b/scripts/release/verify-manifest-remote.test.js
@@ -3,7 +3,6 @@
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const crypto = require('node:crypto');
 const fs = require('node:fs');
 const http = require('node:http');
 const os = require('node:os');
@@ -19,69 +18,7 @@ const {
     verifyManifestSources,
 } = require('./verify-manifest-remote.js');
 const { verifyChecksums } = require('./validate-manifest.js');
-
-/** @param {Buffer} bytes */
-function crc32(bytes) {
-    let crc = 0xffffffff;
-    for (const byte of bytes) {
-        crc ^= byte;
-        for (let bit = 0; bit < 8; bit++) {
-            crc = (crc >>> 1) ^ ((crc & 1) ? 0xedb88320 : 0);
-        }
-    }
-    return (crc ^ 0xffffffff) >>> 0;
-}
-
-/** Builds a small, standards-compliant stored ZIP without external tools. */
-function makeZip(files) {
-    const locals = [];
-    const centrals = [];
-    let offset = 0;
-
-    for (const file of files) {
-        const name = Buffer.from(file.name, 'utf8');
-        const data = Buffer.from(file.data || 'fixture');
-        const checksum = crc32(data);
-
-        const local = Buffer.alloc(30);
-        local.writeUInt32LE(0x04034b50, 0);
-        local.writeUInt16LE(20, 4);
-        local.writeUInt16LE(0x0800, 6);
-        local.writeUInt16LE(0, 8);
-        local.writeUInt32LE(checksum, 14);
-        local.writeUInt32LE(data.length, 18);
-        local.writeUInt32LE(data.length, 22);
-        local.writeUInt16LE(name.length, 26);
-        locals.push(local, name, data);
-
-        const central = Buffer.alloc(46);
-        central.writeUInt32LE(0x02014b50, 0);
-        central.writeUInt16LE(20, 4);
-        central.writeUInt16LE(20, 6);
-        central.writeUInt16LE(0x0800, 8);
-        central.writeUInt16LE(0, 10);
-        central.writeUInt32LE(checksum, 16);
-        central.writeUInt32LE(data.length, 20);
-        central.writeUInt32LE(data.length, 24);
-        central.writeUInt16LE(name.length, 28);
-        central.writeUInt32LE(offset, 42);
-        centrals.push(central, name);
-        offset += local.length + name.length + data.length;
-    }
-
-    const centralBytes = Buffer.concat(centrals);
-    const eocd = Buffer.alloc(22);
-    eocd.writeUInt32LE(0x06054b50, 0);
-    eocd.writeUInt16LE(files.length, 8);
-    eocd.writeUInt16LE(files.length, 10);
-    eocd.writeUInt32LE(centralBytes.length, 12);
-    eocd.writeUInt32LE(offset, 16);
-    return Buffer.concat([...locals, centralBytes, eocd]);
-}
-
-function checksum(bytes) {
-    return crypto.createHash('md5').update(bytes).digest('hex').toUpperCase();
-}
+const { checksum, makeZip } = require('../lib/zip-test-fixture.js');
 
 function manifestEntry(sourceUrl, zip, overrides = {}) {
     return {

--- a/scripts/release/verify-manifest-remote.test.js
+++ b/scripts/release/verify-manifest-remote.test.js
@@ -1,0 +1,417 @@
+#!/usr/bin/env node
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const http = require('node:http');
+const os = require('node:os');
+const path = require('node:path');
+const { clearInterval, setInterval } = require('node:timers');
+
+const {
+    downloadPublicBytes,
+    inspectZipLayout,
+    selectChangedEntries,
+    verifyManifestEndpoint,
+    verifyManifestImages,
+    verifyManifestSources,
+} = require('./verify-manifest-remote.js');
+const { verifyChecksums } = require('./validate-manifest.js');
+
+/** @param {Buffer} bytes */
+function crc32(bytes) {
+    let crc = 0xffffffff;
+    for (const byte of bytes) {
+        crc ^= byte;
+        for (let bit = 0; bit < 8; bit++) {
+            crc = (crc >>> 1) ^ ((crc & 1) ? 0xedb88320 : 0);
+        }
+    }
+    return (crc ^ 0xffffffff) >>> 0;
+}
+
+/** Builds a small, standards-compliant stored ZIP without external tools. */
+function makeZip(files) {
+    const locals = [];
+    const centrals = [];
+    let offset = 0;
+
+    for (const file of files) {
+        const name = Buffer.from(file.name, 'utf8');
+        const data = Buffer.from(file.data || 'fixture');
+        const checksum = crc32(data);
+
+        const local = Buffer.alloc(30);
+        local.writeUInt32LE(0x04034b50, 0);
+        local.writeUInt16LE(20, 4);
+        local.writeUInt16LE(0x0800, 6);
+        local.writeUInt16LE(0, 8);
+        local.writeUInt32LE(checksum, 14);
+        local.writeUInt32LE(data.length, 18);
+        local.writeUInt32LE(data.length, 22);
+        local.writeUInt16LE(name.length, 26);
+        locals.push(local, name, data);
+
+        const central = Buffer.alloc(46);
+        central.writeUInt32LE(0x02014b50, 0);
+        central.writeUInt16LE(20, 4);
+        central.writeUInt16LE(20, 6);
+        central.writeUInt16LE(0x0800, 8);
+        central.writeUInt16LE(0, 10);
+        central.writeUInt32LE(checksum, 16);
+        central.writeUInt32LE(data.length, 20);
+        central.writeUInt32LE(data.length, 24);
+        central.writeUInt16LE(name.length, 28);
+        central.writeUInt32LE(offset, 42);
+        centrals.push(central, name);
+        offset += local.length + name.length + data.length;
+    }
+
+    const centralBytes = Buffer.concat(centrals);
+    const eocd = Buffer.alloc(22);
+    eocd.writeUInt32LE(0x06054b50, 0);
+    eocd.writeUInt16LE(files.length, 8);
+    eocd.writeUInt16LE(files.length, 10);
+    eocd.writeUInt32LE(centralBytes.length, 12);
+    eocd.writeUInt32LE(offset, 16);
+    return Buffer.concat([...locals, centralBytes, eocd]);
+}
+
+function checksum(bytes) {
+    return crypto.createHash('md5').update(bytes).digest('hex').toUpperCase();
+}
+
+function manifestEntry(sourceUrl, zip, overrides = {}) {
+    return {
+        changelog: 'fixture',
+        targetAbi: '12.0.0.0',
+        version: '2.0.0.0',
+        sourceUrl,
+        checksum: checksum(zip),
+        timestamp: '2026-07-14T00:00:00',
+        ...overrides,
+    };
+}
+
+function manifestWith(entry) {
+    return [{
+        name: 'Jellyfin Canopy',
+        guid: '9ffa12bc-f4b5-406c-ab1d-d575acbeea7b',
+        versions: [entry],
+    }];
+}
+
+const goodZip = makeZip([{ name: 'Jellyfin.Plugin.JellyfinCanopy.dll', data: 'plugin' }]);
+const pngImage = Buffer.from('89504e470d0a1a0a0000000d49484452', 'hex');
+const nestedZip = makeZip([{ name: 'nested/Jellyfin.Plugin.JellyfinCanopy.dll', data: 'plugin' }]);
+const extraZip = makeZip([
+    { name: 'Jellyfin.Plugin.JellyfinCanopy.dll', data: 'plugin' },
+    { name: 'README.txt', data: 'unexpected' },
+]);
+const wrongFileZip = makeZip([{ name: 'Jellyfin.Plugin.JellyfinCanopy.txt', data: 'plugin' }]);
+const wrongDllZip = makeZip([{ name: 'Jellyfin.Plugin.SomeOtherPlugin.dll', data: 'plugin' }]);
+const corruptZip = Buffer.from(goodZip);
+const corruptDataOffset = 30 + corruptZip.readUInt16LE(26) + corruptZip.readUInt16LE(28);
+corruptZip[corruptDataOffset] ^= 0xff;
+
+let server;
+let baseUrl;
+const observedHeaders = [];
+
+test.before(async () => {
+    server = http.createServer((request, response) => {
+        observedHeaders.push(request.headers);
+        switch (request.url) {
+            case '/ok.zip':
+                response.writeHead(200, { 'Content-Length': goodZip.length });
+                response.end(goodZip);
+                break;
+            case '/nested.zip':
+                response.writeHead(200);
+                response.end(nestedZip);
+                break;
+            case '/extra.zip':
+                response.writeHead(200);
+                response.end(extraZip);
+                break;
+            case '/wrong-file.zip':
+                response.writeHead(200);
+                response.end(wrongFileZip);
+                break;
+            case '/wrong-dll/Jellyfin.Plugin.JellyfinCanopy_12.0.0.zip':
+                response.writeHead(200);
+                response.end(wrongDllZip);
+                break;
+            case '/corrupt.zip':
+                response.writeHead(200);
+                response.end(corruptZip);
+                break;
+            case '/401':
+                response.writeHead(401);
+                response.end('private');
+                break;
+            case '/403':
+                response.writeHead(403);
+                response.end('forbidden');
+                break;
+            case '/404':
+                response.writeHead(404);
+                response.end('missing');
+                break;
+            case '/auth-redirect':
+                response.writeHead(302, { Location: '/login?return_to=%2Fok.zip' });
+                response.end();
+                break;
+            case '/login?return_to=%2Fok.zip':
+                response.writeHead(200);
+                response.end('<html>sign in</html>');
+                break;
+            case '/manifest.json': {
+                const publicManifest = manifestWith(manifestEntry(
+                    'https://github.com/example/catalog/releases/download/2.0.0.0/plugin.zip',
+                    goodZip
+                ));
+                response.writeHead(200, { 'Content-Type': 'application/json' });
+                response.end(JSON.stringify(publicManifest));
+                break;
+            }
+            case '/icon.png':
+                response.writeHead(200, { 'Content-Type': 'image/png' });
+                response.end(pngImage);
+                break;
+            case '/not-image.png':
+                response.writeHead(200, { 'Content-Type': 'text/html' });
+                response.end('<html>not an image</html>');
+                break;
+            case '/manifest-private':
+                response.writeHead(404);
+                response.end('missing');
+                break;
+            case '/large':
+                response.writeHead(200, { 'Content-Length': 1024 });
+                response.end(Buffer.alloc(1024));
+                break;
+            case '/slow': {
+                response.writeHead(200);
+                const interval = setInterval(() => response.write('.'), 5);
+                request.on('close', () => clearInterval(interval));
+                break;
+            }
+            default:
+                response.writeHead(500);
+                response.end('unexpected fixture route');
+        }
+    });
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+test.after(async () => {
+    await new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
+});
+
+test('positive control downloads anonymously, verifies MD5, and accepts one root DLL', async () => {
+    observedHeaders.length = 0;
+    const manifest = manifestWith(manifestEntry(`${baseUrl}/ok.zip`, goodZip));
+    const result = await verifyManifestSources(manifest, { allowInsecureLocalhost: true });
+
+    assert.deepEqual(result.errors, []);
+    assert.equal(result.verified.length, 1);
+    assert.equal(result.verified[0].dll, 'Jellyfin.Plugin.JellyfinCanopy.dll');
+    assert.equal(observedHeaders.length, 1);
+    assert.equal(observedHeaders[0].authorization, undefined);
+    assert.equal(observedHeaders[0].cookie, undefined);
+});
+
+test('plugin image is anonymously reachable and must contain recognized image bytes', async () => {
+    observedHeaders.length = 0;
+    const valid = manifestWith(manifestEntry(`${baseUrl}/ok.zip`, goodZip));
+    valid[0].imageUrl = `${baseUrl}/icon.png`;
+    const good = await verifyManifestImages(valid, { allowInsecureLocalhost: true });
+    assert.deepEqual(good.errors, []);
+    assert.equal(good.verified.length, 1);
+    assert.equal(observedHeaders[0].authorization, undefined);
+    assert.equal(observedHeaders[0].cookie, undefined);
+
+    valid[0].imageUrl = `${baseUrl}/not-image.png`;
+    const wrong = await verifyManifestImages(valid, { allowInsecureLocalhost: true });
+    assert.match(wrong.errors.join('\n'), /not a recognized/);
+});
+
+for (const status of [401, 403, 404]) {
+    test(`HTTP ${status} blocks catalog verification`, async () => {
+        const manifest = manifestWith(manifestEntry(`${baseUrl}/${status}`, goodZip));
+        const result = await verifyManifestSources(manifest, { allowInsecureLocalhost: true });
+        assert.equal(result.verified.length, 0);
+        assert.match(result.errors.join('\n'), new RegExp(`HTTP ${status}`));
+    });
+}
+
+test('authentication redirect blocks catalog verification even when its destination returns 200', async () => {
+    const manifest = manifestWith(manifestEntry(`${baseUrl}/auth-redirect`, goodZip));
+    const result = await verifyManifestSources(manifest, { allowInsecureLocalhost: true });
+    assert.equal(result.verified.length, 0);
+    assert.match(result.errors.join('\n'), /authentication endpoint/i);
+});
+
+test('wrong advertised MD5 blocks catalog verification', async () => {
+    const manifest = manifestWith(manifestEntry(`${baseUrl}/ok.zip`, goodZip, {
+        checksum: '00000000000000000000000000000000',
+    }));
+    const result = await verifyManifestSources(manifest, { allowInsecureLocalhost: true });
+    assert.equal(result.verified.length, 0);
+    assert.match(result.errors.join('\n'), /does not match/);
+});
+
+for (const [name, route, zip] of [
+    ['nested DLL', '/nested.zip', nestedZip],
+    ['extra root file', '/extra.zip', extraZip],
+    ['wrong root extension', '/wrong-file.zip', wrongFileZip],
+]) {
+    test(`${name} blocks catalog verification`, async () => {
+        const manifest = manifestWith(manifestEntry(`${baseUrl}${route}`, zip));
+        const result = await verifyManifestSources(manifest, { allowInsecureLocalhost: true });
+        assert.equal(result.verified.length, 0);
+        assert.match(result.errors.join('\n'), /exactly one root DLL/);
+    });
+}
+
+test('a different root DLL name blocks catalog verification', async () => {
+    const manifest = manifestWith(manifestEntry(
+        `${baseUrl}/wrong-dll/Jellyfin.Plugin.JellyfinCanopy_12.0.0.zip`,
+        wrongDllZip
+    ));
+    const result = await verifyManifestSources(manifest, { allowInsecureLocalhost: true });
+    assert.equal(result.verified.length, 0);
+    assert.match(result.errors.join('\n'), /expected root DLL/);
+});
+
+test('corrupt DLL bytes fail archive integrity even when the advertised MD5 matches the ZIP', async () => {
+    const manifest = manifestWith(manifestEntry(`${baseUrl}/corrupt.zip`, corruptZip));
+    const result = await verifyManifestSources(manifest, { allowInsecureLocalhost: true });
+    assert.equal(result.verified.length, 0);
+    assert.match(result.errors.join('\n'), /CRC does not match/);
+});
+
+test('non-ZIP bytes are rejected before layout can be advertised', () => {
+    const result = inspectZipLayout(Buffer.from('not a zip'));
+    assert.equal(result.ok, false);
+    assert.match(result.error, /EOCD/);
+});
+
+test('local release validation checks a stable filename only against its newest entry', () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'jc-manifest-assets-'));
+    const zipName = 'Jellyfin.Plugin.JellyfinCanopy_12.0.0.zip';
+    try {
+        fs.writeFileSync(path.join(directory, zipName), goodZip);
+        const newest = manifestEntry(
+            `https://github.com/example/catalog/releases/download/3.0.0.0/${zipName}`,
+            goodZip,
+            { version: '3.0.0.0' }
+        );
+        const historical = manifestEntry(
+            `https://github.com/example/catalog/releases/download/2.0.0.0/${zipName}`,
+            goodZip,
+            { checksum: '00000000000000000000000000000000' }
+        );
+        const result = verifyChecksums(manifestWith(newest).map(plugin => ({
+            ...plugin,
+            versions: [newest, historical],
+        })), directory);
+        assert.deepEqual(result.errors, []);
+    } finally {
+        fs.rmSync(directory, { recursive: true, force: true });
+    }
+});
+
+test('changed-entry selection freezes history but retains new or altered source contracts', () => {
+    const oldEntry = manifestEntry('https://github.com/example/catalog/releases/download/2/old.zip', goodZip);
+    const base = manifestWith(oldEntry);
+    base[0].imageUrl = 'https://example.test/icon.png';
+    const current = manifestWith({ ...oldEntry });
+    current[0].imageUrl = base[0].imageUrl;
+    const unchanged = selectChangedEntries(current, base);
+    assert.deepEqual(unchanged[0].versions, []);
+    assert.equal(unchanged[0].imageUrl, undefined);
+
+    const changed = manifestWith({ ...oldEntry, checksum: '00000000000000000000000000000000' });
+    assert.equal(selectChangedEntries(changed, base)[0].versions.length, 1);
+
+    const addedEntry = { ...oldEntry, version: '3.0.0.0' };
+    assert.equal(selectChangedEntries(manifestWith(addedEntry), base)[0].versions.length, 1);
+
+    const changedImage = manifestWith({ ...oldEntry });
+    changedImage[0].imageUrl = 'https://example.test/new-icon.png';
+    assert.equal(selectChangedEntries(changedImage, base)[0].imageUrl, changedImage[0].imageUrl);
+});
+
+test('local release validation still rejects a wrong newest checksum', () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'jc-manifest-assets-'));
+    const zipName = 'Jellyfin.Plugin.JellyfinCanopy_12.0.0.zip';
+    try {
+        fs.writeFileSync(path.join(directory, zipName), goodZip);
+        const entry = manifestEntry(
+            `https://github.com/example/catalog/releases/download/3.0.0.0/${zipName}`,
+            goodZip,
+            { version: '3.0.0.0', checksum: '00000000000000000000000000000000' }
+        );
+        const result = verifyChecksums(manifestWith(entry), directory);
+        assert.match(result.errors.join('\n'), /does not match/);
+    } finally {
+        fs.rmSync(directory, { recursive: true, force: true });
+    }
+});
+
+test('local release validation blocks a wrong package layout before upload', () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'jc-manifest-assets-'));
+    const zipName = 'Jellyfin.Plugin.JellyfinCanopy_12.0.0.zip';
+    try {
+        fs.writeFileSync(path.join(directory, zipName), nestedZip);
+        const entry = manifestEntry(
+            `https://github.com/example/catalog/releases/download/2.0.0.0/${zipName}`,
+            nestedZip
+        );
+        const result = verifyChecksums(manifestWith(entry), directory);
+        assert.match(result.errors.join('\n'), /exactly one root DLL/);
+    } finally {
+        fs.rmSync(directory, { recursive: true, force: true });
+    }
+});
+
+test('the advertised manifest endpoint must itself return valid JSON with HTTP 200', async () => {
+    const good = await verifyManifestEndpoint(`${baseUrl}/manifest.json`, { allowInsecureLocalhost: true });
+    assert.deepEqual(good.errors, []);
+    assert.equal(good.entryCount, 1);
+
+    const missing = await verifyManifestEndpoint(`${baseUrl}/manifest-private`, {
+        allowInsecureLocalhost: true,
+    });
+    assert.match(missing.errors.join('\n'), /HTTP 404/);
+});
+
+test('download size is bounded even when the server declares a larger body', async () => {
+    await assert.rejects(
+        downloadPublicBytes(`${baseUrl}/large`, {
+            allowInsecureLocalhost: true,
+            maxBytes: 16,
+        }),
+        /above the 16-byte limit/
+    );
+});
+
+test('request timeout is an absolute deadline even while bytes keep arriving', async () => {
+    await assert.rejects(
+        downloadPublicBytes(`${baseUrl}/slow`, {
+            allowInsecureLocalhost: true,
+            timeoutMs: 30,
+        }),
+        /timed out after 30ms/
+    );
+});
+
+test('plain HTTP is rejected outside the explicit loopback test mode', async () => {
+    await assert.rejects(downloadPublicBytes(`${baseUrl}/ok.zip`), /non-HTTPS/);
+});

--- a/scripts/verify.test.js
+++ b/scripts/verify.test.js
@@ -192,6 +192,13 @@ test('CI and release share the verifier while every non-lint workflow gate stays
     assert.match(client, /npm run test:client:coverage/);
     assert.match(release, /dotnet test/);
     assert.match(release, /validate-manifest\.js/);
+    assert.match(build, /verify-manifest-remote\.js "\$\{args\[@\]\}"/);
+    assert.match(build, /args=\(\s*manifest\.json/);
+    assert.match(build, /--base-manifest/);
+    assert.match(release, /Verify current public catalog/);
+    assert.match(release, /Verify anonymous catalog contract before manifest PR/);
+    assert.equal((release.match(/verify-manifest-remote\.js manifest\.json/g) || []).length, 2);
+    assert.match(release, /--manifest-url/);
 });
 
 test('the warning cap and local policy entry points remain explicit', () => {
@@ -206,4 +213,17 @@ test('the warning cap and local policy entry points remain explicit', () => {
     assert.match(preCommit, /pass_filenames: false/);
     assert.doesNotMatch(preCommit, /mirrors-eslint/);
     assert.notEqual(fs.statSync(VERIFY).mode & 0o111, 0, 'verify.sh must be executable');
+});
+
+test('documentation and blocking workflows use the same public catalog URL', () => {
+    const catalogUrl = 'https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/main/manifest.json';
+    for (const relative of [
+        'README.md',
+        'docs/getting-started.md',
+        '.github/workflows/build.yml',
+        '.github/workflows/release.yml',
+    ]) {
+        const source = fs.readFileSync(path.join(ROOT, relative), 'utf8');
+        assert.ok(source.includes(catalogUrl), `${relative} does not use the verified public catalog URL`);
+    }
 });


### PR DESCRIPTION
## What changed

- add a credential-free remote verifier for the public manifest, plugin images, and release assets
- validate advertised MD5 checksums and exact one-root-DLL ZIP layout, including decompression, size, and CRC checks
- gate pull requests on new or changed catalog entries while keeping frozen history out of unrelated live-network checks
- gate releases after publishing the asset and before opening the generated manifest PR
- validate stable per-ABI local filenames against only the newest matching manifest entry

## Why

Jellyfin downloads catalogs and plugin assets anonymously. Shape-only manifest validation could therefore accept private, missing, authentication-redirected, corrupt, or incorrectly packaged assets. Stable release filenames also caused local validation to compare the next ZIP against frozen historical checksums.

## Validation

- `npm run test:scripts` — 167/167 passed
- `npm run syntax`
- changed-file ESLint — no findings
- local and live manifest validation, including both existing public assets
- changed-entry mode verified with zero frozen asset/image downloads
- clean Jellyfin 12 RC2 catalog install in a fresh 2-CPU container; Canopy 2.0.0 loaded Active
- independent Fable low-effort review — approved, no blocker or high findings

Fixes #75
Fixes #238