### PR TITLE
Fix dedicated logger lifecycle and retention

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Configuration/AtomicFileWriteGuardTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Configuration/AtomicFileWriteGuardTests.cs
@@ -29,7 +29,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Configuration
         private static readonly HashSet<string> Allowed = new(StringComparer.Ordinal)
         {
             "AtomicFile.cs",                         // the sanctioned temp+rename helper itself
-            "JellyfinCanopyFileLoggerProvider.cs", // append-only log writer (AppendAllText), torn append loses only the tail
+            "JellyfinCanopyFileLoggerProvider.cs", // bounded append-only log stream; torn append loses only the tail
         };
 
         [Fact]

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/HiddenContentPayloadControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/HiddenContentPayloadControllerTests.cs
@@ -104,7 +104,7 @@ public sealed class HiddenContentPayloadControllerTests : IDisposable
     }
 
     [Fact]
-    public void AcceptedPayload_LogsMetadataOnlyToHostAndDedicatedSinks()
+    public async Task AcceptedPayload_LogsMetadataOnlyToHostAndDedicatedSinks()
     {
         const string secret = "api-key-SUPER-SECRET-sentinel";
         var hostProvider = new CapturingLoggerProvider();
@@ -129,6 +129,7 @@ public sealed class HiddenContentPayloadControllerTests : IDisposable
         };
 
         var result = Controller(logger).SaveUserHiddenContent(UserId, candidate);
+        Assert.True(await fileProvider.FlushAsync(TimeSpan.FromSeconds(5)));
 
         Assert.IsType<OkObjectResult>(result);
         Assert.Equal(secret, candidate.Items["safe-key"].Name);

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Logging/FileLoggerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Logging/FileLoggerTests.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using System.Text;
 using System.Text.RegularExpressions;
 using Jellyfin.Plugin.JellyfinCanopy.Logging;
 using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
@@ -8,13 +10,12 @@ using Xunit;
 namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Logging;
 
 /// <summary>
-/// Covers the dedicated JellyfinCanopy_*.log sink that replaced the custom
-/// Logger type. The file is a documented product feature (users are told to
-/// check it via Dashboard → Logs), so its name pattern, line format, level
-/// labels and CR/LF sanitization are contract.
+/// Covers the dedicated JellyfinCanopy_*.log sink. Its name pattern, line
+/// format, level labels, sanitization and bounded lifecycle are product contract.
 /// </summary>
 public sealed class FileLoggerTests : IDisposable
 {
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(5);
     private readonly string _tempDir;
     private readonly JellyfinCanopyFileLoggerProvider _provider;
 
@@ -27,10 +28,25 @@ public sealed class FileLoggerTests : IDisposable
 
     public void Dispose()
     {
+        _provider.Dispose();
         try { Directory.Delete(_tempDir, recursive: true); } catch { /* best effort */ }
     }
 
     private string ReadLogFile() => File.ReadAllText(_provider.CurrentLogFilePath);
+
+    private async Task FlushAsync(JellyfinCanopyFileLoggerProvider? provider = null)
+        => Assert.True(await (provider ?? _provider).FlushAsync(TestTimeout));
+
+    private static async Task WaitForAsync(Func<bool> condition, string failureMessage)
+    {
+        var deadline = DateTime.UtcNow + TestTimeout;
+        while (!condition() && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(10);
+        }
+
+        Assert.True(condition(), failureMessage);
+    }
 
     [Fact]
     public void CurrentLogFilePath_KeepsDailyNamePattern()
@@ -40,107 +56,158 @@ public sealed class FileLoggerTests : IDisposable
         Assert.Equal(_tempDir, Path.GetDirectoryName(_provider.CurrentLogFilePath));
     }
 
+    [Fact]
+    public async Task FileNameAndTimestamp_StayGregorianUnderNonGregorianCurrentCulture()
+    {
+        var previousCulture = CultureInfo.CurrentCulture;
+        var previousUiCulture = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fa-IR");
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("fa-IR");
+            var clock = new ManualTimeProvider(new DateTimeOffset(2026, 1, 2, 3, 4, 5, TimeSpan.Zero));
+            using var provider = new JellyfinCanopyFileLoggerProvider(
+                new StubAppPaths(_tempDir),
+                clock,
+                FileLogSinkOptions.Default);
+
+            provider.CreateLogger("culture").LogInformation("culture-safe");
+            await FlushAsync(provider);
+
+            Assert.Equal("JellyfinCanopy_2026-01-02.log", Path.GetFileName(provider.CurrentLogFilePath));
+            Assert.StartsWith("[2026-01-02 03:04:05] [INFO]", File.ReadAllText(provider.CurrentLogFilePath));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previousCulture;
+            CultureInfo.CurrentUICulture = previousUiCulture;
+        }
+    }
+
     [Theory]
     [InlineData(LogLevel.Information, "INFO")]
     [InlineData(LogLevel.Warning, "WARN")]
     [InlineData(LogLevel.Error, "ERROR")]
     [InlineData(LogLevel.Critical, "ERROR")]
-    public void Log_WritesOldFormatLineWithSameLevelLabels(LogLevel level, string expectedLabel)
+    public async Task Log_WritesOldFormatLineWithSameLevelLabels(LogLevel level, string expectedLabel)
     {
         _provider.CreateLogger("any").Log(level, default, "hello world", null, (s, _) => s);
+        await FlushAsync();
 
-        // Same shape the old custom Logger wrote: [yyyy-MM-dd HH:mm:ss] [LEVEL] message
         Assert.Matches(
             new Regex(@"^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] \[" + expectedLabel + @"\] hello world\r?\n"),
             ReadLogFile());
     }
 
     [Fact]
-    public void Log_SanitizesCrLf_ToPreventLogForging()
+    public async Task Log_SanitizesCrLf_ToPreventLogForging()
     {
         _provider.CreateLogger("any").Log(LogLevel.Information, default, "line1\r\nline2", null, (s, _) => s);
+        await FlushAsync();
 
         var content = ReadLogFile();
         Assert.Contains(@"line1\r\nline2", content);
-        Assert.Equal(1, content.Count(c => c == '\n')); // single physical line
+        Assert.Equal(1, content.Count(c => c == '\n'));
     }
 
     [Fact]
-    public void FileForwardingLogger_WritesInformationToFile_AndKeepsBraceMessageText()
+    public async Task FileForwardingLogger_WritesInformationToFile_AndKeepsBraceMessageText()
     {
-        // Consumers inject ILogger<T>; the composite writes Information+ to the file.
         var logger = new FileForwardingLogger<FileLoggerTests>(_provider, NullLoggerFactory.Instance);
 
-        // CA2017 flags {braces} as a placeholder without an argument — that is
-        // exactly what this test asserts: brace-bearing messages (e.g. logged
-        // JSON payloads) must pass through as literal text, not be treated as
-        // structured-logging templates.
 #pragma warning disable CA2017
         logger.LogInformation("info with {braces} and JSON {\"mediaId\":42}");
 #pragma warning restore CA2017
+        await FlushAsync();
 
-        var content = ReadLogFile();
-        Assert.Contains("[INFO] info with {braces} and JSON {\"mediaId\":42}", content);
+        Assert.Contains("[INFO] info with {braces} and JSON {\"mediaId\":42}", ReadLogFile());
     }
 
     [Fact]
-    public void FileForwardingLogger_DoesNotWriteDebugToFile()
+    public void FileForwardingLogger_DisabledDebug_DoesNotInvokeFormatterOrTouchFile()
     {
-        // The file sink is Information-floored: a Debug line through the composite must not touch
-        // the file (the host logger still receives it when the host enables Debug).
         var logger = new FileForwardingLogger<FileLoggerTests>(_provider, NullLoggerFactory.Instance);
+        var formatterCalls = 0;
 
-#pragma warning disable CA2017
-        logger.LogDebug("dbg {braces}");
-#pragma warning restore CA2017
+        logger.Log(
+            LogLevel.Debug,
+            default,
+            "debug state",
+            null,
+            (state, _) =>
+            {
+                formatterCalls++;
+                return state;
+            });
 
-        Assert.False(File.Exists(_provider.CurrentLogFilePath), "Debug via the forwarding logger must not touch the file sink");
+        Assert.False(logger.IsEnabled(LogLevel.Debug));
+        Assert.Equal(0, formatterCalls);
+        Assert.False(File.Exists(_provider.CurrentLogFilePath));
     }
 
-    // ---- Information floor (CSSVC-6): hot-path Debug/Trace no longer do a locked file append ----
+    [Fact]
+    public async Task FileForwardingLogger_StoppedFileSink_IsNotEnabledOrFormatted()
+    {
+        using var provider = new JellyfinCanopyFileLoggerProvider(new StubAppPaths(_tempDir));
+        var logger = new FileForwardingLogger<FileLoggerTests>(provider, NullLoggerFactory.Instance);
+        Assert.True(logger.IsEnabled(LogLevel.Information));
+        Assert.True(await provider.StopAsync(TestTimeout));
+        var formatterCalls = 0;
+
+        logger.Log(
+            LogLevel.Information,
+            default,
+            "stopped state",
+            null,
+            (state, _) =>
+            {
+                formatterCalls++;
+                return state;
+            });
+
+        Assert.False(logger.IsEnabled(LogLevel.Information));
+        Assert.Equal(0, formatterCalls);
+    }
 
     [Fact]
-    public void Debug_BelowFloor_DoesNotWriteFile()
+    public async Task Debug_BelowFloor_DoesNotWriteFile()
     {
         var logger = _provider.CreateLogger("any");
 
         logger.Log(LogLevel.Debug, default, "dbg", null, (s, _) => s);
         logger.Log(LogLevel.Trace, default, "trc", null, (s, _) => s);
-        Assert.False(File.Exists(_provider.CurrentLogFilePath), "Debug/Trace are below the file-sink floor and must not create or append the file");
+        Assert.False(File.Exists(_provider.CurrentLogFilePath));
 
         logger.Log(LogLevel.Information, default, "info", null, (s, _) => s);
-        Assert.True(File.Exists(_provider.CurrentLogFilePath));
+        await FlushAsync();
+
         var content = ReadLogFile();
         Assert.Contains("[INFO] info", content);
         Assert.DoesNotContain("dbg", content);
         Assert.DoesNotContain("trc", content);
     }
 
