### PR TITLE
Bound asset cache outage retries and browser fallbacks

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Configuration/AssetFallbackSourceTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Configuration/AssetFallbackSourceTests.cs
@@ -1,0 +1,26 @@
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Configuration
+{
+    /// <summary>Guards the no-third-party-browser-assets half of the local mirror contract.</summary>
+    public sealed class AssetFallbackSourceTests
+    {
+        private static readonly Regex AutomaticRemoteAsset = new(
+            "(?:src|srcset)\\s*=\\s*['\"]\\s*https?://" +
+            "|url\\(\\s*['\"]?\\s*https?://" +
+            "|@import\\s+(?:url\\()?\\s*['\"]?\\s*https?://" +
+            "|onerror\\s*=\\s*['\"][^'\"]*https?://" +
+            "|<link\\b[^>]*\\bhref\\s*=\\s*['\"]\\s*https?://" +
+            "|(?:fetch|import)\\s*\\(\\s*['\"]\\s*https?://",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        [Fact]
+        public void ConfigPage_OutageFallbacks_CannotInitiateThirdPartyAssetRequests()
+        {
+            var match = AutomaticRemoteAsset.Match(ConfigPageSource.Html);
+
+            Assert.False(match.Success, $"Automatic remote asset fallback remains in configPage.html: {match.Value}");
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/AssetCacheServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/AssetCacheServiceTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Text;
 using Jellyfin.Plugin.JellyfinCanopy.Services;
 using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -34,11 +35,17 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             }
         }
 
-        private AssetCacheService CreateService(RecordingHttpMessageHandler handler)
+        private AssetCacheService CreateService(
+            HttpMessageHandler handler,
+            TimeProvider? timeProvider = null,
+            int maxConcurrentFetches = 8,
+            ILogger<AssetCacheService>? logger = null)
             => new(
                 new RecordingHttpClientFactory(handler),
-                NullLogger<AssetCacheService>.Instance,
-                _cacheDir);
+                logger ?? NullLogger<AssetCacheService>.Instance,
+                _cacheDir,
+                timeProvider,
+                maxConcurrentFetches);
 
         // ---- Manifest integrity ------------------------------------------------------------
 
@@ -378,6 +385,95 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             Assert.True(File.Exists(Path.Combine(_cacheDir, "elsewhere", "regions.txt")));
         }
 
+        [Fact]
+        public async Task EnsureCached_OneHundredSameKeyFailures_FetchOncePerBackoffWindow()
+        {
+            var handler = new RecordingHttpMessageHandler();
+            var clock = new ManualTimeProvider(new DateTimeOffset(2026, 7, 15, 0, 0, 0, TimeSpan.Zero));
+            var logger = new CapturingLogger<AssetCacheService>();
+            var service = CreateService(handler, clock, logger: logger);
+            var asset = service.Resolve("icons/seerr.svg");
+
+            var firstWindow = await Task.WhenAll(Enumerable.Range(0, 100)
+                .Select(_ => service.EnsureCachedAsync(asset, forceRefresh: false, CancellationToken.None)));
+
+            Assert.All(firstWindow, Assert.Null);
+            Assert.Single(handler.Requests);
+            Assert.Single(logger.WarningMessages);
+            Assert.Equal(1, service.FailureStateCount);
+
+            clock.Advance(TimeSpan.FromSeconds(29));
+            await Task.WhenAll(Enumerable.Range(0, 100)
+                .Select(_ => service.EnsureCachedAsync(asset, forceRefresh: false, CancellationToken.None)));
+            Assert.Single(handler.Requests);
+            Assert.Single(logger.WarningMessages);
+
+            // At expiry, exactly one caller becomes the retry leader. Its failure opens the next
+            // (one-minute) window before any of the remaining 99 waiters may fetch.
+            clock.Advance(TimeSpan.FromSeconds(1));
+            await Task.WhenAll(Enumerable.Range(0, 100)
+                .Select(_ => service.EnsureCachedAsync(asset, forceRefresh: false, CancellationToken.None)));
+            Assert.Equal(2, handler.Requests.Count);
+            Assert.Equal(2, logger.WarningMessages.Count);
+        }
+
+        [Fact]
+        public async Task EnsureCached_DifferentKeys_NeverExceedGlobalFetchLimit()
+        {
+            const int limit = 3;
+            var handler = new BlockingFailureHandler(limit);
+            var service = CreateService(handler, maxConcurrentFetches: limit);
+            var tasks = Enumerable.Range(0, 20)
+                .Select(i =>
+                {
+                    var first = (char)('a' + (i / 26));
+                    var second = (char)('a' + (i % 26));
+                    return service.EnsureCachedAsync(
+                        service.Resolve($"flags/4x3/{first}{second}.svg"),
+                        forceRefresh: false,
+                        CancellationToken.None);
+                })
+                .ToArray();
+
+            var reached = await Task.WhenAny(handler.ReachedLimit, Task.Delay(TimeSpan.FromSeconds(5)));
+            Assert.Same(handler.ReachedLimit, reached);
+            Assert.Equal(limit, handler.PeakActive);
+
+            handler.Release();
+            await Task.WhenAll(tasks);
+
+            Assert.Equal(20, handler.Calls);
+            Assert.Equal(limit, handler.PeakActive);
+        }
+
+        [Fact]
+        public async Task EnsureCached_SuccessfulRecovery_ClearsNegativeStateOnce()
+        {
+            var handler = new RecordingHttpMessageHandler();
+            var clock = new ManualTimeProvider(new DateTimeOffset(2026, 7, 15, 0, 0, 0, TimeSpan.Zero));
+            var logger = new CapturingLogger<AssetCacheService>();
+            var service = CreateService(handler, clock, logger: logger);
+            var asset = service.Resolve("elsewhere/providers.txt");
+
+            Assert.Null(await service.EnsureCachedAsync(asset, forceRefresh: false, CancellationToken.None));
+            Assert.Equal(1, service.FailureStateCount);
+
+            handler.AddResponse("/resources/providers.txt", "Netflix");
+            clock.Advance(TimeSpan.FromSeconds(30));
+            var recovered = await service.EnsureCachedAsync(asset, forceRefresh: false, CancellationToken.None);
+
+            Assert.NotNull(recovered);
+            Assert.Equal("Netflix", await File.ReadAllTextAsync(recovered!));
+            Assert.Equal(0, service.FailureStateCount);
+            Assert.Single(logger.InformationMessages);
+
+            // A normal cache hit neither contacts upstream nor repeats the recovery transition.
+            var requests = handler.Requests.Count;
+            Assert.Equal(recovered, await service.EnsureCachedAsync(asset, forceRefresh: false, CancellationToken.None));
+            Assert.Equal(requests, handler.Requests.Count);
+            Assert.Single(logger.InformationMessages);
+        }
+
         // ---- Embedded assets --------------------------------------------------------------------
 
         [Fact]
