### PR TITLE
ci: enforce documentation asset ownership and size budgets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,6 +134,9 @@ jobs:
       - name: Internal Markdown links
         run: npm run check:markdown-links
 
+      - name: Documentation asset ownership and size budgets
+        run: npm run check:docs-assets
+
       - name: Setup Python for strict documentation build
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Check internal Markdown links
         run: npm run check:markdown-links
 
+      - name: Check documentation asset ownership and size budgets
+        run: npm run check:docs-assets
+
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,6 +198,9 @@ jobs:
       - name: Internal Markdown links
         run: npm run check:markdown-links
 
+      - name: Documentation asset ownership and size budgets
+        run: npm run check:docs-assets
+
       - name: Type check (opt-in @ts-check files)
         run: npm run typecheck
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -318,8 +318,30 @@ If you touch `docs/` (any user- or admin-visible change should), the site must b
 
 ```bash
 npm run check:markdown-links
+npm run check:docs-assets
 mkdocs build --strict
 ```
+
+`check:docs-assets` treats every tracked visual file anywhere under `docs/` as
+owned content: it must be referenced by the README, documentation, MkDocs
+theme, or this repository's plugin manifest, and both documentation-only and
+repository-wide visual-asset byte budgets are blocking ratchets. An
+intentionally unreferenced asset needs a named owner, rationale, and expiry in
+`scripts/docs-asset-policy.json`. Animated assets additionally need a tracked
+non-animated alternative, a description presented beside it, and source-backed
+`prefers-reduced-motion` evidence; GIFs are rejected.
+
+The #147 baseline recorded 45 documentation images totalling 78,548,499 bytes
+before the two unreferenced panel GIFs were removed. The owned set is now 43
+files / 24,472,975 bytes, a reduction of 54,075,524 bytes (68.8%). Across the
+whole repository the corresponding visual-asset payload fell from 49 files /
+80,910,807 bytes to 47 files / 26,835,283 bytes. Git history was deliberately
+left intact: a history rewrite and force-push would require separate approval.
+For an otherwise identical current tree, removing the two GIFs reduces the
+tracked checkout from 92,929,846 to 38,854,322 bytes (58.2%) and the strict
+MkDocs `site/` artifact from 80,283,129 to 26,207,605 bytes (67.4%). Existing
+clones retain the historical objects even though new checkouts and the
+generated documentation site no longer carry those files in the current tree.
 
 ### Manual checklist
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "check:toolchain": "node scripts/check-node-toolchain.js",
     "check:markdown-links": "node scripts/check-markdown-links.js",
+    "check:docs-assets": "node scripts/check-doc-assets.js",
     "lint": "eslint --exit-on-fatal-error --max-warnings 6586 \"Jellyfin.Plugin.JellyfinCanopy/js/**/*.js\" \"Jellyfin.Plugin.JellyfinCanopy/src/**/*.ts\" \"Jellyfin.Plugin.JellyfinCanopy/Configuration/*.js\" \"scripts/**/*.js\"",
     "lint:fix": "eslint --fix \"Jellyfin.Plugin.JellyfinCanopy/js/**/*.js\" \"Jellyfin.Plugin.JellyfinCanopy/src/**/*.ts\" \"Jellyfin.Plugin.JellyfinCanopy/Configuration/*.js\" \"scripts/**/*.js\"",
     "typecheck": "tsc -p jsconfig.json",

