### PR TITLE
Bound TTL caches with shared weighted LRU

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/ItemInfoAvatarSourceTokenTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/ItemInfoAvatarSourceTokenTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
@@ -11,6 +10,7 @@ using Jellyfin.Plugin.JellyfinCanopy.Configuration;
 using Jellyfin.Plugin.JellyfinCanopy.Controllers;
 using Jellyfin.Plugin.JellyfinCanopy.Data;
 using Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr;
+using Jellyfin.Plugin.JellyfinCanopy.Helpers;
 using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
 using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
 using Microsoft.AspNetCore.Http;
@@ -221,7 +221,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
         [Fact]
         public void TryPublishAvatarCacheEntry_StaleCleanupCannotDeleteNewerReplacement()
         {
-            var cache = new ConcurrentDictionary<string, (byte[] Content, string ContentType, string ETag, DateTime CachedAt)>();
+            var cache = new BoundedTtlCache<string, (byte[] Content, string ContentType, string ETag, DateTime CachedAt)>(4, 4);
             const string key = "same-generation-key";
             var stale = (new byte[] { 1 }, "image/png", "\"old\"", DateTime.UtcNow);
             var newer = (new byte[] { 2 }, "image/png", "\"new\"", DateTime.UtcNow);

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Helpers/BoundedTtlCacheTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Helpers/BoundedTtlCacheTests.cs
@@ -1,0 +1,191 @@
+using Jellyfin.Plugin.JellyfinCanopy.Helpers;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Helpers;
+
+public sealed class BoundedTtlCacheTests
+{
+    [Fact]
+    public void FreshInsertions_NeverExceedEntryOrWeightLimits()
+    {
+        var clock = new FakeTimeProvider();
+        var cache = new BoundedTtlCache<string, string>(
+            maximumEntries: 3,
+            maximumWeight: 7,
+            weight: static (_, value) => value.Length,
+            timeProvider: clock);
+
+        Assert.True(cache.Set("a", "11", TimeSpan.FromMinutes(1)));
+        Assert.True(cache.Set("b", "22", TimeSpan.FromMinutes(1)));
+        Assert.True(cache.Set("c", "33", TimeSpan.FromMinutes(1)));
+        Assert.True(cache.TryGet("a", out _));
+        Assert.True(cache.Set("d", "444", TimeSpan.FromMinutes(1)));
+
+        Assert.InRange(cache.Count, 0, 3);
+        Assert.InRange(cache.TotalWeight, 0, 7);
+        Assert.False(cache.TryGet("b", out _));
+        Assert.True(cache.TryGet("c", out _));
+        Assert.True(cache.TryGet("a", out _));
+        Assert.True(cache.TryGet("d", out _));
+    }
+
+    [Fact]
+    public void FifteenThousandUniqueKeys_StayBoundedWithNearLinearInspectionWork()
+    {
+        var cache = new BoundedTtlCache<int, int>(
+            maximumEntries: 256,
+            maximumWeight: 256);
+
+        for (var i = 0; i < 15_000; i++)
+        {
+            Assert.True(cache.Set(i, i, TimeSpan.FromHours(1)));
+        }
+
+        Assert.Equal(256, cache.Count);
+        Assert.Equal(256, cache.TotalWeight);
+        Assert.InRange(cache.EntryInspections, 15_000, 90_000);
+    }
+
+    [Fact]
+    public void OversizedEntry_IsRejectedAndCannotLeaveAnOldValueBehind()
+    {
+        var cache = new BoundedTtlCache<string, byte[]>(
+            maximumEntries: 4,
+            maximumWeight: 8,
+            weight: static (_, value) => value.LongLength);
+        Assert.True(cache.Set("avatar", new byte[4], TimeSpan.FromMinutes(1)));
+
+        Assert.False(cache.Set("avatar", new byte[9], TimeSpan.FromMinutes(1)));
+
+        Assert.False(cache.TryGet("avatar", out _));
+        Assert.Equal(0, cache.TotalWeight);
+    }
+
+    [Fact]
+    public void ExpiredEntryDisappearsAndStaleTokenCannotRemoveRefresh()
+    {
+        var clock = new FakeTimeProvider();
+        var cache = new BoundedTtlCache<string, string>(4, 4, timeProvider: clock);
+        Assert.True(cache.TrySet("key", "old", TimeSpan.FromSeconds(1), out var oldToken));
+        clock.Advance(TimeSpan.FromSeconds(2));
+
+        Assert.False(cache.TryGet("key", out _));
+        Assert.True(cache.TrySet("key", "fresh", TimeSpan.FromMinutes(1), out _));
+        Assert.False(cache.Remove(oldToken));
+        Assert.True(cache.TryGet("key", out var value));
+        Assert.Equal("fresh", value);
+    }
+
+    [Fact]
+    public void ConcurrentHighCardinalityInsertions_NeverEscapeHardCap()
+    {
+        var cache = new BoundedTtlCache<string, int>(128, 128, comparer: StringComparer.Ordinal);
+
+        Parallel.For(0, 10_000, i =>
+        {
+            cache.Set($"ip:{i}|cookie:{Guid.NewGuid():N}", i, TimeSpan.FromSeconds(2));
+        });
+
+        Assert.Equal(128, cache.Count);
+        Assert.Equal(128, cache.TotalWeight);
+    }
+
+    [Fact]
+    public void BoundedMaintenance_RemovesExpiredEntriesWithoutFullInsertScan()
+    {
+        var clock = new FakeTimeProvider();
+        var cache = new BoundedTtlCache<int, int>(100, 100, timeProvider: clock);
+        for (var i = 0; i < 20; i++)
+        {
+            cache.Set(i, i, TimeSpan.FromSeconds(1));
+        }
+
+        clock.Advance(TimeSpan.FromSeconds(2));
+        var before = cache.EntryInspections;
+        var removed = cache.Maintain(5);
+
+        Assert.Equal(5, removed);
+        Assert.Equal(15, cache.Count);
+        Assert.Equal(5, cache.EntryInspections - before);
+    }
+
+    [Fact]
+    public void TryAdd_IsAtomicUnderConcurrency()
+    {
+        var cache = new BoundedTtlCache<string, int>(16, 16, comparer: StringComparer.Ordinal);
+        var winners = 0;
+
+        Parallel.For(0, 1_000, i =>
+        {
+            if (cache.TryAdd("shared", i, TimeSpan.FromMinutes(1), out _))
+            {
+                Interlocked.Increment(ref winners);
+            }
+        });
+
+        Assert.Equal(1, winners);
+        Assert.Single(cache);
+    }
+
+    [Fact]
+    public void TryAdd_AllowsReplacementOnlyAfterExpiry()
+    {
+        var clock = new FakeTimeProvider();
+        var cache = new BoundedTtlCache<string, int>(4, 4, timeProvider: clock);
+
+        Assert.True(cache.TryAdd("key", 1, TimeSpan.FromSeconds(1), out _));
+        Assert.False(cache.TryAdd("key", 2, TimeSpan.FromMinutes(1), out _));
+        clock.Advance(TimeSpan.FromSeconds(2));
+        Assert.True(cache.TryAdd("key", 3, TimeSpan.FromMinutes(1), out _));
+        Assert.True(cache.TryGet("key", out var value));
+        Assert.Equal(3, value);
+    }
+
+    [Fact]
+    public void ReplacingValueAdjustsWeightInBothDirections()
+    {
+        var cache = new BoundedTtlCache<string, string>(4, 10, weight: static (_, value) => value.Length);
+
+        Assert.True(cache.Set("key", "123456", TimeSpan.FromMinutes(1)));
+        Assert.Equal(6, cache.TotalWeight);
+        Assert.True(cache.Set("key", "12", TimeSpan.FromMinutes(1)));
+        Assert.Equal(2, cache.TotalWeight);
+        Assert.True(cache.Set("key", "1234567890", TimeSpan.FromMinutes(1)));
+        Assert.Equal(10, cache.TotalWeight);
+    }
+
+    [Fact]
+    public void EnumerationAndTryRemoveNeverExposeExpiredValues()
+    {
+        var clock = new FakeTimeProvider();
+        var cache = new BoundedTtlCache<string, int>(4, 4, timeProvider: clock);
+        cache.Set("expired", 1, TimeSpan.FromSeconds(1));
+        clock.Advance(TimeSpan.FromSeconds(2));
+
+        Assert.False(cache.TryRemove("expired", out _));
+        Assert.Empty(cache);
+        Assert.Empty(cache.Keys);
+        Assert.Empty(cache.Values);
+    }
+
+    [Fact]
+    public void ExpectedValueRemovalCannotDeleteARefresh()
+    {
+        var cache = new BoundedTtlCache<string, string>(4, 4);
+        cache.Set("key", "old", TimeSpan.FromMinutes(1));
+        cache.Set("key", "fresh", TimeSpan.FromMinutes(1));
+
+        Assert.False(cache.Remove("key", "old"));
+        Assert.True(cache.TryGet("key", out var value));
+        Assert.Equal("fresh", value);
+    }
+
+    private sealed class FakeTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _utcNow = new(2026, 7, 15, 0, 0, 0, TimeSpan.Zero);
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+
+        public void Advance(TimeSpan elapsed) => _utcNow += elapsed;
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrReadGenerationFenceTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrReadGenerationFenceTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
 using Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr;
+using Jellyfin.Plugin.JellyfinCanopy.Helpers;
 using Jellyfin.Plugin.JellyfinCanopy.Model.Seerr;
 using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
 using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
@@ -239,7 +240,7 @@ public sealed class SeerrReadGenerationFenceTests
     [Fact]
     public void ResponseCache_StalePublicationCleanupCannotDeleteNewerReplacement()
     {
-        var cache = new Dictionary<string, (string Content, DateTime CachedAt, long ConfigurationRevision, string ConfigurationIdentity)>();
+        var cache = new BoundedTtlCache<string, (string Content, DateTime CachedAt, long ConfigurationRevision, string ConfigurationIdentity)>(4, 4);
         var cacheLock = new object();
         const string key = "same-generation-key";
         var stale = ("old", DateTime.UtcNow, 1L, "old-generation");

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SpoilerIdentityTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SpoilerIdentityTests.cs
@@ -284,6 +284,31 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
         }
 
         [Fact]
+        public void RequestIdentity_ArbitraryIpAndCookieKeysRemainHardBounded()
+        {
+            var markers = NewService();
+            var identity = new RequestIdentityService(
+                new CountingSessionManager(),
+                new StubUserManager(),
+                markers,
+                NullLogger<RequestIdentityService>.Instance);
+
+            for (var i = 0; i < 3_000; i++)
+            {
+                var ctx = new DefaultHttpContext();
+                ctx.Connection.RemoteIpAddress = System.Net.IPAddress.Parse(
+                    $"10.{i / 256}.{i % 256}.1");
+                ctx.Request.Headers.Cookie =
+                    RequestIdentityService.SpoilerUidCookie + "=" + Guid.NewGuid();
+                identity.Resolve(ctx);
+            }
+
+            var counts = RequestIdentityService.CacheCountsForTest;
+            Assert.InRange(counts.IpScans, 1, 1_024);
+            Assert.InRange(counts.CookieMisses, 1, 2_048);
+        }
+
+        [Fact]
         public void RequestIdentity_ReadsMarkerFromPathAndIfNoneMatch()
         {
             var user = new User("carrier-user", "Prov", "PwProv");

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/TagCacheUserAccessCacheTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/TagCacheUserAccessCacheTests.cs
@@ -1,0 +1,100 @@
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.JellyfinCanopy.Services;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services;
+
+public sealed class TagCacheUserAccessCacheTests
+{
+    [Fact]
+    public async Task ConcurrentMissesForOneUserShareOneLibraryQuery()
+    {
+        using var release = new ManualResetEventSlim();
+        using var entered = new ManualResetEventSlim();
+        var calls = 0;
+        var library = new CountingLibraryManager
+        {
+            GetItemIdsHook = _ =>
+            {
+                Interlocked.Increment(ref calls);
+                entered.Set();
+                release.Wait(TimeSpan.FromSeconds(10));
+                return Array.Empty<Guid>();
+            },
+        };
+        using var service = new TagCacheService(
+            library,
+            new StubAppPaths(Path.GetTempPath()),
+            NullLogger<TagCacheService>.Instance);
+        var user = new User("singleflight", "provider", "password-provider");
+
+        var tasks = Enumerable.Range(0, 32)
+            .Select(_ => Task.Run(() => service.GetCacheForUser(user)))
+            .ToArray();
+        Assert.True(entered.Wait(TimeSpan.FromSeconds(10)));
+        release.Set();
+        await Task.WhenAll(tasks);
+
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void HighCardinalityUsersCannotEscapeCacheEntryBudget()
+    {
+        var library = new CountingLibraryManager
+        {
+            GetItemIdsHook = _ => Array.Empty<Guid>(),
+        };
+        using var service = new TagCacheService(
+            library,
+            new StubAppPaths(Path.GetTempPath()),
+            NullLogger<TagCacheService>.Instance);
+
+        for (var i = 0; i < 3_000; i++)
+        {
+            service.GetCacheForUser(new User($"user-{i}", "provider", "password-provider"));
+        }
+
+        Assert.InRange(service.UserAccessCacheCount, 1, 2_048);
+    }
+
+    [Fact]
+    public async Task DelayedMissRechecksPublicationBeforeStartingAnotherQuery()
+    {
+        using var delayedMiss = new ManualResetEventSlim();
+        using var releaseMiss = new ManualResetEventSlim();
+        var calls = 0;
+        var misses = 0;
+        var library = new CountingLibraryManager
+        {
+            GetItemIdsHook = _ =>
+            {
+                Interlocked.Increment(ref calls);
+                return Array.Empty<Guid>();
+            },
+        };
+        using var service = new TagCacheService(
+            library,
+            new StubAppPaths(Path.GetTempPath()),
+            NullLogger<TagCacheService>.Instance);
+        service.OnAfterUserAccessCacheMissForTest = () =>
+        {
+            if (Interlocked.Increment(ref misses) == 1)
+            {
+                delayedMiss.Set();
+                releaseMiss.Wait(TimeSpan.FromSeconds(10));
+            }
+        };
+        var user = new User("delayed-miss", "provider", "password-provider");
+
+        var delayed = Task.Run(() => service.GetCacheForUser(user));
+        Assert.True(delayedMiss.Wait(TimeSpan.FromSeconds(10)));
+        await Task.Run(() => service.GetCacheForUser(user));
+        releaseMiss.Set();
+        await delayed;
+
+        Assert.Equal(1, calls);
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/TestDoubles/CountingLibraryManager.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/TestDoubles/CountingLibraryManager.cs
@@ -76,6 +76,9 @@ public sealed class CountingLibraryManager : ILibraryManager
     /// <summary>When set, backs the user-scoped <see cref="GetItemById{T}(Guid, User?)"/>.</summary>
     public Func<Guid, User?, BaseItem?>? GetItemByIdUserHook { get; set; }
 
+    /// <summary>When set, backs the user-access projection query.</summary>
+    public Func<InternalItemsQuery, IReadOnlyList<Guid>>? GetItemIdsHook { get; set; }
+
     // ---- Everything below is an unused NotImplemented stub (per the repo convention). ----
 
     public AggregateFolder RootFolder => throw new NotImplementedException();
@@ -217,7 +220,8 @@ public sealed class CountingLibraryManager : ILibraryManager
 
     public Task UpdatePeopleAsync(BaseItem item, IReadOnlyList<PersonInfo> people, CancellationToken cancellationToken) => throw new NotImplementedException();
 
-    public IReadOnlyList<Guid> GetItemIds(InternalItemsQuery query) => throw new NotImplementedException();
+    public IReadOnlyList<Guid> GetItemIds(InternalItemsQuery query)
+        => GetItemIdsHook is null ? throw new NotImplementedException() : GetItemIdsHook(query);
 
     public IReadOnlyList<string> GetPeopleNames(InternalPeopleQuery query) => throw new NotImplementedException();
 

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/ArrRequestsController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/ArrRequestsController.cs
@@ -2020,24 +2020,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                         && string.IsNullOrEmpty(fetchedResult.PosterUrl);
                     if (!isEmpty && IsReadConfigurationCurrent(configStamp))
                     {
+                        Helpers.BoundedTtlCache<string, (TmdbEnrichmentResult Data, DateTime CachedAt, long ConfigurationRevision)>.CacheToken publication;
                         lock (_seerrCache.TmdbEnrichmentCacheLock)
                         {
-                            _seerrCache.TmdbEnrichmentCache[cacheKey] = (
+                            _seerrCache.TmdbEnrichmentCache.TrySet(cacheKey, (
                                 fetchedResult,
                                 DateTime.UtcNow,
-                                configurationRevision);
-
-                            if (_seerrCache.TmdbEnrichmentCache.Count > 500 || _seerrCache.TmdbEnrichmentCache.Count % 100 == 0)
-                            {
-                                var staleKeys = _seerrCache.TmdbEnrichmentCache
-                                    .Where(kv => DateTime.UtcNow - kv.Value.CachedAt > cacheTtl)
-                                    .Select(kv => kv.Key)
-                                    .ToList();
-                                foreach (var staleKey in staleKeys)
-                                {
-                                    _seerrCache.TmdbEnrichmentCache.Remove(staleKey);
-                                }
-                            }
+                                configurationRevision), cacheTtl, out publication);
                         }
 
                         // A save can race the final publication check. Entries
@@ -2047,11 +2036,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                         {
                             lock (_seerrCache.TmdbEnrichmentCacheLock)
                             {
-                                if (_seerrCache.TmdbEnrichmentCache.TryGetValue(cacheKey, out var published)
-                                    && published.ConfigurationRevision == configurationRevision)
-                                {
-                                    _seerrCache.TmdbEnrichmentCache.Remove(cacheKey);
-                                }
+                                _seerrCache.TmdbEnrichmentCache.Remove(publication);
                             }
                         }
                     }

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/ItemInfoController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/ItemInfoController.cs
@@ -565,24 +565,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                     return ConfigurationChanged();
                 }
 
-                // Evict expired entries periodically.
-                if (_seerrCache.AvatarCache.Count > 50 || _seerrCache.AvatarCache.Count % 10 == 0)
-                {
-                    foreach (var key in _seerrCache.AvatarCache
-                        .Where(kv => DateTime.UtcNow - kv.Value.CachedAt > _seerrCache.AvatarCacheDuration)
-                        .Select(kv => kv.Key)
-                        .ToList())
-                    {
-                        _seerrCache.AvatarCache.TryRemove(key, out _);
-                    }
-                }
-
                 if (!IsConfigurationCurrent())
                 {
-                    AsyncSingleFlight.TryRemoveExact(
-                        _seerrCache.AvatarCache,
-                        cacheKey,
-                        publishedEntry);
+                    _seerrCache.AvatarCache.Remove(cacheKey, publishedEntry);
                     return ConfigurationChanged();
                 }
 
@@ -624,7 +609,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
         }
 
         internal static bool TryPublishAvatarCacheEntry(
-            ConcurrentDictionary<string, (byte[] Content, string ContentType, string ETag, DateTime CachedAt)> cache,
+            BoundedTtlCache<string, (byte[] Content, string ContentType, string ETag, DateTime CachedAt)> cache,
             string cacheKey,
             (byte[] Content, string ContentType, string ETag, DateTime CachedAt) entry,
             Func<bool> isConfigurationCurrent)
@@ -634,13 +619,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 return false;
             }
 
-            cache[cacheKey] = entry;
+            cache.TrySet(cacheKey, entry, out var publication);
             if (isConfigurationCurrent())
             {
                 return true;
             }
 
-            AsyncSingleFlight.TryRemoveExact(cache, cacheKey, entry);
+            cache.Remove(publication);
             return false;
         }
 

--- a/Jellyfin.Plugin.JellyfinCanopy/Helpers/BoundedTtlCache.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Helpers/BoundedTtlCache.cs
@@ -1,0 +1,486 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Helpers
+{
+    /// <summary>
+    /// Thread-safe, weighted LRU cache with per-entry TTLs and hard capacity
+    /// limits. Reads, writes and eviction are O(1) amortized; insertion never
+    /// scans the complete cache.
+    /// </summary>
+    public sealed class BoundedTtlCache<TKey, TValue> : IReadOnlyCollection<KeyValuePair<TKey, TValue>>
+        where TKey : notnull
+    {
+        private const int InsertMaintenanceBudget = 4;
+
+        private readonly object _gate = new();
+        private readonly Dictionary<TKey, Entry> _entries;
+        private readonly LinkedList<TKey> _lru = new();
+        private readonly Func<TKey, TValue, long> _weight;
+        private readonly Func<TimeSpan> _defaultTtl;
+        private readonly TimeProvider _timeProvider;
+        private long _nextVersion;
+        private long _totalWeight;
+        private long _entryInspections;
+
+        public BoundedTtlCache(
+            int maximumEntries,
+            long maximumWeight,
+            Func<TKey, TValue, long>? weight = null,
+            IEqualityComparer<TKey>? comparer = null,
+            TimeProvider? timeProvider = null,
+            Func<TimeSpan>? defaultTtl = null)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumEntries);
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumWeight);
+
+            MaximumEntries = maximumEntries;
+            MaximumWeight = maximumWeight;
+            _weight = weight ?? UnitWeight;
+            _defaultTtl = defaultTtl ?? DefaultTtl;
+            _entries = new Dictionary<TKey, Entry>(comparer);
+            _timeProvider = timeProvider ?? TimeProvider.System;
+        }
+
+        public int MaximumEntries { get; }
+
+        public long MaximumWeight { get; }
+
+        public TValue this[TKey key]
+        {
+            get => TryGet(key, out var value)
+                ? value
+                : throw new KeyNotFoundException($"Cache key '{key}' was not found.");
+            set => Set(key, value, _defaultTtl());
+        }
+
+        public IReadOnlyCollection<TKey> Keys
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    MaintainUnderLock(_entries.Count);
+                    return new List<TKey>(_entries.Keys);
+                }
+            }
+        }
+
+        public IReadOnlyCollection<TValue> Values
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    MaintainUnderLock(_entries.Count);
+                    var values = new List<TValue>(_entries.Count);
+                    foreach (var entry in _entries.Values)
+                    {
+                        values.Add(entry.Value);
+                    }
+
+                    return values;
+                }
+            }
+        }
+
+        public int Count
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _entries.Count;
+                }
+            }
+        }
+
+        public long TotalWeight
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _totalWeight;
+                }
+            }
+        }
+
+        internal long EntryInspections
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _entryInspections;
+                }
+            }
+        }
+
+        public bool TryGet(TKey key, out TValue value)
+        {
+            lock (_gate)
+            {
+                if (!_entries.TryGetValue(key, out var entry))
+                {
+                    value = default!;
+                    return false;
+                }
+
+                _entryInspections++;
+                if (entry.ExpiresAt <= _timeProvider.GetUtcNow())
+                {
+                    RemoveEntry(entry);
+                    value = default!;
+                    return false;
+                }
+
+                Touch(entry);
+                value = entry.Value;
+                return true;
+            }
+        }
+
+        public bool TryGetValue(TKey key, out TValue value) => TryGet(key, out value);
+
+        public bool Set(TKey key, TValue value, TimeSpan ttl)
+            => TrySet(key, value, ttl, out _);
+
+        public bool TrySet(TKey key, TValue value, out CacheToken token)
+            => TrySet(key, value, _defaultTtl(), out token);
+
+        public bool TryAdd(TKey key, TValue value)
+            => TryAdd(key, value, _defaultTtl(), out _);
+
+        public bool TryAdd(TKey key, TValue value, TimeSpan ttl, out CacheToken token)
+        {
+            if (ttl <= TimeSpan.Zero)
+            {
+                token = default;
+                return false;
+            }
+
+            var weight = _weight(key, value);
+            if (weight < 0)
+            {
+                throw new InvalidOperationException("Cache entry weight cannot be negative.");
+            }
+
+            lock (_gate)
+            {
+                if (_entries.TryGetValue(key, out var current))
+                {
+                    _entryInspections++;
+                    if (current.ExpiresAt > _timeProvider.GetUtcNow())
+                    {
+                        Touch(current);
+                        token = default;
+                        return false;
+                    }
+
+                    RemoveEntry(current);
+                }
+
+                return TrySetUnderLock(key, value, ttl, weight, out token);
+            }
+        }
+
+        public bool TrySet(TKey key, TValue value, TimeSpan ttl, out CacheToken token)
+        {
+            if (ttl <= TimeSpan.Zero)
+            {
+                Remove(key);
+                token = default;
+                return false;
+            }
+
+            var weight = _weight(key, value);
+            if (weight < 0)
+            {
+                throw new InvalidOperationException("Cache entry weight cannot be negative.");
+            }
+
+            lock (_gate)
+            {
+                return TrySetUnderLock(key, value, ttl, weight, out token);
+            }
+        }
+
+        public bool Remove(TKey key)
+        {
+            lock (_gate)
+            {
+                if (!_entries.TryGetValue(key, out var entry))
+                {
+                    return false;
+                }
+
+                RemoveEntry(entry);
+                return true;
+            }
+        }
+
+        public bool Remove(CacheToken token)
+        {
+            lock (_gate)
+            {
+                if (token.Version <= 0
+                    || !_entries.TryGetValue(token.Key, out var entry)
+                    || entry.Version != token.Version)
+                {
+                    return false;
+                }
+
+                RemoveEntry(entry);
+                return true;
+            }
+        }
+
+        public bool Remove(TKey key, TValue expectedValue)
+        {
+            lock (_gate)
+            {
+                if (!_entries.TryGetValue(key, out var entry))
+                {
+                    return false;
+                }
+
+                _entryInspections++;
+                if (entry.ExpiresAt <= _timeProvider.GetUtcNow())
+                {
+                    RemoveEntry(entry);
+                    return false;
+                }
+
+                if (!EqualityComparer<TValue>.Default.Equals(entry.Value, expectedValue))
+                {
+                    return false;
+                }
+
+                RemoveEntry(entry);
+                return true;
+            }
+        }
+
+        public bool ContainsKey(TKey key) => TryGet(key, out _);
+
+        public bool TryRemove(TKey key, out TValue value)
+        {
+            lock (_gate)
+            {
+                if (!_entries.TryGetValue(key, out var entry))
+                {
+                    value = default!;
+                    return false;
+                }
+
+                _entryInspections++;
+                if (entry.ExpiresAt <= _timeProvider.GetUtcNow())
+                {
+                    RemoveEntry(entry);
+                    value = default!;
+                    return false;
+                }
+
+                value = entry.Value;
+                RemoveEntry(entry);
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Atomically adds or updates a live entry. Factories execute under the
+        /// cache lock and must not call back into this cache. The returned value
+        /// is the computed value even when its weight exceeds the cache budget
+        /// and therefore cannot be retained.
+        /// </summary>
+        public TValue AddOrUpdate(
+            TKey key,
+            Func<TKey, TValue> addValueFactory,
+            Func<TKey, TValue, TValue> updateValueFactory)
+        {
+            lock (_gate)
+            {
+                TValue value;
+                if (_entries.TryGetValue(key, out var current)
+                    && current.ExpiresAt > _timeProvider.GetUtcNow())
+                {
+                    _entryInspections++;
+                    value = updateValueFactory(key, current.Value);
+                }
+                else
+                {
+                    if (current != null)
+                    {
+                        _entryInspections++;
+                        RemoveEntry(current);
+                    }
+
+                    value = addValueFactory(key);
+                }
+
+                var weight = _weight(key, value);
+                if (weight < 0)
+                {
+                    throw new InvalidOperationException("Cache entry weight cannot be negative.");
+                }
+
+                TrySetUnderLock(key, value, _defaultTtl(), weight, out _);
+                return value;
+            }
+        }
+
+        public int Maintain(int maximumEntriesToInspect = 64)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(maximumEntriesToInspect);
+            lock (_gate)
+            {
+                return MaintainUnderLock(maximumEntriesToInspect);
+            }
+        }
+
+        public void Clear()
+        {
+            lock (_gate)
+            {
+                _entries.Clear();
+                _lru.Clear();
+                _totalWeight = 0;
+            }
+        }
+
+        internal IReadOnlyList<KeyValuePair<TKey, TValue>> Snapshot()
+        {
+            lock (_gate)
+            {
+                MaintainUnderLock(_entries.Count);
+                var snapshot = new List<KeyValuePair<TKey, TValue>>(_entries.Count);
+                foreach (var key in _lru)
+                {
+                    if (_entries.TryGetValue(key, out var entry))
+                    {
+                        snapshot.Add(new KeyValuePair<TKey, TValue>(key, entry.Value));
+                    }
+                }
+
+                return snapshot;
+            }
+        }
+
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+            => Snapshot().GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        private int MaintainUnderLock(int maximumEntriesToInspect)
+        {
+            var removed = 0;
+            var inspected = 0;
+            var now = _timeProvider.GetUtcNow();
+            var node = _lru.First;
+            while (node != null && inspected < maximumEntriesToInspect)
+            {
+                var next = node.Next;
+                if (_entries.TryGetValue(node.Value, out var entry))
+                {
+                    inspected++;
+                    _entryInspections++;
+                    if (entry.ExpiresAt <= now)
+                    {
+                        RemoveEntry(entry);
+                        removed++;
+                    }
+                }
+
+                node = next;
+            }
+
+            return removed;
+        }
+
+        private static long UnitWeight(TKey key, TValue value) => 1;
+
+        private static TimeSpan DefaultTtl() => TimeSpan.FromMinutes(5);
+
+        private bool TrySetUnderLock(
+            TKey key,
+            TValue value,
+            TimeSpan ttl,
+            long weight,
+            out CacheToken token)
+        {
+            if (_entries.TryGetValue(key, out var previous))
+            {
+                RemoveEntry(previous);
+            }
+
+            if (weight > MaximumWeight || ttl <= TimeSpan.Zero)
+            {
+                token = default;
+                return false;
+            }
+
+            MaintainUnderLock(InsertMaintenanceBudget);
+            var node = _lru.AddLast(key);
+            var version = ++_nextVersion;
+            var entry = new Entry(
+                key,
+                value,
+                weight,
+                _timeProvider.GetUtcNow() + ttl,
+                version,
+                node);
+            _entries.Add(key, entry);
+            _totalWeight += weight;
+
+            while (_entries.Count > MaximumEntries || _totalWeight > MaximumWeight)
+            {
+                var oldest = _lru.First;
+                if (oldest == null || !_entries.TryGetValue(oldest.Value, out var eviction))
+                {
+                    throw new InvalidOperationException("Bounded cache LRU index is inconsistent.");
+                }
+
+                _entryInspections++;
+                RemoveEntry(eviction);
+            }
+
+            if (!_entries.TryGetValue(key, out var retained) || retained.Version != version)
+            {
+                token = default;
+                return false;
+            }
+
+            token = new CacheToken(key, version);
+            return true;
+        }
+
+        private void Touch(Entry entry)
+        {
+            _lru.Remove(entry.Node);
+            _lru.AddLast(entry.Node);
+        }
+
+        private void RemoveEntry(Entry entry)
+        {
+            if (!_entries.Remove(entry.Key))
+            {
+                return;
+            }
+
+            _lru.Remove(entry.Node);
+            _totalWeight -= entry.Weight;
+        }
+
+        public readonly record struct CacheToken(TKey Key, long Version);
+
+        private sealed record Entry(
+            TKey Key,
+            TValue Value,
+            long Weight,
+            DateTimeOffset ExpiresAt,
+            long Version,
+            LinkedListNode<TKey> Node);
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/AutoMovieRequestService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/AutoMovieRequestService.cs
@@ -12,6 +12,7 @@ using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Querying;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Helpers;
 using Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr;
 using Jellyfin.Plugin.JellyfinCanopy.Model.Seerr;
 using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
@@ -28,7 +29,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         private readonly ILibraryManager _libraryManager;
 
         // Track which movies have already been requested to avoid duplicates (with timestamps for expiry)
-        private readonly Dictionary<string, DateTime> _requestedMovies = new(StringComparer.Ordinal);
+        private static readonly TimeSpan RequestReservationTtl = TimeSpan.FromHours(1);
+        private readonly BoundedTtlCache<string, byte> _requestedMovies = new(
+            maximumEntries: 16_384,
+            maximumWeight: 16_384,
+            comparer: StringComparer.Ordinal,
+            defaultTtl: () => RequestReservationTtl);
         private readonly object _movieCacheLock = new();
         private readonly Seerr.ISeerrClient _seerrClient;
         private readonly ISeerrParentalFilter _parentalFilter;
@@ -172,18 +178,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             var requestKey = BuildSourceScopedKey(
                 seerrSourceUrl,
                 $"{nextMovieInfo.TmdbId}:{(requestIs4k ? "4k" : "normal")}");
+            BoundedTtlCache<string, byte>.CacheToken reservation;
             lock (_movieCacheLock)
             {
                 // The target reservation is global to this service instance,
                 // not per Jellyfin caller. Seerr's duplicate check is a
                 // non-atomic read/write, so two users racing the same source,
                 // successor, and quality domain must share one lease.
-                var expired = _requestedMovies
-                    .Where(kvp => (DateTime.Now - kvp.Value).TotalHours >= 1)
-                    .Select(kvp => kvp.Key)
-                    .ToList();
-                foreach (var key in expired) _requestedMovies.Remove(key);
-
                 if (_requestedMovies.ContainsKey(requestKey))
                 {
                     _logger.LogDebug($"[Auto-Movie-Request] Already requested '{nextMovieInfo.Title}' (cached)");
@@ -191,7 +192,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 }
 
                 // Reserve the slot so concurrent callers see it immediately
-                _requestedMovies[requestKey] = DateTime.Now;
+                _requestedMovies.TrySet(requestKey, 0, out reservation);
             }
 
             // Request the movie
@@ -215,7 +216,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 // a possibly committed non-idempotent request.
                 lock (_movieCacheLock)
                 {
-                    _requestedMovies.Remove(requestKey);
+                    _requestedMovies.Remove(reservation);
                 }
                 _logger.LogWarning($"[Auto-Movie-Request] ✗ Failed to request '{nextMovieInfo.Title}' (TMDB {nextMovieInfo.TmdbId}) for {user.Username}");
             }

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/AutoRequest/PlaybackWatcherBase.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/AutoRequest/PlaybackWatcherBase.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Helpers;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Session;
 using Microsoft.Extensions.Logging;
