### PR TITLE
ci: stop stale automation closing issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,9 +1,15 @@
-name: "Close stale issues and PRs"
+name: "Remind on stale issues and close stale PRs"
 
 on:
   schedule:
     - cron: "0 2 * * *"
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Audit proposed stale operations without changing issues or PRs"
+        required: true
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -19,19 +25,32 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: >
-            This issue has been marked as stale because it has had no activity for 15 days.
-            It will be closed in 3 days if no further activity occurs.
+            This issue has had no activity for 30 days. This is a triage reminder only:
+            issue automation never closes issues for inactivity. If the report is still
+            actionable, add the appropriate accepted-state label or milestone. A maintainer
+            must record an explicit triage reason before closing an issue.
           stale-pr-message: >
             This pull request has been marked as stale due to 15 days of inactivity.
             It will be closed in 3 days if no updates are made.
-          days-before-stale: 15
-          days-before-close: 3
+          close-pr-message: >
+            Closing this pull request because it remained inactive for 3 days after the
+            15-day stale reminder. Reopen it or open a replacement when the branch is ready.
+          days-before-issue-stale: 30
+          days-before-issue-close: -1
+          days-before-pr-stale: 15
+          days-before-pr-close: 3
           stale-issue-label: "stale"
           stale-pr-label: "stale"
-          exempt-issue-labels: "help wanted, open-for-discussion, enhancement, no-stale"
+          exempt-issue-labels: >-
+            bug, bug-inventory, security, confirmed, P0, P1, help wanted,
+            open-for-discussion, enhancement, tracking, no-stale
+          exempt-all-issue-milestones: true
+          exempt-all-issue-assignees: true
           exempt-draft-pr: true