--- a/scripts/check-doc-assets.js
+++ b/scripts/check-doc-assets.js
@@ -1,0 +1,305 @@
+'use strict';
+
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..');
+const POLICY_FILE = path.join(__dirname, 'docs-asset-policy.json');
+
+function normalize(file) {
+    return file.split(path.sep).join('/').replace(/^\.\//, '');
+}
+
+function collectTrackedFiles(root = ROOT) {
+    return execFileSync('git', ['-C', root, 'ls-files', '-z'], { encoding: 'buffer' })
+        .toString('utf8')
+        .split('\0')
+        .filter(Boolean)
+        .map(normalize)
+        .sort();
+}
+
+function readPolicy(file = POLICY_FILE) {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function validateException(entry, label, now, problems) {
+    if (!entry || typeof entry !== 'object') {
+        problems.push(`${label}: entry must be an object`);
+        return false;
+    }
+    let valid = true;
+    for (const field of ['path', 'owner', 'rationale', 'expires']) {
+        if (typeof entry[field] !== 'string' || entry[field].trim() === '') {
+            problems.push(`${label}: ${field} must be a non-empty string`);
+            valid = false;
+        }
+    }
+    const expires = entry.expires || '';
+    const parsedExpiry = new Date(`${expires}T00:00:00Z`);
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(expires) || Number.isNaN(parsedExpiry.getTime()) ||
+        parsedExpiry.toISOString().slice(0, 10) !== expires) {
+        problems.push(`${label}: expires must use YYYY-MM-DD`);
+        valid = false;
+    } else if (expires < now.toISOString().slice(0, 10)) {
+        problems.push(`${label}: exception expired on ${expires}`);
+        valid = false;
+    }
+    return valid;
+}
+
+function isReferenceSource(file, policy) {
+    if (policy.referenceFiles.includes(file)) return true;
+    const extension = path.posix.extname(file).toLowerCase();
+    if (!policy.referenceExtensions.includes(extension)) return false;
+    return policy.referenceDirectories.some(directory => file.startsWith(`${directory}/`));
+}
+
+function isAnimated(file, buffer) {
+    const extension = path.posix.extname(file).toLowerCase();
+    if (extension === '.gif' || extension === '.mp4' || extension === '.webm') return true;
+    if ((extension === '.png' || extension === '.apng') &&
+        buffer.subarray(0, 8).equals(Buffer.from('89504e470d0a1a0a', 'hex'))) {
+        for (let offset = 8; offset + 12 <= buffer.length;) {
+            const length = buffer.readUInt32BE(offset);
+            if (offset + 12 + length > buffer.length) break;
+            if (buffer.toString('ascii', offset + 4, offset + 8) === 'acTL') return true;
+            offset += 12 + length;
+        }
+    }
+    if (extension === '.webp' && buffer.toString('ascii', 0, 4) === 'RIFF' &&
+        buffer.toString('ascii', 8, 12) === 'WEBP') {
+        for (let offset = 12; offset + 8 <= buffer.length;) {
+            const length = buffer.readUInt32LE(offset + 4);
+            if (offset + 8 + length > buffer.length) break;
+            if (buffer.toString('ascii', offset, offset + 4) === 'ANIM') return true;
+            offset += 8 + length + (length % 2);
+        }
+    }
+    if (extension === '.svg') {
+        const source = buffer.toString('utf8');
+        return /<(?:animate|animateMotion|animateTransform|set|script)\b|@keyframes\b|\banimation\s*:/i.test(source);
+    }
+    if (extension === '.avif') {
+        for (let offset = 0; offset + 8 <= buffer.length;) {
+            const size = buffer.readUInt32BE(offset);
+            if (size < 8 || offset + size > buffer.length) break;
+            if (buffer.toString('ascii', offset + 4, offset + 8) === 'ftyp') {
+                for (let brandOffset = offset + 8; brandOffset + 4 <= offset + size; brandOffset += 4) {
+                    if (brandOffset === offset + 12) continue; // minor-version field
+                    if (buffer.toString('ascii', brandOffset, brandOffset + 4) === 'avis') return true;
+                }
+            }
+            offset += size;
+        }
+    }
+    return false;
+}
+
+function assetAliases(file, docsRoot) {
+    const aliases = [file];
+    if (file.startsWith(`${docsRoot}/`)) {
+        aliases.push(file.slice(docsRoot.length + 1));
+    }
+    return aliases.flatMap(alias => [alias, encodeURI(alias)]);
+}
+
+function hasOwnedReference(source, alias) {
+    const escaped = alias.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return new RegExp(`(?:^|[\\s"'(<{}>=:/])${escaped}(?=$|[\\s"')>\\]}?#])`, 'm').test(source);
+}
+
+function stripUnownedExternalUrls(source, policy) {
+    return source.replace(/(?:[a-z][a-z\d+.-]*:)?\/\/[^\s"'<>]+/gi, (url) =>
+        (policy.allowedExternalAssetPrefixes || []).some(prefix => url.startsWith(prefix)) ? url : '');
+}
+
+function sumBytes(records) {
+    return records.reduce((total, record) => total + record.bytes, 0);
+}
+
+function largestBytes(records) {
+    return records.reduce((largest, record) => Math.max(largest, record.bytes), 0);
+}
+
+function auditAssets(options = {}) {
+    const root = options.root || ROOT;
+    const policy = options.policy || readPolicy();
+    const trackedFiles = (options.trackedFiles || collectTrackedFiles(root)).map(normalize);
+    const now = options.now || new Date();
+    const problems = [];
+    const assetExtensions = new Set(policy.assetExtensions);
+    const assets = [];
+
+    for (const file of trackedFiles) {
+        if (!assetExtensions.has(path.posix.extname(file).toLowerCase())) continue;
+        const absolute = path.join(root, file);
+        if (!fs.existsSync(absolute)) {
+            problems.push(`${file}: tracked asset is missing from the worktree`);
+            continue;
+        }
+        const stat = fs.lstatSync(absolute);
+        if (stat.isSymbolicLink()) {
+            problems.push(`${file}: tracked assets must not be symbolic links`);
+            continue;
+        }
+        if (!stat.isFile()) {
+            problems.push(`${file}: tracked asset is not a regular file`);
+            continue;
+        }
+        const buffer = fs.readFileSync(absolute);
+        assets.push({ file, bytes: buffer.length, animated: isAnimated(file, buffer) });
+    }
+
+    const docsAssets = assets.filter(asset => asset.file.startsWith(`${policy.docsRoot}/`));
+    const docsBytes = sumBytes(docsAssets);
+    const repositoryBytes = sumBytes(assets);
+    const docsLargest = largestBytes(docsAssets);
+    const repositoryLargest = largestBytes(assets);
+
+    const checkBudget = (label, records, total, budget) => {
+        if (total > budget.maxBytes) {
+            problems.push(`${label} asset bytes ${total} exceed budget ${budget.maxBytes}`);
+        }
+        for (const record of records) {
+            if (record.bytes > budget.maxFileBytes) {
+                problems.push(`${record.file}: ${record.bytes} bytes exceed ${label} per-file budget ${budget.maxFileBytes}`);
+            }
+        }
+    };
+    checkBudget('documentation', docsAssets, docsBytes, policy.budgets.documentation);
+    checkBudget('repository', assets, repositoryBytes, policy.budgets.repository);
+
+    const referenceSources = new Map();
+    for (const file of trackedFiles.filter(candidate => isReferenceSource(candidate, policy))) {
+            const absolute = path.join(root, file);
+            if (!fs.existsSync(absolute)) {
+                problems.push(`${file}: tracked reference source is missing from the worktree`);
+                continue;
+            }
+            const stat = fs.lstatSync(absolute);
+            if (stat.isSymbolicLink() || !stat.isFile()) {
+                problems.push(`${file}: reference sources must be regular files, not links`);
+                continue;
+            }
+            referenceSources.set(file, stripUnownedExternalUrls(fs.readFileSync(absolute, 'utf8'), policy));
+    }
+    const referenceText = [...referenceSources.values()].join('\n');
+    const unreferenced = docsAssets.filter(asset =>
+        !assetAliases(asset.file, policy.docsRoot).some(alias => hasOwnedReference(referenceText, alias)));
+
+    const unreferencedExceptions = new Map();
+    for (const [index, entry] of (policy.unreferencedAllowlist || []).entries()) {
+        if (!validateException(entry, `unreferencedAllowlist[${index}]`, now, problems)) continue;
+        if (unreferencedExceptions.has(entry.path)) {
+            problems.push(`unreferencedAllowlist[${index}]: duplicate path ${entry.path}`);
+        }
+        unreferencedExceptions.set(entry.path, entry);
+    }
+    for (const asset of unreferenced) {
+        if (!unreferencedExceptions.has(asset.file)) {
+            problems.push(`${asset.file}: documentation asset is unreferenced and has no owned, expiring exception`);
+        }
+    }
+    for (const file of unreferencedExceptions.keys()) {
+        if (!docsAssets.some(asset => asset.file === file)) {
+            problems.push(`${file}: unreferenced exception does not name a tracked documentation asset`);
+        } else if (!unreferenced.some(asset => asset.file === file)) {
+            problems.push(`${file}: stale unreferenced exception; the asset has a real owner reference`);
+        }
+    }
+
+    const animatedExceptions = new Map();
+    for (const [index, entry] of (policy.animatedAllowlist || []).entries()) {
+        let valid = validateException(entry, `animatedAllowlist[${index}]`, now, problems);
+        if (!entry || typeof entry !== 'object') continue;
+        for (const field of [
+            'staticAlternative',
+            'description',
+            'descriptionSource',
+            'reducedMotionSource',
+            'reducedMotionEvidence',
+        ]) {
+            if (typeof entry[field] !== 'string' || entry[field].trim() === '') {
+                problems.push(`animatedAllowlist[${index}]: ${field} must be a non-empty string`);
+                valid = false;
+            }
+        }
+        if (!valid) continue;
+        if (animatedExceptions.has(entry.path)) {
+            problems.push(`animatedAllowlist[${index}]: duplicate path ${entry.path}`);
+        }
+        animatedExceptions.set(entry.path, entry);
+    }
+    for (const asset of assets.filter(record => record.animated)) {
+        if (path.posix.extname(asset.file).toLowerCase() === '.gif') {
+            problems.push(`${asset.file}: GIF assets are forbidden; use an accessible modern format with a static alternative`);
+        } else if (!animatedExceptions.has(asset.file)) {
+            problems.push(`${asset.file}: animated asset lacks owner, expiry, description, static alternative, and reduced-motion evidence`);
+        }
+    }
+    for (const [file, entry] of animatedExceptions) {
+        const asset = assets.find(record => record.file === file);
+        if (!asset || !asset.animated) {
+            problems.push(`${file}: stale animated exception; no tracked animated asset exists`);
+        }
+        const alternativePath = normalize(entry.staticAlternative || '');
+        const alternative = assets.find(record => record.file === alternativePath);
+        if (!alternative) {
+            problems.push(`${file}: static alternative is not a tracked regular visual asset: ${entry.staticAlternative}`);
+        } else if (alternative.animated) {
+            problems.push(`${file}: static alternative must be non-animated: ${entry.staticAlternative}`);
+        }
+        const descriptionSource = referenceSources.get(normalize(entry.descriptionSource));
+        if (!descriptionSource) {
+            problems.push(`${file}: description source is not a tracked regular documentation source: ${entry.descriptionSource}`);
+        } else {
+            if (!descriptionSource.includes(entry.description)) {
+                problems.push(`${file}: description source does not contain the policy description: ${entry.descriptionSource}`);
+            }
+            if (!assetAliases(file, policy.docsRoot).some(alias => hasOwnedReference(descriptionSource, alias))) {
+                problems.push(`${file}: description source does not present the animation: ${entry.descriptionSource}`);
+            }
+            if (alternative && !assetAliases(alternative.file, policy.docsRoot)
+                .some(alias => hasOwnedReference(descriptionSource, alias))) {
+                problems.push(`${file}: description source does not present the static alternative: ${entry.descriptionSource}`);
+            }
+        }
+        const reducedMotionSource = referenceSources.get(normalize(entry.reducedMotionSource));
+        if (!reducedMotionSource) {
+            problems.push(`${file}: reduced-motion source is not a tracked regular documentation source: ${entry.reducedMotionSource}`);
+        } else if (!reducedMotionSource.includes(entry.reducedMotionEvidence) ||
+            !reducedMotionSource.includes('prefers-reduced-motion')) {
+            problems.push(`${file}: reduced-motion source does not contain the declared prefers-reduced-motion evidence: ${entry.reducedMotionSource}`);
+        }
+    }
+
+    return {
+        problems,
+        metrics: {
+            documentation: { files: docsAssets.length, bytes: docsBytes, largestBytes: docsLargest },
+            repository: { files: assets.length, bytes: repositoryBytes, largestBytes: repositoryLargest },
+        },
+    };
+}
+
+function main() {
+    const result = auditAssets();
+    if (result.problems.length > 0) {
+        console.error(`Documentation asset check failed:\n${result.problems.map(problem => `- ${problem}`).join('\n')}`);
+        process.exitCode = 1;
+        return;
+    }
+    const docs = result.metrics.documentation;
+    const repository = result.metrics.repository;
+    console.log(
+        `Documentation assets OK: ${docs.files} files / ${docs.bytes} bytes ` +
+        `(largest ${docs.largestBytes}); repository visual assets: ${repository.files} files / ` +
+        `${repository.bytes} bytes (largest ${repository.largestBytes})`,
+    );
+}
+
+if (require.main === module) main();
+
+module.exports = { auditAssets, collectTrackedFiles, isAnimated, readPolicy };

--- a/scripts/check-doc-assets.test.js
+++ b/scripts/check-doc-assets.test.js
@@ -1,0 +1,260 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const { auditAssets } = require('./check-doc-assets');
+
+const NOW = new Date('2026-07-16T00:00:00Z');
+
+function policy(overrides = {}) {
+    return {
+        assetExtensions: ['.apng', '.avif', '.gif', '.mp4', '.png', '.svg', '.webm', '.webp'],
+        docsRoot: 'docs',
+        allowedExternalAssetPrefixes: [
+            'https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/',
+        ],
+        referenceFiles: ['README.md', 'manifest.json', 'mkdocs.yml'],
+        referenceDirectories: ['docs', 'theme'],
+        referenceExtensions: ['.css', '.html', '.md', '.yml'],
+        budgets: {
+            documentation: { maxBytes: 100, maxFileBytes: 80 },
+            repository: { maxBytes: 120, maxFileBytes: 80 },
+        },
+        unreferencedAllowlist: [],
+        animatedAllowlist: [],
+        ...overrides,
+    };
+}
+
+function fixture(files, callback) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'jc-doc-assets-'));
+    try {
+        for (const [name, contents] of Object.entries(files)) {
+            const destination = path.join(root, name);
+            fs.mkdirSync(path.dirname(destination), { recursive: true });
+            fs.writeFileSync(destination, contents);
+        }
+        callback(root, Object.keys(files));
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+}
+
+test('live repository assets are referenced, non-animated, and within ratcheted budgets', () => {
+    const result = auditAssets();
+    assert.deepEqual(result.problems, []);
+    assert.deepEqual(result.metrics.documentation, {
+        files: 43,
+        bytes: 24472975,
+        largestBytes: 2941758,
+    });
+    assert.deepEqual(result.metrics.repository, {
+        files: 47,
+        bytes: 26835283,
+        largestBytes: 2941758,
+    });
+});
+
+test('finds orphaned documentation assets and accepts real README, MkDocs, theme and manifest owners', () => {
+    fixture({
+        'README.md': [
+            '![Readme](docs/images/readme.png)',
+            '![Angle destination](<docs/images/angle image.png>)',
+            'A near miss: docs/images/orphan.png.backup',
+            'An external namesake: https://third-party.invalid/docs/images/orphan.png',
+            '',
+        ].join('\n'),
+        'mkdocs.yml': 'logo: images/logo.png\n',
+        'theme/base.html': '<img src="{{ \'images/theme.png\' | url }}">\n',
+        'manifest.json': '{"imageUrl":"https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/main/docs/images/icon.png"}',
+        'docs/images/readme.png': 'a',
+        'docs/images/angle image.png': 'f',
+        'docs/images/logo.png': 'b',
+        'docs/images/theme.png': 'c',
+        'docs/images/icon.png': 'd',
+        'docs/images/orphan.png': 'e',
+    }, (root, trackedFiles) => {
+        const result = auditAssets({ root, trackedFiles, policy: policy(), now: NOW });
+        assert.deepEqual(result.problems, [
+            'docs/images/orphan.png: documentation asset is unreferenced and has no owned, expiring exception',
+        ]);
+    });
+});
+
+test('requires owned expiring exceptions and rejects stale allowlist entries', () => {
+    fixture({
+        'README.md': '![Used](docs/images/used.png)\n',
+        'docs/images/used.png': 'a',
+        'docs/images/orphan.png': 'b',
+    }, (root, trackedFiles) => {
+        const result = auditAssets({
+            root,
+            trackedFiles,
+            now: NOW,
+            policy: policy({
+                unreferencedAllowlist: [
+                    { path: 'docs/images/orphan.png', owner: 'docs', rationale: 'migration evidence', expires: '2026-08-01' },
+                    { path: 'docs/images/used.png', owner: 'docs', rationale: 'stale', expires: '2026-08-01' },
+                    { path: 'docs/images/missing.png', owner: '', rationale: '', expires: '2026-07-01' },
+                    { path: 'docs/images/bad-date.png', owner: 'docs', rationale: 'invalid date', expires: '2026-99-99' },
+                    null,
+                ],
+            }),
+        });
+        assert.ok(!result.problems.some(problem => problem.startsWith('docs/images/orphan.png:')));
+        assert.ok(result.problems.includes('docs/images/used.png: stale unreferenced exception; the asset has a real owner reference'));
+        assert.ok(result.problems.some(problem => problem.includes('owner must be a non-empty string')));
+        assert.ok(result.problems.some(problem => problem.includes('exception expired on 2026-07-01')));
+        assert.ok(result.problems.some(problem => problem.includes('expires must use YYYY-MM-DD')));
+        assert.ok(result.problems.includes('unreferencedAllowlist[4]: entry must be an object'));
+    });
+});
+
+test('enforces aggregate and per-file budgets for all docs paths and repository visual assets', () => {
+    fixture({
+        'README.md': '![Large](docs/images/large.png)\n',
+        'docs/images/large.png': 'x'.repeat(81),
+        'docs/orphan.png': 'z'.repeat(30),
+        'research/evidence/extra.png': 'y'.repeat(50),
+    }, (root, trackedFiles) => {
+        const result = auditAssets({ root, trackedFiles, policy: policy(), now: NOW });
+        assert.ok(result.problems.includes('documentation asset bytes 111 exceed budget 100'));
+        assert.ok(result.problems.includes('docs/images/large.png: 81 bytes exceed documentation per-file budget 80'));
+        assert.ok(result.problems.includes('docs/orphan.png: documentation asset is unreferenced and has no owned, expiring exception'));
+        assert.ok(result.problems.includes('repository asset bytes 161 exceed budget 120'));
+        assert.ok(result.problems.includes('docs/images/large.png: 81 bytes exceed repository per-file budget 80'));
+    });
+});
+
+test('rejects GIFs and requires accessible evidence for modern animation', () => {
+    fixture({
+        'README.md': '![Old](docs/images/old.gif)\n',
+        'docs/demo.md': '[Demo](images/demo.webm)\n![Still](images/still.png)\nText description beside the demonstration.\n',
+        'theme/reduced-motion.css': '@media (prefers-reduced-motion: reduce) { video { display: none; } }\n',
+        'docs/images/old.gif': 'GIF89a',
+        'docs/images/demo.webm': 'video',
+        'docs/images/still.png': 'still',
+    }, (root, trackedFiles) => {
+        const result = auditAssets({
+            root,
+            trackedFiles,
+            now: NOW,
+            policy: policy({
+                animatedAllowlist: [{
+                    path: 'docs/images/demo.webm',
+                    owner: 'docs',
+                    rationale: 'interaction demonstration',
+                    expires: '2026-08-01',
+                    staticAlternative: 'docs/images/still.png',
+                    description: 'Text description beside the demonstration.',
+                    descriptionSource: 'docs/demo.md',
+                    reducedMotionSource: 'theme/reduced-motion.css',
+                    reducedMotionEvidence: 'prefers-reduced-motion: reduce',
+                }],
+            }),
+        });
+        assert.ok(result.problems.includes(
+            'docs/images/old.gif: GIF assets are forbidden; use an accessible modern format with a static alternative',
+        ));
+        assert.ok(!result.problems.some(problem => problem.startsWith('docs/images/demo.webm: animated asset lacks')));
+    });
+});
+
+test('requires a real non-animated visual asset as the animation alternative', () => {
+    fixture({
+        'README.md': '[Demo](docs/images/demo.webm)\n[Other](docs/images/other.webm)\nText description beside the demonstration.\n',
+        'theme/reduced-motion.css': '@media (prefers-reduced-motion: reduce) { video { display: none; } }\n',
+        'docs/images/demo.webm': 'video',
+        'docs/images/other.webm': 'video',
+    }, (root, trackedFiles) => {
+        const base = {
+            path: 'docs/images/demo.webm',
+            owner: 'docs',
+            rationale: 'interaction demonstration',
+            expires: '2026-08-01',
+            description: 'Text description beside the demonstration.',
+            descriptionSource: 'README.md',
+            reducedMotionSource: 'theme/reduced-motion.css',
+            reducedMotionEvidence: 'prefers-reduced-motion: reduce',
+        };
+        const nonAsset = auditAssets({
+            root,
+            trackedFiles,
+            now: NOW,
+            policy: policy({ animatedAllowlist: [{ ...base, staticAlternative: 'README.md' }] }),
+        });
+        assert.ok(nonAsset.problems.includes(
+            'docs/images/demo.webm: static alternative is not a tracked regular visual asset: README.md',
+        ));
+
+        const animated = auditAssets({
+            root,
+            trackedFiles,
+            now: NOW,
+            policy: policy({ animatedAllowlist: [{ ...base, staticAlternative: 'docs/images/other.webm' }] }),
+        });
+        assert.ok(animated.problems.includes(
+            'docs/images/demo.webm: static alternative must be non-animated: docs/images/other.webm',
+        ));
+    });
+});
+
+test('detects PNG/APNG, WebP, SVG and AVIF animation containers', () => {
+    const png = Buffer.concat([
+        Buffer.from('89504e470d0a1a0a', 'hex'),
+        Buffer.from('000000086163544c000000010000000000000000', 'hex'),
+    ]);
+    const webp = Buffer.concat([
+        Buffer.from('RIFF'),
+        Buffer.from([4, 0, 0, 0]),
+        Buffer.from('WEBP'),
+        Buffer.from('ANIM'),
+        Buffer.from([0, 0, 0, 0]),
+    ]);
+    const avif = Buffer.from('00000018667479706176697300000000617669666d696631', 'hex');
+    fixture({
+        'README.md': [
+            '![PNG](docs/images/a.png)',
+            '![APNG](docs/images/a.apng)',
+            '![WebP](docs/images/b.webp)',
+            '![SVG](docs/images/c.svg)',
+            '![AVIF](docs/images/d.avif)',
+            '',
+        ].join('\n'),
+        'docs/images/a.png': png,
+        'docs/images/a.apng': png,
+        'docs/images/b.webp': webp,
+        'docs/images/c.svg': '<svg><animate attributeName="opacity" /></svg>',
+        'docs/images/d.avif': avif,
+    }, (root, trackedFiles) => {
+        const result = auditAssets({ root, trackedFiles, policy: policy(), now: NOW });
+        assert.equal(result.problems.filter(problem => problem.includes('animated asset lacks')).length, 5);
+    });
+});
+
+test('rejects asset and reference-source symlinks instead of following them', () => {
+    fixture({
+        'outside.png': 'asset',
+        'outside.md': 'docs/images/linked.png',
+    }, (root) => {
+        fs.mkdirSync(path.join(root, 'docs', 'images'), { recursive: true });
+        fs.symlinkSync(path.join(root, 'outside.png'), path.join(root, 'docs', 'images', 'linked.png'));
+        fs.symlinkSync(path.join(root, 'outside.md'), path.join(root, 'README.md'));
+        const trackedFiles = ['README.md', 'docs/images/linked.png'];
+        const result = auditAssets({ root, trackedFiles, policy: policy(), now: NOW });
+        assert.ok(result.problems.includes('docs/images/linked.png: tracked assets must not be symbolic links'));
+        assert.ok(result.problems.includes('README.md: reference sources must be regular files, not links'));
+    });
+});
+
+test('build, release and docs workflows run the live asset gate explicitly', () => {
+    const root = path.join(__dirname, '..');
+    for (const workflow of ['build.yml', 'release.yml', 'docs.yml']) {
+        const source = fs.readFileSync(path.join(root, '.github', 'workflows', workflow), 'utf8');
+        assert.match(source, /run: npm run check:docs-assets/);
+        assert.doesNotMatch(source, /check:docs-assets[^\n]*\n\s+continue-on-error:/);
+    }
+});

