### PR TITLE
Make bookmark cleanup authoritative

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/BookmarkRevisionControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/BookmarkRevisionControllerTests.cs
@@ -22,6 +22,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
         private readonly string _baseDir;
         private readonly UserConfigurationManager _manager;
         private readonly User _user;
+        private readonly CountingLibraryManager _libraryManager;
 
         public BookmarkRevisionControllerTests()
         {
@@ -29,6 +30,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             Directory.CreateDirectory(_baseDir);
             _manager = new UserConfigurationManager(new StubAppPaths(_baseDir), NullLogger<UserConfigurationManager>.Instance);
             _user = new User("bookmark-user", "Provider", "PasswordProvider");
+            _libraryManager = new CountingLibraryManager();
         }
 
         private string UserId => _user.Id.ToString("N");
@@ -54,7 +56,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 new StubUserManager(_user),
                 new SeerrCache(provider),
                 provider,
-                _manager);
+                _manager,
+                _libraryManager);
             controller.ControllerContext = new ControllerContext
             {
                 HttpContext = new DefaultHttpContext
@@ -338,6 +341,109 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             var final = State();
             Assert.Equal(2, final.Revision);
             Assert.Equal(new[] { "keep", "new" }, final.Bookmarks.Keys.OrderBy(key => key).ToArray());
+        }
+
+        [Fact]
+        public void Cleanup_MixedExistenceResults_DeleteOnlyGlobalAbsenceAndRemainIdempotent()
+        {
+            var gone = Guid.NewGuid();
+            var visible = Guid.NewGuid();
+            var hidden = Guid.NewGuid();
+            var transient = Guid.NewGuid();
+            Seed(
+                ("gone-a", Bookmark(gone.ToString("N"))),
+                ("gone-b", Bookmark(gone.ToString("N"))),
+                ("visible", Bookmark(visible.ToString("N"))),
+                ("hidden", Bookmark(hidden.ToString("N"))),
+                ("transient", Bookmark(transient.ToString("N"))),
+                ("malformed", Bookmark("not-a-jellyfin-guid")));
+
+            _libraryManager.GetItemByIdHook = id =>
+            {
+                if (id == gone) return null;
+                if (id == transient) throw new IOException("temporary library database failure");
+                return new StubMovie { Id = id };
+            };
+            _libraryManager.GetItemByIdUserHook = (id, _) =>
+                id == hidden ? null : new StubMovie { Id = id };
+
+            var first = Controller().CleanupUserBookmarks(
+                UserId,
+                new UserSettingsController.BookmarkCleanupPayload { Revision = 0 },
+                CancellationToken.None);
+            var firstResponse = Assert.IsType<UserSettingsController.BookmarkMutationResponse>(
+                Assert.IsType<OkObjectResult>(first).Value);
+
+            Assert.Equal(2, firstResponse.Deleted);
+            Assert.Equal(3, firstResponse.RetainedUncertain);
+            Assert.Equal(2, firstResponse.Errors);
+            Assert.Equal(1, firstResponse.Revision);
+            Assert.Equal(
+                new[] { "hidden", "malformed", "transient", "visible" },
+                firstResponse.Bookmarks.Keys.OrderBy(key => key).ToArray());
+
+            // Regaining visibility must not turn the retained bookmark into a
+            // deletion candidate. Repeating cleanup is a no-op revision-wise.
+            _libraryManager.GetItemByIdUserHook = (id, _) => new StubMovie { Id = id };
+            var second = Controller().CleanupUserBookmarks(
+                UserId,
+                new UserSettingsController.BookmarkCleanupPayload { Revision = 1 },
+                CancellationToken.None);
+            var secondResponse = Assert.IsType<UserSettingsController.BookmarkMutationResponse>(
+                Assert.IsType<OkObjectResult>(second).Value);
+
+            Assert.Equal(0, secondResponse.Deleted);
+            Assert.Equal(2, secondResponse.RetainedUncertain);
+            Assert.Equal(2, secondResponse.Errors);
+            Assert.Equal(1, secondResponse.Revision);
+            Assert.Equal(firstResponse.Bookmarks.Keys.OrderBy(key => key), secondResponse.Bookmarks.Keys.OrderBy(key => key));
+        }
+
+        [Fact]
+        public void Cleanup_CancelledBeforeClassification_PreservesExactState()
+        {
+            var itemId = Guid.NewGuid();
+            Seed(("keep", Bookmark(itemId.ToString("N"))));
+            using var cancellation = new CancellationTokenSource();
+            cancellation.Cancel();
+
+            var result = Controller().CleanupUserBookmarks(
+                UserId,
+                new UserSettingsController.BookmarkCleanupPayload { Revision = 0 },
+                cancellation.Token);
+
+            Assert.Equal(499, Assert.IsType<ObjectResult>(result).StatusCode);
+            Assert.Equal(0, State().Revision);
+            Assert.Contains("keep", State().Bookmarks.Keys);
+        }
+
+        [Fact]
+        public void Cleanup_OverBound_Returns413WithoutAnyLookupOrMutation()
+        {
+            var state = new UserBookmark
+            {
+                Revision = 0,
+                Bookmarks = Enumerable.Range(0, 1001).ToDictionary(
+                    index => $"bookmark-{index}",
+                    _ => Bookmark(Guid.NewGuid().ToString("N")),
+                    StringComparer.Ordinal)
+            };
+            _manager.SaveUserConfiguration(UserId, "bookmark.json", state);
+            _libraryManager.GetItemByIdHook = _ => throw new InvalidOperationException("lookup must remain bounded");
+
+            var result = Controller().CleanupUserBookmarks(
+                UserId,
+                new UserSettingsController.BookmarkCleanupPayload { Revision = 0 },
+                CancellationToken.None);
+            var response = Assert.IsType<UserSettingsController.BookmarkMutationResponse>(
+                Assert.IsType<ObjectResult>(result).Value);
+
+            Assert.Equal(StatusCodes.Status413PayloadTooLarge, Assert.IsType<ObjectResult>(result).StatusCode);
+            Assert.Equal(0, response.Deleted);
+            Assert.Equal(1001, response.RetainedUncertain);
+            Assert.Equal(1, response.Errors);
+            Assert.Equal(0, State().Revision);
+            Assert.Equal(1001, State().Bookmarks.Count);
         }
 
         [Fact]

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/UserSettingsRevisionControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/UserSettingsRevisionControllerTests.cs
@@ -51,7 +51,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 new StubUserManager(_user),
                 new SeerrCache(_provider),
                 _provider,
-                _manager);
+                _manager,
+                new CountingLibraryManager());
             controller.ControllerContext = new ControllerContext
             {
                 HttpContext = new DefaultHttpContext

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/UserSettingsController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/UserSettingsController.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+using System.Threading;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.Security.Cryptography;
@@ -52,6 +53,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
     public class UserSettingsController : JellyfinCanopyControllerBase
     {
         private readonly UserConfigurationManager _userConfigurationManager;
+        private readonly ILibraryManager _libraryManager;
 
         public UserSettingsController(
             IHttpClientFactory httpClientFactory,
@@ -59,10 +61,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             IUserManager userManager,
             ISeerrCache seerrCache,
             IPluginConfigProvider configProvider,
-            UserConfigurationManager userConfigurationManager)
+            UserConfigurationManager userConfigurationManager,
+            ILibraryManager libraryManager)
             : base(httpClientFactory, logger, userManager, seerrCache, configProvider)
         {
             _userConfigurationManager = userConfigurationManager;
+            _libraryManager = libraryManager;
         }
 
         [HttpGet("user-settings/{userId}/settings.json")]
@@ -878,6 +882,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             public bool? Removed { get; set; }
             public long Revision { get; set; }
             public Dictionary<string, BookmarkItem> Bookmarks { get; set; } = new Dictionary<string, BookmarkItem>();
+            public int Deleted { get; set; }
+            public int RetainedUncertain { get; set; }
+            public int Errors { get; set; }
         }
 
         [HttpPost("user-settings/{userId}/bookmark.json/batch")]