@@ -30,7 +31,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.AutoRequest
         protected readonly IPluginConfigProvider _configProvider;
 
         // Track which user+item combinations have already been checked to avoid duplicate checks
-        private readonly Dictionary<string, DateTime> _checkedSessions = new();
+        private static readonly TimeSpan CheckedSessionTtl = TimeSpan.FromHours(1);
+        private readonly BoundedTtlCache<string, byte> _checkedSessions = new(
+            maximumEntries: 16_384,
+            maximumWeight: 16_384,
+            comparer: StringComparer.Ordinal,
+            defaultTtl: () => CheckedSessionTtl);
         private readonly object _sessionLock = new();
         private readonly object _subLock = new();
         private bool _subscribed;
@@ -121,15 +127,6 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.AutoRequest
         {
             lock (_sessionLock)
             {
-                // Clean up expired cache entries (older than 1 hour)
-                var expiredKeys = _checkedSessions.Where(kvp => (DateTime.Now - kvp.Value).TotalHours > 1)
-                    .Select(kvp => kvp.Key)
-                    .ToList();
-                foreach (var key in expiredKeys)
-                {
-                    _checkedSessions.Remove(key);
-                }
-
                 // Skip if we've checked this user+item combination in the last hour
                 if (_checkedSessions.ContainsKey(sessionItemKey))
                 {
@@ -137,7 +134,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.AutoRequest
                 }
 
                 // Mark as checked with current timestamp
-                _checkedSessions[sessionItemKey] = DateTime.Now;
+                _checkedSessions.Set(sessionItemKey, 0, CheckedSessionTtl);
                 return true;
             }
         }

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/AutoSeasonRequestService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/AutoSeasonRequestService.cs
@@ -14,6 +14,7 @@ using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Querying;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Helpers;
 using Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr;
 using Jellyfin.Plugin.JellyfinCanopy.Model.Seerr;
 using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