@@ -394,6 +490,104 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             Assert.Contains("<svg", svg, StringComparison.Ordinal);
             // The guaranteed placeholder must not itself depend on the network.
             Assert.DoesNotContain("http", svg.Replace("http://www.w3.org", string.Empty, StringComparison.Ordinal), StringComparison.Ordinal);
+        }
+
+        private sealed class ManualTimeProvider : TimeProvider
+        {
+            private DateTimeOffset _now;
+
+            public ManualTimeProvider(DateTimeOffset now) => _now = now;
+
+            public override DateTimeOffset GetUtcNow() => _now;
+
+            public void Advance(TimeSpan amount) => _now = _now.Add(amount);
+        }
+
+        private sealed class BlockingFailureHandler : HttpMessageHandler
+        {
+            private readonly int _expectedLimit;
+            private readonly TaskCompletionSource _reachedLimit = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly TaskCompletionSource _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private int _active;
+            private int _calls;
+            private int _peakActive;
+
+            public BlockingFailureHandler(int expectedLimit) => _expectedLimit = expectedLimit;
+
+            public Task ReachedLimit => _reachedLimit.Task;
+
+            public int Calls => Volatile.Read(ref _calls);
+
+            public int PeakActive => Volatile.Read(ref _peakActive);
+
+            public void Release() => _release.TrySetResult();
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                Interlocked.Increment(ref _calls);
+                var active = Interlocked.Increment(ref _active);
+                UpdatePeak(active);
+                if (active >= _expectedLimit)
+                {
+                    _reachedLimit.TrySetResult();
+                }
+
+                try
+                {
+                    await _release.Task.WaitAsync(cancellationToken);
+                    return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+                    {
+                        Content = new StringContent("unavailable"),
+                    };
+                }
+                finally
+                {
+                    Interlocked.Decrement(ref _active);
+                }
+            }
+
+            private void UpdatePeak(int candidate)
+            {
+                while (true)
+                {
+                    var current = Volatile.Read(ref _peakActive);
+                    if (candidate <= current || Interlocked.CompareExchange(ref _peakActive, candidate, current) == current)
+                    {
+                        return;
+                    }
+                }
+            }
+        }
+
+        private sealed class CapturingLogger<T> : ILogger<T>
+        {
+            public List<string> WarningMessages { get; } = new();
+
+            public List<string> InformationMessages { get; } = new();
+
+            public IDisposable? BeginScope<TState>(TState state)
+                where TState : notnull
+                => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                var message = formatter(state, exception);
+                if (logLevel == LogLevel.Warning)
+                {
+                    WarningMessages.Add(message);
+                }
+                else if (logLevel == LogLevel.Information)
+                {
+                    InformationMessages.Add(message);
+                }
+            }
         }
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinCanopy/Configuration/configPage.html
@@ -20,17 +20,14 @@
         })();
     </script>
     <style>
