### PR TITLE
Protect release provenance and repository policy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,18 +43,70 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  provenance:
+    name: Verify release source provenance
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      tag_sha: ${{ steps.provenance.outputs.tag_sha }}
+      default_branch: ${{ steps.provenance.outputs.default_branch }}
+      default_sha: ${{ steps.provenance.outputs.default_sha }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Fetch reviewed default branch
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: git fetch --no-tags origin "+refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
+
+      - name: Require tag commit on reviewed default-branch history
+        id: provenance
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          EVENT_SHA: ${{ github.sha }}
+        run: >-
+          node scripts/release/verify-provenance.js
+          --tag-ref "${EVENT_SHA}"
+          --default-ref "refs/remotes/origin/${DEFAULT_BRANCH}"
+          --default-branch "${DEFAULT_BRANCH}"
+          --github-output "${GITHUB_OUTPUT}"
+          --summary "${GITHUB_STEP_SUMMARY}"
+
   quality-gates:
     name: Required source-SHA quality gates
+    needs: provenance
     uses: ./.github/workflows/build.yml
     permissions:
       actions: read
       contents: read
 
+  security-gates:
+    name: Required source-SHA security gates
+    needs: provenance
+    uses: ./.github/workflows/security-scan.yml
+    with:
+      verify_repository_policy: true
+    permissions:
+      # The called policy-verifier job needs write-level repository identity
+      # so GitHub returns bypass actors; its other jobs stay contents:read.
+      contents: write
+
   release:
     name: Build, test, package & publish
-    needs: quality-gates
+    needs: [provenance, quality-gates, security-gates]
     runs-on: ubuntu-latest
+    environment:
+      name: release
     permissions:
+      actions: write # dispatch required checks for the generated manifest PR
       contents: write # create the release + push the manifest branch
       pull-requests: write # open the manifest-update PR
     steps:
@@ -94,6 +146,24 @@ jobs:
           version="$(IFS='.'; echo "${parts[*]}")"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "Releasing version $version from tag $GITHUB_REF_NAME"
+
+      - name: Record approved source provenance
+        env:
+          TAG_SHA: ${{ needs.provenance.outputs.tag_sha }}
+          DEFAULT_BRANCH: ${{ needs.provenance.outputs.default_branch }}
+          DEFAULT_SHA: ${{ needs.provenance.outputs.default_sha }}
+          QUALITY_RESULT: ${{ needs.quality-gates.result }}
+          SECURITY_RESULT: ${{ needs.security-gates.result }}
+        run: |
+          {
+            echo '### Approved release provenance'
+            echo "- Tag commit: \`${TAG_SHA}\`"
+            echo "- Reviewed branch: \`${DEFAULT_BRANCH}\` at \`${DEFAULT_SHA}\`"
+            echo "- Default-branch ancestry: verified"
+            echo "- Required Build & Test workflow: \`${QUALITY_RESULT}\`"
+            echo "- Required Security Scan workflow: \`${SECURITY_RESULT}\`"
+            echo "- Protected environment: \`release\` (explicit approval recorded by GitHub)"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       # ---- Quality policy mirrors build.yml: lint findings are advisory; ----
       # ---- every other failure (including broken lint tooling) blocks.  ----
@@ -428,6 +498,9 @@ jobs:
             echo '`scripts/release/validate-manifest.js`.'
             echo
             echo "Merging this PR is what publishes the update to installed plugins."
+            echo "If main advances, first update this proposal branch from main. After"
+            echo "any proposal-head change, rerun the source Release workflow so it"
+            echo "dispatches both required suites for that exact new head SHA."
           } > pr-body.md
           open_pr="$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')"
           if [ -z "$open_pr" ]; then
@@ -439,6 +512,72 @@ jobs:
           else
             echo "PR $open_pr already owns $BRANCH; leaving it unchanged"
           fi
+
+      # PRs opened with GITHUB_TOKEN intentionally do not trigger other
+      # workflows. Dispatch the same required suites explicitly against the
+      # exact proposal SHA so the protected default branch remains mergeable
+      # without weakening or bypassing its status-check rules.
+      - name: Dispatch required checks for manifest proposal
+        if: steps.release_state.outputs.action != 'noop-main'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.release_state.outputs.branch }}
+        run: |
+          resolve_head() {
+            git ls-remote --exit-code --heads origin "refs/heads/$BRANCH" \
+              | awk 'NR == 1 { print $1 }'
+          }
+          list_runs() {
+            gh run list --workflow "$1" --branch "$BRANCH" \
+              --event workflow_dispatch --limit 100 \
+              --json databaseId,headSha,status,conclusion
+          }
+
+          head_sha="$(resolve_head)"
+          if [[ ! "$head_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Could not resolve one manifest proposal SHA"
+            exit 1
+          fi
+          for workflow in build.yml security-scan.yml; do
+            runs="$(list_runs "$workflow")"
+            action="$(node scripts/release/check-dispatch.js --sha "$head_sha" <<< "$runs")"
+            if [ "$action" = dispatch ]; then
+              before_runs="$RUNNER_TEMP/${workflow}.before-runs.json"
+              printf '%s\n' "$runs" > "$before_runs"
+              if [ "$(resolve_head)" != "$head_sha" ]; then
+                echo "::error::Manifest branch changed before $workflow dispatch; rerun Release"
+                exit 1
+              fi
+              gh workflow run "$workflow" --ref "$BRANCH"
+              observed=false
+              # GitHub's run-list index can lag workflow_dispatch. Allow just
+              # under two minutes, while treating malformed API evidence as an
+              # immediate tooling failure rather than misreporting a timeout.
+              for attempt in {1..24}; do
+                runs="$(list_runs "$workflow")"
+                if node scripts/release/check-dispatch.js \
+                    --sha "$head_sha" --mode observed \
+                    --before "$before_runs" <<< "$runs"; then
+                  observed=true
+                  break
+                else
+                  observation_status=$?
+                  if [ "$observation_status" -ne 1 ]; then
+                    echo "::error::Could not validate $workflow dispatch evidence"
+                    exit "$observation_status"
+                  fi
+                fi
+                if [ "$attempt" -lt 24 ]; then sleep 5; fi
+              done
+              if [ "$observed" != true ]; then
+                current_head="$(resolve_head)"
+                echo "::error::$workflow did not start for exact proposal $head_sha (current head $current_head); rerun Release"
+                exit 1
+              fi
+            else
+              echo "$workflow already has a successful or active run for $head_sha"
+            fi
+          done
 
       - name: Summarize immutable rerun
         if: steps.release_state.outputs.action == 'noop-main'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -5,6 +5,13 @@ on:
     branches: [ "main", "master" ]
   pull_request:
     branches: [ "main", "master" ]
+  workflow_call:
+    inputs:
+      verify_repository_policy:
+        description: Fail unless live release protections match the committed contract
+        required: false
+        type: boolean
+        default: false
   schedule:
     # Run every day at 2:00 AM UTC
     - cron: '0 2 * * *'
@@ -14,6 +21,34 @@ permissions:
   contents: read
 
 jobs:
+  repository-policy:
+    name: Repository Policy
+    # A called workflow inherits the caller's github context, including its
+    # event name. Use an explicit input so a tag-push caller cannot make this
+    # release gate look like an ordinary push and silently skip it.
+    if: github.event_name == 'schedule' || inputs.verify_repository_policy
+    runs-on: ubuntu-latest
+    permissions:
+      # GitHub omits ruleset bypass actors unless the caller has repository
+      # write access. This trusted main/tag job executes no repository writes;
+      # write scope is used only to make the complete policy readable.
+      contents: write
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout reviewed source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+
+      - name: Verify live release policy matches the committed contract
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/release/verify-repository-policy.js
+
   # Scan the FULL git history for committed secrets. TruffleHog runs with --json
   # (all findings, verified AND unverified) and WITHOUT --fail, so its exit code
   # signals only whether the scanner RAN; the gate decision (fail on a verified,

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,8 +7,10 @@ updates, and a malformed entry bricks in-app updates for all users.
 
 ## Cutting a release
 
-1. Make sure the default branch is green (the **Build & Test** workflow).
-2. Tag the commit and push the tag. The existing convention is a bare
+1. Merge the release source through a pull request and make sure every
+   required **Build & Test** and **Security Scan** check is green on the
+   current default branch. Direct pushes to the default branch are blocked.
+2. Tag that reviewed default-branch commit and push the tag. The existing convention is a bare
    4-part version (a `v` prefix with 3 parts also works):
 
    ```bash
@@ -16,11 +18,20 @@ updates, and a malformed entry bricks in-app updates for all users.
    git push origin 12.0.0.0
    ```
 
+   Only the repository maintainer can create a matching release tag. Once
+   created, the tag cannot be moved or deleted; a correction always receives
+   a new version and tag.
+
 3. The **Release** workflow then:
-   - runs the full quality gates (plugin build, unit tests, JS syntax/type
-     checks) and runs ESLint as a visible advisory signal. Lint findings or a
-     warning-cap breach do not abort a release; every non-lint failure and any
-     broken ESLint invocation/configuration does;
+   - proves the tag commit is reachable from the current reviewed default
+     branch before any expensive or write-capable job can start;
+   - reuses the complete **Build & Test** and **Security Scan** workflows on
+     that exact tag SHA. Lint findings remain advisory; every non-lint gate,
+     the secret scan, dependency audit, and Dockerized Jellyfin 12 E2E must
+     succeed;
+   - waits at the protected `release` environment. Review the displayed tag
+     SHA, default-branch SHA, and gate results, then explicitly approve the
+     deployment. Repository administrators cannot bypass this approval;
    - builds the plugin with the tag stamped as `AssemblyVersion`/
      `FileVersion` (the tag is the single source of truth — the version in
      the csproj is never bumped by CI);
@@ -33,9 +44,59 @@ updates, and a malformed entry bricks in-app updates for all users.
      from the real ZIP, timestamped) and opens a PR with the change.
 
 4. **Review and merge the manifest PR.** Merging it is the step that
-   publishes the update to installed plugins. Note that PRs opened with the
-   built-in `GITHUB_TOKEN` do not trigger the Build & Test checks — the
-   manifest was already validated inside the release run.
+   publishes the update to installed plugins. GitHub does not automatically
+   trigger workflows for a PR opened by `GITHUB_TOKEN`, so the release job
+   explicitly dispatches both required workflows against the exact manifest
+   proposal SHA. The protected default branch rejects the merge until those
+   checks succeed and every review thread is resolved. If `main` advances,
+   first update the proposal branch from `main` (using GitHub's **Update
+   branch** control or a reviewer-owned rebase). After any proposal-head
+   change, rerun the original **Release** workflow. Its idempotent resume path
+   dispatches the suites for the exact new branch head; failed/cancelled old
+   runs do not suppress that retry.
+
+## Enforced repository policy
+
+The auditable policy declaration is
+[`scripts/release/repository-policy.json`](scripts/release/repository-policy.json).
+The live repository must match it:
+
+- the default branch accepts changes only through pull requests, rejects
+  deletion/force-push, requires up-to-date branches, and requires the complete
+  blocking Build/Test and Security check set specifically from GitHub Actions;
+- only the named maintainer may create a release-pattern tag, while a separate
+  no-bypass ruleset prevents every actor from moving or deleting one;
+- the `release` environment accepts only release-pattern tags and requires an
+  explicit maintainer approval with administrator bypass disabled.
+
+This is currently a one-collaborator repository. GitHub does not permit a PR
+author to approve their own PR, so the branch ruleset requires PR flow and
+resolved review threads but zero platform approval reviews. Independent code
+review remains recorded on the PR, and the non-bypassable environment approval
+is the enforced human release decision. If a second trusted collaborator is
+added, raise `required_approving_review_count` to `1` in the declaration and
+live ruleset together.
+
+`node scripts/release/verify-repository-policy.js` compares the complete live
+ruleset details, bypass actors, required checks, environment reviewers/admin
+bypass, and tag deployment policies with that declaration. The daily Security
+Scan runs it from reviewed `main`, and every release runs it again on the exact
+tag SHA. API denial or any missing/weakened/different control is blocking.
+
+## Emergency procedure
+
+There is no bypass-by-tag procedure. Never move, delete, or reuse a release
+tag, replace a published asset, or disable a failed gate to make a release run.
+For a bad source or package, fix forward through a reviewed PR and cut a new
+version.
+
+If GitHub policy itself prevents all releases because its configuration is
+wrong, open a dedicated repository issue first. Record the failing rule,
+current live policy, intended temporary change, approver, and UTC timestamps;
+make the narrowest policy repair; then restore and verify the complete JSON
+contract before cutting any tag. Environment approval and source ancestry stay
+mandatory throughout. GitHub's ruleset/environment history plus the issue and
+release summary form the audit trail.
 
 ### Custom release notes
 
@@ -53,7 +114,18 @@ be edited or removed.
 
 ## Tooling (`scripts/release/`)
 
-Both scripts are dependency-free Node and can be run locally:
+The release tools are dependency-free Node and can be run locally:
+
+- `node scripts/release/verify-provenance.js --tag-ref <sha-or-tag>
+  --default-ref <default-ref> --default-branch <name>` — resolves both inputs
+  to commits and fails unless the tag commit is an ancestor of the reviewed
+  branch. The workflow records both immutable SHAs in its summary.
+- `scripts/release/repository-policy.json` — the versioned source of truth for
+  required checks, default-branch PR protection, release-tag creation and
+  immutability, and the approval environment.
+- `node scripts/release/verify-repository-policy.js` — compares that source of
+  truth with GitHub's live ruleset and environment APIs; requires an
+  authenticated `GH_TOKEN` that can read full ruleset bypass details.
 
 - `node scripts/release/validate-manifest.js manifest.json` — validates the
   manifest: JSON shape, required fields, 4-part versions, MD5 checksum and

--- a/scripts/e2e/workflow-sharding.test.js
+++ b/scripts/e2e/workflow-sharding.test.js
@@ -166,8 +166,10 @@ test('the same blocking workflow proves pull-request, main and release source SH
     assert.match(workflow, /push:\n\s+branches: \[main, master\]/);
     assert.match(workflow, /pull_request:\n\s+branches: \[main, master\]/);
     assert.match(workflow, /workflow_call:/);
-    assert.match(releaseWorkflow, /quality-gates:\n\s+name: Required source-SHA quality gates\n\s+uses: \.\/\.github\/workflows\/build\.yml/);
-    assert.match(releaseWorkflow, /release:\n\s+name: Build, test, package & publish\n\s+needs: quality-gates/);
+    assert.match(releaseWorkflow, /provenance:\n\s+name: Verify release source provenance/);
+    assert.match(releaseWorkflow, /quality-gates:\n\s+name: Required source-SHA quality gates\n\s+needs: provenance\n\s+uses: \.\/\.github\/workflows\/build\.yml/);
+    assert.match(releaseWorkflow, /security-gates:\n\s+name: Required source-SHA security gates\n\s+needs: provenance\n\s+uses: \.\/\.github\/workflows\/security-scan\.yml/);
+    assert.match(releaseWorkflow, /release:\n\s+name: Build, test, package & publish\n\s+needs: \[provenance, quality-gates, security-gates\]/);
 });
 
 test('mutable latest-Jellyfin probing is isolated in one advisory workflow', () => {

--- a/scripts/release/check-dispatch.js
+++ b/scripts/release/check-dispatch.js
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+
+function requireSha(value) {
+    const sha = String(value || '').trim().toLowerCase();
+    if (!/^[0-9a-f]{40}$/.test(sha)) {
+        throw new Error('expected head SHA must contain exactly 40 hexadecimal characters');
+    }
+    return sha;
+}
+
+function parseRuns(source) {
+    if (Buffer.byteLength(source, 'utf8') > 1024 * 1024) {
+        throw new Error('workflow-run input exceeds 1 MiB');
+    }
+    const runs = JSON.parse(source);
+    if (!Array.isArray(runs)) throw new Error('workflow-run input must be a JSON array');
+    return runs.map((run, index) => {
+        if (!run || typeof run !== 'object' || Array.isArray(run)) {
+            throw new Error(`workflow run ${index} must be an object`);
+        }
+        const headSha = String(run.headSha || '').toLowerCase();
+        const status = String(run.status || '');
+        const conclusion = run.conclusion == null ? null : String(run.conclusion);
+        const databaseId = Number(run.databaseId);
+        if (!/^[0-9a-f]{40}$/.test(headSha)
+            || !status
+            || !Number.isSafeInteger(databaseId)
+            || databaseId <= 0) {
+            throw new Error(`workflow run ${index} has invalid databaseId/headSha/status`);
+        }
+        return { databaseId, headSha, status, conclusion };
+    });
+}
+
+function observedDispatch(runs, beforeRuns, expectedSha) {
+    const sha = requireSha(expectedSha);
+    const beforeIds = new Set(beforeRuns.map(run => run.databaseId));
+    return runs.some(run => run.headSha === sha && !beforeIds.has(run.databaseId));
+}
+
+function dispatchDecision(runs, expectedSha) {
+    const sha = requireSha(expectedSha);
+    const matching = runs.filter(run => run.headSha === sha);
+    const reusable = matching.filter(run =>
+        run.status !== 'completed' || run.conclusion === 'success');
+    return Object.freeze({
+        action: reusable.length > 0 ? 'reuse' : 'dispatch',
+        matching: matching.length,
+        reusable: reusable.length,
+    });
+}
+
+function parseArgs(argv) {
+    const values = { mode: 'decision' };
+    const allowed = new Set(['sha', 'mode', 'before']);
+    const seen = new Set();
+    for (let index = 0; index < argv.length; index += 2) {
+        const flag = argv[index];
+        const value = argv[index + 1];
+        if (!flag?.startsWith('--') || value === undefined || value.startsWith('--')) {
+            throw new Error(`invalid argument near ${flag || '<end>'}`);
+        }
+        const key = flag.slice(2);
+        if (!allowed.has(key)) throw new Error(`unknown --${key}`);
+        if (seen.has(key)) throw new Error(`duplicate --${key}`);
+        seen.add(key);
+        values[key] = value;
+    }
+    if (!values.sha) throw new Error('--sha is required');
+    if (!['decision', 'observed'].includes(values.mode)) {
+        throw new Error('--mode must be decision or observed');
+    }
+    if (values.mode === 'observed' && !values.before) {
+        throw new Error('--before is required in observed mode');
+    }
+    if (values.mode === 'decision' && values.before) {
+        throw new Error('--before is only valid in observed mode');
+    }
+    return values;
+}
+
+function main(argv) {
+    const args = parseArgs(argv);
+    const runs = parseRuns(fs.readFileSync(0, 'utf8'));
+    if (args.mode === 'observed') {
+        const beforeRuns = parseRuns(fs.readFileSync(args.before, 'utf8'));
+        if (!observedDispatch(runs, beforeRuns, args.sha)) process.exitCode = 1;
+        return;
+    }
+    const result = dispatchDecision(runs, args.sha);
+    process.stdout.write(`${result.action}\n`);
+}
+
+if (require.main === module) {
+    try {
+        main(process.argv.slice(2));
+    } catch (error) {
+        const message = String(error?.message || error).replace(/[\r\n]+/g, ' ');
+        process.stderr.write(`::error title=Manifest check dispatch failed::${message}\n`);
+        process.exitCode = 2;
+    }
+}
+
+module.exports = {
+    dispatchDecision,
+    observedDispatch,
+    parseArgs,
+    parseRuns,
+};

--- a/scripts/release/check-dispatch.test.js
+++ b/scripts/release/check-dispatch.test.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const childProcess = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+    dispatchDecision,
+    observedDispatch,
+    parseArgs,
+    parseRuns,
+} = require('./check-dispatch.js');
+
+const SCRIPT = path.join(__dirname, 'check-dispatch.js');
+const SHA = 'a'.repeat(40);
+const OTHER = 'b'.repeat(40);
+
+function run(status, conclusion, headSha = SHA, databaseId = 1) {
+    return { databaseId, headSha, status, conclusion };
+}
+
+test('success or an unfinished exact-SHA run is reused', () => {
+    for (const candidate of [
+        run('completed', 'success'),
+        run('queued', null),
+        run('in_progress', null),
+        run('waiting', null),
+    ]) {
+        assert.equal(dispatchDecision([candidate], SHA).action, 'reuse');
+    }
+});
+
+test('only failed, cancelled, or stale-SHA runs cause a fresh dispatch', () => {
+    for (const candidates of [
+        [run('completed', 'failure')],
+        [run('completed', 'cancelled')],
+        [run('completed', 'timed_out')],
+        [run('completed', 'success', OTHER)],
+        [],
+    ]) {
+        assert.equal(dispatchDecision(candidates, SHA).action, 'dispatch');
+    }
+});
+
+test('one reusable run wins over older exact-SHA failures', () => {
+    const result = dispatchDecision([
+        run('completed', 'failure'),
+        run('completed', 'success'),
+    ], SHA);
+    assert.deepEqual(result, { action: 'reuse', matching: 2, reusable: 1 });
+});
+
+test('malformed run evidence and malformed expected SHAs fail closed', () => {
+    assert.throws(() => parseRuns('{}'), /JSON array/);
+    assert.throws(() => parseRuns(JSON.stringify([{ headSha: SHA }])), /databaseId\/headSha\/status/);
+    assert.throws(() => parseRuns(JSON.stringify([run('queued', null, SHA, 0)])), /databaseId/);
+    assert.throws(() => dispatchDecision([], 'abc'), /40 hexadecimal/);
+});
+
+test('CLI arguments reject unknown, duplicate, and mode-incompatible flags', () => {
+    assert.throws(() => parseArgs(['--sha', SHA, '--sha', OTHER]), /duplicate --sha/);
+    assert.throws(() => parseArgs(['--sha', SHA, '--unknown', 'value']), /unknown --unknown/);
+    assert.throws(() => parseArgs(['--sha', SHA, '--before', 'before.json']), /only valid/);
+    assert.throws(() => parseArgs([
+        '--sha', SHA,
+        '--mode', 'observed',
+        '--mode', 'decision',
+        '--before', 'before.json',
+    ]), /duplicate --mode/);
+});
+
+test('observed mode requires a new run ID on the exact dispatched SHA', (t) => {
+    const temporary = fs.mkdtempSync(path.join(os.tmpdir(), 'jc-check-dispatch-'));
+    const baseline = path.join(temporary, 'before.json');
+    t.after(() => fs.rmSync(temporary, { recursive: true, force: true }));
+    fs.writeFileSync(baseline, JSON.stringify([run('completed', 'failure', SHA, 10)]));
+    assert.equal(observedDispatch(
+        [run('completed', 'failure', SHA, 10), run('queued', null, SHA, 11)],
+        [run('completed', 'failure', SHA, 10)],
+        SHA
+    ), true);
+    for (const [runs, expectedStatus] of [
+        [[run('completed', 'failure', SHA, 10), run('queued', null, SHA, 11)], 0],
+        [[run('completed', 'failure', SHA, 10)], 1],
+        [[run('completed', 'failure', SHA, 10), run('queued', null, OTHER, 11)], 1],
+    ]) {
+        const result = childProcess.spawnSync(process.execPath, [
+            SCRIPT,
+            '--sha', SHA,
+            '--mode', 'observed',
+            '--before', baseline,
+        ], {
+            input: JSON.stringify(runs),
+            encoding: 'utf8',
+        });
+        assert.equal(result.status, expectedStatus, result.stderr);
+    }
+});

--- a/scripts/release/repository-policy.json
+++ b/scripts/release/repository-policy.json
@@ -1,0 +1,121 @@
+{
+  "repository": "4eh5xitv6787h645ebv/Jellyfin-Canopy",
+  "maintainer": {
+    "login": "4eh5xitv6787h645ebv",
+    "id": 45441845
+  },
+  "rulesets": [
+    {
+      "name": "Protect reviewed default branch",
+      "target": "branch",
+      "enforcement": "active",
+      "bypass_actors": [],
+      "conditions": {
+        "ref_name": {
+          "include": ["~DEFAULT_BRANCH"],
+          "exclude": []
+        }
+      },
+      "rules": [
+        { "type": "deletion" },
+        { "type": "non_fast_forward" },
+        {
+          "type": "pull_request",
+          "parameters": {
+            "allowed_merge_methods": ["squash", "rebase"],
+            "dismiss_stale_reviews_on_push": true,
+            "require_code_owner_review": false,
+            "require_last_push_approval": false,
+            "required_approving_review_count": 0,
+            "required_review_thread_resolution": true
+          }
+        },
+        {
+          "type": "required_status_checks",
+          "parameters": {
+            "do_not_enforce_on_create": false,
+            "required_status_checks": [
+              { "context": "Plugin (Jellyfin 12 / net10.0)", "integration_id": 15368 },
+              { "context": "Unit tests", "integration_id": 15368 },
+              { "context": "Client checks (lint advisory; all other gates blocking)", "integration_id": 15368 },
+              { "context": "E2E (dockerized Jellyfin 12)", "integration_id": 15368 },
+              { "context": "Manifest validation", "integration_id": 15368 },
+              { "context": "Secret Scanning", "integration_id": 15368 },
+              { "context": ".NET Security Audit", "integration_id": 15368 }
+            ],
+            "strict_required_status_checks_policy": true
+          }
+        }
+      ]
+    },
+    {
+      "name": "Restrict release tag creation",
+      "target": "tag",
+      "enforcement": "active",
+      "bypass_actors": [
+        {
+          "actor_id": 45441845,
+          "actor_type": "User",
+          "bypass_mode": "always"
+        }
+      ],
+      "conditions": {
+        "ref_name": {
+          "include": [
+            "refs/tags/v[0-9]*",
+            "refs/tags/[0-9]*.[0-9]*.[0-9]*"
+          ],
+          "exclude": []
+        }
+      },
+      "rules": [
+        { "type": "creation" }
+      ]
+    },
+    {
+      "name": "Make release tags immutable",
+      "target": "tag",
+      "enforcement": "active",
+      "bypass_actors": [],
+      "conditions": {
+        "ref_name": {
+          "include": [
+            "refs/tags/v[0-9]*",
+            "refs/tags/[0-9]*.[0-9]*.[0-9]*"
+          ],
+          "exclude": []
+        }
+      },
+      "rules": [
+        {
+          "type": "update",
+          "parameters": {
+            "update_allows_fetch_and_merge": false
+          }
+        },
+        { "type": "deletion" },
+        { "type": "non_fast_forward" }
+      ]
+    }
+  ],
+  "environment": {
+    "name": "release",
+    "wait_timer": 0,
+    "prevent_self_review": false,
+    "can_admins_bypass": false,
+    "reviewers": [
+      {
+        "type": "User",
+        "id": 45441845
+      }
+    ],
+    "deployment_branch_policy": {
+      "protected_branches": false,
+      "custom_branch_policies": true
+    },
+    "deployment_policies": [
+      { "type": "tag", "name": "v[0-9]*" },
+      { "type": "tag", "name": "[0-9]*.[0-9]*.[0-9]*" }
+    ]
+  }
+}

--- a/scripts/release/repository-policy.test.js
+++ b/scripts/release/repository-policy.test.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const ROOT = path.resolve(__dirname, '../..');
+const policy = JSON.parse(fs.readFileSync(
+    path.join(__dirname, 'repository-policy.json'),
+    'utf8'
+));
+const release = fs.readFileSync(path.join(ROOT, '.github/workflows/release.yml'), 'utf8');
+const security = fs.readFileSync(path.join(ROOT, '.github/workflows/security-scan.yml'), 'utf8');
+
+function ruleset(name) {
+    const result = policy.rulesets.find(candidate => candidate.name === name);
+    assert.ok(result, `missing ruleset ${name}`);
+    return result;
+}
+
+test('default branch requires PR flow, resolved review threads, and every blocking check', () => {
+    const main = ruleset('Protect reviewed default branch');
+    assert.equal(main.target, 'branch');
+    assert.equal(main.enforcement, 'active');
+    assert.deepEqual(main.bypass_actors, []);
+    assert.deepEqual(main.conditions.ref_name, { include: ['~DEFAULT_BRANCH'], exclude: [] });
+    const types = main.rules.map(rule => rule.type);
+    assert.deepEqual(types, ['deletion', 'non_fast_forward', 'pull_request', 'required_status_checks']);
+
+    const pullRequest = main.rules.find(rule => rule.type === 'pull_request').parameters;
+    assert.equal(pullRequest.required_review_thread_resolution, true);
+    assert.equal(pullRequest.dismiss_stale_reviews_on_push, true);
+    // This is a one-collaborator repository. Platform PR self-approval is
+    // impossible, so the protected release environment below owns the one
+    // explicit human approval without creating a permanent merge deadlock.
+    assert.equal(pullRequest.required_approving_review_count, 0);
+
+    const checks = main.rules.find(rule => rule.type === 'required_status_checks').parameters;
+    assert.equal(checks.strict_required_status_checks_policy, true);
+    assert.deepEqual(checks.required_status_checks, [
+        { context: 'Plugin (Jellyfin 12 / net10.0)', integration_id: 15368 },
+        { context: 'Unit tests', integration_id: 15368 },
+        { context: 'Client checks (lint advisory; all other gates blocking)', integration_id: 15368 },
+        { context: 'E2E (dockerized Jellyfin 12)', integration_id: 15368 },
+        { context: 'Manifest validation', integration_id: 15368 },
+        { context: 'Secret Scanning', integration_id: 15368 },
+        { context: '.NET Security Audit', integration_id: 15368 },
+    ]);
+});
+
+test('only the maintainer can create a release tag and nobody can move or delete one', () => {
+    const creation = ruleset('Restrict release tag creation');
+    const immutable = ruleset('Make release tags immutable');
+    const patterns = [
+        'refs/tags/v[0-9]*',
+        'refs/tags/[0-9]*.[0-9]*.[0-9]*',
+    ];
+    assert.deepEqual(creation.conditions.ref_name.include, patterns);
+    assert.deepEqual(immutable.conditions.ref_name.include, patterns);
+    assert.deepEqual(creation.rules, [{ type: 'creation' }]);
+    assert.deepEqual(creation.bypass_actors, [{
+        actor_id: policy.maintainer.id,
+        actor_type: 'User',
+        bypass_mode: 'always',
+    }]);
+    assert.deepEqual(immutable.bypass_actors, []);
+    assert.deepEqual(immutable.rules.map(rule => rule.type), [
+        'update',
+        'deletion',
+        'non_fast_forward',
+    ]);
+});
+
+test('write-capable publication is restricted to release tags and explicit approval', () => {
+    const environment = policy.environment;
+    assert.equal(environment.name, 'release');
+    assert.equal(environment.can_admins_bypass, false);
+    assert.equal(environment.prevent_self_review, false);
+    assert.deepEqual(environment.reviewers, [{ type: 'User', id: policy.maintainer.id }]);
+    assert.deepEqual(environment.deployment_branch_policy, {
+        protected_branches: false,
+        custom_branch_policies: true,
+    });
+    assert.deepEqual(environment.deployment_policies, [
+        { type: 'tag', name: 'v[0-9]*' },
+        { type: 'tag', name: '[0-9]*.[0-9]*.[0-9]*' },
+    ]);
+    assert.match(release, /release:\n\s+name: Build, test, package & publish[\s\S]*?environment:\n\s+name: release/);
+});
+
+test('release reuses exact-SHA Build/Test and Security gates after ancestry proof', () => {
+    assert.match(release, /provenance:\n\s+name: Verify release source provenance/);
+    assert.match(release, /node scripts\/release\/verify-provenance\.js/);
+    assert.match(release, /quality-gates:[\s\S]*?needs: provenance[\s\S]*?uses: \.\/\.github\/workflows\/build\.yml/);
+    assert.match(release, /security-gates:[\s\S]*?needs: provenance[\s\S]*?uses: \.\/\.github\/workflows\/security-scan\.yml/);
+    assert.match(release, /needs: \[provenance, quality-gates, security-gates\]/);
+    assert.match(security, /pull_request:[\s\S]*?workflow_call:[\s\S]*?verify_repository_policy:/);
+    assert.match(release, /security-gates:[\s\S]*?with:\n\s+verify_repository_policy: true/);
+    assert.match(security, /repository-policy:\n\s+name: Repository Policy[\s\S]*?if: github\.event_name == 'schedule' \|\| inputs\.verify_repository_policy[\s\S]*?contents: write[\s\S]*?verify-repository-policy\.js/);
+    assert.match(security, /Checkout reviewed source[\s\S]*?persist-credentials: false/);
+    assert.match(release, /actions: write # dispatch required checks for the generated manifest PR/);
+    assert.match(release, /gh workflow run "\$workflow" --ref "\$BRANCH"/);
+    assert.match(release, /node scripts\/release\/check-dispatch\.js/);
+    assert.match(release, /did not start for exact proposal \$head_sha/);
+});

--- a/scripts/release/verify-provenance.js
+++ b/scripts/release/verify-provenance.js
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+'use strict';
+
+const childProcess = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+function requireRef(value, label) {
+    if (typeof value !== 'string'
+        || value.length === 0
+        || value.length > 512
+        || value.startsWith('-')
+        || /[\0\r\n]/.test(value)) {
+        throw new Error(`${label} is not a safe git object name`);
+    }
+    return value;
+}
+
+function git(args, cwd, acceptedStatuses = [0]) {
+    const result = childProcess.spawnSync('git', args, {
+        cwd,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    if (result.error) {
+        throw new Error(`git ${args[0]} could not start: ${result.error.message}`);
+    }
+    if (!acceptedStatuses.includes(result.status)) {
+        const detail = String(result.stderr || result.stdout || '').trim();
+        throw new Error(`git ${args[0]} failed${detail ? `: ${detail}` : ''}`);
+    }
+    return result;
+}
+
+function resolveCommit(ref, label, cwd) {
+    const safeRef = requireRef(ref, label);
+    const result = git(['rev-parse', '--verify', `${safeRef}^{commit}`], cwd);
+    const sha = String(result.stdout).trim().toLowerCase();
+    if (!/^[0-9a-f]{40,64}$/.test(sha)) {
+        throw new Error(`${label} did not resolve to one commit`);
+    }
+    return sha;
+}
+
+function verifyProvenance({ tagRef, defaultRef, defaultBranch, cwd = process.cwd() }) {
+    const branch = requireRef(defaultBranch, 'default branch');
+    const tagSha = resolveCommit(tagRef, 'tag source', cwd);
+    const defaultSha = resolveCommit(defaultRef, 'default branch ref', cwd);
+    const ancestry = git(
+        ['merge-base', '--is-ancestor', tagSha, defaultSha],
+        cwd,
+        [0, 1]
+    );
+    if (ancestry.status === 1) {
+        throw new Error(
+            `tag commit ${tagSha} is not reachable from reviewed branch ${branch} (${defaultSha})`
+        );
+    }
+    return Object.freeze({ tagSha, defaultBranch: branch, defaultSha });
+}
+
+function parseArgs(argv) {
+    const values = {};
+    for (let index = 0; index < argv.length; index += 2) {
+        const flag = argv[index];
+        const value = argv[index + 1];
+        if (!flag?.startsWith('--') || value === undefined || value.startsWith('--')) {
+            throw new Error(`invalid argument near ${flag || '<end>'}`);
+        }
+        const key = flag.slice(2);
+        if (Object.hasOwn(values, key)) {
+            throw new Error(`duplicate --${key}`);
+        }
+        values[key] = value;
+    }
+    for (const key of ['tag-ref', 'default-ref', 'default-branch']) {
+        if (!values[key]) throw new Error(`--${key} is required`);
+    }
+    return values;
+}
+
+function appendOutput(file, result) {
+    if (!file) return;
+    fs.appendFileSync(path.resolve(file), [
+        `tag_sha=${result.tagSha}`,
+        `default_branch=${result.defaultBranch}`,
+        `default_sha=${result.defaultSha}`,
+        '',
+    ].join('\n'));
+}
+
+function appendSummary(file, result) {
+    if (!file) return;
+    fs.appendFileSync(path.resolve(file), [
+        '### Release source ancestry',
+        `- Tag commit: \`${result.tagSha}\``,
+        `- Reviewed branch: \`${result.defaultBranch}\` at \`${result.defaultSha}\``,
+        '- Result: tag commit is reachable from the reviewed default branch',
+        '',
+    ].join('\n'));
+}
+
+function main(argv) {
+    const args = parseArgs(argv);
+    const result = verifyProvenance({
+        tagRef: args['tag-ref'],
+        defaultRef: args['default-ref'],
+        defaultBranch: args['default-branch'],
+    });
+    appendOutput(args['github-output'], result);
+    appendSummary(args.summary, result);
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (require.main === module) {
+    try {
+        main(process.argv.slice(2));
+    } catch (error) {
+        const message = String(error?.message || error).replace(/[\r\n]+/g, ' ');
+        process.stderr.write(`::error title=Release provenance rejected::${message}\n`);
+        process.exitCode = 1;
+    }
+}
+
+module.exports = {
+    parseArgs,
+    resolveCommit,
+    verifyProvenance,
+};

--- a/scripts/release/verify-provenance.test.js
+++ b/scripts/release/verify-provenance.test.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const childProcess = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const { verifyProvenance } = require('./verify-provenance.js');
+
+const SCRIPT = path.join(__dirname, 'verify-provenance.js');
+
+function git(cwd, ...args) {
+    return childProcess.execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+}
+
+function commit(cwd, name, content) {
+    fs.writeFileSync(path.join(cwd, name), content);
+    git(cwd, 'add', name);
+    git(cwd, 'commit', '-m', `commit ${name}`);
+    return git(cwd, 'rev-parse', 'HEAD');
+}
+
+function repository(t) {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'jc-release-provenance-'));
+    t.after(() => fs.rmSync(cwd, { recursive: true, force: true }));
+    git(cwd, 'init', '--initial-branch=main');
+    git(cwd, 'config', 'user.name', 'Release Test');
+    git(cwd, 'config', 'user.email', 'release-test@example.invalid');
+    const root = commit(cwd, 'root.txt', 'root\n');
+    git(cwd, 'branch', 'reviewed', root);
+    const main = commit(cwd, 'main.txt', 'reviewed main\n');
+    git(cwd, 'switch', '--create', 'unreviewed', root);
+    const unreviewed = commit(cwd, 'feature.txt', 'unreviewed history\n');
+    return { cwd, root, main, unreviewed };
+}
+
+test('a tag on the reviewed branch or any reviewed ancestor is accepted', (t) => {
+    const repo = repository(t);
+    for (const tagRef of [repo.root, repo.main]) {
+        const result = verifyProvenance({
+            tagRef,
+            defaultRef: 'main',
+            defaultBranch: 'main',
+            cwd: repo.cwd,
+        });
+        assert.equal(result.tagSha, tagRef);
+        assert.equal(result.defaultSha, repo.main);
+        assert.equal(result.defaultBranch, 'main');
+    }
+});
+
+test('a tag on unreviewed side history is rejected with both source SHAs', (t) => {
+    const repo = repository(t);
+    assert.throws(() => verifyProvenance({
+        tagRef: repo.unreviewed,
+        defaultRef: 'main',
+        defaultBranch: 'main',
+        cwd: repo.cwd,
+    }), new RegExp(`not reachable.*${repo.main}`));
+});
+
+test('missing, non-commit and option-shaped refs fail closed', (t) => {
+    const repo = repository(t);
+    for (const tagRef of ['missing', '-c', 'bad\nref']) {
+        assert.throws(() => verifyProvenance({
+            tagRef,
+            defaultRef: 'main',
+            defaultBranch: 'main',
+            cwd: repo.cwd,
+        }), /safe git object name|git rev-parse failed/);
+    }
+});
+
+test('CLI rejects a following flag where any value is required', (t) => {
+    const repo = repository(t);
+    const result = childProcess.spawnSync(process.execPath, [
+        SCRIPT,
+        '--tag-ref', repo.main,
+        '--default-ref', 'main',
+        '--default-branch', 'main',
+        '--github-output', '--summary',
+    ], { cwd: repo.cwd, encoding: 'utf8' });
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /invalid argument near --github-output/);
+    assert.equal(fs.existsSync(path.join(repo.cwd, '--summary')), false);
+});
+
+test('CLI records the exact reviewed commits for the workflow summary and outputs', (t) => {
+    const repo = repository(t);
+    const output = path.join(repo.cwd, 'github-output.txt');
+    const summary = path.join(repo.cwd, 'summary.md');
+    const run = childProcess.spawnSync(process.execPath, [
+        SCRIPT,
+        '--tag-ref', repo.main,
+        '--default-ref', 'main',
+        '--default-branch', 'main',
+        '--github-output', output,
+        '--summary', summary,
+    ], { cwd: repo.cwd, encoding: 'utf8' });
+    assert.equal(run.status, 0, run.stderr);
+    assert.match(fs.readFileSync(output, 'utf8'), new RegExp(`tag_sha=${repo.main}`));
+    assert.match(fs.readFileSync(output, 'utf8'), new RegExp(`default_sha=${repo.main}`));
+    assert.match(fs.readFileSync(summary, 'utf8'), /Result: tag commit is reachable/);
+});

--- a/scripts/release/verify-repository-policy.js
+++ b/scripts/release/verify-repository-policy.js
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { URL } = require('node:url');
+const util = require('node:util');
+
+const DEFAULT_POLICY = path.join(__dirname, 'repository-policy.json');
+const API_VERSION = '2026-03-10';
+
+function clone(value) {
+    return JSON.parse(JSON.stringify(value));
+}
+
+function sortBy(values, key) {
+    return [...values].sort((left, right) => key(left).localeCompare(key(right)));
+}
+
+function projectObject(actual, expected) {
+    if (!expected || typeof expected !== 'object' || Array.isArray(expected)) return actual;
+    return Object.fromEntries(Object.keys(expected).map(key => [
+        key,
+        projectObject(actual?.[key], expected[key]),
+    ]));
+}
+
+function normalizeRuleset(ruleset, expected) {
+    const expectedRules = new Map(expected.rules.map(rule => [rule.type, rule]));
+    const rules = ruleset.rules.map(rule => {
+        const contract = expectedRules.get(rule.type);
+        if (!contract) return { type: rule.type };
+        const normalized = { type: rule.type };
+        if (contract.parameters) {
+            normalized.parameters = projectObject(rule.parameters, contract.parameters);
+            if (rule.type === 'required_status_checks') {
+                normalized.parameters.required_status_checks = sortBy(
+                    normalized.parameters.required_status_checks.map(check => ({
+                        context: check.context,
+                        integration_id: check.integration_id,
+                    })),
+                    check => check.context
+                );
+            }
+            if (rule.type === 'pull_request' && normalized.parameters.allowed_merge_methods) {
+                normalized.parameters.allowed_merge_methods.sort();
+            }
+        }
+        return normalized;
+    });
+    const expectedNormalized = clone(expected);
+    expectedNormalized.rules.sort((left, right) => left.type.localeCompare(right.type));
+    const expectedChecks = expectedNormalized.rules
+        .find(rule => rule.type === 'required_status_checks')?.parameters?.required_status_checks;
+    if (expectedChecks) expectedChecks.sort((left, right) => left.context.localeCompare(right.context));
+    const expectedMergeMethods = expectedNormalized.rules
+        .find(rule => rule.type === 'pull_request')?.parameters?.allowed_merge_methods;
+    if (expectedMergeMethods) expectedMergeMethods.sort();
+    expectedNormalized.bypass_actors = sortBy(expectedNormalized.bypass_actors, actor =>
+        `${actor.actor_type}:${actor.actor_id}`);
+    expectedNormalized.rules = sortBy(expectedNormalized.rules, rule => rule.type);
+
+    return {
+        actual: {
+            name: ruleset.name,
+            target: ruleset.target,
+            enforcement: ruleset.enforcement,
+            bypass_actors: sortBy(ruleset.bypass_actors || [], actor =>
+                `${actor.actor_type}:${actor.actor_id}`).map(actor => ({
+                actor_id: actor.actor_id,
+                actor_type: actor.actor_type,
+                bypass_mode: actor.bypass_mode,
+            })),
+            conditions: projectObject(ruleset.conditions, expected.conditions),
+            rules: sortBy(rules, rule => rule.type),
+        },
+        expected: expectedNormalized,
+    };
+}
+
+function normalizeEnvironment(environment, deploymentPolicies, expected) {
+    const reviewerRule = environment.protection_rules
+        ?.find(rule => rule.type === 'required_reviewers');
+    const waitRule = environment.protection_rules
+        ?.find(rule => rule.type === 'wait_timer');
+    return {
+        actual: {
+            name: environment.name,
+            wait_timer: waitRule?.wait_timer || 0,
+            prevent_self_review: reviewerRule?.prevent_self_review,
+            can_admins_bypass: environment.can_admins_bypass,
+            reviewers: sortBy(reviewerRule?.reviewers || [], reviewer =>
+                `${reviewer.type}:${reviewer.reviewer?.id}`).map(reviewer => ({
+                type: reviewer.type,
+                id: reviewer.reviewer?.id,
+            })),
+            deployment_branch_policy: environment.deployment_branch_policy,
+            deployment_policies: sortBy(deploymentPolicies, policy =>
+                `${policy.type}:${policy.name}`).map(policy => ({
+                type: policy.type,
+                name: policy.name,
+            })),
+        },
+        expected: {
+            ...clone(expected),
+            reviewers: sortBy(expected.reviewers, reviewer =>
+                `${reviewer.type}:${reviewer.id}`),
+            deployment_policies: sortBy(expected.deployment_policies, policy =>
+                `${policy.type}:${policy.name}`),
+        },
+    };
+}
+
+function assertContract(label, pair) {
+    if (!util.isDeepStrictEqual(pair.actual, pair.expected)) {
+        throw new Error(`${label} drifted from repository-policy.json\n`
+            + `expected=${JSON.stringify(pair.expected)}\n`
+            + `actual=${JSON.stringify(pair.actual)}`);
+    }
+}
+
+async function fetchJson(fetchImpl, url, token) {
+    const response = await fetchImpl(url, {
+        headers: {
+            Accept: 'application/vnd.github+json',
+            Authorization: `Bearer ${token}`,
+            'X-GitHub-Api-Version': API_VERSION,
+        },
+        redirect: 'error',
+    });
+    if (!response.ok) {
+        throw new Error(`GitHub API ${response.status} for ${new URL(url).pathname}`);
+    }
+    return response.json();
+}
+
+async function verifyLivePolicy({ policy, token, fetchImpl = globalThis.fetch }) {
+    if (!token) throw new Error('GH_TOKEN is required to verify protected policy details');
+    if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(policy.repository)) {
+        throw new Error('policy repository must be owner/name');
+    }
+    const root = `https://api.github.com/repos/${policy.repository}`;
+    const summaries = await fetchJson(fetchImpl, `${root}/rulesets`, token);
+    if (!Array.isArray(summaries)) throw new Error('GitHub ruleset response must be an array');
+    for (const expected of policy.rulesets) {
+        const matches = summaries.filter(ruleset => ruleset.name === expected.name);
+        if (matches.length !== 1) {
+            throw new Error(`expected exactly one live ruleset named ${expected.name}; found ${matches.length}`);
+        }
+        const detail = await fetchJson(fetchImpl, `${root}/rulesets/${matches[0].id}`, token);
+        assertContract(`ruleset ${expected.name}`, normalizeRuleset(detail, expected));
+    }
+
+    const encodedEnvironment = encodeURIComponent(policy.environment.name);
+    const environment = await fetchJson(
+        fetchImpl,
+        `${root}/environments/${encodedEnvironment}`,
+        token
+    );
+    const policies = await fetchJson(
+        fetchImpl,
+        `${root}/environments/${encodedEnvironment}/deployment-branch-policies?per_page=100`,
+        token
+    );
+    assertContract(
+        `environment ${policy.environment.name}`,
+        normalizeEnvironment(
+            environment,
+            policies.branch_policies || [],
+            policy.environment
+        )
+    );
+    return {
+        repository: policy.repository,
+        rulesets: policy.rulesets.map(ruleset => ruleset.name),
+        environment: policy.environment.name,
+    };
+}
+
+function parseArgs(argv) {
+    const values = { policy: DEFAULT_POLICY };
+    const seen = new Set();
+    for (let index = 0; index < argv.length; index += 2) {
+        const flag = argv[index];
+        const value = argv[index + 1];
+        if (!flag?.startsWith('--') || value === undefined || value.startsWith('--')) {
+            throw new Error(`invalid argument near ${flag || '<end>'}`);
+        }
+        const key = flag.slice(2);
+        if (key !== 'policy') throw new Error(`unknown --${key}`);
+        if (seen.has(key)) throw new Error('duplicate --policy');
+        seen.add(key);
+        values.policy = value;
+    }
+    return values;
+}
+
+async function main(argv) {
+    const args = parseArgs(argv);
+    const policy = JSON.parse(fs.readFileSync(path.resolve(args.policy), 'utf8'));
+    const result = await verifyLivePolicy({ policy, token: process.env.GH_TOKEN });
+    const message = `Verified ${result.rulesets.length} release rulesets and environment ${result.environment}`;
+    process.stdout.write(`${message}\n`);
+    if (process.env.GITHUB_STEP_SUMMARY) {
+        fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, [
+            '### Repository release policy',
+            `- Repository: \`${result.repository}\``,
+            `- Rulesets: ${result.rulesets.map(name => `\`${name}\``).join(', ')}`,
+            `- Approval environment: \`${result.environment}\``,
+            '- Result: live GitHub policy matches the committed contract',
+            '',
+        ].join('\n'));
+    }
+}
+
+if (require.main === module) {
+    main(process.argv.slice(2)).catch(error => {
+        const message = String(error?.message || error).replace(/[\r\n]+/g, ' ');
+        process.stderr.write(`::error title=Repository policy drift::${message}\n`);
+        process.exitCode = 1;
+    });
+}
+
+module.exports = {
+    normalizeEnvironment,
+    normalizeRuleset,
+    parseArgs,
+    verifyLivePolicy,
+};