@@ -30,11 +31,20 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         private readonly ILibraryManager _libraryManager;
 
         // In-memory cache of recently requested seasons to avoid duplicates (keyed by tmdbId_seasonNumber, global across all users)
-        private readonly Dictionary<string, DateTime> _requestedSeasons = new();
+        private static readonly TimeSpan RequestReservationTtl = TimeSpan.FromHours(1);
+        private readonly BoundedTtlCache<string, byte> _requestedSeasons = new(
+            maximumEntries: 16_384,
+            maximumWeight: 16_384,
+            comparer: StringComparer.Ordinal,
+            defaultTtl: () => RequestReservationTtl);
         private readonly object _requestCacheLock = new();
         private readonly Seerr.ISeerrClient _seerrClient;
         private readonly ISeerrParentalFilter _parentalFilter;
-        private readonly Dictionary<string, (string Content, DateTime CachedAt)> _seriesDetailsCache = new();
+        private readonly BoundedTtlCache<string, string> _seriesDetailsCache = new(
+            maximumEntries: 256,
+            maximumWeight: 16L * 1024 * 1024,
+            weight: static (key, content) => Encoding.UTF8.GetByteCount(key) + Encoding.UTF8.GetByteCount(content),
+            comparer: StringComparer.Ordinal);
         private readonly object _seriesDetailsCacheLock = new();
         private readonly ConcurrentDictionary<string, Lazy<Task<string?>>> _seriesDetailsInFlight = new();
 
