### PR TITLE
Lock the deterministic BoxSet E2E anchor

### DIFF
--- a/e2e/docker/seed.sh
+++ b/e2e/docker/seed.sh
@@ -255,7 +255,12 @@ if ! "${COMPOSE[@]}" down -v --remove-orphans >/dev/null 2>&1; then
 fi
 rm -rf -- "${CONFIG_DIR}" "${CACHE_DIR}" "${MEDIA_DIR}" "${MOCK_STATE_DIR}"
 rm -f -- "${SEED_RESULT}" "${SEED_RESULT_TMP}"
-mkdir -p -- "${CONFIG_DIR}/plugins/JellyfinCanopy_e2e" "${CACHE_DIR}" "${MEDIA_DIR}" "${MOCK_STATE_DIR}"
+mkdir -p -- \
+    "${CONFIG_DIR}/plugins/JellyfinCanopy_e2e" \
+    "${CONFIG_DIR}/data/collections" \
+    "${CACHE_DIR}" \
+    "${MEDIA_DIR}" \
+    "${MOCK_STATE_DIR}"
 cp -- "${PLUGIN_DLL}" "${CONFIG_DIR}/plugins/JellyfinCanopy_e2e/"
 log "installed plugin DLL into the isolated config volume"
 
@@ -447,10 +452,15 @@ log "creating the Shows library"
 api POST "/Library/VirtualFolders?name=Shows&collectionType=tvshows&paths=%2Fmedia%2FShows&refreshLibrary=false" \
     '{"LibraryOptions":{"EnableRealtimeMonitor":false}}'
 
-# A refresh per library creates two independent scans. Their state can briefly
-# become Idle between runs, and the later scan can overwrite deterministic
-# ProviderIds written below. Capture a high-resolution timestamp and trigger
-# exactly one scan after both libraries exist; metadata writes later require a
+log "creating the Collections library without an implicit scan"
+api POST "/Library/VirtualFolders?name=Collections&collectionType=boxsets&paths=%2Fconfig%2Fdata%2Fcollections&refreshLibrary=false" \
+    '{"LibraryOptions":{"EnableRealtimeMonitor":false,"SaveLocalMetadata":true}}'
+
+# A refresh per library creates independent scans. First-use collection
+# creation also adds this boxsets virtual folder with refresh enabled when
+# it is absent. Those queued scans can overwrite deterministic ProviderIds
+# written below. Capture a high-resolution timestamp and trigger exactly one
+# scan after all three libraries exist; metadata writes later require a
 # completed run whose own start time is strictly later than this trigger bound.
 LIBRARY_SCAN_TRIGGERED_AT="$(date -u +%Y-%m-%dT%H:%M:%S.%NZ)"
 log "starting one explicit library scan"

--- a/e2e/docker/seed.sh
+++ b/e2e/docker/seed.sh
@@ -713,22 +713,43 @@ log "updated metadata on ${i} movies (genres + community rating; audio lang bake
 log "creating the TMDB-anchored incomplete collection fixture"
 BOXSET_SEED_IDS="$(api GET "/Items?IncludeItemTypes=Movie&Recursive=true&userId=${ADMIN_ID}&Limit=2" \
     | jq -er '[.Items[].Id] | if length == 2 then join(",") else empty end')"
-BOXSET_CREATED="$(api POST "/Collections?Name=JC%20E2E%20Fixture%20Collection&Ids=${BOXSET_SEED_IDS}")"
+# Collection creation queues a full BoxSet metadata refresh. Lock at creation
+# time so Jellyfin's metadata owner skips that refresh before it can race and
+# overwrite the deterministic provider anchor written below.
+BOXSET_CREATED="$(api POST "/Collections?Name=JC%20E2E%20Fixture%20Collection&Ids=${BOXSET_SEED_IDS}&isLocked=true")"
 BOXSET_ID="$(printf '%s' "${BOXSET_CREATED}" | jq -er '.Id // empty')"
 BOXSET_DTO="$(api GET "/Users/${ADMIN_ID}/Items/${BOXSET_ID}?Fields=ProviderIds,Path")"
