### PR TITLE
Stabilize Auto-Skip cleanup and concurrent logout E2E

### DIFF
--- a/e2e/account-switch.spec.ts
+++ b/e2e/account-switch.spec.ts
@@ -17,6 +17,7 @@ import {
 } from './fixtures/auth';
 import type { Page, Request, Route } from 'playwright/test';
 import {
+    hasValidConcurrentLogoutResponses,
     isExpectedSignedOutHomeAxios401,
     isExpectedSignedOutHostLogout4xx,
 } from '../scripts/e2e/jellyfin-host-noise';
@@ -456,17 +457,10 @@ async function spaLogout(
             ({ requestIndex, status, bodyBytes }))
             .sort((left, right) => left.requestIndex - right.requestIndex);
         expect(
-            orderedResponses[0],
-            'the first native logout call revokes the session cleanly'
-        ).toEqual({ requestIndex: 0, status: 204, bodyBytes: 0 });
-        expect(
-            { requestIndex: orderedResponses[1]?.requestIndex, bodyBytes: orderedResponses[1]?.bodyBytes },
-            'the concurrent duplicate returns no body'
-        ).toEqual({ requestIndex: 1, bodyBytes: 0 });
-        expect(
-            [204, 401],
-            'the duplicate either authenticates before revocation or is rejected after it'
-        ).toContain(orderedResponses[1]?.status);
+            hasValidConcurrentLogoutResponses(orderedResponses),
+            'the concurrent native logout pair has exact empty 204/401 outcomes '
+                + `independent of server completion order: ${JSON.stringify(orderedResponses)}`
+        ).toBe(true);
 
         expect(signedOut.identityCleared, 'Canopy identity is null after logout').toBe(true);
         expect(signedOut.userId, 'the host client has no current user after logout').toBe('');

--- a/e2e/auto-skip.spec.ts
+++ b/e2e/auto-skip.spec.ts
@@ -14,9 +14,13 @@ import {
     AUTO_SKIP_FIXTURE,
     PLAYWRIGHT_DEVICE_PROFILE,
     TICKS_PER_SECOND,
+    isAutoSkipZeroProgressResponse,
+    preservePrimaryError,
+    resetAutoSkipPlaybackState,
     resolveAutoSkipFixture,
     type FixtureApiClient,
     type JellyfinItem,
+    type PlaybackStateApiClient,
     type PlaybackInfo,
 } from '../scripts/e2e/auto-skip-fixture';
 
@@ -89,37 +93,42 @@ function fixtureApi(baseURL: string, session: Session): FixtureApiClient {
     };
 }
 