@@ -112,13 +122,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 lock (_seriesDetailsCacheLock)
                 {
                     if (_seriesDetailsCache.TryGetValue(cacheKey, out var cached) &&
-                        DateTime.UtcNow - cached.CachedAt < cacheTtl &&
                         IsCapturedConfigurationCurrent())
                     {
-                        return cached.Content;
+                        return cached;
                     }
                 }
             }
+
+            BoundedTtlCache<string, string>.CacheToken publication = default;
 
             async Task<string?> FetchAsync()
             {
@@ -162,7 +173,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                         // removal cannot expose a miss before the result lands.
                         lock (_seriesDetailsCacheLock)
                         {
-                            _seriesDetailsCache[cacheKey] = (fetchedContent, DateTime.UtcNow);
+                            _seriesDetailsCache.TrySet(cacheKey, fetchedContent, cacheTtl, out publication);
                         }
                     }
 
@@ -188,7 +199,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 // transition within this service instance.
                 lock (_seriesDetailsCacheLock)
                 {
-                    _seriesDetailsCache.Remove(cacheKey);
+                    _seriesDetailsCache.Remove(publication);
                 }
 
                 return null;
@@ -353,13 +364,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             var cacheKey = BuildSourceScopedKey(
                 seerrSourceUrl,
                 $"{tmdbId}:S{nextSeasonNumber}");
+            BoundedTtlCache<string, byte>.CacheToken reservation;
             lock (_requestCacheLock)
             {
-                // Clean up expired entries
-                var expiredKeys = _requestedSeasons.Where(kvp => (DateTime.Now - kvp.Value).TotalHours > 1)
-                    .Select(kvp => kvp.Key).ToList();
-                foreach (var key in expiredKeys) _requestedSeasons.Remove(key);
-
                 if (_requestedSeasons.ContainsKey(cacheKey))
                 {
                     _logger.LogDebug($"[Auto-Season-Request] Already requested S{nextSeasonNumber} for TMDB {tmdbId} (cached)");
@@ -367,7 +374,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 }
 
                 // Reserve the slot so concurrent callers see it immediately
-                _requestedSeasons[cacheKey] = DateTime.Now;
+                _requestedSeasons.TrySet(cacheKey, 0, out reservation);
             }
 
             // Get episode count for next season to verify it has started
@@ -384,7 +391,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 // TMDB updates with the new season's data.
                 lock (_requestCacheLock)
                 {
-                    _requestedSeasons.Remove(cacheKey);
+                    _requestedSeasons.Remove(reservation);
                 }
                 return;
             }
@@ -400,7 +407,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 _logger.LogDebug($"[Auto-Season-Request] Season {nextSeasonNumber} does not exist for '{series.Name}' (not available on TMDB)");
                 lock (_requestCacheLock)
                 {
-                    _requestedSeasons.Remove(cacheKey);
+                    _requestedSeasons.Remove(reservation);
                 }
                 return;
             }
@@ -437,7 +444,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 // a possibly committed non-idempotent request.
                 lock (_requestCacheLock)
                 {
-                    _requestedSeasons.Remove(cacheKey);
+                    _requestedSeasons.Remove(reservation);
                 }
                 _logger.LogWarning($"[Auto-Season-Request] ✗ Failed to request '{series.Name}' S{nextSeasonNumber} for {user.Username}");
             }

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/HiddenContentResponseFilter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/HiddenContentResponseFilter.cs
@@ -22,8 +22,15 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
 
         // Cross-request in-memory cache keyed by userId (N-format string).
         // Eliminates per-request disk reads for hidden-content.json.
-        private static readonly ConcurrentDictionary<string, (HideContext Ctx, DateTime CachedAt)> _hcCache = new(StringComparer.OrdinalIgnoreCase);
         private static readonly TimeSpan _hcCacheTtl = TimeSpan.FromSeconds(30);
+        private static readonly BoundedTtlCache<string, (HideContext Ctx, DateTime CachedAt)> _hcCache = new(
+            maximumEntries: 2_048,
+            maximumWeight: 100_000,
+            weight: static (_, entry) => 1L
+                + entry.Ctx.ItemIdScopes.Count
+                + entry.Ctx.SeriesIdScopes.Count,
+            comparer: StringComparer.OrdinalIgnoreCase,
+            defaultTtl: () => _hcCacheTtl);
 
         /// <summary>
         /// Removes the cached hidden-content context for the given user so the next
@@ -88,8 +95,16 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
 
         // Re-warn at most once per hour so a real Jellyfin upgrade isn't permanently invisible after the first warn.
         private static readonly TimeSpan ShapeMismatchReWarnInterval = TimeSpan.FromHours(1);