+BOXSET_LOCKED="$(printf '%s' "${BOXSET_DTO}" | jq -r '.LockData // false')"
+[ "${BOXSET_LOCKED}" = true ] \
+    || fail "BoxSet ${BOXSET_ID} was not locked before its queued metadata refresh"
 BOXSET_PATCHED="$(printf '%s' "${BOXSET_DTO}" | jq \
-    '.ProviderIds = (.ProviderIds // {}) | .ProviderIds.Tmdb = "10"')"
-api POST "/Items/${BOXSET_ID}" "${BOXSET_PATCHED}" >/dev/null \
-    || fail "could not anchor BoxSet ${BOXSET_ID} to TMDB collection 10"
+    '.LockData = true | .ProviderIds = (.ProviderIds // {}) | .ProviderIds.Tmdb = "10"')"
+if ! api POST "/Items/${BOXSET_ID}" "${BOXSET_PATCHED}" >/dev/null; then
+    BOXSET_DTO="$(api GET "/Users/${ADMIN_ID}/Items/${BOXSET_ID}?Fields=ProviderIds,Path" 2>/dev/null || true)"
+    BOXSET_LOCKED="$(printf '%s' "${BOXSET_DTO}" | jq -r '.LockData // "missing"' 2>/dev/null || true)"
+    BOXSET_NATIVE_TMDB="$(printf '%s' "${BOXSET_DTO}" | jq -r '.ProviderIds.Tmdb // "missing"' 2>/dev/null || true)"
+    fail "could not anchor BoxSet ${BOXSET_ID} to TMDB collection 10 (locked=${BOXSET_LOCKED:-missing}, nativeTmdb=${BOXSET_NATIVE_TMDB:-missing})"
+fi
+BOXSET_NATIVE_TMDB=""
 BOXSET_VISIBLE_TMDB=""
-for _ in $(seq 1 60); do
+BOXSET_ANCHOR_ATTEMPTS=10
+for attempt in $(seq 1 "${BOXSET_ANCHOR_ATTEMPTS}"); do
+    BOXSET_DTO="$(api GET "/Users/${ADMIN_ID}/Items/${BOXSET_ID}?Fields=ProviderIds,Path" 2>/dev/null || true)"
+    BOXSET_LOCKED="$(printf '%s' "${BOXSET_DTO}" | jq -r '.LockData // "missing"' 2>/dev/null || true)"
+    BOXSET_NATIVE_TMDB="$(printf '%s' "${BOXSET_DTO}" | jq -r '.ProviderIds.Tmdb // empty' 2>/dev/null || true)"
     BOXSET_VISIBLE_TMDB="$(api GET "/JellyfinCanopy/boxset/${BOXSET_ID}" 2>/dev/null \
         | jq -r '.tmdbId // empty' || true)"
-    [ "${BOXSET_VISIBLE_TMDB}" = 10 ] && break
-    sleep 1
+    if [ "${BOXSET_LOCKED}" = true ] \
+        && [ "${BOXSET_NATIVE_TMDB}" = 10 ] \
+        && [ "${BOXSET_VISIBLE_TMDB}" = 10 ]; then
+        break
+    fi
+    [ "${attempt}" -lt "${BOXSET_ANCHOR_ATTEMPTS}" ] && sleep 1
 done
-[ "${BOXSET_VISIBLE_TMDB}" = 10 ] \
-    || fail "BoxSet ${BOXSET_ID} never exposed TMDB collection 10 through the plugin endpoint"
+[ "${BOXSET_LOCKED}" = true ] \
+    && [ "${BOXSET_NATIVE_TMDB}" = 10 ] \
+    && [ "${BOXSET_VISIBLE_TMDB}" = 10 ] \
+    || fail "BoxSet anchor verification failed after ${BOXSET_ANCHOR_ATTEMPTS} attempts (id=${BOXSET_ID}, locked=${BOXSET_LOCKED:-missing}, nativeTmdb=${BOXSET_NATIVE_TMDB:-missing}, pluginTmdb=${BOXSET_VISIBLE_TMDB:-missing})"
 api GET "/JellyfinCanopy/seerr/collection/10" \
     | jq -e '.parts | length >= 2 and any(.[]; ((.mediaInfo.status // 1) != 5))' >/dev/null \
     || fail "hermetic Seerr collection 10 has no missing movie fixture"

--- a/scripts/e2e/boxset-seed.test.js
+++ b/scripts/e2e/boxset-seed.test.js
@@ -7,6 +7,9 @@ const test = require('node:test');
 
 const ROOT = path.resolve(__dirname, '../..');
 const seed = fs.readFileSync(path.join(ROOT, 'e2e/docker/seed.sh'), 'utf8');
