### PR TITLE
fix(hidden-content): resolve SearchHint series hierarchy

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/HiddenContentSearchHintHierarchyTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/HiddenContentSearchHintHierarchyTests.cs
@@ -1,0 +1,364 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Jellyfin.Data.Enums;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Services;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Model.Search;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
+{
+    /// <summary>
+    /// Privacy contract for SearchHint DTOs, which omit SeriesId. These tests
+    /// intentionally cover hierarchy decisions only. Global filtered totals,
+    /// backfill, and cursor/page reachability remain owned by issue #151.
+    /// </summary>
+    public sealed class HiddenContentSearchHintHierarchyTests : IDisposable
+    {
+        private readonly string _baseDir;
+        private readonly UserConfigurationManager _configManager;
+
+        public HiddenContentSearchHintHierarchyTests()
+        {
+            _baseDir = Path.Combine(Path.GetTempPath(), "jc-hidden-search-hierarchy-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_baseDir);
+            _configManager = new UserConfigurationManager(
+                new StubAppPaths(_baseDir),
+                NullLogger<UserConfigurationManager>.Instance);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_baseDir, recursive: true); } catch { /* best effort */ }
+        }
+
+        [Theory]
+        [InlineData("global")]
+        [InlineData("search")]
+        public void HiddenSeries_RemovesSeriesSeasonAndEpisodeHints_InOneUserScopedBatch(string scope)
+        {
+            var user = NewUser();
+            var seriesId = Guid.NewGuid();
+            var seasonId = Guid.NewGuid();
+            var episodeId = Guid.NewGuid();
+            var queryCount = 0;
+            var library = new CountingLibraryManager
+            {
+                GetItemListHook = query =>
+                {
+                    queryCount++;
+                    Assert.Same(user, query.User);
+                    Assert.True(query.Recursive);
+                    Assert.Equal(2, query.Limit);
+                    Assert.Equal(
+                        new[] { episodeId, seasonId }.OrderBy(static id => id),
+                        query.ItemIds.OrderBy(static id => id));
+                    return new BaseItem[]
+                    {
+                        new Season { Id = seasonId, SeriesId = seriesId },
+                        new Episode { Id = episodeId, SeriesId = seriesId },
+                    };
+                },
+            };
+            var filter = NewFilter(library, user);
+            var result = filter.FilterSearchHintsForTest(
+                Result(
+                    Hint(seriesId, BaseItemKind.Series),
+                    Hint(seasonId, BaseItemKind.Season),
+                    Hint(episodeId, BaseItemKind.Episode)),
+                SeriesPolicy(seriesId, scope),
+                user.Id);
+
+            Assert.Empty(result.SearchHints);
+            Assert.Equal(0, result.TotalRecordCount);
+            Assert.Equal(1, queryCount);
+        }
+
+        [Fact]
+        public void ExplicitItemOnlyHide_DoesNotCascadeOrResolveSiblingHierarchy()
+        {
+            var user = NewUser();
+            var hiddenEpisodeId = Guid.NewGuid();
+            var siblingEpisodeId = Guid.NewGuid();
+            var seriesId = Guid.NewGuid();
+            var library = new CountingLibraryManager
+            {
+                GetItemListHook = _ => throw new Xunit.Sdk.XunitException("item-only policy must not query hierarchy"),
+            };
+            var filter = NewFilter(library, user);
+            var policy = EnabledSearchPolicy();
+            policy.Items["episode"] = new HiddenContentItem
+            {
+                ItemId = hiddenEpisodeId.ToString(),
+                Type = "Episode",
+                HideScope = "global",
+            };
+
+            var result = filter.FilterSearchHintsForTest(
+                Result(
+                    Hint(hiddenEpisodeId, BaseItemKind.Episode),
+                    Hint(siblingEpisodeId, BaseItemKind.Episode),
+                    Hint(seriesId, BaseItemKind.Series)),
+                policy,
+                user.Id);
+
+            Assert.Equal(new[] { siblingEpisodeId, seriesId }, result.SearchHints.Select(static hint => hint.Id));
+        }
+
+        [Fact]
+        public void MixedHints_KeepUnrelatedShapesAndDropSuccessfullyUnresolvedDescendant()
+        {
+            var user = NewUser();
+            var hiddenSeriesId = Guid.NewGuid();
+            var allowedSeriesId = Guid.NewGuid();
+            var allowedEpisodeId = Guid.NewGuid();
+            var inaccessibleOrDeletedSeasonId = Guid.NewGuid();
+            var movieId = Guid.NewGuid();
+            var personId = Guid.NewGuid();
+            var audioId = Guid.NewGuid();
+            var library = new CountingLibraryManager
+            {
+                // A successful user-scoped query omits the Season: whether it
+                // was deleted or inaccessible, its parent cannot be trusted.
+                GetItemListHook = query =>
+                {
+                    Assert.Same(user, query.User);
+                    return new BaseItem[]
+                    {
+                        new Episode { Id = allowedEpisodeId, SeriesId = allowedSeriesId },
+                    };
+                },
+            };
+            var filter = NewFilter(library, user);
+
+            var result = filter.FilterSearchHintsForTest(
+                Result(
+                    Hint(movieId, BaseItemKind.Movie),
+                    Hint(personId, BaseItemKind.Person),
+                    Hint(audioId, BaseItemKind.Audio),
+                    Hint(inaccessibleOrDeletedSeasonId, BaseItemKind.Season),
+                    Hint(allowedEpisodeId, BaseItemKind.Episode)),
+                SeriesPolicy(hiddenSeriesId),
+                user.Id);
+
+            Assert.Equal(
+                new[] { movieId, personId, audioId, allowedEpisodeId },
+                result.SearchHints.Select(static hint => hint.Id));
+        }
+
+        [Fact]
+        public void QueryFailure_DropsCompletePayloadWithoutPublishingDirectPartialResult()
+        {
+            var user = NewUser();
+            var seriesId = Guid.NewGuid();
+            var library = new CountingLibraryManager
+            {
+                GetItemListHook = _ => throw new IOException("transient library fault"),
+            };
+            var filter = NewFilter(library, user);
+
+            var result = filter.FilterSearchHintsForTest(
+                Result(
+                    Hint(Guid.NewGuid(), BaseItemKind.Movie),
+                    Hint(Guid.NewGuid(), BaseItemKind.Episode)),
+                SeriesPolicy(seriesId),
+                user.Id);
+
+            Assert.Empty(result.SearchHints);
+            Assert.Equal(0, result.TotalRecordCount);
+        }
+
+        [Fact]
+        public void CandidateCapFailure_DropsCompletePayloadWithoutQuerying()
+        {
+            var user = NewUser();
+            var queryCount = 0;
+            var library = new CountingLibraryManager
+            {
+                GetItemListHook = _ =>
+                {
+                    queryCount++;
+                    return Array.Empty<BaseItem>();
+                },
+            };
+            var filter = NewFilter(library, user);
+            var hints = Enumerable.Range(0, HiddenContentHierarchyResolver.MaximumItemIds + 1)
+                .Select(_ => Hint(Guid.NewGuid(), BaseItemKind.Episode))
+                .ToArray();
+
+            var result = filter.FilterSearchHintsForTest(
+                new SearchHintResult(hints, hints.Length),
+                SeriesPolicy(Guid.NewGuid()),
+                user.Id);
+
+            Assert.Empty(result.SearchHints);
+            Assert.Equal(0, queryCount);
+        }
+
+        [Fact]
+        public void CandidateCap_AllowsExactlyMaximumUniqueIdsAndDeduplicatesTheBatch()
+        {
+            var user = NewUser();
+            var allowedSeriesId = Guid.NewGuid();
+            var ids = Enumerable.Range(0, HiddenContentHierarchyResolver.MaximumItemIds)
+                .Select(_ => Guid.NewGuid())
+                .ToArray();
+            var queryCount = 0;
+            var library = new CountingLibraryManager
+            {
+                GetItemListHook = query =>
+                {
+                    queryCount++;
+                    Assert.Equal(HiddenContentHierarchyResolver.MaximumItemIds, query.Limit);
+                    Assert.Equal(
+                        ids.OrderBy(static id => id),
+                        query.ItemIds.OrderBy(static id => id));
+                    return ids
+                        .Select(id => (BaseItem)new Episode { Id = id, SeriesId = allowedSeriesId })
+                        .ToArray();
+                },
+            };
+            var filter = NewFilter(library, user);
+            var hints = ids
+                .Select(id => Hint(id, BaseItemKind.Episode))
+                .Append(Hint(ids[0], BaseItemKind.Episode))
+                .ToArray();
+
+            var result = filter.FilterSearchHintsForTest(
+                new SearchHintResult(hints, hints.Length),
+                SeriesPolicy(Guid.NewGuid()),
+                user.Id);
+
+            Assert.Equal(hints.Length, result.SearchHints.Count);
+            Assert.Equal(1, queryCount);
+        }
+
+        [Fact]
+        public void PreQueryCancellation_DropsCompletePayloadWithoutQuerying()
+        {
+            var user = NewUser();
+            var queryCount = 0;
+            var library = new CountingLibraryManager
+            {
+                GetItemListHook = _ =>
+                {
+                    queryCount++;
+                    return Array.Empty<BaseItem>();
+                },
+            };
+            var filter = NewFilter(library, user);
+            using var cancelled = new CancellationTokenSource();
+            cancelled.Cancel();
+
+            var result = filter.FilterSearchHintsForTest(
+                Result(Hint(Guid.NewGuid(), BaseItemKind.Episode)),
+                SeriesPolicy(Guid.NewGuid()),
+                user.Id,
+                cancelled.Token);
+
+            Assert.Empty(result.SearchHints);
+            Assert.Equal(0, queryCount);
+        }
+
+        [Fact]
+        public void PostQueryCancellation_DropsCompletePayloadWithoutPublishingResolvedPartialResult()
+        {
+            var user = NewUser();
+            var seriesId = Guid.NewGuid();
+            var episodeId = Guid.NewGuid();
+            using var cancelled = new CancellationTokenSource();
+            var library = new CountingLibraryManager
+            {
+                GetItemListHook = _ =>
+                {
+                    cancelled.Cancel();
+                    return new BaseItem[] { new Episode { Id = episodeId, SeriesId = seriesId } };
+                },
+            };
+            var filter = NewFilter(library, user);
+
+            var result = filter.FilterSearchHintsForTest(
+                Result(
+                    Hint(Guid.NewGuid(), BaseItemKind.Movie),
+                    Hint(episodeId, BaseItemKind.Episode)),
+                SeriesPolicy(seriesId),
+                user.Id,
+                cancelled.Token);
+
+            Assert.Empty(result.SearchHints);
+            Assert.Equal(0, result.TotalRecordCount);
+        }
+
+        [Fact]
+        public void MissingRequestUser_DropsCompletePayloadWithoutQuerying()
+        {
+            var queryCount = 0;
+            var library = new CountingLibraryManager
+            {
+                GetItemListHook = _ =>
+                {
+                    queryCount++;
+                    return Array.Empty<BaseItem>();
+                },
+            };
+            var filter = NewFilter(library, Array.Empty<User>());
+
+            var result = filter.FilterSearchHintsForTest(
+                Result(Hint(Guid.NewGuid(), BaseItemKind.Episode)),
+                SeriesPolicy(Guid.NewGuid()),
+                Guid.NewGuid());
+
+            Assert.Empty(result.SearchHints);
+            Assert.Equal(0, queryCount);
+        }
+
+        private HiddenContentResponseFilter NewFilter(CountingLibraryManager library, params User[] users)
+        {
+            var hierarchy = new HiddenContentHierarchyResolver(library, new StubUserManager(users));
+            return new HiddenContentResponseFilter(
+                _configManager,
+                NullLogger<HiddenContentResponseFilter>.Instance,
+                new FakePluginConfigProvider(new PluginConfiguration()),
+                hierarchy);
+        }
+
+        private static User NewUser()
+            => new("search-hint-user", "Provider", "PasswordProvider") { Id = Guid.NewGuid() };
+
+        private static UserHiddenContent EnabledSearchPolicy()
+            => new()
+            {
+                Settings = new HiddenContentSettings
+                {
+                    Enabled = true,
+                    FilterSearch = true,
+                },
+            };
+
+        private static UserHiddenContent SeriesPolicy(Guid seriesId, string scope = "global")
+        {
+            var policy = EnabledSearchPolicy();
+            policy.Items["series"] = new HiddenContentItem
+            {
+                ItemId = seriesId.ToString(),
+                Type = "Series",
+                HideScope = scope,
+            };
+            return policy;
+        }
+
+        private static SearchHint Hint(Guid id, BaseItemKind type)
+            => new() { Id = id, Type = type, Name = type.ToString() };
+
+        private static SearchHintResult Result(params SearchHint[] hints)
+            => new(hints, hints.Length);
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/HiddenContentSearchHintHierarchyTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/HiddenContentSearchHintHierarchyTests.cs
@@ -52,6 +52,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             var queryCount = 0;
             var library = new CountingLibraryManager
             {
+                ConfigureUserAccessHook = (query, configuredUser) =>
+                {
+                    Assert.Same(user, configuredUser);
+                    Assert.Empty(query.ItemIds);
+                },
                 GetItemListHook = query =>
                 {
                     queryCount++;
@@ -126,6 +131,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             var audioId = Guid.NewGuid();
             var library = new CountingLibraryManager
             {
+                ConfigureUserAccessHook = (_, _) => { },
                 // A successful user-scoped query omits the Season: whether it
                 // was deleted or inaccessible, its parent cannot be trusted.
                 GetItemListHook = query =>
@@ -161,6 +167,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             var seriesId = Guid.NewGuid();
             var library = new CountingLibraryManager
             {
+                ConfigureUserAccessHook = (_, _) => { },
                 GetItemListHook = _ => throw new IOException("transient library fault"),
             };
             var filter = NewFilter(library, user);
@@ -214,6 +221,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             var queryCount = 0;
             var library = new CountingLibraryManager
             {
+                ConfigureUserAccessHook = (_, _) => { },
                 GetItemListHook = query =>
                 {
                     queryCount++;
@@ -242,12 +250,127 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
         }
 
         [Fact]
+        public void EnabledLibraryAccess_IsConfiguredBeforeExactIds_AndDropsDisabledLibraryDescendant()
+        {
+            var user = NewUser();
+            var allowedLibraryId = Guid.NewGuid();
+            var allowedSeriesId = Guid.NewGuid();
+            var disabledSeriesId = Guid.NewGuid();
+            var unrelatedHiddenSeriesId = Guid.NewGuid();
+            var allowedEpisodeId = Guid.NewGuid();
+            var disabledEpisodeId = Guid.NewGuid();
+            var configureCount = 0;
+            var queryCount = 0;
+            var library = new CountingLibraryManager
+            {
+                ConfigureUserAccessHook = (query, configuredUser) =>
+                {
+                    configureCount++;
+                    Assert.Same(user, configuredUser);
+                    Assert.Empty(query.ItemIds);
+                    query.TopParentIds = new[] { allowedLibraryId };
+                },
+                GetItemListHook = query =>
+                {
+                    queryCount++;
+                    Assert.Equal(
+                        new[] { allowedEpisodeId, disabledEpisodeId }.OrderBy(static id => id),
+                        query.ItemIds.OrderBy(static id => id));
+
+                    var enabledAndDisabled = new BaseItem[]
+                    {
+                        new Episode { Id = allowedEpisodeId, SeriesId = allowedSeriesId },
+                        new Episode { Id = disabledEpisodeId, SeriesId = disabledSeriesId },
+                    };
+
+                    // Reproduce Jellyfin 12's exact-ID hazard: without the
+                    // enabled-library TopParentIds derived above, both rows are
+                    // returned even though one belongs to a disabled library.
+                    return query.TopParentIds.Contains(allowedLibraryId)
+                        ? enabledAndDisabled.Take(1).ToArray()
+                        : enabledAndDisabled;
+                },
+            };
+            var filter = NewFilter(library, user);
+
+            var result = filter.FilterSearchHintsForTest(
+                Result(
+                    Hint(allowedEpisodeId, BaseItemKind.Episode),
+                    Hint(disabledEpisodeId, BaseItemKind.Episode)),
+                SeriesPolicy(unrelatedHiddenSeriesId),
+                user.Id);
+
+            Assert.Equal(new[] { allowedEpisodeId }, result.SearchHints.Select(static hint => hint.Id));
+            Assert.Equal(1, configureCount);
+            Assert.Equal(1, queryCount);
+        }
+
+        [Fact]
+        public void UserAccessConfigurationFailure_DropsCompletePayloadWithoutQuerying()
+        {
+            var user = NewUser();
+            var queryCount = 0;
+            var library = new CountingLibraryManager
+            {
+                ConfigureUserAccessHook = (_, _) => throw new IOException("access configuration fault"),
+                GetItemListHook = _ =>
+                {
+                    queryCount++;
+                    return Array.Empty<BaseItem>();
+                },
+            };
+            var filter = NewFilter(library, user);
+
+            var result = filter.FilterSearchHintsForTest(
+                Result(
+                    Hint(Guid.NewGuid(), BaseItemKind.Movie),
+                    Hint(Guid.NewGuid(), BaseItemKind.Episode)),
+                SeriesPolicy(Guid.NewGuid()),
+                user.Id);
+
+            Assert.Empty(result.SearchHints);
+            Assert.Equal(0, result.TotalRecordCount);
+            Assert.Equal(0, queryCount);
+        }
+
+        [Fact]
+        public void UserAccessConfigurationCancellation_DropsCompletePayloadWithoutQuerying()
+        {
+            var user = NewUser();
+            using var cancelled = new CancellationTokenSource();
+            var queryCount = 0;
+            var library = new CountingLibraryManager
+            {
+                ConfigureUserAccessHook = (_, _) => cancelled.Cancel(),
+                GetItemListHook = _ =>
+                {
+                    queryCount++;
+                    return Array.Empty<BaseItem>();
+                },
+            };
+            var filter = NewFilter(library, user);
+
+            var result = filter.FilterSearchHintsForTest(
+                Result(
+                    Hint(Guid.NewGuid(), BaseItemKind.Movie),
+                    Hint(Guid.NewGuid(), BaseItemKind.Episode)),
+                SeriesPolicy(Guid.NewGuid()),
+                user.Id,
+                cancelled.Token);
+
+            Assert.Empty(result.SearchHints);
+            Assert.Equal(0, result.TotalRecordCount);
+            Assert.Equal(0, queryCount);
+        }
+
+        [Fact]
         public void PreQueryCancellation_DropsCompletePayloadWithoutQuerying()
         {
             var user = NewUser();
             var queryCount = 0;
             var library = new CountingLibraryManager
             {
+                ConfigureUserAccessHook = (_, _) => { },
                 GetItemListHook = _ =>
                 {
                     queryCount++;
@@ -277,6 +400,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             using var cancelled = new CancellationTokenSource();
             var library = new CountingLibraryManager
             {
+                ConfigureUserAccessHook = (_, _) => { },
                 GetItemListHook = _ =>
                 {
                     cancelled.Cancel();

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/PrivacyPolicyFaultContractTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/PrivacyPolicyFaultContractTests.cs
@@ -50,10 +50,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
         private static void Corrupt(string path) => File.WriteAllText(path, "{ this is not : valid json ]");
 
         private HiddenContentResponseFilter NewHcFilter()
-            => new HiddenContentResponseFilter(
+        {
+            var hierarchy = new HiddenContentHierarchyResolver(new CountingLibraryManager(), new StubUserManager());
+            return new HiddenContentResponseFilter(
                 _mgr,
                 NullLogger<HiddenContentResponseFilter>.Instance,
-                new FakePluginConfigProvider(new PluginConfiguration()));
+                new FakePluginConfigProvider(new PluginConfiguration()),
+                hierarchy);
+        }
 
         private SpoilerUserResolver NewResolver()
         {

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/TestDoubles/CountingLibraryManager.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/TestDoubles/CountingLibraryManager.cs
@@ -79,6 +79,9 @@ public sealed class CountingLibraryManager : ILibraryManager
     /// <summary>When set, backs the user-access projection query.</summary>
     public Func<InternalItemsQuery, IReadOnlyList<Guid>>? GetItemIdsHook { get; set; }
 
+    /// <summary>When set, backs Jellyfin's query access-scope configurator.</summary>
+    public Action<InternalItemsQuery, User>? ConfigureUserAccessHook { get; set; }
+
     // ---- Everything below is an unused NotImplemented stub (per the repo convention). ----
 
     public AggregateFolder RootFolder => throw new NotImplementedException();
@@ -289,7 +292,11 @@ public sealed class CountingLibraryManager : ILibraryManager
 
     public Dictionary<Guid, (int Played, int Total)> GetPlayedAndTotalCountBatch(IReadOnlyList<Guid> folderIds, User user) => throw new NotImplementedException();
 
-    public void ConfigureUserAccess(InternalItemsQuery query, User user) => throw new NotImplementedException();
+    public void ConfigureUserAccess(InternalItemsQuery query, User user)
+    {
+        if (ConfigureUserAccessHook is null) throw new NotImplementedException();
+        ConfigureUserAccessHook(query, user);
+    }
 
     public Task RunMetadataSavers(BaseItem item, ItemUpdateType updateReason) => throw new NotImplementedException();
 

--- a/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
@@ -136,6 +136,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy
             // Continue Watching" via HideScope=continuewatching in hidden-content.json.
             serviceCollection.AddSingleton<MaintenanceModeService>();
             serviceCollection.AddHostedService(serviceProvider => serviceProvider.GetRequiredService<MaintenanceModeService>());
+            serviceCollection.AddSingleton<HiddenContentHierarchyResolver>();
             serviceCollection.AddSingleton<HiddenContentResponseFilter>();
             serviceCollection.AddScoped<IEventConsumer<PlaybackStartEventArgs>, ContinueWatchingPlaybackConsumer>();
             serviceCollection.AddHostedService<ContinueWatchingLibraryHook>();

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/HiddenContentHierarchyResolver.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/HiddenContentHierarchyResolver.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Jellyfin.Database.Implementations.Entities;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Library;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Services
+{
+    /// <summary>
+    /// Resolves item identities to their canonical parent series through one
+    /// user-scoped Jellyfin query. DTO filters whose response shape omits
+    /// <c>SeriesId</c> share this owner instead of probing items one at a time.
+    /// </summary>
+    public sealed class HiddenContentHierarchyResolver
+    {
+        internal const int MaximumItemIds = 512;
+
+        private readonly ILibraryManager _libraryManager;
+        private readonly IUserManager _userManager;
+
+        public HiddenContentHierarchyResolver(ILibraryManager libraryManager, IUserManager userManager)
+        {
+            _libraryManager = libraryManager;
+            _userManager = userManager;
+        }
+
+        /// <summary>
+        /// Resolves at most <see cref="MaximumItemIds"/> unique item IDs as one
+        /// atomic operation. A successful result can omit IDs only when Jellyfin
+        /// did not return an accessible Episode/Season with a live parent series.
+        /// No partial map is returned for cancellation or a transient query fault.
+        /// </summary>
+        internal HiddenContentHierarchyResolution ResolveSeriesIds(
+            Guid userId,
+            IReadOnlyCollection<Guid> itemIds,
+            CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return HiddenContentHierarchyResolution.Failed(HiddenContentHierarchyResolutionStatus.Cancelled);
+            }
+
+            var uniqueIds = new HashSet<Guid>();
+            foreach (var itemId in itemIds)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return HiddenContentHierarchyResolution.Failed(HiddenContentHierarchyResolutionStatus.Cancelled);
+                }
+
+                if (itemId == Guid.Empty || !uniqueIds.Add(itemId)) continue;
+                if (uniqueIds.Count > MaximumItemIds)
+                {
+                    return HiddenContentHierarchyResolution.Failed(HiddenContentHierarchyResolutionStatus.TooManyCandidates);
+                }
+            }
+
+            if (uniqueIds.Count == 0)
+            {
+                return HiddenContentHierarchyResolution.Succeeded(new Dictionary<Guid, Guid>());
+            }
+
+            User? user;
+            try
+            {
+                user = _userManager.GetUserById(userId);
+            }
+            catch
+            {
+                return HiddenContentHierarchyResolution.Failed(HiddenContentHierarchyResolutionStatus.UserResolutionFailed);
+            }
+
+            if (user is null)
+            {
+                return HiddenContentHierarchyResolution.Failed(HiddenContentHierarchyResolutionStatus.UserResolutionFailed);
+            }
+
+            IReadOnlyList<MediaBrowser.Controller.Entities.BaseItem> items;
+            try
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                items = _libraryManager.GetItemList(new InternalItemsQuery(user)
+                {
+                    ItemIds = new List<Guid>(uniqueIds).ToArray(),
+                    Recursive = true,
+                    Limit = uniqueIds.Count,
+                });
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return HiddenContentHierarchyResolution.Failed(HiddenContentHierarchyResolutionStatus.Cancelled);
+            }
+            catch
+            {
+                return HiddenContentHierarchyResolution.Failed(HiddenContentHierarchyResolutionStatus.QueryFailed);
+            }
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return HiddenContentHierarchyResolution.Failed(HiddenContentHierarchyResolutionStatus.Cancelled);
+            }
+
+            // The query limit bounds the real Jellyfin result. Keep the owner
+            // fail-closed if an implementation violates that contract rather
+            // than traversing or publishing an unbounded partial response.
+            if (items.Count > MaximumItemIds)
+            {
+                return HiddenContentHierarchyResolution.Failed(HiddenContentHierarchyResolutionStatus.QueryFailed);
+            }
+
+            var seriesByItemId = new Dictionary<Guid, Guid>();
+            foreach (var item in items)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return HiddenContentHierarchyResolution.Failed(HiddenContentHierarchyResolutionStatus.Cancelled);
+                }
+
+                if (!uniqueIds.Contains(item.Id)) continue;
+                var seriesId = item switch
+                {
+                    Episode episode => episode.SeriesId,
+                    Season season => season.SeriesId,
+                    _ => Guid.Empty,
+                };
+                if (seriesId != Guid.Empty)
+                {
+                    seriesByItemId[item.Id] = seriesId;
+                }
+            }
+
+            return HiddenContentHierarchyResolution.Succeeded(seriesByItemId);
+        }
+    }
+
+    internal enum HiddenContentHierarchyResolutionStatus
+    {
+        Success,
+        Cancelled,
+        TooManyCandidates,
+        UserResolutionFailed,
+        QueryFailed,
+    }
+
+    internal sealed class HiddenContentHierarchyResolution
+    {
+        private HiddenContentHierarchyResolution(
+            HiddenContentHierarchyResolutionStatus status,
+            IReadOnlyDictionary<Guid, Guid> seriesByItemId)
+        {
+            Status = status;
+            SeriesByItemId = seriesByItemId;
+        }
+
+        public HiddenContentHierarchyResolutionStatus Status { get; }
+
+        public IReadOnlyDictionary<Guid, Guid> SeriesByItemId { get; }
+
+        public bool IsSuccess => Status == HiddenContentHierarchyResolutionStatus.Success;
+
+        public static HiddenContentHierarchyResolution Succeeded(IReadOnlyDictionary<Guid, Guid> seriesByItemId)
+            => new(HiddenContentHierarchyResolutionStatus.Success, seriesByItemId);
+
+        public static HiddenContentHierarchyResolution Failed(HiddenContentHierarchyResolutionStatus status)
+            => new(status, new Dictionary<Guid, Guid>());
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/HiddenContentHierarchyResolver.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/HiddenContentHierarchyResolver.cs
@@ -81,12 +81,22 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             try
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                items = _libraryManager.GetItemList(new InternalItemsQuery(user)
+                var query = new InternalItemsQuery(user)
                 {
-                    ItemIds = new List<Guid>(uniqueIds).ToArray(),
-                    Recursive = true,
-                    Limit = uniqueIds.Count,
-                });
+                    ItemIds = Array.Empty<Guid>(),
+                };
+
+                // Jellyfin 12 deliberately skips its normal enabled-library
+                // derivation when ItemIds is already populated. Configure access
+                // while the exact-ID set is still empty so TopParentIds is owned
+                // by Jellyfin's canonical user-access implementation.
+                _libraryManager.ConfigureUserAccess(query, user);
+                cancellationToken.ThrowIfCancellationRequested();
+
+                query.ItemIds = new List<Guid>(uniqueIds).ToArray();
+                query.Recursive = true;
+                query.Limit = uniqueIds.Count;
+                items = _libraryManager.GetItemList(query);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/HiddenContentResponseFilter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/HiddenContentResponseFilter.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+using Jellyfin.Data.Enums;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
 using Jellyfin.Plugin.JellyfinCanopy.Helpers;
 using MediaBrowser.Model.Dto;
@@ -91,7 +93,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             { ("Search", "GetSearchHints"),            ("search",          FilterSearchHints) },
         };
 
-        private delegate void ResponseHandler(ActionExecutedContext executed, HideContext hide, string surface, ILogger<HiddenContentResponseFilter> logger);
+        private delegate void ResponseHandler(
+            ActionExecutedContext executed,
+            HideContext hide,
+            string surface,
+            ILogger<HiddenContentResponseFilter> logger,
+            HiddenContentHierarchyResolver hierarchyResolver,
+            Guid userId,
+            CancellationToken cancellationToken);
 
         // Re-warn at most once per hour so a real Jellyfin upgrade isn't permanently invisible after the first warn.
         private static readonly TimeSpan ShapeMismatchReWarnInterval = TimeSpan.FromHours(1);
@@ -105,6 +114,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             maximumEntries: 2_048,
             maximumWeight: 2_048,
             defaultTtl: static () => TimeSpan.FromDays(7));
+        private static readonly BoundedTtlCache<string, byte> _warnedHierarchyFailure = new(
+            maximumEntries: 16,
+            maximumWeight: 512,
+            weight: static (key, _) => key.Length + 1L,
+            comparer: StringComparer.Ordinal,
+            defaultTtl: static () => TimeSpan.FromHours(1));
 
         private static void WarnShapeMismatchOnce(ILogger<HiddenContentResponseFilter> logger, string surface, string handlerName, IActionResult? result)
         {
@@ -122,12 +137,18 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         private readonly UserConfigurationManager _configManager;
         private readonly ILogger<HiddenContentResponseFilter> _logger;
         private readonly IPluginConfigProvider _configProvider;
+        private readonly HiddenContentHierarchyResolver _hierarchyResolver;
 
-        public HiddenContentResponseFilter(UserConfigurationManager configManager, ILogger<HiddenContentResponseFilter> logger, IPluginConfigProvider configProvider)
+        public HiddenContentResponseFilter(
+            UserConfigurationManager configManager,
+            ILogger<HiddenContentResponseFilter> logger,
+            IPluginConfigProvider configProvider,
+            HiddenContentHierarchyResolver hierarchyResolver)
         {
             _configManager = configManager;
             _logger = logger;
             _configProvider = configProvider;
+            _hierarchyResolver = hierarchyResolver;
         }
 
         public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
@@ -180,7 +201,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             var executed = await next().ConfigureAwait(false);
             try
             {
-                route.Handler(executed, hide, surface, _logger);
+                route.Handler(
+                    executed,
+                    hide,
+                    surface,
+                    _logger,
+                    _hierarchyResolver,
+                    userId,
+                    context.HttpContext.RequestAborted);
             }
             catch (Exception ex)
             {
@@ -280,7 +308,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 ? HideContext.Build(read.Value)
                 : (lastKnownGood ?? HideContext.FailClosed);
 
-        private static void FilterQueryResult(ActionExecutedContext executed, HideContext hide, string surface, ILogger<HiddenContentResponseFilter> logger)
+        private static void FilterQueryResult(
+            ActionExecutedContext executed,
+            HideContext hide,
+            string surface,
+            ILogger<HiddenContentResponseFilter> logger,
+            HiddenContentHierarchyResolver hierarchyResolver,
+            Guid userId,
+            CancellationToken cancellationToken)
         {
             if (executed.Result is not ObjectResult or || or.Value is not QueryResult<BaseItemDto> qr)
             {
@@ -305,7 +340,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 kept);
         }
 
-        private static void FilterEnumerable(ActionExecutedContext executed, HideContext hide, string surface, ILogger<HiddenContentResponseFilter> logger)
+        private static void FilterEnumerable(
+            ActionExecutedContext executed,
+            HideContext hide,
+            string surface,
+            ILogger<HiddenContentResponseFilter> logger,
+            HiddenContentHierarchyResolver hierarchyResolver,
+            Guid userId,
+            CancellationToken cancellationToken)
         {
             if (executed.Result is not ObjectResult or || or.Value is not IEnumerable<BaseItemDto> raw)
             {
@@ -324,8 +366,16 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             or.Value = kept;
         }
 
-        // SearchHint has no SeriesId, so series-scope cascade falls back to the /Items?searchTerm path.
-        private static void FilterSearchHints(ActionExecutedContext executed, HideContext hide, string surface, ILogger<HiddenContentResponseFilter> logger)
+        // SearchHint has no SeriesId. Resolve every Episode/Season candidate at
+        // the shared hierarchy owner before publishing one final policy result.
+        private static void FilterSearchHints(
+            ActionExecutedContext executed,
+            HideContext hide,
+            string surface,
+            ILogger<HiddenContentResponseFilter> logger,
+            HiddenContentHierarchyResolver hierarchyResolver,
+            Guid userId,
+            CancellationToken cancellationToken)
         {
             if (executed.Result is not ObjectResult or || or.Value is not SearchHintResult sh)
             {
@@ -335,16 +385,115 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             var hints = sh.SearchHints;
             if (hints is null || hints.Count == 0) return;
 
+            or.Value = FilterSearchHintsCore(
+                sh,
+                hide,
+                surface,
+                logger,
+                hierarchyResolver,
+                userId,
+                cancellationToken);
+        }
+
+        private static SearchHintResult FilterSearchHintsCore(
+            SearchHintResult result,
+            HideContext hide,
+            string surface,
+            ILogger<HiddenContentResponseFilter> logger,
+            HiddenContentHierarchyResolver hierarchyResolver,
+            Guid userId,
+            CancellationToken cancellationToken)
+        {
+            var hints = result.SearchHints;
+            if (hints is null || hints.Count == 0) return result;
+
+            // Explicit item entries and Series rows are decidable from the hint
+            // itself. Parent resolution is needed only while an applicable
+            // series-cascade policy exists; this keeps item-only hiding distinct.
+            var needsSeriesResolution = hide.HasApplicableSeriesScope(surface);
+            var descendantIds = new List<Guid>();
+            if (needsSeriesResolution)
+            {
+                foreach (var hint in hints)
+                {
+                    if (IsDescendantHint(hint) && hint.Id != Guid.Empty)
+                    {
+                        descendantIds.Add(hint.Id);
+                    }
+                }
+            }
+
+            IReadOnlyDictionary<Guid, Guid> seriesByItemId = new Dictionary<Guid, Guid>();
+            if (descendantIds.Count > 0)
+            {
+                var resolution = hierarchyResolver.ResolveSeriesIds(userId, descendantIds, cancellationToken);
+                if (!resolution.IsSuccess)
+                {
+                    var warningKey = resolution.Status.ToString();
+                    if (_warnedHierarchyFailure.TryAdd(warningKey, 0))
+                    {
+                        logger.LogWarning(
+                            $"HC SearchHint hierarchy resolution failed ({warningKey}); dropping the complete hint payload for this request so no partial policy result is published.");
+                    }
+
+                    return new SearchHintResult(new List<SearchHint>(), 0);
+                }
+
+                seriesByItemId = resolution.SeriesByItemId;
+            }
+
             var kept = new List<SearchHint>(hints.Count);
             var dropped = 0;
             foreach (var hint in hints)
             {
-                if (IsHiddenById(hint.Id.ToString(), null, hide, surface)) { dropped++; continue; }
+                if (IsHiddenById(hint.Id.ToString(), null, hide, surface))
+                {
+                    dropped++;
+                    continue;
+                }
+
+                if (needsSeriesResolution && IsDescendantHint(hint))
+                {
+                    // A successful user-scoped query that omits the item means it
+                    // is deleted, malformed, or inaccessible to this user. Any of
+                    // those shapes is dropped while a series cascade is active:
+                    // without a trusted parent identity it cannot be proven safe.
+                    if (!seriesByItemId.TryGetValue(hint.Id, out var seriesId)
+                        || IsHiddenById(hint.Id.ToString(), seriesId.ToString(), hide, surface))
+                    {
+                        dropped++;
+                        continue;
+                    }
+                }
+
                 kept.Add(hint);
             }
-            if (dropped == 0) return;
-            or.Value = new SearchHintResult(kept, Math.Max(0, sh.TotalRecordCount - dropped));
+            if (dropped == 0) return result;
+
+            // #151 owns pre-pagination filtering/backfill and globally honest
+            // totals. Preserve the existing page-local subtraction here; this
+            // issue changes only hierarchy privacy decisions.
+            return new SearchHintResult(kept, Math.Max(0, result.TotalRecordCount - dropped));
         }
+
+        private static bool IsDescendantHint(SearchHint hint)
+            => hint.Type is BaseItemKind.Episode or BaseItemKind.Season;
+
+        // Focused server-policy seam: exercises the real SearchHint decision and
+        // hierarchy owner without depending on MVC response-shape construction.
+        internal SearchHintResult FilterSearchHintsForTest(
+            SearchHintResult result,
+            UserHiddenContent policy,
+            Guid userId,
+            CancellationToken cancellationToken = default)
+            => FilterSearchHintsCore(
+                result,
+                HideContext.Build(policy),
+                "search",
+                _logger,
+                _hierarchyResolver,
+                userId,
+                cancellationToken);
 
         private static bool IsHidden(BaseItemDto item, HideContext hide, string surface)
         {
@@ -456,6 +605,20 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             // Fail-closed is never "empty": the filter must engage so its handlers
             // over-hide. Otherwise emptiness is the absence of any hide scope.
             public bool IsEmpty => !IsFailClosed && ItemIdScopes.Count == 0 && SeriesIdScopes.Count == 0;
+
+            public bool HasApplicableSeriesScope(string surface)
+            {
+                if (IsFailClosed) return false;
+                foreach (var scopes in SeriesIdScopes.Values)
+                {
+                    foreach (var scope in scopes)
+                    {
+                        if (ScopeAppliesToSurface(scope, surface, Settings)) return true;
+                    }
+                }
+
+                return false;
+            }
 
             public static HideContext Build(UserHiddenContent? data)
             {

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -19,7 +19,7 @@ const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the repeated clean measurements', () => {
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1436, totalLines: 1759 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 16244, totalLines: 24886 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 16360, totalLines: 25016 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);
 });

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -19,7 +19,7 @@ const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the repeated clean measurements', () => {
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1436, totalLines: 1759 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 16360, totalLines: 25016 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 16366, totalLines: 25020 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);
 });

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -21,12 +21,12 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 16360,
-        "totalLines": 25016
+        "coveredLines": 16366,
+        "totalLines": 25020
       },
       "tolerance": {
         "missingCoveredLines": 2,
-        "rationale": "Three clean reviewed local .NET 10/Coverlet integration runs on 2026-07-16 measured 16359, 16359, and 16360 covered lines across the identical 25016-line final scope after adding bounded, user-scoped SearchHint hierarchy resolution for hidden-series Season and Episode descendants, including fail-closed atomic query, user, cap, and cancellation handling. The existing two-line tolerance remains narrow and covers only reproduced cross-run instrumentation variance (0.0080 percentage points)."
+        "rationale": "Two clean reviewed local .NET 10/Coverlet integration runs on 2026-07-16 measured 16366 and 16365 covered lines across the identical 25020-line final scope after adding bounded SearchHint hierarchy resolution and deriving Jellyfin 12 enabled-library TopParentIds before assigning exact item IDs. Focused evidence covers hidden-series descendants plus atomic user, access-configuration, query, cap, and cancellation failures. The existing two-line tolerance remains narrow and covers only the reproduced one-line instrumentation variance (0.0080 percentage points)."
       }
     }
   }

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -21,12 +21,12 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 16244,
-        "totalLines": 24886
+        "coveredLines": 16360,
+        "totalLines": 25016
       },
       "tolerance": {
         "missingCoveredLines": 2,
-        "rationale": "Two clean reviewed local .NET 10/Coverlet integration runs on 2026-07-15 measured 16244 and 16243 covered lines, while the first clean GitHub Actions run measured 16242, across the identical 24886-line final scope after the Continue Watching linear index, outcome-aware playback retry deduplication, bounded asynchronous logging, and strict static locale resolution with immutable responses, silent regional fallback, and bounded miss logging. The two-line tolerance covers only that reproduced cross-run instrumentation variance (0.0081 percentage points)."
+        "rationale": "Three clean reviewed local .NET 10/Coverlet integration runs on 2026-07-16 measured 16359, 16359, and 16360 covered lines across the identical 25016-line final scope after adding bounded, user-scoped SearchHint hierarchy resolution for hidden-series Season and Episode descendants, including fail-closed atomic query, user, cap, and cancellation handling. The existing two-line tolerance remains narrow and covers only reproduced cross-run instrumentation variance (0.0080 percentage points)."
       }
     }
   }