-        private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, DateTime> _warnedShapeMismatchAt = new();
-        private static readonly System.Collections.Concurrent.ConcurrentDictionary<Guid, byte> _warnedReadFailure = new();
+        private static readonly BoundedTtlCache<string, DateTime> _warnedShapeMismatchAt = new(
+            maximumEntries: 256,
+            maximumWeight: 256 * 1024,
+            weight: static (key, _) => key.Length + sizeof(long),
+            comparer: StringComparer.Ordinal,
+            defaultTtl: () => ShapeMismatchReWarnInterval);
+        private static readonly BoundedTtlCache<Guid, byte> _warnedReadFailure = new(
+            maximumEntries: 2_048,
+            maximumWeight: 2_048,
+            defaultTtl: static () => TimeSpan.FromDays(7));
 
         private static void WarnShapeMismatchOnce(ILogger<HiddenContentResponseFilter> logger, string surface, string handlerName, IActionResult? result)
         {
@@ -97,7 +112,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             // AddOrUpdate returns the stored value. Equality with `now` means our new timestamp won the slot — log.
             var stored = _warnedShapeMismatchAt.AddOrUpdate(
                 surface,
-                now,
+                _ => now,
                 (_, last) => (now - last) >= ShapeMismatchReWarnInterval ? now : last);
             if (stored != now) return;
             var actualType = result?.GetType().FullName ?? "(null)";
@@ -250,7 +265,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             // Cache the resolved context (an intentional policy, retained LKG, or the
             // fail-closed sentinel) with a fresh timestamp — never an empty fail-open
             // entry after a fault. A repair invalidates this via InvalidateUser.
-            _hcCache[userIdN] = (ctx, now);
+            _hcCache.Set(userIdN, (ctx, now), _hcCacheTtl);
             httpContext.Items[CacheKey] = ctx;
             return ctx;
         }

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Identity/RequestIdentityService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Identity/RequestIdentityService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using Jellyfin.Plugin.JellyfinCanopy.Helpers;
 using MediaBrowser.Controller.Session;
 using Microsoft.Extensions.Logging;
 
@@ -80,7 +81,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         public const string SpoilerUidCookie = "jc-spoiler-uid";
 
         private static readonly TimeSpan PerKeyWarnInterval = TimeSpan.FromHours(1);
-        private static readonly ConcurrentDictionary<string, DateTime> _warnedAt = new();
+        private static readonly BoundedTtlCache<string, DateTime> _warnedAt = new(
+            maximumEntries: 4_096,
+            maximumWeight: 1024 * 1024,
+            weight: static (key, _) => key.Length + sizeof(long),
+            comparer: StringComparer.Ordinal,
+            defaultTtl: () => PerKeyWarnInterval);
 
         // Short-TTL cache of the per-IP session scan. A single page load fires
         // a burst of image requests from one IP; without this each one would
@@ -90,7 +96,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         // (e.g. a Seerr instance polling the server). Cache the scan result
         // for a couple of seconds so a burst pays for one scan, not dozens.
         private static readonly TimeSpan IpScanCacheTtl = TimeSpan.FromSeconds(2);
-        private static readonly ConcurrentDictionary<string, IpScanCacheEntry> _ipScanCache = new();
+        private static readonly BoundedTtlCache<string, IpScanCacheEntry> _ipScanCache = new(
+            maximumEntries: 1_024,
+            maximumWeight: 1024 * 1024,
+            weight: static (key, entry) => key.Length + (entry.IpUsers.Count * 16L),
+            comparer: StringComparer.Ordinal,
+            defaultTtl: () => IpScanCacheTtl);
 
         private sealed class IpScanCacheEntry
         {
@@ -106,7 +117,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         // moment earlier is never suppressed for longer than the ordinary
         // scan staleness they'd face anyway.
         private static readonly TimeSpan CookieMissNegativeCacheTtl = TimeSpan.FromSeconds(2);
-        private static readonly ConcurrentDictionary<string, DateTime> _cookieMissCache = new(StringComparer.Ordinal);
+        private static readonly BoundedTtlCache<string, DateTime> _cookieMissCache = new(
+            maximumEntries: 2_048,
+            maximumWeight: 1024 * 1024,
+            weight: static (key, _) => key.Length + sizeof(long),
+            comparer: StringComparer.Ordinal,
+            defaultTtl: () => CookieMissNegativeCacheTtl);
 
         // TTL-cached user count for the single-user shortcut so we don't
         // enumerate users per request (GetUsers() is a DB query in JF12).
@@ -134,6 +150,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         private readonly MediaBrowser.Controller.Library.IUserManager _userManager;
         private readonly SpoilerIdentityService _markers;
         private readonly ILogger<RequestIdentityService> _logger;
+
+        internal static (int IpScans, int CookieMisses) CacheCountsForTest
+            => (_ipScanCache.Count, _cookieMissCache.Count);
 
         public RequestIdentityService(
             ISessionManager sessionManager,
@@ -289,15 +308,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                         ipUsers = ScanActiveSessionUsersFresh(httpContext);
                         if (missKey != null && !ipUsers.Contains(cookieUid))
                         {
-                            _cookieMissCache[missKey] = now;
-                            if (_cookieMissCache.Count > 512)
-                            {
-                                foreach (var kvp in _cookieMissCache)
-                                {
-                                    if ((now - kvp.Value) >= CookieMissNegativeCacheTtl)
-                                        _cookieMissCache.TryRemove(kvp.Key, out _);
-                                }
-                            }
+                            _cookieMissCache.Set(missKey, now, CookieMissNegativeCacheTtl);
                         }
                     }
                 }
@@ -397,17 +408,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         {
             var now = DateTime.UtcNow;
             var ipUsers = ScanActiveSessionUsers(httpContext);
-            _ipScanCache[ipKey] = new IpScanCacheEntry { CachedAt = now, IpUsers = ipUsers };
-
-            // Opportunistic prune so the cache can't grow unbounded across
-            // many distinct client IPs over a long uptime.
-            if (_ipScanCache.Count > 512)
-            {
-                foreach (var kvp in _ipScanCache)
-                {
-                    if ((now - kvp.Value.CachedAt) >= IpScanCacheTtl) _ipScanCache.TryRemove(kvp.Key, out _);
-                }
-            }
+            _ipScanCache.Set(
+                ipKey,
+                new IpScanCacheEntry { CachedAt = now, IpUsers = ipUsers },
+                IpScanCacheTtl);
             return ipUsers;
         }
 