-        /* PERF: no remote assets — the local asset cache is tried first (relative
-           URL resolves against /web/, mirroring the injected script tag), and the
-           original fonts.gstatic.com source only loads if the local copy is
-           unavailable (asset cache disabled or not yet populated). */
+        /* PERF: no remote browser assets. The server-side cache owns any upstream
+           lookup; an outage falls back to the existing local copy or system icons. */
         @font-face {
             font-family: 'Material Symbols Rounded';
             font-style: normal;
             font-weight: 100 700;
             font-display: block;
-            src: url(../JellyfinCanopy/assets/fonts/material-symbols-rounded.woff2) format('woff2'),
-                 url(https://fonts.gstatic.com/s/materialsymbolsrounded/v258/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rIelXxc.woff2) format('woff2');
+            src: url(../JellyfinCanopy/assets/fonts/material-symbols-rounded.woff2) format('woff2');
         }
         .material-symbols-rounded {
             font-family: 'Material Symbols Rounded';
@@ -95,7 +92,7 @@
                 <button class="jellyfin-tab-button" data-tab="pages" data-group="pages"><h3><i class="material-icons jc-tab-icon" aria-hidden="true">view_list</i>Page Settings</h3></button>
                 <button class="jellyfin-tab-button" data-tab="discovery" data-group="discovery"><h3><i class="material-icons jc-tab-icon" aria-hidden="true">explore</i>Discovery Feed</h3></button>
                 <button class="jellyfin-tab-button" data-tab="elsewhere" data-group="discovery"><h3><i class="material-icons jc-tab-icon" aria-hidden="true">travel_explore</i>Streaming Availability</h3></button>
-                <button class="jellyfin-tab-button" data-tab="seerr" data-group="connections"><h3><img src="../JellyfinCanopy/assets/icons/seerr.svg" onerror="this.onerror=null;this.src='https://cdn.jsdelivr.net/gh/selfhst/icons/svg/seerr.svg';" alt="" class="jc-tab-icon-img">Seerr</h3></button>
+                <button class="jellyfin-tab-button" data-tab="seerr" data-group="connections"><h3><img src="../JellyfinCanopy/assets/icons/seerr.svg" onerror="this.onerror=null;this.src='../JellyfinCanopy/assets/branding/canopy-mark.svg';" alt="" class="jc-tab-icon-img">Seerr</h3></button>
                 <button class="jellyfin-tab-button" data-tab="arr" data-group="connections"><h3><i class="material-icons jc-tab-icon" aria-hidden="true">dns</i>Media Managers</h3></button>
                 <button class="jellyfin-tab-button" data-tab="admin" data-group="governance"><h3><i class="material-icons jc-tab-icon" aria-hidden="true">admin_panel_settings</i>Server Controls</h3></button>
                 <button class="jellyfin-tab-button" data-tab="docs" data-group="system"><h3><i class="material-icons jc-tab-icon" aria-hidden="true">menu_book</i>Help &amp; Docs</h3></button>
@@ -1568,7 +1565,7 @@
                     </div>
 
                     <fieldset data-dep-setup>
-                        <legend class="sectionTitle"><img class="jc-legend-icon-img" src="../JellyfinCanopy/assets/icons/sonarr.svg" onerror="this.onerror=null;this.src='https://cdn.jsdelivr.net/gh/selfhst/icons/svg/sonarr.svg';" alt="">Sonarr</legend>
+                        <legend class="sectionTitle"><img class="jc-legend-icon-img" src="../JellyfinCanopy/assets/icons/sonarr.svg" onerror="this.onerror=null;this.src='../JellyfinCanopy/assets/branding/canopy-mark.svg';" alt="">Sonarr</legend>
                         <div class="configSection">
                             <div class="jc-setting-description" data-desc-for="sonarrInstancesList">
                                 <div class="fieldDescription">Automated TV show collection management and monitoring. Add one instance per Sonarr server.</div>
@@ -1583,7 +1580,7 @@
                     </fieldset>
 
                     <fieldset data-dep-setup>
-                        <legend class="sectionTitle"><img class="jc-legend-icon-img" src="../JellyfinCanopy/assets/icons/radarr-light-hybrid-light.svg" onerror="this.onerror=null;this.src='https://cdn.jsdelivr.net/gh/selfhst/icons/svg/radarr-light-hybrid-light.svg';" alt="">Radarr</legend>
+                        <legend class="sectionTitle"><img class="jc-legend-icon-img" src="../JellyfinCanopy/assets/icons/radarr-light-hybrid-light.svg" onerror="this.onerror=null;this.src='../JellyfinCanopy/assets/branding/canopy-mark.svg';" alt="">Radarr</legend>
                         <div class="configSection">
                             <div class="jc-setting-description" data-desc-for="radarrInstancesList">
                                 <div class="fieldDescription">Automated movie collection management and monitoring. Add one instance per Radarr server.</div>
@@ -1598,7 +1595,7 @@
                     </fieldset>
 
                     <fieldset data-dep-setup>
-                        <legend class="sectionTitle"><img class="jc-legend-icon-img" src="../JellyfinCanopy/assets/icons/bazarr.svg" onerror="this.onerror=null;this.src='https://cdn.jsdelivr.net/gh/selfhst/icons/svg/bazarr.svg';" alt="">Bazarr</legend>
+                        <legend class="sectionTitle"><img class="jc-legend-icon-img" src="../JellyfinCanopy/assets/icons/bazarr.svg" onerror="this.onerror=null;this.src='../JellyfinCanopy/assets/branding/canopy-mark.svg';" alt="">Bazarr</legend>
                         <div class="configSection">
                             <div class="jc-setting-description" data-desc-for="bazarrUrl">
                                 <div class="fieldDescription">Automated subtitle downloading and management for Sonarr and Radarr. Single instance, no API key — detail-page links only.</div>
@@ -1904,8 +1901,8 @@
                                     Applies color-coded backgrounds to media ratings.
                                     <details class="jc-screenshot-details">
                                 <summary class="jc-screenshot-summary">View Screenshot</summary>
-                                <a href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Enhanced@main/docs/images/ratings.png" target="_blank">
-                                <img alt="Colored Ratings Example" class="jc-screenshot-img" src="../JellyfinCanopy/assets/screenshots/ratings.png" onerror="this.onerror=null;this.src='https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Enhanced@main/docs/images/ratings.png';"/>
+                                <a href="../JellyfinCanopy/assets/screenshots/ratings.png" target="_blank">
+                                <img alt="Colored Ratings Example" class="jc-screenshot-img" src="../JellyfinCanopy/assets/screenshots/ratings.png" onerror="this.onerror=null;this.src='../JellyfinCanopy/assets/seerr/poster-fallback.svg';"/>
                                 </a>
                                 </details>
                                 If you notice missing or incorrect ratings, please submit a PR to <a class="sectionTitle" href="https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/" target="_blank">Jellyfin-Canopy</a>.
@@ -1917,8 +1914,8 @@
                                     Adds a theme selector to quickly switch between Jellyfish color themes.
                                     <details class="jc-screenshot-details">
                                 <summary class="jc-screenshot-summary">View Screenshot</summary>
-                                <a href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Enhanced@main/docs/images/theme-selector.png" target="_blank">
-                                <img alt="Theme Selector Example" class="jc-screenshot-img" src="../JellyfinCanopy/assets/screenshots/theme-selector.png" onerror="this.onerror=null;this.src='https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Enhanced@main/docs/images/theme-selector.png';"/>
+                                <a href="../JellyfinCanopy/assets/screenshots/theme-selector.png" target="_blank">
+                                <img alt="Theme Selector Example" class="jc-screenshot-img" src="../JellyfinCanopy/assets/screenshots/theme-selector.png" onerror="this.onerror=null;this.src='../JellyfinCanopy/assets/seerr/poster-fallback.svg';"/>
                                 </a>
                                 </details>
                                 </div>
@@ -1935,8 +1932,8 @@
                                     Replaces Dashboard Activity Icons with Material Design icons and background color.
                                     <details class="jc-screenshot-details">
                                 <summary class="jc-screenshot-summary">View Screenshot</summary>
-                                <a href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Enhanced@main/docs/images/colored-activity-icons.png" target="_blank">
-                                <img alt="Colored Activity Icons Example" class="jc-screenshot-img" src="../JellyfinCanopy/assets/screenshots/colored-activity-icons.png" onerror="this.onerror=null;this.src='https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Enhanced@main/docs/images/colored-activity-icons.png';"/>
+                                <a href="../JellyfinCanopy/assets/screenshots/colored-activity-icons.png" target="_blank">
+                                <img alt="Colored Activity Icons Example" class="jc-screenshot-img" src="../JellyfinCanopy/assets/screenshots/colored-activity-icons.png" onerror="this.onerror=null;this.src='../JellyfinCanopy/assets/seerr/poster-fallback.svg';"/>
                                 </a>
                                 </details>
                                 </div>
@@ -1947,8 +1944,8 @@
                                     Displays the user's profile picture on the manual login screen instead of the name. When a user is selected, their avatar appears above the password field.
                                     <details class="jc-screenshot-details">
                                 <summary class="jc-screenshot-summary">View Screenshot</summary>
-                                <a href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Enhanced@main/docs/images/login-image.png" target="_blank">
-                                <img alt="Login Image Example" class="jc-screenshot-img" src="../JellyfinCanopy/assets/screenshots/login-image.png" onerror="this.onerror=null;this.src='https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Enhanced@main/docs/images/login-image.png';"/>
+                                <a href="../JellyfinCanopy/assets/screenshots/login-image.png" target="_blank">
+                                <img alt="Login Image Example" class="jc-screenshot-img" src="../JellyfinCanopy/assets/screenshots/login-image.png" onerror="this.onerror=null;this.src='../JellyfinCanopy/assets/seerr/poster-fallback.svg';"/>
                                 </a>
                                 </details>
                                 </div>
@@ -1959,8 +1956,8 @@
                                     Replaces default plugin folder icons with custom icons on the Dashboard sidebar.
                                     <details class="jc-screenshot-details">
                                 <summary class="jc-screenshot-summary">View Screenshot</summary>
-                                <a href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Enhanced@main/docs/images/plugin-icons.png" target="_blank">
-                                <img alt="Plugin Icons Example" class="jc-screenshot-img-sm" src="../JellyfinCanopy/assets/screenshots/plugin-icons.png" onerror="this.onerror=null;this.src='https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Enhanced@main/docs/images/plugin-icons.png';"/>
+                                <a href="../JellyfinCanopy/assets/screenshots/plugin-icons.png" target="_blank">
+                                <img alt="Plugin Icons Example" class="jc-screenshot-img-sm" src="../JellyfinCanopy/assets/screenshots/plugin-icons.png" onerror="this.onerror=null;this.src='../JellyfinCanopy/assets/seerr/poster-fallback.svg';"/>
                                 </a>
                                 </details>
                                 </div>

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/AssetsController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/AssetsController.cs
@@ -79,7 +79,6 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
 
             if (path == null || !System.IO.File.Exists(path))
             {
-                _logger.LogWarning($"[Asset Cache] Asset '{asset.Key}' is not cached and upstream is unreachable; returning 404.");
                 return NotFound();
             }
 

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/AssetCacheService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/AssetCacheService.cs
@@ -79,6 +79,23 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         private const int MaxDerivedPerEntry = 500;
         private const int MaxDerivedTotal = 2000;
         private const long RefreshTotalByteBudget = 256L * 1024 * 1024;
+        private const int DefaultMaxConcurrentFetches = 8;
+        private const int MaxFailureStates = 4096;
+
+        // A failing key is retried progressively less often. Keeping the state for a day after
+        // the most recent failure preserves the exponential step across quiet periods without
+        // allowing the registry to grow forever.
+        private static readonly TimeSpan[] FailureBackoff =
+        {
+            TimeSpan.FromSeconds(30),
+            TimeSpan.FromMinutes(1),
+            TimeSpan.FromMinutes(2),
+            TimeSpan.FromMinutes(4),
+            TimeSpan.FromMinutes(8),
+            TimeSpan.FromMinutes(15),
+        };
+
+        private static readonly TimeSpan FailureStateTtl = TimeSpan.FromDays(1);
 
         private const string DerivedMapFileName = "derived-map.json";
 
@@ -102,21 +119,41 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly ILogger<AssetCacheService> _logger;
         private readonly string? _cacheDirectoryOverride;
+        private readonly TimeProvider _timeProvider;
+        private readonly SemaphoreSlim _outboundFetches;
+        private readonly BoundedTtlCache<string, AssetFailureState> _failureStates;
         private readonly ConcurrentDictionary<string, SemaphoreSlim> _keyLocks = new(StringComparer.Ordinal);
         private readonly object _derivedMapLock = new();
         private ConcurrentDictionary<string, DerivedAsset>? _derivedMap;
 
         public AssetCacheService(IHttpClientFactory httpClientFactory, ILogger<AssetCacheService> logger)
-            : this(httpClientFactory, logger, cacheDirectoryOverride: null)
+            : this(httpClientFactory, logger, cacheDirectoryOverride: null, TimeProvider.System, DefaultMaxConcurrentFetches)
         {
         }
 
-        /// <summary>Test seam: pins the cache directory instead of deriving it from the plugin instance.</summary>
-        internal AssetCacheService(IHttpClientFactory httpClientFactory, ILogger<AssetCacheService> logger, string? cacheDirectoryOverride)
+        /// <summary>
+        /// Test seam: pins the cache directory, clock and global outbound concurrency instead of
+        /// deriving them from production defaults.
+        /// </summary>
+        internal AssetCacheService(
+            IHttpClientFactory httpClientFactory,
+            ILogger<AssetCacheService> logger,
+            string? cacheDirectoryOverride,
+            TimeProvider? timeProvider = null,
+            int maxConcurrentFetches = DefaultMaxConcurrentFetches)
         {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxConcurrentFetches);
             _httpClientFactory = httpClientFactory;
             _logger = logger;
             _cacheDirectoryOverride = cacheDirectoryOverride;
+            _timeProvider = timeProvider ?? TimeProvider.System;
+            _outboundFetches = new SemaphoreSlim(maxConcurrentFetches, maxConcurrentFetches);
+            _failureStates = new BoundedTtlCache<string, AssetFailureState>(
+                MaxFailureStates,
+                MaxFailureStates,
+                comparer: StringComparer.Ordinal,
+                timeProvider: _timeProvider,
+                defaultTtl: () => FailureStateTtl);
         }
 
         /// <summary>
@@ -125,6 +162,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         /// instance is not available yet.
         /// </summary>
         internal string CacheDirectory => _cacheDirectoryOverride ?? JellyfinCanopy.AssetCacheDirectory;
+
+        /// <summary>Number of remembered outage states; exposed internally for boundedness tests.</summary>
+        internal int FailureStateCount => _failureStates.Count;
 
         /// <summary>Classifies a requested key against the manifest. Never touches the network.</summary>
         internal ResolvedAsset Resolve(string? key)
@@ -232,24 +272,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 return path;
             }
 
