### PR TITLE
Quarantine corrupt user stores behind explicit recovery

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Configuration/UserFileReadCompatTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Configuration/UserFileReadCompatTests.cs
@@ -1,6 +1,8 @@
 using System.Text.Json;
+using System.Collections.Concurrent;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
 using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -20,7 +22,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Configuration
     /// save permanently overwrites the user's real data.
     ///
     /// Also pins the STRICT read-modify-write semantics: corrupt files must
-    /// throw (never silently become defaults) and leave a .corrupt-* backup.
+    /// throw (never silently become defaults), enter one durable recovery state,
+    /// and leave bounded .corrupt-* forensic evidence.
     /// </summary>
     public class UserFileReadCompatTests : IDisposable
     {
@@ -28,6 +31,23 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Configuration
 
         private readonly string _baseDir;
         private readonly UserConfigurationManager _manager;
+
+        private sealed class CollectingLogger : ILogger<UserConfigurationManager>
+        {
+            public ConcurrentQueue<string> Messages { get; } = new();
+
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+                => Messages.Enqueue(formatter(state, exception));
+        }
 
         public UserFileReadCompatTests()
         {
@@ -219,29 +239,72 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Configuration
         [InlineData("   \n")]      // whitespace only
         [InlineData("null")]       // literal JSON null
         [InlineData("{{{ nope")]   // parse failure
-        public void StrictRead_CorruptFile_Throws_And_BacksUp(string content)
+        public void StrictRead_CorruptFile_QuarantinesOnce_AndPublishesRecoveryMarker(string content)
         {
             SeedUserFileRaw("settings.json", content);
 
-            Assert.ThrowsAny<Exception>(() => _manager.GetUserConfigurationStrict<UserSettings>(UserId, "settings.json"));
+            var error = Assert.Throws<UserStoreUnhealthyException>(
+                () => _manager.GetUserConfigurationStrict<UserSettings>(UserId, "settings.json"));
 
-            // Original bytes are preserved twice over: in place and as a forensic backup.
-            Assert.Equal(content, File.ReadAllText(Path.Combine(UserDir, "settings.json")));
-            Assert.Single(Directory.GetFiles(UserDir, "settings.json.corrupt-*"));
+            Assert.True(error.NewlyQuarantined);
+            Assert.False(File.Exists(Path.Combine(UserDir, "settings.json")));
+            Assert.True(File.Exists(Path.Combine(UserDir, "settings.json.unhealthy")));
+            var quarantine = Assert.Single(Directory.GetFiles(UserDir, "settings.json.corrupt-*"));
+            Assert.Equal(content, File.ReadAllText(quarantine));
+
+            var status = Assert.Single(_manager.GetUnhealthyUserStores());
+            Assert.Equal(UserId, status.UserId);
+            Assert.Equal("settings.json", status.FileName);
+            Assert.True(status.MarkerReadable);
+            Assert.True(status.QuarantineComplete);
         }
 
         [Fact]
-        public void StrictRead_RepeatedSameCorruption_ReusesOneBoundedForensicBackup()
+        public void StrictRead_OneHundredConcurrentRetries_CreateExactlyOneQuarantine()
         {
             SeedUserFileRaw("settings.json", "{{{ repeated corruption");
+            var outcomes = new ConcurrentBag<UserStoreUnhealthyException>();
 
-            for (var attempt = 0; attempt < 10; attempt++)
+            Parallel.For(0, 100, _ =>
             {
-                Assert.ThrowsAny<Exception>(() =>
-                    _manager.GetUserConfigurationStrict<UserSettings>(UserId, "settings.json"));
+                try
+                {
+                    _manager.GetUserConfigurationStrict<UserSettings>(UserId, "settings.json");
+                }
+                catch (UserStoreUnhealthyException ex)
+                {
+                    outcomes.Add(ex);
+                }
+            });
+
+            Assert.Equal(100, outcomes.Count);
+            Assert.Single(outcomes, outcome => outcome.NewlyQuarantined);
+            Assert.Single(Directory.GetFiles(UserDir, "settings.json.corrupt-*"));
+            Assert.True(File.Exists(Path.Combine(UserDir, "settings.json.unhealthy")));
+            Assert.False(File.Exists(Path.Combine(UserDir, "settings.json")));
+        }
+
+        [Fact]
+        public void StrictRead_RepeatedRetries_DoNotAmplifyStoreLogs()
+        {
+            var logger = new CollectingLogger();
+            var manager = new UserConfigurationManager(new StubAppPaths(_baseDir), logger);
+            SeedUserFileRaw("settings.json", "{{{ one logged transition");
+
+            Assert.Throws<UserStoreUnhealthyException>(() =>
+                manager.GetUserConfigurationStrict<UserSettings>(UserId, "settings.json"));
+            var afterTransition = logger.Messages.Count;
+
+            for (var attempt = 0; attempt < 20; attempt++)
+            {
+                Assert.Throws<UserStoreUnhealthyException>(() =>
+                    manager.GetUserConfigurationStrict<UserSettings>(UserId, "settings.json"));
+                Assert.Throws<UserStoreUnhealthyException>(() =>
+                    manager.SaveUserConfiguration(UserId, "settings.json", new UserSettings()));
             }
 
-            Assert.Single(Directory.GetFiles(UserDir, "settings.json.corrupt-*"));
+            Assert.Equal(afterTransition, logger.Messages.Count);
+            Assert.Single(logger.Messages, message => message.Contains("entered recovery state", StringComparison.Ordinal));
         }
 
         [Fact]
@@ -250,32 +313,103 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Configuration
             for (var version = 0; version < 8; version++)
             {
                 SeedUserFileRaw("settings.json", $"{{{{{{ corruption-{version}");
-                Assert.ThrowsAny<Exception>(() =>
+                Assert.Throws<UserStoreUnhealthyException>(() =>
                     _manager.GetUserConfigurationStrict<UserSettings>(UserId, "settings.json"));
+                if (version < 7)
+                {
+                    Assert.True(_manager.ResetUnhealthyUserStore(UserId, "settings.json"));
+                }
                 System.Threading.Thread.Sleep(2);
             }
 
             Assert.Equal(5, Directory.GetFiles(UserDir, "settings.json.corrupt-*").Length);
-            Assert.Equal("{{{ corruption-7", File.ReadAllText(Path.Combine(UserDir, "settings.json")));
+            Assert.False(File.Exists(Path.Combine(UserDir, "settings.json")));
+            Assert.Contains(
+                Directory.GetFiles(UserDir, "settings.json.corrupt-*"),
+                path => File.ReadAllText(path) == "{{{ corruption-7");
         }
 
         [Fact]
-        public void StrictRead_UnreadableOldBackup_DoesNotPreventPreservingNewCorruptBytes()
+        public void StrictRead_DistinctLargeGenerations_StayWithinByteBudget()
         {
-            const string content = "{{{ current-corrupt";
-            SeedUserFileRaw("settings.json", content);
-            var unreadable = Path.Combine(UserDir, "settings.json.corrupt-20000101000000000");
-            File.WriteAllText(unreadable, new string('x', content.Length));
-
-            using (File.Open(unreadable, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+            var contentBytes = 8 * 1024 * 1024 + 256 * 1024;
+            for (var version = 0; version < 4; version++)
             {
-                Assert.ThrowsAny<Exception>(() =>
+                SeedUserFileRaw("settings.json", new string((char)('a' + version), contentBytes));
+                Assert.Throws<UserStoreUnhealthyException>(() =>
                     _manager.GetUserConfigurationStrict<UserSettings>(UserId, "settings.json"));
+                if (version < 3)
+                {
+                    Assert.True(_manager.ResetUnhealthyUserStore(UserId, "settings.json"));
+                }
+                System.Threading.Thread.Sleep(2);
             }
 
             var backups = Directory.GetFiles(UserDir, "settings.json.corrupt-*");
-            Assert.Equal(2, backups.Length);
-            Assert.Contains(backups, path => path != unreadable && File.ReadAllText(path) == content);
+            Assert.Equal(3, backups.Length);
+            Assert.True(backups.Sum(path => new FileInfo(path).Length) <= 32L * 1024 * 1024);
+        }
+
+        [Fact]
+        public void ResetUnhealthyStore_PreservesEvidence_ClearsMarker_AndRestoresWrites()
+        {
+            SeedUserFileRaw("settings.json", "{{{ needs explicit reset");
+            Assert.Throws<UserStoreUnhealthyException>(() =>
+                _manager.GetUserConfigurationStrict<UserSettings>(UserId, "settings.json"));
+
+            Assert.Throws<UserStoreUnhealthyException>(() =>
+                _manager.SaveUserConfiguration(UserId, "settings.json", new UserSettings()));
+            Assert.True(_manager.UserConfigurationExists(UserId, "settings.json"));
+
+            Assert.True(_manager.ResetUnhealthyUserStore(UserId, "settings.json"));
+            Assert.False(File.Exists(Path.Combine(UserDir, "settings.json.unhealthy")));
+            Assert.Single(Directory.GetFiles(UserDir, "settings.json.corrupt-*"));
+            Assert.False(_manager.UserConfigurationExists(UserId, "settings.json"));
+
+            var defaults = _manager.GetUserConfigurationStrict<UserSettings>(UserId, "settings.json");
+            Assert.Equal(5, defaults.PauseScreenDelaySeconds);
+            defaults.LastOpenedTab = "recovered";
+            _manager.SaveUserConfiguration(UserId, "settings.json", defaults);
+            Assert.Equal("recovered", _manager.GetUserConfiguration<UserSettings>(UserId, "settings.json").LastOpenedTab);
+            Assert.Empty(_manager.GetUnhealthyUserStores());
+        }
+
+        [Fact]
+        public void ResetUnhealthyStore_CompletesMarkerFirstInterruptedQuarantine()
+        {
+            const string corrupt = "{{{ interrupted after marker publish";
+            SeedUserFileRaw("settings.json", corrupt);
+            Assert.Throws<UserStoreUnhealthyException>(() =>
+                _manager.GetUserConfigurationStrict<UserSettings>(UserId, "settings.json"));
+
+            var primary = Path.Combine(UserDir, "settings.json");
+            var quarantine = Assert.Single(Directory.GetFiles(UserDir, "settings.json.corrupt-*"));
+            File.Move(quarantine, primary);
+            Assert.False(Assert.Single(_manager.GetUnhealthyUserStores()).QuarantineComplete);
+
+            Assert.True(_manager.ResetUnhealthyUserStore(UserId, "settings.json"));
+
+            Assert.False(File.Exists(primary));
+            Assert.False(File.Exists(primary + ".unhealthy"));
+            Assert.Equal(
+                corrupt,
+                File.ReadAllText(Assert.Single(Directory.GetFiles(UserDir, "settings.json.corrupt-*"))));
+        }
+
+        [Fact]
+        public void ResetUnhealthyStore_MissingSourceAndQuarantine_LeavesMarkerFailClosed()
+        {
+            SeedUserFileRaw("settings.json", "{{{ evidence will vanish");
+            Assert.Throws<UserStoreUnhealthyException>(() =>
+                _manager.GetUserConfigurationStrict<UserSettings>(UserId, "settings.json"));
+
+            File.Delete(Assert.Single(Directory.GetFiles(UserDir, "settings.json.corrupt-*")));
+
+            Assert.Throws<InvalidDataException>(() =>
+                _manager.ResetUnhealthyUserStore(UserId, "settings.json"));
+            Assert.True(File.Exists(Path.Combine(UserDir, "settings.json.unhealthy")));
+            Assert.Throws<UserStoreUnhealthyException>(() =>
+                _manager.GetUserConfigurationStrict<UserSettings>(UserId, "settings.json"));
         }
 
         /// <summary>
@@ -315,10 +449,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Configuration
         {
             SeedUserFileRaw("hidden-content.json", "{{{ corrupt");
 
-            Assert.ThrowsAny<Exception>(() =>
+            Assert.Throws<UserStoreUnhealthyException>(() =>
                 _manager.RmwUserConfiguration<UserHiddenContent>(UserId, "hidden-content.json", hc => 1));
 
-            Assert.Equal("{{{ corrupt", File.ReadAllText(Path.Combine(UserDir, "hidden-content.json")));
+            Assert.False(File.Exists(Path.Combine(UserDir, "hidden-content.json")));
+            Assert.Equal(
+                "{{{ corrupt",
+                File.ReadAllText(Assert.Single(Directory.GetFiles(UserDir, "hidden-content.json.corrupt-*"))));
+            Assert.True(File.Exists(Path.Combine(UserDir, "hidden-content.json.unhealthy")));
         }
 
         [Fact]

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/BookmarkRevisionControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/BookmarkRevisionControllerTests.cs
@@ -539,7 +539,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 }
             });
             Assert.Equal(StatusCodes.Status503ServiceUnavailable, Assert.IsType<ObjectResult>(migration).StatusCode);
-            Assert.Equal(raw, File.ReadAllText(BookmarkPath));
+            Assert.False(File.Exists(BookmarkPath));
+            Assert.True(File.Exists(BookmarkPath + ".unhealthy"));
+            Assert.Equal(
+                raw,
+                File.ReadAllText(Assert.Single(Directory.GetFiles(Path.GetDirectoryName(BookmarkPath)!, "bookmark.json.corrupt-*"))));
         }
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SpoilerGuardControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SpoilerGuardControllerTests.cs
@@ -315,6 +315,27 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             }
         }
 
