### PR TITLE
fix: bound Seerr response streaming

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Helpers/SeerrHttpHelperTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Helpers/SeerrHttpHelperTests.cs
@@ -1,5 +1,8 @@
 using System.Net;
+using System.Net.Http.Headers;
+using System.Runtime.CompilerServices;
 using System.Text;
+using System.Text.RegularExpressions;
 using Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr;
 using Xunit;
 
@@ -86,6 +89,137 @@ public class SeerrHttpHelperTests
         Assert.Equal("abc123-LHR", error.CfRay);
     }
 
+    [Fact]
+    public async Task ReadResponseAsync_DeclaredOversize_IsRejectedBeforeBodyRead()
+    {
+        const int cap = 8;
+        var stream = new TrackingStream(Encoding.UTF8.GetBytes("{}"));
+        using var response = StreamingJsonResponse(stream);
+        response.Content.Headers.ContentLength = cap + 1;
+
+        var (json, error) = await SeerrHttpHelper.ReadResponseAsync(response, "http://seerr/api", cap);
+
+        Assert.Null(json);
+        Assert.Equal(SeerrErrorCode.ResponseTooLarge, error!.Code);
+        Assert.Equal(0, stream.ReadCalls);
+    }
+
+    [Fact]
+    public async Task ReadResponseAsync_ChunkedCapPlusOne_StopsAtSentinel()
+    {
+        const int cap = 8;
+        var stream = new TrackingStream(new byte[cap + 128]);
+        using var response = StreamingJsonResponse(stream);
+
+        var (json, error) = await SeerrHttpHelper.ReadResponseAsync(response, "http://seerr/api", cap);
+
+        Assert.Null(json);
+        Assert.Equal(SeerrErrorCode.ResponseTooLarge, error!.Code);
+        Assert.Equal(cap + 1, stream.BytesRead);
+        Assert.True(stream.WasDisposed);
+    }
+
+    [Fact]
+    public async Task ReadResponseAsync_MultibyteUtf8_IsLimitedByRawBytes()
+    {
+        var utf8 = Encoding.UTF8.GetBytes("\"éé\"");
+        Assert.Equal(6, utf8.Length);
+        using var response = StreamingJsonResponse(new TrackingStream(utf8));
+
+        var (json, error) = await SeerrHttpHelper.ReadResponseAsync(response, "http://seerr/api", 5);
+
+        Assert.Null(json);
+        Assert.Equal(SeerrErrorCode.ResponseTooLarge, error!.Code);
+    }
+
+    [Fact]
+    public async Task ReadResponseAsync_ExactCapCompleteJson_Succeeds()
+    {
+        using var response = StreamingJsonResponse(new TrackingStream(Encoding.UTF8.GetBytes("{}")));
+
+        var (json, error) = await SeerrHttpHelper.ReadResponseAsync(response, "http://seerr/api", 2);
+
+        Assert.Null(error);
+        Assert.Equal("{}", json);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("{")]
+    [InlineData("{} trailing")]
+    public async Task ReadResponseAsync_InvalidOrIncompleteJson_ReturnsParseError(string body)
+    {
+        var bytes = Encoding.UTF8.GetBytes(body);
+        using var response = StreamingJsonResponse(new TrackingStream(bytes));
+
+        var (json, error) = await SeerrHttpHelper.ReadResponseAsync(response, "http://seerr/api", bytes.Length);
+
+        Assert.Null(json);
+        Assert.Equal(SeerrErrorCode.ParseError, error!.Code);
+    }
+
+    [Fact]
+    public async Task SendAndReadJsonAsync_BodyBlockingAfterCap_DoesNotEagerlyBuffer()
+    {
+        const int cap = 8;
+        var stream = new TrackingStream(new byte[cap + 1], blockAtEnd: true);
+        using var client = new HttpClient(new StaticResponseHandler(StreamingJsonResponse(stream)));
+        using var request = new HttpRequestMessage(HttpMethod.Get, "http://seerr/api");
+
+        var resultTask = SeerrHttpHelper.SendAndReadJsonAsync(client, request, request.RequestUri!.ToString(), cap);
+        var completed = await Task.WhenAny(resultTask, Task.Delay(TimeSpan.FromSeconds(2)));
+
+        Assert.Same(resultTask, completed);
+        var (json, error, _) = await resultTask;
+        Assert.Null(json);
+        Assert.Equal(SeerrErrorCode.ResponseTooLarge, error!.Code);
+        Assert.Equal(cap + 1, stream.BytesRead);
+    }
+
+    [Fact]
+    public async Task SendAndReadJsonAsync_CancellationStopsBlockedBodyRead()
+    {
+        var stream = new TrackingStream([], blockAtEnd: true);
+        using var client = new HttpClient(new StaticResponseHandler(StreamingJsonResponse(stream)));
+        using var request = new HttpRequestMessage(HttpMethod.Get, "http://seerr/api");
+        using var cts = new CancellationTokenSource();
+
+        var resultTask = SeerrHttpHelper.SendAndReadJsonAsync(
+            client,
+            request,
+            request.RequestUri!.ToString(),
+            8,
+            cts.Token);
+        await stream.ReadStarted.WaitAsync(TimeSpan.FromSeconds(2));
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => resultTask);
+
+        Assert.True(stream.CancellationObserved);
+    }
+
+    [Fact]
+    public async Task SendAndReadJsonAsync_CancellationStopsUpstreamSend()
+    {
+        var handler = new BlockingHandler();
+        using var client = new HttpClient(handler);
+        using var request = new HttpRequestMessage(HttpMethod.Get, "http://seerr/api");
+        using var cts = new CancellationTokenSource();
+
+        var resultTask = SeerrHttpHelper.SendAndReadJsonAsync(
+            client,
+            request,
+            request.RequestUri!.ToString(),
+            8,
+            cts.Token);
+        await handler.SendStarted.WaitAsync(TimeSpan.FromSeconds(2));
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => resultTask);
+        Assert.True(handler.CancellationObserved);
+    }
+
     [Theory]
     [InlineData("application/json", true)]
     [InlineData("application/problem+json", true)]
