### PR TITLE
Serialize E2E metadata after library scan

### DIFF
--- a/e2e/docker/seed.sh
+++ b/e2e/docker/seed.sh
@@ -440,12 +440,21 @@ api GET /Plugins | jq -e --arg id "${PLUGIN_ID}" \
     || fail "Jellyfin Canopy plugin did not load (check config/log/)"
 
 log "creating the Movies library"
-api POST "/Library/VirtualFolders?name=Movies&collectionType=movies&paths=%2Fmedia%2FMovies&refreshLibrary=true" \
+api POST "/Library/VirtualFolders?name=Movies&collectionType=movies&paths=%2Fmedia%2FMovies&refreshLibrary=false" \
     '{"LibraryOptions":{"EnableRealtimeMonitor":false}}'
 
 log "creating the Shows library"
-api POST "/Library/VirtualFolders?name=Shows&collectionType=tvshows&paths=%2Fmedia%2FShows&refreshLibrary=true" \
+api POST "/Library/VirtualFolders?name=Shows&collectionType=tvshows&paths=%2Fmedia%2FShows&refreshLibrary=false" \
     '{"LibraryOptions":{"EnableRealtimeMonitor":false}}'
+
+# A refresh per library creates two independent scans. Their state can briefly
+# become Idle between runs, and the later scan can overwrite deterministic
+# ProviderIds written below. Capture a high-resolution timestamp and trigger
+# exactly one scan after both libraries exist; metadata writes later require a
+# completed run whose own start time is strictly later than this trigger bound.
+LIBRARY_SCAN_TRIGGERED_AT="$(date -u +%Y-%m-%dT%H:%M:%S.%NZ)"
+log "starting one explicit library scan"
+api POST "/Library/Refresh"
 
 log "creating the seeded non-admin user"
 api POST /Users/New "$(jq -nc --arg name "${USER_NAME}" --arg password "${USER_PASS}" \
@@ -557,6 +566,56 @@ done
     || fail "Auto-Skip fixture '${AUTOSKIP_NAME}' at ${AUTOSKIP_CONTAINER_PATH} has no probed media source after the scan wait"
 [ "${AUTOSKIP_SCAN_TICKS}" -ge "${AUTOSKIP_MIN_TICKS}" ] 2>/dev/null \
     || fail "Auto-Skip fixture '${AUTOSKIP_NAME}' at ${AUTOSKIP_CONTAINER_PATH} has ${AUTOSKIP_SCAN_TICKS} ticks; ${AUTOSKIP_MIN_TICKS} required"