@@ -927,9 +934,81 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             }
         }
 
+        public sealed class BookmarkCleanupPayload
+        {
+            public long? Revision { get; set; }
+        }
+
+        /// <summary>
+        /// Classifies the loaded user's bookmarked Jellyfin items and removes
+        /// only entries whose item is authoritatively absent from the server.
+        /// A globally present item that is not visible to this user is retained,
+        /// as is every malformed, cancelled, or failed lookup.
+        /// </summary>
+        [HttpPost("user-settings/{userId}/bookmark.json/cleanup")]
+        [Authorize]
+        [Produces("application/json")]
+        public IActionResult CleanupUserBookmarks(
+            string userId,
+            [FromBody] BookmarkCleanupPayload payload,
+            CancellationToken cancellationToken)
+        {
+            var authorizationResult = AuthorizeUserConfigAccess(userId, out var authorizedUserId);
+            if (authorizationResult != null)
+            {
+                return authorizationResult;
+            }
+
+            if (payload == null || !payload.Revision.HasValue)
+            {
+                return PreconditionRequired();
+            }
+
+            if (!Guid.TryParseExact(authorizedUserId, "N", out var authorizedUserGuid))
+            {
+                return BadRequest(new BookmarkMutationResponse { Success = false, Message = "Invalid authorized user id." });
+            }
+
+            var user = _userManager.GetUserById(authorizedUserGuid);
+            if (user == null)
+            {
+                return NotFound(new BookmarkMutationResponse { Success = false, Message = "The authorized user no longer exists." });
+            }
+
+            var counts = new BookmarkCleanupCounts();
+            try
+            {
+                var result = CommitBookmarkMutation(
+                    authorizedUserId,
+                    payload.Revision,
+                    current => PlanBookmarkCleanup(current, user, cancellationToken, counts));
+                if (result.Status == BookmarkCommitStatus.Success)
+                {
+                    _logger.LogInformation(
+                        $"Bookmark cleanup for {ResolveUserDisplay(authorizedUserId)} deleted {counts.Deleted}, retained {counts.RetainedUncertain} uncertain, and observed {counts.Errors} lookup errors at revision {result.State!.Revision}");
+                }
+                return ToBookmarkActionResult(result, counts);
+            }
+            catch (OperationCanceledException)
+            {
+                return StatusCode(499, new BookmarkMutationResponse
+                {
+                    Success = false,
+                    Message = "Bookmark cleanup was cancelled; no deletion set was committed.",
+                    RetainedUncertain = counts.RetainedUncertain,
+                    Errors = counts.Errors
+                });
+            }
+            catch (Exception ex)
+            {
+                return BookmarkWriteFailure(authorizedUserId, "clean up bookmarks", ex);
+            }
+        }
+
         private const string BookmarkFileName = "bookmark.json";
         private const int MaxBookmarkIdLength = 256;
         private const int MaxBookmarkStringLength = 4096;
+        private const int MaxBookmarkCleanupEntries = 1000;
         private const string BookmarkInputMessage = "Bookmark ids must be 1-256 characters; ItemId is required; bookmark strings are capped at 4096 characters; Timestamp must be finite and non-negative.";
 
         private enum BookmarkCommitStatus
@@ -938,7 +1017,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             PreconditionRequired,
             Conflict,
             Invalid,
-            NotFound
+            NotFound,
+            TooLarge
         }
 
         private sealed class BookmarkCommitResult
@@ -961,6 +1041,140 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             public static BookmarkMutationPlan Invalid(string message) => new BookmarkMutationPlan { Status = BookmarkCommitStatus.Invalid, Message = message };
             public static BookmarkMutationPlan Missing(string message) => new BookmarkMutationPlan { Status = BookmarkCommitStatus.NotFound, Message = message };
             public static BookmarkMutationPlan Conflict(string message) => new BookmarkMutationPlan { Status = BookmarkCommitStatus.Conflict, Message = message };
+            public static BookmarkMutationPlan TooLarge(string message) => new BookmarkMutationPlan { Status = BookmarkCommitStatus.TooLarge, Message = message };
+        }
+
+        private sealed class BookmarkCleanupCounts
+        {
+            public int Deleted { get; set; }
+            public int RetainedUncertain { get; set; }
+            public int Errors { get; set; }
+        }
+
+        private enum BookmarkItemExistenceKind
+        {
+            Exists,
+            NotFound,
+            ForbiddenOrNotVisible,
+            TransientFailure,
+            Cancelled
+        }
+
+        private readonly struct BookmarkItemExistenceResult
+        {
+            public BookmarkItemExistenceResult(BookmarkItemExistenceKind kind, string errorType = "")
+            {
+                Kind = kind;
+                ErrorType = errorType;
+            }
+
+            public BookmarkItemExistenceKind Kind { get; }
+            public string ErrorType { get; }
+        }
+
+        private BookmarkItemExistenceResult ClassifyBookmarkItem(
+            Guid itemId,
+            JUser user,
+            CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return new BookmarkItemExistenceResult(BookmarkItemExistenceKind.Cancelled);
+            }
+
+            try
+            {
+                var serverItem = _libraryManager.GetItemById<BaseItem>(itemId);
+                if (serverItem == null)
+                {
+                    return new BookmarkItemExistenceResult(BookmarkItemExistenceKind.NotFound);
+                }
+
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return new BookmarkItemExistenceResult(BookmarkItemExistenceKind.Cancelled);
+                }
+
+                // Global existence plus a null user-scoped lookup means the
+                // item is forbidden/not visible, never deleted.
+                return _libraryManager.GetItemById<BaseItem>(itemId, user) == null
+                    ? new BookmarkItemExistenceResult(BookmarkItemExistenceKind.ForbiddenOrNotVisible)
+                    : new BookmarkItemExistenceResult(BookmarkItemExistenceKind.Exists);
+            }
+            catch (OperationCanceledException)
+            {
+                return new BookmarkItemExistenceResult(BookmarkItemExistenceKind.Cancelled);
+            }
+            catch (Exception ex)
+            {
+                return new BookmarkItemExistenceResult(
+                    BookmarkItemExistenceKind.TransientFailure,
+                    ex.GetType().Name);
+            }
+        }
+
+        private BookmarkMutationPlan PlanBookmarkCleanup(
+            UserBookmark current,
+            JUser user,
+            CancellationToken cancellationToken,
+            BookmarkCleanupCounts counts)
+        {
+            if (current.Bookmarks.Count > MaxBookmarkCleanupEntries)
+            {
+                counts.RetainedUncertain = current.Bookmarks.Count;
+                counts.Errors = 1;
+                return BookmarkMutationPlan.TooLarge(
+                    $"Bookmark cleanup is bounded to {MaxBookmarkCleanupEntries} entries per request; no entries were removed.");
+            }
+
+            var deleteIds = new List<string>();
+            foreach (var itemGroup in current.Bookmarks.GroupBy(
+                pair => pair.Value?.ItemId ?? string.Empty,
+                StringComparer.Ordinal))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var entries = itemGroup.ToList();
+                if (!Guid.TryParse(itemGroup.Key, out var itemId))
+                {
+                    counts.RetainedUncertain += entries.Count;
+                    counts.Errors++;
+                    continue;
+                }
+
+                var existence = ClassifyBookmarkItem(itemId, user, cancellationToken);
+                switch (existence.Kind)
+                {
+                    case BookmarkItemExistenceKind.NotFound:
+                        deleteIds.AddRange(entries.Select(entry => entry.Key));
+                        break;
+                    case BookmarkItemExistenceKind.ForbiddenOrNotVisible:
+                        counts.RetainedUncertain += entries.Count;
+                        break;
+                    case BookmarkItemExistenceKind.TransientFailure:
+                        counts.RetainedUncertain += entries.Count;
+                        counts.Errors++;
+                        _logger.LogWarning(
+                            $"Retaining {entries.Count} bookmark(s) for item {itemId:N}; existence classification failed: {existence.ErrorType}");
+                        break;
+                    case BookmarkItemExistenceKind.Cancelled:
+                        throw new OperationCanceledException(cancellationToken);
+                    case BookmarkItemExistenceKind.Exists:
+                    default:
+                        break;
+                }
+            }
+
+            // Cancellation before this point cannot mutate the bookmark map.
+            // Once the deletion set is complete, commit it as one revision.
+            cancellationToken.ThrowIfCancellationRequested();
+            foreach (var bookmarkId in deleteIds)
+            {
+                current.Bookmarks.Remove(bookmarkId);
+            }
+            counts.Deleted = deleteIds.Count;
+            return deleteIds.Count == 0
+                ? BookmarkMutationPlan.NoChange()
+                : BookmarkMutationPlan.Change();
         }
 
         private BookmarkCommitResult CommitBookmarkMutation(
@@ -1153,7 +1367,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 Message = "A bookmark Revision from the latest committed state is required."
             });
 
