### PR TITLE
Fix explicit empty Discovery rows

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/discovery/customize.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/discovery/customize.ts
@@ -9,7 +9,7 @@
 import { JC } from '../globals';
 import { installModalA11y, type ModalA11yHandle } from '../core/modal-a11y';
 import type { DiscoveryMediaType, DiscoveryRowSpec } from './rows';
-import { specFromId, adminDefaultRowIds, genreRowsEnabled, BUILTIN_ORDER } from './rows';
+import { specFromId, defaultRowIds, BUILTIN_ORDER } from './rows';
 import { getUserRowIds, setUserRowIds, clearUserRowIds } from './prefs';
 
 interface Item { id: string; label: string; checked: boolean }
@@ -38,13 +38,6 @@ function buildItems(mt: DiscoveryMediaType, genres: Map<number, string>): Item[]
         if (spec) { items.push({ id, label: labelFor(spec), checked: false }); seen.add(id); }
     }
     return items;
-}
-
-/** The default (uncustomised) row-id set = admin defaults + a few genre rows, mirroring the feed. */
-function defaultRowIds(genres: Map<number, string>): string[] {
-    const ids = adminDefaultRowIds();
-    if (genreRowsEnabled()) ids.push(...[...genres.keys()].slice(0, 4).map((g) => `genre:${g}`));
-    return ids;
 }
 
 /**

--- a/Jellyfin.Plugin.JellyfinCanopy/src/discovery/feed.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/discovery/feed.ts
@@ -12,7 +12,7 @@ import { JC } from '../globals';
 import { injectCss } from '../core/ui-kit';
 import type { DiscoveryMediaType, DiscoveryRowSpec } from './rows';
 import type { IdentityContext } from '../types/jc';
-import { resolveRows, genreRowsEnabled } from './rows';
+import { resolveRows } from './rows';
 import { fetchRow, fetchGenres } from './data';
 
 const CSS_ID = 'jc-discovery-feed-css';
@@ -141,13 +141,7 @@ export async function renderFeed(container: HTMLElement, mt: DiscoveryMediaType,
         destroy();
         return { element: feed, destroy };
     }
-    let specs = resolveRows(userRowIds, genres);
-    if (!userRowIds && genreRowsEnabled()) {
-        // Enrich the default feed with a few real genre rows so it's rich out of the box.
-        const genreRowIds = [...genres.keys()].slice(0, 4).map((id) => `genre:${id}`);
-        const genreSpecs = resolveRows(genreRowIds, genres).filter((s) => !specs.some((e) => e.id === s.id));
-        specs = specs.concat(genreSpecs);
-    }
+    const specs = resolveRows(userRowIds, genres);
 
     if (specs.length === 0) {
         const msg = document.createElement('div');

--- a/Jellyfin.Plugin.JellyfinCanopy/src/discovery/library-tab.config.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/discovery/library-tab.config.test.ts
@@ -1,0 +1,147 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { JC } from '../globals';
+import type { DiscoveryFeedHandle } from './feed';
+import { resolveRows, type DiscoveryMediaType } from './rows';
+
+const mocks = vi.hoisted(() => ({
+    renderFeed: vi.fn(),
+}));
+
+vi.mock('./feed', () => ({
+    renderFeed: mocks.renderFeed,
+}));
+vi.mock('./data', () => ({
+    fetchGenres: vi.fn(() => Promise.resolve(new Map([[28, 'Action']]))),
+}));
+vi.mock('./customize', () => ({ openCustomize: vi.fn() }));
+vi.mock('../enhanced/helpers', () => ({
+    getHeaderRightContainer: () => document.querySelector<HTMLElement>('.headerRight'),
+}));
+vi.mock('../core/navigation', () => ({ onNavigate: () => () => undefined }));
+vi.mock('../core/ui-kit', () => ({ injectCss: vi.fn() }));
+
+let initLibraryTab: () => void;
+const listenerCleanups: Array<() => void> = [];
+
+function disableEveryDefaultRow(): void {
+    JC.pluginConfig.DiscoveryRowTrending = false;
+    JC.pluginConfig.DiscoveryRowPopular = false;
+    JC.pluginConfig.DiscoveryRowUpcoming = false;
+    JC.pluginConfig.DiscoveryRowTopRated = false;
+    JC.pluginConfig.DiscoveryRowWatchlist = false;
+    JC.pluginConfig.DiscoveryGenreRows = false;
+}
+
+beforeAll(async () => {
+    const lifecycle = {
+        name: 'discovery-library-tab-test',
+        track: <T>(resource: T): T => resource,
+        untrack: () => undefined,
+        addListener: (
+            element: EventTarget,
+            type: string,
+            listener: EventListenerOrEventListenerObject,
+            options?: boolean | AddEventListenerOptions,
+        ): void => {
+            element.addEventListener(type, listener, options);
+            listenerCleanups.push(() => element.removeEventListener(type, listener, options));
+        },
+        onTeardown: () => lifecycle,
+        teardown: (): void => {
+            while (listenerCleanups.length > 0) listenerCleanups.pop()?.();
+        },
+        teardownOn: () => () => undefined,
+    };
+    JC.core.lifecycle = {
+        register: () => lifecycle,
+        get: () => lifecycle,
+        teardownAll: () => lifecycle.teardown(),
+        getFeatures: () => ['discovery-library-tab-test'],
+    };
+    JC.core.dom = {
+        onBodyMutation: () => ({ unsubscribe: () => undefined }),
+    } as unknown as NonNullable<typeof JC.core.dom>;
+    JC.core.ui = {
+        muiIconButton: (options: { id: string; className?: string; onClick: () => void }) => {
+            const button = document.createElement('button');
+            button.id = options.id;
+            button.className = options.className || '';
+            button.addEventListener('click', options.onClick);
+            return button;
+        },
+        expandIn: () => undefined,
+    } as unknown as NonNullable<typeof JC.core.ui>;
+    JC.t = (key: string) => key;
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+        callback(0);
+        return 1;
+    });
+    vi.stubGlobal('cancelAnimationFrame', () => undefined);
+    ({ initLibraryTab } = await import('./library-tab'));
+});
+
+afterAll(() => {
+    JC.identity.transition('', '', 'discovery-config-test-cleanup');
+    while (listenerCleanups.length > 0) listenerCleanups.pop()?.();
+    vi.unstubAllGlobals();
+});
+
+describe('Discovery active-pane config hot reload', () => {
+    it('keeps an explicit-empty feed mounted until its hot-reloaded replacement is ready', async () => {
+        document.body.innerHTML = '<div class="headerRight"></div><div id="moviesPage"></div>';
+        const page = document.getElementById('moviesPage')!;
+        Object.defineProperty(page, 'offsetParent', { value: document.body, configurable: true });
+        localStorage.clear();
+        Object.assign(JC.pluginConfig, {
+            DiscoveryEnabled: true,
+            DiscoveryLibraryTab: true,
+            SeerrEnabled: true,
+        });
+        disableEveryDefaultRow();
+
+        const genres = new Map([[28, 'Action']]);
+        const firstDestroy = vi.fn();
+        mocks.renderFeed.mockImplementationOnce((
+            container: HTMLElement,
+            _mediaType: DiscoveryMediaType,
+            userRowIds: string[] | null,
+        ): Promise<DiscoveryFeedHandle> => {
+            const feed = document.createElement('div');
+            feed.dataset.rows = resolveRows(userRowIds, genres).map((row) => row.id).join(',') || 'empty';
+            container.appendChild(feed);
+            return Promise.resolve({ element: feed, destroy: firstDestroy });
+        });
+
+        initLibraryTab();
+        document.getElementById('jc-discovery-toggle-movies')!.click();
+        await vi.waitFor(() => {
+            expect(document.querySelector<HTMLElement>('[data-rows="empty"]')).not.toBeNull();
+        });
+        const originalEmptyFeed = document.querySelector<HTMLElement>('[data-rows="empty"]')!;
+
+        let finishReplacement: (() => void) | null = null;
+        const replacementDestroy = vi.fn();
+        mocks.renderFeed.mockImplementationOnce((container: HTMLElement) => {
+            const replacement = document.createElement('div');
+            replacement.dataset.rows = 'empty';
+            container.appendChild(replacement);
+            return new Promise<DiscoveryFeedHandle>((resolve) => {
+                finishReplacement = () => resolve({ element: replacement, destroy: replacementDestroy });
+            });
+        });
+
+        window.dispatchEvent(new CustomEvent('jc:config-changed'));
+        expect(mocks.renderFeed).toHaveBeenCalledTimes(2);
+        expect(originalEmptyFeed.isConnected).toBe(true);
+        expect(firstDestroy).not.toHaveBeenCalled();
+
+        expect(finishReplacement).not.toBeNull();
+        finishReplacement!();
+        await vi.waitFor(() => {
+            expect(firstDestroy).toHaveBeenCalledTimes(1);
+            expect(originalEmptyFeed.isConnected).toBe(false);
+            expect(document.querySelector<HTMLElement>('[data-rows="empty"]')).not.toBeNull();
+        });
+        expect(replacementDestroy).not.toHaveBeenCalled();
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/discovery/library-tab.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/discovery/library-tab.ts
@@ -36,6 +36,7 @@ interface PaneState {
     feed: DiscoveryFeedHandle | null;
     pane: HTMLElement | null;
     feedHost: HTMLElement | null;
+    renderGeneration: number;
 }
 
 const state = new Map<string, PaneState>();
@@ -47,7 +48,10 @@ const lifecycle = JC.core.lifecycle!.register('discovery-library-tab');
 
 function stateFor(id: string): PaneState {
     let s = state.get(id);
-    if (!s) { s = { active: false, feed: null, pane: null, feedHost: null }; state.set(id, s); }
+    if (!s) {
+        s = { active: false, feed: null, pane: null, feedHost: null, renderGeneration: 0 };
+        state.set(id, s);
+    }
     return s;
 }
 
@@ -92,6 +96,7 @@ function currentPage(): LibraryPageDef | null {
 
 function closePane(def: LibraryPageDef): void {
     const s = stateFor(def.id);
+    s.renderGeneration += 1;
     s.feed?.destroy();
     s.feed = null;
     s.pane?.remove();
@@ -102,23 +107,31 @@ function closePane(def: LibraryPageDef): void {
     document.getElementById('jc-discovery-toggle-' + def.id)?.classList.remove('is-active');
 }
 
-/** (Re)renders the feed into the pane's feed host using the caller's current saved row prefs. */
+/**
+ * (Re)renders the feed using the caller's current saved row prefs. Build into a detached staging
+ * host and swap only after the new feed is complete, so a config push never blanks the current
+ * explicit-empty/default view while genres and row state are being resolved.
+ */
 async function renderFeedHost(def: LibraryPageDef, context: IdentityContext): Promise<void> {
     if (!JC.identity.isCurrent(context)) return;
     const s = stateFor(def.id);
     if (!s.feedHost) return;
     const feedHost = s.feedHost;
-    s.feed?.destroy();
-    feedHost.textContent = '';
-    const handle = await renderFeed(feedHost, def.mediaType, getUserRowIds(def.mediaType));
+    const generation = ++s.renderGeneration;
+    const stagingHost = document.createElement('div');
+    const handle = await renderFeed(stagingHost, def.mediaType, getUserRowIds(def.mediaType));
     if (!JC.identity.isCurrent(context)
         || state.get(def.id) !== s
         || !s.active
-        || s.feedHost !== feedHost) {
+        || s.feedHost !== feedHost
+        || s.renderGeneration !== generation) {
         handle.destroy();
         return;
     }
+    const previous = s.feed;
+    feedHost.replaceChildren(...Array.from(stagingHost.childNodes));
     s.feed = handle;
+    previous?.destroy();
 }
 
 /** Builds the pane toolbar with the per-user "Customize" button. */