+
+log "waiting for the explicit library scan to complete before metadata writes"
+LIBRARY_SCAN_STATE=""
+LIBRARY_SCAN_STATUS=""
+LIBRARY_SCAN_START=""
+LIBRARY_SCAN_END=""
+LIBRARY_SCAN_AFTER_TRIGGER=false
+for _ in $(seq 1 120); do
+    LIBRARY_SCAN_TASK="$(api GET /ScheduledTasks | jq -ec \
+        '[.[] | select(.Key == "RefreshLibrary")][0] // empty' || true)"
+    if [ -n "${LIBRARY_SCAN_TASK}" ]; then
+        LIBRARY_SCAN_STATE="$(printf '%s' "${LIBRARY_SCAN_TASK}" | jq -r '.State // ""')"
+        LIBRARY_SCAN_STATUS="$(printf '%s' "${LIBRARY_SCAN_TASK}" | jq -r \
+            '.LastExecutionResult.Status // ""')"
+        LIBRARY_SCAN_START="$(printf '%s' "${LIBRARY_SCAN_TASK}" | jq -r \
+            '.LastExecutionResult.StartTimeUtc // ""')"
+        LIBRARY_SCAN_END="$(printf '%s' "${LIBRARY_SCAN_TASK}" | jq -r \
+            '.LastExecutionResult.EndTimeUtc // ""')"
+        # Normalize both supported ISO-8601 fractional precisions to nine
+        # digits, then compare fixed-width UTC strings without floating-point
+        # timestamp loss. A startup scan already in flight before the POST can
+        # therefore never satisfy this gate when it later completes.
+        if jq -en --arg start "${LIBRARY_SCAN_START}" \
+            --arg trigger "${LIBRARY_SCAN_TRIGGERED_AT}" '
+                def canonical:
+                    capture("^(?<base>[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2})(?:\\.(?<fraction>[0-9]+))?Z$") as $v
+                    | $v.base + "." + ((($v.fraction // "") + "000000000")[0:9]) + "Z";
+                ($start | canonical) > ($trigger | canonical)
+            ' >/dev/null; then
+            LIBRARY_SCAN_AFTER_TRIGGER=true
+        else
+            LIBRARY_SCAN_AFTER_TRIGGER=false
+        fi
+        if [ "${LIBRARY_SCAN_STATE}" = Idle ] \
+            && [ "${LIBRARY_SCAN_STATUS}" = Completed ] \
+            && [ "${LIBRARY_SCAN_AFTER_TRIGGER}" = true ] \
+            && [ -n "${LIBRARY_SCAN_END}" ] \
+            && [ "${LIBRARY_SCAN_END}" != "${LIBRARY_SCAN_START}" ]; then
+            break
+        fi
+    fi
+    sleep 1
+done
+[ "${LIBRARY_SCAN_STATE}" = Idle ] \
+    && [ "${LIBRARY_SCAN_STATUS}" = Completed ] \
+    && [ "${LIBRARY_SCAN_AFTER_TRIGGER}" = true ] \
+    && [ -n "${LIBRARY_SCAN_END}" ] \
+    && [ "${LIBRARY_SCAN_END}" != "${LIBRARY_SCAN_START}" ] \
+    || fail "explicit Scan Media Library task did not complete after trigger=${LIBRARY_SCAN_TRIGGERED_AT} (state=${LIBRARY_SCAN_STATE:-missing}, status=${LIBRARY_SCAN_STATUS:-missing}, start=${LIBRARY_SCAN_START:-missing}, end=${LIBRARY_SCAN_END:-missing})"
+log "explicit library scan completed at ${LIBRARY_SCAN_END}"
 
 # Resolve by the physical path owned by this seed, validate the media metadata,
 # then apply the stable logical name used by the spec. Re-read after the update

--- a/scripts/e2e/library-scan-seed.test.js
+++ b/scripts/e2e/library-scan-seed.test.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const ROOT = path.resolve(__dirname, '../..');
+const seed = fs.readFileSync(path.join(ROOT, 'e2e/docker/seed.sh'), 'utf8');
+
+test('seed starts one explicit scan only after both libraries exist', () => {
+    const movies = seed.indexOf('name=Movies&collectionType=movies&paths=%2Fmedia%2FMovies&refreshLibrary=false');
+    const shows = seed.indexOf('name=Shows&collectionType=tvshows&paths=%2Fmedia%2FShows&refreshLibrary=false');
+    const trigger = seed.indexOf('LIBRARY_SCAN_TRIGGERED_AT="$(date -u');
+    const refresh = seed.indexOf('api POST "/Library/Refresh"');
+
+    assert.ok(movies >= 0);
+    assert.ok(shows > movies);
+    assert.ok(trigger > shows);
+    assert.ok(refresh > trigger);
+    assert.equal((seed.match(/refreshLibrary=true/g) || []).length, 0);
+    assert.equal((seed.match(/api POST "\/Library\/Refresh"/g) || []).length, 1);
+});
+
+test('metadata writes wait for a RefreshLibrary run started after the trigger', () => {
+    const wait = seed.indexOf('waiting for the explicit library scan to complete before metadata writes');
+    const firstWrite = seed.indexOf('AUTOSKIP_PATCHED=');
+
+    assert.ok(wait >= 0);
+    assert.ok(firstWrite > wait);
+    assert.match(seed, /select\(\.Key == "RefreshLibrary"\)/);
+    assert.match(seed, /\[ "\$\{LIBRARY_SCAN_STATE\}" = Idle \]/);
+    assert.match(seed, /\[ "\$\{LIBRARY_SCAN_STATUS\}" = Completed \]/);
+    assert.match(seed, /\(\$start \| canonical\) > \(\$trigger \| canonical\)/);
+    assert.match(seed, /\[ "\$\{LIBRARY_SCAN_AFTER_TRIGGER\}" = true \]/);
+    assert.match(seed, /fail "explicit Scan Media Library task did not complete after trigger=/);
+    assert.match(seed, /state=\$\{LIBRARY_SCAN_STATE:-missing\}/);
+});


### PR DESCRIPTION
## What changed

- create both disposable libraries without scheduling a scan per library
- trigger one explicit `RefreshLibrary` run after both libraries exist
- bind all deterministic metadata writes to a completed scan whose own start time is strictly after the trigger timestamp
- normalize Jellyfin and host fractional UTC timestamps before comparing them, without floating-point conversion
- fail with the observed task state, status, start, and end if the exact scan never completes
- add source-contract coverage for the single-scan ordering and completion gate

## Root cause

The seed considered the library ready as soon as its expected items were queryable, but Jellyfin's scan was still running. The subsequent fixture metadata writes could therefore be overwritten by that same scan; in the observed failure, the BoxSet update returned success but `ProviderIds.Tmdb` was later empty for the Jellyfin and Canopy endpoints.

The old flow also requested a separate refresh for each new library. The corrected flow performs one explicit scan and proves that exact post-trigger run completed before the first item metadata mutation.

## Validation

- `bash -n e2e/docker/seed.sh`
- `node --test scripts/e2e/library-scan-seed.test.js` — 2/2
- `npm run test:scripts` — 233/233
- `npm run typecheck`
- `npm run syntax`
- `npm run lint` — 0 errors; existing warnings remain below the cap
- `dotnet build Jellyfin.Plugin.JellyfinCanopy/JellyfinCanopy.csproj -c Release`
- one serial and four concurrent empty-state seed proofs after the fix
- concurrent proof retained 2 CPUs per server and isolated Compose/state/ports
- image for every live proof: `jellyfin/jellyfin:unstable@sha256:9040e988eca1e53cd90679d16edf7bd842cc661bf85da124431e25452b4abeb5`
- final stronger post-review timestamp gate passed another fresh empty-state seed
- Fable low independent review — APPROVED after the startup-scan edge case was addressed

Closes #251