+        [Fact]
+        public void CorruptionBanner_RepeatedMarkerHitsKeepFirstEvent()
+        {
+            var userKey = Guid.NewGuid().ToString("N");
+            try
+            {
+                SpoilerUserResolver.RecordCorruption(userKey, "user", "first marker hit");
+                var first = SpoilerUserResolver.GetCorruptionLog()[userKey];
+
+                SpoilerUserResolver.RecordCorruption(userKey, "changed", "retry");
+                var afterRetry = SpoilerUserResolver.GetCorruptionLog()[userKey];
+
+                Assert.Same(first, afterRetry);
+                Assert.Equal("first marker hit", afterRetry.Reason);
+            }
+            finally
+            {
+                SpoilerUserResolver.ClearCorruption(userKey);
+            }
+        }
+
         // ─── F4: movie scope probe endpoint ───────────────────────────────────────
 
         [Fact]

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/UserSettingsRevisionControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/UserSettingsRevisionControllerTests.cs
@@ -240,7 +240,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
         }
 
         [Fact]
-        public void CorruptStore_FailsReadAndWriteWithoutReplacingRawBytes()
+        public void CorruptStore_FailsReadAndWriteWhileQuarantiningExactRawBytes()
         {
             SeedSettings();
             File.WriteAllText(FilePath("settings.json"), "{ malformed settings");
@@ -253,7 +253,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 UserId,
                 new UserSettings { Revision = 0, WatchProgressMode = "time" });
             Assert.Equal(StatusCodes.Status503ServiceUnavailable, Assert.IsType<ObjectResult>(save).StatusCode);
-            Assert.Equal(raw, File.ReadAllText(FilePath("settings.json")));
+            var settingsPath = FilePath("settings.json");
+            Assert.False(File.Exists(settingsPath));
+            Assert.True(File.Exists(settingsPath + ".unhealthy"));
+            Assert.Equal(
+                raw,
+                File.ReadAllText(Assert.Single(Directory.GetFiles(Path.GetDirectoryName(settingsPath)!, "settings.json.corrupt-*"))));
         }
 
         [Fact]
@@ -283,6 +288,24 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 UserId,
                 new UserSettings { Revision = 8, WatchProgressMode = "percentage" });
             Assert.IsType<ConflictObjectResult>(stale);
+        }
+
+        [Fact]
+        public void AdminReset_ReportsQuarantinedHiddenContentAndContinuesOtherUsers()
+        {
+            SeedSettings(revision: 4, mode: "time");
+            Directory.CreateDirectory(Path.GetDirectoryName(FilePath("hidden-content.json"))!);
+            File.WriteAllText(FilePath("hidden-content.json"), "{{{ corrupt hidden content");
+            Assert.Throws<UserStoreUnhealthyException>(() =>
+                _manager.GetUserConfigurationStrict<UserHiddenContent>(UserId, "hidden-content.json"));
+
+            var reset = Assert.IsType<OkObjectResult>(Controller().ResetAllUsersSettings());
+
+            Assert.Equal(5, _manager.GetUserConfigurationStrict<UserSettings>(UserId, "settings.json").Revision);
+            Assert.True(File.Exists(FilePath("hidden-content.json.unhealthy")));
+            var responseJson = JsonSerializer.Serialize(reset.Value);
+            Assert.Contains(UserId, responseJson, StringComparison.Ordinal);
+            Assert.Contains("skippedHcUserIds", responseJson, StringComparison.Ordinal);
         }
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/UserStoreRecoveryControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/UserStoreRecoveryControllerTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.IO;
+using System.Reflection;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Controllers;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using MediaBrowser.Common.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
+{
+    public sealed class UserStoreRecoveryControllerTests : IDisposable
+    {
+        private readonly string _baseDir;
+        private readonly string _userId = Guid.NewGuid().ToString("N");
+        private readonly UserConfigurationManager _manager;
+
+        public UserStoreRecoveryControllerTests()
+        {
+            _baseDir = Path.Combine(Path.GetTempPath(), "jc-user-recovery-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_baseDir);
+            _manager = new UserConfigurationManager(
+                new StubAppPaths(_baseDir),
+                NullLogger<UserConfigurationManager>.Instance);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_baseDir, recursive: true); } catch { }
+        }
+
+        private string UserDir
+            => Path.Combine(_baseDir, "configurations", "Jellyfin.Plugin.JellyfinCanopy", _userId);
+
+        private UserStoreRecoveryController Controller()
+            => new(_manager, NullLogger<UserStoreRecoveryController>.Instance);
+
+        private void QuarantineSettings()
+        {
+            Directory.CreateDirectory(UserDir);
+            File.WriteAllText(Path.Combine(UserDir, "settings.json"), "{{{ corrupt");
+            Assert.Throws<UserStoreUnhealthyException>(() =>
+                _manager.GetUserConfigurationStrict<UserSettings>(_userId, "settings.json"));
+        }
+
+        [Fact]
+        public void Controller_IsElevationGatedAtClassBoundary()
+        {
+            var authorize = typeof(UserStoreRecoveryController).GetCustomAttribute<AuthorizeAttribute>();
+            Assert.NotNull(authorize);
+            Assert.Equal(Policies.RequiresElevation, authorize!.Policy);
+        }
+
+        [Fact]
+        public void AdminStatusAndReset_RetireMarkerOnlyAfterEvidenceIsPreserved()
+        {
+            QuarantineSettings();
+            Assert.IsType<OkObjectResult>(Controller().GetUnhealthyStores());
+
+            var result = Controller().ResetUnhealthyStore(_userId, "settings.json");
+
+            Assert.IsType<OkObjectResult>(result);
+            Assert.False(File.Exists(Path.Combine(UserDir, "settings.json.unhealthy")));
+            Assert.Single(Directory.GetFiles(UserDir, "settings.json.corrupt-*"));
+            Assert.Empty(_manager.GetUnhealthyUserStores());
+        }
+
+        [Fact]
+        public void Reset_RejectsUnknownStoreAndInvalidUser()
+        {
+            Assert.IsType<BadRequestObjectResult>(
+                Controller().ResetUnhealthyStore("not-a-guid", "settings.json"));
+            Assert.IsType<BadRequestObjectResult>(
+                Controller().ResetUnhealthyStore(_userId, "arbitrary.json"));
+        }
+
+        [Fact]
+        public void Reset_MalformedMarkerWithoutSource_ReturnsContract503AndKeepsMarker()
+        {
+            Directory.CreateDirectory(UserDir);
+            var marker = Path.Combine(UserDir, "settings.json.unhealthy");
+            File.WriteAllText(marker, "{{{ malformed marker");
+
+            var result = Assert.IsType<ObjectResult>(
+                Controller().ResetUnhealthyStore(_userId, "settings.json"));
+
+            Assert.Equal(StatusCodes.Status503ServiceUnavailable, result.StatusCode);
+            Assert.True(File.Exists(marker));
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/ContinueWatchingEventWritersTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/ContinueWatchingEventWritersTests.cs
@@ -5,6 +5,7 @@ using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Session;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -18,6 +19,23 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
     /// </summary>
     public sealed class ContinueWatchingEventWritersTests
     {
+        private sealed class CollectingLogger<T> : ILogger<T>
+        {
+            public List<string> Messages { get; } = new();
+
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+                => Messages.Add(formatter(state, exception));
+        }
+
         [Fact]
         public async Task Consumer_OnResume_InvalidatesHcFilterCache()
         {
@@ -57,6 +75,45 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             finally
             {
                 try { Directory.Delete(tempDir, recursive: true); } catch { /* best-effort cleanup */ }
+            }
+        }
+
+        [Fact]
+        public async Task Consumer_QuarantinedStore_SkipsRepeatedPlaybackWithoutLogging()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "jc-cw-quarantine-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var ucm = new UserConfigurationManager(new StubAppPaths(tempDir), NullLogger<UserConfigurationManager>.Instance);
+                var userId = Guid.NewGuid();
+                var userDir = Path.Combine(
+                    tempDir,
+                    "configurations",
+                    "Jellyfin.Plugin.JellyfinCanopy",
+                    userId.ToString("N"));
+                Directory.CreateDirectory(userDir);
+                File.WriteAllText(Path.Combine(userDir, "hidden-content.json"), "{{{ corrupt");
+                Assert.Throws<UserStoreUnhealthyException>(() =>
+                    ucm.GetUserConfigurationStrict<UserHiddenContent>(userId.ToString("N"), "hidden-content.json"));
+
+                var logger = new CollectingLogger<ContinueWatchingPlaybackConsumer>();
+                var provider = new FakePluginConfigProvider(new PluginConfiguration { RemoveContinueWatchingEnabled = true });
+                var consumer = new ContinueWatchingPlaybackConsumer(ucm, logger, provider);
+                var args = new PlaybackStartEventArgs
+                {
+                    Item = new Movie { Id = Guid.NewGuid() },
+                    Session = new SessionInfo(null!, NullLogger.Instance) { UserId = userId }
+                };
+
+                await consumer.OnEvent(args);
+                await consumer.OnEvent(args);
+
+                Assert.Empty(logger.Messages);
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch { }
             }
         }
 

--- a/Jellyfin.Plugin.JellyfinCanopy/Configuration/UserConfigurationManager.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Configuration/UserConfigurationManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using MediaBrowser.Common.Configuration;
 using Microsoft.Extensions.Logging;
@@ -51,7 +52,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Configuration
         public T GetUserConfiguration<T>(string userId, string fileName) where T : new()
             => _store.GetUserConfiguration<T>(userId, fileName);
 
-        // Strict read for RMW: existing empty/null/garbage is corruption; backs up to .corrupt-{ts} and throws.
+        // Strict read for RMW: existing empty/null/garbage enters durable quarantine and throws.
         public T GetUserConfigurationStrict<T>(string userId, string fileName) where T : new()
             => _store.GetUserConfigurationStrict<T>(userId, fileName);
 
@@ -76,6 +77,21 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Configuration
         /// </summary>
         public string[] GetAllUserIds()
             => _store.GetAllUserIds();
+
+        /// <summary>
+        /// Returns durable per-user corruption markers for the elevation-gated
+        /// recovery surface. No quarantined payload bytes are exposed.
+        /// </summary>
+        internal IReadOnlyList<UserStoreRecoveryStatus> GetUnhealthyUserStores()
+            => _store.GetUnhealthyUserStores();
+
+        /// <summary>
+        /// Explicitly retires one unhealthy generation after preserving any
+        /// source bytes left by an interrupted quarantine. The next ordinary
+        /// access initializes the file's normal defaults.
+        /// </summary>
+        internal bool ResetUnhealthyUserStore(string userId, string fileName)
+            => _store.ResetUnhealthyUserStore(userId, fileName);
 
         // ─── Indexed shared reviews (ReviewsStore) ───────────────────────────────
 
@@ -133,7 +149,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Configuration
         /// (WatchlistMonitor + SeerrWatchlistSyncTask) MUST go through this so
         /// concurrent event/scheduled writers cannot lose each other's markers. The
         /// mutator returns the number of changes; a return of 0 skips the save.
-        /// Strict-read semantics apply (a corrupt file backs up + throws), so callers
+        /// Strict-read semantics apply (a corrupt file is quarantined + throws), so callers
         /// running off the request path must catch/log/skip rather than propagate.
         /// </summary>
         public int RmwProcessedWatchlistItems(Guid userId, Func<ProcessedWatchlistItems, int> mutate)
@@ -160,6 +176,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Configuration
                     }
                     return removed;
                 });
