### PR TITLE
Reconcile bookmark markers through player lifecycle

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/bookmarks.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/bookmarks.identity.test.ts
@@ -350,6 +350,38 @@ describe('bookmark player identity ownership', () => {
     expect(slider.querySelectorAll('.jc-bookmark-marker[data-jc-identity-owned="true"]')).toHaveLength(0);
   });
 
+  it('removes owned markers from a detached OSD before the host reattaches it', async () => {
+    const api = await loadModule({ existing: bookmark('item-a', 'Detached item') });
+    await api.updateMarkers();
+    const osd = document.querySelector<HTMLElement>('.videoOsdBottom')!;
+    const slider = osd.querySelector<HTMLElement>('.osdPositionSliderContainer')!;
+    const unowned = document.createElement('div');
+    unowned.className = 'jc-bookmark-marker';
+    slider.appendChild(unowned);
+    expect(slider.querySelectorAll('.jc-bookmark-marker[data-jc-identity-owned="true"]')).toHaveLength(1);
+
+    osd.remove();
+    await api.updateMarkers();
+    document.body.appendChild(osd);
+
+    expect(slider.querySelectorAll('.jc-bookmark-marker[data-jc-identity-owned="true"]')).toHaveLength(0);
+    expect(unowned.isConnected).toBe(true);
+  });
+
+  it('does not let pending debounce callbacks recreate player output after cleanup', async () => {
+    vi.useFakeTimers();
+    await loadModule({ existing: bookmark('item-a', 'Pending') });
+    JC.initializeBookmarks();
+    video.dispatchEvent(new Event('playing', { bubbles: true }));
+
+    JC.cleanupBookmarks();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(document.getElementById('jcBookmarkBtn')).toBeNull();
+    expect(document.querySelector('.jc-bookmark-marker[data-jc-identity-owned="true"]')).toBeNull();
+    expect(ajax).not.toHaveBeenCalled();
+  });
+
   it('keeps the committed marker until deletion is acknowledged and removes it afterward', async () => {
     const api = await loadModule({ existing: bookmark('item-a', 'Committed') });
     await api.updateMarkers();
@@ -388,6 +420,35 @@ describe('bookmark player identity ownership', () => {
     expect(document.querySelectorAll('.jc-bookmark-marker[data-jc-identity-owned="true"]')).toHaveLength(1);
     expect(document.querySelector<HTMLElement>('.jc-bookmark-marker[data-jc-identity-owned="true"]')?.title)
       .toContain('Still committed');
+  });
+
+  it('reconciles a retained marker to authoritative 409 state when the delete retry fails', async () => {
+    const api = await loadModule({ existing: bookmark('item-a', 'Before conflict') });
+    await api.updateMarkers();
+    JC.initializeBookmarks();
+    const authoritative = {
+      ...bookmark('item-a', 'Changed remotely'),
+      timestamp: 77,
+      updatedAt: '2026-02-01T00:00:00.000Z'
+    };
+    save
+      .mockRejectedValueOnce(Object.assign(new Error('conflict'), {
+        status: 409,
+        responseJSON: { revision: 1, bookmarks: { existing: authoritative } }
+      }))
+      .mockRejectedValueOnce(new Error('retry failed'));
+
+    await expect(api.delete('existing')).resolves.toBe(false);
+    await vi.waitFor(() => {
+      expect(document.querySelector<HTMLElement>(
+        '.jc-bookmark-marker[data-jc-identity-owned="true"]'
+      )?.title).toContain('Changed remotely - 1:17');
+    });
+
+    expect(JC.userConfig.bookmark).toEqual({
+      revision: 1,
+      bookmarks: { existing: authoritative }
+    });
   });
 
   it('does not publish a held reconciliation into a replacement video playback instance', async () => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/bookmarks.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/bookmarks.identity.test.ts
@@ -299,6 +299,123 @@ describe('bookmark player identity ownership', () => {
     expect(document.querySelector('.jellyfin-canopy-toast')).toBeNull();
   });
 
+  it('reconciles one bookmark to empty idempotently without removing an unowned marker', async () => {
+    const api = await loadModule({ existing: bookmark('item-a', 'Owned') });
+    const slider = document.querySelector<HTMLElement>('.osdPositionSliderContainer')!;
+    const unowned = document.createElement('div');
+    unowned.className = 'jc-bookmark-marker';
+    unowned.dataset.testOwner = 'host';
+    slider.appendChild(unowned);
+
+    await api.updateMarkers();
+
+    expect(slider.querySelectorAll('.jc-bookmark-marker[data-jc-identity-owned="true"]')).toHaveLength(1);
+    expect(unowned.isConnected).toBe(true);
+
+    await expect(api.delete('existing')).resolves.toBe(true);
+    await api.updateMarkers();
+    await api.updateMarkers();
+
+    expect(slider.querySelectorAll('.jc-bookmark-marker[data-jc-identity-owned="true"]')).toHaveLength(0);
+    expect(unowned.isConnected).toBe(true);
+    expect(JC.userConfig.bookmark.bookmarks).toEqual({});
+  });
+
+  it('clears prior-item markers immediately while a reused OSD waits for an unbookmarked item', async () => {
+    const api = await loadModule({ existing: bookmark('item-a', 'Item A') });
+    await api.updateMarkers();
+    const slider = document.querySelector<HTMLElement>('.osdPositionSliderContainer')!;
+    const reusedSlider = slider;
+    expect(slider.querySelectorAll('.jc-bookmark-marker[data-jc-identity-owned="true"]')).toHaveLength(1);
+
+    const itemB = deferred<unknown>();
+    ajax.mockClear();
+    ajax.mockReturnValueOnce(itemB.promise);
+    document.querySelector<HTMLElement>('.btnUserRating')!.dataset.id = 'item-b';
+
+    const reconciliation = api.updateMarkers();
+    await vi.waitFor(() => expect(ajax).toHaveBeenCalledTimes(1));
+
+    expect(document.querySelector('.osdPositionSliderContainer')).toBe(reusedSlider);
+    expect(slider.querySelectorAll('.jc-bookmark-marker[data-jc-identity-owned="true"]')).toHaveLength(0);
+
+    itemB.resolve({ Items: [{
+      Id: 'item-b',
+      Name: 'Movie B',
+      Type: 'Movie',
+      ProviderIds: { Tmdb: 'tmdb-b' }
+    }] });
+    await reconciliation;
+
+    expect(slider.querySelectorAll('.jc-bookmark-marker[data-jc-identity-owned="true"]')).toHaveLength(0);
+  });
+
+  it('keeps the committed marker until deletion is acknowledged and removes it afterward', async () => {
+    const api = await loadModule({ existing: bookmark('item-a', 'Committed') });
+    await api.updateMarkers();
+    JC.initializeBookmarks();
+    await vi.waitFor(() => expect(document.getElementById('jcBookmarkBtn')).not.toBeNull());
+    const heldDelete = deferred<unknown>();
+    save.mockReturnValueOnce(heldDelete.promise);
+
+    const deletion = api.delete('existing');
+    await vi.waitFor(() => expect(save).toHaveBeenCalledTimes(1));
+
+    expect(document.querySelectorAll('.jc-bookmark-marker[data-jc-identity-owned="true"]')).toHaveLength(1);
+    expect(JC.userConfig.bookmark.bookmarks.existing).toBeDefined();
+
+    heldDelete.resolve({ revision: 1, bookmarks: {} });
+    await expect(deletion).resolves.toBe(true);
+    await vi.waitFor(() => expect(JC.userConfig.bookmark.bookmarks).toEqual({}));
+    await vi.waitFor(() => {
+      expect(document.querySelectorAll('.jc-bookmark-marker[data-jc-identity-owned="true"]')).toHaveLength(0);
+    });
+  });
+
+  it('preserves the marker and committed state when deletion persistence fails', async () => {
+    const api = await loadModule({ existing: bookmark('item-a', 'Still committed') });
+    await api.updateMarkers();
+    await api.showModal('view');
+    save.mockRejectedValueOnce(new Error('disk full'));
+
+    document.querySelector<HTMLButtonElement>('.jc-bookmark-btn-delete')!.click();
+    await vi.waitFor(() => expect(save).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => {
+      expect(document.querySelector('.jellyfin-canopy-toast')).not.toBeNull();
+    });
+
+    expect(JC.userConfig.bookmark.bookmarks.existing).toEqual(bookmark('item-a', 'Still committed'));
+    expect(document.querySelectorAll('.jc-bookmark-marker[data-jc-identity-owned="true"]')).toHaveLength(1);
+    expect(document.querySelector<HTMLElement>('.jc-bookmark-marker[data-jc-identity-owned="true"]')?.title)
+      .toContain('Still committed');
+  });
+
+  it('does not publish a held reconciliation into a replacement video playback instance', async () => {
+    const api = await loadModule({ current: bookmark('item-b', 'Item B') });
+    const itemB = deferred<unknown>();
+    ajax.mockReturnValueOnce(itemB.promise);
+    document.querySelector<HTMLElement>('.btnUserRating')!.dataset.id = 'item-b';
+
+    const stalePlayback = api.updateMarkers();
+    await vi.waitFor(() => expect(ajax).toHaveBeenCalledTimes(1));
+
+    const replacement = document.createElement('video');
+    Object.defineProperty(replacement, 'duration', { configurable: true, value: 120 });
+    video.replaceWith(replacement);
+    itemB.resolve({ Items: [{
+      Id: 'item-b',
+      Name: 'Movie B',
+      Type: 'Movie',
+      ProviderIds: { Tmdb: 'tmdb-b' }
+    }] });
+    await stalePlayback;
+
+    expect(document.querySelector('.jc-bookmark-marker[data-jc-identity-owned="true"]')).toBeNull();
+
+    await api.updateMarkers();
+    expect(document.querySelectorAll('.jc-bookmark-marker[data-jc-identity-owned="true"]')).toHaveLength(1);
+  });
+
   it('does not save a bookmark when playback changes during its item-details fetch', async () => {
     const api = await loadModule({});
     const heldDetails = deferred<unknown>();

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/bookmarks.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/bookmarks.ts
@@ -21,6 +21,8 @@ import type { IdentityContext } from '../../types/jc';
   const ownedBookmarkMarkerSelector = '.jc-bookmark-marker[data-jc-identity-owned="true"]';
   let bookmarkGeneration = 0;
   let bookmarkMarkerGeneration = 0;
+  const ownedBookmarkMarkers = new Set<HTMLElement>();
+  const ownedBookmarkButtons = new Set<HTMLButtonElement>();
   const activeModalDisposers = new Map<HTMLElement, () => void>();
   const bookmarkTimers = new Set<number>();
   let forceCleanupBookmarks: (() => void) | null = null;
@@ -316,9 +318,36 @@ import type { IdentityContext } from '../../types/jc';
   }
 
   function removeOwnedBookmarkMarkers(root: ParentNode = document): number {
-    const markers = root.querySelectorAll(ownedBookmarkMarkerSelector);
-    markers.forEach(marker => marker.remove());
-    return markers.length;
+    let removed = 0;
+    // The host may temporarily detach and later reuse the OSD. Keep explicit
+    // ownership so cleanup also reaches markers outside the connected document.
+    for (const marker of [...ownedBookmarkMarkers]) {
+      marker.remove();
+      ownedBookmarkMarkers.delete(marker);
+      removed += 1;
+    }
+    // Also clean up owned output created by an older bundle instance.
+    for (const marker of root.querySelectorAll<HTMLElement>(ownedBookmarkMarkerSelector)) {
+      marker.remove();
+      removed += 1;
+    }
+    return removed;
+  }
+
+  function removeOwnedBookmarkButtons(root: ParentNode = document): number {
+    let removed = 0;
+    for (const button of [...ownedBookmarkButtons]) {
+      button.remove();
+      ownedBookmarkButtons.delete(button);
+      removed += 1;
+    }
+    for (const button of root.querySelectorAll<HTMLButtonElement>(
+      '#jcBookmarkBtn[data-jc-identity-owned="true"]'
+    )) {
+      button.remove();
+      removed += 1;
+    }
+    return removed;
   }
 
   function invalidateBookmarkMarkerOutput(): number {
@@ -616,6 +645,7 @@ import type { IdentityContext } from '../../types/jc';
       return false;
     }
 
+    const startingRevision = root.revision;
     try {
       const committed = await commitBookmarkBatch(captured, root, state =>
         state.bookmarks[bookmarkId] ? [{ type: 'delete', bookmarkId }] : []);
@@ -625,6 +655,12 @@ import type { IdentityContext } from '../../types/jc';
       return emitBookmarksUpdated(captured, 'delete');
     } catch (e) {
       if (!isBookmarkRootCurrent(captured, root)) return false;
+      // A 409 can advance the local root to an authoritative server snapshot
+      // before the rebased retry fails. Reconcile every view to that retained
+      // snapshot instead of leaving the pre-conflict marker on screen.
+      if (root.revision !== startingRevision) {
+        emitBookmarksUpdated(captured, 'authoritative-reconcile');
+      }
       console.error(`${logPrefix} Failed to delete bookmark:`, e);
       return false;
     }
@@ -908,7 +944,10 @@ import type { IdentityContext } from '../../types/jc';
       });
 
       if (isBookmarkMarkerReconciliationCurrent(captured, mediaItemId, video, generation)
-        && sliderContainer.isConnected) sliderContainer.appendChild(marker);
+        && sliderContainer.isConnected) {
+        sliderContainer.appendChild(marker);
+        ownedBookmarkMarkers.add(marker);
+      }
     });
 
     console.log(`${logPrefix} ✓ Created ${bookmarksList.length} bookmark markers`);