-        private IActionResult ToBookmarkActionResult(BookmarkCommitResult result)
+        private IActionResult ToBookmarkActionResult(
+            BookmarkCommitResult result,
+            BookmarkCleanupCounts? cleanup = null)
         {
             if (result.State != null) SetBookmarkEtag(result.State.Revision);
             var response = new BookmarkMutationResponse
@@ -1164,7 +1380,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 Id = result.ResponseId,
                 Removed = result.Removed,
                 Revision = result.State?.Revision ?? 0,
-                Bookmarks = result.State?.Bookmarks ?? new Dictionary<string, BookmarkItem>()
+                Bookmarks = result.State?.Bookmarks ?? new Dictionary<string, BookmarkItem>(),
+                Deleted = cleanup?.Deleted ?? 0,
+                RetainedUncertain = cleanup?.RetainedUncertain ?? 0,
+                Errors = cleanup?.Errors ?? 0
             };
 
             return result.Status switch
@@ -1174,6 +1393,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 BookmarkCommitStatus.Conflict => Conflict(response),
                 BookmarkCommitStatus.Invalid => BadRequest(response),
                 BookmarkCommitStatus.NotFound => NotFound(response),
+                BookmarkCommitStatus.TooLarge => StatusCode(StatusCodes.Status413PayloadTooLarge, response),
                 _ => StatusCode(StatusCodes.Status500InternalServerError, response)
             };
         }

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/ar.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/ar.json
@@ -381,6 +381,7 @@
   "toast_bookmark_save_failed": "{{icon:error}} فشل في حفظ الإشارة المرجعية",
   "toast_jumped_to_bookmark": "{{icon:bookmark}} تم التخطي إلى الإشارة المرجعية",
   "bookmark_cleanup_complete": "اكتمل التنظيف: تمت إزالة {count} إشارة مرجعية معزولة",
+  "bookmark_cleanup_uncertain_summary": "تم الاحتفاظ بغير المؤكد: {retained}؛ الأخطاء: {errors}",
   "bookmark_cleanup_failed": "فشل التنظيف",
   "bookmark_delete_all_confirm": "هل تريد حذف جميع الإشارات المرجعية؟ لا يمكن التراجع عن هذا الإجراء!",
   "bookmark_deleted_all": "تم حذف جميع الإشارات المرجعية",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/bg.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/bg.json
@@ -381,6 +381,7 @@
   "toast_bookmark_save_failed": "{{icon:error}} Неуспешно запазване на отметката",
   "toast_jumped_to_bookmark": "{{icon:bookmark}} Прескачане до отметка",
   "bookmark_cleanup_complete": "Почистването завърши: премахнати са {count} изоставени отметки",
+  "bookmark_cleanup_uncertain_summary": "Запазени несигурни: {retained}; грешки: {errors}",
   "bookmark_cleanup_failed": "Почистването е неуспешно",
   "bookmark_delete_all_confirm": "Изтриване на ВСИЧКИ отметки? Това действие не може да бъде отменено!",
   "bookmark_deleted_all": "Всички отметки са изтрити",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/ca.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/ca.json
@@ -381,6 +381,7 @@
   "toast_bookmark_save_failed": "{{icon:error}} Error en desar el marcador",
   "toast_jumped_to_bookmark": "{{icon:bookmark}} Saltat al marcador",
   "bookmark_cleanup_complete": "Neteja completada: s'han eliminat {count} marcadors orfes",
+  "bookmark_cleanup_uncertain_summary": "Conservats per incertesa: {retained}; errors: {errors}",
   "bookmark_cleanup_failed": "Neteja fallida",
   "bookmark_delete_all_confirm": "Eliminar TOTS els marcadors? Això no es pot desfer!",
   "bookmark_deleted_all": "Tots els marcadors eliminats",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/cs.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/cs.json
@@ -381,6 +381,7 @@
   "toast_bookmark_save_failed": "{{icon:error}} Nepodařilo se uložit záložku",
   "toast_jumped_to_bookmark": "{{icon:bookmark}} Přeskočeno na záložku",
   "bookmark_cleanup_complete": "Čištění dokončeno: odstraněno {count} osiřelých záložek",
+  "bookmark_cleanup_uncertain_summary": "Ponecháno jako nejisté: {retained}; chyby: {errors}",
   "bookmark_cleanup_failed": "Čištění selhalo",
   "bookmark_delete_all_confirm": "Smazat VŠECHNY záložky? Toto nelze vrátit zpět!",
   "bookmark_deleted_all": "Všechny záložky smazány",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/da.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/da.json
@@ -381,6 +381,7 @@
   "toast_bookmark_save_failed": "{{icon:error}} Kunne ikke gemme bogmærke",
   "toast_jumped_to_bookmark": "{{icon:bookmark}} Sprang til bogmærke",
   "bookmark_cleanup_complete": "Oprydning fuldført: fjernede {count} forældreløse bogmærker",
+  "bookmark_cleanup_uncertain_summary": "Beholdt som usikre: {retained}; fejl: {errors}",
   "bookmark_cleanup_failed": "Oprydning mislykkedes",
   "bookmark_delete_all_confirm": "Slet ALLE bogmærker? Dette kan ikke fortrydes!",
   "bookmark_deleted_all": "Alle bogmærker slettet",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/de.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/de.json
@@ -381,6 +381,7 @@
   "toast_bookmark_save_failed": "{{icon:error}} Fehler beim Speichern des Lesezeichens",
   "toast_jumped_to_bookmark": "{{icon:bookmark}} Zu Lesezeichen gesprungen",
   "bookmark_cleanup_complete": "Bereinigung abgeschlossen: {count} verwaiste Lesezeichen entfernt",
+  "bookmark_cleanup_uncertain_summary": "Unsichere beibehalten: {retained}; Fehler: {errors}",
   "bookmark_cleanup_failed": "Bereinigung fehlgeschlagen",
   "bookmark_delete_all_confirm": "ALLE Lesezeichen löschen? Dies kann nicht rückgängig gemacht werden!",
   "bookmark_deleted_all": "Alle Lesezeichen gelöscht",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/en-GB.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/en-GB.json
@@ -382,6 +382,7 @@
   "toast_bookmark_save_failed": "{{icon:error}} Failed to save bookmark",
   "toast_jumped_to_bookmark": "{{icon:bookmark}} Jumped to bookmark",
   "bookmark_cleanup_complete": "Cleanup complete: removed {count} orphaned bookmarks",