+            }
+            catch (UserStoreUnhealthyException)
+            {
+                // The quarantine transition was logged once by the store.
             }
             catch (Exception ex)
             {

--- a/Jellyfin.Plugin.JellyfinCanopy/Configuration/UserConfigurationStore.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Configuration/UserConfigurationStore.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -20,6 +21,19 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Configuration
         private readonly string _configBaseDir;
         private readonly ILogger _logger;
         private const int MaxCorruptBackupsPerFile = 5;
+        private const long MaxCorruptBackupBytesPerFile = 32L * 1024 * 1024;
+        private const string UnhealthySuffix = ".unhealthy";
+
+        private static readonly HashSet<string> RecoverableFileNames = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "settings.json",
+            "shortcuts.json",
+            "elsewhere.json",
+            "bookmark.json",
+            "hidden-content.json",
+            "spoilerblur.json",
+            "processed-watchlist-items.json"
+        };
 
         // Static so the Singleton ResponseFilter and the Scoped IEventConsumer share one pool.
         private static readonly ConcurrentDictionary<string, object> _userFileLocks = new ConcurrentDictionary<string, object>();
@@ -73,7 +87,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Configuration
             try
             {
                 var configPath = ResolveUserFile(userId, fileName);
-                return File.Exists(configPath);
+                // A quarantined file is deliberately absent from its authoritative
+                // path, but it is not a first-run/missing store. Treat the durable
+                // marker as existence so initialization paths cannot silently seed
+                // defaults and bypass explicit recovery.
+                return File.Exists(configPath) || UnhealthyMarkerExists(configPath);
             }
             catch (Exception ex)
             {
@@ -86,6 +104,19 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Configuration
         public T GetUserConfiguration<T>(string userId, string fileName) where T : new()
         {
             var configPath = ResolveUserFile(userId, fileName);
+
+            // Lenient presentation reads keep their historical default-value
+            // contract, but never reparse or relog a quarantined generation.
+            try
+            {
+                if (UnhealthyMarkerExists(configPath)) return new T();
+            }
+            catch
+            {
+                // Preserve the lenient read contract for ordinary display state.
+                // Strict and typed security reads below surface this as unavailable.
+                return new T();
+            }
 
             if (File.Exists(configPath))
             {
@@ -126,61 +157,88 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Configuration
             return new T();
         }
 
-        // Strict read for RMW: existing empty/null/garbage is corruption; backs up to .corrupt-{ts} and throws.
+        // Strict read for RMW: existing empty/null/garbage enters a durable,
+        // fail-closed recovery state. The original bytes are atomically moved to
+        // bounded forensic storage once; subsequent retries inspect only the
+        // marker and cannot create more files or logs.
         public T GetUserConfigurationStrict<T>(string userId, string fileName) where T : new()
         {
-            var configPath = ResolveUserFile(userId, fileName);
-            if (!File.Exists(configPath)) return new T();
-
-            string json;
-            try
+            lock (GetUserFileLock(userId, fileName))
             {
-                json = File.ReadAllText(configPath);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError($"Failed to read '{fileName}' for user '{userId}': {ex.Message}");
-                BackupCorruptFile(configPath);
-                throw;
-            }
-
-            if (string.IsNullOrWhiteSpace(json)
-                || string.Equals(json.Trim(), "null", StringComparison.Ordinal))
-            {
-                _logger.LogError($"'{fileName}' for user '{userId}' exists but is empty or literal-null; refusing to overwrite.");
-                BackupCorruptFile(configPath);
-                throw new InvalidDataException($"'{fileName}' is empty or literal null; refusing to overwrite.");
-            }
-
-            try
-            {
-                // Tolerate the SAME legacy nulls the lenient GET path skips: a field
-                // that was once nullable (bool?/int?/string?) left a literal JSON null
-                // on disk and has since become non-nullable. Binding it directly throws,
-                // which used to 500 every save of an otherwise-fine file while the GET
-                // path read it correctly. Strip null members first (constructor defaults
-                // kept), exactly like GetUserConfiguration. Genuine corruption still
-                // fails: empty/whitespace/literal-null is rejected above, malformed JSON
-                // throws in JsonNode.Parse, and a non-object payload deserializes to null
-                // (or throws) — both caught below and backed up.
-                var parsed = TryDeserializeStripped<T>(json);
-                if (parsed == null)
+                var configPath = ResolveUserFile(userId, fileName);
+                if (UnhealthyMarkerExists(configPath))
                 {
-                    _logger.LogError($"'{fileName}' for user '{userId}' deserialized to null; refusing to overwrite.");
-                    BackupCorruptFile(configPath);
-                    throw new InvalidDataException($"'{fileName}' deserialized to null.");
+                    throw new UserStoreUnhealthyException(fileName, newlyQuarantined: false);
                 }
-                return parsed;
-            }
-            catch (InvalidDataException)
-            {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError($"Failed to parse '{fileName}' for user '{userId}': {ex.Message}");
-                BackupCorruptFile(configPath);
-                throw;
+
+                if (!File.Exists(configPath)) return new T();
+
+                var sourceLength = new FileInfo(configPath).Length;
+                if (sourceLength > PersistedPayloadPolicy.AbsolutePersistedBytes)
+                {
+                    string sourceHash;
+                    using (var source = File.OpenRead(configPath))
+                    {
+                        sourceHash = Convert.ToHexString(SHA256.HashData(source)).ToLowerInvariant();
+                    }
+
+                    var fault = new InvalidDataException(
+                        $"'{fileName}' exceeds the absolute {PersistedPayloadPolicy.AbsolutePersistedBytes}-byte store limit.");
+                    throw QuarantineCorruptFile(userId, fileName, configPath, sourceHash, sourceLength, fault);
+                }
+
+                byte[] sourceBytes;
+                string json;
+                try
+                {
+                    sourceBytes = File.ReadAllBytes(configPath);
+                    using var reader = new StreamReader(
+                        new MemoryStream(sourceBytes, writable: false),
+                        Encoding.UTF8,
+                        detectEncodingFromByteOrderMarks: true);
+                    json = reader.ReadToEnd();
+                }
+                catch (Exception ex)
+                {
+                    // An unavailable file is not proof of corrupt content. Do not
+                    // create a misleading marker or copy when the bytes could not
+                    // be read; callers surface the transient storage failure.
+                    _logger.LogError($"Failed to read '{fileName}' for user '{userId}': {ex.Message}");
+                    throw;
+                }
+
+                if (string.IsNullOrWhiteSpace(json)
+                    || string.Equals(json.Trim(), "null", StringComparison.Ordinal))
+                {
+                    var fault = new InvalidDataException($"'{fileName}' is empty or literal null; refusing to overwrite.");
+                    throw QuarantineCorruptFile(userId, fileName, configPath, sourceBytes, fault);
+                }
+
+                try
+                {
+                    // Tolerate the SAME legacy nulls the lenient GET path skips: a field
+                    // that was once nullable (bool?/int?/string?) left a literal JSON null
+                    // on disk and has since become non-nullable. Binding it directly throws,
+                    // which used to 500 every save of an otherwise-fine file while the GET
+                    // path read it correctly. Strip null members first (constructor defaults
+                    // kept), exactly like GetUserConfiguration. Genuine corruption still
+                    // fails: empty/whitespace/literal-null is rejected above, malformed JSON
+                    // throws in JsonNode.Parse, and a non-object payload deserializes to null.
+                    var parsed = TryDeserializeStripped<T>(json);
+                    if (parsed == null)
+                    {
+                        throw new InvalidDataException($"'{fileName}' deserialized to null.");
+                    }
+                    return parsed;
+                }
+                catch (UserStoreUnhealthyException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    throw QuarantineCorruptFile(userId, fileName, configPath, sourceBytes, ex);
+                }
             }
         }
 
@@ -226,6 +284,19 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Configuration
                 // Fail closed: treat as Unavailable so callers retain protection.
                 _logger.LogError($"Refusing to resolve policy file '{fileName}' for user '{userId}': {ex.Message}");
                 return new UserConfigReadResult<T>(UserConfigReadStatus.Unavailable, default, ex.Message);
+            }
+
+            try
+            {
+                if (UnhealthyMarkerExists(configPath))
+                {
+                    return new UserConfigReadResult<T>(UserConfigReadStatus.Corrupt, default, "quarantined-recovery-required");
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Unable to inspect recovery marker for policy file '{fileName}' for user '{userId}' — treating as UNAVAILABLE (protection retained): {ex.Message}");
+                return new UserConfigReadResult<T>(UserConfigReadStatus.Unavailable, default, "recovery-marker-unavailable");
             }
 
             // Read directly and let the exception type classify the outcome. A
@@ -317,9 +388,22 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Configuration
                 // Resolve only after validation so a rejected future caller cannot
                 // create a user directory as a side effect of an oversized write.
                 var configPath = ResolveUserFile(userId, fileName);
+                lock (GetUserFileLock(userId, fileName))
+                {
+                    if (UnhealthyMarkerExists(configPath))
+                    {
+                        throw new UserStoreUnhealthyException(fileName, newlyQuarantined: false);
+                    }
 
-                // AtomicFile owns the per-call temp sibling + rename + temp cleanup.
-                AtomicFile.WriteAllText(configPath, jsonToSave);
+                    // AtomicFile owns the per-call temp sibling + rename + temp cleanup.
+                    AtomicFile.WriteAllText(configPath, jsonToSave);
+                }
+            }
+            catch (UserStoreUnhealthyException)
+            {
+                // The transition was logged once when the marker was published.
+                // Ordinary save retries must not amplify that event.
+                throw;
             }
             catch (Exception ex)
             {
@@ -330,67 +414,314 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Configuration
             }
         }
 
