### PR TITLE
Bound spoiler image inputs and transforms

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/JellyfinCanopy.Tests.csproj
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/JellyfinCanopy.Tests.csproj
@@ -35,6 +35,7 @@
          pull the native asset in here (TEST project only) to exercise
          ImageBlurService's Skia paths (StockCard/Blur/eviction). Skia-dependent
          tests skip themselves if the native lib fails to load. -->
+    <PackageReference Include="SkiaSharp" Version="3.116.1" PrivateAssets="all" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.116.1" />
   </ItemGroup>
 

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/AvatarFetchServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/AvatarFetchServiceTests.cs
@@ -52,7 +52,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             Assert.All(results, result => Assert.Equal(AvatarFetchStatus.Available, result.Status));
             Assert.Equal(1, handler.Calls);
             Assert.Single(cache.AvatarCache);
-            Assert.Equal(0, service.InFlightCount);
+            await WaitForNoFlightsAsync(service);
         }
 
         [Fact]
@@ -86,7 +86,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             Assert.Equal(ValidPng, result.Content);
             Assert.Single(cache.AvatarCache);
             Assert.Equal(1, handler.Calls);
-            Assert.Equal(0, service.InFlightCount);
+            await WaitForNoFlightsAsync(service);
         }
 
         [Fact]
@@ -108,7 +108,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => fetch);
             await stream.CancellationObserved.WaitAsync(TimeSpan.FromSeconds(5));
             Assert.Empty(cache.AvatarCache);
-            Assert.Equal(0, service.InFlightCount);
+            await WaitForNoFlightsAsync(service);
         }
 
         [Fact]
