### PR TITLE
Normalize GitHub tag-rule readback

### DIFF
--- a/scripts/release/verify-repository-policy.js
+++ b/scripts/release/verify-repository-policy.js
@@ -33,6 +33,17 @@ function normalizeRuleset(ruleset, expected) {
         const normalized = { type: rule.type };
         if (contract.parameters) {
             normalized.parameters = projectObject(rule.parameters, contract.parameters);
+            if (rule.type === 'update'
+                && expected.target === 'tag'
+                && contract.parameters.update_allows_fetch_and_merge === false
+                && normalized.parameters.update_allows_fetch_and_merge === undefined) {
+                // GitHub requires and accepts this field when creating an
+                // update rule, but omits the false/default value when reading
+                // tag rules back. For tags there is no upstream fetch/merge
+                // exception; the update rule itself (with no bypass actors)
+                // is the complete immutable-ref control.
+                normalized.parameters.update_allows_fetch_and_merge = false;
+            }
             if (rule.type === 'required_status_checks') {
                 normalized.parameters.required_status_checks = sortBy(
                     normalized.parameters.required_status_checks.map(check => ({

--- a/scripts/release/verify-repository-policy.test.js
+++ b/scripts/release/verify-repository-policy.test.js
@@ -23,6 +23,12 @@ function liveState() {
         id: index + 100,
         source_type: 'Repository',
     }));
+    const immutableTagUpdate = rulesets
+        .find(ruleset => ruleset.name === 'Make release tags immutable')
+        .rules.find(rule => rule.type === 'update');
+    // The live API omits this false/default parameter from tag-rule reads,
+    // even though the create endpoint requires and accepts it.
+    delete immutableTagUpdate.parameters;
     const environment = {
         name: policy.environment.name,
         can_admins_bypass: policy.environment.can_admins_bypass,
@@ -80,11 +86,19 @@ async function verify(state) {
     });
 }
 
-test('exact live rulesets, bypasses, checks, reviewers, and tag policies pass', async () => {
+test('exact live policy passes with GitHub-normalized tag update parameters', async () => {
     const result = await verify(liveState());
     assert.equal(result.repository, policy.repository);
     assert.equal(result.rulesets.length, 3);
     assert.equal(result.environment, 'release');
+});
+
+test('an explicit false tag-update parameter remains compatible', async () => {
+    const state = liveState();
+    state.rulesets[2].rules.find(rule => rule.type === 'update').parameters = {
+        update_allows_fetch_and_merge: false,
+    };
+    await verify(state);
 });
 
 test('missing or duplicate named rulesets fail closed', async () => {
@@ -102,6 +116,15 @@ test('weakened enforcement, status checks, or immutable-tag bypasses are detecte
         state => { state.rulesets[0].enforcement = 'disabled'; },
         state => { state.rulesets[0].rules.at(-1).parameters.required_status_checks.pop(); },
         state => { state.rulesets[0].rules.at(-1).parameters.required_status_checks[0].integration_id = 1; },
+        state => {
+            state.rulesets[2].rules = state.rulesets[2].rules
+                .filter(rule => rule.type !== 'update');
+        },
+        state => {
+            state.rulesets[2].rules.find(rule => rule.type === 'update').parameters = {
+                update_allows_fetch_and_merge: true,
+            };
+        },
         state => { state.rulesets[2].bypass_actors.push({ actor_id: 45441845, actor_type: 'User', bypass_mode: 'always' }); },
     ];
     for (const mutate of mutations) {


### PR DESCRIPTION
Closes #99.

## What changed

Normalize GitHub's read-back representation for immutable tag update rules. The ruleset creation endpoint requires and accepts `update_allows_fetch_and_merge: false`, but the live detail endpoint omits that false/default parameter for tag targets and returns only `{ "type": "update" }`.

The verifier now treats that one documented/observed omission as semantically false only when:

- the committed contract targets tags;
- the live `update` rule is present;
- the committed expected value is exactly `false`; and
- the live field is actually omitted.

It still fails if the update rule is missing, the ruleset targets branches, bypass actors appear, or the API returns `true` or any other non-omitted value.

## Validation

- focused verifier tests — 7/7 passed
- complete script suite — 213/213 passed
- both TypeScript checks — passed
- ESLint advisory run — 0 errors (existing warnings only)
- live verifier — `Verified 3 release rulesets and environment release`
- Fable low-effort independent review — normalization is sound and fail-closed; no blocking findings

This follow-up was discovered by applying and immediately verifying the live policy after #243 merged. Issue #99 was reopened and returned to In Progress until this normalization lands and the verifier succeeds from committed `main`.