+  "bookmark_cleanup_uncertain_summary": "Retained uncertain: {retained}; errors: {errors}",
   "bookmark_cleanup_failed": "Cleanup failed",
   "bookmark_delete_all_confirm": "Delete ALL bookmarks? This cannot be undone!",
   "bookmark_deleted_all": "All bookmarks deleted",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/en-US.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/en-US.json
@@ -382,6 +382,7 @@
   "toast_bookmark_save_failed": "{{icon:error}} Failed to save bookmark",
   "toast_jumped_to_bookmark": "{{icon:bookmark}} Jumped to bookmark",
   "bookmark_cleanup_complete": "Cleanup complete: removed {count} orphaned bookmarks",
+  "bookmark_cleanup_uncertain_summary": "Retained uncertain: {retained}; errors: {errors}",
   "bookmark_cleanup_failed": "Cleanup failed",
   "bookmark_delete_all_confirm": "Delete ALL bookmarks? This cannot be undone!",
   "bookmark_deleted_all": "All bookmarks deleted",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/en.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/en.json
@@ -384,6 +384,7 @@
   "toast_bookmark_save_failed": "{{icon:error}} Failed to save bookmark",
   "toast_jumped_to_bookmark": "{{icon:bookmark}} Jumped to bookmark",
   "bookmark_cleanup_complete": "Cleanup complete: removed {count} orphaned bookmarks",
+  "bookmark_cleanup_uncertain_summary": "Retained uncertain: {retained}; errors: {errors}",
   "bookmark_cleanup_failed": "Cleanup failed",
   "bookmark_delete_all_confirm": "Delete ALL bookmarks? This cannot be undone!",
   "bookmark_deleted_all": "All bookmarks deleted",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/es.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/es.json
@@ -381,6 +381,7 @@
   "toast_bookmark_save_failed": "{{icon:error}} Error al guardar marcador",
   "toast_jumped_to_bookmark": "{{icon:bookmark}} Saltado a marcador",
   "bookmark_cleanup_complete": "Limpieza completada: se eliminaron {count} marcadores huérfanos",
+  "bookmark_cleanup_uncertain_summary": "Conservados por incertidumbre: {retained}; errores: {errors}",
   "bookmark_cleanup_failed": "Limpieza fallida",
   "bookmark_delete_all_confirm": "¿Eliminar TODOS los marcadores? ¡Esto no se puede deshacer!",
   "bookmark_deleted_all": "Todos los marcadores eliminados",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/fr.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/fr.json
@@ -381,6 +381,7 @@
   "toast_bookmark_save_failed": "{{icon:error}} Échec de l'enregistrement du signet",
   "toast_jumped_to_bookmark": "{{icon:bookmark}} Sauté au signet",
   "bookmark_cleanup_complete": "Nettoyage terminé : {count} signets orphelins supprimés",
+  "bookmark_cleanup_uncertain_summary": "Conservés car incertains : {retained} ; erreurs : {errors}",
   "bookmark_cleanup_failed": "Échec du nettoyage",
   "bookmark_delete_all_confirm": "Supprimer TOUS les signets ? Cette action est irréversible !",
   "bookmark_deleted_all": "Tous les signets supprimés",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/he.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/he.json
@@ -180,6 +180,7 @@
   "seerr_modal_toast_request_fail": "{{icon:error}} Failed to request seasons",
   "seerr_discover_all": "All",
   "bookmark_cleanup_complete": "Cleanup complete: removed {count} orphaned bookmarks",
+  "bookmark_cleanup_uncertain_summary": "נשמרו בשל אי-ודאות: {retained}; שגיאות: {errors}",
   "seerr_btn_error": "Error",
   "bookmark_merge_success": "{{icon:success}} Merged {count} bookmark(s) to primary version",
   "seerr_select_all_movies": "Select All Movies",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/hu.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/hu.json
@@ -381,6 +381,7 @@
   "toast_bookmark_save_failed": "{{icon:error}} Sikertelen könyvjelző mentés",
   "toast_jumped_to_bookmark": "{{icon:bookmark}} Ugrás könyvjelzőhöz",
   "bookmark_cleanup_complete": "Takarítás befejezve: {count} árva könyvjelző eltávolítva",
+  "bookmark_cleanup_uncertain_summary": "Bizonytalanság miatt megtartva: {retained}; hibák: {errors}",
   "bookmark_cleanup_failed": "Takarítás sikertelen",
   "bookmark_delete_all_confirm": "Töröljöd az ÖSSZES könyvjelzőt? Ez nem vonható vissza!",
   "bookmark_deleted_all": "Minden könyvjelző törölve",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/it.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/it.json
@@ -381,6 +381,7 @@
   "toast_bookmark_save_failed": "{{icon:error}} Impossibile salvare il segnalibro",
   "toast_jumped_to_bookmark": "{{icon:bookmark}} Saltato al segnalibro",
   "bookmark_cleanup_complete": "Pulizia completata: rimossi {count} segnalibri orfani",
+  "bookmark_cleanup_uncertain_summary": "Conservati perché incerti: {retained}; errori: {errors}",
   "bookmark_cleanup_failed": "Pulizia fallita",
   "bookmark_delete_all_confirm": "Eliminare TUTTI i segnalibri? Questa azione non può essere annullata!",
   "bookmark_deleted_all": "Tutti i segnalibri eliminati",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/nl.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/nl.json
@@ -381,6 +381,7 @@
   "toast_bookmark_save_failed": "{{icon:error}} Bladwijzer opslaan mislukt",
   "toast_jumped_to_bookmark": "{{icon:bookmark}} Gesprongen naar bladwijzer",
   "bookmark_cleanup_complete": "Opschonen voltooid: {count} weesbladwijzer(s) verwijderd",
+  "bookmark_cleanup_uncertain_summary": "Onzekere behouden: {retained}; fouten: {errors}",
   "bookmark_cleanup_failed": "Opschonen mislukt",
   "bookmark_delete_all_confirm": "ALLE bladwijzers verwijderen? Dit kan niet ongedaan worden gemaakt!",
   "bookmark_deleted_all": "Alle bladwijzers verwijderd",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/no.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/no.json
@@ -381,6 +381,7 @@
   "toast_bookmark_save_failed": "{{icon:error}} Kunne ikke lagre bokmerke",
   "toast_jumped_to_bookmark": "{{icon:bookmark}} Hoppet til bokmerke",
   "bookmark_cleanup_complete": "Opprydding fullført: fjernet {count} foreldreløse bokmerker",
+  "bookmark_cleanup_uncertain_summary": "Beholdt som usikre: {retained}; feil: {errors}",
   "bookmark_cleanup_failed": "Opprydding mislyktes",
   "bookmark_delete_all_confirm": "Slett ALLE bokmerker permanent? Dette kan ikke angres!",
   "bookmark_deleted_all": "Alle bokmerker slettet",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/pl.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/pl.json
@@ -380,6 +380,7 @@
   "toast_bookmark_save_failed": "{{icon:error}} Nie udało się zapisać zakładki",
   "toast_jumped_to_bookmark": "{{icon:bookmark}} Przeskoczono do zakładki",
   "bookmark_cleanup_complete": "Czyszczenie zakończone: usunięto {count} osieroconych zakładek",
+  "bookmark_cleanup_uncertain_summary": "Zachowane jako niepewne: {retained}; błędy: {errors}",
   "bookmark_cleanup_failed": "Czyszczenie nie powiodło się",
   "bookmark_delete_all_confirm": "Usunąć WSZYSTKIE zakładki? Nie można tego cofnąć!",
   "bookmark_deleted_all": "Wszystkie zakładki usunięte",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/pr.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/pr.json
@@ -381,6 +381,7 @@
   "toast_bookmark_save_failed": "{{icon:error}} Failed to mark th' spot",
   "toast_jumped_to_bookmark": "{{icon:bookmark}} Sailed to marked spot",
   "bookmark_cleanup_complete": "Cleanup complete: threw {count} abandoned bookmarks overboard",