### PR DESCRIPTION
## Summary

- resolve SearchHint Episode and Season identities to their parent Series in one bounded batch
- apply Jellyfin 12 enabled-library access before assigning exact candidate IDs
- fail closed atomically on query, access-configuration, cap, user, or cancellation failure
- preserve explicit item-only hiding and leave paging/backfill ownership to #151
- raise the reviewed server coverage high-water without widening its tolerance

## Root cause

Jellyfin SearchHint DTOs omit SeriesId, so the hidden-content response filter passed `null` to the shared series-cascade policy. A naive exact-ID query is also insufficient: Jellyfin 12 skips deriving allowed TopParentIds once ItemIds are populated. The resolver now calls Jellyfin's supported ConfigureUserAccess owner while ItemIds are empty, then assigns the bounded IDs and performs one query.

## Validation

- focused SearchHint hierarchy tests: 13/13
- privacy fault regressions: 12/12
- full server suite: 1,433/1,433
- server coverage: 16,366/25,020 lines (65.412% high-water; existing two-line tolerance retained)
- script tests: 346/346
- Release build: 0 warnings, 0 errors
- NuGet vulnerable audit: none
- independent review of corrected commit: APPROVE

## Scope

Paging totals and backfill remain tracked by #151. No deployment or runtime mutation is included.

Developed with AI assistance and independently reviewed.

Fixes #150