-    // ---- Rotation keyed on filename date, not birth/creation time (CSSVC-6) ----
-
     [Fact]
     public void RotateLogs_UsesFilenameDate_NotWriteTime()
     {
-        // A file whose NAME date is far in the past must be rotated out even though its last-write
-        // time is now — Linux birth-time is unreliable, so the filename date is the retention key.
         var oldByName = Path.Combine(_tempDir, "JellyfinCanopy_2000-01-01.log");
-        var recentByName = Path.Combine(_tempDir, $"JellyfinCanopy_{DateTime.Now:yyyy-MM-dd}.log");
-        File.WriteAllText(oldByName, "old");       // last-write time = now
+        var recentByName = Path.Combine(
+            _tempDir,
+            $"JellyfinCanopy_{DateTime.Now.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}.log");
+        File.WriteAllText(oldByName, "old");
         File.WriteAllText(recentByName, "recent");
 
-        // A fresh provider runs RotateLogs in its ctor.
         using var provider = new JellyfinCanopyFileLoggerProvider(new StubAppPaths(_tempDir));
 
-        Assert.False(File.Exists(oldByName), "a log dated far in the past must be rotated out by filename date");
-        Assert.True(File.Exists(recentByName), "today's log must be kept");
+        Assert.False(File.Exists(oldByName));
+        Assert.True(File.Exists(recentByName));
     }
 
     [Theory]
     [InlineData("JellyfinCanopy_2020-01-01.log", 2020, 1, 1)]
-    [InlineData("JellyfinCanopy_2026-12-31.log", 2026, 12, 31)]
+    [InlineData("JellyfinCanopy_2026-12-31.004.log", 2026, 12, 31)]
     public void ResolveLogFileDate_PrefersFilenameDate(string fileName, int year, int month, int day)
     {
-        // The recent fallback must be ignored when the filename carries a parseable date.
         var resolved = JellyfinCanopyFileLoggerProvider.ResolveLogFileDate(fileName, () => DateTime.Now);
         Assert.Equal(new DateTime(year, month, day), resolved);
     }
@@ -152,5 +219,705 @@ public sealed class FileLoggerTests : IDisposable
         Assert.Equal(
             fallback,
             JellyfinCanopyFileLoggerProvider.ResolveLogFileDate("JellyfinCanopy_not-a-date.log", () => fallback));