@@ -108,6 +242,172 @@ public class SeerrHttpHelperTests
 
         Assert.Null(result);
         Assert.Equal(SeerrErrorCode.ParseError, error!.Code);
+    }
+
+    [Fact]
+    public void SeerrRequestCallers_DoNotBypassBoundedTransport()
+    {
+        var directSend = new Regex(@"\.SendAsync\s*\(", RegexOptions.Compiled);
+        var offenders = Directory
+            .EnumerateFiles(PluginSourceRoot(), "*.cs", SearchOption.AllDirectories)
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                && !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Where(path =>
+            {
+                var source = File.ReadAllText(path);
+                return source.Contains("SeerrHttpHelper.BuildRequest", StringComparison.Ordinal)
+                    && directSend.IsMatch(source);
+            })
+            .Select(Path.GetFileName)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.True(
+            offenders.Length == 0,
+            "Seerr request caller(s) bypass the ResponseHeadersRead + bounded JSON transport: "
+            + string.Join(", ", offenders));
+    }
+
+    private static string PluginSourceRoot([CallerFilePath] string sourceFile = "")
+        => Path.GetFullPath(Path.Combine(
+            Path.GetDirectoryName(sourceFile)!, "..", "..", "Jellyfin.Plugin.JellyfinCanopy"));
+
+    private static HttpResponseMessage StreamingJsonResponse(Stream stream)
+    {
+        var content = new StreamContent(stream);
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+        return new HttpResponseMessage(HttpStatusCode.OK) { Content = content };
+    }
+
+    private sealed class StaticResponseHandler(HttpResponseMessage response) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) => Task.FromResult(response);
+    }
+
+    private sealed class BlockingHandler : HttpMessageHandler
+    {
+        private readonly TaskCompletionSource<bool> _sendStarted = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task SendStarted => _sendStarted.Task;
+
+        public bool CancellationObserved { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            _sendStarted.TrySetResult(true);
+            try
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                throw new InvalidOperationException("The blocking handler unexpectedly resumed.");
+            }
+            catch (OperationCanceledException)
+            {
+                CancellationObserved = true;
+                throw;
+            }
+        }
+    }
+
+    private sealed class TrackingStream(byte[] data, bool blockAtEnd = false) : Stream
+    {
+        private int _position;
+        private readonly TaskCompletionSource<bool> _readStarted = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int ReadCalls { get; private set; }
+
+        public int BytesRead { get; private set; }
+
+        public bool CancellationObserved { get; private set; }
+
+        public bool WasDisposed { get; private set; }
+
+        public Task ReadStarted => _readStarted.Task;
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => _position;
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            ReadCalls++;
+            _readStarted.TrySetResult(true);
+            var available = data.Length - _position;
+            if (available <= 0)
+            {
+                return 0;
+            }
+
+            var copied = Math.Min(available, count);
+            data.AsSpan(_position, copied).CopyTo(buffer.AsSpan(offset, copied));
+            _position += copied;
+            BytesRead += copied;
+            return copied;
+        }
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            ReadCalls++;
+            _readStarted.TrySetResult(true);
+            var available = data.Length - _position;
+            if (available > 0)
+            {
+                var copied = Math.Min(available, buffer.Length);
+                data.AsMemory(_position, copied).CopyTo(buffer);
+                _position += copied;
+                BytesRead += copied;
+                return copied;
+            }
+
+            if (!blockAtEnd)
+            {
+                return 0;
+            }
+
+            try
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                return 0;
+            }
+            catch (OperationCanceledException)
+            {
+                CancellationObserved = true;
+                throw;
+            }
+        }
+
+        public override void Flush()
+        {
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            WasDisposed = true;
+            base.Dispose(disposing);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
     }
 }
 

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrReadGenerationFenceTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrReadGenerationFenceTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Text;
 using System.Text.Json;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr;
 using Jellyfin.Plugin.JellyfinCanopy.Model.Seerr;
 using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
 using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
@@ -92,6 +93,30 @@ public sealed class SeerrReadGenerationFenceTests
             "parental_filter_unavailable",
             result.Value?.GetType().GetProperty("code")?.GetValue(result.Value));
         Assert.Single(handler.Requests, request => request.Path == "/api/v1/keyword");
