### PR TITLE
Bound avatar proxy streaming and cold-miss fan-out

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/ItemInfoAvatarSourceTokenTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/ItemInfoAvatarSourceTokenTests.cs
@@ -47,11 +47,16 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
         {
             var factory = new RecordingHttpClientFactory(handler);
             var library = new CountingLibraryManager();
+            var avatarFetch = new AvatarFetchService(
+                factory,
+                cache,
+                NullLogger<AvatarFetchService>.Instance);
             var controller = new ItemInfoController(
                 factory,
                 NullLogger<ItemInfoController>.Instance,
                 new StubUserManager(),
                 cache,
+                avatarFetch,
                 provider,
                 library,
                 new ItemLookupService(library));
@@ -193,12 +198,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 await oldRequest.WaitAsync(TimeSpan.FromSeconds(5)));
             Assert.Equal(409, staleResult.StatusCode);
 
-            var newKey = ItemInfoController.BuildAvatarCacheKey(
+            var newKey = AvatarFetchService.BuildCacheKey(
                 SourceB,
                 Path,
                 newRevision,
                 "new-key");
-            var oldKey = ItemInfoController.BuildAvatarCacheKey(
+            var oldKey = AvatarFetchService.BuildCacheKey(
                 SourceB,
                 Path,
                 oldRevision,
@@ -227,10 +232,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             var newer = (new byte[] { 2 }, "image/png", "\"new\"", DateTime.UtcNow);
             var checks = 0;
 
-            var published = ItemInfoController.TryPublishAvatarCacheEntry(
+            var published = AvatarFetchService.TryPublishCacheEntry(
                 cache,
                 key,
                 stale,
+                TimeSpan.FromHours(1),
                 () =>
                 {
                     if (++checks == 1)
@@ -260,7 +266,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 CancellationToken cancellationToken)
             {
                 Requests.Add(request);
-                var content = new ByteArrayContent(new byte[] { 137, 80, 78, 71 });
+                var content = new ByteArrayContent(new byte[] { 137, 80, 78, 71, 13, 10, 26, 10, 1 });
                 content.Headers.ContentType = new MediaTypeHeaderValue("image/png");
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = content });
             }
@@ -268,8 +274,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
 
         private sealed class BlockingAvatarGenerationHandler : HttpMessageHandler
         {
-            public static readonly byte[] OldBytes = { 1, 2, 3 };
-            public static readonly byte[] NewBytes = { 4, 5, 6 };
+            public static readonly byte[] OldBytes = { 137, 80, 78, 71, 13, 10, 26, 10, 1 };
+            public static readonly byte[] NewBytes = { 137, 80, 78, 71, 13, 10, 26, 10, 2 };
 
             private readonly TaskCompletionSource _oldRequestStarted = new(
                 TaskCreationOptions.RunContinuationsAsynchronously);

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/AvatarFetchServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/AvatarFetchServiceTests.cs
@@ -1,0 +1,365 @@
+using System.Net;
+using System.Net.Http.Headers;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
+{
+    public sealed class AvatarFetchServiceTests
+    {
+        private static readonly byte[] ValidPng = { 137, 80, 78, 71, 13, 10, 26, 10, 1, 2, 3 };
+
+        [Fact]
+        public async Task ChunkedCapPlusOne_StopsAtBoundaryAndNeverCaches()
+        {
+            const int cap = 32;
+            var bytes = new byte[cap + 1000];
+            ValidPng.CopyTo(bytes, 0);
+            var stream = new CountingReadStream(bytes);
+            var handler = new DelegateHandler((_, _) => Task.FromResult(ImageResponse(stream, "image/png")));
+            var (service, cache) = Create(handler, maximumAvatarBytes: cap);
+
+            var result = await service.GetAsync("avatar", "http://seerr/avatar/a.png", () => true, CancellationToken.None);
+
+            Assert.Equal(AvatarFetchStatus.Missing, result.Status);
+            Assert.Equal(cap + 1, stream.BytesRead);
+            Assert.Empty(cache.AvatarCache);
+        }
+
+        [Fact]
+        public async Task OneHundredConcurrentColdMisses_InvokeUpstreamOnce()
+        {
+            var handler = new BlockingSuccessHandler();
+            var (service, cache) = Create(handler);
+
+            var calls = Enumerable.Range(0, 100)
+                .Select(_ => service.GetAsync(
+                    "same-avatar",
+                    "http://seerr/avatar/a.png",
+                    () => true,
+                    CancellationToken.None))
+                .ToArray();
+            await handler.Started.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Equal(1, handler.Calls);
+            Assert.Equal(1, service.InFlightCount);
+            handler.Release();
+            var results = await Task.WhenAll(calls);
+
+            Assert.All(results, result => Assert.Equal(AvatarFetchStatus.Available, result.Status));
+            Assert.Equal(1, handler.Calls);
+            Assert.Single(cache.AvatarCache);
+            Assert.Equal(0, service.InFlightCount);
+        }
+
+        [Fact]
+        public async Task LeaderCancellation_DoesNotFailLiveFollowerOrRestartUpstream()
+        {
+            var handler = new BlockingSuccessHandler();
+            var (service, cache) = Create(handler);
+            using var leaderCancellation = new CancellationTokenSource();
+
+            var leader = service.GetAsync(
+                "shared-avatar",
+                "http://seerr/avatar/a.png",
+                () => true,
+                leaderCancellation.Token);
+            await handler.Started.WaitAsync(TimeSpan.FromSeconds(5));
+            var follower = service.GetAsync(
+                "shared-avatar",
+                "http://seerr/avatar/a.png",
+                () => true,
+                CancellationToken.None);
+
+            leaderCancellation.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => leader);
+            Assert.Equal(1, handler.Calls);
+            Assert.Equal(1, service.InFlightCount);
+
+            handler.Release();
+            var result = await follower.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Equal(AvatarFetchStatus.Available, result.Status);
+            Assert.Equal(ValidPng, result.Content);
+            Assert.Single(cache.AvatarCache);
+            Assert.Equal(1, handler.Calls);
+            Assert.Equal(0, service.InFlightCount);
+        }
+
+        [Fact]
+        public async Task CallerCancellation_StopsUpstreamReadAndPublishesNothing()
+        {
+            var stream = new CancellationObservingStream();
+            var handler = new DelegateHandler((_, _) => Task.FromResult(ImageResponse(stream, "image/png")));
+            var (service, cache) = Create(handler);
+            using var cancellation = new CancellationTokenSource();
+
+            var fetch = service.GetAsync(
+                "cancelled-avatar",
+                "http://seerr/avatar/a.png",
+                () => true,
+                cancellation.Token);
+            await stream.ReadStarted.WaitAsync(TimeSpan.FromSeconds(5));
+            cancellation.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => fetch);
+            await stream.CancellationObserved.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Empty(cache.AvatarCache);
+            Assert.Equal(0, service.InFlightCount);
+        }
+
+        [Fact]
+        public async Task InvalidSignature_NeverEntersCache()
+        {
+            var handler = new DelegateHandler((_, _) => Task.FromResult(ImageResponse(
+                new MemoryStream("<html>not an image</html>"u8.ToArray()),
+                "image/png")));
+            var (service, cache) = Create(handler);
+
+            var result = await service.GetAsync("invalid", "http://seerr/avatar/a.png", () => true, CancellationToken.None);
+
+            Assert.Equal(AvatarFetchStatus.Missing, result.Status);
+            Assert.Empty(cache.AvatarCache);
+            Assert.Equal(1, service.FailureStateCount);
+        }
+
+        [Fact]
+        public async Task FailureWindow_CoalescesDefinitiveMissesAndRetriesAfterFakeClockExpiry()
+        {
+            var clock = new ManualTimeProvider(new DateTimeOffset(2026, 7, 15, 0, 0, 0, TimeSpan.Zero));
+            var handler = new CountingStatusHandler(HttpStatusCode.NotFound);
+            var (service, _) = Create(handler, clock);
+
+            var first = await Task.WhenAll(Enumerable.Range(0, 100)
+                .Select(_ => service.GetAsync("missing", "http://seerr/avatar/missing.png", () => true, CancellationToken.None)));
+            Assert.All(first, result => Assert.Equal(AvatarFetchStatus.Missing, result.Status));
+            Assert.Equal(1, handler.Calls);
+
+            clock.Advance(TimeSpan.FromSeconds(14));
+            Assert.Equal(
+                AvatarFetchStatus.Missing,
+                (await service.GetAsync("missing", "http://seerr/avatar/missing.png", () => true, CancellationToken.None)).Status);
+            Assert.Equal(1, handler.Calls);
+
+            clock.Advance(TimeSpan.FromSeconds(1));
+            await Task.WhenAll(Enumerable.Range(0, 100)
+                .Select(_ => service.GetAsync("missing", "http://seerr/avatar/missing.png", () => true, CancellationToken.None)));
+            Assert.Equal(2, handler.Calls);
+        }
+
+        [Fact]
+        public async Task StaleLastGood_IsServedDuringFailureAndBackoff()
+        {
+            var clock = new ManualTimeProvider(new DateTimeOffset(2026, 7, 15, 0, 0, 0, TimeSpan.Zero));
+            var handler = new SwitchableHandler();
+            var (service, cache) = Create(handler, clock);
+
+            var fresh = await service.GetAsync("last-good", "http://seerr/avatar/a.png", () => true, CancellationToken.None);
+            Assert.Equal(AvatarFetchStatus.Available, fresh.Status);
+            clock.Advance(TimeSpan.FromHours(2));
+            handler.Status = HttpStatusCode.ServiceUnavailable;
+
+            var duringFailure = await service.GetAsync("last-good", "http://seerr/avatar/a.png", () => true, CancellationToken.None);
+            var duringBackoff = await service.GetAsync("last-good", "http://seerr/avatar/a.png", () => true, CancellationToken.None);
+
+            Assert.Equal(AvatarFetchStatus.Available, duringFailure.Status);
+            Assert.Equal(ValidPng, duringFailure.Content);
+            Assert.Equal(AvatarFetchStatus.Available, duringBackoff.Status);
+            Assert.Equal(2, handler.Calls);
+            Assert.Single(cache.AvatarCache);
+        }
+
+        [Fact]
+        public async Task HighCardinality_StaysWithinEntryAndByteBudgets()
+        {
+            var handler = new DelegateHandler((_, _) => Task.FromResult(ImageResponse(
+                new MemoryStream(ValidPng, writable: false),
+                "image/png")));
+            var (_, cache, service) = CreateWithService(handler);
+
+            for (var i = 0; i < 200; i++)
+            {
+                var result = await service.GetAsync(
+                    $"avatar-{i}",
+                    $"http://seerr/avatar/{i}.png",
+                    () => true,
+                    CancellationToken.None);
+                Assert.Equal(AvatarFetchStatus.Available, result.Status);
+            }
+
+            Assert.True(cache.AvatarCache.Count <= SeerrCache.AvatarMaximumEntries);
+            Assert.True(cache.AvatarCache.TotalWeight <= SeerrCache.AvatarMaximumBytes);
+        }
+
+        private static (AvatarFetchService Service, SeerrCache Cache) Create(
+            HttpMessageHandler handler,
+            TimeProvider? timeProvider = null,
+            long maximumAvatarBytes = AvatarFetchService.DefaultMaximumAvatarBytes)
+        {
+            var (_, cache, service) = CreateWithService(handler, timeProvider, maximumAvatarBytes);
+            return (service, cache);
+        }
+
+        private static (RecordingHttpClientFactory Factory, SeerrCache Cache, AvatarFetchService Service) CreateWithService(
+            HttpMessageHandler handler,
+            TimeProvider? timeProvider = null,
+            long maximumAvatarBytes = AvatarFetchService.DefaultMaximumAvatarBytes)
+        {
+            var provider = new FakePluginConfigProvider(new PluginConfiguration());
+            var cache = new SeerrCache(provider);
+            var factory = new RecordingHttpClientFactory(handler);
+            var service = new AvatarFetchService(
+                factory,
+                cache,
+                NullLogger<AvatarFetchService>.Instance,
+                timeProvider ?? TimeProvider.System,
+                maximumAvatarBytes);
+            return (factory, cache, service);
+        }
+
+        private static HttpResponseMessage ImageResponse(Stream stream, string contentType)
+        {
+            var content = new StreamContent(stream);
+            content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+            content.Headers.ContentLength = null;
+            return new HttpResponseMessage(HttpStatusCode.OK) { Content = content };
+        }
+
+        private sealed class DelegateHandler : HttpMessageHandler
+        {
+            private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _send;
+
+            public DelegateHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> send)
+                => _send = send;
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+                => _send(request, cancellationToken);
+        }
+
+        private sealed class BlockingSuccessHandler : HttpMessageHandler
+        {
+            private readonly TaskCompletionSource _started = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly TaskCompletionSource _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private int _calls;
+
+            public Task Started => _started.Task;
+
+            public int Calls => Volatile.Read(ref _calls);
+
+            public void Release() => _release.TrySetResult();
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                Interlocked.Increment(ref _calls);
+                _started.TrySetResult();
+                await _release.Task.WaitAsync(cancellationToken);
+                return ImageResponse(new MemoryStream(ValidPng, writable: false), "image/png");
+            }
+        }
+
+        private sealed class CountingStatusHandler : HttpMessageHandler
+        {
+            private readonly HttpStatusCode _status;
+            private int _calls;
+
+            public CountingStatusHandler(HttpStatusCode status) => _status = status;
+
+            public int Calls => Volatile.Read(ref _calls);
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                Interlocked.Increment(ref _calls);
+                return Task.FromResult(new HttpResponseMessage(_status));
+            }
+        }
+
+        private sealed class SwitchableHandler : HttpMessageHandler
+        {
+            private int _calls;
+
+            public HttpStatusCode Status { get; set; } = HttpStatusCode.OK;
+
+            public int Calls => Volatile.Read(ref _calls);
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                Interlocked.Increment(ref _calls);
+                if (Status != HttpStatusCode.OK)
+                {
+                    return Task.FromResult(new HttpResponseMessage(Status));
+                }
+
+                return Task.FromResult(ImageResponse(new MemoryStream(ValidPng, writable: false), "image/png"));
+            }
+        }
+
+        private sealed class CountingReadStream : MemoryStream
+        {
+            public CountingReadStream(byte[] bytes)
+                : base(bytes, writable: false)
+            {
+            }
+
+            public int BytesRead { get; private set; }
+
+            public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                var read = await base.ReadAsync(buffer, cancellationToken);
+                BytesRead += read;
+                return read;
+            }
+        }
+
+        private sealed class CancellationObservingStream : Stream
+        {
+            private readonly TaskCompletionSource _readStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly TaskCompletionSource _cancellationObserved = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public Task ReadStarted => _readStarted.Task;
+
+            public Task CancellationObserved => _cancellationObserved.Task;
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => throw new NotSupportedException();
+            public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+            public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+            public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                _readStarted.TrySetResult();
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                    return 0;
+                }
+                catch (OperationCanceledException)
+                {
+                    _cancellationObserved.TrySetResult();
+                    throw;
+                }
+            }
+
+            public override void Flush() => throw new NotSupportedException();
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        }
+
+        private sealed class ManualTimeProvider : TimeProvider
+        {
+            private DateTimeOffset _now;
+
+            public ManualTimeProvider(DateTimeOffset now) => _now = now;
+
+            public override DateTimeOffset GetUtcNow() => _now;
+
+            public void Advance(TimeSpan amount) => _now = _now.Add(amount);
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/ItemInfoController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/ItemInfoController.cs
@@ -4,13 +4,10 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Reflection;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using System.Collections.Generic;
-using System.Collections.Concurrent;
-using System.Security.Cryptography;
 using Jellyfin.Data;
 using Jellyfin.Data.Enums;
 using MediaBrowser.Controller.Dto;
@@ -48,12 +45,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
     {
         private readonly ILibraryManager _libraryManager;
         private readonly IItemLookupService _itemLookup;
+        private readonly AvatarFetchService _avatarFetch;
 
         public ItemInfoController(
             IHttpClientFactory httpClientFactory,
             ILogger<ItemInfoController> logger,
             IUserManager userManager,
             ISeerrCache seerrCache,
+            AvatarFetchService avatarFetch,
             IPluginConfigProvider configProvider,
             ILibraryManager libraryManager,
             IItemLookupService itemLookup)
@@ -61,6 +60,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
         {
             _libraryManager = libraryManager;
             _itemLookup = itemLookup;
+            _avatarFetch = avatarFetch;
         }
 
         /// <summary>
@@ -462,121 +462,36 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 // rotation must not reuse bytes fetched by the prior identity
                 // generation, including when a custom provider mutates its
                 // configuration object in place without advancing revision.
-                var cacheKey = BuildAvatarCacheKey(
+                var cacheKey = AvatarFetchService.BuildCacheKey(
                     seerrUrl,
                     avatarPath,
                     configurationRevision,
                     seerrApiKey);
 
-                // Check server-side cache first to avoid hitting upstream Seerr
-                // on every request. This is critical for large avatars (e.g., animated
-                // GIFs) that would otherwise be re-downloaded on every conditional request.
-                if (_seerrCache.AvatarCache.TryGetValue(cacheKey, out var cached)
-                    && DateTime.UtcNow - cached.CachedAt < _seerrCache.AvatarCacheDuration)
-                {
-                    if (!IsConfigurationCurrent())
-                    {
-                        return ConfigurationChanged();
-                    }
-
-                    // Serve 304 if client already has this version
-                    if (Request.Headers.TryGetValue("If-None-Match", out var cachedIfNoneMatch)
-                        && cachedIfNoneMatch.ToString().Contains(cached.ETag))
-                    {
-                        Response.Headers["Cache-Control"] = "private, no-cache";
-                        Response.Headers["ETag"] = cached.ETag;
-                        return StatusCode(304);
-                    }
-
-                    Response.Headers["Cache-Control"] = "private, no-cache";
-                    Response.Headers["ETag"] = cached.ETag;
-                    return File(cached.Content, cached.ContentType);
-                }
-
-                var client = Helpers.Seerr.SeerrHttpHelper.CreateClient(_httpClientFactory);
-                client.Timeout = TimeSpan.FromSeconds(10);
-
-                if (!IsConfigurationCurrent())
-                {
-                    return ConfigurationChanged();
-                }
-
-                using var avatarRequest = new System.Net.Http.HttpRequestMessage(System.Net.Http.HttpMethod.Get, $"{seerrUrl}{avatarPath}");
-                // explicit User-Agent + Accept so Cloudflare's bot
-                // mode doesn't return an HTML challenge page that we'd try to
-                // serve as an image.
-                avatarRequest.Headers.UserAgent.ParseAdd(Helpers.Seerr.SeerrHttpHelper.UserAgent);
-                avatarRequest.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("image/*"));
-                using var response = await client.SendAsync(
-                    avatarRequest,
-                    HttpContext.RequestAborted).ConfigureAwait(false);
-                if (!IsConfigurationCurrent())
-                {
-                    return ConfigurationChanged();
-                }
-
-                if (!response.IsSuccessStatusCode)
-                {
-                    return NotFound();
-                }
-
-                // Closed-set MIME whitelist. previously
-                // accepted `image/svg+xml`, so a compromised Seerr could serve
-                // an SVG with embedded `<script>` that we'd cache for 1 hour.
-                // SVG is intentionally excluded — TMDB avatars are always
-                // raster formats.
-                var contentType = response.Content.Headers.ContentType?.MediaType ?? "image/jpeg";
-                var allowedAvatarTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-                {
-                    "image/png", "image/jpeg", "image/jpg", "image/gif",
-                    "image/webp", "image/avif", "image/bmp"
-                };
-                if (!allowedAvatarTypes.Contains(contentType))
-                {
-                    _logger.LogDebug($"ProxyAvatar rejected unsafe content-type: {contentType}");
-                    return NotFound();
-                }
-
-                var content = await response.Content.ReadAsByteArrayAsync(
-                    HttpContext.RequestAborted).ConfigureAwait(false);
-                if (!IsConfigurationCurrent())
-                {
-                    return ConfigurationChanged();
-                }
-
-                // Compute ETag from content hash for conditional request support.
-                var hash = SHA256.HashData(content);
-                var etag = $"\"{Convert.ToHexString(hash)}\"";
-
-                // Store only in the captured generation. The post-write check
-                // closes the narrow check-to-publication race; exact removal
-                // cannot delete a newer flight's replacement at the same key.
-                var publishedEntry = (
-                    Content: content,
-                    ContentType: contentType,
-                    ETag: etag,
-                    CachedAt: DateTime.UtcNow);
-                if (!TryPublishAvatarCacheEntry(
-                    _seerrCache.AvatarCache,
+                var avatar = await _avatarFetch.GetAsync(
                     cacheKey,
-                    publishedEntry,
-                    IsConfigurationCurrent))
+                    $"{seerrUrl}{avatarPath}",
+                    IsConfigurationCurrent,
+                    HttpContext.RequestAborted).ConfigureAwait(false);
+                if (avatar.Status == AvatarFetchStatus.ConfigurationChanged || !IsConfigurationCurrent())
                 {
                     return ConfigurationChanged();
                 }
 
-                if (!IsConfigurationCurrent())
+                if (avatar.Status != AvatarFetchStatus.Available
+                    || avatar.Content == null
+                    || avatar.ContentType == null
+                    || avatar.ETag == null)
                 {
-                    _seerrCache.AvatarCache.Remove(cacheKey, publishedEntry);
-                    return ConfigurationChanged();
+                    return NotFound();
                 }
 
                 // Serve 304 if client already has this version
                 if (Request.Headers.TryGetValue("If-None-Match", out var ifNoneMatch)
-                    && ifNoneMatch.ToString().Contains(etag))
+                    && ifNoneMatch.ToString().Contains(avatar.ETag))
                 {
                     Response.Headers["Cache-Control"] = "private, no-cache";
-                    Response.Headers["ETag"] = etag;
+                    Response.Headers["ETag"] = avatar.ETag;
                     return StatusCode(304);
                 }
 
@@ -586,47 +501,19 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 // bytes but must revalidate; the server-side AvatarCache still
                 // avoids another upstream download and can answer with 304.
                 Response.Headers["Cache-Control"] = "private, no-cache";
-                Response.Headers["ETag"] = etag;
+                Response.Headers["ETag"] = avatar.ETag;
 
-                return File(content, contentType);
+                return File(avatar.Content, avatar.ContentType);
+            }
+            catch (OperationCanceledException) when (HttpContext.RequestAborted.IsCancellationRequested)
+            {
+                return new EmptyResult();
             }
             catch (Exception ex)
             {
                 _logger.LogWarning($"ProxyAvatar exception: {ex.Message}");
                 return NotFound();
             }