+    }
+
+    [Fact]
+    public async Task OneProviderAcrossTenDays_EnforcesRetentionAndByteBudgets()
+    {
+        var clock = new ManualTimeProvider(new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero));
+        var options = new FileLogSinkOptions
+        {
+            QueueCapacity = 128,
+            RetentionDays = 3,
+            MaxEntryBytes = 128,
+            MaxFileBytes = 256,
+            MaxTotalBytes = 600,
+            ShutdownTimeout = TestTimeout,
+        };
+        using var provider = new JellyfinCanopyFileLoggerProvider(
+            new StubAppPaths(_tempDir),
+            clock,
+            options);
+        var logger = provider.CreateLogger("long-uptime");
+
+        for (var day = 0; day < 10; day++)
+        {
+            for (var line = 0; line < 4; line++)
+            {
+                logger.LogInformation("day={Day} line={Line} {Payload}", day, line, new string('x', 64));
+            }
+
+            await FlushAsync(provider);
+            if (day < 9)
+            {
+                clock.Advance(TimeSpan.FromDays(1));
+            }
+        }
+
+        await FlushAsync(provider);
+        var files = Directory.GetFiles(_tempDir, "JellyfinCanopy_*.log")
+            .Select(path => new FileInfo(path))
+            .ToArray();
+        var cutoff = clock.GetLocalNow().Date.AddDays(-2);
+
+        Assert.NotEmpty(files);
+        Assert.All(
+            files,
+            file =>
+            {
+                Assert.True(file.Length <= options.MaxFileBytes, $"{file.Name} exceeded the per-file cap");
+                Assert.True(
+                    JellyfinCanopyFileLoggerProvider.ResolveLogFileDate(file.Name, () => file.LastWriteTime).Date >= cutoff,
+                    $"{file.Name} escaped the three-day retention window");
+            });
+        Assert.True(files.Sum(file => file.Length) <= options.MaxTotalBytes);
+        Assert.True(files
+            .Select(file => JellyfinCanopyFileLoggerProvider.ResolveLogFileDate(file.Name, () => file.LastWriteTime).Date)
+            .Distinct()
+            .Count() <= options.RetentionDays);
+        Assert.True(provider.Metrics.SizeRotationCount > 0);
+        Assert.Equal(10, provider.Metrics.MaintenanceRunCount);
+    }
+
+    [Fact]
+    public async Task RollingTotalCap_ReservesActiveFileHeadroomWithoutExplicitFlush()
+    {
+        var clock = new ManualTimeProvider(new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero));
+        var options = new FileLogSinkOptions
+        {
+            QueueCapacity = 64,
+            RetentionDays = 3,
+            MaxEntryBytes = 128,
+            MaxFileBytes = 256,
+            MaxTotalBytes = 600,
+            ShutdownTimeout = TestTimeout,
+        };
+        using var provider = new JellyfinCanopyFileLoggerProvider(
+            new StubAppPaths(_tempDir),
+            clock,
+            options);
+        var logger = provider.CreateLogger("rolling-cap");
+
+        const int lineCount = 12;
+        for (var line = 0; line < lineCount; line++)
+        {
+            logger.LogInformation("entry {Line} {Payload}", line, new string('x', 64));
+        }
+
+        await WaitForAsync(
+            () => provider.Metrics.Written == lineCount,
+            "the asynchronous sink did not process every rolling-cap line");
+        var files = Directory.GetFiles(_tempDir, "JellyfinCanopy_*.log")
+            .Select(path => new FileInfo(path))
+            .ToArray();
+        var activePath = Path.GetFullPath(provider.CurrentLogFilePath);
+        var archivedBytes = files
+            .Where(file => !string.Equals(Path.GetFullPath(file.FullName), activePath, StringComparison.Ordinal))
+            .Sum(file => file.Length);
+
+        Assert.True(provider.Metrics.SizeRotationCount > 0);
+        Assert.Equal(0, provider.Metrics.Dropped);
+        Assert.True(
+            archivedBytes + options.MaxFileBytes <= options.MaxTotalBytes,
+            "closed segments did not reserve enough room for the active file to reach its cap");
+        Assert.True(files.Sum(file => file.Length) <= options.MaxTotalBytes);
+    }
+
+    [Fact]
+    public async Task PreexistingOversizedBase_IsTrimmedAndRolledWithinPhysicalFileCap()
+    {
+        var clock = new ManualTimeProvider(new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero));
+        var basePath = Path.Combine(_tempDir, "JellyfinCanopy_2026-01-01.log");
+        var priorSegmentPath = Path.Combine(_tempDir, "JellyfinCanopy_2025-12-31.002.log");
+        File.WriteAllText(
+            basePath,
+            "oldest\n" + new string('é', 300) + "\nnewest-tail\n");
+        File.WriteAllText(
+            priorSegmentPath,
+            "prior-oldest\n" + new string('é', 300) + "\nprior-tail\n");
+        var options = new FileLogSinkOptions
+        {
+            QueueCapacity = 16,
+            MaxEntryBytes = 128,
+            MaxFileBytes = 256,
+            MaxTotalBytes = 2048,
+            ShutdownTimeout = TestTimeout,
+        };
+        using var provider = new JellyfinCanopyFileLoggerProvider(
+            new StubAppPaths(_tempDir),
+            clock,
+            options);
+
+        provider.CreateLogger("upgrade").LogInformation("new bounded line");
+        await FlushAsync(provider);
+        var files = Directory.GetFiles(_tempDir, "JellyfinCanopy_*.log")
+            .Select(path => new FileInfo(path))
+            .ToArray();
+        var strictUtf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
+        Assert.Equal(1, provider.Metrics.SizeRotationCount);
+        Assert.All(files, file => Assert.True(file.Length <= options.MaxFileBytes));
+        Assert.All(files, file => strictUtf8.GetString(File.ReadAllBytes(file.FullName)));
+        var combined = string.Concat(files.Select(file => File.ReadAllText(file.FullName)));
+        Assert.Contains("newest-tail", combined);
+        Assert.Contains("prior-tail", combined);
+    }
+
+    [Fact]
+    public async Task ConcurrentMidnightTransition_RotatesExactlyOnce()
+    {
+        var clock = new ManualTimeProvider(new DateTimeOffset(2026, 2, 1, 23, 59, 59, TimeSpan.Zero));
+        var options = new FileLogSinkOptions
+        {
+            QueueCapacity = 2048,
+            MaxEntryBytes = 1024,
+            MaxFileBytes = 1024 * 1024,
+            MaxTotalBytes = 3 * 1024 * 1024,
+            ShutdownTimeout = TestTimeout,
+        };
+        using var provider = new JellyfinCanopyFileLoggerProvider(new StubAppPaths(_tempDir), clock, options);
+        var logger = provider.CreateLogger("midnight");
+        logger.LogInformation("before midnight");
+        await FlushAsync(provider);
+
+        clock.Advance(TimeSpan.FromSeconds(2));
+        Parallel.For(0, 512, index => logger.LogInformation("after midnight {Index}", index));
+        await FlushAsync(provider);
+
+        Assert.Equal(1, provider.Metrics.DayRotationCount);
+        Assert.Equal(2, provider.Metrics.MaintenanceRunCount);
+        Assert.Equal(2, provider.Metrics.FileOpenCount);
+        Assert.Equal(0, provider.Metrics.Dropped);
+        Assert.True(File.Exists(provider.CurrentLogFilePath));
+    }
+
+    [Fact]
+    public async Task DayBoundaryTimer_UsesCalendarMidnightAcrossSpringDstTransition()
+    {
+        var timeZone = CreateDstTestTimeZone();
+        var clock = new ManualTimeProvider(
+            new DateTimeOffset(2026, 3, 8, 5, 0, 0, TimeSpan.Zero),
+            timeZone);
+        using var provider = new JellyfinCanopyFileLoggerProvider(
+            new StubAppPaths(_tempDir),
+            clock,
+            FileLogSinkOptions.Default);
+
+        clock.Advance(TimeSpan.FromHours(22) + TimeSpan.FromMinutes(59));
+        Assert.Equal(1, provider.Metrics.MaintenanceRunCount);
+        clock.Advance(TimeSpan.FromMinutes(1));
+        await WaitForAsync(
+            () => provider.Metrics.MaintenanceRunCount == 2,
+            "maintenance did not run at the 23-hour spring-DST day boundary");
+
+        Assert.Equal(new DateTime(2026, 3, 9), clock.GetLocalNow().Date);
+        Assert.Equal(1, provider.Metrics.DayRotationCount);
+    }
+
+    [Fact]
+    public async Task HighVolumeLogging_ReusesOneOpenStreamAndDoesNotDropWithinCapacity()
+    {
+        var options = new FileLogSinkOptions
+        {
+            QueueCapacity = 12_000,
+            MaxEntryBytes = 1024,
+            MaxFileBytes = 8 * 1024 * 1024,
+            MaxTotalBytes = 24 * 1024 * 1024,
+            ShutdownTimeout = TestTimeout,
+        };
+        using var provider = new JellyfinCanopyFileLoggerProvider(
+            new StubAppPaths(_tempDir),
+            TimeProvider.System,
+            options);
+        var logger = provider.CreateLogger("high-volume");
+
+        Parallel.For(0, 10_000, index => logger.LogInformation("request/scan line {Index}", index));
+        await FlushAsync(provider);
+
+        Assert.Equal(10_000, provider.Metrics.Written);
+        Assert.Equal(0, provider.Metrics.Dropped);
+        Assert.Equal(1, provider.Metrics.FileOpenCount);
+    }
+
+    [Fact]
+    public async Task PeriodicWorkerFlush_MakesLowVolumeLineVisibleWithoutProductionCaller()
+    {
+        var clock = new ManualTimeProvider(new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero));
+        var options = new FileLogSinkOptions
+        {
+            QueueCapacity = 16,
+            MaxEntryBytes = 1024,
+            MaxFileBytes = 1024 * 1024,
+            MaxTotalBytes = 3 * 1024 * 1024,
+            FlushInterval = TimeSpan.FromSeconds(1),
+            ShutdownTimeout = TestTimeout,
+        };
+        using var provider = new JellyfinCanopyFileLoggerProvider(
+            new StubAppPaths(_tempDir),
+            clock,
+            options);
+        provider.CreateLogger("low-volume").LogInformation("visible after periodic flush");
+        await WaitForAsync(
+            () => provider.Metrics.Written == 1,
+            "the low-volume line never reached the worker");
+
+        clock.Advance(options.FlushInterval);
+        await WaitForAsync(
+            () => provider.Metrics.PeriodicFlushCount == 1,
+            "the periodic worker flush did not complete");
+
+        Assert.Contains("visible after periodic flush", File.ReadAllText(provider.CurrentLogFilePath));
+    }
+
+    [Fact]
+    public async Task FullQueue_DropsNewestLineWithoutBlockingProducer()
+    {
+        var clock = new ManualTimeProvider(new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero));
+        var gate = new GatedWriteStreamFactory();
+        var options = new FileLogSinkOptions
+        {
+            QueueCapacity = 1,
+            MaxEntryBytes = 1024,
+            MaxFileBytes = 1024 * 1024,
+            MaxTotalBytes = 3 * 1024 * 1024,
+            ShutdownTimeout = TestTimeout,
+        };
+        using var provider = new JellyfinCanopyFileLoggerProvider(
+            new StubAppPaths(_tempDir),
+            clock,
+            options,
+            gate.Open);
+        var logger = provider.CreateLogger("drop-new");
+        logger.LogInformation("worker-held line");
+        await WaitForAsync(
+            () => provider.Metrics.Written == 1,
+            "the worker-held line never reached the stream buffer");
+        clock.Advance(options.FlushInterval);
+        await gate.WriteStarted.Task.WaitAsync(TestTimeout);
+
+        logger.LogInformation("queued line");
+        logger.LogInformation("dropped line");
+
+        Assert.Equal(2, provider.Metrics.Enqueued);
+        Assert.Equal(1, provider.Metrics.Dropped);
+        gate.Release.TrySetResult();
+        await WaitForAsync(
+            () => provider.Metrics.Written == 2,
+            "the accepted queue entries did not drain after the writer was released");
+        Assert.True(await provider.FlushAsync(TestTimeout));
+    }
+
+    [Fact]
+    public async Task SlowWriter_CoalescesPeriodicFlushWakeupsWithoutCrowdingOutLogs()
+    {
+        var clock = new ManualTimeProvider(new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero));
+        var gate = new GatedWriteStreamFactory();
+        var options = new FileLogSinkOptions
+        {
+            QueueCapacity = 4,
+            MaxEntryBytes = 1024,
+            MaxFileBytes = 1024 * 1024,
+            MaxTotalBytes = 3 * 1024 * 1024,
+            FlushInterval = TimeSpan.FromSeconds(1),
+            ShutdownTimeout = TestTimeout,
+        };
+        using var provider = new JellyfinCanopyFileLoggerProvider(
+            new StubAppPaths(_tempDir),
+            clock,
+            options,
+            gate.Open);
+        var logger = provider.CreateLogger("coalesced-flush");
+        logger.LogInformation("worker-held line");
+        await WaitForAsync(
+            () => provider.Metrics.Written == 1,
+            "the worker-held line never reached the stream buffer");
+        clock.Advance(options.FlushInterval);
+        await gate.WriteStarted.Task.WaitAsync(TestTimeout);
+
+        for (var interval = 0; interval < 4; interval++)
+        {
+            clock.Advance(options.FlushInterval);
+        }
+
+        logger.LogInformation("real line behind one coalesced wake-up");
+        Assert.Equal(0, provider.Metrics.Dropped);
+        gate.Release.TrySetResult();
+        await WaitForAsync(
+            () => provider.Metrics.Written == 2,
+            "periodic wake-ups crowded a real log line out of the bounded queue");
+        Assert.True(await provider.FlushAsync(TestTimeout));
+    }
+
+    [Fact]
+    public async Task FlushAndShutdown_AreBoundedAndReportDurabilityTruthfully()
+    {
+        var gate = new GatedWriteStreamFactory();
+        var options = new FileLogSinkOptions
+        {
+            QueueCapacity = 16,
+            MaxEntryBytes = 1024,
+            MaxFileBytes = 1024 * 1024,
+            MaxTotalBytes = 3 * 1024 * 1024,
+            ShutdownTimeout = TestTimeout,
+        };
+        using var provider = new JellyfinCanopyFileLoggerProvider(
+            new StubAppPaths(_tempDir),
+            TimeProvider.System,
+            options,
+            gate.Open);
+        var logger = provider.CreateLogger("flush");
+        logger.LogInformation("held write");
+
+        var timedFlush = provider.FlushAsync(TimeSpan.FromMilliseconds(100));
+        await gate.WriteStarted.Task.WaitAsync(TestTimeout);
+        Assert.False(await timedFlush);
+
+        gate.Release.TrySetResult();
+        Assert.True(await provider.FlushAsync(TestTimeout));
+        Assert.True(await provider.StopAsync(TestTimeout));
+        Assert.True(provider.ShutdownFlushed);
+    }
+
+    [Fact]
+    public async Task ShutdownTimeout_ReturnsFalseWithoutBlockingCaller()
+    {
+        var gate = new GatedWriteStreamFactory();
+        var options = new FileLogSinkOptions
+        {
+            QueueCapacity = 16,
+            MaxEntryBytes = 1024,
+            MaxFileBytes = 1024 * 1024,
+            MaxTotalBytes = 3 * 1024 * 1024,
+            ShutdownTimeout = TimeSpan.FromMilliseconds(100),
+        };
+        using var provider = new JellyfinCanopyFileLoggerProvider(
+            new StubAppPaths(_tempDir),
+            TimeProvider.System,
+            options,
+            gate.Open);
+        provider.CreateLogger("shutdown-timeout").LogInformation("held write");
+
+        var stop = provider.StopAsync(options.ShutdownTimeout);
+        await gate.WriteStarted.Task.WaitAsync(TestTimeout);
+
+        Assert.False(await stop);
+        Assert.False(provider.ShutdownFlushed);
+        await gate.StreamDisposed.Task.WaitAsync(TestTimeout);
+        gate.Release.TrySetResult();
+    }
+
+    [Fact]
+    public async Task FileFailure_MakesFlushAndShutdownReportFalse()
+    {
+        var options = new FileLogSinkOptions
+        {
+            QueueCapacity = 16,
+            MaxEntryBytes = 1024,
+            MaxFileBytes = 1024 * 1024,
+            MaxTotalBytes = 3 * 1024 * 1024,
+            ShutdownTimeout = TestTimeout,
+        };
+        using var provider = new JellyfinCanopyFileLoggerProvider(
+            new StubAppPaths(_tempDir),
+            TimeProvider.System,
+            options,
+            _ => throw new IOException("read-only log directory"));
+        provider.CreateLogger("failed-sink").LogInformation("cannot persist");
+
+        Assert.False(await provider.FlushAsync(TestTimeout));
+        Assert.Equal(1, provider.Metrics.DurabilityFailures);
+        Assert.False(await provider.StopAsync(TestTimeout));
+        Assert.False(provider.ShutdownFlushed);
+    }
+
+    [Fact]
+    public async Task FatalFlushCleanup_CompletesDequeuedInfiniteMarkerAsFalse()
+    {
+        var options = new FileLogSinkOptions
+        {
+            QueueCapacity = 16,
+            MaxEntryBytes = 1024,
+            MaxFileBytes = 1024 * 1024,
+            MaxTotalBytes = 3 * 1024 * 1024,
+            ShutdownTimeout = TestTimeout,
+        };
+        using var provider = new JellyfinCanopyFileLoggerProvider(
+            new StubAppPaths(_tempDir),
+            TimeProvider.System,
+            options,
+            _ => new FailingFlushAndDisposeStream());
+        provider.CreateLogger("fatal-flush").LogInformation("buffered before fatal flush");
+
+        var flushed = await provider.FlushAsync(Timeout.InfiniteTimeSpan).WaitAsync(TestTimeout);
+
+        Assert.False(flushed);
+        Assert.True(provider.Metrics.DurabilityFailures > 0);
+    }
+
+    private sealed class ManualTimeProvider : TimeProvider
+    {
+        private readonly object _sync = new();
+        private readonly List<ManualTimer> _timers = new();
+        private readonly TimeZoneInfo _localTimeZone;
+        private DateTimeOffset _now;
+
+        public ManualTimeProvider(DateTimeOffset now, TimeZoneInfo? localTimeZone = null)
+        {
+            _now = now.ToUniversalTime();
+            _localTimeZone = localTimeZone ?? TimeZoneInfo.Utc;
+        }
+
+        public override TimeZoneInfo LocalTimeZone => _localTimeZone;
+
+        public override DateTimeOffset GetUtcNow()
+        {
+            lock (_sync)
+            {
+                return _now;
+            }
+        }
+
+        public override ITimer CreateTimer(
+            TimerCallback callback,
+            object? state,
+            TimeSpan dueTime,
+            TimeSpan period)
+        {
+            var timer = new ManualTimer(this, callback, state, dueTime, period);
+            lock (_sync)
+            {
+                _timers.Add(timer);
+            }
+
+            return timer;
+        }
+
+        public void Advance(TimeSpan amount)
+        {
+            List<ManualTimer> due;
+            DateTimeOffset now;
+            lock (_sync)
+            {
+                _now = _now.Add(amount);
+                now = _now;
+                due = _timers.Where(timer => timer.IsDue(now)).ToList();
+            }
+
+            foreach (var timer in due)
+            {
+                timer.Fire(now);
+            }
+        }
+
+        private sealed class ManualTimer : ITimer
+        {
+            private readonly object _sync = new();
+            private readonly ManualTimeProvider _owner;
+            private readonly TimerCallback _callback;
+            private readonly object? _state;
+            private TimeSpan _period;
+            private DateTimeOffset _dueAt;
+            private bool _armed;
+            private bool _disposed;
+
+            public ManualTimer(
+                ManualTimeProvider owner,
+                TimerCallback callback,
+                object? state,
+                TimeSpan dueTime,
+                TimeSpan period)
+            {
+                _owner = owner;
+                _callback = callback;
+                _state = state;
+                _period = period;
+                Change(dueTime, period);
+            }
+
+            public bool Change(TimeSpan dueTime, TimeSpan period)
+            {
+                var now = _owner.GetUtcNow();
+                lock (_sync)
+                {
+                    if (_disposed)
+                    {
+                        return false;
+                    }
+
+                    _period = period;
+                    _armed = dueTime != Timeout.InfiniteTimeSpan;
+                    _dueAt = _armed ? now.Add(dueTime) : DateTimeOffset.MaxValue;
+                    return true;
+                }
+            }
+
+            public bool IsDue(DateTimeOffset now)
+            {
+                lock (_sync)
+                {
+                    return !_disposed && _armed && _dueAt <= now;
+                }
+            }
+
+            public void Fire(DateTimeOffset now)
+            {
+                lock (_sync)
+                {
+                    if (_disposed || !_armed || _dueAt > now)
+                    {
+                        return;
+                    }
+
+                    _armed = false;
+                }
+
+                _callback(_state);
+            }
+
+            public void Dispose()
+            {
+                lock (_sync)
+                {
+                    _disposed = true;
+                    _armed = false;
+                }
+            }
+
+            public ValueTask DisposeAsync()
+            {
+                Dispose();
+                return ValueTask.CompletedTask;
+            }
+        }
+    }
+
+    private static TimeZoneInfo CreateDstTestTimeZone()
+    {
+        var daylightStart = TimeZoneInfo.TransitionTime.CreateFixedDateRule(
+            new DateTime(1, 1, 1, 2, 0, 0),
+            3,
+            8);
+        var daylightEnd = TimeZoneInfo.TransitionTime.CreateFixedDateRule(
+            new DateTime(1, 1, 1, 2, 0, 0),
+            11,
+            1);
+        var adjustment = TimeZoneInfo.AdjustmentRule.CreateAdjustmentRule(
+            new DateTime(2026, 1, 1),
+            new DateTime(2026, 12, 31),
+            TimeSpan.FromHours(1),
+            daylightStart,
+            daylightEnd);
+        return TimeZoneInfo.CreateCustomTimeZone(
+            "Canopy-DST-Test",
+            TimeSpan.FromHours(-5),
+            "Canopy DST test zone",
+            "Canopy standard",
+            "Canopy daylight",
+            [adjustment]);
+    }
+
+    private sealed class GatedWriteStreamFactory
+    {
+        public TaskCompletionSource WriteStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Release { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource StreamDisposed { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Stream Open(string path)
+            => new GatedWriteStream(
+                new FileStream(
+                    path,
+                    FileMode.Append,
+                    FileAccess.Write,
+                    FileShare.ReadWrite | FileShare.Delete,
+                    4096,
+                    FileOptions.Asynchronous),
+                WriteStarted,
+                Release,
+                StreamDisposed);
+    }
+
+    private sealed class FailingFlushAndDisposeStream : MemoryStream
+    {
+        public override void Flush() => throw new IOException("flush failed");
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+            => Task.FromException(new IOException("flush failed"));
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            throw new IOException("dispose failed");
+        }
+    }
+
+    private sealed class GatedWriteStream : Stream
+    {
+        private readonly Stream _inner;
+        private readonly TaskCompletionSource _started;
+        private readonly TaskCompletionSource _release;
+        private readonly TaskCompletionSource _disposed;
+
+        public GatedWriteStream(
+            Stream inner,
+            TaskCompletionSource started,
+            TaskCompletionSource release,
+            TaskCompletionSource disposed)
+        {
+            _inner = inner;
+            _started = started;
+            _release = release;
+            _disposed = disposed;
+        }
+
+        public override bool CanRead => false;
+
+        public override bool CanSeek => _inner.CanSeek;
+
+        public override bool CanWrite => true;
+
+        public override long Length => _inner.Length;
+
+        public override long Position
+        {
+            get => _inner.Position;
+            set => _inner.Position = value;
+        }
+
+        public override void Flush() => _inner.Flush();
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+            => _inner.FlushAsync(cancellationToken);
+
+        public override int Read(byte[] buffer, int offset, int count)
+            => throw new NotSupportedException();
+
+        public override long Seek(long offset, SeekOrigin origin) => _inner.Seek(offset, origin);
+
+        public override void SetLength(long value) => _inner.SetLength(value);
+
+        public override void Write(byte[] buffer, int offset, int count)
+            => _inner.Write(buffer, offset, count);
+
+        public override async ValueTask WriteAsync(
+            ReadOnlyMemory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            _started.TrySetResult();
+            await _release.Task.WaitAsync(cancellationToken);
+            await _inner.WriteAsync(buffer, cancellationToken);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _inner.Dispose();
+                _disposed.TrySetResult();
+            }
+
+            base.Dispose(disposing);
+        }
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/Logging/FileForwardingLogger.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Logging/FileForwardingLogger.cs
@@ -34,24 +34,32 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Logging
             where TState : notnull
             => _hostLogger.BeginScope(state);
 
-        // Enabled for any real level: the host sink accepts all levels; the file sink additionally
-        // level-floors itself in FileLogger.IsEnabled, so below-floor lines are dropped there.
-        public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+        // Composite enablement is the union of the actual sinks. In particular,
+        // Debug/Trace formatters are never invoked when the host rejects them and
+        // they are below the dedicated file floor.
+        public bool IsEnabled(LogLevel logLevel)
+            => logLevel != LogLevel.None
+                && (_fileLogger.IsEnabled(logLevel) || _hostLogger.IsEnabled(logLevel));
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
         {
-            if (logLevel == LogLevel.None)
+            var fileEnabled = _fileLogger.IsEnabled(logLevel);
+            var hostEnabled = _hostLogger.IsEnabled(logLevel);
+            if (logLevel == LogLevel.None || (!fileEnabled && !hostEnabled))
             {
                 return;
             }
 
             var sanitizedMessage = JellyfinCanopyFileLoggerProvider.SanitizeForLog(formatter(state, exception));
 
-            _fileLogger.Log(logLevel, eventId, sanitizedMessage, exception, static (s, _) => s);
+            if (fileEnabled)
+            {
+                _fileLogger.Log(logLevel, eventId, sanitizedMessage, exception, static (s, _) => s);
+            }
 
             // Also forward to Jellyfin's main logger for visibility (same
             // pass-as-argument shape the old Logger used).
-            if (_hostLogger.IsEnabled(logLevel))
+            if (hostEnabled)
             {
                 _hostLogger.Log(logLevel, eventId, exception, "{Message}", sanitizedMessage);
             }

--- a/Jellyfin.Plugin.JellyfinCanopy/Logging/JellyfinCanopyFileLoggerProvider.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Logging/JellyfinCanopyFileLoggerProvider.cs
@@ -3,75 +3,243 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
 using MediaBrowser.Common.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.JellyfinCanopy.Logging
 {
     /// <summary>
-    /// Standard <see cref="ILoggerProvider"/> over the plugin's dedicated
-    /// <c>JellyfinCanopy_yyyy-MM-dd.log</c> file. The file is a documented
-    /// product feature (docs/faq-support/faq.md tells users to check it via
-    /// Dashboard → Logs), so its location, line format, CR/LF sanitization,
-    /// daily naming and 3-day retention are preserved verbatim from the former
-    /// custom Logger type.
-    ///
-    /// NOTE: this provider is intentionally self-wired (see the closed-generic
-    /// ILogger&lt;T&gt; registrations in <see cref="PluginServiceRegistrator"/>)
-    /// rather than registered as an ILoggerProvider service: Jellyfin boots its
-    /// host with UseSerilog() and no LoggerProviderCollection, so DI-registered
-    /// ILoggerProviders are never invoked — and if a future host did honor
-    /// them, a globally registered provider would receive every core Jellyfin
-    /// category, not just the plugin's.
+    /// Owns the plugin's dedicated <c>JellyfinCanopy_yyyy-MM-dd.log</c> sink.
+    /// Producers only format and attempt a non-blocking enqueue into a bounded
+    /// queue. One worker owns the open stream, daily/file-size rotation and
+    /// retention. When the queue is full the newest line is dropped and counted;
+    /// request and scan threads are never blocked on file I/O. Flush returns
+    /// <see langword="true"/> only after every line queued before its marker is
+    /// durable, and shutdown waits for that drain for a fixed, bounded interval.
     /// </summary>
     public sealed class JellyfinCanopyFileLoggerProvider : ILoggerProvider
     {
-        private readonly IApplicationPaths _appPaths;
-        private readonly object _writeLock = new object();
-        private const int LogRetentionDays = 3; // How many days of logs to keep
         private const string LogFilePrefix = "JellyfinCanopy_";
+        private static readonly UTF8Encoding Utf8NoBom = new(encoderShouldEmitUTF8Identifier: false);
 
-        // The file sink is Information-floored: hot-path Debug/Trace lines no longer do a synchronous
-        // File.AppendAllText under the global write lock. The host (Serilog) logger still receives all
-        // levels via FileForwardingLogger, so Debug is available in the main log when the host enables it.
+        // The file sink is Information-floored. Debug/Trace may still flow to
+        // the host logger when its category enables those levels.
         internal const LogLevel MinFileLogLevel = LogLevel.Information;
 
+        private readonly string _logDirectory;
+        private readonly TimeProvider _timeProvider;
+        private readonly FileLogSinkOptions _options;
+        private readonly Func<string, Stream> _openAppendStream;
+        private readonly Channel<SinkCommand> _commands;
+        private readonly CancellationTokenSource _workerCancellation = new();
+        private readonly object _stopLock = new();
+        private readonly Task _workerTask;
+        private readonly ITimer _maintenanceTimer;
+        private readonly ITimer _flushTimer;
+        private Stream? _stream;
+        private StreamWriter? _writer;
+        private DateOnly? _writerDate;
+        private string? _writerPath;
+        private long _writerBytes;
+        private DateOnly? _lastMaintenanceDate;
+        private Task<bool>? _stopTask;
+        private int _accepting = 1;
+        private int _maintenanceRequested;
+        private int _flushRequested;
+        private int _shutdownFlushed = -1;
+        private long _enqueued;
+        private long _dropped;
+        private long _written;
+        private long _failures;
+        private long _durabilityFailures;
+        private long _fileOpenCount;
+        private long _dayRotationCount;
+        private long _sizeRotationCount;
+        private long _maintenanceRunCount;
+        private long _periodicFlushCount;
+
         public JellyfinCanopyFileLoggerProvider(IApplicationPaths appPaths)
+            : this(appPaths, TimeProvider.System, FileLogSinkOptions.Default, OpenAppendStream)
         {
-            _appPaths = appPaths;
-            RotateLogs(); // Clean up old logs on startup
         }
 
-        public string CurrentLogFilePath => Path.Combine(_appPaths.LogDirectoryPath, $"{LogFilePrefix}{DateTime.Now:yyyy-MM-dd}.log");
+        internal JellyfinCanopyFileLoggerProvider(
+            IApplicationPaths appPaths,
+            TimeProvider timeProvider,
+            FileLogSinkOptions options,
+            Func<string, Stream>? openAppendStream = null)
+        {
+            ArgumentNullException.ThrowIfNull(appPaths);
+            ArgumentNullException.ThrowIfNull(timeProvider);
+            ArgumentNullException.ThrowIfNull(options);
+            options.Validate();
+
+            _logDirectory = appPaths.LogDirectoryPath;
+            _timeProvider = timeProvider;
+            _options = options;
+            _openAppendStream = openAppendStream ?? OpenAppendStream;
+            Directory.CreateDirectory(_logDirectory);
+
+            _commands = Channel.CreateBounded<SinkCommand>(new BoundedChannelOptions(options.QueueCapacity)
+            {
+                SingleReader = true,
+                SingleWriter = false,
+                FullMode = BoundedChannelFullMode.Wait,
+                AllowSynchronousContinuations = false,
+            });
+
+            // Startup is the first maintenance boundary. Subsequent boundaries
+            // are clock-owned by the timer and are also checked on every entry,
+            // so a delayed/full timer signal cannot defer retention indefinitely.
+            var today = DateOnly.FromDateTime(_timeProvider.GetLocalNow().Date);
+            RunRetention(today, activePath: null);
+            _lastMaintenanceDate = today;
+            Interlocked.Increment(ref _maintenanceRunCount);
+
+            _workerTask = RunAsync();
+            _maintenanceTimer = _timeProvider.CreateTimer(
+                static state => ((JellyfinCanopyFileLoggerProvider)state!).RequestMaintenance(),
+                this,
+                DelayUntilNextLocalDay(),
+                Timeout.InfiniteTimeSpan);
+            _flushTimer = _timeProvider.CreateTimer(
+                static state => ((JellyfinCanopyFileLoggerProvider)state!).RequestPeriodicFlush(),
+                this,
+                _options.FlushInterval,
+                Timeout.InfiniteTimeSpan);
+        }
+
+        public string CurrentLogFilePath
+            => LogPath(DateOnly.FromDateTime(_timeProvider.GetLocalNow().Date));
+
+        internal FileLogSinkMetrics Metrics => new(
+            QueueCapacity: _options.QueueCapacity,
+            Enqueued: Interlocked.Read(ref _enqueued),
+            Dropped: Interlocked.Read(ref _dropped),
+            Written: Interlocked.Read(ref _written),
+            Failures: Interlocked.Read(ref _failures),
+            DurabilityFailures: Interlocked.Read(ref _durabilityFailures),
+            FileOpenCount: Interlocked.Read(ref _fileOpenCount),
+            DayRotationCount: Interlocked.Read(ref _dayRotationCount),
+            SizeRotationCount: Interlocked.Read(ref _sizeRotationCount),
+            MaintenanceRunCount: Interlocked.Read(ref _maintenanceRunCount),
+            PeriodicFlushCount: Interlocked.Read(ref _periodicFlushCount));
+
+        internal bool? ShutdownFlushed => Volatile.Read(ref _shutdownFlushed) switch
+        {
+            0 => false,
+            1 => true,
+            _ => null,
+        };
+
+        internal bool IsAccepting => Volatile.Read(ref _accepting) != 0;
 
         public ILogger CreateLogger(string categoryName) => new FileLogger(this);
 
         public void Dispose()
         {
+            var flushed = StopAsync(_options.ShutdownTimeout).GetAwaiter().GetResult();
+            if (!flushed)
+            {
+                Console.WriteLine(
+                    "Jellyfin Canopy log shutdown was not durable within "
+                    + $"{_options.ShutdownTimeout.TotalSeconds.ToString(CultureInfo.InvariantCulture)} seconds; "
+                    + "the sink stopped accepting lines and may have lost queued output.");
+            }
+
+            var dropped = Interlocked.Read(ref _dropped);
+            if (dropped > 0)
+            {
+                Console.WriteLine(
+                    $"Jellyfin Canopy log queue dropped {dropped.ToString(CultureInfo.InvariantCulture)} line(s) "
+                    + "because the bounded sink was full or stopping.");
+            }
+
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Flushes every line accepted before this call. A false result means the
+        /// marker could not be queued or did not become durable before timeout.
+        /// </summary>
+        internal async Task<bool> FlushAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
+        {
+            if (timeout < TimeSpan.Zero && timeout != Timeout.InfiniteTimeSpan)
+            {
+                throw new ArgumentOutOfRangeException(nameof(timeout));
+            }
+
+            if (Volatile.Read(ref _accepting) == 0)
+            {
+                return false;
+            }
+
+            var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            if (!_commands.Writer.TryWrite(SinkCommand.Flush(completion)))
+            {
+                return false;
+            }
+
+            try
+            {
+                return timeout == Timeout.InfiniteTimeSpan
+                    ? await completion.Task.WaitAsync(cancellationToken).ConfigureAwait(false)
+                    : await completion.Task.WaitAsync(timeout, cancellationToken).ConfigureAwait(false);
+            }
+            catch (TimeoutException)
+            {
+                return false;
+            }
+        }
+
+        internal Task<bool> StopAsync(TimeSpan timeout)
+        {
+            if (timeout < TimeSpan.Zero && timeout != Timeout.InfiniteTimeSpan)
+            {
+                throw new ArgumentOutOfRangeException(nameof(timeout));
+            }
+
+            lock (_stopLock)
+            {
+                if (_stopTask != null)
+                {
+                    return _stopTask;
+                }
+
+                Volatile.Write(ref _accepting, 0);
+                _maintenanceTimer.Dispose();
+                _flushTimer.Dispose();
+                _commands.Writer.TryComplete();
+                _stopTask = WaitForWorkerAsync(timeout);
+                return _stopTask;
+            }
         }
 
         internal void Write(LogLevel logLevel, string sanitizedMessage)
         {
-            try
+            if (Volatile.Read(ref _accepting) == 0)
             {
-                var logFileName = $"{LogFilePrefix}{DateTime.Now:yyyy-MM-dd}.log";
-                var logFilePath = Path.Combine(_appPaths.LogDirectoryPath, logFileName);
-                var logMessage = $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] [{LevelLabel(logLevel)}] {sanitizedMessage}{Environment.NewLine}";
-
-                // Write to dedicated plugin log file
-                lock (_writeLock)
-                {
-                    File.AppendAllText(logFilePath, logMessage);
-                }
+                Interlocked.Increment(ref _dropped);
+                return;
             }
-            catch (Exception ex)
+
+            var timestamp = _timeProvider.GetLocalNow();
+            var line = FormatLine(timestamp, logLevel, sanitizedMessage);
+            if (_commands.Writer.TryWrite(SinkCommand.Log(timestamp, line)))
             {
-                // Fallback to console if file logging fails
-                Console.WriteLine($"Failed to write to JellyfinCanopy log file: {ex.Message}");
+                Interlocked.Increment(ref _enqueued);
+            }
+            else
+            {
+                Interlocked.Increment(ref _dropped);
             }
         }
 
-        // Same level labels the custom Logger wrote (people grep these).
+        // Same level labels the former custom Logger wrote (people grep these).
         private static string LevelLabel(LogLevel level) => level switch
         {
             LogLevel.Trace => "DEBUG",
@@ -82,41 +250,683 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Logging
             _ => "INFO",
         };
 
-        private void RotateLogs()
+        private static Stream OpenAppendStream(string path)
+            => new FileStream(
+                path,
+                FileMode.Append,
+                FileAccess.Write,
+                FileShare.ReadWrite | FileShare.Delete,
+                bufferSize: 16 * 1024,
+                FileOptions.Asynchronous | FileOptions.SequentialScan);
+
+        private async Task<bool> WaitForWorkerAsync(TimeSpan timeout)
         {
             try
             {
-                var logDirectory = _appPaths.LogDirectoryPath;
-                var cutoffDate = DateTime.Now.AddDays(-LogRetentionDays).Date;
-
-                var oldLogFiles = Directory.GetFiles(logDirectory, $"{LogFilePrefix}*.log")
-                    .Where(f => ResolveLogFileDate(Path.GetFileName(f), () => new FileInfo(f).LastWriteTime).Date < cutoffDate);
-
-                foreach (var file in oldLogFiles)
+                if (timeout == Timeout.InfiniteTimeSpan)
                 {
-                    File.Delete(file);
-                    Console.WriteLine($"Deleted old log file: {Path.GetFileName(file)}");
+                    await _workerTask.ConfigureAwait(false);
+                }
+                else
+                {
+                    await _workerTask.WaitAsync(timeout).ConfigureAwait(false);
+                }
+
+                var durable = Interlocked.Read(ref _durabilityFailures) == 0;
+                Volatile.Write(ref _shutdownFlushed, durable ? 1 : 0);
+                return durable;
+            }
+            catch (TimeoutException)
+            {
+                Volatile.Write(ref _shutdownFlushed, 0);
+                _workerCancellation.Cancel();
+                return false;
+            }
+            catch (Exception ex)
+            {
+                Volatile.Write(ref _shutdownFlushed, 0);
+                Console.WriteLine($"Jellyfin Canopy log worker failed during shutdown: {ex.Message}");
+                return false;
+            }
+        }
+
+        private async Task RunAsync()
+        {
+            SinkCommand? currentCommand = null;
+            try
+            {
+                await foreach (var command in _commands.Reader.ReadAllAsync(_workerCancellation.Token).ConfigureAwait(false))
+                {
+                    currentCommand = command;
+                    if (Interlocked.Exchange(ref _maintenanceRequested, 0) != 0)
+                    {
+                        try
+                        {
+                            await MaintainForDateAsync(
+                                DateOnly.FromDateTime(_timeProvider.GetLocalNow().Date),
+                                _workerCancellation.Token).ConfigureAwait(false);
+                        }
+                        catch (OperationCanceledException) when (_workerCancellation.IsCancellationRequested)
+                        {
+                            throw;
+                        }
+                        catch (Exception ex)
+                        {
+                            RecordDurabilityFailure("maintenance", ex);
+                            await CloseWriterAfterFailureAsync().ConfigureAwait(false);
+                        }
+                    }
+
+                    switch (command.Kind)
+                    {
+                        case SinkCommandKind.Log:
+                            await ProcessLogAsync(command, _workerCancellation.Token).ConfigureAwait(false);
+                            break;
+                        case SinkCommandKind.Flush:
+                            await ProcessFlushAsync(command).ConfigureAwait(false);
+                            break;
+                        case SinkCommandKind.Maintenance:
+                            try
+                            {
+                                await MaintainForDateAsync(
+                                    DateOnly.FromDateTime(command.Timestamp.Date),
+                                    _workerCancellation.Token).ConfigureAwait(false);
+                            }
+                            catch (OperationCanceledException) when (_workerCancellation.IsCancellationRequested)
+                            {
+                                throw;
+                            }
+                            catch (Exception ex)
+                            {
+                                RecordDurabilityFailure("maintenance", ex);
+                                await CloseWriterAfterFailureAsync().ConfigureAwait(false);
+                            }
+
+                            break;
+                        case SinkCommandKind.PeriodicFlush:
+                            // The command is a wake-up signal. The coalesced flag
+                            // above owns the actual flush, including when an older
+                            // wake-up was dropped because the queue was full.
+                            break;
+                    }
+
+                    currentCommand = null;
+
+                    if (Interlocked.Exchange(ref _flushRequested, 0) != 0)
+                    {
+                        await ProcessPeriodicFlushAsync().ConfigureAwait(false);
+                    }
+                }
+
+                await FlushAndCloseWriterAsync(_workerCancellation.Token).ConfigureAwait(false);
+                RunRetention(
+                    DateOnly.FromDateTime(_timeProvider.GetLocalNow().Date),
+                    activePath: null);
+            }
+            catch (OperationCanceledException) when (_workerCancellation.IsCancellationRequested)
+            {
+                // Bounded shutdown timed out. The caller has already been told
+                // that durability is false; abandon remaining queue work.
+            }
+            catch (Exception ex)
+            {
+                RecordDurabilityFailure("worker", ex);
+            }
+            finally
+            {
+                if (currentCommand is { } interrupted)
+                {
+                    AbandonCommand(interrupted);
+                }
+
+                try
+                {
+                    await CloseWriterAfterFailureAsync().ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Jellyfin Canopy log stream close failed: {ex.Message}");
+                }
+
+                while (_commands.Reader.TryRead(out var abandoned))
+                {
+                    AbandonCommand(abandoned);
+                }
+            }
+        }
+
+        private void AbandonCommand(SinkCommand command)
+        {
+            if (command.Kind == SinkCommandKind.Log)
+            {
+                Interlocked.Increment(ref _dropped);
+            }
+            else if (command.Kind == SinkCommandKind.Flush)
+            {
+                command.Completion?.TrySetResult(false);
+            }
+        }
+
+        private async Task ProcessLogAsync(SinkCommand command, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var entryDate = DateOnly.FromDateTime(command.Timestamp.Date);
+                await MaintainForDateAsync(entryDate, cancellationToken).ConfigureAwait(false);
+                var targetDate = _lastMaintenanceDate.HasValue && entryDate < _lastMaintenanceDate.Value
+                    ? _lastMaintenanceDate.Value
+                    : entryDate;
+                var lineBytes = Utf8NoBom.GetByteCount(command.Line!);
+                await EnsureWriterAsync(targetDate, lineBytes, cancellationToken).ConfigureAwait(false);
+                await _writer!.WriteAsync(command.Line.AsMemory(), cancellationToken).ConfigureAwait(false);
+                _writerBytes += lineBytes;
+                Interlocked.Increment(ref _written);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                RecordDurabilityFailure("write", ex);
+                await CloseWriterAfterFailureAsync().ConfigureAwait(false);
+            }
+        }
+
+        private async Task ProcessFlushAsync(SinkCommand command)
+        {
+            var durable = Interlocked.Read(ref _durabilityFailures) == 0;
+            try
+            {
+                if (_writer != null)
+                {
+                    await _writer.FlushAsync(_workerCancellation.Token).ConfigureAwait(false);
+                }
+
+                RunRetention(
+                    DateOnly.FromDateTime(_timeProvider.GetLocalNow().Date),
+                    _writerPath,
+                    _writer == null ? 0 : Math.Max(0, _options.MaxFileBytes - _writerBytes));
+            }
+            catch (OperationCanceledException) when (_workerCancellation.IsCancellationRequested)
+            {
+                durable = false;
+            }
+            catch (Exception ex)
+            {
+                durable = false;
+                RecordDurabilityFailure("flush", ex);
+                await CloseWriterAfterFailureAsync().ConfigureAwait(false);
+            }
+
+            command.Completion!.TrySetResult(durable);
+        }
+
+        private async Task ProcessPeriodicFlushAsync()
+        {
+            if (_writer == null)
+            {
+                return;
+            }
+
+            try
+            {
+                await _writer.FlushAsync(_workerCancellation.Token).ConfigureAwait(false);
+                Interlocked.Increment(ref _periodicFlushCount);
+            }
+            catch (OperationCanceledException) when (_workerCancellation.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                RecordDurabilityFailure("periodic flush", ex);
+                await CloseWriterAfterFailureAsync().ConfigureAwait(false);
+            }
+        }
+
+        private async Task MaintainForDateAsync(DateOnly date, CancellationToken cancellationToken)
+        {
+            if (_lastMaintenanceDate.HasValue && date <= _lastMaintenanceDate.Value)
+            {
+                return;
+            }
+
+            if (_writerDate.HasValue && _writerDate.Value < date)
+            {
+                await FlushAndCloseWriterAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            RunRetention(date, _writerPath);
+            if (_lastMaintenanceDate.HasValue)
+            {
+                Interlocked.Increment(ref _dayRotationCount);
+            }
+
+            _lastMaintenanceDate = date;
+            Interlocked.Increment(ref _maintenanceRunCount);
+        }
+
+        private async Task EnsureWriterAsync(DateOnly date, int nextLineBytes, CancellationToken cancellationToken)
+        {
+            if (_writer == null || _writerDate != date)
+            {
+                await FlushAndCloseWriterAsync(cancellationToken).ConfigureAwait(false);
+                OpenWriter(date);
+            }
+
+            if (_writerBytes > 0 && _writerBytes + nextLineBytes > _options.MaxFileBytes)
+            {
+                await FlushAndCloseWriterAsync(cancellationToken).ConfigureAwait(false);
+                RollBaseFile(date);
+                OpenWriter(date);
+            }
+        }
+
+        private void OpenWriter(DateOnly date)
+        {
+            var path = LogPath(date);
+            var existingBytes = File.Exists(path) ? new FileInfo(path).Length : 0;
+            if (existingBytes > _options.MaxFileBytes)
+            {
+                TrimLogFileToNewestBytes(path);
+                RollBaseFile(date);
+                existingBytes = 0;
+            }
+            else if (existingBytes == _options.MaxFileBytes)
+            {
+                RollBaseFile(date);
+                existingBytes = 0;
+            }
+
+            // Reserve the active base file's remaining capacity before opening
+            // it. Otherwise MaxTotalBytes of closed segments plus a growing
+            // MaxFileBytes base can exceed the advertised aggregate cap until
+            // the next flush or roll.
+            RunRetention(
+                date,
+                activePath: existingBytes > 0 ? path : null,
+                reservedBytes: _options.MaxFileBytes - existingBytes);
+
+            var stream = _openAppendStream(path);
+            try
+            {
+                _writer = new StreamWriter(stream, Utf8NoBom, bufferSize: 4096, leaveOpen: false);
+                _stream = stream;
+                _writerDate = date;
+                _writerPath = path;
+                _writerBytes = stream.CanSeek ? stream.Length : new FileInfo(path).Length;
+                Interlocked.Increment(ref _fileOpenCount);
+            }
+            catch
+            {
+                stream.Dispose();
+                throw;
+            }
+        }
+
+        private void TrimLogFileToNewestBytes(string path)
+        {
+            var temporaryPath = Path.Combine(
+                _logDirectory,
+                $".jellyfin-canopy-log-trim-{Guid.NewGuid():N}.tmp");
+            try
+            {
+                long retainedBytes;
+                using (var input = new FileStream(
+                    path,
+                    FileMode.Open,
+                    FileAccess.Read,
+                    FileShare.ReadWrite | FileShare.Delete,
+                    bufferSize: 16 * 1024,
+                    FileOptions.SequentialScan))
+                using (var output = new FileStream(
+                    temporaryPath,
+                    FileMode.CreateNew,
+                    FileAccess.Write,
+                    FileShare.None,
+                    bufferSize: 16 * 1024,
+                    FileOptions.SequentialScan))
+                {
+                    var start = Math.Max(0, input.Length - _options.MaxFileBytes);
+                    input.Position = start;
+                    if (start > 0)
+                    {
+                        // Do not begin the retained tail inside a UTF-8 rune.
+                        while (input.Position < input.Length)
+                        {
+                            var next = input.ReadByte();
+                            if (next < 0)
+                            {
+                                break;
+                            }
+
+                            if ((next & 0xC0) != 0x80)
+                            {
+                                input.Position--;
+                                break;
+                            }
+                        }
+                    }
+
+                    input.CopyTo(output, 16 * 1024);
+                    output.Flush(flushToDisk: true);
+                    retainedBytes = output.Length;
+                }
+
+                // Same-directory overwrite atomically replaces the oversized
+                // base with its newest bounded tail before normal segment roll.
+                File.Move(temporaryPath, path, overwrite: true);
+                Console.WriteLine(
+                    $"Trimmed oversized Jellyfin Canopy log {Path.GetFileName(path)} to its newest "
+                    + $"{retainedBytes.ToString(CultureInfo.InvariantCulture)} byte(s) during retention.");
+            }
+            finally
+            {
+                try
+                {
+                    File.Delete(temporaryPath);
+                }
+                catch
+                {
+                    // Best effort after a failed atomic replacement.
+                }
+            }
+        }
+
+        private async Task FlushAndCloseWriterAsync(CancellationToken cancellationToken)
+        {
+            var writer = _writer;
+            var stream = _stream;
+            _writer = null;
+            _stream = null;
+            _writerDate = null;
+            _writerPath = null;
+            _writerBytes = 0;
+            if (writer == null)
+            {
+                return;
+            }
+
+            try
+            {
+                await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                try
+                {
+                    writer.Dispose();
+                }
+                finally
+                {
+                    stream?.Dispose();
+                }
+            }
+        }
+
+        private Task CloseWriterAfterFailureAsync()
+        {
+            var writer = _writer;
+            var stream = _stream;
+            _writer = null;
+            _stream = null;
+            _writerDate = null;
+            _writerPath = null;
+            _writerBytes = 0;
+            if (writer == null)
+            {
+                return Task.CompletedTask;
+            }
+
+            try
+            {
+                writer.Dispose();
+            }
+            catch
+            {
+                // The original write/flush failure is already reported.
+            }
+            finally
+            {
+                stream?.Dispose();
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private void RecordDurabilityFailure(string operation, Exception exception)
+        {
+            Interlocked.Increment(ref _failures);
+            Interlocked.Increment(ref _durabilityFailures);
+            Console.WriteLine($"Jellyfin Canopy log {operation} failed: {exception.Message}");
+        }
+
+        private void RollBaseFile(DateOnly date)
+        {
+            var basePath = LogPath(date);
+            if (!File.Exists(basePath))
+            {
+                return;
+            }
+
+            var sequence = 1;
+            string segmentPath;
+            do
+            {
+                segmentPath = Path.Combine(
+                    _logDirectory,
+                    $"{LogFilePrefix}{date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}."
+                    + $"{sequence.ToString("D3", CultureInfo.InvariantCulture)}.log");
+                sequence++;
+            }
+            while (File.Exists(segmentPath));
+
+            // Same-directory rename is atomic: readers see either the complete
+            // old base file or the new segment, never a copied partial file.
+            File.Move(basePath, segmentPath);
+            Interlocked.Increment(ref _sizeRotationCount);
+        }
+
+        private void RunRetention(DateOnly today, string? activePath, long reservedBytes = 0)
+        {
+            try
+            {
+                var cutoff = today.AddDays(1 - _options.RetentionDays);
+                var files = EnumerateLogFiles();
+                foreach (var file in files.Where(file => file.Date < cutoff && !PathEquals(file.Path, activePath)))
+                {
+                    DeleteLogFile(file.Path);
+                }
+
+                files = EnumerateLogFiles();
+                foreach (var file in files.Where(file => file.Length > _options.MaxFileBytes && !PathEquals(file.Path, activePath)))
+                {
+                    try
+                    {
+                        TrimLogFileToNewestBytes(file.Path);
+                    }
+                    catch (Exception ex)
+                    {
+                        Interlocked.Increment(ref _failures);
+                        Console.WriteLine(
+                            $"Error trimming oversized Jellyfin Canopy log {Path.GetFileName(file.Path)}: {ex.Message}");
+                    }
+                }
+
+                files = EnumerateLogFiles();
+                var totalBytes = files.Sum(file => file.Length);
+                var retainedBytesLimit = Math.Max(0, _options.MaxTotalBytes - reservedBytes);
+                foreach (var file in files
+                    .Where(file => !PathEquals(file.Path, activePath))
+                    .OrderBy(file => file.Date)
+                    .ThenBy(file => file.LastWriteTimeUtc)
+                    .ThenBy(file => file.Path, StringComparer.Ordinal))
+                {
+                    if (totalBytes <= retainedBytesLimit)
+                    {
+                        break;
+                    }
+
+                    DeleteLogFile(file.Path);
+                    totalBytes -= file.Length;
                 }
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Error during log rotation: {ex.Message}");
+                Interlocked.Increment(ref _failures);
+                Console.WriteLine($"Error during Jellyfin Canopy log retention: {ex.Message}");
             }
         }
 
+        private List<LogFileInfo> EnumerateLogFiles()
+            => Directory.GetFiles(_logDirectory, $"{LogFilePrefix}*.log")
+                .Select(path =>
+                {
+                    var info = new FileInfo(path);
+                    return new LogFileInfo(
+                        path,
+                        DateOnly.FromDateTime(ResolveLogFileDate(info.Name, () => info.LastWriteTime).Date),
+                        info.Length,
+                        info.LastWriteTimeUtc);
+                })
+                .ToList();
+
+        private static bool PathEquals(string path, string? other)
+            => other != null && string.Equals(
+                Path.GetFullPath(path),
+                Path.GetFullPath(other),
+                OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+
+        private static void DeleteLogFile(string path)
+        {
+            File.Delete(path);
+            Console.WriteLine($"Deleted old log file: {Path.GetFileName(path)}");
+        }
+
+        private void RequestMaintenance()
+        {
+            if (Volatile.Read(ref _accepting) == 0)
+            {
+                return;
+            }
+
+            Interlocked.Exchange(ref _maintenanceRequested, 1);
+            _commands.Writer.TryWrite(SinkCommand.Maintenance(_timeProvider.GetLocalNow()));
+            try
+            {
+                _maintenanceTimer.Change(DelayUntilNextLocalDay(), Timeout.InfiniteTimeSpan);
+            }
+            catch (ObjectDisposedException)
+            {
+                // Shutdown raced the day-boundary callback.
+            }
+        }
+
+        private void RequestPeriodicFlush()
+        {
+            if (Volatile.Read(ref _accepting) == 0)
+            {
+                return;
+            }
+
+            if (Interlocked.Exchange(ref _flushRequested, 1) == 0)
+            {
+                _commands.Writer.TryWrite(SinkCommand.PeriodicFlush());
+            }
+            try
+            {
+                _flushTimer.Change(_options.FlushInterval, Timeout.InfiniteTimeSpan);
+            }
+            catch (ObjectDisposedException)
+            {
+                // Shutdown raced the periodic callback.
+            }
+        }
+
+        private TimeSpan DelayUntilNextLocalDay()
+        {
+            var nowUtc = _timeProvider.GetUtcNow().ToUniversalTime();
+            var timeZone = _timeProvider.LocalTimeZone;
+            var nowLocal = TimeZoneInfo.ConvertTime(nowUtc, timeZone);
+            var nextLocal = DateTime.SpecifyKind(nowLocal.Date.AddDays(1), DateTimeKind.Unspecified);
+
+            // A few zones move their clocks at midnight. Treat a skipped
+            // midnight as the first valid instant of the new local day, and an
+            // ambiguous midnight as its first occurrence.
+            while (timeZone.IsInvalidTime(nextLocal))
+            {
+                nextLocal = nextLocal.AddMinutes(1);
+            }
+
+            var nextOffset = timeZone.IsAmbiguousTime(nextLocal)
+                ? timeZone.GetAmbiguousTimeOffsets(nextLocal).Max()
+                : timeZone.GetUtcOffset(nextLocal);
+            var nextDay = new DateTimeOffset(nextLocal, nextOffset).ToUniversalTime();
+            var delay = nextDay - nowUtc;
+            return delay > TimeSpan.Zero ? delay : TimeSpan.FromDays(1);
+        }
+
+        private string FormatLine(DateTimeOffset timestamp, LogLevel level, string message)
+        {
+            var prefix = $"[{timestamp.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)}] "
+                + $"[{LevelLabel(level)}] ";
+            var suffix = Environment.NewLine;
+            var messageBudget = _options.MaxEntryBytes
+                - Utf8NoBom.GetByteCount(prefix)
+                - Utf8NoBom.GetByteCount(suffix);
+            return prefix + TruncateUtf8(message, messageBudget) + suffix;
+        }
+
+        private static string TruncateUtf8(string value, int maxBytes)
+        {
+            if (Utf8NoBom.GetByteCount(value) <= maxBytes)
+            {
+                return value;
+            }
+
+            const string marker = "…[truncated]";
+            var available = Math.Max(0, maxBytes - Utf8NoBom.GetByteCount(marker));
+            var builder = new StringBuilder();
+            var used = 0;
+            foreach (var rune in value.EnumerateRunes())
+            {
+                if (used + rune.Utf8SequenceLength > available)
+                {
+                    break;
+                }
+
+                builder.Append(rune.ToString());
+                used += rune.Utf8SequenceLength;
+            }
+
+            builder.Append(marker);
+            return builder.ToString();
+        }
+
+        private string LogPath(DateOnly date)
+            => Path.Combine(
+                _logDirectory,
+                $"{LogFilePrefix}{date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}.log");
+
         /// <summary>
-        /// Retention key for a log file: the yyyy-MM-dd embedded in the filename, which is the
-        /// reliable signal on Linux where file birth-time (CreationTime) is often unavailable and
-        /// reports the last-write or epoch instead. Falls back to <paramref name="lastWriteTimeFallback"/>
-        /// only when the filename doesn't carry a parseable date.
+        /// Retention key for a log file: the yyyy-MM-dd embedded in the filename.
+        /// Size-rolled suffixes (for example <c>.001</c>) retain that same date.
         /// </summary>
         internal static DateTime ResolveLogFileDate(string fileName, Func<DateTime> lastWriteTimeFallback)
         {
             var name = Path.GetFileNameWithoutExtension(fileName);
             if (name.StartsWith(LogFilePrefix, StringComparison.Ordinal))
             {
-                var datePart = name.Substring(LogFilePrefix.Length);
-                if (DateTime.TryParseExact(datePart, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed))
+                var remainder = name.Substring(LogFilePrefix.Length);
+                if (remainder.Length >= 10
+                    && (remainder.Length == 10 || remainder[10] == '.')
+                    && DateTime.TryParseExact(
+                        remainder.Substring(0, 10),
+                        "yyyy-MM-dd",
+                        CultureInfo.InvariantCulture,
+                        DateTimeStyles.None,
+                        out var parsed))
                 {
                     return parsed;
                 }
@@ -132,13 +942,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Logging
                 return string.Empty;
             }
 
-            // Prevent log forging via CR/LF injection while preserving visible intent.
             return message.Replace("\r", "\\r", StringComparison.Ordinal)
                 .Replace("\n", "\\n", StringComparison.Ordinal);
         }
 
-        /// <summary>File-only logger; writes at or above <see cref="MinFileLogLevel"/> so hot-path
-        /// Debug/Trace don't do a synchronous locked append (the host log still gets all levels).</summary>
         private sealed class FileLogger : ILogger
         {
             private readonly JellyfinCanopyFileLoggerProvider _provider;
@@ -149,9 +956,17 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Logging
                 where TState : notnull
                 => null;
 
-            public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None && logLevel >= MinFileLogLevel;
+            public bool IsEnabled(LogLevel logLevel)
+                => _provider.IsAccepting
+                    && logLevel != LogLevel.None
+                    && logLevel >= MinFileLogLevel;
 
-            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
             {
                 if (!IsEnabled(logLevel))
                 {
@@ -167,5 +982,81 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Logging
                 _provider.Write(logLevel, message);
             }
         }
+
+        private readonly record struct LogFileInfo(
+            string Path,
+            DateOnly Date,
+            long Length,
+            DateTime LastWriteTimeUtc);
+
+        private enum SinkCommandKind
+        {
+            Log,
+            Flush,
+            Maintenance,
+            PeriodicFlush,
+        }
+
+        private readonly record struct SinkCommand(
+            SinkCommandKind Kind,
+            DateTimeOffset Timestamp,
+            string? Line,
+            TaskCompletionSource<bool>? Completion)
+        {
+            public static SinkCommand Log(DateTimeOffset timestamp, string line)
+                => new(SinkCommandKind.Log, timestamp, line, null);
+
+            public static SinkCommand Flush(TaskCompletionSource<bool> completion)
+                => new(SinkCommandKind.Flush, default, null, completion);
+
+            public static SinkCommand Maintenance(DateTimeOffset timestamp)
+                => new(SinkCommandKind.Maintenance, timestamp, null, null);
+
+            public static SinkCommand PeriodicFlush()
+                => new(SinkCommandKind.PeriodicFlush, default, null, null);
+        }
     }
+
+    internal sealed class FileLogSinkOptions
+    {
+        public static FileLogSinkOptions Default { get; } = new();
+
+        public int QueueCapacity { get; init; } = 2048;
+
+        public int RetentionDays { get; init; } = 3;
+
+        public long MaxFileBytes { get; init; } = 8 * 1024 * 1024;
+
+        public long MaxTotalBytes { get; init; } = 24 * 1024 * 1024;
+
+        public int MaxEntryBytes { get; init; } = 32 * 1024;
+
+        public TimeSpan ShutdownTimeout { get; init; } = TimeSpan.FromSeconds(5);
+
+        public TimeSpan FlushInterval { get; init; } = TimeSpan.FromSeconds(1);
+
+        public void Validate()
+        {
+            if (QueueCapacity <= 0) throw new ArgumentOutOfRangeException(nameof(QueueCapacity));
+            if (RetentionDays <= 0) throw new ArgumentOutOfRangeException(nameof(RetentionDays));
+            if (MaxEntryBytes < 128) throw new ArgumentOutOfRangeException(nameof(MaxEntryBytes));
+            if (MaxFileBytes < MaxEntryBytes) throw new ArgumentOutOfRangeException(nameof(MaxFileBytes));
+            if (MaxTotalBytes < MaxFileBytes) throw new ArgumentOutOfRangeException(nameof(MaxTotalBytes));
+            if (ShutdownTimeout <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(ShutdownTimeout));
+            if (FlushInterval <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(FlushInterval));
+        }
+    }
+
+    internal readonly record struct FileLogSinkMetrics(
+        int QueueCapacity,
+        long Enqueued,
+        long Dropped,
+        long Written,
+        long Failures,
+        long DurabilityFailures,
+        long FileOpenCount,
+        long DayRotationCount,
+        long SizeRotationCount,
+        long MaintenanceRunCount,
+        long PeriodicFlushCount);
 }

--- a/docs/help.md
+++ b/docs/help.md
@@ -299,8 +299,10 @@ Good logs turn a vague report into a fixable one. Collect from all three sources
 
 1. Go to **Dashboard → Logs**.
 2. Look for `JellyfinCanopy` entries.
-3. Check the log files named `JellyfinCanopy_yyyy-mm-dd.log`.
+3. Check the log files named `JellyfinCanopy_yyyy-mm-dd.log` (a busy day may also have size-rolled `.001.log`, `.002.log`, and later segments).
 4. Copy the relevant errors.
+
+The dedicated log sink keeps today plus the previous two calendar days, caps each file at 8 MiB, and reserves enough active-file headroom to keep all Canopy log files together within 24 MiB. File writes run through one bounded asynchronous queue, so request and scan threads never wait for disk I/O. If its 2,048-entry queue is full, the newest line is dropped. The file worker flushes accepted batches once per second under normal storage conditions; an abrupt process or host failure can lose the still-buffered tail, while orderly shutdown drains accepted lines for up to five seconds and prints a console warning if that deadline cannot be met.
 
 When you write up the report, include: the plugin version, Jellyfin version, browser and version, operating system, exact steps to reproduce, the console errors, the server-log errors, and screenshots where they help.
 

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -19,7 +19,7 @@ const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the repeated clean measurements', () => {
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1428, totalLines: 1751 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 15648, totalLines: 24215 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 16063, totalLines: 24704 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 1);
 });

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -21,12 +21,12 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 15648,
-        "totalLines": 24215
+        "coveredLines": 16063,
+        "totalLines": 24704
       },
       "tolerance": {
         "missingCoveredLines": 1,
-        "rationale": "Two clean reviewed 2026-07-15 .NET 10/Coverlet runs measured 15647 and 15648 covered lines across the 24215-line combined scope after the Continue Watching linear-index change and deterministic coverage for outcome-aware playback singleflight, immediate transient retry, cancellation release, definitive cooldown, and bounded backoff. The one-line tolerance covers that reproduced instrumentation variance."
+        "rationale": "Two clean reviewed 2026-07-15 .NET 10/Coverlet runs identically measured 16063 covered lines across the 24704-line combined scope after the Continue Watching linear index and playback retry deduplication, plus the bounded asynchronous log sink, hard retention budgets, DST-aware midnight rotation, periodic flush coalescing, oversized-file normalization, stream reuse, and truthful bounded shutdown. One line permits only the reproduced instrumentation variance."
       }
     }
   }


### PR DESCRIPTION
Closes #115

Replaces synchronous per-line file appends with a single-owner bounded asynchronous sink. The sink has a 2,048-entry drop-new queue, one-second coalesced flush, truthful five-second shutdown, and sink-aware composite level checks that avoid formatting disabled messages.

Retention is now a true three-day policy with an 8 MiB physical-file cap and 24 MiB aggregate cap, including active-file headroom and inherited oversized-file normalization. Rotation is atomic and local-midnight scheduling is DST-safe.

Validation:
- independent review: APPROVE
- focused logger tests: 28/28
- combined server suite: 1412/1412 twice after rebase
- repeated combined server coverage: 16063/24704 lines
- client tests: 846/846; script tests: 294/294
- syntax, typechecks, translations, formatting, lint (0 errors), and diff checks passed