--- a/scripts/docs-asset-policy.json
+++ b/scripts/docs-asset-policy.json
@@ -1,0 +1,51 @@
+{
+  "assetExtensions": [
+    ".apng",
+    ".avif",
+    ".gif",
+    ".ico",
+    ".jpeg",
+    ".jpg",
+    ".mp4",
+    ".png",
+    ".svg",
+    ".webm",
+    ".webp"
+  ],
+  "docsRoot": "docs",
+  "allowedExternalAssetPrefixes": [
+    "https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/"
+  ],
+  "referenceFiles": [
+    "CONTRIBUTING.md",
+    "README.md",
+    "manifest.json",
+    "mkdocs.yml"
+  ],
+  "referenceDirectories": [
+    "docs",
+    "theme"
+  ],
+  "referenceExtensions": [
+    ".css",
+    ".html",
+    ".js",
+    ".json",
+    ".md",
+    ".ts",
+    ".yml",
+    ".yaml"
+  ],
+  "budgets": {
+    "documentation": {
+      "maxBytes": 24472975,
+      "maxFileBytes": 2941758
+    },
+    "repository": {
+      "maxBytes": 26835283,
+      "maxFileBytes": 2941758
+    }
+  },
+  "unreferencedAllowlist": [],
+  "animatedAllowlist": []
+}


