### PR TITLE
Upgrade workflow actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,14 +29,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -45,7 +45,7 @@ jobs:
         run: npm run check:toolchain
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           dotnet-version: 10.0.x
 
@@ -72,14 +72,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -88,7 +88,7 @@ jobs:
         run: npm run check:toolchain
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           dotnet-version: 10.0.x
 
@@ -104,14 +104,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -168,14 +168,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
 
@@ -230,19 +230,19 @@ jobs:
       JF_MOCK_IMAGE: node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           dotnet-version: 10.0.x
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -384,14 +384,14 @@ jobs:
       contents: read
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
 
@@ -450,7 +450,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
@@ -459,7 +459,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
 

--- a/.github/workflows/check-unused-translations.yml
+++ b/.github/workflows/check-unused-translations.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/e2e-compatibility.yml
+++ b/.github/workflows/e2e-compatibility.yml
@@ -26,19 +26,19 @@ jobs:
       JF_CPUS: "2"
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           dotnet-version: 10.0.x
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
       default_sha: ${{ steps.provenance.outputs.default_sha }}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
@@ -62,7 +62,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
 
@@ -127,7 +127,7 @@ jobs:
       pull-requests: write # open the manifest-update PR
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
@@ -136,12 +136,12 @@ jobs:
           fetch-depth: 0 # full history: changelog + previous-tag detection
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           dotnet-version: 10.0.x
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -35,7 +35,7 @@ jobs:
       contents: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
@@ -45,7 +45,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
 
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
@@ -80,7 +80,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
 
@@ -136,7 +136,7 @@ jobs:
       # artifact for its whole retention window even after the commit is rewritten.
       - name: Upload secret-scan report
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: secret-scan-report
           path: ${{ runner.temp }}/secret-scan/report.json
@@ -149,7 +149,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
@@ -157,7 +157,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           dotnet-version: '10.0.x'
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/translation_validation.yml
+++ b/.github/workflows/translation_validation.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
 

--- a/scripts/github-action-runtime-pins.json
+++ b/scripts/github-action-runtime-pins.json
@@ -1,0 +1,26 @@
+{
+  "actions/setup-node": {
+    "sha": "820762786026740c76f36085b0efc47a31fe5020",
+    "version": "v7.0.0",
+    "runtime": "node24",
+    "metadataUrl": "https://raw.githubusercontent.com/actions/setup-node/820762786026740c76f36085b0efc47a31fe5020/action.yml"
+  },
+  "actions/setup-dotnet": {
+    "sha": "26b0ec14cb23fa6904739307f278c14f94c95bf1",
+    "version": "v5.4.0",
+    "runtime": "node24",
+    "metadataUrl": "https://raw.githubusercontent.com/actions/setup-dotnet/26b0ec14cb23fa6904739307f278c14f94c95bf1/action.yml"
+  },
+  "step-security/harden-runner": {
+    "sha": "bf7454d06d71f1098171f2acdf0cd4708d7b5920",
+    "version": "v2.20.0",
+    "runtime": "node24",
+    "metadataUrl": "https://raw.githubusercontent.com/step-security/harden-runner/bf7454d06d71f1098171f2acdf0cd4708d7b5920/action.yml"
+  },
+  "actions/upload-artifact": {
+    "sha": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+    "version": "v7.0.1",
+    "runtime": "node24",
+    "metadataUrl": "https://raw.githubusercontent.com/actions/upload-artifact/043fb46d1a93c77aae656e7c1c64a875d1fc6a0a/action.yml"
+  }
+}

