### PR TITLE
Manage every stored bookmark media type

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/ar.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/ar.json
@@ -369,6 +369,7 @@
   "bookmarks_library_title": "الإشارات المرجعية",
   "bookmarks_library_tab_movies": "أفلام",
   "bookmarks_library_tab_series": "مسلسلات",
+  "bookmarks_library_tab_other": "أخرى",
   "bookmarks_library_button_find_duplicates": "البحث عن التكرارات",
   "bookmarks_library_button_cleanup": "تنظيف المعزولة",
   "bookmarks_library_button_delete_all": "حذف الكل",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/bg.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/bg.json
@@ -369,6 +369,7 @@
   "bookmarks_library_title": "Отметки",
   "bookmarks_library_tab_movies": "Филми",
   "bookmarks_library_tab_series": "Сериали",
+  "bookmarks_library_tab_other": "Other",
   "bookmarks_library_button_find_duplicates": "Намиране на дубликати",
   "bookmarks_library_button_cleanup": "Изчистване на изоставени",
   "bookmarks_library_button_delete_all": "Изтриване на всички",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/ca.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/ca.json
@@ -369,6 +369,7 @@
   "bookmarks_library_title": "Marcadors",
   "bookmarks_library_tab_movies": "Pel·lícules",
   "bookmarks_library_tab_series": "Sèries",
+  "bookmarks_library_tab_other": "Altre",
   "bookmarks_library_button_find_duplicates": "Cercar duplicats",
   "bookmarks_library_button_cleanup": "Netejar orfes",
   "bookmarks_library_button_delete_all": "Eliminar tot",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/cs.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/cs.json
@@ -369,6 +369,7 @@
   "bookmarks_library_title": "Záložky",
   "bookmarks_library_tab_movies": "Filmy",
   "bookmarks_library_tab_series": "Seriály",
+  "bookmarks_library_tab_other": "Jiné",
   "bookmarks_library_button_find_duplicates": "Najít duplikáty",
   "bookmarks_library_button_cleanup": "Vyčistit osiřelé",
   "bookmarks_library_button_delete_all": "Smazat všechny",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/da.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/da.json
@@ -369,6 +369,7 @@
   "bookmarks_library_title": "Bogmærker",
   "bookmarks_library_tab_movies": "Film",
   "bookmarks_library_tab_series": "Serier",
+  "bookmarks_library_tab_other": "Øvrigt",
   "bookmarks_library_button_find_duplicates": "Find dubletter",
   "bookmarks_library_button_cleanup": "Ryd forladte op",
   "bookmarks_library_button_delete_all": "Slet alle",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/de.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/de.json
@@ -369,6 +369,7 @@
   "bookmarks_library_title": "Lesezeichen",
   "bookmarks_library_tab_movies": "Filme",
   "bookmarks_library_tab_series": "Serien",
+  "bookmarks_library_tab_other": "Sonstige",
   "bookmarks_library_button_find_duplicates": "Duplikate finden",
   "bookmarks_library_button_cleanup": "Verwaiste aufräumen",
   "bookmarks_library_button_delete_all": "Alle löschen",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/en-GB.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/en-GB.json
@@ -370,6 +370,7 @@
   "bookmarks_library_title": "Bookmarks",
   "bookmarks_library_tab_movies": "Movies",
   "bookmarks_library_tab_series": "Series",
+  "bookmarks_library_tab_other": "Other",
   "bookmarks_library_button_find_duplicates": "Find Duplicates",
   "bookmarks_library_button_cleanup": "Cleanup Orphaned",
   "bookmarks_library_button_delete_all": "Delete All",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/en-US.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/en-US.json
@@ -370,6 +370,7 @@
   "bookmarks_library_title": "Bookmarks",
   "bookmarks_library_tab_movies": "Movies",
   "bookmarks_library_tab_series": "Series",
+  "bookmarks_library_tab_other": "Other",
   "bookmarks_library_button_find_duplicates": "Find Duplicates",
   "bookmarks_library_button_cleanup": "Cleanup Orphaned",
   "bookmarks_library_button_delete_all": "Delete All",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/en.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/en.json
@@ -372,6 +372,7 @@
   "bookmarks_library_title": "Bookmarks",
   "bookmarks_library_tab_movies": "Movies",
   "bookmarks_library_tab_series": "Series",
+  "bookmarks_library_tab_other": "Other",
   "bookmarks_library_button_find_duplicates": "Find Duplicates",
   "bookmarks_library_button_cleanup": "Cleanup Orphaned",
   "bookmarks_library_button_delete_all": "Delete All",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/es.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/es.json
@@ -369,6 +369,7 @@
   "bookmarks_library_title": "Marcadores",
   "bookmarks_library_tab_movies": "Películas",
   "bookmarks_library_tab_series": "Series",
+  "bookmarks_library_tab_other": "Otro",
   "bookmarks_library_button_find_duplicates": "Buscar duplicados",
   "bookmarks_library_button_cleanup": "Limpiar huérfanos",
   "bookmarks_library_button_delete_all": "Eliminar todo",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/fr.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/fr.json
@@ -369,6 +369,7 @@
   "bookmarks_library_title": "Signets",
   "bookmarks_library_tab_movies": "Films",
   "bookmarks_library_tab_series": "Séries",
+  "bookmarks_library_tab_other": "Autre",
   "bookmarks_library_button_find_duplicates": "Trouver les doublons",
   "bookmarks_library_button_cleanup": "Nettoyer les orphelins",
   "bookmarks_library_button_delete_all": "Tout supprimer",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/he.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/he.json
@@ -452,6 +452,7 @@
   "hidden_content_filter_upcoming_desc": "Hide items from upcoming releases",
   "bookmark_from": "From: {source}",
   "bookmarks_library_tab_series": "Series",
+  "bookmarks_library_tab_other": "Other",
   "toast_translation_cache_cleared": "{{icon:trash}} Translation cache cleared! {count} cached translation(s) removed. Refreshing…",
   "hidden_content_1_hidden_item": "1 hidden item",
   "seerr_advanced_options": "Advanced Options",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/hu.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/hu.json