+        Assert.Empty(cache.ResponseCache);
+    }
+
+    [Fact]
+    public async Task GenericProxy_ChunkedCapPlusOne_ReturnsTypedErrorAndNeverCaches()
+    {
+        const string apiPath = "/api/v1/keyword?query=space";
+        var provider = new FakePluginConfigProvider(Configuration(SourceA, "key-a"));
+        var cache = new SeerrCache(provider);
+        var handler = new ChunkedOversizeHandler();
+        var client = CreateClient(handler, provider, cache, new PassthroughParentalFilter());
+
+        var result = Assert.IsType<ObjectResult>(await client.ProxyRequestAsync(
+            apiPath,
+            HttpMethod.Get,
+            content: null,
+            new SeerrCaller(JellyfinUserId, IsAdmin: false),
+            BoundUser()));
+
+        Assert.Equal(502, result.StatusCode);
+        Assert.Equal(
+            nameof(SeerrErrorCode.ResponseTooLarge),
+            result.Value?.GetType().GetProperty("code")?.GetValue(result.Value));
+        Assert.Equal(SeerrHttpHelper.MaxBodyBytes + 1, handler.Body.BytesRead);
         Assert.Empty(cache.ResponseCache);
     }
 
@@ -355,6 +380,79 @@ public sealed class SeerrReadGenerationFenceTests
     }
 
     private sealed record CapturedRequest(string Host, string Path, string? ApiKey);