@@ -201,6 +201,17 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
         {
             var (_, cache, service) = CreateWithService(handler, timeProvider, maximumAvatarBytes);
             return (service, cache);
+        }
+
+        private static async Task WaitForNoFlightsAsync(AvatarFetchService service)
+        {
+            var deadline = DateTime.UtcNow.AddSeconds(5);
+            while (service.InFlightCount != 0 && DateTime.UtcNow < deadline)
+            {
+                await Task.Delay(10);
+            }
+
+            Assert.Equal(0, service.InFlightCount);
         }
 
         private static (RecordingHttpClientFactory Factory, SeerrCache Cache, AvatarFetchService Service) CreateWithService(

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SpoilerImageBudgetTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SpoilerImageBudgetTests.cs
@@ -1,0 +1,528 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using SkiaSharp;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
+{
+    public sealed class SpoilerImageBudgetTests
+    {
+        [Fact]
+        public async Task ChunkedInput_StopsAtCapPlusOne()
+        {
+            const int cap = 32;
+            var stream = new CountingNonSeekableStream(new byte[cap + 1000]);
+            var result = new FileStreamResult(stream, "image/jpeg");
+
+            var extracted = await Jellyfin.Plugin.JellyfinCanopy.Services.SpoilerBlurImageFilter.ExtractBytesAsync(
+                result,
+                cap,
+                CancellationToken.None);
+
+            Assert.Equal(
+                Jellyfin.Plugin.JellyfinCanopy.Services.SpoilerBlurImageFilter.ImageExtractionStatus.Rejected,
+                extracted.Status);
+            Assert.Null(extracted.Bytes);
+            Assert.Equal(cap + 1, stream.BytesRead);
+        }
+
+        [Fact]
+        public async Task Cancellation_StopsInputExtraction()
+        {
+            var stream = new CancellationObservingStream();
+            var result = new FileStreamResult(stream, "image/jpeg");
+            using var cancellation = new CancellationTokenSource();
+
+            var extraction = Jellyfin.Plugin.JellyfinCanopy.Services.SpoilerBlurImageFilter.ExtractBytesAsync(
+                result,
+                1024,
+                cancellation.Token);
+            await stream.ReadStarted.WaitAsync(TimeSpan.FromSeconds(5));
+            cancellation.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => extraction);
+            await stream.CancellationObserved.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+
+        [Fact]
+        public async Task StatusOnlyResult_RemainsUnderCallerNoContentPolicy()
+        {
+            var result = new NotFoundResult();
+
+            var extracted = await Jellyfin.Plugin.JellyfinCanopy.Services.SpoilerBlurImageFilter.ExtractBytesAsync(
+                result,
+                1024,
+                CancellationToken.None);
+
+            Assert.Equal(
+                Jellyfin.Plugin.JellyfinCanopy.Services.SpoilerBlurImageFilter.ImageExtractionStatus.Unrecognized,
+                extracted.Status);
+            Assert.True(Jellyfin.Plugin.JellyfinCanopy.Services.SpoilerBlurImageFilter.IsRecognizedNoContentResult(result));
+            Assert.False(Jellyfin.Plugin.JellyfinCanopy.Services.SpoilerBlurImageFilter.IsRecognizedNoContentResult(
+                new StatusCodeResult(304)));
+            Assert.False(Jellyfin.Plugin.JellyfinCanopy.Services.SpoilerBlurImageFilter.CanEnterTransformFlight(
+                new StatusCodeResult(304)));
+            Assert.True(Jellyfin.Plugin.JellyfinCanopy.Services.SpoilerBlurImageFilter.CanEnterTransformFlight(
+                new FileContentResult(new byte[] { 1 }, "image/jpeg")));
+            var unknownFile = new UnknownFileResult();
+            Assert.False(Jellyfin.Plugin.JellyfinCanopy.Services.SpoilerBlurImageFilter.CanEnterTransformFlight(unknownFile));
+            Assert.False(Jellyfin.Plugin.JellyfinCanopy.Services.SpoilerBlurImageFilter.IsRecognizedNoContentResult(unknownFile));
+        }
+
+        [Fact]
+        public void ReplacedEmptyFileStream_IsDisposed()
+        {
+            var stream = new MemoryStream();
+            var result = new FileStreamResult(stream, "image/jpeg");
+
+            Jellyfin.Plugin.JellyfinCanopy.Services.SpoilerBlurImageFilter.DisposeReplacedFileStream(result);
+
+            Assert.Throws<ObjectDisposedException>(() => stream.ReadByte());
+        }
+
+        [Fact]
+        public void HugeDimensionHeader_IsRejectedBeforeDecodeAllocation()
+        {
+            var service = new Jellyfin.Plugin.JellyfinCanopy.Services.ImageBlurService(
+                NullLogger<Jellyfin.Plugin.JellyfinCanopy.Services.ImageBlurService>.Instance);
+            var png = BuildHeaderBombPng(30_000, 30_000);
+
+            var result = service.Blur(png, 40, "header-bomb");
+
+            Assert.Null(result);
+            Assert.Equal(0, service.DecodeAttemptCountForTest);
+            Assert.True(service.RejectedSourceCountForTest > 0);
+        }
+
+        [Fact]
+        public void StockCard_UsesMetadataWithoutPixelDecode()
+        {
+            var service = new Jellyfin.Plugin.JellyfinCanopy.Services.ImageBlurService(
+                NullLogger<Jellyfin.Plugin.JellyfinCanopy.Services.ImageBlurService>.Instance);
+
+            var result = service.StockCard(service.HardcodedFallbackJpeg, "metadata-only");
+
+            Assert.NotNull(result);
+            Assert.Equal(0, service.DecodeAttemptCountForTest);
+        }
+
+        [Fact]
+        public async Task FourKConcurrentColdRequests_SampleDecodeOnce()
+        {
+            var service = new Jellyfin.Plugin.JellyfinCanopy.Services.ImageBlurService(
+                NullLogger<Jellyfin.Plugin.JellyfinCanopy.Services.ImageBlurService>.Instance);
+            var fourK = EncodeJpeg(3840, 2160);
+
+            var requests = Enumerable.Range(0, 32)
+                .Select(_ => service.RunBoundedTransformAsync(
+                    "4k-same-key",
+                    _ => Task.FromResult(BuildBlurResult(service, fourK, "4k-output")),
+                    releaseUnusedInput: null,
+                    CancellationToken.None))
+                .ToArray();
+            var results = await Task.WhenAll(requests);
+
+            Assert.All(results, result => Assert.Equal(
+                Jellyfin.Plugin.JellyfinCanopy.Services.SpoilerTransformStatus.Available,
+                result.Status));
+            Assert.Equal(1, service.TransformExecutionCountForTest);
+            Assert.Equal(1, service.DecodeAttemptCountForTest);
+            Assert.Equal(0, service.InFlightCountForTest);
+
+            using var output = SKBitmap.Decode(results[0].Bytes);
+            Assert.NotNull(output);
+            Assert.True(Math.Max(output.Width, output.Height) <= 1920);
+        }
+
+        [Fact]
+        public void FourKPng_UsesBoundedDecodeFallbackAndStillBlurs()
+        {
+            var service = new Jellyfin.Plugin.JellyfinCanopy.Services.ImageBlurService(
+                NullLogger<Jellyfin.Plugin.JellyfinCanopy.Services.ImageBlurService>.Instance);
+            var fourK = EncodeImage(3840, 2160, SKEncodedImageFormat.Png);
+
+            var result = service.Blur(fourK, 40, "4k-png");
+
+            Assert.NotNull(result);
+            Assert.Equal(1, service.DecodeAttemptCountForTest);
+            using var output = SKBitmap.Decode(result);
+            Assert.NotNull(output);
+            Assert.True(Math.Max(output.Width, output.Height) <= 1920);
+        }
+
+        [Fact]
+        public async Task OneHundredColdRequests_ExtractDecodeAndTransformOnce()
+        {
+            var service = new Jellyfin.Plugin.JellyfinCanopy.Services.ImageBlurService(
+                NullLogger<Jellyfin.Plugin.JellyfinCanopy.Services.ImageBlurService>.Instance);
+            var releaseRead = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var readStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var streams = Enumerable.Range(0, 100)
+                .Select(_ => new GateCountingStream(service.HardcodedFallbackJpeg, readStarted, releaseRead))
+                .ToArray();
+            var factoryCalls = 0;
+
+            var requests = streams.Select(stream =>
+            {
+                var source = new FileStreamResult(stream, "image/jpeg");
+                return service.RunBoundedTransformAsync(
+                    "whole-pipeline",
+                    async token =>
+                    {
+                        Interlocked.Increment(ref factoryCalls);
+                        try
+                        {
+                            var extracted = await Jellyfin.Plugin.JellyfinCanopy.Services.SpoilerBlurImageFilter.ExtractBytesAsync(
+                                source,
+                                1024,
+                                token);
+                            Assert.Equal(
+                                Jellyfin.Plugin.JellyfinCanopy.Services.SpoilerBlurImageFilter.ImageExtractionStatus.Available,
+                                extracted.Status);
+                            return BuildBlurResult(service, extracted.Bytes!, "whole-pipeline-output");
+                        }
+                        finally
+                        {
+                            await stream.DisposeAsync();
+                        }
+                    },
+                    () => stream.DisposeAsync(),
+                    CancellationToken.None);
+            }).ToArray();
+
+            await readStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            releaseRead.TrySetResult();
+            var results = await Task.WhenAll(requests);
+
+            Assert.All(results, result => Assert.Equal(
+                Jellyfin.Plugin.JellyfinCanopy.Services.SpoilerTransformStatus.Available,
+                result.Status));
+            Assert.Equal(1, factoryCalls);
+            Assert.Equal(1, service.TransformExecutionCountForTest);
+            Assert.Equal(1, service.DecodeAttemptCountForTest);
+            Assert.Equal(service.HardcodedFallbackJpeg.Length, streams.Sum(stream => stream.BytesRead));
+            Assert.All(streams, stream => Assert.Equal(1, stream.DisposeCount));
+        }
+
+        [Fact]
+        public async Task LeaderCancellation_DoesNotPoisonLiveFollower()
+        {
+            var service = new Jellyfin.Plugin.JellyfinCanopy.Services.ImageBlurService(
+                NullLogger<Jellyfin.Plugin.JellyfinCanopy.Services.ImageBlurService>.Instance);
+            var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var leaderCancellation = new CancellationTokenSource();
+
+            async Task<Jellyfin.Plugin.JellyfinCanopy.Services.SpoilerTransformResult> Factory(CancellationToken token)
+            {
+                started.TrySetResult();
+                await release.Task.WaitAsync(token);
+                return Jellyfin.Plugin.JellyfinCanopy.Services.SpoilerTransformResult.Available(new byte[] { 1, 2, 3 });
+            }
+
+            var leader = service.RunBoundedTransformAsync(
+                "shared",
+                Factory,
+                releaseUnusedInput: null,
+                leaderCancellation.Token);
+            await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            var follower = service.RunBoundedTransformAsync(
+                "shared",
+                Factory,
+                releaseUnusedInput: null,
+                CancellationToken.None);
+
+            leaderCancellation.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => leader);
+            Assert.Equal(1, service.TransformExecutionCountForTest);
+            release.TrySetResult();
+
+            var result = await follower.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal(Jellyfin.Plugin.JellyfinCanopy.Services.SpoilerTransformStatus.Available, result.Status);
+            Assert.Equal(new byte[] { 1, 2, 3 }, result.Bytes);
+            Assert.Equal(1, service.TransformExecutionCountForTest);
+            Assert.Equal(0, service.InFlightCountForTest);
+        }
+
+        [Fact]
+        public async Task LastCallerCancellation_StopsSharedWork()
+        {
+            var service = new Jellyfin.Plugin.JellyfinCanopy.Services.ImageBlurService(
+                NullLogger<Jellyfin.Plugin.JellyfinCanopy.Services.ImageBlurService>.Instance);
+            var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var cancellationObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var cancellation = new CancellationTokenSource();
+
+            async Task<Jellyfin.Plugin.JellyfinCanopy.Services.SpoilerTransformResult> Factory(CancellationToken token)
+            {
+                started.TrySetResult();
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                    return Jellyfin.Plugin.JellyfinCanopy.Services.SpoilerTransformResult.Rejected();
+                }
+                catch (OperationCanceledException)
+                {
+                    cancellationObserved.TrySetResult();
+                    throw;
+                }
+            }
+
+            var transform = service.RunBoundedTransformAsync(
+                "cancel-last",
+                Factory,
+                releaseUnusedInput: null,
+                cancellation.Token);
+            await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            cancellation.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => transform);
+            await cancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await WaitForAsync(() => service.InFlightCountForTest == 0);
+            Assert.Equal(0, service.InFlightCountForTest);
+        }
+
+        [Fact]
+        public async Task DifferentKeys_NeverExceedGlobalTransformBudget()
+        {
+            var service = new Jellyfin.Plugin.JellyfinCanopy.Services.ImageBlurService(
+                NullLogger<Jellyfin.Plugin.JellyfinCanopy.Services.ImageBlurService>.Instance,
+                maximumConcurrentTransforms: 2);
+            var active = 0;
+            var maximumActive = 0;
+
+            async Task<Jellyfin.Plugin.JellyfinCanopy.Services.SpoilerTransformResult> Factory(CancellationToken token)
+            {
+                var nowActive = Interlocked.Increment(ref active);
+                UpdateMaximum(ref maximumActive, nowActive);
+                try
+                {
+                    await Task.Delay(40, token);
+                    return Jellyfin.Plugin.JellyfinCanopy.Services.SpoilerTransformResult.Available(new byte[] { 1 });
+                }
+                finally
+                {
+                    Interlocked.Decrement(ref active);
+                }
+            }
+
+            await Task.WhenAll(Enumerable.Range(0, 12).Select(i => service.RunBoundedTransformAsync(
+                $"different-{i}",
+                Factory,
+                releaseUnusedInput: null,
+                CancellationToken.None)));
+
+            Assert.InRange(maximumActive, 1, 2);
+            Assert.Equal(12, service.TransformExecutionCountForTest);
+        }
+
+        private static Jellyfin.Plugin.JellyfinCanopy.Services.SpoilerTransformResult BuildBlurResult(
+            Jellyfin.Plugin.JellyfinCanopy.Services.ImageBlurService service,
+            byte[] input,
+            string cacheKey)
+        {
+            var blurred = service.Blur(input, 40, cacheKey);
+            return blurred == null
+                ? Jellyfin.Plugin.JellyfinCanopy.Services.SpoilerTransformResult.Rejected()
+                : Jellyfin.Plugin.JellyfinCanopy.Services.SpoilerTransformResult.Available(blurred);
+        }
+
+        private static byte[] EncodeJpeg(int width, int height)
+            => EncodeImage(width, height, SKEncodedImageFormat.Jpeg);
+
+        private static byte[] EncodeImage(int width, int height, SKEncodedImageFormat format)
+        {
+            using var bitmap = new SKBitmap(width, height);
+            bitmap.Erase(new SKColor(40, 80, 120));
+            using var image = SKImage.FromBitmap(bitmap);
+            using var encoded = image.Encode(format, 85);
+            Assert.NotNull(encoded);
+            return encoded.ToArray();
+        }
+
+        private static byte[] BuildHeaderBombPng(int width, int height)
+        {
+            using var bitmap = new SKBitmap(1, 1);
+            bitmap.Erase(SKColors.Black);
+            using var image = SKImage.FromBitmap(bitmap);
+            using var encoded = image.Encode(SKEncodedImageFormat.Png, 100);
+            Assert.NotNull(encoded);
+            var bytes = encoded.ToArray();
+
+            WriteBigEndian(bytes, 16, width);
+            WriteBigEndian(bytes, 20, height);
+            var crc = Crc32(bytes.AsSpan(12, 17));
+            WriteBigEndian(bytes, 29, unchecked((int)crc));
+            return bytes;
+        }
+
+        private static void WriteBigEndian(byte[] bytes, int offset, int value)
+        {
+            bytes[offset] = (byte)((uint)value >> 24);
+            bytes[offset + 1] = (byte)((uint)value >> 16);
+            bytes[offset + 2] = (byte)((uint)value >> 8);
+            bytes[offset + 3] = (byte)value;
+        }
+
+        private static uint Crc32(ReadOnlySpan<byte> bytes)
+        {
+            var crc = 0xFFFFFFFFu;
+            foreach (var value in bytes)
+            {
+                crc ^= value;
+                for (var bit = 0; bit < 8; bit++)
+                {
+                    crc = (crc & 1) != 0 ? (crc >> 1) ^ 0xEDB88320u : crc >> 1;
+                }
+            }
+
+            return ~crc;
+        }
+
+        private static void UpdateMaximum(ref int maximum, int candidate)
+        {
+            while (true)
+            {
+                var current = Volatile.Read(ref maximum);
+                if (candidate <= current || Interlocked.CompareExchange(ref maximum, candidate, current) == current)
+                {
+                    return;
+                }
+            }
+        }
+
+        private static async Task WaitForAsync(Func<bool> predicate)
+        {
+            var deadline = DateTime.UtcNow.AddSeconds(5);
+            while (!predicate() && DateTime.UtcNow < deadline)
+            {
+                await Task.Delay(10);
+            }
+        }
+
+        private sealed class CountingNonSeekableStream : Stream
+        {
+            private readonly MemoryStream _inner;
+
+            public CountingNonSeekableStream(byte[] bytes) => _inner = new MemoryStream(bytes, writable: false);
+
+            public int BytesRead { get; private set; }
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => throw new NotSupportedException();
+            public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+            public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+            public override void Flush() => throw new NotSupportedException();
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+            public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                var read = await _inner.ReadAsync(buffer, cancellationToken);
+                BytesRead += read;
+                return read;
+            }
+        }
+
+        private sealed class UnknownFileResult : FileResult
+        {
+            public UnknownFileResult()
+                : base("image/jpeg")
+            {
+            }
+        }
+
+        private sealed class CancellationObservingStream : Stream
+        {
+            private readonly TaskCompletionSource _readStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly TaskCompletionSource _cancellationObserved = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public Task ReadStarted => _readStarted.Task;
+            public Task CancellationObserved => _cancellationObserved.Task;
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => throw new NotSupportedException();
+            public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+            public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+            public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                _readStarted.TrySetResult();
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                    return 0;
+                }
+                catch (OperationCanceledException)
+                {
+                    _cancellationObserved.TrySetResult();
+                    throw;
+                }
+            }
+
+            public override void Flush() => throw new NotSupportedException();
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        }
+
+        private sealed class GateCountingStream : Stream
+        {
+            private readonly MemoryStream _inner;
+            private readonly TaskCompletionSource _started;
+            private readonly TaskCompletionSource _release;
+            private int _firstRead = 1;
+            private int _disposeCount;
+
+            public GateCountingStream(
+                byte[] bytes,
+                TaskCompletionSource started,
+                TaskCompletionSource release)
+            {
+                _inner = new MemoryStream(bytes, writable: false);
+                _started = started;
+                _release = release;
+            }
+
+            public int BytesRead { get; private set; }
+            public int DisposeCount => Volatile.Read(ref _disposeCount);
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => throw new NotSupportedException();
+            public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+            public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+            public override void Flush() => throw new NotSupportedException();
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+            public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                if (Interlocked.Exchange(ref _firstRead, 0) == 1)
+                {
+                    _started.TrySetResult();
+                    await _release.Task.WaitAsync(cancellationToken);
+                }
+
+                var read = await _inner.ReadAsync(buffer, cancellationToken);
+                BytesRead += read;
+                return read;
+            }
+
+            public override ValueTask DisposeAsync()
+            {
+                if (Interlocked.Increment(ref _disposeCount) == 1)
+                {
+                    _inner.Dispose();
+                }
+
+                GC.SuppressFinalize(this);
+                return ValueTask.CompletedTask;
+            }
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/ImageBlurService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/ImageBlurService.cs
@@ -1,11 +1,34 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using SkiaSharp;
 
 namespace Jellyfin.Plugin.JellyfinCanopy.Services
 {
+    internal enum SpoilerTransformStatus
+    {
+        Available,
+        NoContent,
+        Unrecognized,
+        Rejected,
+    }
+
+    internal sealed record SpoilerTransformResult(
+        SpoilerTransformStatus Status,
+        byte[]? Bytes = null)
+    {
+        public static SpoilerTransformResult Available(byte[] bytes) => new(SpoilerTransformStatus.Available, bytes);
+
+        public static SpoilerTransformResult NoContent() => new(SpoilerTransformStatus.NoContent);
+
+        public static SpoilerTransformResult Unrecognized() => new(SpoilerTransformStatus.Unrecognized);
+
+        public static SpoilerTransformResult Rejected() => new(SpoilerTransformStatus.Rejected);
+    }
+
     // Produces a "spoiler-style" blurred version of an input image, using
     // SkiaSharp's CreateBlur ImageFilter (a separable Gaussian implemented
     // in native code, with proper edge handling).
@@ -25,6 +48,22 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         private const int MaxCacheEntries = 256;
         private const long MaxCacheBytes = 64L * 1024 * 1024; // 64 MiB
 
+        // Every protected source is bounded before it reaches Skia. The encoded
+        // ceiling accommodates high-quality 4K artwork while preventing one image
+        // request from materializing an arbitrarily large managed buffer.
+        internal const long MaximumEncodedImageBytes = 32L * 1024 * 1024;
+
+        // Metadata budgets are checked before allocating a bitmap. The source
+        // pixel budget admits ordinary 8K artwork, but rejects header bombs and
+        // impossible row strides. The actual decoded bitmap is sampled to the
+        // much smaller MaxDecodeEdgePx / MaxDecodedBytes budget below.
+        internal const int MaximumSourceDimension = 16 * 1024;
+        internal const long MaximumSourcePixels = 128L * 1024 * 1024;
+        internal const long MaximumDecodedBytes = 16L * 1024 * 1024;
+        private const long MaximumFallbackDecodePixels = 16L * 1024 * 1024;
+        private const long MaximumFallbackDecodeBytes = 64L * 1024 * 1024;
+        private const int MaximumConcurrentTransforms = 2;
+
         // Decoded source pixel ceiling (long edge). Episode thumbnails are at
         // most ~1280x720; constraining bounds runtime in case Jellyfin serves
         // a 4K backdrop here.
@@ -38,7 +77,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
 
         private readonly ILogger<ImageBlurService> _logger;
         private readonly ConcurrentDictionary<string, CacheEntry> _cache = new();
+        private readonly ConcurrentDictionary<string, TransformFlight> _transformFlights = new(StringComparer.Ordinal);
+        private readonly SemaphoreSlim _transformSlots;
         private long _cacheBytes;
+        private int _transformExecutionCount;
+        private int _decodeAttemptCount;
+        private int _rejectedSourceCount;
         private readonly object _evictionLock = new();
 
         // Hardcoded last-resort fallback served when both the parent-art path
@@ -60,8 +104,83 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         public byte[] HardcodedFallbackJpeg => _hardcodedFallbackJpeg;
 
         public ImageBlurService(ILogger<ImageBlurService> logger)
+            : this(logger, MaximumConcurrentTransforms)
         {
+        }
+
+        internal ImageBlurService(ILogger<ImageBlurService> logger, int maximumConcurrentTransforms)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumConcurrentTransforms);
             _logger = logger;