@@ -369,6 +369,7 @@
   "bookmarks_library_title": "Könyvjelzők",
   "bookmarks_library_tab_movies": "Filmek",
   "bookmarks_library_tab_series": "Sorozatok",
+  "bookmarks_library_tab_other": "Egyéb",
   "bookmarks_library_button_find_duplicates": "Duplikátumok keresése",
   "bookmarks_library_button_cleanup": "Árva könyvjelzők törlése",
   "bookmarks_library_button_delete_all": "Összes törlése",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/it.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/it.json
@@ -369,6 +369,7 @@
   "bookmarks_library_title": "Segnalibri",
   "bookmarks_library_tab_movies": "Film",
   "bookmarks_library_tab_series": "Serie",
+  "bookmarks_library_tab_other": "Altro",
   "bookmarks_library_button_find_duplicates": "Trova duplicati",
   "bookmarks_library_button_cleanup": "Pulisci orfani",
   "bookmarks_library_button_delete_all": "Elimina tutto",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/nl.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/nl.json
@@ -369,6 +369,7 @@
   "bookmarks_library_title": "Bladwijzers",
   "bookmarks_library_tab_movies": "Films",
   "bookmarks_library_tab_series": "Serie",
+  "bookmarks_library_tab_other": "Overig",
   "bookmarks_library_button_find_duplicates": "Duplicaten zoeken",
   "bookmarks_library_button_cleanup": "Weesbladen opschonen",
   "bookmarks_library_button_delete_all": "Alles verwijderen",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/no.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/no.json
@@ -369,6 +369,7 @@
   "bookmarks_library_title": "Bokmerker",
   "bookmarks_library_tab_movies": "Filmer",
   "bookmarks_library_tab_series": "Serier",
+  "bookmarks_library_tab_other": "Annet",
   "bookmarks_library_button_find_duplicates": "Finn duplikater",
   "bookmarks_library_button_cleanup": "Rydd opp i foreldreløse bokmerker",
   "bookmarks_library_button_delete_all": "Slett alle",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/pl.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/pl.json
@@ -368,6 +368,7 @@
   "bookmarks_library_title": "Zakładki",
   "bookmarks_library_tab_movies": "Filmy",
   "bookmarks_library_tab_series": "Seriale",
+  "bookmarks_library_tab_other": "Inny",
   "bookmarks_library_button_find_duplicates": "Znajdź duplikaty",
   "bookmarks_library_button_cleanup": "Wyczyść osierocone",
   "bookmarks_library_button_delete_all": "Usuń wszystko",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/pr.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/pr.json
@@ -369,6 +369,7 @@
   "bookmarks_library_title": "Marked Spots",
   "bookmarks_library_tab_movies": "Film Marks",
   "bookmarks_library_tab_series": "Series Marks",
+  "bookmarks_library_tab_other": "Other Problems",
   "bookmarks_library_button_find_duplicates": "Hunt fer Duplicates",
   "bookmarks_library_button_cleanup": "Toss Abandoned Ones",
   "bookmarks_library_button_delete_all": "Throw All Overboard",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/pt-BR.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/pt-BR.json
@@ -369,6 +369,7 @@
   "bookmarks_library_title": "Marcadores",
   "bookmarks_library_tab_movies": "Filmes",
   "bookmarks_library_tab_series": "Séries",
+  "bookmarks_library_tab_other": "Outro",
   "bookmarks_library_button_find_duplicates": "Encontrar duplicados",
   "bookmarks_library_button_cleanup": "Limpar órfãos",
   "bookmarks_library_button_delete_all": "Eliminar tudo",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/pt.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/pt.json
@@ -369,6 +369,7 @@
   "bookmarks_library_title": "Marcadores",
   "bookmarks_library_tab_movies": "Filmes",
   "bookmarks_library_tab_series": "Séries",
+  "bookmarks_library_tab_other": "Outro",
   "bookmarks_library_button_find_duplicates": "Encontrar duplicados",
   "bookmarks_library_button_cleanup": "Limpar órfãos",
   "bookmarks_library_button_delete_all": "Eliminar tudo",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/ru.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/ru.json
@@ -368,6 +368,7 @@
   "bookmarks_library_title": "Закладки",
   "bookmarks_library_tab_movies": "Фильмы",
   "bookmarks_library_tab_series": "Сериалы",
+  "bookmarks_library_tab_other": "Прочие",
   "bookmarks_library_button_find_duplicates": "Найти дубликаты",
   "bookmarks_library_button_cleanup": "Очистить потерянные",
   "bookmarks_library_button_delete_all": "Удалить все",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/sk.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/sk.json
@@ -369,6 +369,7 @@
   "bookmarks_library_title": "Záložky",
   "bookmarks_library_tab_movies": "Filmy",
   "bookmarks_library_tab_series": "Seriály",
+  "bookmarks_library_tab_other": "Iné",
   "bookmarks_library_button_find_duplicates": "Nájsť duplikáty",
   "bookmarks_library_button_cleanup": "Vyčistiť osirelé",
   "bookmarks_library_button_delete_all": "Vymazať všetky",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/sv.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/sv.json
@@ -369,6 +369,7 @@
   "bookmarks_library_title": "Bokmärken",
   "bookmarks_library_tab_movies": "Filmer",
   "bookmarks_library_tab_series": "Serier",
+  "bookmarks_library_tab_other": "Övrigt",
   "bookmarks_library_button_find_duplicates": "Hitta dubbletter",
   "bookmarks_library_button_cleanup": "Rensa föräldralösa",
   "bookmarks_library_button_delete_all": "Ta bort alla",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/tr.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/tr.json
@@ -369,6 +369,7 @@
   "bookmarks_library_title": "Yer İmleri",
   "bookmarks_library_tab_movies": "Filmler",
   "bookmarks_library_tab_series": "Diziler",
