### PR TITLE
fix: canonicalize keyboard shortcuts

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/config.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/config.identity.test.ts
@@ -76,7 +76,7 @@ describe('identity-owned user settings', () => {
             file: 'shortcuts.json',
             revision: 1,
             contentHash: 'a'.repeat(64),
-            data: { Revision: 1, Shortcuts: [{ Name: 'A', Key: 'a' }] }
+            data: { Revision: 1, Shortcuts: [{ Name: 'A', Key: 'A' }] }
         });
         const originalCoreApi = JC.core.api;
         delete JC.core.api;
@@ -101,7 +101,7 @@ describe('identity-owned user settings', () => {
             file: 'shortcuts.json',
             revision: 1,
             contentHash: 'b'.repeat(64),
-            data: { Revision: 1, Shortcuts: [{ Name: 'Open', Key: 'o' }] }
+            data: { Revision: 1, Shortcuts: [{ Name: 'Open', Key: 'O' }] }
         };
         const ajax = vi.spyOn(ApiClient, 'ajax')
             .mockReturnValueOnce(firstPost)
@@ -147,6 +147,6 @@ describe('identity-owned user settings', () => {
 
         JC.initializeShortcuts!();
 
-        expect(JC.state!.activeShortcuts).toEqual({ Default: 'd', UserB: 'b' });
+        expect(JC.state!.activeShortcuts).toEqual({ Default: 'D', UserB: 'B' });
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/config.shortcuts.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/config.shortcuts.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../globals';
+import './config';
+
+const persistUserSettings = JC.saveUserSettings!;
+
+describe('shortcut configuration migration', () => {
+    beforeEach(() => {
+        JC.identity.transition('', '', 'shortcut-config-test-reset');
+        const context = JC.identity.transition('shortcut-server', 'shortcut-user', 'shortcut-config-test-start')!;
+        JC.pluginConfig = {
+            Shortcuts: [
+                { Name: 'Default', Key: 'shift+ctrl+d' },
+                { Name: 'Legacy', Key: 'L' },
+            ],
+        };
+        JC.state = {
+            activeShortcuts: {},
+            removeContext: null,
+            pauseScreenClickTimer: null,
+        };
+        JC.userConfig = {
+            shortcuts: JC.identity.own({
+                Revision: 4,
+                Shortcuts: [
+                    { Name: 'Legacy', Key: 'shift+CTRL+k' },
+                    { Name: 'LegacySpace', Key: 'ctrl+ ' },
+                ],
+            }, context),
+        };
+        JC.saveUserSettings = persistUserSettings;
+        vi.spyOn(ApiClient, 'getCurrentUserId').mockReturnValue('shortcut-user');
+        vi.spyOn(ApiClient as JellyfinApiClient & { serverId: () => string }, 'serverId')
+            .mockReturnValue('shortcut-server');
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('publishes canonical bindings and stages a loaded legacy permutation for the next save', () => {
+        const save = vi.fn();
+        JC.saveUserSettings = save;
+
+        JC.initializeShortcuts!();
+
+        expect(JC.state!.activeShortcuts).toEqual({
+            Default: 'Ctrl+Shift+D',
+            Legacy: 'Ctrl+Shift+K',
+            LegacySpace: 'Ctrl+Space',
+        });
+        expect(JC.userConfig!.shortcuts!.Shortcuts).toEqual([
+            { Name: 'Legacy', Key: 'Ctrl+Shift+K' },
+            { Name: 'LegacySpace', Key: 'Ctrl+Space' },
+        ]);
+        expect(save).not.toHaveBeenCalled();
+
+        JC.initializeShortcuts!();
+        expect(save).not.toHaveBeenCalled();
+    });
+
+    it('canonicalizes the wire payload for every shortcut persistence caller', async () => {
+        const payload = JC.userConfig!.shortcuts!;
+        JC.rememberUserSettingsSnapshot!('shortcuts.json', payload);
+        const ajax = vi.spyOn(ApiClient, 'ajax').mockResolvedValue({
+            success: true,
+            file: 'shortcuts.json',
+            revision: 5,
+            contentHash: 'a'.repeat(64),
+            data: {
+                Revision: 5,
+                Shortcuts: [
+                    { Name: 'Legacy', Key: 'Ctrl+Shift+K' },
+                    { Name: 'LegacySpace', Key: 'Ctrl+Space' },
+                ],
+            },
+        });
+
+        await persistUserSettings('shortcuts.json', payload);
+
+        expect(JSON.parse(String(ajax.mock.calls[0][0].data))).toEqual({
+            Revision: 4,
+            Shortcuts: [
+                { Name: 'Legacy', Key: 'Ctrl+Shift+K' },
+                { Name: 'LegacySpace', Key: 'Ctrl+Space' },
+            ],
+        });
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/config.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/config.ts
@@ -7,6 +7,7 @@ import { JC } from '../globals';
 import type { UserSettings } from '../types/jc';
 import { adminDefaultsView } from '../core/config-resolve';
 import { escapeHtml, toast } from '../core/ui-kit';
+import { canonicalizeShortcut, normalizeShortcutEntries } from './shortcut-codec';
 
 function normalizeIdentityPart(value: unknown): string {
     if (typeof value !== 'string' && typeof value !== 'number') return '';
@@ -178,7 +179,9 @@ function wireValue(fileName: string, settings: unknown): Record<string, unknown>
     if (!value || typeof value !== 'object' || Array.isArray(value)) {
         throw new UserSettingsPersistenceError(`Invalid ${fileName} payload`, { kind: 'validation' });
     }
-    return cloneRecord(value as Record<string, unknown>);
+    const wire = cloneRecord(value as Record<string, unknown>);
+    if (fileName === 'shortcuts.json') normalizeShortcutEntries(wire.Shortcuts);
+    return wire;
 }
 
 function localValue(fileName: string, wire: Record<string, unknown>): Record<string, unknown> {
@@ -833,17 +836,18 @@ JC.initializeShortcuts = function (): void {
     const pluginDefaults = JC.pluginConfig || {};
     const userShortcutsConfig = JC.userConfig?.shortcuts || {};
     JC.rememberUserSettingsSnapshot?.('shortcuts.json', userShortcutsConfig);
+    normalizeShortcutEntries(userShortcutsConfig.Shortcuts);
 
     const defaultShortcuts = Array.isArray(pluginDefaults.Shortcuts)
         ? (pluginDefaults.Shortcuts as ShortcutEntry[]).reduce<Record<string, string>>((acc, s) => {
-            if (s && s.Name && s.Key !== undefined) acc[s.Name] = s.Key;
+            if (s && s.Name && s.Key !== undefined) acc[s.Name] = canonicalizeShortcut(s.Key);
             return acc;
           }, {})
         : {};
 
     const userShortcuts = Array.isArray(userShortcutsConfig.Shortcuts)
         ? (userShortcutsConfig.Shortcuts as ShortcutEntry[]).reduce<Record<string, string>>((acc, s) => {
-            if (s && s.Name && s.Key !== undefined) acc[s.Name] = s.Key;
+            if (s && s.Name && s.Key !== undefined) acc[s.Name] = canonicalizeShortcut(s.Key);
             return acc;
           }, {})
         : {};

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/events.shortcuts.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/events.shortcuts.test.ts
@@ -1,0 +1,71 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../globals';
+
+describe('enhanced shortcut dispatch', () => {
+    beforeAll(async () => {
+        window.Events = { on: vi.fn() } as unknown as JellyfinEvents;
+        await import('./events');
+    });
+
+    beforeEach(() => {
+        JC.identity.transition('', '', 'shortcut-dispatch-test-reset');
+        JC.identity.transition('shortcut-server', 'shortcut-user', 'shortcut-dispatch-test-start');
+        JC.pluginConfig = { DisableAllShortcuts: false };
+        JC.currentSettings = { disableAllShortcuts: false };
+        JC.state = {
+            activeShortcuts: { GoToHome: 'Ctrl+Shift+K' },
+            removeContext: null,
+            pauseScreenClickTimer: null,
+        };
+        (JC as unknown as { isVideoPage: () => boolean }).isVideoPage = () => false;
+        JC.t = (key: string) => key;
+        window.location.hash = '#/start';
+    });
+
+    it('dispatches a legacy persisted multi-modifier permutation semantically', () => {
+        const event = new KeyboardEvent('keydown', {
+            key: 'k',
+            ctrlKey: true,
+            shiftKey: true,
+            cancelable: true,
+        });
+
+        JC.keyListener!(event);
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(window.location.hash).toBe('#/home.html');
+    });
+
+    it('keeps the built-in plus shortcut compatible with a shifted physical key', () => {
+        document.body.innerHTML = '<video></video>';
+        JC.state!.activeShortcuts = { IncreasePlaybackSpeed: '+' };
+        (JC as unknown as { isVideoPage: () => boolean }).isVideoPage = () => true;
+        const adjust = vi.fn();
+        JC.adjustPlaybackSpeed = adjust;
+        const event = new KeyboardEvent('keydown', {
+            key: '+',
+            shiftKey: true,
+            cancelable: true,
+        });
+
+        JC.keyListener!(event);
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(adjust).toHaveBeenCalledWith('increase');
+    });
+
+    it('dispatches a legacy modified-Space binding without treating it as plus', () => {
+        JC.state!.activeShortcuts = { GoToHome: 'shift+ctrl+ ' };
+        const event = new KeyboardEvent('keydown', {
+            key: ' ',
+            ctrlKey: true,
+            shiftKey: true,
+            cancelable: true,
+        });
+
+        JC.keyListener!(event);
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(window.location.hash).toBe('#/home.html');
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/events.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/events.ts
@@ -11,6 +11,7 @@ import { stampLayoutClass } from '../core/layout';
 import { migrateLegacyClientStorage } from './legacy-storage-migration';
 import { throttle } from './helpers';
 import type { IdentityContext } from '../types/jc';
+import { canonicalizeShortcut, shortcutFromEvent, shortcutsEqual } from './shortcut-codec';
 
 const shortcutTimers = new Set<number>();
 let actionSheetFrame: number | null = null;
@@ -59,37 +60,34 @@ JC.keyListener = (e: KeyboardEvent) => {
     if (isAnyModalOpen() || document.body.classList.contains('jc-modal-open')) return;
     if (['INPUT', 'TEXTAREA'].includes(document.activeElement!.tagName)) return;
 
-    const key = e.key;
-    const combo = (e.shiftKey ? 'Shift+' : '') +
-                  (e.metaKey ? 'Meta+' : '') +
-                  (e.ctrlKey ? 'Ctrl+' : '') +
-                  (e.altKey ? 'Alt+' : '') +
-                  (key.match(/^[a-zA-Z]$/) ? key.toUpperCase() : key);
+    const combo = shortcutFromEvent(e);
+    if (!combo) return;
 
     const video = document.querySelector('video');
     const activeShortcuts = JC.state!.activeShortcuts || {};
+    const matches = (name: string) => shortcutsEqual(combo, activeShortcuts[name]);
 
     // --- Global Shortcuts ---
-    if (combo === activeShortcuts.OpenSearch) {
+    if (matches('OpenSearch')) {
         e.preventDefault();
         document.querySelector<HTMLElement>('button.headerSearchButton')?.click();
         scheduleIdentityTimer(context, () => {
             document.querySelector<HTMLInputElement>('input[type="search"]')?.focus();
         }, 100);
         toast(JC.t!('toast_search'));
-    } else if (combo === activeShortcuts.GoToHome) {
+    } else if (matches('GoToHome')) {
         e.preventDefault();
         window.location.hash = '#/home.html';
         toast(JC.t!('toast_home'));
-    } else if (combo === activeShortcuts.GoToDashboard) {
+    } else if (matches('GoToDashboard')) {
         e.preventDefault();
         window.location.hash = '#/dashboard';
         toast(JC.t!('toast_dashboard'));
-    } else if (combo === activeShortcuts.QuickConnect) {
+    } else if (matches('QuickConnect')) {
         e.preventDefault();
         window.location.hash = '#/quickconnect';
         toast(`${JC.icon!(JC.IconName!.LINK)} Quick Connect`);
-    } else if (combo === activeShortcuts.PlayRandomItem && !(JC as any).isVideoPage()) {
+    } else if (matches('PlayRandomItem') && !(JC as any).isVideoPage()) {
         e.preventDefault();
         document.getElementById('randomItemButton')?.click();
     }
@@ -98,7 +96,7 @@ JC.keyListener = (e: KeyboardEvent) => {
     if (!(JC as any).isVideoPage() || !video) return;
 
     switch (combo) {
-        case activeShortcuts.BookmarkCurrentTime:
+        case canonicalizeShortcut(activeShortcuts.BookmarkCurrentTime):
             e.preventDefault();
             e.stopPropagation();
             // Open bookmark modal to add/view bookmarks
@@ -108,12 +106,12 @@ JC.keyListener = (e: KeyboardEvent) => {
                 console.warn('🪼 Jellyfin Canopy: New bookmark system not loaded, using fallback');
             }
             break;
-        case activeShortcuts.CycleAspectRatio:
+        case canonicalizeShortcut(activeShortcuts.CycleAspectRatio):
             e.preventDefault();
             e.stopPropagation();
             JC.cycleAspect!();
             break;
-        case activeShortcuts.ShowPlaybackInfo: {
+        case canonicalizeShortcut(activeShortcuts.ShowPlaybackInfo): {
             e.preventDefault();
             e.stopPropagation();
             // Check if stats dialog is already open
@@ -139,7 +137,7 @@ JC.keyListener = (e: KeyboardEvent) => {
             }
             break;
         }
-        case activeShortcuts.SubtitleMenu: {
+        case canonicalizeShortcut(activeShortcuts.SubtitleMenu): {
             e.preventDefault();
             e.stopPropagation();
             const subtitleMenuTitle = Array.from(document.querySelectorAll('.actionSheetContent .actionSheetTitle')).find(el => el.textContent === 'Subtitles');
@@ -155,32 +153,32 @@ JC.keyListener = (e: KeyboardEvent) => {
             }
             break;
         }
-        case activeShortcuts.CycleSubtitleTracks:
+        case canonicalizeShortcut(activeShortcuts.CycleSubtitleTracks):
             e.preventDefault();
             e.stopPropagation();
             JC.cycleSubtitleTrack!();
             break;
-        case activeShortcuts.CycleAudioTracks:
+        case canonicalizeShortcut(activeShortcuts.CycleAudioTracks):
             e.preventDefault();
             e.stopPropagation();
             JC.cycleAudioTrack!();
             break;
-        case activeShortcuts.ResetPlaybackSpeed:
+        case canonicalizeShortcut(activeShortcuts.ResetPlaybackSpeed):
             e.preventDefault();
             e.stopPropagation();
             JC.resetPlaybackSpeed!();
             break;
-        case activeShortcuts.IncreasePlaybackSpeed:
+        case canonicalizeShortcut(activeShortcuts.IncreasePlaybackSpeed):
             e.preventDefault();
             e.stopPropagation();
             JC.adjustPlaybackSpeed!('increase');
             break;
-        case activeShortcuts.DecreasePlaybackSpeed:
+        case canonicalizeShortcut(activeShortcuts.DecreasePlaybackSpeed):
             e.preventDefault();
             e.stopPropagation();
             JC.adjustPlaybackSpeed!('decrease');
             break;
-        case activeShortcuts.OpenEpisodePreview: {
+        case canonicalizeShortcut(activeShortcuts.OpenEpisodePreview): {
             e.preventDefault();
             e.stopPropagation();
             const popupFocusContainer = document.getElementById('popupFocusContainer');
@@ -200,30 +198,30 @@ JC.keyListener = (e: KeyboardEvent) => {
             }
             break;
         }
-        case activeShortcuts.SkipIntroOutro:
+        case canonicalizeShortcut(activeShortcuts.SkipIntroOutro):
             e.preventDefault();
             e.stopPropagation();
             JC.skipIntroOutro!();
             break;
-        case activeShortcuts.FrameStepBack:
+        case canonicalizeShortcut(activeShortcuts.FrameStepBack):
             e.preventDefault();
             e.stopPropagation();
             void JC.frameStep!('back');
             break;
-        case activeShortcuts.FrameStepForward:
+        case canonicalizeShortcut(activeShortcuts.FrameStepForward):
             e.preventDefault();
             e.stopPropagation();
             void JC.frameStep!('forward');
             break;
-        case activeShortcuts.JumpToLastPosition:
+        case canonicalizeShortcut(activeShortcuts.JumpToLastPosition):
             e.preventDefault();
             e.stopPropagation();
             JC.jumpToLastPosition!();
             break;
     }
 
-    if (key.match(/^[0-9]$/)) {
-        JC.jumpToPercentage!(parseInt(key) * 10);
+    if (e.key.match(/^[0-9]$/)) {
+        JC.jumpToPercentage!(parseInt(e.key) * 10);
     }
 };
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/shortcut-editor.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/shortcut-editor.identity.test.ts
@@ -32,4 +32,81 @@ describe('settings shortcut editor identity ownership', () => {
         expect(bShortcuts.Shortcuts).toEqual([]);
         expect(save).not.toHaveBeenCalled();
     });
+
+    it('rejects a duplicate semantic binding regardless of legacy modifier order', () => {
+        JC.identity.transition('server-a', 'user-a', 'shortcut-conflict-test-start');
+        const context = JC.identity.capture()!;
+        const help = document.createElement('div');
+        help.innerHTML = [
+            '<span class="shortcut-key" data-action="first">Ctrl+Shift+K</span><span></span>',
+            '<span class="shortcut-key" data-action="second">Alt+K</span><span></span>',
+        ].join('');
+        const second = help.querySelectorAll<HTMLElement>('.shortcut-key')[1];
+        JC.pluginConfig = { DisableAllShortcuts: false };
+        JC.state = {
+            // Put the edited action first to prove conflict detection does not
+            // stop at its own matching binding before checking other actions.
+            activeShortcuts: { second: 'Ctrl+Shift+K', first: 'shift+CTRL+k' },
+        } as unknown as NonNullable<typeof JC.state>;
+        JC.userConfig = { shortcuts: { Shortcuts: [] } };
+        const save = vi.fn().mockResolvedValue(undefined);
+        JC.saveUserSettings = save;
+
+        wireShortcutEditor({
+            help,
+            pluginShortcuts: [
+                { Name: 'first', Key: 'Ctrl+Shift+K' },
+                { Name: 'second', Key: 'Alt+K' },
+            ],
+            primaryAccentColor: '#0ff',
+            kbdBackground: '#111',
+            identityContext: context,
+            trackTimer: vi.fn(),
+        } as unknown as PanelContext);
+
+        second.dispatchEvent(new KeyboardEvent('keydown', {
+            key: 'k', ctrlKey: true, shiftKey: true, bubbles: true,
+        }));
+
+        expect(second.classList.contains('shake-error')).toBe(true);
+        expect(save).not.toHaveBeenCalled();
+        expect(JC.userConfig.shortcuts!.Shortcuts).toEqual([]);
+    });
+
+    it('captures Meta independently and saves every entry in canonical form', async () => {
+        JC.identity.transition('server-a', 'user-a', 'shortcut-meta-test-start');
+        const context = JC.identity.capture()!;
+        const help = document.createElement('div');
+        help.innerHTML = '<span class="shortcut-key" data-action="play">P</span><span></span>';
+        const key = help.querySelector<HTMLElement>('.shortcut-key')!;
+        JC.pluginConfig = { DisableAllShortcuts: false };
+        JC.state = { activeShortcuts: { play: 'P', other: 'Alt+O' } } as unknown as NonNullable<typeof JC.state>;
+        JC.userConfig = {
+            shortcuts: {
+                Shortcuts: [{ Name: 'other', Key: 'alt+o' }],
+            },
+        };
+        const save = vi.fn().mockResolvedValue(undefined);
+        JC.saveUserSettings = save;
+
+        wireShortcutEditor({
+            help,
+            pluginShortcuts: [{ Name: 'play', Key: 'P' }],
+            primaryAccentColor: '#0ff',
+            kbdBackground: '#111',
+            identityContext: context,
+            trackTimer: vi.fn(),
+        } as unknown as PanelContext);
+
+        key.dispatchEvent(new KeyboardEvent('keydown', {
+            key: 'k', metaKey: true, ctrlKey: true, bubbles: true,
+        }));
+
+        expect(JC.userConfig.shortcuts!.Shortcuts).toEqual([
+            { Name: 'other', Key: 'Alt+O' },
+            { Name: 'play', Key: 'Meta+Ctrl+K' },
+        ]);
+        expect(save).toHaveBeenCalledWith('shortcuts.json', JC.userConfig.shortcuts);
+        await vi.waitFor(() => expect(JC.state!.activeShortcuts.play).toBe('Meta+Ctrl+K'));
+    });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/shortcut-editor.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/shortcut-editor.ts
@@ -6,6 +6,12 @@
 // (Converted from js/enhanced/ui-panel-shortcut-editor.js — bodies semantically identical.)
 
 import { JC } from '../../globals';
+import {
+    formatShortcut,
+    normalizeShortcutEntries,
+    shortcutFromEvent,
+    shortcutsEqual,
+} from '../shortcut-codec';
 import type { PanelContext } from './panel';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -22,7 +28,7 @@ export function wireShortcutEditor(ctx: PanelContext): void {
     if (!JC.pluginConfig.DisableAllShortcuts) {
         const shortcutKeys = help.querySelectorAll<HTMLElement>('.shortcut-key');
         shortcutKeys.forEach(keyElement => {
-            const getOriginalKey = () => JC.state!.activeShortcuts[keyElement.dataset.action!];
+            const getOriginalKey = () => formatShortcut(JC.state!.activeShortcuts[keyElement.dataset.action!]);
 
             keyElement.addEventListener('click', () => { if (isCurrent()) keyElement.focus(); });
 
@@ -50,12 +56,13 @@ export function wireShortcutEditor(ctx: PanelContext): void {
 
                 if (e.key === 'Backspace') {
                     const defaultConfig = pluginShortcuts.find((s: any) => s.Name === action);
-                    const defaultKey = defaultConfig ? defaultConfig.Key : '';
+                    const defaultKey = formatShortcut(defaultConfig ? defaultConfig.Key : '');
 
                     const shortcutIndex = (JC.userConfig as any).shortcuts.Shortcuts.findIndex((s: any) => s.Name === action);
                     if (shortcutIndex > -1) {
                         (JC.userConfig as any).shortcuts.Shortcuts.splice(shortcutIndex, 1);
                     }
+                    normalizeShortcutEntries((JC.userConfig as any).shortcuts.Shortcuts);
 
                     void JC.saveUserSettings!('shortcuts.json', (JC.userConfig as any).shortcuts).then(() => {
                         if (!isCurrent()) return;
@@ -71,13 +78,11 @@ export function wireShortcutEditor(ctx: PanelContext): void {
                     return;
                 }
 
-                if (['Shift', 'Control', 'Alt', 'Meta'].includes(e.key)) {
-                    return; // Don't allow setting only a modifier key
-                }
-
-                const combo = (e.metaKey ? 'Meta+' : '') + (e.ctrlKey ? 'Ctrl+' : '') + (e.altKey ? 'Alt+' : '') + (e.shiftKey ? 'Shift+' : '') + (e.key.match(/^[a-zA-Z]$/) ? e.key.toUpperCase() : e.key);
-                const existingAction = Object.keys(JC.state!.activeShortcuts).find(name => JC.state!.activeShortcuts[name] === combo);
-                if (existingAction && existingAction !== action) {
+                const combo = shortcutFromEvent(e);
+                if (!combo) return; // Don't allow setting only a modifier key.
+                const existingAction = Object.keys(JC.state!.activeShortcuts)
+                    .find(name => name !== action && shortcutsEqual(JC.state!.activeShortcuts[name], combo));
+                if (existingAction) {
                     keyElement.style.background = 'rgb(255 0 0 / 60%)';
                     keyElement.classList.add('shake-error');
                     const timer = window.setTimeout(() => {
@@ -100,6 +105,7 @@ export function wireShortcutEditor(ctx: PanelContext): void {
                     const defaultConfig = pluginShortcuts.find((s: any) => s.Name === action);
                     (JC.userConfig as any).shortcuts.Shortcuts.push({ ...defaultConfig, Key: combo });
                 }
+                normalizeShortcutEntries((JC.userConfig as any).shortcuts.Shortcuts);
                 void JC.saveUserSettings!('shortcuts.json', (JC.userConfig as any).shortcuts).then(() => {
                     if (!isCurrent()) return;
                     JC.state!.activeShortcuts[action] = combo;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/template.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/template.ts
@@ -7,6 +7,7 @@
 
 import { JC } from '../../globals';
 import { assetUrl } from '../../core/asset-urls';
+import { formatShortcut } from '../shortcut-codec';
 import { escapeHtml } from '../../core/ui-kit';
 import { cssColorOr } from '../../core/css-safe';
 import { GITHUB_REPO } from './release-notes';
@@ -116,7 +117,7 @@ export function buildPanelHtml(ctx: PanelContext): string {
                             <div style="display: grid; gap: 8px; font-size: 14px;">
                                 ${((JC.pluginConfig.Shortcuts as any[]) || []).filter((s: any, index: number, self: any[]) => s.Category === 'Global' && index === self.findIndex((t: any) => t.Name === s.Name)).map((action: any) => `
                                     <div style="display: flex; justify-content: space-between; align-items: center;">
-                                        <span class="shortcut-key" tabindex="0" data-action="${escapeHtml(action.Name)}" style="background:${kbdBackground}; padding:2px 8px; border-radius:3px; cursor:pointer; transition: all 0.2s;">${escapeHtml(JC.state!.activeShortcuts[action.Name] || '')}</span>
+                                        <span class="shortcut-key" tabindex="0" data-action="${escapeHtml(action.Name)}" style="background:${kbdBackground}; padding:2px 8px; border-radius:3px; cursor:pointer; transition: all 0.2s;">${escapeHtml(formatShortcut(JC.state!.activeShortcuts[action.Name]))}</span>
                                         <div style="display: flex; align-items: center; gap: 8px;">
                                             ${userShortcuts.hasOwnProperty(action.Name) ? `<span title="Modified by user" class="modified-indicator" style="color:${primaryAccentColor}; font-size: 20px; line-height: 1;">•</span>` : ''}
                                             <span>${escapeHtml(tWithFallback('shortcut_' + action.Name, action.Label))}</span>
@@ -133,7 +134,7 @@ export function buildPanelHtml(ctx: PanelContext): string {
                                     const fallbackLabel = a?.Label || action;
                                     return `
                                     <div style="display: flex; justify-content: space-between; align-items: center;">
-                                        <span class="shortcut-key" tabindex="0" data-action="${escapeHtml(action)}" style="background:${kbdBackground}; padding:2px 8px; border-radius:3px; cursor:pointer; transition: all 0.2s;">${escapeHtml(JC.state!.activeShortcuts[action] || '')}</span>
+                                        <span class="shortcut-key" tabindex="0" data-action="${escapeHtml(action)}" style="background:${kbdBackground}; padding:2px 8px; border-radius:3px; cursor:pointer; transition: all 0.2s;">${escapeHtml(formatShortcut(JC.state!.activeShortcuts[action]))}</span>
                                         <div style="display: flex; align-items: center; gap: 8px;">
                                             ${userShortcuts.hasOwnProperty(action) ? `<span class="modified-indicator" title="Modified by user" style="color:${primaryAccentColor}; font-size: 20px; line-height: 1;">•</span>` : ''}
                                             <span>${escapeHtml(tWithFallback('shortcut_' + action, fallbackLabel))}${action === 'OpenEpisodePreview' ? ' <span style="font-size: 11px; opacity: 0.7;" title="Requires InPlayerEpisodePreview plugin from https://github.com/Namo2/InPlayerEpisodePreview/">ⓘ</span>' : ''}</span>

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/shortcut-codec.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/shortcut-codec.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import {
+    canonicalizeShortcut,
+    formatShortcut,
+    normalizeShortcutEntries,
+    shortcutFromEvent,
+    shortcutsEqual,
+} from './shortcut-codec';
+
+const MODIFIERS = ['Meta', 'Ctrl', 'Alt', 'Shift'] as const;
+
+function permutations(values: readonly string[]): string[][] {
+    if (values.length <= 1) return [Array.from(values)];
+    return values.flatMap((value, index) => permutations([
+        ...values.slice(0, index),
+        ...values.slice(index + 1),
+    ]).map(rest => [value, ...rest]));
+}
+
+describe('canonical shortcut codec', () => {
+    it('normalizes every modifier pair, triple, and quad permutation and casing', () => {
+        for (let mask = 0; mask < (1 << MODIFIERS.length); mask += 1) {
+            const selected = MODIFIERS.filter((_modifier, index) => (mask & (1 << index)) !== 0);
+            if (selected.length < 2) continue;
+            const canonical = `${MODIFIERS.filter(modifier => selected.includes(modifier)).join('+')}+K`;
+            for (const permutation of permutations(selected)) {
+                const legacy = `${permutation.map(modifier => modifier.toLowerCase()).join('+')}+k`;
+                expect(canonicalizeShortcut(legacy)).toBe(canonical);
+            }
+            expect(shortcutFromEvent({
+                key: 'k',
+                metaKey: selected.includes('Meta'),
+                ctrlKey: selected.includes('Ctrl'),
+                altKey: selected.includes('Alt'),
+                shiftKey: selected.includes('Shift'),
+            })).toBe(canonical);
+        }
+    });
+
+    it('preserves Meta semantics while accepting Cmd/Command legacy spellings', () => {
+        expect(canonicalizeShortcut('cmd+shift+k')).toBe('Meta+Shift+K');
+        expect(canonicalizeShortcut('Control+Command+Option+k')).toBe('Meta+Ctrl+Alt+K');
+        expect(shortcutsEqual('Meta+Ctrl+K', 'ctrl+CMD+k')).toBe(true);
+        expect(shortcutsEqual('Meta+K', 'Ctrl+K')).toBe(false);
+    });
+
+    it.each([
+        ['h', 'H'],
+        ['shift+h', 'Shift+H'],
+        ['/', '/'],
+        ['+', '+'],
+        ['ctrl++', 'Ctrl++'],
+        ['ctrl+shift++', 'Ctrl++'],
+        ['-', '-'],
+        [',', ','],
+        ['.', '.'],
+        ['arrowleft', 'ArrowLeft'],
+        ['ESC', 'Escape'],
+        [' ', 'Space'],
+        ['ctrl+ ', 'Ctrl+Space'],
+        ['ctrl+shift+ ', 'Ctrl+Shift+Space'],
+        ['ctrl++ ', 'Ctrl++'],
+        ['f12', 'F12'],
+        ['ß', 'ß'],
+    ])('keeps single-modifier and special key %j compatible', (stored, expected) => {
+        expect(canonicalizeShortcut(stored)).toBe(expected);
+        expect(formatShortcut(stored)).toBe(expected);
+        expect(canonicalizeShortcut(expected)).toBe(expected);
+    });
+
+    it('treats Shift used to type a punctuation glyph as part of that key', () => {
+        expect(shortcutFromEvent({
+            key: '+', metaKey: false, ctrlKey: false, altKey: false, shiftKey: true,
+        })).toBe('+');
+        expect(shortcutFromEvent({
+            key: '+', metaKey: false, ctrlKey: true, altKey: false, shiftKey: true,
+        })).toBe('Ctrl++');
+        expect(shortcutFromEvent({
+            key: 'ArrowUp', metaKey: false, ctrlKey: false, altKey: false, shiftKey: true,
+        })).toBe('Shift+ArrowUp');
+    });
+
+    it('rejects modifier-only and ambiguous bindings', () => {
+        expect(canonicalizeShortcut('Shift')).toBe('');
+        expect(canonicalizeShortcut('Ctrl+Alt')).toBe('');
+        expect(canonicalizeShortcut('A+B')).toBe('');
+        expect(shortcutFromEvent({ key: 'Meta', metaKey: true, ctrlKey: false, altKey: false, shiftKey: false })).toBe('');
+    });
+
+    it('matches legacy modified-Space persistence to the physical event', () => {
+        const event = shortcutFromEvent({
+            key: ' ', metaKey: false, ctrlKey: true, altKey: false, shiftKey: true,
+        });
+        expect(event).toBe('Ctrl+Shift+Space');
+        expect(shortcutsEqual('shift+ctrl+ ', event)).toBe(true);
+    });
+
+    it('normalizes loaded entries deterministically without changing unrelated fields', () => {
+        const entries = [
+            { Name: 'First', Key: 'shift+CTRL+k', Label: 'First' },
+            { Name: 'Second', Key: 'cmd+alt+ArrowLeft', Extra: true },
+            { Name: 'Empty', Key: '' },
+        ];
+        expect(normalizeShortcutEntries(entries)).toBe(true);
+        expect(entries).toEqual([
+            { Name: 'First', Key: 'Ctrl+Shift+K', Label: 'First' },
+            { Name: 'Second', Key: 'Meta+Alt+ArrowLeft', Extra: true },
+            { Name: 'Empty', Key: '' },
+        ]);
+        expect(normalizeShortcutEntries(entries)).toBe(false);
+    });
+
+    it('detects duplicate semantic bindings independent of legacy spelling', () => {
+        expect(shortcutsEqual('Ctrl+Shift+K', 'shift+ctrl+k')).toBe(true);
+        expect(shortcutsEqual('Ctrl+K', 'Ctrl+Shift+K')).toBe(false);
+        expect(shortcutsEqual('', '')).toBe(false);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/shortcut-codec.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/shortcut-codec.ts
@@ -1,0 +1,192 @@
+// Canonical keyboard-shortcut codec shared by capture, persistence, display,
+// conflict detection, and dispatch. Persisted modifiers always use this order;
+// aliases and legacy permutations normalize to the same semantic binding.
+
+const MODIFIER_ORDER = ['Meta', 'Ctrl', 'Alt', 'Shift'] as const;
+type Modifier = typeof MODIFIER_ORDER[number];
+
+const MODIFIER_ALIASES: Readonly<Record<string, Modifier>> = {
+    meta: 'Meta',
+    cmd: 'Meta',
+    command: 'Meta',
+    os: 'Meta',
+    super: 'Meta',
+    win: 'Meta',
+    windows: 'Meta',
+    ctrl: 'Ctrl',
+    control: 'Ctrl',
+    alt: 'Alt',
+    option: 'Alt',
+    shift: 'Shift',
+};
+
+const NAMED_KEYS: Readonly<Record<string, string>> = {
+    altgraph: 'AltGraph',
+    arrowdown: 'ArrowDown',
+    arrowleft: 'ArrowLeft',
+    arrowright: 'ArrowRight',
+    arrowup: 'ArrowUp',
+    backspace: 'Backspace',
+    browserback: 'BrowserBack',
+    browserfavorites: 'BrowserFavorites',
+    browserforward: 'BrowserForward',
+    browserhome: 'BrowserHome',
+    browserrefresh: 'BrowserRefresh',
+    browsersearch: 'BrowserSearch',
+    browserstop: 'BrowserStop',
+    capslock: 'CapsLock',
+    clear: 'Clear',
+    contextmenu: 'ContextMenu',
+    dead: 'Dead',
+    delete: 'Delete',
+    end: 'End',
+    enter: 'Enter',
+    escape: 'Escape',
+    esc: 'Escape',
+    execute: 'Execute',
+    help: 'Help',
+    home: 'Home',
+    insert: 'Insert',
+    launchapplication1: 'LaunchApplication1',
+    launchapplication2: 'LaunchApplication2',
+    launchmail: 'LaunchMail',
+    mediapause: 'MediaPause',
+    mediaplay: 'MediaPlay',
+    mediaplaypause: 'MediaPlayPause',
+    mediastop: 'MediaStop',
+    mediatracknext: 'MediaTrackNext',
+    mediatrackprevious: 'MediaTrackPrevious',
+    numlock: 'NumLock',
+    pagedown: 'PageDown',
+    pageup: 'PageUp',
+    pause: 'Pause',
+    printscreen: 'PrintScreen',
+    scrolllock: 'ScrollLock',
+    select: 'Select',
+    space: 'Space',
+    spacebar: 'Space',
+    tab: 'Tab',
+    unidentified: 'Unidentified',
+    audiovolumedown: 'AudioVolumeDown',
+    audiovolumemute: 'AudioVolumeMute',
+    audiovolumeup: 'AudioVolumeUp',
+    zoomin: 'ZoomIn',
+    zoomout: 'ZoomOut',
+};
+
+export interface ShortcutEntryLike {
+    Key?: unknown;
+    [key: string]: unknown;
+}
+
+export interface ShortcutKeyboardEvent {
+    key: string;
+    metaKey: boolean;
+    ctrlKey: boolean;
+    altKey: boolean;
+    shiftKey: boolean;
+}
+
+function modifierFor(token: string): Modifier | undefined {
+    return MODIFIER_ALIASES[token.trim().toLowerCase()];
+}
+
+function canonicalKey(rawKey: string): string {
+    if (rawKey === ' ') return 'Space';
+    const key = rawKey.trim();
+    if (!key) return '';
+    if (key === '+') return '+';
+    if ([...key].length === 1) return /^[a-z]$/i.test(key) ? key.toUpperCase() : key;
+    const functionKey = key.match(/^f([1-9]|1[0-9]|2[0-4])$/i);
+    if (functionKey) return `F${functionKey[1]}`;
+    return NAMED_KEYS[key.toLowerCase()] || key.toLowerCase();
+}
+
+function serialize(modifiers: ReadonlySet<Modifier>, key: string): string {
+    return [...MODIFIER_ORDER.filter(modifier => modifiers.has(modifier)), key].join('+');
+}
+
+function keyAlreadyEncodesShift(key: string): boolean {
+    return [...key].length === 1 && !/[\p{L}\p{N}]/u.test(key) && key !== ' ';
+}
+
+/** Convert any supported persisted spelling/order into one stable wire/display value. */
+export function canonicalizeShortcut(value: unknown): string {
+    if (typeof value !== 'string') return '';
+    if (value === ' ') return 'Space';
+    // The legacy editor concatenated KeyboardEvent.key directly, so a
+    // modified Space was persisted as (for example) `Ctrl+ `. Preserve that
+    // trailing literal key without confusing a whitespace-padded `Ctrl++`.
+    const legacySpacePrefix = value.endsWith('+ ') ? value.slice(0, -1) : '';
+    const legacySpaceTokens = legacySpacePrefix.endsWith('+')
+        ? legacySpacePrefix.slice(0, -1).split('+').map(token => token.trim())
+        : [];
+    const hasLegacySpaceKey = legacySpaceTokens.length > 0
+        && legacySpaceTokens.every(token => token !== '' && modifierFor(token) !== undefined);
+    const source = hasLegacySpaceKey ? `${legacySpacePrefix}Space` : value.trim();
+    if (!source) return '';
+
+    let tokens: string[];
+    if (source.endsWith('+')) {
+        tokens = source.slice(0, -1).split('+').map(token => token.trim()).filter(Boolean);
+        tokens.push('+');
+    } else {
+        tokens = source.split('+').map(token => token.trim()).filter(Boolean);
+    }
+
+    const modifiers = new Set<Modifier>();
+    const keys: string[] = [];
+    for (const token of tokens) {
+        const modifier = modifierFor(token);
+        if (modifier) modifiers.add(modifier);
+        else keys.push(token);
+    }
+    if (keys.length !== 1) return '';
+    const key = canonicalKey(keys[0]);
+    if (keyAlreadyEncodesShift(key)) modifiers.delete('Shift');
+    return key ? serialize(modifiers, key) : '';
+}
+
+/** Canonicalize a physical event without depending on the event's modifier-key order. */
+export function shortcutFromEvent(event: ShortcutKeyboardEvent): string {
+    if (modifierFor(event.key)) return '';
+    const key = canonicalKey(event.key);
+    if (!key) return '';
+    const modifiers = new Set<Modifier>();
+    if (event.metaKey) modifiers.add('Meta');
+    if (event.ctrlKey) modifiers.add('Ctrl');
+    if (event.altKey) modifiers.add('Alt');
+    // Printable punctuation already identifies the shifted glyph (`+`, `?`,
+    // `<`, ...). Retaining Shift as a second semantic modifier would make the
+    // built-in `+` shortcut impossible to trigger on ordinary keyboards.
+    if (event.shiftKey && !keyAlreadyEncodesShift(event.key)) modifiers.add('Shift');
+    return serialize(modifiers, key);
+}
+
+/** Empty/invalid bindings never conflict; every valid permutation compares semantically. */
+export function shortcutsEqual(left: unknown, right: unknown): boolean {
+    const canonicalLeft = canonicalizeShortcut(left);
+    return canonicalLeft !== '' && canonicalLeft === canonicalizeShortcut(right);
+}
+
+/** Display uses the same representation that persistence and dispatch consume. */
+export function formatShortcut(value: unknown): string {
+    return canonicalizeShortcut(value);
+}
+
+/** Normalize a loaded payload in place so its next save migrates legacy values. */
+export function normalizeShortcutEntries(entries: unknown): boolean {
+    if (!Array.isArray(entries)) return false;
+    let changed = false;
+    for (const candidate of entries) {
+        if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) continue;
+        const entry = candidate as ShortcutEntryLike;
+        if (typeof entry.Key !== 'string') continue;
+        const normalized = canonicalizeShortcut(entry.Key);
+        if (normalized && normalized !== entry.Key) {
+            entry.Key = normalized;
+            changed = true;
+        }
+    }
+    return changed;
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/src/test/escape-guard.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/test/escape-guard.test.ts
@@ -183,13 +183,13 @@ const ALLOWLIST: AllowlistEntry[] = [
     {
         file: 'enhanced/settings-panel/template.ts',
         expr: 'preset.size',
-        line: 53,
+        line: 54,
         why: 'plugin-defined font-size preset tables (legacy js/ tree) — fixed numeric em values',
     },
     {
         file: 'enhanced/settings-panel/template.ts',
         expr: 'preset.family',
-        line: 55,
+        line: 56,
         why: 'plugin-defined font-family preset tables (legacy js/ tree) — fixed font-family literals',
     },
 ];

--- a/docs/enhanced.md
+++ b/docs/enhanced.md
@@ -93,6 +93,13 @@ Drive Jellyfin without reaching for the mouse: a comprehensive set of hotkeys co
 3. Click any key to set a custom binding.
 4. Changes save automatically, per user.
 
+Modifier combinations work in any pressed order and are displayed consistently
+as `Meta+Ctrl+Alt+Shift+Key` (only the modifiers you use are shown). On macOS,
+the Command key is stored as `Meta`; existing `Cmd`, `Command`, and differently
+ordered legacy bindings are normalized automatically without changing what the
+physical shortcut does. The editor rejects another binding with the same
+semantic key combination, even when its stored spelling or order differs.
+
 !!! note "Admin: disabling shortcuts server-wide"
 
     An administrator can turn off **all** keyboard shortcuts for every user with


### PR DESCRIPTION
Closes #125

## Outcome

Multi-modifier shortcuts now have one semantic codec across capture, initialization, persistence, display, conflict detection, and dispatch. Legacy modifier order/casing and Meta/Cmd aliases migrate deterministically instead of silently failing exact-string comparisons.

## Changes

- add the shared typed shortcut parser/canonicalizer
- normalize legacy persisted values without losing platform Meta behavior
- canonicalize editor capture, runtime dispatch, display, and duplicate detection
- preserve punctuation, shifted-key, special-key, and modified-Space behavior
- document the canonical persistence contract

## Validation

- focused regressions — 7 files / 68 tests
- full client coverage — 142 files / 897 tests
- client coverage ratchet — 81.553%
- `npm run test:scripts` — 303/303
- `npm run typecheck:src` and `npm run typecheck`
- `npm run build:bundle` and `npm run syntax`
- Markdown links and strict MkDocs build
- ESLint — 0 errors (existing warnings remain advisory)
- independent review — APPROVE at `bd10c8f4eb98651f0ac3302185236afd40cc9195`

## AI assistance

Developed with AI assistance. The implementation and exact commit were independently reviewed.