### PR TITLE
Fix plugin release version and Jellyfin ABI policy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,8 @@ name: Release
 # installed copy polls for updates — a mistake there bricks in-app updates)
 # was hand-edited.
 #
-# Push a version tag (existing convention: bare "12.0.0.0"; "v12.0.0" also
-# works) and this workflow:
+# Push the next Canopy plugin-version tag (for example "2.0.1.0"; "v2.0.1"
+# also works) and this workflow:
 #   1. runs the full quality gates (plugin build, unit tests, JS syntax/type
 #      checks) and reports ESLint findings/cap breaches as advisory; every
 #      non-lint failure and any broken lint invocation aborts the release,
@@ -21,9 +21,8 @@ name: Release
 #      and opens the manifest PR. A valid rerun is a verified no-op; neither
 #      release bytes/notes nor reviewer commits are overwritten.
 #
-# New releases publish only targetAbi 12.0.0.0 manifest entries; the
-# existing 10.11.0.0 entries in manifest.json are frozen history that keeps
-# serving the final 10.11-compatible release line.
+# New releases publish only targetAbi 12.0.0.0 manifest entries. This catalog
+# has no Jellyfin 10.11-compatible stream.
 #
 # Note: because the PR is opened with the built-in GITHUB_TOKEN, GitHub does
 # not trigger the Build & Test workflow on it. The manifest is fully
@@ -61,6 +60,15 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
+
+      - name: Validate plugin version and Jellyfin ABI policy
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: >-
+          node scripts/release/version-policy.js
+          --tag "${RELEASE_TAG}"
+          --manifest manifest.json
+          --project Jellyfin.Plugin.JellyfinCanopy/JellyfinCanopy.csproj
 
       - name: Fetch reviewed default branch
         env:
@@ -130,22 +138,19 @@ jobs:
           node-version: 22
           cache: npm
 
-      # $GITHUB_REF_NAME is used via the environment everywhere below —
-      # never interpolated into scripts — so a crafted ref cannot inject
-      # commands. This step also rejects anything that is not a version tag.
+      # Keep the plugin version and Jellyfin target ABI as separate outputs.
+      # The same policy already ran in the provenance job, before the reusable
+      # quality gates and protected release environment.
       - name: Derive version from tag
         id: version