-            var keyLock = _keyLocks.GetOrAdd(asset.Key, _ => new SemaphoreSlim(1, 1));
-            await keyLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-            try
-            {
-                if (!forceRefresh && File.Exists(path))
-                {
-                    return path; // Someone else fetched it while we waited.
-                }
-
-                await FetchAssetAsync(asset, path, cancellationToken).ConfigureAwait(false);
-                // Whatever the outcome, serve the file when one exists: a fresh fetch and a
-                // failed refresh over a last-good copy are both "serve the cached file".
-                return File.Exists(path) ? path : null;
-            }
-            finally
-            {
-                keyLock.Release();
-            }
+            await FetchWithBackoffAsync(asset, path, forceRefresh, cancellationToken).ConfigureAwait(false);
+            // Whatever the outcome, serve the file when one exists: a fresh fetch and a failed or
+            // backed-off refresh over a last-good copy are all "serve the cached file".
+            return File.Exists(path) ? path : null;
         }
 
         /// <summary>
@@ -296,8 +322,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     try
                     {
                         TryGetSafeCachePath(asset.Key, out var path);
-                        var outcome = await FetchAssetAsync(asset, path, cancellationToken).ConfigureAwait(false);
-                        switch (outcome)
+                        var result = await FetchWithBackoffAsync(asset, path, forceRefresh: true, cancellationToken).ConfigureAwait(false);
+                        switch (result.Outcome)
                         {
                             case FetchOutcome.Fetched:
                                 succeeded++;
@@ -395,7 +421,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             Fetched,
             NotModified,
             Failed,
+            BackedOff,
         }
+
+        private sealed record AssetFetchResult(FetchOutcome Outcome, string? FailureReason = null);
+
+        private sealed record AssetFailureState(int ConsecutiveFailures, DateTimeOffset RetryAfter);
 
         private ConcurrentDictionary<string, DerivedAsset> DerivedMap
         {
@@ -516,11 +547,84 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             return null;
         }
 
-        private async Task<FetchOutcome> FetchAssetAsync(ResolvedAsset asset, string path, CancellationToken cancellationToken)
+        private async Task<AssetFetchResult> FetchWithBackoffAsync(
+            ResolvedAsset asset,
+            string path,
+            bool forceRefresh,
+            CancellationToken cancellationToken)
+        {
+            if (IsBackedOff(asset.Key))
+            {
+                return new AssetFetchResult(FetchOutcome.BackedOff);
+            }
+
+            var keyLock = _keyLocks.GetOrAdd(asset.Key, _ => new SemaphoreSlim(1, 1));
+            await keyLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                // A successful on-demand leader makes every waiter a cache hit. Forced refreshes
+                // still serialize, but an outage window suppresses every follower after its one
+                // retry leader records the failure below.
+                if (!forceRefresh && File.Exists(path))
+                {
+                    return new AssetFetchResult(FetchOutcome.NotModified);
+                }
+
+                if (IsBackedOff(asset.Key))
+                {
+                    return new AssetFetchResult(FetchOutcome.BackedOff);
+                }
+
+                var result = await FetchAssetAsync(asset, path, cancellationToken).ConfigureAwait(false);
+                if (result.Outcome == FetchOutcome.Failed)
+                {
+                    RecordFailure(asset, path, result.FailureReason ?? "unknown upstream failure");
+                }
+                else
+                {
+                    ClearFailure(asset.Key);
+                }
+
+                return result;
+            }
+            finally
+            {
+                keyLock.Release();
+            }
+        }
+
+        private bool IsBackedOff(string key)
+            => _failureStates.TryGet(key, out var state) && _timeProvider.GetUtcNow() < state.RetryAfter;
+
+        private void RecordFailure(ResolvedAsset asset, string path, string reason)
+        {
+            var failures = 1;
+            if (_failureStates.TryGet(asset.Key, out var previous))
+            {
+                failures = Math.Min(previous.ConsecutiveFailures + 1, FailureBackoff.Length);
+            }
+
+            var delay = FailureBackoff[Math.Min(failures - 1, FailureBackoff.Length - 1)];
+            var retryAfter = _timeProvider.GetUtcNow().Add(delay);
+            _failureStates.Set(asset.Key, new AssetFailureState(failures, retryAfter), FailureStateTtl);
+            _logger.LogWarning(
+                $"[Asset Cache] Upstream unavailable for '{asset.Key}' ({reason}); retry in {delay}. " +
+                $"Consecutive failures: {failures}; last-good copy: {(File.Exists(path) ? "available" : "missing")}.");
+        }
+
+        private void ClearFailure(string key)
+        {
+            if (_failureStates.Remove(key))
+            {
+                _logger.LogInformation($"[Asset Cache] Upstream recovered for '{key}'; outage backoff cleared.");
+            }
+        }
+
+        private async Task<AssetFetchResult> FetchAssetAsync(ResolvedAsset asset, string path, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(path) || string.IsNullOrEmpty(asset.UpstreamUrl))
             {
-                return FetchOutcome.Failed;
+                return new AssetFetchResult(FetchOutcome.Failed, "invalid cache path or upstream URL");
             }
 
             using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -547,52 +651,59 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     }
                 }
 