--- a/scripts/release/verify-repository-policy.test.js
+++ b/scripts/release/verify-repository-policy.test.js
@@ -1,0 +1,144 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const { URL } = require('node:url');
+
+const { parseArgs, verifyLivePolicy } = require('./verify-repository-policy.js');
+
+const policy = JSON.parse(fs.readFileSync(
+    path.join(__dirname, 'repository-policy.json'),
+    'utf8'
+));
+
+function clone(value) {
+    return JSON.parse(JSON.stringify(value));
+}
+
+function liveState() {
+    const rulesets = policy.rulesets.map((ruleset, index) => ({
+        ...clone(ruleset),
+        id: index + 100,
+        source_type: 'Repository',
+    }));
+    const environment = {
+        name: policy.environment.name,
+        can_admins_bypass: policy.environment.can_admins_bypass,
+        deployment_branch_policy: clone(policy.environment.deployment_branch_policy),
+        protection_rules: [
+            {
+                type: 'required_reviewers',
+                prevent_self_review: policy.environment.prevent_self_review,
+                reviewers: policy.environment.reviewers.map(reviewer => ({
+                    type: reviewer.type,
+                    reviewer: { id: reviewer.id, login: policy.maintainer.login },
+                })),
+            },
+            { type: 'branch_policy' },
+        ],
+    };
+    return {
+        rulesets,
+        environment,
+        branchPolicies: {
+            total_count: policy.environment.deployment_policies.length,
+            branch_policies: clone(policy.environment.deployment_policies),
+        },
+    };
+}
+
+function fakeFetch(state) {
+    return async url => {
+        const pathname = new URL(url).pathname;
+        let body;
+        if (pathname.endsWith('/rulesets')) {
+            body = state.rulesets.map(({ id, name, target, enforcement }) =>
+                ({ id, name, target, enforcement }));
+        } else if (/\/rulesets\/\d+$/.test(pathname)) {
+            const id = Number(pathname.split('/').at(-1));
+            body = state.rulesets.find(ruleset => ruleset.id === id);
+        } else if (pathname.endsWith('/deployment-branch-policies')) {
+            body = state.branchPolicies;
+        } else if (pathname.endsWith('/environments/release')) {
+            body = state.environment;
+        }
+        return {
+            ok: body !== undefined,
+            status: body === undefined ? 404 : 200,
+            json: async () => clone(body),
+        };
+    };
+}
+
+async function verify(state) {
+    return verifyLivePolicy({
+        policy,
+        token: 'test-token',
+        fetchImpl: fakeFetch(state),
+    });
+}
+
+test('exact live rulesets, bypasses, checks, reviewers, and tag policies pass', async () => {
+    const result = await verify(liveState());
+    assert.equal(result.repository, policy.repository);
+    assert.equal(result.rulesets.length, 3);
+    assert.equal(result.environment, 'release');
+});
+
+test('missing or duplicate named rulesets fail closed', async () => {
+    const missing = liveState();
+    missing.rulesets.shift();
+    await assert.rejects(verify(missing), /expected exactly one live ruleset/);
+
+    const duplicate = liveState();
+    duplicate.rulesets.push({ ...clone(duplicate.rulesets[0]), id: 999 });
+    await assert.rejects(verify(duplicate), /found 2/);
+});
+
+test('weakened enforcement, status checks, or immutable-tag bypasses are detected', async () => {
+    const mutations = [
+        state => { state.rulesets[0].enforcement = 'disabled'; },
+        state => { state.rulesets[0].rules.at(-1).parameters.required_status_checks.pop(); },
+        state => { state.rulesets[0].rules.at(-1).parameters.required_status_checks[0].integration_id = 1; },
+        state => { state.rulesets[2].bypass_actors.push({ actor_id: 45441845, actor_type: 'User', bypass_mode: 'always' }); },
+    ];
+    for (const mutate of mutations) {
+        const state = liveState();
+        mutate(state);
+        await assert.rejects(verify(state), /drifted from repository-policy/);
+    }
+});
+
+test('environment approval removal, admin bypass, and tag-policy drift are detected', async () => {
+    const mutations = [
+        state => { state.environment.protection_rules = [{ type: 'branch_policy' }]; },
+        state => { state.environment.can_admins_bypass = true; },
+        state => { state.branchPolicies.branch_policies.pop(); },
+    ];
+    for (const mutate of mutations) {
+        const state = liveState();
+        mutate(state);
+        await assert.rejects(verify(state), /drifted from repository-policy/);
+    }
+});
+
+test('missing authentication and API failures are blocking', async () => {
+    await assert.rejects(verifyLivePolicy({
+        policy,
+        token: '',
+        fetchImpl: fakeFetch(liveState()),
+    }), /GH_TOKEN is required/);
+    await assert.rejects(verifyLivePolicy({
+        policy,
+        token: 'test-token',
+        fetchImpl: async () => ({ ok: false, status: 403 }),
+    }), /GitHub API 403/);
+});
+
+test('policy CLI rejects unknown, duplicate, and flag-shaped values', () => {
+    assert.throws(() => parseArgs(['--unknown', 'value']), /unknown --unknown/);
+    assert.throws(() => parseArgs(['--policy', 'one.json', '--policy', 'two.json']), /duplicate --policy/);
+    assert.throws(() => parseArgs(['--policy', '--unknown']), /invalid argument/);
+});


