### PR TITLE
fix: enforce canonical locale inventory

### DIFF
--- a/.github/workflows/translation_validation.yml
+++ b/.github/workflows/translation_validation.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     paths:
       - 'Jellyfin.Plugin.JellyfinCanopy/js/locales/**.json'
+      - 'Jellyfin.Plugin.JellyfinCanopy/locale-manifest.json'
+      - 'scripts/validate-translations.js'
+      - 'scripts/validate-translations.test.js'
 
 permissions:
   contents: read
@@ -30,76 +33,17 @@ jobs:
       - name: Verify Node toolchain
         run: node scripts/check-node-toolchain.js
 
-      - name: Get changed translation files
-        id: changed_files
+      - name: Record added, deleted, and renamed locale paths
         run: |
-          # Get all changed locale files in the PR
-          changed_files=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}...${{ github.sha }} -- 'Jellyfin.Plugin.JellyfinCanopy/js/locales/*.json')
-          new_files=$(git diff --name-only --diff-filter=A origin/${{ github.event.pull_request.base.ref }}...${{ github.sha }} -- 'Jellyfin.Plugin.JellyfinCanopy/js/locales/*.json')
+          git diff --name-status --find-renames \
+            "origin/${{ github.event.pull_request.base.ref }}...${{ github.sha }}" -- \
+            'Jellyfin.Plugin.JellyfinCanopy/js/locales/*.json' \
+            'Jellyfin.Plugin.JellyfinCanopy/locale-manifest.json'
 
-          echo "changed_files<<EOF" >> $GITHUB_OUTPUT
-          echo "$changed_files" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+      # Validate the complete registered set. A deleted file is absent from the
+      # tree but remains registered, so it cannot become a successful skip.
+      - name: Validate canonical inventory and every translation
+        run: npm run validate-translations
 
-          echo "new_files<<EOF" >> $GITHUB_OUTPUT
-          echo "$new_files" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
-          # Count number of changed files
-          count=$(echo "$changed_files" | grep -c . || echo "0")
-          echo "count=$count" >> $GITHUB_OUTPUT
-
-          echo "Changed files:"
-          echo "$changed_files"
-          echo "New files:"
-          echo "$new_files"
-
-      - name: Validate new language file naming
-        if: steps.changed_files.outputs.new_files != ''
-        run: |
-          echo "${{ steps.changed_files.outputs.new_files }}" | while IFS= read -r file; do
-            if [ -z "$file" ]; then
-              continue
-            fi
-
-            filename=$(basename "$file")
-            echo "Checking filename: $filename"
-
-            # Check if filename is a two-letter code or region-specific code (e.g., en.json, zh-HK.json)
-            if ! [[ "$filename" =~ ^[a-z]{2}(-[A-Z]{2})?\.json$ ]]; then
-              echo "::error file=$file::Invalid filename. Filename must be ISO 639-1 language code, optionally with ISO 3166-1 region (e.g., es.json, zh-HK.json, pt-BR.json)."
-              exit 1
-            fi
-          done
-
-      - name: Validate changed translation files
-        if: steps.changed_files.outputs.changed_files != ''
-        run: |
-          echo "${{ steps.changed_files.outputs.changed_files }}" | while IFS= read -r file; do
-            if [ -z "$file" ] || [ ! -f "$file" ]; then
-              continue
-            fi
-
-            lang=$(basename "$file" .json)
-            if [ "$lang" = "en" ]; then
-              echo "Skipping base language (en.json)"
-              continue
-            fi
-
-            echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-            echo "Validating: $lang"
-            echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-            node scripts/validate-translations.js validate "$lang"
-            if [ $? -ne 0 ]; then
-              exit 1
-            fi
-          done
-
-      - name: Show completion statistics (multiple files changed)
-        if: steps.changed_files.outputs.count > 1
-        run: |
-          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-          echo "Translation Completion Statistics"
-          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-          # Registered for Jellyfin Canopy CI (no functional change).
-          node scripts/validate-translations.js stats
+      - name: Show completion statistics
+        run: node scripts/validate-translations.js stats

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ You can contribute code through:
 
 ### 2. Translation Contributions
 