-                using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
-                if (response.StatusCode == HttpStatusCode.NotModified && File.Exists(path))
+                await _outboundFetches.WaitAsync(ct).ConfigureAwait(false);
+                try
                 {
-                    WriteMeta(path, meta?.ETag, meta?.LastModified);
-                    return FetchOutcome.NotModified;
-                }
+                    using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
+                    if (response.StatusCode == HttpStatusCode.NotModified && File.Exists(path))
+                    {
+                        WriteMeta(path, meta?.ETag, meta?.LastModified);
+                        return new AssetFetchResult(FetchOutcome.NotModified);
+                    }
 
-                if (!response.IsSuccessStatusCode)
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        return new AssetFetchResult(FetchOutcome.Failed, $"HTTP {(int)response.StatusCode}");
+                    }
+
+                    var declaredLength = response.Content.Headers.ContentLength;
+                    if (declaredLength.HasValue && declaredLength.Value > asset.MaxBytes)
+                    {
+                        return new AssetFetchResult(
+                            FetchOutcome.Failed,
+                            $"declared size {declaredLength.Value} exceeds {asset.MaxBytes}-byte cap");
+                    }
+
+                    byte[] content;
+                    await using (var upstream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false))
+                    {
+                        content = await ReadWithCapAsync(upstream, asset.MaxBytes, ct).ConfigureAwait(false);
+                    }
+
+                    if (content.LongLength > asset.MaxBytes)
+                    {
+                        return new AssetFetchResult(FetchOutcome.Failed, $"stream exceeds {asset.MaxBytes}-byte cap");
+                    }
+
+                    if (asset.Rewrite)
+                    {
+                        var (css, derived) = RewriteCss(Encoding.UTF8.GetString(content), asset);
+                        content = Encoding.UTF8.GetBytes(css);
+                        RegisterDerived(derived);
+                    }
+
+                    Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+                    WriteAtomic(path, content);
+                    WriteMeta(
+                        path,
+                        response.Headers.ETag?.ToString(),
+                        response.Content.Headers.LastModified?.ToString("R"));
+                    return new AssetFetchResult(FetchOutcome.Fetched);
+                }
+                finally
                 {
-                    _logger.LogWarning($"[Asset Cache] Upstream returned {(int)response.StatusCode} for '{asset.Key}' ({asset.UpstreamUrl}); keeping last good copy if any.");
-                    return FetchOutcome.Failed;
+                    _outboundFetches.Release();
                 }
