### PR TITLE
Centralize bounded discovery response caching

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/requests/data.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/requests/data.identity.test.ts
@@ -57,4 +57,29 @@ describe('Requests page identity ownership', () => {
 
         expect(plugin).not.toHaveBeenCalled();
     });
+
+    it('delegates issue-media ownership to the bounded core cache and retries transient failure', async () => {
+        const plugin = vi.fn()
+            .mockRejectedValueOnce(new Error('temporary upstream failure'))
+            .mockResolvedValueOnce({ id: 42, title: 'Recovered' });
+        JC.core.api = { plugin } as unknown as ApiApi;
+        const { fetchIssueMediaDetails } = await import('./data');
+        const context = JC.identity.capture()!;
+
+        await expect(fetchIssueMediaDetails('movie', 42, undefined, context)).resolves.toBeNull();
+        await expect(fetchIssueMediaDetails('movie', 42, undefined, context))
+            .resolves.toMatchObject({ id: 42, title: 'Recovered' });
+
+        expect(plugin).toHaveBeenCalledTimes(2);
+        expect(plugin).toHaveBeenNthCalledWith(1, '/seerr/movie/42', {
+            cacheKey: 'arr:issue-media:/seerr/movie/42',
+            cacheDisposition: expect.any(Function),
+            cacheNotFound: true,
+        });
+        expect(plugin).toHaveBeenNthCalledWith(2, '/seerr/movie/42', {
+            cacheKey: 'arr:issue-media:/seerr/movie/42',
+            cacheDisposition: expect.any(Function),
+            cacheNotFound: true,
+        });
+    });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/requests/data.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/requests/data.ts
@@ -10,6 +10,8 @@
 import { JC } from '../arr-globals';
 import { renderPage } from './render';
 import { describeFetchError } from '../../core/fetch-error';
+import { classifyObjectDetails } from '../../core/cache-policy';
+import { waitForSharedResult } from '../../core/shared-result';
 import type { ApiApi, IdentityContext } from '../../types/jc';
 
 const logPrefix = '🪼 Jellyfin Canopy: Requests Page:';
@@ -183,7 +185,6 @@ export const state: RequestsPageState = {
     searchDebounceTimer: null,
 };
 
-const issueMediaCache = new Map<string, IssueMediaDetails | null>();
 const avatarObjectUrlCache = new Map<string, string>();
 const avatarFetchPromises = new Map<string, Promise<string>>();
 const avatarAbortControllers = new Map<string, AbortController>();
@@ -486,7 +487,7 @@ function applyIssueMediaDetails(issue: IssueItem, details: IssueMediaDetails | n
     return issue;
 }
 