-        private void BackupCorruptFile(string filePath)
+        private UserStoreUnhealthyException QuarantineCorruptFile(
+            string userId,
+            string fileName,
+            string filePath,
+            byte[] sourceBytes,
+            Exception cause)
+            => QuarantineCorruptFile(
+                userId,
+                fileName,
+                filePath,
+                Convert.ToHexString(SHA256.HashData(sourceBytes)).ToLowerInvariant(),
+                sourceBytes.LongLength,
+                cause);
+
+        private UserStoreUnhealthyException QuarantineCorruptFile(
+            string userId,
+            string fileName,
+            string filePath,
+            string hash,
+            long sourceLength,
+            Exception cause)
         {
+            var markerPath = GetUnhealthyMarkerPath(filePath);
+            if (UnhealthyMarkerExists(filePath))
+            {
+                return new UserStoreUnhealthyException(fileName, newlyQuarantined: false, cause);
+            }
+
+            var stamp = DateTime.UtcNow.ToString("yyyyMMddHHmmssfff");
+            var quarantineFileName = $"{fileName}.corrupt-{stamp}-{hash.Substring(0, 16)}-{Guid.NewGuid():N}";
+            var marker = new UserStoreUnhealthyMarker
+            {
+                FileName = fileName,
+                QuarantineFileName = quarantineFileName,
+                ContentSha256 = hash,
+                SourceBytes = sourceLength,
+                DetectedAtUtc = DateTime.UtcNow.ToString("O")
+            };
+
+            // Publish the fail-closed marker first. A crash before the following
+            // rename leaves the source plus marker (still unhealthy and recoverable),
+            // never an absent source that can be mistaken for first-run defaults.
+            AtomicFile.WriteAllText(markerPath, JsonSerializer.Serialize(marker, PersistedJson.WriteOptions));
+
+            var quarantinePath = Path.Combine(Path.GetDirectoryName(filePath)!, quarantineFileName);
+            var moved = false;
             try
             {
-                var existingBackups = Directory.GetFiles(
-                    Path.GetDirectoryName(filePath)!,
-                    Path.GetFileName(filePath) + ".corrupt-*");
-                foreach (var existing in existingBackups)
+                File.Move(filePath, quarantinePath);
+                moved = true;
+                PruneCorruptBackups(filePath);
+            }
+            catch (Exception ex)
+            {
+                // The marker remains authoritative. Do not remove it merely because
+                // the best-effort rename/prune failed; the admin recovery surface can
+                // safely finish or reset this generation later.
+                _logger.LogError(
+                    $"Per-user store '{fileName}' entered recovery state but its quarantine move did not complete " +
+                    $"(exception={ex.GetType().Name}).");
+            }
+
+            _logger.LogWarning(
+                $"Per-user store '{fileName}' entered recovery state for user '{NormalizeUserId(userId)}' " +
+                $"(bytes={sourceLength}, sha256Prefix={hash.Substring(0, 16)}, quarantineComplete={moved}).");
+            return new UserStoreUnhealthyException(fileName, newlyQuarantined: true, cause);
+        }
+
+        public IReadOnlyList<UserStoreRecoveryStatus> GetUnhealthyUserStores()
+        {
+            var results = new List<UserStoreRecoveryStatus>();
+            if (!Directory.Exists(_configBaseDir)) return results;
+
+            foreach (var userDir in Directory.GetDirectories(_configBaseDir))
+            {
+                var userId = Path.GetFileName(userDir);
+                if (!Guid.TryParseExact(userId, "N", out _)) continue;
+
+                foreach (var markerPath in Directory.GetFiles(userDir, "*" + UnhealthySuffix))
                 {
+                    var markerFileName = Path.GetFileName(markerPath);
+                    var fileName = markerFileName.Substring(0, markerFileName.Length - UnhealthySuffix.Length);
+                    if (!IsRecoverableFileName(fileName)) continue;
+
+                    var status = new UserStoreRecoveryStatus
+                    {
+                        UserId = userId,
+                        FileName = fileName
+                    };
                     try
                     {
-                        if (FilesHaveSameContent(filePath, existing))
+                        var marker = ReadValidMarker(markerPath, fileName);
+                        status.MarkerReadable = true;
+                        status.DetectedAtUtc = marker.DetectedAtUtc;
+                        status.SourceBytes = marker.SourceBytes;
+                        status.ContentSha256 = marker.ContentSha256;
+                        status.QuarantineFileName = marker.QuarantineFileName;
+                        status.QuarantineComplete = File.Exists(Path.Combine(userDir, marker.QuarantineFileName));
+                    }
+                    catch
+                    {
+                        // A malformed marker is itself a fail-closed recovery state.
+                        // Surface it to the admin without trusting any of its fields.
+                        status.MarkerReadable = false;
+                        status.QuarantineComplete = false;
+                    }
+
+                    results.Add(status);
+                }
+            }
+
+            return results
+                .OrderBy(status => status.UserId, StringComparer.Ordinal)
+                .ThenBy(status => status.FileName, StringComparer.Ordinal)
+                .ToArray();
+        }
+
+        public bool ResetUnhealthyUserStore(string userId, string fileName)
+        {
+            if (!IsRecoverableFileName(fileName))
+            {
+                throw new ArgumentException($"Unsupported recoverable user-config filename: '{fileName}'", nameof(fileName));
+            }
+
+            lock (GetUserFileLock(userId, fileName))
+            {
+                var filePath = ResolveUserFile(userId, fileName);
+                var markerPath = GetUnhealthyMarkerPath(filePath);
+                if (!UnhealthyMarkerExists(filePath)) return false;
+
+                UserStoreUnhealthyMarker? validMarker = null;
+                try
+                {
+                    validMarker = ReadValidMarker(markerPath, fileName);
+                }
+                catch when (File.Exists(filePath))
+                {
+                    // A source left in place is still preservable under a fresh,
+                    // validated name even when the marker itself was damaged.
+                }
+
+                // Preserve any source left by a crash/failed rename before clearing
+                // the marker. The marker is deleted last, so every interruption is
+                // retry-safe and can never publish an unacknowledged default state.
+                if (File.Exists(filePath))
+                {
+                    var sourceLength = new FileInfo(filePath).Length;
+                    string sourceHash;
+                    using (var source = File.OpenRead(filePath))
+                    {
+                        sourceHash = Convert.ToHexString(SHA256.HashData(source)).ToLowerInvariant();
+                    }
+                    string? preferredName = null;
+                    if (validMarker != null
+                        && string.Equals(validMarker.ContentSha256, sourceHash, StringComparison.Ordinal))
+                    {
+                        preferredName = validMarker.QuarantineFileName;
+                    }
+
+                    PreserveSourceForReset(filePath, fileName, sourceLength, sourceHash, preferredName);
+                }
+                else if (validMarker == null
+                    || !File.Exists(Path.Combine(Path.GetDirectoryName(filePath)!, validMarker.QuarantineFileName)))
+                {
+                    throw new InvalidDataException(
+                        "The unhealthy marker has no readable source or completed quarantine artifact; refusing to discard the recovery record.");
+                }
+
+                File.Delete(markerPath);
+                PruneCorruptBackups(filePath);
+                _logger.LogInformation(
+                    $"Explicitly reset unhealthy per-user store '{fileName}' for user '{NormalizeUserId(userId)}'; " +
+                    "the next normal access will initialize defaults.");
+                return true;
+            }
+        }
+
+        private void PreserveSourceForReset(
+            string filePath,
+            string fileName,
+            long sourceLength,
+            string sourceHash,
+            string? preferredName)
+        {
+            var directory = Path.GetDirectoryName(filePath)!;
+            foreach (var existing in Directory.GetFiles(directory, fileName + ".corrupt-*"))
+            {
+                try
+                {
+                    var info = new FileInfo(existing);
+                    if (info.Length == sourceLength)
+                    {
+                        using var candidate = File.OpenRead(existing);
+                        if (Convert.ToHexString(SHA256.HashData(candidate)).Equals(sourceHash, StringComparison.OrdinalIgnoreCase))
                         {
-                            _logger.LogWarning($"Corrupt config already preserved at {existing} — skipping duplicate backup.");
+                            File.Delete(filePath);
                             return;
                         }
                     }
-                    catch (Exception ex)
-                    {
-                        // A stale/unreadable old backup must not prevent the
-                        // newly observed corrupt bytes from being preserved.
-                        _logger.LogWarning($"Could not compare corrupt config backup {existing}; preserving a new copy: {ex.Message}");
-                    }
                 }
-
-                // Millisecond resolution so two corruption events in the same UTC second get distinct backups.
-                var backupPath = filePath + ".corrupt-" + DateTime.UtcNow.ToString("yyyyMMddHHmmssfff");
-                if (File.Exists(backupPath))
+                catch
                 {
-                    _logger.LogWarning($"Corrupt config backup already exists at {backupPath} — skipping new copy.");
-                    return;
+                    // An unreadable older artifact cannot authorize deleting the
+                    // current source. Preserve the current bytes under a new name.
                 }
-                File.Copy(filePath, backupPath);
-                _logger.LogWarning($"Corrupt config backed up to {backupPath}");
+            }
 
-                foreach (var stale in Directory.GetFiles(
+            var targetName = preferredName;
+            if (string.IsNullOrEmpty(targetName)
+                || !IsValidQuarantineFileName(fileName, targetName)
+                || File.Exists(Path.Combine(directory, targetName)))
+            {
+                targetName = $"{fileName}.corrupt-{DateTime.UtcNow:yyyyMMddHHmmssfff}-{sourceHash.Substring(0, 16)}-{Guid.NewGuid():N}";
+            }
+
+            File.Move(filePath, Path.Combine(directory, targetName));
+        }
+
+        private void PruneCorruptBackups(string filePath)
+        {
+            try
+            {
+                var retainedBytes = 0L;
+                var index = 0;
+                foreach (var path in Directory.GetFiles(
                     Path.GetDirectoryName(filePath)!,
                     Path.GetFileName(filePath) + ".corrupt-*")
-                    .OrderByDescending(path => path, StringComparer.Ordinal)
-                    .Skip(MaxCorruptBackupsPerFile))
+                    .OrderByDescending(candidate => candidate, StringComparer.Ordinal))
                 {
-                    File.Delete(stale);
-                    _logger.LogWarning($"Removed stale corrupt config backup {stale} (retaining newest {MaxCorruptBackupsPerFile}).");
+                    var length = new FileInfo(path).Length;
+                    // Always retain the newest generation even when an externally
+                    // created corrupt source already exceeds the byte budget. Moving
+                    // it adds no disk usage; every older generation is then removed.
+                    var keep = index == 0
+                        || (index < MaxCorruptBackupsPerFile
+                            && retainedBytes <= MaxCorruptBackupBytesPerFile - length);
+                    if (keep)
+                    {
+                        retainedBytes += length;
+                        index++;
+                        continue;
+                    }
+
+                    File.Delete(path);
+                    _logger.LogWarning(
+                        $"Removed stale corrupt config backup for '{Path.GetFileName(filePath)}' " +
+                        $"(retaining at most {MaxCorruptBackupsPerFile} generations / {MaxCorruptBackupBytesPerFile} bytes).");
                 }
             }
             catch (Exception ex)
             {
-                _logger.LogError($"Failed to back up corrupt config: {ex.Message}");
+                // Retention maintenance is secondary to preserving the new evidence
+                // and publishing the unhealthy marker.
+                _logger.LogWarning(
+                    $"Could not fully enforce corrupt-backup retention for '{Path.GetFileName(filePath)}' " +
+                    $"(exception={ex.GetType().Name}).");
             }
         }
 
-        private static bool FilesHaveSameContent(string leftPath, string rightPath)
+        private static UserStoreUnhealthyMarker ReadValidMarker(string markerPath, string expectedFileName)
         {
-            var leftInfo = new FileInfo(leftPath);
-            var rightInfo = new FileInfo(rightPath);
-            if (leftInfo.Length != rightInfo.Length) return false;
+            var marker = JsonSerializer.Deserialize<UserStoreUnhealthyMarker>(
+                File.ReadAllText(markerPath),
+                PersistedJson.ReadOptions)
+                ?? throw new InvalidDataException("Unhealthy marker deserialized to null.");
 
-            using var left = File.OpenRead(leftPath);
-            using var right = File.OpenRead(rightPath);
-            return SHA256.HashData(left).AsSpan().SequenceEqual(SHA256.HashData(right));
+            if (marker.Version != UserStoreUnhealthyMarker.CurrentVersion
+                || !string.Equals(marker.FileName, expectedFileName, StringComparison.Ordinal)
+                || marker.SourceBytes < 0
+                || marker.ContentSha256.Length != 64
+                || !marker.ContentSha256.All(Uri.IsHexDigit)
+                || !IsValidQuarantineFileName(expectedFileName, marker.QuarantineFileName))
+            {
+                throw new InvalidDataException("Unhealthy marker failed validation.");
+            }
+
+            return marker;
         }
+
+        private static bool IsValidQuarantineFileName(string fileName, string quarantineFileName)
+            => string.Equals(Path.GetFileName(quarantineFileName), quarantineFileName, StringComparison.Ordinal)
+                && quarantineFileName.StartsWith(fileName + ".corrupt-", StringComparison.Ordinal);
+
+        private static string GetUnhealthyMarkerPath(string filePath) => filePath + UnhealthySuffix;
+
+        private static bool UnhealthyMarkerExists(string filePath)
+        {
+            var markerPath = GetUnhealthyMarkerPath(filePath);
+            try
+            {
+                _ = File.GetAttributes(markerPath);
+                return true;
+            }
+            catch (FileNotFoundException)
+            {
+                return false;
+            }
+            catch (DirectoryNotFoundException)
+            {
+                return false;
+            }
+        }
+
+        private static bool IsRecoverableFileName(string fileName)
+            => RecoverableFileNames.Contains(fileName);
+
+        private static string NormalizeUserId(string userId)
+            => (userId ?? string.Empty).Replace("-", string.Empty, StringComparison.Ordinal).ToLowerInvariant();
 
         /// <summary>
         /// Gets all canonical user IDs that have configuration directories.

--- a/Jellyfin.Plugin.JellyfinCanopy/Configuration/UserStoreRecovery.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Configuration/UserStoreRecovery.cs
@@ -1,0 +1,64 @@
+using System;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Configuration
+{
+    /// <summary>
+    /// Raised when a per-user JSON store has entered the durable recovery state.
+    /// Retrying the original mutation cannot clear this state; an elevated reset
+    /// or an operator repair is required.
+    /// </summary>
+    internal sealed class UserStoreUnhealthyException : Exception
+    {
+        public UserStoreUnhealthyException(string fileName, bool newlyQuarantined, Exception? innerException = null)
+            : base($"'{fileName}' is quarantined and requires explicit recovery.", innerException)
+        {
+            FileName = fileName;
+            NewlyQuarantined = newlyQuarantined;
+        }
+
+        public string FileName { get; }
+
+        /// <summary>
+        /// True only for the call that created the durable unhealthy marker.
+        /// Consumers that maintain a user-visible corruption event can use this
+        /// to avoid recording the same generation on every retry.
+        /// </summary>
+        public bool NewlyQuarantined { get; }
+    }
+
+    internal sealed class UserStoreUnhealthyMarker
+    {
+        public const int CurrentVersion = 1;
+
+        public int Version { get; set; } = CurrentVersion;
+
+        public string FileName { get; set; } = string.Empty;
+
+        public string QuarantineFileName { get; set; } = string.Empty;
+
+        public string ContentSha256 { get; set; } = string.Empty;
+
+        public long SourceBytes { get; set; }
+
+        public string DetectedAtUtc { get; set; } = string.Empty;
+    }
+
+    internal sealed class UserStoreRecoveryStatus
+    {
+        public string UserId { get; set; } = string.Empty;
+
+        public string FileName { get; set; } = string.Empty;
+
+        public string DetectedAtUtc { get; set; } = string.Empty;
+
+        public long SourceBytes { get; set; }
+
+        public string ContentSha256 { get; set; } = string.Empty;
+
+        public string QuarantineFileName { get; set; } = string.Empty;
+
+        public bool MarkerReadable { get; set; }
+
+        public bool QuarantineComplete { get; set; }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/HiddenContentController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/HiddenContentController.cs
@@ -53,6 +53,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
         private readonly UserConfigurationManager _userConfigurationManager;
         private readonly ILibraryManager _libraryManager;
 
+        private IActionResult QuarantinedHiddenStore()
+            => StatusCode(StatusCodes.Status503ServiceUnavailable, new
+            {
+                success = false,
+                message = "Hidden-content state is quarantined. Retry alone cannot recover it; an administrator must inspect and reset or repair the store."
+            });
+
         public HiddenContentController(
             IHttpClientFactory httpClientFactory,
             ILogger<HiddenContentController> logger,
@@ -101,8 +108,19 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 }
             }
 
-            var userConfig = _userConfigurationManager.GetUserConfiguration<UserHiddenContent>(authorizedUserId, "hidden-content.json");
-            return Ok(userConfig);
+            var read = _userConfigurationManager.ReadUserConfiguration<UserHiddenContent>(authorizedUserId, "hidden-content.json");
+            if (!read.HasUsableValue || read.Value == null)
+            {
+                return string.Equals(read.FaultDetail, "quarantined-recovery-required", StringComparison.Ordinal)
+                    ? QuarantinedHiddenStore()
+                    : StatusCode(StatusCodes.Status503ServiceUnavailable, new
+                    {
+                        success = false,
+                        message = "Hidden-content state is corrupt or temporarily unavailable. No empty replacement state was published."
+                    });
+            }
+
+            return Ok(read.Value);
         }
 
         [HttpPost("user-settings/{userId}/hidden-content.json")]
@@ -154,19 +172,24 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             {
                 lock (_userConfigurationManager.GetUserFileLock(authorizedUserId, "hidden-content.json"))
                 {
-                    // Pre-write strict read so a corrupt existing file 503s + backs up instead of being overwritten.
+                    // Pre-write strict read so a corrupt existing file enters recovery
+                    // and returns 503 instead of being overwritten.
                     try
                     {
                         _userConfigurationManager.GetUserConfigurationStrict<UserHiddenContent>(
                             authorizedUserId, "hidden-content.json");
+                    }
+                    catch (UserStoreUnhealthyException)
+                    {
+                        return QuarantinedHiddenStore();
                     }
                     catch (Exception strictEx) when (strictEx is InvalidDataException
                                                   || strictEx is System.Text.Json.JsonException)
                     {
                         _logger.LogWarning(
                             $"hidden-content.json corrupt for {ResolveUserDisplay(authorizedUserId)} " +
-                            $"(backed up; exception={strictEx.GetType().Name}).");
-                        return StatusCode(503, new { success = false, message = "Hidden-content store is corrupt; backed up. Please retry." });
+                            $"(recovery required; exception={strictEx.GetType().Name}).");
+                        return StatusCode(503, new { success = false, message = "Hidden-content store is corrupt and requires administrator recovery." });
                     }
                     catch (IOException ioEx)
                     {
@@ -183,6 +206,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                     $"Saved hidden content for {ResolveUserDisplay(authorizedUserId)} to hidden-content.json " +
                     $"(items={validatedCopy.Items.Count}, bytes={validation.SerializedBytes}).");
                 return Ok(new { success = true, file = "hidden-content.json" });
+            }
+            catch (UserStoreUnhealthyException)
+            {
+                return QuarantinedHiddenStore();
             }
             catch (Exception ex)
             {
@@ -338,7 +365,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             try
             {
                 var removed = 0;
-                // RMW holds the per-user file lock, strict-reads (corruption → backup + throw), applies
+                // RMW holds the per-user file lock, strict-reads (corruption → quarantine + throw), applies
                 // the mutation, and persists only when it reports a change (returns > 0).
                 _userConfigurationManager.RmwUserConfiguration<UserHiddenContent>(userIdN, "hidden-content.json", cfg =>
                 {
@@ -358,10 +385,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 _logger.LogInformation($"Admin unhid {removed} item(s) for {ResolveUserDisplay(userIdN)}.");
                 return Ok(new { success = true, removed });
             }
+            catch (UserStoreUnhealthyException)
+            {
+                return QuarantinedHiddenStore();
+            }
             catch (Exception ex) when (ex is InvalidDataException || ex is System.Text.Json.JsonException)
             {
-                _logger.LogWarning($"hidden-content.json corrupt for {ResolveUserDisplay(userIdN)} during admin unhide (backed up): {ex.Message}");
-                return StatusCode(503, new { success = false, message = "Hidden-content store is corrupt; backed up. Please retry." });
+                _logger.LogWarning($"hidden-content.json corrupt for {ResolveUserDisplay(userIdN)} during admin unhide (recovery required): {ex.Message}");
+                return StatusCode(503, new { success = false, message = "Hidden-content store is corrupt and requires administrator recovery." });
             }
             catch (IOException ioEx)
             {
@@ -446,10 +477,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 _logger.LogInformation($"Admin hid {added} item(s) for {ResolveUserDisplay(userIdN)}.");
                 return Ok(new { success = true, added });
             }
+            catch (UserStoreUnhealthyException)
+            {
+                return QuarantinedHiddenStore();
+            }
             catch (Exception ex) when (ex is InvalidDataException || ex is System.Text.Json.JsonException)
             {
-                _logger.LogWarning($"hidden-content.json corrupt for {ResolveUserDisplay(userIdN)} during admin hide (backed up): {ex.Message}");
-                return StatusCode(503, new { success = false, message = "Hidden-content store is corrupt; backed up. Please retry." });
+                _logger.LogWarning($"hidden-content.json corrupt for {ResolveUserDisplay(userIdN)} during admin hide (recovery required): {ex.Message}");
+                return StatusCode(503, new { success = false, message = "Hidden-content store is corrupt and requires administrator recovery." });
             }
             catch (IOException ioEx)
             {
@@ -627,9 +662,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 Services.HiddenContentResponseFilter.InvalidateUser(authorizedUserId);
                 return Ok(new { success = true, key, entry });
             }
+            catch (UserStoreUnhealthyException)
+            {
+                return QuarantinedHiddenStore();
+            }
             catch (Exception ex) when (ex is InvalidDataException || ex is System.Text.Json.JsonException)
             {
-                return StatusCode(503, new { success = false, message = "Hidden-content store is corrupt; backed up. Please retry." });
+                return StatusCode(503, new { success = false, message = "Hidden-content store is corrupt and requires administrator recovery." });
             }
             catch (Exception ex)
             {
@@ -693,9 +732,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 Services.HiddenContentResponseFilter.InvalidateUser(authorizedUserId);
                 return Ok(new { success = true });
             }
+            catch (UserStoreUnhealthyException)
+            {
+                return QuarantinedHiddenStore();
+            }
             catch (Exception ex) when (ex is InvalidDataException || ex is System.Text.Json.JsonException)
             {
-                return StatusCode(503, new { success = false, message = "Hidden-content store is corrupt; backed up. Please retry." });
+                return StatusCode(503, new { success = false, message = "Hidden-content store is corrupt and requires administrator recovery." });
             }
             catch (Exception ex)
             {

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/SpoilerGuardController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/SpoilerGuardController.cs
@@ -13,6 +13,7 @@ using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 
@@ -59,13 +60,20 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
 
         private const string SpoilerFileName = "spoilerblur.json";
 
-        // Standard corrupt-store response: log, record the corruption event (so the
-        // health endpoint / management banner can surface it), and 503.
+        private static bool IsCorruptStoreException(Exception exception)
+            => exception is UserStoreUnhealthyException or InvalidDataException or JsonException;
+
+        // Standard corrupt-store response. The store itself logs only the transition;
+        // the in-memory banner is likewise recorded only for the new generation so
+        // request retries cannot amplify logs or events.
         private IActionResult CorruptStore(string userKey, Exception strictEx)
         {
-            _logger.LogWarning($"{SpoilerFileName} corrupt for {ResolveUserDisplay(userKey)} (backed up): {strictEx.Message}");
             SpoilerUserResolver.RecordCorruption(userKey, ResolveUserDisplay(userKey), strictEx.Message);
-            return StatusCode(503, new { success = false, message = "Spoiler Guard data was corrupt and has been backed up. Your stored values have been reset to defaults — please reconfigure." });
+            return StatusCode(503, new
+            {
+                success = false,
+                message = "Spoiler Guard state is quarantined. Retry alone cannot recover it; an administrator must inspect and reset or repair the store."
+            });
         }
 
         // ─── Self-or-admin spoilerblur.json accessor pair ───────────────────────
@@ -83,13 +91,24 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 return authorizationResult;
             }
 
-            // Lenient read on purpose: this is an inspection surface, so a corrupt
-            // file should still return the (empty) default rather than 503 — the
-            // user-facing spoiler-blur endpoints already handle strict reads,
-            // backups and corruption reporting.
-            var state = _userConfigurationManager.GetUserConfiguration<UserSpoilerBlur>(
+            var read = _userConfigurationManager.ReadUserConfiguration<UserSpoilerBlur>(
                 authorizedUserId, SpoilerFileName);
-            return Ok(state);
+            if (!read.HasUsableValue || read.Value == null)
+            {
+                var quarantined = string.Equals(
+                    read.FaultDetail,
+                    "quarantined-recovery-required",
+                    StringComparison.Ordinal);
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, new
+                {
+                    success = false,
+                    message = quarantined
+                        ? "Spoiler Guard state is quarantined. Retry alone cannot recover it; an administrator must inspect and reset or repair the store."
+                        : "Spoiler Guard state is corrupt or temporarily unavailable. No empty replacement state was published."
+                });
+            }
+
+            return Ok(read.Value);
         }
 
         // Hard cap per spoiler-list dict on the raw full-state save endpoint: the
@@ -146,17 +165,16 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             {
                 lock (_userConfigurationManager.GetUserFileLock(authorizedUserId, SpoilerFileName))
                 {
-                    // Pre-write strict read so a corrupt existing file 503s + backs up
+                    // Pre-write strict read so a corrupt existing file enters recovery
                     // instead of being silently overwritten (same as hidden-content).
                     try
                     {
                         _userConfigurationManager.GetUserConfigurationStrict<UserSpoilerBlur>(
                             authorizedUserId, SpoilerFileName);
                     }
-                    catch (Exception strictEx) when (strictEx is InvalidDataException || strictEx is JsonException)
+                    catch (Exception strictEx) when (IsCorruptStoreException(strictEx))
                     {
-                        _logger.LogWarning($"{SpoilerFileName} corrupt for {ResolveUserDisplay(authorizedUserId)} (backed up): {strictEx.Message}");
-                        return StatusCode(503, new { success = false, message = "Spoiler Guard store is corrupt; backed up. Please retry." });
+                        return CorruptStore(authorizedUserId, strictEx);
                     }
                     catch (IOException ioEx)
                     {
@@ -286,7 +304,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 var state = _userConfigurationManager.GetUserConfigurationStrict<UserSpoilerBlur>(userKey, SpoilerFileName);
                 return Ok(state);
             }
-            catch (Exception strictEx) when (strictEx is InvalidDataException || strictEx is JsonException)
+            catch (Exception strictEx) when (IsCorruptStoreException(strictEx))
             {
                 return CorruptStore(userKey, strictEx);
             }
@@ -313,7 +331,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 var state = _userConfigurationManager.GetUserConfigurationStrict<UserSpoilerBlur>(userKey, SpoilerFileName);
                 return Ok(state.Prefs ?? new SpoilerBlurUserPrefs());
             }
-            catch (Exception strictEx) when (strictEx is InvalidDataException || strictEx is JsonException)
+            catch (Exception strictEx) when (IsCorruptStoreException(strictEx))
             {
                 return CorruptStore(userKey, strictEx);
             }
@@ -354,7 +372,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 SpoilerUserResolver.InvalidateUser(userKey);
                 return Ok(new { success = true, prefs = body });
             }
-            catch (Exception strictEx) when (strictEx is InvalidDataException || strictEx is JsonException)
+            catch (Exception strictEx) when (IsCorruptStoreException(strictEx))
             {
                 return CorruptStore(userKey, strictEx);
             }
@@ -432,7 +450,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 _logger.LogInformation($"Spoiler Guard enabled for series '{series.Name}' ({key}) by {ResolveUserDisplay(userKey)}");
                 return Ok(new { success = true, seriesId = key, name = series.Name });
             }
-            catch (Exception strictEx) when (strictEx is InvalidDataException || strictEx is JsonException)
+            catch (Exception strictEx) when (IsCorruptStoreException(strictEx))
             {
                 return CorruptStore(userKey, strictEx);
             }
@@ -476,7 +494,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 _logger.LogInformation($"Spoiler Guard disabled for series {key} by {ResolveUserDisplay(userKey)}");
                 return Ok(new { success = true, seriesId = key, removed = true });
             }
-            catch (Exception strictEx) when (strictEx is InvalidDataException || strictEx is JsonException)
+            catch (Exception strictEx) when (IsCorruptStoreException(strictEx))
             {
                 return CorruptStore(userKey, strictEx);
             }
@@ -558,7 +576,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 _logger.LogInformation($"Spoiler Guard enabled for movie '{movie.Name}' ({key}) by {ResolveUserDisplay(userKey)}");
                 return Ok(new { success = true, movieId = key, name = movie.Name });
             }
