### PR TITLE
Bound user configuration payloads

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Configuration/PersistedPayloadPolicyTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Configuration/PersistedPayloadPolicyTests.cs
@@ -1,0 +1,328 @@
+using System.Text.Json;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Configuration;
+
+public sealed class PersistedPayloadPolicyTests
+{
+    [Fact]
+    public void Settings_FreeTextFields_AcceptExactBoundaryAndRejectNPlusOne()
+    {
+        var setters = new (string Name, Action<UserSettings, string> Set)[]
+        {
+            (nameof(UserSettings.CustomSubtitleTextColor), (p, v) => p.CustomSubtitleTextColor = v),
+            (nameof(UserSettings.CustomSubtitleBgColor), (p, v) => p.CustomSubtitleBgColor = v),
+            (nameof(UserSettings.WatchProgressMode), (p, v) => p.WatchProgressMode = v),
+            (nameof(UserSettings.WatchProgressTimeFormat), (p, v) => p.WatchProgressTimeFormat = v),
+            (nameof(UserSettings.QualityTagsPosition), (p, v) => p.QualityTagsPosition = v),
+            (nameof(UserSettings.GenreTagsPosition), (p, v) => p.GenreTagsPosition = v),
+            (nameof(UserSettings.LanguageTagsPosition), (p, v) => p.LanguageTagsPosition = v),
+            (nameof(UserSettings.RatingTagsPosition), (p, v) => p.RatingTagsPosition = v),
+            (nameof(UserSettings.LastOpenedTab), (p, v) => p.LastOpenedTab = v),
+            (nameof(UserSettings.DisplayLanguage), (p, v) => p.DisplayLanguage = v),
+            (nameof(UserSettings.CalendarDisplayMode), (p, v) => p.CalendarDisplayMode = v),
+            (nameof(UserSettings.CalendarDefaultViewMode), (p, v) => p.CalendarDefaultViewMode = v)
+        };
+
+        foreach (var (name, set) in setters)
+        {
+            var exact = new UserSettings();
+            set(exact, new string('x', PersistedPayloadPolicy.MaximumStandardStringLength));
+            Assert.True(PersistedPayloadPolicy.Validate(exact).IsValid, $"{name} exact boundary");
+
+            var over = new UserSettings();
+            set(over, new string('x', PersistedPayloadPolicy.MaximumStandardStringLength + 1));
+            Assert.Equal(PersistedPayloadStatus.Invalid, PersistedPayloadPolicy.Validate(over).Status);
+        }
+    }
+
+    [Fact]
+    public void Settings_NumericFields_EnforceBothBoundaries()
+    {
+        AssertRange((p, v) => p.PauseScreenDelaySeconds = v, 1, 60);
+        AssertRange((p, v) => p.SelectedStylePresetIndex = v, 0, 5);
+        AssertRange((p, v) => p.SelectedFontSizePresetIndex = v, 0, 5);
+        AssertRange((p, v) => p.SelectedFontFamilyPresetIndex = v, 0, 4);
+        AssertRange((p, v) => p.SubtitleVerticalPosition = v, 0, 100);
+        AssertRange((p, v) => p.SubtitleHorizontalPosition = v, 0, 100);
+
+        var orderSetters = new Action<UserSettings, int?>[]
+        {
+            (p, v) => p.ResolutionTagOrder = v,
+            (p, v) => p.SourceTagOrder = v,
+            (p, v) => p.DynamicRangeTagOrder = v,
+            (p, v) => p.SpecialFormatTagOrder = v,
+            (p, v) => p.VideoCodecTagOrder = v,
+            (p, v) => p.AudioInfoTagOrder = v
+        };
+        foreach (var set in orderSetters)
+        {
+            AssertSettingsValid(set, null);
+            AssertSettingsValid(set, 1);
+            AssertSettingsValid(set, 6);
+            AssertSettingsInvalid(set, 0);
+            AssertSettingsInvalid(set, 7);
+        }
+    }
+
+    [Fact]
+    public void ShortcutAndElsewhereFieldsAndLists_EnforceExactBoundaries()
+    {
+        var shortcutSetters = new Action<Shortcut, string>[]
+        {
+            (p, v) => p.Name = v,
+            (p, v) => p.Key = v,
+            (p, v) => p.Label = v,
+            (p, v) => p.Category = v
+        };
+        foreach (var set in shortcutSetters)
+        {
+            var exactItem = new Shortcut();
+            set(exactItem, new string('x', PersistedPayloadPolicy.MaximumStandardStringLength));
+            AssertValid(new UserShortcuts { Shortcuts = new List<Shortcut> { exactItem } });
+
+            var overItem = new Shortcut();
+            set(overItem, new string('x', PersistedPayloadPolicy.MaximumStandardStringLength + 1));
+            AssertInvalid(new UserShortcuts { Shortcuts = new List<Shortcut> { overItem } });
+        }
+
+        AssertValid(new UserShortcuts
+        {
+            Shortcuts = Enumerable.Range(0, PersistedPayloadPolicy.MaximumShortcuts)
+                .Select(_ => new Shortcut()).ToList()
+        });
+        AssertInvalid(new UserShortcuts
+        {
+            Shortcuts = Enumerable.Range(0, PersistedPayloadPolicy.MaximumShortcuts + 1)
+                .Select(_ => new Shortcut()).ToList()
+        });
+
+        var exactText = new string('x', PersistedPayloadPolicy.MaximumStandardStringLength);
+        var overText = exactText + "x";
+        AssertValid(new ElsewhereSettings { Region = exactText });
+        AssertInvalid(new ElsewhereSettings { Region = overText });
+        AssertValid(new ElsewhereSettings { Regions = new List<string> { exactText } });
+        AssertInvalid(new ElsewhereSettings { Regions = new List<string> { overText } });
+        AssertValid(new ElsewhereSettings { Services = new List<string> { exactText } });
+        AssertInvalid(new ElsewhereSettings { Services = new List<string> { overText } });
+
+        AssertValid(new ElsewhereSettings
+        {
+            Regions = Enumerable.Repeat(string.Empty, PersistedPayloadPolicy.MaximumElsewhereEntries).ToList(),
+            Services = Enumerable.Repeat(string.Empty, PersistedPayloadPolicy.MaximumElsewhereEntries).ToList()
+        });
+        AssertInvalid(new ElsewhereSettings
+        {
+            Regions = Enumerable.Repeat(string.Empty, PersistedPayloadPolicy.MaximumElsewhereEntries + 1).ToList()
+        });
+        AssertInvalid(new ElsewhereSettings
+        {
+            Services = Enumerable.Repeat(string.Empty, PersistedPayloadPolicy.MaximumElsewhereEntries + 1).ToList()
+        });
+    }
+
+    [Fact]
+    public void ExtensionData_EnforcesPropertyStringDepthAndNodeBoundaries()
+    {
+        using var nullDocument = JsonDocument.Parse("null");
+        var exactProperties = new UserSettings();
+        for (var i = 0; i < PersistedPayloadPolicy.MaximumExtensionProperties; i++)
+        {
+            exactProperties.ExtensionData.Add($"p{i}", nullDocument.RootElement.Clone());
+        }
+        AssertValid(exactProperties);
+        exactProperties.ExtensionData.Add("over", nullDocument.RootElement.Clone());
+        AssertInvalid(exactProperties);
+
+        using var exactStringDocument = JsonDocument.Parse(
+            JsonSerializer.Serialize(new string('x', PersistedPayloadPolicy.MaximumExtensionStringLength)));
+        using var overStringDocument = JsonDocument.Parse(
+            JsonSerializer.Serialize(new string('x', PersistedPayloadPolicy.MaximumExtensionStringLength + 1)));
+        AssertValid(WithExtension("future", exactStringDocument.RootElement));
+        AssertInvalid(WithExtension("future", overStringDocument.RootElement));
+
+        AssertValid(WithExtension(
+            new string('p', PersistedPayloadPolicy.MaximumExtensionPropertyNameLength),
+            nullDocument.RootElement));
+        AssertInvalid(WithExtension(
+            new string('p', PersistedPayloadPolicy.MaximumExtensionPropertyNameLength + 1),
+            nullDocument.RootElement));
+
+        using var exactDepth = JsonDocument.Parse(NestedArrayJson(PersistedPayloadPolicy.MaximumExtensionDepth - 1));
+        using var overDepth = JsonDocument.Parse(NestedArrayJson(PersistedPayloadPolicy.MaximumExtensionDepth));
+        AssertValid(WithExtension("future", exactDepth.RootElement));
+        AssertInvalid(WithExtension("future", overDepth.RootElement));
+
+        using var exactNodes = JsonDocument.Parse(
+            "[" + string.Join(',', Enumerable.Repeat("0", PersistedPayloadPolicy.MaximumExtensionNodes - 1)) + "]");
+        using var overNodes = JsonDocument.Parse(
+            "[" + string.Join(',', Enumerable.Repeat("0", PersistedPayloadPolicy.MaximumExtensionNodes)) + "]");
+        AssertValid(WithExtension("future", exactNodes.RootElement));
+        AssertInvalid(WithExtension("future", overNodes.RootElement));
+    }
+
+    [Fact]
+    public void HiddenContent_FieldsRangesScopesAndLargeLibraryCount_AreBounded()
+    {
+        var stringFields = new (int Maximum, Action<HiddenContentItem, string> Set)[]
+        {
+            (128, (p, v) => p.ItemId = v),
+            (512, (p, v) => p.Name = v),
+            (64, (p, v) => p.Type = v),
+            (32, (p, v) => p.TmdbId = v),
+            (64, (p, v) => p.HiddenAt = v),
+            (512, (p, v) => p.PosterPath = v),
+            (128, (p, v) => p.SeriesId = v),
+            (512, (p, v) => p.SeriesName = v)
+        };
+        foreach (var (maximum, set) in stringFields)
+        {
+            var exact = new HiddenContentItem();
+            set(exact, new string('x', maximum));
+            AssertHiddenValid("key", exact);
+
+            var over = new HiddenContentItem();
+            set(over, new string('x', maximum + 1));
+            AssertHiddenInvalid("key", over);
+        }
+
+        AssertHiddenValid(new string('k', PersistedPayloadPolicy.MaximumHiddenKeyLength), new HiddenContentItem());
+        AssertHiddenInvalid(new string('k', PersistedPayloadPolicy.MaximumHiddenKeyLength + 1), new HiddenContentItem());
+
+        foreach (var scope in new[] { string.Empty, "global", "series", "continuewatching", "nextup", "homesections" })
+        {
+            AssertHiddenValid("key", new HiddenContentItem { HideScope = scope });
+        }
+        AssertHiddenInvalid("key", new HiddenContentItem { HideScope = "unknown" });
+
+        AssertHiddenNumberRange((p, v) => p.SeasonNumber = v);
+        AssertHiddenNumberRange((p, v) => p.EpisodeNumber = v);
+
+        var largeLibrary = new UserHiddenContent();
+        for (var i = 0; i < PersistedPayloadPolicy.MaximumHiddenItems; i++)
+        {
+            var id = i.ToString("x32");
+            largeLibrary.Items.Add(id, new HiddenContentItem
+            {
+                ItemId = id,
+                Name = $"A realistic library title {i} with some descriptive text",
+                Type = i % 2 == 0 ? "Movie" : "Episode",
+                TmdbId = (100_000 + i).ToString(System.Globalization.CultureInfo.InvariantCulture),
+                HiddenAt = "2026-07-15T12:34:56.7890123Z",
+                PosterPath = $"/metadata/library/{id}/poster.jpg",
+                SeriesId = i % 2 == 0 ? string.Empty : id,
+                SeriesName = i % 2 == 0 ? string.Empty : $"A realistic series name {i}",
+                SeasonNumber = i % 2 == 0 ? null : 12,
+                EpisodeNumber = i % 2 == 0 ? null : 34,
+                HideScope = i % 3 == 0 ? "continuewatching" : "global"
+            });
+        }
+        var largeValidation = PersistedPayloadPolicy.Validate(largeLibrary);
+        Assert.True(largeValidation.IsValid, "10,000 realistically populated hidden items must remain supported");
+        Assert.True(largeValidation.SerializedBytes > 4 * 1024 * 1024, "fixture must catch the former 4 MiB false-positive");
+        largeLibrary.Items.Add("over", new HiddenContentItem());
+        Assert.Equal(PersistedPayloadStatus.Invalid, PersistedPayloadPolicy.Validate(largeLibrary).Status);
+    }
+
+    [Fact]
+    public void HiddenContent_LegacyNullStrings_AreAcceptedAndNormalizedOnlyInTheWriteCopy()
+    {
+        var source = new HiddenContentItem
+        {
+            ItemId = null!,
+            Name = null!,
+            Type = null!,
+            TmdbId = null!,
+            HiddenAt = null!,
+            PosterPath = null!,
+            SeriesId = null!,
+            SeriesName = null!,
+            HideScope = null!
+        };
+        var payload = new UserHiddenContent
+        {
+            Items = new Dictionary<string, HiddenContentItem> { ["key"] = source }
+        };
+
+        Assert.True(PersistedPayloadPolicy.Validate(payload).IsValid);
+        var clone = PersistedPayloadPolicy.CloneValidated(payload);
+        Assert.Equal(string.Empty, clone.Items["key"].Name);
+        Assert.Equal("global", clone.Items["key"].HideScope);
+        Assert.Null(source.Name);
+        Assert.Null(source.HideScope);
+    }
+
+    [Fact]
+    public void AggregateByteBudget_AcceptsExactBoundaryAndRejectsNPlusOne()
+    {
+        Assert.True(PersistedPayloadPolicy.ValidateByteCount(1024, 1024).IsValid);
+        Assert.Equal(PersistedPayloadStatus.TooLarge, PersistedPayloadPolicy.ValidateByteCount(1025, 1024).Status);
+    }
+
+    private static UserSettings WithExtension(string name, JsonElement value)
+    {
+        var settings = new UserSettings();
+        settings.ExtensionData.Add(name, value.Clone());
+        return settings;
+    }
+
+    private static string NestedArrayJson(int containers)
+        => new string('[', containers) + "0" + new string(']', containers);
+
+    private static void AssertRange(Action<UserSettings, int> set, int minimum, int maximum)
+    {
+        AssertSettingsValid(set, minimum);
+        AssertSettingsValid(set, maximum);
+        AssertSettingsInvalid(set, minimum - 1);
+        AssertSettingsInvalid(set, maximum + 1);
+    }
+
+    private static void AssertSettingsValid<T>(Action<UserSettings, T> set, T value)
+    {
+        var settings = new UserSettings();
+        set(settings, value);
+        AssertValid(settings);
+    }
+
+    private static void AssertSettingsInvalid<T>(Action<UserSettings, T> set, T value)
+    {
+        var settings = new UserSettings();
+        set(settings, value);
+        AssertInvalid(settings);
+    }
+
+    private static void AssertHiddenNumberRange(Action<HiddenContentItem, int?> set)
+    {
+        foreach (var value in new int?[] { null, 0, 100_000 })
+        {
+            var item = new HiddenContentItem();
+            set(item, value);
+            AssertHiddenValid("key", item);
+        }
+        foreach (var value in new int?[] { -1, 100_001 })
+        {
+            var item = new HiddenContentItem();
+            set(item, value);
+            AssertHiddenInvalid("key", item);
+        }
+    }
+
+    private static void AssertHiddenValid(string key, HiddenContentItem item)
+        => Assert.True(PersistedPayloadPolicy.Validate(new UserHiddenContent
+        {
+            Items = new Dictionary<string, HiddenContentItem> { [key] = item }
+        }).IsValid);
+
+    private static void AssertHiddenInvalid(string key, HiddenContentItem item)
+        => Assert.Equal(PersistedPayloadStatus.Invalid, PersistedPayloadPolicy.Validate(new UserHiddenContent
+        {
+            Items = new Dictionary<string, HiddenContentItem> { [key] = item }
+        }).Status);
+
+    private static void AssertValid(IRevisionedUserConfiguration value)
+        => Assert.True(PersistedPayloadPolicy.Validate(value).IsValid);
+
+    private static void AssertInvalid(IRevisionedUserConfiguration value)
+        => Assert.Equal(PersistedPayloadStatus.Invalid, PersistedPayloadPolicy.Validate(value).Status);
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Configuration/UserConfigurationStoreBudgetTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Configuration/UserConfigurationStoreBudgetTests.cs
@@ -1,0 +1,62 @@
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Configuration;
+
+public sealed class UserConfigurationStoreBudgetTests : IDisposable
+{
+    private readonly string _baseDir;
+    private readonly UserConfigurationManager _manager;
+
+    public UserConfigurationStoreBudgetTests()
+    {
+        _baseDir = Path.Combine(Path.GetTempPath(), "jc-store-budget-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_baseDir);
+        _manager = new UserConfigurationManager(
+            new StubAppPaths(_baseDir),
+            NullLogger<UserConfigurationManager>.Instance);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_baseDir, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public void AbsoluteStoreBudget_AllowsExactBytesAndRejectsNPlusOneWithoutMutation()
+    {
+        const string userId = "0123456789abcdef0123456789abcdef";
+        const string fileName = "large.json";
+        var exact = new string('x', PersistedPayloadPolicy.AbsolutePersistedBytes - 2);
+        _manager.SaveUserConfiguration(userId, fileName, exact);
+
+        var path = Path.Combine(
+            _baseDir,
+            "configurations",
+            "Jellyfin.Plugin.JellyfinCanopy",
+            userId,
+            fileName);
+        var before = File.ReadAllBytes(path);
+        Assert.Equal(PersistedPayloadPolicy.AbsolutePersistedBytes, before.Length);
+
+        var over = new string('x', PersistedPayloadPolicy.AbsolutePersistedBytes - 1);
+        Assert.Throws<InvalidDataException>(() => _manager.SaveUserConfiguration(userId, fileName, over));
+        Assert.Equal(before, File.ReadAllBytes(path));
+    }
+
+    [Fact]
+    public void RejectedAbsoluteBudget_DoesNotCreateUserDirectory()
+    {
+        const string userId = "fedcba9876543210fedcba9876543210";
+        var over = new string('x', PersistedPayloadPolicy.AbsolutePersistedBytes - 1);
+
+        Assert.Throws<InvalidDataException>(() => _manager.SaveUserConfiguration(userId, "large.json", over));
+        Assert.False(Directory.Exists(Path.Combine(
+            _baseDir,
+            "configurations",
+            "Jellyfin.Plugin.JellyfinCanopy",
+            userId)));
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/HiddenContentPayloadControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/HiddenContentPayloadControllerTests.cs
@@ -1,0 +1,238 @@
+using System.Security.Claims;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Controllers;
+using Jellyfin.Plugin.JellyfinCanopy.Logging;
+using Jellyfin.Plugin.JellyfinCanopy.Services;
+using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers;
+
+public sealed class HiddenContentPayloadControllerTests : IDisposable
+{
+    private readonly string _baseDir;
+    private readonly UserConfigurationManager _manager;
+    private readonly User _user;
+    private readonly FakePluginConfigProvider _provider;
+
+    public HiddenContentPayloadControllerTests()
+    {
+        _baseDir = Path.Combine(Path.GetTempPath(), "jc-hidden-payload-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_baseDir);
+        _manager = new UserConfigurationManager(
+            new StubAppPaths(_baseDir),
+            NullLogger<UserConfigurationManager>.Instance);
+        _user = new User("hidden-user", "Provider", "PasswordProvider");
+        _provider = new FakePluginConfigProvider(new PluginConfiguration());
+    }
+
+    private string UserId => _user.Id.ToString("N");
+
+    private string HiddenPath => Path.Combine(
+        _baseDir,
+        "configurations",
+        "Jellyfin.Plugin.JellyfinCanopy",
+        UserId,
+        "hidden-content.json");
+
+    public void Dispose()
+    {
+        HiddenContentResponseFilter.InvalidateUser(UserId);
+        try { Directory.Delete(_baseDir, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public void RejectedPayload_LeavesDiskAndCacheUnchanged()
+    {
+        _manager.SaveUserConfiguration(UserId, "hidden-content.json", new UserHiddenContent
+        {
+            Items = new Dictionary<string, HiddenContentItem>
+            {
+                ["old"] = new HiddenContentItem { Name = "old-value", HideScope = "global" }
+            }
+        });
+        var before = File.ReadAllBytes(HiddenPath);
+        HiddenContentResponseFilter.SeedCacheForTest(UserId);
+
+        var candidate = new UserHiddenContent
+        {
+            Items = new Dictionary<string, HiddenContentItem>
+            {
+                ["new"] = new HiddenContentItem
+                {
+                    Name = new string('x', 513),
+                    PosterPath = "API_KEY_SHOULD_NEVER_BE_LOGGED"
+                }
+            }
+        };
+        var result = Controller(NullLogger<HiddenContentController>.Instance)
+            .SaveUserHiddenContent(UserId, candidate);
+
+        var rejected = Assert.IsType<BadRequestObjectResult>(result);
+        var response = Assert.IsType<PersistedPayloadErrorResponse>(rejected.Value);
+        Assert.Equal("invalid_hidden_item", response.Code);
+        Assert.Equal(before, File.ReadAllBytes(HiddenPath));
+        Assert.True(HiddenContentResponseFilter.IsCachedForTest(UserId));
+    }
+
+    [Fact]
+    public void NormalizationCrossingPersistedCeiling_IsRejectedWithoutDiskOrCacheMutation()
+    {
+        _manager.SaveUserConfiguration(UserId, "hidden-content.json", new UserHiddenContent());
+        var before = File.ReadAllBytes(HiddenPath);
+        HiddenContentResponseFilter.SeedCacheForTest(UserId);
+        var candidate = BuildNormalizationBoundaryPayload();
+        Assert.True(PersistedPayloadPolicy.Validate(candidate).IsValid);
+        Assert.Equal(
+            PersistedPayloadStatus.TooLarge,
+            PersistedPayloadPolicy.Validate(PersistedPayloadPolicy.CloneValidated(candidate)).Status);
+
+        var result = Controller(NullLogger<HiddenContentController>.Instance)
+            .SaveUserHiddenContent(UserId, candidate);
+
+        var rejected = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status413PayloadTooLarge, rejected.StatusCode);
+        Assert.Equal("payload_too_large", Assert.IsType<PersistedPayloadErrorResponse>(rejected.Value).Code);
+        Assert.Equal(before, File.ReadAllBytes(HiddenPath));
+        Assert.True(HiddenContentResponseFilter.IsCachedForTest(UserId));
+    }
+
+    [Fact]
+    public void AcceptedPayload_LogsMetadataOnlyToHostAndDedicatedSinks()
+    {
+        const string secret = "api-key-SUPER-SECRET-sentinel";
+        var hostProvider = new CapturingLoggerProvider();
+        using var hostFactory = LoggerFactory.Create(builder =>
+        {
+            builder.SetMinimumLevel(LogLevel.Trace);
+            builder.AddProvider(hostProvider);
+        });
+        using var fileProvider = new JellyfinCanopyFileLoggerProvider(new StubAppPaths(_baseDir));
+        var logger = new FileForwardingLogger<HiddenContentController>(fileProvider, hostFactory);
+        var candidate = new UserHiddenContent
+        {
+            Items = new Dictionary<string, HiddenContentItem>
+            {
+                ["safe-key"] = new HiddenContentItem
+                {
+                    Name = secret,
+                    PosterPath = "/poster/" + secret,
+                    HideScope = "series"
+                }
+            }
+        };
+
+        var result = Controller(logger).SaveUserHiddenContent(UserId, candidate);
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Equal(secret, candidate.Items["safe-key"].Name);
+        var stored = _manager.GetUserConfigurationStrict<UserHiddenContent>(UserId, "hidden-content.json");
+        Assert.Equal(secret, stored.Items["safe-key"].Name);
+        var hostText = string.Join('\n', hostProvider.Messages);
+        var fileText = File.ReadAllText(fileProvider.CurrentLogFilePath);
+        Assert.DoesNotContain(secret, hostText, StringComparison.Ordinal);
+        Assert.DoesNotContain(secret, fileText, StringComparison.Ordinal);
+        Assert.Contains("items=1", hostText, StringComparison.Ordinal);
+        Assert.Contains("items=1", fileText, StringComparison.Ordinal);
+    }
+
+    private HiddenContentController Controller(ILogger<HiddenContentController> logger)
+    {
+        var controller = new HiddenContentController(
+            new RecordingHttpClientFactory(new HttpClientHandler()),
+            logger,
+            new StubUserManager(_user),
+            new SeerrCache(_provider),
+            _provider,
+            _manager,
+            new CountingLibraryManager());
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(
+                    new[] { new Claim("Jellyfin-UserId", _user.Id.ToString()) },
+                    "TestAuth"))
+            }
+        };
+        return controller;
+    }
+
+    private static UserHiddenContent BuildNormalizationBoundaryPayload()
+    {
+        var payload = new UserHiddenContent();
+        for (var i = 0; i < PersistedPayloadPolicy.MaximumHiddenItems; i++)
+        {
+            payload.Items.Add(i.ToString("x32"), new HiddenContentItem { HideScope = null! });
+        }
+
+        // null -> "global" adds exactly four UTF-8 bytes per item. Place the
+        // bound graph 20,000 bytes below the ceiling, so only normalization
+        // crosses it. ASCII field padding changes serialized size one-for-one.
+        var targetBytes = PersistedPayloadPolicy.HiddenContentPersistedBytes - 20_000;
+        var baseBytes = PersistedPayloadPolicy.ValidateSerializedSize(payload, int.MaxValue).SerializedBytes;
+        var remaining = targetBytes - baseBytes;
+        Assert.True(remaining > 0, "boundary fixture base unexpectedly exceeds its target");
+        foreach (var item in payload.Items.Values)
+        {
+            item.Name = Padding(ref remaining, 512);
+            item.SeriesName = Padding(ref remaining, 512);
+            item.PosterPath = Padding(ref remaining, 512);
+            if (remaining == 0)
+            {
+                break;
+            }
+        }
+
+        Assert.Equal(0, remaining);
+        Assert.Equal(
+            targetBytes,
+            PersistedPayloadPolicy.ValidateSerializedSize(payload, int.MaxValue).SerializedBytes);
+        return payload;
+    }
+
+    private static string Padding(ref int remaining, int maximum)
+    {
+        var length = Math.Min(remaining, maximum);
+        remaining -= length;
+        return new string('x', length);
+    }
+
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        public List<string> Messages { get; } = new();
+
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(Messages);
+
+        public void Dispose()
+        {
+        }
+
+        private sealed class CapturingLogger : ILogger
+        {
+            private readonly List<string> _messages;
+
+            public CapturingLogger(List<string> messages) => _messages = messages;
+
+            public IDisposable? BeginScope<TState>(TState state)
+                where TState : notnull
+                => null;
+
+            public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+                => _messages.Add(formatter(state, exception));
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/PersistedPayloadLimitAttributeTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/PersistedPayloadLimitAttributeTests.cs
@@ -1,0 +1,129 @@
+using System.Text;
+using System.Text.Json;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Routing;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers;
+
+public sealed class PersistedPayloadLimitAttributeTests
+{
+    [Fact]
+    public void AllFourCompleteReplacementEndpoints_UseTheSharedPreBindingPolicy()
+    {
+        AssertLimit(
+            typeof(UserSettingsController),
+            nameof(UserSettingsController.SaveUserSettingsSettings),
+            PersistedPayloadPolicy.StandardRequestBytes);
+        AssertLimit(
+            typeof(UserSettingsController),
+            nameof(UserSettingsController.SaveUserSettingsShortcuts),
+            PersistedPayloadPolicy.StandardRequestBytes);
+        AssertLimit(
+            typeof(UserSettingsController),
+            nameof(UserSettingsController.SaveUserSettingsElsewhere),
+            PersistedPayloadPolicy.StandardRequestBytes);
+        AssertLimit(
+            typeof(HiddenContentController),
+            nameof(HiddenContentController.SaveUserHiddenContent),
+            PersistedPayloadPolicy.HiddenContentRequestBytes);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ExactBoundary_ReachesModelBindingForDeclaredAndChunkedBodies(bool declaredLength)
+    {
+        const int limit = 1024;
+        var bytes = Enumerable.Repeat((byte)'x', limit).ToArray();
+        var (context, actionContext, filters) = Context(bytes, declaredLength ? limit : null);
+        var called = false;
+        var observedBytes = 0;
+
+        await new PersistedPayloadLimitAttribute(limit).OnResourceExecutionAsync(context, async () =>
+        {
+            called = true;
+            using var copy = new MemoryStream();
+            await actionContext.HttpContext.Request.Body.CopyToAsync(copy);
+            observedBytes = checked((int)copy.Length);
+            return new ResourceExecutedContext(actionContext, filters);
+        });
+
+        Assert.True(called);
+        Assert.Equal(limit, observedBytes);
+        Assert.Equal(StatusCodes.Status200OK, actionContext.HttpContext.Response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task NPlusOne_IsStructured413BeforeModelBinding(bool declaredLength)
+    {
+        const int limit = 1024;
+        var bytes = Enumerable.Repeat((byte)'x', limit + 1).ToArray();
+        var (context, actionContext, filters) = Context(bytes, declaredLength ? limit + 1 : null);
+        var called = false;
+
+        await new PersistedPayloadLimitAttribute(limit).OnResourceExecutionAsync(context, () =>
+        {
+            called = true;
+            return Task.FromResult(new ResourceExecutedContext(actionContext, filters));
+        });
+
+        Assert.False(called);
+        Assert.Equal(StatusCodes.Status413PayloadTooLarge, actionContext.HttpContext.Response.StatusCode);
+        actionContext.HttpContext.Response.Body.Position = 0;
+        using var response = await JsonDocument.ParseAsync(actionContext.HttpContext.Response.Body);
+        Assert.Equal("payload_too_large", response.RootElement.GetProperty("code").GetString());
+        Assert.False(response.RootElement.GetProperty("success").GetBoolean());
+        Assert.DoesNotContain(Encoding.UTF8.GetString(bytes), response.RootElement.GetRawText(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ClientAbortWhileBuffering_DoesNotInvokePipelineOrSurfaceAnError()
+    {
+        using var aborted = new CancellationTokenSource();
+        aborted.Cancel();
+        var (context, actionContext, filters) = Context(new byte[16], contentLength: null);
+        actionContext.HttpContext.RequestAborted = aborted.Token;
+        var called = false;
+
+        await new PersistedPayloadLimitAttribute(1024).OnResourceExecutionAsync(context, () =>
+        {
+            called = true;
+            return Task.FromResult(new ResourceExecutedContext(actionContext, filters));
+        });
+
+        Assert.False(called);
+    }
+
+    private static (ResourceExecutingContext Context, ActionContext Action, IList<IFilterMetadata> Filters) Context(
+        byte[] body,
+        long? contentLength)
+    {
+        var http = new DefaultHttpContext();
+        http.Request.Body = new MemoryStream(body, writable: false);
+        http.Request.ContentLength = contentLength;
+        http.Response.Body = new MemoryStream();
+        var action = new ActionContext(
+            http,
+            new RouteData(),
+            new ActionDescriptor(),
+            new ModelStateDictionary());
+        IList<IFilterMetadata> filters = new List<IFilterMetadata>();
+        return (new ResourceExecutingContext(action, filters, new List<IValueProviderFactory>()), action, filters);
+    }
+
+    private static void AssertLimit(Type controller, string methodName, long expected)
+    {
+        var method = controller.GetMethod(methodName) ?? throw new InvalidOperationException(methodName);
+        var attribute = Assert.Single(method.GetCustomAttributes(typeof(PersistedPayloadLimitAttribute), inherit: true));
+        Assert.Equal(expected, Assert.IsType<PersistedPayloadLimitAttribute>(attribute).MaximumBytes);
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Configuration/PersistedPayloadPolicy.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Configuration/PersistedPayloadPolicy.cs
@@ -1,0 +1,343 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Configuration
+{
+    internal enum PersistedPayloadStatus
+    {
+        Valid,
+        Invalid,
+        TooLarge
+    }
+
+    internal readonly record struct PersistedPayloadValidation(
+        PersistedPayloadStatus Status,
+        string Code,
+        int SerializedBytes)
+    {
+        public bool IsValid => Status == PersistedPayloadStatus.Valid;
+
+        public static PersistedPayloadValidation Valid(int serializedBytes)
+            => new(PersistedPayloadStatus.Valid, string.Empty, serializedBytes);
+
+        public static PersistedPayloadValidation Invalid(string code)
+            => new(PersistedPayloadStatus.Invalid, code, 0);
+
+        public static PersistedPayloadValidation TooLarge(int serializedBytes)
+            => new(PersistedPayloadStatus.TooLarge, "payload_too_large", serializedBytes);
+    }
+
+    /// <summary>
+    /// One policy primitive for every complete user-owned configuration payload.
+    /// Request limits are enforced before model binding; these typed limits are
+    /// the second line of defence before a lock, cache mutation, or disk write.
+    /// </summary>
+    internal static class PersistedPayloadPolicy
+    {
+        public const long StandardRequestBytes = 1024 * 1024;
+        public const int StandardPersistedBytes = 1024 * 1024;
+        public const long HiddenContentRequestBytes = 8L * 1024 * 1024;
+        public const int HiddenContentPersistedBytes = 7 * 1024 * 1024;
+        public const int AbsolutePersistedBytes = 8 * 1024 * 1024;
+
+        public const int MaximumStandardStringLength = 512;
+        public const int MaximumExtensionProperties = 1000;
+        public const int MaximumExtensionPropertyNameLength = 256;
+        public const int MaximumExtensionStringLength = 4096;
+        public const int MaximumExtensionDepth = 16;
+        public const int MaximumExtensionNodes = 20_000;
+        public const int MaximumShortcuts = 1000;
+        public const int MaximumElsewhereEntries = 500;
+        public const int MaximumHiddenItems = 10_000;
+        public const int MaximumHiddenKeyLength = 256;
+
+        public static PersistedPayloadValidation Validate(IRevisionedUserConfiguration? payload)
+            => payload switch
+            {
+                UserSettings settings => ValidateSettings(settings),
+                UserShortcuts shortcuts => ValidateShortcuts(shortcuts),
+                ElsewhereSettings elsewhere => ValidateElsewhere(elsewhere),
+                null => PersistedPayloadValidation.Invalid("payload_required"),
+                _ => PersistedPayloadValidation.Invalid("unsupported_payload")
+            };
+
+        public static PersistedPayloadValidation Validate(UserHiddenContent? payload)
+        {
+            if (payload?.Items == null || payload.Settings == null)
+            {
+                return PersistedPayloadValidation.Invalid("invalid_hidden_content_shape");
+            }
+
+            if (payload.Items.Count > MaximumHiddenItems)
+            {
+                return PersistedPayloadValidation.Invalid("too_many_hidden_items");
+            }
+
+            foreach (var pair in payload.Items)
+            {
+                if (!IsBoundedRequiredString(pair.Key, MaximumHiddenKeyLength)
+                    || !IsValidHiddenItem(pair.Value))
+                {
+                    return PersistedPayloadValidation.Invalid("invalid_hidden_item");
+                }
+            }
+
+            return ValidateSerializedSize(payload, HiddenContentPersistedBytes);
+        }
+
+        public static UserHiddenContent CloneValidated(UserHiddenContent payload)
+        {
+            var clone = new UserHiddenContent
+            {
+                Settings = new HiddenContentSettings
+                {
+                    Enabled = payload.Settings.Enabled,
+                    FilterLibrary = payload.Settings.FilterLibrary,
+                    FilterDiscovery = payload.Settings.FilterDiscovery,
+                    FilterUpcoming = payload.Settings.FilterUpcoming,
+                    FilterCalendar = payload.Settings.FilterCalendar,
+                    FilterSearch = payload.Settings.FilterSearch,
+                    FilterRecommendations = payload.Settings.FilterRecommendations,
+                    FilterRequests = payload.Settings.FilterRequests,
+                    FilterNextUp = payload.Settings.FilterNextUp,
+                    FilterContinueWatching = payload.Settings.FilterContinueWatching,
+                    ShowHideButtons = payload.Settings.ShowHideButtons,
+                    ShowHideConfirmation = payload.Settings.ShowHideConfirmation,
+                    ShowButtonSeerr = payload.Settings.ShowButtonSeerr,
+                    ShowButtonLibrary = payload.Settings.ShowButtonLibrary,
+                    ShowButtonDetails = payload.Settings.ShowButtonDetails,
+                    ShowButtonCast = payload.Settings.ShowButtonCast,
+                    ExperimentalHideCollections = payload.Settings.ExperimentalHideCollections
+                },
+                Items = new Dictionary<string, HiddenContentItem>(payload.Items.Count, StringComparer.Ordinal)
+            };
+
+            foreach (var pair in payload.Items)
+            {
+                var item = pair.Value;
+                clone.Items.Add(pair.Key, new HiddenContentItem
+                {
+                    ItemId = item.ItemId ?? string.Empty,
+                    Name = item.Name ?? string.Empty,
+                    Type = item.Type ?? string.Empty,
+                    TmdbId = item.TmdbId ?? string.Empty,
+                    HiddenAt = item.HiddenAt ?? string.Empty,
+                    PosterPath = item.PosterPath ?? string.Empty,
+                    SeriesId = item.SeriesId ?? string.Empty,
+                    SeriesName = item.SeriesName ?? string.Empty,
+                    SeasonNumber = item.SeasonNumber,
+                    EpisodeNumber = item.EpisodeNumber,
+                    HideScope = item.HideScope ?? "global"
+                });
+            }
+
+            return clone;
+        }
+
+        public static PersistedPayloadValidation ValidateSerializedSize(object payload, int maximumBytes)
+        {
+            try
+            {
+                var bytes = JsonSerializer.SerializeToUtf8Bytes(
+                    payload,
+                    payload.GetType(),
+                    PersistedJson.WriteOptions).Length;
+                return ValidateByteCount(bytes, maximumBytes);
+            }
+            catch (JsonException)
+            {
+                return PersistedPayloadValidation.Invalid("invalid_json_value");
+            }
+        }
+
+        internal static PersistedPayloadValidation ValidateByteCount(int serializedBytes, int maximumBytes)
+            => serializedBytes <= maximumBytes
+                ? PersistedPayloadValidation.Valid(serializedBytes)
+                : PersistedPayloadValidation.TooLarge(serializedBytes);
+
+        private static PersistedPayloadValidation ValidateSettings(UserSettings settings)
+        {
+            if (settings.Revision < 0
+                || settings.PauseScreenDelaySeconds is < 1 or > 60
+                || settings.SelectedStylePresetIndex is < 0 or > 5
+                || settings.SelectedFontSizePresetIndex is < 0 or > 5
+                || settings.SelectedFontFamilyPresetIndex is < 0 or > 4
+                || settings.SubtitleVerticalPosition is < 0 or > 100
+                || settings.SubtitleHorizontalPosition is < 0 or > 100
+                || !IsOptionalOrder(settings.ResolutionTagOrder)
+                || !IsOptionalOrder(settings.SourceTagOrder)
+                || !IsOptionalOrder(settings.DynamicRangeTagOrder)
+                || !IsOptionalOrder(settings.SpecialFormatTagOrder)
+                || !IsOptionalOrder(settings.VideoCodecTagOrder)
+                || !IsOptionalOrder(settings.AudioInfoTagOrder)
+                || !AreBoundedSettingsStrings(settings)
+                || !HasValidExtensionData(settings.ExtensionData))
+            {
+                return PersistedPayloadValidation.Invalid("invalid_settings_payload");
+            }
+
+            return ValidateSerializedSize(settings, StandardPersistedBytes);
+        }
+
+        private static PersistedPayloadValidation ValidateShortcuts(UserShortcuts shortcuts)
+        {
+            if (shortcuts.Revision < 0
+                || shortcuts.Shortcuts == null
+                || shortcuts.Shortcuts.Count > MaximumShortcuts
+                || !HasValidExtensionData(shortcuts.ExtensionData))
+            {
+                return PersistedPayloadValidation.Invalid("invalid_shortcuts_payload");
+            }
+
+            foreach (var shortcut in shortcuts.Shortcuts)
+            {
+                if (shortcut == null
+                    || !IsBoundedString(shortcut.Name, MaximumStandardStringLength)
+                    || !IsBoundedString(shortcut.Key, MaximumStandardStringLength)
+                    || !IsBoundedString(shortcut.Label, MaximumStandardStringLength)
+                    || !IsBoundedString(shortcut.Category, MaximumStandardStringLength))
+                {
+                    return PersistedPayloadValidation.Invalid("invalid_shortcuts_payload");
+                }
+            }
+
+            return ValidateSerializedSize(shortcuts, StandardPersistedBytes);
+        }
+
+        private static PersistedPayloadValidation ValidateElsewhere(ElsewhereSettings elsewhere)
+        {
+            if (elsewhere.Revision < 0
+                || elsewhere.Regions == null
+                || elsewhere.Services == null
+                || elsewhere.Regions.Count > MaximumElsewhereEntries
+                || elsewhere.Services.Count > MaximumElsewhereEntries
+                || !IsBoundedString(elsewhere.Region, MaximumStandardStringLength)
+                || !HasValidExtensionData(elsewhere.ExtensionData))
+            {
+                return PersistedPayloadValidation.Invalid("invalid_elsewhere_payload");
+            }
+
+            foreach (var value in elsewhere.Regions)
+            {
+                if (!IsBoundedString(value, MaximumStandardStringLength))
+                {
+                    return PersistedPayloadValidation.Invalid("invalid_elsewhere_payload");
+                }
+            }
+
+            foreach (var value in elsewhere.Services)
+            {
+                if (!IsBoundedString(value, MaximumStandardStringLength))
+                {
+                    return PersistedPayloadValidation.Invalid("invalid_elsewhere_payload");
+                }
+            }
+
+            return ValidateSerializedSize(elsewhere, StandardPersistedBytes);
+        }
+
+        private static bool AreBoundedSettingsStrings(UserSettings settings)
+            => IsBoundedString(settings.CustomSubtitleTextColor, MaximumStandardStringLength)
+                && IsBoundedString(settings.CustomSubtitleBgColor, MaximumStandardStringLength)
+                && IsBoundedString(settings.WatchProgressMode, MaximumStandardStringLength)
+                && IsBoundedString(settings.WatchProgressTimeFormat, MaximumStandardStringLength)
+                && IsBoundedString(settings.QualityTagsPosition, MaximumStandardStringLength)
+                && IsBoundedString(settings.GenreTagsPosition, MaximumStandardStringLength)
+                && IsBoundedString(settings.LanguageTagsPosition, MaximumStandardStringLength)
+                && IsBoundedString(settings.RatingTagsPosition, MaximumStandardStringLength)
+                && IsBoundedString(settings.LastOpenedTab, MaximumStandardStringLength)
+                && IsBoundedString(settings.DisplayLanguage, MaximumStandardStringLength)
+                && IsBoundedString(settings.CalendarDisplayMode, MaximumStandardStringLength)
+                && IsBoundedString(settings.CalendarDefaultViewMode, MaximumStandardStringLength);
+
+        private static bool IsValidHiddenItem(HiddenContentItem? item)
+            => item != null
+                && IsOptionalBoundedString(item.ItemId, 128)
+                && IsOptionalBoundedString(item.Name, 512)
+                && IsOptionalBoundedString(item.Type, 64)
+                && IsOptionalBoundedString(item.TmdbId, 32)
+                && IsOptionalBoundedString(item.HiddenAt, 64)
+                && IsOptionalBoundedString(item.PosterPath, 512)
+                && IsOptionalBoundedString(item.SeriesId, 128)
+                && IsOptionalBoundedString(item.SeriesName, 512)
+                && IsOptionalNonNegativeRange(item.SeasonNumber, 100_000)
+                && IsOptionalNonNegativeRange(item.EpisodeNumber, 100_000)
+                && item.HideScope is null or "" or "global" or "series" or "continuewatching" or "nextup" or "homesections";
+
+        private static bool HasValidExtensionData(Dictionary<string, JsonElement>? extensionData)
+        {
+            if (extensionData == null || extensionData.Count > MaximumExtensionProperties)
+            {
+                return false;
+            }
+
+            var nodeCount = 0;
+            foreach (var pair in extensionData)
+            {
+                if (!IsBoundedRequiredString(pair.Key, MaximumExtensionPropertyNameLength)
+                    || !VisitExtensionValue(pair.Value, 1, ref nodeCount))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool VisitExtensionValue(JsonElement element, int depth, ref int nodeCount)
+        {
+            nodeCount++;
+            if (depth > MaximumExtensionDepth || nodeCount > MaximumExtensionNodes)
+            {
+                return false;
+            }
+
+            switch (element.ValueKind)
+            {
+                case JsonValueKind.String:
+                    return element.GetString()?.Length <= MaximumExtensionStringLength;
+                case JsonValueKind.Object:
+                    foreach (var property in element.EnumerateObject())
+                    {
+                        if (!IsBoundedRequiredString(property.Name, MaximumExtensionPropertyNameLength)
+                            || !VisitExtensionValue(property.Value, depth + 1, ref nodeCount))
+                        {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                case JsonValueKind.Array:
+                    foreach (var child in element.EnumerateArray())
+                    {
+                        if (!VisitExtensionValue(child, depth + 1, ref nodeCount))
+                        {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                case JsonValueKind.Undefined:
+                    return false;
+                default:
+                    return true;
+            }
+        }
+
+        private static bool IsOptionalOrder(int? value)
+            => !value.HasValue || value.Value is >= 1 and <= 6;
+
+        private static bool IsOptionalNonNegativeRange(int? value, int maximum)
+            => !value.HasValue || value.Value >= 0 && value.Value <= maximum;
+
+        private static bool IsBoundedString(string? value, int maximum)
+            => value != null && value.Length <= maximum;
+
+        private static bool IsOptionalBoundedString(string? value, int maximum)
+            => value == null || value.Length <= maximum;
+
+        private static bool IsBoundedRequiredString(string? value, int maximum)
+            => !string.IsNullOrEmpty(value) && value.Length <= maximum;
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Configuration/UserConfigurationStore.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Configuration/UserConfigurationStore.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.Extensions.Logging;
@@ -300,21 +301,31 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Configuration
         {
             try
             {
-                var configPath = ResolveUserFile(userId, fileName);
-
                 // Serialize with the runtime type: callers pass both typed DTOs and
                 // raw JsonElement payloads (client JSON pass-through). JsonElement is
                 // written verbatim — unlike the old JToken.Parse round-trip, which
                 // re-parsed and normalized ISO date strings and exponent numbers.
                 // Both forms read identically; pinned by RawClientJson_* tests.
                 var jsonToSave = JsonSerializer.Serialize(config, config.GetType(), PersistedJson.WriteOptions);
+                var serializedBytes = Encoding.UTF8.GetByteCount(jsonToSave);
+                if (serializedBytes > PersistedPayloadPolicy.AbsolutePersistedBytes)
+                {
+                    throw new InvalidDataException(
+                        $"User configuration exceeds the absolute {PersistedPayloadPolicy.AbsolutePersistedBytes}-byte store limit.");
+                }
+
+                // Resolve only after validation so a rejected future caller cannot
+                // create a user directory as a side effect of an oversized write.
+                var configPath = ResolveUserFile(userId, fileName);
 
                 // AtomicFile owns the per-call temp sibling + rename + temp cleanup.
                 AtomicFile.WriteAllText(configPath, jsonToSave);
             }
             catch (Exception ex)
             {
-                _logger.LogError($"Failed to save user configuration for user '{userId}' to file '{fileName}'. Exception: {ex.Message}");
+                _logger.LogError(
+                    $"Failed to save user configuration for user '{userId}' to file '{fileName}' " +
+                    $"(exception={ex.GetType().Name}).");
                 throw;
             }
         }

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/HiddenContentController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/HiddenContentController.cs
@@ -108,6 +108,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
         [HttpPost("user-settings/{userId}/hidden-content.json")]
         [Authorize]
         [Produces("application/json")]
+        [PersistedPayloadLimit(PersistedPayloadPolicy.HiddenContentRequestBytes)]
         public IActionResult SaveUserHiddenContent(string userId, [FromBody] UserHiddenContent userConfiguration)
         {
             var authorizationResult = AuthorizeUserConfigAccess(userId, out var authorizedUserId);
@@ -116,9 +117,37 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 return authorizationResult;
             }
 
-            if (userConfiguration == null)
+            var validation = PersistedPayloadPolicy.Validate(userConfiguration);
+            if (!validation.IsValid)
             {
-                return BadRequest(new { success = false, message = "Invalid hidden content payload." });
+                var response = new PersistedPayloadErrorResponse
+                {
+                    Code = validation.Code,
+                    Message = validation.Status == PersistedPayloadStatus.TooLarge
+                        ? "The hidden-content payload exceeds the supported size limit."
+                        : "The hidden-content payload is invalid."
+                };
+                return validation.Status == PersistedPayloadStatus.TooLarge
+                    ? StatusCode(StatusCodes.Status413PayloadTooLarge, response)
+                    : BadRequest(response);
+            }
+
+            // Never mutate or retain MVC's bound graph. The validated copy is the
+            // only object allowed to cross the lock/write boundary.
+            var validatedCopy = PersistedPayloadPolicy.CloneValidated(userConfiguration);
+            validation = PersistedPayloadPolicy.Validate(validatedCopy);
+            if (!validation.IsValid)
+            {
+                var response = new PersistedPayloadErrorResponse
+                {
+                    Code = validation.Code,
+                    Message = validation.Status == PersistedPayloadStatus.TooLarge
+                        ? "The normalized hidden-content payload exceeds the supported size limit."
+                        : "The normalized hidden-content payload is invalid."
+                };
+                return validation.Status == PersistedPayloadStatus.TooLarge
+                    ? StatusCode(StatusCodes.Status413PayloadTooLarge, response)
+                    : BadRequest(response);
             }
 
             try
@@ -134,24 +163,32 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                     catch (Exception strictEx) when (strictEx is InvalidDataException
                                                   || strictEx is System.Text.Json.JsonException)
                     {
-                        _logger.LogWarning($"hidden-content.json corrupt for {ResolveUserDisplay(authorizedUserId)} (backed up): {strictEx.Message}");
+                        _logger.LogWarning(
+                            $"hidden-content.json corrupt for {ResolveUserDisplay(authorizedUserId)} " +
+                            $"(backed up; exception={strictEx.GetType().Name}).");
                         return StatusCode(503, new { success = false, message = "Hidden-content store is corrupt; backed up. Please retry." });
                     }
                     catch (IOException ioEx)
                     {
-                        _logger.LogWarning($"hidden-content.json temporarily unreadable for {ResolveUserDisplay(authorizedUserId)}: {ioEx.Message}");
+                        _logger.LogWarning(
+                            $"hidden-content.json temporarily unreadable for {ResolveUserDisplay(authorizedUserId)} " +
+                            $"(exception={ioEx.GetType().Name}).");
                         return StatusCode(500, new { success = false, message = "Hidden-content store is temporarily unavailable. Please retry." });
                     }
 
-                    _userConfigurationManager.SaveUserConfiguration(authorizedUserId, "hidden-content.json", userConfiguration);
+                    _userConfigurationManager.SaveUserConfiguration(authorizedUserId, "hidden-content.json", validatedCopy);
                 }
                 Services.HiddenContentResponseFilter.InvalidateUser(authorizedUserId);
-                _logger.LogInformation($"Saved hidden content for {ResolveUserDisplay(authorizedUserId)} to hidden-content.json");
+                _logger.LogInformation(
+                    $"Saved hidden content for {ResolveUserDisplay(authorizedUserId)} to hidden-content.json " +
+                    $"(items={validatedCopy.Items.Count}, bytes={validation.SerializedBytes}).");
                 return Ok(new { success = true, file = "hidden-content.json" });
             }
             catch (Exception ex)
             {
-                _logger.LogError($"Failed to save hidden content for {ResolveUserDisplay(authorizedUserId)}: {ex.Message}");
+                _logger.LogError(
+                    $"Failed to save hidden content for {ResolveUserDisplay(authorizedUserId)} " +
+                    $"(exception={ex.GetType().Name}).");
                 return StatusCode(500, new { success = false, message = "Failed to save hidden content." });
             }
         }

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/PersistedPayloadLimitAttribute.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/PersistedPayloadLimitAttribute.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Buffers;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
+{
+    public sealed class PersistedPayloadErrorResponse
+    {
+        public bool Success { get; set; }
+
+        public string Code { get; set; } = string.Empty;
+
+        public string Message { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// Buffers a bounded request before MVC model binding so declared-length and
+    /// chunked bodies receive the same structured rejection without deserializing.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    internal sealed class PersistedPayloadLimitAttribute : Attribute, IAsyncResourceFilter, IOrderedFilter
+    {
+        private const int CopyBufferBytes = 81_920;
+        private readonly long _maximumBytes;
+
+        public PersistedPayloadLimitAttribute(long maximumBytes)
+        {
+            if (maximumBytes <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maximumBytes));
+            }
+
+            _maximumBytes = maximumBytes;
+        }
+
+        public int Order => int.MinValue;
+
+        internal long MaximumBytes => _maximumBytes;
+
+        public async Task OnResourceExecutionAsync(
+            ResourceExecutingContext context,
+            ResourceExecutionDelegate next)
+        {
+            var request = context.HttpContext.Request;
+            if (request.ContentLength > _maximumBytes)
+            {
+                await RejectAsync(context.HttpContext).ConfigureAwait(false);
+                return;
+            }
+
+            var originalBody = request.Body;
+            await using var buffered = new MemoryStream();
+            var rented = ArrayPool<byte>.Shared.Rent(CopyBufferBytes);
+            var pipelineInvoked = false;
+            try
+            {
+                long total = 0;
+                while (true)
+                {
+                    var read = await originalBody.ReadAsync(
+                        rented.AsMemory(0, CopyBufferBytes),
+                        context.HttpContext.RequestAborted).ConfigureAwait(false);
+                    if (read == 0)
+                    {
+                        break;
+                    }
+
+                    total += read;
+                    if (total > _maximumBytes)
+                    {
+                        await RejectAsync(context.HttpContext).ConfigureAwait(false);
+                        return;
+                    }
+
+                    await buffered.WriteAsync(
+                        rented.AsMemory(0, read),
+                        context.HttpContext.RequestAborted).ConfigureAwait(false);
+                }
+
+                buffered.Position = 0;
+                request.Body = buffered;
+                pipelineInvoked = true;
+                await next().ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (!pipelineInvoked && context.HttpContext.RequestAborted.IsCancellationRequested)
+            {
+                // The peer disconnected while its body was still being buffered.
+                // There is no client left to receive an error response.
+            }
+            finally
+            {
+                request.Body = originalBody;
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
+
+        private static Task RejectAsync(HttpContext context)
+        {
+            context.Response.StatusCode = StatusCodes.Status413PayloadTooLarge;
+            return context.Response.WriteAsJsonAsync(new PersistedPayloadErrorResponse
+            {
+                Code = "payload_too_large",
+                Message = "The request payload exceeds the supported size limit."
+            }, context.RequestAborted);
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/UserSettingsController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/UserSettingsController.cs
@@ -172,6 +172,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
         [HttpPost("user-settings/{userId}/settings.json")]
         [Authorize]
         [Produces("application/json")]
+        [PersistedPayloadLimit(PersistedPayloadPolicy.StandardRequestBytes)]
         public IActionResult SaveUserSettingsSettings(string userId, [FromBody] UserSettings userConfiguration)
         {
             var authorizationResult = AuthorizeUserConfigAccess(userId, out var authorizedUserId);
@@ -186,6 +187,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
         [HttpPost("user-settings/{userId}/shortcuts.json")]
         [Authorize]
         [Produces("application/json")]
+        [PersistedPayloadLimit(PersistedPayloadPolicy.StandardRequestBytes)]
         public IActionResult SaveUserSettingsShortcuts(string userId, [FromBody] UserShortcuts userConfiguration)
         {
             var authorizationResult = AuthorizeUserConfigAccess(userId, out var authorizedUserId);
@@ -202,7 +204,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             Success,
             PreconditionRequired,
             Conflict,
-            Invalid
+            Invalid,
+            TooLarge
         }
 
         public sealed class UserFileMutationResponse<T>
@@ -211,6 +214,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             public bool Success { get; set; }
             public bool Conflict { get; set; }
             public string Message { get; set; } = string.Empty;
+            public string Code { get; set; } = string.Empty;
             public string File { get; set; } = string.Empty;
             public long Revision { get; set; }
             public string ContentHash { get; set; } = string.Empty;
@@ -237,13 +241,20 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 StampServerManagedFields(authorizedUserId, candidate);
             }
 
-            if (candidate == null || !IsValidUserFileState(candidate))
+            var validation = PersistedPayloadPolicy.Validate(candidate);
+            if (candidate == null || !validation.IsValid)
             {
-                return BadRequest(new UserFileMutationResponse<T>
+                var response = new UserFileMutationResponse<T>
                 {
+                    Code = validation.Code,
                     File = fileName,
-                    Message = $"The {displayName} payload is invalid."
-                });
+                    Message = validation.Status == PersistedPayloadStatus.TooLarge
+                        ? $"The {displayName} payload exceeds the supported size limit."
+                        : $"The {displayName} payload is invalid."
+                };
+                return validation.Status == PersistedPayloadStatus.TooLarge
+                    ? StatusCode(StatusCodes.Status413PayloadTooLarge, response)
+                    : BadRequest(response);
             }
 
             if (!TryParseIfMatchRevision(out var expectedRevision))
@@ -282,6 +293,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 {
                     Success = result.Status == UserFileCommitStatus.Success,
                     Conflict = result.Status == UserFileCommitStatus.Conflict,
+                    Code = result.Status == UserFileCommitStatus.TooLarge
+                        ? "payload_too_large"
+                        : result.Status == UserFileCommitStatus.Invalid ? "invalid_payload" : string.Empty,
                     Message = result.Message,
                     File = fileName,
                     Revision = result.State?.Revision ?? 0,
@@ -302,12 +316,15 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                     UserFileCommitStatus.PreconditionRequired => StatusCode(StatusCodes.Status428PreconditionRequired, response),
                     UserFileCommitStatus.Conflict => Conflict(response),
                     UserFileCommitStatus.Invalid => BadRequest(response),
+                    UserFileCommitStatus.TooLarge => StatusCode(StatusCodes.Status413PayloadTooLarge, response),
                     _ => StatusCode(StatusCodes.Status500InternalServerError, response)
                 };
             }
             catch (Exception ex)
             {
-                _logger.LogError($"Failed to save user {displayName} for {ResolveUserDisplay(authorizedUserId)}: {ex.Message}");
+                _logger.LogError(
+                    $"Failed to save user {displayName} for {ResolveUserDisplay(authorizedUserId)} " +
+                    $"(exception={ex.GetType().Name}).");
                 var response = new UserFileMutationResponse<T>
                 {
                     File = fileName,
@@ -365,6 +382,21 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 }
 
                 candidate.Revision = checked(current.Revision + 1);
+                var validation = PersistedPayloadPolicy.Validate(candidate);
+                if (!validation.IsValid)
+                {
+                    return new UserFileCommitResult<T>
+                    {
+                        Status = validation.Status == PersistedPayloadStatus.TooLarge
+                            ? UserFileCommitStatus.TooLarge
+                            : UserFileCommitStatus.Invalid,
+                        State = current,
+                        Message = validation.Status == PersistedPayloadStatus.TooLarge
+                            ? "The payload exceeds the supported size limit; no mutation was committed."
+                            : "The payload is invalid; no mutation was committed."
+                    };
+                }
+
                 _userConfigurationManager.SaveUserConfiguration(authorizedUserId, fileName, candidate);
                 return new UserFileCommitResult<T> { Status = UserFileCommitStatus.Success, State = candidate };
             }
@@ -372,70 +404,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
 
         private static bool IsValidUserFileState<T>(T state)
             where T : class, IRevisionedUserConfiguration
-            => state.Revision >= 0 && state switch
-            {
-                UserSettings settings => settings.ExtensionData != null
-                    && settings.ExtensionData.Count <= 1000
-                    && settings.PauseScreenDelaySeconds is >= 1 and <= 60
-                    && settings.SubtitleVerticalPosition is >= 0 and <= 100
-                    && settings.SubtitleHorizontalPosition is >= 0 and <= 100
-                    && HasValidSettingsStrings(settings)
-                    && HasBoundedSerializedSize(settings),
-                UserShortcuts shortcuts => shortcuts.Shortcuts != null
-                    && shortcuts.Shortcuts.Count <= 1000
-                    && shortcuts.Shortcuts.All(shortcut => shortcut != null
-                        && IsBoundedString(shortcut.Name)
-                        && IsBoundedString(shortcut.Key)
-                        && IsBoundedString(shortcut.Label)
-                        && IsBoundedString(shortcut.Category))
-                    && shortcuts.ExtensionData != null
-                    && shortcuts.ExtensionData.Count <= 1000
-                    && HasBoundedSerializedSize(shortcuts),
-                ElsewhereSettings elsewhere => elsewhere.Regions != null
-                    && elsewhere.Services != null
-                    && elsewhere.Regions.Count <= 500
-                    && elsewhere.Services.Count <= 500
-                    && IsBoundedString(elsewhere.Region)
-                    && elsewhere.Regions.All(IsBoundedString)
-                    && elsewhere.Services.All(IsBoundedString)
-                    && elsewhere.ExtensionData != null
-                    && elsewhere.ExtensionData.Count <= 1000
-                    && HasBoundedSerializedSize(elsewhere),
-                _ => false
-            };
-
-        private const int MaxUserFileBytes = 1024 * 1024;
-        private const int MaxUserStringLength = 512;
-
-        private static bool IsBoundedString(string? value)
-            => value != null && value.Length <= MaxUserStringLength;
-
-        private static bool HasValidSettingsStrings(UserSettings settings)
-            => IsBoundedString(settings.CustomSubtitleTextColor)
-                && IsBoundedString(settings.CustomSubtitleBgColor)
-                && IsBoundedString(settings.WatchProgressMode)
-                && IsBoundedString(settings.WatchProgressTimeFormat)
-                && IsBoundedString(settings.QualityTagsPosition)
-                && IsBoundedString(settings.GenreTagsPosition)
-                && IsBoundedString(settings.LanguageTagsPosition)
-                && IsBoundedString(settings.RatingTagsPosition)
-                && IsBoundedString(settings.LastOpenedTab)
-                && IsBoundedString(settings.DisplayLanguage)
-                && IsBoundedString(settings.CalendarDisplayMode)
-                && IsBoundedString(settings.CalendarDefaultViewMode);
-
-        private static bool HasBoundedSerializedSize<T>(T state)
-        {
-            try
-            {
-                return JsonSerializer.SerializeToUtf8Bytes(state, state!.GetType(), PersistedJson.WriteOptions).Length
-                    <= MaxUserFileBytes;
-            }
-            catch (JsonException)
-            {
-                return false;
-            }
-        }
+            => PersistedPayloadPolicy.Validate(state).IsValid;
 
         private void StampServerManagedFields<T>(string authorizedUserId, T state)
             where T : class, IRevisionedUserConfiguration
@@ -1423,6 +1392,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
         [HttpPost("user-settings/{userId}/elsewhere.json")]
         [Authorize]
         [Produces("application/json")]
+        [PersistedPayloadLimit(PersistedPayloadPolicy.StandardRequestBytes)]
         public IActionResult SaveUserSettingsElsewhere(string userId, [FromBody] ElsewhereSettings userConfiguration)
         {
             var authorizationResult = AuthorizeUserConfigAccess(userId, out var authorizedUserId);

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -211,6 +211,21 @@ curl -X GET \
 - **Non-admin** authenticated callers receive an empty object (`{}`) rather than a `403`, so the client still initialises but never sees admin-only fields.
 - If the plugin configuration is unavailable, the endpoint returns `503`.
 
+### User configuration payload budgets
+
+Complete replacements for `settings.json`, `shortcuts.json`, `elsewhere.json`, and `hidden-content.json` share one server-side payload policy. The request body is bounded **before JSON model binding** for both `Content-Length` and chunked uploads; an oversized body returns HTTP `413` with `{"success":false,"code":"payload_too_large",...}` and is never deserialized, logged, cached, or written. Field/count/range failures return HTTP `400` with a stable non-value-bearing reason code. A rejection leaves the existing file and Hidden Content cache untouched.
+
+| Payload | HTTP body | Persisted JSON | Collection limits |
+| --- | ---: | ---: | --- |
+| `settings.json` | 1 MiB | 1 MiB | Up to 1,000 extension properties |
+| `shortcuts.json` | 1 MiB | 1 MiB | Up to 1,000 shortcuts and 1,000 extension properties |
+| `elsewhere.json` | 1 MiB | 1 MiB | Up to 500 regions, 500 services, and 1,000 extension properties |
+| `hidden-content.json` | 8 MiB | 7 MiB | Up to **10,000 hidden items** (intentionally sized and tested with realistic populated records for large supported libraries) |
+
+Known settings/shortcut/Elsewhere free-text fields are capped at 512 characters. Hidden Content keys are capped at 256 characters; display fields at 512; identifiers and type/timestamp fields use narrower 32–128 character limits. Season and episode numbers accept `0` through `100000`. Legacy `series` hide scope remains accepted alongside `global`, `continuewatching`, `nextup`, and `homesections`.
+
+Forward-compatible `[JsonExtensionData]` remains supported, but unknown JSON is recursively bounded across the complete extension map: property names 256 characters, string values 4,096 characters, depth 16, and 20,000 JSON nodes. Finally, the shared user-configuration store refuses every serialized file over 8 MiB as a caller-independent backstop. Successful logs contain metadata such as file, revision, hash, item count, and byte count—not old/new values or supplied secrets.
+
 ### Bookmark API
 
 Bookmarks are stored **per user** under the plugin's configurations directory. The user id is normalized (dashes stripped, lowercased) to form the folder name, and the file is named `bookmark.json` (singular):

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -19,7 +19,7 @@ const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the repeated clean measurements', () => {
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1364, totalLines: 1692 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 14003, totalLines: 22259 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 14239, totalLines: 22500 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 1);
 });

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -21,8 +21,8 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 14003,
-        "totalLines": 22259
+        "coveredLines": 14239,
+        "totalLines": 22500
       },
       "tolerance": {
         "missingCoveredLines": 1,


### PR DESCRIPTION
## What changed

- enforce bounded Settings, Shortcuts, Elsewhere, and Hidden Content request bodies before MVC deserialization, including chunked uploads
- centralize field, range, collection, recursive extension-JSON, and serialized-size policies
- validate and clone Hidden Content before locking, writing, or invalidating cache; retain large-library and legacy-null compatibility
- add an 8 MiB caller-independent store ceiling and metadata-only logging
- document the exact limits and update reviewed server coverage evidence

## Why

User configuration endpoints had inconsistent post-binding checks, and the complete Hidden Content replacement had no equivalent payload policy. Oversized or deeply nested input could consume resources before rejection, while value-bearing exception messages risked reaching both log sinks.

## Impact

Oversized bodies now return a structured `413 payload_too_large` before model binding. Invalid fields and ranges return stable `400` codes. Rejected payloads leave disk and cache unchanged. Hidden Content supports 10,000 realistically populated records within an 8 MiB request / 7 MiB persisted budget.

## Validation

- server: 1,337/1,337 tests; exact coverage 14,239/22,500 (63.284%)
- client: 845/845 tests
- scripts: full suite passed; coverage baseline tests 13/13 after reviewed update
- lint: 0 errors (existing warning baseline only)
- Release build: 0 warnings, 0 errors
- Fable low-effort independent final review: APPROVE
- rendered E2E Compose image: pinned `jellyfin/jellyfin:unstable` nightly digest

Closes #110
