### PR TITLE
Make Continue Watching orphan cleanup linear

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/ContinueWatchingEventWritersTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/ContinueWatchingEventWritersTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
 using Jellyfin.Plugin.JellyfinCanopy.EventHandlers;
 using Jellyfin.Plugin.JellyfinCanopy.Services;
@@ -8,6 +9,7 @@ using MediaBrowser.Controller.Session;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
 {
@@ -19,6 +21,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
     /// </summary>
     public sealed class ContinueWatchingEventWritersTests
     {
+        private readonly ITestOutputHelper _output;
+
+        public ContinueWatchingEventWritersTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         private sealed class CollectingLogger<T> : ILogger<T>
         {
             public List<string> Messages { get; } = new();
@@ -127,14 +136,16 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
 
             var callsPerUser = new Dictionary<Guid, int>();
             var batchSizesSeen = new List<int>();
+            var indexesSeen = new List<CwRemovedIdIndex>();
 
             var prunedUsers = ContinueWatchingLibraryHook.DrainBatch(
                 removedIds,
                 users,
-                (userId, ids) =>
+                (userId, index) =>
                 {
                     callsPerUser[userId] = callsPerUser.GetValueOrDefault(userId) + 1;
-                    batchSizesSeen.Add(ids.Count);
+                    batchSizesSeen.Add(index.Count);
+                    indexesSeen.Add(index);
                 });
 
             Assert.Equal(2, prunedUsers);
@@ -142,6 +153,99 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             Assert.Equal(1, callsPerUser[users[1]]);
             // Every prune received the whole batch of 5 ids (coalesced), never a single id at a time.
             Assert.All(batchSizesSeen, size => Assert.Equal(5, size));
+            Assert.Same(indexesSeen[0], indexesSeen[1]);
+            Assert.Equal(5, indexesSeen[0].RemovedIdentifierNormalizations);
+            Assert.Equal(5, indexesSeen[0].RemovedGuidParseAttempts);
+        }
+
+        [Fact]
+        public void LibraryHook_MixedGuidFormsAndOpaqueIds_MatchExactly()
+        {
+            var first = Guid.Parse("1f78f651-67a8-4fb4-b24f-6e4b81bc1234");
+            var second = Guid.Parse("2a89e762-78b9-40c5-a350-7f5c92cd5678");
+            var other = Guid.Parse("3b90f873-89ca-41d6-b461-806da3de9012");
+            var removedIds = new[]
+            {
+                first.ToString("D").ToUpperInvariant(),
+                first.ToString("N").ToLowerInvariant(),
+                second.ToString("N").ToLowerInvariant(),
+                "Opaque-Item"
+            };
+            var hidden = new UserHiddenContent();
+            hidden.Items["first-n-lower"] = new HiddenContentItem { ItemId = first.ToString("N").ToLowerInvariant() };
+            hidden.Items["second-d-upper"] = new HiddenContentItem { ItemId = second.ToString("D").ToUpperInvariant() };
+            hidden.Items["opaque-case"] = new HiddenContentItem { ItemId = "opaque-item" };
+            hidden.Items["keep-guid"] = new HiddenContentItem { ItemId = other.ToString("N") };
+            hidden.Items["keep-opaque"] = new HiddenContentItem { ItemId = "opaque-item-extra" };
+
+            var index = CwRemovedIdIndex.Create(removedIds);
+            var removed = ContinueWatchingLibraryHook.PruneOrphansCore(hidden, index);
+
+            Assert.Equal(3, removed);
+            Assert.Equal(new[] { "keep-guid", "keep-opaque" }, hidden.Items.Keys.OrderBy(key => key));
+            Assert.Equal(3, index.Count);
+            Assert.Equal(4, index.RemovedIdentifierNormalizations);
+            Assert.Equal(4, index.RemovedGuidParseAttempts);
+            Assert.Equal(5, index.EntryIdentifierNormalizations);
+            Assert.Equal(5, index.EntryGuidParseAttempts);
+            Assert.Equal(5, index.MembershipComparisons);
+        }
+
+        [Fact]
+        public void LibraryHook_FifteenThousandByFifteenThousand_StaysWithinLinearBudgets()
+        {
+            const int scale = 15_000;
+            const long allocationBudget = 8L * 1024 * 1024;
+            var timeBudget = TimeSpan.FromSeconds(5);
+            var removedIds = new string[scale];
+            var hidden = new UserHiddenContent();
+            for (var index = 0; index < scale; index++)
+            {
+                var removedId = DeterministicGuid(index, family: 0x11);
+                removedIds[index] = index % 2 == 0
+                    ? removedId.ToString("D").ToUpperInvariant()
+                    : removedId.ToString("N").ToLowerInvariant();
+
+                hidden.Items[$"hidden-{index}"] = new HiddenContentItem
+                {
+                    ItemId = index % 2 == 0
+                        ? removedId.ToString("N").ToLowerInvariant()
+                        : removedId.ToString("D").ToUpperInvariant()
+                };
+            }
+
+            var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+            var stopwatch = Stopwatch.StartNew();
+            var targetIds = CwRemovedIdIndex.Create(removedIds);
+            var removed = ContinueWatchingLibraryHook.PruneOrphansCore(hidden, targetIds);
+            stopwatch.Stop();
+            var allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+
+            _output.WriteLine(
+                "removedIds={0} hiddenEntries={1} removedNormalizations={2} entryNormalizations={3} "
+                + "membershipComparisons={4} elapsedMs={5:F3} allocatedBytes={6}",
+                scale,
+                scale,
+                targetIds.RemovedIdentifierNormalizations,
+                targetIds.EntryIdentifierNormalizations,
+                targetIds.MembershipComparisons,
+                stopwatch.Elapsed.TotalMilliseconds,
+                allocated);
+
+            Assert.Equal(scale, removed);
+            Assert.Empty(hidden.Items);
+            Assert.Equal(scale, targetIds.Count);
+            Assert.Equal(scale, targetIds.RemovedIdentifierNormalizations);
+            Assert.Equal(scale, targetIds.RemovedGuidParseAttempts);
+            Assert.Equal(scale, targetIds.EntryIdentifierNormalizations);
+            Assert.Equal(scale, targetIds.EntryGuidParseAttempts);
+            Assert.Equal(scale, targetIds.MembershipComparisons);
+            Assert.True(
+                stopwatch.Elapsed < timeBudget,
+                $"15k x 15k cleanup took {stopwatch.Elapsed}; budget is {timeBudget}.");
+            Assert.True(
+                allocated < allocationBudget,
+                $"15k x 15k cleanup allocated {allocated} bytes; budget is {allocationBudget} bytes.");
         }
 
         [Fact]
@@ -195,5 +299,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
                 try { Directory.Delete(tempDir, recursive: true); } catch { /* best-effort */ }
             }
         }