+            _transformSlots = new SemaphoreSlim(maximumConcurrentTransforms, maximumConcurrentTransforms);
+        }
+
+        /// <summary>
+        /// Coalesces the complete cold transform pipeline for one privacy-safe key.
+        /// The shared work owns its cancellation token: one disconnected caller
+        /// detaches without cancelling live followers, while the final departing
+        /// caller cancels queued extraction/transform work. A process-wide slot
+        /// budget also bounds different-key encoded buffers and native Skia work.
+        /// </summary>
+        internal async Task<SpoilerTransformResult> RunBoundedTransformAsync(
+            string transformKey,
+            Func<CancellationToken, Task<SpoilerTransformResult>> transform,
+            Func<ValueTask>? releaseUnusedInput,
+            CancellationToken callerCancellationToken)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(transformKey);
+            ArgumentNullException.ThrowIfNull(transform);
+            if (callerCancellationToken.IsCancellationRequested)
+            {
+                if (releaseUnusedInput != null)
+                {
+                    await releaseUnusedInput().ConfigureAwait(false);
+                }
+
+                callerCancellationToken.ThrowIfCancellationRequested();
+            }
+
+            while (true)
+            {
+                var candidate = new TransformFlight();
+                var flight = _transformFlights.GetOrAdd(transformKey, candidate);
+                if (!ReferenceEquals(flight, candidate))
+                {
+                    candidate.DisposeUnused();
+                }
+
+                if (!flight.TryJoin())
+                {
+                    _transformFlights.TryRemove(new KeyValuePair<string, TransformFlight>(transformKey, flight));
+                    continue;
+                }
+
+                var isLeader = ReferenceEquals(flight, candidate);
+                if (isLeader)
+                {
+                    _ = CompleteTransformFlightAsync(transformKey, transform, flight);
+                }
+
+                try
+                {
+                    return await flight.Completion.Task.WaitAsync(callerCancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    flight.Leave();
+                    if (!isLeader && releaseUnusedInput != null)
+                    {
+                        try
+                        {
+                            await releaseUnusedInput().ConfigureAwait(false);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogDebug(ex, "Spoiler Guard could not release a coalesced follower input.");
+                        }
+                    }
+                }
+            }
         }
 
         // Returns a tiny solid-#101010 JPEG sized to the input (or default