-        }
-
-        internal static string BuildAvatarCacheKey(
-            string seerrUrl,
-            string avatarPath,
-            long configurationRevision,
-            string seerrApiKey)
-        {
-            var apiKeyFingerprint = Convert.ToHexString(
-                SHA256.HashData(Encoding.UTF8.GetBytes(seerrApiKey)));
-            return $"{configurationRevision.ToString(System.Globalization.CultureInfo.InvariantCulture)}:{apiKeyFingerprint}:{seerrUrl.Length.ToString(System.Globalization.CultureInfo.InvariantCulture)}:{seerrUrl}{avatarPath}";
-        }
-
-        internal static bool TryPublishAvatarCacheEntry(
-            BoundedTtlCache<string, (byte[] Content, string ContentType, string ETag, DateTime CachedAt)> cache,
-            string cacheKey,
-            (byte[] Content, string ContentType, string ETag, DateTime CachedAt) entry,
-            Func<bool> isConfigurationCurrent)
-        {
-            if (!isConfigurationCurrent())
-            {
-                return false;
-            }
-
-            cache.TrySet(cacheKey, entry, out var publication);
-            if (isConfigurationCurrent())
-            {
-                return true;
-            }
-
-            cache.Remove(publication);
-            return false;
         }
 
         [Authorize]