+  "bookmarks_library_tab_other": "Diğer",
   "bookmarks_library_button_find_duplicates": "Duplikaları bul",
   "bookmarks_library_button_cleanup": "Yetim yer imlerini temizle",
   "bookmarks_library_button_delete_all": "Tümünü sil",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/zh-CN.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/zh-CN.json
@@ -369,6 +369,7 @@
   "bookmarks_library_title": "书签",
   "bookmarks_library_tab_movies": "电影",
   "bookmarks_library_tab_series": "剧集",
+  "bookmarks_library_tab_other": "其他",
   "bookmarks_library_button_find_duplicates": "寻找重复",
   "bookmarks_library_button_cleanup": "清理孤立书签",
   "bookmarks_library_button_delete_all": "全部删除",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/zh-HK.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/zh-HK.json
@@ -369,6 +369,7 @@
   "bookmarks_library_title": "書籤",
   "bookmarks_library_tab_movies": "電影",
   "bookmarks_library_tab_series": "劇集",
+  "bookmarks_library_tab_other": "其他",
   "bookmarks_library_button_find_duplicates": "尋找重複",
   "bookmarks_library_button_cleanup": "清理孤立書籤",
   "bookmarks_library_button_delete_all": "全部刪除",

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/bookmarks.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/bookmarks.identity.test.ts
@@ -498,6 +498,48 @@ describe('bookmark player identity ownership', () => {
     expect(JC.userConfig.bookmark.bookmarks).toEqual({});
   });
 
