### PR TITLE
Enforce immutable release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,12 @@ name: Release
 #   3. packages the Jellyfin 12 ZIP with the DLL at the zip root
 #      (Jellyfin.Plugin.JellyfinCanopy_12.0.0.zip — the exact layout and
 #      naming of the existing release assets),
-#   4. creates the GitHub Release (or attaches assets to a pre-drafted one,
-#      reusing its body as the changelog),
-#   5. regenerates manifest.json via scripts/release/update-manifest.js,
-#      publishes the release asset, then proves the catalog and exact ZIP are
-#      anonymously downloadable/checksum-valid before opening the manifest PR
-#      (MD5 checksums from the real ZIPs, monotonic version guard) and opens
-#      a PR with the change — manifest.json is never pushed directly.
+#   4. creates or resumes an unadvertised draft and finalizes its immutable
+#      asset; an already-published tag is verified and never modified,
+#   5. generates a create-only manifest branch from the downloaded final ZIP,
+#      publishes the draft, proves the exact bytes anonymously downloadable,
+#      and opens the manifest PR. A valid rerun is a verified no-op; neither
+#      release bytes/notes nor reviewer commits are overwritten.
 #
 # New releases publish only targetAbi 12.0.0.0 manifest entries; the
 # existing 10.11.0.0 entries in manifest.json are frozen history that keeps
@@ -140,20 +139,51 @@ jobs:
             -p:AssemblyVersion="$VERSION" -p:FileVersion="$VERSION"
           # Existing release-asset layout: exactly one file, the plugin DLL
           # at the zip root, named after the targetAbi.
-          zip -j dist/Jellyfin.Plugin.JellyfinCanopy_12.0.0.zip \
-            Jellyfin.Plugin.JellyfinCanopy/bin/Release/net10.0/Jellyfin.Plugin.JellyfinCanopy.dll
+          dll=Jellyfin.Plugin.JellyfinCanopy/bin/Release/net10.0/Jellyfin.Plugin.JellyfinCanopy.dll
+          # Give repeat builds of the same tag stable ZIP metadata. Published
+          # bytes are immutable regardless; determinism is diagnostic aid only.
+          source_date_epoch="$(git log -1 --format=%ct "refs/tags/$GITHUB_REF_NAME^{commit}")"
+          touch -d "@$source_date_epoch" "$dll"
+          TZ=UTC zip -X -j dist/Jellyfin.Plugin.JellyfinCanopy_12.0.0.zip "$dll"
           ls -l dist/
+
+      # Query the REST collection once so API failures are blocking and so two
+      # manual drafts for one tag cannot be mistaken for one resumable release.
+      - name: Discover existing release metadata
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api --paginate --slurp \
+            "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
+            > "$RUNNER_TEMP/release-pages.json"
+          jq --arg tag "$GITHUB_REF_NAME" \
+            '[.[][] | select(.tag_name == $tag)]' \
+            "$RUNNER_TEMP/release-pages.json" > "$RUNNER_TEMP/tag-releases.json"
+          release_count="$(jq length "$RUNNER_TEMP/tag-releases.json")"
+          if [ "$release_count" -gt 1 ]; then
+            echo "::error::Multiple releases/drafts exist for tag $GITHUB_REF_NAME"
+            exit 1
+          fi
+          if [ "$release_count" -eq 1 ]; then
+            jq '.[0] | {
+              id,
+              isDraft: .draft,
+              tagName: .tag_name,
+              body,
+              assets: [.assets[] | { id, name }]
+            }' "$RUNNER_TEMP/tag-releases.json" > "$RUNNER_TEMP/release.json"
+          fi
 
       # Changelog precedence: a pre-drafted release body for this tag wins;
       # otherwise commit subjects since the previous tag, in the same
       # "- first\n - second" shape the manifest has always used. The text is
       # only ever passed around as a file — never through the shell.
       - name: Collect changelog
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if gh release view "$GITHUB_REF_NAME" --json body --jq .body > changelog.txt 2>/dev/null \
-              && [ -s changelog.txt ]; then
+          if [ -f "$RUNNER_TEMP/release.json" ]; then
+            jq -r '.body // ""' "$RUNNER_TEMP/release.json" > changelog.txt
+          fi
+          if [ -s changelog.txt ]; then
             echo "Using existing release body as changelog"
           else
             prev_tag="$(git describe --tags --abbrev=0 "${GITHUB_REF_NAME}^" 2>/dev/null || true)"
@@ -177,71 +207,210 @@ jobs:
             exit 1
           fi
 