@@ -1527,6 +1566,14 @@ import type { IdentityContext } from '../../types/jc';
    */
   function addOsdBookmarkButton(captured: BookmarkIdentityCapture = captureIdentity()): void {
     if (!captured.context || !isIdentityCurrent(captured)) return;
+    // A replaced OSD may leave its button detached for later host reuse. Retire
+    // it before creating output for the current controls and keep the registry
+    // bounded to connected ownership.
+    for (const button of [...ownedBookmarkButtons]) {
+      if (button.isConnected) continue;
+      button.remove();
+      ownedBookmarkButtons.delete(button);
+    }
     // Don't add if already exists
     if (document.getElementById('jcBookmarkBtn')) return;
 
@@ -1555,6 +1602,7 @@ import type { IdentityContext } from '../../types/jc';
     // Insert before the settings button
     if (!isIdentityCurrent(captured)) return;
     nativeSettingsButton.parentElement!.insertBefore(bookmarkBtn, nativeSettingsButton);
+    ownedBookmarkButtons.add(bookmarkBtn);
     console.log(`${logPrefix} ✓ Added OSD bookmark button`);
   }
 
@@ -1583,8 +1631,11 @@ import type { IdentityContext } from '../../types/jc';
 
       let lastVideoUrl: string | null = null;
       let lastInjectedOsdKey: string | null = null;