-async function fetchIssueMediaDetails(
+export async function fetchIssueMediaDetails(
     mediaType: string,
     tmdbId: number | string | null,
     signal: AbortSignal | undefined,
@@ -494,21 +495,21 @@ async function fetchIssueMediaDetails(
 ): Promise<IssueMediaDetails | null> {
     if (!mediaType || !tmdbId) return null;
     if (!JC.identity.isCurrent(context)) return null;
-    const cacheKey = `${mediaType}:${tmdbId}`;
-    if (issueMediaCache.has(cacheKey)) return issueMediaCache.get(cacheKey) ?? null;
-
     const path = mediaType === 'tv'
         ? `/seerr/tv/${tmdbId}`
         : `/seerr/movie/${tmdbId}`;
 
     try {
-        const data = await api.plugin(path, { signal }) as IssueMediaDetails | null;
+        const sharedRequest = api.plugin(path, {
+            cacheKey: `arr:issue-media:${path}`,
+            cacheDisposition: classifyObjectDetails,
+            cacheNotFound: true,
+        }) as Promise<IssueMediaDetails | null>;
+        const data = await waitForSharedResult(sharedRequest, signal);
         if (!JC.identity.isCurrent(context)) return null;
-        issueMediaCache.set(cacheKey, data || null);
         return data || null;
     } catch {
         if (signal?.aborted || !JC.identity.isCurrent(context)) return null;
-        issueMediaCache.set(cacheKey, null);
         return null;
     }
 }
@@ -702,7 +703,6 @@ function resetRequestsIdentityState(): void {
     });
     activeSignal = null;
     loadQueued = false;
-    issueMediaCache.clear();
     _toastedDownloadsErrors.clear();
     clearAvatarObjectUrlCache(true);
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/api-client.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/api-client.test.ts
@@ -1,13 +1,22 @@
 // Unit tests for src/core/api-client.ts — the pure retry/backoff decision
 // logic and the in-flight request deduplication.
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { calculateBackoff, deduplicatedFetch, fetchWithRetry, isRetryable } from './api-client';
+import {
+    calculateBackoff,
+    deduplicatedFetch,
+    fetchWithRetry,
+    isRetryable,
+} from './api-client';
+import { classifyObjectDetails } from './cache-policy';
+import { waitForSharedResult } from './shared-result';
 import { JC } from '../globals';
 import type { IdentityApi, IdentityContext, RetryConfig } from '../types/jc';
 
 const originalApiClient = ApiClient;
 const originalIdentity = (JC as typeof JC & { identity?: IdentityApi }).identity;
 const originalMaxConcurrent = JC.core.api!.manager.CONFIG.concurrency.maxConcurrent;
+const originalMaxCacheEntries = JC.core.api!.manager.CONFIG.cache.maxEntries;
+const originalMaxCacheBytes = JC.core.api!.manager.CONFIG.cache.maxBytes;
 
 function responseJson(value: unknown): Response {
     const text = JSON.stringify(value);
@@ -17,6 +26,13 @@ function responseJson(value: unknown): Response {
         text: () => Promise.resolve(text),
         clone() { return responseJson(value); }
     } as unknown as Response;
+}
+
+function responseError(status: number, value: unknown = {}): Response {
+    const response = responseJson(value) as Response & { ok: boolean; status: number };
+    response.ok = false;
+    response.status = status;
+    return response;
 }
 
 function installApiClient(userId: string, token: string, serverId = 'server-a'): JellyfinApiClient {
@@ -73,6 +89,8 @@ afterEach(() => {
     try { JC.core.api!.manager.abortAllRequests(); } catch { /* test cleanup */ }
     JC.core.api!.manager.clearCache();
     JC.core.api!.manager.CONFIG.concurrency.maxConcurrent = originalMaxConcurrent;
+    JC.core.api!.manager.CONFIG.cache.maxEntries = originalMaxCacheEntries;
+    JC.core.api!.manager.CONFIG.cache.maxBytes = originalMaxCacheBytes;
     window.ApiClient = originalApiClient;
     (globalThis as Record<string, unknown>).ApiClient = originalApiClient;
     if (originalIdentity) {
@@ -221,6 +239,46 @@ describe('deduplicatedFetch', () => {
         ]);
         expect(fetchFn).toHaveBeenCalledTimes(2);
     });
+
+    it('shares one transport while independently aborting a feature waiter', async () => {
+        installIdentity();
+        installApiClient('user-a', 'token-a');
+        let resolveFetch!: (response: Response) => void;
+        const heldFetch = new Promise<Response>(resolve => { resolveFetch = resolve; });
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockReturnValue(heldFetch);
+        const api = JC.core.api!;
+        const url = 'http://jellyfin.test/shared-lifecycle';
+        const firstController = new AbortController();
+        const secondController = new AbortController();
+
+        const first = waitForSharedResult(
+            api.fetch(url, { cacheKey: 'shared-lifecycle' }),
+            firstController.signal,
+        );
+        const second = waitForSharedResult(
+            api.fetch(url, { cacheKey: 'shared-lifecycle' }),
+            secondController.signal,
+        );
+        await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+
+        firstController.abort();
+        await expect(first).rejects.toMatchObject({ name: 'AbortError' });
+        resolveFetch(responseJson({ payload: 'shared' }));
+
+        await expect(second).resolves.toEqual({ payload: 'shared' });
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps an already-started shared rejection observed for an aborted waiter', async () => {
+        const controller = new AbortController();
+        controller.abort();
+        const shared = Promise.reject(new Error('transport failed later'));
+        const observeSpy = vi.spyOn(shared, 'catch');
+
+        await expect(waitForSharedResult(shared, controller.signal))
+            .rejects.toMatchObject({ name: 'AbortError' });
+        expect(observeSpy).toHaveBeenCalledTimes(1);
+    });
 });
 
 describe('deduplicatedFetch identity eviction', () => {
@@ -295,6 +353,140 @@ describe('getCached / coreFetch falsy-cache sentinel', () => {
 
         expect(result).toBe(false);
         expect(fetchSpy).not.toHaveBeenCalled();
+    });
+});
+
+describe('response cache memory budgets', () => {
+    it('uses a short TTL only for a successful authoritative null', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+        installIdentity();
+        installApiClient('user-a', 'token-a');
+        const api = JC.core.api!;
+        const url = 'http://jellyfin.test/semantic-missing';
+        const fetchSpy = vi.spyOn(globalThis, 'fetch')
+            .mockResolvedValueOnce(responseJson(null))
+            .mockResolvedValueOnce(responseJson({ id: 1 }));
+
+        const options = {
+            cacheKey: 'semantic-missing',
+            cacheDisposition: classifyObjectDetails,
+        } as const;
+        await expect(api.fetch(url, options)).resolves.toBeNull();
+        await expect(api.fetch(url, options)).resolves.toBeNull();
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+        vi.advanceTimersByTime(api.manager.CONFIG.cache.negativeTtlMs + 1);
+
+        await expect(api.fetch(url, options)).resolves.toEqual({ id: 1 });
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not guess that an unclassified successful null is authoritative', async () => {
+        installIdentity();
+        installApiClient('user-a', 'token-a');
+        const api = JC.core.api!;
+        const url = 'http://jellyfin.test/unclassified-null';
+        const fetchSpy = vi.spyOn(globalThis, 'fetch')
+            .mockResolvedValue(responseJson(null));
+
+        await expect(api.fetch(url, { cacheKey: 'unclassified-null' })).resolves.toBeNull();
+        await expect(api.fetch(url, { cacheKey: 'unclassified-null' })).resolves.toBeNull();
+
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('short-caches only explicitly authoritative 404 responses', async () => {
+        installIdentity();
+        installApiClient('user-a', 'token-a');
+        const api = JC.core.api!;
+        const url = 'http://jellyfin.test/missing-details';
+        const fetchSpy = vi.spyOn(globalThis, 'fetch')
+            .mockResolvedValue(responseError(404, { code: 'not_found' }));
+
+        await expect(api.fetch(url, {
+            cacheKey: 'missing-details',
+            cacheNotFound: true,
+        })).resolves.toBeNull();
+        await expect(api.fetch(url, {
+            cacheKey: 'missing-details',
+            cacheNotFound: true,
+        })).resolves.toBeNull();
+
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('enforces byte and entry caps with least-recently-used eviction', () => {
+        const manager = JC.core.api!.manager;
+        manager.CONFIG.cache.maxEntries = 3;
+        manager.CONFIG.cache.maxBytes = 10;
+
+        manager.setCache('a', { id: 'a' }, 4);
+        manager.setCache('b', { id: 'b' }, 4);
+        manager.setCache('c', { id: 'c' }, 4);
+
+        expect(manager.getCached('a')).toBeUndefined();
+        expect(manager.getCacheUsage()).toEqual({ entries: 2, bytes: 8 });
+
+        // Touch b so c becomes least recently used. A 6-byte response then
+        // evicts c and fits exactly at the byte ceiling.
+        expect(manager.getCached('b')).toEqual({ id: 'b' });
+        manager.setCache('d', { id: 'd' }, 6);
+
+        expect(manager.getCached('c')).toBeUndefined();
+        expect(manager.getCached('b')).toEqual({ id: 'b' });
+        expect(manager.getCached('d')).toEqual({ id: 'd' });
+        expect(manager.getCacheUsage()).toEqual({ entries: 2, bytes: 10 });
+    });
+
+    it('does not retain a single response larger than the total byte budget', () => {
+        const manager = JC.core.api!.manager;
+        manager.CONFIG.cache.maxEntries = 200;
+        manager.CONFIG.cache.maxBytes = 5;
+
+        manager.setCache('oversize', { payload: 'large' }, 6);
+
+        expect(manager.getCached('oversize')).toBeUndefined();
+        expect(manager.getCacheUsage()).toEqual({ entries: 0, bytes: 0 });
+    });
+
+    it('releases byte ownership when matching entries are cleared', () => {
+        const manager = JC.core.api!.manager;
+        manager.setCache('discovery:one', 1, 3);
+        manager.setCache('other:two', 2, 4);
+
+        manager.clearCacheMatching('discovery:');
+
+        expect(manager.getCacheUsage()).toEqual({ entries: 1, bytes: 4 });
+        expect(manager.getCached('other:two')).toBe(2);
+    });
+
+    it('bounds high-cardinality real response bytes through coreFetch', async () => {
+        installIdentity();
+        installApiClient('user-a', 'token-a');
+        const api = JC.core.api!;
+        api.manager.CONFIG.cache.maxEntries = 20;
+        api.manager.CONFIG.cache.maxBytes = 500;
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(input => {
+            const url = typeof input === 'string'
+                ? input
+                : input instanceof URL
+                    ? input.href
+                    : input.url;
+            return Promise.resolve(responseJson({ url, payload: 'x'.repeat(40) }));
+        });
+
+        for (let index = 0; index < 100; index++) {
+            await api.fetch(`http://jellyfin.test/high-cardinality/${index}`, {
+                cacheKey: `high-cardinality:${index}`,
+            });
+        }
+
+        const usage = api.manager.getCacheUsage();
+        expect(fetchSpy).toHaveBeenCalledTimes(100);
+        expect(usage.entries).toBeGreaterThan(0);
+        expect(usage.entries).toBeLessThanOrEqual(20);
+        expect(usage.bytes).toBeLessThanOrEqual(500);
     });
 });
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/api-client.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/api-client.ts
@@ -45,7 +45,13 @@ const CONFIG: ApiClientConfig = {
     },
     cache: {
         ttlMs: 30 * 60 * 1000, // 30 minutes - discovery data rarely changes
-        maxEntries: 200
+        // A successful JSON null is an authoritative absence, but should
+        // recover much sooner than positive discovery data.
+        negativeTtlMs: 30 * 1000,
+        maxEntries: 200,
+        // Parsed discovery payloads can be large even when the entry count is
+        // small. Bound retained response memory as well as cardinality.
+        maxBytes: 16 * 1024 * 1024
     },
     concurrency: {
         maxConcurrent: 8,
@@ -57,7 +63,13 @@ const CONFIG: ApiClientConfig = {
 const inFlightRequests = new Map<string, Promise<unknown>>();
 
 // Response cache with TTL
-const responseCache = new Map<string, { data: unknown; timestamp: number }>();
+const responseCache = new Map<string, {
+    data: unknown;
+    timestamp: number;
+    ttlMs: number;
+    sizeBytes: number;
+}>();
+let responseCacheBytes = 0;
 
 // AbortController management per page/context
 const activeControllers = new Map<string, AbortController>();
@@ -488,7 +500,7 @@ function abortRequest(pageKey: string): void {
  */
 function getCached(key: string): unknown {
     const entry = responseCache.get(key);
-    if (entry && Date.now() - entry.timestamp < CONFIG.cache.ttlMs) {
+    if (entry && Date.now() - entry.timestamp < entry.ttlMs) {
         if (metrics.enabled) {
             console.debug(`${logPrefix} Cache hit for ${key}`);
         }
@@ -499,7 +511,7 @@ function getCached(key: string): unknown {
     }
     // Remove stale entry
     if (entry) {
-        responseCache.delete(key);
+        deleteCacheEntry(key);
     }
     // `undefined` is the unambiguous miss sentinel: a faithfully-cached falsy
     // value (false / 0 / '' / null) is still a hit and must not be re-fetched.
@@ -507,20 +519,61 @@ function getCached(key: string): unknown {
     return undefined;
 }
 
+function deleteCacheEntry(key: string): boolean {
+    const entry = responseCache.get(key);
+    if (!entry) return false;
+    responseCacheBytes = Math.max(0, responseCacheBytes - entry.sizeBytes);
+    return responseCache.delete(key);
+}
+
+function estimateCacheBytes(data: unknown): number {
+    try {
+        const serialized = JSON.stringify(data);
+        return new TextEncoder().encode(serialized === undefined ? String(data) : serialized).byteLength;
+    } catch {
+        // Cyclic/non-serializable values are not valid JSON API responses. Do
+        // not retain an unmeasurable value outside the byte budget.
+        return Number.POSITIVE_INFINITY;
+    }
+}
+
 /**
  * Set cached response
  */
-function setCache(key: string, data: unknown): void {
-    // Evict oldest entries if at capacity
-    if (responseCache.size >= CONFIG.cache.maxEntries) {
+function setCache(
+    key: string,
+    data: unknown,
+    measuredSizeBytes?: number,
+    ttlMs = CONFIG.cache.ttlMs
+): void {
+    const sizeBytes = measuredSizeBytes === undefined
+        ? estimateCacheBytes(data)
+        : measuredSizeBytes;
+
+    // Replacing a key must release the old weight before applying either cap.
+    deleteCacheEntry(key);
+
+    if (!Number.isFinite(sizeBytes) || sizeBytes < 0 || sizeBytes > CONFIG.cache.maxBytes
+        || !Number.isFinite(ttlMs) || ttlMs <= 0
+        || CONFIG.cache.maxEntries <= 0 || CONFIG.cache.maxBytes <= 0) {
+        return;
+    }
+
+    // Evict least-recently-used entries until both explicit budgets fit.
+    while (responseCache.size >= CONFIG.cache.maxEntries
+        || responseCacheBytes + sizeBytes > CONFIG.cache.maxBytes) {
         const oldestKey = responseCache.keys().next().value;
-        if (oldestKey !== undefined) responseCache.delete(oldestKey);
+        if (oldestKey === undefined) break;
+        deleteCacheEntry(oldestKey);
     }
 
     responseCache.set(key, {
         data,
-        timestamp: Date.now()
+        timestamp: Date.now(),
+        ttlMs,
+        sizeBytes
     });
+    responseCacheBytes += sizeBytes;
 }
 
 /**
@@ -528,6 +581,7 @@ function setCache(key: string, data: unknown): void {
  */
 function clearCache(): void {
     responseCache.clear();
+    responseCacheBytes = 0;
 }
 
 /**
@@ -536,9 +590,13 @@ function clearCache(): void {
 function clearCacheMatching(pattern: string): void {
     for (const key of responseCache.keys()) {
         if (key.includes(pattern)) {
-            responseCache.delete(key);
+            deleteCacheEntry(key);
         }
     }
+}
+
+function getCacheUsage(): { entries: number; bytes: number } {
+    return { entries: responseCache.size, bytes: responseCacheBytes };
 }
 
 // Metrics API
@@ -642,6 +700,7 @@ const manager: RequestManagerApi = {
     setCache,
     clearCache,
     clearCacheMatching,
+    getCacheUsage,
 
     // Metrics
     metrics,
@@ -747,6 +806,8 @@ async function coreFetch(
         body,
         signal,
         cacheKey,
+        cacheDisposition,
+        cacheNotFound = false,
         skipCache = false,
         skipRetry = false,
         auth = true,
@@ -851,12 +912,24 @@ async function coreFetch(
 
     const fetchFn = async (): Promise<unknown> => {
         guard();
-        const response = await fetchWithRetry(
-            url,
-            init,
-            skipRetry ? { ...CONFIG.retry, maxAttempts: 1 } : undefined,
-            guard
-        );
+        let response: Response;
+        try {
+            response = await fetchWithRetry(
+                url,
+                init,
+                skipRetry ? { ...CONFIG.retry, maxAttempts: 1 } : undefined,
+                guard
+            );
+        } catch (error) {
+            const status = (error as HttpError | null)?.status;
+            if (isGet && identityCacheKey && cacheNotFound && status === 404) {
+                guard();
+                setCache(identityCacheKey, null, 4, CONFIG.cache.negativeTtlMs);
+                guard();
+                return null;
+            }
+            throw error;
+        }
         guard();
 
         // Tolerant JSON parse: some endpoints reply with empty bodies.
@@ -867,7 +940,23 @@ async function coreFetch(
 
         if (isGet && identityCacheKey) {
             guard();
-            setCache(identityCacheKey, data);
+            let disposition: 'positive' | 'negative' | 'skip' = data === null
+                ? 'skip'
+                : 'positive';
+            if (cacheDisposition) {
+                try {
+                    disposition = cacheDisposition(data);
+                } catch {
+                    disposition = 'skip';
+                }
+            }
+            if (disposition !== 'skip') {
+                const responseBytes = new TextEncoder().encode(text || '{}').byteLength;
+                const ttlMs = disposition === 'negative'
+                    ? CONFIG.cache.negativeTtlMs
+                    : CONFIG.cache.ttlMs;
+                setCache(identityCacheKey, data, responseBytes, ttlMs);
+            }
         }
         guard();
         return data;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/cache-policy.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/cache-policy.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import {
+    classifyArrayPayload,
+    classifyObjectDetails,
+    classifyResultsEnvelope,
+} from './cache-policy';
+
+describe('semantic response cache policy', () => {
+    it('classifies only explicit object absence as negative', () => {
+        expect(classifyObjectDetails(null)).toBe('negative');
+        expect(classifyObjectDetails({ id: 1 })).toBe('positive');
+        expect(classifyObjectDetails(undefined)).toBe('skip');
+        expect(classifyObjectDetails([])).toBe('skip');
+    });
+
+    it('requires a valid results envelope before caching search absence', () => {
+        expect(classifyResultsEnvelope({ results: [] })).toBe('negative');
+        expect(classifyResultsEnvelope({ results: [{ id: 1 }] })).toBe('positive');
+        expect(classifyResultsEnvelope({})).toBe('skip');
+        expect(classifyResultsEnvelope(null)).toBe('skip');
+    });
+
+    it('treats only a valid empty list as authoritative list absence', () => {
+        expect(classifyArrayPayload([])).toBe('negative');
+        expect(classifyArrayPayload([{ id: 1 }])).toBe('positive');
+        expect(classifyArrayPayload({ results: [] })).toBe('skip');
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/cache-policy.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/cache-policy.ts
@@ -1,0 +1,21 @@
+export type CacheDisposition = 'positive' | 'negative' | 'skip';
+
+/** Successful object details, with an explicit JSON null as authoritative absence. */
+export function classifyObjectDetails(data: unknown): CacheDisposition {
+    if (data === null) return 'negative';
+    return typeof data === 'object' && !Array.isArray(data) ? 'positive' : 'skip';
+}
+
+/** Successful TMDB-style search envelopes: an empty results array is definitive. */
+export function classifyResultsEnvelope(data: unknown): CacheDisposition {
+    if (!data || typeof data !== 'object') return 'skip';
+    const results = (data as { results?: unknown }).results;
+    if (!Array.isArray(results)) return 'skip';
+    return results.length === 0 ? 'negative' : 'positive';
+}
+
+/** Successful list endpoints: an empty list is a short-lived authoritative absence. */
+export function classifyArrayPayload(data: unknown): CacheDisposition {
+    if (!Array.isArray(data)) return 'skip';
+    return data.length === 0 ? 'negative' : 'positive';
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/live-config.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/live-config.test.ts
@@ -20,7 +20,12 @@ describe('config hot-reload reaction', () => {
             if (path.startsWith('/private-config')) return Promise.resolve({ SecretUrl: 'http://x' });
             return Promise.resolve({});
         });
-        JC.core.api = { plugin } as unknown as NonNullable<typeof JC.core.api>;
+        const abortAllRequests = vi.fn();
+        const clearCache = vi.fn();
+        JC.core.api = {
+            plugin,
+            manager: { abortAllRequests, clearCache },
+        } as unknown as NonNullable<typeof JC.core.api>;
 
         const domEvent = vi.fn();
         window.addEventListener('jc:config-changed', domEvent);
@@ -40,6 +45,8 @@ describe('config hot-reload reaction', () => {
         expect(JC.pluginConfig).toBe(configRef);
         // legacy hook fired for unmigrated modules.
         expect(domEvent).toHaveBeenCalledTimes(1);
+        expect(abortAllRequests).toHaveBeenCalledTimes(1);
+        expect(clearCache).toHaveBeenCalledTimes(1);
 
         // both endpoints hit with a cache-buster.
         expect(plugin).toHaveBeenCalledWith(expect.stringMatching(/^\/public-config\?_je=\d+/), expect.anything());

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/live-config.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/live-config.ts
@@ -215,6 +215,15 @@ on(LIVE.CONFIG_CHANGED, () => {
         const refreshed = await refreshPluginConfig(context);
         if (!refreshed || refreshed.seq !== refreshSeq || !JC.identity.isCurrent(context)) return;
 
+        // Discovery/Arr responses can depend on Seerr URL, credentials and
+        // feature policy. Once the new configuration generation is current,
+        // cancel old-generation work and drop its shared response cache before
+        // feature listeners re-render.
+        try {
+            JC.core.api?.manager?.abortAllRequests();
+            JC.core.api?.manager?.clearCache();
+        } catch { /* request manager unavailable — feature refresh still proceeds */ }
+
         const observationGeneration = observeTagPolicy(
             policyState,
             refreshed.tagPolicyFingerprint

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/shared-result.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/shared-result.ts
@@ -1,0 +1,32 @@
+/**
+ * Lets one feature lifecycle stop waiting for shared work without cancelling
+ * the identity-owned transport or affecting other same-key waiters.
+ */
+export function waitForSharedResult<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+    if (!signal) return promise;
+    if (signal.aborted) {
+        // The shared transport was already started before this waiter observed
+        // cancellation. Keep its rejection observed even when no waiter remains.
+        void promise.catch(() => undefined);
+        return Promise.reject(new DOMException('Aborted', 'AbortError'));
+    }
+
+    return new Promise<T>((resolve, reject) => {
+        const onAbort = (): void => {
+            cleanup();
+            reject(new DOMException('Aborted', 'AbortError'));
+        };
+        const cleanup = (): void => signal.removeEventListener('abort', onAbort);
+        signal.addEventListener('abort', onAbort, { once: true });
+        void promise.then(
+            value => {
+                cleanup();
+                resolve(value);
+            },
+            error => {
+                cleanup();
+                reject(error instanceof Error ? error : new Error('Shared result rejected'));
+            }
+        );
+    });
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/cache-ownership.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/cache-ownership.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import ts from 'typescript';
+
+const DISCOVERY_MODULES = [
+    './tag.ts',
+    './person.ts',
+    './network.ts',
+    './genre.ts',
+    './collection.ts',
+];
+
+function readRelative(relativePath: string): string {
+    const path = decodeURIComponent(new URL(relativePath, import.meta.url).pathname);
+    const source = ts.sys.readFile(path);
+    expect(source, `missing source: ${path}`).toBeTruthy();
+    return source!;
+}
+
+describe('discovery response cache ownership', () => {
+    it.each(DISCOVERY_MODULES)('%s has no permanent feature-local response map', (modulePath) => {
+        const source = readRelative(modulePath);
+
+        expect(source).not.toMatch(/new\s+Map\s*</u);
+        expect(source).toContain('fetchWithManagedRequest');
+    });
+
+    it('keeps Arr issue-media results in the bounded core request cache', () => {
+        const source = readRelative('../../arr/requests/data.ts');
+
+        expect(source).not.toContain('issueMediaCache');
+        expect(source).toContain("cacheKey: `arr:issue-media:${path}`");
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/collection.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/collection.ts
@@ -4,13 +4,12 @@
 // metrics and lifecycle wiring; this module keeps only the BoxSet lookup
 // and the missing-movies render.
 import { JC } from '../../globals';
+import { classifyObjectDetails } from '../../core/cache-policy';
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- legacy Seerr payload shapes; typed incrementally */
 
 
 const logPrefix = '🪼 Jellyfin Canopy: Collection Discovery:';
-
-const boxsetInfoCache = new Map<string, any>();
 
 // Alias for shared utilities
 const fetchWithManagedRequest = (path: string, options?: any) =>
@@ -23,23 +22,21 @@ const fetchWithManagedRequest = (path: string, options?: any) =>
  * @returns {Promise<{id: string, name: string, tmdbId: string|null, type: string}|null>}
  */
 async function getBoxSetInfo(boxsetId: string, signal?: AbortSignal): Promise<any> {
-    if (boxsetInfoCache.has(boxsetId)) {
-        return boxsetInfoCache.get(boxsetId);
-    }
     try {
         if (signal?.aborted) {
             throw new DOMException('Aborted', 'AbortError');
         }
 
-        const response = await fetchWithManagedRequest(`/JellyfinCanopy/boxset/${boxsetId}`, { signal });
+        const response = await fetchWithManagedRequest(`/JellyfinCanopy/boxset/${boxsetId}`, {
+            signal,
+            cacheDisposition: classifyObjectDetails,
+            cacheNotFound: true,
+        });
 
         if (signal?.aborted) {
             throw new DOMException('Aborted', 'AbortError');
         }
 
-        if (response) {
-            boxsetInfoCache.set(boxsetId, response);
-        }
         return response;
     } catch (error: any) {
         if (error.name === 'AbortError') throw error;
@@ -222,8 +219,7 @@ const discovery = JC.discoveryBase!.createDiscovery({
     logLabel: 'Collection Discovery',
     configKey: 'SeerrShowCollectionDiscovery',
     getIdFromUrl: JC.discoveryBase!.idFromDetailUrl,
-    renderOneShot: renderCollectionDiscovery,
-    onCleanup: () => boxsetInfoCache.clear()
+    renderOneShot: renderCollectionDiscovery
 });
 
 discovery.start();

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/filter-utils.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/filter-utils.identity.test.ts
@@ -36,12 +36,37 @@ describe('discovery managed request identity paving', () => {
         expect(jf).toHaveBeenCalledWith(
             '/JellyfinCanopy/tmdb/genres/movie',
             {
-                signal,
                 cacheKey: 'genre:/JellyfinCanopy/tmdb/genres/movie',
+                cacheDisposition: undefined,
+                cacheNotFound: undefined,
             },
         );
         expect(getCached).not.toHaveBeenCalled();
         expect(setCache).not.toHaveBeenCalled();
         expect(fetchWithRetry).not.toHaveBeenCalled();
+    });
+
+    it('cancels only the lifecycle waiter and leaves shared transport ownership in core', async () => {
+        let resolve!: (value: unknown) => void;
+        jf.mockReturnValue(new Promise(done => { resolve = done; }));
+        const controller = new AbortController();
+
+        const waiting = JC.discoveryFilter!.fetchWithManagedRequest(
+            '/JellyfinCanopy/tmdb/search/person?query=a',
+            'person',
+            { signal: controller.signal },
+        );
+        controller.abort();
+
+        await expect(waiting).rejects.toMatchObject({ name: 'AbortError' });
+        expect(jf).toHaveBeenCalledWith(
+            '/JellyfinCanopy/tmdb/search/person?query=a',
+            expect.not.objectContaining({ signal: expect.anything() }),
+        );
+
+        // The underlying shared request remains settleable/cacheable for other
+        // waiters; this aborted lifecycle did not own its transport.
+        resolve({ results: [] });
+        await Promise.resolve();
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/filter-utils.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/filter-utils.ts
@@ -2,6 +2,7 @@
 // Shared utilities for discovery section content type filtering
 import { JC } from '../../globals';
 import { getVisibleDetailsPage } from '../../core/details-view';
+import { waitForSharedResult } from '../../core/shared-result';
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- legacy Seerr payload shapes; typed incrementally */
 
@@ -33,6 +34,8 @@ export interface DiscoveryFilterApi {
 
 interface ManagedRequestOptions {
     signal?: AbortSignal;
+    cacheDisposition?: (data: unknown) => 'positive' | 'negative' | 'skip';
+    cacheNotFound?: boolean;
 }
 
 declare module '../../types/jc' {
@@ -392,15 +395,17 @@ async function fetchWithManagedRequest(
     cachePrefix: string,
     options: ManagedRequestOptions = {}
 ): Promise<any> {
-    const { signal } = options;
+    const { signal, cacheDisposition, cacheNotFound } = options;
     // The core paved road owns auth, per-identity cache keys, parsing fences,
     // abort-on-transition, dedup and concurrency. Calling manager primitives
     // directly here previously allowed an unsignalled A response to parse and
     // setCache after B had become current.
-    return JC.core.api!.jf(path, {
-        signal,
+    const sharedRequest = JC.core.api!.jf(path, {
         cacheKey: `${cachePrefix}:${path}`,
+        cacheDisposition,
+        cacheNotFound,
     });
+    return waitForSharedResult(sharedRequest, signal);
 }
 
 /**

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/genre.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/genre.ts
@@ -4,14 +4,9 @@
 // pagination, filter/sort controls, infinite scroll, dedup and lifecycle
 // wiring; this module keeps the Jellyfin-genre → TMDB-genre resolution.
 import { JC } from '../../globals';
+import { classifyArrayPayload, classifyObjectDetails } from '../../core/cache-policy';
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- legacy Seerr payload shapes; typed incrementally */
-
-
-const genreInfoCache = new Map<string, any>();
-
-// Dynamic genre cache (populated from TMDB API)
-let tmdbGenreCache: any = null;
 
 // Alias for shared utilities
 const fetchWithManagedRequest = (path: string, options?: any) =>
@@ -22,14 +17,12 @@ const fetchWithManagedRequest = (path: string, options?: any) =>
  * @param {AbortSignal} [signal] - Optional abort signal
  */
 async function fetchTmdbGenres(signal?: AbortSignal): Promise<any> {
-    if (tmdbGenreCache) return tmdbGenreCache;
-
     try {
         if (signal?.aborted) {
             throw new DOMException('Aborted', 'AbortError');
         }
 
-        const fetchOptions = { signal };
+        const fetchOptions = { signal, cacheDisposition: classifyArrayPayload };
         const [tvResponse, movieResponse] = await Promise.all([
             fetchWithManagedRequest('/JellyfinCanopy/tmdb/genres/tv', fetchOptions).catch(() => []),
             fetchWithManagedRequest('/JellyfinCanopy/tmdb/genres/movie', fetchOptions).catch(() => [])
@@ -40,19 +33,19 @@ async function fetchTmdbGenres(signal?: AbortSignal): Promise<any> {
         }
 
         // Build lookup map by genre name (lowercase for matching)
-        tmdbGenreCache = {};
+        const genres: Record<string, { tv: number | null; movie: number | null }> = {};
         (tvResponse || []).forEach((g: any) => {
             const key = g.name.toLowerCase();
-            if (!tmdbGenreCache[key]) tmdbGenreCache[key] = { tv: null, movie: null };
-            tmdbGenreCache[key].tv = g.id;
+            if (!genres[key]) genres[key] = { tv: null, movie: null };
+            genres[key].tv = g.id;
         });
         (movieResponse || []).forEach((g: any) => {
             const key = g.name.toLowerCase();
-            if (!tmdbGenreCache[key]) tmdbGenreCache[key] = { tv: null, movie: null };
-            tmdbGenreCache[key].movie = g.id;
+            if (!genres[key]) genres[key] = { tv: null, movie: null };
+            genres[key].movie = g.id;
         });
 
-        return tmdbGenreCache;
+        return genres;
     } catch (error: any) {
         if (error.name === 'AbortError') throw error;
         return {};
@@ -66,23 +59,21 @@ async function fetchTmdbGenres(signal?: AbortSignal): Promise<any> {
  * @returns {Promise<Object|null>} Genre info object or null
  */
 async function getGenreInfo(genreId: string, signal?: AbortSignal): Promise<any> {
-    if (genreInfoCache.has(genreId)) {
-        return genreInfoCache.get(genreId);
-    }
     try {
         if (signal?.aborted) {
             throw new DOMException('Aborted', 'AbortError');
         }
 
-        const response = await fetchWithManagedRequest(`/JellyfinCanopy/genre/${genreId}`, { signal });
+        const response = await fetchWithManagedRequest(`/JellyfinCanopy/genre/${genreId}`, {
+            signal,
+            cacheDisposition: classifyObjectDetails,
+            cacheNotFound: true,
+        });
 
         if (signal?.aborted) {
             throw new DOMException('Aborted', 'AbortError');
         }
 
-        if (response) {
-            genreInfoCache.set(genreId, response);
-        }
         return response;
     } catch (error: any) {
         if (error.name === 'AbortError') throw error;
@@ -96,9 +87,8 @@ async function getGenreInfo(genreId: string, signal?: AbortSignal): Promise<any>
  * @param {AbortSignal} [signal]
  * @returns {Promise<{tv: number|null, movie: number|null}|null>} Genre IDs or null
  */
-async function getTmdbGenreIds(genreName: string, signal?: AbortSignal): Promise<any> {
+function getTmdbGenreIds(genreName: string, genres: Record<string, { tv: number | null; movie: number | null }>): any {
     const cacheKey = genreName.toLowerCase().trim();
-    const genres = await fetchTmdbGenres(signal);
 
     // Start with exact match result (if any)
     const result: { tv: any; movie: any } = { tv: null, movie: null };
@@ -135,14 +125,17 @@ async function resolveFeeds({ id: genreId, signal }: { id: string; signal: Abort
     const statusPromise = JC.seerrAPI?.checkUserStatus();
     const tmdbGenresPromise = fetchTmdbGenres(signal);
 
-    const [genreInfo, status] = await Promise.all([genreInfoPromise, statusPromise, tmdbGenresPromise]);
+    const [genreInfo, status, tmdbGenres] = await Promise.all([
+        genreInfoPromise,
+        statusPromise,
+        tmdbGenresPromise
+    ]);
 
     if (signal.aborted) return null;
 
     if (!status?.active || !genreInfo?.name) return null;
 
-    // TMDB genres are already cached from the parallel fetch above
-    const tmdbGenreIds = await getTmdbGenreIds(genreInfo.name, signal);
+    const tmdbGenreIds = getTmdbGenreIds(genreInfo.name, tmdbGenres);
     if (signal.aborted) return null;
 
     if (!tmdbGenreIds || (!tmdbGenreIds.tv && !tmdbGenreIds.movie)) return null;
@@ -163,11 +156,7 @@ const discovery = JC.discoveryBase!.createDiscovery({
     resolveFeeds,
     buildDiscoverPath: (kind: string, id: number) => kind === 'tv'
         ? `/JellyfinCanopy/seerr/discover/tv/genre/${id}`
-        : `/JellyfinCanopy/seerr/discover/movies/genre/${id}`,
-    onCleanup: () => {
-        genreInfoCache.clear();
-        tmdbGenreCache = null;
-    }
+        : `/JellyfinCanopy/seerr/discover/movies/genre/${id}`
 });
 
 discovery.start();

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/network.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/network.ts
@@ -5,15 +5,10 @@
 // lifecycle wiring; this module keeps the studio → TMDB network/company
 // resolution (known-network map + company search scoring).
 import { JC } from '../../globals';
+import { classifyObjectDetails, classifyResultsEnvelope } from '../../core/cache-policy';
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- legacy Seerr payload shapes; typed incrementally */
 
-
-// Cache for network ID mappings (studioName -> TMDB networkId)
-const networkIdCache = new Map<string, any>();
-
-// Cache for studio info (studioId -> studioInfo)
-const studioInfoCache = new Map<string, any>();
 
 // Alias for shared utilities
 const fetchWithManagedRequest = (path: string, options?: any) =>
@@ -82,24 +77,21 @@ const TV_NETWORKS: Record<string, number> = {
  * @param {AbortSignal} [signal]
  */
 async function getStudioInfo(studioId: string, signal?: AbortSignal): Promise<any> {
-    if (studioInfoCache.has(studioId)) {
-        return studioInfoCache.get(studioId);
-    }
-
     try {
         if (signal?.aborted) {
             throw new DOMException('Aborted', 'AbortError');
         }
 
-        const response = await fetchWithManagedRequest(`/JellyfinCanopy/studio/${studioId}`, { signal });
+        const response = await fetchWithManagedRequest(`/JellyfinCanopy/studio/${studioId}`, {
+            signal,
+            cacheDisposition: classifyObjectDetails,
+            cacheNotFound: true,
+        });
 
         if (signal?.aborted) {
             throw new DOMException('Aborted', 'AbortError');
         }
 
-        if (response) {
-            studioInfoCache.set(studioId, response);
-        }
         return response;
     } catch (error: any) {
         if (error.name === 'AbortError') throw error;
@@ -130,12 +122,6 @@ function getKnownNetworkId(networkName: string): number | null {
  * @param {AbortSignal} [signal]
  */
 async function searchTmdbCompany(networkName: string, signal?: AbortSignal): Promise<any> {
-    const cacheKey = networkName.toLowerCase().trim();
-
-    if (networkIdCache.has(cacheKey)) {
-        return networkIdCache.get(cacheKey);
-    }
-
     try {
         if (signal?.aborted) {
             throw new DOMException('Aborted', 'AbortError');
@@ -143,7 +129,7 @@ async function searchTmdbCompany(networkName: string, signal?: AbortSignal): Pro
 
         const response = await fetchWithManagedRequest(
             `/JellyfinCanopy/tmdb/search/company?query=${encodeURIComponent(networkName)}`,
-            { signal }
+            { signal, cacheDisposition: classifyResultsEnvelope }
         );
 
         if (signal?.aborted) {
@@ -166,10 +152,7 @@ async function searchTmdbCompany(networkName: string, signal?: AbortSignal): Pro
             scored.sort((a: any, b: any) => b.score - a.score);
 
             if (scored.length === 0) return null;
-            const companyId = scored[0].id;
-
-            networkIdCache.set(cacheKey, companyId);
-            return companyId;
+            return scored[0].id;
         }
     } catch (error: any) {
         if (error.name === 'AbortError') throw error;
@@ -227,11 +210,7 @@ const discovery = JC.discoveryBase!.createDiscovery({
     resolveFeeds,
     buildDiscoverPath: (kind: string, id: number) => kind === 'tv'
         ? `/JellyfinCanopy/seerr/discover/tv/network/${id}`
-        : `/JellyfinCanopy/seerr/discover/movies/studio/${id}`,
-    onCleanup: () => {
-        networkIdCache.clear();
-        studioInfoCache.clear();
-    }
+        : `/JellyfinCanopy/seerr/discover/movies/studio/${id}`
 });
 
 discovery.start();

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/person.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/person.ts
@@ -4,15 +4,12 @@
 // pagination, filter/sort controls, infinite scroll and lifecycle wiring;
 // this module keeps the TMDB person resolution and the credits fetch.
 import { JC } from '../../globals';
+import { classifyObjectDetails, classifyResultsEnvelope } from '../../core/cache-policy';
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- legacy Seerr payload shapes; typed incrementally */
 
 
 const logPrefix = '🪼 Jellyfin Canopy: Person Discovery:';
-
-// Cache for person ID mappings (personName -> TMDB personId)
-const personIdCache = new Map<string, any>();
-const personInfoCache = new Map<string, any>();
 
 // Alias for shared utilities
 const fetchWithManagedRequest = (path: string, options?: any) =>
@@ -24,23 +21,21 @@ const fetchWithManagedRequest = (path: string, options?: any) =>
  * @param {AbortSignal} [signal]
  */
 async function getPersonInfo(personId: string, signal?: AbortSignal): Promise<any> {
-    if (personInfoCache.has(personId)) {
-        return personInfoCache.get(personId);
-    }
     try {
         if (signal?.aborted) {
             throw new DOMException('Aborted', 'AbortError');
         }
 
-        const response = await fetchWithManagedRequest(`/JellyfinCanopy/person/${personId}`, { signal });
+        const response = await fetchWithManagedRequest(`/JellyfinCanopy/person/${personId}`, {
+            signal,
+            cacheDisposition: classifyObjectDetails,
+            cacheNotFound: true,
+        });
 
         if (signal?.aborted) {
             throw new DOMException('Aborted', 'AbortError');
         }
 
-        if (response) {
-            personInfoCache.set(personId, response);
-        }
         return response;
     } catch (error: any) {
         if (error.name === 'AbortError') throw error;
@@ -80,11 +75,6 @@ async function isPersonPage(itemId: string, signal?: AbortSignal): Promise<any> 
  * @param {AbortSignal} [signal]
  */
 async function searchTmdbPerson(personName: string, signal?: AbortSignal): Promise<any> {
-    const cacheKey = personName.toLowerCase().trim();
-    if (personIdCache.has(cacheKey)) {
-        return personIdCache.get(cacheKey);
-    }
-
     try {
         if (signal?.aborted) {
             throw new DOMException('Aborted', 'AbortError');
@@ -92,7 +82,7 @@ async function searchTmdbPerson(personName: string, signal?: AbortSignal): Promi
 
         const response = await fetchWithManagedRequest(
             `/JellyfinCanopy/tmdb/search/person?query=${encodeURIComponent(personName)}`,
-            { signal }
+            { signal, cacheDisposition: classifyResultsEnvelope }
         );
 
         if (signal?.aborted) {
@@ -116,10 +106,7 @@ async function searchTmdbPerson(personName: string, signal?: AbortSignal): Promi
                 scored.sort((a: any, b: any) => b.score - a.score);
 
                 if (scored.length === 0) return null;
-                const personId = scored[0].id;
-
-                personIdCache.set(cacheKey, personId);
-                return personId;
+                return scored[0].id;
             }
         }
     } catch (error: any) {
@@ -215,11 +202,7 @@ const discovery = JC.discoveryBase!.createDiscovery({
     configKey: 'SeerrShowPersonDiscovery',
     getIdFromUrl: JC.discoveryBase!.idFromDetailUrl,
     pageSize: 40,
-    resolveItems,
-    onCleanup: () => {
-        personIdCache.clear();
-        personInfoCache.clear();
-    }
+    resolveItems
 });
 
 discovery.start();

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/tag.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/tag.ts
@@ -5,11 +5,9 @@
 // wiring; this module keeps the tag → TMDB-keyword resolution. Both feeds
 // share the same keyword id.
 import { JC } from '../../globals';
+import { classifyResultsEnvelope } from '../../core/cache-policy';
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- legacy Seerr payload shapes; typed incrementally */
-
-
-const keywordIdCache = new Map<string, any>();
 
 // Alias for shared utilities
 const fetchWithManagedRequest = (path: string, options?: any) =>
@@ -39,11 +37,6 @@ function getTagFromUrl(): string | null {
  * @param {AbortSignal} [signal]
  */
 async function searchTmdbKeyword(tagName: string, signal?: AbortSignal): Promise<any> {
-    const cacheKey = tagName.toLowerCase().trim();
-    if (keywordIdCache.has(cacheKey)) {
-        return keywordIdCache.get(cacheKey);
-    }
-
     try {
         if (signal?.aborted) {
             throw new DOMException('Aborted', 'AbortError');
@@ -51,7 +44,7 @@ async function searchTmdbKeyword(tagName: string, signal?: AbortSignal): Promise
 
         const response = await fetchWithManagedRequest(
             `/JellyfinCanopy/tmdb/search/keyword?query=${encodeURIComponent(tagName)}`,
-            { signal }
+            { signal, cacheDisposition: classifyResultsEnvelope }
         );
 
         if (signal?.aborted) {
@@ -62,9 +55,7 @@ async function searchTmdbKeyword(tagName: string, signal?: AbortSignal): Promise
             const exactMatch = response.results.find((r: any) =>
                 r.name.toLowerCase() === tagName.toLowerCase()
             );
-            const keywordId = exactMatch ? exactMatch.id : response.results[0].id;
-            keywordIdCache.set(cacheKey, keywordId);
-            return keywordId;
+            return exactMatch ? exactMatch.id : response.results[0].id;
         }
     } catch (error: any) {
         if (error.name === 'AbortError') throw error;
@@ -108,8 +99,7 @@ const discovery = JC.discoveryBase!.createDiscovery({
     resolveFeeds,
     buildDiscoverPath: (kind: string, id: number) => kind === 'tv'
         ? `/JellyfinCanopy/seerr/discover/tv/keyword/${id}`
-        : `/JellyfinCanopy/seerr/discover/movies/keyword/${id}`,
-    onCleanup: () => keywordIdCache.clear()
+        : `/JellyfinCanopy/seerr/discover/movies/keyword/${id}`
 });
 
 discovery.start();

--- a/Jellyfin.Plugin.JellyfinCanopy/src/types/jc.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/types/jc.ts
@@ -367,7 +367,7 @@ export interface RetryConfig {
 
 export interface ApiClientConfig {
     retry: RetryConfig;
-    cache: { ttlMs: number; maxEntries: number };
+    cache: { ttlMs: number; negativeTtlMs: number; maxEntries: number; maxBytes: number };
     concurrency: { maxConcurrent: number; maxQueueSize: number };
 }
 
@@ -401,9 +401,10 @@ export interface RequestManagerApi {
     abortAllRequests(): void;
     abortRequest(pageKey: string): void;
     getCached(key: string): unknown;
-    setCache(key: string, data: unknown): void;
+    setCache(key: string, data: unknown, sizeBytes?: number, ttlMs?: number): void;
     clearCache(): void;
     clearCacheMatching(pattern: string): void;
+    getCacheUsage(): { entries: number; bytes: number };
     metrics: { enabled: boolean; sections: Map<string, SectionMetrics>; requests: RequestMetric[] };
     startMeasurement(sectionName: string): void;
     recordRequest(sectionName: string, bytes: number, fromCache?: boolean): void;
@@ -420,6 +421,10 @@ export interface CoreFetchOptions {
     signal?: AbortSignal;
     /** Enables response cache + in-flight dedup (GET only). */
     cacheKey?: string;
+    /** Classifies a successful JSON response for positive, short negative, or no caching. */
+    cacheDisposition?: (data: unknown) => 'positive' | 'negative' | 'skip';
+    /** Treat an HTTP 404 as an authoritative short-lived negative result. */
+    cacheNotFound?: boolean;
     skipCache?: boolean;
     skipRetry?: boolean;
     /** Include the Jellyfin auth headers (default true). */

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -889,7 +889,7 @@ Jellyfin.Plugin.JellyfinCanopy/
     │   ├── lifecycle.ts     # Per-feature teardown registry (observers, intervals, listeners)
     │   ├── dom-observer.ts  # Multiplexed body MutationObserver, waitForElement, ensureInjected
     │   │                    # (keyed, idempotent, re-render-proof injection)
-    │   ├── api-client.ts    # One fetch wrapper: auth headers, retry/dedup/concurrency
+    │   ├── api-client.ts    # One fetch wrapper: auth, retry/dedup/concurrency, identity-scoped response LRU
     │   ├── asset-urls.ts    # CDN-URL ↔ local-asset map: same-origin when the asset cache
     │   │                    # is on (AssetCacheEnabled, default ON), original CDN URL when off (R6)
     │   ├── ui-kit.ts        # escapeHtml, toast, injectCss + the theme-token MUI component kit

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -18,7 +18,7 @@ const ROOT = path.join(__dirname, '..');
 const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the repeated clean measurements', () => {
-    assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1364, totalLines: 1692 });
+    assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1428, totalLines: 1751 });
     assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 15648, totalLines: 24215 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 1);

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -9,12 +9,12 @@
       "scope": "Jellyfin.Plugin.JellyfinCanopy/src/core/**",
       "report": "coverage/coverage-summary.json",
       "measured": {
-        "coveredLines": 1364,
-        "totalLines": 1692
+        "coveredLines": 1428,
+        "totalLines": 1751
       },
       "tolerance": {
         "missingCoveredLines": 1,
-        "rationale": "Focused fake-timer coverage removes host-scheduling variance; repeated clean Node 22/V8 runs on 2026-07-15 were identical, and one line permits only negligible instrumentation variance."
+        "rationale": "A final clean reviewed Node 22/V8 run on 2026-07-15 measured 1428 covered lines across the 1751-line core scope after centralizing bounded discovery response ownership, explicit semantic negative caching, shared-result waiter cancellation, and rejection observation for an already-aborted waiter. One line permits only negligible instrumentation variance."
       }
     },
     "server": {


### PR DESCRIPTION
Closes #117

Centralizes discovery and Arr detail response ownership in the identity-aware core request manager. The shared cache is now bounded by both 200 entries and 16 MiB of serialized UTF-8 response bytes, uses explicit endpoint classifiers for short-lived semantic negative caching, and clears/aborts on live configuration generation changes.

Feature lifecycle cancellation now stops only that waiter while leaving shared transport ownership with the core manager. Permanent feature-local response maps are removed.

Validation:
- independent review: APPROVE
- focused discovery/core tests: 66/66 after final rejection-observer hardening
- full client suite: 866/866 including isolated performance guards
- final client coverage: 1428/1751 lines
- typecheck, syntax, bundle, scoped lint, coverage policy tests, and diff checks passed