-            catch (Exception strictEx) when (strictEx is InvalidDataException || strictEx is JsonException)
+            catch (Exception strictEx) when (IsCorruptStoreException(strictEx))
             {
                 return CorruptStore(userKey, strictEx);
             }
@@ -602,7 +620,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 _logger.LogInformation($"Spoiler Guard disabled for movie {key} by {ResolveUserDisplay(userKey)}");
                 return Ok(new { success = true, movieId = key, removed = true });
             }
-            catch (Exception strictEx) when (strictEx is InvalidDataException || strictEx is JsonException)
+            catch (Exception strictEx) when (IsCorruptStoreException(strictEx))
             {
                 return CorruptStore(userKey, strictEx);
             }
@@ -731,7 +749,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 _logger.LogInformation($"Spoiler Guard enabled for collection '{boxSet.Name}' ({key}) by {ResolveUserDisplay(userKey)}");
                 return Ok(new { success = true, collectionId = key, name = boxSet.Name });
             }
-            catch (Exception strictEx) when (strictEx is InvalidDataException || strictEx is JsonException)
+            catch (Exception strictEx) when (IsCorruptStoreException(strictEx))
             {
                 return CorruptStore(userKey, strictEx);
             }
@@ -775,7 +793,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 _logger.LogInformation($"Spoiler Guard disabled for collection {key} by {ResolveUserDisplay(userKey)}");
                 return Ok(new { success = true, collectionId = key, removed = true });
             }