@@ -535,7 +539,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         private void WarnRateLimited(string key, string message)
         {
             var now = DateTime.UtcNow;
-            var stored = _warnedAt.AddOrUpdate(key, now,
+            var stored = _warnedAt.AddOrUpdate(key, _ => now,
                 (_, last) => (now - last) >= PerKeyWarnInterval ? now : last);
             if (stored != now) return;
             _logger.LogWarning(message);

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/ISeerrCache.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/ISeerrCache.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinCanopy.Helpers;
 using Jellyfin.Plugin.JellyfinCanopy.Model.Seerr;
 
 namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
@@ -43,17 +44,17 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
         /// Server-side cache for proxied avatar images to avoid re-fetching from
         /// upstream Seerr on every request. Entries expire after <see cref="AvatarCacheDuration"/>.
         /// </summary>
-        ConcurrentDictionary<string, (byte[] Content, string ContentType, string ETag, DateTime CachedAt)> AvatarCache { get; }
+        BoundedTtlCache<string, (byte[] Content, string ContentType, string ETag, DateTime CachedAt)> AvatarCache { get; }
 
         TimeSpan AvatarCacheDuration { get; }
 
         /// <summary>Cache for Seerr user ID lookups (JellyfinUserId -> SeerrUserId).</summary>
-        Dictionary<string, (string SeerrUserId, DateTime CachedAt, long ConfigurationRevision, string ConfigurationIdentity)> UserIdCache { get; }
+        BoundedTtlCache<string, (string SeerrUserId, DateTime CachedAt, long ConfigurationRevision, string ConfigurationIdentity)> UserIdCache { get; }
 
         object UserIdCacheLock { get; }
 
         /// <summary>Cache for Seerr user lookups (JellyfinUserId -> full Seerr user payload, null = negative cache).</summary>
-        Dictionary<string, (SeerrUser? User, DateTime CachedAt, long ConfigurationRevision, string ConfigurationIdentity)> UserCache { get; }
+        BoundedTtlCache<string, (SeerrUser? User, DateTime CachedAt, long ConfigurationRevision, string ConfigurationIdentity)> UserCache { get; }
 
         object UserCacheLock { get; }
 
@@ -63,14 +64,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
         /// burst of callers cannot fan out duplicate import POSTs. This is not
         /// an authoritative negative-user cache.
         /// </summary>
-        Dictionary<string, DateTime> AutoImportFailureThrottle { get; }
+        BoundedTtlCache<string, DateTime> AutoImportFailureThrottle { get; }
 
         object AutoImportFailureThrottleLock { get; }
 
         TimeSpan AutoImportFailureThrottleTtl { get; }
 
         /// <summary>Cache for Seerr proxy responses (discovery/search endpoints).</summary>
-        Dictionary<string, (string Content, DateTime CachedAt, long ConfigurationRevision, string ConfigurationIdentity)> ResponseCache { get; }
+        BoundedTtlCache<string, (string Content, DateTime CachedAt, long ConfigurationRevision, string ConfigurationIdentity)> ResponseCache { get; }
 
         object ResponseCacheLock { get; }
 
@@ -95,14 +96,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
         /// URL. The response is user-neutral within one Seerr instance, but
         /// separate configured instances are distinct settings domains.
         /// </summary>
-        Dictionary<string, (bool Movie4kEnabled, bool Series4kEnabled, DateTime CachedAt, long ConfigurationRevision, string ApiKeyFingerprint)> Public4kSettingsCache { get; }
+        BoundedTtlCache<string, (bool Movie4kEnabled, bool Series4kEnabled, DateTime CachedAt, long ConfigurationRevision, string ApiKeyFingerprint)> Public4kSettingsCache { get; }
 
         object Public4kSettingsCacheLock { get; }
 
         TimeSpan Public4kSettingsCacheTtl { get; }
 
         /// <summary>Cache for request-page TMDB enrichments (movie/tv detail lookups via Seerr).</summary>
-        Dictionary<string, (TmdbEnrichmentResult Data, DateTime CachedAt, long ConfigurationRevision)> TmdbEnrichmentCache { get; }
+        BoundedTtlCache<string, (TmdbEnrichmentResult Data, DateTime CachedAt, long ConfigurationRevision)> TmdbEnrichmentCache { get; }
 
         object TmdbEnrichmentCacheLock { get; }
 
@@ -126,7 +127,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
         /// null Keywords as a cache miss when tag rules are active. Like the
         /// score, they depend only on the title, never the caller.
         /// </remarks>
-        ConcurrentDictionary<string, (int? Score, int? SubScore, string[]? Keywords, string[]? Genres, DateTime CachedAt)> CertScoreCache { get; }
+        BoundedTtlCache<string, (int? Score, int? SubScore, string[]? Keywords, string[]? Genres, DateTime CachedAt)> CertScoreCache { get; }
 
         TimeSpan GetResponseCacheTtl();
 

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrCache.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrCache.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinCanopy.Helpers;
 using Jellyfin.Plugin.JellyfinCanopy.Model.Seerr;
 
 namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
@@ -15,26 +16,84 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
     /// </summary>
     public sealed class SeerrCache : ISeerrCache
     {
+        internal const int AvatarMaximumEntries = 64;
+        internal const long AvatarMaximumBytes = 32 * 1024 * 1024;
+        internal const int UserMaximumEntries = 2048;
+        internal const long UserMaximumBytes = 4 * 1024 * 1024;
+        internal const int ResponseMaximumEntries = 256;
+        internal const long ResponseMaximumBytes = 32 * 1024 * 1024;
+        internal const int TmdbEnrichmentMaximumEntries = 512;
+        internal const long TmdbEnrichmentMaximumBytes = 4 * 1024 * 1024;
+        internal const int CertificationMaximumEntries = 4096;
+        internal const long CertificationMaximumBytes = 16 * 1024 * 1024;
+        internal const int Public4kMaximumEntries = 64;
+
         private readonly IPluginConfigProvider _configProvider;
 
         public SeerrCache(IPluginConfigProvider configProvider)
         {
             _configProvider = configProvider;
+            AvatarCache = new(
+                AvatarMaximumEntries,
+                AvatarMaximumBytes,
+                AvatarWeight,
+                StringComparer.Ordinal,
+                defaultTtl: () => AvatarCacheDuration);
+            UserIdCache = new(
+                UserMaximumEntries,
+                UserMaximumBytes,
+                UserIdWeight,
+                StringComparer.Ordinal,
+                defaultTtl: GetUserIdCacheTtl);
+            UserCache = new(
+                UserMaximumEntries,
+                UserMaximumBytes,
+                UserWeight,
+                StringComparer.Ordinal,
+                defaultTtl: GetUserIdCacheTtl);
+            AutoImportFailureThrottle = new(
+                maximumEntries: UserMaximumEntries,
+                maximumWeight: UserMaximumEntries, // unit-weight entries
+                comparer: StringComparer.Ordinal,
+                defaultTtl: () => AutoImportFailureThrottleTtl);
+            ResponseCache = new(
+                ResponseMaximumEntries,
+                ResponseMaximumBytes,
+                ResponseWeight,
+                StringComparer.Ordinal,
+                defaultTtl: GetResponseCacheTtl);
+            Public4kSettingsCache = new(
+                maximumEntries: Public4kMaximumEntries,
+                maximumWeight: Public4kMaximumEntries, // unit-weight entries
+                comparer: StringComparer.Ordinal,
+                defaultTtl: () => Public4kSettingsCacheTtl);
+            TmdbEnrichmentCache = new(
+                TmdbEnrichmentMaximumEntries,
+                TmdbEnrichmentMaximumBytes,
+                TmdbEnrichmentWeight,
+                StringComparer.Ordinal,
+                defaultTtl: GetTmdbEnrichmentCacheTtl);
+            CertScoreCache = new(
+                CertificationMaximumEntries,
+                CertificationMaximumBytes,
+                CertificationWeight,
+                StringComparer.Ordinal,
+                defaultTtl: GetParentalRatingCacheTtl);
         }
 
         // Server-side cache for proxied avatar images to avoid re-fetching from
         // upstream Seerr on every request. Entries expire after 1 hour.
-        public ConcurrentDictionary<string, (byte[] Content, string ContentType, string ETag, DateTime CachedAt)> AvatarCache { get; } = new();
+        public BoundedTtlCache<string, (byte[] Content, string ContentType, string ETag, DateTime CachedAt)> AvatarCache { get; }
 
         public TimeSpan AvatarCacheDuration { get; } = TimeSpan.FromHours(1);
 
         // Cache for Seerr user ID lookups (JellyfinUserId -> SeerrUserId)
-        public Dictionary<string, (string SeerrUserId, DateTime CachedAt, long ConfigurationRevision, string ConfigurationIdentity)> UserIdCache { get; } = new();
+        public BoundedTtlCache<string, (string SeerrUserId, DateTime CachedAt, long ConfigurationRevision, string ConfigurationIdentity)> UserIdCache { get; }
 
         public object UserIdCacheLock { get; } = new();
 
         // Cache for Seerr user lookups (JellyfinUserId -> full Seerr user payload, null = negative cache)
-        public Dictionary<string, (SeerrUser? User, DateTime CachedAt, long ConfigurationRevision, string ConfigurationIdentity)> UserCache { get; } = new();
+        public BoundedTtlCache<string, (SeerrUser? User, DateTime CachedAt, long ConfigurationRevision, string ConfigurationIdentity)> UserCache { get; }
 
         public object UserCacheLock { get; } = new();
 
@@ -42,14 +101,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
         // imports. The timestamp is written before the POST and retained only
         // when its outcome is incomplete, preventing concurrent/repeated
         // requests from creating an import storm without publishing absence.
-        public Dictionary<string, DateTime> AutoImportFailureThrottle { get; } = new();
+        public BoundedTtlCache<string, DateTime> AutoImportFailureThrottle { get; }
 
         public object AutoImportFailureThrottleLock { get; } = new();
 
         public TimeSpan AutoImportFailureThrottleTtl { get; } = TimeSpan.FromSeconds(60);
 
         // Cache for Seerr proxy responses (discovery/search endpoints)
-        public Dictionary<string, (string Content, DateTime CachedAt, long ConfigurationRevision, string ConfigurationIdentity)> ResponseCache { get; } = new();
+        public BoundedTtlCache<string, (string Content, DateTime CachedAt, long ConfigurationRevision, string ConfigurationIdentity)> ResponseCache { get; }
 
         public object ResponseCacheLock { get; } = new();
 
@@ -68,14 +127,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
         public TimeSpan SeerrStatusCacheTtl { get; } = TimeSpan.FromSeconds(30);
 
         // Source-keyed cache of Seerr's /api/v1/settings/public 4K flags.
-        public Dictionary<string, (bool Movie4kEnabled, bool Series4kEnabled, DateTime CachedAt, long ConfigurationRevision, string ApiKeyFingerprint)> Public4kSettingsCache { get; } = new(StringComparer.Ordinal);
+        public BoundedTtlCache<string, (bool Movie4kEnabled, bool Series4kEnabled, DateTime CachedAt, long ConfigurationRevision, string ApiKeyFingerprint)> Public4kSettingsCache { get; }
 
         public object Public4kSettingsCacheLock { get; } = new();
 
         public TimeSpan Public4kSettingsCacheTtl { get; } = TimeSpan.FromMinutes(5);
 
         // Cache for request-page TMDB enrichments (movie/tv detail lookups via Seerr)
-        public Dictionary<string, (TmdbEnrichmentResult Data, DateTime CachedAt, long ConfigurationRevision)> TmdbEnrichmentCache { get; } = new();
+        public BoundedTtlCache<string, (TmdbEnrichmentResult Data, DateTime CachedAt, long ConfigurationRevision)> TmdbEnrichmentCache { get; }
 
         public object TmdbEnrichmentCacheLock { get; } = new();
 
@@ -86,7 +145,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
         // source, credentials, and full configuration. Null Score =
         // unrated/unknown; null Keywords = tag data not fetched (light
         // cert-only endpoint) — a tag-rule pass treats that as a miss.
-        public ConcurrentDictionary<string, (int? Score, int? SubScore, string[]? Keywords, string[]? Genres, DateTime CachedAt)> CertScoreCache { get; } = new();
+        public BoundedTtlCache<string, (int? Score, int? SubScore, string[]? Keywords, string[]? Genres, DateTime CachedAt)> CertScoreCache { get; }
 
         public TimeSpan GetResponseCacheTtl()
         {
@@ -110,6 +169,72 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
         {
             var minutes = _configProvider.ConfigurationOrNull?.SeerrResponseCacheTtlMinutes ?? 10;
             return TimeSpan.FromMinutes(Math.Max(1, minutes));
+        }
+
+        private static long AvatarWeight(
+            string key,
+            (byte[] Content, string ContentType, string ETag, DateTime CachedAt) value)
+            => (key.Length * 2L)
+                + value.Content.LongLength
+                + (value.ContentType.Length * 2L)
+                + (value.ETag.Length * 2L)
+                + 128;
+
+        private static long UserIdWeight(
+            string key,
+            (string SeerrUserId, DateTime CachedAt, long ConfigurationRevision, string ConfigurationIdentity) value)
+            => ((key.Length + value.SeerrUserId.Length + value.ConfigurationIdentity.Length) * 2L) + 128;
+
+        private static long UserWeight(
+            string key,
+            (SeerrUser? User, DateTime CachedAt, long ConfigurationRevision, string ConfigurationIdentity) value)
+            => ((key.Length
+                    + value.ConfigurationIdentity.Length
+                    + (value.User?.JellyfinUserId?.Length ?? 0)
+                    + (value.User?.SourceUrl?.Length ?? 0)) * 2L)
+                + 256;
+
+        private static long ResponseWeight(
+            string key,
+            (string Content, DateTime CachedAt, long ConfigurationRevision, string ConfigurationIdentity) value)
+            => ((key.Length + value.Content.Length) * 2L)
+                + (value.ConfigurationIdentity.Length * 2L)
+                + 128;
+
+        private static long TmdbEnrichmentWeight(
+            string key,
+            (TmdbEnrichmentResult Data, DateTime CachedAt, long ConfigurationRevision) value)
+            => ((key.Length
+                    + (value.Data.Title?.Length ?? 0)
+                    + (value.Data.PosterUrl?.Length ?? 0)
+                    + (value.Data.DigitalReleaseDate?.Length ?? 0)
+                    + (value.Data.TheatricalReleaseDate?.Length ?? 0)
+                    + (value.Data.InitialAirDate?.Length ?? 0)
+                    + (value.Data.NextAirDate?.Length ?? 0)) * 2L)
+                + 256;
+
+        private static long CertificationWeight(
+            string key,
+            (int? Score, int? SubScore, string[]? Keywords, string[]? Genres, DateTime CachedAt) value)
+            => (key.Length * 2L)
+                + StringArrayWeight(value.Keywords)
+                + StringArrayWeight(value.Genres)
+                + 128;
+
+        private static long StringArrayWeight(string[]? values)
+        {
+            if (values == null)
+            {
+                return 0;
+            }
+
+            long weight = values.Length * 8L;
+            foreach (var value in values)
+            {
+                weight += (value?.Length ?? 0) * 2L;
+            }
+
+            return weight;
         }
 
         public void ClearUserCaches()

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrClient.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrClient.cs
@@ -1376,7 +1376,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
         }
 
         internal static bool TryPublishResponseCacheEntry(
-            Dictionary<string, (string Content, DateTime CachedAt, long ConfigurationRevision, string ConfigurationIdentity)> cache,
+            Helpers.BoundedTtlCache<string, (string Content, DateTime CachedAt, long ConfigurationRevision, string ConfigurationIdentity)> cache,
             object cacheLock,
             string cacheKey,
             (string Content, DateTime CachedAt, long ConfigurationRevision, string ConfigurationIdentity) entry,
@@ -1387,9 +1387,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                 return false;
             }
 
+            Helpers.BoundedTtlCache<string, (string Content, DateTime CachedAt, long ConfigurationRevision, string ConfigurationIdentity)>.CacheToken publication;
             lock (cacheLock)
             {
-                cache[cacheKey] = entry;
+                cache.TrySet(cacheKey, entry, out publication);
             }
 
             if (isConfigurationCurrent())
@@ -1402,11 +1403,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             // must not be deleted by stale cleanup.
             lock (cacheLock)
             {
-                if (cache.TryGetValue(cacheKey, out var published)
-                    && published.Equals(entry))
-                {
-                    cache.Remove(cacheKey);
-                }
+                cache.Remove(publication);
             }
 
             return false;
@@ -2152,18 +2149,6 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                                 { StatusCode = 409 };
                             }
 
-                            lock (_seerrCache.ResponseCacheLock)
-                            {
-                                if (_seerrCache.ResponseCache.Count > 200 || _seerrCache.ResponseCache.Count % 50 == 0)
-                                {
-                                    var staleKeys = _seerrCache.ResponseCache
-                                        .Where(kv => DateTime.UtcNow - kv.Value.CachedAt > _seerrCache.GetResponseCacheTtl())
-                                        .Select(kv => kv.Key)
-                                        .ToList();
-                                    foreach (var key in staleKeys)
-                                        _seerrCache.ResponseCache.Remove(key);
-                                }
-                            }
                         }
 
                         // a successful POST /api/v1/request changes
@@ -2711,9 +2696,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
 
         // Dedup tracker for high-frequency polling log lines.
         // Key = (userId, apiPath), Value = (last logged message, count since last log, last log time)
-        private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, (string LastMsg, int Count, DateTime LastLogged)>
-            _pollLogDedup = new();
         private static readonly TimeSpan _pollLogInterval = TimeSpan.FromMinutes(5);
+        private static readonly Helpers.BoundedTtlCache<string, (string LastMsg, int Count, DateTime LastLogged)>
+            _pollLogDedup = new(
+                maximumEntries: 4_096,
+                maximumWeight: 4L * 1024 * 1024,
+                weight: static (key, entry) => key.Length + entry.LastMsg.Length + 16,
+                comparer: StringComparer.Ordinal,
+                defaultTtl: static () => TimeSpan.FromMinutes(30));
 
         private void LogPollingRequest(string userDisplay, string requestUri, string dedupKey)
         {

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrParentalFilter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrParentalFilter.cs
@@ -939,10 +939,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             // value and never return it to a waiter from a newer generation.
             if (!IsCurrentConfiguration(gate))
             {
-                Helpers.AsyncSingleFlight.TryRemoveExact(
-                    _seerrCache.CertScoreCache,
-                    generationCacheKey,
-                    published);
+                _seerrCache.CertScoreCache.Remove(generationCacheKey, published);
                 return null;
             }
 

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/SpoilerBlurImageFilter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/SpoilerBlurImageFilter.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Helpers;
 using MediaBrowser.Controller.Chapters;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.TV;
@@ -87,7 +88,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         // Re-warn at most once per hour per surface so a real Jellyfin upgrade
         // changing the response shape isn't permanently invisible.
         private static readonly TimeSpan ShapeWarnInterval = TimeSpan.FromHours(1);
-        private static readonly ConcurrentDictionary<string, DateTime> _warnedShapeAt = new();
+        private static readonly BoundedTtlCache<string, DateTime> _warnedShapeAt = new(
+            maximumEntries: 256,
+            maximumWeight: 256 * 1024,
+            weight: static (key, _) => key.Length + sizeof(long),
+            comparer: StringComparer.Ordinal,
+            defaultTtl: () => ShapeWarnInterval);
 
         // Rate-limited warning helper + per-request user-state caching now
         // live on SpoilerUserResolver (single shared HttpContext.Items key
@@ -752,13 +758,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         // mark-watched → next-navigation roundtrips see fresh data.
         private static readonly TimeSpan SeasonWatchedCacheTtl = TimeSpan.FromSeconds(30);
 
-        private sealed class WatchedCacheEntry
-        {
-            public required bool AnyWatched { get; init; }
-            public required DateTime ExpiresAt { get; init; }
-        }
-
-        private static readonly ConcurrentDictionary<string, WatchedCacheEntry> _watchedCache = new();
+        private static readonly BoundedTtlCache<string, bool> _watchedCache = new(
+            maximumEntries: 512,
+            maximumWeight: 512,
+            comparer: StringComparer.Ordinal,
+            defaultTtl: () => SeasonWatchedCacheTtl);
 
         // Does this candidate's spoiler state cover the item at all? Used to
         // pick the effective user when a shared-IP request yields several
@@ -945,10 +949,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         private bool HasWatchedAnyEpisodeInSeason(JUser user, Season season)
         {
             var key = user.Id.ToString("N") + ":" + season.Id.ToString("N");
-            var now = DateTime.UtcNow;
-            if (_watchedCache.TryGetValue(key, out var hit) && hit.ExpiresAt > now)
+            if (_watchedCache.TryGetValue(key, out var hit))
             {
-                return hit.AnyWatched;
+                return hit;
             }
 
             bool anyWatched = false;
@@ -996,24 +999,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             // succeeds.
             if (!determinationFailed)
             {
-                _watchedCache[key] = new WatchedCacheEntry
-                {
-                    AnyWatched = anyWatched,
-                    ExpiresAt = now + SeasonWatchedCacheTtl,
-                };
-            }
-
-            // Periodic eviction so the dictionary doesn't grow unbounded
-            // across long server uptimes. Snapshot via ToArray so a
-            // concurrent insert during the scan can't trip
-            // InvalidOperationException — `ConcurrentDictionary` enumerator
-            // only guarantees stable iteration when snapshotted.
-            if (_watchedCache.Count > 512)
-            {
-                foreach (var kvp in _watchedCache.ToArray())
-                {
-                    if (kvp.Value.ExpiresAt < now) _watchedCache.TryRemove(kvp.Key, out _);
-                }
+                _watchedCache.Set(key, anyWatched, SeasonWatchedCacheTtl);
             }
 
             return anyWatched;
@@ -1341,7 +1327,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             var now = DateTime.UtcNow;
             var stored = _warnedShapeAt.AddOrUpdate(
                 key,
-                now,
+                _ => now,
                 (_, last) => (now - last) >= ShapeWarnInterval ? now : last);
             if (stored != now) return;
             _logger.LogWarning($"Spoiler Guard: image action produced an unrecognized result type ({key}); blur is no-op for this shape. Re-warns hourly. Likely a Jellyfin upgrade changed the image controller's return type.");

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/SpoilerUserResolver.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/SpoilerUserResolver.cs
@@ -26,7 +26,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         public const string ContextKeyUserState = "__JE_SpoilerBlur_UserState_Shared";
 
         private static readonly TimeSpan PerKeyWarnInterval = TimeSpan.FromHours(1);
-        private static readonly ConcurrentDictionary<string, DateTime> _warnedAt = new();
+        private static readonly BoundedTtlCache<string, DateTime> _warnedAt = new(
+            maximumEntries: 4_096,
+            maximumWeight: 1024 * 1024,
+            weight: static (key, _) => key.Length + sizeof(long),
+            comparer: StringComparer.Ordinal,
+            defaultTtl: () => PerKeyWarnInterval);
 
         // F7: cross-request in-memory cache of each user's spoiler state, keyed
         // by userId (N-format). An anonymous image burst on a shared IP probes
@@ -35,8 +40,17 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         // every controller/pending/promoter write path via InvalidateUser, and
         // per-request the HttpContext.Items layer still short-circuits repeats.
         private static readonly TimeSpan UserStateCacheTtl = TimeSpan.FromSeconds(30);
-        private static readonly ConcurrentDictionary<string, (UserSpoilerBlur State, DateTime CachedAt)> _userStateCache
-            = new(StringComparer.OrdinalIgnoreCase);
+        private static readonly BoundedTtlCache<string, (UserSpoilerBlur State, DateTime CachedAt)> _userStateCache
+            = new(
+                maximumEntries: 2_048,
+                maximumWeight: 100_000,
+                weight: static (_, entry) => 1L
+                    + entry.State.Series.Count
+                    + entry.State.Movies.Count
+                    + entry.State.Collections.Count
+                    + entry.State.PendingTmdb.Count,
+                comparer: StringComparer.OrdinalIgnoreCase,
+                defaultTtl: () => UserStateCacheTtl);
 
         // F6: memoized result of the O(opted-collections × members) collection
         // walk in FindOptedInCollectionForMovie (runs 2-3× per movie image/DTO).
@@ -46,8 +60,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         // automatically (self-invalidating) and two users with the same set share
         // safely. Short TTL bounds staleness from library edits.
         private static readonly TimeSpan CollectionScopeCacheTtl = TimeSpan.FromSeconds(30);
-        private static readonly ConcurrentDictionary<string, (Guid? CollectionId, DateTime CachedAt)> _collectionScopeCache
-            = new(StringComparer.Ordinal);
+        private static readonly BoundedTtlCache<string, (Guid? CollectionId, DateTime CachedAt)> _collectionScopeCache
+            = new(
+                maximumEntries: 1_024,
+                maximumWeight: 8L * 1024 * 1024,
+                weight: static (key, _) => key.Length + 16,
+                comparer: StringComparer.Ordinal,
+                defaultTtl: () => CollectionScopeCacheTtl);
 
         /// <summary>
         /// Drops the cross-request caches for a user so the next request re-reads
@@ -147,17 +166,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
 
             if (cacheKey != null)
             {
-                _collectionScopeCache[cacheKey] = (result, now);
-                // Opportunistic eviction, mirroring the season-watched cache in
-                // SpoilerBlurImageFilter: snapshot-free, only removes expired.
-                if (_collectionScopeCache.Count > 1024)
-                {
-                    foreach (var kvp in _collectionScopeCache)
-                    {
-                        if ((now - kvp.Value.CachedAt) >= CollectionScopeCacheTtl)
-                            _collectionScopeCache.TryRemove(kvp.Key, out _);
-                    }
-                }
+                _collectionScopeCache.Set(
+                    cacheKey,
+                    (result, now),
+                    CollectionScopeCacheTtl);
             }
             return result;
         }
@@ -264,17 +276,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     $"Spoiler Guard resolver: {read.Status} spoilerblur.json for {userId} ({read.FaultDetail}) — {posture} until repaired.");
             }
 