-      - name: Update manifest.json
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          cp manifest.json "$RUNNER_TEMP/manifest-before-release.json"
-          node scripts/release/update-manifest.js \
-            --manifest manifest.json \
-            --tag "$GITHUB_REF_NAME" \
-            --repo "$GITHUB_REPOSITORY" \
-            --changelog-file changelog.txt \
-            --asset "12.0.0.0=dist/Jellyfin.Plugin.JellyfinCanopy_12.0.0.zip" > new-entries.json
-          node scripts/release/validate-manifest.js manifest.json --assets-dir dist
-          {
-            echo '### New manifest entries'
-            echo '````json'
-            cat new-entries.json
-            echo '````'
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Create release & attach ZIPs
+      # This is the release-state ownership boundary. It downloads any existing
+      # asset before choosing an action and fails closed when published bytes do
+      # not match main or the create-only proposal branch.
+      - name: Inspect release and manifest state
+        id: release_state
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          if gh release view "$GITHUB_REF_NAME" > /dev/null 2>&1; then
-            echo "Release for $GITHUB_REF_NAME already exists; attaching assets"
-            gh release upload "$GITHUB_REF_NAME" dist/*.zip --clobber
-            # A pre-drafted release stays a DRAFT after upload, and draft assets
-            # are not served at releases/download/<tag>/... — the URL the
-            # manifest entry points at. Publish it, or every install polling
-            # the merged manifest would hit a 404.
-            gh release edit "$GITHUB_REF_NAME" --draft=false
-          else
-            gh release create "$GITHUB_REF_NAME" dist/*.zip \
-              --verify-tag \
-              --title "v$VERSION" \
-              --notes-file changelog.txt
+          zip_name=Jellyfin.Plugin.JellyfinCanopy_12.0.0.zip
+          default_branch="$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)"
+          branch="release/manifest-$VERSION"
+
+          git fetch origin "$default_branch"
+          git show "origin/$default_branch:manifest.json" > "$RUNNER_TEMP/main-manifest.json"
+
+          args=(
+            --repo "$GITHUB_REPOSITORY"
+            --tag "$GITHUB_REF_NAME"
+            --target-abi 12.0.0.0
+            --zip-name "$zip_name"
+            --built-asset "dist/$zip_name"
+            --main-manifest "$RUNNER_TEMP/main-manifest.json"
+            --github-output "$GITHUB_OUTPUT"
+            --contract-manifest-output "$RUNNER_TEMP/existing-contract.json"
+          )
+
+          if git ls-remote --exit-code --heads origin "refs/heads/$branch" > /dev/null; then
+            git fetch origin "refs/heads/$branch:refs/remotes/origin/$branch"
+            git show "refs/remotes/origin/$branch:manifest.json" \
+              > "$RUNNER_TEMP/proposal-manifest.json"
+            args+=(--proposal-manifest "$RUNNER_TEMP/proposal-manifest.json")
           fi
 
-      # A published GitHub release can still be unreachable to Jellyfin when
-      # the repository is private, the asset path is wrong, or GitHub redirects
-      # anonymous callers to authentication. Do not even open the manifest PR
-      # until the exact newly generated sourceUrl passes the public contract.
-      - name: Verify anonymous catalog contract before manifest PR
-        run: >-
-          node scripts/release/verify-manifest-remote.js manifest.json
-          --base-manifest "$RUNNER_TEMP/manifest-before-release.json"
-          --manifest-url
-          https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/main/manifest.json
+          rejected_pr="$(gh pr list --head "$branch" --state closed --limit 100 \
+            --json number,mergedAt \
+            --jq '[.[] | select(.mergedAt == null) | .number] | join(",")')"
+          if [ -n "$rejected_pr" ]; then
+            echo "::error::Manifest branch has rejected/closed PR(s) $rejected_pr; refusing release mutation"
+            exit 1
+          fi
+
+          if [ -f "$RUNNER_TEMP/release.json" ]; then
+            args+=(--release-json "$RUNNER_TEMP/release.json")
+            asset_count="$(jq --arg name "$zip_name" \
+              '[.assets[] | select(.name == $name)] | length' "$RUNNER_TEMP/release.json")"
+            if [ "$asset_count" -gt 1 ]; then
+              echo "::error::Release contains duplicate $zip_name assets"
+              exit 1
+            fi
+            if [ "$asset_count" -eq 1 ]; then
+              mkdir -p "$RUNNER_TEMP/existing-assets"
+              gh release download "$GITHUB_REF_NAME" \
+                --pattern "$zip_name" --dir "$RUNNER_TEMP/existing-assets"
+              args+=(--remote-asset "$RUNNER_TEMP/existing-assets/$zip_name")
+            fi
+          fi
+
+          node scripts/release/release-state.js "${args[@]}"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          echo "default_branch=$default_branch" >> "$GITHUB_OUTPUT"
+
+      - name: Create or reconcile draft release asset
+        env:
+          ACTION: ${{ steps.release_state.outputs.action }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          zip_name=Jellyfin.Plugin.JellyfinCanopy_12.0.0.zip
+          require_existing_draft() {
+            current="$(gh release view "$GITHUB_REF_NAME" --json isDraft --jq .isDraft)"
+            if [ "$current" != true ]; then
+              echo "::error::Release is no longer a draft; refusing asset mutation"
+              exit 1
+            fi
+          }
+          case "$ACTION" in
+            create-draft)
+              gh release create "$GITHUB_REF_NAME" "dist/$zip_name" \
+                --draft --verify-tag --title "v$VERSION" --notes-file changelog.txt
+              ;;
+            upload-draft-asset)
+              require_existing_draft
+              gh release upload "$GITHUB_REF_NAME" "dist/$zip_name"
+              ;;
+            reuse-draft-asset|resume-draft-proposal)
+              echo "Draft already has the verified immutable asset"
+              ;;
+            replace-draft-asset)
+              # The state gate permits this only with no main/proposal contract.
+              require_existing_draft
+              gh release upload "$GITHUB_REF_NAME" "dist/$zip_name" --clobber
+              ;;
+            noop-main|resume-published-proposal)
+              echo "Published release is immutable; no release mutation"
+              ;;
+            *)
+              echo "::error::Unknown release action: $ACTION"
+              exit 1
+              ;;
+          esac
+
+      - name: Download finalized draft asset
+        if: >-
+          steps.release_state.outputs.action != 'noop-main' &&
+          steps.release_state.outputs.action != 'resume-published-proposal'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          zip_name=Jellyfin.Plugin.JellyfinCanopy_12.0.0.zip
+          mkdir -p "$RUNNER_TEMP/final-assets"
+          gh release download "$GITHUB_REF_NAME" \
+            --pattern "$zip_name" --dir "$RUNNER_TEMP/final-assets"
+          test -f "$RUNNER_TEMP/final-assets/$zip_name"
+
+      - name: Generate manifest from finalized immutable bytes
+        if: >-
+          steps.release_state.outputs.action != 'noop-main' &&
+          steps.release_state.outputs.action != 'resume-published-proposal' &&
+          steps.release_state.outputs.action != 'resume-draft-proposal'
+        run: |
+          cp "$RUNNER_TEMP/main-manifest.json" "$RUNNER_TEMP/generated-manifest.json"
+          node scripts/release/update-manifest.js \
+            --manifest "$RUNNER_TEMP/generated-manifest.json" \
+            --tag "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --changelog-file changelog.txt \
+            --asset "12.0.0.0=$RUNNER_TEMP/final-assets/Jellyfin.Plugin.JellyfinCanopy_12.0.0.zip" \
+            > "$RUNNER_TEMP/new-entries.json"
+          node scripts/release/validate-manifest.js \
+            "$RUNNER_TEMP/generated-manifest.json" --assets-dir "$RUNNER_TEMP/final-assets"
+          {
+            echo '### New manifest entries'
+            echo '````json'
+            cat "$RUNNER_TEMP/new-entries.json"
+            echo '````'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create manifest branch without overwriting reviewer commits
+        if: >-
+          steps.release_state.outputs.action != 'noop-main' &&
+          steps.release_state.outputs.action != 'resume-published-proposal' &&
+          steps.release_state.outputs.action != 'resume-draft-proposal'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+          BRANCH: ${{ steps.release_state.outputs.branch }}
+          DEFAULT_BRANCH: ${{ steps.release_state.outputs.default_branch }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch --create "$BRANCH" "origin/$DEFAULT_BRANCH"
+          cp "$RUNNER_TEMP/generated-manifest.json" manifest.json
+          git add manifest.json
+          git commit -m "chore: update manifest for $VERSION"
+          # Create-only push: a concurrent run or reviewer-owned branch wins.
+          # There is deliberately no force/lease update of an existing ref.
+          git push --force-with-lease="refs/heads/$BRANCH:" \
+            origin "HEAD:refs/heads/$BRANCH"
+
+      - name: Publish verified draft
+        if: >-
+          steps.release_state.outputs.action != 'noop-main' &&
+          steps.release_state.outputs.action != 'resume-published-proposal'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.release_state.outputs.branch }}
+        run: |
+          git ls-remote --exit-code --heads origin "refs/heads/$BRANCH" > /dev/null
+          is_draft="$(gh release view "$GITHUB_REF_NAME" --json isDraft --jq .isDraft)"
+          if [ "$is_draft" != true ]; then
+            echo "::error::Release changed state after inspection; refusing to mutate it"
+            exit 1
+          fi
+          gh release edit "$GITHUB_REF_NAME" --draft=false
+
+      - name: Verify exact immutable asset anonymously
+        env:
+          ACTION: ${{ steps.release_state.outputs.action }}
+        run: |
+          if [[ "$ACTION" == noop-main \
+              || "$ACTION" == resume-published-proposal \
+              || "$ACTION" == resume-draft-proposal ]]; then
+            manifest="$RUNNER_TEMP/existing-contract.json"
+            args=("$manifest")
+          else
+            manifest="$RUNNER_TEMP/generated-manifest.json"
+            args=("$manifest" --base-manifest "$RUNNER_TEMP/main-manifest.json")
+          fi
+          node scripts/release/verify-manifest-remote.js "${args[@]}" \
+            --manifest-url \
+            https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/main/manifest.json
 
       # The manifest lands via PR, not a direct push: a human reviews the
       # generated entry before every installed plugin starts seeing it.
       - name: Open manifest update PR
+        if: steps.release_state.outputs.action != 'noop-main'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
+          BRANCH: ${{ steps.release_state.outputs.branch }}
+          DEFAULT_BRANCH: ${{ steps.release_state.outputs.default_branch }}
         run: |
-          branch="release/manifest-$VERSION"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -B "$branch"
-          git add manifest.json
-          git commit -m "chore: update manifest for $VERSION"
-          git push --force origin "$branch"
-          default_branch="$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)"
+          git ls-remote --exit-code --heads origin "refs/heads/$BRANCH" > /dev/null
           release_url="https://github.com/$GITHUB_REPOSITORY/releases/tag/$GITHUB_REF_NAME"
           {
             echo "Automated manifest update for release [$GITHUB_REF_NAME]($release_url)."
@@ -252,13 +421,21 @@ jobs:
             echo
             echo "Merging this PR is what publishes the update to installed plugins."
           } > pr-body.md
-          if [ -z "$(gh pr list --head "$branch" --state open --json number --jq '.[].number')" ]; then
+          open_pr="$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')"
+          if [ -z "$open_pr" ]; then
             gh pr create \
-              --base "$default_branch" \
-              --head "$branch" \
+              --base "$DEFAULT_BRANCH" \
+              --head "$BRANCH" \
               --title "chore: update manifest for $VERSION" \
               --body-file pr-body.md
           else
-            echo "PR for $branch already open; branch updated"
+            echo "PR $open_pr already owns $BRANCH; leaving it unchanged"
           fi
+
+      - name: Summarize immutable rerun
+        if: steps.release_state.outputs.action == 'noop-main'
+        run: >-
+          echo "Verified existing published release, committed manifest, ZIP layout,
+          checksum, and anonymous download; rerun made no release or manifest changes."
+          >> "$GITHUB_STEP_SUMMARY"
 # Registered for Jellyfin Canopy CI (no functional change).

--- a/scripts/release/release-state.js
+++ b/scripts/release/release-state.js
@@ -1,0 +1,314 @@
+#!/usr/bin/env node
+'use strict';
+
+// @ts-check
+
+/**
+ * Classifies an existing GitHub release before the workflow is allowed to
+ * mutate it. Published assets are immutable. A draft may be completed or
+ * replaced only while neither main nor a reviewer-visible manifest branch has
+ * committed a different byte contract.
+ */
+
+const fs = require('node:fs');
+
+const { computeZipChecksum } = require('../lib/md5.js');
+const { expectedDllFromZipName, inspectZipLayout } = require('../lib/zip-layout.js');
+const { validateManifest } = require('./validate-manifest.js');
+
+const ACTIONS = Object.freeze({
+    CREATE_DRAFT: 'create-draft',
+    NOOP_MAIN: 'noop-main',
+    REPLACE_DRAFT: 'replace-draft-asset',
+    RESUME_DRAFT_PROPOSAL: 'resume-draft-proposal',
+    RESUME_PUBLISHED_PROPOSAL: 'resume-published-proposal',
+    REUSE_DRAFT: 'reuse-draft-asset',
+    UPLOAD_DRAFT: 'upload-draft-asset',
+});
+
+class ReleaseStateError extends Error {
+    /** @param {string} message */
+    constructor(message) {
+        super(message);
+        this.name = 'ReleaseStateError';
+    }
+}
+
+/** @param {string} tag */
+function tagToVersion(tag) {
+    if (!/^v?\d+\.\d+\.\d+(?:\.\d+)?$/.test(tag)) {
+        throw new ReleaseStateError(`tag ${tag} is not a supported release version`);
+    }
+    const parts = tag.replace(/^v/, '').split('.');
+    while (parts.length < 4) parts.push('0');
+    return parts.join('.');
+}
+
+/**
+ * @param {string} manifestPath
+ * @param {string} label
+ * @returns {unknown[]}
+ */
+function readManifest(manifestPath, label) {
+    let data;
+    try {
+        data = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    } catch (error) {
+        throw new ReleaseStateError(
+            `${label} cannot be read: ${error instanceof Error ? error.message : String(error)}`
+        );
+    }
+    const { errors } = validateManifest(data);
+    if (errors.length > 0) {
+        throw new ReleaseStateError(`${label} is invalid: ${errors.join('; ')}`);
+    }
+    return data;
+}
+
+/**
+ * @typedef {{checksum: string, sourceUrl: string, targetAbi: string, version: string}} ContractEntry
+ * @typedef {{entry: ContractEntry, plugin: Record<string, unknown>}} ManifestContract
+ */
+
+/**
+ * Finds the one entry that owns the tag-stable public URL. A same-version ABI
+ * entry at another URL is a conflict, not an absent contract.
+ * @param {unknown[]} data
+ * @param {{repo: string, tag: string, version: string, targetAbi: string, zipName: string}} identity
+ * @param {string} label
+ * @returns {ManifestContract | null}
+ */
+function findManifestContract(data, identity, label) {
+    const expectedUrl = `https://github.com/${identity.repo}/releases/download/${identity.tag}/${identity.zipName}`;
+    const exact = [];
+    const conflicting = [];
+
+    for (const plugin of data) {
+        if (typeof plugin !== 'object' || plugin === null || !Array.isArray(plugin.versions)) continue;
+        for (const entry of plugin.versions) {
+            if (typeof entry !== 'object' || entry === null) continue;
+            if (entry.targetAbi === identity.targetAbi && entry.version === identity.version) {
+                if (entry.sourceUrl === expectedUrl) exact.push({ entry, plugin });
+                else conflicting.push(entry.sourceUrl);
+            }
+        }
+    }
+
+    if (exact.length > 1) {
+        throw new ReleaseStateError(`${label} contains duplicate contracts for ${expectedUrl}`);
+    }
+    if (exact.length === 0 && conflicting.length > 0) {
+        throw new ReleaseStateError(
+            `${label} already assigns version ${identity.version} / ABI ${identity.targetAbi} `
+            + `to a different URL: ${conflicting.join(', ')}`
+        );
+    }
+    return exact[0] || null;
+}
+
+/**
+ * @typedef {{checksum: string, layoutOk: boolean, layoutError?: string}} AssetEvidence
+ */
+
+/**
+ * @param {string} assetPath
+ * @param {string} zipName
+ * @param {string} targetAbi
+ * @returns {AssetEvidence}
+ */
+function inspectAsset(assetPath, zipName, targetAbi) {
+    const bytes = fs.readFileSync(assetPath);
+    const layout = inspectZipLayout(bytes, expectedDllFromZipName(zipName, targetAbi));
+    return {
+        checksum: computeZipChecksum(assetPath),
+        layoutOk: layout.ok,
+        ...(layout.error ? { layoutError: layout.error } : {}),
+    };
+}
+
+/**
+ * @param {ManifestContract} contract
+ * @param {AssetEvidence | null} asset
+ * @param {string} scope
+ */
+function requireMatchingAsset(contract, asset, scope) {
+    if (asset === null) {
+        throw new ReleaseStateError(`${scope} exists but the published asset is missing`);
+    }
+    if (!asset.layoutOk) {
+        throw new ReleaseStateError(`${scope} asset has an invalid ZIP: ${asset.layoutError}`);
+    }
+    if (asset.checksum !== contract.entry.checksum) {
+        throw new ReleaseStateError(
+            `${scope} checksum ${contract.entry.checksum} does not match the immutable asset `
+            + `${asset.checksum}; create a new version/tag instead of replacing it`
+        );
+    }
+}
+
+/**
+ * @param {{release: {isDraft: boolean} | null, mainContract: ManifestContract | null,
+ *   proposalContract: ManifestContract | null, proposalPresent: boolean,
+ *   remoteAsset: AssetEvidence | null, builtAsset: AssetEvidence}} state
+ * @returns {{action: string, contractScope: '' | 'main' | 'proposal'}}
+ */
+function decideReleaseState(state) {
+    if (!state.builtAsset.layoutOk) {
+        throw new ReleaseStateError(`newly built asset has an invalid ZIP: ${state.builtAsset.layoutError}`);
+    }
+    if (state.release === null) {
+        if (state.mainContract || state.proposalPresent) {
+            throw new ReleaseStateError('a manifest contract/branch exists but the GitHub release is missing');
+        }
+        return { action: ACTIONS.CREATE_DRAFT, contractScope: '' };
+    }
+
+    if (!state.release.isDraft) {
+        // Once main advertises the immutable bytes it is authoritative. A
+        // leftover proposal branch must not turn a valid rerun into a failure,
+        // and this workflow never updates or deletes that branch.
+        if (state.mainContract) {
+            requireMatchingAsset(state.mainContract, state.remoteAsset, 'committed manifest');
+            return { action: ACTIONS.NOOP_MAIN, contractScope: 'main' };
+        }
+        if (state.proposalContract) {
+            requireMatchingAsset(state.proposalContract, state.remoteAsset, 'manifest proposal');
+            return { action: ACTIONS.RESUME_PUBLISHED_PROPOSAL, contractScope: 'proposal' };
+        }
+        throw new ReleaseStateError(
+            'published release has no matching committed/proposed manifest contract; '
+            + 'its bytes are immutable, so create a new version/tag'
+        );
+    }
+
+    if (state.mainContract) {
+        throw new ReleaseStateError('a draft release is already advertised by the committed manifest');
+    }
+    if (state.proposalPresent) {
+        if (!state.proposalContract) {
+            throw new ReleaseStateError('the manifest branch exists but does not contain this release contract');
+        }
+        requireMatchingAsset(state.proposalContract, state.remoteAsset, 'manifest proposal');
+        return { action: ACTIONS.RESUME_DRAFT_PROPOSAL, contractScope: 'proposal' };
+    }
+    if (state.remoteAsset === null) {
+        return { action: ACTIONS.UPLOAD_DRAFT, contractScope: '' };
+    }
+    if (state.remoteAsset.layoutOk && state.remoteAsset.checksum === state.builtAsset.checksum) {
+        return { action: ACTIONS.REUSE_DRAFT, contractScope: '' };
+    }
+    return { action: ACTIONS.REPLACE_DRAFT, contractScope: '' };
+}
+
+/** @param {string[]} argv */
+function parseArgs(argv) {
+    const options = {};
+    for (let index = 0; index < argv.length; index += 2) {
+        const flag = argv[index];
+        const value = argv[index + 1];
+        if (!flag?.startsWith('--') || value === undefined) {
+            throw new ReleaseStateError(`invalid or missing argument near ${flag || '(end)'}`);
+        }
+        options[flag.slice(2)] = value;
+    }
+    return options;
+}
+
+/** @param {string} outputPath @param {Record<string, string>} values */
+function writeGitHubOutput(outputPath, values) {
+    const lines = Object.entries(values).map(([key, value]) => `${key}=${value}`).join('\n');
+    fs.appendFileSync(outputPath, `${lines}\n`);
+}
+
+function main() {
+    try {
+        const options = parseArgs(process.argv.slice(2));
+        for (const required of ['repo', 'tag', 'target-abi', 'zip-name', 'built-asset', 'main-manifest']) {
+            if (!options[required]) throw new ReleaseStateError(`--${required} is required`);
+        }
+        if (!/^[\w.-]+\/[\w.-]+$/.test(options.repo)) {
+            throw new ReleaseStateError('--repo must be owner/name');
+        }
+        const identity = {
+            repo: options.repo,
+            tag: options.tag,
+            version: tagToVersion(options.tag),
+            targetAbi: options['target-abi'],
+            zipName: options['zip-name'],
+        };
+
+        const builtAsset = inspectAsset(options['built-asset'], identity.zipName, identity.targetAbi);
+        const mainData = readManifest(options['main-manifest'], 'main manifest');
+        const mainContract = findManifestContract(mainData, identity, 'main manifest');
+        const proposalPresent = Boolean(options['proposal-manifest']);
+        const proposalData = proposalPresent
+            ? readManifest(options['proposal-manifest'], 'manifest proposal')
+            : null;
+        const proposalContract = proposalData
+            ? findManifestContract(proposalData, identity, 'manifest proposal')
+            : null;
+
+        let release = null;
+        let remoteAsset = null;
+        if (options['release-json']) {
+            const releaseData = JSON.parse(fs.readFileSync(options['release-json'], 'utf8'));
+            if (typeof releaseData.isDraft !== 'boolean' || !Array.isArray(releaseData.assets)) {
+                throw new ReleaseStateError('release metadata lacks boolean isDraft or assets array');
+            }
+            if (releaseData.tagName !== undefined && releaseData.tagName !== identity.tag) {
+                throw new ReleaseStateError(`release metadata is for unexpected tag ${releaseData.tagName}`);
+            }
+            const assets = releaseData.assets.filter(asset => asset?.name === identity.zipName);
+            if (assets.length > 1) throw new ReleaseStateError(`release has duplicate ${identity.zipName} assets`);
+            release = { isDraft: releaseData.isDraft };
+            if (assets.length === 1) {
+                if (!options['remote-asset']) {
+                    throw new ReleaseStateError(`release lists ${identity.zipName}, but it was not downloaded`);
+                }
+                remoteAsset = inspectAsset(options['remote-asset'], identity.zipName, identity.targetAbi);
+            }
+        }
+
+        const decision = decideReleaseState({
+            release,
+            mainContract,
+            proposalContract,
+            proposalPresent,
+            remoteAsset,
+            builtAsset,
+        });
+
+        const selected = decision.contractScope === 'main' ? mainContract : proposalContract;
+        if (selected && options['contract-manifest-output']) {
+            fs.writeFileSync(
+                options['contract-manifest-output'],
+                `${JSON.stringify([{ ...selected.plugin, imageUrl: undefined, versions: [selected.entry] }], null, 2)}\n`
+            );
+        }
+        if (options['github-output']) {
+            writeGitHubOutput(options['github-output'], {
+                action: decision.action,
+                contract_scope: decision.contractScope,
+            });
+        }
+        console.log(JSON.stringify({
+            ...decision,
+            builtChecksum: builtAsset.checksum,
+            remoteChecksum: remoteAsset?.checksum || null,
+        }));
+    } catch (error) {
+        console.error(`error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exitCode = 1;
+    }
+}
+
+if (require.main === module) main();
+
+module.exports = {
+    ACTIONS,
+    ReleaseStateError,
+    decideReleaseState,
+    findManifestContract,
+    inspectAsset,
+    tagToVersion,
+};

--- a/scripts/release/release-state.test.js
+++ b/scripts/release/release-state.test.js
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const childProcess = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+    ACTIONS,
+    decideReleaseState,
+    findManifestContract,
+    tagToVersion,
+} = require('./release-state.js');
+const { writeZipFixture } = require('../lib/zip-test-fixture.js');
+
+const ROOT = path.resolve(__dirname, '../..');
+const SCRIPT = path.join(__dirname, 'release-state.js');
+
+const built = { checksum: 'A'.repeat(32), layoutOk: true };
+const sameRemote = { ...built };
+const differentRemote = { checksum: 'B'.repeat(32), layoutOk: true };
+const invalidRemote = { checksum: 'C'.repeat(32), layoutOk: false, layoutError: 'nested DLL' };
+const contract = checksum => ({
+    entry: {
+        checksum,
+        sourceUrl: 'https://github.com/o/r/releases/download/2.0.0/a.zip',
+        targetAbi: '12.0.0.0',
+        version: '2.0.0.0',
+    },
+    plugin: { name: 'Canopy', guid: '00000000-0000-0000-0000-000000000000' },
+});
+
+function decide(overrides = {}) {
+    return decideReleaseState({
+        release: null,
+        mainContract: null,
+        proposalContract: null,
+        proposalPresent: false,
+        remoteAsset: null,
+        builtAsset: built,
+        ...overrides,
+    });
+}
+
+test('a new tag creates a draft rather than publishing immediately', () => {
+    assert.deepEqual(decide(), { action: ACTIONS.CREATE_DRAFT, contractScope: '' });
+});
+
+test('an unadvertised draft may upload, reuse, or explicitly replace its asset', () => {
+    assert.equal(decide({ release: { isDraft: true } }).action, ACTIONS.UPLOAD_DRAFT);
+    assert.equal(decide({ release: { isDraft: true }, remoteAsset: sameRemote }).action, ACTIONS.REUSE_DRAFT);
+    assert.equal(decide({ release: { isDraft: true }, remoteAsset: differentRemote }).action, ACTIONS.REPLACE_DRAFT);
+    assert.equal(decide({ release: { isDraft: true }, remoteAsset: invalidRemote }).action, ACTIONS.REPLACE_DRAFT);
+});
+
+test('a draft with a reviewed proposal resumes only when its immutable bytes match', () => {
+    assert.equal(decide({
+        release: { isDraft: true },
+        proposalPresent: true,
+        proposalContract: contract(sameRemote.checksum),
+        remoteAsset: sameRemote,
+    }).action, ACTIONS.RESUME_DRAFT_PROPOSAL);
+
+    assert.throws(() => decide({
+        release: { isDraft: true },
+        proposalPresent: true,
+        proposalContract: contract(differentRemote.checksum),
+        remoteAsset: sameRemote,
+    }), /create a new version\/tag/);
+});
+
+test('a published artifact with a matching committed manifest is a verified no-op', () => {
+    assert.deepEqual(decide({
+        release: { isDraft: false },
+        mainContract: contract(sameRemote.checksum),
+        proposalPresent: true,
+        proposalContract: contract(differentRemote.checksum),
+        remoteAsset: sameRemote,
+    }), { action: ACTIONS.NOOP_MAIN, contractScope: 'main' });
+});
+
+test('a published artifact may resume an unchanged proposal but is never replaced', () => {
+    assert.deepEqual(decide({
+        release: { isDraft: false },
+        proposalPresent: true,
+        proposalContract: contract(sameRemote.checksum),
+        remoteAsset: sameRemote,
+    }), { action: ACTIONS.RESUME_PUBLISHED_PROPOSAL, contractScope: 'proposal' });
+
+    for (const remoteAsset of [differentRemote, invalidRemote, null]) {
+        assert.throws(() => decide({
+            release: { isDraft: false },
+            mainContract: contract(sameRemote.checksum),
+            remoteAsset,
+        }), /immutable asset|invalid ZIP|missing/);
+    }
+});
+
+test('a published release without any manifest contract fails closed', () => {
+    assert.throws(() => decide({
+        release: { isDraft: false },
+        remoteAsset: sameRemote,
+    }), /no matching committed\/proposed manifest contract/);
+});
+
+test('manifest state cannot exist without its release or advertise a draft', () => {
+    assert.throws(() => decide({ proposalPresent: true }), /release is missing/);
+    assert.throws(() => decide({
+        release: { isDraft: true },
+        mainContract: contract(sameRemote.checksum),
+        remoteAsset: sameRemote,
+    }), /draft release is already advertised/);
+    assert.throws(() => decide({
+        release: { isDraft: true },
+        proposalPresent: true,
+        remoteAsset: sameRemote,
+    }), /branch exists but does not contain/);
+});
+
+test('a malformed new package blocks every state before remote mutation', () => {
+    assert.throws(() => decide({ builtAsset: invalidRemote }), /newly built asset has an invalid ZIP/);
+});
+
+test('v-prefixed and four-part aliases normalize to one version/branch identity', () => {
+    assert.equal(tagToVersion('v12.0.0'), '12.0.0.0');
+    assert.equal(tagToVersion('12.0.0.0'), '12.0.0.0');
+    assert.throws(() => tagToVersion('release-12'), /not a supported release version/);
+});
+
+test('duplicate and alias-conflicting manifest contracts fail closed', () => {
+    const identity = {
+        repo: 'o/r',
+        tag: 'v12.0.0',
+        version: '12.0.0.0',
+        targetAbi: '12.0.0.0',
+        zipName: 'Jellyfin.Plugin.JellyfinCanopy_12.0.0.zip',
+    };
+    const exact = {
+        targetAbi: identity.targetAbi,
+        version: identity.version,
+        sourceUrl: `https://github.com/${identity.repo}/releases/download/${identity.tag}/${identity.zipName}`,
+        checksum: 'A'.repeat(32),
+    };
+    const plugin = { name: 'Canopy', versions: [exact, { ...exact }] };
+    assert.throws(() => findManifestContract([plugin], identity, 'proposal'), /duplicate contracts/);
+
+    plugin.versions = [{
+        ...exact,
+        sourceUrl: `https://github.com/${identity.repo}/releases/download/12.0.0.0/${identity.zipName}`,
+    }];
+    assert.throws(() => findManifestContract([plugin], identity, 'proposal'), /different URL/);
+});
+
+test('CLI proves a rebuilt ZIP cannot replace the bytes owned by a published manifest', () => {
+    const temporary = fs.mkdtempSync(path.join(os.tmpdir(), 'jc-release-state-'));
+    try {
+        const zipName = 'Jellyfin.Plugin.JellyfinCanopy_12.0.0.zip';
+        const remotePath = path.join(temporary, 'remote', zipName);
+        const builtPath = path.join(temporary, 'built', zipName);
+        fs.mkdirSync(path.dirname(remotePath));
+        fs.mkdirSync(path.dirname(builtPath));
+        const remoteChecksum = writeZipFixture(remotePath, [
+            { name: 'Jellyfin.Plugin.JellyfinCanopy.dll', data: 'published bytes' },
+        ]);
+        const immutableBytes = fs.readFileSync(remotePath);
+        const builtChecksum = writeZipFixture(builtPath, [
+            { name: 'Jellyfin.Plugin.JellyfinCanopy.dll', data: 'rebuilt metadata/bytes' },
+        ]);
+        assert.notEqual(remoteChecksum, builtChecksum);
+
+        const manifest = JSON.parse(fs.readFileSync(path.join(ROOT, 'manifest.json'), 'utf8'));
+        manifest[0].versions = [{
+            changelog: 'fixture',
+            targetAbi: '12.0.0.0',
+            version: '9.0.0.0',
+            sourceUrl: `https://github.com/o/r/releases/download/9.0.0.0/${zipName}`,
+            checksum: remoteChecksum,
+            timestamp: '2026-01-01T00:00:00',
+        }];
+        const manifestPath = path.join(temporary, 'manifest.json');
+        const releasePath = path.join(temporary, 'release.json');
+        const contractPath = path.join(temporary, 'contract.json');
+        fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+        fs.writeFileSync(releasePath, JSON.stringify({
+            isDraft: false,
+            tagName: '9.0.0.0',
+            assets: [{ name: zipName }],
+        }));
+
+        const args = [
+            SCRIPT,
+            '--repo', 'o/r',
+            '--tag', '9.0.0.0',
+            '--target-abi', '12.0.0.0',
+            '--zip-name', zipName,
+            '--built-asset', builtPath,
+            '--main-manifest', manifestPath,
+            '--release-json', releasePath,
+            '--remote-asset', remotePath,
+            '--contract-manifest-output', contractPath,
+        ];
+        const noOp = childProcess.spawnSync(process.execPath, args, { encoding: 'utf8' });
+        assert.equal(noOp.status, 0, noOp.stderr);
+        assert.equal(JSON.parse(noOp.stdout).action, ACTIONS.NOOP_MAIN);
+        assert.equal(JSON.parse(fs.readFileSync(contractPath, 'utf8'))[0].versions[0].checksum, remoteChecksum);
+
+        manifest[0].versions[0].checksum = builtChecksum;
+        fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+        const mismatch = childProcess.spawnSync(process.execPath, args, { encoding: 'utf8' });
+        assert.equal(mismatch.status, 1);
+        assert.match(mismatch.stderr, /create a new version\/tag instead of replacing it/);
+        assert.equal(fs.readFileSync(remotePath).equals(immutableBytes), true);
+    } finally {
+        fs.rmSync(temporary, { recursive: true, force: true });
+    }
+});

--- a/scripts/verify.test.js
+++ b/scripts/verify.test.js
@@ -196,9 +196,60 @@ test('CI and release share the verifier while every non-lint workflow gate stays
     assert.match(build, /args=\(\s*manifest\.json/);
     assert.match(build, /--base-manifest/);
     assert.match(release, /Verify current public catalog/);
-    assert.match(release, /Verify anonymous catalog contract before manifest PR/);
-    assert.equal((release.match(/verify-manifest-remote\.js manifest\.json/g) || []).length, 2);
+    assert.match(release, /Verify exact immutable asset anonymously/);
+    assert.equal((release.match(/verify-manifest-remote\.js/g) || []).length, 2);
     assert.match(release, /--manifest-url/);
+});
+
+test('release reruns preserve published bytes and reviewer-owned manifest state', () => {
+    const release = fs.readFileSync(path.join(ROOT, '.github/workflows/release.yml'), 'utf8');
+    const step = (name, nextName) => release.slice(
+        release.indexOf(`- name: ${name}`),
+        nextName ? release.indexOf(`- name: ${nextName}`) : release.length,
+    );
+    const inspect = release.indexOf('- name: Inspect release and manifest state');
+    const reconcile = release.indexOf('- name: Create or reconcile draft release asset');
+    const finalized = release.indexOf('- name: Download finalized draft asset');
+    const generated = release.indexOf('- name: Generate manifest from finalized immutable bytes');
+    const branch = release.indexOf('- name: Create manifest branch without overwriting reviewer commits');
+    const publish = release.indexOf('- name: Publish verified draft');
+    const anonymous = release.indexOf('- name: Verify exact immutable asset anonymously');
+    const pullRequest = release.indexOf('- name: Open manifest update PR');
+
+    assert.ok(inspect > 0, 'release-state inspection is missing');
+    assert.ok(inspect < reconcile && reconcile < finalized && finalized < generated);
+    assert.ok(generated < branch && branch < publish && publish < anonymous && anonymous < pullRequest);
+    assert.match(release, /node scripts\/release\/release-state\.js/);
+    assert.match(release, /gh release create "\$GITHUB_REF_NAME"[\s\S]*?--draft/);
+    assert.equal((release.match(/gh release upload[^\n]*--clobber/g) || []).length, 1);
+    assert.match(release, /replace-draft-asset\)[\s\S]*?require_existing_draft[\s\S]*?gh release upload[^\n]*--clobber/);
+    assert.match(release, /upload-draft-asset\)[\s\S]*?require_existing_draft[\s\S]*?gh release upload/);
+    assert.match(release, /noop-main\|resume-published-proposal\)[\s\S]*?no release mutation/);
+    assert.match(release, /gh release download[\s\S]*?generated-manifest\.json/);
+    assert.match(release, /git push --force-with-lease="refs\/heads\/\$BRANCH:"/);
+    assert.doesNotMatch(release, /git push[^\n]*--force(?:\s|$)/);
+    assert.doesNotMatch(release, /git (?:checkout|switch)[^\n]*-[Bb] /);
+    const rejectedGuard = release.indexOf('rejected/closed PR(s)');
+    assert.ok(rejectedGuard > inspect && rejectedGuard < reconcile, 'closed PR guard runs after mutation');
+    assert.match(release, /rerun made no release or manifest changes/);
+
+    assert.match(step('Download finalized draft asset', 'Generate manifest from finalized immutable bytes'),
+        /action != 'noop-main'[\s\S]*action != 'resume-published-proposal'/);
+    for (const name of [
+        'Generate manifest from finalized immutable bytes',
+        'Create manifest branch without overwriting reviewer commits',
+    ]) {
+        const source = step(name, name.startsWith('Generate')
+            ? 'Create manifest branch without overwriting reviewer commits'
+            : 'Publish verified draft');
+        assert.match(source, /action != 'noop-main'/);
+        assert.match(source, /action != 'resume-published-proposal'/);
+        assert.match(source, /action != 'resume-draft-proposal'/);
+    }
+    assert.match(step('Publish verified draft', 'Verify exact immutable asset anonymously'),
+        /action != 'noop-main'[\s\S]*action != 'resume-published-proposal'/);
+    assert.match(step('Open manifest update PR', 'Summarize immutable rerun'),
+        /if: steps\.release_state\.outputs\.action != 'noop-main'/);
 });
 
 test('the warning cap and local policy entry points remain explicit', () => {


### PR DESCRIPTION
## What changed

- replace the release rerun `--clobber` path with an explicit release-state machine
- treat published release assets as immutable and verify valid reruns as no-ops
- permit replacement only for unadvertised drafts, with a draft-state recheck immediately before mutation
- generate the manifest from the downloaded finalized asset
- create proposal branches with an expect-absent lease so reviewer commits cannot be overwritten
- fail closed on duplicate releases/assets, conflicting manifest contracts, rejected proposal PRs, API errors, and mismatched published bytes
- make same-tag ZIP metadata deterministic for diagnostics
- add unit, CLI integration, and workflow-contract regression coverage

## Root cause

The release workflow used `gh release upload --clobber` whenever a release already existed and force-pushed the deterministic manifest branch. A same-tag rerun could therefore replace already-published bytes and overwrite reviewer-owned proposal history.

## Impact

Published tags now retain their original artifact bytes. Valid reruns verify the committed manifest, checksum, ZIP layout, and anonymous download without mutating the release or branch. Any changed published bytes require a new version/tag.

## Validation

- independent Fable review: approved after addressing release-mutation ordering, draft rechecks, annotated-tag timestamps, API ambiguity, duplicate releases, alias conflicts, and action-condition coverage
- `npm run test:scripts`: 179/179 passed
- `npm run test:client`: 799/799 passed across 136 files
- `npm run typecheck`, `npm run typecheck:src`, `npm run syntax`, and `npm run build:bundle`: passed
- focused release/workflow tests: 24/24 passed
- changed-file ESLint, YAML parse, Node syntax check, and `git diff --check`: passed
- .NET restore/build: passed
- local .NET testhost execution is unavailable because the host has Microsoft.NETCore.App 10.0.8 while the testhost requests 10.0.9; GitHub Actions installs `10.0.x` and is the authoritative test run
- live published 2.0.0.0 asset/manifest: verified as `noop-main` with matching MD5 and exact root-DLL ZIP layout

Fixes #76