--- a/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
@@ -81,6 +81,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy
             // holder). Must stay a singleton: controllers, the user-import task
             // and the plugin's config-change hook all share one instance.
             serviceCollection.AddSingleton<Services.Seerr.ISeerrCache, Services.Seerr.SeerrCache>();
+            // One process-wide owner for bounded avatar streaming, per-key cold-flight
+            // coalescing, outage backoff and last-good publication.
+            serviceCollection.AddSingleton<Services.Seerr.AvatarFetchService>();
             // Server-side parental-rating filter for Seerr search/discovery results.
             // Injected into SeerrClient; must NOT depend on ISeerrClient
             // (that would be a DI cycle) — it fetches per-item certifications via the

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/AvatarFetchService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/AvatarFetchService.cs
@@ -1,0 +1,501 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinCanopy.Helpers;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
+{
+    internal enum AvatarFetchStatus
+    {
+        Available,
+        Missing,
+        ConfigurationChanged,
+    }
+
+    internal sealed record AvatarFetchResult(
+        AvatarFetchStatus Status,
+        byte[]? Content = null,
+        string? ContentType = null,
+        string? ETag = null);
+
+    /// <summary>
+    /// Bounded streaming owner for authenticated Seerr avatar reads. It coalesces one cold flight
+    /// per generation-aware cache key, validates declared and streamed sizes plus raster signatures,
+    /// retains a bounded last-good copy, and suppresses repeated definitive misses during a short
+    /// exponential outage window.
+    /// </summary>
+    public sealed class AvatarFetchService
+    {
+        internal const long DefaultMaximumAvatarBytes = 8L * 1024 * 1024;
+        private const int MaximumFailureStates = 2048;
+
+        private static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(10);
+        private static readonly TimeSpan LastGoodRetention = TimeSpan.FromHours(24);
+        private static readonly TimeSpan FailureStateRetention = TimeSpan.FromHours(24);
+        private static readonly TimeSpan[] FailureBackoff =
+        {
+            TimeSpan.FromSeconds(15),
+            TimeSpan.FromSeconds(30),
+            TimeSpan.FromMinutes(1),
+            TimeSpan.FromMinutes(2),
+            TimeSpan.FromMinutes(5),
+        };
+
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly ISeerrCache _cache;
+        private readonly ILogger<AvatarFetchService> _logger;
+        private readonly TimeProvider _timeProvider;
+        private readonly long _maximumAvatarBytes;
+        private readonly ConcurrentDictionary<string, AvatarFlight> _flights = new(StringComparer.Ordinal);
+        private readonly BoundedTtlCache<string, FailureState> _failures;
+
+        public AvatarFetchService(
+            IHttpClientFactory httpClientFactory,
+            ISeerrCache cache,
+            ILogger<AvatarFetchService> logger)
+            : this(httpClientFactory, cache, logger, TimeProvider.System, DefaultMaximumAvatarBytes)
+        {
+        }
+
+        internal AvatarFetchService(
+            IHttpClientFactory httpClientFactory,
+            ISeerrCache cache,
+            ILogger<AvatarFetchService> logger,
+            TimeProvider timeProvider,
+            long maximumAvatarBytes)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumAvatarBytes);
+            _httpClientFactory = httpClientFactory;
+            _cache = cache;
+            _logger = logger;
+            _timeProvider = timeProvider;
+            _maximumAvatarBytes = maximumAvatarBytes;
+            _failures = new BoundedTtlCache<string, FailureState>(
+                MaximumFailureStates,
+                MaximumFailureStates,
+                comparer: StringComparer.Ordinal,
+                timeProvider: timeProvider,
+                defaultTtl: () => FailureStateRetention);
+        }
+
+        internal int InFlightCount => _flights.Count;
+
+        internal int FailureStateCount => _failures.Count;
+
+        internal async Task<AvatarFetchResult> GetAsync(
+            string cacheKey,
+            string upstreamUrl,
+            Func<bool> isConfigurationCurrent,
+            CancellationToken cancellationToken)
+        {
+            if (TryGetLastGood(cacheKey, out var cached) && IsFresh(cached))
+            {
+                return Available(cached);
+            }
+
+            if (IsBackedOff(cacheKey))
+            {
+                return cached.Content != null ? Available(cached) : Missing();
+            }
+
+            if (!isConfigurationCurrent())
+            {
+                return ConfigurationChanged();
+            }
+
+            while (true)
+            {
+                var candidate = new AvatarFlight();
+                var flight = _flights.GetOrAdd(cacheKey, candidate);
+                if (!flight.TryJoin())
+                {
+                    _flights.TryRemove(new KeyValuePair<string, AvatarFlight>(cacheKey, flight));
+                    continue;
+                }
+
+                if (ReferenceEquals(flight, candidate))
+                {
+                    _ = CompleteFlightAsync(
+                        cacheKey,
+                        upstreamUrl,
+                        isConfigurationCurrent,
+                        candidate);
+                }
+
+                try
+                {
+                    return await flight.Completion.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    flight.Leave();
+                }
+            }
+        }
+
+        internal static string BuildCacheKey(
+            string seerrUrl,
+            string avatarPath,
+            long configurationRevision,
+            string seerrApiKey)
+        {
+            var apiKeyFingerprint = Convert.ToHexString(
+                SHA256.HashData(Encoding.UTF8.GetBytes(seerrApiKey)));
+            return $"{configurationRevision.ToString(System.Globalization.CultureInfo.InvariantCulture)}:{apiKeyFingerprint}:{seerrUrl.Length.ToString(System.Globalization.CultureInfo.InvariantCulture)}:{seerrUrl}{avatarPath}";
+        }
+
+        internal static bool TryPublishCacheEntry(
+            BoundedTtlCache<string, (byte[] Content, string ContentType, string ETag, DateTime CachedAt)> cache,
+            string cacheKey,
+            (byte[] Content, string ContentType, string ETag, DateTime CachedAt) entry,
+            TimeSpan retention,
+            Func<bool> isConfigurationCurrent)
+        {
+            if (!isConfigurationCurrent() || !cache.TrySet(cacheKey, entry, retention, out var publication))
+            {
+                return false;
+            }
+
+            if (isConfigurationCurrent())
+            {
+                return true;
+            }
+
+            cache.Remove(publication);
+            return false;
+        }
+
+        private async Task CompleteFlightAsync(
+            string cacheKey,
+            string upstreamUrl,
+            Func<bool> isConfigurationCurrent,
+            AvatarFlight flight)
+        {
+            var flightCancellationToken = flight.CancellationToken;
+            try
+            {
+                var result = await FetchLeaderAsync(
+                    cacheKey,
+                    upstreamUrl,
+                    isConfigurationCurrent,
+                    flightCancellationToken).ConfigureAwait(false);
+                flight.Completion.TrySetResult(result);
+            }
+            catch (OperationCanceledException) when (flightCancellationToken.IsCancellationRequested)
+            {
+                flight.Completion.TrySetCanceled(flightCancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Avatar fetch flight failed unexpectedly for key {AvatarKey}.", LogKey(cacheKey));
+                flight.Completion.TrySetResult(FailureResult(cacheKey, "internal fetch failure"));
+            }
+            finally
+            {
+                flight.MarkComplete();
+                _flights.TryRemove(new KeyValuePair<string, AvatarFlight>(cacheKey, flight));
+            }
+        }
+
+        private async Task<AvatarFetchResult> FetchLeaderAsync(
+            string cacheKey,
+            string upstreamUrl,
+            Func<bool> isConfigurationCurrent,
+            CancellationToken cancellationToken)
+        {
+            TryGetLastGood(cacheKey, out var lastGood);
+            if (IsFresh(lastGood))
+            {
+                return Available(lastGood);
+            }
+
+            if (IsBackedOff(cacheKey))
+            {
+                return lastGood.Content != null ? Available(lastGood) : Missing();
+            }
+
+            if (!isConfigurationCurrent())
+            {
+                return ConfigurationChanged();
+            }
+
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeout.CancelAfter(RequestTimeout);
+            var fetchToken = timeout.Token;
+
+            try
+            {
+                var client = Helpers.Seerr.SeerrHttpHelper.CreateClient(_httpClientFactory);
+                using var request = new HttpRequestMessage(HttpMethod.Get, upstreamUrl);
+                request.Headers.UserAgent.ParseAdd(Helpers.Seerr.SeerrHttpHelper.UserAgent);
+                request.Headers.Accept.ParseAdd("image/*");
+                using var response = await client.SendAsync(
+                    request,
+                    HttpCompletionOption.ResponseHeadersRead,
+                    fetchToken).ConfigureAwait(false);
+
+                if (!isConfigurationCurrent())
+                {
+                    return ConfigurationChanged();
+                }
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    return FailureResult(cacheKey, $"HTTP {(int)response.StatusCode}", lastGood);
+                }
+
+                var contentType = response.Content.Headers.ContentType?.MediaType;
+                if (!IsAllowedContentType(contentType))
+                {
+                    return FailureResult(cacheKey, $"disallowed content type '{contentType ?? "missing"}'", lastGood);
+                }
+
+                var declaredLength = response.Content.Headers.ContentLength;
+                if (declaredLength.HasValue && declaredLength.Value > _maximumAvatarBytes)
+                {
+                    return FailureResult(
+                        cacheKey,
+                        $"declared size {declaredLength.Value} exceeds {_maximumAvatarBytes}-byte cap",
+                        lastGood);
+                }
+
+                byte[]? content;
+                await using (var stream = await response.Content.ReadAsStreamAsync(fetchToken).ConfigureAwait(false))
+                {
+                    content = await ReadWithCapAsync(stream, _maximumAvatarBytes, fetchToken).ConfigureAwait(false);
+                }
+
+                if (content == null)
+                {
+                    return FailureResult(cacheKey, $"stream exceeds {_maximumAvatarBytes}-byte cap", lastGood);
+                }
+
+                if (!HasMatchingSignature(content, contentType!))
+                {
+                    return FailureResult(cacheKey, $"signature does not match {contentType}", lastGood);
+                }
+
+                if (!isConfigurationCurrent())
+                {
+                    return ConfigurationChanged();
+                }
+
+                var etag = $"\"{Convert.ToHexString(SHA256.HashData(content))}\"";
+                var entry = (
+                    Content: content,
+                    ContentType: contentType!,
+                    ETag: etag,
+                    CachedAt: _timeProvider.GetUtcNow().UtcDateTime);
+                if (!TryPublishCacheEntry(
+                    _cache.AvatarCache,
+                    cacheKey,
+                    entry,
+                    LastGoodRetention,
+                    isConfigurationCurrent))
+                {
+                    return isConfigurationCurrent()
+                        ? FailureResult(cacheKey, "cache capacity rejected avatar", lastGood)
+                        : ConfigurationChanged();
+                }
+
+                ClearFailure(cacheKey);
+                return Available(entry);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (OperationCanceledException)
+            {
+                return FailureResult(cacheKey, "upstream timed out", lastGood);
+            }
+            catch (Exception ex)
+            {
+                return FailureResult(cacheKey, ex.GetType().Name, lastGood);
+            }
+        }
+
+        private AvatarFetchResult FailureResult(
+            string cacheKey,
+            string reason,
+            (byte[] Content, string ContentType, string ETag, DateTime CachedAt) lastGood = default)
+        {
+            var failures = 1;
+            if (_failures.TryGet(cacheKey, out var previous))
+            {
+                failures = Math.Min(previous.ConsecutiveFailures + 1, FailureBackoff.Length);
+            }
+
+            var delay = FailureBackoff[Math.Min(failures - 1, FailureBackoff.Length - 1)];
+            _failures.Set(
+                cacheKey,
+                new FailureState(failures, _timeProvider.GetUtcNow().Add(delay)),
+                FailureStateRetention);
+            _logger.LogWarning(
+                "Avatar upstream unavailable for key {AvatarKey} ({Reason}); retry in {Delay}. Consecutive failures: {Failures}; last-good: {LastGood}.",
+                LogKey(cacheKey),
+                reason,
+                delay,
+                failures,
+                lastGood.Content != null ? "available" : "missing");
+            return lastGood.Content != null ? Available(lastGood) : Missing();
+        }
+
+        private bool TryGetLastGood(
+            string cacheKey,
+            out (byte[] Content, string ContentType, string ETag, DateTime CachedAt) entry)
+            => _cache.AvatarCache.TryGet(cacheKey, out entry);
+
+        private bool IsFresh((byte[] Content, string ContentType, string ETag, DateTime CachedAt) entry)
+            => entry.Content != null
+                && _timeProvider.GetUtcNow().UtcDateTime - entry.CachedAt < _cache.AvatarCacheDuration;
+
+        private bool IsBackedOff(string cacheKey)
+            => _failures.TryGet(cacheKey, out var failure)
+                && _timeProvider.GetUtcNow() < failure.RetryAfter;
+
+        private void ClearFailure(string cacheKey)
+        {
+            if (_failures.Remove(cacheKey))
+            {
+                _logger.LogInformation("Avatar upstream recovered for key {AvatarKey}; outage backoff cleared.", LogKey(cacheKey));
+            }
+        }
+
+        private static string LogKey(string cacheKey)
+            => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(cacheKey)))[..12];
+
+        private static bool IsAllowedContentType(string? contentType)
+            => contentType is not null && contentType.ToLowerInvariant() switch
+            {
+                "image/png" or "image/jpeg" or "image/jpg" or "image/gif" or
+                "image/webp" or "image/avif" or "image/bmp" => true,
+                _ => false,
+            };
+
+        private static bool HasMatchingSignature(ReadOnlySpan<byte> content, string contentType)
+            => contentType.ToLowerInvariant() switch
+            {
+                "image/png" => content.StartsWith(new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A }),
+                "image/jpeg" or "image/jpg" => content.StartsWith(new byte[] { 0xFF, 0xD8, 0xFF }),
+                "image/gif" => content.StartsWith("GIF87a"u8) || content.StartsWith("GIF89a"u8),
+                "image/webp" => content.Length >= 12 && content[..4].SequenceEqual("RIFF"u8) && content.Slice(8, 4).SequenceEqual("WEBP"u8),
+                "image/bmp" => content.StartsWith("BM"u8),
+                "image/avif" => content.Length >= 12
+                    && content.Slice(4, 4).SequenceEqual("ftyp"u8)
+                    && (content.Slice(8, 4).SequenceEqual("avif"u8)
+                        || content.Slice(8, 4).SequenceEqual("avis"u8)
+                        || content.Slice(8, 4).SequenceEqual("mif1"u8)),
+                _ => false,
+            };
+
+        private static async Task<byte[]?> ReadWithCapAsync(
+            Stream stream,
+            long maximumBytes,
+            CancellationToken cancellationToken)
+        {
+            using var buffer = new MemoryStream();
+            var chunk = new byte[81920];
+            while (buffer.Length <= maximumBytes)
+            {
+                var remainingThroughCap = maximumBytes + 1 - buffer.Length;
+                var requested = (int)Math.Min(chunk.Length, remainingThroughCap);
+                var read = await stream.ReadAsync(
+                    chunk.AsMemory(0, requested),
+                    cancellationToken).ConfigureAwait(false);
+                if (read == 0)
+                {
+                    return buffer.ToArray();
+                }
+
+                buffer.Write(chunk, 0, read);
+            }
+
+            return null;
+        }
+
+        private static AvatarFetchResult Available(
+            (byte[] Content, string ContentType, string ETag, DateTime CachedAt) entry)
+            => new(AvatarFetchStatus.Available, entry.Content, entry.ContentType, entry.ETag);
+
+        private static AvatarFetchResult Missing() => new(AvatarFetchStatus.Missing);
+
+        private static AvatarFetchResult ConfigurationChanged() => new(AvatarFetchStatus.ConfigurationChanged);
+
+        private sealed record FailureState(int ConsecutiveFailures, DateTimeOffset RetryAfter);
+
+        private sealed class AvatarFlight
+        {
+            private readonly object _gate = new();
+            private readonly CancellationTokenSource _cancellation = new();
+            private int _participants;
+            private bool _accepting = true;
+            private bool _complete;
+
+            public TaskCompletionSource<AvatarFetchResult> Completion { get; } = new(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public CancellationToken CancellationToken => _cancellation.Token;
+
+            public bool TryJoin()
+            {
+                lock (_gate)
+                {
+                    if (!_accepting)
+                    {
+                        return false;
+                    }
+
+                    _participants++;
+                    return true;
+                }
+            }
+
+            public void Leave()
+            {
+                lock (_gate)
+                {
+                    if (_participants <= 0)
+                    {
+                        return;
+                    }
+
+                    _participants--;
+                    if (_participants != 0)
+                    {
+                        return;
+                    }
+
+                    if (_complete)
+                    {
+                        _cancellation.Dispose();
+                    }
+                    else
+                    {
+                        _accepting = false;
+                        _cancellation.Cancel();
+                    }
+                }
+            }
+
+            public void MarkComplete()
+            {
+                lock (_gate)
+                {
+                    _accepting = false;
+                    _complete = true;
+                    if (_participants == 0)
+                    {
+                        _cancellation.Dispose();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -19,7 +19,7 @@ const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the repeated clean measurements', () => {
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1364, totalLines: 1692 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 13540, totalLines: 21712 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 13705, totalLines: 21906 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 1);
 });

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -21,12 +21,12 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 13540,
-        "totalLines": 21712
+        "coveredLines": 13705,
+        "totalLines": 21906
       },
       "tolerance": {
         "missingCoveredLines": 1,
-        "rationale": "The 2026-07-15 .NET 10/Coverlet run measured asset-cache same-key outage storms, fake-clock retry windows, globally bounded different-key fetches, last-good recovery, and no-remote-browser fallback coverage; one line permits only negligible instrumentation variance."
+        "rationale": "The 2026-07-15 .NET 10/Coverlet run measured bounded avatar streaming, cap-plus-one rejection, signature validation, reference-counted same-key singleflight cancellation, fake-clock negative backoff, last-good recovery, and high-cardinality cache budgets; one line permits only negligible instrumentation variance."
       }
     }
   }


### PR DESCRIPTION
Closes #108

## What changed
- stream upstream avatars with ResponseHeadersRead and an exact 8 MiB cap-plus-one rejection boundary
- validate raster MIME types against their file signatures before cache publication
- coalesce same-key cold misses with follower-safe cancellation ownership
- retain bounded last-good bytes and apply bounded exponential negative backoff
- preserve configuration-generation publication safety and the existing 64-entry / 32 MiB cache budget

## Validation
- server tests: 1307 passed
- client tests: 845 passed
- script/workflow tests: 294 passed
- server coverage: 13705 / 21906 lines (62.563%)
- typecheck, source typecheck, syntax, translations, lint, diff check: passed
- Release build: 0 warnings, 0 errors
- independent Fable review: approved

Official Docker E2E remains six shards at 2 CPUs/server using the digest-pinned jellyfin/jellyfin:unstable nightly image; no RC image is introduced.