+  "bookmark_cleanup_uncertain_summary": "Kept aboard as uncertain: {retained}; mishaps: {errors}",
   "bookmark_cleanup_failed": "Cleanup failed, blast!",
   "bookmark_delete_all_confirm": "Throw ALL bookmarks overboard? This cannot be undone, matey!",
   "bookmark_deleted_all": "All bookmarks sent to Davy Jones' locker",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/pt-BR.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/pt-BR.json
@@ -381,6 +381,7 @@
   "toast_bookmark_save_failed": "{{icon:error}} Falha ao guardar marcador",
   "toast_jumped_to_bookmark": "{{icon:bookmark}} Saltou para o marcador",
   "bookmark_cleanup_complete": "Limpeza concluída: {count} marcadores órfãos removidos",
+  "bookmark_cleanup_uncertain_summary": "Mantidos por incerteza: {retained}; erros: {errors}",
   "bookmark_cleanup_failed": "Limpeza falhada",
   "bookmark_delete_all_confirm": "Eliminar TODOS os marcadores? Isto não pode ser desfeito!",
   "bookmark_deleted_all": "Todos os marcadores eliminados",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/pt.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/pt.json
@@ -381,6 +381,7 @@
   "toast_bookmark_save_failed": "{{icon:error}} Falha ao guardar marcador",
   "toast_jumped_to_bookmark": "{{icon:bookmark}} Saltou para o marcador",
   "bookmark_cleanup_complete": "Limpeza concluída: {count} marcadores órfãos removidos",
+  "bookmark_cleanup_uncertain_summary": "Mantidos por incerteza: {retained}; erros: {errors}",
   "bookmark_cleanup_failed": "Limpeza falhada",
   "bookmark_delete_all_confirm": "Eliminar TODOS os marcadores? Isto não pode ser desfeito!",
   "bookmark_deleted_all": "Todos os marcadores eliminados",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/ru.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/ru.json
@@ -380,6 +380,7 @@
   "toast_bookmark_save_failed": "{{icon:error}} Не удалось сохранить закладку",
   "toast_jumped_to_bookmark": "{{icon:bookmark}} Переход к закладке",
   "bookmark_cleanup_complete": "Очистка завершена: удалено {count} потерянных закладок",
+  "bookmark_cleanup_uncertain_summary": "Сохранено как неопределённое: {retained}; ошибок: {errors}",
   "bookmark_cleanup_failed": "Очистка не удалась",
   "bookmark_delete_all_confirm": "Удалить ВСЕ закладки? Это действие нельзя отменить!",
   "bookmark_deleted_all": "Все закладки удалены",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/sk.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/sk.json
@@ -381,6 +381,7 @@
   "toast_bookmark_save_failed": "{{icon:error}} Nepodarilo sa uložiť záložku",
   "toast_jumped_to_bookmark": "{{icon:bookmark}} Preskočené na záložku",
   "bookmark_cleanup_complete": "Čistenie dokončené: odstránených {count} osirelých záložiek",
+  "bookmark_cleanup_uncertain_summary": "Ponechané ako neisté: {retained}; chyby: {errors}",
   "bookmark_cleanup_failed": "Čistenie zlyhalo",
   "bookmark_delete_all_confirm": "Vymazať VŠETKY záložky? Toto nie je možné vrátiť späť!",
   "bookmark_deleted_all": "Všetky záložky vymazané",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/sv.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/sv.json
@@ -381,6 +381,7 @@
   "toast_bookmark_save_failed": "{{icon:error}} Misslyckades spara bokmärke",
   "toast_jumped_to_bookmark": "{{icon:bookmark}} Hoppade till bokmärke",
   "bookmark_cleanup_complete": "Upprensning klar: tog bort {count} föräldralösa bokmärken",
+  "bookmark_cleanup_uncertain_summary": "Behölls som osäkra: {retained}; fel: {errors}",
   "bookmark_cleanup_failed": "Upprensning misslyckades",
   "bookmark_delete_all_confirm": "Ta bort ALLA bokmärken? Detta kan inte ångras!",
   "bookmark_deleted_all": "Alla bokmärken borttagna",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/tr.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/tr.json
@@ -381,6 +381,7 @@
   "toast_bookmark_save_failed": "{{icon:error}} Yer imi kaydedilemedi",
   "toast_jumped_to_bookmark": "{{icon:bookmark}} Yer imine atlandı",
   "bookmark_cleanup_complete": "Temizleme tamamlandı: {count} yetim yer imi kaldırıldı",
+  "bookmark_cleanup_uncertain_summary": "Belirsiz olduğu için korunan: {retained}; hatalar: {errors}",
   "bookmark_cleanup_failed": "Temizleme başarısız",
   "bookmark_delete_all_confirm": "TÜM yer imlerini sil? Bu geri alınamaz!",
   "bookmark_deleted_all": "Tüm yer imleri silindi",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/zh-CN.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/zh-CN.json
@@ -381,6 +381,7 @@
   "toast_bookmark_save_failed": "{{icon:error}} 储存书签失败",
   "toast_jumped_to_bookmark": "{{icon:bookmark}} 已跳至书签",
   "bookmark_cleanup_complete": "清理完成：已移除 {count} 个孤立书签",
+  "bookmark_cleanup_uncertain_summary": "因状态不确定而保留：{retained}；错误：{errors}",
   "bookmark_cleanup_failed": "清理失败",
   "bookmark_delete_all_confirm": "确定要删除所有书签？此操作无法复原！",
   "bookmark_deleted_all": "已删除所有书签",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/zh-HK.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/zh-HK.json
@@ -381,6 +381,7 @@
   "toast_bookmark_save_failed": "{{icon:error}} 儲存書籤失敗",
   "toast_jumped_to_bookmark": "{{icon:bookmark}} 已跳至書籤",
   "bookmark_cleanup_complete": "清理完成：已移除 {count} 個孤立書籤",
+  "bookmark_cleanup_uncertain_summary": "因狀態不確定而保留：{retained}；錯誤：{errors}",
   "bookmark_cleanup_failed": "清理失敗",
   "bookmark_delete_all_confirm": "確定要刪除所有書籤？此操作無法復原！",
   "bookmark_deleted_all": "已刪除所有書籤",

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/bookmarks.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/bookmarks.ts
@@ -5,9 +5,9 @@
 
 import { JC } from '../../globals';
 import { escapeHtml, toast } from '../../core/ui-kit';
-import { getItemCached, debounce } from '../helpers';
+import { debounce } from '../helpers';
 import { createObserver, disconnectObserver } from '../../core/dom-observer';
-import type { BookmarksApi } from './surface';
+import type { BookmarkCleanupResult, BookmarksApi } from './surface';
 import type { IdentityContext } from '../../types/jc';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -126,6 +126,17 @@ import type { IdentityContext } from '../../types/jc';
     if (direct) return direct;
     if (!shaped.responseText) return null;
     try { return committedState(JSON.parse(shaped.responseText)); } catch { return null; }
+  }
+
+  function cleanupResponse(value: unknown): { state: BookmarkCommittedState; result: BookmarkCleanupResult } | null {
+    const state = committedState(value);
+    if (!state || !value || typeof value !== 'object' || Array.isArray(value)) return null;
+    const record = value as Record<string, unknown>;
+    const deleted = Number(record.deleted ?? record.Deleted);
+    const retainedUncertain = Number(record.retainedUncertain ?? record.RetainedUncertain);
+    const errors = Number(record.errors ?? record.Errors);
+    if (![deleted, retainedUncertain, errors].every(count => Number.isSafeInteger(count) && count >= 0)) return null;
+    return { state, result: { deleted, retainedUncertain, errors } };
   }
 
   function httpStatus(error: unknown): number | undefined {
@@ -658,71 +669,73 @@ import type { IdentityContext } from '../../types/jc';
   }
 
   /**
-   * Delete bookmarks for items that no longer exist in Jellyfin
+   * Ask the server to classify every bookmarked item in the current user's
+   * library scope and atomically delete only authoritative global absences.
    */
