### PR TITLE
Bound and coalesce watchlist event work (#106)

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Configuration/ProcessedWatchlistConcurrencyTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Configuration/ProcessedWatchlistConcurrencyTests.cs
@@ -11,7 +11,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Configuration
 {
     /// <summary>
     /// Regression net for W4-LEAK-4: the processed-watchlist file is mutated by both
-    /// the event-driven <c>WatchlistMonitor</c> (off-thread <c>Task.Run</c>) and the
+    /// the event-driven <c>WatchlistMonitor</c> (bounded off-thread worker) and the
     /// scheduled <c>SeerrWatchlistSyncTask</c>, plus a periodic cleanup. Before the
     /// fix each did an UNLOCKED get → mutate → save, so a writer's stale-read save could
     /// clobber another writer's just-added "processed" marker (lost update → the item is

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Helpers/BoundedCoalescingWorkerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Helpers/BoundedCoalescingWorkerTests.cs
@@ -1,0 +1,266 @@
+using System.Diagnostics;
+using Jellyfin.Plugin.JellyfinCanopy.Helpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Helpers;
+
+public sealed class BoundedCoalescingWorkerTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public BoundedCoalescingWorkerTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public async Task TenThousandDuplicateEvents_UseOneWorkerAndOneCurrentKey()
+    {
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+        var concurrent = 0;
+        var maximumConcurrent = 0;
+        var observedValues = new System.Collections.Concurrent.ConcurrentQueue<int>();
+        await using var worker = new BoundedCoalescingWorker<int, int>(
+            capacity: 16,
+            maximumAttempts: 2,
+            async (value, cancellationToken) =>
+            {
+                Interlocked.Increment(ref calls);
+                observedValues.Enqueue(value);
+                var current = Interlocked.Increment(ref concurrent);
+                SetMaximum(ref maximumConcurrent, current);
+                started.TrySetResult();
+                await release.Task.WaitAsync(cancellationToken);
+                Interlocked.Decrement(ref concurrent);
+            });
+
+        Assert.True(worker.TryEnqueue(7, 0));
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        for (var index = 1; index <= 10_000; index++)
+        {
+            Assert.True(worker.TryEnqueue(7, index));
+        }
+
+        var busy = worker.Metrics;
+        Assert.Equal(1, busy.WorkerTasks);
+        Assert.Equal(1, busy.StateCount);
+        Assert.InRange(busy.QueueDepth, 0, 1);
+        Assert.Equal(10_000, busy.Coalesced);
+        Assert.Equal(0, busy.Dropped);
+
+        release.TrySetResult();
+        await WaitUntilAsync(() => worker.Metrics.StateCount == 0);
+
+        Assert.Equal(2, Volatile.Read(ref calls));
+        Assert.Equal(new[] { 0, 10_000 }, observedValues.ToArray());
+        Assert.Equal(1, Volatile.Read(ref maximumConcurrent));
+        Assert.InRange(worker.Metrics.PeakQueueDepth, 1, worker.Metrics.Capacity);
+    }
+
+    [Fact]
+    public async Task DistinctEventStorm_RejectsBeyondFixedCapacityWithoutCreatingTasks()
+    {
+        const int capacity = 64;
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+        await using var worker = new BoundedCoalescingWorker<int, int>(
+            capacity,
+            maximumAttempts: 1,
+            async (_, cancellationToken) =>
+            {
+                Interlocked.Increment(ref calls);
+                started.TrySetResult();
+                await release.Task.WaitAsync(cancellationToken);
+            });
+
+        var allocatedBefore = GC.GetTotalAllocatedBytes(precise: true);
+        var stopwatch = Stopwatch.StartNew();
+        Assert.True(worker.TryEnqueue(0, 0));
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var accepted = 1;
+        for (var index = 1; index < 15_000; index++)
+        {
+            if (worker.TryEnqueue(index, index)) accepted++;
+        }
+
+        stopwatch.Stop();
+        var allocated = GC.GetTotalAllocatedBytes(precise: true) - allocatedBefore;
+        var metrics = worker.Metrics;
+        _output.WriteLine(
+            "events=15000 workerTasks={0} capacity={1} accepted={2} dropped={3} peakDepth={4} callsWhileBlocked={5} elapsedMs={6:F3} allocatedBytes={7}",
+            metrics.WorkerTasks,
+            metrics.Capacity,
+            accepted,
+            metrics.Dropped,
+            metrics.PeakQueueDepth,
+            Volatile.Read(ref calls),
+            stopwatch.Elapsed.TotalMilliseconds,
+            allocated);
+
+        Assert.Equal(capacity, accepted);
+        Assert.Equal(15_000 - capacity, metrics.Dropped);
+        Assert.Equal(capacity, metrics.StateCount);
+        Assert.Equal(capacity - 1, metrics.QueueDepth);
+        Assert.Equal(capacity - 1, metrics.PeakQueueDepth);
+        Assert.Equal(1, metrics.WorkerTasks);
+        Assert.Equal(1, Volatile.Read(ref calls));
+
+        release.TrySetResult();
+        await WaitUntilAsync(() => worker.Metrics.StateCount == 0);
+        Assert.Equal(capacity, Volatile.Read(ref calls));
+    }
+
+    [Fact]
+    public async Task FailureRetryBudget_IsExactAndBounded()
+    {
+        var calls = 0;
+        var observedFailures = 0;
+        await using var worker = new BoundedCoalescingWorker<int, int>(
+            capacity: 4,
+            maximumAttempts: 2,
+            (_, _) =>
+            {
+                Interlocked.Increment(ref calls);
+                throw new InvalidOperationException("sentinel");
+            },
+            failureObserver: _ => Interlocked.Increment(ref observedFailures));
+
+        Assert.True(worker.TryEnqueue(1, 1));
+        await WaitUntilAsync(() =>
+            worker.Metrics.StateCount == 0 && Volatile.Read(ref observedFailures) == 2);
+
+        var metrics = worker.Metrics;
+        Assert.Equal(2, Volatile.Read(ref calls));
+        Assert.Equal(2, Volatile.Read(ref observedFailures));
+        Assert.Equal(2, metrics.Failures);
+        Assert.Equal(1, metrics.Retried);
+        Assert.Equal(0, metrics.Processed);
+    }
+
+    [Fact]
+    public async Task Dispose_CancelsAndJoinsTheOwnedWorker()
+    {
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancellationObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var worker = new BoundedCoalescingWorker<int, int>(
+            capacity: 4,
+            maximumAttempts: 2,
+            async (_, cancellationToken) =>
+            {
+                started.TrySetResult();
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    cancellationObserved.TrySetResult();
+                    throw;
+                }
+            });
+
+        Assert.True(worker.TryEnqueue(1, 1));
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await worker.DisposeAsync();
+
+        Assert.True(cancellationObserved.Task.IsCompletedSuccessfully);
+        Assert.False(worker.TryEnqueue(2, 2));
+        Assert.True(worker.Metrics.Cancelled >= 1);
+    }
+
+    [Fact]
+    public async Task ConcurrentDisposeAsyncCallers_AwaitTheSameShutdownJoin()
+    {
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancellationObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var allowExit = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var worker = new BoundedCoalescingWorker<int, int>(
+            capacity: 4,
+            maximumAttempts: 1,
+            async (_, cancellationToken) =>
+            {
+                started.TrySetResult();
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    cancellationObserved.TrySetResult();
+                    await allowExit.Task;
+                    throw;
+                }
+            });
+
+        Assert.True(worker.TryEnqueue(1, 1));
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var first = worker.DisposeAsync().AsTask();
+        await cancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var second = worker.DisposeAsync().AsTask();
+
+        Assert.False(first.IsCompleted);
+        Assert.False(second.IsCompleted);
+        allowExit.TrySetResult();
+        await Task.WhenAll(first, second).WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task CapacityDrop_RecoversAfterAnEntryCompletes()
+    {
+        var releases = new System.Collections.Concurrent.ConcurrentQueue<TaskCompletionSource>();
+        await using var worker = new BoundedCoalescingWorker<int, int>(
+            capacity: 2,
+            maximumAttempts: 1,
+            async (_, cancellationToken) =>
+            {
+                var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                releases.Enqueue(release);
+                await release.Task.WaitAsync(cancellationToken);
+            });
+
+        Assert.True(worker.TryEnqueue(1, 1));
+        await WaitUntilAsync(() => !releases.IsEmpty);
+        Assert.True(worker.TryEnqueue(2, 2));
+        Assert.False(worker.TryEnqueue(3, 3));
+
+        Assert.True(releases.TryDequeue(out var firstRelease));
+        firstRelease.TrySetResult();
+        await WaitUntilAsync(() => worker.Metrics.StateCount == 1);
+        Assert.True(worker.TryEnqueue(3, 3));
+
+        while (worker.Metrics.StateCount > 0)
+        {
+            if (releases.TryDequeue(out var release)) release.TrySetResult();
+            await Task.Delay(1);
+        }
+
+        Assert.Equal(1, worker.Metrics.Dropped);
+        Assert.Equal(3, worker.Metrics.Processed);
+    }
+
+    private static void SetMaximum(ref int target, int value)
+    {
+        var current = Volatile.Read(ref target);
+        while (value > current)
+        {
+            var observed = Interlocked.CompareExchange(ref target, value, current);
+            if (observed == current) return;
+            current = observed;
+        }
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition)
+    {
+        var timeoutAt = DateTime.UtcNow.AddSeconds(5);
+        while (!condition() && DateTime.UtcNow < timeoutAt)
+        {
+            await Task.Delay(10);
+        }
+
+        Assert.True(condition(), "Timed out waiting for the bounded worker to become idle.");
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/LibraryScanEventGuardTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/LibraryScanEventGuardTests.cs
@@ -53,7 +53,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
         {
             "TagCacheMonitor.cs",             // record id -> TagCacheService debounced flush worker
             "SeerrScanTriggerService.cs",     // cheap config/kind check -> counter + debounce timer
-            "WatchlistMonitor.cs",            // cheap Movie/Series reject -> Task.Run (lookup + writes off-thread)
+            "WatchlistMonitor.cs",            // constant-time gates -> bounded coalescing channel worker
             "ContinueWatchingPlaybackEvents.cs", // record id -> debounced timer drain (GetUsers + per-user prune off-thread, coalesced)
             "SpoilerSeerrPendingPromoter.cs", // cheap gate ContainsKey -> coalesced Task.Run sweep (GetItemById + RMW off-thread)
         };
@@ -66,9 +66,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
         // would hide the exact regression this guard exists to catch. One justification per file.
         private static readonly Dictionary<string, string[]> OffThreadWorkerMethods = new(StringComparer.Ordinal)
         {
-            // ScheduleWatchlistCheck (sync handler) defers to Task.Run(() => ProcessItemForWatchlist(...));
-            // that method resolves ids, GetUsers() and writes watchlists off the scan thread.
-            ["WatchlistMonitor.cs"] = new[] { "ProcessItemForWatchlist" },
+            // ScheduleWatchlistCheck (sync handler) performs a non-blocking bounded enqueue;
+            // ProcessQueuedItemAsync / ProcessItemForWatchlist run on the owned channel worker.
+            ["WatchlistMonitor.cs"] = new[] { "ProcessQueuedItemAsync", "ProcessItemForWatchlist" },
             // OnItemRemoved (sync handler) only records ids + arms a debounce Timer; Drain is the
             // timer callback and DrainBatch/PruneOrphans are its per-user workers (GetUsers + prune).
             ["ContinueWatchingPlaybackEvents.cs"] = new[] { "Drain", "DrainBatch", "PruneOrphans" },

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/WatchlistMonitorAuthorizationTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/WatchlistMonitorAuthorizationTests.cs
@@ -204,6 +204,38 @@ public sealed class WatchlistMonitorAuthorizationTests
         Assert.DoesNotContain("secret", canonical, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void RequestSnapshot_IndexesEachMediaIdentityOnceAndRetainsAllOwners()
+    {
+        var requests = Enumerable.Range(1, 10_000)
+            .Select(tmdbId => new WatchlistMonitor.RequestItemWithUser
+            {
+                TmdbId = tmdbId,
+                MediaType = "movie",
+                SourceUrl = "http://seerr:5055",
+                RequestedBySeerrUserId = tmdbId.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                RequestedByJellyfinUserId = Guid.NewGuid().ToString("N"),
+            })
+            .ToList();
+        requests.Add(new WatchlistMonitor.RequestItemWithUser
+        {
+            TmdbId = 5_000,
+            MediaType = "movie",
+            SourceUrl = "http://seerr:5055",
+            RequestedBySeerrUserId = "duplicate-owner",
+            RequestedByJellyfinUserId = Guid.NewGuid().ToString("N"),
+        });
+
+        var snapshot = WatchlistMonitor.RequestSnapshot.Create(requests);
+
+        Assert.Equal(10_001, snapshot.Count);
+        Assert.Equal(20_001, snapshot.Weight); // 10,001 rows + 10,000 unique keys.
+        Assert.True(snapshot.TryGet("movie", 5_000, out var owners));
+        Assert.Equal(2, owners.Count);
+        Assert.False(snapshot.TryGet("tv", 5_000, out var wrongMedia));
+        Assert.Empty(wrongMedia);
+    }
+
     private static WatchlistMonitor CreateMonitor(
         User user,
         RecordingUserDataManager data,

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/WatchlistMonitorLifecycleTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/WatchlistMonitorLifecycleTests.cs
@@ -1,10 +1,16 @@
 using System.Net;
 using System.Collections.Concurrent;
+using System.Text;
+using System.Text.Json;
+using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
 using Jellyfin.Plugin.JellyfinCanopy.Helpers;
 using Jellyfin.Plugin.JellyfinCanopy.Services;
 using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Entities;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -12,6 +18,119 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services;
 
 public sealed class WatchlistMonitorLifecycleTests
 {
+    [Fact]
+    public async Task DisposeDuringPreparedMutation_JoinsWorkerAndPreventsLateSave()
+    {
+        var library = new CountingLibraryManager();
+        var user = new User("dispose-user", "provider", "password-provider");
+        var readStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var allowRead = new ManualResetEventSlim(false);
+        var saveCalls = 0;
+        var userData = new UserItemData { Key = "dispose-watchlist-test" };
+        var data = new StubUserDataManager
+        {
+            GetUserDataHook = (_, _) =>
+            {
+                readStarted.TrySetResult();
+                allowRead.Wait();
+                return userData;
+            },
+            SaveUserDataHook = (_, _, _, _, _) => Interlocked.Increment(ref saveCalls),
+        };
+        var handler = new AuthorizedResponsesHandler(user);
+        var monitor = new WatchlistMonitor(
+            library,
+            new StubUserManager(user),
+            data,
+            new RecordingHttpClientFactory(handler),
+            null!,
+            NullLogger<WatchlistMonitor>.Instance,
+            new FakePluginConfigProvider(EnabledConfiguration()));
+
+        monitor.Initialize();
+        library.RaiseItemAdded(Movie(123));
+        await readStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var disposeTask = Task.Run(monitor.Dispose);
+        await WaitUntilAsync(() => library.ItemAddedCount == 0);
+        await Task.Delay(20);
+        Assert.False(disposeTask.IsCompleted);
+        allowRead.Set();
+        await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(0, Volatile.Read(ref saveCalls));
+        Assert.NotEqual(true, userData.Likes);
+    }
+
+    [Fact]
+    public async Task TenThousandDuplicateLibraryEvents_CoalesceOnOneBoundedWorker()
+    {
+        var library = new CountingLibraryManager();
+        var handler = new BlockingEmptyRequestsHandler();
+        var monitor = CreateEventMonitor(library, handler, out _);
+        var movie = Movie(123);
+
+        monitor.Initialize();
+        library.RaiseItemAdded(movie);
+        await handler.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        for (var index = 0; index < 10_000; index++)
+        {
+            library.RaiseItemAdded(movie);
+        }
+
+        var busy = monitor.QueueMetrics;
+        Assert.Equal(1, busy.WorkerTasks);
+        Assert.Equal(1, busy.StateCount);
+        Assert.Equal(10_000, busy.Coalesced);
+        Assert.Equal(0, busy.Dropped);
+
+        handler.Release.TrySetResult();
+        await WaitUntilAsync(() => monitor.QueueMetrics.StateCount == 0);
+
+        Assert.InRange(monitor.QueueMetrics.Processed, 1, 2);
+        // The pagination helper deliberately reads each complete source twice for a stable
+        // snapshot. The coalesced follow-up hits the populated 30-second cache, so it adds no call.
+        Assert.Equal(2, handler.RequestCount);
+        monitor.Dispose();
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ConfigurationReplacement_CancelsActiveAndDrainsQueuedOldGeneration(
+        bool notifyBeforeProviderObservation)
+    {
+        var library = new CountingLibraryManager();
+        var handler = new BlockingEmptyRequestsHandler();
+        var monitor = CreateEventMonitor(library, handler, out var provider);
+
+        monitor.Initialize();
+        library.RaiseItemAdded(Movie(123));
+        await handler.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        library.RaiseItemAdded(Movie(456));
+        Assert.Equal(2, monitor.QueueMetrics.StateCount);
+
+        if (notifyBeforeProviderObservation)
+        {
+            // Model the provider revision being observed only after the event callback. The
+            // monitor's explicit generation must invalidate old work independently of that timing.
+            monitor.NotifyConfigurationChanged();
+            provider.Current = EnabledConfiguration();
+        }
+        else
+        {
+            provider.Current = EnabledConfiguration();
+            monitor.NotifyConfigurationChanged();
+        }
+        await handler.CancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await WaitUntilAsync(() => monitor.QueueMetrics.StateCount == 0);
+
+        // The active request was cancelled on the save event. The queued item from the replaced
+        // generation is drained before making any additional remote call.
+        Assert.Equal(1, handler.RequestCount);
+        monitor.Dispose();
+    }
+
     [Fact]
     public async Task CompletedOlderFlight_DoesNotDeleteNewerReplacement()
     {
@@ -114,6 +233,151 @@ public sealed class WatchlistMonitorLifecycleTests
         }
 
         Assert.True(condition(), "Timed out waiting for the expected single-flight state.");
+    }
+
+    private static WatchlistMonitor CreateEventMonitor(
+        CountingLibraryManager library,
+        HttpMessageHandler handler,
+        out FakePluginConfigProvider provider)
+    {
+        provider = new FakePluginConfigProvider(EnabledConfiguration());
+        return new WatchlistMonitor(
+            library,
+            null!,
+            null!,
+            new RecordingHttpClientFactory(handler),
+            null!,
+            NullLogger<WatchlistMonitor>.Instance,
+            provider);
+    }
+
+    private static PluginConfiguration EnabledConfiguration()
+        => new()
+        {
+            AddRequestedMediaToWatchlist = true,
+            SeerrEnabled = true,
+            SeerrUrls = "http://seerr:5055",
+            SeerrApiKey = "key",
+            PreventWatchlistReAddition = false,
+        };
+
+    private static Movie Movie(int tmdbId)
+    {
+        var movie = new Movie
+        {
+            Id = Guid.NewGuid(),
+            Name = $"Movie {tmdbId}",
+        };
+        movie.ProviderIds["Tmdb"] = tmdbId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        return movie;
+    }
+
+    private sealed class BlockingEmptyRequestsHandler : HttpMessageHandler
+    {
+        private int _requestCount;
+
+        public TaskCompletionSource Started { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Release { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource CancellationObserved { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int RequestCount => Volatile.Read(ref _requestCount);
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            _ = request;
+            Interlocked.Increment(ref _requestCount);
+            Started.TrySetResult();
+            try
+            {
+                await Release.Task.WaitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                CancellationObserved.TrySetResult();
+                throw;
+            }
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    JsonSerializer.Serialize(new
+                    {
+                        page = 1,
+                        totalPages = 1,
+                        totalResults = 0,
+                        pageInfo = new
+                        {
+                            page = 1,
+                            pages = 1,
+                            pageSize = 0,
+                            results = 0,
+                        },
+                        results = Array.Empty<object>(),
+                    }),
+                    Encoding.UTF8,
+                    "application/json"),
+            };
+        }
+    }
+
+    private sealed class AuthorizedResponsesHandler : HttpMessageHandler
+    {
+        private readonly User _user;
+
+        public AuthorizedResponsesHandler(User user)
+        {
+            _user = user;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            object row = request.RequestUri!.AbsolutePath switch
+            {
+                "/api/v1/request" => new
+                {
+                    id = 1,
+                    type = "movie",
+                    requestedBy = new { id = 7, jellyfinUserId = _user.Id.ToString() },
+                    media = new { tmdbId = 123, mediaType = "movie" },
+                },
+                "/api/v1/user" => new
+                {
+                    id = 7,
+                    jellyfinUserId = _user.Id.ToString(),
+                },
+                var path => throw new Xunit.Sdk.XunitException($"Unexpected path {path}."),
+            };
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    JsonSerializer.Serialize(new
+                    {
+                        page = 1,
+                        totalPages = 1,
+                        totalResults = 1,
+                        pageInfo = new
+                        {
+                            page = 1,
+                            pages = 1,
+                            pageSize = 1,
+                            results = 1,
+                        },
+                        results = new[] { row },
+                    }),
+                    Encoding.UTF8,
+                    "application/json"),
+            });
+        }
     }
 
     private sealed class CancellationObservingHandler : HttpMessageHandler

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/TestDoubles/StubUserDataManager.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/TestDoubles/StubUserDataManager.cs
@@ -22,6 +22,9 @@ public sealed class StubUserDataManager : IUserDataManager
     /// <summary>When set, backs <see cref="GetUserData(User, BaseItem)"/>.</summary>
     public Func<User, BaseItem, UserItemData?>? GetUserDataHook { get; set; }
 
+    /// <summary>When set, backs the token-aware <see cref="SaveUserData(User, BaseItem, UserItemData, UserDataSaveReason, CancellationToken)"/>.</summary>
+    public Action<User, BaseItem, UserItemData, UserDataSaveReason, CancellationToken>? SaveUserDataHook { get; set; }
+
     public event EventHandler<UserDataSaveEventArgs>? UserDataSaved
     {
         add => _userDataSaved += value;
@@ -53,7 +56,11 @@ public sealed class StubUserDataManager : IUserDataManager
 
     // ---- Everything below is an unused NotImplemented stub (per the repo convention). ----
 
-    public void SaveUserData(User user, BaseItem item, UserItemData userData, UserDataSaveReason reason, CancellationToken cancellationToken) => throw new NotImplementedException();
+    public void SaveUserData(User user, BaseItem item, UserItemData userData, UserDataSaveReason reason, CancellationToken cancellationToken)
+    {
+        if (SaveUserDataHook == null) throw new NotImplementedException();
+        SaveUserDataHook(user, item, userData, reason, cancellationToken);
+    }
 
     public void SaveUserData(User user, BaseItem item, UpdateUserItemDataDto userDataDto, UserDataSaveReason reason) => throw new NotImplementedException();
 

--- a/Jellyfin.Plugin.JellyfinCanopy/Helpers/BoundedCoalescingWorker.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Helpers/BoundedCoalescingWorker.cs
@@ -1,0 +1,348 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Helpers
+{
+    /// <summary>
+    /// A single-consumer, bounded work queue that keeps only the newest value for each key.
+    /// Producers never wait: a distinct key is rejected once the fixed state capacity is full,
+    /// while updates to an already queued or active key are coalesced in constant time. The
+    /// processor must honor its cancellation token: disposal deliberately joins without a timeout
+    /// so returning from disposal is proof that no late work remains.
+    /// </summary>
+    internal sealed class BoundedCoalescingWorker<TKey, TValue> : IDisposable, IAsyncDisposable
+        where TKey : notnull
+    {
+        private readonly object _gate = new();
+        private readonly Dictionary<TKey, WorkState> _states;
+        private readonly Channel<TKey> _channel;
+        private readonly CancellationTokenSource _lifetimeCts = new();
+        private readonly Func<TValue, CancellationToken, Task> _processor;
+        private readonly Action<Exception>? _failureObserver;
+        private readonly int _capacity;
+        private readonly int _maximumAttempts;
+        private readonly Task _workerTask;
+        private long _enqueued;
+        private long _coalesced;
+        private long _dropped;
+        private long _processed;
+        private long _failures;
+        private long _retried;
+        private long _cancelled;
+        private int _queued;
+        private int _peakQueued;
+        private bool _disposed;
+        private TaskCompletionSource? _shutdownCompletion;
+
+        public BoundedCoalescingWorker(
+            int capacity,
+            int maximumAttempts,
+            Func<TValue, CancellationToken, Task> processor,
+            IEqualityComparer<TKey>? comparer = null,
+            Action<Exception>? failureObserver = null)
+        {
+            if (capacity <= 0) throw new ArgumentOutOfRangeException(nameof(capacity));
+            if (maximumAttempts <= 0) throw new ArgumentOutOfRangeException(nameof(maximumAttempts));
+
+            _capacity = capacity;
+            _maximumAttempts = maximumAttempts;
+            _processor = processor ?? throw new ArgumentNullException(nameof(processor));
+            _failureObserver = failureObserver;
+            _states = new Dictionary<TKey, WorkState>(capacity, comparer);
+            _channel = Channel.CreateBounded<TKey>(new BoundedChannelOptions(capacity)
+            {
+                SingleReader = true,
+                SingleWriter = false,
+                FullMode = BoundedChannelFullMode.Wait,
+                AllowSynchronousContinuations = false,
+            });
+            _workerTask = RunAsync();
+        }
+
+        public CoalescingWorkerMetrics Metrics
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return new CoalescingWorkerMetrics(
+                        Capacity: _capacity,
+                        WorkerTasks: 1,
+                        StateCount: _states.Count,
+                        QueueDepth: _queued,
+                        PeakQueueDepth: _peakQueued,
+                        Enqueued: _enqueued,
+                        Coalesced: _coalesced,
+                        Dropped: _dropped,
+                        Processed: _processed,
+                        Failures: _failures,
+                        Retried: _retried,
+                        Cancelled: _cancelled);
+                }
+            }
+        }
+
+        public bool TryEnqueue(TKey key, TValue value)
+        {
+            lock (_gate)
+            {
+                if (_disposed)
+                {
+                    _dropped++;
+                    return false;
+                }
+
+                if (_states.TryGetValue(key, out var existing))
+                {
+                    existing.Value = value;
+                    existing.Version++;
+                    existing.Attempt = 0;
+                    _coalesced++;
+                    return true;
+                }
+
+                if (_states.Count >= _capacity)
+                {
+                    _dropped++;
+                    return false;
+                }
+
+                var state = new WorkState(value);
+                _states.Add(key, state);
+                if (!TryPublishLocked(key, state))
+                {
+                    _states.Remove(key);
+                    _dropped++;
+                    return false;
+                }
+
+                _enqueued++;
+                return true;
+            }
+        }
+
+        public void Dispose()
+        {
+            DisposeAsync().AsTask().GetAwaiter().GetResult();
+            GC.SuppressFinalize(this);
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            TaskCompletionSource shutdownCompletion;
+            lock (_gate)
+            {
+                if (_shutdownCompletion != null)
+                {
+                    return new ValueTask(_shutdownCompletion.Task);
+                }
+
+                shutdownCompletion = new TaskCompletionSource(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                _shutdownCompletion = shutdownCompletion;
+                _disposed = true;
+                _cancelled += _states.Count;
+                _states.Clear();
+                _queued = 0;
+                _channel.Writer.TryComplete();
+            }
+
+            _ = FinishDisposeAsync(shutdownCompletion);
+            return new ValueTask(shutdownCompletion.Task);
+        }
+
+        private async Task FinishDisposeAsync(TaskCompletionSource shutdownCompletion)
+        {
+            Exception? shutdownFailure = null;
+            try
+            {
+                _lifetimeCts.Cancel();
+            }
+            catch (Exception ex)
+            {
+                shutdownFailure = ex;
+            }
+
+            try
+            {
+                await _workerTask.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (_lifetimeCts.IsCancellationRequested)
+            {
+                // Expected deterministic shutdown path.
+            }
+            catch (Exception ex)
+            {
+                shutdownFailure = shutdownFailure == null
+                    ? ex
+                    : new AggregateException(shutdownFailure, ex);
+            }
+            finally
+            {
+                _lifetimeCts.Dispose();
+            }
+
+            if (shutdownFailure == null)
+            {
+                shutdownCompletion.TrySetResult();
+            }
+            else
+            {
+                shutdownCompletion.TrySetException(shutdownFailure);
+            }
+        }
+
+        private async Task RunAsync()
+        {
+            try
+            {
+                await foreach (var key in _channel.Reader.ReadAllAsync(_lifetimeCts.Token).ConfigureAwait(false))
+                {
+                    TValue value;
+                    long version;
+                    int attempt;
+                    lock (_gate)
+                    {
+                        if (_disposed || !_states.TryGetValue(key, out var state))
+                        {
+                            continue;
+                        }
+
+                        state.Queued = false;
+                        _queued--;
+                        value = state.Value;
+                        version = state.Version;
+                        attempt = state.Attempt;
+                    }
+
+                    Exception? failure = null;
+                    try
+                    {
+                        await _processor(value, _lifetimeCts.Token).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException) when (_lifetimeCts.IsCancellationRequested)
+                    {
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        failure = ex;
+                        ObserveFailure(ex);
+                    }
+
+                    lock (_gate)
+                    {
+                        if (_disposed || !_states.TryGetValue(key, out var current))
+                        {
+                            continue;
+                        }
+
+                        if (failure == null)
+                        {
+                            _processed++;
+                            if (current.Version == version)
+                            {
+                                _states.Remove(key);
+                            }
+                            else
+                            {
+                                current.Attempt = 0;
+                                PublishRequiredLocked(key, current);
+                            }
+
+                            continue;
+                        }
+
+                        _failures++;
+                        if (current.Version != version)
+                        {
+                            current.Attempt = 0;
+                            PublishRequiredLocked(key, current);
+                        }
+                        else if (attempt + 1 < _maximumAttempts)
+                        {
+                            current.Attempt = attempt + 1;
+                            _retried++;
+                            PublishRequiredLocked(key, current);
+                        }
+                        else
+                        {
+                            _states.Remove(key);
+                        }
+                    }
+
+                }
+            }
+            catch (OperationCanceledException) when (_lifetimeCts.IsCancellationRequested)
+            {
+                // Expected deterministic shutdown path.
+            }
+        }
+
+        private bool TryPublishLocked(TKey key, WorkState state)
+        {
+            if (!_channel.Writer.TryWrite(key)) return false;
+            state.Queued = true;
+            _queued++;
+            if (_queued > _peakQueued) _peakQueued = _queued;
+            return true;
+        }
+
+        private void ObserveFailure(Exception failure)
+        {
+            if (_failureObserver == null) return;
+            try
+            {
+                _failureObserver(failure);
+            }
+            catch
+            {
+                // Diagnostics must never terminate the bounded worker.
+            }
+        }
+
+        private void PublishRequiredLocked(TKey key, WorkState state)
+        {
+            // The channel capacity equals the maximum state count. An active key occupies state
+            // capacity but no channel slot, so its replacement/retry always has one reserved slot.
+            if (!TryPublishLocked(key, state))
+            {
+                throw new InvalidOperationException("Coalescing worker lost its reserved channel slot.");
+            }
+        }
+
+        private sealed class WorkState
+        {
+            public WorkState(TValue value)
+            {
+                Value = value;
+            }
+
+            public TValue Value { get; set; }
+
+            public long Version { get; set; }
+
+            public int Attempt { get; set; }
+
+            public bool Queued { get; set; }
+
+        }
+    }
+
+    internal readonly record struct CoalescingWorkerMetrics(
+        int Capacity,
+        int WorkerTasks,
+        int StateCount,
+        int QueueDepth,
+        int PeakQueueDepth,
+        long Enqueued,
+        long Coalesced,
+        long Dropped,
+        long Processed,
+        long Failures,
+        long Retried,
+        long Cancelled);
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/LiveNotifierService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/LiveNotifierService.cs
@@ -55,6 +55,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         private readonly ISessionManager _sessionManager;
         private readonly ILiveSessionRegistry _liveSessionRegistry;
         private readonly ISeerrCache _seerrCache;
+        private readonly WatchlistMonitor _watchlistMonitor;
         private readonly ILogger<LiveNotifierService> _logger;
 
         private BasePlugin<PluginConfiguration>? _plugin;
@@ -65,12 +66,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             ISessionManager sessionManager,
             ILiveSessionRegistry liveSessionRegistry,
             ISeerrCache seerrCache,
+            WatchlistMonitor watchlistMonitor,
             ILogger<LiveNotifierService> logger)
         {
             _pluginManager = pluginManager;
             _sessionManager = sessionManager;
             _liveSessionRegistry = liveSessionRegistry;
             _seerrCache = seerrCache;
+            _watchlistMonitor = watchlistMonitor;
             _logger = logger;
         }
 
@@ -129,6 +132,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         /// </summary>
         internal async Task HandleConfigurationChangedAsync(CancellationToken cancellationToken)
         {
+            _watchlistMonitor.NotifyConfigurationChanged();
+
             try
             {
                 _seerrCache.ClearAllSeerrCachesOnConfigChange();

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/WatchlistMonitor.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/WatchlistMonitor.cs
@@ -34,21 +34,25 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         private readonly UserConfigurationManager _userConfigurationManager;
         private readonly ILogger<WatchlistMonitor> _logger;
         private readonly IPluginConfigProvider _configProvider;
-        private readonly BoundedTtlCache<string, List<RequestItemWithUser>> _requestsCache = new(
+        private const int WorkQueueCapacity = 1024;
+        // A local mutation batch can be partially committed before an unexpected exception.
+        // Do not replay it automatically; the next Jellyfin update event is the safe re-drive.
+        private const int WorkMaximumAttempts = 1;
+        private readonly BoundedTtlCache<string, RequestSnapshot> _requestsCache = new(
             maximumEntries: 64,
             maximumWeight: 100_000,
-            weight: static (key, items) => key.Length + items.Count,
+            weight: static (key, snapshot) => key.Length + snapshot.Weight,
             comparer: StringComparer.Ordinal,
             defaultTtl: GetRequestsCacheTtl);
         private readonly object _requestsCacheLock = new();
-        private readonly ConcurrentDictionary<string, Lazy<Task<List<RequestItemWithUser>?>>> _requestsInFlight = new();
+        private readonly ConcurrentDictionary<string, Lazy<Task<RequestSnapshot?>>> _requestsInFlight = new();
         private readonly object _lifecycleLock = new();
-        private readonly HashSet<Task> _activeTasks = new();
-        private readonly CancellationTokenSource _lifetimeCts = new();
+        private readonly object _configurationCancellationLock = new();
+        private readonly BoundedCoalescingWorker<Guid, WatchlistWorkItem> _workQueue;
+        private ConfigurationGeneration _configurationGeneration = new(0);
         private bool _subscribed;
         private bool _disposed;
-        private bool _cancellationIssued;
-        private bool _lifetimeCtsDisposed;
+        private bool _configurationCtsDisposed;
 
         public WatchlistMonitor(
             ILibraryManager libraryManager,
@@ -66,6 +70,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             _userConfigurationManager = userConfigurationManager;
             _configProvider = configProvider;
             _logger = logger;
+            _workQueue = new BoundedCoalescingWorker<Guid, WatchlistWorkItem>(
+                WorkQueueCapacity,
+                WorkMaximumAttempts,
+                ProcessQueuedItemAsync);
         }
 
         private static TimeSpan GetRequestsCacheTtl()
@@ -109,61 +117,111 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         // Handle library item updated events (fires after metadata refresh) to check if they match pending watchlist items.
         private void OnItemUpdated(object? sender, ItemChangeEventArgs e) => ScheduleWatchlistCheck(e, "ItemUpdated");
 
-        // PERF(S1): ItemAdded/ItemUpdated fire synchronously on Jellyfin's library-scan thread. Do only
-        // the cheap Movie/Series reject here, then run the Seerr request lookup + per-user watchlist
-        // writes off-thread. (Awaiting ProcessItemForWatchlist is NOT enough: GetAllSeerrRequests
-        // returns synchronously on a cache hit, so the continuation would run on the scan thread.)
+        // PERF(S1): ItemAdded/ItemUpdated fire synchronously on Jellyfin's library-scan thread. Do
+        // only constant-time gates and a non-blocking bounded enqueue here. One lifecycle-owned
+        // worker performs the Seerr request lookup + per-user watchlist writes off-thread.
         // See docs/advanced/performance-rules.md (S1).
         private void ScheduleWatchlistCheck(ItemChangeEventArgs e, string eventType)
         {
             var kind = e.Item?.GetBaseItemKind();
             if (kind != BaseItemKind.Movie && kind != BaseItemKind.Series) return;
 
-            Task task;
+            var configRevision = _configProvider.ConfigurationRevision;
+            var config = _configProvider.ConfigurationOrNull;
+            if (_configProvider.ConfigurationRevision != configRevision) return;
+            if (config?.AddRequestedMediaToWatchlist != true || !config.SeerrEnabled) return;
+
+            long configurationGeneration;
+            lock (_configurationCancellationLock)
+            {
+                if (_configurationCtsDisposed) return;
+                configurationGeneration = _configurationGeneration.Number;
+            }
+
+            var work = new WatchlistWorkItem(
+                e.Item!,
+                eventType,
+                configRevision,
+                configurationGeneration);
+            if (!_workQueue.TryEnqueue(e.Item!.Id, work))
+            {
+                var metrics = _workQueue.Metrics;
+                if (metrics.Dropped == 1 || (metrics.Dropped & (metrics.Dropped - 1)) == 0)
+                {
+                    _logger.LogWarning(
+                        "[Watchlist] Bounded event queue rejected work: depth={QueueDepth}, states={StateCount}, capacity={Capacity}, dropped={Dropped}.",
+                        metrics.QueueDepth,
+                        metrics.StateCount,
+                        metrics.Capacity,
+                        metrics.Dropped);
+                }
+            }
+        }
+
+        private async Task ProcessQueuedItemAsync(WatchlistWorkItem work, CancellationToken cancellationToken)
+        {
+            ConfigurationGeneration configurationGeneration;
+            CancellationToken configurationToken;
+            lock (_configurationCancellationLock)
+            {
+                if (_configurationCtsDisposed) return;
+                configurationGeneration = _configurationGeneration;
+                configurationToken = configurationGeneration.Cancellation.Token;
+            }
+
+            // The explicit generation is advanced by the ConfigurationChanged event and does not
+            // depend on when the provider first observes the replacement object. Capturing the
+            // state object before both checks means a concurrent save either changes the number or
+            // cancels this exact token; old work can never adopt a new generation's token.
+            if (configurationGeneration.Number != work.ConfigurationGeneration
+                || _configProvider.ConfigurationRevision != work.ConfigurationRevision)
+            {
+                return;
+            }
+
+            using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(
+                cancellationToken,
+                configurationToken);
+            try
+            {
+                await ProcessItemForWatchlist(
+                    work.Item,
+                    work.EventType,
+                    operationCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (
+                configurationToken.IsCancellationRequested
+                && !cancellationToken.IsCancellationRequested)
+            {
+                // A plugin configuration/account save superseded this generation. Queued keys
+                // carry the prior revision and are discarded before their next remote read.
+            }
+        }
+
+        internal CoalescingWorkerMetrics QueueMetrics => _workQueue.Metrics;
+
+        internal void NotifyConfigurationChanged()
+        {
             lock (_lifecycleLock)
             {
                 if (_disposed) return;
-
-                var cancellationToken = _lifetimeCts.Token;
-                task = Task.Run(
-                    () => ProcessItemForWatchlist(e, eventType, cancellationToken),
-                    CancellationToken.None);
-                _activeTasks.Add(task);
             }
 
-            _ = task.ContinueWith(
-                completedTask => OnScheduledTaskCompleted(completedTask),
-                CancellationToken.None,
-                TaskContinuationOptions.ExecuteSynchronously,
-                TaskScheduler.Default);
-        }
-
-        private void OnScheduledTaskCompleted(Task completedTask)
-        {
-            // ProcessItemForWatchlist handles operation failures itself. Observe any unexpected
-            // scheduling fault here so a fire-and-forget task can never become unobserved.
-            if (completedTask.IsFaulted)
+            ConfigurationGeneration previous;
+            lock (_configurationCancellationLock)
             {
-                _logger.LogError(
-                    completedTask.Exception,
-                    "[Watchlist] Unexpected failure in scheduled watchlist processing");
+                if (_configurationCtsDisposed) return;
+                previous = _configurationGeneration;
+                _configurationGeneration = new ConfigurationGeneration(previous.Number + 1);
             }
 
-            CancellationTokenSource? ctsToDispose = null;
-            lock (_lifecycleLock)
-            {
-                _activeTasks.Remove(completedTask);
-                if (_disposed
-                    && _cancellationIssued
-                    && _activeTasks.Count == 0
-                    && !_lifetimeCtsDisposed)
-                {
-                    _lifetimeCtsDisposed = true;
-                    ctsToDispose = _lifetimeCts;
-                }
-            }
-
-            ctsToDispose?.Dispose();
+            // Cancel outside locks because callbacks can complete the active operation inline.
+            // Cancel-before-dispose guarantees already-captured tokens observe cancellation; .NET
+            // cancellation tokens remain readable after their source is disposed.
+            previous.Cancellation.Cancel();
+            previous.Cancellation.Dispose();
+            _logger.LogInformation(
+                "[Watchlist] Configuration changed; cancelled the active generation and invalidated queued work.");
         }
 
         // Deterministic test seam over the same operation scheduled by library events. Keeping
@@ -172,14 +230,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         internal Task ProcessItemForWatchlistForTestAsync(
             BaseItem item,
             CancellationToken cancellationToken = default)
-            => ProcessItemForWatchlist(
-                new ItemChangeEventArgs { Item = item },
-                "Test",
-                cancellationToken);
+            => ProcessItemForWatchlist(item, "Test", cancellationToken);
 
         // Process an item from library events to check if it matches any Seerr requests.
         private async Task ProcessItemForWatchlist(
-            ItemChangeEventArgs e,
+            BaseItem item,
             string eventType,
             CancellationToken cancellationToken)
         {
@@ -188,7 +243,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 cancellationToken.ThrowIfCancellationRequested();
 
                 // Only process movies and TV series - check this first to avoid spam
-                var itemKind = e.Item?.GetBaseItemKind();
+                var itemKind = item.GetBaseItemKind();
                 if (itemKind != BaseItemKind.Movie && itemKind != BaseItemKind.Series)
                 {
                     return;
@@ -224,15 +279,15 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 var configStamp = SeerrMutationConfigStamp.Capture(config, configRevision);
 
                 // Check if item has TMDB ID
-                if (e.Item?.ProviderIds == null)
+                if (item.ProviderIds == null)
                 {
-                    _logger.LogDebug($"[Watchlist] [{eventType}] Item has no ProviderIds yet: {e.Item?.Name}");
+                    _logger.LogDebug($"[Watchlist] [{eventType}] Item has no ProviderIds yet: {item.Name}");
                     return;
                 }
 
-                if (!e.Item.ProviderIds.TryGetValue("Tmdb", out var tmdbIdString))
+                if (!item.ProviderIds.TryGetValue("Tmdb", out var tmdbIdString))
                 {
-                    _logger.LogDebug($"[Watchlist] [{eventType}] Item has no TMDB ID yet: {e.Item.Name}");
+                    _logger.LogDebug($"[Watchlist] [{eventType}] Item has no TMDB ID yet: {item.Name}");
                     return;
                 }
 
@@ -269,14 +324,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     return;
                 }
 
-                // Find requests matching this TMDB ID and media type. Every row retained here
-                // already carries its normalized source, positive source-local Seerr owner id,
-                // and canonical Jellyfin GUID.
-                var matchingRequests = allRequests
-                    .Where(r => r.TmdbId == tmdbId && r.MediaType == mediaType)
-                    .ToList();
-
-                if (matchingRequests.Count == 0)
+                // The complete request projection is indexed once when its cache snapshot is
+                // built, so each library item performs one O(1) key lookup rather than rescanning
+                // every Seerr request.
+                if (!allRequests.TryGet(mediaType, tmdbId, out var matchingRequests))
                 {
                     return;
                 }
@@ -347,7 +398,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                         }
                     }
 
-                    var userData = _userDataManager.GetUserData(user, e.Item);
+                    var userData = _userDataManager.GetUserData(user, item);
                     if (userData != null && userData.Likes != true)
                     {
                         pendingMutations.Add(new PendingWatchlistMutation(user, userData, addLike: true));
@@ -405,7 +456,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                         pending.UserData.Likes = true;
                         _userDataManager.SaveUserData(
                             pending.User,
-                            e.Item,
+                            item,
                             pending.UserData,
                             UserDataSaveReason.UpdateUserRating,
                             cancellationToken);
@@ -427,17 +478,17 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 // Only log if we actually added the item to at least one watchlist
                 if (addedCount > 0)
                 {
-                    _logger.LogInformation($"[Watchlist] ✓ Added '{e.Item.Name}' to watchlist for {string.Join(", ", addedUsers)}");
+                    _logger.LogInformation($"[Watchlist] ✓ Added '{item.Name}' to watchlist for {string.Join(", ", addedUsers)}");
                 }
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
-                // The lifetime token is cancelled only by Dispose. Shutdown cancellation is an
-                // expected completion path and must not be reported as an operation failure.
+                throw;
             }
             catch (Exception ex)
             {
                 _logger.LogError($"[Watchlist] Error in ProcessItemForWatchlist: {ex.Message}\nStack trace: {ex.StackTrace}");
+                throw;
             }
         }
 
@@ -475,7 +526,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         // Get a complete request snapshot from every configured Seerr identity
         // domain. No domain's rows are cached or acted on unless all domains
         // complete independently.
-        private async Task<List<RequestItemWithUser>?> GetAllSeerrRequests(
+        private async Task<RequestSnapshot?> GetAllSeerrRequests(
             HttpClient httpClient,
             IReadOnlyList<string> seerrUrls,
             string apiKey,
@@ -494,7 +545,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 }
             }
 
-            async Task<List<RequestItemWithUser>?> FetchAsync()
+            async Task<RequestSnapshot?> FetchAsync()
             {
                 try
                 {
@@ -540,7 +591,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                         }
                     }
 
-                    return items;
+                    return RequestSnapshot.Create(items);
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
@@ -553,30 +604,30 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 }
             }
 
-            async Task<List<RequestItemWithUser>?> FetchAndCacheAsync()
+            async Task<RequestSnapshot?> FetchAndCacheAsync()
             {
-                var fetchedItems = await FetchAsync().ConfigureAwait(false);
-                if (fetchedItems != null)
+                var fetchedSnapshot = await FetchAsync().ConfigureAwait(false);
+                if (fetchedSnapshot != null)
                 {
                     // Populate the result cache before the shared task completes.
                     // This closes the completion/removal window in which a new
                     // caller could otherwise start a duplicate fetch.
                     lock (_requestsCacheLock)
                     {
-                        _requestsCache.Set(cacheKey, fetchedItems, cacheTtl);
+                        _requestsCache.Set(cacheKey, fetchedSnapshot, cacheTtl);
                     }
                 }
 
-                return fetchedItems;
+                return fetchedSnapshot;
             }
 
             var fetchTask = Helpers.AsyncSingleFlight.GetOrAdd(
                 _requestsInFlight,
                 cacheKey,
                 FetchAndCacheAsync);
-            var items = await fetchTask.ConfigureAwait(false);
+            var snapshot = await fetchTask.ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
-            return items;
+            return snapshot;
         }
 
         internal static string BuildRequestsCacheKey(
@@ -828,24 +879,50 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 _subscribed = false;
             }
 
-            // Cancellation runs outside the lifecycle lock because token callbacks are allowed to
-            // complete scheduled tasks synchronously. The CTS is disposed only after every task
-            // that captured its token has completed.
-            _lifetimeCts.Cancel();
-
-            CancellationTokenSource? ctsToDispose = null;
-            lock (_lifecycleLock)
+            ConfigurationGeneration configurationGeneration;
+            lock (_configurationCancellationLock)
             {
-                _cancellationIssued = true;
-                if (_activeTasks.Count == 0 && !_lifetimeCtsDisposed)
-                {
-                    _lifetimeCtsDisposed = true;
-                    ctsToDispose = _lifetimeCts;
-                }
+                _configurationCtsDisposed = true;
+                configurationGeneration = _configurationGeneration;
             }
 
-            ctsToDispose?.Dispose();
+            configurationGeneration.Cancellation.Cancel();
+
+            // Complete/cancel and synchronously join the one owned worker so no operation can
+            // outlive plugin disposal or perform a late local write.
+            _workQueue.Dispose();
+            configurationGeneration.Cancellation.Dispose();
+            var metrics = _workQueue.Metrics;
+            _logger.LogInformation(
+                "[Watchlist] Worker stopped: capacity={Capacity}, peakDepth={PeakQueueDepth}, enqueued={Enqueued}, coalesced={Coalesced}, dropped={Dropped}, processed={Processed}, failures={Failures}, retries={Retried}, cancelled={Cancelled}.",
+                metrics.Capacity,
+                metrics.PeakQueueDepth,
+                metrics.Enqueued,
+                metrics.Coalesced,
+                metrics.Dropped,
+                metrics.Processed,
+                metrics.Failures,
+                metrics.Retried,
+                metrics.Cancelled);
             GC.SuppressFinalize(this);
+        }
+
+        private sealed record WatchlistWorkItem(
+            BaseItem Item,
+            string EventType,
+            long ConfigurationRevision,
+            long ConfigurationGeneration);
+
+        private sealed class ConfigurationGeneration
+        {
+            public ConfigurationGeneration(long number)
+            {
+                Number = number;
+            }
+
+            public long Number { get; }
+
+            public CancellationTokenSource Cancellation { get; } = new();
         }
 
         private sealed class PendingWatchlistMutation
@@ -865,7 +942,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         }
 
         // Model for Seerr request items with requesting user
-        private sealed class RequestItemWithUser
+        internal sealed class RequestItemWithUser
         {
             public int TmdbId { get; set; }
             public string MediaType { get; set; } = string.Empty;
@@ -873,5 +950,60 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             public string RequestedBySeerrUserId { get; set; } = string.Empty;
             public string RequestedByJellyfinUserId { get; set; } = string.Empty;
         }
+
+        internal sealed class RequestSnapshot
+        {
+            private readonly IReadOnlyDictionary<RequestKey, IReadOnlyList<RequestItemWithUser>> _index;
+
+            private RequestSnapshot(
+                int count,
+                IReadOnlyDictionary<RequestKey, IReadOnlyList<RequestItemWithUser>> index)
+            {
+                Count = count;
+                _index = index;
+            }
+
+            public int Count { get; }
+
+            public int Weight => Count + _index.Count;
+
+            public bool TryGet(
+                string mediaType,
+                int tmdbId,
+                out IReadOnlyList<RequestItemWithUser> requests)
+            {
+                if (_index.TryGetValue(new RequestKey(mediaType, tmdbId), out var found))
+                {
+                    requests = found;
+                    return true;
+                }
+
+                requests = Array.Empty<RequestItemWithUser>();
+                return false;
+            }
+
+            public static RequestSnapshot Create(IReadOnlyCollection<RequestItemWithUser> items)
+            {
+                var mutable = new Dictionary<RequestKey, List<RequestItemWithUser>>();
+                foreach (var item in items)
+                {
+                    var key = new RequestKey(item.MediaType, item.TmdbId);
+                    if (!mutable.TryGetValue(key, out var requests))
+                    {
+                        requests = new List<RequestItemWithUser>();
+                        mutable.Add(key, requests);
+                    }
+
+                    requests.Add(item);
+                }
+
+                var index = mutable.ToDictionary(
+                    pair => pair.Key,
+                    pair => (IReadOnlyList<RequestItemWithUser>)pair.Value);
+                return new RequestSnapshot(items.Count, index);
+            }
+        }
+
+        internal readonly record struct RequestKey(string MediaType, int TmdbId);
     }
 }