-Help make Jellyfin Canopy accessible to more users by contributing translations. Locale JSON files live in `Jellyfin.Plugin.JellyfinCanopy/js/locales/` (one per language, `en.json` is the base). To add or update a language, edit the relevant file and open a pull request; `npm run validate-translations` must pass, and all 26 locales must stay in sync with `en.json`.
+Help make Jellyfin Canopy accessible to more users by contributing translations. Locale JSON files live in `Jellyfin.Plugin.JellyfinCanopy/js/locales/` (one per language, `en.json` is the base). The exact supported list lives only in [`locale-manifest.json`](Jellyfin.Plugin.JellyfinCanopy/locale-manifest.json). To add or update a language, edit the relevant file and open a pull request; `npm run validate-translations` must pass, and all registered locales must stay in sync with `en.json`.
 
 See the [Contributing Translations](https://4eh5xitv6787h645ebv.github.io/Jellyfin-Canopy/faq-support/contributing-translations/) section for details.
 

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/LocaleManifestTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/LocaleManifestTests.cs
@@ -1,0 +1,29 @@
+using Jellyfin.Plugin.JellyfinCanopy.Controllers;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
+{
+    public sealed class LocaleManifestTests
+    {
+        [Fact]
+        public void SupportedLocaleInventory_MatchesEmbeddedCatalogsExactly()
+        {
+            const string prefix = "Jellyfin.Plugin.JellyfinCanopy.js.locales.";
+            const string suffix = ".json";
+            var embeddedLocales = typeof(ConfigController).Assembly
+                .GetManifestResourceNames()
+                .Where(name => name.StartsWith(prefix, StringComparison.Ordinal)
+                    && name.EndsWith(suffix, StringComparison.Ordinal))
+                .Select(name => name.Substring(prefix.Length, name.Length - prefix.Length - suffix.Length))
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToArray();
+            var registeredLocales = ConfigController.SupportedLocaleCodes
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToArray();
+
+            Assert.Equal(26, registeredLocales.Length);
+            Assert.Contains("en", registeredLocales);
+            Assert.Equal(registeredLocales, embeddedLocales);
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Configuration/config-page.js
+++ b/Jellyfin.Plugin.JellyfinCanopy/Configuration/config-page.js
@@ -2826,8 +2826,12 @@
                     cultureMap[c.TwoLetterISOLanguageName.toLowerCase()] = c;
                 });
 
-                const localeSet = new Set(localeCodes.map(c => c.toLowerCase()));
-                const options = localeCodes.map(code => {
+                // The endpoint exposes the complete canonical inventory. Generic
+                // English is the fallback catalog, while the two regional English
+                // variants remain the selectable UI choices.
+                const selectableLocaleCodes = localeCodes.filter(code => code !== 'en');
+                const localeSet = new Set(selectableLocaleCodes.map(c => c.toLowerCase()));
+                const options = selectableLocaleCodes.map(code => {
                     let displayName = CUSTOM_DISPLAY_NAMES[code]
                         || cultureMap[code.toLowerCase()]?.DisplayName;
                     if (!displayName && code.includes('-')) {

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/ConfigController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/ConfigController.cs
@@ -209,48 +209,73 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
         [ResponseCache(Duration = 86400)]
         public ActionResult GetAvailableLocales()
         {
-            var prefix = "Jellyfin.Plugin.JellyfinCanopy.js.locales.";
-            var suffix = ".json";
-            var locales = Assembly.GetExecutingAssembly()
-                .GetManifestResourceNames()
-                .Where(n => n.StartsWith(prefix, StringComparison.Ordinal) && n.EndsWith(suffix, StringComparison.Ordinal))
-                .Select(n => n.Substring(prefix.Length, n.Length - prefix.Length - suffix.Length))
-                .Where(code => code != "en") // Exclude base English (en-GB and en-US are the usable variants)
-                .OrderBy(code => code, StringComparer.OrdinalIgnoreCase)
-                .ToArray();
-
-            return Ok(locales);
+            return Ok(SupportedLocaleCodes);
         }
 
         [HttpGet("locales/{lang}.json")]
         public ActionResult GetLocale(string lang)
         {
             var sanitizedLang = Path.GetFileName(lang); // Basic sanitization
-            var resourcePath = $"Jellyfin.Plugin.JellyfinCanopy.js.locales.{sanitizedLang}.json";
-            var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourcePath);
+            var selectedLang = SupportedLocaleCodes.Contains(sanitizedLang, StringComparer.Ordinal)
+                ? sanitizedLang
+                : null;
 
-            if (stream == null && sanitizedLang.Contains('-'))
+            if (selectedLang == null && sanitizedLang.Contains('-'))
             {
                 // Fall back from regional variant (e.g. de-DE) to the base language (de).
                 // Jellyfin reports BCP-47 codes like de-DE when the user picks "Auto" or a
                 // regional locale, but the plugin only ships base-language files for most
                 // languages. Without this fallback the user gets English instead of German.
                 var baseLang = sanitizedLang.Split('-')[0];
-                var fallbackPath = $"Jellyfin.Plugin.JellyfinCanopy.js.locales.{baseLang}.json";
-                stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(fallbackPath);
-                if (stream != null)
+                if (SupportedLocaleCodes.Contains(baseLang, StringComparer.Ordinal))
                 {
+                    selectedLang = baseLang;
                     _logger.LogInformation($"Locale file not found for {sanitizedLang}, falling back to base language {baseLang}");
                 }
             }
 
-            if (stream == null)
+            if (selectedLang == null)
             {
                 _logger.LogWarning($"Locale file not found for language: {sanitizedLang}");
                 return NotFound();
             }
 
+            var resourcePath = $"Jellyfin.Plugin.JellyfinCanopy.js.locales.{selectedLang}.json";
+            var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourcePath);
+            if (stream == null)
+            {
+                throw new InvalidOperationException($"Registered locale resource is missing: {selectedLang}.json");
+            }
+
             return new FileStreamResult(stream, "application/json");
+        }
+
+        private const string LocaleManifestResource = "Jellyfin.Plugin.JellyfinCanopy.locale-manifest.json";
+
+        internal static IReadOnlyList<string> SupportedLocaleCodes { get; } = LoadSupportedLocaleCodes();
+
+        private static IReadOnlyList<string> LoadSupportedLocaleCodes()
+        {
+            using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(LocaleManifestResource)
+                ?? throw new InvalidOperationException($"Embedded locale inventory is missing: {LocaleManifestResource}");
+            var manifest = JsonSerializer.Deserialize<LocaleManifest>(stream)
+                ?? throw new InvalidOperationException("Embedded locale inventory is empty");
+            if (manifest.Locales.Length == 0
+                || !manifest.Locales.Contains(manifest.BaseLocale, StringComparer.Ordinal))
+            {
+                throw new InvalidOperationException("Embedded locale inventory has no registered base locale");
+            }
+
+            return Array.AsReadOnly(manifest.Locales);
+        }
+
+        private sealed class LocaleManifest
+        {
+            [JsonPropertyName("baseLocale")]
+            public string BaseLocale { get; init; } = string.Empty;
+
+            [JsonPropertyName("locales")]
+            public string[] Locales { get; init; } = Array.Empty<string>();
         }
 
         private ActionResult GetScriptResource(string resourcePath)

--- a/Jellyfin.Plugin.JellyfinCanopy/JellyfinCanopy.csproj
+++ b/Jellyfin.Plugin.JellyfinCanopy/JellyfinCanopy.csproj
@@ -54,6 +54,9 @@
     <EmbeddedResource Include="Configuration\config-page.js"/>
     <None Remove="plugin.js"/>
     <EmbeddedResource Include="js\**" />
+    <!-- Canonical locale inventory consumed by the server endpoints and CI. -->
+    <EmbeddedResource Include="locale-manifest.json"
+                      LogicalName="Jellyfin.Plugin.JellyfinCanopy.locale-manifest.json" />
     <!-- Ship-safe assets served by AssetsController (guaranteed-available tier of the
          third-party asset cache; see Services/AssetCacheManifest.cs). -->
     <None Remove="Assets\poster-fallback.svg"/>

--- a/Jellyfin.Plugin.JellyfinCanopy/locale-manifest.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/locale-manifest.json
@@ -1,0 +1,31 @@
+{
+  "baseLocale": "en",
+  "locales": [
+    "ar",
+    "bg",
+    "ca",
+    "cs",
+    "da",
+    "de",
+    "en",
+    "en-GB",
+    "en-US",
+    "es",
+    "fr",
+    "he",
+    "hu",
+    "it",
+    "nl",
+    "no",
+    "pl",
+    "pr",
+    "pt",
+    "pt-BR",
+    "ru",
+    "sk",
+    "sv",
+    "tr",
+    "zh-CN",
+    "zh-HK"
+  ]
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/src/bootstrap/translations.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/bootstrap/translations.ts
@@ -9,6 +9,7 @@
 // to the former js/enhanced/translations.js; this is a typed port.
 
 import type { JEGlobal } from '../types/jc';
+import localeManifest from '../../locale-manifest.json';
 
 (function (JC: JEGlobal) {
     'use strict';
@@ -18,6 +19,7 @@ import type { JEGlobal } from '../types/jc';
     // strings. Only used as the last-resort fallback when AssetCacheEnabled === false.
     const GITHUB_RAW_BASE = 'https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/main/Jellyfin.Plugin.JellyfinCanopy/js/locales';
     const CACHE_DURATION = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
+    const SUPPORTED_LOCALES = new Set(localeManifest.locales);
 
     type LangResult = { translations: Record<string, string>; usedLang: string };
 
@@ -33,19 +35,19 @@ import type { JEGlobal } from '../types/jc';
         const normalizedLang = normalizeLangCode(primaryLang);
         const langCodes: string[] = [];
 
-        if (normalizedLang) {
+        if (normalizedLang && SUPPORTED_LOCALES.has(normalizedLang)) {
             langCodes.push(normalizedLang);
         }
 
         if (normalizedLang && normalizedLang.includes('-')) {
             const baseLang = normalizedLang.split('-')[0];
-            if (!langCodes.includes(baseLang)) {
+            if (SUPPORTED_LOCALES.has(baseLang) && !langCodes.includes(baseLang)) {
                 langCodes.push(baseLang);
             }
         }
 
-        if (langCodes[langCodes.length - 1] !== 'en') {
-            langCodes.push('en');
+        if (langCodes[langCodes.length - 1] !== localeManifest.baseLocale) {
+            langCodes.push(localeManifest.baseLocale);
         }
 
         return Array.from(new Set(langCodes.filter(Boolean)));

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/language-nogithub.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/language-nogithub.test.ts
@@ -37,5 +37,6 @@ describe('language control locale source', () => {
         // The server locale endpoint WAS used.
         expect(plugin).toHaveBeenCalledWith('/locales');
         expect(jf).toHaveBeenCalledWith('/Localization/Cultures');
+        expect(Array.from(select.options, option => option.value).sort()).toEqual(['de', 'fr']);
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/language.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/language.ts
@@ -78,8 +78,11 @@ export function wireLanguageControls(ctx: PanelContext): void {
                     cultureMap[c.TwoLetterISOLanguageName.toLowerCase()] = c;
                 });
 
-                const localeSet = new Set(localeCodes.map((c: any) => c.toLowerCase()));
-                const options = localeCodes.map((code: any) => {
+                // Generic English is the fallback catalog, not a selectable
+                // language alongside the en-GB and en-US variants.
+                const selectableLocaleCodes = localeCodes.filter((code: any) => code !== 'en');
+                const localeSet = new Set(selectableLocaleCodes.map((c: any) => c.toLowerCase()));
+                const options = selectableLocaleCodes.map((code: any) => {
                     let displayName = CUSTOM_DISPLAY_NAMES[code]
                         || cultureMap[code.toLowerCase()]?.DisplayName;
                     if (!displayName && code.includes('-')) {

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Jellyfin Canopy is developed **entirely with AI** (agentic coding tools driving 
 
 - 🐛 [Report issues](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues)
 - 💡 [Suggest features](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/discussions)
-- 🌍 Help translate — Canopy ships 26 synchronized language catalogs, and better translations are always welcome
+- 🌍 Help translate — Canopy ships [26 synchronized language catalogs](Jellyfin.Plugin.JellyfinCanopy/locale-manifest.json), and better translations are always welcome
 
 Developers: [CONTRIBUTING.md](CONTRIBUTING.md) has the workflow, quality gates, and the paved road for new features.
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -382,7 +382,7 @@ The strongest requests pair a clear description with a concrete use case, add mo
 
 ## Translate Jellyfin Canopy
 
-Jellyfin Canopy ships its translations as JSON files in the repository — one per locale in `Jellyfin.Plugin.JellyfinCanopy/js/locales/`. Adding or improving a language is a plain pull request: edit a file and open a PR. There's **no external translation platform to sign up for** and no Weblate — the workflow is validated entirely in CI.
+Jellyfin Canopy ships its translations as JSON files in the repository — one per locale in `Jellyfin.Plugin.JellyfinCanopy/js/locales/`. The repository's [`locale-manifest.json`](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/blob/main/Jellyfin.Plugin.JellyfinCanopy/locale-manifest.json) is the canonical supported-language list. Adding or improving a language is a plain pull request: edit a file and open a PR. There's **no external translation platform to sign up for** and no Weblate — the workflow is validated entirely in CI.
 
 ### Add or update a language
 
@@ -392,7 +392,7 @@ Jellyfin Canopy ships its translations as JSON files in the repository — one p
 4. Run the validator locally: `npm run validate-translations`.
 5. Commit your changes and open a pull request.
 
-When a pull request touches any `js/locales/*.json` file, the **Translation Checks** workflow re-runs the same validation and gates the merge. A locale that is missing keys, drops a placeholder, or leaves a value blank fails CI — all 26 locales must stay in sync with `en.json`.
+When a pull request touches a locale or the inventory, the **Translation Checks** workflow validates the complete registered set and gates the merge. Missing or unregistered files, case/region-code drift, missing keys, dropped placeholders, and blank values all fail CI. Intentional language additions or removals must update the inventory and its documented count in the same reviewed migration.
 
 ### What the validator checks
 

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -19,7 +19,7 @@ const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the repeated clean measurements', () => {
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1364, totalLines: 1692 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 12781, totalLines: 20998 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 12792, totalLines: 21005 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 1);
 });

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -21,12 +21,12 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 12781,
-        "totalLines": 20998
+        "coveredLines": 12792,
+        "totalLines": 21005
       },
       "tolerance": {
         "missingCoveredLines": 1,
-        "rationale": "Four clean .NET 10/Coverlet runs on 2026-07-15 were identical after deterministic tests covered both valid bookmark update/delete race outcomes; one line permits only negligible instrumentation variance."
+        "rationale": "The 2026-07-15 hosted .NET 10/Coverlet run measured the seven-line locale-manifest loader scope increase and its dedicated embedded-resource test; one line permits only negligible instrumentation variance."
       }
     }
   }

--- a/scripts/validate-translations.js
+++ b/scripts/validate-translations.js
@@ -25,13 +25,16 @@ const fs = require('fs');
 const path = require('path');
 
 const LOCALES_DIR = path.join(__dirname, '../Jellyfin.Plugin.JellyfinCanopy/js/locales');
+const LOCALE_INVENTORY_PATH = path.join(
+    __dirname,
+    '../Jellyfin.Plugin.JellyfinCanopy/locale-manifest.json'
+);
 // Translation call sites live in the TypeScript module tree (src/) plus the
 // remaining legacy loader files under js/ — scan both.
 const CODE_DIRS = [
     path.join(__dirname, '../Jellyfin.Plugin.JellyfinCanopy/src'),
     path.join(__dirname, '../Jellyfin.Plugin.JellyfinCanopy/js'),
 ];
-const BASE_LANG = 'en';
 const WEBLATE_URL = 'https://hosted.weblate.org/projects/jellyfincanopy/';
 
 // ANSI color codes for terminal output
@@ -82,17 +85,113 @@ function loadTranslation(lang) {
     }
 }
 
+function readLocaleInventory(inventoryPath = LOCALE_INVENTORY_PATH) {
+    return JSON.parse(fs.readFileSync(inventoryPath, 'utf8'));
+}
+
 /**
- * Get all available translation languages
+ * Compare the canonical supported-locale inventory with the files on disk.
+ * Exact spelling matters: Linux can hold both fr.json and FR.json, while other
+ * filesystems cannot, so case collisions and case-only renames are hard errors.
+ */
+function validateLocaleInventory(
+    localesDir = LOCALES_DIR,
+    inventoryPath = LOCALE_INVENTORY_PATH
+) {
+    const errors = [];
+    let inventory;
+    try {
+        inventory = readLocaleInventory(inventoryPath);
+    } catch (error) {
+        return {
+            valid: false,
+            errors: [`Cannot read locale inventory: ${error.message}`],
+            baseLocale: '',
+            locales: [],
+            files: [],
+        };
+    }
+
+    const baseLocale = typeof inventory.baseLocale === 'string' ? inventory.baseLocale : '';
+    const locales = Array.isArray(inventory.locales) ? inventory.locales : [];
+    if (!baseLocale) errors.push('Locale inventory must define baseLocale');
+    if (locales.length === 0 || locales.some(code => typeof code !== 'string')) {
+        errors.push('Locale inventory must define a non-empty string locales array');
+    }
+
+    const validCode = /^[a-z]{2}(?:-[A-Z]{2})?$/;
+    for (const code of locales) {
+        if (typeof code === 'string' && !validCode.test(code)) {
+            errors.push(`Invalid locale code in inventory: ${code}`);
+        }
+    }
+    if (baseLocale && !locales.includes(baseLocale)) {
+        errors.push(`Base locale is not registered: ${baseLocale}`);
+    }
+
+    const exactCodes = new Set();
+    const foldedCodes = new Map();
+    for (const code of locales.filter(value => typeof value === 'string')) {
+        if (exactCodes.has(code)) errors.push(`Duplicate locale in inventory: ${code}`);
+        exactCodes.add(code);
+        const folded = code.toLowerCase();
+        if (foldedCodes.has(folded) && foldedCodes.get(folded) !== code) {
+            errors.push(`Case-colliding locales in inventory: ${foldedCodes.get(folded)} and ${code}`);
+        }
+        foldedCodes.set(folded, code);
+    }
+    const sortedLocales = [...locales].sort();
+    if (JSON.stringify(locales) !== JSON.stringify(sortedLocales)) {
+        errors.push('Locale inventory must remain sorted');
+    }
+
+    let files = [];
+    try {
+        files = fs.readdirSync(localesDir, { withFileTypes: true })
+            .filter(entry => entry.isFile() && /\.json$/i.test(entry.name))
+            .map(entry => entry.name)
+            .sort();
+    } catch (error) {
+        errors.push(`Cannot read locale directory: ${error.message}`);
+    }
+
+    const actualCodes = files.map(file => file.replace(/\.json$/i, ''));
+    const actualByFolded = new Map();
+    for (const [index, code] of actualCodes.entries()) {
+        if (!files[index].endsWith('.json')) {
+            errors.push(`Invalid locale filename extension casing: ${files[index]}`);
+        }
+        const folded = code.toLowerCase();
+        if (actualByFolded.has(folded)) {
+            errors.push(`Case-colliding locale files: ${actualByFolded.get(folded)}.json and ${code}.json`);
+        }
+        actualByFolded.set(folded, code);
+        if (!validCode.test(code)) errors.push(`Invalid locale filename: ${code}.json`);
+    }
+
+    for (const code of locales.filter(value => typeof value === 'string')) {
+        if (actualCodes.includes(code)) continue;
+        const caseVariant = actualByFolded.get(code.toLowerCase());
+        if (caseVariant) {
+            errors.push(`Locale filename case mismatch: expected ${code}.json, found ${caseVariant}.json`);
+        } else {
+            errors.push(`Registered locale file is missing: ${code}.json`);
+        }
+    }
+    for (const code of actualCodes) {
+        if (!locales.includes(code) && !foldedCodes.has(code.toLowerCase())) {
+            errors.push(`Unregistered locale file: ${code}.json`);
+        }
+    }
+
+    return { valid: errors.length === 0, errors, baseLocale, locales, files };
+}
+
+/**
+ * Get all supported translation languages from the canonical inventory.
  */
 function getAvailableLanguages() {
-    if (!fs.existsSync(LOCALES_DIR)) {
-        return [];
-    }
-    return fs.readdirSync(LOCALES_DIR)
-        .filter(file => file.endsWith('.json'))
-        .map(file => file.replace('.json', ''))
-        .sort();
+    return readLocaleInventory().locales;
 }
 
 /**
@@ -202,6 +301,7 @@ function validateEntries(baseTranslation, translation) {
  * Validate a single translation file against base
  */
 function validateTranslation(lang, verbose = false) {
+    const BASE_LANG = readLocaleInventory().baseLocale;
     if (lang === BASE_LANG) {
         logInfo(`Skipping validation of base language (${BASE_LANG})`);
         return { valid: true, errors: [], warnings: [] };
@@ -256,6 +356,7 @@ function validateTranslation(lang, verbose = false) {
  * Find translation keys that are not used in the codebase
  */
 function findUnusedKeys() {
+    const BASE_LANG = readLocaleInventory().baseLocale;
     const baseTranslation = loadTranslation(BASE_LANG);
     if (!baseTranslation) {
         logError('Base translation file not found!');
@@ -366,6 +467,7 @@ function findUnusedKeys() {
  * Create a new translation file template
  */
 function createTranslationTemplate(lang) {
+    const BASE_LANG = readLocaleInventory().baseLocale;
     if (!lang || !/^[a-z]{2}(-[A-Z]{2})?$/.test(lang)) {
         logError('Language code must be ISO 639-1 (e.g., es, fr, de) or with region (e.g., zh-HK, pt-BR)');
         return;
@@ -387,6 +489,13 @@ function createTranslationTemplate(lang) {
 
     try {
         fs.writeFileSync(filePath, JSON.stringify(template, null, 4) + '\n', { encoding: 'utf8', flag: 'wx' });
+        const inventory = readLocaleInventory();
+        if (!inventory.locales.includes(lang)) {
+            inventory.locales.push(lang);
+            inventory.locales.sort();
+            fs.writeFileSync(LOCALE_INVENTORY_PATH, JSON.stringify(inventory, null, 2) + '\n');
+            logInfo(`Registered ${lang} in locale-manifest.json`);
+        }
         logSuccess(`Created translation template: ${filePath}`);
         logInfo(`Now edit ${lang}.json and translate the English values to ${lang.toUpperCase()}`);
         logInfo(`Preferred workflow for contributors is Weblate: ${WEBLATE_URL}`);
@@ -404,6 +513,7 @@ function createTranslationTemplate(lang) {
  * Show translation statistics for all languages
  */
 function showStats() {
+    const BASE_LANG = readLocaleInventory().baseLocale;
     const languages = getAvailableLanguages();
     const baseTranslation = loadTranslation(BASE_LANG);
 
@@ -533,10 +643,19 @@ function main() {
 
     switch (command) {
         case 'validate': {
+            const inventory = validateLocaleInventory();
+            if (!inventory.valid) {
+                inventory.errors.forEach(error => logError(error));
+                process.exit(1);
+            }
             const targetLang = args[1];
+            if (targetLang && !inventory.locales.includes(targetLang)) {
+                logError(`Locale is not registered in locale-manifest.json: ${targetLang}`);
+                process.exit(1);
+            }
             const languages = targetLang
                 ? [targetLang]
-                : getAvailableLanguages().filter(lang => lang !== BASE_LANG);
+                : inventory.locales.filter(lang => lang !== inventory.baseLocale);
 
             if (languages.length === 0) {
                 logError('No translation files found!');
@@ -597,5 +716,8 @@ module.exports = {
     validateTranslation,
     findUnusedKeys,
     createTranslationTemplate,
-    showStats
+    showStats,
+    getAvailableLanguages,
+    readLocaleInventory,
+    validateLocaleInventory
 };

--- a/scripts/validate-translations.test.js
+++ b/scripts/validate-translations.test.js
@@ -19,11 +19,35 @@
 const test = require('node:test');
 const assert = require('node:assert');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
-const { extractPlaceholders, validateEntries } = require('./validate-translations.js');
+const {
+    extractPlaceholders,
+    getAvailableLanguages,
+    readLocaleInventory,
+    validateEntries,
+    validateLocaleInventory,
+} = require('./validate-translations.js');
 // The require is side-effect-free: main() is guarded by require.main === module.
 
 const LOCALES_DIR = path.join(__dirname, '../Jellyfin.Plugin.JellyfinCanopy/js/locales');
+const INVENTORY_PATH = path.join(
+    __dirname,
+    '../Jellyfin.Plugin.JellyfinCanopy/locale-manifest.json'
+);
+
+function inventoryFixture(t, locales = ['en', 'fr']) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'jc-locales-'));
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+    const localeDir = path.join(root, 'locales');
+    const inventoryPath = path.join(root, 'locale-manifest.json');
+    fs.mkdirSync(localeDir);
+    fs.writeFileSync(inventoryPath, `${JSON.stringify({ baseLocale: 'en', locales }, null, 2)}\n`);
+    for (const locale of [...new Set(locales)]) {
+        fs.writeFileSync(path.join(localeDir, `${locale}.json`), '{}\n');
+    }
+    return { localeDir, inventoryPath };
+}
 
 // --- MB-5: icon-token + curly placeholder parity ---
 test('extractPlaceholders captures well-formed icon tokens', () => {
@@ -70,12 +94,112 @@ test('a clean matching locale produces no errors', () => {
 
 // --- Class guard over the REAL shipped locales ---
 test('all shipped locales validate clean against en.json', () => {
+    const inventory = validateLocaleInventory();
+    assert.deepStrictEqual(inventory.errors, []);
     const en = JSON.parse(fs.readFileSync(path.join(LOCALES_DIR, 'en.json'), 'utf8'));
-    for (const f of fs.readdirSync(LOCALES_DIR).filter(x => x.endsWith('.json') && x !== 'en.json')) {
-        const t = JSON.parse(fs.readFileSync(path.join(LOCALES_DIR, f), 'utf8'));
-        const { errors } = validateEntries(en, t);
-        assert.deepStrictEqual(errors, [], `${f}: ${errors.join(' | ')}`);
+    for (const locale of inventory.locales.filter(code => code !== inventory.baseLocale)) {
+        const translation = JSON.parse(
+            fs.readFileSync(path.join(LOCALES_DIR, `${locale}.json`), 'utf8')
+        );
+        const { errors } = validateEntries(en, translation);
+        assert.deepStrictEqual(errors, [], `${locale}.json: ${errors.join(' | ')}`);
     }
+});
+
+test('canonical inventory is the exact source for all 26 shipped locale files', () => {
+    const inventory = readLocaleInventory();
+    assert.strictEqual(inventory.baseLocale, 'en');
+    assert.strictEqual(inventory.locales.length, 26);
+    assert.deepStrictEqual(getAvailableLanguages(), inventory.locales);
+    assert.deepStrictEqual(validateLocaleInventory().errors, []);
+});
+
+test('deleting a registered locale is a hard inventory failure', t => {
+    const fixture = inventoryFixture(t);
+    fs.rmSync(path.join(fixture.localeDir, 'fr.json'));
+    assert.match(
+        validateLocaleInventory(fixture.localeDir, fixture.inventoryPath).errors.join('\n'),
+        /Registered locale file is missing: fr\.json/
+    );
+});
+
+test('adding an unregistered locale is a hard inventory failure', t => {
+    const fixture = inventoryFixture(t);
+    fs.writeFileSync(path.join(fixture.localeDir, 'it.json'), '{}\n');
+    assert.match(
+        validateLocaleInventory(fixture.localeDir, fixture.inventoryPath).errors.join('\n'),
+        /Unregistered locale file: it\.json/
+    );
+});
+
+test('case-only locale renames are rejected', t => {
+    const fixture = inventoryFixture(t);
+    fs.renameSync(
+        path.join(fixture.localeDir, 'fr.json'),
+        path.join(fixture.localeDir, 'FR.json')
+    );
+    const errors = validateLocaleInventory(fixture.localeDir, fixture.inventoryPath).errors.join('\n');
+    assert.match(errors, /Invalid locale filename: FR\.json/);
+    assert.match(errors, /Locale filename case mismatch: expected fr\.json, found FR\.json/);
+});
+
+test('locale filename extension casing is rejected', t => {
+    const fixture = inventoryFixture(t);
+    fs.renameSync(
+        path.join(fixture.localeDir, 'fr.json'),
+        path.join(fixture.localeDir, 'fr.JSON')
+    );
+    assert.match(
+        validateLocaleInventory(fixture.localeDir, fixture.inventoryPath).errors.join('\n'),
+        /Invalid locale filename extension casing: fr\.JSON/
+    );
+});
+
+test('region casing and case-colliding inventory entries are rejected', t => {
+    const fixture = inventoryFixture(t, ['en', 'pt-BR', 'pt-br']);
+    const errors = validateLocaleInventory(fixture.localeDir, fixture.inventoryPath).errors.join('\n');
+    assert.match(errors, /Invalid locale code in inventory: pt-br/);
+    assert.match(errors, /Case-colliding locales in inventory: pt-BR and pt-br/);
+});
+
+test('server loader, workflow, and contributor docs consume the canonical inventory', () => {
+    const root = path.join(__dirname, '..');
+    const controller = fs.readFileSync(
+        path.join(root, 'Jellyfin.Plugin.JellyfinCanopy/Controllers/ConfigController.cs'),
+        'utf8'
+    );
+    const project = fs.readFileSync(
+        path.join(root, 'Jellyfin.Plugin.JellyfinCanopy/JellyfinCanopy.csproj'),
+        'utf8'
+    );
+    const loader = fs.readFileSync(
+        path.join(root, 'Jellyfin.Plugin.JellyfinCanopy/src/bootstrap/translations.ts'),
+        'utf8'
+    );
+    const workflow = fs.readFileSync(
+        path.join(root, '.github/workflows/translation_validation.yml'),
+        'utf8'
+    );
+    assert.match(project, /EmbeddedResource Include="locale-manifest\.json"/);
+    assert.match(controller, /SupportedLocaleCodes \{ get; \} = LoadSupportedLocaleCodes\(\)/);
+    assert.match(controller, /Contains\(sanitizedLang, StringComparer\.Ordinal\)/);
+    assert.match(loader, /import localeManifest from '\.\.\/\.\.\/locale-manifest\.json'/);
+    assert.match(loader, /SUPPORTED_LOCALES\.has\(normalizedLang\)/);
+    assert.match(workflow, /locale-manifest\.json/);
+    assert.match(workflow, /npm run validate-translations/);
+
+    for (const file of ['README.md', 'CONTRIBUTING.md', 'docs/help.md']) {
+        assert.match(
+            fs.readFileSync(path.join(root, file), 'utf8'),
+            /locale-manifest\.json/,
+            `${file} must point to the canonical supported-locale list`
+        );
+    }
+    assert.match(
+        fs.readFileSync(path.join(root, 'README.md'), 'utf8'),
+        new RegExp(`${readLocaleInventory().locales.length} synchronized language catalogs`)
+    );
+    assert.ok(fs.existsSync(INVENTORY_PATH));
 });
 
 // --- Presence of the localized nav/calendar labels ---

--- a/tsconfig.src.json
+++ b/tsconfig.src.json
@@ -12,6 +12,7 @@
         "target": "es2022",
         "module": "esnext",
         "moduleResolution": "bundler",
+        "resolveJsonModule": true,
         "lib": ["es2022", "dom", "dom.iterable"],
         "noEmit": true,
         "skipLibCheck": true,


### PR DESCRIPTION
Closes #103

## Summary
- add one canonical 26-locale manifest consumed by the TypeScript translation loader, C# locale endpoints, admin/user selectors, validator, docs, and CI
- make complete-set validation fail on deleted, unregistered, mis-cased, colliding, or malformed locale files
- replace deleted-file skipping in Translation Checks with full inventory/catalog validation
- embed and runtime-test the inventory against the exact locale resources shipped in the plugin DLL
- keep generic `en` as the fallback catalog while en-GB/en-US remain the selectable English variants

## Validation
- `npm run validate-translations` (26 catalogs, 705/705 keys each)
- `npm run test:scripts` (294/294)
- `npm run test:client` (845/845)
- focused dropdown Vitest regression
- `npm run typecheck:src`
- production bundle build
- targeted ESLint
- `dotnet build Jellyfin.Plugin.JellyfinCanopy/JellyfinCanopy.csproj -c Release` (0 warnings, 0 errors)
- test project compiles; local testhost execution is unavailable because this PC has .NET runtime 10.0.8 while SDK testhost requests 10.0.9, so hosted Unit tests provide execution evidence
- independent Fable low-effort re-review: APPROVE