### PR TITLE
Import Jellyfin Enhanced state safely

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Configuration/EnhancedStateMigrationTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Configuration/EnhancedStateMigrationTests.cs
@@ -1,0 +1,282 @@
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Configuration
+{
+    public sealed class EnhancedStateMigrationTests : IDisposable
+    {
+        private const string SourceXml = "Jellyfin.Plugin.JellyfinEnhanced.xml";
+        private const string TargetXml = "Jellyfin.Plugin.JellyfinCanopy.xml";
+        private const string SourceData = "Jellyfin.Plugin.JellyfinEnhanced";
+        private const string TargetData = "Jellyfin.Plugin.JellyfinCanopy";
+        private const string UserId = "0123456789abcdef0123456789abcdef";
+
+        private readonly string _root = Path.Combine(
+            Path.GetTempPath(),
+            "jc-enhanced-import-" + Guid.NewGuid().ToString("N"));
+
+        public EnhancedStateMigrationTests()
+        {
+            Directory.CreateDirectory(_root);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+            catch
+            {
+                // Best-effort test cleanup.
+            }
+
+            GC.SuppressFinalize(this);
+        }
+
+        [Fact]
+        public void ImportsCompleteEnhancedFixtureAndPreservesRollbackSource()
+        {
+            WriteSourceConfig("<DevMode>true</DevMode><JellyseerrEnabled>true</JellyseerrEnabled>");
+            WriteSourceData(UserId + "/settings.json", "{\"language\":\"fr\"}");
+            WriteSourceData(UserId + "/shortcuts.json", "{\"Shortcuts\":[]}");
+            WriteSourceData(UserId + "/bookmark.json", "{\"Bookmarks\":{\"Bm_1\":{\"ItemId\":\"abc\"}}}");
+            WriteSourceData(UserId + "/elsewhere.json", "{\"Region\":\"AU\"}");
+            WriteSourceData(UserId + "/hidden-content.json", "{\"Items\":{\"abc\":{\"ItemId\":\"abc\"}}}");
+            WriteSourceData(UserId + "/processed-watchlist-items.json", "{\"Items\":[]}");
+            WriteSourceData("reviews.json", "{\"Reviews\":{\"r1\":{\"Content\":\"great\"}}}");
+            WriteSourceData("custom_branding/login.css", ".login { color: red; }");
+            WriteSourceData("tag-cache.json", "{\"Items\":{}}");
+
+            var status = Run();
+
+            Assert.Equal(EnhancedStateMigrationStatus.Imported, status);
+            Assert.Equal(File.ReadAllText(PathOf(SourceXml)), File.ReadAllText(PathOf(TargetXml)));
+            Assert.Equal(
+                "{\"Bookmarks\":{\"Bm_1\":{\"ItemId\":\"abc\"}}}",
+                File.ReadAllText(PathOf(TargetData, UserId, "bookmark.json")));
+            Assert.Equal(
+                "{\"Items\":{\"abc\":{\"ItemId\":\"abc\"}}}",
+                File.ReadAllText(PathOf(TargetData, UserId, "hidden-content.json")));
+            Assert.Equal(
+                "{\"Reviews\":{\"r1\":{\"Content\":\"great\"}}}",
+                File.ReadAllText(PathOf(TargetData, "reviews.json")));
+            Assert.Equal(
+                ".login { color: red; }",
+                File.ReadAllText(PathOf(TargetData, "custom_branding", "login.css")));
+            Assert.True(File.Exists(PathOf(TargetData, EnhancedStateMigration.ImportMarkerFileName)));
+            Assert.True(File.Exists(PathOf(TargetXml + EnhancedStateMigration.CompletionMarkerSuffix)));
+
+            // The old plugin remains a complete rollback/export source.
+            Assert.True(File.Exists(PathOf(SourceXml)));
+            Assert.True(File.Exists(PathOf(SourceData, UserId, "settings.json")));
+            Assert.True(File.Exists(PathOf(SourceData, "reviews.json")));
+        }
+
+        [Fact]
+        public void CompletedImportIsIdempotentAndDoesNotReplayLaterSourceChanges()
+        {
+            WriteSourceConfig("<DevMode>true</DevMode>");
+            WriteSourceData(UserId + "/settings.json", "{\"Language\":\"en\"}");
+            Assert.Equal(EnhancedStateMigrationStatus.Imported, Run());
+
+            File.WriteAllText(PathOf(TargetXml), "<PluginConfiguration><DevMode>false</DevMode></PluginConfiguration>");
+            File.WriteAllText(PathOf(SourceData, UserId, "settings.json"), "{\"Language\":\"de\"}");
+
+            Assert.Equal(EnhancedStateMigrationStatus.AlreadyImported, Run());
+            Assert.Contains("<DevMode>false", File.ReadAllText(PathOf(TargetXml)), StringComparison.Ordinal);
+            Assert.Equal(
+                "{\"Language\":\"en\"}",
+                File.ReadAllText(PathOf(TargetData, UserId, "settings.json")));
+        }
+
+        [Fact]
+        public void ExistingIndependentCanopyConfigRejectsTheWholeImport()
+        {
+            WriteSourceConfig("<DevMode>true</DevMode>");
+            WriteSourceData(UserId + "/settings.json", "{}");
+            File.WriteAllText(PathOf(TargetXml), "<PluginConfiguration><DevMode>false</DevMode></PluginConfiguration>");
+
+            Assert.Equal(EnhancedStateMigrationStatus.Conflict, Run());
+            Assert.False(Directory.Exists(PathOf(TargetData)));
+            Assert.Contains("<DevMode>false", File.ReadAllText(PathOf(TargetXml)), StringComparison.Ordinal);
+            Assert.Equal(EnhancedStateMigrationStatus.AlreadyImported, Run());
+        }
+
+        [Fact]
+        public void ExistingIndependentCanopyDataRejectsTheWholeImport()
+        {
+            WriteSourceConfig("<DevMode>true</DevMode>");
+            WriteSourceData(UserId + "/settings.json", "{\"Language\":\"en\"}");
+            Directory.CreateDirectory(PathOf(TargetData, UserId));
+            File.WriteAllText(PathOf(TargetData, UserId, "settings.json"), "{\"Language\":\"fr\"}");
+
+            Assert.Equal(EnhancedStateMigrationStatus.Conflict, Run());
+            Assert.False(File.Exists(PathOf(TargetXml)));
+            Assert.Equal(
+                "{\"Language\":\"fr\"}",
+                File.ReadAllText(PathOf(TargetData, UserId, "settings.json")));
+            Assert.Equal(EnhancedStateMigrationStatus.AlreadyImported, Run());
+        }
+
+        [Fact]
+        public void RetryFinishesDataAfterConfigWasAlreadyPublished()
+        {
+            WriteSourceConfig("<DevMode>true</DevMode>");
+            File.Copy(PathOf(SourceXml), PathOf(TargetXml));
+            WriteSourceData(UserId + "/bookmark.json", "{\"Bookmarks\":{}}");
+
+            Assert.Equal(EnhancedStateMigrationStatus.Imported, Run());
+            Assert.True(File.Exists(PathOf(TargetData, UserId, "bookmark.json")));
+        }
+
+        [Fact]
+        public void RetryFinishesConfigAfterMarkedDataWasAlreadyPublished()
+        {
+            WriteSourceConfig("<DevMode>true</DevMode>");
+            WriteSourceData(UserId + "/bookmark.json", "{\"Bookmarks\":{}}");
+            Directory.CreateDirectory(PathOf(TargetData));
+            WriteValidTargetMarker();
+
+            Assert.Equal(EnhancedStateMigrationStatus.Imported, Run());
+            Assert.True(File.Exists(PathOf(TargetXml)));
+        }
+
+        [Fact]
+        public void StaleStagingTreeIsRebuiltBeforePublish()
+        {
+            WriteSourceData(UserId + "/hidden-content.json", "{\"Items\":{}}");
+            var staging = PathOf(TargetData + ".enhanced-importing");
+            Directory.CreateDirectory(staging);
+            File.WriteAllText(Path.Combine(staging, "partial.txt"), "partial");
+
+            Assert.Equal(EnhancedStateMigrationStatus.Imported, Run());
+            Assert.False(File.Exists(PathOf(TargetData, "partial.txt")));
+            Assert.True(File.Exists(PathOf(TargetData, UserId, "hidden-content.json")));
+        }
+
+        [Fact]
+        public void InvalidEnhancedXmlFailsWithoutPublishingOrMutatingSource()
+        {
+            File.WriteAllText(PathOf(SourceXml), "<PluginConfigur");
+            WriteSourceData(UserId + "/settings.json", "{}");
+
+            Assert.Equal(EnhancedStateMigrationStatus.Failed, Run());
+            Assert.Equal("<PluginConfigur", File.ReadAllText(PathOf(SourceXml)));
+            Assert.False(File.Exists(PathOf(TargetXml)));
+            Assert.False(Directory.Exists(PathOf(TargetData)));
+        }
+
+        [Theory]
+        [InlineData("reviews.json")]
+        [InlineData(UserId + "/settings.json")]
+        [InlineData(UserId + "/bookmark.json")]
+        [InlineData(UserId + "/hidden-content.json")]
+        public void InvalidCriticalJsonFailsWithoutPublishing(string relativePath)
+        {
+            WriteSourceConfig("<DevMode>true</DevMode>");
+            WriteSourceData(relativePath, "{not-json");
+
+            Assert.Equal(EnhancedStateMigrationStatus.Failed, Run());
+            Assert.False(File.Exists(PathOf(TargetXml)));
+            Assert.False(Directory.Exists(PathOf(TargetData)));
+            Assert.Equal("{not-json", File.ReadAllText(PathOf(SourceData, relativePath)));
+        }
+
+        [Fact]
+        public void MissingHalfOfSourceImportsTheAvailableHalf()
+        {
+            WriteSourceData(UserId + "/settings.json", "{}");
+
+            Assert.Equal(EnhancedStateMigrationStatus.Imported, Run());
+            Assert.False(File.Exists(PathOf(TargetXml)));
+            Assert.True(File.Exists(PathOf(TargetData, UserId, "settings.json")));
+        }
+
+        [Fact]
+        public void UnrelatedNestedJsonWithACriticalFileNameIsCopiedWithoutUserSchemaValidation()
+        {
+            WriteSourceData("custom_branding/settings.json", "[\"asset-metadata\"]");
+
+            Assert.Equal(EnhancedStateMigrationStatus.Imported, Run());
+            Assert.Equal(
+                "[\"asset-metadata\"]",
+                File.ReadAllText(PathOf(TargetData, "custom_branding", "settings.json")));
+        }
+
+        [Fact]
+        public void InvalidMarkerCannotDisguiseIndependentCanopyData()
+        {
+            WriteSourceData(UserId + "/settings.json", "{\"Language\":\"en\"}");
+            Directory.CreateDirectory(PathOf(TargetData));
+            File.WriteAllText(PathOf(TargetData, EnhancedStateMigration.ImportMarkerFileName), "{}");
+
+            Assert.Equal(EnhancedStateMigrationStatus.Conflict, Run());
+            Assert.False(File.Exists(PathOf(TargetData, UserId, "settings.json")));
+        }
+
+        [Fact]
+        public void LinkedSourceOrTargetDataFailsClosedWithoutTouchingTheLinkTarget()
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                return;
+            }
+
+            var realSource = PathOf("real-source");
+            Directory.CreateDirectory(realSource);
+            File.WriteAllText(Path.Combine(realSource, "reviews.json"), "{\"Reviews\":{}}");
+            Directory.CreateSymbolicLink(PathOf(SourceData), realSource);
+
+            Assert.Equal(EnhancedStateMigrationStatus.Failed, Run());
+            Assert.True(File.Exists(Path.Combine(realSource, "reviews.json")));
+            Directory.Delete(PathOf(SourceData));
+
+            Directory.CreateDirectory(PathOf(SourceData));
+            File.WriteAllText(PathOf(SourceData, "reviews.json"), "{\"Reviews\":{}}");
+            var realTarget = PathOf("real-target");
+            Directory.CreateDirectory(realTarget);
+            Directory.CreateSymbolicLink(PathOf(TargetData), realTarget);
+
+            Assert.Equal(EnhancedStateMigrationStatus.Failed, Run());
+            Assert.True(Directory.Exists(realTarget));
+        }
+
+        [Fact]
+        public void NoEnhancedSourceIsANoOp()
+        {
+            Assert.Equal(EnhancedStateMigrationStatus.NoSource, Run());
+            Assert.Empty(Directory.EnumerateFileSystemEntries(_root));
+        }
+
+        private EnhancedStateMigrationStatus Run()
+            => EnhancedStateMigration.Run(
+                _root,
+                PathOf(TargetXml),
+                TargetData,
+                _ => { },
+                _ => { });
+
+        private void WriteSourceConfig(string innerXml)
+        {
+            File.WriteAllText(PathOf(SourceXml), $"<PluginConfiguration>{innerXml}</PluginConfiguration>");
+        }
+
+        private void WriteSourceData(string relativePath, string content)
+        {
+            var path = PathOf(SourceData, relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, content);
+        }
+
+        private void WriteValidTargetMarker()
+        {
+            File.WriteAllText(
+                PathOf(TargetData, EnhancedStateMigration.ImportMarkerFileName),
+                "{\"Source\":\"Jellyfin.Plugin.JellyfinEnhanced\",\"ContractVersion\":1,\"ConfigurationImported\":true,\"DataImported\":true,\"Resolution\":\"Imported\"}");
+        }
+
+        private string PathOf(params string[] parts)
+            => parts.Aggregate(_root, Path.Combine);
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Configuration/EnhancedStateMigration.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Configuration/EnhancedStateMigration.cs
@@ -1,0 +1,419 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Xml.Linq;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Configuration
+{
+    internal enum EnhancedStateMigrationStatus
+    {
+        NoSource,
+        Imported,
+        AlreadyImported,
+        Conflict,
+        Failed,
+    }
+
+    /// <summary>
+    /// Imports state left by the separately identified Jellyfin Enhanced plugin.
+    /// Enhanced remains the rollback owner: its XML and data directory are never
+    /// moved, renamed, deleted, or modified. Canopy publishes only a validated,
+    /// staged copy and refuses to mix it with independently-created Canopy state.
+    /// </summary>
+    internal static class EnhancedStateMigration
+    {
+        internal const string EnhancedAssemblyName = "Jellyfin.Plugin.JellyfinEnhanced";
+        internal const string ImportMarkerFileName = ".enhanced-import.json";
+        internal const string CompletionMarkerSuffix = ".enhanced-import.json";
+        private const long MaxAdministrationXmlBytes = 16L * 1024 * 1024;
+        private const long MaxCriticalJsonBytes = 64L * 1024 * 1024;
+
+        private static readonly HashSet<string> CriticalUserFiles = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "settings.json",
+            "shortcuts.json",
+            "bookmark.json",
+            "elsewhere.json",
+            "hidden-content.json",
+            "processed-watchlist-items.json",
+        };
+
+        internal static EnhancedStateMigrationStatus Run(
+            string configDirectory,
+            string canopyConfigFilePath,
+            string canopyDataDirectoryName,
+            Action<string> logInfo,
+            Action<string> logError)
+        {
+            var sourceConfig = Path.Combine(configDirectory, EnhancedAssemblyName + ".xml");
+            var sourceData = Path.Combine(configDirectory, EnhancedAssemblyName);
+            var targetData = Path.Combine(configDirectory, canopyDataDirectoryName);
+            var stagingData = targetData + ".enhanced-importing";
+            var markerPath = Path.Combine(targetData, ImportMarkerFileName);
+            var completionMarkerPath = canopyConfigFilePath + CompletionMarkerSuffix;
+
+            // Once the complete available source was published, Canopy owns its
+            // copy. The preserved Enhanced rollback source is intentionally stale
+            // from this point onward and must never be compared or replayed over
+            // later Canopy administration changes.
+            if (TryReadImportMarker(
+                    completionMarkerPath,
+                    out var completedConfig,
+                    out var completedData,
+                    out var completedResolution)
+                && (string.Equals(completedResolution, "CanopyWins", StringComparison.Ordinal)
+                    || ((!completedConfig || File.Exists(canopyConfigFilePath))
+                        && (!completedData
+                            || TryReadImportMarker(markerPath, out _, out var dataTreeImported, out var dataResolution)
+                                && dataTreeImported
+                                && string.Equals(dataResolution, "Imported", StringComparison.Ordinal)))))
+            {
+                logInfo(string.Equals(completedResolution, "CanopyWins", StringComparison.Ordinal)
+                    ? "A prior Jellyfin Enhanced conflict was resolved by preserving the existing Canopy state; the Enhanced rollback source remains unchanged."
+                    : "Jellyfin Enhanced state was already imported; leaving both the current Canopy state and Enhanced rollback source unchanged.");
+                return EnhancedStateMigrationStatus.AlreadyImported;
+            }
+
+            var hasSourceConfig = File.Exists(sourceConfig);
+            var hasSourceData = Directory.Exists(sourceData);
+            if (!hasSourceConfig && !hasSourceData)
+            {
+                return EnhancedStateMigrationStatus.NoSource;
+            }
+
+            try
+            {
+                if (hasSourceConfig)
+                {
+                    ThrowIfReparsePoint(sourceConfig, isDirectory: false);
+                }
+
+                if (File.Exists(canopyConfigFilePath))
+                {
+                    ThrowIfReparsePoint(canopyConfigFilePath, isDirectory: false);
+                }
+
+                // Preflight every conflict before writing either destination. A
+                // partial import from an earlier attempt is recognized by exact
+                // config bytes and the marker published with the staged data tree.
+                if (hasSourceConfig && File.Exists(canopyConfigFilePath)
+                    && !FilesHaveSameContent(sourceConfig, canopyConfigFilePath))
+                {
+                    logError($"Jellyfin Enhanced migration conflict: both {Path.GetFileName(sourceConfig)} and {Path.GetFileName(canopyConfigFilePath)} contain independent configuration. Nothing was imported; both remain untouched.");
+                    RecordCanopyWins(completionMarkerPath, logInfo, logError);
+                    return EnhancedStateMigrationStatus.Conflict;
+                }
+
+                var targetDataExists = Directory.Exists(targetData);
+                if (targetDataExists)
+                {
+                    ThrowIfReparsePoint(targetData, isDirectory: true);
+                }
+
+                var targetDataIsEmpty = targetDataExists && !Directory.EnumerateFileSystemEntries(targetData).Any();
+                var targetDataWasImported = TryReadImportMarker(markerPath, out _, out var dataImported, out var targetResolution)
+                    && dataImported
+                    && string.Equals(targetResolution, "Imported", StringComparison.Ordinal);
+                if (hasSourceData && targetDataExists && !targetDataIsEmpty && !targetDataWasImported)
+                {
+                    logError($"Jellyfin Enhanced migration conflict: both {sourceData} and {targetData} contain data. Nothing was imported or merged; both remain untouched.");
+                    RecordCanopyWins(completionMarkerPath, logInfo, logError);
+                    return EnhancedStateMigrationStatus.Conflict;
+                }
+
+                if (hasSourceConfig)
+                {
+                    ValidateEnhancedConfiguration(sourceConfig);
+                }
+
+                var needsDataImport = hasSourceData && !targetDataWasImported;
+                if (needsDataImport)
+                {
+                    ValidateCriticalJson(sourceData);
+                    DeleteStagingDirectory(stagingData);
+                    CopyDirectoryTree(sourceData, stagingData);
+                    WriteImportMarker(
+                        Path.Combine(stagingData, ImportMarkerFileName),
+                        configurationImported: hasSourceConfig,
+                        dataImported: true,
+                        resolution: "Imported");
+                }
+
+                if (hasSourceConfig && !File.Exists(canopyConfigFilePath))
+                {
+                    AtomicFile.WriteAllBytes(canopyConfigFilePath, File.ReadAllBytes(sourceConfig));
+                    logInfo($"Imported Jellyfin Enhanced administration configuration into {Path.GetFileName(canopyConfigFilePath)}; the Enhanced source was preserved for rollback.");
+                }
+
+                if (needsDataImport)
+                {
+                    if (targetDataIsEmpty)
+                    {
+                        Directory.Delete(targetData);
+                    }
+
+                    Directory.Move(stagingData, targetData);
+                    logInfo($"Imported Jellyfin Enhanced per-user settings, bookmarks, hidden content, reviews, branding, and supporting data into {Path.GetFileName(targetData)}; the Enhanced source was preserved for rollback.");
+                }
+
+                // Publish last. Its presence proves every available source half
+                // reached an authoritative destination. A crash before this write
+                // is recovered through exact config comparison + the data marker.
+                WriteImportMarker(
+                    completionMarkerPath,
+                    configurationImported: hasSourceConfig,
+                    dataImported: hasSourceData,
+                    resolution: "Imported");
+                return EnhancedStateMigrationStatus.Imported;
+            }
+            catch (Exception ex)
+            {
+                try
+                {
+                    DeleteStagingDirectory(stagingData);
+                }
+                catch (Exception cleanupEx)
+                {
+                    logError($"Failed to clean the incomplete Jellyfin Enhanced migration staging directory {stagingData}: {cleanupEx.Message}");
+                }
+
+                logError($"Jellyfin Enhanced state migration failed before a complete import was published; the Enhanced source is unchanged and migration will retry on restart: {ex.Message}");
+                return EnhancedStateMigrationStatus.Failed;
+            }
+        }
+
+        private static void ValidateEnhancedConfiguration(string path)
+        {
+            if (new FileInfo(path).Length > MaxAdministrationXmlBytes)
+            {
+                throw new InvalidDataException($"{Path.GetFileName(path)} exceeds the {MaxAdministrationXmlBytes / (1024 * 1024)} MiB migration limit.");
+            }
+
+            using var stream = File.OpenRead(path);
+            var document = XDocument.Load(stream, LoadOptions.PreserveWhitespace);
+            if (document.Root == null
+                || !string.Equals(document.Root.Name.LocalName, "PluginConfiguration", StringComparison.Ordinal))
+            {
+                throw new InvalidDataException($"{Path.GetFileName(path)} is not a Jellyfin plugin configuration document.");
+            }
+        }
+
+        private static void ValidateCriticalJson(string sourceData)
+        {
+            foreach (var path in EnumerateRegularFiles(sourceData))
+            {
+                if (!string.Equals(Path.GetExtension(path), ".json", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var relative = Path.GetRelativePath(sourceData, path);
+                var isSharedReviews = string.Equals(relative, "reviews.json", StringComparison.OrdinalIgnoreCase);
+                var segments = relative.Split(
+                    new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar },
+                    StringSplitOptions.RemoveEmptyEntries);
+                var isUserFile = segments.Length == 2
+                    && UserDirMigration.GuidShapeRe.IsMatch(segments[0])
+                    && CriticalUserFiles.Contains(segments[1]);
+                if (!isSharedReviews && !isUserFile)
+                {
+                    continue;
+                }
+
+                if (new FileInfo(path).Length > MaxCriticalJsonBytes)
+                {
+                    throw new InvalidDataException($"Enhanced migration source {relative} exceeds the {MaxCriticalJsonBytes / (1024 * 1024)} MiB validation limit.");
+                }
+
+                using var stream = File.OpenRead(path);
+                using var document = JsonDocument.Parse(stream, PersistedJson.ParseOptions);
+                if (document.RootElement.ValueKind != JsonValueKind.Object)
+                {
+                    throw new InvalidDataException($"Enhanced migration source {relative} must contain a JSON object.");
+                }
+            }
+        }
+
+        private static void CopyDirectoryTree(string sourceRoot, string destinationRoot)
+        {
+            Directory.CreateDirectory(destinationRoot);
+            var pending = new Stack<(string Source, string Destination)>();
+            pending.Push((sourceRoot, destinationRoot));
+            while (pending.Count > 0)
+            {
+                var current = pending.Pop();
+                ThrowIfReparsePoint(current.Source, isDirectory: true);
+
+                foreach (var file in Directory.EnumerateFiles(current.Source))
+                {
+                    ThrowIfReparsePoint(file, isDirectory: false);
+                    var info = new FileInfo(file);
+                    var destination = Path.Combine(current.Destination, Path.GetFileName(file));
+                    File.Copy(file, destination, overwrite: false);
+                    File.SetLastWriteTimeUtc(destination, info.LastWriteTimeUtc);
+                }
+
+                foreach (var directory in Directory.EnumerateDirectories(current.Source))
+                {
+                    ThrowIfReparsePoint(directory, isDirectory: true);
+                    var destination = Path.Combine(current.Destination, Path.GetFileName(directory));
+                    Directory.CreateDirectory(destination);
+                    pending.Push((directory, destination));
+                }
+            }
+        }
+
+        private static IEnumerable<string> EnumerateRegularFiles(string sourceRoot)
+        {
+            var pending = new Stack<string>();
+            pending.Push(sourceRoot);
+            while (pending.Count > 0)
+            {
+                var current = pending.Pop();
+                ThrowIfReparsePoint(current, isDirectory: true);
+                foreach (var file in Directory.EnumerateFiles(current))
+                {
+                    ThrowIfReparsePoint(file, isDirectory: false);
+                    yield return file;
+                }
+
+                foreach (var directory in Directory.EnumerateDirectories(current))
+                {
+                    ThrowIfReparsePoint(directory, isDirectory: true);
+                    pending.Push(directory);
+                }
+            }
+        }
+
+        private static void ThrowIfReparsePoint(string path, bool isDirectory)
+        {
+            var attributes = File.GetAttributes(path);
+            if ((attributes & FileAttributes.ReparsePoint) != 0)
+            {
+                throw new InvalidDataException(
+                    $"Refusing to import linked Enhanced data {(isDirectory ? "directory" : "file")} {path}.");
+            }
+        }
+
+        private static void DeleteStagingDirectory(string path)
+        {
+            if (Directory.Exists(path))
+            {
+                ThrowIfReparsePoint(path, isDirectory: true);
+                Directory.Delete(path, recursive: true);
+            }
+        }
+
+        private static bool TryReadImportMarker(
+            string path,
+            out bool configurationImported,
+            out bool dataImported,
+            out string resolution)
+        {
+            configurationImported = false;
+            dataImported = false;
+            resolution = string.Empty;
+            if (!File.Exists(path))
+            {
+                return false;
+            }
+
+            try
+            {
+                ThrowIfReparsePoint(path, isDirectory: false);
+                using var stream = File.OpenRead(path);
+                using var document = JsonDocument.Parse(stream, PersistedJson.ParseOptions);
+                var root = document.RootElement;
+                if (!(root.ValueKind == JsonValueKind.Object
+                    && root.TryGetProperty("Source", out var source)
+                    && string.Equals(source.GetString(), EnhancedAssemblyName, StringComparison.Ordinal)
+                    && root.TryGetProperty("ContractVersion", out var version)
+                    && version.ValueKind == JsonValueKind.Number
+                    && version.TryGetInt32(out var contractVersion)
+                    && contractVersion == 1
+                    && root.TryGetProperty("ConfigurationImported", out var configFlag)
+                    && (configFlag.ValueKind == JsonValueKind.True || configFlag.ValueKind == JsonValueKind.False)
+                    && root.TryGetProperty("DataImported", out var dataFlag)
+                    && (dataFlag.ValueKind == JsonValueKind.True || dataFlag.ValueKind == JsonValueKind.False)
+                    && root.TryGetProperty("Resolution", out var resolutionValue)
+                    && resolutionValue.ValueKind == JsonValueKind.String
+                    && (string.Equals(resolutionValue.GetString(), "Imported", StringComparison.Ordinal)
+                        || string.Equals(resolutionValue.GetString(), "CanopyWins", StringComparison.Ordinal))))
+                {
+                    return false;
+                }
+
+                configurationImported = configFlag.GetBoolean();
+                dataImported = dataFlag.GetBoolean();
+                resolution = resolutionValue.GetString()!;
+                return true;
+            }
+            catch
+            {
+                // An invalid marker is not proof that Canopy owns an imported tree.
+                // The normal non-empty-directory conflict path preserves everything.
+                return false;
+            }
+        }
+
+        private static void WriteImportMarker(
+            string path,
+            bool configurationImported,
+            bool dataImported,
+            string resolution)
+        {
+            AtomicFile.WriteAllText(
+                path,
+                JsonSerializer.Serialize(
+                    new
+                    {
+                        Source = EnhancedAssemblyName,
+                        ImportedAtUtc = DateTime.UtcNow,
+                        ContractVersion = 1,
+                        ConfigurationImported = configurationImported,
+                        DataImported = dataImported,
+                        Resolution = resolution,
+                    },
+                    PersistedJson.WriteOptions));
+        }
+
+        private static void RecordCanopyWins(
+            string completionMarkerPath,
+            Action<string> logInfo,
+            Action<string> logError)
+        {
+            try
+            {
+                WriteImportMarker(
+                    completionMarkerPath,
+                    configurationImported: false,
+                    dataImported: false,
+                    resolution: "CanopyWins");
+                logInfo($"Recorded the conflict resolution at {Path.GetFileName(completionMarkerPath)} so later startups keep the existing Canopy state without repeating the import attempt.");
+            }
+            catch (Exception ex)
+            {
+                // The existing Canopy state is authoritative and remains usable;
+                // inability to persist the acknowledgement must not block startup.
+                logError($"Could not record the Jellyfin Enhanced conflict resolution; the safe Canopy-wins decision will be re-evaluated next startup: {ex.Message}");
+            }
+        }
+
+        private static bool FilesHaveSameContent(string leftPath, string rightPath)
+        {
+            var left = new FileInfo(leftPath);
+            var right = new FileInfo(rightPath);
+            if (left.Length != right.Length)
+            {
+                return false;
+            }
+
+            using var leftStream = File.OpenRead(leftPath);
+            using var rightStream = File.OpenRead(rightPath);
+            return SHA256.HashData(leftStream).AsSpan().SequenceEqual(SHA256.HashData(rightStream));
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/JellyfinCanopy.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/JellyfinCanopy.cs
@@ -35,15 +35,36 @@ namespace Jellyfin.Plugin.JellyfinCanopy
             _applicationPaths = applicationPaths;
             _logger = logger;
             // Must run before anything touches Configuration: BasePlugin loads the
-            // config XML lazily on first access, so adopting the legacy file here
-            // means the first load already sees the migrated copy.
+            // config XML lazily on first access, so adopting legacy state here
+            // means the first load already sees the migrated copy. Elevate runs
+            // first because it is the same-GUID predecessor; a separately installed
+            // Enhanced source is considered only when that path did not establish
+            // independent Canopy state.
             MigrateLegacyElevateState(applicationPaths);
+            var enhancedMigration = EnhancedStateMigration.Run(
+                applicationPaths.PluginConfigurationsPath,
+                ConfigurationFilePath,
+                Path.GetFileNameWithoutExtension(ConfigurationFileName),
+                msg => _logger.LogInformation(msg),
+                msg => _logger.LogError(msg));
+            _configWritesSuspendedByFailedMigration = enhancedMigration == EnhancedStateMigrationStatus.Failed;
+            if (_configWritesSuspendedByFailedMigration)
+            {
+                // An XML-only save barrier is insufficient: per-user managers and
+                // hosted services can also create files in the Canopy data root,
+                // converting a retryable import failure into a mixed-state conflict.
+                // Refuse this plugin instance before DI services start. Jellyfin
+                // itself remains available and will retry the plugin next startup.
+                Instance = null;
+                throw new InvalidOperationException(
+                    "Jellyfin Enhanced state migration failed. Canopy was not started so no new state can contaminate the retry; repair or move aside the source named in the preceding log entry and restart Jellyfin.");
+            }
             // After the file itself is adopted, rename any pre-rename "Jellyseerr"
             // element names inside it — a ≤2.0 config would otherwise deserialize
             // those settings to defaults. A failed migration arms the write
             // suppressor below: saving the defaults-loaded configuration would
             // permanently overwrite the legacy values the retry depends on.
-            _configWritesSuspendedByFailedMigration = !MigrateLegacySeerrElementNamesCore(ConfigurationFilePath, msg => _logger.LogInformation(msg), msg => _logger.LogError(msg));
+            _configWritesSuspendedByFailedMigration |= !MigrateLegacySeerrElementNamesCore(ConfigurationFilePath, msg => _logger.LogInformation(msg), msg => _logger.LogError(msg));
             _logger.LogInformation($"{PluginName} v{Version} initialized. Plugin logs will be written to: {fileLogProvider.CurrentLogFilePath}");
             // Set the User-Agent used by every Seerr/TMDB outbound HTTP call.
             // Cloudflare's Browser Integrity Check / Bot Fight Mode flags
@@ -209,21 +230,20 @@ namespace Jellyfin.Plugin.JellyfinCanopy
             base.UpdateConfiguration(configuration);
         }
 
-        // Armed when the legacy Jellyseerr-name migration failed: the loaded
-        // Configuration then holds defaults for every un-migrated setting, and
-        // persisting it (startup backfills, scheduled-task saves, admin saves,
-        // and BasePlugin.LoadConfiguration's own on-deserialization-failure
-        // save) would overwrite the legacy XML with those defaults — permanent
-        // data loss. Every write path ends in the TYPED SaveConfiguration
-        // virtual (the parameterless overload delegates to it), so guarding it
-        // here protects the file until a later startup migrates successfully.
+        // Armed while a startup migration failure is being handled. Enhanced import
+        // failures abort construction before services start; legacy Jellyseerr-name
+        // failures retain the save barrier below. The loaded Configuration can hold
+        // defaults for settings whose source is still awaiting a safe retry. Persisting it
+        // (startup backfills, scheduled-task saves, admin saves, and
+        // BasePlugin.LoadConfiguration's own on-deserialization-failure save) would
+        // overwrite that recovery path. Every write ends in this typed virtual.
         private bool _configWritesSuspendedByFailedMigration;
 
         public override void SaveConfiguration(PluginConfiguration config)
         {
             if (_configWritesSuspendedByFailedMigration)
             {
-                _logger.LogError("Configuration save suppressed: the legacy Jellyseerr-name migration failed this startup, and saving now would overwrite the un-migrated settings with defaults. Fix the configuration file/permissions and restart Jellyfin; changes made this session are not persisted.");
+                _logger.LogError("Configuration save suppressed: a startup state migration failed, and saving now could overwrite settings still awaiting a safe retry. Fix the source configuration/data or permissions and restart Jellyfin; changes made this session are not persisted.");
                 return;
             }
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,7 +12,7 @@ Jellyfin Canopy layers a richer, faster front-end and a set of opt-in power feat
 
 Jellyfin Canopy targets **Jellyfin 12 and nothing else**. Its manifest publishes only a Jellyfin 12 build (target ABI `12.0.0.0`), so a Jellyfin 10.11 server's catalog will never list it — there is no 10.11-compatible release to install.
 
-If you're still on Jellyfin 10.11, install the original [Jellyfin Enhanced](https://github.com/n00bcodr/Jellyfin-Enhanced) plugin instead. It stays actively maintained for 10.11, and your settings carry across cleanly if you later move to Jellyfin 12.
+If you're still on Jellyfin 10.11, install the original [Jellyfin Enhanced](https://github.com/n00bcodr/Jellyfin-Enhanced) plugin instead. When you later move to Jellyfin 12, Canopy can import that installation as described in [Upgrading from Jellyfin Enhanced](#upgrading-from-jellyfin-enhanced-1011).
 
 ## Install the plugin
 
@@ -53,6 +53,25 @@ After the restart:
 3. If the **Enhanced Panel** opens, the install worked.
 
 If nothing appears, jump to [Troubleshooting the install](#troubleshooting-the-install).
+
+## Upgrading from Jellyfin Enhanced (10.11)
+
+Jellyfin Enhanced and Jellyfin Canopy are separate plugins with different IDs and storage roots, so Jellyfin's catalog cannot update one into the other. Canopy has a one-time importer for the final Enhanced 10.11 state.
+
+1. Before upgrading, stop Jellyfin and back up its complete configuration directory. Keep that backup until you have verified the migration.
+2. Upgrade Jellyfin to 12, add the Canopy repository, install Canopy, and restart Jellyfin.
+3. On its first startup, Canopy looks for Enhanced's administration XML and `configurations/Jellyfin.Plugin.JellyfinEnhanced` directory. It validates and stages a copy before publishing it under the Canopy names.
+4. Check the Jellyfin log for both `Imported Jellyfin Enhanced` messages, then verify the admin page and each user's settings, shortcuts, bookmarks, hidden content, Elsewhere preferences, reviews, and custom branding.
+
+The importer never modifies or removes Enhanced's files. They remain the rollback/export copy. Running Canopy again is idempotent: a completed import is not replayed over newer Canopy changes, while an interrupted staged copy is rebuilt on the next restart.
+
+!!! warning "Conflicts are never auto-merged"
+
+    If Canopy already has an independently created configuration or non-empty data directory, the importer imports **nothing** and logs both paths. This prevents a mixed installation and makes the existing Canopy state the winner. The decision is recorded in `Jellyfin.Plugin.JellyfinCanopy.xml.enhanced-import.json`, so later restarts do not repeatedly attempt the import. To retry the automatic Enhanced import, stop Jellyfin, back up and move aside the Canopy XML, that marker, and the `configurations/Jellyfin.Plugin.JellyfinCanopy` directory, then restart. If you need values from both installations, retain both backups and reconcile them manually; do not copy individual live files while Jellyfin is running.
+
+Malformed Enhanced administration XML, or malformed critical Enhanced JSON such as settings, bookmarks, hidden content, or reviews, also blocks publication. Canopy logs the exact source file and refuses to finish loading for that startup, preventing defaults or background writers from contaminating the retry path; Jellyfin itself remains available. Repair or move aside the reported source, then restart. A genuinely missing XML or data half is reported by its absence and the available half is still imported.
+
+For rollback, stop Jellyfin, remove or move aside the Canopy installation/state, restore your pre-upgrade server backup, and start Jellyfin 10.11 with Enhanced. Because the importer copied rather than moved the Enhanced source, the original state is still available. Enhanced and Canopy are not intended to run side by side: Enhanced targets Jellyfin 10.11, while Canopy targets Jellyfin 12.
 
 ## Upgrading from Jellyfin Elevate
 


### PR DESCRIPTION
Closes #139

## Summary
- discover the separately identified Jellyfin Enhanced admin XML and data root before Canopy configuration/services start
- validate critical XML/JSON, reject links, stage data, publish atomically, and retain Enhanced as the untouched rollback source
- make interrupted imports retryable and completed imports idempotent without replaying over newer Canopy changes
- resolve pre-existing Canopy conflicts deterministically in Canopy’s favor and record that decision without mixing state
- fail the plugin instance safely on a fresh corrupt/import failure so background writers cannot contaminate the retry path
- document install, verification, conflict retry, corruption, coexistence, backup, and rollback behavior

## Validation
- 1,252/1,252 .NET tests
- focused migration/rebrand suite: 27/27
- 843/843 client tests
- 214/214 script tests
- syntax, both typechecks, 26-locale validation
- Release coverage: 60.79% (16% threshold)
- strict MkDocs build
- lint: 0 errors (advisory warnings unchanged)
- live two-CPU Docker proof on digest-pinned jellyfin/jellyfin:unstable: full fixture imported, source preserved, legacy Seerr names adopted, restart idempotent
- independent Fable-low review: APPROVED

The E2E Compose/default workflow remains Jellyfin unstable/nightly only; no RC image is used.