+
+        private static Guid DeterministicGuid(int value, byte family)
+            => new(value, family, 0, family, 0, 0, 0, 0, 0, 0, 1);
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/EventHandlers/ContinueWatchingPlaybackEvents.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/EventHandlers/ContinueWatchingPlaybackEvents.cs
@@ -29,6 +29,83 @@ namespace Jellyfin.Plugin.JellyfinCanopy.EventHandlers
         }
     }
 
+    /// <summary>
+    /// Drain-owned lookup index for removed item identifiers. Removed identifiers are normalized
+    /// exactly once, before any user is visited; each hidden entry then performs one parse and one
+    /// hash membership comparison instead of scanning and reparsing the whole removal batch.
+    /// </summary>
+    internal sealed class CwRemovedIdIndex
+    {
+        private readonly HashSet<Guid> _guidIds;
+        private readonly HashSet<string> _stringIds;
+
+        private CwRemovedIdIndex(
+            HashSet<Guid> guidIds,
+            HashSet<string> stringIds,
+            int removedIdentifierNormalizations,
+            int removedGuidParseAttempts)
+        {
+            _guidIds = guidIds;
+            _stringIds = stringIds;
+            RemovedIdentifierNormalizations = removedIdentifierNormalizations;
+            RemovedGuidParseAttempts = removedGuidParseAttempts;
+        }
+
+        internal int Count => _guidIds.Count + _stringIds.Count;
+
+        // Regression instrumentation: these counters make the linear ownership boundary exact in
+        // tests without relying only on wall-clock timing.
+        internal int RemovedIdentifierNormalizations { get; }
+
+        internal int RemovedGuidParseAttempts { get; }
+
+        internal long EntryIdentifierNormalizations { get; private set; }
+
+        internal long EntryGuidParseAttempts { get; private set; }
+
+        internal long MembershipComparisons { get; private set; }
+
+        internal static CwRemovedIdIndex Create(IReadOnlyCollection<string> removedIds)
+        {
+            ArgumentNullException.ThrowIfNull(removedIds);
+
+            var guidIds = new HashSet<Guid>(removedIds.Count);
+            var stringIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var guidParseAttempts = 0;
+            foreach (var removedId in removedIds)
+            {
+                if (string.IsNullOrEmpty(removedId)) continue;
+                guidParseAttempts++;
+                if (Guid.TryParse(removedId, out var guid))
+                {
+                    guidIds.Add(guid);
+                }
+                else
+                {
+                    stringIds.Add(removedId);
+                }
+            }
+
+            return new CwRemovedIdIndex(
+                guidIds,
+                stringIds,
+                removedIds.Count,
+                guidParseAttempts);
+        }
+
+        internal bool Contains(string? entryId)
+        {
+            EntryIdentifierNormalizations++;
+            if (string.IsNullOrEmpty(entryId)) return false;
+
+            EntryGuidParseAttempts++;
+            MembershipComparisons++;
+            return Guid.TryParse(entryId, out var guid)
+                ? _guidIds.Contains(guid)
+                : _stringIds.Contains(entryId);
+        }
+    }
+
     public sealed class ContinueWatchingPlaybackConsumer : IEventConsumer<PlaybackStartEventArgs>
     {
         private static readonly HashSet<string> AutoRemoveScopes =
@@ -261,13 +338,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.EventHandlers
         internal static int DrainBatch(
             IReadOnlyCollection<string> removedIds,
             IEnumerable<Guid> userIds,
-            Action<Guid, IReadOnlyCollection<string>> pruneUser)
+            Action<Guid, CwRemovedIdIndex> pruneUser)
         {
             if (removedIds.Count == 0) return 0;
+            var targetIds = CwRemovedIdIndex.Create(removedIds);
             var users = 0;
             foreach (var userId in userIds)
             {
-                pruneUser(userId, removedIds);
+                pruneUser(userId, targetIds);
                 users++;
             }
             return users;
@@ -275,24 +353,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.EventHandlers
 
         // One locked RMW per user that removes every batched orphan id, then invalidates the response
         // filter's HideContext cache for that user if anything changed.
-        private void PruneOrphans(Guid userId, IReadOnlyCollection<string> targetIds)
+        private void PruneOrphans(Guid userId, CwRemovedIdIndex targetIds)
         {
             try
             {
                 var removed = _configManager.RmwUserConfiguration<UserHiddenContent>(
-                    userId.ToString("N"), "hidden-content.json", hidden =>
-                {
-                    if (hidden?.Items == null || hidden.Items.Count == 0) return 0;
-                    var keysToDrop = new List<string>();
-                    foreach (var kvp in hidden.Items)
-                    {
-                        var entry = kvp.Value;
-                        if (entry == null) continue;
-                        if (targetIds.Any(t => CwEventHelpers.IdMatches(entry.ItemId, t))) keysToDrop.Add(kvp.Key);
-                    }
-                    foreach (var k in keysToDrop) hidden.Items.Remove(k);
-                    return keysToDrop.Count;
-                });
+                    userId.ToString("N"),
+                    "hidden-content.json",
+                    hidden => PruneOrphansCore(hidden, targetIds));
                 if (removed > 0)
                 {
                     HiddenContentResponseFilter.InvalidateUser(userId.ToString("N"));
@@ -311,6 +379,25 @@ namespace Jellyfin.Plugin.JellyfinCanopy.EventHandlers
             {
                 _logger.LogWarning($"CW: orphan-prune failed for user {userId}: {ex.Message}");
             }
+        }
+
+        // Runs inside the config manager's locked read-modify-write transaction, preserving one
+        // atomic mutation per user while making the per-entry work independently testable.
+        internal static int PruneOrphansCore(UserHiddenContent? hidden, CwRemovedIdIndex targetIds)
+        {
+            ArgumentNullException.ThrowIfNull(targetIds);
+            if (hidden?.Items == null || hidden.Items.Count == 0) return 0;
+
+            var keysToDrop = new List<string>();
+            foreach (var kvp in hidden.Items)
+            {
+                var entry = kvp.Value;
+                if (entry == null) continue;
+                if (targetIds.Contains(entry.ItemId)) keysToDrop.Add(kvp.Key);
+            }
+
+            foreach (var key in keysToDrop) hidden.Items.Remove(key);
+            return keysToDrop.Count;
         }
     }
 }

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -19,7 +19,7 @@ const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the repeated clean measurements', () => {
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1364, totalLines: 1692 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 15511, totalLines: 24034 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 15558, totalLines: 24072 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 1);
 });

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -20,13 +20,13 @@
     "server": {
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
-      "measured": {
-        "coveredLines": 15511,
-        "totalLines": 24034
+    "measured": {
+      "coveredLines": 15558,
+      "totalLines": 24072
       },
       "tolerance": {
         "missingCoveredLines": 1,
-        "rationale": "Four clean post-review 2026-07-15 .NET 10/Coverlet runs measured 15511, 15511, 15510, and 15510 covered lines across the same 24034-line scope. They include the bounded Seerr first-event deadline, one lifecycle-owned dispatch worker, one coalesced follow-up, atomic multi-domain manual drain/join, per-target configuration fences, and cancellation-aware disposal; one line permits only the reproduced instrumentation variance."
+      "rationale": "Two independent clean 2026-07-15 .NET 10/Coverlet runs (GitHub Actions and local .NET 10.0.9) both measured 15558 covered lines across the same 24072-line scope. They include the drain-owned Continue Watching identifier index, one-time removed-ID normalization, O(1) mixed GUID/opaque membership, and the 15000-by-15000 linear-work regression; one line retains only the existing negligible instrumentation tolerance."
       }
     }
   }


### PR DESCRIPTION
Closes #116

## Summary
- normalize removed GUID and opaque identifiers once per drain
- use O(1) hash membership for every hidden entry while preserving the locked per-user mutation
- instrument normalization and comparison counts to pin linear work
- cover mixed GUID forms, opaque IDs, multiple users, and a 15k x 15k benchmark

## Validation
- focused ContinueWatchingEventWritersTests: 7/7
- full server suite: 1,389/1,389
- Release build: 0 warnings, 0 errors
- dotnet format verification: clean
- independent Codex review: APPROVE
- Fable low review attempted; unavailable because usage credits are exhausted

## Benchmark
Observed Debug run: 8.752 ms and 753,304 allocated bytes; enforced budgets are 5 seconds and 8 MiB.