-
-                var declaredLength = response.Content.Headers.ContentLength;
-                if (declaredLength.HasValue && declaredLength.Value > asset.MaxBytes)
-                {
-                    _logger.LogWarning($"[Asset Cache] '{asset.Key}' exceeds its size cap ({declaredLength.Value} > {asset.MaxBytes} bytes); rejected.");
-                    return FetchOutcome.Failed;
-                }
-
-                byte[] content;
-                await using (var upstream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false))
-                {
-                    content = await ReadWithCapAsync(upstream, asset.MaxBytes, ct).ConfigureAwait(false);
-                }
-
-                if (content.LongLength > asset.MaxBytes)
-                {
-                    _logger.LogWarning($"[Asset Cache] '{asset.Key}' exceeds its size cap (> {asset.MaxBytes} bytes); rejected.");
-                    return FetchOutcome.Failed;
-                }
-
-                if (asset.Rewrite)
-                {
-                    var (css, derived) = RewriteCss(Encoding.UTF8.GetString(content), asset);
-                    content = Encoding.UTF8.GetBytes(css);
-                    RegisterDerived(derived);
-                }
-
-                Directory.CreateDirectory(Path.GetDirectoryName(path)!);
-                WriteAtomic(path, content);
-                WriteMeta(
-                    path,
-                    response.Headers.ETag?.ToString(),
-                    response.Content.Headers.LastModified?.ToString("R"));
-                return FetchOutcome.Fetched;
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -600,8 +711,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             }
             catch (Exception ex)
             {
-                _logger.LogWarning($"[Asset Cache] Fetch failed for '{asset.Key}' ({asset.UpstreamUrl}): {ex.Message}");
-                return FetchOutcome.Failed;
+                return new AssetFetchResult(FetchOutcome.Failed, $"{ex.GetType().Name}: {ex.Message}");
             }
         }
 