+const boxsetSeedStart = seed.indexOf('log "creating the TMDB-anchored incomplete collection fixture"');
+const boxsetSeedEnd = seed.indexOf('log "collection fixture ready:', boxsetSeedStart);
+const boxsetSeed = seed.slice(boxsetSeedStart, boxsetSeedEnd);
 
 test('BoxSet is locked atomically before its queued metadata refresh', () => {
     const create = seed.indexOf('&isLocked=true")');
@@ -18,6 +21,20 @@ test('BoxSet is locked atomically before its queued metadata refresh', () => {
     assert.ok(metadataWrite > createdLockCheck);
     assert.match(seed, /\.LockData = true \| \.ProviderIds =/);
     assert.doesNotMatch(seed, /\/Collections\?Name=JC%20E2E%20Fixture%20Collection&Ids=\$\{BOXSET_SEED_IDS\}"/);
+});
+
+test('BoxSet lock verification consumes the Jellyfin 12 LockData DTO field', () => {
+    assert.ok(boxsetSeedStart >= 0);
+    assert.ok(boxsetSeedEnd > boxsetSeedStart);
+    assert.equal(
+        (boxsetSeed.match(/BOXSET_LOCKED="\$\(printf[^\n]+\.LockData \/\/ false/g) || []).length,
+        1
+    );
+    assert.equal(
+        (boxsetSeed.match(/BOXSET_LOCKED="\$\(printf[^\n]+\.LockData \/\/ "missing"/g) || []).length,
+        2
+    );
+    assert.doesNotMatch(boxsetSeed, /\.IsLocked/);
 });
 
 test('BoxSet anchor proof reconciles native and feature-facing state', () => {

--- a/scripts/e2e/boxset-seed.test.js
+++ b/scripts/e2e/boxset-seed.test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const ROOT = path.resolve(__dirname, '../..');
+const seed = fs.readFileSync(path.join(ROOT, 'e2e/docker/seed.sh'), 'utf8');
+
+test('BoxSet is locked atomically before its queued metadata refresh', () => {
+    const create = seed.indexOf('&isLocked=true")');
+    const createdLockCheck = seed.indexOf('[ "${BOXSET_LOCKED}" = true ]');
+    const metadataWrite = seed.indexOf('api POST "/Items/${BOXSET_ID}" "${BOXSET_PATCHED}"');
+
+    assert.ok(create >= 0);
+    assert.ok(createdLockCheck > create);
+    assert.ok(metadataWrite > createdLockCheck);
+    assert.match(seed, /\.LockData = true \| \.ProviderIds =/);
+    assert.doesNotMatch(seed, /\/Collections\?Name=JC%20E2E%20Fixture%20Collection&Ids=\$\{BOXSET_SEED_IDS\}"/);
+});
+
+test('BoxSet anchor proof reconciles native and feature-facing state', () => {
+    const write = seed.indexOf('api POST "/Items/${BOXSET_ID}" "${BOXSET_PATCHED}"');
+    const nativeRead = seed.indexOf('BOXSET_NATIVE_TMDB=', write);
+    const featureRead = seed.indexOf('api GET "/JellyfinCanopy/boxset/${BOXSET_ID}"', write);
+    const seerrProof = seed.indexOf('api GET "/JellyfinCanopy/seerr/collection/10"', write);
+
+    assert.ok(write >= 0);
+    assert.ok(nativeRead > write);
+    assert.ok(featureRead > nativeRead);
+    assert.ok(seerrProof > featureRead);
+    assert.match(seed, /\[ "\$\{BOXSET_LOCKED\}" = true \]/);
+    assert.match(seed, /\[ "\$\{BOXSET_NATIVE_TMDB\}" = 10 \]/);
+    assert.match(seed, /\[ "\$\{BOXSET_VISIBLE_TMDB\}" = 10 \]/);
+});
+
+test('BoxSet anchor failure is bounded and reports both state owners', () => {
+    assert.match(seed, /BOXSET_ANCHOR_ATTEMPTS=10/);
+    assert.doesNotMatch(seed, /for _ in \$\(seq 1 60\); do\n\s+BOXSET_VISIBLE_TMDB=/);
+    assert.match(seed, /BoxSet anchor verification failed after \$\{BOXSET_ANCHOR_ATTEMPTS\} attempts/);
+    assert.match(seed, /locked=\$\{BOXSET_LOCKED:-missing\}/);
+    assert.match(seed, /nativeTmdb=\$\{BOXSET_NATIVE_TMDB:-missing\}/);
+    assert.match(seed, /pluginTmdb=\$\{BOXSET_VISIBLE_TMDB:-missing\}/);
+});

--- a/scripts/e2e/library-scan-seed.test.js
+++ b/scripts/e2e/library-scan-seed.test.js
@@ -8,26 +8,39 @@ const test = require('node:test');
 const ROOT = path.resolve(__dirname, '../..');
 const seed = fs.readFileSync(path.join(ROOT, 'e2e/docker/seed.sh'), 'utf8');
 
-test('seed starts one explicit scan only after both libraries exist', () => {
+test('seed starts one explicit scan only after all seed-owned libraries exist', () => {
+    const precreatedCollections = seed.indexOf('"${CONFIG_DIR}/data/collections"');
+    const composeUp = seed.indexOf('"${COMPOSE[@]}" up -d');
     const movies = seed.indexOf('name=Movies&collectionType=movies&paths=%2Fmedia%2FMovies&refreshLibrary=false');
     const shows = seed.indexOf('name=Shows&collectionType=tvshows&paths=%2Fmedia%2FShows&refreshLibrary=false');
+    const collections = seed.indexOf('name=Collections&collectionType=boxsets&paths=%2Fconfig%2Fdata%2Fcollections&refreshLibrary=false');
     const trigger = seed.indexOf('LIBRARY_SCAN_TRIGGERED_AT="$(date -u');
     const refresh = seed.indexOf('api POST "/Library/Refresh"');
 
+    assert.ok(precreatedCollections >= 0);
+    assert.ok(composeUp > precreatedCollections);
     assert.ok(movies >= 0);
     assert.ok(shows > movies);
-    assert.ok(trigger > shows);
+    assert.ok(collections > shows);
+    assert.ok(trigger > collections);
     assert.ok(refresh > trigger);
     assert.equal((seed.match(/refreshLibrary=true/g) || []).length, 0);
+    assert.equal((seed.match(/collectionType=boxsets/g) || []).length, 1);
+    assert.match(seed, /collectionType=boxsets[^\n]+refreshLibrary=false/);
+    assert.match(seed, /"SaveLocalMetadata":true/);
     assert.equal((seed.match(/api POST "\/Library\/Refresh"/g) || []).length, 1);
 });
 
 test('metadata writes wait for a RefreshLibrary run started after the trigger', () => {
     const wait = seed.indexOf('waiting for the explicit library scan to complete before metadata writes');
+    const completed = seed.indexOf('log "explicit library scan completed at ${LIBRARY_SCAN_END}"');
     const firstWrite = seed.indexOf('AUTOSKIP_PATCHED=');
+    const boxsetCreate = seed.indexOf('BOXSET_CREATED="$(api POST "/Collections?');
 
     assert.ok(wait >= 0);
-    assert.ok(firstWrite > wait);
+    assert.ok(completed > wait);
+    assert.ok(firstWrite > completed);
+    assert.ok(boxsetCreate > completed);
     assert.match(seed, /select\(\.Key == "RefreshLibrary"\)/);
     assert.match(seed, /\[ "\$\{LIBRARY_SCAN_STATE\}" = Idle \]/);
     assert.match(seed, /\[ "\$\{LIBRARY_SCAN_STATUS\}" = Completed \]/);


### PR DESCRIPTION
## Root causes

The original seed serialized Movies/Shows, but first-ever collection creation still had two later owners:

1. `CollectionManager.EnsureLibraryFolder` implicitly added the Collections virtual library with `refreshLibrary=true`, starting a second full media-library scan that could recreate the BoxSet without its provider ID.
2. `CreateCollectionAsync` queued a BoxSet metadata refresh; a failing hermetic TMDB call could race the deterministic anchor unless the BoxSet was locked at creation.

Both failures occurred before Playwright started. The first patch removed owner 2, and PR CI then exposed owner 1 with `locked=true, nativeTmdb=missing, pluginTmdb=missing`.

## What changed

- precreate the seed-owned Collections path and register its `boxsets` virtual folder with `refreshLibrary=false` before the single explicit scan
- let the existing timestamp/completion gate cover Movies, Shows, and Collections before any metadata write
- create the BoxSet atomically with `isLocked=true` so Jellyfin skips its queued metadata providers
- prove Jellyfin returns `LockData=true` and preserve the lock while writing TMDB collection 10
- reconcile both native `ProviderIds.Tmdb` and Canopy `/boxset/{id}` state in ten bounded attempts
- report lock/native/plugin state without secrets on failure
- add mutation-strengthened contracts for library ordering, one explicit scan, `refreshLibrary=false`, and the correct `.LockData` DTO field

## Evidence and validation

- reproduced in four required CI jobs across PRs #288, #289, and the first #292 run
- final exact live proof: 4/4 concurrent servers passed
- each server: Jellyfin 12.0.0, digest-pinned `jellyfin/jellyfin:unstable`, exactly 2 CPUs
- every proof retained `LockData=true`, native TMDB `10`, and plugin TMDB `10` after settling
- logs show startup scan + the single explicit scan and no third post-collection scan
- script tests: 316/316
- focused BoxSet + scan contracts: 6/6
- Release build: zero warnings/errors
- lint, syntax, both typechecks, Bash syntax, and diff checks passed
- two independent final reviews approved exact `0a8232c5` with no findings

Closes #251