+
+    private sealed class ChunkedOversizeHandler : HttpMessageHandler
+    {
+        public CountingBodyStream Body { get; } = new(SeerrHttpHelper.MaxBodyBytes + 1024);
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var content = new StreamContent(Body);
+            content.Headers.ContentType = new("application/json");
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = content });
+        }
+    }
+
+    private sealed class CountingBodyStream : Stream
+    {
+        private readonly long _length;
+        private long _remaining;
+
+        public CountingBodyStream(long length)
+        {
+            _length = length;
+            _remaining = length;
+        }
+
+        public long BytesRead { get; private set; }
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => _length - _remaining;
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var read = (int)Math.Min(_remaining, count);
+            Array.Clear(buffer, offset, read);
+            _remaining -= read;
+            BytesRead += read;
+            return read;
+        }
+
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var read = (int)Math.Min(_remaining, buffer.Length);
+            buffer.Span[..read].Clear();
+            _remaining -= read;
+            BytesRead += read;
+            return ValueTask.FromResult(read);
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
 
     private sealed class PassthroughParentalFilter : ISeerrParentalFilter
     {

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/ArrRequestsController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/ArrRequestsController.cs
@@ -1754,11 +1754,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             var client = Helpers.Seerr.SeerrHttpHelper.CreateClient(_httpClientFactory);
             using var httpRequest = Helpers.Seerr.SeerrHttpHelper.BuildRequest(
                 HttpMethod.Post, requestUri, config.SeerrApiKey, seerrUser.Id.ToString());
-            using var response = await client.SendAsync(
+            var (content, error, _) = await Helpers.Seerr.SeerrHttpHelper.SendAndReadJsonAsync(
+                client,
                 httpRequest,
-                HttpContext.RequestAborted).ConfigureAwait(false);
-            var (content, error) = await Helpers.Seerr.SeerrHttpHelper.ReadResponseAsync(
-                response,
                 requestUri,
                 HttpContext.RequestAborted).ConfigureAwait(false);
 
@@ -1889,11 +1887,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                     var enrichUri = $"{normalizedSource}/api/v1/{endpoint}/{tmdbId}";
                     using var enrichRequest = Helpers.Seerr.SeerrHttpHelper.BuildRequest(
                         HttpMethod.Get, enrichUri, apiKey);
-                    using var response = await client.SendAsync(
+                    var (content, enrichError, _) = await Helpers.Seerr.SeerrHttpHelper.SendAndReadJsonAsync(
+                        client,
                         enrichRequest,
-                        fetchCancellationToken).ConfigureAwait(false);
-                    var (content, enrichError) = await Helpers.Seerr.SeerrHttpHelper.ReadResponseAsync(
-                        response,
                         enrichUri,
                         fetchCancellationToken).ConfigureAwait(false);
 

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/SeerrProxyController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/SeerrProxyController.cs
@@ -138,8 +138,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             {
                 using var request = Helpers.Seerr.SeerrHttpHelper.BuildRequest(
                     HttpMethod.Get, requestUri, apiKey);
-                using var resp = await http.SendAsync(request);
-                var (_, error) = await Helpers.Seerr.SeerrHttpHelper.ReadResponseAsync(resp, requestUri);
+                var (_, error, _) = await Helpers.Seerr.SeerrHttpHelper.SendAndReadJsonAsync(http, request, requestUri);
                 if (error == null) return Ok(new { ok = true });
 
                 _logger.LogWarning($"Seerr validate failed for {url}: code={error.Code} status={error.HttpStatus} cf-ray={error.CfRay} — {error.Message}");
@@ -199,9 +198,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             {
                 using var request = Helpers.Seerr.SeerrHttpHelper.BuildRequest(
                     HttpMethod.Post, requestUri, apiKey, bodyJson: "{}");
-                using var resp = await http.SendAsync(request, HttpContext.RequestAborted).ConfigureAwait(false);
-                var (_, error) = await Helpers.Seerr.SeerrHttpHelper.ReadResponseAsync(
-                    resp,
+                var (_, error, _) = await Helpers.Seerr.SeerrHttpHelper.SendAndReadJsonAsync(
+                    http,
+                    request,
                     requestUri,
                     HttpContext.RequestAborted).ConfigureAwait(false);
                 if (error == null)
@@ -1296,11 +1295,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
 
                 using var request = Helpers.Seerr.SeerrHttpHelper.BuildRequest(
                     HttpMethod.Get, requestUri, apiKey);
-                using var response = await httpClient.SendAsync(
+                var (responseContent, error, _) = await Helpers.Seerr.SeerrHttpHelper.SendAndReadJsonAsync(
+                    httpClient,
                     request,
-                    HttpContext.RequestAborted).ConfigureAwait(false);
-                var (responseContent, error) = await Helpers.Seerr.SeerrHttpHelper.ReadResponseAsync(
-                    response,
                     requestUri,
                     HttpContext.RequestAborted).ConfigureAwait(false);
 

--- a/Jellyfin.Plugin.JellyfinCanopy/Helpers/Seerr/SeerrHttpHelper.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Helpers/Seerr/SeerrHttpHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -22,6 +23,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
         Cloudflare5xx,
         UpstreamError,
         ParseError,
+        ResponseTooLarge,
         Timeout,
         UrlNotAllowed,
         ConfigInvalid,
@@ -68,6 +70,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
             SeerrErrorCode.Cloudflare5xx     => "Seerr is having connection issues. Please try again in a moment.",
             SeerrErrorCode.UpstreamError     => "Seerr returned an error. Please try again in a moment.",
             SeerrErrorCode.ParseError        => "Got an unexpected response from Seerr. Please try again in a moment.",
+            SeerrErrorCode.ResponseTooLarge  => "Seerr returned too much data. Please try again in a moment.",
             SeerrErrorCode.Timeout           => "Seerr took too long to respond. Please try again in a moment.",
             SeerrErrorCode.UrlNotAllowed     => "Seerr is not configured correctly. Ask your administrator to check the Seerr URL.",
             SeerrErrorCode.ConfigInvalid     => "Seerr is not configured. Ask your administrator to set it up.",
@@ -101,7 +104,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
             catch { return factory.CreateClient(); }
         }
 
-        private const int MaxBodyBytes = 8 * 1024 * 1024;
+        internal const int MaxBodyBytes = 8 * 1024 * 1024;
+        private const int ReadBufferBytes = 64 * 1024;
+        private static readonly UTF8Encoding StrictUtf8 = new(false, true);
 
         public static HttpRequestMessage BuildRequest(
             HttpMethod method,
@@ -133,8 +138,45 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
                 || (ct.StartsWith("application/", StringComparison.OrdinalIgnoreCase) && ct.EndsWith("+json", StringComparison.OrdinalIgnoreCase));
         }
 
-        public static async Task<(string? Json, SeerrError? Error)> ReadResponseAsync(HttpResponseMessage response, string url, CancellationToken ct = default)
+        internal static Task<HttpResponseMessage> SendResponseHeadersReadAsync(
+            HttpClient httpClient,
+            HttpRequestMessage request,
+            CancellationToken ct = default)
+            => httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+
+        public static Task<(string? Json, SeerrError? Error, int HttpStatus)> SendAndReadJsonAsync(
+            HttpClient httpClient,
+            HttpRequestMessage request,
+            string url,
+            CancellationToken ct = default)
+            => SendAndReadJsonAsync(httpClient, request, url, MaxBodyBytes, ct);
+
+        internal static async Task<(string? Json, SeerrError? Error, int HttpStatus)> SendAndReadJsonAsync(
+            HttpClient httpClient,
+            HttpRequestMessage request,
+            string url,
+            int maxBodyBytes,
+            CancellationToken ct = default)
         {
+            using var response = await SendResponseHeadersReadAsync(httpClient, request, ct).ConfigureAwait(false);
+            var (json, error) = await ReadResponseAsync(response, url, maxBodyBytes, ct).ConfigureAwait(false);
+            return (json, error, (int)response.StatusCode);
+        }
+
+        internal static Task<(string? Json, SeerrError? Error)> ReadResponseAsync(
+            HttpResponseMessage response,
+            string url,
+            CancellationToken ct = default)
+            => ReadResponseAsync(response, url, MaxBodyBytes, ct);
+
+        internal static async Task<(string? Json, SeerrError? Error)> ReadResponseAsync(
+            HttpResponseMessage response,
+            string url,
+            int maxBodyBytes,
+            CancellationToken ct = default)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(maxBodyBytes);
+
             string? cfRay = null;
             if (response.Headers.TryGetValues("cf-ray", out var rays))
             {
@@ -168,23 +210,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
                 });
             }
 
-            string body;
-            using (var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false))
-            using (var reader = new StreamReader(stream, Encoding.UTF8))
-            {
-                var buffer = new char[8192];
-                var sb = new StringBuilder(8192);
-                int read;
-                while ((read = await reader.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false)) > 0)
-                {
-                    if (sb.Length + read > MaxBodyBytes) { sb.Append(buffer, 0, MaxBodyBytes - sb.Length); break; }
-                    sb.Append(buffer, 0, read);
-                }
-                body = sb.ToString();
-            }
-
             // HTML when JSON expected = reverse-proxy auth challenge intercepting
-            // the request. Reject before attempting to parse.
+            // the request. Reject before reading or attempting to parse.
             if (!IsJsonContentType(response))
             {
                 return (null, new SeerrError
@@ -198,46 +225,129 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
                 });
             }
 
-            if (response.IsSuccessStatusCode)
+            // Preserve status-specific upstream errors without requiring an
+            // error body to be buffered or even well-formed JSON.
+            if (!response.IsSuccessStatusCode)
             {
-                return (body, null);
+                if (status == 401)
+                {
+                    return (null, new SeerrError
+                    {
+                        Code = SeerrErrorCode.Unauthorized,
+                        HttpStatus = 401,
+                        CfRay = cfRay,
+                        Url = url,
+                        Message = "Seerr rejected the API key. Check the key has not been rotated and matches the Seerr install.",
+                        UserMessage = "Seerr couldn't sign in. Ask your administrator to check the Seerr settings."
+                    });
+                }
+
+                if (status == 403)
+                {
+                    return (null, new SeerrError
+                    {
+                        Code = SeerrErrorCode.Forbidden,
+                        HttpStatus = 403,
+                        CfRay = cfRay,
+                        Url = url,
+                        Message = "Seerr returned 403. Common causes: API key rotated, user lacks permission, or CSRF protection enabled in Seerr.",
+                        UserMessage = "Seerr declined the request. Ask your administrator to check your account permissions."
+                    });
+                }
+
+                return (null, new SeerrError
+                {
+                    Code = SeerrErrorCode.UpstreamError,
+                    HttpStatus = status,
+                    CfRay = cfRay,
+                    Url = url,
+                    Message = $"Seerr returned {status} from {url}.",
+                    UserMessage = "Seerr returned an error. Please try again in a moment."
+                });
             }
 
-            if (status == 401)
+            var declaredLength = response.Content.Headers.ContentLength;
+            if (declaredLength > maxBodyBytes)
+            {
+                return (null, ResponseTooLarge(url, status, cfRay, maxBodyBytes, declaredLength));
+            }
+
+            byte[] bodyBytes;
+            var readBuffer = ArrayPool<byte>.Shared.Rent(Math.Min(ReadBufferBytes, maxBodyBytes + 1));
+            try
+            {
+                using var body = new MemoryStream(
+                    declaredLength.HasValue
+                        ? Math.Min(checked((int)declaredLength.Value), ReadBufferBytes)
+                        : Math.Min(8192, maxBodyBytes));
+                using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+                while (true)
+                {
+                    var remainingWithSentinel = (long)maxBodyBytes + 1 - body.Length;
+                    if (remainingWithSentinel <= 0)
+                    {
+                        return (null, ResponseTooLarge(url, status, cfRay, maxBodyBytes, body.Length));
+                    }
+
+                    var readSize = (int)Math.Min(readBuffer.Length, remainingWithSentinel);
+                    var read = await stream.ReadAsync(readBuffer.AsMemory(0, readSize), ct).ConfigureAwait(false);
+                    if (read == 0)
+                    {
+                        break;
+                    }
+
+                    body.Write(readBuffer, 0, read);
+                }
+
+                if (body.Length > maxBodyBytes)
+                {
+                    return (null, ResponseTooLarge(url, status, cfRay, maxBodyBytes, body.Length));
+                }
+
+                bodyBytes = body.ToArray();
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(readBuffer);
+            }
+
+            string bodyText;
+            try
+            {
+                using var _ = JsonDocument.Parse(bodyBytes);
+                bodyText = StrictUtf8.GetString(bodyBytes);
+            }
+            catch (Exception ex) when (ex is JsonException or DecoderFallbackException)
             {
                 return (null, new SeerrError
                 {
-                    Code = SeerrErrorCode.Unauthorized,
-                    HttpStatus = 401,
+                    Code = SeerrErrorCode.ParseError,
+                    HttpStatus = 502,
                     CfRay = cfRay,
                     Url = url,
-                    Message = "Seerr rejected the API key. Check the key has not been rotated and matches the Seerr install.",
-                    UserMessage = "Seerr couldn't sign in. Ask your administrator to check the Seerr settings."
-                });
-            }
-            if (status == 403)
-            {
-                return (null, new SeerrError
-                {
-                    Code = SeerrErrorCode.Forbidden,
-                    HttpStatus = 403,
-                    CfRay = cfRay,
-                    Url = url,
-                    Message = "Seerr returned 403. Common causes: API key rotated, user lacks permission, or CSRF protection enabled in Seerr.",
-                    UserMessage = "Seerr declined the request. Ask your administrator to check your account permissions."
+                    Message = $"Failed to parse complete Seerr response JSON from {url}: {ex.Message}",
+                    UserMessage = "Got an unexpected response from Seerr. Please try again in a moment."
                 });
             }
 
-            return (null, new SeerrError
+            return (bodyText, null);
+        }
+
+        private static SeerrError ResponseTooLarge(
+            string url,
+            int status,
+            string? cfRay,
+            int maxBodyBytes,
+            long? observedBytes) => new()
             {
-                Code = SeerrErrorCode.UpstreamError,
-                HttpStatus = status,
+                Code = SeerrErrorCode.ResponseTooLarge,
+                HttpStatus = 502,
                 CfRay = cfRay,
                 Url = url,
-                Message = $"Seerr returned {status} from {url}.",
-                UserMessage = "Seerr returned an error. Please try again in a moment."
-            });
-        }
+                Message = $"Seerr response from {url} (upstream HTTP {status}) exceeded the {maxBodyBytes}-byte limit"
+                    + (observedBytes.HasValue ? $" ({observedBytes.Value} bytes observed)." : "."),
+                UserMessage = "Seerr returned too much data. Please try again in a moment."
+            };
 
         public static (T? Result, SeerrError? Error) TryDeserialize<T>(string json, string url)
         {

--- a/Jellyfin.Plugin.JellyfinCanopy/Helpers/Seerr/SeerrPaginationHelper.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Helpers/Seerr/SeerrPaginationHelper.cs
@@ -368,9 +368,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
                         requestUri,
                         apiKey,
                         apiUserId);