@@ -241,6 +254,22 @@ function scheduleInject(context: IdentityContext | null = activeContext): void {
     });
 }
 
+function handleConfigChanged(): void {
+    const context = activeContext;
+    if (!context || !JC.identity.isCurrent(context)) return;
+    if (!enabled()) {
+        for (const def of PAGES) {
+            if (stateFor(def.id).active) closePane(def);
+            document.getElementById('jc-discovery-toggle-' + def.id)?.remove();
+        }
+        return;
+    }
+    for (const def of PAGES) {
+        if (stateFor(def.id).active) void renderFeedHost(def, context);
+    }
+    scheduleInject(context);
+}
+
 /** Wires the library-page Discovery surface. Idempotent — safe to call once at init. */
 export function initLibraryTab(): void {
     if (initialized) return;
@@ -251,6 +280,7 @@ export function initLibraryTab(): void {
     ensureCss();
     lifecycle.track(JC.core.dom!.onBodyMutation('jc-discovery-library', () => scheduleInject(context)));
     lifecycle.track(onNavigate(() => scheduleInject(context)));
+    lifecycle.addListener(window, 'jc:config-changed', handleConfigChanged);
     scheduleInject(context);
 }
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/discovery/prefs.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/discovery/prefs.identity.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { JC } from '../globals';
-import { getUserRowIds, setUserRowIds } from './prefs';
+import { clearUserRowIds, getUserRowIds, setUserRowIds } from './prefs';
+import { resolveRows } from './rows';
 
 describe('Discovery preferences identity scope', () => {
     beforeEach(() => {
@@ -20,5 +21,20 @@ describe('Discovery preferences identity scope', () => {
         expect(getUserRowIds('movie')).toEqual(['server-b-row']);
         JC.identity.transition('server-a', 'same-user', 'server-switch-back');
         expect(getUserRowIds('movie')).toEqual(['server-a-row']);
+    });
+
+    it('reset removes an explicit empty override and restores the current admin defaults', () => {
+        JC.pluginConfig.DiscoveryRowTrending = false;
+        JC.pluginConfig.DiscoveryRowPopular = true;
+        JC.pluginConfig.DiscoveryRowUpcoming = false;
+        JC.pluginConfig.DiscoveryRowTopRated = false;
+        JC.pluginConfig.DiscoveryRowWatchlist = false;
+        JC.pluginConfig.DiscoveryGenreRows = false;
+        setUserRowIds('movie', []);
+
+        expect(resolveRows(getUserRowIds('movie')).map((row) => row.id)).toEqual([]);
+        clearUserRowIds('movie');
+        expect(getUserRowIds('movie')).toBeNull();
+        expect(resolveRows(getUserRowIds('movie')).map((row) => row.id)).toEqual(['popular']);
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/discovery/rows.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/discovery/rows.test.ts
@@ -4,7 +4,21 @@
 
 import { afterEach, describe, expect, it } from 'vitest';
 import { JC } from '../globals';
-import { adminDefaultRowIds, resolveRows, specFromId, genreRowsEnabled } from './rows';
+import {
+    adminDefaultRowIds,
+    defaultRowIds,
+    genreRowsEnabled,
+    resolveRows,
+    specFromId,
+} from './rows';
+
+function disableAllBuiltIns(): void {
+    JC.pluginConfig.DiscoveryRowTrending = false;
+    JC.pluginConfig.DiscoveryRowPopular = false;
+    JC.pluginConfig.DiscoveryRowUpcoming = false;
+    JC.pluginConfig.DiscoveryRowTopRated = false;
+    JC.pluginConfig.DiscoveryRowWatchlist = false;
+}
 
 afterEach(() => {
     const cfg = JC.pluginConfig as Record<string, unknown>;
@@ -24,11 +38,31 @@ describe('discovery rows', () => {
         expect(specFromId('genre:notanumber')).toBeNull();
     });
 
-    it('adminDefaultRowIds honors the per-row admin toggles', () => {
+    it('uses documented built-ins when row config is absent', () => {
         expect(adminDefaultRowIds()).toEqual(['trending', 'popular', 'upcoming', 'topRated']);
+    });
+
+    it('adminDefaultRowIds honors the per-row admin toggles', () => {
         JC.pluginConfig.DiscoveryRowTrending = false;
         JC.pluginConfig.DiscoveryRowWatchlist = true;
         expect(adminDefaultRowIds()).toEqual(['popular', 'upcoming', 'topRated', 'watchlist']);
+    });
+
+    it('preserves an explicit all-off admin selection', () => {
+        disableAllBuiltIns();
+        JC.pluginConfig.DiscoveryGenreRows = false;
+
+        expect(adminDefaultRowIds()).toEqual([]);
+        expect(resolveRows(null, new Map([[28, 'Action']]))).toEqual([]);
+    });
+
+    it('composes generated genres with only the explicitly enabled built-ins', () => {
+        disableAllBuiltIns();
+        JC.pluginConfig.DiscoveryGenreRows = true;
+        const genres = new Map([[28, 'Action'], [35, 'Comedy']]);
+
+        expect(defaultRowIds(genres)).toEqual(['genre:28', 'genre:35']);
+        expect(resolveRows(null, genres).map((spec) => spec.id)).toEqual(['genre:28', 'genre:35']);
     });
 
     it('resolveRows prefers the user list, dropping unknowns and duplicates', () => {
@@ -39,7 +73,7 @@ describe('discovery rows', () => {
     it('resolveRows uses admin defaults for null but honors an explicit empty selection', () => {
         expect(resolveRows(null).map((s) => s.id)).toEqual(['trending', 'popular', 'upcoming', 'topRated']);
         // An explicit [] (user hid every row) is honored, not conflated with "not customized".
-        expect(resolveRows([]).map((s) => s.id)).toEqual([]);
+        expect(resolveRows([], new Map([[28, 'Action']])).map((s) => s.id)).toEqual([]);
     });
 
     it('genreRowsEnabled defaults on and honors the admin toggle', () => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/discovery/rows.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/discovery/rows.ts
@@ -79,9 +79,10 @@ export function specFromId(id: string, genreNames?: Map<number, string>): Discov
 }
 
 /**
- * The admin default row order, built from the per-row admin toggles (PluginConfiguration). Absent
- * config (not yet loaded / older server) falls back to the built-in defaults, so the client always
- * resolves user → admin → hardcoded per the settings doctrine. `!== false` keeps a row on by default.
+ * The admin built-in row order, built from the per-row admin toggles (PluginConfiguration).
+ * Missing fields (config not yet loaded / older server) retain their documented defaults, while
+ * fields that are explicitly false remain authoritative even when every built-in row is disabled.
+ * That presence/value distinction is why this must not replace an empty `ids` array with defaults.
  */
 export function adminDefaultRowIds(): string[] {
     const cfg = JC.pluginConfig;
@@ -92,12 +93,24 @@ export function adminDefaultRowIds(): string[] {
     if (cfg.DiscoveryRowUpcoming !== false) ids.push('upcoming');
     if (cfg.DiscoveryRowTopRated !== false) ids.push('topRated');
     if (cfg.DiscoveryRowWatchlist === true) ids.push('watchlist');
-    return ids.length > 0 ? ids : [...DEFAULT_ROW_IDS];
+    return ids;
 }
 
 /** Whether the admin wants a few real genre rows appended to the default feed. */
 export function genreRowsEnabled(): boolean {
     return JC.pluginConfig?.DiscoveryGenreRows !== false;
+}
+
+/**
+ * Complete uncustomised row-id set. Generated genre rows compose with exactly the built-ins the
+ * admin selected; they never make an explicit all-off built-in selection fall back to defaults.
+ */
+export function defaultRowIds(genreNames?: Map<number, string>): string[] {
+    const ids = adminDefaultRowIds();
+    if (genreNames && genreRowsEnabled()) {
+        ids.push(...[...genreNames.keys()].slice(0, 4).map((id) => `genre:${id}`));
+    }
+    return ids;
 }
 
 /**
@@ -108,7 +121,7 @@ export function genreRowsEnabled(): boolean {
  * upstream, a renamed built-in) so the feed never breaks.
  */
 export function resolveRows(userRowIds: string[] | null, genreNames?: Map<number, string>): DiscoveryRowSpec[] {
-    const ids = userRowIds !== null ? userRowIds : adminDefaultRowIds();
+    const ids = userRowIds !== null ? userRowIds : defaultRowIds(genreNames);
     const out: DiscoveryRowSpec[] = [];
     const seen = new Set<string>();
     for (const id of ids) {


### PR DESCRIPTION
## What changed

- distinguish absent row configuration from explicit `false` and explicit empty selections
- compose generated genre rows only with explicitly enabled built-ins
- preserve a user-scoped explicit empty list in feed and customization flows
- stage hot-reload replacement atomically and reject stale pane/identity generations
- add regressions for absent defaults, all-off, genre-only, reset, and explicit-empty hot reload

## Validation

- focused discovery tests: 3 files, 11 tests passed
- full plain client suite passed
- source and legacy typechecks passed
- bundle build passed (188 modules)
- syntax and changed-file ESLint passed with zero errors
- diff check clean
- independent adversarial review: approved with no material findings
- local V8 coverage ran 140 files / 871 tests; 139 files and 870 tests passed, with only the unchanged host CPU-budget guard failing (15.4s measured vs 5s). The same exact blocking GitHub coverage gate is green on current PR CI and will run here.

Closes #131