### PR TITLE
Preserve Jellyfin base URLs in web routes

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/navigation.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/navigation.test.ts
@@ -164,6 +164,7 @@ describe('routeHref', () => {
     it('rejects route text that could escape the Jellyfin SPA route grammar', () => {
         expect(() => routeHref('https://attacker.example/')).toThrow(TypeError);
         expect(() => routeHref('details?admin=true')).toThrow(TypeError);
+        expect(routeHref('home')).toBe('#/home');
         expect(routeHref('details', { optional: null, enabled: false }))
             .toBe('#/details?enabled=false');
     });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/navigation.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/navigation.test.ts
@@ -6,7 +6,16 @@
 // history/event calls. URLs are unique per test because the dedup guard
 // (last dispatched href) is module state.
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { handleHistoryUpdate, installEmbyHook, navDedupKey, offNavigate, onNavigate, onViewPage } from './navigation';
+import {
+    handleHistoryUpdate,
+    installEmbyHook,
+    navDedupKey,
+    offNavigate,
+    onNavigate,
+    onViewPage,
+    routeHref,
+    routePath
+} from './navigation';
 
 describe('onNavigate dedup', () => {
     it('notifies exactly once for a pushState URL change', () => {
@@ -115,6 +124,53 @@ describe('navDedupKey', () => {
         const first = navDedupKey({ pathname: '/home', search: '?tab=2', hash: '' });
         const second = navDedupKey({ pathname: '/home', search: '?tab=2', hash: '' });
         expect(first).toBe(second);
+    });
+});
+
+describe('routeHref', () => {
+    it('keeps details navigation inside a non-root Jellyfin web mount', () => {
+        const href = routeHref('details', { id: 'item/with ?#& delimiters' });
+        const resolved = new URL(
+            href,
+            'https://media.example/jellyfin/web/index.html#/bookmarks'
+        );
+
+        expect(href).toBe('#/details?id=item%2Fwith%20%3F%23%26%20delimiters');
+        expect(resolved.href).toBe(
+            'https://media.example/jellyfin/web/index.html#/details?id=item%2Fwith%20%3F%23%26%20delimiters'
+        );
+    });
+
+    it('keeps configuration navigation inside a root-mounted Jellyfin web client', () => {
+        const resolved = new URL(
+            routeHref('/configurationpage', { name: 'Custom Tabs' }),
+            'https://media.example/web/index.html#/dashboard/plugins'
+        );
+
+        expect(resolved.href).toBe(
+            'https://media.example/web/index.html#/configurationpage?name=Custom%20Tabs'
+        );
+    });
+
+    it('preserves a native WebView document origin instead of switching to an HTTP server URL', () => {
+        const resolved = new URL(
+            routeHref('details', { id: 'movie-1' }),
+            'file:///android_asset/www/index.html#/bookmarks'
+        );
+
+        expect(resolved.href).toBe('file:///android_asset/www/index.html#/details?id=movie-1');
+    });
+
+    it('rejects route text that could escape the Jellyfin SPA route grammar', () => {
+        expect(() => routeHref('https://attacker.example/')).toThrow(TypeError);
+        expect(() => routeHref('details?admin=true')).toThrow(TypeError);
+        expect(routeHref('details', { optional: null, enabled: false }))
+            .toBe('#/details?enabled=false');
+    });
+
+    it('provides the same encoded path for Jellyfin native router calls', () => {
+        expect(routePath('details', { id: 'item/with?query' }))
+            .toBe('/details?id=item%2Fwith%3Fquery');
     });
 });
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/navigation.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/navigation.ts
@@ -9,11 +9,13 @@
 // navs and missing pushState navs entirely. This module patches history once,
 // listens once, dedupes, and fans out to registered callbacks.
 //
-// Public surface: JC.core.navigation { onNavigate, offNavigate, onViewPage,
-// getCurrentView }. JC.helpers keeps thin aliases for unmigrated callers.
+// Public surface: JC.core.navigation { routeHref, onNavigate, offNavigate,
+// onViewPage, getCurrentView }. JC.helpers keeps thin aliases for unmigrated
+// callers.
 
 import { JC } from '../globals';
 import type {
+    JellyfinRouteParam,
     NavigateCallback,
     NavigationApi,
     ViewPageCallback,
@@ -27,6 +29,42 @@ const logPrefix = '🪼 Jellyfin Canopy: Navigation:';
 // ── Navigation events (URL changes) ─────────────────────────────────────
 
 const navCallbacks = new Set<NavigateCallback>();
+
+/**
+ * Build an href for a Jellyfin SPA destination without assuming that the web
+ * client is mounted at the origin root. A hash-only href deliberately stays
+ * on the active document, which preserves reverse-proxy base paths as well as
+ * the non-HTTP document origins used by native WebView clients.
+ *
+ * Route names are limited to Jellyfin's path-shaped route vocabulary. Query
+ * names and values are encoded exactly once here so feature renderers cannot
+ * accidentally turn an item id or configuration-page name into route syntax.
+ */
+export function routePath(
+    route: string,
+    params: Record<string, JellyfinRouteParam> = {}
+): string {
+    const normalizedRoute = route.trim().replace(/^#?\/+/, '');
+    if (!/^[A-Za-z0-9][A-Za-z0-9/_-]*$/.test(normalizedRoute)) {
+        throw new TypeError(`Invalid Jellyfin route: ${route}`);
+    }
+
+    const query = Object.entries(params)
+        .filter((entry): entry is [string, Exclude<JellyfinRouteParam, null | undefined>] =>
+            entry[1] !== null && entry[1] !== undefined)
+        .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`)
+        .join('&');
+
+    return `/${normalizedRoute}${query ? `?${query}` : ''}`;
+}
+
+/** Build a document-relative anchor for a Jellyfin SPA route. */
+export function routeHref(
+    route: string,
+    params: Record<string, JellyfinRouteParam> = {}
+): string {
+    return `#${routePath(route, params)}`;
+}
 
 // Dedup guard: a hash navigation fires BOTH popstate and hashchange for
 // the same URL change; on the modern layout HISTORY_UPDATE can fire twice for
@@ -452,6 +490,7 @@ if (document.readyState === 'loading') {
 }
 
 const navigation: NavigationApi = {
+    routeHref,
     onNavigate,
     offNavigate,
     onViewPage,

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-items.navigation.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-items.navigation.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+
+vi.mock('../helpers', () => ({
+    getItemCached: vi.fn((itemId: string) => Promise.resolve({ Id: itemId, ImageTags: {} })),
+}));
+vi.mock('./library-render', () => ({
+    formatTimestamp: (value: unknown) => String(value),
+    parseTimestampInput: () => null,
+    renderActiveBookmarks: vi.fn(),
+}));
+vi.mock('./library-replacements', () => ({ findAndOfferReplacement: vi.fn() }));
+vi.mock('./library-modals', () => ({ showOffsetAdjustmentModal: vi.fn() }));
+
+import { renderBookmarkItems } from './library-items';
+
+describe('bookmark details navigation', () => {
+    let show: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        history.replaceState({}, '', '/jellyfin/web/index.html#/bookmarks');
+        JC.t = (key: string) => key === 'bookmark_count' ? '{count} bookmarks' : key;
+        (window.ApiClient as unknown as { getImageUrl: (id: string) => string }).getImageUrl =
+            (id: string) => `https://media.example/jellyfin/Items/${encodeURIComponent(id)}/Images/Primary`;
+        show = vi.fn();
+        window.Emby = { Page: { show } };
+    });
+
+    it('renders an encoded, document-relative link that retains the configured base URL', async () => {
+        const container = document.createElement('div');
+        const itemId = 'item/with ?#& delimiters';
+
+        await renderBookmarkItems(container, {
+            group: {
+                type: 'movie',
+                details: { itemId, name: 'Base URL fixture' },
+                bookmarks: [],
+            },
+        }, 'movie');
+
+        const title = container.querySelector<HTMLAnchorElement>('.jc-bookmark-item-title');
+        expect(title?.getAttribute('href'))
+            .toBe('#/details?id=item%2Fwith%20%3F%23%26%20delimiters');
+        expect(title?.href).toBe(
+            'http://localhost:3000/jellyfin/web/index.html#/details?id=item%2Fwith%20%3F%23%26%20delimiters'
+        );
+
+        container.querySelector<HTMLElement>('.jc-bookmark-item-poster')?.click();
+        expect(show).toHaveBeenCalledWith(
+            '/details?id=item%2Fwith%20%3F%23%26%20delimiters'
+        );
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-items.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-items.ts
@@ -5,6 +5,7 @@
 // (Converted from js/enhanced/bookmarks-library-items.js — bodies semantically identical.)
 
 import { JC } from '../../globals';
+import { routeHref, routePath } from '../../core/navigation';
 import { escapeHtml, toast } from '../../core/ui-kit';
 import { getItemCached } from '../helpers';
 import { formatTimestamp, parseTimestampInput, renderActiveBookmarks } from './library-render';
@@ -113,6 +114,7 @@ export async function renderBookmarkItems(
     }
 
     // Create the card header HTML
+    const detailsHref = routeHref('details', { id: group.details.itemId || '' });
     const headerHtml = `
       <div class="jc-bookmark-item-header">
         ${posterUrl ? `
@@ -123,7 +125,7 @@ export async function renderBookmarkItems(
           <div class="jc-bookmark-item-placeholder"><span class="material-icons" style="font-size: 48px; opacity: 0.3;">image_not_supported</span></div>
         `}
         <div class="jc-bookmark-item-info">
-          <a href="/web/#/details?id=${escapeHtml(group.details.itemId || '')}" class="jc-bookmark-item-title">${titleDisplay}</a>
+          <a href="${escapeHtml(detailsHref)}" class="jc-bookmark-item-title">${titleDisplay}</a>
           <div class="jc-bookmark-item-meta">
             ${JC.t!('bookmark_count').replace('{count}', group.bookmarks.length)}
             ${orphaned ? ` • <span style="color: #ff9800;">${JC.t!('bookmark_orphaned')}</span>` : ''}
@@ -171,7 +173,8 @@ export async function renderBookmarkItems(
         if (!JC.identity.isCurrent(context)) return;
         const itemId = poster.dataset.itemId;
         if (itemId) {
-          (window.Emby?.Page as { show?: (path: string) => void } | undefined)?.show?.(`/details?id=${itemId}`);
+          (window.Emby?.Page as { show?: (path: string) => void } | undefined)
+            ?.show?.(routePath('details', { id: itemId }));
         }
       });
     }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/plugin-icons.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/plugin-icons.ts
@@ -3,6 +3,7 @@
 
 import { JC as JEBase } from '../globals';
 import { assetUrl } from '../core/asset-urls';
+import { routeHref } from '../core/navigation';
 import type { IdentityContext, LifecycleApi, LifecycleHandle, NavigationApi } from '../types/jc';
 
 /** Icon override descriptor for a built-in plugin link. */
@@ -139,9 +140,7 @@ function createCustomPluginLink(plugin: CustomPlugin): void {
     const existingLink = pluginsSection.querySelector(`[data-jellyfin-canopy-plugin-id="${plugin.id}"]`);
     if (existingLink) return;
 
-    // Get current base URL
-    const baseUrl = window.location.origin + window.location.pathname;
-    const pluginUrl = `${baseUrl}#/configurationpage?name=${encodeURIComponent(plugin.name)}`;
+    const pluginUrl = routeHref('configurationpage', { name: plugin.name });
 
     // Create the link element
     const link = document.createElement('a');

--- a/Jellyfin.Plugin.JellyfinCanopy/src/test/web-route-guard.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/test/web-route-guard.test.ts
@@ -1,0 +1,202 @@
+// Architecture guard for BI-CLIENT-074. Jellyfin SPA routes must be
+// document-relative so reverse-proxy base paths and native WebView document
+// origins survive navigation. Feature code must use core/navigation.routeHref
+// instead of embedding an origin-root /web hash route.
+
+import { describe, expect, it } from 'vitest';
+import * as ts from 'typescript';
+
+const TEST_FILE_PATH = decodeURIComponent(new URL(import.meta.url).pathname);
+const PLUGIN_ROOT = TEST_FILE_PATH.replace(/\/src\/test\/[^/]+$/, '/');
+const ROUTE_IN_STRING = /(^|["'\s=])\/web\/(?:index\.html)?#\//;
+
+interface GuardSource {
+    file: string;
+    source: string;
+    kind: 'html' | 'js' | 'ts';
+    lineOffset?: number;
+}
+interface Violation { file: string; line: number; literal: string; }
+
+function lineAt(source: string, offset: number): number {
+    return source.slice(0, offset).split('\n').length;
+}
+
+function scriptKind(kind: GuardSource['kind']): ts.ScriptKind {
+    return kind === 'js' ? ts.ScriptKind.JS : ts.ScriptKind.TS;
+}
+
+function joinedStringFragments(node: ts.Expression): string {
+    if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) return node.text;
+    if (ts.isParenthesizedExpression(node)) return joinedStringFragments(node.expression);
+    if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.PlusToken) {
+        return joinedStringFragments(node.left) + joinedStringFragments(node.right);
+    }
+    if (ts.isTemplateExpression(node)) {
+        return node.head.text + node.templateSpans.map((span) => span.literal.text).join('');
+    }
+    return '';
+}
+
+function isNestedStringBuild(node: ts.Node): boolean {
+    const parent = node.parent;
+    return (ts.isBinaryExpression(parent) && parent.operatorToken.kind === ts.SyntaxKind.PlusToken)
+        || ts.isTemplateExpression(parent)
+        || ts.isTemplateSpan(parent);
+}
+
+function scriptViolations(source: GuardSource): Violation[] {
+    // Most production files contain neither half of the forbidden route. This
+    // prefilter keeps the guard cheap while AST parsing makes candidate results
+    // comment-proof and joins multiline/string-fragment constructions.
+    if (!source.source.includes('/web/') || !source.source.includes('#/')) return [];
+
+    const parsed = ts.createSourceFile(
+        source.file,
+        source.source,
+        ts.ScriptTarget.ES2022,
+        true,
+        scriptKind(source.kind)
+    );
+    const violations: Violation[] = [];
+    const record = (node: ts.Expression): void => {
+        const literal = joinedStringFragments(node);
+        if (!ROUTE_IN_STRING.test(literal)) return;
+        violations.push({
+            file: source.file,
+            line: (source.lineOffset ?? 0)
+                + parsed.getLineAndCharacterOfPosition(node.getStart(parsed)).line + 1,
+            literal,
+        });
+    };
+    const visit = (node: ts.Node): void => {
+        if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.PlusToken) {
+            if (!isNestedStringBuild(node)) record(node);
+        } else if (ts.isTemplateExpression(node)) {
+            if (!isNestedStringBuild(node)) record(node);
+        } else if ((ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node))
+            && !isNestedStringBuild(node)) {
+            record(node);
+        }
+        ts.forEachChild(node, visit);
+    };
+    visit(parsed);
+    return violations;
+}
+
+function mask(value: string): string {
+    return value.replace(/[^\n]/g, ' ');
+}
+
+function htmlViolations(source: GuardSource): Violation[] {
+    const scripts: GuardSource[] = [];
+    let markup = source.source.replace(/<!--[\s\S]*?-->/g, mask);
+    markup = markup.replace(/<script\b[^>]*>([\s\S]*?)<\/script\s*>/gi, (whole, body: string, offset: number) => {
+        const bodyOffset = offset + whole.indexOf(body);
+        scripts.push({
+            file: source.file,
+            source: body,
+            kind: 'js',
+            lineOffset: lineAt(source.source, bodyOffset) - 1,
+        });
+        return mask(whole);
+    });
+
+    const violations = scripts.flatMap(scriptViolations);
+    const tagPattern = /<[A-Za-z][^>]*>/g;
+    for (const tag of markup.matchAll(tagPattern)) {
+        const hrefPattern = /\bhref\s*=\s*(["'])(.*?)\1/gi;
+        for (const href of tag[0].matchAll(hrefPattern)) {
+            const literal = href[2];
+            if (!ROUTE_IN_STRING.test(literal)) continue;
+            violations.push({
+                file: source.file,
+                line: lineAt(markup, (tag.index ?? 0) + (href.index ?? 0)),
+                literal,
+            });
+        }
+    }
+    return violations;
+}
+
+function findViolations(sources: GuardSource[]): Violation[] {
+    return sources.flatMap((source) =>
+        source.kind === 'html' ? htmlViolations(source) : scriptViolations(source));
+}
+
+function productionSources(): GuardSource[] {
+    const roots = [
+        `${PLUGIN_ROOT}src`,
+        `${PLUGIN_ROOT}js`,
+        `${PLUGIN_ROOT}Configuration`,
+    ];
+    return roots.flatMap((root) =>
+        ts.sys.readDirectory(root, ['.ts', '.js', '.mjs', '.cjs', '.html', '.htm'], undefined, undefined)
+            .filter((file) => !file.endsWith('.test.ts') && !file.endsWith('.d.ts'))
+            .map((file): GuardSource => ({
+                file: file.substring(PLUGIN_ROOT.length).replace(/\\/g, '/'),
+                source: ts.sys.readFile(file) ?? '',
+                kind: /\.html?$/i.test(file) ? 'html' : file.endsWith('.ts') ? 'ts' : 'js',
+            }))
+    );
+}
+
+describe('Jellyfin web-route architecture guard', () => {
+    it('rejects origin-root Jellyfin SPA routes across production client code', () => {
+        expect(findViolations(productionSources())).toEqual([]);
+    });
+
+    it('joins multiline concatenations and template fragments with precise lines', () => {
+        const findings = findViolations([{
+            file: 'feature.ts',
+            kind: 'ts',
+            source: [
+                'const details =',
+                "    '/web/' +",
+                "    '#/details?id=1';",
+                'const page = `/web/index.html#/configurationpage?name=${name}`;',
+            ].join('\n'),
+        }]);
+
+        expect(findings).toEqual([
+            { file: 'feature.ts', line: 2, literal: '/web/#/details?id=1' },
+            { file: 'feature.ts', line: 4, literal: '/web/index.html#/configurationpage?name=' },
+        ]);
+    });
+
+    it('ignores comments and fully qualified external URLs', () => {
+        expect(findViolations([{
+            file: 'allowed.ts',
+            kind: 'ts',
+            source: [
+                '// Never write `/web/#/details` as a Jellyfin route.',
+                "const upstreamDocs = 'https://example.test/web/#/details';",
+            ].join('\n'),
+        }])).toEqual([]);
+    });
+
+    it('checks real HTML hrefs and inline scripts without matching HTML comments', () => {
+        const findings = findViolations([{
+            file: 'configPage.html',
+            kind: 'html',
+            source: [
+                '<!-- <a href="/web/#/commented">ignored</a> -->',
+                '<a href="https://example.test/web/#/external">external</a>',
+                '<a href="/web/#/configurationpage?name=Custom%20Tabs">bad</a>',
+                '<script>',
+                "const details = '/web/' +",
+                "    '#/details?id=1';",
+                '</script>',
+            ].join('\n'),
+        }]);
+
+        expect(findings).toEqual([
+            { file: 'configPage.html', line: 5, literal: '/web/#/details?id=1' },
+            {
+                file: 'configPage.html',
+                line: 3,
+                literal: '/web/#/configurationpage?name=Custom%20Tabs',
+            },
+        ]);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/types/jc.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/types/jc.ts
@@ -140,7 +140,14 @@ export interface ViewPageOptions {
     immediate?: boolean;
 }
 
+export type JellyfinRouteParam = string | number | boolean | null | undefined;
+
 export interface NavigationApi {
+    /**
+     * Build a hash-only Jellyfin SPA link. Keeping the href document-relative
+     * preserves reverse-proxy base paths and native WebView origins.
+     */
+    routeHref(route: string, params?: Record<string, JellyfinRouteParam>): string;
     onNavigate(callback: NavigateCallback): () => void;
     offNavigate(callback: NavigateCallback): boolean;
     onViewPage(callback: ViewPageCallback, options?: ViewPageOptions): () => void;

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -18,7 +18,7 @@ const ROOT = path.join(__dirname, '..');
 const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the repeated clean measurements', () => {
-    assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1428, totalLines: 1751 });
+    assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1436, totalLines: 1759 });
     assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 16244, totalLines: 24886 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -9,12 +9,12 @@
       "scope": "Jellyfin.Plugin.JellyfinCanopy/src/core/**",
       "report": "coverage/coverage-summary.json",
       "measured": {
-        "coveredLines": 1428,
-        "totalLines": 1751
+        "coveredLines": 1436,
+        "totalLines": 1759
       },
       "tolerance": {
         "missingCoveredLines": 1,
-        "rationale": "A final clean reviewed Node 22/V8 run on 2026-07-15 measured 1428 covered lines across the 1751-line core scope after centralizing bounded discovery response ownership, explicit semantic negative caching, shared-result waiter cancellation, and rejection observation for an already-aborted waiter. One line permits only negligible instrumentation variance."
+        "rationale": "A clean GitHub Actions Node 22/V8 run on 2026-07-16 measured 1436 covered lines across the 1759-line core scope after adding the shared document-relative Jellyfin SPA route builders. Focused V8 evidence exercised every new executable line, including encoded parameters, invalid routes, and the parameter-free path. One line permits only negligible instrumentation variance."
       }
     },
     "server": {


### PR DESCRIPTION
Closes #138.

## Summary
- add shared encoded document-relative Jellyfin SPA route builders
- preserve reverse-proxy base paths and WebView/file origins for bookmark and plugin configuration links
- add consumer, architecture, and parameter-free route coverage
- ratchet the reviewed client coverage baseline to the exact 1436/1759 CI measurement without changing tolerance

## Validation
- 33 focused assertions plus navigation 21/21
- 324 script tests and 13 coverage-policy tests
- TypeScript typechecks, Release build, bundle/syntax, ESLint, and diff check
- all eight new executable lines shown covered by focused V8 evidence
- independent review approved exact rebased head f6348bf39921701a8916bc9488409f6a75114745; both commit patch IDs match prior approvals