@@ -656,7 +766,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         {
             try
             {
-                var meta = new AssetMeta(etag, lastModified, DateTimeOffset.UtcNow);
+                var meta = new AssetMeta(etag, lastModified, _timeProvider.GetUtcNow());
                 WriteAtomic(MetaPath(path), Encoding.UTF8.GetBytes(JsonSerializer.Serialize(meta, JsonOptions)));
             }
             catch (Exception ex)

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -19,7 +19,7 @@ const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the repeated clean measurements', () => {
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1364, totalLines: 1692 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 13487, totalLines: 21661 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 13540, totalLines: 21712 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 1);
 });

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -21,12 +21,12 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 13487,
-        "totalLines": 21661
+        "coveredLines": 13540,
+        "totalLines": 21712
       },
       "tolerance": {
         "missingCoveredLines": 1,
-        "rationale": "The 2026-07-15 .NET 10/Coverlet run measured the bounded Seerr streaming transport, full caller migration, and its byte-limit, JSON, cancellation, blocking-body, disposal, and cache-publication tests; one line permits only negligible instrumentation variance."
+        "rationale": "The 2026-07-15 .NET 10/Coverlet run measured asset-cache same-key outage storms, fake-clock retry windows, globally bounded different-key fetches, last-good recovery, and no-remote-browser fallback coverage; one line permits only negligible instrumentation variance."
       }
     }
   }


### PR DESCRIPTION
Closes #107.

## What changed

- cap server-side asset mirror traffic at eight concurrent outbound fetches
- coalesce same-key outage callers behind one retry leader
- retain bounded per-key failure state with fake-clock exponential backoff from 30 seconds to 15 minutes
- keep serving verified last-good files during failed or suppressed refreshes
- emit one failure transition per key/window and one recovery transition, removing request-level 404 warning storms
- remove automatic third-party font, icon, and screenshot fallbacks from the admin page in favor of same-origin embedded assets
- retain strict manifest URL allowlisting, path validation, atomic writes, and streaming byte caps

## Evidence

- 1,299/1,299 .NET tests
- 294/294 workflow/script tests
- 845/845 client tests
- new 100-caller same-key outage/fake-clock expiry tests
- new 20-key global concurrency test (configured peak exactly 3)
- exact server coverage: 13,540/21,712 lines (62.362%)
- lint: 0 errors (existing warnings only)
- typecheck, source typecheck, syntax inventory, translations, and Release build pass
- independent Fable low-effort review: APPROVE, no blocking findings

Official Docker E2E remains pinned to `jellyfin/jellyfin:unstable` by digest; no RC image is introduced.