-  async function cleanupOrphanedBookmarks(): Promise<{ cleaned: number; errors: number }> {
+  async function cleanupOrphanedBookmarks(): Promise<BookmarkCleanupResult> {
+    const empty = (): BookmarkCleanupResult => ({ deleted: 0, retainedUncertain: 0, errors: 0 });
     const captured = captureIdentity();
-    if (!captured.context) return { cleaned: 0, errors: 0 };
+    if (!captured.context) return empty();
     const root = bookmarkRootFor(captured);
-    if (!root) return { cleaned: 0, errors: 0 };
-    const allBookmarks = root.bookmarks;
-    const itemIds = new Set<string>();
-    const toDelete: string[] = [];
+    if (!root) return empty();
+    const plugin = JC.core.api?.plugin?.bind(JC.core.api);
+    if (typeof plugin !== 'function') throw new Error('Bookmark cleanup transport is unavailable');
+    const evidenceDeleted = new Set<string>();
 
-    // Collect all unique item IDs
-    for (const bookmark of Object.values<any>(allBookmarks)) {
-      if (bookmark?.itemId) itemIds.add(bookmark.itemId);
-    }
-
-    // Check which items still exist
-    const userId = captured.context.userId;
-
-    let cleaned = 0;
-    let errors = 0;
-
-    for (const itemId of itemIds) {
+    for (let attempt = 0; attempt < 5; attempt++) {
+      if (!isBookmarkRootCurrent(captured, root)) return empty();
+      const base = committedState(root);
+      if (!base) throw new Error('Bookmark state is unavailable; reload before cleanup');
       try {
-        await getItemCached(itemId, { userId });
-        if (!isIdentityCurrent(captured)) return { cleaned, errors };
-        // Item exists, keep bookmarks
-      } catch (e) {
-        if (!isBookmarkRootCurrent(captured, root)) return { cleaned, errors };
-        // DATA-SAFETY: only an EXPLICIT 404 (item confirmed gone) may delete a
-        // bookmark. A network blip, 5xx, timeout or any other failure must NOT
-        // destroy data — keep the bookmark and surface a warning instead.
-        const status = (e as { status?: number } | null)?.status;
-        if (status === 404) {
-          for (const [bookmarkId, bookmark] of Object.entries<any>(allBookmarks)) {
-            if (bookmark?.itemId === itemId) {
-              toDelete.push(bookmarkId);
+        const response = await plugin(
+          `/user-settings/${encodeURIComponent(captured.context.userId)}/bookmark.json/cleanup`,
+          { method: 'POST', body: { revision: base.revision }, skipRetry: true }
+        );
+        const cleaned = cleanupResponse(response);
+        if (!cleaned) throw new Error('Bookmark cleanup returned an invalid committed state');
+        if (!adoptCommittedState(captured, root, cleaned.state)) return empty();
+        const result = {
+          ...cleaned.result,
+          deleted: cleaned.result.deleted + evidenceDeleted.size
+        };
+        if (result.deleted > 0) emitBookmarksUpdated(captured, 'cleanup');
+        console.log(
+          `${logPrefix} Cleanup: ${result.deleted} removed, `
+          + `${result.retainedUncertain} retained uncertain, ${result.errors} errors`
+        );
+        return result;
+      } catch (error) {
+        if (isAmbiguousBookmarkTransportError(error)) {
+          if (!isBookmarkRootCurrent(captured, root)) return empty();
+          try {
+            const response = await plugin(
+              `/user-settings/${encodeURIComponent(captured.context.userId)}/bookmark.json`,
+              { method: 'GET', skipRetry: true }
+            );
+            const evidence = committedState(response);
+            if (!evidence) throw new Error('Bookmark evidence response was invalid');
+            // Evidence cannot distinguish our response-lost commit from a
+            // concurrent session deleting the same bookmark in this narrow
+            // window. Counting every newly absent id avoids false zero-success;
+            // this affects only the informational toast, never deletion policy.
+            for (const bookmarkId of Object.keys(base.bookmarks)) {
+              if (!evidence.bookmarks[bookmarkId]) evidenceDeleted.add(bookmarkId);
             }
+            if (!adoptCommittedState(captured, root, evidence)) return empty();
+            if ((error as { name?: string }).name === 'AbortError') throw error;
+            continue;
+          } catch {
+            throw error;
           }
-        } else {
-          errors++;
-          console.warn(`${logPrefix} Keeping bookmarks for ${itemId}; existence check failed (status=${status ?? 'n/a'}), not a 404:`, e);
         }
+        if (httpStatus(error) !== 409) throw error;
+        const latest = conflictState(error);
+        if (!latest) throw new Error('Bookmark conflict response omitted authoritative state');
+        if (!adoptCommittedState(captured, root, latest)) return empty();
       }
     }
 
-    // Delete every confirmed orphan in one revisioned transaction. A malformed
-    // or failed batch leaves every prior bookmark intact.
-    if (toDelete.length > 0) {
-      try {
-        const committed = await commitBookmarkBatch(captured, root, state =>
-          toDelete
-            .filter(bookmarkId => !!state.bookmarks[bookmarkId])
-            .map(bookmarkId => ({ type: 'delete' as const, bookmarkId })));
-        if (!committed) return { cleaned, errors };
-        cleaned = toDelete.filter(bookmarkId => !committed.bookmarks[bookmarkId]).length;
-      } catch (e) {
-        if (!isBookmarkRootCurrent(captured, root)) return { cleaned, errors };
-        errors += toDelete.length;
-      }
-    }
-
-    if (!isBookmarkRootCurrent(captured, root)) return { cleaned, errors };
-    console.log(`${logPrefix} Cleanup: ${cleaned} orphaned bookmarks removed, ${errors} kept/failed (non-404 or delete error)`);
-    return { cleaned, errors };
+    throw new Error('Bookmark state kept changing; retry cleanup');
   }
 
   /** Delete the currently loaded bookmark set in one atomic transaction. */

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/data-safety.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/data-safety.test.ts
@@ -1,10 +1,9 @@
 // Unit tests for the two bookmarks data-safety fixes shipped with the pages
 // cutover:
 //
-//  1. cleanup-orphans / orphan-detection deletes a bookmark ONLY when the item
-//     fetch fails with an explicit 404. Any other failure (5xx, network, etc.)
-//     keeps the bookmark.
-//  2. sync/cleanup use one revisioned server transaction and rebase on conflict.
+//  1. cleanup-orphans delegates existence classification to one bounded,
+//     revisioned server transaction and adopts only its committed state.
+//  2. transport/auth failures preserve the exact prior bookmark state.
 //
 // The functions under test live inside bookmarks.ts's `if (BookmarksEnabled)`
 // closure and are reached through the frozen JC.bookmarks facade, so each test
@@ -53,9 +52,18 @@ describe('bookmarks data-safety', () => {
             ]));
         };
         JC.toCamelCase = camel;
-        plugin = vi.fn((_path: string, options: AnyRec) => {
-            const payload = options.body as { revision: number; operations: AnyRec[] };
+        plugin = vi.fn((path: string, options: AnyRec) => {
             const current = JC.userConfig.bookmark;
+            if (path.endsWith('/cleanup')) {
+                return Promise.resolve({
+                    revision: current.revision,
+                    bookmarks: structuredClone(current.bookmarks),
+                    deleted: 0,
+                    retainedUncertain: 0,
+                    errors: 0
+                });
+            }
+            const payload = options.body as { revision: number; operations: AnyRec[] };
             if (payload.revision !== current.revision) throw httpError(409);
             const next = structuredClone(current.bookmarks);
             for (const operation of payload.operations) {
@@ -91,8 +99,8 @@ describe('bookmarks data-safety', () => {
         vi.restoreAllMocks();
     });
 
-    describe('cleanupOrphaned: delete only on explicit 404', () => {
-        it('removes bookmarks for 404 items and KEEPS bookmarks whose fetch failed for any other reason', async () => {
+    describe('cleanupOrphaned: authoritative server transaction', () => {
+        it('adopts a mixed cleanup result and reports deleted, retained-uncertain, and errors separately', async () => {
             const store: AnyRec = {
                 a: { itemId: 'gone', timestamp: 1 },
                 b: { itemId: 'flaky', timestamp: 2 },
@@ -100,39 +108,109 @@ describe('bookmarks data-safety', () => {
                 d: { itemId: 'ok', timestamp: 4 },
             };
             const api = await loadModule(store);
-
-            getItem.mockImplementation((_u: string, itemId: string) => {
-                if (itemId === 'gone') return Promise.reject(httpError(404));
-                if (itemId === 'flaky') return Promise.reject(httpError(500));
-                return Promise.resolve({ Id: itemId });
+            plugin.mockResolvedValueOnce({
+                revision: 1,
+                bookmarks: {
+                    b: store.b,
+                    d: store.d
+                },
+                deleted: 2,
+                retainedUncertain: 1,
+                errors: 1
             });
 
             const result = await api.cleanupOrphaned();
 
-            // Only the confirmed-404 item's bookmarks are deleted.
-            expect(result.cleaned).toBe(2);
-            expect(result.errors).toBe(1); // the 5xx item was kept, counted
+            expect(result).toEqual({ deleted: 2, retainedUncertain: 1, errors: 1 });
             const remaining = JC.userConfig.bookmark.bookmarks;
             expect(Object.keys(remaining).sort()).toEqual(['b', 'd']);
-            expect(remaining.b.itemId).toBe('flaky'); // transient failure -> kept
+            expect(remaining.b.itemId).toBe('flaky');
             expect(plugin).toHaveBeenCalledTimes(1);
-            expect(plugin.mock.calls[0][1].body.operations).toHaveLength(2);
+            expect(plugin).toHaveBeenCalledWith(
+                '/user-settings/u1/bookmark.json/cleanup',
+                { method: 'POST', body: { revision: 0 }, skipRetry: true }
+            );
+            expect(getItem).not.toHaveBeenCalled();
         });
 
-        it('deletes nothing when every item fetch fails transiently', async () => {
+        it.each([
+            ['401', httpError(401)],
+            ['403', httpError(403)],
+            ['429', httpError(429)],
+            ['500', httpError(500)],
+            ['503', httpError(503)],
+            ['network', new TypeError('Failed to fetch')],
+            ['abort', Object.assign(new Error('aborted'), { name: 'AbortError' })]
+        ])('preserves exact state when the cleanup request fails with %s', async (_label, failure) => {
             const store: AnyRec = {
                 a: { itemId: 'x', timestamp: 1 },
                 b: { itemId: 'y', timestamp: 2 },
             };
             const api = await loadModule(store);
-            getItem.mockRejectedValue(httpError(503));
+            plugin.mockRejectedValue(failure);
 
-            const result = await api.cleanupOrphaned();
+            await expect(api.cleanupOrphaned()).rejects.toBe(failure);
 
-            expect(result.cleaned).toBe(0);
-            expect(result.errors).toBe(2);
             expect(Object.keys(JC.userConfig.bookmark.bookmarks).sort()).toEqual(['a', 'b']);
-            expect(plugin).not.toHaveBeenCalled();
+            expect(JC.userConfig.bookmark.revision).toBe(0);
+        });
+
+        it('rebases a 409 cleanup on authoritative state without dropping a concurrent bookmark', async () => {
+            const store: AnyRec = {
+                gone: { itemId: 'gone', timestamp: 1 },
+                keep: { itemId: 'keep', timestamp: 2 }
+            };
+            const api = await loadModule(store);
+            const concurrent = { itemId: 'concurrent', timestamp: 3 };
+            plugin
+                .mockRejectedValueOnce(Object.assign(httpError(409), {
+                    responseJSON: {
+                        revision: 1,
+                        bookmarks: { ...store, concurrent }
+                    }
+                }))
+                .mockResolvedValueOnce({
+                    revision: 2,
+                    bookmarks: { keep: store.keep, concurrent },
+                    deleted: 1,
+                    retainedUncertain: 0,
+                    errors: 0
+                });
+
+            await expect(api.cleanupOrphaned()).resolves.toEqual({
+                deleted: 1,
+                retainedUncertain: 0,
+                errors: 0
+            });
+            expect(JC.userConfig.bookmark.bookmarks).toEqual({ keep: store.keep, concurrent });
+            expect(plugin.mock.calls[1][1].body.revision).toBe(1);
+        });
+
+        it('uses exact GET evidence after response loss and reports the committed deletions once', async () => {
+            const store: AnyRec = {
+                gone: { itemId: 'gone', timestamp: 1 },
+                keep: { itemId: 'keep', timestamp: 2 }
+            };
+            const api = await loadModule(store);
+            plugin
+                .mockRejectedValueOnce(new TypeError('Failed to fetch after commit'))
+                .mockResolvedValueOnce({ revision: 1, bookmarks: { keep: store.keep } })
+                .mockResolvedValueOnce({
+                    revision: 1,
+                    bookmarks: { keep: store.keep },
+                    deleted: 0,
+                    retainedUncertain: 0,
+                    errors: 0
+                });
+
+            await expect(api.cleanupOrphaned()).resolves.toEqual({
+                deleted: 1,
+                retainedUncertain: 0,
+                errors: 0
+            });
+            expect(JC.userConfig.bookmark.bookmarks).toEqual({ keep: store.keep });
+            expect(plugin).toHaveBeenCalledTimes(3);
+            expect(plugin.mock.calls[1][0]).toBe('/user-settings/u1/bookmark.json');
         });
     });
 
@@ -321,8 +399,7 @@ describe('bookmarks data-safety', () => {
         ));
         expect(JC.userConfig.bookmark.bookmarks).toEqual(initial);
 
-        getItem.mockRejectedValue(httpError(404));
-        await expect(api.cleanupOrphaned()).resolves.toEqual({ cleaned: 0, errors: 2 });
+        await expectTypedRejection(api.cleanupOrphaned());
         expect(JC.userConfig.bookmark.bookmarks).toEqual(initial);
 
         await expectTypedRejection(api.deleteAll());

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-identity.test.ts
@@ -46,7 +46,7 @@ describe('bookmarks library identity ownership', () => {
     JC.bookmarks = {
       delete: deleteBookmark,
       update: vi.fn().mockResolvedValue(true),
-      cleanupOrphaned: vi.fn().mockResolvedValue({ cleaned: 0, errors: 0 }),
+      cleanupOrphaned: vi.fn().mockResolvedValue({ deleted: 0, retainedUncertain: 0, errors: 0 }),
       syncBookmarks: vi.fn().mockResolvedValue([]),
     } as any;
     JC.saveUserSettings = saveUserSettings;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-render.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-render.ts
@@ -6,7 +6,7 @@
 // (Converted from js/enhanced/bookmarks-library-render.js — bodies semantically identical.)
 
 import { JC } from '../../globals';
-import { toast } from '../../core/ui-kit';
+import { escapeHtml, toast } from '../../core/ui-kit';
 import { renderBookmarkItems } from './library-items';
 import { showDuplicatesSyncModal } from './library-modals';
 import type { IdentityContext } from '../../types/jc';
@@ -218,7 +218,16 @@ export async function renderBookmarksLibrary(
     try {
       const result = await JC.bookmarks!.cleanupOrphaned();
       if (!JC.identity.isCurrent(context)) return;
-      toast(JC.t!('bookmark_cleanup_complete').replace('{count}', String(Number(result.cleaned) || 0)), 4000);
+      const deletedCount = Number(result.deleted) || 0;
+      const retainedCount = Number(result.retainedUncertain) || 0;
+      const errorCount = Number(result.errors) || 0;
+      const removed = JC.t!('bookmark_cleanup_complete').replace('{count}', String(deletedCount));
+      const details = retainedCount > 0 || errorCount > 0
+        ? JC.t!('bookmark_cleanup_uncertain_summary')
+          .replace('{retained}', String(retainedCount))
+          .replace('{errors}', String(errorCount))
+        : '';
+      toast([removed, details].filter(Boolean).map(escapeHtml).join(' · '), 5000);
       renderActiveBookmarks(context);
     } catch (error) {
       if (!JC.identity.isCurrent(context)) return;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/surface.d.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/surface.d.ts
@@ -9,6 +9,12 @@ import type { JEGlobal } from '../../types/jc';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+export interface BookmarkCleanupResult {
+    deleted: number;
+    retainedUncertain: number;
+    errors: number;
+}
+
 /** Public bookmarks API attached to JC.bookmarks by enhanced/bookmarks. */
 export interface BookmarksApi {
     add(timestamp: number, label?: string): Promise<Record<string, unknown> | null>;
@@ -30,7 +36,7 @@ export interface BookmarksApi {
     // `removeOldIds` migrates (deletes the originals) rather than merely
     // duplicating; copies and removals share one revisioned server transaction.
     syncBookmarks(oldBookmarks: any[], newItemDetails: any, timeOffset?: number, removeOldIds?: string[]): Promise<any[]>;
-    cleanupOrphaned(): Promise<{ cleaned: number; errors: number }>;
+    cleanupOrphaned(): Promise<BookmarkCleanupResult>;
     /** Delete the loaded bookmark set in one revisioned server transaction. */
     deleteAll(): Promise<number>;
 }

--- a/e2e/bookmark-revisions.spec.ts
+++ b/e2e/bookmark-revisions.spec.ts
@@ -19,6 +19,12 @@ interface BookmarkState {
     Bookmarks: Record<string, BookmarkItem>;
 }
 
+interface BookmarkCleanupState extends BookmarkState {
+    Deleted: number;
+    RetainedUncertain: number;
+    Errors: number;
+}
+
 function pathFor(session: Session, suffix = ''): string {
     return `/JellyfinCanopy/user-settings/${encodeURIComponent(session.userId)}/bookmark.json${suffix}`;
 }
@@ -139,6 +145,66 @@ test.describe('bookmark revision data integrity', () => {
             expect(final.Bookmarks[ids.tab2]?.ItemId).toBe('jc-tab-2');
         } finally {
             await removeTestBookmarks(session, allIds);
+        }
+    });
+
+    test('server cleanup deletes only a globally absent item and is idempotent', async () => {
+        const session = await authenticate(BASE, process.env.JF_USER_NAME || 'jc_arruser', process.env.JF_USER_PASS || 'Test669Pw!x');
+        const itemsResponse = await apiRaw(
+            BASE,
+            `/Users/${encodeURIComponent(session.userId)}/Items?Recursive=true&Limit=1`,
+            session.token
+        );
+        expect(itemsResponse.status).toBe(200);
+        const items = (await itemsResponse.json()) as { Items?: Array<{ Id?: string }> };
+        const visibleItemId = String(items.Items?.[0]?.Id || '');
+        expect(visibleItemId).toMatch(/^[0-9a-f]{32}$/i);
+
+        const nonce = `${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+        const visibleBookmarkId = `bm_e2e_cleanup_${nonce}_visible`;
+        const missingBookmarkId = `bm_e2e_cleanup_${nonce}_missing`;
+        const missingItemId = crypto.randomUUID().replaceAll('-', '');
+
+        try {
+            const initial = await readState(session);
+            const added = await batch(session, initial.Revision, [
+                {
+                    Type: 'add',
+                    BookmarkId: visibleBookmarkId,
+                    Bookmark: { ItemId: visibleItemId, Timestamp: 10, Label: 'visible' },
+                },
+                {
+                    Type: 'add',
+                    BookmarkId: missingBookmarkId,
+                    Bookmark: { ItemId: missingItemId, Timestamp: 20, Label: 'missing' },
+                },
+            ]);
+            expect(added.status).toBe(200);
+            const afterAdd = (await added.json()) as BookmarkState;
+
+            const cleaned = await apiRaw(BASE, pathFor(session, '/cleanup'), session.token, {
+                method: 'POST',
+                body: JSON.stringify({ Revision: afterAdd.Revision }),
+            });
+            expect(cleaned.status).toBe(200);
+            const cleanupState = (await cleaned.json()) as BookmarkCleanupState;
+            expect(cleanupState.Deleted).toBeGreaterThanOrEqual(1);
+            expect(cleanupState.RetainedUncertain).toBeGreaterThanOrEqual(0);
+            expect(cleanupState.Errors).toBeGreaterThanOrEqual(0);
+            expect(cleanupState.Bookmarks[visibleBookmarkId]?.ItemId).toBe(visibleItemId);
+            expect(cleanupState.Bookmarks[missingBookmarkId]).toBeUndefined();
+
+            const repeated = await apiRaw(BASE, pathFor(session, '/cleanup'), session.token, {
+                method: 'POST',
+                body: JSON.stringify({ Revision: cleanupState.Revision }),
+            });
+            expect(repeated.status).toBe(200);
+            const repeatedState = (await repeated.json()) as BookmarkCleanupState;
+            expect(repeatedState.Deleted).toBe(0);
+            expect(repeatedState.Revision).toBe(cleanupState.Revision);
+            expect(repeatedState.Bookmarks[visibleBookmarkId]?.ItemId).toBe(visibleItemId);
+        } finally {
+            await removeTestBookmarks(session, [visibleBookmarkId, missingBookmarkId]);
         }
     });
 });

--- a/e2e/required-test-inventory.json
+++ b/e2e/required-test-inventory.json
@@ -10,6 +10,7 @@
     "e2e/arr-search.spec.ts › arr Search — action-sheet items › non-admin sees none of the arr Search items",
     "e2e/auto-skip.spec.ts › Auto-Skip v2 (native media segments) › resolves the clean-seed item, seeks to exact end once, and ignores direct seek-back",
     "e2e/bookmark-revisions.spec.ts › bookmark revision data integrity › stale replacement conflicts and same-revision tabs converge without lost bookmarks",
+    "e2e/bookmark-revisions.spec.ts › bookmark revision data integrity › server cleanup deletes only a globally absent item and is idempotent",
     "e2e/boot.spec.ts › boot › initializes with all core namespaces and no real console errors",
     "e2e/console-net.spec.ts › console and HTTP error safety net › structured console errors retain their source script URL",
     "e2e/console-net.spec.ts › console and HTTP error safety net › unexpected4xx() catches a broken plugin endpoint but not an allowlisted url",


### PR DESCRIPTION
Closes #86

## Summary
- move orphan detection to a bounded, revision-checked server endpoint
- delete only when Jellyfin proves the item is globally absent; preserve hidden, forbidden, transient, malformed, and cancelled lookups
- make the client resilient to conflicts and lost responses, with localized uncertainty reporting
- add controller, client data-safety, inventory, and real Jellyfin unstable/nightly E2E coverage

## Validation
- 1,235 .NET tests
- 843 client tests plus coverage thresholds
- 214 script tests
- translation validation (26 locales at 100%)
- source typecheck, lint, release build, inventory checks
- focused Docker E2E against digest-pinned jellyfin/jellyfin:unstable (2/2)
- independent Fable-low review: APPROVED