--- a/scripts/github-action-runtime-pins.test.js
+++ b/scripts/github-action-runtime-pins.test.js
@@ -1,0 +1,79 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const ROOT = path.resolve(__dirname, '..');
+const WORKFLOW_DIR = path.join(ROOT, '.github', 'workflows');
+const pins = JSON.parse(fs.readFileSync(
+    path.join(__dirname, 'github-action-runtime-pins.json'),
+    'utf8'
+));
+
+function auditWorkflowPins(workflows) {
+    const counts = Object.fromEntries(Object.keys(pins).map((action) => [action, 0]));
+    for (const workflow of workflows) {
+        const lines = workflow.source.split('\n');
+        for (const [index, line] of lines.entries()) {
+            const affectedAction = Object.keys(pins).find((action) => line.includes(`${action}@`));
+            if (!affectedAction) continue;
+
+            const match = line.match(/^\s*uses:\s+((?:actions\/setup-node|actions\/setup-dotnet|step-security\/harden-runner|actions\/upload-artifact))@(\S+?)(?:\s+#\s+(\S+))?\s*$/);
+            const location = `${workflow.name}:${index + 1}`;
+            assert.ok(match, `${location} has an unrecognized ${affectedAction} reference`);
+
+            const [, action, ref, version] = match;
+            const pin = pins[action];
+            assert.equal(ref, pin.sha, `${location} uses an unreviewed ${action} commit`);
+            assert.equal(version, pin.version, `${location} has a stale or missing ${action} version comment`);
+            counts[action] += 1;
+        }
+    }
+
+    for (const [action, count] of Object.entries(counts)) {
+        assert.ok(count > 0, `no workflow consumer was inventoried for ${action}`);
+    }
+}
+
+test('the reviewed action ledger records immutable Node 24 metadata', () => {
+    for (const [action, pin] of Object.entries(pins)) {
+        assert.match(pin.sha, /^[0-9a-f]{40}$/, `${action} is not pinned to a full commit SHA`);
+        assert.match(pin.version, /^v\d+\.\d+\.\d+$/, `${action} lacks an exact release version`);
+        assert.equal(pin.runtime, 'node24', `${action} is not reviewed as Node 24-native`);
+        assert.equal(
+            pin.metadataUrl,
+            `https://raw.githubusercontent.com/${action}/${pin.sha}/action.yml`,
+            `${action} metadata evidence is not immutable`
+        );
+    }
+});
+
+test('every affected workflow consumer uses the reviewed Node 24-native pin', () => {
+    const workflows = fs.readdirSync(WORKFLOW_DIR)
+        .filter((name) => /\.ya?ml$/.test(name))
+        .sort()
+        .map((name) => ({
+            name,
+            source: fs.readFileSync(path.join(WORKFLOW_DIR, name), 'utf8'),
+        }));
+
+    auditWorkflowPins(workflows);
+});
+
+test('stale commits and missing version comments fail the inventory guard', () => {
+    const setupNode = pins['actions/setup-node'];
+    assert.throws(
+        () => auditWorkflowPins([{
+            name: 'stale.yml',
+            source: `uses: actions/setup-node@${'0'.repeat(40)} # ${setupNode.version}`,
+        }]),
+        /uses an unreviewed actions\/setup-node commit/
+    );
+    assert.throws(
+        () => auditWorkflowPins([{
+            name: 'unlabelled.yml',
+            source: `uses: actions/setup-node@${setupNode.sha}`,
+        }]),
+        /has a stale or missing actions\/setup-node version comment/
+    );
+});


### PR DESCRIPTION
Closes #192.

## What changed

- upgrade every workflow consumer of the affected JavaScript actions to one full-SHA-pinned Node-24-native release:
  - `actions/setup-node` v7.0.0 (`8207627…`)
  - `actions/setup-dotnet` v5.4.0 (`26b0ec1…`)
  - `step-security/harden-runner` v2.20.0 (`bf7454d…`)
  - `actions/upload-artifact` v7.0.1 (`043fb46…`)
- cover Build & Test, release, security, advisory compatibility, docs, translations, and stale automation, including conditional artifact paths
- retain every existing tool version, cache input, permission, hardening policy, artifact setting, and failure condition
- add an immutable Node-runtime pin ledger and a repository-wide guard with stale-SHA and missing-version negative fixtures

## Verification

- every ledger metadata URL was fetched at its immutable commit SHA and confirmed `runs.using: node24`
- every workflow YAML file parsed with `js-yaml`
- `npm run test:scripts`: 279/279
- focused runtime-pin tests: 3/3
- changed-file ESLint
- `npm run syntax`
- `npm ci`: 0 vulnerabilities
- `git diff --check`
- release tag path reviewed without creating or publishing a release

Independent Fable low-effort review: **APPROVE**. It found no missed consumer or behavior regression; its upstream-access limitation is covered by the successful immutable metadata verification above.
