### PR TITLE
Harden signed-out Jellyfin host noise checks

### DIFF
--- a/e2e/account-switch.spec.ts
+++ b/e2e/account-switch.spec.ts
@@ -16,6 +16,10 @@ import {
     type FailedResponse,
 } from './fixtures/auth';
 import type { Page, Request, Route } from 'playwright/test';
+import {
+    isExpectedSignedOutHomeAxios401,
+    isExpectedSignedOutHostLogout4xx,
+} from '../scripts/e2e/jellyfin-host-noise';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -77,6 +81,7 @@ interface LogoutResponseEvidence extends FailedResponse {
 interface SignedOutEvidence {
     identityCleared: boolean;
     userId: string;
+    oldUserId: string;
     route: string;
     cookie: string;
     initialized: boolean;
@@ -272,6 +277,10 @@ async function spaLogout(
         () => String((window as any).ApiClient?.deviceId?.() || '')
     );
     expect(clientDeviceId, 'the authenticated host client exposes its device ID').not.toBe('');
+    const oldUserId = normalizeIdentityPart(await page.evaluate(
+        () => String((window as any).ApiClient?.getCurrentUserId?.() || '')
+    ));
+    expect(oldUserId, 'logout starts with an authenticated owner').not.toBe('');
 
     const requests: LogoutRequestEvidence[] = [];
     const responses: LogoutResponseEvidence[] = [];
@@ -411,7 +420,7 @@ async function spaLogout(
             // without printing the token-bearing request configuration.
             oldTokenStatus = 0;
         }
-        const signedOut: SignedOutEvidence = { ...state, oldTokenStatus };
+        const signedOut: SignedOutEvidence = { ...state, oldUserId, oldTokenStatus };
 
         expect(routeErrors, 'both concurrent native logout routes complete without errors').toBe(0);
         expect(
@@ -710,32 +719,6 @@ function authorizationParameter(authorization: string, name: 'Token' | 'DeviceId
     return match?.[1] || '';
 }
 
-function isExpectedHostLogout4xx(response: FailedResponse, origin: string): boolean {
-    if (response.url.includes('/JellyfinCanopy/')) return false;
-    const parsed = new URL(response.url);
-    if (response.status === 401) {
-        if (parsed.origin !== origin || parsed.hash !== '') return false;
-        if (response.method === 'POST') {
-            return parsed.search === '' && parsed.pathname === '/Sessions/Logout';
-        }
-        if (response.method !== 'GET') return false;
-        // The host can finish these already-scheduled connection/home probes
-        // after logout has revoked its token. Keep the allowance bound to the
-        // exact read-only endpoints and exact BitrateTest query.
-        if (parsed.search === '' && [
-            '/System/Info',
-            '/System/Endpoint',
-            '/UserViews',
-        ].includes(parsed.pathname)) return true;
-        return parsed.pathname === '/Playback/BitrateTest'
-            && parsed.searchParams.size === 1
-            && ['500000', '1000000', '3000000'].includes(
-                parsed.searchParams.get('Size') || ''
-            );
-    }
-    return response.status === 400 && /\/SyncPlay\/List(?:\?|$)/i.test(response.url);
-}
-
 function assertOnlyHostLogoutNoise(
     consoleErrors: ConsoleErrors,
     label: string,
@@ -747,17 +730,22 @@ function assertOnlyHostLogoutNoise(
     ).toEqual([]);
     const failed = consoleErrors.unexpected4xx();
     const syncPlay400 = failed.some((response) =>
-        response.status === 400 && /\/SyncPlay\/List(?:\?|$)/i.test(response.url));
+        response.status === 400
+        && isExpectedSignedOutHostLogout4xx(response, evidence));
+    const hasAllowedHost401 = failed.some((response) =>
+        response.status === 401
+        && isExpectedSignedOutHostLogout4xx(response, evidence));
     const unexpectedDetails = consoleErrors.realDetails().filter((detail) =>
         !HOST_LOGOUT_NOISE.test(detail.text)
         && !EXPECTED_IDENTITY_ABORT.test(detail.text)
+        && !isExpectedSignedOutHomeAxios401(detail, evidence, hasAllowedHost401)
         && !(syncPlay400 && /Failed to load resource:.*status of 400 \(Bad Request\)/i.test(detail.text)));
     expect(
         unexpectedDetails.map(({ text, url, source }) => ({ text, url, source })),
         `${label}: no errors beyond Jellyfin Web's own logout cancellation`
     ).toEqual([]);
     expect(
-        failed.filter((response) => !isExpectedHostLogout4xx(response, evidence.origin)),
+        failed.filter((response) => !isExpectedSignedOutHostLogout4xx(response, evidence)),
         `${label}: no plugin 4xx or unexpected host 4xx responses`
     ).toEqual([]);
 }

--- a/scripts/e2e/jellyfin-host-noise.d.ts
+++ b/scripts/e2e/jellyfin-host-noise.d.ts
@@ -1,6 +1,31 @@
 export const SCROLL_HANDLER_ERROR: 'pageerror: t.scrollHandler is not a function';
 export const HOME_TAB_PREFIX: "[Home] failed to get tab controller TypeError: Cannot read properties of undefined (reading 'querySelector')";
 export const HOME_SELECTED_INDEX_ERROR: "pageerror: Cannot read properties of undefined (reading 'selectedIndex')";
+export const HOME_LOGOUT_AXIOS_401: 'AxiosError: Request failed with status code 401';
 
 export function isKnownHiddenContentHostNoise(text: string): boolean;
 export function isKnownJellyfinWebHostNoise(detail: { text: string; stack?: string }): boolean;
+export function isExpectedSignedOutHostLogout4xx(
+    response: { url: string; status: number; method: string },
+    evidence: LogoutEvidence
+): boolean;
+export function isExpectedSignedOutHomeAxios401(
+    detail: { text: string; url?: string; source?: string },
+    evidence: LogoutEvidence,
+    hasAllowedHost401: boolean
+): boolean;
+
+interface LogoutEvidence {
+    origin: string;
+    signedOut: {
+        identityCleared: boolean;
+        userId: string;
+        oldUserId: string;
+        route: string;
+        cookie: string;
+        initialized: boolean;
+        pendingInitializations: number;
+        initializationControllers: number;
+        oldTokenStatus: number;
+    };
+}

--- a/scripts/e2e/jellyfin-host-noise.js
+++ b/scripts/e2e/jellyfin-host-noise.js
@@ -1,13 +1,183 @@
 // @ts-check
 'use strict';
 
+const { URL } = require('node:url');
+
 const SCROLL_HANDLER_ERROR = 'pageerror: t.scrollHandler is not a function';
 const HOME_TAB_PREFIX = "[Home] failed to get tab controller TypeError: Cannot read properties of undefined (reading 'querySelector')";
 const HOME_SELECTED_INDEX_ERROR = "pageerror: Cannot read properties of undefined (reading 'selectedIndex')";
+const HOME_LOGOUT_AXIOS_401 = 'AxiosError: Request failed with status code 401';
 const HOME_TAB_CHUNK = /\/web\/hometab\.[A-Za-z0-9]+\.chunk\.js:\d+:\d+/;
 const HOME_CHUNK = /\/web\/home\.[A-Za-z0-9]+\.chunk\.js:\d+:\d+/;
 const JELLYFIN_WEB_BUNDLE_FRAME = /\/web\/[A-Za-z0-9_.%-]+\.[A-Fa-f0-9]{12,}\.chunk\.js:\d+:\d+/;
 const CANOPY_STACK_FRAME = /(?:^|\n)[^\n]*(?:\bJellyfinCanopy\b|\/JellyfinCanopy(?:\/|[?#]))/i;
+const HOME_TAB_SOURCE = /^\/web\/hometab\.[A-Za-z0-9]{12,}\.chunk\.js$/;
+const AXIOS_BUNDLE_PATH = '/web/node_modules.axios.bundle.js';
+
+/**
+ * @typedef {object} SignedOutEvidence
+ * @property {boolean} identityCleared
+ * @property {string} userId
+ * @property {string} oldUserId
+ * @property {string} route
+ * @property {string} cookie
+ * @property {boolean} initialized
+ * @property {number} pendingInitializations
+ * @property {number} initializationControllers
+ * @property {number} oldTokenStatus
+ *
+ * @typedef {object} LogoutEvidence
+ * @property {string} origin
+ * @property {SignedOutEvidence} signedOut
+ */
+
+/**
+ * @param {URLSearchParams} actual
+ * @param {[string, string][]} expected
+ */
+function hasExactSearch(actual, expected) {
+    const sortEntries = (entries) => entries
+        .map(([key, value]) => [String(key), String(value)])
+        .sort(([leftKey, leftValue], [rightKey, rightValue]) =>
+            leftKey.localeCompare(rightKey) || leftValue.localeCompare(rightValue));
+    return JSON.stringify(sortEntries([...actual.entries()]))
+        === JSON.stringify(sortEntries(expected));
+}
+
+/**
+ * @param {LogoutEvidence | null | undefined} evidence
+ */
+function hasCompleteSignedOutEvidence(evidence) {
+    const signedOut = evidence?.signedOut;
+    return !!signedOut
+        && signedOut.identityCleared === true
+        && signedOut.userId === ''
+        && /login|selectserver/i.test(signedOut.route)
+        && !/(?:^|;\s*)jc-spoiler-uid=/i.test(signedOut.cookie)
+        && signedOut.initialized === false
+        && signedOut.pendingInitializations === 0
+        && signedOut.initializationControllers === 0
+        && signedOut.oldTokenStatus === 401;
+}
+
+/**
+ * Exact read-only Home requests Jellyfin Web can leave in flight while logout
+ * revokes the old owner token. Every query field is part of the contract; the
+ * only variable values are the proven prior user, a library parent ID, and the
+ * host-generated Next Up cutoff date.
+ *
+ * @param {URL} parsed
+ * @param {string} oldUserId
+ */
+function isExpectedSignedOutHomeRead(parsed, oldUserId) {
+    const commonImages = [
+        ['enableImageTypes', 'Primary'],
+        ['enableImageTypes', 'Backdrop'],
+        ['enableImageTypes', 'Thumb'],
+    ];
+    if (parsed.pathname === '/UserItems/Resume') {
+        const mediaType = parsed.searchParams.get('mediaTypes') || '';
+        if (!['Audio', 'Book', 'Video'].includes(mediaType)) return false;
+        return hasExactSearch(parsed.searchParams, [
+            ['userId', oldUserId],
+            ['limit', '12'],
+            ['fields', 'PrimaryImageAspectRatio'],
+            ['mediaTypes', mediaType],
+            ['imageTypeLimit', '1'],
+            ...commonImages,
+            ['enableTotalRecordCount', 'false'],
+        ]);
+    }
+    if (parsed.pathname === '/Items/Latest') {
+        const parentId = parsed.searchParams.get('parentId') || '';
+        if (!/^[A-Fa-f0-9]{32}$/.test(parentId)) return false;
+        return hasExactSearch(parsed.searchParams, [
+            ['userId', oldUserId],
+            ['parentId', parentId],
+            ['fields', 'PrimaryImageAspectRatio'],
+            ['fields', 'Path'],
+            ['imageTypeLimit', '1'],
+            ...commonImages,
+            ['limit', '16'],
+        ]);
+    }
+    if (parsed.pathname === '/Shows/NextUp') {
+        const cutoff = parsed.searchParams.get('nextUpDateCutoff') || '';
+        if (!/^\d{4}-\d{2}-\d{2}$/.test(cutoff)) return false;
+        return hasExactSearch(parsed.searchParams, [
+            ['userId', oldUserId],
+            ['limit', '24'],
+            ['fields', 'PrimaryImageAspectRatio'],
+            ['fields', 'DateCreated'],
+            ['fields', 'Path'],
+            ['fields', 'MediaSourceCount'],
+            ['imageTypeLimit', '1'],
+            ...commonImages,
+            ['nextUpDateCutoff', cutoff],
+            ['enableTotalRecordCount', 'false'],
+            ['enableResumable', 'false'],
+            ['enableRewatching', 'false'],
+        ]);
+    }
+    if (parsed.pathname === '/LiveTv/Programs/Recommended') {
+        return hasExactSearch(parsed.searchParams, [
+            ['userId', oldUserId],
+            ['limit', '1'],
+            ['isAiring', 'true'],
+            ['imageTypeLimit', '1'],
+            ...commonImages,
+            ['fields', 'ChannelInfo'],
+            ['fields', 'PrimaryImageAspectRatio'],
+            ['enableTotalRecordCount', 'false'],
+        ]);
+    }
+    return false;
+}
+
+/**
+ * Phase-local response classifier for Jellyfin Web logout. It never runs as a
+ * global noise filter: callers must pass the completed evidence returned by
+ * the same logout operation.
+ *
+ * @param {{url: string, status: number, method: string}} response
+ * @param {LogoutEvidence} evidence
+ */
+function isExpectedSignedOutHostLogout4xx(response, evidence) {
+    let origin;
+    let parsed;
+    try {
+        origin = new URL(String(evidence?.origin || ''));
+        parsed = new URL(String(response?.url || ''));
+    } catch {
+        return false;
+    }
+    if (origin.pathname !== '/' || origin.search !== '' || origin.hash !== '') return false;
+    if (parsed.origin !== origin.origin || parsed.hash !== ''
+        || /\/JellyfinCanopy(?:\/|$)/i.test(parsed.pathname)) return false;
+
+    if (response.status === 400) {
+        return response.method === 'GET' && parsed.pathname === '/SyncPlay/List';
+    }
+    if (response.status !== 401 || !hasCompleteSignedOutEvidence(evidence)) return false;
+    if (response.method === 'POST') {
+        return parsed.pathname === '/Sessions/Logout' && parsed.search === '';
+    }
+    if (response.method !== 'GET') return false;
+    if (parsed.search === '' && [
+        '/System/Info',
+        '/System/Endpoint',
+        '/UserViews',
+    ].includes(parsed.pathname)) return true;
+    if (parsed.pathname === '/Playback/BitrateTest') {
+        return hasExactSearch(parsed.searchParams, [['Size', parsed.searchParams.get('Size') || '']])
+            && ['500000', '1000000', '3000000'].includes(
+                parsed.searchParams.get('Size') || ''
+            );
+    }
+    const oldUserId = String(evidence.signedOut.oldUserId || '');
+    return /^[A-Fa-f0-9]{32}$/.test(oldUserId)
+        && isExpectedSignedOutHomeRead(parsed, oldUserId);
+}
 
 /**
  * Exact Jellyfin-web host errors observed while the standalone Hidden Content
@@ -41,10 +211,62 @@ function isKnownJellyfinWebHostNoise(detail) {
         && !CANOPY_STACK_FRAME.test(stack);
 }
 
+/**
+ * Classifies the exact Jellyfin Web console error observed when a Home query
+ * settles after logout has revoked its token. This is intentionally not part
+ * of the global host-noise filter: callers must supply complete signed-out
+ * evidence and separately prove that the response recorder saw an allowed
+ * host-only 401 during this logout phase.
+ *
+ * @param {{text: string, url?: string, source?: string}} detail
+ * @param {LogoutEvidence} evidence
+ * @param {boolean} hasAllowedHost401
+ */
+function isExpectedSignedOutHomeAxios401(detail, evidence, hasAllowedHost401) {
+    if (!hasAllowedHost401 || detail?.source !== 'console') return false;
+    if (!hasCompleteSignedOutEvidence(evidence)) return false;
+
+    let origin;
+    let source;
+    try {
+        origin = new URL(evidence.origin);
+        source = new URL(String(detail.url || ''));
+    } catch {
+        return false;
+    }
+    if (origin.pathname !== '/' || origin.search !== '' || origin.hash !== '') return false;
+    if (source.origin !== origin.origin
+        || source.search !== ''
+        || source.hash !== ''
+        || !HOME_TAB_SOURCE.test(source.pathname)) return false;
+
+    const text = String(detail.text || '');
+    if (CANOPY_STACK_FRAME.test(text)) return false;
+    const lines = text.split('\n');
+    if (lines[0] !== HOME_LOGOUT_AXIOS_401 || lines.length < 2) return false;
+    return lines.slice(1).every((line) => {
+        const urls = line.match(/https?:\/\/[^)\s]+/g) || [];
+        if (urls.length !== 1 || !/^\s+at\s/.test(line)) return false;
+        try {
+            const frame = new URL(urls[0].replace(/:\d+:\d+$/, ''));
+            return frame.origin === origin.origin
+                && frame.pathname === AXIOS_BUNDLE_PATH
+                && /^\?[A-Za-z0-9]{12,}$/.test(frame.search)
+                && frame.hash === ''
+                && /:\d+:\d+\)?$/.test(line);
+        } catch {
+            return false;
+        }
+    });
+}
+
 module.exports = {
+    HOME_LOGOUT_AXIOS_401,
     HOME_SELECTED_INDEX_ERROR,
     HOME_TAB_PREFIX,
     SCROLL_HANDLER_ERROR,
     isKnownHiddenContentHostNoise,
     isKnownJellyfinWebHostNoise,
+    isExpectedSignedOutHostLogout4xx,
+    isExpectedSignedOutHomeAxios401,
 };

--- a/scripts/e2e/jellyfin-host-noise.test.js
+++ b/scripts/e2e/jellyfin-host-noise.test.js
@@ -6,11 +6,14 @@ const path = require('node:path');
 const test = require('node:test');
 
 const {
+    HOME_LOGOUT_AXIOS_401,
     HOME_SELECTED_INDEX_ERROR,
     HOME_TAB_PREFIX,
     SCROLL_HANDLER_ERROR,
     isKnownHiddenContentHostNoise,
     isKnownJellyfinWebHostNoise,
+    isExpectedSignedOutHostLogout4xx,
+    isExpectedSignedOutHomeAxios401,
 } = require('./jellyfin-host-noise');
 
 const ROOT = path.resolve(__dirname, '../..');
@@ -18,6 +21,40 @@ const ROOT = path.resolve(__dirname, '../..');
 const OBSERVED_HOME_RACE = `${HOME_TAB_PREFIX}\n`
     + '    at new e (http://localhost:8100/web/hometab.2be9340f81cc7f0987ef.chunk.js:1:1173)\n'
     + '    at http://localhost:8100/web/home.ea733a1f3e4e4f7bee3b.chunk.js:1:2950';
+
+const LOGOUT_ORIGIN = 'http://127.0.0.1:8100';
+const OLD_USER_ID = '92bdc95c7381435689451ad246198f74';
+const OBSERVED_LOGOUT_401 = {
+    source: 'console',
+    url: `${LOGOUT_ORIGIN}/web/hometab.0ec3d9a22cad691c217e.chunk.js`,
+    text: `${HOME_LOGOUT_AXIOS_401}\n`
+        + `    at Pt (${LOGOUT_ORIGIN}/web/node_modules.axios.bundle.js?a67e682eb9f27a7ad49a:2:36652)\n`
+        + `    at XMLHttpRequest.h (${LOGOUT_ORIGIN}/web/node_modules.axios.bundle.js?a67e682eb9f27a7ad49a:2:48025)\n`
+        + `    at Generator.throw (${LOGOUT_ORIGIN}/web/node_modules.axios.bundle.js?a67e682eb9f27a7ad49a:2:77011)`,
+};
+const COMPLETE_SIGNED_OUT = {
+    origin: LOGOUT_ORIGIN,
+    signedOut: {
+        identityCleared: true,
+        userId: '',
+        oldUserId: OLD_USER_ID,
+        route: '/web/#/login.html',
+        cookie: 'other=value',
+        initialized: false,
+        pendingInitializations: 0,
+        initializationControllers: 0,
+        oldTokenStatus: 401,
+    },
+};
+
+const OBSERVED_SIGNED_OUT_HOME_401S = [
+    '/LiveTv/Programs/Recommended?userId=92bdc95c7381435689451ad246198f74&limit=1&isAiring=true&imageTypeLimit=1&enableImageTypes=Primary&enableImageTypes=Thumb&enableImageTypes=Backdrop&fields=ChannelInfo&fields=PrimaryImageAspectRatio&enableTotalRecordCount=false',
+    '/UserItems/Resume?userId=92bdc95c7381435689451ad246198f74&limit=12&fields=PrimaryImageAspectRatio&mediaTypes=Video&imageTypeLimit=1&enableImageTypes=Primary&enableImageTypes=Backdrop&enableImageTypes=Thumb&enableTotalRecordCount=false',
+    '/UserItems/Resume?userId=92bdc95c7381435689451ad246198f74&limit=12&fields=PrimaryImageAspectRatio&mediaTypes=Audio&imageTypeLimit=1&enableImageTypes=Primary&enableImageTypes=Backdrop&enableImageTypes=Thumb&enableTotalRecordCount=false',
+    '/UserItems/Resume?userId=92bdc95c7381435689451ad246198f74&limit=12&fields=PrimaryImageAspectRatio&mediaTypes=Book&imageTypeLimit=1&enableImageTypes=Primary&enableImageTypes=Backdrop&enableImageTypes=Thumb&enableTotalRecordCount=false',
+    '/Shows/NextUp?userId=92bdc95c7381435689451ad246198f74&limit=24&fields=PrimaryImageAspectRatio&fields=DateCreated&fields=Path&fields=MediaSourceCount&imageTypeLimit=1&enableImageTypes=Primary&enableImageTypes=Backdrop&enableImageTypes=Thumb&nextUpDateCutoff=2025-07-14&enableTotalRecordCount=false&enableResumable=false&enableRewatching=false',
+    '/Items/Latest?userId=92bdc95c7381435689451ad246198f74&parentId=f137a2dd21bbc1b99aa5c0f6bf02a805&fields=PrimaryImageAspectRatio&fields=Path&imageTypeLimit=1&enableImageTypes=Primary&enableImageTypes=Backdrop&enableImageTypes=Thumb&limit=16',
+];
 
 test('accepts only the exact observed scroll-handler host message', () => {
     assert.equal(isKnownHiddenContentHostNoise(SCROLL_HANDLER_ERROR), true);
@@ -104,6 +141,173 @@ test('selectedIndex host race requires an immutable Jellyfin-web stack without a
     );
 });
 
+test('logout Axios 401 requires the exact host bundle plus complete signed-out evidence', () => {
+    assert.equal(
+        isExpectedSignedOutHomeAxios401(OBSERVED_LOGOUT_401, COMPLETE_SIGNED_OUT, true),
+        true
+    );
+    assert.equal(
+        isExpectedSignedOutHomeAxios401(OBSERVED_LOGOUT_401, COMPLETE_SIGNED_OUT, false),
+        false
+    );
+});
+
+test('logout Axios classifier rejects wrong source, origin, bundle, status, and mixed stacks', () => {
+    const mutations = [
+        { ...OBSERVED_LOGOUT_401, source: 'pageerror' },
+        { ...OBSERVED_LOGOUT_401, url: `${LOGOUT_ORIGIN}/web/hometab.chunk.js` },
+        { ...OBSERVED_LOGOUT_401, url: 'http://attacker.invalid/web/hometab.0ec3d9a22cad691c217e.chunk.js' },
+        { ...OBSERVED_LOGOUT_401, text: OBSERVED_LOGOUT_401.text.replace('status code 401', 'status code 403') },
+        { ...OBSERVED_LOGOUT_401, text: OBSERVED_LOGOUT_401.text.replace('node_modules.axios', 'other') },
+        { ...OBSERVED_LOGOUT_401, text: `${OBSERVED_LOGOUT_401.text}\n    at ${LOGOUT_ORIGIN}/JellyfinCanopy/dist/jc.bundle.js:1:20` },
+        { ...OBSERVED_LOGOUT_401, text: HOME_LOGOUT_AXIOS_401 },
+    ];
+    for (const detail of mutations) {
+        assert.equal(
+            isExpectedSignedOutHomeAxios401(detail, COMPLETE_SIGNED_OUT, true),
+            false,
+            JSON.stringify(detail)
+        );
+    }
+});
+
+test('logout Axios classifier rejects every incomplete sign-out invariant', () => {
+    const invalid = [
+        { identityCleared: false },
+        { userId: 'old-user' },
+        { route: '/web/#/home' },
+        { cookie: 'jc-spoiler-uid=old-user' },
+        { initialized: true },
+        { pendingInitializations: 1 },
+        { initializationControllers: 1 },
+        { oldTokenStatus: 200 },
+    ];
+    for (const mutation of invalid) {
+        const evidence = {
+            ...COMPLETE_SIGNED_OUT,
+            signedOut: { ...COMPLETE_SIGNED_OUT.signedOut, ...mutation },
+        };
+        assert.equal(
+            isExpectedSignedOutHomeAxios401(OBSERVED_LOGOUT_401, evidence, true),
+            false,
+            JSON.stringify(mutation)
+        );
+    }
+});
+
+test('signed-out response classifier accepts only exact observed Jellyfin Home reads', () => {
+    for (const path of OBSERVED_SIGNED_OUT_HOME_401S) {
+        assert.equal(
+            isExpectedSignedOutHostLogout4xx(
+                { url: `${LOGOUT_ORIGIN}${path}`, status: 401, method: 'GET' },
+                COMPLETE_SIGNED_OUT
+            ),
+            true,
+            path
+        );
+    }
+});
+
+test('signed-out response classifier preserves exact legacy logout allowances', () => {
+    const accepted = [
+        { url: `${LOGOUT_ORIGIN}/Sessions/Logout`, status: 401, method: 'POST' },
+        { url: `${LOGOUT_ORIGIN}/System/Info`, status: 401, method: 'GET' },
+        { url: `${LOGOUT_ORIGIN}/System/Endpoint`, status: 401, method: 'GET' },
+        { url: `${LOGOUT_ORIGIN}/UserViews`, status: 401, method: 'GET' },
+        { url: `${LOGOUT_ORIGIN}/Playback/BitrateTest?Size=500000`, status: 401, method: 'GET' },
+        { url: `${LOGOUT_ORIGIN}/Playback/BitrateTest?Size=1000000`, status: 401, method: 'GET' },
+        { url: `${LOGOUT_ORIGIN}/Playback/BitrateTest?Size=3000000`, status: 401, method: 'GET' },
+        { url: `${LOGOUT_ORIGIN}/SyncPlay/List`, status: 400, method: 'GET' },
+    ];
+    for (const response of accepted) {
+        assert.equal(
+            isExpectedSignedOutHostLogout4xx(response, COMPLETE_SIGNED_OUT),
+            true,
+            JSON.stringify(response)
+        );
+    }
+});
+
+test('legacy logout allowances reject incomplete evidence and predicate drift', () => {
+    const incomplete = {
+        ...COMPLETE_SIGNED_OUT,
+        signedOut: { ...COMPLETE_SIGNED_OUT.signedOut, oldTokenStatus: 200 },
+    };
+    assert.equal(
+        isExpectedSignedOutHostLogout4xx(
+            { url: `${LOGOUT_ORIGIN}/System/Info`, status: 401, method: 'GET' },
+            incomplete
+        ),
+        false
+    );
+
+    const rejected = [
+        { url: `${LOGOUT_ORIGIN}/Sessions/Logout?extra=true`, status: 401, method: 'POST' },
+        { url: `${LOGOUT_ORIGIN}/System/Info?extra=true`, status: 401, method: 'GET' },
+        { url: `${LOGOUT_ORIGIN}/Playback/BitrateTest?Size=1`, status: 401, method: 'GET' },
+        { url: `${LOGOUT_ORIGIN}/Playback/BitrateTest?Size=500000&extra=true`, status: 401, method: 'GET' },
+        { url: `${LOGOUT_ORIGIN}/SyncPlay/List`, status: 400, method: 'POST' },
+        { url: `${LOGOUT_ORIGIN}/syncplay/list`, status: 400, method: 'GET' },
+    ];
+    for (const response of rejected) {
+        assert.equal(
+            isExpectedSignedOutHostLogout4xx(response, COMPLETE_SIGNED_OUT),
+            false,
+            JSON.stringify(response)
+        );
+    }
+});
+
+test('signed-out response classifier rejects unrelated or weakened Home 401s', () => {
+    const observed = `${LOGOUT_ORIGIN}${OBSERVED_SIGNED_OUT_HOME_401S[1]}`;
+    const mutations = [
+        { url: observed.replace(OLD_USER_ID, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'), status: 401, method: 'GET' },
+        { url: observed.replace('limit=12', 'limit=100'), status: 401, method: 'GET' },
+        { url: `${observed}&extra=true`, status: 401, method: 'GET' },
+        { url: observed.replace(LOGOUT_ORIGIN, 'http://attacker.invalid'), status: 401, method: 'GET' },
+        { url: observed.replace('/UserItems/Resume', '/JellyfinCanopy/user-settings'), status: 401, method: 'GET' },
+        { url: observed, status: 403, method: 'GET' },
+        { url: observed, status: 401, method: 'POST' },
+        { url: `${LOGOUT_ORIGIN}/Users/${OLD_USER_ID}`, status: 401, method: 'GET' },
+    ];
+    for (const response of mutations) {
+        assert.equal(
+            isExpectedSignedOutHostLogout4xx(response, COMPLETE_SIGNED_OUT),
+            false,
+            JSON.stringify(response)
+        );
+    }
+});
+
+test('signed-out response classifier requires complete logout evidence', () => {
+    const response = {
+        url: `${LOGOUT_ORIGIN}${OBSERVED_SIGNED_OUT_HOME_401S[0]}`,
+        status: 401,
+        method: 'GET',
+    };
+    const invalid = [
+        { identityCleared: false },
+        { userId: OLD_USER_ID },
+        { oldUserId: '' },
+        { route: '/web/#/home' },
+        { initialized: true },
+        { pendingInitializations: 1 },
+        { initializationControllers: 1 },
+        { oldTokenStatus: 200 },
+    ];
+    for (const mutation of invalid) {
+        const evidence = {
+            ...COMPLETE_SIGNED_OUT,
+            signedOut: { ...COMPLETE_SIGNED_OUT.signedOut, ...mutation },
+        };
+        assert.equal(
+            isExpectedSignedOutHostLogout4xx(response, evidence),
+            false,
+            JSON.stringify(mutation)
+        );
+    }
+});
+
 test('both admin and non-admin Hidden Content paths use the strict host-noise assertion', () => {
     const source = fs.readFileSync(path.join(ROOT, 'e2e/admin.spec.ts'), 'utf8');
     const assertionCalls = source.match(/assertNoHiddenContentRuntimeErrors\(consoleErrors\);/g) ?? [];
@@ -112,4 +316,12 @@ test('both admin and non-admin Hidden Content paths use the strict host-noise as
     assert.match(source, /!isKnownHiddenContentHostNoise\(text\)/);
     assert.match(source, /consoleErrors\.unexpected4xx\(\)/);
     assert.doesNotMatch(source, /assertNoRuntimeErrors/);
+});
+
+test('account switching scopes logout Axios noise to the phase-local response classifier', () => {
+    const source = fs.readFileSync(path.join(ROOT, 'e2e/account-switch.spec.ts'), 'utf8');
+    assert.match(source, /isExpectedSignedOutHomeAxios401\(detail, evidence, hasAllowedHost401\)/);
+    assert.match(source, /response\.status === 401\s*&& isExpectedSignedOutHostLogout4xx\(response, evidence\)/);
+    assert.match(source, /failed\.filter\(\(response\) => !isExpectedSignedOutHostLogout4xx\(response, evidence\)\)/);
+    assert.doesNotMatch(source, /HOST_LOGOUT_NOISE[\s\S]*AxiosError/);
 });


### PR DESCRIPTION
## What changed

- classify the exact Jellyfin Web `hometab` Axios 401 emitted when a Home request settles after logout
- require complete signed-out evidence, an independently recorded allowed host 401, same-origin immutable host bundles, and a stack with no Canopy frame
- move logout-response classification into the tested host-noise module and bind Home reads to the exact prior user, method, endpoint, and complete query set
- preserve the existing exact native logout, connection probe, BitrateTest, and SyncPlay allowances while keeping every unrelated 4xx/5xx blocking

## Why

PR #249 produced a false-red E2E shard after the real logout had succeeded and the old token was independently proven revoked. Jellyfin Web can leave read-only Home requests in flight during logout; those requests return 401 and its hashed `hometab` bundle can log an Axios error. The previous strict net correctly surfaced the event but could not distinguish this host-owned cancellation from a Canopy failure.

## Validation

- `node --test scripts/e2e/jellyfin-host-noise.test.js` — 15/15
- `npm run test:scripts` — 231/231 on current `main`
- `npm run typecheck`
- `npm run syntax`
- `npm run lint` — 0 errors; existing warnings remain below the repository cap
- `dotnet build Jellyfin.Plugin.JellyfinCanopy/JellyfinCanopy.csproj -c Release`
- account-switch live E2E — five successful repetitions across three fresh empty-state servers
- live image — `jellyfin/jellyfin:unstable@sha256:9040e988eca1e53cd90679d16edf7bd842cc661bf85da124431e25452b4abeb5`
- live quota — 2 CPUs (`2000000000 NanoCpus`)
- Fable low independent review — APPROVED after all minor comments were addressed

One intervening fresh seed failed before Playwright because its BoxSet TMDB anchor never became visible; that separate fixture-readiness defect is tracked in #251 and was not hidden or folded into this change.

Closes #250