@@ -86,20 +205,18 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             int height = 900;
             try
             {
-                if (input != null && input.Length > 0)
+                if (input != null
+                    && input.Length > 0
+                    && TryReadSourceInfo(input, out var sourceInfo))
                 {
-                    using var probe = SKBitmap.Decode(input);
-                    if (probe != null && probe.Width > 0 && probe.Height > 0)
+                    width = sourceInfo.Width;
+                    height = sourceInfo.Height;
+                    var longEdge = Math.Max(width, height);
+                    if (longEdge > MaxDecodeEdgePx)
                     {
-                        width = probe.Width;
-                        height = probe.Height;
-                        var longEdge = Math.Max(width, height);
-                        if (longEdge > MaxDecodeEdgePx)
-                        {
-                            var ratio = (float)MaxDecodeEdgePx / longEdge;
-                            width = Math.Max(1, (int)(width * ratio));
-                            height = Math.Max(1, (int)(height * ratio));
-                        }
+                        var ratio = (float)MaxDecodeEdgePx / longEdge;
+                        width = Math.Max(1, (int)(width * ratio));
+                        height = Math.Max(1, (int)(height * ratio));
                     }
                 }
             }
@@ -156,14 +273,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             int targetW = 600, targetH = 900;
             try
             {
-                if (referenceBytes != null && referenceBytes.Length > 0)
+                if (referenceBytes != null
+                    && referenceBytes.Length > 0
+                    && TryReadSourceInfo(referenceBytes, out var referenceInfo))
                 {
-                    using var probe = SKBitmap.Decode(referenceBytes);
-                    if (probe != null && probe.Width > 0 && probe.Height > 0)
-                    {
-                        targetW = probe.Width;
-                        targetH = probe.Height;
-                    }
+                    targetW = referenceInfo.Width;
+                    targetH = referenceInfo.Height;
                 }
             }
             catch (Exception ex)