--- a/research/watchlist-worker-106-benchmark.md
+++ b/research/watchlist-worker-106-benchmark.md
@@ -1,0 +1,25 @@
+# Watchlist worker #106 bounded-load benchmark
+
+The regression harness submits 15,000 distinct work keys while the single consumer is
+deliberately blocked. It records the worker-task count, accepted calls, queue depth, elapsed
+producer time, and process-wide managed allocations. The assertions deliberately avoid a
+machine-specific time or allocation threshold; they enforce the structural bounds instead.
+
+Run on 2026-07-15 with .NET 10.0.9:
+
+```text
+events=15000 workerTasks=1 capacity=64 accepted=64 dropped=14936 peakDepth=63 callsWhileBlocked=1 elapsedMs=6.815 allocatedBytes=6088
+```
+
+Reproduce with:
+
+```bash
+dotnet test Jellyfin.Plugin.JellyfinCanopy.Tests/JellyfinCanopy.Tests.csproj \
+  --filter 'FullyQualifiedName~DistinctEventStorm_RejectsBeyondFixedCapacityWithoutCreatingTasks' \
+  --logger 'console;verbosity=detailed'
+```
+
+The production `WatchlistMonitor` uses the same primitive at a capacity of 1,024. A separate
+monitor integration test raises 10,000 duplicate Jellyfin library events for one item while the
+worker is active and proves they retain one state entry, one owned worker task, zero drops, and
+exactly one follow-up operation containing the newest event.

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -19,7 +19,7 @@ const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the repeated clean measurements', () => {
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1364, totalLines: 1692 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 13486, totalLines: 21660 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 13487, totalLines: 21661 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 1);
 });

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -19,7 +19,7 @@ const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the repeated clean measurements', () => {
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1364, totalLines: 1692 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 13263, totalLines: 21411 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 13486, totalLines: 21660 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 1);
 });

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -21,8 +21,8 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 13486,
-        "totalLines": 21660
+        "coveredLines": 13487,
+        "totalLines": 21661
       },
       "tolerance": {
         "missingCoveredLines": 1,

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -21,8 +21,8 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 13263,
-        "totalLines": 21411
+        "coveredLines": 13486,
+        "totalLines": 21660
       },
       "tolerance": {
         "missingCoveredLines": 1,


### PR DESCRIPTION
Closes #106

## What changed

- replace one detached `Task.Run` per Jellyfin library event with one lifecycle-owned bounded channel worker
- coalesce ItemAdded/ItemUpdated events by Jellyfin item ID while retaining the newest event
- enforce a hard 1,024-key production bound, fixed single-worker concurrency, explicit drop/failure/retry metrics, and deterministic shutdown joining
- cancel active work and drain stale queued generations on plugin configuration/account saves
- index each complete Seerr request snapshot once by `(mediaType, tmdbId)` for O(1) item matching
- retain mutation authorization barriers and avoid replaying partially applied local mutation batches
- add 10,000-duplicate and 15,000-distinct load evidence, config-race, disposal/no-late-write, retry-bound, and request-index tests

## Validation

- 1,295/1,295 .NET tests
- server coverage: 13,486/21,660 lines = 62.262% on two identical clean runs
- 294/294 script tests
- 845/845 client tests
- lint: 0 errors (existing warning inventory only)
- TypeScript checks, syntax inventory, translations, and Release build pass
- three independent Fable-low review passes: APPROVE; all concrete race/test findings addressed

## E2E image policy

The Dockerized Jellyfin 12 evidence lane remains on the digest-pinned `jellyfin/jellyfin:unstable` nightly. The advisory compatibility lane remains on the moving `unstable` tag. No RC1/RC2 image is introduced.