### PR TITLE
Stabilize server coverage across bookmark race outcomes

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/BookmarkRevisionControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/BookmarkRevisionControllerTests.cs
@@ -253,6 +253,68 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
         }
 
         [Fact]
+        public void BatchUpdateExistingBookmark_CommitsUpdatedBookmark()
+        {
+            Seed(("target", Bookmark("item-target", "old")));
+
+            var result = Controller().BatchUserBookmarks(UserId, new UserSettingsController.BookmarkBatchPayload
+            {
+                Revision = 0,
+                Operations = new List<UserSettingsController.BookmarkOperationPayload>
+                {
+                    new UserSettingsController.BookmarkOperationPayload
+                    {
+                        Type = "update",
+                        BookmarkId = "target",
+                        Bookmark = Bookmark("item-target", "new")
+                    }
+                }
+            });
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var response = Assert.IsType<UserSettingsController.BookmarkMutationResponse>(ok.Value);
+            Assert.True(response.Success);
+            Assert.Equal(1, response.Revision);
+            Assert.Equal("new", response.Bookmarks["target"].Label);
+
+            var final = State();
+            Assert.Equal(1, final.Revision);
+            Assert.Equal("new", final.Bookmarks["target"].Label);
+        }
+
+        [Fact]
+        public void BatchUpdateMissingBookmark_ReturnsNotFoundWithoutChangingState()
+        {
+            Seed(("keep", Bookmark("item-keep", "unchanged")));
+
+            var result = Controller().BatchUserBookmarks(UserId, new UserSettingsController.BookmarkBatchPayload
+            {
+                Revision = 0,
+                Operations = new List<UserSettingsController.BookmarkOperationPayload>
+                {
+                    new UserSettingsController.BookmarkOperationPayload
+                    {
+                        Type = "update",
+                        BookmarkId = "missing",
+                        Bookmark = Bookmark("item-missing", "new")
+                    }
+                }
+            });
+
+            var notFound = Assert.IsType<NotFoundObjectResult>(result);
+            var response = Assert.IsType<UserSettingsController.BookmarkMutationResponse>(notFound.Value);
+            Assert.False(response.Success);
+            Assert.Equal(0, response.Revision);
+            Assert.Contains("does not exist", response.Message, StringComparison.Ordinal);
+            Assert.Equal(new[] { "keep" }, response.Bookmarks.Keys);
+
+            var final = State();
+            Assert.Equal(0, final.Revision);
+            Assert.Equal(new[] { "keep" }, final.Bookmarks.Keys);
+            Assert.Equal("unchanged", final.Bookmarks["keep"].Label);
+        }
+
+        [Fact]
         public async Task ConcurrentUpdateDelete_DoesNotResurrectDeletedBookmark()
         {
             Seed(("target", Bookmark("item-target", "old")));

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -19,7 +19,7 @@ const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the repeated clean measurements', () => {
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1361, totalLines: 1692 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 12765, totalLines: 20998 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 12781, totalLines: 20998 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 1);
 });

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -21,12 +21,12 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 12765,
+        "coveredLines": 12781,
         "totalLines": 20998
       },
       "tolerance": {
         "missingCoveredLines": 1,
-        "rationale": "Two clean .NET 10/Coverlet runs on 2026-07-15 were identical; one line permits only negligible instrumentation variance."
+        "rationale": "Four clean .NET 10/Coverlet runs on 2026-07-15 were identical after deterministic tests covered both valid bookmark update/delete race outcomes; one line permits only negligible instrumentation variance."
       }
     }
   }


### PR DESCRIPTION
Closes #255

## Summary
- add deterministic controller proofs for both valid bookmark update/delete race outcomes
- retain the concurrent no-resurrection test
- raise the reviewed server line-coverage baseline after four identical clean collections

## Evidence
- BookmarkRevisionControllerTests: 13/13 passed
- four clean full-suite Coverlet runs: 1,254/1,254 tests and exactly 12,781/20,998 covered lines each
- server coverage ratchet: exact baseline match with one-line tolerance retained
- script policy suite: 246/246 passed
- Fable low independent review: APPROVED