-            catch (Exception strictEx) when (strictEx is InvalidDataException || strictEx is JsonException)
+            catch (Exception strictEx) when (IsCorruptStoreException(strictEx))
             {
                 return CorruptStore(userKey, strictEx);
             }
@@ -824,7 +842,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 }
                 return Ok(new { success = true, promoted = summary.Promoted, jellyfinId = summary.JellyfinId, name = summary.Name });
             }
-            catch (Exception strictEx) when (strictEx is InvalidDataException || strictEx is JsonException)
+            catch (Exception strictEx) when (IsCorruptStoreException(strictEx))
             {
                 return CorruptStore(userKey, strictEx);
             }
@@ -887,7 +905,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 _logger.LogInformation($"Spoiler Guard pending DELETE removed {pendingKey} ({removedFrom}) for {ResolveUserDisplay(userKey)}");
                 return Ok(new { success = true, removed = true, removedFrom, jellyfinId = removedJellyfinId });
             }
-            catch (Exception strictEx) when (strictEx is InvalidDataException || strictEx is JsonException)
+            catch (Exception strictEx) when (IsCorruptStoreException(strictEx))
             {
                 return CorruptStore(userKey, strictEx);
             }

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/UserSettingsController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/UserSettingsController.cs
@@ -322,14 +322,23 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(
-                    $"Failed to save user {displayName} for {ResolveUserDisplay(authorizedUserId)} " +
-                    $"(exception={ex.GetType().Name}).");
                 var response = new UserFileMutationResponse<T>
                 {
                     File = fileName,
-                    Message = $"The {displayName} store is unavailable; no write was acknowledged."
+                    Message = ex is UserStoreUnhealthyException
+                        ? $"The {displayName} store is quarantined. Retry alone cannot recover it; an administrator must inspect and reset or repair it."
+                        : $"The {displayName} store is unavailable; no write was acknowledged."
                 };
