### PR TITLE
test: make performance guard contention-stable

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/test/perf-rules-guard.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/test/perf-rules-guard.test.ts
@@ -7,10 +7,9 @@
 //   R6 — no per-interaction third-party calls (api.github.com) and no broken
 //        relative `url(assets/img/…)` in injected styles.
 //
-// Literal scans use the TS AST so COMMENTS never false-match (the fix comments
-// deliberately mention the old patterns). Genuinely-intentional / out-of-group
-// pre-existing instances are ALLOWLISTED with a justification; the staleness
-// tests keep each list from rotting.
+// The complete production TypeScript tree is parsed once. One AST traversal
+// per source file builds the immutable rule/literal index used by every
+// assertion, including allowlist freshness. Comments never false-match.
 
 import { describe, expect, it } from 'vitest';
 import * as ts from 'typescript';
@@ -20,6 +19,18 @@ const SRC_ROOT = TEST_FILE_PATH.replace(/\/test\/[^/]+$/, '/');
 
 interface Allow { file: string; why: string; }
 interface Violation { file: string; line: number; detail: string; }
+interface GuardIndex {
+    files: number;
+    parses: number;
+    traversals: number;
+    r3: Violation[];
+    r5: Violation[];
+    github: Violation[];
+    assets: Violation[];
+}
+interface GuardSource { rel: string; source: string; }
+interface CpuUsage { user: number; system: number; }
+interface GuardProcess { threadCpuUsage(previous?: CpuUsage): CpuUsage; }
 
 // R6-github: release-notes.ts's update check is user-triggered (not per-open) —
 // the ENH-5 fix removed only the language dropdown's per-open enumeration.