-async function resetPlaybackState(
+function playbackStateApi(
     baseURL: string,
-    session: Session,
+    session: Session
+): PlaybackStateApiClient {
+    return {
+        markUnplayed: (itemId) => api<UserData>(
+            baseURL,
+            `/UserPlayedItems/${encodeURIComponent(itemId)}?userId=${encodeURIComponent(session.userId)}`,
+            session.token,
+            { method: 'DELETE' }
+        ),
+        getUserData: (itemId) => api<UserData>(
+            baseURL,
+            `/UserItems/${encodeURIComponent(itemId)}/UserData?userId=${encodeURIComponent(session.userId)}`,
+            session.token
+        ),
+    };
+}
+
+function isZeroProgressResponse(
+    response: import('playwright/test').Response,
     itemId: string
-): Promise<void> {
-    const path = `/UserItems/${encodeURIComponent(itemId)}/UserData?userId=${encodeURIComponent(session.userId)}`;
-    const existing = (await api<UserData>(baseURL, path, session.token)) ?? {};
-    await api<UserData>(baseURL, path, session.token, {
-        method: 'POST',
-        body: JSON.stringify({
-            ...existing,
-            PlaybackPositionTicks: 0,
-            PlayedPercentage: 0,
-            Played: false,
-        }),
-    });
-    const verified = await api<UserData>(baseURL, path, session.token);
-    const position = Number(verified?.PlaybackPositionTicks);
-    const percentage = verified?.PlayedPercentage;
-    if (!verified
-        || !Number.isFinite(position)
-        || position !== 0
-        || (percentage !== null && percentage !== undefined && Number(percentage) !== 0)
-        || verified.Played !== false) {
-        throw new Error(
-            `Auto-Skip fixture ${itemId} playback reset failed: `
-            + `PlaybackPositionTicks=${String(verified?.PlaybackPositionTicks)}, `
-            + `PlayedPercentage=${String(percentage)}, `
-            + `Played=${String(verified?.Played)}`
-        );
+): boolean {
+    const request = response.request();
+    let body: unknown;
+    try {
+        body = request.postDataJSON();
+    } catch {
+        return false;
     }
+    return isAutoSkipZeroProgressResponse({
+        method: request.method(),
+        pathname: new URL(response.url()).pathname,
+        status: response.status(),
+        body: body as { ItemId?: string; PositionTicks?: number },
+    }, itemId);
 }
 
 async function readTrace(page: import('playwright/test').Page): Promise<AutoSkipTrace> {
@@ -161,7 +170,8 @@ test.describe('Auto-Skip v2 (native media segments)', () => {
 
         // Every Playwright retry starts with zero resume state. The finally
         // block repeats the reset so later local runs are isolated as well.
-        await resetPlaybackState(baseURL, session, resolved.id);
+        const resetApi = playbackStateApi(baseURL, session);
+        await resetAutoSkipPlaybackState(resetApi, resolved.id);
 
         const requestedSegmentIds: string[] = [];
         await page.route('**/MediaSegments/**', async (route) => {
@@ -199,6 +209,8 @@ test.describe('Auto-Skip v2 (native media segments)', () => {
             window.localStorage.setItem(`${userId}-language`, 'he');
         }, session.userId);
 
+        let testBodyFailed = false;
+        let testBodyError: unknown;
         try {
             await loginAs(page, 'admin', consoleErrors);
 
@@ -375,14 +387,52 @@ test.describe('Auto-Skip v2 (native media segments)', () => {
                 .unexpected4xx()
                 .filter((response) => /\/JellyfinCanopy\//i.test(response.url));
             expect(pluginFourxx, 'no 4xx from plugin endpoints').toEqual([]);
-        } finally {
-            await page.evaluate(() => {
-                const video = document.querySelector('video');
-                if (!video) return;
-                video.pause();
-                video.currentTime = 0;
-            }).catch(() => undefined);
-            await resetPlaybackState(baseURL, session, resolved.id);
+        } catch (error) {
+            testBodyFailed = true;
+            testBodyError = error;
+        }
+
+        const cleanupErrors: unknown[] = [];
+        const hasVideo = await page.evaluate(
+            () => Boolean(document.querySelector('video'))
+        ).catch(() => false);
+        if (hasVideo) {
+            try {
+                await Promise.all([
+                    page.waitForResponse(
+                        (response) => isZeroProgressResponse(response, resolved.id),
+                        { timeout: 10_000 }
+                    ),
+                    page.evaluate(() => {
+                        const video = document.querySelector('video');
+                        if (!video) throw new Error('Auto-Skip video disappeared during cleanup');
+                        video.currentTime = 0;
+                        video.pause();
+                        video.dispatchEvent(new Event('timeupdate'));
+                    }),
+                ]);
+            } catch (error) {
+                cleanupErrors.push(error);
+            }
+        }
+        try {
+            // Unload the Jellyfin player before resetting server state so its
+            // final playback beacon cannot overwrite the cleanup.
+            await page.goto('about:blank', { waitUntil: 'load' });
+        } catch (error) {
+            cleanupErrors.push(error);
+        }
+        try {
+            await resetAutoSkipPlaybackState(resetApi, resolved.id);
+        } catch (error) {
+            cleanupErrors.push(error);
+        }
+
+        if (testBodyFailed) {
+            throw preservePrimaryError(testBodyError, cleanupErrors);
+        }
+        if (cleanupErrors.length > 0) {
+            throw preservePrimaryError(cleanupErrors[0], cleanupErrors.slice(1));
         }
     });
 });

--- a/scripts/e2e/auto-skip-fixture.d.ts
+++ b/scripts/e2e/auto-skip-fixture.d.ts
@@ -36,6 +36,33 @@ export interface FixtureApiClient {
     ): Promise<PlaybackInfo>;
 }
 
+export interface PlaybackUserData {
+    PlaybackPositionTicks?: number;
+    PlayedPercentage?: number;
+    Played?: boolean;
+}
+
+export interface PlaybackStateApiClient {
+    markUnplayed(itemId: string): Promise<PlaybackUserData | null>;
+    getUserData(itemId: string): Promise<PlaybackUserData | null>;
+}
+
+export interface PlaybackResetOptions {
+    attempts?: number;
+    settleMs?: number;
+    wait?: (milliseconds: number) => Promise<void>;
+}
+
+export interface PlaybackProgressResponseCandidate {
+    method?: string;
+    pathname?: string;
+    status?: number;
+    body?: {
+        ItemId?: string;
+        PositionTicks?: number;
+    };
+}
+
 export interface ResolvedAutoSkipFixture {
     id: string;
     name: string;
@@ -59,3 +86,13 @@ export function resolveAutoSkipFixture(
     apiClient: FixtureApiClient,
     overrideId?: string
 ): Promise<Readonly<ResolvedAutoSkipFixture>>;
+export function isAutoSkipZeroProgressResponse(
+    candidate: PlaybackProgressResponseCandidate,
+    itemId: string
+): boolean;
+export function preservePrimaryError(primary: unknown, cleanupErrors?: unknown[]): Error;
+export function resetAutoSkipPlaybackState(
+    apiClient: PlaybackStateApiClient,
+    itemId: string,
+    options?: PlaybackResetOptions
+): Promise<void>;

--- a/scripts/e2e/auto-skip-fixture.js
+++ b/scripts/e2e/auto-skip-fixture.js
@@ -5,6 +5,8 @@
 const fixtureManifest = require('../../e2e/fixtures/media-fixtures.json');
 
 const TICKS_PER_SECOND = 10_000_000;
+const PLAYBACK_RESET_ATTEMPTS = 6;
+const PLAYBACK_RESET_SETTLE_MS = 250;
 
 function positiveNumber(value, label) {
     const number = Number(value);
@@ -219,11 +221,117 @@ async function resolveAutoSkipFixture(apiClient, overrideId = '') {
     return validatePlaybackInfo(item, playbackInfo, normalizedOverride);
 }
 
+function playbackStateIsReset(userData) {
+    const position = Number(userData?.PlaybackPositionTicks);
+    const percentage = userData?.PlayedPercentage;
+    return Boolean(userData)
+        && Number.isFinite(position)
+        && position === 0
+        && (percentage === null || percentage === undefined || Number(percentage) === 0)
+        && userData.Played === false;
+}
+
+function playbackStateDiagnostic(userData) {
+    return `PlaybackPositionTicks=${String(userData?.PlaybackPositionTicks)}, `
+        + `PlayedPercentage=${String(userData?.PlayedPercentage)}, `
+        + `Played=${String(userData?.Played)}`;
+}
+
+function errorDetail(error, index) {
+    if (error instanceof Error) {
+        return `[cleanup ${index}] ${error.name}: ${error.message}\n${error.stack || '<no stack>'}`;
+    }
+    return `[cleanup ${index}] ${String(error)}`;
+}
+
+function preservePrimaryError(primary, cleanupErrors = []) {
+    const primaryError = primary instanceof Error
+        ? primary
+        : new Error(`Auto-Skip test failed with a non-Error value: ${String(primary)}`);
+    if (!Array.isArray(cleanupErrors) || cleanupErrors.length === 0) return primaryError;
+
+    const existingCause = primaryError.cause;
+    const cleanupCause = new Error(
+        `Auto-Skip cleanup failures:\n${cleanupErrors
+            .map((error, index) => errorDetail(error, index + 1))
+            .join('\n\n')}`,
+        existingCause === undefined ? undefined : { cause: existingCause }
+    );
+    Object.defineProperty(primaryError, 'cause', {
+        configurable: true,
+        value: cleanupCause,
+    });
+    return primaryError;
+}
+
+function isAutoSkipZeroProgressResponse(candidate, itemId) {
+    const normalizedItemId = String(itemId || '').replaceAll('-', '').toLowerCase();
+    const bodyItemId = String(candidate?.body?.ItemId || '').replaceAll('-', '').toLowerCase();
+    return Boolean(normalizedItemId)
+        && candidate?.method === 'POST'
+        && candidate?.pathname === '/Sessions/Playing/Progress'
+        && Number.isInteger(candidate?.status)
+        && candidate.status >= 200
+        && candidate.status < 300
+        && bodyItemId === normalizedItemId
+        && typeof candidate?.body?.PositionTicks === 'number'
+        && candidate.body.PositionTicks === 0;
+}
+
+async function resetAutoSkipPlaybackState(apiClient, itemId, options = {}) {
+    if (!apiClient
+        || typeof apiClient.markUnplayed !== 'function'
+        || typeof apiClient.getUserData !== 'function') {
+        throw new Error('Auto-Skip playback reset requires an authenticated playback-state ApiClient');
+    }
+
+    const normalizedItemId = String(itemId || '').trim();
+    if (!normalizedItemId) {
+        throw new Error('Auto-Skip playback reset requires a Jellyfin item ID');
+    }
+
+    const attempts = Number.isInteger(options.attempts) && options.attempts > 0
+        ? options.attempts
+        : PLAYBACK_RESET_ATTEMPTS;
+    const settleMs = Number.isFinite(options.settleMs) && options.settleMs >= 0
+        ? options.settleMs
+        : PLAYBACK_RESET_SETTLE_MS;
+    const wait = typeof options.wait === 'function'
+        ? options.wait
+        : (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+    let verified;
+
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+        // Jellyfin's canonical unplayed route clears Played, play count,
+        // position, and last-played state together. The generic UserData route
+        // leaves some of those fields behind and can lose a race to a late
+        // playback-session update during Playwright cleanup.
+        await apiClient.markUnplayed(normalizedItemId);
+        verified = await apiClient.getUserData(normalizedItemId);
+        if (!playbackStateIsReset(verified)) continue;
+
+        // Require a second clean read after a short quiet window. A page-unload
+        // beacon can otherwise overwrite the first reset immediately after it
+        // is observed, contaminating the next retry or local run.
+        await wait(settleMs);
+        verified = await apiClient.getUserData(normalizedItemId);
+        if (playbackStateIsReset(verified)) return;
+    }
+
+    throw new Error(
+        `Auto-Skip fixture ${normalizedItemId} playback reset did not converge `
+        + `after ${attempts} attempts: ${playbackStateDiagnostic(verified)}`
+    );
+}
+
 module.exports = {
     AUTO_SKIP_FIXTURE,
     PLAYWRIGHT_DEVICE_PROFILE,
     TICKS_PER_SECOND,
     minimumDurationSeconds,
+    isAutoSkipZeroProgressResponse,
+    preservePrimaryError,
+    resetAutoSkipPlaybackState,
     resolveAutoSkipFixture,
     selectFixtureItem,
     validatePlaybackInfo,

--- a/scripts/e2e/auto-skip-fixture.test.js
+++ b/scripts/e2e/auto-skip-fixture.test.js
@@ -11,7 +11,10 @@ const {
     AUTO_SKIP_FIXTURE,
     PLAYWRIGHT_DEVICE_PROFILE,
     TICKS_PER_SECOND,
+    isAutoSkipZeroProgressResponse,
     minimumDurationSeconds,
+    preservePrimaryError,
+    resetAutoSkipPlaybackState,
     resolveAutoSkipFixture,
     selectFixtureItem,
     validatePlaybackInfo,
@@ -59,6 +62,22 @@ function fakeApi({ items = [item()], playback = playbackInfo(), overrideItem, fa
         getPlaybackInfo: async (id, options, profile) => {
             calls.push(['getPlaybackInfo', id, options, profile]);
             return playback;
+        },
+    };
+}
+
+function fakePlaybackStateApi(states) {
+    const queue = [...states];
+    const calls = [];
+    return {
+        calls,
+        markUnplayed: async (itemId) => {
+            calls.push(['markUnplayed', itemId]);
+            return { PlaybackPositionTicks: 0, Played: false };
+        },
+        getUserData: async (itemId) => {
+            calls.push(['getUserData', itemId]);
+            return queue.length > 1 ? queue.shift() : queue[0];
         },
     };
 }
@@ -202,6 +221,101 @@ test('lookup and PlaybackInfo errors name the phase and happen before navigation
     );
 });
 
+test('playback reset requires two stable reads after the canonical unplayed write', async () => {
+    const clean = { PlaybackPositionTicks: 0, PlayedPercentage: undefined, Played: false };
+    const api = fakePlaybackStateApi([clean, clean]);
+    const waits = [];
+
+    await resetAutoSkipPlaybackState(api, 'fixture-id', {
+        settleMs: 17,
+        wait: async (milliseconds) => waits.push(milliseconds),
+    });
+
+    assert.deepEqual(api.calls, [
+        ['markUnplayed', 'fixture-id'],
+        ['getUserData', 'fixture-id'],
+        ['getUserData', 'fixture-id'],
+    ]);
+    assert.deepEqual(waits, [17]);
+});
+
+test('zero-progress response matcher owns only the exact successful Jellyfin write', () => {
+    const exact = {
+        method: 'POST',
+        pathname: '/Sessions/Playing/Progress',
+        status: 204,
+        body: { ItemId: 'fixture-id', PositionTicks: 0 },
+    };
+    assert.equal(isAutoSkipZeroProgressResponse(exact, 'fixture-id'), true);
+    assert.equal(isAutoSkipZeroProgressResponse(exact, 'other-id'), false);
+    assert.equal(isAutoSkipZeroProgressResponse({ ...exact, method: 'GET' }, 'fixture-id'), false);
+    assert.equal(isAutoSkipZeroProgressResponse({ ...exact, status: 500 }, 'fixture-id'), false);
+    assert.equal(isAutoSkipZeroProgressResponse({
+        ...exact,
+        body: { ...exact.body, PositionTicks: 1 },
+    }, 'fixture-id'), false);
+    assert.equal(isAutoSkipZeroProgressResponse({
+        ...exact,
+        pathname: '/Sessions/Playing/Stopped',
+    }, 'fixture-id'), false);
+});
+
+test('cleanup diagnostics preserve the primary Error for Playwright cause serialization', () => {
+    const originalCause = new Error('original cause');
+    const primary = new Error('PRIMARY ASSERTION', { cause: originalCause });
+    primary.stack = 'PRIMARY STACK';
+    const firstCleanup = new Error('progress handshake failed');
+    firstCleanup.stack = 'PROGRESS STACK';
+    const secondCleanup = new Error('native reset failed');
+    secondCleanup.stack = 'RESET STACK';
+
+    const preserved = preservePrimaryError(primary, [firstCleanup, secondCleanup]);
+
+    assert.equal(preserved, primary);
+    assert.equal(preserved.message, 'PRIMARY ASSERTION');
+    assert.equal(preserved.stack, 'PRIMARY STACK');
+    assert.ok(preserved.cause instanceof Error);
+    assert.match(preserved.cause.message, /progress handshake failed[\s\S]*native reset failed/);
+    assert.match(preserved.cause.message, /PROGRESS STACK[\s\S]*RESET STACK/);
+    assert.equal(preserved.cause.cause, originalCause);
+});
+
+test('non-Error primary values remain visible while cleanup is attached as cause', () => {
+    const preserved = preservePrimaryError('plain failure', ['plain cleanup']);
+    assert.match(preserved.message, /plain failure/);
+    assert.ok(preserved.cause instanceof Error);
+    assert.match(preserved.cause.message, /plain cleanup/);
+});
+
+test('playback reset repairs a late player-session overwrite before returning', async () => {
+    const clean = { PlaybackPositionTicks: 0, PlayedPercentage: 0, Played: false };
+    const lateStop = { PlaybackPositionTicks: 0, PlayedPercentage: undefined, Played: true };
+    const api = fakePlaybackStateApi([clean, lateStop, clean, clean]);
+
+    await resetAutoSkipPlaybackState(api, 'fixture-id', {
+        settleMs: 0,
+        wait: async () => undefined,
+    });
+
+    assert.equal(api.calls.filter(([name]) => name === 'markUnplayed').length, 2);
+    assert.equal(api.calls.filter(([name]) => name === 'getUserData').length, 4);
+});
+
+test('playback reset is bounded and reports the last server state', async () => {
+    const stale = { PlaybackPositionTicks: 0, PlayedPercentage: undefined, Played: true };
+    const api = fakePlaybackStateApi([stale]);
+
+    await assert.rejects(
+        resetAutoSkipPlaybackState(api, 'fixture-id', {
+            attempts: 3,
+            settleMs: 0,
+            wait: async () => undefined,
+        }),
+        /fixture fixture-id.*did not converge after 3 attempts:.*Played=true/
+    );
+    assert.equal(api.calls.filter(([name]) => name === 'markUnplayed').length, 3);
+});
+
 test('seed, spec, compose, and CI consume the dynamic fixture contract', () => {
     const seed = fs.readFileSync(path.join(ROOT, 'e2e/docker/seed.sh'), 'utf8');
     const spec = fs.readFileSync(path.join(ROOT, 'e2e/auto-skip.spec.ts'), 'utf8');
@@ -214,6 +328,22 @@ test('seed, spec, compose, and CI consume the dynamic fixture contract', () => {
     assert.match(seed, /sine=frequency=\$2:duration=\$\{duration\}/);
     assert.match(seed, /seed-result\.json/);
     assert.match(spec, /resolveAutoSkipFixture/);
+    assert.match(spec, /UserPlayedItems\/\$\{encodeURIComponent\(itemId\)\}/);
+    assert.doesNotMatch(spec, /method: 'POST',[\s\S]{0,200}PlaybackPositionTicks: 0/);
+    assert.match(spec, /page\.waitForResponse/);
+    assert.match(spec, /isZeroProgressResponse\(response, resolved\.id\)/);
+    assert.match(spec, /video\.dispatchEvent\(new Event\('timeupdate'\)\)/);
+    assert.match(spec, /let testBodyFailed = false/);
+    assert.match(spec, /preservePrimaryError\(testBodyError, cleanupErrors\)/);
+    assert.ok(
+        spec.indexOf('testBodyError = error') < spec.lastIndexOf('resetAutoSkipPlaybackState(resetApi'),
+        'the primary test error must be captured before cleanup can fail'
+    );
+    assert.match(spec, /page\.goto\('about:blank'/);
+    assert.ok(
+        spec.indexOf("page.goto('about:blank'") < spec.lastIndexOf('resetAutoSkipPlaybackState('),
+        'the player must unload before the final server-state reset'
+    );
     assert.doesNotMatch(spec, /14ba72cbe419e23f29d748060beef153/);
     assert.ok(
         spec.indexOf('await resolveAutoSkipFixture(') < spec.indexOf('showRoute(page'),

--- a/scripts/e2e/jellyfin-host-noise.d.ts
+++ b/scripts/e2e/jellyfin-host-noise.d.ts
@@ -3,6 +3,9 @@ export const HOME_TAB_PREFIX: "[Home] failed to get tab controller TypeError: Ca
 export const HOME_SELECTED_INDEX_ERROR: "pageerror: Cannot read properties of undefined (reading 'selectedIndex')";
 export const HOME_LOGOUT_AXIOS_401: 'AxiosError: Request failed with status code 401';
 
+export function hasValidConcurrentLogoutResponses(
+    responses: Array<{ requestIndex: number; status: number; bodyBytes: number }>
+): boolean;
 export function isKnownHiddenContentHostNoise(text: string): boolean;
 export function isKnownJellyfinWebHostNoise(detail: { text: string; stack?: string }): boolean;
 export function isExpectedSignedOutHostLogout4xx(

--- a/scripts/e2e/jellyfin-host-noise.js
+++ b/scripts/e2e/jellyfin-host-noise.js
@@ -61,6 +61,24 @@ function hasCompleteSignedOutEvidence(evidence) {
 }
 
 /**
+ * The two native logout requests are dispatched concurrently. Browser request
+ * index records dispatch order, not the order Jellyfin authenticates and
+ * revokes them, so either request may own the successful 204. Require the
+ * complete response set without assigning server ownership by index.
+ *
+ * @param {{requestIndex: number, status: number, bodyBytes: number}[]} responses
+ */
+function hasValidConcurrentLogoutResponses(responses) {
+    if (!Array.isArray(responses) || responses.length !== 2) return false;
+    const ordered = [...responses].sort((left, right) => left.requestIndex - right.requestIndex);
+    return ordered[0]?.requestIndex === 0
+        && ordered[1]?.requestIndex === 1
+        && ordered.every((response) => response.bodyBytes === 0)
+        && ordered.every((response) => response.status === 204 || response.status === 401)
+        && ordered.some((response) => response.status === 204);
+}
+
+/**
  * Exact read-only Home requests Jellyfin Web can leave in flight while logout
  * revokes the old owner token. Every query field is part of the contract; the
  * only variable values are the proven prior user, a library parent ID, and the
@@ -265,6 +283,7 @@ module.exports = {
     HOME_SELECTED_INDEX_ERROR,
     HOME_TAB_PREFIX,
     SCROLL_HANDLER_ERROR,
+    hasValidConcurrentLogoutResponses,
     isKnownHiddenContentHostNoise,
     isKnownJellyfinWebHostNoise,
     isExpectedSignedOutHostLogout4xx,

--- a/scripts/e2e/jellyfin-host-noise.test.js
+++ b/scripts/e2e/jellyfin-host-noise.test.js
@@ -10,6 +10,7 @@ const {
     HOME_SELECTED_INDEX_ERROR,
     HOME_TAB_PREFIX,
     SCROLL_HANDLER_ERROR,
+    hasValidConcurrentLogoutResponses,
     isKnownHiddenContentHostNoise,
     isKnownJellyfinWebHostNoise,
     isExpectedSignedOutHostLogout4xx,
@@ -46,6 +47,51 @@ const COMPLETE_SIGNED_OUT = {
         oldTokenStatus: 401,
     },
 };
+
+test('concurrent logout accepts either request as the session-revocation owner', () => {
+    const requestZeroWins = [
+        { requestIndex: 0, status: 204, bodyBytes: 0 },
+        { requestIndex: 1, status: 401, bodyBytes: 0 },
+    ];
+    const requestOneWins = [
+        { requestIndex: 0, status: 401, bodyBytes: 0 },
+        { requestIndex: 1, status: 204, bodyBytes: 0 },
+    ];
+    const bothAuthenticatedBeforeRevocation = [
+        { requestIndex: 1, status: 204, bodyBytes: 0 },
+        { requestIndex: 0, status: 204, bodyBytes: 0 },
+    ];
+
+    assert.equal(hasValidConcurrentLogoutResponses(requestZeroWins), true);
+    assert.equal(hasValidConcurrentLogoutResponses(requestOneWins), true);
+    assert.equal(hasValidConcurrentLogoutResponses(bothAuthenticatedBeforeRevocation), true);
+});
+
+test('concurrent logout rejects missing success, bodies, indices, statuses, and cardinality', () => {
+    const rejected = [
+        [
+            { requestIndex: 0, status: 401, bodyBytes: 0 },
+            { requestIndex: 1, status: 401, bodyBytes: 0 },
+        ],
+        [
+            { requestIndex: 0, status: 204, bodyBytes: 1 },
+            { requestIndex: 1, status: 401, bodyBytes: 0 },
+        ],
+        [
+            { requestIndex: 0, status: 204, bodyBytes: 0 },
+            { requestIndex: 0, status: 401, bodyBytes: 0 },
+        ],
+        [
+            { requestIndex: 0, status: 204, bodyBytes: 0 },
+            { requestIndex: 1, status: 500, bodyBytes: 0 },
+        ],
+        [{ requestIndex: 0, status: 204, bodyBytes: 0 }],
+    ];
+
+    for (const responses of rejected) {
+        assert.equal(hasValidConcurrentLogoutResponses(responses), false, JSON.stringify(responses));
+    }
+});
 
 const OBSERVED_SIGNED_OUT_HOME_401S = [
     '/LiveTv/Programs/Recommended?userId=92bdc95c7381435689451ad246198f74&limit=1&isAiring=true&imageTypeLimit=1&enableImageTypes=Primary&enableImageTypes=Thumb&enableImageTypes=Backdrop&fields=ChannelInfo&fields=PrimaryImageAspectRatio&enableTotalRecordCount=false',
@@ -320,6 +366,8 @@ test('both admin and non-admin Hidden Content paths use the strict host-noise as
 
 test('account switching scopes logout Axios noise to the phase-local response classifier', () => {
     const source = fs.readFileSync(path.join(ROOT, 'e2e/account-switch.spec.ts'), 'utf8');
+    assert.match(source, /hasValidConcurrentLogoutResponses\(orderedResponses\)/);
+    assert.doesNotMatch(source, /orderedResponses\[0\][\s\S]{0,200}status: 204/);
     assert.match(source, /isExpectedSignedOutHomeAxios401\(detail, evidence, hasAllowedHost401\)/);
     assert.match(source, /response\.status === 401\s*&& isExpectedSignedOutHostLogout4xx\(response, evidence\)/);
     assert.match(source, /failed\.filter\(\(response\) => !isExpectedSignedOutHostLogout4xx\(response, evidence\)\)/);


### PR DESCRIPTION
Closes #74.
Closes #232.

## Protected-run findings

- Run `29438791315`: Auto-Skip product assertions completed, but final cleanup raced a late Jellyfin Web playback update and read back stale `Played=true`.
- Run `29441166641`: the repaired Auto-Skip test passed in 13.0s; account-switch then observed the valid reversed completion order for two intentionally concurrent native logouts (`[401,204]`), exposing an order-specific test assertion.

## Fixes

### Auto-Skip cleanup
- await the exact successful zero-position `POST /Sessions/Playing/Progress` response for the current fixture item
- unload the player, then use Jellyfin 12's canonical `DELETE /UserPlayedItems/{id}` owner
- require bounded two-read convergence after a quiet window
- keep the primary test Error and attach all cleanup diagnostics through Playwright's supported `cause` chain

### Concurrent logout evidence
- validate the two-response set independent of browser dispatch index
- require exact indices 0/1, empty bodies, statuses limited to 204/401, and at least one 204
- retain exact same-origin/session request identity, signed-out state, old-token 401, same-document continuity, and strict host-noise gates

## Verification
- 324/324 script tests
- TypeScript, syntax, focused ESLint, Playwright discovery, diff check
- Release build: 0 warnings / 0 errors
- Auto-Skip: 3/3 consecutive no-retry passes on one clean seed plus 2/2 passes across two fully wiped seeds with distinct item IDs
- account switching: 3/3 consecutive no-retry passes on a fresh seed
- all live proofs used digest-pinned `jellyfin/jellyfin:unstable@sha256:9040e988...`, exactly 2 CPUs / 2,000,000,000 NanoCPUs, dynamic loopback ports, and complete teardown
- two independent reviews approved exact commits `5143455d` and `9e0ee8f3` with no findings