+                if (ex is UserStoreUnhealthyException)
+                {
+                    // The central store logged the generation exactly once when it
+                    // published the marker. Do not amplify logs on client retries.
+                    return StatusCode(StatusCodes.Status503ServiceUnavailable, response);
+                }
+
+                _logger.LogError(
+                    $"Failed to save user {displayName} for {ResolveUserDisplay(authorizedUserId)} " +
+                    $"(exception={ex.GetType().Name}).");
                 if (ex is InvalidDataException || ex is JsonException || ex is IOException || ex is UnauthorizedAccessException)
                 {
                     return StatusCode(StatusCodes.Status503ServiceUnavailable, response);
@@ -498,11 +507,17 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             string? detail)
             where T : class, IRevisionedUserConfiguration, new()
         {
-            _logger.LogWarning($"Refusing to publish {fileName} (status={status}, detail={detail ?? "invalid-state"}).");
+            var quarantined = string.Equals(detail, "quarantined-recovery-required", StringComparison.Ordinal);
+            if (!quarantined)
+            {
+                _logger.LogWarning($"Refusing to publish {fileName} (status={status}, detail={detail ?? "invalid-state"}).");
+            }
             return StatusCode(StatusCodes.Status503ServiceUnavailable, new UserFileMutationResponse<T>
             {
                 File = fileName,
-                Message = "User settings are corrupt or temporarily unavailable. No empty replacement state was published."
+                Message = quarantined
+                    ? "User settings are quarantined. Retry alone cannot recover them; an administrator must inspect and reset or repair the store."
+                    : "User settings are corrupt or temporarily unavailable. No empty replacement state was published."
             });
         }
 
@@ -1369,6 +1384,15 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
 
         private IActionResult BookmarkWriteFailure(string authorizedUserId, string operation, Exception ex)
         {
+            if (ex is UserStoreUnhealthyException)
+            {
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, new BookmarkMutationResponse
+                {
+                    Success = false,
+                    Message = "Bookmark state is quarantined. Retry alone cannot recover it; an administrator must inspect and reset or repair the store."
+                });
+            }
+
             _logger.LogError($"Failed to {operation} for {ResolveUserDisplay(authorizedUserId)}: {ex.Message}");
             if (ex is InvalidDataException || ex is JsonException || ex is IOException || ex is UnauthorizedAccessException)
             {
@@ -1460,6 +1484,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                             return 1;
                         });
                     Services.HiddenContentResponseFilter.InvalidateUser(userId);
+                }
+                catch (UserStoreUnhealthyException)
+                {
+                    // The durable transition was already logged once. Report this
+                    // user in the response without amplifying logs on admin retries.
+                    skippedHc.Add(userId);
                 }
                 catch (Exception ex) when (ex is InvalidDataException
                                         || ex is System.Text.Json.JsonException

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/UserStoreRecoveryController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/UserStoreRecoveryController.cs
@@ -1,0 +1,109 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Services;
+using MediaBrowser.Common.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
+{
+    /// <summary>
+    /// Elevation-gated recovery surface for per-user JSON stores that have been
+    /// quarantined by a strict read. It exposes metadata only, never payload bytes.
+    /// </summary>
+    [Route("JellyfinCanopy/admin/user-store-recovery")]
+    [ApiController]
+    [Authorize(Policy = Policies.RequiresElevation)]
+    public sealed class UserStoreRecoveryController : ControllerBase
+    {
+        private readonly UserConfigurationManager _manager;
+        private readonly ILogger<UserStoreRecoveryController> _logger;
+
+        public UserStoreRecoveryController(
+            UserConfigurationManager manager,
+            ILogger<UserStoreRecoveryController> logger)
+        {
+            _manager = manager;
+            _logger = logger;
+        }
+
+        [HttpGet]
+        [Produces("application/json")]
+        public IActionResult GetUnhealthyStores()
+        {
+            var stores = _manager.GetUnhealthyUserStores();
+            return Ok(new
+            {
+                healthy = stores.Count == 0,
+                stores,
+                message = stores.Count == 0
+                    ? "No per-user stores require recovery."
+                    : "Retry alone cannot recover these stores. Inspect the named quarantine artifact, then explicitly reset the store or perform the documented offline repair."
+            });
+        }
+
+        [HttpPost("{userId}/{fileName}/reset")]
+        [Produces("application/json")]
+        public IActionResult ResetUnhealthyStore(string userId, string fileName)
+        {
+            if ((!Guid.TryParse(userId, out var userGuid)
+                    && !Guid.TryParseExact(userId, "N", out userGuid))
+                || userGuid == Guid.Empty)
+            {
+                return BadRequest(new { success = false, message = "Invalid userId." });
+            }
+
+            var canonicalUserId = userGuid.ToString("N");
+            try
+            {
+                if (!_manager.ResetUnhealthyUserStore(canonicalUserId, fileName))
+                {
+                    return NotFound(new
+                    {
+                        success = false,
+                        message = "The requested per-user store is not in recovery state."
+                    });
+                }
+
+                if (string.Equals(fileName, "hidden-content.json", StringComparison.Ordinal))
+                {
+                    HiddenContentResponseFilter.InvalidateUser(canonicalUserId);
+                }
+                else if (string.Equals(fileName, "spoilerblur.json", StringComparison.Ordinal))
+                {
+                    SpoilerUserResolver.InvalidateUser(canonicalUserId);
+                    SpoilerUserResolver.ClearCorruption(canonicalUserId);
+                }
+
+                return Ok(new
+                {
+                    success = true,
+                    userId = canonicalUserId,
+                    file = fileName,
+                    message = "The unhealthy marker was cleared after preserving forensic bytes. The next normal access will initialize defaults."
+                });
+            }
+            catch (ArgumentException)
+            {
+                return BadRequest(new { success = false, message = "Unsupported per-user store filename." });
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException or JsonException)
+            {
+                _logger.LogError(
+                    ex,
+                    "Failed to reset unhealthy per-user store {FileName} for {UserId}; the marker remains active.",
+                    fileName,
+                    canonicalUserId);
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, new
+                {
+                    success = false,
+                    message = "The recovery reset could not be committed; the store remains quarantined."
+                });
+            }
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/EventHandlers/ContinueWatchingPlaybackEvents.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/EventHandlers/ContinueWatchingPlaybackEvents.cs
@@ -113,6 +113,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.EventHandlers
                         return keysToDrop.Count + keysToDemote.Count;
                     });
                 }
+                catch (UserStoreUnhealthyException)
+                {
+                    return Task.CompletedTask;
+                }
                 catch (InvalidDataException ex)
                 {
                     _logger.LogWarning($"CW: skipping playback drop for user {userId} due to corrupt hidden-content.json: {ex.Message}");
@@ -293,6 +297,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.EventHandlers
                 {
                     HiddenContentResponseFilter.InvalidateUser(userId.ToString("N"));
                 }
+            }
+            catch (UserStoreUnhealthyException)
+            {
+                // The marker transition is already logged centrally. Repeated
+                // library events must remain silent until explicit recovery.
             }
             catch (InvalidDataException ex)
             {

--- a/Jellyfin.Plugin.JellyfinCanopy/EventHandlers/SpoilerAutoEnableEvents.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/EventHandlers/SpoilerAutoEnableEvents.cs
@@ -118,6 +118,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.EventHandlers
                             return 1;
                         });
                 }
+                catch (UserStoreUnhealthyException)
+                {
+                    return Task.CompletedTask;
+                }
                 catch (InvalidDataException ex)
                 {
                     _logger.LogWarning($"SpoilerAutoEnable: skipping {userId}/{seriesIdN} due to corrupt spoilerblur.json: {ex.Message}");

--- a/Jellyfin.Plugin.JellyfinCanopy/ScheduledTasks/SeerrWatchlistSyncTask.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/ScheduledTasks/SeerrWatchlistSyncTask.cs
@@ -841,7 +841,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
 
         // Serialize the processed-watchlist marker append through the locked RMW primitive so this
         // scheduled task can't clobber a marker the event monitor just added (or vice versa). The
-        // in-lock re-check keeps the append idempotent; strict-read corruption is logged + skipped
+        // in-lock re-check keeps the append idempotent; strict-read quarantine is skipped silently
         // so a single corrupt user file can't fail the whole sync task.
         private void TryMarkProcessed(Guid userId, int tmdbId, string mediaType, string source)
         {
@@ -863,6 +863,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                     });
                     return 1;
                 });
+            }
+            catch (UserStoreUnhealthyException)
+            {
+                // The durable generation was logged once when quarantined.
             }
             catch (Exception ex)
             {

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/SpoilerSeerrPendingPromoter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/SpoilerSeerrPendingPromoter.cs
@@ -395,6 +395,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 // TOCTOU path, or removed by the user) — nothing to do.
                 return PromotionOutcome.NotPending;
             }