+  it('persists a generic playable Video in the manageable other category', async () => {
+    const api = await loadModule({});
+    ajax.mockResolvedValueOnce({
+      Items: [{
+        Id: 'item-a',
+        Name: 'Home video',
+        Type: 'Video',
+        ProviderIds: {}
+      }]
+    });
+
+    await expect(api.add(5, 'Clip')).resolves.toMatchObject({ mediaType: 'other' });
+    const operation = save.mock.calls[0][1].body.operations[0];
+    expect(operation.bookmark.mediaType).toBe('other');
+  });
+
+  it('uses the canonical media category for provider fallback matching', async () => {
+    const api = await loadModule({
+      movie: { ...bookmark('old-movie', 'Movie'), tmdbId: 'shared', mediaType: 'Movie' },
+      episode: { ...bookmark('old-episode', 'Episode'), tmdbId: 'shared', mediaType: 'Episode' },
+      legacy: { ...bookmark('old-video', 'Video'), tmdbId: 'shared', mediaType: 'Video' }
+    });
+
+    expect(api.findForItem('new-movie', 'shared', '', 'movie').bookmarks.map((bm: AnyRecord) => bm.id))
+      .toEqual(['movie']);
+    expect(api.findForItem('new-series', 'shared', '', 'Series').bookmarks.map((bm: AnyRecord) => bm.id))
+      .toEqual(['episode']);
+    expect(api.findForItem('new-video', 'shared', '', 'other').bookmarks.map((bm: AnyRecord) => bm.id))
+      .toEqual(['legacy']);
+    expect(api.findForItem('legacy-caller', 'shared').bookmarks).toHaveLength(3);
+  });
+
+  it('canonically migrates a legacy type when that bookmark is edited', async () => {
+    const api = await loadModule({
+      legacy: { ...bookmark('item-a', 'Before'), mediaType: 'Podcast' }
+    });
+
+    await expect(api.update('legacy', { label: 'After' })).resolves.toBe(true);
+    const operation = save.mock.calls[0][1].body.operations[0];
+    expect(operation.bookmark).toMatchObject({ label: 'After', mediaType: 'other' });
+  });
+
   it('does not let a held rejected A add roll back a same-key B bookmark', async () => {
     const api = await loadModule({});
     const heldSave = deferred<void>();

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/bookmarks.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/bookmarks.ts
@@ -9,6 +9,7 @@ import { debounce } from '../helpers';
 import { createObserver, disconnectObserver } from '../../core/dom-observer';
 import type { BookmarkCleanupResult, BookmarksApi } from './surface';
 import type { IdentityContext } from '../../types/jc';
+import { normalizeBookmarkMediaType, sameBookmarkMediaType } from './media-types';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -272,7 +273,7 @@ import type { IdentityContext } from '../../types/jc';
    *     itemId: "jellyfin-item-id",
    *     tmdbId: "12345",
    *     tvdbId: "67890",
-   *     mediaType: "movie" | "tv",
+   *     mediaType: "movie" | "tv" | "other",
    *     name: "Item Name",
    *     timestamp: 123.45,
    *     label: "Epic scene" (optional),
@@ -454,9 +455,7 @@ import type { IdentityContext } from '../../types/jc';
 
         const tmdbId = sourceItem.ProviderIds?.Tmdb || null;
         const tvdbId = sourceItem.ProviderIds?.Tvdb || null;
-        const mediaType = item.Type === 'Movie' ? 'movie'
-          : (item.Type === 'Series' || item.Type === 'Episode' || item.Type === 'Season') ? 'tv'
-          : (item.Type || '').toString().toLowerCase();
+        const mediaType = normalizeBookmarkMediaType(item.Type);
 
         const details = {
           itemId: item.Id,
@@ -499,7 +498,12 @@ import type { IdentityContext } from '../../types/jc';
    * Find bookmarks for current item (by itemId or TMDB/TVDB fallback)
    * Returns both exact matches and provider ID matches separately
    */
-  function findBookmarksForItem(itemId: string, tmdbId?: string, tvdbId?: string): { bookmarks: any[]; hasIdMismatch: boolean; exactMatches: any[]; providerMatches: any[] } {
+  function findBookmarksForItem(
+    itemId: string,
+    tmdbId?: string,
+    tvdbId?: string,
+    mediaType?: unknown
+  ): { bookmarks: any[]; hasIdMismatch: boolean; exactMatches: any[]; providerMatches: any[] } {
     const allBookmarks = (JC.userConfig as any)?.bookmark?.bookmarks || {};
     const exactMatches: any[] = [];
     const providerMatches: any[] = [];
@@ -513,6 +517,13 @@ import type { IdentityContext } from '../../types/jc';
         exactMatches.push({ id: bookmarkId, ...bookmark, exactMatch: true });
         continue;
       }
+
+      // Provider ids are not globally unique across Jellyfin media classes.
+      // Apply the same canonical category used by creation and the library so
+      // a movie cannot acquire a TV/legacy-other bookmark by fallback alone.
+      // The fourth argument extends the frozen three-argument public facade;
+      // legacy callers that omit it retain their prior provider-id behavior.
+      if (mediaType !== undefined && !sameBookmarkMediaType(bookmark.mediaType, mediaType)) continue;
 
       // Fallback: TMDB/TVDB match (different item ID)
       if (tmdbId && bookmark.tmdbId === tmdbId) {
@@ -565,7 +576,7 @@ import type { IdentityContext } from '../../types/jc';
       itemId: details.itemId || '',
       tmdbId: details.tmdbId || '',
       tvdbId: details.tvdbId || '',
-      mediaType: details.mediaType || '',
+      mediaType: normalizeBookmarkMediaType(details.mediaType),
       name: details.name || '',
       timestamp: timestamp,
       label: label || '',
@@ -619,7 +630,12 @@ import type { IdentityContext } from '../../types/jc';
         return [{
           type: 'update',
           bookmarkId,
-          bookmark: { ...current, ...updates, updatedAt }
+          bookmark: {
+            ...current,
+            ...updates,
+            mediaType: normalizeBookmarkMediaType(updates.mediaType ?? current.mediaType),
+            updatedAt
+          }
         }];
       });
       if (!committed || !committed.bookmarks[bookmarkId]) return false;
@@ -690,7 +706,7 @@ import type { IdentityContext } from '../../types/jc';
         itemId: newItemDetails.itemId,
         tmdbId: newItemDetails.tmdbId,
         tvdbId: newItemDetails.tvdbId,
-        mediaType: newItemDetails.mediaType,
+        mediaType: normalizeBookmarkMediaType(newItemDetails.mediaType),
         name: newItemDetails.name,
         timestamp: newTimestamp,
         label: oldBookmark.label || '',
@@ -997,7 +1013,8 @@ import type { IdentityContext } from '../../types/jc';
     const { bookmarks: bookmarksList } = findBookmarksForItem(
       details.itemId,
       details.tmdbId,
-      details.tvdbId
+      details.tvdbId,
+      details.mediaType
     );
 
     console.log(`${logPrefix} Found ${bookmarksList.length} bookmarks for this item`);
@@ -1037,7 +1054,8 @@ import type { IdentityContext } from '../../types/jc';
     const { bookmarks: existingBookmarks } = findBookmarksForItem(
       details.itemId,
       details.tmdbId,
-      details.tvdbId
+      details.tvdbId,
+      details.mediaType
     );
 
     console.log('🪼 Bookmarks modal: Found', existingBookmarks.length, 'existing bookmarks for item', details.itemId);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-identity.test.ts
@@ -3,6 +3,7 @@ import { JC } from '../../globals';
 import type { ApiApi } from '../../types/jc';
 import type { UserSettingsSaveResult } from '../config';
 import { renderBookmarksLibrary } from './library-render';
+import { findDuplicateBookmarks } from './library-modals';
 
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access */
 
@@ -117,5 +118,61 @@ describe('bookmarks library identity ownership', () => {
     await Promise.resolve();
 
     expect(jf).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows every canonical and legacy media type in a counted management tab', async () => {
+    const entries = [
+      ['movie', 'Movie', 'Movie bookmark'],
+      ['episode', 'Episode', 'Episode bookmark'],
+      ['series', 'Series', 'Series bookmark'],
+      ['music', 'MusicVideo', 'Music video bookmark'],
+      ['video', 'Video', 'Generic video bookmark'],
+      ['unknown', 'Podcast', 'Unknown bookmark'],
+      ['missing', undefined, 'Missing-type bookmark']
+    ] as const;
+    (JC as any).userConfig = {
+      bookmark: {
+        bookmarks: Object.fromEntries(entries.map(([itemId, mediaType, name]) => [itemId, {
+          itemId,
+          ...(mediaType === undefined ? {} : { mediaType }),
+          timestamp: 42,
+          name
+        }]))
+      }
+    };
+    getItem.mockResolvedValue({ Id: 'available', Name: 'Available item', Type: 'Video', ImageTags: {} });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    await renderBookmarksLibrary(container);
+
+    const tabs = [...container.querySelectorAll<HTMLButtonElement>('.jc-tab')];
+    expect(tabs.map(tab => [tab.dataset.tab, tab.querySelector('.jc-tab-count')?.textContent]))
+      .toEqual([['movie', '2'], ['tv', '2'], ['other', '3']]);
+    expect(container.querySelectorAll('.jc-bookmark-row')).toHaveLength(2);
+
+    tabs.find(tab => tab.dataset.tab === 'other')!.click();
+    await vi.waitFor(() => expect(container.querySelectorAll('.jc-bookmark-row')).toHaveLength(3));
+    expect(container.textContent).toContain('Generic video bookmark');
+    expect(container.textContent).toContain('Unknown bookmark');
+    expect(container.textContent).toContain('Missing-type bookmark');
+
+    tabs.find(tab => tab.dataset.tab === 'tv')!.click();
+    await vi.waitFor(() => expect(container.querySelectorAll('.jc-bookmark-row')).toHaveLength(2));
+    expect(container.textContent).toContain('Episode bookmark');
+    expect(container.textContent).toContain('Series bookmark');
+  });
+
+  it('never offers a cross-category provider-id duplicate merge', () => {
+    const duplicates = findDuplicateBookmarks({
+      movieA: { itemId: 'movie-a', tmdbId: '10', mediaType: 'Movie', name: 'Movie A' },
+      movieB: { itemId: 'movie-b', tmdbId: '10', mediaType: 'MusicVideo', name: 'Movie B' },
+      series: { itemId: 'series', tmdbId: '10', mediaType: 'Series', name: 'Series' },
+      legacy: { itemId: 'legacy', tmdbId: '10', mediaType: 'Video', name: 'Video' }
+    });
+
+    expect(duplicates).toHaveLength(1);
+    expect(duplicates[0].providerKey).toBe('movie:tmdb:10');
+    expect(Object.keys(duplicates[0].itemGroups)).toEqual(['movie-a', 'movie-b']);
   });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-items.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-items.ts
@@ -12,6 +12,7 @@ import { formatTimestamp, parseTimestampInput, renderActiveBookmarks } from './l
 import { findAndOfferReplacement } from './library-replacements';
 import { showOffsetAdjustmentModal } from './library-modals';
 import type { IdentityContext } from '../../types/jc';
+import type { BookmarkMediaType } from './media-types';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -30,7 +31,7 @@ JC.identity.registerReset('bookmarks-library-playback', () => {
 export async function renderBookmarkItems(
   container: HTMLElement,
   groupedByItem: Record<string, any>,
-  currentTab: string,
+  currentTab: BookmarkMediaType,
   context: IdentityContext | null = JC.identity.capture()
 ): Promise<void> {
   if (!context || !JC.identity.isCurrent(context)) return;
@@ -74,14 +75,14 @@ export async function renderBookmarkItems(
   if (!JC.identity.isCurrent(context)) return;
 
   // Apply tab filter
-  const filtered = results.filter(({ group }) => {
-    if (currentTab === 'tv') return group.type === 'tv';
-    if (currentTab === 'movie') return group.type === 'movie';
-    return true;
-  });
+  const filtered = results.filter(({ group }) => group.type === currentTab);
 
   if (filtered.length === 0) {
-    const emptyTitle = currentTab === 'tv' ? JC.t!('bookmark_empty_tv') : JC.t!('bookmark_empty_movie');
+    const emptyTitle = currentTab === 'tv'
+      ? JC.t!('bookmark_empty_tv')
+      : currentTab === 'movie'
+        ? JC.t!('bookmark_empty_movie')
+        : JC.t!('bookmark_none');
     const emptyHint = JC.t!('bookmark_empty_hint');
     container.innerHTML = `
       <div class="jc-bookmarks-empty">

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-modals.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-modals.ts
@@ -9,6 +9,7 @@ import { currentPageHandle } from '../pages/fallback-host';
 import { escapeHtml, toast } from '../../core/ui-kit';
 import { formatTimestamp, renderActiveBookmarks } from './library-render';
 import type { IdentityContext } from '../../types/jc';
+import { normalizeBookmarkMediaType } from './media-types';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -174,13 +175,14 @@ export function showOffsetAdjustmentModal(
 /**
  * Find duplicate bookmarks (same TMDB/TVDB but different item IDs)
  */
-function findDuplicateBookmarks(bookmarks: Record<string, any>): any[] {
+export function findDuplicateBookmarks(bookmarks: Record<string, any>): any[] {
   const byProvider: Record<string, any> = {}; // Group by TMDB/TVDB ID
   const duplicateGroups: any[] = [];
 
   for (const [id, bm] of Object.entries<any>(bookmarks)) {
-    const tmdbKey = bm.tmdbId ? `tmdb:${bm.tmdbId}` : null;
-    const tvdbKey = bm.tvdbId ? `tvdb:${bm.tvdbId}` : null;
+    const mediaType = normalizeBookmarkMediaType(bm.mediaType);
+    const tmdbKey = bm.tmdbId ? `${mediaType}:tmdb:${bm.tmdbId}` : null;
+    const tvdbKey = bm.tvdbId ? `${mediaType}:tvdb:${bm.tvdbId}` : null;
 
     for (const key of [tmdbKey, tvdbKey].filter(Boolean) as string[]) {
       if (!byProvider[key]) {
@@ -354,7 +356,7 @@ export function showDuplicatesSyncModal(
           itemId: primaryItemId,
           tmdbId: primaryBookmarks[0].tmdbId,
           tvdbId: primaryBookmarks[0].tvdbId,
-          mediaType: primaryBookmarks[0].mediaType,
+          mediaType: normalizeBookmarkMediaType(primaryBookmarks[0].mediaType),
           name: primaryBookmarks[0].name
         };
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-render.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-render.ts
@@ -10,6 +10,11 @@ import { escapeHtml, toast } from '../../core/ui-kit';
 import { renderBookmarkItems } from './library-items';
 import { showDuplicatesSyncModal } from './library-modals';
 import type { IdentityContext } from '../../types/jc';
+import {
+  BOOKMARK_MEDIA_TYPES,
+  normalizeBookmarkMediaType,
+  type BookmarkMediaType
+} from './media-types';
 
 const logPrefix = '🪼 Jellyfin Canopy: Bookmarks Library:';
 
@@ -29,7 +34,7 @@ interface BookmarkConfig {
 interface BookmarkGroup {
   details: StoredBookmark;
   bookmarks: Array<StoredBookmark & { id: string }>;
-  type: string;
+  type: BookmarkMediaType;
 }
 
 function bookmarkConfigOrEmpty(value: unknown): BookmarkConfig {
@@ -109,28 +114,30 @@ export async function renderBookmarksLibrary(
 
   // Group by item
   const groupedByItem: Record<string, BookmarkGroup> = {};
-  const typeCounts: Record<string, { items: number; bookmarks: number }> = {
+  const typeCounts: Record<BookmarkMediaType, { items: number; bookmarks: number }> = {
     tv: { items: 0, bookmarks: 0 },
-    movie: { items: 0, bookmarks: 0 }
+    movie: { items: 0, bookmarks: 0 },
+    other: { items: 0, bookmarks: 0 }
   };
 
   for (const [id, bm] of bookmarkEntries) {
-    const key = bm.itemId || bm.tmdbId || bm.tvdbId || 'unknown';
-    const normalizedType = normalizeMediaType(bm.mediaType);
+    const normalizedType = normalizeBookmarkMediaType(bm.mediaType);
+    // Include the canonical category in the group identity. Provider ids can
+    // overlap across media classes, and conflicting legacy values for one item
+    // must remain visible in their own fallback category rather than inheriting
+    // whichever record happened to be enumerated first.
+    const itemKey = bm.itemId || bm.tmdbId || bm.tvdbId || 'unknown';
+    const key = `${normalizedType}:${itemKey}`;
     if (!groupedByItem[key]) {
       groupedByItem[key] = {
         details: bm,
         bookmarks: [],
         type: normalizedType
       };
-      if (typeCounts[normalizedType]) {
-        typeCounts[normalizedType].items += 1;
-      }
+      typeCounts[normalizedType].items += 1;
     }
     groupedByItem[key].bookmarks.push({ id, ...bm });
-    if (typeCounts[groupedByItem[key].type]) {
-      typeCounts[groupedByItem[key].type].bookmarks += 1;
-    }
+    typeCounts[groupedByItem[key].type].bookmarks += 1;
   }
 
   // Sort bookmarks within each group by timestamp
@@ -139,12 +146,13 @@ export async function renderBookmarksLibrary(
   });
 
   const totalBookmarks = bookmarkEntries.length;
-  let currentTab = container.dataset.currentTab || 'movie';
-  if (currentTab === 'tv' && typeCounts.tv.items === 0 && typeCounts.movie.items > 0) {
-    currentTab = 'movie';
-  } else if (currentTab === 'movie' && typeCounts.movie.items === 0 && typeCounts.tv.items > 0) {
-    currentTab = 'tv';
-  }
+  const requestedTab = BOOKMARK_MEDIA_TYPES.includes(container.dataset.currentTab as BookmarkMediaType)
+    ? container.dataset.currentTab as BookmarkMediaType
+    : 'movie';
+  const firstPopulatedTab = BOOKMARK_MEDIA_TYPES.find(type => typeCounts[type].items > 0);
+  const currentTab = typeCounts[requestedTab].items > 0 || !firstPopulatedTab
+    ? requestedTab
+    : firstPopulatedTab;
   container.dataset.currentTab = currentTab;
 
   // Create UI
@@ -152,10 +160,13 @@ export async function renderBookmarksLibrary(
     <div class="jc-bookmarks-wrapper">
       <div class="jc-bookmark-tabs">
         <button class="jc-tab ${currentTab === 'movie' ? 'active' : ''}" data-tab="movie">
-          ${JC.t!('bookmarks_library_tab_movies')}
+          ${JC.t!('bookmarks_library_tab_movies')} <span class="jc-tab-count">${typeCounts.movie.bookmarks}</span>
         </button>
         <button class="jc-tab ${currentTab === 'tv' ? 'active' : ''}" data-tab="tv">
-          ${JC.t!('bookmarks_library_tab_series')}
+          ${JC.t!('bookmarks_library_tab_series')} <span class="jc-tab-count">${typeCounts.tv.bookmarks}</span>
+        </button>
+        <button class="jc-tab ${currentTab === 'other' ? 'active' : ''}" data-tab="other">
+          ${JC.t!('bookmarks_library_tab_other')} <span class="jc-tab-count">${typeCounts.other.bookmarks}</span>
         </button>
       </div>
 
@@ -282,7 +293,7 @@ export async function renderBookmarksLibrary(
       container.querySelectorAll<HTMLElement>('.jc-tab').forEach(btn => {
         btn.addEventListener('click', () => { void (async () => {
           if (!JC.identity.isCurrent(context)) return;
-          const tab = btn.dataset.tab!;
+          const tab = btn.dataset.tab as BookmarkMediaType;
           container.dataset.currentTab = tab;
           container.querySelectorAll<HTMLElement>('.jc-tab').forEach(b => {
             b.classList.toggle('active', b.dataset.tab === tab);
@@ -305,13 +316,6 @@ export function formatTimestamp(seconds: number): string {
     return `${h}:${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
   }
   return `${m}:${s.toString().padStart(2, '0')}`;
-}
-
-function normalizeMediaType(mediaType: unknown): string {
-  const type = typeof mediaType === 'string' ? mediaType.toLowerCase() : '';
-  if (type === 'series' || type === 'episode' || type === 'tvshow' || type === 'tv') return 'tv';
-  if (type === 'movie' || type === 'film' || type === 'musicvideo') return 'movie';
-  return 'other';
 }
 
 // Parse HH:MM:SS or MM:SS or seconds into numeric seconds

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-replacements.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-replacements.ts
@@ -10,6 +10,7 @@ import { escapeHtml, toast } from '../../core/ui-kit';
 import { getItemCached } from '../helpers';
 import { renderActiveBookmarks } from './library-render';
 import type { IdentityContext } from '../../types/jc';
+import { normalizeBookmarkMediaType, replacementItemTypes } from './media-types';
 
 const replacementModalTimers = new Set<number>();
 
@@ -17,7 +18,7 @@ interface StoredBookmark {
   itemId: string;
   tmdbId: string;
   tvdbId: string;
-  mediaType: string;
+  mediaType?: string;
   name: string;
   [key: string]: unknown;
 }
@@ -30,6 +31,7 @@ interface BookmarkGroup {
 interface JellyfinReplacementItem {
   Id: string;
   Name: string;
+  Type?: string;
   ProductionYear?: string | number;
   ProviderIds?: { Tmdb?: string; Tvdb?: string };
   ImageTags?: { Primary?: string };
@@ -95,7 +97,7 @@ JC.identity.registerReset('bookmarks-library-replacement-modals', () => {
 async function searchForReplacementItem(
   tmdbId: string,
   tvdbId: string,
-  mediaType: string,
+  mediaType: unknown,
   context: IdentityContext
 ): Promise<JellyfinReplacementItem[] | null> {
   if (!JC.identity.isCurrent(context)) return null;
@@ -103,11 +105,13 @@ async function searchForReplacementItem(
 
   try {
     // Search using Jellyfin's provider ID filtering
-    const itemTypes = mediaType === 'tv' ? 'Series,Episode' : 'Movie';
+    const normalizedMediaType = normalizeBookmarkMediaType(mediaType);
+    const itemTypes = replacementItemTypes(normalizedMediaType);
 
     // Fetch all items of this type and filter by provider ID client-side
     // This is more reliable than relying on AnyProviderIdEquals
-    const url = `/Users/${userId}/Items?Recursive=true&IncludeItemTypes=${itemTypes}&SortBy=DateCreated&SortOrder=Descending&Limit=500`;
+    const typeFilter = itemTypes ? `&IncludeItemTypes=${itemTypes}` : '';
+    const url = `/Users/${userId}/Items?Recursive=true${typeFilter}&SortBy=DateCreated&SortOrder=Descending&Limit=500`;
 
     // Routed through the core fetch layer (auth + JSON parse identical to the
     // former ApiClient.ajax call; failures still land in the catch below).
@@ -126,7 +130,7 @@ async function searchForReplacementItem(
       && 'Items' in response && Array.isArray(response.Items)
       ? response.Items.filter(isJellyfinReplacementItem)
       : [];
-    console.log(`🪼 Jellyfin Canopy: Bookmarks Library: Fetched ${items.length} total items of type ${itemTypes}`);
+    console.log(`🪼 Jellyfin Canopy: Bookmarks Library: Fetched ${items.length} total items of type ${itemTypes || 'other/legacy'}`);
 
     if (!Array.isArray(items) || items.length === 0) {
       console.warn(`🪼 Jellyfin Canopy: Bookmarks Library: No items found or items is not an array`);
@@ -136,6 +140,8 @@ async function searchForReplacementItem(
     // Filter items by matching provider IDs
     // Check both ProviderIds and UserData.Key (TMDB ID is often stored there)
     const matches = items.filter((item) => {
+      const candidateType = normalizeBookmarkMediaType(item.Type);
+      if (item.Type && candidateType !== normalizedMediaType) return false;
       const providerIds = item.ProviderIds || {};
       const userData = item.UserData || {};
 
@@ -319,7 +325,7 @@ function showReplacementSelectionModal(
         itemId: fullItem.Id,
         tmdbId: fullItem.ProviderIds?.Tmdb || oldGroup.details.tmdbId,
         tvdbId: fullItem.ProviderIds?.Tvdb || oldGroup.details.tvdbId,
-        mediaType: oldGroup.details.mediaType,
+        mediaType: normalizeBookmarkMediaType(fullItem.Type ?? oldGroup.details.mediaType),
         name: fullItem.Name
       };
 
@@ -367,21 +373,23 @@ export async function findAllOrphanedAndOfferMigration(
   const userId = context.userId;
   const orphanedGroups: BookmarkGroup[] = [];
 
-  // Group by item ID
+  // Group by canonical category and item ID.
   const byItem: Record<string, BookmarkGroup> = {};
   for (const [id, bm] of Object.entries(bookmarks)) {
-    if (!byItem[bm.itemId]) {
-      byItem[bm.itemId] = {
+    const key = `${normalizeBookmarkMediaType(bm.mediaType)}:${bm.itemId}`;
+    if (!byItem[key]) {
+      byItem[key] = {
         details: bm,
         bookmarks: []
       };
     }
-    byItem[bm.itemId].bookmarks.push({ id, ...bm });
+    byItem[key].bookmarks.push({ id, ...bm });
   }
 
   // Check each item
-  for (const [itemId, group] of Object.entries(byItem)) {
+  for (const group of Object.values(byItem)) {
     if (!JC.identity.isCurrent(context)) return;
+    const itemId = group.details.itemId;
     try {
       await getItemCached(itemId, { userId });
       if (!JC.identity.isCurrent(context)) return;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-styles.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-styles.ts
@@ -52,6 +52,18 @@ if (!JC.pluginConfig?.BookmarksEnabled) {
       border-bottom-color: #fff;
     }
 
+    .jc-tab-count {
+      display: inline-block;
+      min-width: 1.6em;
+      margin-left: 4px;
+      padding: 1px 5px;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.12);
+      font-size: 11px;
+      line-height: 1.4;
+      text-align: center;
+    }
+
     .bookmarks-container {
       padding: 12px 3vw;
     }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/media-types.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/media-types.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+  normalizeBookmarkMediaType,
+  replacementItemTypes,
+  sameBookmarkMediaType
+} from './media-types';
+
+describe('bookmark media-type contract', () => {
+  it.each([
+    ['Movie', 'movie'],
+    ['film', 'movie'],
+    ['MusicVideo', 'movie'],
+    ['Episode', 'tv'],
+    ['Series', 'tv'],
+    ['Season', 'tv'],
+    ['TVShow', 'tv'],
+    [' Video ', 'other'],
+    ['future-playable-type', 'other'],
+    ['', 'other'],
+    [undefined, 'other'],
+    [null, 'other']
+  ])('normalizes %j to %s', (input, expected) => {
+    expect(normalizeBookmarkMediaType(input)).toBe(expected);
+  });
+
+  it('uses normalized categories when matching legacy and current values', () => {
+    expect(sameBookmarkMediaType('MusicVideo', 'movie')).toBe(true);
+    expect(sameBookmarkMediaType('Episode', 'tv')).toBe(true);
+    expect(sameBookmarkMediaType('Video', undefined)).toBe(true);
+    expect(sameBookmarkMediaType('movie', 'tv')).toBe(false);
+  });
+
+  it('defines bounded replacement policies without hiding legacy other records', () => {
+    expect(replacementItemTypes('MusicVideo')).toBe('Movie,MusicVideo');
+    expect(replacementItemTypes('Season')).toBe('Series,Season,Episode');
+    expect(replacementItemTypes('Video')).toBeNull();
+    expect(replacementItemTypes(undefined)).toBeNull();
+  });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/media-types.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/media-types.ts
@@ -1,0 +1,35 @@
+/** Stable categories persisted by new bookmark writes and consumed by every bookmark view. */
+export const BOOKMARK_MEDIA_TYPES = ['movie', 'tv', 'other'] as const;
+
+export type BookmarkMediaType = typeof BOOKMARK_MEDIA_TYPES[number];
+
+/**
+ * Normalize Jellyfin item types and legacy persisted values into the bookmark
+ * storage contract. Unknown and missing legacy values remain manageable in the
+ * explicit `other` category instead of being discarded.
+ */
+export function normalizeBookmarkMediaType(value: unknown): BookmarkMediaType {
+  const type = typeof value === 'string' ? value.trim().toLowerCase() : '';
+  if (type === 'movie' || type === 'film' || type === 'musicvideo') return 'movie';
+  if (type === 'series' || type === 'season' || type === 'episode'
+      || type === 'tvshow' || type === 'tv') return 'tv';
+  return 'other';
+}
+
+/** True when two raw or canonical values belong to the same bookmark category. */
+export function sameBookmarkMediaType(left: unknown, right: unknown): boolean {
+  return normalizeBookmarkMediaType(left) === normalizeBookmarkMediaType(right);
+}
+
+/**
+ * Restrict orphan replacement searches where the category has a stable
+ * Jellyfin type set. `other` deliberately searches all playable/library types
+ * so unknown legacy records still have a provider-id migration path.
+ */
+export function replacementItemTypes(value: unknown): string | null {
+  switch (normalizeBookmarkMediaType(value)) {
+    case 'movie': return 'Movie,MusicVideo';
+    case 'tv': return 'Series,Season,Episode';
+    case 'other': return null;
+  }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/surface.d.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/surface.d.ts
@@ -23,7 +23,8 @@ export interface BookmarksApi {
     findForItem(
         itemId: string,
         tmdbId?: string,
-        tvdbId?: string
+        tvdbId?: string,
+        mediaType?: unknown
     ): {
         bookmarks: any[];
         hasIdMismatch: boolean;

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -244,7 +244,7 @@ The data structure is (property names are persisted as-is, in PascalCase):
       "ItemId": "jellyfin-item-id",
       "TmdbId": "12345",
       "TvdbId": "67890",
-      "MediaType": "movie" | "tv",
+      "MediaType": "movie" | "tv" | "other",
       "Name": "Item Name",
       "Timestamp": 123.45,
       "Label": "Epic scene",
@@ -255,6 +255,13 @@ The data structure is (property names are persisted as-is, in PascalCase):
   }
 }
 ```
+
+New client writes normalize Jellyfin Movie and MusicVideo items to `movie`,
+Series/Season/Episode items to `tv`, and every remaining playable type to
+`other`. Existing unknown or missing values remain readable and appear in the
+Other management tab; the next edit or migration writes their canonical
+category. Provider-id fallback matching and duplicate/replacement workflows use
+the same categories so identifiers from different media classes are not merged.
 
 External applications read and write bookmarks through the endpoints below. `{userId}` is the 32-character hex (`"N"` format) Jellyfin user id. Bookmark state is server-authoritative and revisioned: retain the `Revision` returned by every GET/mutation, submit it with the next operation, and rebase on the authoritative state returned with HTTP `409 Conflict`. Missing preconditions return `428 Precondition Required`. A successful mutation increments the revision once and returns the complete committed state.
 

--- a/docs/enhanced.md
+++ b/docs/enhanced.md
@@ -357,7 +357,7 @@ Drop a marker at any moment in a video and jump straight back to it later — gr
 
 Bookmarks **sync across duplicate items** — copies of the same title that share a TMDB/TVDB ID — so a marker you set on one version shows up on the others.
 
-**Managing bookmarks:** a dedicated Bookmarks page collects every bookmark across your library, where you can view them all, **clean up orphaned** bookmarks, **detect and merge duplicates**, and **adjust time offsets** for synced bookmarks.
+**Managing bookmarks:** a dedicated Bookmarks page collects every bookmark across your library, where you can view them all, **clean up orphaned** bookmarks, **detect and merge duplicates**, and **adjust time offsets** for synced bookmarks. Counted **Movies**, **Series**, and **Other** tabs keep generic videos and older bookmarks with unknown or missing media types visible and editable instead of hiding them.
 
 The management page is a real routed destination. Enable Bookmarks under the **Bookmarks** section of **Dashboard** → **Plugins** → **Jellyfin Canopy** → **Pages** tab, and Jellyfin Canopy adds its entry points automatically — a **Bookmarks** link in the **Jellyfin Canopy** section of the sidebar drawer (and the mobile drawer), plus a header-tray icon button and a user-preferences-menu link on the modern layout. Its position among the pages follows the admin **Pages order** setting on the **Pages** tab. You can also open it directly at `/web/index.html#/bookmarks` — browser back/forward, page refresh, and deep links all work.
 


### PR DESCRIPTION
Closes #136.

## Summary
- define one canonical bookmark media-type owner
- surface stored movie, TV, and all other bookmark types in library management
- preserve exact category filtering, empty-state behavior, persistence, and legacy migration
- add complete media matrix coverage, locale updates, and developer/user documentation
- retain #295 reverse-proxy-safe title and poster navigation

## Validation
- conflict-focused bookmark/base-URL tests: 65/65; broader focused set: 86/86
- full client assertions: 929/929 before the separately resolved #100 topology change
- both TypeScript typechecks, syntax, bundle, Release build, translations (26 locales × 706 keys), docs links/assets, MkDocs strict
- independent review approved exact current-main commit 1561cd485f6cef1f1b17acd3c04cc4714f682d9c; patch-id matches the original approval
- current standalone performance gate passes at 953ms under 5,000ms