### PR TITLE
Make mobile E2E feature setup explicit

### DIFF
--- a/e2e/docker/seed.sh
+++ b/e2e/docker/seed.sh
@@ -524,6 +524,13 @@ PLUGIN_CONFIG="$(api GET "/Plugins/${PLUGIN_ID}/Configuration" \
                 | .SeerrRespectParentalRatings = $seerrParental
              else . end)')"
 api POST "/Plugins/${PLUGIN_ID}/Configuration" "${PLUGIN_CONFIG}" >/dev/null
+SAVED_PLUGIN_CONFIG="$(api GET "/Plugins/${PLUGIN_ID}/Configuration")"
+if ! jq -e '
+    .CalendarPageEnabled == true
+    and .DownloadsPageEnabled == true
+' <<<"${SAVED_PLUGIN_CONFIG}" >/dev/null; then
+    fail "saved plugin configuration did not enable the Calendar and Downloads E2E fixtures"
+fi
 log "layout enforcement: ${LAYOUT_ENFORCEMENT}"
 
 log "TMDB configured (${TMDB_API_KEY:+key present})"

--- a/e2e/mobile-fits.spec.ts
+++ b/e2e/mobile-fits.spec.ts
@@ -9,7 +9,8 @@
 //     horizontally and the Hidden Content heading clears the header,
 //   - the collection "Missing from …" cards are native-grid-sized (≈3 across),
 //     not the vw-based giants (≈2 across) they used to be.
-import { test, expect, loginAs, assertNoRuntimeErrors } from './fixtures/auth';
+import { test, expect, loginAs, assertNoRuntimeErrors, USERS } from './fixtures/auth';
+import { api, authenticate, PLUGIN_ID, type Session } from './fixtures/api';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -22,6 +23,33 @@ test.use({
     hasTouch: true,
     deviceScaleFactor: 3,
 });