@@ -30,23 +41,10 @@ const ALLOW_GITHUB: Allow[] = [
 // osd-rating.ts and ratingtags.ts inline their tomato glyphs as data URIs.
 const ALLOW_ASSETS: Allow[] = [];
 
-const R5_NAV_FILES = [
+const R5_NAV_FILES = new Set([
     'enhanced/hidden-content-page/nav.ts',
     'enhanced/bookmarks/library-page.ts',
-];
-
-function listFiles(): Array<{ rel: string; sf: ts.SourceFile }> {
-    return ts.sys
-        .readDirectory(SRC_ROOT, ['.ts'], undefined, undefined)
-        .filter((p) => {
-            const rel = p.substring(SRC_ROOT.length).replace(/\\/g, '/');
-            return !rel.endsWith('.test.ts') && !rel.endsWith('.d.ts') && !rel.startsWith('test/');
-        })
-        .map((p) => {
-            const rel = p.substring(SRC_ROOT.length).replace(/\\/g, '/');
-            return { rel, sf: ts.createSourceFile(rel, ts.sys.readFile(p) ?? '', ts.ScriptTarget.ES2022, true, ts.ScriptKind.TS) };
-        });
-}
+]);
 
 function lineOf(sf: ts.SourceFile, node: ts.Node): number {
     return sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1;
@@ -57,111 +55,192 @@ function isDocumentBody(expr: ts.Expression): boolean {
         && ts.isIdentifier(expr.expression) && expr.expression.text === 'document';
 }
 
-/** R3: `X.observe(document.body, { attributes:true | attributeFilter:[...] })`. */
-function scanR3(rel: string, sf: ts.SourceFile): Violation[] {
-    const out: Violation[] = [];
-    const visit = (node: ts.Node): void => {
-        if (ts.isCallExpression(node)
-            && ts.isPropertyAccessExpression(node.expression)
-            && node.expression.name.text === 'observe'
-            && node.arguments.length >= 2
-            && isDocumentBody(node.arguments[0])
-            && ts.isObjectLiteralExpression(node.arguments[1])) {
-            const opts = node.arguments[1];
-            const observesAttributes = opts.properties.some((p) => {
-                if (!p.name || !(ts.isIdentifier(p.name) || ts.isStringLiteral(p.name))) return false;
-                if (p.name.text === 'attributeFilter') return true;
-                if (p.name.text === 'attributes' && ts.isPropertyAssignment(p)) {
-                    return p.initializer.kind === ts.SyntaxKind.TrueKeyword;
+function recordsR3(node: ts.Node): node is ts.CallExpression {
+    if (!ts.isCallExpression(node)
+        || !ts.isPropertyAccessExpression(node.expression)
+        || node.expression.name.text !== 'observe'
+        || node.arguments.length < 2
+        || !isDocumentBody(node.arguments[0])
+        || !ts.isObjectLiteralExpression(node.arguments[1])) return false;
+
+    return node.arguments[1].properties.some((property) => {
+        if (!property.name
+            || !(ts.isIdentifier(property.name) || ts.isStringLiteral(property.name))) return false;
+        if (property.name.text === 'attributeFilter') return true;
+        return property.name.text === 'attributes'
+            && ts.isPropertyAssignment(property)
+            && property.initializer.kind === ts.SyntaxKind.TrueKeyword;
+    });
+}
+
+function recordsR5(rel: string, node: ts.Node): node is ts.CallExpression {
+    if (!R5_NAV_FILES.has(rel) || !ts.isCallExpression(node)) return false;
+    const callee = node.expression;
+    const name = ts.isIdentifier(callee) ? callee.text
+        : ts.isPropertyAccessExpression(callee) ? callee.name.text : null;
+    return name === 'setInterval';
+}
+
+function buildIndexFromSources(sources: GuardSource[]): GuardIndex {
+    const index: GuardIndex = {
+        files: 0,
+        parses: 0,
+        traversals: 0,
+        r3: [],
+        r5: [],
+        github: [],
+        assets: [],
+    };
+    index.files = sources.length;
+
+    for (const { rel, source } of sources) {
+        const sf = ts.createSourceFile(
+            rel,
+            source,
+            ts.ScriptTarget.ES2022,
+            true,
+            ts.ScriptKind.TS
+        );
+        index.parses += 1;
+
+        const recordLiteral = (node: ts.Node, text: string): void => {
+            if (text.includes('api.github.com')) {
+                index.github.push({ file: rel, line: lineOf(sf, node), detail: 'api.github.com' });
+            }
+            if (text.includes('url(assets/img/')) {
+                index.assets.push({ file: rel, line: lineOf(sf, node), detail: 'url(assets/img/' });
+            }
+        };
+        const visit = (node: ts.Node): void => {
+            if (recordsR3(node)) {
+                index.r3.push({
+                    file: rel,
+                    line: lineOf(sf, node),
+                    detail: 'body-wide MutationObserver with attribute observation (R3)',
+                });
+            }
+            if (recordsR5(rel, node)) {
+                index.r5.push({
+                    file: rel,
+                    line: lineOf(sf, node),
+                    detail: 'setInterval nav-polling is banned (R5) — use onNavigate',
+                });
+            }
+            if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+                recordLiteral(node, node.text);
+            } else if (ts.isTemplateExpression(node)) {
+                recordLiteral(node.head, node.head.text);
+                for (const span of node.templateSpans) {
+                    recordLiteral(span.literal, span.literal.text);
                 }
-                return false;
-            });
-            if (observesAttributes) {
-                out.push({ file: rel, line: lineOf(sf, node), detail: 'body-wide MutationObserver with attribute observation (R3)' });
             }
-        }
-        ts.forEachChild(node, visit);
-    };
-    visit(sf);
-    return out;
+            ts.forEachChild(node, visit);
+        };
+
+        index.traversals += 1;
+        visit(sf);
+    }
+    return index;
 }
 
-/** R5: any setInterval call in an enumerated nav-watcher file. */
-function scanR5(rel: string, sf: ts.SourceFile): Violation[] {
-    if (!R5_NAV_FILES.includes(rel)) return [];
-    const out: Violation[] = [];
-    const visit = (node: ts.Node): void => {
-        if (ts.isCallExpression(node)) {
-            const callee = node.expression;
-            const name = ts.isIdentifier(callee) ? callee.text
-                : ts.isPropertyAccessExpression(callee) ? callee.name.text : null;
-            if (name === 'setInterval') {
-                out.push({ file: rel, line: lineOf(sf, node), detail: 'setInterval nav-polling is banned (R5) — use onNavigate' });
-            }
-        }
-        ts.forEachChild(node, visit);
-    };
-    visit(sf);
-    return out;
+function buildIndex(root: string): GuardIndex {
+    const sources = ts.sys.readDirectory(root, ['.ts'], undefined, undefined)
+        .map((file) => ({ file, rel: file.substring(root.length).replace(/\\/g, '/') }))
+        .filter(({ rel }) =>
+            !rel.endsWith('.test.ts')
+            && !rel.endsWith('.d.ts')
+            && !rel.startsWith('test/'))
+        .map((file) => ({
+            rel: file.rel,
+            source: ts.sys.readFile(file.file) ?? '',
+        }));
+    return buildIndexFromSources(sources);
 }
 
-/** Collect string/template literal texts that CONTAIN `needle` (comments excluded). */
-function literalHits(rel: string, sf: ts.SourceFile, needle: string): Violation[] {
-    const out: Violation[] = [];
-    const visit = (node: ts.Node): void => {
-        if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
-            if (node.text.includes(needle)) out.push({ file: rel, line: lineOf(sf, node), detail: needle });
-        } else if (ts.isTemplateExpression(node)) {
-            if (node.head.text.includes(needle)) out.push({ file: rel, line: lineOf(sf, node.head), detail: needle });
-            for (const span of node.templateSpans) {
-                if (span.literal.text.includes(needle)) out.push({ file: rel, line: lineOf(sf, span.literal), detail: needle });
-            }
-        }
-        ts.forEachChild(node, visit);
-    };
-    visit(sf);
-    return out;
+function fmt(violations: Violation[]): string {
+    return violations.map((item) =>
+        `  ${item.file}:${item.line}  ${item.detail}`).join('\n');
 }
 
-function fmt(v: Violation[]): string {
-    return v.map((x) => `  ${x.file}:${x.line}  ${x.detail}`).join('\n');
-}
+const guardProcess = (globalThis as typeof globalThis & { process?: GuardProcess }).process;
+if (!guardProcess) throw new Error('perf-rules guard requires the Vitest Node process');
+const scanStarted = guardProcess.threadCpuUsage();
+const INDEX = buildIndex(SRC_ROOT);
+const scanUsage = guardProcess.threadCpuUsage(scanStarted);
+const scanCpuMs = (scanUsage.user + scanUsage.system) / 1_000;
 
 describe('perf-rules guard (R3/R5/R6)', () => {
-    const files = listFiles();
-
-    it('scans the client tree (sanity floor)', () => {
-        expect(files.length).toBeGreaterThan(100);
+    it('indexes the client tree once within the reviewed scan CPU budget', () => {
+        expect(INDEX.files).toBeGreaterThan(100);
+        expect(INDEX.parses, 'each production source must be parsed exactly once').toBe(INDEX.files);
+        expect(INDEX.traversals, 'each production AST must be traversed exactly once').toBe(INDEX.files);
+        // CPU time measures discovery + parsing + indexing without treating
+        // time descheduled behind coverage workers as guard work. The 5s
+        // threshold was reviewed on the supported two-core baseline; Vitest's
+        // 15s timeout remains a backstop for genuine assertion-time hangs.
+        expect(scanCpuMs, `one-pass AST index used ${scanCpuMs.toFixed(0)}ms CPU`).toBeLessThan(5_000);
     });
 
     it('R3: no body-wide attribute observation', () => {
-        const v = files.flatMap((f) => scanR3(f.rel, f.sf));
-        expect(v, 'Body-wide attribute MutationObserver (R3) — scope it to a container:\n' + fmt(v)).toEqual([]);
+        expect(
+            INDEX.r3,
+            'Body-wide attribute MutationObserver (R3) — scope it to a container:\n' + fmt(INDEX.r3)
+        ).toEqual([]);
     });
 
     it('R5: the standalone-page nav watchers do not setInterval-poll', () => {
-        const v = files.flatMap((f) => scanR5(f.rel, f.sf));
-        expect(v, 'setInterval nav-polling (R5):\n' + fmt(v)).toEqual([]);
+        expect(INDEX.r5, 'setInterval nav-polling (R5):\n' + fmt(INDEX.r5)).toEqual([]);
     });
 
     it('R6: no api.github.com per-interaction fetch (outside the update-check allowlist)', () => {
-        const hits = files.flatMap((f) => literalHits(f.rel, f.sf, 'api.github.com'));
-        const unmatched = hits.filter((h) => !ALLOW_GITHUB.some((a) => a.file === h.file));
+        const unmatched = INDEX.github.filter((hit) =>
+            !ALLOW_GITHUB.some((allow) => allow.file === hit.file));
         expect(unmatched, 'api.github.com literal (R6):\n' + fmt(unmatched)).toEqual([]);
     });
 
     it('R6: no broken url(assets/img/ in injected styles (outside the allowlist)', () => {
-        const hits = files.flatMap((f) => literalHits(f.rel, f.sf, 'url(assets/img/'));
-        const unmatched = hits.filter((h) => !ALLOW_ASSETS.some((a) => a.file === h.file));
+        const unmatched = INDEX.assets.filter((hit) =>
+            !ALLOW_ASSETS.some((allow) => allow.file === hit.file));
         expect(unmatched, 'url(assets/img/ literal (R6):\n' + fmt(unmatched)).toEqual([]);
     });
 
     it('R6 allowlists are current (no rot)', () => {
-        const gh = files.flatMap((f) => literalHits(f.rel, f.sf, 'api.github.com'));
-        const assets = files.flatMap((f) => literalHits(f.rel, f.sf, 'url(assets/img/'));
-        const staleGh = ALLOW_GITHUB.filter((a) => !gh.some((h) => h.file === a.file));
-        const staleAssets = ALLOW_ASSETS.filter((a) => !assets.some((h) => h.file === a.file));
-        expect(staleGh.map((a) => a.file), 'stale ALLOW_GITHUB').toEqual([]);
-        expect(staleAssets.map((a) => a.file), 'stale ALLOW_ASSETS').toEqual([]);
+        const staleGithub = ALLOW_GITHUB.filter((allow) =>
+            !INDEX.github.some((hit) => hit.file === allow.file));
+        const staleAssets = ALLOW_ASSETS.filter((allow) =>
+            !INDEX.assets.some((hit) => hit.file === allow.file));
+        expect(staleGithub.map((allow) => allow.file), 'stale ALLOW_GITHUB').toEqual([]);
+        expect(staleAssets.map((allow) => allow.file), 'stale ALLOW_ASSETS').toEqual([]);
+    });
+
+    it('injected R3, R5, and R6 violations retain precise file and line diagnostics', () => {
+        const fixture = buildIndexFromSources([
+            {
+                rel: 'r3.ts',
+                source: [
+                    'const observer = new MutationObserver(() => {});',
+                    'observer.observe(document.body, { attributes: true });',
+                ].join('\n'),
+            },
+            {
+                rel: 'enhanced/hidden-content-page/nav.ts',
+                source: 'window.setInterval(() => {}, 1000);',
+            },
+            {
+                rel: 'r6.ts',
+                source: [
+                    "const github = 'https://api.github.com/repos/example/project';",
+                    'const asset = `url(assets/img/icon.png)`;',
+                ].join('\n'),
+            },
+        ]);
+        expect(fixture.parses).toBe(3);
+        expect(fixture.traversals).toBe(3);
+        expect(fmt(fixture.r3)).toContain('r3.ts:2  body-wide MutationObserver');
+        expect(fmt(fixture.r5)).toContain(
+            'enhanced/hidden-content-page/nav.ts:1  setInterval nav-polling'
+        );
+        expect(fmt(fixture.github)).toContain('r6.ts:1  api.github.com');
+        expect(fmt(fixture.assets)).toContain('r6.ts:2  url(assets/img/');
     });
 });


### PR DESCRIPTION
Closes #100

## Summary
- parse every production TypeScript source exactly once and build all R3/R5/R6 findings during one AST traversal per file
- evaluate rule and allowlist-staleness assertions from the shared index
- enforce a documented 5-second current-thread CPU budget so coverage-worker descheduling cannot create false reds
- retain precise file/line diagnostics with injected R3, R5, and R6 negative fixtures

## Validation
- focused guard: 7/7 passing
- three full client suites constrained to CPUs 0-1: 137/137 files and 845/845 tests each; 2m58s, 2m55s, 2m55s; 269-270 MB peak RSS; zero swaps
- client coverage: 137/137 files, 845/845 tests, exact reviewed 1364/1692 line baseline
- syntax inventory, 279 script tests, JavaScript and source TypeScript typechecks, ESLint, and bundle build all pass
- independent Fable low-effort review: APPROVE

E2E remains on the required digest-pinned jellyfin/jellyfin:unstable nightly image; no RC image is introduced.