-            _userStateCache[userIdN] = (state, now);
-            // Opportunistic prune so the cache can't grow unbounded across many
-            // users over a long uptime (mirrors the IP-scan cache prune).
-            if (_userStateCache.Count > 512)
-            {
-                foreach (var kvp in _userStateCache)
-                {
-                    if ((now - kvp.Value.CachedAt) >= UserStateCacheTtl)
-                        _userStateCache.TryRemove(kvp.Key, out _);
-                }
-            }
+            _userStateCache.Set(userIdN, (state, now), UserStateCacheTtl);
             httpContext.Items[cacheKey] = state;
             return state;
         }
@@ -300,7 +302,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         public void WarnRateLimited(string key, string message)
         {
             var now = DateTime.UtcNow;
-            var stored = _warnedAt.AddOrUpdate(key, now,
+            var stored = _warnedAt.AddOrUpdate(key, _ => now,
                 (_, last) => (now - last) >= PerKeyWarnInterval ? now : last);
             if (stored != now) return;
             _logger.LogWarning(message);

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/TagCacheService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/TagCacheService.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Threading;
 using Jellyfin.Data.Enums;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Helpers;
 using Jellyfin.Plugin.JellyfinCanopy.Model;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Entities;
@@ -52,6 +53,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         // holding the guard" state and drive the rebuild against it deterministically.
         internal Action? OnAfterFlushApplyForTest;
 
+        // Test seam after a user-access cache miss and before joining the
+        // per-user singleflight. A delayed miss must re-check the cache inside
+        // the winning Lazy so it cannot query after another flight publishes.
+        internal Action? OnAfterUserAccessCacheMissForTest;
+
         // Incremental cache maintenance. Library-scan events are recorded here (O(1),
         // no DB/probe work) and drained by a debounced background worker so scans are
         // never blocked and repeated hits on the same id coalesce to one rebuild.
@@ -79,8 +85,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         private const int CurrentCacheSchemaVersion = 2;
 
         // User access cache: avoids expensive GetItemIds query on every request
-        private readonly ConcurrentDictionary<string, (HashSet<string> Ids, DateTime CachedAt)> _userAccessCache = new();
         private static readonly TimeSpan UserAccessCacheTtl = TimeSpan.FromSeconds(60);
+        private readonly BoundedTtlCache<string, (HashSet<string> Ids, DateTime CachedAt)> _userAccessCache = new(
+            maximumEntries: 2_048,
+            maximumWeight: 2_000_000,
+            weight: static (key, entry) => key.Length + entry.Ids.Count,
+            comparer: StringComparer.Ordinal,
+            defaultTtl: () => UserAccessCacheTtl);
+        private readonly ConcurrentDictionary<string, Lazy<HashSet<string>>> _userAccessInFlight = new(StringComparer.Ordinal);
 
         public static readonly HashSet<BaseItemKind> TaggableTypes = new()
         {
@@ -625,15 +637,41 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             }
             else
             {
-                var accessibleIds = _libraryManager.GetItemIds(new InternalItemsQuery(user)
+                OnAfterUserAccessCacheMissForTest?.Invoke();
+                var flight = _userAccessInFlight.GetOrAdd(
+                    userKey,
+                    _ => new Lazy<HashSet<string>>(
+                        () =>
+                        {
+                            if (_userAccessCache.TryGetValue(userKey, out var published)
+                                && DateTime.UtcNow - published.CachedAt < UserAccessCacheTtl)
+                            {
+                                return published.Ids;
+                            }
+
+                            var accessibleIds = _libraryManager.GetItemIds(new InternalItemsQuery(user)
+                            {
+                                IncludeItemTypes = TaggableTypes.ToArray(),
+                                Recursive = true,
+                            });
+                            var result = new HashSet<string>(
+                                accessibleIds.Select(id => id.ToString("N").ToLowerInvariant()));
+                            _userAccessCache.Set(
+                                userKey,
+                                (result, DateTime.UtcNow),
+                                UserAccessCacheTtl);
+                            return result;
+                        },
+                        LazyThreadSafetyMode.ExecutionAndPublication));
+                try
                 {
-                    IncludeItemTypes = TaggableTypes.ToArray(),
-                    Recursive = true
-                });
-                accessibleSet = new HashSet<string>(
-                    accessibleIds.Select(id => id.ToString("N").ToLowerInvariant())
-                );
-                _userAccessCache[userKey] = (accessibleSet, DateTime.UtcNow);
+                    accessibleSet = flight.Value;
+                }
+                finally
+                {
+                    ((ICollection<KeyValuePair<string, Lazy<HashSet<string>>>>)_userAccessInFlight)
+                        .Remove(new KeyValuePair<string, Lazy<HashSet<string>>>(userKey, flight));
+                }
             }
 
             var result = new Dictionary<string, TagCacheEntry>();

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/WatchlistMonitor.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/WatchlistMonitor.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Helpers;
 using Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr;
 using Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks;
 using MediaBrowser.Controller;
@@ -33,7 +34,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         private readonly UserConfigurationManager _userConfigurationManager;
         private readonly ILogger<WatchlistMonitor> _logger;
         private readonly IPluginConfigProvider _configProvider;
-        private readonly Dictionary<string, (List<RequestItemWithUser> Items, DateTime CachedAt)> _requestsCache = new();
+        private readonly BoundedTtlCache<string, List<RequestItemWithUser>> _requestsCache = new(
+            maximumEntries: 64,
+            maximumWeight: 100_000,
+            weight: static (key, items) => key.Length + items.Count,
+            comparer: StringComparer.Ordinal,
+            defaultTtl: GetRequestsCacheTtl);
         private readonly object _requestsCacheLock = new();
         private readonly ConcurrentDictionary<string, Lazy<Task<List<RequestItemWithUser>?>>> _requestsInFlight = new();
         private readonly object _lifecycleLock = new();
@@ -482,10 +488,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
 
             lock (_requestsCacheLock)
             {
-                if (_requestsCache.TryGetValue(cacheKey, out var cached) &&
-                    DateTime.UtcNow - cached.CachedAt < cacheTtl)
+                if (_requestsCache.TryGetValue(cacheKey, out var cached))
                 {
-                    return cached.Items;
+                    return cached;
                 }
             }
 
@@ -558,7 +563,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     // caller could otherwise start a duplicate fetch.
                     lock (_requestsCacheLock)
                     {
-                        _requestsCache[cacheKey] = (fetchedItems, DateTime.UtcNow);
+                        _requestsCache.Set(cacheKey, fetchedItems, cacheTtl);
                     }
                 }
 