+
+const CONFIG_PATH = `/Plugins/${PLUGIN_ID}/Configuration`;
+
+interface StandaloneFeatureFlags {
+    CalendarPageEnabled: boolean;
+    DownloadsPageEnabled: boolean;
+}
+
+async function writePluginConfig(
+    baseURL: string,
+    admin: Session,
+    config: Record<string, unknown>
+): Promise<void> {
+    await api(baseURL, CONFIG_PATH, admin.token, {
+        method: 'POST',
+        body: JSON.stringify(config),
+    });
+}
+
+async function readClientFeatureFlags(page: any): Promise<StandaloneFeatureFlags> {
+    return page.evaluate(() => ({
+        CalendarPageEnabled:
+            (window as any).JellyfinCanopy?.pluginConfig?.CalendarPageEnabled === true,
+        DownloadsPageEnabled:
+            (window as any).JellyfinCanopy?.pluginConfig?.DownloadsPageEnabled === true,
+    }));
+}
 
 /** Horizontal overflow of the whole document (px). 0 = no horizontal scroll. */
 async function docOverflow(page: any): Promise<number> {
@@ -191,6 +219,76 @@ async function deleteBoxSet(page: any, id: string): Promise<void> {
 }
 
 test.describe('mobile viewport fits', () => {
+    let admin: Session | undefined;
+    let originalConfig: Record<string, unknown> | undefined;
+    let configMutated = false;
+
+    test.beforeAll(async ({ baseURL }) => {
+        admin = await authenticate(baseURL!, USERS.admin.username, USERS.admin.password);
+        const config = await api<Record<string, unknown>>(
+            baseURL!,
+            CONFIG_PATH,
+            admin.token
+        );
+        expect(config, 'mobile fixture must be able to read the saved plugin configuration').toBeTruthy();
+        originalConfig = config!;
+        expect({
+            CalendarPageEnabled: config!.CalendarPageEnabled,
+            DownloadsPageEnabled: config!.DownloadsPageEnabled,
+        }, 'clean E2E seed must enable Calendar and Downloads before mobile navigation').toEqual({
+            CalendarPageEnabled: true,
+            DownloadsPageEnabled: true,
+        });
+    });
+
+    test.afterAll(async ({ baseURL }) => {
+        if (!configMutated || !admin || !originalConfig) return;
+        await writePluginConfig(baseURL!, admin, originalConfig);
+        configMutated = false;
+    });
+
+    test('disabled Calendar and Downloads stay unavailable without leaking configuration', async ({
+        page,
+        consoleErrors,
+        baseURL,
+    }) => {
+        expect(admin, 'admin session must exist before the disabled-feature proof').toBeTruthy();
+        expect(originalConfig, 'original plugin configuration must be captured').toBeTruthy();
+
+        await writePluginConfig(baseURL!, admin!, {
+            ...originalConfig!,
+            CalendarPageEnabled: false,
+            DownloadsPageEnabled: false,
+        });
+        configMutated = true;
+
+        try {
+            await loginAs(page, 'admin', consoleErrors);
+            expect(
+                await readClientFeatureFlags(page),
+                'disabled fixture must reach the client before page entry points run'
+            ).toEqual({
+                CalendarPageEnabled: false,
+                DownloadsPageEnabled: false,
+            });
+
+            await page.evaluate(() => {
+                (window as any).JellyfinCanopy.calendarPage.showPage();
+                (window as any).JellyfinCanopy.downloadsPage.showPage();
+            });
+            await page.waitForTimeout(250);
+
+            await expect(page.locator('#jc-calendar-container')).toHaveCount(0);
+            await expect(page.locator('#jc-downloads-container')).toHaveCount(0);
+            expect(page.url()).not.toContain('#/calendar');
+            expect(page.url()).not.toContain('#/downloads');
+            assertNoRuntimeErrors(consoleErrors);
+        } finally {
+            await writePluginConfig(baseURL!, admin!, originalConfig!);
+            configMutated = false;
+        }
+    });
+
     test('settings panel + shortcuts fit the phone (no clipping)', async ({ page, consoleErrors }) => {
         await loginAs(page, 'admin', consoleErrors);
 
@@ -259,6 +357,14 @@ test.describe('mobile viewport fits', () => {
 
     test('standalone pages do not scroll horizontally', async ({ page, consoleErrors }) => {
         await loginAs(page, 'admin', consoleErrors);
+
+        expect(
+            await readClientFeatureFlags(page),
+            'mobile standalone-page precondition failed: Calendar and Downloads must be enabled'
+        ).toEqual({
+            CalendarPageEnabled: true,
+            DownloadsPageEnabled: true,
+        });
 
         await page.evaluate(() => { (window as any).JellyfinCanopy.calendarPage.showPage(); });
         await page.waitForSelector('#jc-calendar-container', { state: 'visible', timeout: 30_000 });

--- a/e2e/required-test-inventory.json
+++ b/e2e/required-test-inventory.json
@@ -29,6 +29,7 @@
     "e2e/live-updates.spec.ts › live updates › admin config save hot-reloads JC.pluginConfig without a page reload",
     "e2e/mobile-fits.spec.ts › mobile viewport fits › Hidden Content page: heading clears the header, no horizontal scroll",
     "e2e/mobile-fits.spec.ts › mobile viewport fits › collection Missing-from cards are native-grid-sized (≈3 across)",
+    "e2e/mobile-fits.spec.ts › mobile viewport fits › disabled Calendar and Downloads stay unavailable without leaking configuration",
     "e2e/mobile-fits.spec.ts › mobile viewport fits › settings panel + shortcuts fit the phone (no clipping)",
     "e2e/mobile-fits.spec.ts › mobile viewport fits › standalone pages do not scroll horizontally",
     "e2e/navigation.spec.ts › navigation › header button survives route, param-only and /video navigations",


### PR DESCRIPTION
Closes #78.

## What changed

- make the disposable seed read the saved plugin config back and fail immediately unless Calendar and Downloads are enabled
- make the mobile spec verify the server-side flags in `beforeAll` and the client-side flags before navigation
- add a feature-specific disabled-state E2E proving both entry points remain unavailable when their flags are off
- restore the exact captured configuration in both `finally` and `afterAll` timeout/failure paths
- add the disabled-state proof to the zero-skip required inventory

## Local verification

- two independent empty-state seeds on the digest-pinned Jellyfin unstable/nightly image, each at the official 2-CPU quota
- focused mobile run A: 5/5, 23.6s, retries disabled
- focused mobile run B: 5/5, 23.4s, retries disabled
- forced `CalendarPageEnabled=false`: failed in `beforeAll` with the named seed-precondition diagnostic
- forced `DownloadsPageEnabled=false`: failed in `beforeAll` with the same actionable diagnostic
- direct server reads after each positive/negative flow confirmed both flags restored to `true`
- both disposable stacks removed
- `npm run test:scripts`: 279/279
- `npm run typecheck`
- `npm run typecheck:src`
- `bash -n e2e/docker/seed.sh`
- `git diff --check`

Independent Fable low-effort review: **APPROVE** with no actionable findings.