-        run: |
-          if [[ ! "$GITHUB_REF_NAME" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
-            echo "::error::Tag '$GITHUB_REF_NAME' is not a release version tag (expected 11.13.0.0 or v11.13.0)"
-            exit 1
-          fi
-          bare="${GITHUB_REF_NAME#v}"
-          IFS='.' read -ra parts <<< "$bare"
-          while [ "${#parts[@]}" -lt 4 ]; do parts+=("0"); done
-          version="$(IFS='.'; echo "${parts[*]}")"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "Releasing version $version from tag $GITHUB_REF_NAME"
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: >-
+          node scripts/release/version-policy.js
+          --tag "${RELEASE_TAG}"
+          --manifest manifest.json
+          --project Jellyfin.Plugin.JellyfinCanopy/JellyfinCanopy.csproj
+          --github-output "${GITHUB_OUTPUT}"
 
       - name: Record approved source provenance
         env:
@@ -209,6 +214,7 @@ jobs:
       - name: Build & package
         env:
           VERSION: ${{ steps.version.outputs.version }}
+          TARGET_ABI: ${{ steps.version.outputs.target_abi }}
         run: |
           mkdir -p dist
           # Jellyfin 12 / net10.0
@@ -222,7 +228,8 @@ jobs:
           # bytes are immutable regardless; determinism is diagnostic aid only.
           source_date_epoch="$(git log -1 --format=%ct "refs/tags/$GITHUB_REF_NAME^{commit}")"
           touch -d "@$source_date_epoch" "$dll"
-          TZ=UTC zip -X -j dist/Jellyfin.Plugin.JellyfinCanopy_12.0.0.zip "$dll"
+          abi_asset="${TARGET_ABI%.*}"
+          TZ=UTC zip -X -j "dist/Jellyfin.Plugin.JellyfinCanopy_${abi_asset}.zip" "$dll"
           ls -l dist/
 
       # Query the REST collection once so API failures are blocking and so two
@@ -293,8 +300,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
+          TARGET_ABI: ${{ steps.version.outputs.target_abi }}
         run: |
-          zip_name=Jellyfin.Plugin.JellyfinCanopy_12.0.0.zip
+          zip_name="Jellyfin.Plugin.JellyfinCanopy_${TARGET_ABI%.*}.zip"
           default_branch="$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)"
           branch="release/manifest-$VERSION"
 
@@ -304,7 +312,7 @@ jobs:
           args=(
             --repo "$GITHUB_REPOSITORY"
             --tag "$GITHUB_REF_NAME"
-            --target-abi 12.0.0.0
+            --target-abi "$TARGET_ABI"
             --zip-name "$zip_name"
             --built-asset "dist/$zip_name"
             --main-manifest "$RUNNER_TEMP/main-manifest.json"
@@ -352,8 +360,9 @@ jobs:
           ACTION: ${{ steps.release_state.outputs.action }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
+          TARGET_ABI: ${{ steps.version.outputs.target_abi }}
         run: |
-          zip_name=Jellyfin.Plugin.JellyfinCanopy_12.0.0.zip
+          zip_name="Jellyfin.Plugin.JellyfinCanopy_${TARGET_ABI%.*}.zip"
           require_existing_draft() {
             current="$(gh release view "$GITHUB_REF_NAME" --json isDraft --jq .isDraft)"
             if [ "$current" != true ]; then
@@ -393,8 +402,9 @@ jobs:
           steps.release_state.outputs.action != 'resume-published-proposal'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_ABI: ${{ steps.version.outputs.target_abi }}
         run: |
-          zip_name=Jellyfin.Plugin.JellyfinCanopy_12.0.0.zip
+          zip_name="Jellyfin.Plugin.JellyfinCanopy_${TARGET_ABI%.*}.zip"
           mkdir -p "$RUNNER_TEMP/final-assets"
           gh release download "$GITHUB_REF_NAME" \
             --pattern "$zip_name" --dir "$RUNNER_TEMP/final-assets"
@@ -405,14 +415,17 @@ jobs:
           steps.release_state.outputs.action != 'noop-main' &&
           steps.release_state.outputs.action != 'resume-published-proposal' &&
           steps.release_state.outputs.action != 'resume-draft-proposal'
+        env:
+          TARGET_ABI: ${{ steps.version.outputs.target_abi }}
         run: |
+          zip_name="Jellyfin.Plugin.JellyfinCanopy_${TARGET_ABI%.*}.zip"
           cp "$RUNNER_TEMP/main-manifest.json" "$RUNNER_TEMP/generated-manifest.json"
           node scripts/release/update-manifest.js \
             --manifest "$RUNNER_TEMP/generated-manifest.json" \
             --tag "$GITHUB_REF_NAME" \
             --repo "$GITHUB_REPOSITORY" \
             --changelog-file changelog.txt \
-            --asset "12.0.0.0=$RUNNER_TEMP/final-assets/Jellyfin.Plugin.JellyfinCanopy_12.0.0.zip" \
+            --asset "$TARGET_ABI=$RUNNER_TEMP/final-assets/$zip_name" \
             > "$RUNNER_TEMP/new-entries.json"
           node scripts/release/validate-manifest.js \
             "$RUNNER_TEMP/generated-manifest.json" --assets-dir "$RUNNER_TEMP/final-assets"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,12 +10,14 @@ updates, and a malformed entry bricks in-app updates for all users.
 1. Merge the release source through a pull request and make sure every
    required **Build & Test** and **Security Scan** check is green on the
    current default branch. Direct pushes to the default branch are blocked.
-2. Tag that reviewed default-branch commit and push the tag. The existing convention is a bare
-   4-part version (a `v` prefix with 3 parts also works):
+2. Tag that reviewed default-branch commit with the **next plugin version** and
+   push the tag. Canopy is currently on its 2.x plugin release line; the
+   Jellyfin target ABI is separately fixed at `12.0.0.0`. The tag convention
+   is a bare 4-part plugin version (a `v` prefix with 3 parts also works):
 
    ```bash
-   git tag 12.0.0.0
-   git push origin 12.0.0.0
+   git tag 2.0.1.0
+   git push origin 2.0.1.0
    ```
 
    Only the repository maintainer can create a matching release tag. Once
@@ -105,12 +107,13 @@ your notes as the body) *before* pushing the tag, or push the tag from the
 release UI. When a release for the tag already exists, the workflow reuses
 its body as the manifest changelog and only attaches the ZIPs.
 
-### Manifest ABI streams
+### Plugin versions and the manifest ABI stream
 
-New releases publish only `targetAbi: 12.0.0.0` manifest entries. The
-manifest's existing `targetAbi: 10.11.0.0` entries are frozen history: they
-keep serving the final Jellyfin 10.11-compatible release line and must never
-be edited or removed.
+The git tag, assembly version, and manifest `version` are the Canopy plugin
+version. The package name and manifest `targetAbi` describe Jellyfin
+compatibility and remain `12.0.0` / `12.0.0.0` independently. This catalog
+contains only Jellyfin 12 entries; Jellyfin 10.11 users must use the original
+Jellyfin Enhanced repository instead.
 
 ## Tooling (`scripts/release/`)
 

--- a/scripts/release/release-state.js
+++ b/scripts/release/release-state.js
@@ -15,6 +15,7 @@ const fs = require('node:fs');
 const { computeZipChecksum } = require('../lib/md5.js');
 const { expectedDllFromZipName, inspectZipLayout } = require('../lib/zip-layout.js');
 const { validateManifest } = require('./validate-manifest.js');
+const { normalizePluginVersion } = require('./version-policy.js');
 
 const ACTIONS = Object.freeze({
     CREATE_DRAFT: 'create-draft',
@@ -36,12 +37,11 @@ class ReleaseStateError extends Error {
 
 /** @param {string} tag */
 function tagToVersion(tag) {
-    if (!/^v?\d+\.\d+\.\d+(?:\.\d+)?$/.test(tag)) {
+    try {
+        return normalizePluginVersion(tag);
+    } catch {
         throw new ReleaseStateError(`tag ${tag} is not a supported release version`);
     }
-    const parts = tag.replace(/^v/, '').split('.');
-    while (parts.length < 4) parts.push('0');
-    return parts.join('.');
 }
 
 /**

--- a/scripts/release/release-state.test.js
+++ b/scripts/release/release-state.test.js
@@ -127,6 +127,7 @@ test('a malformed new package blocks every state before remote mutation', () => 
 test('v-prefixed and four-part aliases normalize to one version/branch identity', () => {
     assert.equal(tagToVersion('v12.0.0'), '12.0.0.0');
     assert.equal(tagToVersion('12.0.0.0'), '12.0.0.0');
+    assert.throws(() => tagToVersion('012.0.0.0'), /not a supported release version/);
     assert.throws(() => tagToVersion('release-12'), /not a supported release version/);
 });
 

--- a/scripts/release/update-manifest.js
+++ b/scripts/release/update-manifest.js
@@ -13,14 +13,14 @@
  *   {
  *     "changelog":  <text from --changelog-file, verbatim>,
  *     "targetAbi":  <the asset's ABI, e.g. "12.0.0.0">,
- *     "version":    <tag normalized to 4 parts, e.g. "11.13.0.0">,
+ *     "version":    <plugin tag normalized to 4 parts, e.g. "2.0.1.0">,
  *     "sourceUrl":  https://github.com/<repo>/releases/download/<tag>/<zip>,
  *     "checksum":   <uppercase MD5 of the zip — Jellyfin manifests use MD5>,
  *     "timestamp":  <current UTC, "YYYY-MM-DDTHH:MM:SS", no timezone>
  *   }
  *
  * Guard rails:
- *   - the tag must be v-prefixed or bare dotted numbers (v11.13.0, 11.13.0.0)
+ *   - the tag must be a version in the configured Canopy 2.x plugin line
  *   - the new version must be strictly greater than every version already in
  *     the manifest (monotonic — prevents accidentally re-tagging lower)
  *   - each zip must exist and be named Jellyfin.Plugin.JellyfinCanopy_<abi
@@ -31,13 +31,13 @@
  * Usage:
  *   node scripts/release/update-manifest.js \
  *     --manifest manifest.json \
- *     --tag 12.0.0.0 \
+ *     --tag 2.0.1.0 \
  *     --repo 4eh5xitv6787h645ebv/Jellyfin-Canopy \
  *     --changelog-file /tmp/changelog.txt \
  *     --asset 12.0.0.0=dist/Jellyfin.Plugin.JellyfinCanopy_12.0.0.zip
  *
- * New releases carry only the Jellyfin 12 asset (targetAbi 12.0.0.0); the
- * manifest's existing 10.11.0.0 entries are frozen history and stay as-is.
+ * New releases carry only the Jellyfin 12 asset (targetAbi 12.0.0.0). The
+ * catalog has no Jellyfin 10.11 stream.
  *
  * The generated entries are printed to stdout as JSON for use in workflow
  * summaries.
@@ -45,10 +45,15 @@
 
 const fs = require('fs');
 
-const { validateManifest, compareVersions, expectedZipName } = require('./validate-manifest.js');
+const { validateManifest, expectedZipName } = require('./validate-manifest.js');
+const {
+    normalizePluginVersion,
+    readVersionPolicy,
+    requireNewPluginVersion,
+    requirePluginReleaseLine,
+} = require('./version-policy.js');
 const { computeZipChecksum } = require('../lib/md5.js');
 
-const TAG_RE = /^v?\d+\.\d+\.\d+(\.\d+)?$/;
 const REPO_RE = /^[\w.-]+\/[\w.-]+$/;
 
 function fail(message) {
@@ -85,16 +90,6 @@ function parseArgs(argv) {
     return options;
 }
 
-/** Normalizes a git tag ("v11.13.0" / "11.13.0.0") to a 4-part manifest version. */
-function tagToVersion(tag) {
-    if (!TAG_RE.test(tag)) {
-        fail(`tag "${tag}" must look like v11.13.0 or 11.13.0.0`);
-    }
-    const parts = tag.replace(/^v/, '').split('.');
-    while (parts.length < 4) parts.push('0');
-    return parts.join('.');
-}
-
 /** Current UTC time in the manifest's "YYYY-MM-DDTHH:MM:SS" format. */
 function manifestTimestamp() {
     return new Date().toISOString().slice(0, 19);
@@ -104,7 +99,15 @@ function main() {
     const options = parseArgs(process.argv.slice(2));
     if (!REPO_RE.test(options.repo)) fail(`--repo "${options.repo}" must be owner/name`);
 
-    const version = tagToVersion(options.tag);
+    let version;
+    let policy;
+    try {
+        policy = readVersionPolicy();
+        version = normalizePluginVersion(options.tag);
+        requirePluginReleaseLine(version, policy);
+    } catch (error) {
+        fail(error instanceof Error ? error.message : String(error));
+    }
     const changelog = fs.readFileSync(options.changelogFile, 'utf8').trim();
     if (changelog.length === 0) fail(`changelog file ${options.changelogFile} is empty`);
 
@@ -117,20 +120,22 @@ function main() {
     }
     const plugin = data[0];
 
-    // Monotonic guard: the new version must beat everything already published.
-    for (const existing of plugin.versions) {
-        if (compareVersions(version, existing.version) <= 0) {
-            fail(
-                `new version ${version} is not greater than existing ${existing.version} ` +
-                `(targetAbi ${existing.targetAbi}) — releases must be monotonic`
-            );
-        }
+    try {
+        requireNewPluginVersion(version, data);
+    } catch (error) {
+        fail(error instanceof Error ? error.message : String(error));
     }
 
     const timestamp = manifestTimestamp();
     const newEntries = options.assets.map(({ targetAbi, zipPath }) => {
         if (!/^\d+\.\d+\.\d+\.\d+$/.test(targetAbi)) {
             fail(`asset targetAbi "${targetAbi}" is not a 4-part dotted version`);
+        }
+        if (targetAbi !== policy.targetAbi) {
+            fail(
+                `asset targetAbi ${targetAbi} does not match the configured Jellyfin target ABI ` +
+                `${policy.targetAbi}`
+            );
         }
         if (!fs.existsSync(zipPath)) fail(`asset zip not found: ${zipPath}`);
 

--- a/scripts/release/version-policy.js
+++ b/scripts/release/version-policy.js
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+'use strict';
+
+// @ts-check
+
+/**
+ * Keeps the plugin's release version independent from the Jellyfin ABI.
+ * The version tag stamps the plugin assembly/catalog version; targetAbi only
+ * selects the Jellyfin-compatible package stream.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { compareVersions, validateManifest } = require('./validate-manifest.js');
+
+const DEFAULT_POLICY = path.join(__dirname, 'version-policy.json');
+const VERSION_RE = /^v?(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*))?$/;
+const FOUR_PART_RE = /^\d+\.\d+\.\d+\.\d+$/;
+
+class ReleaseVersionError extends Error {
+    /** @param {string} message */
+    constructor(message) {
+        super(message);
+        this.name = 'ReleaseVersionError';
+    }
+}
+
+/** @param {string} tag */
+function normalizePluginVersion(tag) {
+    if (!VERSION_RE.test(tag)) {
+        throw new ReleaseVersionError(
+            `tag "${tag}" is not a plugin version (expected major.minor.patch[.revision])`
+        );
+    }
+    const parts = tag.replace(/^v/, '').split('.');
+    while (parts.length < 4) parts.push('0');
+    return parts.join('.');
+}
+
+/** @param {string} [policyPath] */
+function readVersionPolicy(policyPath = DEFAULT_POLICY) {
+    /** @type {unknown} */
+    let parsed;
+    try {
+        parsed = JSON.parse(fs.readFileSync(policyPath, 'utf8'));
+    } catch (error) {
+        throw new ReleaseVersionError(
+            `release version policy cannot be read: ${error instanceof Error ? error.message : String(error)}`
+        );
+    }
+    if (typeof parsed !== 'object' || parsed === null) {
+        throw new ReleaseVersionError('release version policy must be an object');
+    }
+    const policy = /** @type {{pluginReleaseMajor?: unknown, targetAbi?: unknown}} */ (parsed);
+    if (!Number.isSafeInteger(policy.pluginReleaseMajor) || Number(policy.pluginReleaseMajor) < 1) {
+        throw new ReleaseVersionError('pluginReleaseMajor must be a positive integer');
+    }
+    if (typeof policy.targetAbi !== 'string' || !FOUR_PART_RE.test(policy.targetAbi)) {
+        throw new ReleaseVersionError('targetAbi must be a four-part dotted version');
+    }
+    return {
+        pluginReleaseMajor: Number(policy.pluginReleaseMajor),
+        targetAbi: policy.targetAbi,
+    };
+}
+
+/**
+ * @param {string} version
+ * @param {{pluginReleaseMajor: number, targetAbi: string}} policy
+ */
+function requirePluginReleaseLine(version, policy) {
+    const major = Number(version.split('.')[0]);
+    if (major !== policy.pluginReleaseMajor) {
+        const abiHint = version === policy.targetAbi
+            ? `; ${policy.targetAbi} is the Jellyfin target ABI, not the plugin version`
+            : '';
+        throw new ReleaseVersionError(
+            `plugin version ${version} is outside the configured ${policy.pluginReleaseMajor}.x release line${abiHint}`
+        );
+    }
+}
+
+/** @param {string} projectPath */
+function readProjectVersions(projectPath) {
+    const source = fs.readFileSync(projectPath, 'utf8');
+    const assembly = source.match(/<AssemblyVersion>([^<]+)<\/AssemblyVersion>/)?.[1];
+    const file = source.match(/<FileVersion>([^<]+)<\/FileVersion>/)?.[1];
+    if (!assembly || !FOUR_PART_RE.test(assembly) || !file || !FOUR_PART_RE.test(file)) {
+        throw new ReleaseVersionError('project must define four-part AssemblyVersion and FileVersion values');
+    }
+    if (assembly !== file) {
+        throw new ReleaseVersionError(`project AssemblyVersion ${assembly} and FileVersion ${file} disagree`);
+    }
+    return { assembly, file };
+}
+
+/**
+ * Requires a genuinely new plugin version. The release workflow deliberately
+ * does not call this at startup because rerunning an immutable published tag
+ * must reach release-state verification and become a safe no-op.
+ * @param {string} version
+ * @param {unknown[]} manifest
+ */
+function requireNewPluginVersion(version, manifest) {
+    const result = validateManifest(manifest);
+    if (result.errors.length > 0) {
+        throw new ReleaseVersionError(`manifest is invalid: ${result.errors.join('; ')}`);
+    }
+    const existing = manifest.flatMap(plugin => plugin.versions || []);
+    for (const entry of existing) {
+        if (compareVersions(version, entry.version) <= 0) {
+            throw new ReleaseVersionError(
+                `plugin version ${version} is not newer than published ${entry.version}`
+            );
+        }
+    }
+}
+
+/**
+ * @param {{tag: string, manifestPath: string, projectPath: string, policyPath?: string}} options
+ */
+function validateReleaseVersion(options) {
+    const policy = readVersionPolicy(options.policyPath);
+    const version = normalizePluginVersion(options.tag);
+    requirePluginReleaseLine(version, policy);
+
+    const project = readProjectVersions(options.projectPath);
+    requirePluginReleaseLine(project.assembly, policy);
+
+    const manifest = JSON.parse(fs.readFileSync(options.manifestPath, 'utf8'));
+    const result = validateManifest(manifest);
+    if (result.errors.length > 0) {
+        throw new ReleaseVersionError(`manifest is invalid: ${result.errors.join('; ')}`);
+    }
+    return { version, targetAbi: policy.targetAbi };
+}
+
+/** @param {string[]} argv */
+function parseArgs(argv) {
+    /** @type {Record<string, string>} */
+    const options = {};
+    const allowed = new Set(['github-output', 'manifest', 'policy', 'project', 'tag']);
+    for (let index = 0; index < argv.length; index += 2) {
+        const flag = argv[index];
+        const value = argv[index + 1];
+        if (!flag?.startsWith('--') || value === undefined || value.startsWith('--')) {
+            throw new ReleaseVersionError(`invalid or missing argument near ${flag || '(end)'}`);
+        }
+        const name = flag.slice(2);
+        if (!allowed.has(name)) throw new ReleaseVersionError(`unknown option ${flag}`);
+        if (Object.hasOwn(options, name)) throw new ReleaseVersionError(`duplicate option ${flag}`);
+        options[name] = value;
+    }
+    return options;
+}
+
+function main() {
+    try {
+        const options = parseArgs(process.argv.slice(2));
+        for (const required of ['tag', 'manifest', 'project']) {
+            if (!options[required]) throw new ReleaseVersionError(`--${required} is required`);
+        }
+        const result = validateReleaseVersion({
+            tag: options.tag,
+            manifestPath: options.manifest,
+            projectPath: options.project,
+            policyPath: options.policy,
+        });
+        if (options['github-output']) {
+            fs.appendFileSync(
+                options['github-output'],
+                `version=${result.version}\ntarget_abi=${result.targetAbi}\n`
+            );
+        }
+        console.log(
+            `Plugin version ${result.version}; Jellyfin target ABI ${result.targetAbi}`
+        );
+    } catch (error) {
+        console.error(`error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exitCode = 1;
+    }
+}
+
+if (require.main === module) main();
+
+module.exports = {
+    ReleaseVersionError,
+    normalizePluginVersion,
+    readProjectVersions,
+    readVersionPolicy,
+    requireNewPluginVersion,
+    requirePluginReleaseLine,
+    validateReleaseVersion,
+};

--- a/scripts/release/version-policy.json
+++ b/scripts/release/version-policy.json
@@ -1,0 +1,4 @@
+{
+  "pluginReleaseMajor": 2,
+  "targetAbi": "12.0.0.0"
+}

--- a/scripts/release/version-policy.test.js
+++ b/scripts/release/version-policy.test.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const childProcess = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+    normalizePluginVersion,
+    requireNewPluginVersion,
+    readVersionPolicy,
+    requirePluginReleaseLine,
+    validateReleaseVersion,
+} = require('./version-policy.js');
+const { writeZipFixture } = require('../lib/zip-test-fixture.js');
+
+const ROOT = path.resolve(__dirname, '../..');
+const MANIFEST = path.join(ROOT, 'manifest.json');
+const PROJECT = path.join(ROOT, 'Jellyfin.Plugin.JellyfinCanopy', 'JellyfinCanopy.csproj');
+const SCRIPT = path.join(__dirname, 'version-policy.js');
+
+test('plugin tags normalize independently from the Jellyfin target ABI', () => {
+    const policy = readVersionPolicy();
+    assert.equal(normalizePluginVersion('v2.0.1'), '2.0.1.0');
+    assert.equal(normalizePluginVersion('2.0.1.0'), '2.0.1.0');
+    assert.throws(() => normalizePluginVersion('02.0.1.0'), /not a plugin version/);
+    assert.doesNotThrow(() => requirePluginReleaseLine('2.0.1.0', policy));
+    assert.throws(
+        () => requirePluginReleaseLine('12.0.0.0', policy),
+        /12\.0\.0\.0 is the Jellyfin target ABI, not the plugin version/
+    );
+});
+
+test('the documented next tag is monotonic and remains in the configured release line', () => {
+    const releasing = fs.readFileSync(path.join(ROOT, 'RELEASING.md'), 'utf8');
+    const example = releasing.match(/git tag (\d+\.\d+\.\d+\.\d+)/)?.[1];
+    assert.ok(example, 'RELEASING.md must contain a four-part git tag example');
+    const result = validateReleaseVersion({
+        tag: example,
+        manifestPath: MANIFEST,
+        projectPath: PROJECT,
+    });
+    assert.deepEqual(result, {
+        version: '2.0.1.0',
+        targetAbi: '12.0.0.0',
+    });
+    const manifest = JSON.parse(fs.readFileSync(MANIFEST, 'utf8'));
+    assert.doesNotThrow(() => requireNewPluginVersion(result.version, manifest));
+});
+
+test('an existing immutable tag remains valid for release-state resume', () => {
+    assert.deepEqual(validateReleaseVersion({
+        tag: '2.0.0.0',
+        manifestPath: MANIFEST,
+        projectPath: PROJECT,
+    }), {
+        version: '2.0.0.0',
+        targetAbi: '12.0.0.0',
+    });
+});
+
+test('the workflow rejects an ABI-shaped plugin tag before release mutation', () => {
+    const result = childProcess.spawnSync(process.execPath, [
+        SCRIPT,
+        '--tag', '12.0.0.0',
+        '--manifest', MANIFEST,
+        '--project', PROJECT,
+    ], { encoding: 'utf8' });
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /target ABI, not the plugin version/);
+});
+
+test('the workflow output carries separate plugin-version and target-ABI fields', () => {
+    const temporary = fs.mkdtempSync(path.join(os.tmpdir(), 'jc-version-policy-'));
+    try {
+        const output = path.join(temporary, 'github-output');
+        const result = childProcess.spawnSync(process.execPath, [
+            SCRIPT,
+            '--tag', '2.0.1.0',
+            '--manifest', MANIFEST,
+            '--project', PROJECT,
+            '--github-output', output,
+        ], { encoding: 'utf8' });
+        assert.equal(result.status, 0, result.stderr);
+        assert.equal(fs.readFileSync(output, 'utf8'), 'version=2.0.1.0\ntarget_abi=12.0.0.0\n');
+    } finally {
+        fs.rmSync(temporary, { recursive: true, force: true });
+    }
+});
+
+test('the policy CLI rejects unknown, duplicate, and flag-shaped values', () => {
+    for (const args of [
+        ['--unknown', 'value'],
+        ['--tag', '2.0.1.0', '--tag', '2.0.2.0'],
+        ['--tag', '--manifest'],
+    ]) {
+        const result = childProcess.spawnSync(process.execPath, [SCRIPT, ...args], { encoding: 'utf8' });
+        assert.equal(result.status, 1);
+        assert.match(result.stderr, /unknown option|duplicate option|invalid or missing argument/);
+    }
+});
+
+test('release guidance does not claim an ABI stream absent from the catalog', () => {
+    const manifest = JSON.parse(fs.readFileSync(MANIFEST, 'utf8'));
+    const targetAbis = new Set(manifest.flatMap(plugin => plugin.versions.map(entry => entry.targetAbi)));
+    assert.deepEqual([...targetAbis], ['12.0.0.0']);
+
+    const sources = [
+        'RELEASING.md',
+        '.github/workflows/release.yml',
+        'scripts/release/update-manifest.js',
+    ].map(relative => fs.readFileSync(path.join(ROOT, relative), 'utf8')).join('\n');
+    assert.doesNotMatch(sources, /existing [`"]?targetAbi:? 10\.11\.0\.0|existing 10\.11\.0\.0 entries/i);
+
+    const workflow = fs.readFileSync(path.join(ROOT, '.github/workflows/release.yml'), 'utf8');
+    assert.match(workflow, /TARGET_ABI: \$\{\{ steps\.version\.outputs\.target_abi \}\}/);
+    assert.doesNotMatch(workflow, /--target-abi 12\.0\.0\.0|--asset "12\.0\.0\.0=/);
+});
+
+test('manifest generation writes plugin version 2.0.1.0 with ABI 12 independently', () => {
+    const temporary = fs.mkdtempSync(path.join(os.tmpdir(), 'jc-update-manifest-'));
+    try {
+        const manifestPath = path.join(temporary, 'manifest.json');
+        const changelogPath = path.join(temporary, 'changelog.txt');
+        const zipName = 'Jellyfin.Plugin.JellyfinCanopy_12.0.0.zip';
+        const zipPath = path.join(temporary, zipName);
+        const wrongZipPath = path.join(temporary, 'Jellyfin.Plugin.JellyfinCanopy_13.0.0.zip');
+        const manifest = JSON.parse(fs.readFileSync(MANIFEST, 'utf8'));
+        fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+        fs.writeFileSync(changelogPath, 'Version-policy fixture');
+        writeZipFixture(zipPath, [
+            { name: 'Jellyfin.Plugin.JellyfinCanopy.dll', data: 'plugin bytes' },
+        ]);
+        writeZipFixture(wrongZipPath, [
+            { name: 'Jellyfin.Plugin.JellyfinCanopy.dll', data: 'wrong ABI bytes' },
+        ]);
+
+        const wrongAbi = childProcess.spawnSync(process.execPath, [
+            path.join(__dirname, 'update-manifest.js'),
+            '--manifest', manifestPath,
+            '--tag', '2.0.1.0',
+            '--repo', 'o/r',
+            '--changelog-file', changelogPath,
+            '--asset', `13.0.0.0=${wrongZipPath}`,
+        ], { encoding: 'utf8' });
+        assert.equal(wrongAbi.status, 1);
+        assert.match(wrongAbi.stderr, /does not match the configured Jellyfin target ABI 12\.0\.0\.0/);
+        assert.equal(JSON.parse(fs.readFileSync(manifestPath, 'utf8'))[0].versions[0].version, '2.0.0.0');
+
+        const result = childProcess.spawnSync(process.execPath, [
+            path.join(__dirname, 'update-manifest.js'),
+            '--manifest', manifestPath,
+            '--tag', '2.0.1.0',
+            '--repo', 'o/r',
+            '--changelog-file', changelogPath,
+            '--asset', `12.0.0.0=${zipPath}`,
+        ], { encoding: 'utf8' });
+        assert.equal(result.status, 0, result.stderr);
+        const entry = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))[0].versions[0];
+        assert.equal(entry.version, '2.0.1.0');
+        assert.equal(entry.targetAbi, '12.0.0.0');
+        assert.match(entry.sourceUrl, /releases\/download\/2\.0\.1\.0\/Jellyfin\.Plugin\.JellyfinCanopy_12\.0\.0\.zip$/);
+    } finally {
+        fs.rmSync(temporary, { recursive: true, force: true });
+    }
+});


### PR DESCRIPTION
Closes #77

## Summary

- define one explicit Canopy 2.x plugin release line independently from Jellyfin target ABI 12.0.0.0
- reject ABI-shaped plugin tags before expensive release gates while preserving immutable-tag reruns
- drive package names, release-state checks, and manifest generation from the policy-derived ABI
- correct release guidance and remove nonexistent Jellyfin 10.11 catalog claims
- add end-to-end policy, workflow-output, argument, monotonicity, ABI-mismatch, and documentation consistency regressions

## Validation

- `npm run test:scripts` — 222/222 passed
- focused release policy/state tests — 19/19 passed
- focused ESLint on all touched scripts — clean
- full lint — 0 errors; existing advisory warnings remain below the cap
- `npm run syntax`
- `node scripts/release/validate-manifest.js manifest.json`
- YAML lint
- `git diff --check`
- independent Fable low review — APPROVED