### PR DESCRIPTION
Closes #99.

## What changed

- prove every release tag commit is reachable from the reviewed default branch before any downstream gate or publication job can run;
- run the complete reusable Build & Test and Security Scan workflows against the exact tag SHA;
- gate the write-capable release job behind a protected `release` environment;
- declare the required default-branch, release-tag, and environment policy in `scripts/release/repository-policy.json`;
- bind every required status context to the GitHub Actions app, prevent release-tag movement/deletion, and verify live policy drift daily and before releases;
- dispatch required checks for generated manifest PRs against an exact branch-head SHA, using new workflow-run IDs so stale failed runs cannot masquerade as a new dispatch;
- document the approval model, strict-check branch-update recovery, and auditable emergency procedure.

## Why

Previously, any matching version tag could publish from history that was not reachable from the reviewed default branch, without protected repository gates or an explicit release approval. This adds workflow-level provenance checks and versioned live repository policy as defense in depth.

## Validation

- `npm run test:scripts` — 213/213 passed
- `npm run typecheck` and `npm run typecheck:src` — passed
- `npm run syntax` — passed
- `JC_LINT_OUTPUT=compact ./verify.sh lint` — completed with 0 errors (existing advisory warnings only)
- Actionlint 1.7.12 — all workflows passed
- `git diff --check` — passed
- GitHub live API schema validation accepted the declared ruleset, including all seven `integration_id: 15368` required checks; the temporary disabled validation ruleset was deleted
- Fable low-effort independent follow-up review — no actionable findings

After this PR merges, the three active rulesets and protected `release` environment will be applied from the committed contract and the live drift verifier must pass before #99 is considered complete.