+      let disposed = false;
       const osdObserverId = 'jc-bookmarks-osd';
       const videoObserverId = 'jc-bookmarks-video-changes';
+
+      const isActivationCurrent = (): boolean => !disposed && isIdentityCurrent(activation);
 
       function getOsdKey(): string {
         const video = document.querySelector<HTMLVideoElement>('.videoPlayerContainer video');
@@ -1593,7 +1644,7 @@ import type { IdentityContext } from '../../types/jc';
 
       // Debounced OSD injection - prevents rapid re-injection
       const debouncedOsdInjection = debounce(() => {
-        if (!isIdentityCurrent(activation)) return;
+        if (!isActivationCurrent()) return;
         if (!(JC as any).isVideoPage()) return;
 
         const osdBottom = document.querySelector('.videoOsdBottom');
@@ -1604,7 +1655,7 @@ import type { IdentityContext } from '../../types/jc';
         if (osdBottom && video && currentOsdKey !== lastInjectedOsdKey) {
           void updateBookmarkMarkersForCurrentVideo();
           addOsdBookmarkButton(activation);
-          if (!isIdentityCurrent(activation)) return;
+          if (!isActivationCurrent()) return;
           lastInjectedOsdKey = currentOsdKey;
           console.log(`${logPrefix} Injected markers/button for ${currentOsdKey}`);
         }
@@ -1612,7 +1663,7 @@ import type { IdentityContext } from '../../types/jc';
 
       // Managed observer: only watches when on video page
       function ensureOsdObserver(): void {
-        if (!isIdentityCurrent(activation)) return;
+        if (!isActivationCurrent()) return;
         if (!(JC as any).isVideoPage()) {
           disconnectObserver(osdObserverId);
           return;
@@ -1629,21 +1680,21 @@ import type { IdentityContext } from '../../types/jc';
 
       // Debounced handlers for video events
       const handlePlayingEvent = debounce((e: Event) => {
-        if (!isIdentityCurrent(activation)) return;
+        if (!isActivationCurrent()) return;
         if ((e.target as HTMLElement).tagName === 'VIDEO' && (JC as any).isVideoPage()) {
           debouncedOsdInjection();
         }
       }, 300);
 
       const handleMetadataEvent = debounce((e: Event) => {
-        if (!isIdentityCurrent(activation)) return;
+        if (!isActivationCurrent()) return;
         if ((e.target as HTMLElement).tagName === 'VIDEO' && (JC as any).isVideoPage()) {
           debouncedOsdInjection();
         }
       }, 300);
 
       const handleViewShow = () => {
-        if (!isIdentityCurrent(activation)) return;
+        if (!isActivationCurrent()) return;
         if ((JC as any).isVideoPage()) {
           lastInjectedOsdKey = null; // Reset for new page
           ensureOsdObserver();
@@ -1672,7 +1723,7 @@ import type { IdentityContext } from '../../types/jc';
       // been adopted. This keeps every persistence entry point on the same
       // marker reconciliation path without publishing optimistic output.
       const handleBookmarksUpdated = () => {
-        if (isIdentityCurrent(activation)
+        if (isActivationCurrent()
           && (JC as unknown as { isVideoPage(): boolean }).isVideoPage()) {
           void updateBookmarkMarkersForCurrentVideo();
         }
@@ -1687,7 +1738,11 @@ import type { IdentityContext } from '../../types/jc';
       }
 
       const cleanupActivation = (force = false): void => {
+        if (disposed) return;
         if (!force && !isIdentityCurrent(activation)) return;
+        // Mark disposal before draining listeners/observers. Already-queued
+        // debounce callbacks then fail closed even when the identity is unchanged.
+        disposed = true;
         cleanupFunctions.forEach(fn => fn());
         cleanupFunctions = [];
         disconnectObserver(osdObserverId);
@@ -1696,7 +1751,7 @@ import type { IdentityContext } from '../../types/jc';
         bookmarkTimers.clear();
         disposeActiveModals();
         invalidateBookmarkMarkerOutput();
-        document.getElementById('jcBookmarkBtn')?.remove();
+        removeOwnedBookmarkButtons();
         document.querySelectorAll('.jc-bm-player-modal-overlay').forEach((node) => node.remove());
         initialized = false;
         console.log(`${logPrefix} Cleaned up`);
@@ -1725,7 +1780,7 @@ import type { IdentityContext } from '../../types/jc';
     itemDetailsCache.requestId += 1;
     forceCleanupBookmarks?.();
     forceCleanupBookmarks = null;
-    document.getElementById('jcBookmarkBtn')?.remove();
+    removeOwnedBookmarkButtons();
     document.querySelectorAll('.jc-bm-player-modal-overlay').forEach((node) => node.remove());
   });
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/bookmarks.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/bookmarks.ts
@@ -18,7 +18,9 @@ import type { IdentityContext } from '../../types/jc';
 {
 
   const logPrefix = '🪼 Jellyfin Canopy: Bookmarks:';
+  const ownedBookmarkMarkerSelector = '.jc-bookmark-marker[data-jc-identity-owned="true"]';
   let bookmarkGeneration = 0;
+  let bookmarkMarkerGeneration = 0;
   const activeModalDisposers = new Map<HTMLElement, () => void>();
   const bookmarkTimers = new Set<number>();
   let forceCleanupBookmarks: (() => void) | null = null;
@@ -307,6 +309,33 @@ import type { IdentityContext } from '../../types/jc';
    */
   function isMediaItemCurrent(captured: BookmarkIdentityCapture, itemId: string): boolean {
     return isIdentityCurrent(captured) && getCurrentItemData()?.itemId === itemId;
+  }
+
+  function currentVideoElement(): HTMLVideoElement | null {
+    return document.querySelector<HTMLVideoElement>('.videoPlayerContainer video');
+  }
+
+  function removeOwnedBookmarkMarkers(root: ParentNode = document): number {
+    const markers = root.querySelectorAll(ownedBookmarkMarkerSelector);
+    markers.forEach(marker => marker.remove());
+    return markers.length;
+  }
+
+  function invalidateBookmarkMarkerOutput(): number {
+    bookmarkMarkerGeneration += 1;
+    removeOwnedBookmarkMarkers();
+    return bookmarkMarkerGeneration;
+  }
+
+  function isBookmarkMarkerReconciliationCurrent(
+    captured: BookmarkIdentityCapture,
+    mediaItemId: string,
+    video: HTMLVideoElement,
+    generation: number
+  ): boolean {
+    return generation === bookmarkMarkerGeneration
+      && currentVideoElement() === video
+      && isMediaItemCurrent(captured, mediaItemId);
   }
 
   interface ItemDetailsCache {
@@ -775,16 +804,20 @@ import type { IdentityContext } from '../../types/jc';
     video: HTMLVideoElement,
     bookmarksList: any[],
     captured: BookmarkIdentityCapture,
-    mediaItemId: string
+    mediaItemId: string,
+    generation: number
   ): void {
     console.log(`${logPrefix} createBookmarkMarkers called - video:`, !!video, 'bookmarks:', bookmarksList.length);
 
-    if (!captured.context || !isIdentityCurrent(captured) || !video || !bookmarksList.length) {
-      console.log(`${logPrefix} Early return - no video or no bookmarks`);
+    if (!captured.context
+      || !video
+      || !isBookmarkMarkerReconciliationCurrent(captured, mediaItemId, video, generation)) {
+      console.log(`${logPrefix} Early return - stale marker owner or no video`);
       return;
     }
 
-    // Find or create marker container
+    // Resolve the current OSD owner before reconciling. Jellyfin reuses this
+    // DOM across item transitions, so an empty result must replace prior output.
     const osdBottom = document.querySelector('.videoOsdBottom');
     if (!osdBottom) {
       console.log(`${logPrefix} No .videoOsdBottom found`);
@@ -804,16 +837,20 @@ import type { IdentityContext } from '../../types/jc';
       return;
     }
 
+    if (!isBookmarkMarkerReconciliationCurrent(captured, mediaItemId, video, generation)) return;
+
+    const removed = removeOwnedBookmarkMarkers(sliderContainer);
+    console.log(`${logPrefix} Removing ${removed} existing owned markers`);
+    if (!bookmarksList.length) {
+      console.log(`${logPrefix} Reconciled empty bookmark marker set`);
+      return;
+    }
+
     // Ensure markers position relative to the slider container
     const sliderPos = window.getComputedStyle(sliderContainer).position;
     if (sliderPos === 'static') {
       sliderContainer.style.position = 'relative';
     }
-
-    // Remove existing markers
-    const existingMarkers = sliderContainer.querySelectorAll('.jc-bookmark-marker');
-    console.log(`${logPrefix} Removing ${existingMarkers.length} existing markers`);
-    existingMarkers.forEach(el => el.remove());
 
     const duration = video.duration;
     if (!duration || !isFinite(duration)) {
@@ -830,6 +867,9 @@ import type { IdentityContext } from '../../types/jc';
       marker.className = 'jc-bookmark-marker';
       marker.dataset.jcIdentityOwned = 'true';
       marker.dataset.jcIdentityEpoch = String(captured.context!.epoch);
+      marker.dataset.jcBookmarkMarkerOwner = 'canopy';
+      marker.dataset.jcBookmarkMediaItemId = mediaItemId;
+      marker.dataset.jcBookmarkGeneration = String(generation);
       marker.style.cssText = `
         position: absolute;
         left: ${percent}%;
@@ -861,13 +901,14 @@ import type { IdentityContext } from '../../types/jc';
 
       // Click to jump to bookmark
       marker.addEventListener('click', (e) => {
-        if (!isMediaItemCurrent(captured, mediaItemId)) return;
+        if (!isBookmarkMarkerReconciliationCurrent(captured, mediaItemId, video, generation)) return;
         e.stopPropagation();
         video.currentTime = bookmark.timestamp;
         toast(`${JC.t!('toast_jumped_to_bookmark')}: ${formatTimestamp(bookmark.timestamp)}`, 2000);
       });
 
-      if (isMediaItemCurrent(captured, mediaItemId)) sliderContainer.appendChild(marker);
+      if (isBookmarkMarkerReconciliationCurrent(captured, mediaItemId, video, generation)
+        && sliderContainer.isConnected) sliderContainer.appendChild(marker);
     });
 
     console.log(`${logPrefix} ✓ Created ${bookmarksList.length} bookmark markers`);
@@ -878,11 +919,15 @@ import type { IdentityContext } from '../../types/jc';
    * Update bookmark markers for current video
    */
   async function updateBookmarkMarkersForCurrentVideo(): Promise<void> {
+    // Claim a new playback-render generation and synchronously withdraw every
+    // prior owned marker before item-details I/O can suspend. A reused OSD
+    // therefore never displays item A's output while item B is loading.
+    const reconciliationGeneration = invalidateBookmarkMarkerOutput();
     const captured = captureIdentity();
     if (!captured.context) return;
     console.log(`${logPrefix} updateBookmarkMarkersForCurrentVideo called`);
 
-    const video = document.querySelector<HTMLVideoElement>('.videoPlayerContainer video');
+    const video = currentVideoElement();
     if (!video) {
       console.log(`${logPrefix} No video element found`);
       return;
@@ -899,7 +944,12 @@ import type { IdentityContext } from '../../types/jc';
     const details = await fetchItemDetails(requestedItemId);
     if (!details
       || details.itemId !== requestedItemId
-      || !isMediaItemCurrent(captured, requestedItemId)) {
+      || !isBookmarkMarkerReconciliationCurrent(
+        captured,
+        requestedItemId,
+        video,
+        reconciliationGeneration
+      )) {
       console.log(`${logPrefix} Failed to fetch item details`);
       return;
     }
@@ -912,7 +962,13 @@ import type { IdentityContext } from '../../types/jc';
     );
 
     console.log(`${logPrefix} Found ${bookmarksList.length} bookmarks for this item`);
-    createBookmarkMarkers(video, bookmarksList, captured, requestedItemId);
+    createBookmarkMarkers(
+      video,
+      bookmarksList,
+      captured,
+      requestedItemId,
+      reconciliationGeneration
+    );
   }
 
   /**
@@ -1594,6 +1650,7 @@ import type { IdentityContext } from '../../types/jc';
           debouncedOsdInjection();
         } else {
           // Clean up when leaving video page
+          invalidateBookmarkMarkerOutput();
           lastVideoUrl = null;
           lastInjectedOsdKey = null;
           disconnectObserver(osdObserverId);
@@ -1611,6 +1668,18 @@ import type { IdentityContext } from '../../types/jc';
       document.addEventListener('viewshow', handleViewShow);
       cleanupFunctions.push(() => document.removeEventListener('viewshow', handleViewShow));
 
+      // Mutations emit this event only after the server acknowledgement has
+      // been adopted. This keeps every persistence entry point on the same
+      // marker reconciliation path without publishing optimistic output.
+      const handleBookmarksUpdated = () => {
+        if (isIdentityCurrent(activation)
+          && (JC as unknown as { isVideoPage(): boolean }).isVideoPage()) {
+          void updateBookmarkMarkersForCurrentVideo();
+        }
+      };
+      document.addEventListener('jc-bookmarks-updated', handleBookmarksUpdated);
+      cleanupFunctions.push(() => document.removeEventListener('jc-bookmarks-updated', handleBookmarksUpdated));
+
       // Initial setup if already on video page
       if ((JC as any).isVideoPage()) {
         ensureOsdObserver();
@@ -1626,8 +1695,9 @@ import type { IdentityContext } from '../../types/jc';
         for (const timer of bookmarkTimers) clearTimeout(timer);
         bookmarkTimers.clear();
         disposeActiveModals();
+        invalidateBookmarkMarkerOutput();
         document.getElementById('jcBookmarkBtn')?.remove();
-        document.querySelectorAll('.jc-bookmark-marker, .jc-bm-player-modal-overlay').forEach((node) => node.remove());
+        document.querySelectorAll('.jc-bm-player-modal-overlay').forEach((node) => node.remove());
         initialized = false;
         console.log(`${logPrefix} Cleaned up`);
       };
@@ -1644,6 +1714,7 @@ import type { IdentityContext } from '../../types/jc';
 
   JC.identity.registerReset('bookmarks', () => {
     bookmarkGeneration += 1;
+    invalidateBookmarkMarkerOutput();
     for (const timer of bookmarkTimers) clearTimeout(timer);
     bookmarkTimers.clear();
     disposeActiveModals();
@@ -1655,7 +1726,7 @@ import type { IdentityContext } from '../../types/jc';
     forceCleanupBookmarks?.();
     forceCleanupBookmarks = null;
     document.getElementById('jcBookmarkBtn')?.remove();
-    document.querySelectorAll('.jc-bookmark-marker, .jc-bm-player-modal-overlay').forEach((node) => node.remove());
+    document.querySelectorAll('.jc-bm-player-modal-overlay').forEach((node) => node.remove());
   });
 
 }


### PR DESCRIPTION
## What changed

- reconcile Canopy-owned OSD markers from authoritative bookmark state instead of append-only injection
- scope marker ownership by item, user identity, video element, and generation
- synchronously withdraw stale output during player reuse, navigation, cleanup, and disabled-state transitions
- preserve non-owned markers and failed deletions while removing acknowledged final-bookmark deletions
- reconcile a server-adopted 409 root even when the follow-up delete fails
- track detached/reused OSD marker and button ownership so stale DOM cannot reappear
- gate queued debounce callbacks after cleanup

## Validation

- bookmark suites: 3 files, 45 tests passed
- focused identity/lifecycle suite: 18 tests passed
- script tests: 303/303 passed
- source and legacy typechecks passed
- bundle build passed (188 modules)
- syntax passed
- changed-file ESLint: zero errors; advisory legacy-any warnings only
- diff check clean
- fresh independent adversarial review: approved with no actionable findings
- local full V8 coverage passed 138/139 non-guard files and 870/871 tests; only the unchanged host CPU-budget guard exceeded its 5-second budget. The exact blocking GitHub coverage gate will run here.

Closes #91