@@ -176,7 +291,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             byte[]? output;
             try
             {
-                using var srcBitmap = SKBitmap.Decode(source);
+                using var srcBitmap = DecodeBounded(source);
                 if (srcBitmap == null) return null;
 
                 int srcW = srcBitmap.Width;
@@ -263,68 +378,232 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
 
         private byte[]? BlurInternal(byte[] input, float sigma)
         {
-            using var bitmap = SKBitmap.Decode(input);
+            using var bitmap = DecodeBounded(input);
             if (bitmap == null) return null;
 
             int width = bitmap.Width;
             int height = bitmap.Height;
             if (width <= 0 || height <= 0) return null;
 
-            // Constrain very large source images first; saves CPU + memory.
-            SKBitmap workingBitmap = bitmap;
-            SKBitmap? resized = null;
+            using var surface = SKSurface.Create(new SKImageInfo(width, height));
+            if (surface == null) return null;
+
+            using var paint = new SKPaint
+            {
+                // Clamp tile mode samples the edge pixel beyond the canvas
+                // so we don't get a black halo from the kernel reading
+                // transparent pixels. The SKImageFilter is owned by the
+                // SKPaint via SkiaSharp's internal ref-counting — wrapping
+                // it in `using var` and assigning to ImageFilter caused
+                // the filter to be released early in some draw paths and
+                // silently produce unblurred output.
+                ImageFilter = SKImageFilter.CreateBlur(sigma, sigma, SKShaderTileMode.Clamp),
+                IsAntialias = true,
+            };
+
+            surface.Canvas.Clear(SKColors.Transparent);
+            surface.Canvas.DrawBitmap(bitmap, 0, 0, paint);
+
+            using var image = surface.Snapshot();
+            // Quality 85: heavily smoothed images don't benefit from
+            // higher q; 85 keeps file size small (~30-40 KB at 1280x720).
+            using var encoded = image.Encode(SKEncodedImageFormat.Jpeg, 85);
+            if (encoded == null) return null;
+            return encoded.ToArray();
+        }
+
+        private async Task CompleteTransformFlightAsync(
+            string transformKey,
+            Func<CancellationToken, Task<SpoilerTransformResult>> transform,
+            TransformFlight flight)
+        {
+            var flightToken = flight.CancellationToken;
+            var slotHeld = false;
             try
             {
-                int longEdge = Math.Max(width, height);
-                if (longEdge > MaxDecodeEdgePx)
-                {
-                    var ratio = (float)MaxDecodeEdgePx / longEdge;
-                    int newW = Math.Max(1, (int)(width * ratio));
-                    int newH = Math.Max(1, (int)(height * ratio));
-                    resized = bitmap.Resize(new SKImageInfo(newW, newH), SKSamplingOptions.Default);
-                    if (resized != null)
-                    {
-                        workingBitmap = resized;
-                        width = newW;
-                        height = newH;
-                    }
-                }
-
-                using var surface = SKSurface.Create(new SKImageInfo(width, height));
-                if (surface == null) return null;
-
-                using var paint = new SKPaint
-                {
-                    // Clamp tile mode samples the edge pixel beyond the canvas
-                    // so we don't get a black halo from the kernel reading
-                    // transparent pixels. The SKImageFilter is owned by the
-                    // SKPaint via SkiaSharp's internal ref-counting — wrapping
-                    // it in `using var` and assigning to ImageFilter caused
-                    // the filter to be released early in some draw paths and
-                    // silently produce unblurred output.
-                    ImageFilter = SKImageFilter.CreateBlur(sigma, sigma, SKShaderTileMode.Clamp),
-                    IsAntialias = true,
-                };
-
-                surface.Canvas.Clear(SKColors.Transparent);
-                surface.Canvas.DrawBitmap(workingBitmap, 0, 0, paint);
-
-                using var image = surface.Snapshot();
-                // Quality 85: heavily smoothed images don't benefit from
-                // higher q; 85 keeps file size small (~30-40 KB at 1280x720).
-                using var encoded = image.Encode(SKEncodedImageFormat.Jpeg, 85);
-                if (encoded == null) return null;
-                return encoded.ToArray();
+                // Publish the flight before invoking a factory that may complete
+                // synchronously (FileContentResult + native Skia). Without this
+                // boundary, the first request could finish the whole cold transform
+                // before concurrent callers have a chance to join it.
+                await Task.Yield();
+                await _transformSlots.WaitAsync(flightToken).ConfigureAwait(false);
+                slotHeld = true;
+                Interlocked.Increment(ref _transformExecutionCount);
+                flight.Completion.TrySetResult(await transform(flightToken).ConfigureAwait(false));
+            }
+            catch (OperationCanceledException) when (flightToken.IsCancellationRequested)
+            {
+                flight.Completion.TrySetCanceled(flightToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Spoiler Guard bounded transform failed for key {TransformKey}.", transformKey);
+                flight.Completion.TrySetResult(SpoilerTransformResult.Rejected());
             }
             finally
             {
-                resized?.Dispose();
+                if (slotHeld)
+                {
+                    _transformSlots.Release();
+                }
+
+                flight.MarkComplete();
+                _transformFlights.TryRemove(new KeyValuePair<string, TransformFlight>(transformKey, flight));
             }
         }
+
+        private SKBitmap? DecodeBounded(byte[] input)
+        {
+            if (input.LongLength > MaximumEncodedImageBytes)
+            {
+                Interlocked.Increment(ref _rejectedSourceCount);
+                return null;
+            }
+
+            using var stream = new SKMemoryStream(input);
+            using var codec = SKCodec.Create(stream);
+            if (codec == null || !IsSourceInfoAllowed(codec.Info))
+            {
+                Interlocked.Increment(ref _rejectedSourceCount);
+                return null;
+            }
+
+            var sourceInfo = codec.Info;
+            var desiredScale = Math.Min(1f, (float)MaxDecodeEdgePx / Math.Max(sourceInfo.Width, sourceInfo.Height));
+            var scaled = codec.GetScaledDimensions(desiredScale);
+
+            // Some codecs expose only coarse native sampling ratios. Step down
+            // until the codec advertises a destination inside our allocation
+            // budget. Formats with no safe sampled decode (notably large PNGs
+            // on some Skia builds) fail closed instead of allocating full size.
+            for (var attempt = 0; attempt < 8 && Math.Max(scaled.Width, scaled.Height) > MaxDecodeEdgePx; attempt++)
+            {
+                desiredScale *= 0.75f;
+                scaled = codec.GetScaledDimensions(desiredScale);
+            }
+
+            if (scaled.Width <= 0 || scaled.Height <= 0)
+            {
+                Interlocked.Increment(ref _rejectedSourceCount);
+                return null;
+            }
+
+            var requiresPostDecodeResize = Math.Max(scaled.Width, scaled.Height) > MaxDecodeEdgePx;
+            if (requiresPostDecodeResize)
+            {
+                // PNG/BMP and a few platform codecs cannot sample during decode.
+                // Preserve ordinary 4K artwork compatibility with a separately
+                // bounded full decode, then immediately resize. Adversarial or
+                // very large sources still reject before native allocation.
+                var sourcePixels = (long)sourceInfo.Width * sourceInfo.Height;
+                var sourceBytes = sourcePixels * 4;
+                if (sourcePixels > MaximumFallbackDecodePixels
+                    || sourceBytes > MaximumFallbackDecodeBytes)
+                {
+                    Interlocked.Increment(ref _rejectedSourceCount);
+                    return null;
+                }
+
+                scaled = new SKSizeI(sourceInfo.Width, sourceInfo.Height);
+            }
+
+            var decodeInfo = new SKImageInfo(
+                scaled.Width,
+                scaled.Height,
+                SKColorType.Rgba8888,
+                SKAlphaType.Premul);
+            var allocationBudget = requiresPostDecodeResize
+                ? MaximumFallbackDecodeBytes
+                : MaximumDecodedBytes;
+            if (decodeInfo.BytesSize64 <= 0
+                || decodeInfo.BytesSize64 > allocationBudget
+                || decodeInfo.RowBytes64 <= 0
+                || decodeInfo.RowBytes64 > (requiresPostDecodeResize
+                    ? (long)MaximumSourceDimension * 4
+                    : (long)MaxDecodeEdgePx * 4))
+            {
+                Interlocked.Increment(ref _rejectedSourceCount);
+                return null;
+            }
+
+            Interlocked.Increment(ref _decodeAttemptCount);
+            var bitmap = SKBitmap.Decode(codec, decodeInfo);
+            if (bitmap == null)
+            {
+                return null;
+            }
+
+            if (bitmap.Width <= 0 || bitmap.Height <= 0 || bitmap.ByteCount > allocationBudget)
+            {
+                bitmap.Dispose();
+                Interlocked.Increment(ref _rejectedSourceCount);
+                return null;
+            }
+
+            if (requiresPostDecodeResize)
+            {
+                var ratio = (float)MaxDecodeEdgePx / Math.Max(bitmap.Width, bitmap.Height);
+                var targetWidth = Math.Max(1, (int)(bitmap.Width * ratio));
+                var targetHeight = Math.Max(1, (int)(bitmap.Height * ratio));
+                var resized = bitmap.Resize(
+                    new SKImageInfo(targetWidth, targetHeight, SKColorType.Rgba8888, SKAlphaType.Premul),
+                    SKSamplingOptions.Default);
+                bitmap.Dispose();
+                if (resized == null
+                    || Math.Max(resized.Width, resized.Height) > MaxDecodeEdgePx
+                    || resized.ByteCount > MaximumDecodedBytes)
+                {
+                    resized?.Dispose();
+                    Interlocked.Increment(ref _rejectedSourceCount);
+                    return null;
+                }
+
+                return resized;
+            }
+
+            return bitmap;
+        }
+
+        private bool TryReadSourceInfo(byte[] input, out SKImageInfo info)
+        {
+            info = default;
+            if (input.LongLength > MaximumEncodedImageBytes)
+            {
+                Interlocked.Increment(ref _rejectedSourceCount);
+                return false;
+            }
+
+            using var stream = new SKMemoryStream(input);
+            using var codec = SKCodec.Create(stream);
+            if (codec == null || !IsSourceInfoAllowed(codec.Info))
+            {
+                Interlocked.Increment(ref _rejectedSourceCount);
+                return false;
+            }
+
+            info = codec.Info;
+            return true;
+        }
+
+        internal static bool IsSourceInfoAllowed(SKImageInfo info)
+            => info.Width > 0
+                && info.Height > 0
+                && info.Width <= MaximumSourceDimension
+                && info.Height <= MaximumSourceDimension
+                && (long)info.Width * info.Height <= MaximumSourcePixels
+                && (long)info.Width * 4 <= MaximumSourceDimension * 4L;
 
         // Test seam (Tests has InternalsVisibleTo): current entry count, so a
         // test can prove eviction keeps the cache bounded at MaxCacheEntries.
         internal int CacheEntryCountForTest => _cache.Count;
+
+        internal int InFlightCountForTest => _transformFlights.Count;
+
+        internal int TransformExecutionCountForTest => Volatile.Read(ref _transformExecutionCount);
+
+        internal int DecodeAttemptCountForTest => Volatile.Read(ref _decodeAttemptCount);
+
+        internal int RejectedSourceCountForTest => Volatile.Read(ref _rejectedSourceCount);
 
         private void StoreInCache(string key, byte[] bytes)
         {
@@ -391,6 +670,130 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         {
             public required byte[] Bytes { get; init; }
             public long LastAccessTicks;
+        }
+
+        private sealed class TransformFlight
+        {
+            private readonly object _gate = new();
+            private readonly CancellationTokenSource _cancellation = new();
+            private int _participants;
+            private bool _accepting = true;
+            private bool _complete;
+            private bool _disposed;
+            private bool _cancellationRequested;
+            private bool _cancellationCompleted;
+
+            public TaskCompletionSource<SpoilerTransformResult> Completion { get; } = new(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public CancellationToken CancellationToken => _cancellation.Token;
+
+            public bool TryJoin()
+            {
+                lock (_gate)
+                {
+                    if (!_accepting)
+                    {
+                        return false;
+                    }
+
+                    _participants++;
+                    return true;
+                }
+            }
+
+            public void Leave()
+            {
+                var cancel = false;
+                var dispose = false;
+                lock (_gate)
+                {
+                    if (_participants <= 0)
+                    {
+                        return;
+                    }
+
+                    _participants--;
+                    if (_participants == 0)
+                    {
+                        if (_complete)
+                        {
+                            dispose = MarkDisposedUnderLock();
+                        }
+                        else
+                        {
+                            _accepting = false;
+                            _cancellationRequested = true;
+                            cancel = true;
+                        }
+                    }
+                }
+
+                if (cancel)
+                {
+                    _cancellation.Cancel();
+                    lock (_gate)
+                    {
+                        _cancellationCompleted = true;
+                        if (_complete && _participants == 0)
+                        {
+                            dispose = MarkDisposedUnderLock();
+                        }
+                    }
+                }
+
+                if (dispose)
+                {
+                    _cancellation.Dispose();
+                }
+            }
+
+            public void MarkComplete()
+            {
+                var dispose = false;
+                lock (_gate)
+                {
+                    _accepting = false;
+                    _complete = true;
+                    if (_participants == 0
+                        && (!_cancellationRequested || _cancellationCompleted))
+                    {
+                        dispose = MarkDisposedUnderLock();
+                    }
+                }
+
+                if (dispose)
+                {
+                    _cancellation.Dispose();
+                }
+            }
+
+            public void DisposeUnused()
+            {
+                var dispose = false;
+                lock (_gate)
+                {
+                    _accepting = false;
+                    _complete = true;
+                    dispose = MarkDisposedUnderLock();
+                }
+
+                if (dispose)
+                {
+                    _cancellation.Dispose();
+                }
+            }
+
+            private bool MarkDisposedUnderLock()
+            {
+                if (_disposed)
+                {
+                    return false;
+                }
+
+                _disposed = true;
+                return true;
+            }
         }
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/SpoilerBlurImageFilter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/SpoilerBlurImageFilter.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
 using Jellyfin.Plugin.JellyfinCanopy.Helpers;
@@ -36,6 +37,32 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
     // DOM manipulation needed.
     public sealed class SpoilerBlurImageFilter : IAsyncActionFilter, IDisposable
     {
+        internal enum ImageExtractionStatus
+        {
+            Available,
+            NoContent,
+            Unrecognized,
+            Rejected,
+        }
+
+        internal sealed record ImageExtractionResult(
+            ImageExtractionStatus Status,
+            byte[]? Bytes,
+            string? ContentType)
+        {
+            public static ImageExtractionResult Available(byte[] bytes, string? contentType)
+                => new(ImageExtractionStatus.Available, bytes, contentType);
+
+            public static ImageExtractionResult NoContent(string? contentType)
+                => new(ImageExtractionStatus.NoContent, null, contentType);
+
+            public static ImageExtractionResult Unrecognized()
+                => new(ImageExtractionStatus.Unrecognized, null, null);
+
+            public static ImageExtractionResult Rejected(string? contentType)
+                => new(ImageExtractionStatus.Rejected, null, contentType);
+        }
+
         private const string ImageController = "Image";
         // Trickplay tile-sheet endpoint (Videos/{id}/Trickplay/{w}/{i}.jpg).
         // Each tile is a sprite-sheet JPEG containing many small thumbnails for
@@ -435,9 +462,15 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             // picks art from that specific user's Collections). First blurring
             // candidate wins.
             UserSpoilerBlur userState = inScope[0].State;
+            Guid transformUserId = inScope[0].User.Id;
             for (var i = 0; i < inScope.Count; i++)
             {
-                if (!decisions[i]) { userState = inScope[i].State; break; }
+                if (!decisions[i])
+                {
+                    userState = inScope[i].State;
+                    transformUserId = inScope[i].User.Id;
+                    break;
+                }
             }
 
             // Artwork tier with the toggle OFF — pass through the original
@@ -465,11 +498,29 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             {
                 if (spoilerMode == "hide")
                 {
-                    await ReplaceWithStockCardAsync(executed, pluginConfig.SpoilerBlurIntensity, cacheKey, imageType, item, userState).ConfigureAwait(false);
+                    await ReplaceWithStockCardAsync(
+                        executed,
+                        pluginConfig.SpoilerBlurIntensity,
+                        cacheKey,
+                        imageType,
+                        item,
+                        userState,
+                        transformUserId).ConfigureAwait(false);
                 }
                 else
                 {
                     await ReplaceWithBlurredAsync(executed, pluginConfig.SpoilerBlurIntensity, cacheKey, imageType).ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException) when (executed.HttpContext.RequestAborted.IsCancellationRequested)
+            {
+                // The client is gone, but the original result must still never be
+                // allowed to execute. A live coalesced follower may continue using
+                // the shared leader input under the flight-owned cancellation token.
+                if (!executed.HttpContext.Response.HasStarted)
+                {
+                    executed.Result = new FileContentResult(_blurService.HardcodedFallbackJpeg, "image/jpeg");
+                    ApplyNoStoreToResponse(executed.HttpContext);
                 }
             }
             catch (Exception ex)
@@ -1024,7 +1075,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             string cacheKey,
             string imageType,
             MediaBrowser.Controller.Entities.BaseItem item,
-            UserSpoilerBlur userState)
+            UserSpoilerBlur userState,
+            Guid transformUserId)
         {
             if (executed.Result == null) return;
             if (string.Equals(executed.HttpContext.Request.Method, "HEAD", StringComparison.OrdinalIgnoreCase))
@@ -1032,55 +1084,78 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 ApplyNoStoreToResponse(executed.HttpContext);
                 return;
             }
-
-            var (originalBytes, _) = await ExtractBytesAsync(executed.Result).ConfigureAwait(false);
-            if (originalBytes == null || originalBytes.Length == 0)
+            if (HandlePreFlightResult(executed, imageType))
             {
-                FailClosedOnEmptyExtraction(executed, imageType);
                 return;
             }
 
-            var parentBytes = TryGetParentArtBytes(item, userState, originalBytes, cacheKey + ":pp");
-            if (parentBytes != null && parentBytes.Length > 0)
-            {
-                executed.Result = new FileContentResult(parentBytes, "image/jpeg");
-                if (executed.HttpContext.Response.HasStarted) return;
-                ApplyNoStoreHeadersDirect(executed.HttpContext, imageType);
-                return;
-            }
+            var sourceResult = executed.Result;
+            var outcome = await _blurService.RunBoundedTransformAsync(
+                cacheKey + ":pipeline:user:" + transformUserId.ToString("N"),
+                token => BuildStockCardResultAsync(sourceResult, sigma, cacheKey, item, userState, token),
+                () => DisposeSourceResultAsync(sourceResult),
+                executed.HttpContext.RequestAborted).ConfigureAwait(false);
+            ApplyTransformOutcome(executed, outcome, imageType);
+        }
 
-            // No safe parent art available (e.g. movie directly opted in,
-            // series without a Backdrop, season without a Series Primary).
-            // Fall back to a blur of the original bytes so the card still
-            // has content rather than rendering as a flat dark "broken"
-            // tile. Visually consistent with what the user would see in
-            // blur-mode for the same item.
-            var blurred = _blurService.Blur(originalBytes, sigma, cacheKey);
-            if (blurred != null)
+        private async Task<SpoilerTransformResult> BuildStockCardResultAsync(
+            IActionResult sourceResult,
+            int sigma,
+            string cacheKey,
+            MediaBrowser.Controller.Entities.BaseItem item,
+            UserSpoilerBlur userState,
+            CancellationToken cancellationToken)
+        {
+            try
             {
-                executed.Result = new FileContentResult(blurred, "image/jpeg");
-                if (executed.HttpContext.Response.HasStarted) return;
-                ApplyNoStoreHeadersDirect(executed.HttpContext, imageType);
-                return;
-            }
+                var extracted = await ExtractBytesAsync(
+                    sourceResult,
+                    ImageBlurService.MaximumEncodedImageBytes,
+                    cancellationToken).ConfigureAwait(false);
+                if (extracted.Status == ImageExtractionStatus.NoContent)
+                {
+                    return SpoilerTransformResult.NoContent();
+                }
 
-            var stock = _blurService.StockCard(originalBytes, cacheKey);
-            if (stock == null)
+                if (extracted.Status == ImageExtractionStatus.Unrecognized)
+                {
+                    return SpoilerTransformResult.Unrecognized();
+                }
+
+                if (extracted.Status != ImageExtractionStatus.Available || extracted.Bytes == null)
+                {
+                    return SpoilerTransformResult.Rejected();
+                }
+
+                var parentBytes = await TryGetParentArtBytesAsync(
+                    item,
+                    userState,
+                    extracted.Bytes,
+                    cacheKey + ":pp",
+                    cancellationToken).ConfigureAwait(false);
+                if (parentBytes != null && parentBytes.Length > 0)
+                {
+                    return SpoilerTransformResult.Available(parentBytes);
+                }
+
+                // No safe parent art available. Blur the original; if that fails,
+                // generate a dark stock card, then use the pre-encoded structural
+                // fallback. None of these paths can publish the source bytes.
+                cancellationToken.ThrowIfCancellationRequested();
+                var blurred = _blurService.Blur(extracted.Bytes, sigma, cacheKey);
+                if (blurred != null)
+                {
+                    return SpoilerTransformResult.Available(blurred);
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+                var stock = _blurService.StockCard(extracted.Bytes, cacheKey);
+                return SpoilerTransformResult.Available(stock ?? _blurService.HardcodedFallbackJpeg);
+            }
+            finally
             {
-                // Skia render failed on a flat-fill — practically unreachable
-                // (Jellyfin's whole image pipeline shares the same Skia copy)
-                // but the hide-mode spoiler contract is "never serve original
-                // bytes through this path". Fall back to the pre-encoded
-                // 16x16 #101010 JPEG so the invariant is structural, not
-                // dependent on Skia liveness.
-                executed.Result = new FileContentResult(_blurService.HardcodedFallbackJpeg, "image/jpeg");
-                ApplyNoStoreToResponse(executed.HttpContext);
-                return;
+                await DisposeSourceResultAsync(sourceResult).ConfigureAwait(false);
             }
-
-            executed.Result = new FileContentResult(stock, "image/jpeg");
-            if (executed.HttpContext.Response.HasStarted) return;
-            ApplyNoStoreHeadersDirect(executed.HttpContext, imageType);
         }
 
         // Returns the bytes of a "safe parent" art image scaled to roughly
@@ -1097,11 +1172,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         // falls back to blurring the original (then a flat dark stock card,
         // then the hardcoded fallback JPEG). JPEG-encoded, suitable for
         // FileContentResult.
-        private byte[]? TryGetParentArtBytes(
+        private async Task<byte[]?> TryGetParentArtBytesAsync(
             MediaBrowser.Controller.Entities.BaseItem item,
             UserSpoilerBlur userState,
             byte[] originalBytes,
-            string cacheKey)
+            string cacheKey,
+            CancellationToken cancellationToken)
         {
             try
             {
@@ -1145,9 +1221,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 if (imgInfo == null || string.IsNullOrEmpty(imgInfo.Path)) return null;
                 if (!System.IO.File.Exists(imgInfo.Path)) return null;
 
-                // Cache via the same LRU as StockCard — same cacheKey
-                // shape so successive identical requests are free.
-                var fileBytes = System.IO.File.ReadAllBytes(imgInfo.Path);
+                var fileBytes = await ReadFileWithCapAsync(
+                    imgInfo.Path,
+                    ImageBlurService.MaximumEncodedImageBytes,
+                    cancellationToken).ConfigureAwait(false);
                 if (fileBytes == null || fileBytes.Length == 0) return null;
 
                 // Resize to roughly match the original dimensions so the
@@ -1162,6 +1239,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 // could be served user A's Collection A art from the cache.
                 var parentArtKey = cacheKey + ":" + parentId.ToString("N") + ":" + parentImageType;
                 return _blurService.ResizeToMatch(fileBytes, originalBytes, parentArtKey);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception ex)
             {
@@ -1182,74 +1263,298 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 ApplyNoStoreToResponse(executed.HttpContext);
                 return;
             }
-
-            var (originalBytes, _) = await ExtractBytesAsync(executed.Result).ConfigureAwait(false);
-            if (originalBytes == null || originalBytes.Length == 0)
+            if (HandlePreFlightResult(executed, imageType))
             {
+                return;
+            }
+
+            var sourceResult = executed.Result;
+            var outcome = await _blurService.RunBoundedTransformAsync(
+                cacheKey + ":pipeline",
+                token => BuildBlurredResultAsync(sourceResult, sigma, cacheKey, token),
+                () => DisposeSourceResultAsync(sourceResult),
+                executed.HttpContext.RequestAborted).ConfigureAwait(false);
+            ApplyTransformOutcome(executed, outcome, imageType);
+        }
+
+        private async Task<SpoilerTransformResult> BuildBlurredResultAsync(
+            IActionResult sourceResult,
+            int sigma,
+            string cacheKey,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                var extracted = await ExtractBytesAsync(
+                    sourceResult,
+                    ImageBlurService.MaximumEncodedImageBytes,
+                    cancellationToken).ConfigureAwait(false);
+                if (extracted.Status == ImageExtractionStatus.NoContent)
+                {
+                    return SpoilerTransformResult.NoContent();
+                }
+
+                if (extracted.Status == ImageExtractionStatus.Unrecognized)
+                {
+                    return SpoilerTransformResult.Unrecognized();
+                }
+
+                if (extracted.Status != ImageExtractionStatus.Available || extracted.Bytes == null)
+                {
+                    return SpoilerTransformResult.Rejected();
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+                var blurred = _blurService.Blur(extracted.Bytes, sigma, cacheKey);
+                if (blurred != null)
+                {
+                    return SpoilerTransformResult.Available(blurred);
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+                var fallback = _blurService.StockCard(extracted.Bytes, null) ?? _blurService.HardcodedFallbackJpeg;
+                return SpoilerTransformResult.Available(fallback);
+            }
+            finally
+            {
+                await DisposeSourceResultAsync(sourceResult).ConfigureAwait(false);
+            }
+        }
+
+        private void ApplyTransformOutcome(
+            ActionExecutedContext executed,
+            SpoilerTransformResult outcome,
+            string imageType)
+        {
+            if (outcome.Status == SpoilerTransformStatus.NoContent)
+            {
+                if (executed.Result is FileResult)
+                {
+                    executed.Result = new EmptyResult();
+                    ApplyNoStoreToResponse(executed.HttpContext);
+                }
+                else
+                {
+                    FailClosedOnEmptyExtraction(executed, imageType);
+                }
+
+                return;
+            }
+
+            if (outcome.Status == SpoilerTransformStatus.Unrecognized)
+            {
+                // Preserve the caller's exact result semantics. Known status-only
+                // shapes (404/204/4xx/5xx) pass through with no-store, 304 remains
+                // fail-closed, and truly unknown content-bearing shapes still get
+                // the structural fallback plus the existing observability warning.
                 FailClosedOnEmptyExtraction(executed, imageType);
                 return;
             }
 
-            var blurred = _blurService.Blur(originalBytes, sigma, cacheKey);
-            if (blurred == null)
-            {
-                // Blur failed, and we already consumed the source stream during
-                // ExtractBytesAsync, so we MUST write a complete body — but it
-                // must NEVER be the original spoiler bytes (fail CLOSED, same as
-                // hide mode). Fall back to a stock card sized to the original
-                // (keeps the grid from shifting), then the hardcoded JPEG if even
-                // that fails. Not cached (null key) since this is a transient
-                // error path. Force `no-store`.
-                var fallback = _blurService.StockCard(originalBytes, null) ?? _blurService.HardcodedFallbackJpeg;
-                executed.Result = new FileContentResult(fallback, "image/jpeg");
-                ApplyNoStoreToResponse(executed.HttpContext);
-                return;
-            }
-
-            // We always re-encode as JPEG (the blur service does), so set the
-            // content type explicitly. Cache-Control: private, no-store keeps
-            // clients from holding the blurred copy after the user marks the
-            // episode watched or disables Spoiler Guard for the series.
-            // Chapter images get a short browser-cache window via
-            // ApplyNoStoreHeadersDirect so timeline-hover preview thumbs
-            // don't round-trip on every cursor move.
-            executed.Result = new FileContentResult(blurred, "image/jpeg");
-
+            var bytes = outcome.Status == SpoilerTransformStatus.Available
+                && outcome.Bytes is { Length: > 0 }
+                ? outcome.Bytes
+                : _blurService.HardcodedFallbackJpeg;
+            executed.Result = new FileContentResult(bytes, "image/jpeg");
             if (executed.HttpContext.Response.HasStarted) return;
             ApplyNoStoreHeadersDirect(executed.HttpContext, imageType);
         }
 
-        private static async Task<(byte[]? Bytes, string? ContentType)> ExtractBytesAsync(IActionResult result)
+        private bool HandlePreFlightResult(ActionExecutedContext executed, string imageType)
         {
+            // A flight outcome is shared, so status-only and unknown shapes must
+            // be adjudicated against this caller's own result before coalescing.
+            // Otherwise a 304 leader could lend its "no body" classification to
+            // a normal FileResult follower and expose that follower's clear bytes.
+            if (!CanEnterTransformFlight(executed.Result))
+            {
+                FailClosedOnEmptyExtraction(executed, imageType);
+                return true;
+            }
+
+            var definitelyEmpty = executed.Result switch
+            {
+                FileContentResult content => content.FileContents == null || content.FileContents.Length == 0,
+                FileStreamResult stream => stream.FileStream == null
+                    || (stream.FileStream.CanSeek
+                        && stream.FileStream.Length - stream.FileStream.Position == 0),
+                PhysicalFileResult physical => IsMissingOrEmptyFile(physical.FileName),
+                VirtualFileResult virtualFile => IsMissingOrEmptyFile(virtualFile.FileName),
+                _ => false,
+            };
+            if (!definitelyEmpty)
+            {
+                return false;
+            }
+
+            DisposeReplacedFileStream(executed.Result);
+
+            executed.Result = new EmptyResult();
+            ApplyNoStoreToResponse(executed.HttpContext);
+            return true;
+        }
+
+        internal static bool CanEnterTransformFlight(IActionResult? result)
+            => result is FileContentResult
+                or FileStreamResult
+                or PhysicalFileResult
+                or VirtualFileResult;
+
+        internal static void DisposeReplacedFileStream(IActionResult? result)
+        {
+            if (result is FileStreamResult streamResult)
+            {
+                streamResult.FileStream?.Dispose();
+            }
+        }
+
+        private static bool IsMissingOrEmptyFile(string? path)
+            => string.IsNullOrEmpty(path)
+                || !File.Exists(path)
+                || new FileInfo(path).Length == 0;
+
+        internal static async Task<ImageExtractionResult> ExtractBytesAsync(
+            IActionResult result,
+            long maximumBytes,
+            CancellationToken cancellationToken)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumBytes);
+            cancellationToken.ThrowIfCancellationRequested();
+
             switch (result)
             {
                 case FileContentResult fcr:
-                    return (fcr.FileContents, fcr.ContentType);
-
-                case FileStreamResult fsr:
-                    if (fsr.FileStream == null) return (null, fsr.ContentType);
-                    using (var ms = new MemoryStream())
+                    if (fcr.FileContents == null || fcr.FileContents.Length == 0)
                     {
-                        await fsr.FileStream.CopyToAsync(ms).ConfigureAwait(false);
-                        return (ms.ToArray(), fsr.ContentType);
+                        return ImageExtractionResult.NoContent(fcr.ContentType);
                     }
 
+                    return fcr.FileContents.LongLength > maximumBytes
+                        ? ImageExtractionResult.Rejected(fcr.ContentType)
+                        : ImageExtractionResult.Available(fcr.FileContents, fcr.ContentType);
+
+                case FileStreamResult fsr:
+                    if (fsr.FileStream == null)
+                    {
+                        return ImageExtractionResult.NoContent(fsr.ContentType);
+                    }
+
+                    if (fsr.FileStream.CanSeek
+                        && fsr.FileStream.Length - fsr.FileStream.Position > maximumBytes)
+                    {
+                        return ImageExtractionResult.Rejected(fsr.ContentType);
+                    }
+
+                    var streamBytes = await ReadStreamWithCapAsync(
+                        fsr.FileStream,
+                        maximumBytes,
+                        cancellationToken).ConfigureAwait(false);
+                    if (streamBytes == null)
+                    {
+                        return ImageExtractionResult.Rejected(fsr.ContentType);
+                    }
+
+                    return streamBytes.Length == 0
+                        ? ImageExtractionResult.NoContent(fsr.ContentType)
+                        : ImageExtractionResult.Available(streamBytes, fsr.ContentType);
+
                 case PhysicalFileResult pfr:
-                    if (string.IsNullOrEmpty(pfr.FileName) || !File.Exists(pfr.FileName))
-                        return (null, pfr.ContentType);
-                    return (await File.ReadAllBytesAsync(pfr.FileName).ConfigureAwait(false), pfr.ContentType);
+                    return await ExtractFileAsync(
+                        pfr.FileName,
+                        pfr.ContentType,
+                        maximumBytes,
+                        cancellationToken).ConfigureAwait(false);
 
                 case VirtualFileResult vfr:
-                    if (string.IsNullOrEmpty(vfr.FileName)) return (null, vfr.ContentType);
-                    var fp = vfr.FileName;
-                    return File.Exists(fp)
-                        ? (await File.ReadAllBytesAsync(fp).ConfigureAwait(false), vfr.ContentType)
-                        : (null, vfr.ContentType);
+                    return await ExtractFileAsync(
+                        vfr.FileName,
+                        vfr.ContentType,
+                        maximumBytes,
+                        cancellationToken).ConfigureAwait(false);
 
                 default:
-                    return (null, null);
+                    return ImageExtractionResult.Unrecognized();
             }
         }
+
+        private static async Task<ImageExtractionResult> ExtractFileAsync(
+            string? path,
+            string? contentType,
+            long maximumBytes,
+            CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(path) || !File.Exists(path))
+            {
+                return ImageExtractionResult.NoContent(contentType);
+            }
+
+            var file = new FileInfo(path);
+            if (file.Length > maximumBytes)
+            {
+                return ImageExtractionResult.Rejected(contentType);
+            }
+
+            var bytes = await ReadFileWithCapAsync(path, maximumBytes, cancellationToken).ConfigureAwait(false);
+            if (bytes == null)
+            {
+                return ImageExtractionResult.Rejected(contentType);
+            }
+
+            return bytes.Length == 0
+                ? ImageExtractionResult.NoContent(contentType)
+                : ImageExtractionResult.Available(bytes, contentType);
+        }
+
+        private static async Task<byte[]?> ReadFileWithCapAsync(
+            string path,
+            long maximumBytes,
+            CancellationToken cancellationToken)
+        {
+            var file = new FileInfo(path);
+            if (!file.Exists || file.Length > maximumBytes)
+            {
+                return null;
+            }
+
+            await using var stream = new FileStream(
+                path,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read,
+                bufferSize: 81920,
+                FileOptions.Asynchronous | FileOptions.SequentialScan);
+            return await ReadStreamWithCapAsync(stream, maximumBytes, cancellationToken).ConfigureAwait(false);
+        }
+
+        private static async Task<byte[]?> ReadStreamWithCapAsync(
+            Stream stream,
+            long maximumBytes,
+            CancellationToken cancellationToken)
+        {
+            using var buffer = new MemoryStream();
+            var chunk = new byte[81920];
+            while (buffer.Length <= maximumBytes)
+            {
+                var remainingThroughCap = maximumBytes + 1 - buffer.Length;
+                var requested = (int)Math.Min(chunk.Length, remainingThroughCap);
+                var read = await stream.ReadAsync(
+                    chunk.AsMemory(0, requested),
+                    cancellationToken).ConfigureAwait(false);
+                if (read == 0)
+                {
+                    return buffer.ToArray();
+                }
+
+                buffer.Write(chunk, 0, read);
+            }
+
+            return null;
+        }
+
+        private static ValueTask DisposeSourceResultAsync(IActionResult sourceResult)
+            => sourceResult is FileStreamResult { FileStream: not null } streamResult
+                ? streamResult.FileStream.DisposeAsync()
+                : ValueTask.CompletedTask;
 
         // F2 fail-closed on empty extraction. ExtractBytesAsync returned no
         // bytes. Two very different situations produce that:
@@ -1297,7 +1602,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             {
                 case null:
                     return true; // nothing to write
-                case FileResult:
+                case FileContentResult:
+                case FileStreamResult:
+                case PhysicalFileResult:
+                case VirtualFileResult:
                     // Recognized file shape (Content/Stream/Physical/Virtual)
                     // that yielded no bytes → an empty body, no leak.
                     return true;

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -19,7 +19,7 @@ const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the repeated clean measurements', () => {
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1364, totalLines: 1692 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 13705, totalLines: 21906 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 14003, totalLines: 22259 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 1);
 });

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -21,12 +21,12 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 13705,
-        "totalLines": 21906
+        "coveredLines": 14003,
+        "totalLines": 22259
       },
       "tolerance": {
         "missingCoveredLines": 1,
-        "rationale": "The 2026-07-15 .NET 10/Coverlet run measured bounded avatar streaming, cap-plus-one rejection, signature validation, reference-counted same-key singleflight cancellation, fake-clock negative backoff, last-good recovery, and high-cardinality cache budgets; one line permits only negligible instrumentation variance."
+        "rationale": "The 2026-07-15 .NET 10/Coverlet run measured cap-plus-one spoiler input extraction, metadata-first dimension and pixel rejection, sampled decode with a bounded compatibility fallback, whole-pipeline same-key singleflight, global transform concurrency, follower-safe cancellation, and per-caller fail-closed status handling; one line permits only negligible instrumentation variance."
       }
     }
   }