-# Registered for Jellyfin Canopy CI (no functional change).
+          debug-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+          enable-statistics: true
+# Guarded by scripts/stale-policy.test.js.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,30 @@ Help make Jellyfin Canopy accessible to more users by contributing translations.
 
 See the [Contributing Translations](https://4eh5xitv6787h645ebv.github.io/Jellyfin-Canopy/faq-support/contributing-translations/) section for details.
 
+### Issue triage and inactivity
+
+Inactivity is not evidence that an accepted report is fixed. The scheduled stale
+workflow therefore treats issues and pull requests differently:
+
+- Issues without an accepted-state exemption receive a reminder after 30
+  inactive days. They are never closed by stale automation. This reminder window
+  applies to untriaged reports and `awaiting-reporter`/`question` support states.
+- `bug`, `bug-inventory`, `security`, `confirmed`, P0/P1, `enhancement`,
+  `tracking`, `help wanted`, and `no-stale` are accepted backlog states and do
+  not receive stale reminders. Any milestone or assignee also exempts an issue.
+- Adding an issue to a GitHub Project must be paired with `no-stale`. Project 4
+  already applies that label to every tracked item; issue auto-close is disabled
+  as a second, policy-level safeguard.
+- A maintainer may close an issue only after leaving a triage reason such as
+  resolved, duplicate, invalid, superseded, or reporter-unavailable. Elapsed
+  time alone is not a closure reason.
+- Pull requests retain a 15-day reminder and a 3-day close window. The workflow
+  posts the inactivity reason when it closes a PR; draft PRs remain exempt.
+
+Manual runs default to the workflow's `dry_run` audit mode, which logs proposed
+operations without changing issues or pull requests. Set it to false only after
+reviewing that audit and intentionally applying the documented policy.
+
 ## 🚀 Getting Started
 
 ### Project Structure

--- a/scripts/stale-policy.test.js
+++ b/scripts/stale-policy.test.js
@@ -1,0 +1,92 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const ROOT = path.join(__dirname, '..');
+const workflow = fs.readFileSync(path.join(ROOT, '.github', 'workflows', 'stale.yml'), 'utf8');
+const contributing = fs.readFileSync(path.join(ROOT, 'CONTRIBUTING.md'), 'utf8');
+
+function scalar(name) {
+    const match = workflow.match(new RegExp(`^\\s+${name}: ["']?([^\\n"']+)["']?\\s*$`, 'm'));
+    assert.ok(match, `missing scalar stale input ${name}`);
+    return match[1].trim();
+}
+
+function exemptLabels() {
+    const match = workflow.match(/exempt-issue-labels: >-\n((?:\s{12}.+\n?)+)/);
+    assert.ok(match, 'missing folded exempt-issue-labels input');
+    return new Set(match[1]
+        .replace(/^\s+/gm, '')
+        .split(',')
+        .map((label) => label.trim())
+        .filter(Boolean));
+}
+
+function classifyIssue(fixture) {
+    const exemptions = exemptLabels();
+    const exempt = fixture.labels.some((label) => exemptions.has(label))
+        || (fixture.milestone && scalar('exempt-all-issue-milestones') === 'true')
+        || (fixture.assigned && scalar('exempt-all-issue-assignees') === 'true');
+    return {
+        reminderAfterDays: exempt ? null : Number(scalar('days-before-issue-stale')),
+        autoCloses: !exempt && Number(scalar('days-before-issue-close')) !== -1,
+    };
+}
+
+test('accepted, priority, milestone, Project and owned issues cannot become stale or auto-close', () => {
+    const fixtures = [
+        { name: 'confirmed bug', labels: ['bug'], milestone: false, assigned: false },
+        { name: 'security report', labels: ['security'], milestone: false, assigned: false },
+        { name: 'confirmed report', labels: ['confirmed'], milestone: false, assigned: false },
+        { name: 'P0 priority', labels: ['P0'], milestone: false, assigned: false },
+        { name: 'P1 priority', labels: ['P1'], milestone: false, assigned: false },
+        { name: 'milestone backlog', labels: [], milestone: true, assigned: false },
+        { name: 'Project-tracked', labels: ['no-stale'], milestone: false, assigned: false },
+        { name: 'assigned roadmap work', labels: [], milestone: false, assigned: true },
+    ];
+
+    for (const fixture of fixtures) {
+        assert.deepEqual(classifyIssue(fixture), {
+            reminderAfterDays: null,
+            autoCloses: false,
+        }, fixture.name);
+    }
+});
+
+test('untriaged and awaiting-reporter issues have a reminder timer but no close timer', () => {
+    const fixtures = [
+        { name: 'untriaged', labels: [], milestone: false, assigned: false },
+        { name: 'awaiting reporter', labels: ['awaiting-reporter'], milestone: false, assigned: false },
+        { name: 'support question', labels: ['question'], milestone: false, assigned: false },
+    ];
+
+    for (const fixture of fixtures) {
+        assert.deepEqual(classifyIssue(fixture), {
+            reminderAfterDays: 30,
+            autoCloses: false,
+        }, fixture.name);
+    }
+    assert.match(workflow, /triage reminder only:[\s\S]+issue automation never closes issues/);
+    assert.match(contributing, /They are never closed by stale automation/);
+    assert.match(contributing, /maintainer may close an issue only after leaving a triage reason/);
+});
+
+test('pull-request cleanup retains explicit timers and records its inactivity reason', () => {
+    assert.equal(scalar('days-before-pr-stale'), '15');
+    assert.equal(scalar('days-before-pr-close'), '3');
+    assert.match(workflow, /close-pr-message: >[\s\S]+Closing this pull request because/);
+    assert.match(workflow, /exempt-draft-pr: true/);
+});
+
+test('manual policy runs default to a non-mutating audit', () => {
+    assert.match(workflow, /workflow_dispatch:\n\s+inputs:\n\s+dry_run:/);
+    assert.match(workflow, /dry_run:[\s\S]+default: true/);
+    assert.match(
+        workflow,
+        /debug-only: \$\{\{ github\.event_name == 'workflow_dispatch' && inputs\.dry_run \}\}/
+    );
+    assert.match(contributing, /Manual runs default to the workflow's `dry_run` audit mode/);
+});


### PR DESCRIPTION
Closes #101

## Summary
- disable issue auto-close entirely while retaining a 30-day reminder for non-exempt untriaged and awaiting-reporter states
- preserve the independent 15-day stale plus 3-day close policy for non-draft pull requests, with an explicit closure message
- exempt accepted bugs, security reports, confirmed work, P0/P1, milestones, assignees, tracking states, and no-stale Project work from issue reminders
- make manual workflow runs dry-run by default and document label/state transitions and manual triage reasons
- add a fixture matrix that reads the committed workflow and proves issue exemptions, reminder-only behavior, PR timers, and audit mode

## Operational alignment
- created the canonical confirmed, P0, P1, and awaiting-reporter labels
- audited all 175 Project 4 cards and repaired no-stale on #207, #245, #259, and #260; zero Project issue cards now lack no-stale

## Validation
- focused stale-policy matrix: 4/4 passing
- full script suite: 283/283 passing
- ESLint: passing for the new policy test
- independent Fable low-effort review: APPROVE

E2E remains on the digest-pinned jellyfin/jellyfin:unstable nightly image; this PR does not change the Docker image contract.