### PR DESCRIPTION
Closes #147

## Outcome

Completes the orphaned-documentation-asset fix after the two 54 MB legacy panel GIFs were removed on `main`. The repository now has a blocking, owner-aware asset inventory instead of relying on manual searches.

## Changes

- audit every tracked visual asset under `docs/` for a real README/docs/theme/owned-manifest reference
- enforce ratcheted documentation and repository aggregate/per-file byte budgets
- require owned, expiring exceptions for intentional unreferenced assets
- reject GIFs and require source-backed descriptions, non-animated alternatives, and reduced-motion evidence for modern animation
- detect PNG/APNG, WebP, SVG, AVIF, MP4 and WebM animation; reject symlinked assets/reference sources
- run the gate explicitly and blockingly in build, release, and docs workflows
- record before/after asset, checkout, and strict-site metrics in CONTRIBUTING

## Validation

- `npm run test:scripts` — 312/312
- focused asset-policy suite — 9/9
- `npm run check:docs-assets` — 43 docs assets / 24,472,975 bytes; 47 repository visual assets / 26,835,283 bytes
- `npm run check:markdown-links` — 14 files
- `mkdocs build --strict`
- `npm run syntax`
- `npm run typecheck`
- changed-file ESLint — 0 findings
- independent adversarial review — APPROVE at `e7ef57200e2bbf3a93105848ce41db5f8ade3add`

## AI assistance

Developed with AI assistance. The exact diff and validation evidence were independently reviewed.