-                    using var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
-                    (json, responseError) = await SeerrHttpHelper.ReadResponseAsync(
-                        response,
+                    (json, responseError, _) = await SeerrHttpHelper.SendAndReadJsonAsync(
+                        httpClient,
+                        request,
                         requestUri,
                         cancellationToken).ConfigureAwait(false);
                 }

--- a/Jellyfin.Plugin.JellyfinCanopy/Helpers/Seerr/SeerrUserImportHelper.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Helpers/Seerr/SeerrUserImportHelper.cs
@@ -180,7 +180,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
             {
                 using var request = SeerrHttpHelper.BuildRequest(
                     HttpMethod.Post, requestUri, apiKey, bodyJson: requestBody);
-                using var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                using var response = await SeerrHttpHelper.SendResponseHeadersReadAsync(
+                    httpClient,
+                    request,
+                    cancellationToken).ConfigureAwait(false);
                 result.Reached = true;
 
                 var (json, error) = await SeerrHttpHelper.ReadResponseAsync(

--- a/Jellyfin.Plugin.JellyfinCanopy/ScheduledTasks/JellyfinToSeerrWatchlistSyncTask.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/ScheduledTasks/JellyfinToSeerrWatchlistSyncTask.cs
@@ -484,11 +484,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                     HttpMethod.Get,
                     requestUri,
                     apiKey);
-                using var response = await httpClient.SendAsync(
+                var (content, error, _) = await Helpers.Seerr.SeerrHttpHelper.SendAndReadJsonAsync(
+                    httpClient,
                     request,
-                    cancellationToken).ConfigureAwait(false);
-                var (content, error) = await Helpers.Seerr.SeerrHttpHelper.ReadResponseAsync(
-                    response,
                     requestUri,
                     cancellationToken).ConfigureAwait(false);
                 if (error != null || string.IsNullOrWhiteSpace(content))
@@ -715,9 +713,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                 var requestUri = $"{seerrUrl.TrimEnd('/')}/api/v1/watchlist";
                 var body = JsonSerializer.Serialize(new { tmdbId, mediaType, title });
                 using var request = Helpers.Seerr.SeerrHttpHelper.BuildRequest(HttpMethod.Post, requestUri, apiKey, seerrUserId, body);
-                using var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
-                var (_, error) = await Helpers.Seerr.SeerrHttpHelper.ReadResponseAsync(
-                    response,
+                var (_, error, _) = await Helpers.Seerr.SeerrHttpHelper.SendAndReadJsonAsync(
+                    httpClient,
+                    request,
                     requestUri,
                     cancellationToken).ConfigureAwait(false);
 

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/AutoMovieRequestService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/AutoMovieRequestService.cs
@@ -410,8 +410,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 {
                     using var request = Helpers.Seerr.SeerrHttpHelper.BuildRequest(
                         HttpMethod.Get, requestUrl, config.SeerrApiKey);
-                    using var response = await httpClient.SendAsync(request);
-                    var (content, error) = await Helpers.Seerr.SeerrHttpHelper.ReadResponseAsync(response, requestUrl);
+                    var (content, error, _) = await Helpers.Seerr.SeerrHttpHelper.SendAndReadJsonAsync(
+                        httpClient,
+                        request,
+                        requestUrl);
                     if (error != null)
                     {
                         _logger.LogDebug($"[Auto-Movie-Request] Seerr collection fetch failed: code={error.Code} status={error.HttpStatus} cf-ray={error.CfRay}");
@@ -588,8 +590,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 var requestUrl = $"{pinnedSource}/api/v1/movie/{tmdbId}";
                 using var request = Helpers.Seerr.SeerrHttpHelper.BuildRequest(
                     HttpMethod.Get, requestUrl, config.SeerrApiKey);
-                using var response = await httpClient.SendAsync(request);
-                var (content, error) = await Helpers.Seerr.SeerrHttpHelper.ReadResponseAsync(response, requestUrl);
+                var (content, error, _) = await Helpers.Seerr.SeerrHttpHelper.SendAndReadJsonAsync(
+                    httpClient,
+                    request,
+                    requestUrl);
                 if (error != null)
                 {
                     _logger.LogDebug($"[Auto-Movie-Request] Quality profile lookup for movie {tmdbId} failed: code={error.Code} status={error.HttpStatus} cf-ray={error.CfRay}");
@@ -958,8 +962,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 using var request = Helpers.Seerr.SeerrHttpHelper.BuildRequest(
                     HttpMethod.Post, requestUri, config.SeerrApiKey, seerrUserId, jsonContent);
                 dispatched = true;
-                using var response = await httpClient.SendAsync(request);
-                var (_, error) = await Helpers.Seerr.SeerrHttpHelper.ReadResponseAsync(response, requestUri);
+                var (_, error, _) = await Helpers.Seerr.SeerrHttpHelper.SendAndReadJsonAsync(
+                    httpClient,
+                    request,
+                    requestUri);
 
                 if (error == null)
                 {

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/AutoSeasonRequestService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/AutoSeasonRequestService.cs
@@ -129,8 +129,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     var requestUrl = $"{pinnedSource}/api/v1/tv/{tmdbId}";
                     using var request = Helpers.Seerr.SeerrHttpHelper.BuildRequest(
                         HttpMethod.Get, requestUrl, apiKey);
-                    using var response = await httpClient.SendAsync(request);
-                    var (content, error) = await Helpers.Seerr.SeerrHttpHelper.ReadResponseAsync(response, requestUrl);
+                    var (content, error, _) = await Helpers.Seerr.SeerrHttpHelper.SendAndReadJsonAsync(
+                        httpClient,
+                        request,
+                        requestUrl);
                     if (error != null)
                     {
                         _logger.LogDebug($"[Auto-Season-Request] Series details fetch for TMDB {tmdbId} failed: code={error.Code} status={error.HttpStatus} cf-ray={error.CfRay}");
@@ -545,8 +547,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 var requestUrl = $"{pinnedSource}/api/v1/tv/{tmdbId}";
                 using var statusRequest = Helpers.Seerr.SeerrHttpHelper.BuildRequest(
                     HttpMethod.Get, requestUrl, config.SeerrApiKey);
-                using var response = await httpClient.SendAsync(statusRequest);
-                var (content, error) = await Helpers.Seerr.SeerrHttpHelper.ReadResponseAsync(response, requestUrl);
+                var (content, error, _) = await Helpers.Seerr.SeerrHttpHelper.SendAndReadJsonAsync(
+                    httpClient,
+                    statusRequest,
+                    requestUrl);
                 if (error != null)
                 {
                     _logger.LogDebug($"[Auto-Season-Request] Status check for TMDB {tmdbId} failed: code={error.Code} status={error.HttpStatus} cf-ray={error.CfRay}");
@@ -935,8 +939,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 using var request = Helpers.Seerr.SeerrHttpHelper.BuildRequest(
                     HttpMethod.Post, requestUri, config.SeerrApiKey, seerrUserId, jsonContent);
                 dispatched = true;
-                using var response = await httpClient.SendAsync(request);
-                var (_, error) = await Helpers.Seerr.SeerrHttpHelper.ReadResponseAsync(response, requestUri);
+                var (_, error, _) = await Helpers.Seerr.SeerrHttpHelper.SendAndReadJsonAsync(
+                    httpClient,
+                    request,
+                    requestUri);
 
                 if (error == null)
                 {

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrClient.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrClient.cs
@@ -122,8 +122,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                 try
                 {
                     using var request = SeerrHttpHelper.BuildRequest(HttpMethod.Get, requestUri, config.SeerrApiKey);
-                    using var response = await httpClient.SendAsync(request);
-                    var (_, error) = await SeerrHttpHelper.ReadResponseAsync(response, requestUri);
+                    var (_, error, _) = await SeerrHttpHelper.SendAndReadJsonAsync(httpClient, request, requestUri);
                     if (error == null)
                     {
                         return true;
@@ -313,8 +312,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
 
                 // User-neutral within this pinned source: no X-Api-User.
                 using var request = SeerrHttpHelper.BuildRequest(HttpMethod.Get, requestUri, apiKey);
-                using var response = await httpClient.SendAsync(request).ConfigureAwait(false);
-                var (json, error) = await SeerrHttpHelper.ReadResponseAsync(response, requestUri).ConfigureAwait(false);
+                var (json, error, _) = await SeerrHttpHelper.SendAndReadJsonAsync(
+                    httpClient,
+                    request,
+                    requestUri).ConfigureAwait(false);
                 if (!IsConfigurationCurrent())
                 {
                     return (false, false);
@@ -997,9 +998,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                 var requestBody = JsonSerializer.Serialize(new { jellyfinUserIds = new[] { normalizedUserId } });
 
                 using var importRequest = SeerrHttpHelper.BuildRequest(HttpMethod.Post, importUri, apiKey, bodyJson: requestBody);
-                using var importResponse = await httpClient.SendAsync(importRequest, cancellationToken).ConfigureAwait(false);
-                var (importJson, importError) = await SeerrHttpHelper.ReadResponseAsync(
-                    importResponse,
+                var (importJson, importError, _) = await SeerrHttpHelper.SendAndReadJsonAsync(
+                    httpClient,
+                    importRequest,
                     importUri,
                     cancellationToken).ConfigureAwait(false);
 
@@ -2101,11 +2102,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                     using var request = SeerrHttpHelper.BuildRequest(method, requestUri, config.SeerrApiKey, requestUserId, content);
                     if (content != null) _logger.LogDebug($"Request body: {content}");
 
-                    using var response = await httpClient.SendAsync(
+                    var (json, error, _) = await SeerrHttpHelper.SendAndReadJsonAsync(
+                        httpClient,
                         request,
-                        cancellationToken).ConfigureAwait(false);
-                    var (json, error) = await SeerrHttpHelper.ReadResponseAsync(
-                        response,
                         requestUri,
                         cancellationToken).ConfigureAwait(false);
 
@@ -2125,9 +2124,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                             { StatusCode = 409 };
                         }
 
-                        // Cache only verified-JSON 2xx responses. The Content-Type
-                        // guard inside ReadResponseAsync prevents HTML challenge
-                        // pages from being cached as JSON for 10 min.
+                        // Cache only complete, size-bounded, parsed JSON 2xx responses.
+                        // SendAndReadJsonAsync also prevents HTML challenge pages from
+                        // being cached as JSON for 10 min.
                         if (isCacheable)
                         {
                             var publishedEntry = (
@@ -2274,11 +2273,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                     HttpMethod.Get,
                     requestUri,
                     apiKey);
-                using var response = await httpClient.SendAsync(
+                var (json, error, _) = await SeerrHttpHelper.SendAndReadJsonAsync(
+                    httpClient,
                     request,
-                    cancellationToken).ConfigureAwait(false);
-                var (json, error) = await SeerrHttpHelper.ReadResponseAsync(
-                    response,
                     requestUri,
                     cancellationToken).ConfigureAwait(false);
                 if (error != null || json == null) return null;

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrParentalFilter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrParentalFilter.cs
@@ -1039,8 +1039,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                     // X-Api-User is intentionally omitted: certification data does not
                     // vary per user, which is what makes the shared cert cache correct.
                     using var request = SeerrHttpHelper.BuildRequest(HttpMethod.Get, requestUri, config.SeerrApiKey);
-                    using var response = await httpClient.SendAsync(request, ct).ConfigureAwait(false);
-                    var (body, error) = await SeerrHttpHelper.ReadResponseAsync(response, requestUri, ct).ConfigureAwait(false);
+                    var (body, error, _) = await SeerrHttpHelper.SendAndReadJsonAsync(
+                        httpClient,
+                        request,
+                        requestUri,
+                        ct).ConfigureAwait(false);
                     if (error != null || string.IsNullOrEmpty(body))
                     {
                         continue;

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/SeerrScanTriggerService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/SeerrScanTriggerService.cs
@@ -213,13 +213,15 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 using var request = Helpers.Seerr.SeerrHttpHelper.BuildRequest(
                     HttpMethod.Post, endpoint, apiKey, bodyJson: "{}");
 
-                using var response = await http.SendAsync(request).ConfigureAwait(false);
-                var (json, error) = await Helpers.Seerr.SeerrHttpHelper.ReadResponseAsync(response, endpoint).ConfigureAwait(false);
+                var (json, error, httpStatus) = await Helpers.Seerr.SeerrHttpHelper.SendAndReadJsonAsync(
+                    http,
+                    request,
+                    endpoint).ConfigureAwait(false);
                 return new DispatchResult
                 {
                     Url = url,
                     Success = error == null,
-                    StatusCode = error?.HttpStatus ?? (int)response.StatusCode,
+                    StatusCode = error?.HttpStatus ?? httpStatus,
                     Body = Truncate(error?.Message ?? (json ?? string.Empty), 256)
                 };
             }

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -19,7 +19,7 @@ const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the repeated clean measurements', () => {
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1364, totalLines: 1692 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 12792, totalLines: 21005 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 12855, totalLines: 21058 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 1);
 });

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -21,12 +21,12 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 12792,
-        "totalLines": 21005
+        "coveredLines": 12855,
+        "totalLines": 21058
       },
       "tolerance": {
         "missingCoveredLines": 1,
-        "rationale": "The 2026-07-15 hosted .NET 10/Coverlet run measured the seven-line locale-manifest loader scope increase and its dedicated embedded-resource test; one line permits only negligible instrumentation variance."
+        "rationale": "The 2026-07-15 .NET 10/Coverlet run measured the bounded Seerr streaming transport, full caller migration, and its byte-limit, JSON, cancellation, blocking-body, disposal, and cache-publication tests; one line permits only negligible instrumentation variance."
       }
     }
   }


### PR DESCRIPTION
Closes #104

## Summary
- centralize Seerr JSON transport on ResponseHeadersRead with deterministic response/stream disposal
- enforce the 8 MiB limit on raw bytes, reject oversized Content-Length before reading, and stop unknown-length bodies at cap+1
- return typed ResponseTooLarge / ParseError failures and require complete valid JSON before callers can publish or cache a body
- migrate every SeerrHttpHelper.BuildRequest caller to the bounded transport while retaining the two-phase response-received signal for non-idempotent bulk import
- add a source guard against future eager SendAsync bypasses

## Evidence
- npm run test:server:coverage: 1,269 passed; 12,855/21,058 lines (exact reviewed baseline)
- npm run test:scripts: 294 passed
- focused helper/cache tests: 32 passed
- Release build: 0 warnings, 0 errors
- independent Fable low review: APPROVE

## Boundary coverage
- declared oversize rejected with zero body reads
- chunked/unknown cap+1 stops at exactly cap+1 and never caches
- UTF-8 counted by raw bytes
- exact-cap complete JSON succeeds; empty, whitespace, truncated, and trailing-data JSON fail
- blocking body after the sentinel proves no eager buffering
- cancellation stops both upstream send and blocked body reads
- initial allocation is capped at 64 KiB even for an 8 MiB declared body

E2E continues to use the digest-pinned Jellyfin unstable/nightly image; no RC tags are introduced.