### PR DESCRIPTION
Closes #109.

## What changed

- Cap encoded spoiler-image inputs at 32 MiB with exact cap-plus-one streaming for unknown lengths.
- Inspect codec metadata before allocation and reject oversized dimensions/pixel counts before decode.
- Sample supported codecs directly to the 1920-pixel output ceiling; retain a separately bounded compatibility decode for codecs such as PNG that cannot sample natively.
- Coalesce the complete extraction/decode/transform pipeline per cache key, with two global transform slots across different keys.
- Keep cancellation participant-owned: one cancelled caller cannot poison a live follower, while the last departure cancels queued or active shared work.
- Adjudicate status-only and unknown MVC result shapes per caller before sharing any outcome, preventing a 304/no-body leader from exposing another caller's clear image.
- Dispose leader, follower, cancelled, and already-empty stream inputs deterministically.
- Make the existing avatar-flight cleanup assertions wait for the owner's bounded asynchronous `finally`, removing a test-only scheduling race found during final validation.

## Why

Spoiler Guard previously applied its dimensions only after `SKBitmap.Decode(byte[])` had allocated the full decoded image. A small encoded image with adversarial dimensions, a burst of identical cold requests, or many different keys could therefore create disproportionate managed/native memory pressure. Shared result classification also needs to remain strictly per-caller wherever passing through original bytes would be privacy-sensitive.

## Validation

- Fable low-effort independent review: **APPROVE** (security/privacy, pre-allocation memory bounds, flight ownership/cancellation, MVC result classification, and stream disposal).
- Server: **1,319/1,319** tests passed.
- Server coverage: **14,003/22,259 lines (62.909%)**, exact ratchet match.
- Client: **845/845** tests passed.
- Scripts: **294/294** tests passed.
- Focused Spoiler Guard/image-budget suite: **51/51** passed.
- Release build: **0 warnings, 0 errors**.
- Lint: **0 errors**, 5,591 existing advisory warnings (below cap).
- 4K JPEG/PNG/header-bomb benchmark: **231,528 KiB** maximum test-host RSS, **0 swap**.
- `git diff --check`, type checks, syntax inventory, and all translation validations passed.

## Hosted compatibility evidence

Run the official six-shard Docker E2E suite with 2 CPUs per Jellyfin server against the digest-pinned `jellyfin/jellyfin:unstable` image. No RC1/RC2 image is used.