--- a/research/ttl-cache-capacity-audit.md
+++ b/research/ttl-cache-capacity-audit.md
@@ -1,0 +1,55 @@
+# TTL cache capacity audit
+
+Issue #105 replaces threshold-triggered expiry sweeps with
+`BoundedTtlCache<TKey, TValue>`. The shared primitive is thread-safe, uses a
+deterministic LRU, enforces both entry and weight ceilings, expires on access or
+bounded maintenance, and supports versioned publication tokens so stale work
+cannot remove a refresh.
+
+## Shared primitive callers
+
+| Scope | Entry ceiling | Weight ceiling |
+| --- | ---: | ---: |
+| Seerr avatars | 64 | 32 MiB |
+| Seerr user IDs/users/import throttle | 2,048 each | 4 MiB / 4 MiB / 2,048 units |
+| Seerr responses | 256 | 32 MiB |
+| Seerr public 4K settings | 64 | 64 units |
+| TMDB enrichment | 512 | 4 MiB |
+| certification/keyword signals | 4,096 | 16 MiB |
+| auto-season details | 256 | 16 MiB |
+| auto movie/season and playback reservations | 16,384 each | 16,384 units each |
+| watchlist request snapshots | 64 | 100,000 item/key units |
+| request IP scans / cookie misses | 1,024 / 2,048 | 1 MiB each |
+| privacy user state / collection scope / watched-season state | 2,048 / 1,024 / 512 | 100,000 scope units / 8 MiB / 512 units |
+| hidden-content state | 2,048 | 100,000 scope units |
+| tag-cache user-access projections | 2,048 | 2,000,000 ID/key units |
+| warning and polling deduplication | 256–4,096 | 256 KiB–4 MiB |
+
+The Seerr, auto-season, watchlist, parental-signal, and tag-access expensive
+lookups retain per-key singleflight. Negative Seerr users remain restricted to
+authoritative absence and retain their shorter read-side TTL.
+
+## Reviewed equivalent or non-cache state
+
+- `LiveSessionRegistry` is an equivalent bounded implementation: 500 entries,
+  24-hour expiry, deterministic stalest-first eviction, and pair-conditional
+  removal so a refresh survives cleanup.
+- `ImageBlurService` is an equivalent bounded implementation: 256 entries and
+  64 MiB, with access timestamps and locked eviction. Its entry and byte caps
+  have direct tests.
+- `SeerrStatusCache` is one source-neutral singleton value, not a key-cardinality
+  cache.
+- `TagCacheService._cache` and the asset derived registry are durable
+  projections of the finite library/manifest and are persisted source state,
+  not TTL memoization.
+- Route/action dictionaries are immutable finite tables.
+- In-flight, pending-change, and invalidation dictionaries represent currently
+  executing work. Their owners remove exact key/value pairs on completion or
+  clear them at the documented lifecycle boundary; they are not retained TTL
+  caches.
+- Spoiler identity marker maps are projections of the current Jellyfin user
+  topology and are explicitly invalidated on user creation/deletion.
+
+No insertion path is allowed to start an unbounded full-cache expiry scan. A
+future TTL memoization dictionary should use the shared primitive unless it has
+both a hard capacity proof and documented lifecycle/eviction semantics here.

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -19,7 +19,7 @@ const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the repeated clean measurements', () => {
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1364, totalLines: 1692 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 12855, totalLines: 21058 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 13263, totalLines: 21411 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 1);
 });

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -21,8 +21,8 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 12855,
-        "totalLines": 21058
+        "coveredLines": 13263,
+        "totalLines": 21411
       },
       "tolerance": {
         "missingCoveredLines": 1,


### PR DESCRIPTION
Closes #105

## What changed

- add a thread-safe, fake-clock-testable weighted TTL cache with deterministic LRU eviction, hard entry/weight ceilings, bounded insertion maintenance, atomic add/update, and versioned publication tokens
- migrate Seerr, auto-request, watchlist, identity, privacy, spoiler, polling, and tag-access TTL/dedup caches away from unbounded threshold sweeps
- retain per-key singleflight for expensive fetches and add it to tag-cache user-access projections
- use exact publication/reservation cleanup so stale work cannot delete a refresh
- document the complete cache inventory and the remaining proven-equivalent bounded implementations
- update the reviewed server coverage baseline after two identical clean measurements

## Root cause and impact

The former hand-rolled caches only scanned for expired entries after crossing a threshold. Fresh high-cardinality keys were never evicted, so memory grew without a hard limit and each insertion could rescan the full dictionary. The shared primitive keeps insertion near O(1), bounds retained memory, and preserves source/user/configuration scoping.

## Validation

- 1,284/1,284 .NET server tests
- 294/294 script tests
- 15,000-key complexity and entry/weight boundary tests
- concurrent arbitrary identity cardinality and per-user singleflight race tests
- server coverage measured identically twice at 13,263/21,411 lines; ratchet passes at the reviewed baseline
- lint passes with the existing advisory warnings; both TypeScript checks pass
- Fable-low independent review: primitive APPROVE and caller APPROVE after closing its singleflight timing observation
- E2E remains pinned to the Jellyfin unstable/nightly digest; no RC image is introduced