+            catch (UserStoreUnhealthyException)
+            {
+                // Keep the registration for a post-repair event, but do not log
+                // every library notification for the same durable generation.
+                return PromotionOutcome.StillPending;
+            }
             catch (InvalidDataException ex)
             {
                 _logger.LogWarning($"SpoilerSeerrPromoter: skipping {userId}/{pendingKey} due to corrupt spoilerblur.json: {ex.Message}");

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/SpoilerUserResolver.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/SpoilerUserResolver.cs
@@ -310,8 +310,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
 
         // Track per-user corruption events so the admin can surface a banner in the
         // JC management UI. Populated by the controller/tag-cache STRICT read+write
-        // path when a mutation hits a corrupt spoilerblur.json (it backs the file up
-        // to .corrupt-* and refuses to overwrite). Note the runtime ENFORCEMENT read
+        // path when a mutation hits a corrupt spoilerblur.json (it quarantines the
+        // bytes to .corrupt-* and refuses to overwrite). Note the runtime ENFORCEMENT read
         // (LoadUserState) no longer fails open on corruption: it retains
         // last-known-good or fails CLOSED, so protection is preserved rather than
         // silently no-op'd. The banner still lets the user know a repair is needed.
@@ -326,12 +326,15 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
 
         public static void RecordCorruption(string userKey, string userDisplay, string reason)
         {
-            _corruptionLog[userKey] = new CorruptionEvent
+            // TryAdd makes marker hits idempotent: retries do not refresh the event
+            // timestamp, while the first hit after a process restart reconstructs
+            // the in-memory banner from the still-durable marker.
+            _corruptionLog.TryAdd(userKey, new CorruptionEvent
             {
                 UserDisplay = userDisplay,
                 At = DateTime.UtcNow,
                 Reason = reason,
-            };
+            });
         }
 
         public static IReadOnlyDictionary<string, CorruptionEvent> GetCorruptionLog()

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/WatchlistMonitor.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/WatchlistMonitor.cs
@@ -494,7 +494,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
 
         // Serialize the processed-watchlist marker append through the locked RMW primitive so a
         // concurrent scheduled sync (or another event) can't clobber a just-added marker. The
-        // in-lock re-check keeps the append idempotent; strict-read corruption is logged + skipped
+        // in-lock re-check keeps the append idempotent; strict-read quarantine is skipped silently
         // (this runs off the request path in Task.Run — never throw into the scan thread).
         private void TryMarkProcessed(Guid userId, int tmdbId, string mediaType, string source)
         {
@@ -516,6 +516,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     });
                     return 1;
                 });
+            }
+            catch (UserStoreUnhealthyException)
+            {
+                // The durable generation was logged once when quarantined.
             }
             catch (Exception ex)
             {

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -987,7 +987,7 @@ Jellyfin.Plugin.JellyfinCanopy/
 │   ├── UserConfiguration.cs / UserConfigurationManager.cs (+ store/migration/reviews classes)
 │   │                          # UserConfigurationStore owns three read tiers: LENIENT (GetUserConfiguration,
 │   │                          # any fault → new T(), for ordinary display settings), STRICT (RMW writes,
-│   │                          # corrupt → backup + throw), and the TYPED policy read (ReadUserConfiguration →
+│   │                          # corrupt → durable quarantine + throw), and the TYPED policy read (ReadUserConfiguration →
 │   │                          # UserConfigReadResult classifying Missing/Valid/Corrupt/Unavailable). Security
 │   │                          # enforcement (Hidden Content, Spoiler Guard) uses the typed read so a corrupt or
 │   │                          # unavailable file retains last-known-good or fails CLOSED instead of failing open
@@ -1023,6 +1023,36 @@ Jellyfin.Plugin.JellyfinCanopy/
 ├── ScheduledTasks/ · Model/ · Logging/ · PluginPages/
 └── dist/                      # esbuild output (generated at build time, never committed)
 ```
+
+#### Per-user store recovery
+
+A malformed strict-read store does not remain at its authoritative path. Under the
+same per-user/file lock used by every mutation, `UserConfigurationStore` first
+publishes `<file>.unhealthy`, then atomically moves the exact source generation to
+`<file>.corrupt-<timestamp>-<hash>-<nonce>`. Publishing the marker first makes both
+crash windows fail closed: a crash before the move leaves the source plus marker;
+a crash after the move leaves the quarantine plus marker. Neither state can be
+mistaken for a new user. Normal saves refuse to overwrite a marked store, and
+retries inspect the marker without reparsing, copying, or relogging the same bytes.
+
+Forensic history is capped at five generations and 32 MiB per source file. The
+newest generation is always retained even when an externally created source was
+already larger than that budget; because quarantine is a same-directory move, that
+case does not add disk usage, and all older generations are removed.
+
+Recovery metadata (never payload bytes) is elevation-gated:
+
+- `GET /JellyfinCanopy/admin/user-store-recovery` lists active markers and whether
+  their recorded quarantine move completed.
+- `POST /JellyfinCanopy/admin/user-store-recovery/{userId}/{fileName}/reset`
+  preserves any source left by an interrupted move, deletes the marker last, and
+  intentionally starts that one store from its normal defaults on next access.
+
+Retrying a failed user mutation is not recovery. To retain repaired data instead
+of resetting it, stop Jellyfin, keep the quarantine artifact, validate and place
+the repaired JSON at the original filename, remove the matching `.unhealthy`
+marker only after that validation, and restart. Never replace a live marked file
+or delete the marker before the repaired primary is durable.
 
 #### Indexed review persistence
 

--- a/docs/enhanced.md
+++ b/docs/enhanced.md
@@ -426,10 +426,11 @@ When enabled, the Hidden Content management page is a routed destination reachab
     keeps enforcing your **last known-good** list; and if the fault happens
     before any good copy was loaded (e.g. right after a server restart) the
     affected rows are **hidden entirely** rather than risk your hidden items
-    reappearing. The fault is logged for the operator, and normal filtering
-    resumes automatically once the file is readable again (or the moment you
-    next change your hidden list). A storage fault can never silently *reveal*
-    what you hid.
+    reappearing. A temporary read/permission fault resumes automatically once the
+    file is readable. Confirmed malformed JSON is quarantined once and requires an
+    administrator to inspect and repair it or explicitly reset that one store;
+    repeatedly saving or reloading cannot overwrite the forensic copy. A storage
+    fault can never silently *reveal* what you hid.
 
 #### Admin: other users' hidden content
 

--- a/docs/spoiler-guard.md
+++ b/docs/spoiler-guard.md
@@ -247,9 +247,18 @@ Spoiler Guard **fails closed** whenever it can't read your spoiler policy — it
 
 - If your `spoilerblur.json` becomes corrupt or is temporarily unreadable (a disk or permission fault), the server keeps protecting your **last known-good** list.
 - If the fault happens before any good copy was ever loaded — for example right after a server restart — it protects **everything** until the file is readable.
-- The server logs the fault, and protection returns to normal automatically on the next successful read, or on any change you make to your Spoiler Guard list.
+- A temporary I/O or permission fault recovers on the next successful read. Confirmed malformed JSON is quarantined and stays fail-closed until an administrator explicitly repairs or resets it.
 
-Separately, when a corrupt file is *detected* (truncated by a power loss mid-write, mangled by a backup tool, and so on), the plugin backs it up to `spoilerblur.json.corrupt-{timestamp}`, resets the on-disk state to defaults, and records the event so the affected user knows to re-enable their items. This is automatic and needs no configuration.
+When corruption is *detected* (truncated by a power loss mid-write, mangled by a
+backup tool, and so on), the plugin moves the exact bytes once to a bounded
+`spoilerblur.json.corrupt-*` artifact and publishes a durable
+`spoilerblur.json.unhealthy` marker. It does **not** silently reset or allow an
+ordinary save to overwrite that state. An administrator can inspect all marked
+stores at `GET /JellyfinCanopy/admin/user-store-recovery`, then either repair the
+JSON offline or deliberately reset this store with
+`POST /JellyfinCanopy/admin/user-store-recovery/{userId}/spoilerblur.json/reset`.
+Reset preserves the forensic artifact and starts Spoiler Guard from defaults on
+the next access.
 
 ### Health and diagnostics endpoints
 
@@ -290,4 +299,4 @@ Most issues come down to one of two things: a master switch that isn't on yet, o
 - Clear the client's image cache once (or force-stop and reopen) so it refetches fresh, marker-carrying URLs; or
 - configure the proxy to send `X-Forwarded-For` and add it under **Dashboard → Networking → Known proxies**, restoring real client IPs for the fallback path. The **Per-user image identity tags** setting must stay enabled (it is by default) for marker-based identification.
 
-**Everything is suddenly blurred, even shows I never opted in.** That's Spoiler Guard [failing closed](#fail-closed-behavior) because it couldn't read your spoiler policy — for example a corrupt or temporarily unreadable `spoilerblur.json`. Protection returns to normal automatically once the file is readable again (the next successful read, or any change you make to your list). The server logs the fault so an operator can investigate.
+**Everything is suddenly blurred, even shows I never opted in.** That's Spoiler Guard [failing closed](#fail-closed-behavior) because it couldn't read your spoiler policy. A temporarily unreadable `spoilerblur.json` recovers when storage is readable again. A malformed file is quarantined and requires the administrator to repair it offline or use the explicit recovery reset; ordinary retries and list changes cannot bypass the marker. The server records the first corruption transition so an operator can investigate without retry-log amplification.

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -19,7 +19,7 @@ const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the repeated clean measurements', () => {
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1364, totalLines: 1692 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 14995, totalLines: 23448 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 15210, totalLines: 23760 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 1);
 });

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -21,12 +21,12 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 14995,
-        "totalLines": 23448
+        "coveredLines": 15210,
+        "totalLines": 23760
       },
       "tolerance": {
         "missingCoveredLines": 1,
-        "rationale": "The 2026-07-15 .NET 10/Coverlet run includes indexed review uniqueness and keyset pages, exact quota boundaries, verified legacy migration, concurrent durable upserts, bounded corruption recovery including interrupted restore, and 1/100/1000/15000-row warm-path bounds; one line permits only negligible instrumentation variance."
+        "rationale": "Four clean post-review 2026-07-15 .NET 10/Coverlet runs measured 15209, 15210, 15209, and 15210 covered lines across the same 23760-line scope. They include indexed review persistence plus atomic per-user corruption quarantine, 100-reader idempotence, marker-first crash recovery, explicit elevated reset, five-generation/32 MiB retention, fail-closed display reads, and silent background retries; one line permits only the reproduced instrumentation variance."
       }
     }
   }


### PR DESCRIPTION
Closes #112

## Root cause
Strict user-store reads copied the same corrupt source while leaving it at the primary path, so every retry repeated quarantine work without actually recovering or entering a bounded unhealthy state.

## Changes
- Persist a durable unhealthy marker before atomically moving corrupt data to evidence storage.
- Deduplicate concurrent quarantine attempts and bound retained evidence to five generations and 32 MiB of older data.
- Fail closed across controllers and silence repeated background retries while a store is unhealthy.
- Add elevated metadata and explicit reset endpoints without exposing stored payloads.
- Preserve recoverable evidence and clear the marker only after a successful reset.
- Document the recovery lifecycle and cover concurrency, retry, retention, malformed-marker, interrupted-move, controller, and event-consumer behavior.

## Validation
- Server tests: 1368/1368 passed.
- Server coverage: 15210/23760 lines, 64.015%; checker and baseline tests passed.
- Client tests: 845/845 passed; coverage 1364/1692 lines, 80.615%.
- Source and full TypeScript typechecks passed.
- Syntax inventory passed.
- Release build passed with 0 warnings and 0 errors.
- NuGet vulnerability audit reported no vulnerable packages.
- Repository lint passed with 0 errors.
- Independent Fable low-effort re-review: APPROVE.
- Official dockerized Jellyfin 12 unstable/nightly CI pending.