### PR TITLE
fix(seerr): enforce the master policy at every edge

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/ArrRequestsApprovalsGateTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/ArrRequestsApprovalsGateTests.cs
@@ -87,9 +87,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
 
         private static PluginConfiguration Config(
             bool approvalsEnabled,
-            string urls = "http://seerr:5055") => new()
+            string urls = "http://seerr:5055",
+            bool seerrEnabled = true) => new()
         {
-            SeerrEnabled = true,
+            SeerrEnabled = seerrEnabled,
             SeerrUrls = urls,
             SeerrApiKey = "key",
             RequestApprovalsEnabled = approvalsEnabled,
@@ -120,6 +121,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             var ok = Assert.IsType<OkObjectResult>(result);
             var json = JsonNode.Parse(JsonSerializer.Serialize(ok.Value))!.AsObject();
             return (bool)json["canApproveRequests"]!;
+        }
+
+        private static JsonObject BodyOf(IActionResult result)
+        {
+            var objectResult = Assert.IsAssignableFrom<ObjectResult>(result);
+            return JsonNode.Parse(JsonSerializer.Serialize(objectResult.Value))!.AsObject();
         }
 
         // ── 1. ActOnRequest is gated server-side, even for an admin ───────────
@@ -202,6 +209,66 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 isAdmin: false);
 
             Assert.True(CanApprove(await controller.GetRequests()));
+        }
+
+        [Fact]
+        public async Task GetRequests_MasterDisabledWithRetainedCredentials_ReportsDisabledWithoutResolutionOrHttp()
+        {
+            var handler = new RecordingHttpMessageHandler();
+            handler.AddResponse("/api/v1/request", @"{ ""results"": [], ""pageInfo"": { ""results"": 0 } }");
+            var seerr = new RecordingSeerrClient(new SeerrUser
+            {
+                Id = CallerSeerrId,
+                Permissions = SeerrPermission.ADMIN,
+                SourceUrl = "http://seerr:5055",
+            });
+            var controller = BuildController(
+                Config(approvalsEnabled: true, seerrEnabled: false),
+                SeerrPermission.ADMIN,
+                handler,
+                seerr,
+                isAdmin: true);
+
+            var result = await controller.GetRequests();
+            var body = BodyOf(result);
+
+            Assert.IsType<OkObjectResult>(result);
+            Assert.Equal("seerr_disabled", (string?)body["code"]);
+            Assert.True((bool?)body["disabled"]);
+            Assert.False((bool?)body["canApproveRequests"]);
+            Assert.Empty(body["requests"]!.AsArray());
+            Assert.Empty(seerr.Resolutions);
+            Assert.Empty(handler.Sent);
+        }
+
+        [Theory]
+        [InlineData("approve")]
+        [InlineData("decline")]
+        public async Task ActOnRequest_MasterDisabledWithRetainedCredentials_ReportsDisabledWithoutResolutionOrHttp(string action)
+        {
+            var handler = new RecordingHttpMessageHandler();
+            var seerr = new RecordingSeerrClient(new SeerrUser
+            {
+                Id = CallerSeerrId,
+                Permissions = SeerrPermission.ADMIN,
+                SourceUrl = "http://seerr:5055",
+            });
+            var controller = BuildController(
+                Config(approvalsEnabled: true, seerrEnabled: false),
+                SeerrPermission.ADMIN,
+                handler,
+                seerr,
+                isAdmin: true,
+                requestPath: $"/JellyfinCanopy/arr/requests/9/{action}");
+
+            var result = await controller.ActOnRequest(9, ActionToken(9));
+            var body = BodyOf(result);
+
+            Assert.Equal(503, Assert.IsType<ObjectResult>(result).StatusCode);
+            Assert.Equal("seerr_disabled", (string?)body["code"]);
+            Assert.False((bool?)body["canApproveRequests"]);
+            Assert.Empty(seerr.Resolutions);
+            Assert.Empty(handler.Sent);
         }
 
         [Fact]

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/ArrRequestsQueueFilterTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/ArrRequestsQueueFilterTests.cs
@@ -83,6 +83,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             var factory = new RecordingHttpClientFactory(handler);
             var provider = new FakePluginConfigProvider(new PluginConfiguration
             {
+                SeerrEnabled = true,
                 SeerrUrls = "http://seerr:5055",
                 SeerrApiKey = "key",
             });

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/ComingSoonPaginationTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/ComingSoonPaginationTests.cs
@@ -33,6 +33,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 "http://seerr",
                 "key",
                 "&requestedBy=7",
+                SeerrDispatchFenceTestFactory.Create(),
                 CancellationToken.None,
                 pageSize: 100);
 
@@ -60,6 +61,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 "http://seerr",
                 "key",
                 string.Empty,
+                SeerrDispatchFenceTestFactory.Create(),
                 CancellationToken.None,
                 pageSize: 100);
 
@@ -83,6 +85,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 "http://seerr",
                 "key",
                 string.Empty,
+                SeerrDispatchFenceTestFactory.Create(),
                 CancellationToken.None,
                 pageSize: 2,
                 maxItems: 3);
@@ -107,6 +110,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 "http://seerr",
                 "key",
                 string.Empty,
+                SeerrDispatchFenceTestFactory.Create(),
                 CancellationToken.None,
                 pageSize: 1,
                 maxPages: 2);
@@ -132,6 +136,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 "http://seerr",
                 "key",
                 string.Empty,
+                SeerrDispatchFenceTestFactory.Create(),
                 CancellationToken.None);
 
             Assert.False(result.IsComplete);
@@ -155,6 +160,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 new[] { "http://seerr" },
                 "key",
                 "7",
+                SeerrDispatchFenceTestFactory.Create(),
                 CancellationToken.None,
                 pageSize: 500);
 

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/ItemInfoAvatarSourceTokenTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/ItemInfoAvatarSourceTokenTests.cs
@@ -50,6 +50,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             var avatarFetch = new AvatarFetchService(
                 factory,
                 cache,
+                provider,
                 NullLogger<AvatarFetchService>.Instance);
             var controller = new ItemInfoController(
                 factory,

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/ItemInfoAvatarSourceTokenTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/ItemInfoAvatarSourceTokenTests.cs
@@ -238,7 +238,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 key,
                 stale,
                 TimeSpan.FromHours(1),
-                () =>
+                SeerrDispatchFenceTestFactory.Create(() =>
                 {
                     if (++checks == 1)
                     {
@@ -249,7 +249,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                     // write-to-postcheck interval. Exact cleanup must preserve it.
                     cache[key] = newer;
                     return false;
-                });
+                }));
 
             Assert.False(published);
             Assert.Equal(2, checks);

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SeerrPermissionAuditGenerationFenceTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SeerrPermissionAuditGenerationFenceTests.cs
@@ -1,0 +1,190 @@
+using System.Text.Json;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Controllers;
+using Jellyfin.Plugin.JellyfinCanopy.Model.Seerr;
+using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers;
+
+public sealed class SeerrPermissionAuditGenerationFenceTests
+{
+    [Fact]
+    public async Task PermissionAudit_DisabledDuringResolverAwait_PublishesNoPartialAudit()
+    {
+        var fixture = CreateFixture();
+        var pending = fixture.Controller.GetPermissionAudit();
+        await fixture.Seerr.FirstResolutionStarted.WaitAsync(TimeSpan.FromSeconds(5));
+
+        fixture.OriginalConfiguration.SeerrEnabled = false;
+        fixture.Seerr.ReleaseFirstResolution();
+
+        var unavailable = Assert.IsType<ObjectResult>(
+            await pending.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.Equal(503, unavailable.StatusCode);
+        AssertTypedFailure(unavailable.Value, "seerr_disabled", fixture.Users);
+        Assert.Equal(1, fixture.Seerr.ResolutionCalls);
+    }
+
+    [Fact]
+    public async Task PermissionAudit_ConfigurationReplacedDuringResolverAwait_PublishesNoPartialAudit()
+    {
+        var fixture = CreateFixture();
+        var pending = fixture.Controller.GetPermissionAudit();
+        await fixture.Seerr.FirstResolutionStarted.WaitAsync(TimeSpan.FromSeconds(5));
+
+        fixture.Provider.Current = Configuration();
+        fixture.Seerr.ReleaseFirstResolution();
+
+        var conflict = Assert.IsType<ConflictObjectResult>(
+            await pending.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.Equal(409, conflict.StatusCode);
+        AssertTypedFailure(conflict.Value, "audit_configuration_changed", fixture.Users);
+        Assert.Equal(1, fixture.Seerr.ResolutionCalls);
+    }
+
+    private static void AssertTypedFailure(
+        object? value,
+        string expectedCode,
+        IReadOnlyList<User> users)
+    {
+        var body = JsonSerializer.SerializeToElement(value);
+        Assert.True(body.GetProperty("error").GetBoolean());
+        Assert.False(body.GetProperty("active").GetBoolean());
+        Assert.Equal(expectedCode, body.GetProperty("code").GetString());
+        Assert.False(body.TryGetProperty("permissions", out _));
+        Assert.False(body.TryGetProperty("results", out _));
+
+        var serialized = body.GetRawText();
+        foreach (var user in users)
+        {
+            Assert.DoesNotContain(user.Username, serialized, StringComparison.Ordinal);
+            Assert.DoesNotContain(user.Id.ToString("N"), serialized, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    private static Fixture CreateFixture()
+    {
+        var users = new[]
+        {
+            new User("audit-first", "provider", "password-provider"),
+            new User("audit-second", "provider", "password-provider"),
+        };
+        var configuration = Configuration();
+        var provider = new FakePluginConfigProvider(configuration);
+        var seerr = new BlockingAuditSeerrClient();
+        var userManager = new StubUserManager(users);
+        var factory = new RecordingHttpClientFactory(new RecordingHttpMessageHandler());
+        var controller = new SeerrUserController(
+            factory,
+            NullLogger<SeerrUserController>.Instance,
+            userManager,
+            new SeerrCache(provider),
+            provider,
+            userDataManager: null!,
+            libraryManager: null!,
+            seerr)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            },
+        };
+
+        return new Fixture(controller, provider, configuration, seerr, users);
+    }
+
+    private static PluginConfiguration Configuration()
+        => new()
+        {
+            SeerrEnabled = true,
+            SeerrUrls = "http://seerr:5055",
+            SeerrApiKey = "audit-key",
+            SeerrEnable4KRequests = true,
+            SeerrShowAdvanced = true,
+        };
+
+    private sealed record Fixture(
+        SeerrUserController Controller,
+        FakePluginConfigProvider Provider,
+        PluginConfiguration OriginalConfiguration,
+        BlockingAuditSeerrClient Seerr,
+        IReadOnlyList<User> Users);
+
+    private sealed class BlockingAuditSeerrClient : ISeerrClient
+    {
+        private readonly TaskCompletionSource _firstResolutionStarted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _releaseFirstResolution =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _resolutionCalls;
+
+        public Task FirstResolutionStarted => _firstResolutionStarted.Task;
+
+        public int ResolutionCalls => Volatile.Read(ref _resolutionCalls);
+
+        public void ReleaseFirstResolution() => _releaseFirstResolution.TrySetResult();
+
+        public async Task<SeerrUserResolution> ResolveSeerrUser(
+            string jellyfinUserId,
+            bool bypassCache = false,
+            bool allowAutoImport = true,
+            CancellationToken cancellationToken = default)
+        {
+            var call = Interlocked.Increment(ref _resolutionCalls);
+            if (call == 1)
+            {
+                _firstResolutionStarted.TrySetResult();
+                await _releaseFirstResolution.Task.WaitAsync(cancellationToken);
+            }
+
+            return SeerrUserResolution.Found(new SeerrUser
+            {
+                Id = 100 + call,
+                JellyfinUserId = jellyfinUserId,
+                Permissions = SeerrPermission.ADMIN,
+                SourceUrl = "http://seerr:5055",
+            });
+        }
+
+        public Task<SeerrUser?> GetSeerrUser(
+            string jellyfinUserId,
+            bool bypassCache = false,
+            bool allowAutoImport = true)
+            => throw new NotImplementedException();
+
+        public Task<string?> GetSeerrUserId(string jellyfinUserId, bool allowAutoImport = true)
+            => throw new NotImplementedException();
+
+        public bool IsImportBlocked(string jellyfinUserId, PluginConfiguration config) => false;
+
+        public Task<bool> GetStatusActiveAsync() => throw new NotImplementedException();
+
+        public Task<Seerr4kCapability> GetSeerr4kCapabilityAsync(
+            string jellyfinUserId,
+            bool isAdmin = false)
+            => throw new NotImplementedException();
+
+        public void EvictMediaDetailCache(int tmdbId, string mediaType)
+        {
+        }
+
+        public Task<IActionResult> ProxyRequestAsync(
+            string apiPath,
+            HttpMethod method,
+            string? content,
+            SeerrCaller caller)
+            => throw new NotImplementedException();
+
+        public Task<List<WatchlistItem>?> GetWatchlistForUser(string seerrUserId)
+            => throw new NotImplementedException();
+
+        public Task<List<WatchlistItem>?> GetRequestsForUser(string seerrUserId)
+            => throw new NotImplementedException();
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SeerrQuotaPaginationTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SeerrQuotaPaginationTests.cs
@@ -27,6 +27,7 @@ public class SeerrQuotaPaginationTests
             "http://seerr",
             "key",
             "7",
+            SeerrDispatchFenceTestFactory.Create(),
             CancellationToken.None);
 
         Assert.True(result.IsComplete, result.FailureReason);
@@ -54,6 +55,7 @@ public class SeerrQuotaPaginationTests
             "http://seerr",
             "key",
             "7",
+            SeerrDispatchFenceTestFactory.Create(),
             CancellationToken.None);
 
         Assert.False(result.IsComplete);

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SeerrScanTriggerControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SeerrScanTriggerControllerTests.cs
@@ -34,7 +34,7 @@ public sealed class SeerrScanTriggerControllerTests
         handler.AddResponse(
             "/api/v1/settings/jobs/jellyfin-recently-added-scan/run",
             "{}");
-        using var service = CreateService(handler);
+        using var service = CreateService(handler, "http://localhost:5055", "key");
         var controller = CreateController(service);
 
         var action = await controller.TriggerSeerrRecentlyAddedScan(
@@ -51,7 +51,10 @@ public sealed class SeerrScanTriggerControllerTests
     [Fact]
     public async Task ManualEndpoint_PreservesTypedUpstreamStatus()
     {
-        using var service = CreateService(new JsonFailureHandler(HttpStatusCode.Unauthorized));
+        using var service = CreateService(
+            new JsonFailureHandler(HttpStatusCode.Unauthorized),
+            "http://localhost:5055",
+            "bad-key");
         var controller = CreateController(service);
 
         var action = await controller.TriggerSeerrRecentlyAddedScan(
@@ -69,7 +72,10 @@ public sealed class SeerrScanTriggerControllerTests
         handler.AddResponse(
             "/api/v1/settings/jobs/jellyfin-recently-added-scan/run",
             "{}");
-        using var service = CreateService(handler);
+        using var service = CreateService(
+            handler,
+            "http://localhost:5055,http://127.0.0.1:5055",
+            "key");
         var controller = CreateController(service);
 
         var action = await controller.TriggerSeerrRecentlyAddedScan(
@@ -84,7 +90,10 @@ public sealed class SeerrScanTriggerControllerTests
     [Fact]
     public async Task ManualEndpoint_ServiceStopping_ReturnsServiceUnavailable()
     {
-        var service = CreateService(new JsonFailureHandler(HttpStatusCode.OK));
+        var service = CreateService(
+            new JsonFailureHandler(HttpStatusCode.OK),
+            "http://localhost:5055",
+            "key");
         service.Dispose();
         var controller = CreateController(service);
 
@@ -96,12 +105,20 @@ public sealed class SeerrScanTriggerControllerTests
         Assert.Equal(StatusCodes.Status503ServiceUnavailable, result.StatusCode);
     }
 
-    private static SeerrScanTriggerService CreateService(HttpMessageHandler handler)
+    private static SeerrScanTriggerService CreateService(
+        HttpMessageHandler handler,
+        string urls,
+        string apiKey)
         => new(
             new CountingLibraryManager(),
             new RecordingHttpClientFactory(handler),
             NullLogger<SeerrScanTriggerService>.Instance,
-            new FakePluginConfigProvider(new PluginConfiguration()));
+            new FakePluginConfigProvider(new PluginConfiguration
+            {
+                SeerrEnabled = true,
+                SeerrUrls = urls,
+                SeerrApiKey = apiKey,
+            }));
 
     private static SeerrScanTriggerController CreateController(SeerrScanTriggerService service)
         => new(service, NullLogger<SeerrScanTriggerController>.Instance)

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SeerrUserManualWatchlistSyncTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SeerrUserManualWatchlistSyncTests.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
 using Jellyfin.Plugin.JellyfinCanopy.Controllers;
+using Jellyfin.Plugin.JellyfinCanopy.Model.Seerr;
 using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
 using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
 using MediaBrowser.Controller.Entities;
@@ -200,15 +201,131 @@ public sealed class SeerrUserManualWatchlistSyncTests
         Assert.All(handler.Requests, request => Assert.Equal("seerr", request.Uri.Host));
     }
 
+    [Fact]
+    public async Task ConfigurationDisabledDuringWatchlistAwait_DoesNotStartRequestCollection()
+    {
+        var user = new User("generation-user", "provider", "password-provider");
+        var handler = new RoutingHandler(request =>
+        {
+            if (request.RequestUri!.AbsolutePath == "/api/v1/user")
+            {
+                return Page(new { id = 44, jellyfinUserId = user.Id.ToString() });
+            }
+
+            throw new Xunit.Sdk.XunitException(
+                $"Unexpected direct request {request.Method} {request.RequestUri}.");
+        });
+        var provider = new FakePluginConfigProvider(new PluginConfiguration
+        {
+            SeerrEnabled = true,
+            SyncSeerrWatchlist = true,
+            AddRequestedMediaToWatchlist = true,
+            SeerrUrls = "http://seerr",
+            SeerrApiKey = "key",
+        });
+        var seerr = new BlockingWatchlistClient();
+        var controller = BuildController(
+            user,
+            handler,
+            new CountingLibraryManager(),
+            new StubUserDataManager(),
+            "http://seerr",
+            addRequests: true,
+            provider,
+            seerr);
+
+        var syncTask = controller.SyncSeerrWatchlist();
+        await seerr.WatchlistStarted.WaitAsync(TimeSpan.FromSeconds(5));
+
+        provider.Current!.SeerrEnabled = false;
+        seerr.ReleaseWatchlist();
+
+        var conflict = Assert.IsType<ConflictObjectResult>(
+            await syncTask.WaitAsync(TimeSpan.FromSeconds(5)));
+        var body = JsonSerializer.SerializeToElement(conflict.Value);
+        Assert.Equal("sync_configuration_changed", body.GetProperty("code").GetString());
+        Assert.Equal(0, seerr.RequestCalls);
+    }
+
+    [Fact]
+    public async Task ConfigurationDisabledByFirstLocalSave_StopsRemainingItemMutations()
+    {
+        var user = new User("commit-generation-user", "provider", "password-provider");
+        var firstMovie = MovieWithTmdbId(501);
+        var secondMovie = MovieWithTmdbId(502);
+        var handler = new RoutingHandler(request =>
+        {
+            var uri = request.RequestUri!;
+            if (uri.AbsolutePath == "/api/v1/user")
+            {
+                return Page(new { id = 44, jellyfinUserId = user.Id.ToString() });
+            }
+
+            if (uri.AbsolutePath == "/api/v1/user/44/watchlist")
+            {
+                return Page(
+                    new { tmdbId = 501, mediaType = "movie" },
+                    new { tmdbId = 502, mediaType = "movie" });
+            }
+
+            throw new Xunit.Sdk.XunitException($"Unexpected request {request.Method} {uri}.");
+        });
+        var provider = new FakePluginConfigProvider(new PluginConfiguration
+        {
+            SeerrEnabled = true,
+            SyncSeerrWatchlist = true,
+            AddRequestedMediaToWatchlist = false,
+            SeerrUrls = "http://seerr",
+            SeerrApiKey = "key",
+        });
+        var saveCalls = 0;
+        var userData = new StubUserDataManager
+        {
+            GetUserDataHook = (_, item) => new UserItemData
+            {
+                Key = item.Id.ToString("N"),
+                Likes = false,
+            },
+            SaveUserDataHook = (_, _, _, _, _) =>
+            {
+                if (Interlocked.Increment(ref saveCalls) == 1)
+                {
+                    provider.Current!.SeerrEnabled = false;
+                }
+            },
+        };
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = _ => new BaseItem[] { firstMovie, secondMovie },
+        };
+        var controller = BuildController(
+            user,
+            handler,
+            library,
+            userData,
+            "http://seerr",
+            addRequests: false,
+            provider);
+
+        var conflict = Assert.IsType<ConflictObjectResult>(
+            await controller.SyncSeerrWatchlist());
+
+        Assert.Equal(1, Volatile.Read(ref saveCalls));
+        var body = JsonSerializer.SerializeToElement(conflict.Value);
+        Assert.Equal("sync_configuration_changed", body.GetProperty("code").GetString());
+    }
+
     private static SeerrUserController BuildController(
         User user,
         RoutingHandler handler,
         CountingLibraryManager library,
         StubUserDataManager userData,
         string seerrUrls,
-        bool addRequests)
+        bool addRequests,
+        FakePluginConfigProvider? provider = null,
+        ISeerrClient? seerrOverride = null)
     {
-        var config = new PluginConfiguration
+        var config = provider?.ConfigurationOrNull ?? new PluginConfiguration
         {
             SeerrEnabled = true,
             SyncSeerrWatchlist = true,
@@ -216,11 +333,11 @@ public sealed class SeerrUserManualWatchlistSyncTests
             SeerrUrls = seerrUrls,
             SeerrApiKey = "key",
         };
-        var provider = new FakePluginConfigProvider(config);
+        provider ??= new FakePluginConfigProvider(config);
         var users = new StubUserManager(user);
         var factory = new RecordingHttpClientFactory(handler);
         var cache = new SeerrCache(provider);
-        var seerr = new SeerrClient(
+        var seerr = seerrOverride ?? new SeerrClient(
             factory,
             NullLogger<SeerrClient>.Instance,
             users,
@@ -286,6 +403,62 @@ public sealed class SeerrUserManualWatchlistSyncTests
             cancellationToken.ThrowIfCancellationRequested();
             Requests.Add(new CapturedRequest(request.Method, request.RequestUri!));
             return Task.FromResult(_route(request));
+        }
+    }
+
+    private sealed class BlockingWatchlistClient : ISeerrClient
+    {
+        private readonly TaskCompletionSource _watchlistStarted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _releaseWatchlist =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task WatchlistStarted => _watchlistStarted.Task;
+
+        public int RequestCalls { get; private set; }
+
+        public void ReleaseWatchlist() => _releaseWatchlist.TrySetResult();
+
+        public Task<SeerrUser?> GetSeerrUser(
+            string jellyfinUserId,
+            bool bypassCache = false,
+            bool allowAutoImport = true)
+            => throw new NotImplementedException();
+
+        public Task<string?> GetSeerrUserId(string jellyfinUserId, bool allowAutoImport = true)
+            => throw new NotImplementedException();
+
+        public bool IsImportBlocked(string jellyfinUserId, PluginConfiguration config) => false;
+
+        public Task<bool> GetStatusActiveAsync() => throw new NotImplementedException();
+
+        public Task<Seerr4kCapability> GetSeerr4kCapabilityAsync(
+            string jellyfinUserId,
+            bool isAdmin = false)
+            => throw new NotImplementedException();
+
+        public void EvictMediaDetailCache(int tmdbId, string mediaType)
+        {
+        }
+
+        public Task<IActionResult> ProxyRequestAsync(
+            string apiPath,
+            HttpMethod method,
+            string? content,
+            SeerrCaller caller)
+            => throw new NotImplementedException();
+
+        public async Task<List<WatchlistItem>?> GetWatchlistForUser(string seerrUserId)
+        {
+            _watchlistStarted.TrySetResult();
+            await _releaseWatchlist.Task;
+            return new List<WatchlistItem>();
+        }
+
+        public Task<List<WatchlistItem>?> GetRequestsForUser(string seerrUserId)
+        {
+            RequestCalls++;
+            return Task.FromResult<List<WatchlistItem>?>(new List<WatchlistItem>());
         }
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SeerrUserStatusGenerationFenceTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SeerrUserStatusGenerationFenceTests.cs
@@ -1,0 +1,133 @@
+using System.Security.Claims;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Controllers;
+using Jellyfin.Plugin.JellyfinCanopy.Model.Seerr;
+using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers;
+
+public sealed class SeerrUserStatusGenerationFenceTests
+{
+    [Fact]
+    public async Task UserStatus_MasterDisabledByCapabilityCallback_DoesNotPublishLinkedState()
+    {
+        var user = new User("status-user", "provider", "password-provider");
+        var config = new PluginConfiguration
+        {
+            SeerrEnabled = true,
+            SeerrUrls = "http://seerr:5055",
+            SeerrApiKey = "retained-key",
+        };
+        var provider = new FakePluginConfigProvider(config);
+        var seerr = new CapabilityCallbackSeerrClient(
+            new SeerrUser
+            {
+                Id = 42,
+                JellyfinUserId = user.Id.ToString("N"),
+                SourceUrl = "http://seerr:5055",
+            },
+            () => config.SeerrEnabled = false);
+        var users = new StubUserManager(user);
+        var factory = new RecordingHttpClientFactory(new RecordingHttpMessageHandler());
+        var controller = new SeerrUserController(
+            factory,
+            NullLogger<SeerrUserController>.Instance,
+            users,
+            new SeerrCache(provider),
+            provider,
+            null!,
+            null!,
+            seerr)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = new ClaimsPrincipal(new ClaimsIdentity(
+                        new[] { new Claim("Jellyfin-UserId", user.Id.ToString()) },
+                        "TestAuth")),
+                },
+            },
+        };
+
+        var result = Assert.IsType<OkObjectResult>(await controller.GetSeerrUserStatus());
+
+        Assert.False(Read<bool>(result.Value, "active"));
+        Assert.False(Read<bool>(result.Value, "userFound"));
+        Assert.Equal("disabled", Read<string>(result.Value, "reason"));
+        Assert.Equal(1, seerr.CapabilityCalls);
+        Assert.Equal("retained-key", config.SeerrApiKey);
+    }
+
+    private static T Read<T>(object? value, string propertyName)
+        => Assert.IsType<T>(value?.GetType().GetProperty(propertyName)?.GetValue(value));
+
+    private sealed class CapabilityCallbackSeerrClient : ISeerrClient
+    {
+        private readonly SeerrUser _user;
+        private readonly Action _capabilityCallback;
+
+        public CapabilityCallbackSeerrClient(SeerrUser user, Action capabilityCallback)
+        {
+            _user = user;
+            _capabilityCallback = capabilityCallback;
+        }
+
+        public int CapabilityCalls { get; private set; }
+
+        public Task<SeerrUserResolution> ResolveSeerrUser(
+            string jellyfinUserId,
+            bool bypassCache = false,
+            bool allowAutoImport = true,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(SeerrUserResolution.Found(_user));
+        }
+
+        public Task<SeerrUser?> GetSeerrUser(
+            string jellyfinUserId,
+            bool bypassCache = false,
+            bool allowAutoImport = true)
+            => Task.FromResult<SeerrUser?>(_user);
+
+        public Task<string?> GetSeerrUserId(string jellyfinUserId, bool allowAutoImport = true)
+            => Task.FromResult<string?>(_user.Id.ToString());
+
+        public bool IsImportBlocked(string jellyfinUserId, PluginConfiguration config) => false;
+
+        public Task<bool> GetStatusActiveAsync() => Task.FromResult(true);
+
+        public Task<Seerr4kCapability> GetSeerr4kCapabilityAsync(
+            string jellyfinUserId,
+            bool isAdmin = false)
+        {
+            CapabilityCalls++;
+            _capabilityCallback();
+            return Task.FromResult(new Seerr4kCapability(true, true, true, true));
+        }
+
+        public void EvictMediaDetailCache(int tmdbId, string mediaType)
+        {
+        }
+
+        public Task<IActionResult> ProxyRequestAsync(
+            string apiPath,
+            HttpMethod method,
+            string? content,
+            SeerrCaller caller)
+            => throw new NotImplementedException();
+
+        public Task<List<WatchlistItem>?> GetWatchlistForUser(string seerrUserId)
+            => throw new NotImplementedException();
+
+        public Task<List<WatchlistItem>?> GetRequestsForUser(string seerrUserId)
+            => throw new NotImplementedException();
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SeerrUserStatusGenerationFenceTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SeerrUserStatusGenerationFenceTests.cs
@@ -14,8 +14,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers;
 
 public sealed class SeerrUserStatusGenerationFenceTests
 {
-    [Fact]
-    public async Task UserStatus_MasterDisabledByCapabilityCallback_DoesNotPublishLinkedState()
+    [Theory]
+    [InlineData(ConfigurationMutation.MasterDisabled)]
+    [InlineData(ConfigurationMutation.UrlAndKeyChanged)]
+    [InlineData(ConfigurationMutation.RevisionChanged)]
+    public async Task UserStatus_ConfigurationChangesDuringCapabilityAwait_DoesNotPublishLinkedState(
+        ConfigurationMutation mutation)
     {
         var user = new User("status-user", "provider", "password-provider");
         var config = new PluginConfiguration
@@ -25,17 +29,110 @@ public sealed class SeerrUserStatusGenerationFenceTests
             SeerrApiKey = "retained-key",
         };
         var provider = new FakePluginConfigProvider(config);
-        var seerr = new CapabilityCallbackSeerrClient(
+        var seerr = new BlockingSeerrClient(
             new SeerrUser
             {
                 Id = 42,
                 JellyfinUserId = user.Id.ToString("N"),
                 SourceUrl = "http://seerr:5055",
             },
-            () => config.SeerrEnabled = false);
+            BlockedStage.Capability);
+        var controller = BuildController(user, provider, seerr);
+
+        var pending = controller.GetSeerrUserStatus();
+        await seerr.CapabilityStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Mutate(provider, config, mutation);
+        seerr.ReleaseCapability();
+        var result = Assert.IsType<OkObjectResult>(await pending);
+
+        AssertInactive(result);
+        Assert.Equal(1, seerr.ResolutionCalls);
+        Assert.Equal(1, seerr.CapabilityCalls);
+    }
+
+    [Theory]
+    [InlineData(ConfigurationMutation.MasterDisabled)]
+    [InlineData(ConfigurationMutation.UrlAndKeyChanged)]
+    [InlineData(ConfigurationMutation.RevisionChanged)]
+    public async Task UserStatus_ConfigurationChangesDuringResolutionAwait_DoesNotStartCapabilityOrPublishLinkedState(
+        ConfigurationMutation mutation)
+    {
+        var user = new User("status-resolution-user", "provider", "password-provider");
+        var config = new PluginConfiguration
+        {
+            SeerrEnabled = true,
+            SeerrUrls = "http://seerr:5055",
+            SeerrApiKey = "retained-key",
+        };
+        var provider = new FakePluginConfigProvider(config);
+        var seerr = new BlockingSeerrClient(
+            new SeerrUser
+            {
+                Id = 43,
+                JellyfinUserId = user.Id.ToString("N"),
+                SourceUrl = "http://seerr:5055",
+            },
+            BlockedStage.Resolution);
+        var controller = BuildController(user, provider, seerr);
+
+        var pending = controller.GetSeerrUserStatus();
+        await seerr.ResolutionStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Mutate(provider, config, mutation);
+        seerr.ReleaseResolution();
+        var result = Assert.IsType<OkObjectResult>(await pending);
+
+        AssertInactive(result);
+        Assert.Equal(1, seerr.ResolutionCalls);
+        Assert.Equal(0, seerr.CapabilityCalls);
+    }
+
+    private static void AssertInactive(OkObjectResult result)
+    {
+        Assert.False(Read<bool>(result.Value, "active"));
+        Assert.False(Read<bool>(result.Value, "userFound"));
+        Assert.Equal("disabled", Read<string>(result.Value, "reason"));
+        Assert.Null(result.Value?.GetType().GetProperty("seerrUserId"));
+        Assert.Null(result.Value?.GetType().GetProperty("movie4kEnabled"));
+        Assert.Null(result.Value?.GetType().GetProperty("series4kEnabled"));
+        Assert.Null(result.Value?.GetType().GetProperty("canRequest4kMovie"));
+        Assert.Null(result.Value?.GetType().GetProperty("canRequest4kTv"));
+    }
+
+    private static void Mutate(
+        FakePluginConfigProvider provider,
+        PluginConfiguration original,
+        ConfigurationMutation mutation)
+    {
+        switch (mutation)
+        {
+            case ConfigurationMutation.MasterDisabled:
+                original.SeerrEnabled = false;
+                break;
+            case ConfigurationMutation.UrlAndKeyChanged:
+                original.SeerrUrls = "http://replacement:5055";
+                original.SeerrApiKey = "replacement-key";
+                break;
+            case ConfigurationMutation.RevisionChanged:
+                provider.Current = new PluginConfiguration
+                {
+                    SeerrEnabled = true,
+                    SeerrUrls = original.SeerrUrls,
+                    SeerrApiKey = original.SeerrApiKey,
+                };
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(mutation));
+        }
+    }
+
+    private static SeerrUserController BuildController(
+        User user,
+        FakePluginConfigProvider provider,
+        ISeerrClient seerr)
+    {
         var users = new StubUserManager(user);
         var factory = new RecordingHttpClientFactory(new RecordingHttpMessageHandler());
-        var controller = new SeerrUserController(
+        return new SeerrUserController(
             factory,
             NullLogger<SeerrUserController>.Instance,
             users,
@@ -55,40 +152,62 @@ public sealed class SeerrUserStatusGenerationFenceTests
                 },
             },
         };
-
-        var result = Assert.IsType<OkObjectResult>(await controller.GetSeerrUserStatus());
-
-        Assert.False(Read<bool>(result.Value, "active"));
-        Assert.False(Read<bool>(result.Value, "userFound"));
-        Assert.Equal("disabled", Read<string>(result.Value, "reason"));
-        Assert.Equal(1, seerr.CapabilityCalls);
-        Assert.Equal("retained-key", config.SeerrApiKey);
     }
 
     private static T Read<T>(object? value, string propertyName)
         => Assert.IsType<T>(value?.GetType().GetProperty(propertyName)?.GetValue(value));
 
-    private sealed class CapabilityCallbackSeerrClient : ISeerrClient
+    public enum ConfigurationMutation
+    {
+        MasterDisabled,
+        UrlAndKeyChanged,
+        RevisionChanged,
+    }
+
+    private enum BlockedStage
+    {
+        Resolution,
+        Capability,
+    }
+
+    private sealed class BlockingSeerrClient : ISeerrClient
     {
         private readonly SeerrUser _user;
-        private readonly Action _capabilityCallback;
+        private readonly BlockedStage _blockedStage;
+        private readonly TaskCompletionSource<bool> _releaseResolution = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<bool> _releaseCapability = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public CapabilityCallbackSeerrClient(SeerrUser user, Action capabilityCallback)
+        public BlockingSeerrClient(
+            SeerrUser user,
+            BlockedStage blockedStage)
         {
             _user = user;
-            _capabilityCallback = capabilityCallback;
+            _blockedStage = blockedStage;
         }
+
+        public TaskCompletionSource<bool> ResolutionStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource<bool> CapabilityStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int ResolutionCalls { get; private set; }
 
         public int CapabilityCalls { get; private set; }
 
-        public Task<SeerrUserResolution> ResolveSeerrUser(
+        public async Task<SeerrUserResolution> ResolveSeerrUser(
             string jellyfinUserId,
             bool bypassCache = false,
             bool allowAutoImport = true,
             CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            return Task.FromResult(SeerrUserResolution.Found(_user));
+            ResolutionCalls++;
+            if (_blockedStage == BlockedStage.Resolution)
+            {
+                ResolutionStarted.TrySetResult(true);
+                await _releaseResolution.Task.WaitAsync(cancellationToken);
+            }
+
+            return SeerrUserResolution.Found(_user);
         }
 
         public Task<SeerrUser?> GetSeerrUser(
@@ -104,14 +223,23 @@ public sealed class SeerrUserStatusGenerationFenceTests
 
         public Task<bool> GetStatusActiveAsync() => Task.FromResult(true);
 
-        public Task<Seerr4kCapability> GetSeerr4kCapabilityAsync(
+        public async Task<Seerr4kCapability> GetSeerr4kCapabilityAsync(
             string jellyfinUserId,
             bool isAdmin = false)
         {
             CapabilityCalls++;
-            _capabilityCallback();
-            return Task.FromResult(new Seerr4kCapability(true, true, true, true));
+            if (_blockedStage == BlockedStage.Capability)
+            {
+                CapabilityStarted.TrySetResult(true);
+                await _releaseCapability.Task;
+            }
+
+            return new Seerr4kCapability(true, true, true, true);
         }
+
+        public void ReleaseResolution() => _releaseResolution.TrySetResult(true);
+
+        public void ReleaseCapability() => _releaseCapability.TrySetResult(true);
 
         public void EvictMediaDetailCache(int tmdbId, string mediaType)
         {

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Helpers/SeerrHttpHelperTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Helpers/SeerrHttpHelperTests.cs
@@ -167,7 +167,12 @@ public class SeerrHttpHelperTests
         using var client = new HttpClient(new StaticResponseHandler(StreamingJsonResponse(stream)));
         using var request = new HttpRequestMessage(HttpMethod.Get, "http://seerr/api");
 
-        var resultTask = SeerrHttpHelper.SendAndReadJsonAsync(client, request, request.RequestUri!.ToString(), cap);
+        var resultTask = SeerrHttpHelper.SendAndReadJsonAsync(
+            client,
+            request,
+            request.RequestUri!.ToString(),
+            cap,
+            SeerrDispatchFenceTestFactory.Create());
         var completed = await Task.WhenAny(resultTask, Task.Delay(TimeSpan.FromSeconds(2)));
 
         Assert.Same(resultTask, completed);
@@ -190,6 +195,7 @@ public class SeerrHttpHelperTests
             request,
             request.RequestUri!.ToString(),
             8,
+            SeerrDispatchFenceTestFactory.Create(),
             cts.Token);
         await stream.ReadStarted.WaitAsync(TimeSpan.FromSeconds(2));
         cts.Cancel();
@@ -212,6 +218,7 @@ public class SeerrHttpHelperTests
             request,
             request.RequestUri!.ToString(),
             8,
+            SeerrDispatchFenceTestFactory.Create(),
             cts.Token);
         await handler.SendStarted.WaitAsync(TimeSpan.FromSeconds(2));
         cts.Cancel();

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Helpers/SeerrPaginationHelperTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Helpers/SeerrPaginationHelperTests.cs
@@ -34,7 +34,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Helpers
                 "key",
                 "7",
                 requestedPageSize: 100,
-                Id);
+                Id,
+                SeerrDispatchFenceTestFactory.Create());
 
             Assert.True(result.IsComplete, result.FailureReason);
             Assert.Equal(21, result.Items.Count);
@@ -66,7 +67,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Helpers
                 "key",
                 apiUserId: null,
                 requestedPageSize: 500,
-                Id);
+                Id,
+                SeerrDispatchFenceTestFactory.Create());
 
             Assert.True(result.IsComplete, result.FailureReason);
             Assert.Equal(21, result.Items.Count);
@@ -102,7 +104,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Helpers
                 "key",
                 apiUserId: null,
                 requestedPageSize: 20,
-                Id);
+                Id,
+                SeerrDispatchFenceTestFactory.Create());
 
             Assert.True(result.IsComplete, result.FailureReason);
             Assert.Equal("http://second", result.SourceUrl);
@@ -132,7 +135,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Helpers
                 "key",
                 apiUserId: null,
                 requestedPageSize: 2,
-                Id);
+                Id,
+                SeerrDispatchFenceTestFactory.Create());
 
             Assert.False(result.IsComplete);
             Assert.Empty(result.Items);
@@ -166,7 +170,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Helpers
                 "key",
                 apiUserId: null,
                 requestedPageSize: 2,
-                Id);
+                Id,
+                SeerrDispatchFenceTestFactory.Create());
 
             Assert.False(result.IsComplete);
             Assert.Empty(result.Items);
@@ -193,7 +198,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Helpers
                 "key",
                 apiUserId: null,
                 requestedPageSize: 3,
-                Id);
+                Id,
+                SeerrDispatchFenceTestFactory.Create());
 
             Assert.False(result.IsComplete);
             Assert.Empty(result.Items);
@@ -219,7 +225,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Helpers
                 "key",
                 apiUserId: null,
                 requestedPageSize: 2,
-                static row => SeerrPaginationHelper.CanonicalPositiveIntegerPropertyIdentity(row, "id"));
+                static row => SeerrPaginationHelper.CanonicalPositiveIntegerPropertyIdentity(row, "id"),
+                SeerrDispatchFenceTestFactory.Create());
 
             Assert.False(result.IsComplete);
             Assert.Empty(result.Items);
@@ -249,7 +256,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Helpers
                 "key",
                 apiUserId: null,
                 requestedPageSize: 1,
-                static row => SeerrPaginationHelper.CanonicalPositiveIntegerPropertyIdentity(row, "id"));
+                static row => SeerrPaginationHelper.CanonicalPositiveIntegerPropertyIdentity(row, "id"),
+                SeerrDispatchFenceTestFactory.Create());
 
             Assert.False(result.IsComplete);
             Assert.Empty(result.Items);
@@ -275,7 +283,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Helpers
                 "key",
                 apiUserId: null,
                 requestedPageSize: 1,
-                Id);
+                Id,
+                SeerrDispatchFenceTestFactory.Create());
 
             Assert.False(result.IsComplete);
             Assert.Empty(result.Items);
@@ -301,7 +310,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Helpers
                 "key",
                 apiUserId: null,
                 requestedPageSize: 1,
-                Id);
+                Id,
+                SeerrDispatchFenceTestFactory.Create());
 
             Assert.False(result.IsComplete);
             Assert.Empty(result.Items);
@@ -328,7 +338,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Helpers
                 "key",
                 apiUserId: null,
                 requestedPageSize: 1,
-                Id);
+                Id,
+                SeerrDispatchFenceTestFactory.Create());
 
             Assert.False(result.IsComplete);
             Assert.Empty(result.Items);
@@ -355,7 +366,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Helpers
                 "key",
                 apiUserId: null,
                 requestedPageSize: 2,
-                Id);
+                Id,
+                SeerrDispatchFenceTestFactory.Create());
 
             Assert.False(result.IsComplete);
             Assert.Empty(result.Items);
@@ -381,7 +393,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Helpers
                 "key",
                 apiUserId: null,
                 requestedPageSize: 1,
-                Id);
+                Id,
+                SeerrDispatchFenceTestFactory.Create());
 
             Assert.False(result.IsComplete);
             Assert.Empty(result.Items);
@@ -402,7 +415,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Helpers
                 "key",
                 apiUserId: null,
                 requestedPageSize: 1000,
-                Id);
+                Id,
+                SeerrDispatchFenceTestFactory.Create());
 
             Assert.False(result.IsComplete);
             Assert.Empty(result.Items);
@@ -432,7 +446,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Helpers
                 "key",
                 apiUserId: null,
                 requestedPageSize: 1,
-                Id);
+                Id,
+                SeerrDispatchFenceTestFactory.Create());
 
             Assert.False(result.IsComplete);
             Assert.Empty(result.Items);
@@ -457,7 +472,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Helpers
                 "key",
                 apiUserId: null,
                 requestedPageSize: 1,
-                Id);
+                Id,
+                SeerrDispatchFenceTestFactory.Create());
 
             Assert.False(result.IsComplete);
             Assert.Empty(result.Items);
@@ -483,7 +499,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Helpers
                 "key",
                 apiUserId: null,
                 requestedPageSize: 2,
-                Id);
+                Id,
+                SeerrDispatchFenceTestFactory.Create());
 
             Assert.False(result.IsComplete);
             Assert.Empty(result.Items);
@@ -510,7 +527,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Helpers
                 "key",
                 apiUserId: null,
                 requestedPageSize: 1,
-                Id);
+                Id,
+                SeerrDispatchFenceTestFactory.Create());
 
             Assert.False(result.IsComplete);
             Assert.Empty(result.Items);
@@ -543,6 +561,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Helpers
                         cancellation.Cancel();
                         return Id(item);
                     },
+                    SeerrDispatchFenceTestFactory.Create(),
                     cancellation.Token));
         }
 
@@ -559,11 +578,172 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Helpers
                 "key",
                 apiUserId: null,
                 requestedPageSize: 1,
-                Id);
+                Id,
+                SeerrDispatchFenceTestFactory.Create());
 
             Assert.False(result.IsComplete);
             Assert.Empty(result.Items);
             Assert.Contains("root", result.FailureReason, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task DispatchFenceClosesAfterFirstPage_DoesNotSendContinuationPage()
+        {
+            var allowed = true;
+            var handler = new RoutingHandler(uri =>
+            {
+                allowed = false;
+                return Json(new
+                {
+                    page = QueryInt(uri, "page"),
+                    totalPages = 2,
+                    totalResults = 2,
+                    results = new[] { new { id = 1 } },
+                });
+            });
+            using var client = new HttpClient(handler);
+
+            var result = await SeerrPaginationHelper.FetchAllAsync(
+                client,
+                new[] { "http://seerr" },
+                static (url, page, _) => $"{url}/items?page={page}",
+                "key",
+                apiUserId: null,
+                requestedPageSize: 1,
+                Id,
+                dispatchFence: SeerrDispatchFenceTestFactory.Create(() => allowed));
+
+            Assert.False(result.IsComplete);
+            Assert.Empty(result.Items);
+            Assert.Contains("configuration changed", result.FailureReason, StringComparison.OrdinalIgnoreCase);
+            Assert.Single(handler.Requests);
+        }
+
+        [Fact]
+        public async Task DispatchFenceClosesAfterFirstScan_DoesNotSendConfirmationScan()
+        {
+            var allowed = true;
+            var handler = new RoutingHandler(_ =>
+            {
+                allowed = false;
+                return Json(new
+                {
+                    page = 1,
+                    totalPages = 1,
+                    totalResults = 1,
+                    results = new[] { new { id = 1 } },
+                });
+            });
+            using var client = new HttpClient(handler);
+
+            var result = await SeerrPaginationHelper.FetchAllAsync(
+                client,
+                new[] { "http://seerr" },
+                static (url, page, _) => $"{url}/items?page={page}",
+                "key",
+                apiUserId: null,
+                requestedPageSize: 1,
+                Id,
+                dispatchFence: SeerrDispatchFenceTestFactory.Create(() => allowed));
+
+            Assert.False(result.IsComplete);
+            Assert.Single(handler.Requests);
+        }
+
+        [Fact]
+        public async Task DispatchFenceClosesAfterFailedReplica_DoesNotSendFailoverReplica()
+        {
+            var allowed = true;
+            var handler = new RoutingHandler(_ =>
+            {
+                allowed = false;
+                return Json(new { error = true }, HttpStatusCode.BadGateway);
+            });
+            using var client = new HttpClient(handler);
+
+            var result = await SeerrPaginationHelper.FetchAllAsync(
+                client,
+                new[] { "http://first", "http://second" },
+                static (url, page, _) => $"{url}/items?page={page}",
+                "key",
+                apiUserId: null,
+                requestedPageSize: 1,
+                Id,
+                dispatchFence: SeerrDispatchFenceTestFactory.Create(() => allowed));
+
+            Assert.False(result.IsComplete);
+            var request = Assert.Single(handler.Requests);
+            Assert.Equal("first", request.Host);
+        }
+
+        [Fact]
+        public async Task DispatchFenceClosesAfterStableFirstSource_DoesNotSendNextIdentityDomain()
+        {
+            var firstSourceRequests = 0;
+            var allowed = true;
+            var handler = new RoutingHandler(uri =>
+            {
+                if (uri.Host == "first" && ++firstSourceRequests == 2)
+                {
+                    allowed = false;
+                }
+
+                return Json(new
+                {
+                    page = 1,
+                    totalPages = 1,
+                    totalResults = 1,
+                    results = new[] { new { id = 1 } },
+                });
+            });
+            using var client = new HttpClient(handler);
+
+            var result = await SeerrPaginationHelper.FetchAllSourcesAsync(
+                client,
+                new[] { "http://first", "http://second" },
+                static (url, page, _) => $"{url}/items?page={page}",
+                "key",
+                apiUserId: null,
+                requestedPageSize: 1,
+                Id,
+                dispatchFence: SeerrDispatchFenceTestFactory.Create(() => allowed));
+
+            Assert.False(result.IsComplete);
+            Assert.Equal(2, handler.Requests.Count);
+            Assert.All(handler.Requests, request => Assert.Equal("first", request.Host));
+        }
+
+        [Fact]
+        public async Task DispatchFenceThrowsAfterFirstResponse_FailsClosedWithoutLaterSend()
+        {
+            var throwOnCheck = false;
+            var handler = new RoutingHandler(_ =>
+            {
+                throwOnCheck = true;
+                return Json(new
+                {
+                    page = 1,
+                    totalPages = 2,
+                    totalResults = 2,
+                    results = new[] { new { id = 1 } },
+                });
+            });
+            using var client = new HttpClient(handler);
+
+            var result = await SeerrPaginationHelper.FetchAllAsync(
+                client,
+                new[] { "http://seerr" },
+                static (url, page, _) => $"{url}/items?page={page}",
+                "key",
+                apiUserId: null,
+                requestedPageSize: 1,
+                Id,
+                dispatchFence: SeerrDispatchFenceTestFactory.Create(() => throwOnCheck
+                    ? throw new InvalidOperationException("provider failed")
+                    : true));
+
+            Assert.False(result.IsComplete);
+            Assert.Single(handler.Requests);
         }
 
         private static string? Id(JsonElement item)

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Helpers/SeerrUserImportHelperTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Helpers/SeerrUserImportHelperTests.cs
@@ -272,6 +272,7 @@ public sealed class SeerrUserImportHelperTests
     public async Task BulkImport_DispatchAuthorizationChangesAfterStableProof_SendsNoMutation()
     {
         var handler = WithEmptyPreflight(_ => Json(new[] { new { id = 99 } }));
+        var authorizationChecks = 0;
 
         var result = await SeerrUserImportHelper.BulkImportAsync(
             UserIds,
@@ -279,10 +280,12 @@ public sealed class SeerrUserImportHelperTests
             "test-key",
             new ImportHttpClientFactory(handler),
             NullLogger.Instance,
-            CancellationToken.None,
-            canDispatch: static () => false);
+            SeerrDispatchFenceTestFactory.Create(
+                () => Interlocked.Increment(ref authorizationChecks) < 23),
+            CancellationToken.None);
 
         Assert.False(result.Succeeded);
+        Assert.Equal(23, authorizationChecks);
         Assert.Equal(4, Gets(handler).Count());
         Assert.Empty(Posts(handler));
         Assert.Contains(
@@ -354,6 +357,7 @@ public sealed class SeerrUserImportHelperTests
             "test-key",
             new ImportHttpClientFactory(handler),
             NullLogger.Instance,
+            SeerrDispatchFenceTestFactory.Create(),
             cancellationToken);
 
     private static object UserRow(int id, string jellyfinUserId) => new

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/ScheduledTasks/SeerrScheduledTaskPaginationTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/ScheduledTasks/SeerrScheduledTaskPaginationTests.cs
@@ -27,11 +27,13 @@ public sealed class SeerrScheduledTaskPaginationTests
                 client,
                 new[] { "http://first", "http://second" },
                 "key",
+                SeerrDispatchFenceTestFactory.Create(),
                 token),
             static (client, token) => JellyfinToSeerrWatchlistSyncTask.FetchSeerrUserMapSnapshotsAsync(
                 client,
                 new[] { "http://first", "http://second" },
                 "key",
+                SeerrDispatchFenceTestFactory.Create(),
                 token),
         };
 
@@ -76,6 +78,7 @@ public sealed class SeerrScheduledTaskPaginationTests
             client,
             new[] { "http://first" },
             "key",
+            SeerrDispatchFenceTestFactory.Create(),
             CancellationToken.None);
 
         Assert.True(snapshots.IsComplete, snapshots.FailureReason);
@@ -91,11 +94,13 @@ public sealed class SeerrScheduledTaskPaginationTests
                 client,
                 new[] { "http://first", "http://second" },
                 "key",
+                SeerrDispatchFenceTestFactory.Create(),
                 token),
             static (client, token) => JellyfinToSeerrWatchlistSyncTask.FetchSeerrUserMapSnapshotsAsync(
                 client,
                 new[] { "http://first", "http://second" },
                 "key",
+                SeerrDispatchFenceTestFactory.Create(),
                 token),
         };
 
@@ -201,6 +206,189 @@ public sealed class SeerrScheduledTaskPaginationTests
         Assert.Equal(
             new[] { "first", "first", "second", "second", "first", "first", "second" },
             handler.Requests.Select(request => request.Uri.Host));
+    }
+
+    [Fact]
+    public async Task JellyfinToSeerrTask_DisabledDuringFirstWatchlistSend_DoesNotDispatchLaterTraffic()
+    {
+        var user = new User("generation-user", "provider", "password-provider");
+        var provider = new FakePluginConfigProvider(OutboundConfig());
+        var watchlistStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseWatchlist = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handler = new AsyncRequestRoutingHandler(async (request, cancellationToken) =>
+        {
+            var uri = request.RequestUri!;
+            if (uri.AbsolutePath == "/api/v1/user")
+            {
+                return UserMap(user, 7);
+            }
+
+            if (uri.AbsolutePath == "/api/v1/user/7/watchlist")
+            {
+                watchlistStarted.TrySetResult();
+                await releaseWatchlist.Task.WaitAsync(cancellationToken);
+                return EmptyWatchlist();
+            }
+
+            if (request.Method == HttpMethod.Post)
+            {
+                return Json(new { id = 1 });
+            }
+
+            throw new Xunit.Sdk.XunitException($"Unexpected request {request.Method} {uri}.");
+        });
+        var task = CreateOutboundTask(
+            user,
+            new[] { MovieWithTmdbId("Generation movie", "101") },
+            handler,
+            provider);
+
+        var executeTask = task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
+        await watchlistStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        provider.Current!.SeerrEnabled = false;
+        releaseWatchlist.TrySetResult();
+
+        await executeTask.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Single(handler.Requests, request =>
+            request.Uri.AbsolutePath == "/api/v1/user/7/watchlist");
+        Assert.DoesNotContain(handler.Requests, request => request.Method == HttpMethod.Post);
+    }
+
+    [Fact]
+    public async Task SeerrToJellyfinTask_DisabledDuringFirstWatchlistSend_DoesNotDispatchRequestCollection()
+    {
+        var user = new User("generation-user", "provider", "password-provider");
+        var provider = new FakePluginConfigProvider(new PluginConfiguration
+        {
+            SeerrEnabled = true,
+            SyncSeerrWatchlist = true,
+            AddRequestedMediaToWatchlist = true,
+            SeerrUrls = "http://only",
+            SeerrApiKey = "key",
+        });
+        var watchlistStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseWatchlist = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handler = new AsyncRequestRoutingHandler(async (request, cancellationToken) =>
+        {
+            var uri = request.RequestUri!;
+            if (uri.AbsolutePath == "/api/v1/user")
+            {
+                return UserMap(user, 7);
+            }
+
+            if (uri.AbsolutePath == "/api/v1/user/7/watchlist")
+            {
+                watchlistStarted.TrySetResult();
+                await releaseWatchlist.Task.WaitAsync(cancellationToken);
+                return EmptyWatchlist();
+            }
+
+            if (uri.AbsolutePath == "/api/v1/request")
+            {
+                return Json(new
+                {
+                    results = Array.Empty<object>(),
+                    pageInfo = new { page = 1, pages = 1, results = 0 },
+                });
+            }
+
+            throw new Xunit.Sdk.XunitException($"Unexpected request {request.Method} {uri}.");
+        });
+        var task = new SeerrWatchlistSyncTask(
+            new CountingLibraryManager(),
+            new StubUserManager(user),
+            new StubUserDataManager(),
+            new RecordingHttpClientFactory(handler),
+            userConfigurationManager: null!,
+            NullLogger<SeerrWatchlistSyncTask>.Instance,
+            provider);
+
+        var executeTask = task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
+        await watchlistStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        provider.Current!.SeerrEnabled = false;
+        releaseWatchlist.TrySetResult();
+
+        await executeTask.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Single(handler.Requests, request =>
+            request.Uri.AbsolutePath == "/api/v1/user/7/watchlist");
+        Assert.DoesNotContain(handler.Requests, request =>
+            request.Uri.AbsolutePath == "/api/v1/request");
+    }
+
+    [Fact]
+    public async Task SeerrToJellyfinTask_DisabledByFirstLocalSave_StopsRemainingItemMutations()
+    {
+        var user = new User("commit-generation-user", "provider", "password-provider");
+        var firstMovie = MovieWithTmdbId("First commit movie", "601");
+        var secondMovie = MovieWithTmdbId("Second commit movie", "602");
+        var handler = new RequestRoutingHandler(request =>
+        {
+            var uri = request.RequestUri!;
+            if (uri.AbsolutePath == "/api/v1/user")
+            {
+                return UserMap(user, 7);
+            }
+
+            if (uri.AbsolutePath == "/api/v1/user/7/watchlist")
+            {
+                return Json(new
+                {
+                    page = 1,
+                    totalPages = 1,
+                    totalResults = 2,
+                    results = new[]
+                    {
+                        new { tmdbId = 601, mediaType = "movie", title = "First commit movie" },
+                        new { tmdbId = 602, mediaType = "movie", title = "Second commit movie" },
+                    },
+                });
+            }
+
+            throw new Xunit.Sdk.XunitException($"Unexpected request {request.Method} {uri}.");
+        });
+        var provider = new FakePluginConfigProvider(new PluginConfiguration
+        {
+            SeerrEnabled = true,
+            SyncSeerrWatchlist = true,
+            AddRequestedMediaToWatchlist = false,
+            PreventWatchlistReAddition = false,
+            SeerrUrls = "http://only",
+            SeerrApiKey = "key",
+        });
+        var saveCalls = 0;
+        var userData = new StubUserDataManager
+        {
+            GetUserDataHook = (_, item) => new UserItemData
+            {
+                Key = item.Id.ToString("N"),
+                Likes = false,
+            },
+            SaveUserDataHook = (_, _, _, _, _) =>
+            {
+                if (Interlocked.Increment(ref saveCalls) == 1)
+                {
+                    provider.Current!.SeerrEnabled = false;
+                }
+            },
+        };
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = _ => new BaseItem[] { firstMovie, secondMovie },
+        };
+        var task = new SeerrWatchlistSyncTask(
+            library,
+            new StubUserManager(user),
+            userData,
+            new RecordingHttpClientFactory(handler),
+            userConfigurationManager: null!,
+            NullLogger<SeerrWatchlistSyncTask>.Instance,
+            provider);
+
+        await task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
+
+        Assert.Equal(1, Volatile.Read(ref saveCalls));
     }
 
     [Theory]
@@ -504,12 +692,14 @@ public sealed class SeerrScheduledTaskPaginationTests
                 "http://seerr",
                 "7",
                 "key",
+                SeerrDispatchFenceTestFactory.Create(),
                 token),
             static (client, token) => JellyfinToSeerrWatchlistSyncTask.FetchSeerrWatchlistSnapshotAsync(
                 client,
                 "http://seerr",
                 "7",
                 "key",
+                SeerrDispatchFenceTestFactory.Create(),
                 token),
         };
 
@@ -560,6 +750,7 @@ public sealed class SeerrScheduledTaskPaginationTests
             "http://seerr",
             "7",
             "key",
+            SeerrDispatchFenceTestFactory.Create(),
             CancellationToken.None);
 
         Assert.True(result.IsComplete, result.FailureReason);
@@ -595,6 +786,7 @@ public sealed class SeerrScheduledTaskPaginationTests
             client,
             new[] { "http://first", "http://second" },
             "key",
+            SeerrDispatchFenceTestFactory.Create(),
             CancellationToken.None);
 
         Assert.True(result.IsComplete, result.FailureReason);
@@ -619,6 +811,7 @@ public sealed class SeerrScheduledTaskPaginationTests
                 "http://seerr",
                 "7",
                 "key",
+                SeerrDispatchFenceTestFactory.Create(),
                 cts.Token));
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
             JellyfinToSeerrWatchlistSyncTask.FetchSeerrWatchlistSnapshotAsync(
@@ -626,6 +819,7 @@ public sealed class SeerrScheduledTaskPaginationTests
                 "http://seerr",
                 "7",
                 "key",
+                SeerrDispatchFenceTestFactory.Create(),
                 cts.Token));
         Assert.Empty(handler.Requests);
     }
@@ -805,6 +999,26 @@ public sealed class SeerrScheduledTaskPaginationTests
             cancellationToken.ThrowIfCancellationRequested();
             Requests.Add(new CapturedRequest(request.Method, request.RequestUri!));
             return Task.FromResult(_route(request));
+        }
+    }
+
+    private sealed class AsyncRequestRoutingHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _route;
+
+        public AsyncRequestRoutingHandler(
+            Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> route)
+            => _route = route;
+
+        public List<CapturedRequest> Requests { get; } = new();
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Requests.Add(new CapturedRequest(request.Method, request.RequestUri!));
+            return _route(request, cancellationToken);
         }
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/SeerrDispatchFenceTestFactory.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/SeerrDispatchFenceTestFactory.cs
@@ -1,0 +1,26 @@
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests;
+
+internal static class SeerrDispatchFenceTestFactory
+{
+    private const string DefaultTestUrls =
+        "http://seerr,http://seerr:5055,http://first,http://first:5055," +
+        "http://second,http://second:5055,http://only,http://removed:5055," +
+        "http://source-a:5055,http://source-b:5055";
+
+    public static SeerrDispatchFence Create(Func<bool>? restriction = null)
+    {
+        var provider = new FakePluginConfigProvider(new PluginConfiguration
+        {
+            SeerrEnabled = true,
+            SeerrUrls = DefaultTestUrls,
+            SeerrApiKey = "key",
+        });
+        var integration = SeerrIntegrationPolicy.Capture(provider);
+        var fence = integration.CreateDispatchFence(provider);
+        return restriction == null ? fence : fence.Restrict(restriction);
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/SeerrPolicyAliases.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/SeerrPolicyAliases.cs
@@ -1,0 +1,2 @@
+global using SeerrDispatchFence = Jellyfin.Plugin.JellyfinCanopy.Services.Seerr.SeerrIntegrationPolicy.SeerrDispatchFence;
+global using SeerrIntegrationSnapshot = Jellyfin.Plugin.JellyfinCanopy.Services.Seerr.SeerrIntegrationPolicy.SeerrIntegrationSnapshot;

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/AutoRequestSourceAffinityTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/AutoRequestSourceAffinityTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr;
 using Jellyfin.Plugin.JellyfinCanopy.Model.Seerr;
 using Jellyfin.Plugin.JellyfinCanopy.Services;
 using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
@@ -98,6 +99,38 @@ public sealed class AutoRequestSourceAffinityTests
     }
 
     [Fact]
+    public async Task AutoMovie_MasterDisabledDuringTmdbAwait_DoesNotStartLaterSeerrRead()
+    {
+        var handler = new BlockingTmdbPrerequisiteHandler();
+        var user = CreateUser("movie-live-disable");
+        var binding = BoundUser(user, 72, SourceB);
+        var config = CreateConfiguration();
+        var provider = new FakePluginConfigProvider(config);
+        var service = new AutoMovieRequestService(
+            new RecordingHttpClientFactory(handler),
+            NullLogger<AutoMovieRequestService>.Instance,
+            new StubUserManager(user),
+            null!,
+            provider,
+            new SequencedSeerrClient(SeerrUserResolution.Found(binding)),
+            new RecordingParentalFilter());
+        var movie = new Movie { Name = "Current Movie" };
+        movie.ProviderIds["Tmdb"] = "100";
+
+        var check = service.CheckMovieForCollectionRequestAsync(movie, user.Id);
+        await handler.TmdbRequestStarted.WaitAsync(TimeSpan.FromSeconds(5));
+
+        config.SeerrEnabled = false;
+        handler.ReleaseTmdbRequest();
+
+        await check;
+
+        Assert.DoesNotContain(
+            handler.Sent,
+            request => request.Authority.StartsWith("source-", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task AutoSeason_BBoundUserReadsStatusAndMutatesOnlyB()
     {
         var handler = new AutoRequestRoutingHandler();
@@ -146,6 +179,53 @@ public sealed class AutoRequestSourceAffinityTests
             user);
 
         Assert.Equal(1, seerrClient.ResolveCalls);
+        Assert.Empty(handler.Sent);
+    }
+
+    [Fact]
+    public async Task AutoSeason_MasterDisabledDuringPrecedingAwait_DoesNotStartStatusRead()
+    {
+        var handler = new AutoRequestRoutingHandler();
+        var config = CreateConfiguration();
+        var provider = new FakePluginConfigProvider(config);
+        var service = new AutoSeasonRequestService(
+            new RecordingHttpClientFactory(handler),
+            NullLogger<AutoSeasonRequestService>.Instance,
+            null!,
+            null!,
+            null!,
+            provider,
+            new SequencedSeerrClient(SeerrUserResolution.NotFound()),
+            new RecordingParentalFilter());
+        var stamp = SeerrMutationConfigStamp.Capture(
+            config,
+            provider.ConfigurationRevision);
+        var predecessorStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releasePredecessor = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var method = typeof(AutoSeasonRequestService).GetMethod(
+            "GetSeasonStatusFromSeerr",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        async Task InvokeAfterPredecessorAsync()
+        {
+            predecessorStarted.TrySetResult();
+            await releasePredecessor.Task;
+            var statusRead = Assert.IsAssignableFrom<Task>(method!.Invoke(
+                service,
+                new object[] { "500", 2, SourceB, config, stamp }));
+            await statusRead;
+        }
+
+        var statusFlight = InvokeAfterPredecessorAsync();
+        await predecessorStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        config.SeerrEnabled = false;
+        releasePredecessor.TrySetResult();
+
+        await statusFlight;
+
         Assert.Empty(handler.Sent);
     }
 
@@ -897,6 +977,55 @@ public sealed class AutoRequestSourceAffinityTests
         }
 
         private static HttpResponseMessage Json(string body, HttpStatusCode statusCode = HttpStatusCode.OK)
+            => new(statusCode)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            };
+    }
+
+    private sealed class BlockingTmdbPrerequisiteHandler : HttpMessageHandler
+    {
+        private readonly TaskCompletionSource _tmdbRequestStarted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _releaseTmdbRequest =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task TmdbRequestStarted => _tmdbRequestStarted.Task;
+
+        public List<CapturedRequest> Sent { get; } = new();
+
+        public void ReleaseTmdbRequest() => _releaseTmdbRequest.TrySetResult();
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var uri = request.RequestUri!;
+            Sent.Add(new CapturedRequest(
+                request.Method,
+                uri.Authority,
+                uri.AbsolutePath,
+                null,
+                string.Empty));
+
+            if (uri.Host == "api.themoviedb.org" && uri.AbsolutePath == "/3/movie/100")
+            {
+                _tmdbRequestStarted.TrySetResult();
+                await _releaseTmdbRequest.Task.WaitAsync(cancellationToken);
+                return Json("{\"belongs_to_collection\":{\"id\":900,\"name\":\"Collection\"}}");
+            }
+
+            if (uri.Host is "source-a" or "source-b")
+            {
+                return Json("{\"parts\":[]}");
+            }
+
+            return Json("{}", HttpStatusCode.NotFound);
+        }
+
+        private static HttpResponseMessage Json(
+            string body,
+            HttpStatusCode statusCode = HttpStatusCode.OK)
             => new(statusCode)
             {
                 Content = new StringContent(body, Encoding.UTF8, "application/json"),

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/AvatarFetchServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/AvatarFetchServiceTests.cs
@@ -173,12 +173,37 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
         }
 
         [Fact]
+        public async Task MasterDisabledWithRetainedCredentials_DoesNotServeCachedAvatarOrCallUpstream()
+        {
+            var handler = new SwitchableHandler();
+            var (_, cache, service, provider) = CreateWithService(handler);
+            var fresh = await service.GetAsync(
+                "retained-avatar",
+                "http://seerr/avatar/a.png",
+                () => true,
+                CancellationToken.None);
+            Assert.Equal(AvatarFetchStatus.Available, fresh.Status);
+            Assert.Single(cache.AvatarCache);
+            Assert.Equal(1, handler.Calls);
+
+            provider.Current!.SeerrEnabled = false;
+            var disabled = await service.GetAsync(
+                "retained-avatar",
+                "http://seerr/avatar/a.png",
+                () => true,
+                CancellationToken.None);
+
+            Assert.Equal(AvatarFetchStatus.ConfigurationChanged, disabled.Status);
+            Assert.Equal(1, handler.Calls);
+        }
+
+        [Fact]
         public async Task HighCardinality_StaysWithinEntryAndByteBudgets()
         {
             var handler = new DelegateHandler((_, _) => Task.FromResult(ImageResponse(
                 new MemoryStream(ValidPng, writable: false),
                 "image/png")));
-            var (_, cache, service) = CreateWithService(handler);
+            var (_, cache, service, _) = CreateWithService(handler);
 
             for (var i = 0; i < 200; i++)
             {
@@ -199,7 +224,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             TimeProvider? timeProvider = null,
             long maximumAvatarBytes = AvatarFetchService.DefaultMaximumAvatarBytes)
         {
-            var (_, cache, service) = CreateWithService(handler, timeProvider, maximumAvatarBytes);
+            var (_, cache, service, _) = CreateWithService(handler, timeProvider, maximumAvatarBytes);
             return (service, cache);
         }
 
@@ -214,21 +239,31 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             Assert.Equal(0, service.InFlightCount);
         }
 
-        private static (RecordingHttpClientFactory Factory, SeerrCache Cache, AvatarFetchService Service) CreateWithService(
+        private static (
+            RecordingHttpClientFactory Factory,
+            SeerrCache Cache,
+            AvatarFetchService Service,
+            FakePluginConfigProvider Provider) CreateWithService(
             HttpMessageHandler handler,
             TimeProvider? timeProvider = null,
             long maximumAvatarBytes = AvatarFetchService.DefaultMaximumAvatarBytes)
         {
-            var provider = new FakePluginConfigProvider(new PluginConfiguration());
+            var provider = new FakePluginConfigProvider(new PluginConfiguration
+            {
+                SeerrEnabled = true,
+                SeerrUrls = "http://seerr",
+                SeerrApiKey = "key",
+            });
             var cache = new SeerrCache(provider);
             var factory = new RecordingHttpClientFactory(handler);
             var service = new AvatarFetchService(
                 factory,
                 cache,
+                provider,
                 NullLogger<AvatarFetchService>.Instance,
                 timeProvider ?? TimeProvider.System,
                 maximumAvatarBytes);
-            return (factory, cache, service);
+            return (factory, cache, service, provider);
         }
 
         private static HttpResponseMessage ImageResponse(Stream stream, string contentType)

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/AvatarFetchServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/AvatarFetchServiceTests.cs
@@ -20,9 +20,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             ValidPng.CopyTo(bytes, 0);
             var stream = new CountingReadStream(bytes);
             var handler = new DelegateHandler((_, _) => Task.FromResult(ImageResponse(stream, "image/png")));
-            var (service, cache) = Create(handler, maximumAvatarBytes: cap);
+            var (service, cache, fence) = Create(handler, maximumAvatarBytes: cap);
 
-            var result = await service.GetAsync("avatar", "http://seerr/avatar/a.png", () => true, CancellationToken.None);
+            var result = await service.GetAsync("avatar", "http://seerr/avatar/a.png", fence, CancellationToken.None);
 
             Assert.Equal(AvatarFetchStatus.Missing, result.Status);
             Assert.Equal(cap + 1, stream.BytesRead);
@@ -33,13 +33,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
         public async Task OneHundredConcurrentColdMisses_InvokeUpstreamOnce()
         {
             var handler = new BlockingSuccessHandler();
-            var (service, cache) = Create(handler);
+            var (service, cache, fence) = Create(handler);
 
             var calls = Enumerable.Range(0, 100)
                 .Select(_ => service.GetAsync(
                     "same-avatar",
                     "http://seerr/avatar/a.png",
-                    () => true,
+                    fence,
                     CancellationToken.None))
                 .ToArray();
             await handler.Started.WaitAsync(TimeSpan.FromSeconds(5));
@@ -59,19 +59,19 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
         public async Task LeaderCancellation_DoesNotFailLiveFollowerOrRestartUpstream()
         {
             var handler = new BlockingSuccessHandler();
-            var (service, cache) = Create(handler);
+            var (service, cache, fence) = Create(handler);
             using var leaderCancellation = new CancellationTokenSource();
 
             var leader = service.GetAsync(
                 "shared-avatar",
                 "http://seerr/avatar/a.png",
-                () => true,
+                fence,
                 leaderCancellation.Token);
             await handler.Started.WaitAsync(TimeSpan.FromSeconds(5));
             var follower = service.GetAsync(
                 "shared-avatar",
                 "http://seerr/avatar/a.png",
-                () => true,
+                fence,
                 CancellationToken.None);
 
             leaderCancellation.Cancel();
@@ -94,13 +94,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
         {
             var stream = new CancellationObservingStream();
             var handler = new DelegateHandler((_, _) => Task.FromResult(ImageResponse(stream, "image/png")));
-            var (service, cache) = Create(handler);
+            var (service, cache, fence) = Create(handler);
             using var cancellation = new CancellationTokenSource();
 
             var fetch = service.GetAsync(
                 "cancelled-avatar",
                 "http://seerr/avatar/a.png",
-                () => true,
+                fence,
                 cancellation.Token);
             await stream.ReadStarted.WaitAsync(TimeSpan.FromSeconds(5));
             cancellation.Cancel();
@@ -117,9 +117,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             var handler = new DelegateHandler((_, _) => Task.FromResult(ImageResponse(
                 new MemoryStream("<html>not an image</html>"u8.ToArray()),
                 "image/png")));
-            var (service, cache) = Create(handler);
+            var (service, cache, fence) = Create(handler);
 
-            var result = await service.GetAsync("invalid", "http://seerr/avatar/a.png", () => true, CancellationToken.None);
+            var result = await service.GetAsync("invalid", "http://seerr/avatar/a.png", fence, CancellationToken.None);
 
             Assert.Equal(AvatarFetchStatus.Missing, result.Status);
             Assert.Empty(cache.AvatarCache);
@@ -131,22 +131,22 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
         {
             var clock = new ManualTimeProvider(new DateTimeOffset(2026, 7, 15, 0, 0, 0, TimeSpan.Zero));
             var handler = new CountingStatusHandler(HttpStatusCode.NotFound);
-            var (service, _) = Create(handler, clock);
+            var (service, _, fence) = Create(handler, clock);
 
             var first = await Task.WhenAll(Enumerable.Range(0, 100)
-                .Select(_ => service.GetAsync("missing", "http://seerr/avatar/missing.png", () => true, CancellationToken.None)));
+                .Select(_ => service.GetAsync("missing", "http://seerr/avatar/missing.png", fence, CancellationToken.None)));
             Assert.All(first, result => Assert.Equal(AvatarFetchStatus.Missing, result.Status));
             Assert.Equal(1, handler.Calls);
 
             clock.Advance(TimeSpan.FromSeconds(14));
             Assert.Equal(
                 AvatarFetchStatus.Missing,
-                (await service.GetAsync("missing", "http://seerr/avatar/missing.png", () => true, CancellationToken.None)).Status);
+                (await service.GetAsync("missing", "http://seerr/avatar/missing.png", fence, CancellationToken.None)).Status);
             Assert.Equal(1, handler.Calls);
 
             clock.Advance(TimeSpan.FromSeconds(1));
             await Task.WhenAll(Enumerable.Range(0, 100)
-                .Select(_ => service.GetAsync("missing", "http://seerr/avatar/missing.png", () => true, CancellationToken.None)));
+                .Select(_ => service.GetAsync("missing", "http://seerr/avatar/missing.png", fence, CancellationToken.None)));
             Assert.Equal(2, handler.Calls);
         }
 
@@ -155,15 +155,15 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
         {
             var clock = new ManualTimeProvider(new DateTimeOffset(2026, 7, 15, 0, 0, 0, TimeSpan.Zero));
             var handler = new SwitchableHandler();
-            var (service, cache) = Create(handler, clock);
+            var (service, cache, fence) = Create(handler, clock);
 
-            var fresh = await service.GetAsync("last-good", "http://seerr/avatar/a.png", () => true, CancellationToken.None);
+            var fresh = await service.GetAsync("last-good", "http://seerr/avatar/a.png", fence, CancellationToken.None);
             Assert.Equal(AvatarFetchStatus.Available, fresh.Status);
             clock.Advance(TimeSpan.FromHours(2));
             handler.Status = HttpStatusCode.ServiceUnavailable;
 
-            var duringFailure = await service.GetAsync("last-good", "http://seerr/avatar/a.png", () => true, CancellationToken.None);
-            var duringBackoff = await service.GetAsync("last-good", "http://seerr/avatar/a.png", () => true, CancellationToken.None);
+            var duringFailure = await service.GetAsync("last-good", "http://seerr/avatar/a.png", fence, CancellationToken.None);
+            var duringBackoff = await service.GetAsync("last-good", "http://seerr/avatar/a.png", fence, CancellationToken.None);
 
             Assert.Equal(AvatarFetchStatus.Available, duringFailure.Status);
             Assert.Equal(ValidPng, duringFailure.Content);
@@ -177,10 +177,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
         {
             var handler = new SwitchableHandler();
             var (_, cache, service, provider) = CreateWithService(handler);
+            var fence = CreateFence(provider);
             var fresh = await service.GetAsync(
                 "retained-avatar",
                 "http://seerr/avatar/a.png",
-                () => true,
+                fence,
                 CancellationToken.None);
             Assert.Equal(AvatarFetchStatus.Available, fresh.Status);
             Assert.Single(cache.AvatarCache);
@@ -190,11 +191,61 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             var disabled = await service.GetAsync(
                 "retained-avatar",
                 "http://seerr/avatar/a.png",
-                () => true,
+                fence,
                 CancellationToken.None);
 
             Assert.Equal(AvatarFetchStatus.ConfigurationChanged, disabled.Status);
             Assert.Equal(1, handler.Calls);
+        }
+
+        [Fact]
+        public async Task MasterDisabledDuringUpstreamThrow_PublishesNeitherFailureNorAvatar()
+        {
+            var handler = new BlockingFailureHandler(
+                static _ => new InvalidOperationException("upstream failed"));
+            var (_, cache, service, provider) = CreateWithService(handler);
+            var fence = CreateFence(provider);
+
+            var fetch = service.GetAsync(
+                "disabled-during-throw",
+                "http://seerr/avatar/a.png",
+                fence,
+                CancellationToken.None);
+            await handler.Started.WaitAsync(TimeSpan.FromSeconds(5));
+            provider.Current!.SeerrEnabled = false;
+            handler.Release();
+
+            var result = await fetch.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Equal(AvatarFetchStatus.ConfigurationChanged, result.Status);
+            Assert.Equal(0, service.FailureStateCount);
+            Assert.Empty(cache.AvatarCache);
+            await WaitForNoFlightsAsync(service);
+        }
+
+        [Fact]
+        public async Task MasterDisabledDuringNonCallerTimeout_PublishesNeitherFailureNorAvatar()
+        {
+            var handler = new BlockingFailureHandler(
+                static cancellationToken => new OperationCanceledException(cancellationToken));
+            var (_, cache, service, provider) = CreateWithService(handler);
+            var fence = CreateFence(provider);
+
+            var fetch = service.GetAsync(
+                "disabled-during-timeout",
+                "http://seerr/avatar/a.png",
+                fence,
+                CancellationToken.None);
+            await handler.Started.WaitAsync(TimeSpan.FromSeconds(5));
+            provider.Current!.SeerrEnabled = false;
+            handler.Release();
+
+            var result = await fetch.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Equal(AvatarFetchStatus.ConfigurationChanged, result.Status);
+            Assert.Equal(0, service.FailureStateCount);
+            Assert.Empty(cache.AvatarCache);
+            await WaitForNoFlightsAsync(service);
         }
 
         [Fact]
@@ -203,14 +254,15 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             var handler = new DelegateHandler((_, _) => Task.FromResult(ImageResponse(
                 new MemoryStream(ValidPng, writable: false),
                 "image/png")));
-            var (_, cache, service, _) = CreateWithService(handler);
+            var (_, cache, service, provider) = CreateWithService(handler);
+            var fence = CreateFence(provider);
 
             for (var i = 0; i < 200; i++)
             {
                 var result = await service.GetAsync(
                     $"avatar-{i}",
                     $"http://seerr/avatar/{i}.png",
-                    () => true,
+                    fence,
                     CancellationToken.None);
                 Assert.Equal(AvatarFetchStatus.Available, result.Status);
             }
@@ -219,14 +271,17 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             Assert.True(cache.AvatarCache.TotalWeight <= SeerrCache.AvatarMaximumBytes);
         }
 
-        private static (AvatarFetchService Service, SeerrCache Cache) Create(
+        private static (AvatarFetchService Service, SeerrCache Cache, SeerrDispatchFence Fence) Create(
             HttpMessageHandler handler,
             TimeProvider? timeProvider = null,
             long maximumAvatarBytes = AvatarFetchService.DefaultMaximumAvatarBytes)
         {
-            var (_, cache, service, _) = CreateWithService(handler, timeProvider, maximumAvatarBytes);
-            return (service, cache);
+            var (_, cache, service, provider) = CreateWithService(handler, timeProvider, maximumAvatarBytes);
+            return (service, cache, CreateFence(provider));
         }
+
+        private static SeerrDispatchFence CreateFence(FakePluginConfigProvider provider)
+            => SeerrIntegrationPolicy.Capture(provider).CreateDispatchFence(provider);
 
         private static async Task WaitForNoFlightsAsync(AvatarFetchService service)
         {
@@ -303,6 +358,29 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
                 _started.TrySetResult();
                 await _release.Task.WaitAsync(cancellationToken);
                 return ImageResponse(new MemoryStream(ValidPng, writable: false), "image/png");
+            }
+        }
+
+        private sealed class BlockingFailureHandler : HttpMessageHandler
+        {
+            private readonly Func<CancellationToken, Exception> _failureFactory;
+            private readonly TaskCompletionSource _started = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly TaskCompletionSource _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public BlockingFailureHandler(Func<CancellationToken, Exception> failureFactory)
+                => _failureFactory = failureFactory;
+
+            public Task Started => _started.Task;
+
+            public void Release() => _release.TrySetResult();
+
+            protected override async Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request,
+                CancellationToken cancellationToken)
+            {
+                _started.TrySetResult();
+                await _release.Task.WaitAsync(cancellationToken);
+                throw _failureFactory(cancellationToken);
             }
         }
 

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/Seerr/SeerrParentalFilterGenerationTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/Seerr/SeerrParentalFilterGenerationTests.cs
@@ -171,6 +171,81 @@ public sealed class SeerrParentalFilterGenerationTests
         Assert.Equal(1, Volatile.Read(ref requestCount));
     }
 
+    [Fact]
+    public async Task TmdbFallback_DisabledWhileCertificationRequestIsInFlight_DoesNotSendToSeerr()
+    {
+        var tmdbStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseTmdb = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var hosts = new List<string>();
+        var handler = new DelegateHandler(async (request, cancellationToken) =>
+        {
+            hosts.Add(request.RequestUri!.Host);
+            if (request.RequestUri.Host == "api.themoviedb.org")
+            {
+                tmdbStarted.TrySetResult();
+                await releaseTmdb.Task.WaitAsync(cancellationToken);
+                return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+                {
+                    Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+                };
+            }
+
+            return Json(MovieDetail("PG-13"));
+        });
+        var configuration = Configuration("http://seerr-one:5055", "one-key");
+        configuration.TMDB_API_KEY = "tmdb-key";
+        var provider = new FakePluginConfigProvider(configuration);
+        var cache = new SeerrCache(provider);
+        var filter = BuildFilter(handler, provider, cache);
+
+        var decisionTask = filter.IsBlockedAsync("movie", 704, Caller);
+        await tmdbStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        provider.Current!.SeerrEnabled = false;
+        releaseTmdb.TrySetResult();
+
+        Assert.True(await decisionTask.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.Equal(new[] { "api.themoviedb.org" }, hosts);
+        Assert.Empty(cache.CertScoreCache);
+    }
+
+    [Fact]
+    public async Task SeerrDetailFailover_DisabledWhileFirstRequestIsInFlight_DoesNotSendToSecondSource()
+    {
+        var firstRequestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirstRequest = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var hosts = new List<string>();
+        var handler = new DelegateHandler(async (request, cancellationToken) =>
+        {
+            hosts.Add(request.RequestUri!.Host);
+            if (hosts.Count == 1)
+            {
+                firstRequestStarted.TrySetResult();
+                await releaseFirstRequest.Task.WaitAsync(cancellationToken);
+                return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+                {
+                    Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+                };
+            }
+
+            return Json(MovieDetail("PG-13"));
+        });
+        var provider = new FakePluginConfigProvider(
+            Configuration("http://seerr-one:5055,http://seerr-two:5055", "one-key"));
+        var cache = new SeerrCache(provider);
+        var filter = BuildFilter(handler, provider, cache);
+
+        var decisionTask = filter.IsBlockedAsync("movie", 705, Caller);
+        await firstRequestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        provider.Current!.SeerrEnabled = false;
+        releaseFirstRequest.TrySetResult();
+
+        Assert.True(await decisionTask.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.Equal(new[] { "seerr-one" }, hosts);
+        Assert.Empty(cache.CertScoreCache);
+    }
+
     private static SeerrParentalFilter BuildFilter(
         HttpMessageHandler handler,
         FakePluginConfigProvider provider,

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/Seerr/SeerrParentalFilterGenerationTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/Seerr/SeerrParentalFilterGenerationTests.cs
@@ -149,6 +149,28 @@ public sealed class SeerrParentalFilterGenerationTests
         Assert.Equal(2, cache.CertScoreCache.Keys.Distinct(StringComparer.Ordinal).Count());
     }
 
+    [Fact]
+    public async Task MasterDisabledWithRetainedCredentials_DoesNotUseCacheOrCallUpstream()
+    {
+        var requestCount = 0;
+        var handler = new DelegateHandler((_, _) =>
+        {
+            Interlocked.Increment(ref requestCount);
+            return Task.FromResult(Json(MovieDetail("R")));
+        });
+        var provider = new FakePluginConfigProvider(Configuration("http://seerr:5055", "retained-key"));
+        var cache = new SeerrCache(provider);
+        var filter = BuildFilter(handler, provider, cache);
+
+        Assert.True(await filter.IsBlockedAsync("movie", 703, Caller));
+        Assert.Single(cache.CertScoreCache);
+        Assert.Equal(1, Volatile.Read(ref requestCount));
+
+        provider.Current!.SeerrEnabled = false;
+        Assert.False(await filter.IsBlockedAsync("movie", 703, Caller));
+        Assert.Equal(1, Volatile.Read(ref requestCount));
+    }
+
     private static SeerrParentalFilter BuildFilter(
         HttpMessageHandler handler,
         FakePluginConfigProvider provider,

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrCacheTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrCacheTests.cs
@@ -1,7 +1,9 @@
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
 using Jellyfin.Plugin.JellyfinCanopy.Model.Seerr;
+using Jellyfin.Plugin.JellyfinCanopy.Services;
 using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
 using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services;
@@ -27,6 +29,8 @@ public class SeerrCacheTests
         cache.AutoImportFailureThrottle["jf-user-c"] = DateTime.UtcNow;
         cache.ResponseCache["jf-user-a:/api/v1/discover/movies"] = ("{}", DateTime.UtcNow, 1, "test-generation");
         cache.TmdbEnrichmentCache["movie:1"] = (new TmdbEnrichmentResult { Title = "T" }, DateTime.UtcNow, 1);
+        cache.Public4kSettingsCache["http://seerr:5055"] = (true, true, DateTime.UtcNow, 1, "fingerprint");
+        cache.CertScoreCache["movie:1"] = (12, null, null, null, DateTime.UtcNow);
         cache.AvatarCache["avatar-key"] = (new byte[] { 1 }, "image/png", "etag", DateTime.UtcNow);
         cache.SeerrStatusCache = (true, DateTime.UtcNow);
         return cache;
@@ -44,6 +48,8 @@ public class SeerrCacheTests
         Assert.Empty(cache.AutoImportFailureThrottle);
         Assert.Empty(cache.ResponseCache);
         Assert.Empty(cache.TmdbEnrichmentCache);
+        Assert.Empty(cache.Public4kSettingsCache);
+        Assert.Empty(cache.CertScoreCache);
         Assert.Empty(cache.AvatarCache);
         Assert.Null(cache.SeerrStatusCache);
     }
@@ -62,8 +68,43 @@ public class SeerrCacheTests
         // ...but non-user caches keep their entries.
         Assert.Single(cache.ResponseCache);
         Assert.Single(cache.TmdbEnrichmentCache);
+        Assert.Single(cache.Public4kSettingsCache);
+        Assert.Single(cache.CertScoreCache);
         Assert.Single(cache.AvatarCache);
         Assert.NotNull(cache.SeerrStatusCache);
+    }
+
+    [Fact]
+    public void PolicyInvalidation_FencesWatchlistGenerationAndClearsSharedActiveState()
+    {
+        var provider = new FakePluginConfigProvider(new PluginConfiguration
+        {
+            SeerrEnabled = false,
+            SeerrUrls = "http://seerr:5055",
+            SeerrApiKey = "retained-key",
+        });
+        var cache = PopulatedCache();
+        var watchlist = new WatchlistMonitor(
+            null!,
+            null!,
+            null!,
+            null!,
+            null!,
+            NullLogger<WatchlistMonitor>.Instance,
+            provider);
+        var generation = watchlist.ConfigurationGenerationNumber;
+
+        var failures = SeerrIntegrationPolicy.InvalidateCachedActiveState(cache, watchlist);
+
+        Assert.Empty(failures);
+        Assert.Equal(generation + 1, watchlist.ConfigurationGenerationNumber);
+        Assert.Empty(cache.UserCache);
+        Assert.Empty(cache.ResponseCache);
+        Assert.Empty(cache.AvatarCache);
+        Assert.Empty(cache.Public4kSettingsCache);
+        Assert.Empty(cache.CertScoreCache);
+        Assert.Null(cache.SeerrStatusCache);
+        watchlist.Dispose();
     }
 
     [Fact]

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrClientTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrClientTests.cs
@@ -172,6 +172,34 @@ public class SeerrClientTests
         Assert.Equal(1, handler.Calls);
     }
 
+    [Fact]
+    public async Task StatusFailover_DisabledWhileFirstProbeIsInFlight_DoesNotSendSecondProbe()
+    {
+        var provider = new FakePluginConfigProvider(new PluginConfiguration
+        {
+            SeerrEnabled = true,
+            SeerrUrls = "http://seerr-one:5055,http://seerr-two:5055",
+            SeerrApiKey = "key",
+        });
+        var handler = new BlockingFailedProbeHandler();
+        var client = new SeerrClient(
+            new RecordingHttpClientFactory(handler),
+            NullLogger<SeerrClient>.Instance,
+            null!,
+            new SeerrCache(provider),
+            provider,
+            null!);
+
+        var statusTask = client.GetStatusActiveAsync();
+        await handler.FirstProbeStarted.WaitAsync(TimeSpan.FromSeconds(5));
+
+        provider.Current!.SeerrEnabled = false;
+        handler.ReleaseFirstProbe();
+
+        Assert.False(await statusTask.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.Equal(1, handler.Calls);
+    }
+
     private sealed class ThrowingHttpClientFactory : IHttpClientFactory
     {
         public HttpClient CreateClient(string name) =>
@@ -196,6 +224,42 @@ public class SeerrClientTests
             {
                 Content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json"),
             });
+        }
+    }
+
+    private sealed class BlockingFailedProbeHandler : HttpMessageHandler
+    {
+        private readonly TaskCompletionSource _firstProbeStarted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _releaseFirstProbe =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _calls;
+
+        public Task FirstProbeStarted => _firstProbeStarted.Task;
+
+        public int Calls => Volatile.Read(ref _calls);
+
+        public void ReleaseFirstProbe() => _releaseFirstProbe.TrySetResult();
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            _ = request;
+            var call = Interlocked.Increment(ref _calls);
+            if (call == 1)
+            {
+                _firstProbeStarted.TrySetResult();
+                await _releaseFirstProbe.Task.WaitAsync(cancellationToken);
+            }
+
+            return new HttpResponseMessage(System.Net.HttpStatusCode.ServiceUnavailable)
+            {
+                Content = new StringContent(
+                    "{\"message\":\"unavailable\"}",
+                    System.Text.Encoding.UTF8,
+                    "application/json"),
+            };
         }
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrClientTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrClientTests.cs
@@ -96,9 +96,106 @@ public class SeerrClientTests
         Assert.Null(await client.GetSeerrUserId("abcdef1234567890abcdef1234567890"));
     }
 
+    [Fact]
+    public async Task ResolveSeerrUser_MasterDisabledWithRetainedCredentials_DoesNotCallUpstream()
+    {
+        var handler = new RecordingHttpMessageHandler();
+        handler.AddResponse(
+            "/api/v1/user",
+            """{"results":[{"id":42,"jellyfinUserId":"abcdef1234567890abcdef1234567890"}],"pageInfo":{"page":1,"pages":1,"results":1}}""");
+        var provider = new FakePluginConfigProvider(new PluginConfiguration
+        {
+            SeerrEnabled = false,
+            SeerrUrls = "http://seerr:5055",
+            SeerrApiKey = "retained-key",
+        });
+        var client = new SeerrClient(
+            new RecordingHttpClientFactory(handler),
+            NullLogger<SeerrClient>.Instance,
+            null!,
+            new SeerrCache(provider),
+            provider,
+            null!);
+
+        var resolution = await client.ResolveSeerrUser(
+            "abcdef1234567890abcdef1234567890",
+            allowAutoImport: false);
+
+        Assert.Equal(SeerrUserResolutionStatus.Unavailable, resolution.Status);
+        Assert.Empty(handler.Sent);
+    }
+
+    [Fact]
+    public async Task UserCollections_MasterDisabledWithRetainedCredentials_DoNotCallUpstream()
+    {
+        var handler = new RecordingHttpMessageHandler();
+        handler.AddResponse("/api/v1/user/42/watchlist", """{"results":[],"pageInfo":{"page":1,"pages":1,"results":0}}""");
+        handler.AddResponse("/api/v1/request", """{"results":[],"pageInfo":{"page":1,"pages":1,"results":0}}""");
+        var provider = new FakePluginConfigProvider(new PluginConfiguration
+        {
+            SeerrEnabled = false,
+            SeerrUrls = "http://seerr:5055",
+            SeerrApiKey = "retained-key",
+        });
+        var client = new SeerrClient(
+            new RecordingHttpClientFactory(handler),
+            NullLogger<SeerrClient>.Instance,
+            null!,
+            new SeerrCache(provider),
+            provider,
+            null!);
+
+        Assert.Null(await client.GetWatchlistForUser("42"));
+        Assert.Null(await client.GetRequestsForUser("42"));
+        Assert.Empty(handler.Sent);
+    }
+
+    [Fact]
+    public async Task StatusResponse_DisabledDuringRequest_DoesNotPublishActiveCapability()
+    {
+        var provider = new FakePluginConfigProvider(new PluginConfiguration
+        {
+            SeerrEnabled = true,
+            SeerrUrls = "http://seerr:5055",
+            SeerrApiKey = "key",
+        });
+        var handler = new CallbackHandler(() => provider.Current!.SeerrEnabled = false);
+        var client = new SeerrClient(
+            new RecordingHttpClientFactory(handler),
+            NullLogger<SeerrClient>.Instance,
+            null!,
+            new SeerrCache(provider),
+            provider,
+            null!);
+
+        Assert.False(await client.GetStatusActiveAsync());
+        Assert.Equal(1, handler.Calls);
+    }
+
     private sealed class ThrowingHttpClientFactory : IHttpClientFactory
     {
         public HttpClient CreateClient(string name) =>
             throw new InvalidOperationException("Unexpected outbound HTTP call: the config gate should have short-circuited.");
+    }
+
+    private sealed class CallbackHandler(Action callback) : HttpMessageHandler
+    {
+        private int _calls;
+
+        public int Calls => Volatile.Read(ref _calls);
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            _ = request;
+            cancellationToken.ThrowIfCancellationRequested();
+            Interlocked.Increment(ref _calls);
+            callback();
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json"),
+            });
+        }
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrDispatchFenceTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrDispatchFenceTests.cs
@@ -1,0 +1,95 @@
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr;
+using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services;
+
+public sealed class SeerrDispatchFenceTests
+{
+    [Fact]
+    public void CallerRestrictionCannotRestoreDisabledBasePolicy()
+    {
+        var provider = Provider();
+        var fence = SeerrIntegrationPolicy.Capture(provider)
+            .CreateDispatchFence(provider)
+            .Restrict(static () => true);
+
+        provider.Current!.SeerrEnabled = false;
+
+        Assert.False(fence.CanDispatch());
+    }
+
+    [Fact]
+    public void CallerRestrictionCanOnlyNarrowAndThrowsFailClosed()
+    {
+        var provider = Provider();
+        var fence = SeerrIntegrationPolicy.Capture(provider).CreateDispatchFence(provider);
+
+        Assert.True(fence.CanDispatch());
+        Assert.False(fence.Restrict(static () => false).CanDispatch());
+        Assert.False(fence.Restrict(static () => throw new InvalidOperationException("boom")).CanDispatch());
+    }
+
+    [Fact]
+    public void CapturedSourcesAreImmutableAndFenceIsBoundToActualTarget()
+    {
+        var provider = Provider();
+        var snapshot = SeerrIntegrationPolicy.Capture(provider);
+        var exposed = snapshot.Urls;
+        exposed[0] = "http://attacker";
+        var fence = snapshot.CreateDispatchFence(provider);
+
+        Assert.Equal("http://seerr", Assert.Single(snapshot.Urls));
+        Assert.True(fence.CanDispatch(new Uri("http://seerr/api/v1/request")));
+        Assert.False(fence.CanDispatch(new Uri("http://attacker/api/v1/request")));
+        Assert.False(fence.CanDispatch(new Uri("http://seerr.attacker/api/v1/request")));
+    }
+
+    [Fact]
+    public void FenceIsOpaqueAndTransportOwnersRequireIt()
+    {
+        Assert.True(typeof(SeerrDispatchFence).IsSealed);
+        Assert.DoesNotContain(
+            typeof(SeerrDispatchFence).GetConstructors(
+                System.Reflection.BindingFlags.Instance
+                | System.Reflection.BindingFlags.Public
+                | System.Reflection.BindingFlags.NonPublic),
+            constructor => constructor.IsPublic || constructor.IsAssembly);
+        Assert.DoesNotContain(
+            typeof(SeerrIntegrationSnapshot).GetConstructors(
+                System.Reflection.BindingFlags.Instance
+                | System.Reflection.BindingFlags.Public
+                | System.Reflection.BindingFlags.NonPublic),
+            constructor => constructor.IsPublic || constructor.IsAssembly);
+
+        Assert.All(
+            typeof(SeerrPaginationHelper).GetMethods()
+                .Where(method => method.Name is "FetchAllAsync" or "FetchAllSourcesAsync"),
+            method => Assert.Contains(
+                method.GetParameters(),
+                parameter => parameter.ParameterType == typeof(SeerrDispatchFence)));
+        Assert.Contains(
+            typeof(SeerrUserImportHelper).GetMethod(nameof(SeerrUserImportHelper.BulkImportAsync))!
+                .GetParameters(),
+            parameter => parameter.ParameterType == typeof(SeerrDispatchFence));
+        Assert.All(
+            typeof(SeerrHttpHelper).GetMethods(
+                    System.Reflection.BindingFlags.Static
+                    | System.Reflection.BindingFlags.Public
+                    | System.Reflection.BindingFlags.NonPublic)
+                .Where(method => method.Name is "SendAndReadJsonAsync" or "SendResponseHeadersReadAsync"),
+            method => Assert.Contains(
+                method.GetParameters(),
+                parameter => parameter.ParameterType == typeof(SeerrDispatchFence)));
+    }
+
+    private static FakePluginConfigProvider Provider()
+        => new(new PluginConfiguration
+        {
+            SeerrEnabled = true,
+            SeerrUrls = "http://seerr",
+            SeerrApiKey = "key",
+        });
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrIntegrationEntryPointGuardTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrIntegrationEntryPointGuardTests.cs
@@ -24,9 +24,23 @@ public sealed class SeerrIntegrationEntryPointGuardTests
         RegexOptions.Compiled);
 
     private static readonly Regex OutboundSeerrCall = new(
-        @"\bSeerrHttpHelper\.(?:CreateClient|BuildRequest|SendAndReadJsonAsync|SendResponseHeadersReadAsync|ReadResponseAsync)\s*\("
+        @"\bSeerrHttpHelper\.(?:CreateClient|BuildRequest|SendAndReadJsonAsync|SendResponseHeadersReadAsync|SendSetupAndReadJsonAsync|ReadResponseAsync)\s*\("
         + @"|\bSeerrPaginationHelper\.FetchAll(?:Sources)?Async\s*\("
         + @"|\bSeerrUserImportHelper\.BulkImportAsync\s*\(",
+        RegexOptions.Compiled);
+
+    private static readonly Regex DispatchingSeerrCall = new(
+        @"\bSeerrHttpHelper\.(?:SendAndReadJsonAsync|SendResponseHeadersReadAsync|SendSetupAndReadJsonAsync)\s*\("
+        + @"|\bSeerrPaginationHelper\.FetchAll(?:Sources)?Async\s*\("
+        + @"|\bSeerrUserImportHelper\.BulkImportAsync\s*\(",
+        RegexOptions.Compiled);
+
+    private static readonly Regex RawHttpDispatch = new(
+        @"\.\s*(?:SendAsync|GetAsync|PostAsync|PutAsync|DeleteAsync|PatchAsync)\s*\(",
+        RegexOptions.Compiled);
+
+    private static readonly Regex SeerrClientCreation = new(
+        @"\bSeerrHttpHelper\.CreateClient\s*\(|\b_httpClientFactory\.CreateClient\s*\(",
         RegexOptions.Compiled);
 
     private static readonly Regex MethodDeclaration = new(
@@ -66,10 +80,8 @@ public sealed class SeerrIntegrationEntryPointGuardTests
         "ScheduledTasks/SeerrWatchlistSyncTask.cs:FetchSeerrWatchlistSnapshotAsync",
         "Services/AutoMovieRequestService.cs:GetNextMovieInCollectionAsync",
         "Services/AutoMovieRequestService.cs:GetOriginalMovieQualityProfileAsync",
-        "Services/AutoMovieRequestService.cs:ResolveQualityProfileAsync",
         "Services/AutoSeasonRequestService.cs:GetSeasonStatusFromSeerr",
         "Services/AutoSeasonRequestService.cs:GetSeriesDetailsJsonAsync",
-        "Services/AutoSeasonRequestService.cs:GetTotalEpisodesInSeasonFromTmdb",
         "Services/Seerr/AvatarFetchService.cs:CompleteFlightAsync",
         "Services/Seerr/AvatarFetchService.cs:FetchLeaderAsync",
         "Services/Seerr/SeerrClient.cs:FetchExactUserBindingAsync",
@@ -98,11 +110,52 @@ public sealed class SeerrIntegrationEntryPointGuardTests
         "Services/WatchlistMonitor.cs:FetchAllUserSnapshotsAsync",
     };
 
-    private static readonly HashSet<string> NamedElevatedSetupMethods = new(StringComparer.Ordinal)
+    private static readonly HashSet<string> PinnedElevatedSetupTransportMethods = new(StringComparer.Ordinal)
     {
         "Controllers/ArrLinksController.cs:IdentifyUrl",
         "Controllers/ArrLinksController.cs:ValidateArrService",
         "Controllers/SeerrProxyController.cs:ValidateSeerr",
+    };
+
+    private static readonly HashSet<string> ExactElevatedSetupEntryPoints = new(StringComparer.Ordinal)
+    {
+        "Controllers/ArrLinksController.cs:IdentifyUrl",
+        "Controllers/ArrLinksController.cs:ValidateRadarr",
+        "Controllers/ArrLinksController.cs:ValidateSonarr",
+        "Controllers/SeerrProxyController.cs:ValidateSeerr",
+    };
+
+    private static readonly HashSet<string> ElevatedSetupDelegates = new(StringComparer.Ordinal)
+    {
+        "Controllers/ArrLinksController.cs:ValidateArrService",
+    };
+
+    private static readonly HashSet<string> ExactSetupOnlySendOwners = new(StringComparer.Ordinal)
+    {
+        "Controllers/SeerrProxyController.cs:ValidateSeerr",
+    };
+
+    private static readonly Dictionary<string, RawEdgeContract> ExactNonSeerrRawTransportMethods = new(StringComparer.Ordinal)
+    {
+        ["Controllers/ItemInfoController.cs:GetTmdbPersonData"] = new(1, "CreateTmdbClient", "https://api.themoviedb.org", "httpClient.GetAsync(tmdbUrl)"),
+        ["Controllers/SeerrProxyController.cs:ProxyTmdbRequest"] = new(1, "CreateTmdbClient", "https://api.themoviedb.org", ".GetAsync(requestUri, HttpContext.RequestAborted)"),
+        ["Controllers/SeerrProxyController.cs:ValidateTmdb"] = new(1, "CreateTmdbClient", "https://api.themoviedb.org", "httpClient.GetAsync(requestUri)"),
+        ["Services/Arr/ArrFetchService.cs:SendAndMapAsync"] = new(1, "CreateArrClient", "client.SendAsync(request, ct)"),
+        ["Services/Arr/ArrTagService.cs:FetchTagsAndItemsAsync"] = new(2, "CreateArrClient", "httpClient.SendAsync(tagsRequest, ct)", "httpClient.SendAsync(mediaRequest, ct)"),
+        ["Services/AssetCacheService.cs:FetchAssetAsync"] = new(1, "CreateAssetsClient", "new HttpRequestMessage(HttpMethod.Get, asset.UpstreamUrl)", "client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct)"),
+        ["Services/AutoMovieRequestService.cs:GetTmdbCollectionIdAsync"] = new(1, "CreateTmdbClient", "https://api.themoviedb.org", "httpClient.GetAsync(requestUrl)"),
+        ["Services/Seerr/SeerrParentalFilter.cs:FetchCertFromTmdbAsync"] = new(1, "CreateTmdbClient", "https://api.themoviedb.org", "httpClient.GetAsync(requestUri, ct)"),
+    };
+
+    private static readonly Dictionary<string, RawEdgeContract> ExactSetupRawTransportMethods = new(StringComparer.Ordinal)
+    {
+        ["Controllers/ArrLinksController.cs:ValidateArrService"] = new(1, "BuildArrRequest", "http.SendAsync(request)"),
+        ["Controllers/ArrLinksController.cs:IdentifyUrl"] = new(
+            4,
+            "http.GetAsync($\"{cleanUrl}/api/v3/system/status\")",
+            "http.GetAsync($\"{cleanUrl}/System/Info/Public\")",
+            "http.GetAsync($\"{cleanUrl}/api/v1/status\")",
+            "http.GetAsync(cleanUrl, HttpCompletionOption.ResponseHeadersRead)"),
     };
 
     [Fact]
@@ -123,6 +176,32 @@ public sealed class SeerrIntegrationEntryPointGuardTests
             "Production code reads SeerrEnabled outside SeerrIntegrationPolicy: "
             + string.Join(", ", offenders)
             + ". Capture the central policy (or use its scheduling-only gate) instead of interpreting retained credentials locally.");
+    }
+
+    [Fact]
+    public void OnlyOpaqueDispatchFenceMayStoreBooleanAuthorizationDelegates()
+    {
+        var offenders = SourceFiles()
+            .Select(path => (Relative: Relative(path), Source: StripComments(File.ReadAllText(path))))
+            .Where(file => file.Relative != "Services/Seerr/SeerrIntegrationPolicy.cs")
+            .Where(file => Regex.IsMatch(file.Source, @"\bFunc\s*<\s*bool\s*>"))
+            .Select(file => file.Relative)
+            .ToArray();
+
+        Assert.True(
+            offenders.Length == 0,
+            "Production authorization/publication boundaries use arbitrary Func<bool>: "
+            + string.Join(", ", offenders)
+            + ". Accept SeerrDispatchFence and narrow it through Restrict instead.");
+    }
+
+    [Fact]
+    public void NoCacheOnlyStatusOwnerCanPublishActiveOutsideCurrentPolicy()
+    {
+        var source = StripComments(File.ReadAllText(SourcePath("Services/Seerr/SeerrClient.cs")));
+
+        Assert.DoesNotContain("IsSeerrReachableCached", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("SeerrStatusCache.Value.Active", source, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -150,9 +229,13 @@ public sealed class SeerrIntegrationEntryPointGuardTests
                 else
                 {
                     var owner = relative + ":" + method.Name;
-                    if (!HasExplicitPolicyGateBefore(method, call.Index - method.Start)
-                        && !ReviewedDelegatedTransportMethods.Contains(owner)
-                        && !NamedElevatedSetupMethods.Contains(owner))
+                    if (!IsAuthorizedOutboundOwner(
+                            method,
+                            call.Index - method.Start,
+                            owner,
+                            ReviewedDelegatedTransportMethods,
+                            PinnedElevatedSetupTransportMethods,
+                            DispatchingSeerrCall.IsMatch(call.Value)))
                     {
                         offenders.Add(owner);
                     }
@@ -163,6 +246,7 @@ public sealed class SeerrIntegrationEntryPointGuardTests
                 relative,
                 source,
                 policyDominatedMethods: policyDominatedMethods));
+
         }
 
         Assert.True(
@@ -170,6 +254,116 @@ public sealed class SeerrIntegrationEntryPointGuardTests
             "Outbound Seerr owner(s) bypass the central integration policy:\n  "
             + string.Join("\n  ", offenders)
             + "\nOnly transport-only helpers and the named elevated setup probes may omit policy capture.");
+    }
+
+    [Fact]
+    public void EveryRawHttpDispatchIsExactlyClassifiedOrOpaqueFenced()
+    {
+        var offenders = new List<string>();
+        foreach (var path in SourceFiles())
+        {
+            var relative = Relative(path);
+            var source = File.ReadAllText(path);
+            foreach (Match dispatch in RawHttpDispatch.Matches(source))
+            {
+                var method = FindContainingMethod(source, dispatch.Index);
+                if (method == null)
+                {
+                    offenders.Add(relative + " (could not identify raw HTTP owner)");
+                    continue;
+                }
+
+                var owner = relative + ":" + method.Name;
+                if (IsAuthorizedRawTransportHelper(relative, method)
+                    || (ExactNonSeerrRawTransportMethods.TryGetValue(owner, out var nonSeerrContract)
+                        && RawOwnerMatchesContract(method, nonSeerrContract))
+                    || (ExactSetupRawTransportMethods.TryGetValue(owner, out var setupContract)
+                        && PinnedElevatedSetupTransportMethods.Contains(owner)
+                        && RawOwnerMatchesContract(method, setupContract)))
+                {
+                    continue;
+                }
+
+                if (!IsAuthorizedOutboundOwner(
+                        method,
+                        dispatch.Index - method.Start,
+                        owner,
+                        ReviewedDelegatedTransportMethods,
+                        PinnedElevatedSetupTransportMethods,
+                        requiresFreshFence: true))
+                {
+                    var contractDetail = ExactNonSeerrRawTransportMethods.TryGetValue(owner, out var expected)
+                        ? $" (calls={RawHttpDispatch.Matches(method.Source).Count}/{expected.ExpectedCalls}; missing={string.Join("|", expected.RequiredMarkers.Where(marker => !method.Source.Contains(marker, StringComparison.Ordinal)))})"
+                        : string.Empty;
+                    offenders.Add(owner + contractDetail);
+                }
+            }
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            "Raw HTTP dispatch owner(s) are neither exactly classified nor opaque-fenced:\n  "
+            + string.Join("\n  ", offenders));
+    }
+
+    [Fact]
+    public void SetupOnlySendIsCallableOnlyFromExactElevatedSetupOwner()
+    {
+        var offenders = new List<string>();
+        var owners = new List<string>();
+        foreach (var path in SourceFiles())
+        {
+            var relative = Relative(path);
+            if (TransportOnlyHelpers.Contains(relative)) continue;
+            var source = StripComments(File.ReadAllText(path));
+            foreach (Match call in Regex.Matches(source, @"\bSeerrHttpHelper\.SendSetupAndReadJsonAsync\s*\("))
+            {
+                var method = Assert.IsType<MethodSource>(FindContainingMethod(source, call.Index));
+                var owner = relative + ":" + method.Name;
+                owners.Add(owner);
+                if (!IsAuthorizedSetupOnlyOwner(relative, source, method)) offenders.Add(owner);
+            }
+        }
+
+        Assert.Empty(offenders);
+        Assert.Equal(ExactSetupOnlySendOwners, owners.ToHashSet(StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void NormalPolicyGateCannotAuthorizeSetupOnlyTransport()
+    {
+        const string source = """
+            internal sealed class SyntheticOwner
+            {
+                public void GatedButNotSetup()
+                {
+                    var integration = SeerrIntegrationPolicy.Capture(provider);
+                    if (!integration.IsActive) return;
+                    SeerrHttpHelper.SendSetupAndReadJsonAsync(client, request, url);
+            }
+            """;
+        var method = Assert.Single(EnumerateMethods(source));
+
+        Assert.False(IsAuthorizedSetupOnlyOwner("SyntheticOwner.cs", source, method));
+    }
+
+    [Fact]
+    public void UnfencedRawTransportHelperIsRejected()
+    {
+        const string source = """
+            internal static class SyntheticTransport
+            {
+                internal static Task<HttpResponseMessage> SendResponseHeadersReadAsync(
+                    HttpClient client,
+                    HttpRequestMessage request)
+                    => client.SendAsync(request);
+            }
+            """;
+        var method = Assert.Single(EnumerateMethods(source));
+
+        Assert.False(IsAuthorizedRawTransportHelper(
+            "Helpers/Seerr/SyntheticTransport.cs",
+            method));
     }
 
     [Fact]
@@ -270,6 +464,146 @@ public sealed class SeerrIntegrationEntryPointGuardTests
     }
 
     [Fact]
+    public void GuardRejectsIgnoredActivePropertyRead()
+    {
+        const string source = """
+            internal sealed class SyntheticOwner
+            {
+                public void Bypass()
+                {
+                    var integration = SeerrIntegrationPolicy.Capture(provider);
+                    var ignored = integration.IsActive;
+                    SeerrHttpHelper.CreateClient(factory);
+                }
+            }
+            """;
+        var call = Assert.Single(OutboundSeerrCall.Matches(source).Cast<Match>());
+        var method = Assert.IsType<MethodSource>(FindContainingMethod(source, call.Index));
+
+        Assert.False(HasExplicitPolicyGateBefore(method, call.Index - method.Start));
+    }
+
+    [Fact]
+    public void GuardRejectsEmptyNonExitingActiveCondition()
+    {
+        const string source = """
+            internal sealed class SyntheticOwner
+            {
+                public void Bypass()
+                {
+                    var integration = SeerrIntegrationPolicy.Capture(provider);
+                    if (!integration.IsActive) { }
+                    SeerrHttpHelper.CreateClient(factory);
+                }
+            }
+            """;
+        var call = Assert.Single(OutboundSeerrCall.Matches(source).Cast<Match>());
+        var method = Assert.IsType<MethodSource>(FindContainingMethod(source, call.Index));
+
+        Assert.False(HasExplicitPolicyGateBefore(method, call.Index - method.Start));
+    }
+
+    [Fact]
+    public void GuardRejectsReviewedOwnerWithUnfencedDirectDispatch()
+    {
+        const string relative = "SyntheticOwner.cs";
+        const string source = """
+            internal sealed class SyntheticOwner
+            {
+                private void ReviewedTransport()
+                {
+                    SeerrHttpHelper.CreateClient(factory);
+                }
+            }
+            """;
+        var reviewed = new HashSet<string>(StringComparer.Ordinal)
+        {
+            relative + ":ReviewedTransport",
+        };
+        var call = Assert.Single(OutboundSeerrCall.Matches(source).Cast<Match>());
+        var method = Assert.IsType<MethodSource>(FindContainingMethod(source, call.Index));
+
+        Assert.False(IsAuthorizedOutboundOwner(
+            method,
+            call.Index - method.Start,
+            relative + ":ReviewedTransport",
+            reviewed,
+            new HashSet<string>(StringComparer.Ordinal),
+            requiresFreshFence: true));
+    }
+
+    [Fact]
+    public void GuardRecognizesFactoryCreatedRawHttpDispatch()
+    {
+        const string source = """
+            internal sealed class SyntheticOwner
+            {
+                public async Task Bypass()
+                {
+                    await _httpClientFactory.CreateClient("seerr").SendAsync(request);
+                }
+            }
+            """;
+        var method = Assert.Single(EnumerateMethods(source));
+
+        Assert.Matches(SeerrClientCreation, method.Source);
+        Assert.Single(RawHttpDispatch.Matches(method.Source).Cast<Match>());
+        Assert.False(IsAuthorizedOutboundOwner(
+            method,
+            RawHttpDispatch.Match(method.Source).Index,
+            "SyntheticOwner.cs:Bypass",
+            new HashSet<string>(StringComparer.Ordinal),
+            new HashSet<string>(StringComparer.Ordinal),
+            requiresFreshFence: true));
+    }
+
+    [Fact]
+    public void GuardRejectsParameterizedClientRawDispatchWithoutOpaqueFence()
+    {
+        const string source = """
+            internal sealed class SyntheticOwner
+            {
+                public Task<HttpResponseMessage> Bypass(HttpClient client, HttpRequestMessage request)
+                    => client.PatchAsync("http://seerr/api/v1/request", request.Content);
+            }
+            """;
+        var method = Assert.Single(EnumerateMethods(source));
+        var dispatch = Assert.Single(RawHttpDispatch.Matches(method.Source).Cast<Match>());
+
+        Assert.False(IsAuthorizedOutboundOwner(
+            method,
+            dispatch.Index,
+            "SyntheticOwner.cs:Bypass",
+            new HashSet<string>(StringComparer.Ordinal),
+            new HashSet<string>(StringComparer.Ordinal),
+            requiresFreshFence: true));
+    }
+
+    [Fact]
+    public void GuardRejectsLaterDispatchAfterAwaitWithoutFreshFence()
+    {
+        const string source = """
+            internal sealed class SyntheticOwner
+            {
+                public async Task Bypass()
+                {
+                    var integration = SeerrIntegrationPolicy.Capture(provider);
+                    if (!integration.IsActive) return;
+                    SeerrHttpHelper.CreateClient(factory);
+                    await PrepareAsync();
+                    SeerrHttpHelper.CreateClient(factory);
+                }
+            }
+            """;
+        var calls = OutboundSeerrCall.Matches(source).Cast<Match>().ToArray();
+        Assert.Equal(2, calls.Length);
+        var method = Assert.IsType<MethodSource>(FindContainingMethod(source, calls[1].Index));
+
+        Assert.True(HasExplicitPolicyGateBefore(method, calls[0].Index - method.Start));
+        Assert.False(HasExplicitPolicyGateBefore(method, calls[1].Index - method.Start));
+    }
+
+    [Fact]
     public void GuardRejectsUngatedCallerOfAlreadyReviewedTransportDelegate()
     {
         const string relative = "SyntheticOwner.cs";
@@ -304,6 +638,152 @@ public sealed class SeerrIntegrationEntryPointGuardTests
         Assert.Equal(relative + ":FetchReviewedAsync <- Bypass", Assert.Single(offenders));
     }
 
+    [Theory]
+    [InlineData("() => integration.IsCurrent(provider) || true")]
+    [InlineData("() => integration?.IsCurrent(provider) ?? true")]
+    [InlineData("() => !integration.IsCurrent(provider)")]
+    public void GuardRejectsFailOpenPredicateArguments(string predicate)
+    {
+        var source = $$"""
+            internal sealed class SyntheticOwner
+            {
+                public void Bypass()
+                {
+                    FetchReviewedAsync({{predicate}});
+                }
+            }
+            """;
+        var method = Assert.Single(EnumerateMethods(source));
+        var call = method.Source.IndexOf("FetchReviewedAsync", StringComparison.Ordinal);
+
+        Assert.False(InvocationPassesLivePredicate(method, call));
+    }
+
+    [Fact]
+    public void GuardRejectsBlockPredicateThatReturnsAnUnrelatedBoolean()
+    {
+        const string source = """
+            internal sealed class SyntheticOwner
+            {
+                public void Bypass()
+                {
+                    bool CanDispatch()
+                    {
+                        integration.IsCurrent(provider);
+                        return allowed;
+                    }
+
+                    FetchReviewedAsync(CanDispatch);
+                }
+            }
+            """;
+        var method = Assert.Single(EnumerateMethods(source), method => method.Name == "Bypass");
+        var call = method.Source.LastIndexOf("FetchReviewedAsync", StringComparison.Ordinal);
+
+        Assert.False(InvocationPassesLivePredicate(method, call));
+    }
+
+    [Theory]
+    [InlineData("!integration.IsCurrent(provider) && false")]
+    [InlineData("!false && integration.IsCurrent(provider)")]
+    [InlineData("integration.IsCurrent(provider)")]
+    public void GuardRejectsFailOpenOrInvertedTerminalConditions(string condition)
+    {
+        var source = $$"""
+            internal sealed class SyntheticOwner
+            {
+                public void Bypass()
+                {
+                    var integration = SeerrIntegrationPolicy.Capture(provider);
+                    if ({{condition}}) return;
+                    SeerrHttpHelper.CreateClient(factory);
+                }
+            }
+            """;
+        var call = Assert.Single(OutboundSeerrCall.Matches(source).Cast<Match>());
+        var method = Assert.IsType<MethodSource>(FindContainingMethod(source, call.Index));
+
+        Assert.False(HasExplicitPolicyGateBefore(method, call.Index - method.Start));
+    }
+
+    [Fact]
+    public void GuardRejectsTruthNamedCurrentFunction()
+    {
+        const string source = """
+            internal sealed class SyntheticOwner
+            {
+                public void Bypass()
+                {
+                    bool IsDefinitelyCurrent() => true;
+                    if (!IsDefinitelyCurrent()) return;
+                    SeerrHttpHelper.CreateClient(factory);
+                }
+            }
+            """;
+        var call = Assert.Single(OutboundSeerrCall.Matches(source).Cast<Match>());
+        var method = Assert.IsType<MethodSource>(FindContainingMethod(source, call.Index));
+
+        Assert.False(HasExplicitPolicyGateBefore(method, call.Index - method.Start));
+    }
+
+    [Fact]
+    public void BareAuthorizeCallerCannotAuthorizeAnElevatedSetupDelegate()
+    {
+        const string relative = "SyntheticOwner.cs";
+        const string source = """
+            internal sealed class SyntheticOwner
+            {
+                [Authorize]
+                public void BareAuthenticated()
+                {
+                    ValidateSetup();
+                }
+
+                private void ValidateSetup()
+                {
+                    _httpClientFactory.CreateClient("seerr").SendAsync(request);
+                }
+            }
+            """;
+        var delegates = new HashSet<string>(StringComparer.Ordinal)
+        {
+            relative + ":ValidateSetup",
+        };
+
+        var offenders = FindNonElevatedSetupCallers(relative, source, delegates);
+
+        Assert.Equal(relative + ":ValidateSetup <- BareAuthenticated", Assert.Single(offenders));
+    }
+
+    [Fact]
+    public void SetupTransportDelegatesAreReachableOnlyFromExactElevatedEntryPoints()
+    {
+        foreach (var entryPoint in ExactElevatedSetupEntryPoints)
+        {
+            var separator = entryPoint.LastIndexOf(':');
+            var relative = entryPoint[..separator];
+            var methodName = entryPoint[(separator + 1)..];
+            var source = StripComments(File.ReadAllText(SourcePath(relative)));
+            Assert.Single(EnumerateMethods(source), method => method.Name == methodName);
+            Assert.True(
+                HasExactElevationAttribute(source, methodName),
+                $"{entryPoint} must retain the exact RequiresElevation policy.");
+        }
+
+        foreach (var grouping in ElevatedSetupDelegates.GroupBy(entry => entry[..entry.LastIndexOf(':')]))
+        {
+            var source = StripComments(File.ReadAllText(SourcePath(grouping.Key)));
+            var offenders = FindNonElevatedSetupCallers(
+                grouping.Key,
+                source,
+                grouping.ToHashSet(StringComparer.Ordinal),
+                ExactElevatedSetupEntryPoints);
+            Assert.True(
+                offenders.Count == 0,
+                "Setup transport delegate has a non-elevated caller: " + string.Join(", ", offenders));
+        }
+    }
+
     [Fact]
     public void UnsavedConnectionValidationIsTheNamedElevatedSetupExemption()
     {
@@ -314,7 +794,7 @@ public sealed class SeerrIntegrationEntryPointGuardTests
 
         var proxySource = StripComments(File.ReadAllText(SourcePath("Controllers/SeerrProxyController.cs")));
         var validateBody = ExtractMethod(proxySource, nameof(SeerrProxyController.ValidateSeerr));
-        Assert.Contains("SeerrHttpHelper.SendAndReadJsonAsync", validateBody, StringComparison.Ordinal);
+        Assert.Contains("SeerrHttpHelper.SendSetupAndReadJsonAsync", validateBody, StringComparison.Ordinal);
         Assert.DoesNotContain("SeerrIntegrationPolicy.Capture", validateBody, StringComparison.Ordinal);
 
         var linksSource = StripComments(File.ReadAllText(SourcePath("Controllers/ArrLinksController.cs")));
@@ -379,6 +859,13 @@ public sealed class SeerrIntegrationEntryPointGuardTests
         {
             var separator = reviewed.LastIndexOf(':');
             var delegateName = reviewed[(separator + 1)..];
+            var delegateMethod = methods.FirstOrDefault(method =>
+                method.Name == delegateName && DispatchingSeerrCall.IsMatch(method.Source));
+            if (delegateMethod != null && DelegateHasExactEdgeFence(delegateMethod))
+            {
+                continue;
+            }
+
             var invocation = new Regex(
                 @"\b" + Regex.Escape(delegateName) + @"\s*\(",
                 RegexOptions.Compiled);
@@ -393,7 +880,9 @@ public sealed class SeerrIntegrationEntryPointGuardTests
                 var bodyOffset = caller.Source.IndexOf(caller.Body, StringComparison.Ordinal);
                 foreach (Match call in invocation.Matches(caller.Body))
                 {
-                    if (!HasExplicitPolicyGateBefore(caller, bodyOffset + call.Index))
+                    var invocationStart = bodyOffset + call.Index;
+                    if (!HasExplicitPolicyGateBefore(caller, invocationStart)
+                        && !InvocationPassesLivePredicate(caller, invocationStart))
                     {
                         offenders.Add(reviewed + " <- " + caller.Name);
                         break;
@@ -403,6 +892,185 @@ public sealed class SeerrIntegrationEntryPointGuardTests
         }
 
         return offenders;
+    }
+
+    private static IReadOnlyList<string> FindNonElevatedSetupCallers(
+        string relative,
+        string source,
+        HashSet<string> setupDelegates,
+        HashSet<string>? exactElevatedEntryPoints = null)
+    {
+        exactElevatedEntryPoints ??= new HashSet<string>(StringComparer.Ordinal);
+        var methods = EnumerateMethods(source);
+        var offenders = new List<string>();
+        foreach (var setupDelegate in setupDelegates.Where(entry =>
+                     entry.StartsWith(relative + ":", StringComparison.Ordinal)))
+        {
+            var separator = setupDelegate.LastIndexOf(':');
+            var delegateName = setupDelegate[(separator + 1)..];
+            var invocation = new Regex(@"\b" + Regex.Escape(delegateName) + @"\s*\(");
+            foreach (var caller in methods.Where(method => method.Name != delegateName))
+            {
+                if (!invocation.IsMatch(caller.Body)) continue;
+                var callerKey = relative + ":" + caller.Name;
+                if (!exactElevatedEntryPoints.Contains(callerKey)
+                    || !HasExactElevationAttribute(source, caller.Name))
+                {
+                    offenders.Add(setupDelegate + " <- " + caller.Name);
+                }
+            }
+        }
+
+        return offenders;
+    }
+
+    private static bool HasExactElevationAttribute(string source, string methodName)
+        => Regex.IsMatch(
+            source,
+            @"\[Authorize\s*\(\s*Policy\s*=\s*Policies\.RequiresElevation\s*\)\]\s*"
+            + @"public\s+(?:async\s+)?[^\r\n{;=]+?\b"
+            + Regex.Escape(methodName)
+            + @"\s*\(",
+            RegexOptions.Singleline);
+
+    private static bool IsAuthorizedSetupOnlyOwner(
+        string relative,
+        string source,
+        MethodSource method)
+    {
+        var owner = relative + ":" + method.Name;
+        return ExactSetupOnlySendOwners.Contains(owner)
+            && HasExactElevationAttribute(source, method.Name)
+            && EnumerateMethods(source).Count(candidate => candidate.Name == method.Name) == 1;
+    }
+
+    private static bool IsAuthorizedRawTransportHelper(string relative, MethodSource method)
+    {
+        if (!string.Equals(relative, "Helpers/Seerr/SeerrHttpHelper.cs", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (method.Name == "SendSetupAndReadJsonAsync")
+        {
+            return RawHttpDispatch.Matches(method.Source).Count == 1
+                && method.Source.Contains("httpClient.SendAsync(", StringComparison.Ordinal);
+        }
+
+        return method.Name == "SendResponseHeadersReadAsync"
+            && RawHttpDispatch.Matches(method.Source).Count == 1
+            && Regex.IsMatch(method.Source, @"\bSeerrDispatchFence\s+dispatchFence\b")
+            && method.Source.Contains(
+                "dispatchFence.CanDispatch(request.RequestUri)",
+                StringComparison.Ordinal);
+    }
+
+    private static bool RawOwnerMatchesContract(MethodSource method, RawEdgeContract contract)
+        => RawHttpDispatch.Matches(method.Source).Count == contract.ExpectedCalls
+            && contract.RequiredMarkers.All(marker =>
+                method.Source.Contains(marker, StringComparison.Ordinal));
+
+    private static bool DelegateHasExactEdgeFence(MethodSource method)
+    {
+        var dispatches = DispatchingSeerrCall.Matches(method.Source).Cast<Match>().ToArray();
+        return dispatches.Length > 0
+            && dispatches.All(call =>
+                HasExplicitPolicyGateBefore(method, call.Index)
+                || InvocationPassesLivePredicate(method, call.Index));
+    }
+
+    private static bool InvocationPassesLivePredicate(MethodSource caller, int invocationStart)
+    {
+        var open = caller.Source.IndexOf('(', invocationStart);
+        if (open < 0) return false;
+        var close = FindBalancedParenthesisEnd(caller.Source, open);
+        if (close < 0) return false;
+        var arguments = SplitTopLevelArguments(caller.Source[(open + 1)..close]);
+        if (arguments.Any(argument =>
+                argument.Contains(".CreateDispatchFence(", StringComparison.Ordinal)
+                || argument.Contains(".Restrict(", StringComparison.Ordinal)))
+        {
+            return true;
+        }
+
+        foreach (var fenceName in DeclaredDispatchFenceNames(caller.Source))
+        {
+            if (arguments.Any(argument => string.Equals(
+                    argument.Trim(),
+                    fenceName,
+                    StringComparison.Ordinal)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static IReadOnlySet<string> DeclaredDispatchFenceNames(string source)
+    {
+        var names = Regex.Matches(
+                source,
+                @"\bSeerrDispatchFence\s*\??\s+(?<name>[A-Za-z_]\w*)")
+            .Cast<Match>()
+            .Select(match => match.Groups["name"].Value)
+            .ToHashSet(StringComparer.Ordinal);
+        foreach (Match inferred in Regex.Matches(
+                     source,
+                     @"\bvar\s+(?<name>[A-Za-z_]\w*)\s*=\s*[\s\S]{0,240}?(?:\.CreateDispatchFence\s*\(|\.Restrict\s*\()"))
+        {
+            names.Add(inferred.Groups["name"].Value);
+        }
+
+        return names;
+    }
+
+    private static IReadOnlyList<string> SplitTopLevelArguments(string source)
+    {
+        var arguments = new List<string>();
+        var start = 0;
+        var parentheses = 0;
+        var braces = 0;
+        var brackets = 0;
+        var quote = '\0';
+        var escaped = false;
+        for (var index = 0; index < source.Length; index++)
+        {
+            var character = source[index];
+            if (quote != '\0')
+            {
+                if (escaped)
+                {
+                    escaped = false;
+                }
+                else if (character == '\\')
+                {
+                    escaped = true;
+                }
+                else if (character == quote)
+                {
+                    quote = '\0';
+                }
+
+                continue;
+            }
+
+            if (character is '\'' or '"') quote = character;
+            else if (character == '(') parentheses++;
+            else if (character == ')') parentheses--;
+            else if (character == '{') braces++;
+            else if (character == '}') braces--;
+            else if (character == '[') brackets++;
+            else if (character == ']') brackets--;
+            else if (character == ',' && parentheses == 0 && braces == 0 && brackets == 0)
+            {
+                arguments.Add(source[start..index]);
+                start = index + 1;
+            }
+        }
+
+        arguments.Add(source[start..]);
+        return arguments;
     }
 
     private static HashSet<string> FindPolicyDominatedMethods(string relative, string source)
@@ -417,50 +1085,216 @@ public sealed class SeerrIntegrationEntryPointGuardTests
     private static bool HasExplicitPolicyGate(MethodSource method)
         => HasExplicitPolicyGateBefore(method, method.Source.Length);
 
-    private static bool HasExplicitPolicyGateBefore(MethodSource method, int boundary)
+    private static bool IsAuthorizedOutboundOwner(
+        MethodSource method,
+        int boundary,
+        string owner,
+        HashSet<string> reviewedMethods,
+        HashSet<string> elevatedSetupMethods,
+        bool requiresFreshFence)
     {
-        // Capture is only an immutable snapshot operation. It becomes an
-        // authorization gate when that exact local is checked before transport;
-        // merely mentioning policy, or calling a separately gated helper, cannot
-        // dominate an independent outbound call in this method.
+        if (elevatedSetupMethods.Contains(owner)) return true;
+        if (requiresFreshFence && InvocationPassesLivePredicate(method, boundary)) return true;
+        if (HasExplicitPolicyGateBefore(method, boundary, requiresFreshFence)) return true;
+
+        // A reviewed transport delegate is not an exemption by name. It must
+        // make the live fence part of its API and pass that exact predicate to
+        // the lower-level dispatch. FindUngatedDelegateCallers separately proves
+        // every production caller supplies it from a fresh policy gate.
+        return reviewedMethods.Contains(owner)
+            && (!requiresFreshFence || Regex.IsMatch(
+                method.Source,
+                @"\bSeerrDispatchFence\s+(?<fence>[A-Za-z_]\w*)"))
+            && (!requiresFreshFence || ReviewedPredicateIsPassedBefore(method, boundary));
+    }
+
+    private static bool ReviewedPredicateIsPassedBefore(MethodSource method, int boundary)
+    {
+        var parameter = Regex.Match(
+            method.Source,
+            @"\bSeerrDispatchFence\s+(?<fence>[A-Za-z_]\w*)");
+        if (!parameter.Success) return false;
+
+        var fenceName = parameter.Groups["fence"].Value;
+        var callStart = Math.Min(boundary, method.Source.Length);
+        var open = method.Source.IndexOf('(', callStart);
+        if (open < 0) return false;
+        var close = FindBalancedParenthesisEnd(method.Source, open);
+        if (close < 0) return false;
+        var callAndArguments = method.Source[callStart..(close + 1)];
+        return Regex.IsMatch(callAndArguments, @"\b" + Regex.Escape(fenceName) + @"\b");
+    }
+
+    private static int FindBalancedParenthesisEnd(string source, int open)
+    {
+        var depth = 0;
+        for (var index = open; index < source.Length; index++)
+        {
+            if (source[index] == '(') depth++;
+            else if (source[index] == ')' && --depth == 0) return index;
+        }
+
+        return -1;
+    }
+
+    private static bool HasExplicitPolicyGateBefore(
+        MethodSource method,
+        int boundary,
+        bool requiresFreshFence = true)
+    {
+        var bounded = method.Source[..Math.Min(boundary, method.Source.Length)];
+        var freshStart = 0;
+        foreach (Match completedAwait in Regex.Matches(
+                     bounded,
+                     @"\bawait\b[^;]*;",
+                     RegexOptions.Singleline))
+        {
+            freshStart = completedAwait.Index + completedAwait.Length;
+        }
+
+        var freshPrefix = bounded[(requiresFreshFence ? freshStart : 0)..];
+
+        // Capture alone authorizes nothing. The captured local must participate
+        // in a fail-closed branch whose disabled/stale path exits this dispatch
+        // edge. Starting after the last completed await forces a new IsCurrent
+        // check before every later send.
         foreach (Match capturedSnapshot in Regex.Matches(
                      method.Source,
                      @"\bvar\s+(?<snapshot>[A-Za-z_]\w*)\s*=\s*SeerrIntegrationPolicy\.Capture\s*\("))
         {
             var snapshotName = capturedSnapshot.Groups["snapshot"].Value;
-            var afterCapture = method.Source[capturedSnapshot.Index..];
-            var check = Regex.Match(
-                afterCapture,
-                @"\b" + Regex.Escape(snapshotName) + @"\.(?:IsActive|IsCurrent)\b");
-            if (check.Success && capturedSnapshot.Index + check.Index + check.Length <= boundary)
+            if (HasTerminatingNegativeCondition(
+                    freshPrefix,
+                    Regex.Escape(snapshotName) + @"\.(?:IsActive|IsCurrent\s*\([^)]*\))"))
             {
                 return true;
             }
         }
 
-        // Some established entry points retain a named boolean because Seerr is
-        // only conditionally needed. Require that boolean to participate in a
-        // later condition; an ignored HasUsableSavedConfiguration call is not a
-        // gate either.
+        // Some entry points retain a named boolean. It is accepted only when a
+        // false value takes a recognized terminating branch at this edge.
         foreach (Match savedConfiguration in Regex.Matches(
                      method.Source,
                      @"\bvar\s+(?<gate>[A-Za-z_]\w*)\s*=\s*SeerrIntegrationPolicy\.HasUsableSavedConfiguration\s*\("))
         {
             var gateName = savedConfiguration.Groups["gate"].Value;
-            var afterCapture = method.Source[savedConfiguration.Index..];
-            var check = Regex.Match(
-                afterCapture,
-                @"\bif\s*\([\s\S]{0,500}?\b" + Regex.Escape(gateName) + @"\b");
-            if (check.Success && savedConfiguration.Index + check.Index + check.Length <= boundary)
+            if (HasTerminatingNegativeCondition(freshPrefix, Regex.Escape(gateName)))
             {
                 return true;
             }
         }
 
-        var directCheck = Regex.Match(
-            method.Source,
-            @"\bif\s*\([\s\S]{0,500}?SeerrIntegrationPolicy\.HasUsableSavedConfiguration\s*\(");
-        return directCheck.Success && directCheck.Index + directCheck.Length <= boundary;
+        return HasTerminatingNegativeCondition(
+                freshPrefix,
+                @"SeerrIntegrationPolicy\.HasUsableSavedConfiguration\s*\([^)]*\)")
+            || HasTerminatingNegativeCondition(
+                freshPrefix,
+                @"[A-Za-z_]\w*\.(?:IsCurrent|Matches)\s*\([^)]*\)")
+            || DeclaredDispatchFenceNames(method.Source).Any(fenceName =>
+                HasTerminatingNegativeCondition(
+                    freshPrefix,
+                    Regex.Escape(fenceName) + @"(?:\?|)\.CanDispatch\s*\(\s*\)(?:\s*!=\s*true)?"));
+    }
+
+    private static bool HasTerminatingNegativeCondition(string source, string positiveExpression)
+    {
+        foreach (Match branch in Regex.Matches(source, @"\bif\s*\("))
+        {
+            var open = source.IndexOf('(', branch.Index);
+            var close = FindBalancedParenthesisEnd(source, open);
+            if (close < 0) continue;
+            var condition = source[(open + 1)..close];
+            if (!SplitTopLevelOrOperands(condition).Any(operand => Regex.IsMatch(
+                    operand,
+                    @"^\s*!\s*(?:\(\s*)?" + positiveExpression + @"(?:\s*\))?\s*$",
+                    RegexOptions.Singleline)))
+            {
+                continue;
+            }
+
+            var statementStart = close + 1;
+            while (statementStart < source.Length && char.IsWhiteSpace(source[statementStart]))
+            {
+                statementStart++;
+            }
+
+            if (statementStart < source.Length && source[statementStart] == '{')
+            {
+                var bodyEnd = FindBalancedBodyEnd(source, statementStart);
+                if (bodyEnd > statementStart
+                    && BlockHasTopLevelTerminal(source[(statementStart + 1)..bodyEnd]))
+                {
+                    return true;
+                }
+
+                continue;
+            }
+
+            var statementEnd = source.IndexOf(';', statementStart);
+            if (statementEnd > statementStart
+                && Regex.IsMatch(
+                    source[statementStart..(statementEnd + 1)],
+                    @"^\s*(?:return|throw|continue|break)\b"))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static IReadOnlyList<string> SplitTopLevelOrOperands(string source)
+    {
+        var operands = new List<string>();
+        var start = 0;
+        var parentheses = 0;
+        for (var index = 0; index < source.Length - 1; index++)
+        {
+            if (source[index] == '(')
+            {
+                parentheses++;
+            }
+            else if (source[index] == ')')
+            {
+                parentheses--;
+            }
+            else if (source[index] == '|'
+                && source[index + 1] == '|'
+                && parentheses == 0)
+            {
+                operands.Add(source[start..index]);
+                start = index + 2;
+                index++;
+            }
+        }
+
+        operands.Add(source[start..]);
+        return operands;
+    }
+
+    private static bool BlockHasTopLevelTerminal(string body)
+    {
+        var depth = 0;
+        for (var index = 0; index < body.Length; index++)
+        {
+            if (body[index] == '{')
+            {
+                depth++;
+                continue;
+            }
+
+            if (body[index] == '}')
+            {
+                depth--;
+                continue;
+            }
+
+            if (depth != 0 || !char.IsLetter(body[index])) continue;
+            var token = Regex.Match(body[index..], @"^(?:return|throw|continue|break)\b");
+            if (token.Success) return true;
+        }
+
+        return false;
     }
 
     private static MethodSource? FindContainingMethod(string source, int position)
@@ -557,4 +1391,6 @@ public sealed class SeerrIntegrationEntryPointGuardTests
         string Body,
         int Start,
         int End);
+
+    private sealed record RawEdgeContract(int ExpectedCalls, params string[] RequiredMarkers);
 }

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrIntegrationEntryPointGuardTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrIntegrationEntryPointGuardTests.cs
@@ -1,0 +1,560 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Controllers;
+using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services;
+
+/// <summary>
+/// Architecture guard for the Seerr master switch. The old bug existed because
+/// several entry points independently interpreted retained URL/key fields as an
+/// enabled integration. This guard makes the policy owner and the deliberately
+/// narrow administrator setup probes explicit.
+/// </summary>
+public sealed class SeerrIntegrationEntryPointGuardTests
+{
+    private static readonly Regex DirectMasterRead = new(
+        @"\.SeerrEnabled\b",
+        RegexOptions.Compiled);
+
+    private static readonly Regex OutboundSeerrCall = new(
+        @"\bSeerrHttpHelper\.(?:CreateClient|BuildRequest|SendAndReadJsonAsync|SendResponseHeadersReadAsync|ReadResponseAsync)\s*\("
+        + @"|\bSeerrPaginationHelper\.FetchAll(?:Sources)?Async\s*\("
+        + @"|\bSeerrUserImportHelper\.BulkImportAsync\s*\(",
+        RegexOptions.Compiled);
+
+    private static readonly Regex MethodDeclaration = new(
+        @"(?m)^[ \t]*(?:public|private|protected|internal)\s+"
+        + @"(?:(?:static|async|virtual|override|sealed|new|unsafe|readonly|partial|extern)\s+)*"
+        + @"[^\r\n{;=]+?\b(?<name>[A-Za-z_]\w*)(?:<[^>{}]*>)?\s*"
+        + @"\((?:[^(){};]|\([^(){};]*\))*\)\s*(?:where\s+[^\{=>]+)?(?<body>\{|=>)",
+        RegexOptions.Compiled);
+
+    private static readonly HashSet<string> TransportOnlyHelpers = new(StringComparer.Ordinal)
+    {
+        "Helpers/Seerr/SeerrHttpHelper.cs",
+        "Helpers/Seerr/SeerrPaginationHelper.cs",
+        "Helpers/Seerr/SeerrUserImportHelper.cs",
+    };
+
+    // These exact lower-level methods are transport delegates reached only from
+    // policy-gated operations. Keeping the inventory at method granularity means
+    // a new outbound method in an otherwise compliant file is rejected.
+    private static readonly HashSet<string> ReviewedDelegatedTransportMethods = new(StringComparer.Ordinal)
+    {
+        "Controllers/ArrRequestsController.cs:EnrichWithTmdbData",
+        "Controllers/ArrRequestsController.cs:FetchComingSoonCollectionAsync",
+        "Controllers/ArrRequestsController.cs:FetchRequestListCollectionAsync",
+        "Controllers/ArrRequestsController.cs:FetchUserRequestSnapshotAsync",
+        "Controllers/SeerrProxyController.cs:EnrichQuotaWithResetAsync",
+        "Controllers/SeerrProxyController.cs:FetchQuotaRequestHistoryAsync",
+        "Controllers/SeerrProxyController.cs:GetSeerrQuota",
+        "ScheduledTasks/JellyfinToSeerrWatchlistSyncTask.cs:AddToSeerrWatchlist",
+        "ScheduledTasks/JellyfinToSeerrWatchlistSyncTask.cs:FetchSeerrUserMapSnapshotAsync",
+        "ScheduledTasks/JellyfinToSeerrWatchlistSyncTask.cs:FetchSeerrUserMapSnapshotsAsync",
+        "ScheduledTasks/JellyfinToSeerrWatchlistSyncTask.cs:FetchSeerrWatchlistSnapshotAsync",
+        "ScheduledTasks/JellyfinToSeerrWatchlistSyncTask.cs:HasFreshExactBindingAsync",
+        "ScheduledTasks/SeerrWatchlistSyncTask.cs:FetchSeerrRequestSnapshotAsync",
+        "ScheduledTasks/SeerrWatchlistSyncTask.cs:FetchSeerrUserMapSnapshotAsync",
+        "ScheduledTasks/SeerrWatchlistSyncTask.cs:FetchSeerrUserMapSnapshotsAsync",
+        "ScheduledTasks/SeerrWatchlistSyncTask.cs:FetchSeerrWatchlistSnapshotAsync",
+        "Services/AutoMovieRequestService.cs:GetNextMovieInCollectionAsync",
+        "Services/AutoMovieRequestService.cs:GetOriginalMovieQualityProfileAsync",
+        "Services/AutoMovieRequestService.cs:ResolveQualityProfileAsync",
+        "Services/AutoSeasonRequestService.cs:GetSeasonStatusFromSeerr",
+        "Services/AutoSeasonRequestService.cs:GetSeriesDetailsJsonAsync",
+        "Services/AutoSeasonRequestService.cs:GetTotalEpisodesInSeasonFromTmdb",
+        "Services/Seerr/AvatarFetchService.cs:CompleteFlightAsync",
+        "Services/Seerr/AvatarFetchService.cs:FetchLeaderAsync",
+        "Services/Seerr/SeerrClient.cs:FetchExactUserBindingAsync",
+        "Services/Seerr/SeerrClient.cs:GetPublic4kSettingsAsync",
+        "Services/Seerr/SeerrClient.cs:TryAutoImportSeerrUser",
+        "Services/Seerr/SeerrParentalFilter.cs:FetchDetailFromSeerrAsync",
+        "Services/Seerr/SeerrParentalFilter.cs:FetchDetailAsync",
+        "Services/Seerr/SeerrParentalFilter.cs:FetchSignatureAsync",
+        "Services/Seerr/SeerrParentalFilter.cs:FilterListAsync",
+        "Services/Seerr/SeerrParentalFilter.cs:GetSignatureAsync",
+        "Services/Seerr/SeerrParentalFilter.cs:ApplyAsync",
+        "Services/Seerr/SeerrParentalFilter.cs:IsBlockedAsync",
+        "Services/Seerr/SeerrParentalFilter.cs:IsTitleBlockedAsync",
+        "Services/Seerr/SeerrParentalFilter.cs:IsTmdbProxyPathBlockedAsync",
+        "Services/Seerr/SeerrParentalFilter.cs:ResolveScoresAsync",
+        "Services/SeerrScanTriggerService.cs:DispatchAsync",
+        "Services/SeerrScanTriggerService.cs:ExecutePlanAsync",
+        "Services/SeerrScanTriggerService.cs:OnDebounceElapsed",
+        "Services/SeerrScanTriggerService.cs:PostScanTrigger",
+        "Services/SeerrScanTriggerService.cs:QueueAutomaticPlanLocked",
+        "Services/SeerrScanTriggerService.cs:RunWorkerAsync",
+        "Services/SeerrScanTriggerService.cs:StartPlanLocked",
+        "Services/WatchlistMonitor.cs:GetAllSeerrRequests",
+        "Services/WatchlistMonitor.cs:FetchAllRequestsSnapshotAsync",
+        "Services/WatchlistMonitor.cs:FetchAllRequestsSnapshotsAsync",
+        "Services/WatchlistMonitor.cs:FetchAllUserSnapshotsAsync",
+    };
+
+    private static readonly HashSet<string> NamedElevatedSetupMethods = new(StringComparer.Ordinal)
+    {
+        "Controllers/ArrLinksController.cs:IdentifyUrl",
+        "Controllers/ArrLinksController.cs:ValidateArrService",
+        "Controllers/SeerrProxyController.cs:ValidateSeerr",
+    };
+
+    [Fact]
+    public void OnlyCentralPolicyReadsTheMasterSwitch()
+    {
+        var offenders = SourceFiles()
+            .Select(path => (Path: path, Relative: Relative(path), Source: StripComments(File.ReadAllText(path))))
+            .Where(file => DirectMasterRead.IsMatch(file.Source))
+            .Where(file => file.Relative != "Services/Seerr/SeerrIntegrationPolicy.cs")
+            // This descriptor only projects the setting to authenticated clients;
+            // it does not authorize an outbound operation.
+            .Where(file => file.Relative != "Configuration/SettingDescriptors.cs")
+            .Select(file => file.Relative)
+            .ToArray();
+
+        Assert.True(
+            offenders.Length == 0,
+            "Production code reads SeerrEnabled outside SeerrIntegrationPolicy: "
+            + string.Join(", ", offenders)
+            + ". Capture the central policy (or use its scheduling-only gate) instead of interpreting retained credentials locally.");
+    }
+
+    [Fact]
+    public void EveryOutboundOwnerUsesCentralPolicyOrIsReviewedTransportPlumbing()
+    {
+        var offenders = new List<string>();
+        foreach (var path in SourceFiles())
+        {
+            var relative = Relative(path);
+            var source = StripComments(File.ReadAllText(path));
+            if (!OutboundSeerrCall.IsMatch(source) || TransportOnlyHelpers.Contains(relative))
+            {
+                continue;
+            }
+
+            var policyDominatedMethods = FindPolicyDominatedMethods(relative, source);
+
+            foreach (Match call in OutboundSeerrCall.Matches(source))
+            {
+                var method = FindContainingMethod(source, call.Index);
+                if (method == null)
+                {
+                    offenders.Add(relative + " (could not identify outbound owner)");
+                }
+                else
+                {
+                    var owner = relative + ":" + method.Name;
+                    if (!HasExplicitPolicyGateBefore(method, call.Index - method.Start)
+                        && !ReviewedDelegatedTransportMethods.Contains(owner)
+                        && !NamedElevatedSetupMethods.Contains(owner))
+                    {
+                        offenders.Add(owner);
+                    }
+                }
+            }
+
+            offenders.AddRange(FindUngatedDelegateCallers(
+                relative,
+                source,
+                policyDominatedMethods: policyDominatedMethods));
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            "Outbound Seerr owner(s) bypass the central integration policy:\n  "
+            + string.Join("\n  ", offenders)
+            + "\nOnly transport-only helpers and the named elevated setup probes may omit policy capture.");
+    }
+
+    [Fact]
+    public void GuardRejectsUngatedMethodEvenWhenAnotherMethodInTheFileUsesPolicy()
+    {
+        const string source = """
+            internal sealed class SyntheticOwner
+            {
+                public void Gated()
+                {
+                    var integration = SeerrIntegrationPolicy.Capture(provider);
+                    if (!integration.IsActive) return;
+                    SeerrHttpHelper.CreateClient(factory);
+                }
+
+                public void Bypass()
+                {
+                    SeerrHttpHelper.CreateClient(factory);
+                }
+            }
+            """;
+
+        var calls = OutboundSeerrCall.Matches(source).Cast<Match>().ToArray();
+        Assert.Equal(2, calls.Length);
+        Assert.Contains("SeerrIntegrationPolicy.", FindContainingMethod(source, calls[0].Index)!.Source);
+        var bypass = FindContainingMethod(source, calls[1].Index);
+        Assert.NotNull(bypass);
+        Assert.Equal("Bypass", bypass!.Name);
+        Assert.DoesNotContain("SeerrIntegrationPolicy.", bypass.Source);
+    }
+
+    [Fact]
+    public void GuardRejectsCaptureWithoutActiveCheckBeforeDispatch()
+    {
+        const string relative = "SyntheticOwner.cs";
+        const string source = """
+            internal sealed class SyntheticOwner
+            {
+                public void Bypass()
+                {
+                    var integration = SeerrIntegrationPolicy.Capture(provider);
+                    SeerrHttpHelper.CreateClient(factory);
+                }
+            }
+            """;
+
+        var dominated = FindPolicyDominatedMethods(relative, source);
+
+        Assert.DoesNotContain(relative + ":Bypass", dominated);
+    }
+
+    [Fact]
+    public void GuardRejectsGatedHelperCallFollowedByIndependentDispatch()
+    {
+        const string relative = "SyntheticOwner.cs";
+        const string source = """
+            internal sealed class SyntheticOwner
+            {
+                public void Bypass()
+                {
+                    GatedHelper();
+                    SeerrHttpHelper.CreateClient(factory);
+                }
+
+                private void GatedHelper()
+                {
+                    var integration = SeerrIntegrationPolicy.Capture(provider);
+                    if (!integration.IsActive) return;
+                }
+            }
+            """;
+
+        var dominated = FindPolicyDominatedMethods(relative, source);
+
+        Assert.Contains(relative + ":GatedHelper", dominated);
+        Assert.DoesNotContain(relative + ":Bypass", dominated);
+    }
+
+    [Fact]
+    public void GuardRejectsPolicyCheckThatOccursAfterDispatch()
+    {
+        const string source = """
+            internal sealed class SyntheticOwner
+            {
+                public void Bypass()
+                {
+                    var integration = SeerrIntegrationPolicy.Capture(provider);
+                    SeerrHttpHelper.CreateClient(factory);
+                    if (!integration.IsActive) return;
+                }
+            }
+            """;
+        var call = Assert.Single(OutboundSeerrCall.Matches(source).Cast<Match>());
+        var method = FindContainingMethod(source, call.Index);
+
+        Assert.NotNull(method);
+        Assert.False(HasExplicitPolicyGateBefore(method!, call.Index - method!.Start));
+    }
+
+    [Fact]
+    public void GuardRejectsUngatedCallerOfAlreadyReviewedTransportDelegate()
+    {
+        const string relative = "SyntheticOwner.cs";
+        const string source = """
+            internal sealed class SyntheticOwner
+            {
+                public void Gated()
+                {
+                    var integration = SeerrIntegrationPolicy.Capture(provider);
+                    if (!integration.IsActive) return;
+                    FetchReviewedAsync();
+                }
+
+                public void Bypass()
+                {
+                    FetchReviewedAsync();
+                }
+
+                private void FetchReviewedAsync()
+                {
+                    SeerrHttpHelper.CreateClient(factory);
+                }
+            }
+            """;
+        var reviewed = new HashSet<string>(StringComparer.Ordinal)
+        {
+            relative + ":FetchReviewedAsync",
+        };
+
+        var offenders = FindUngatedDelegateCallers(relative, source, reviewed);
+
+        Assert.Equal(relative + ":FetchReviewedAsync <- Bypass", Assert.Single(offenders));
+    }
+
+    [Fact]
+    public void UnsavedConnectionValidationIsTheNamedElevatedSetupExemption()
+    {
+        var validate = typeof(SeerrProxyController).GetMethod(nameof(SeerrProxyController.ValidateSeerr));
+        Assert.NotNull(validate);
+        var authorize = validate!.GetCustomAttribute<Microsoft.AspNetCore.Authorization.AuthorizeAttribute>();
+        Assert.Equal(MediaBrowser.Common.Api.Policies.RequiresElevation, authorize?.Policy);
+
+        var proxySource = StripComments(File.ReadAllText(SourcePath("Controllers/SeerrProxyController.cs")));
+        var validateBody = ExtractMethod(proxySource, nameof(SeerrProxyController.ValidateSeerr));
+        Assert.Contains("SeerrHttpHelper.SendAndReadJsonAsync", validateBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("SeerrIntegrationPolicy.Capture", validateBody, StringComparison.Ordinal);
+
+        var linksSource = StripComments(File.ReadAllText(SourcePath("Controllers/ArrLinksController.cs")));
+        Assert.Contains("[Authorize(Policy = Policies.RequiresElevation)]", linksSource, StringComparison.Ordinal);
+        Assert.Matches(OutboundSeerrCall, ExtractMethod(linksSource, "ValidateArrService"));
+        Assert.Matches(OutboundSeerrCall, ExtractMethod(linksSource, "IdentifyUrl"));
+    }
+
+    [Fact]
+    public async Task ValidateSeerr_MasterDisabled_AllowsExplicitUnsavedAdministratorProbe()
+    {
+        var configProvider = new FakePluginConfigProvider(new PluginConfiguration
+        {
+            SeerrEnabled = false,
+            SeerrUrls = "http://retained-old:5055",
+            SeerrApiKey = "retained-old-key",
+        });
+        var cache = new SeerrCache(configProvider);
+        var handler = new RecordingHttpMessageHandler();
+        handler.AddResponse("/api/v1/user", """{"results":[],"pageInfo":{"page":1,"pages":1,"results":0}}""");
+        var controller = new SeerrProxyController(
+            new RecordingHttpClientFactory(handler),
+            NullLogger<SeerrProxyController>.Instance,
+            null!,
+            cache,
+            configProvider,
+            null!,
+            null!,
+            null!);
+
+        var result = await controller.ValidateSeerr("http://localhost:5055", "unsaved-new-key");
+
+        Assert.IsType<OkObjectResult>(result);
+        var sent = Assert.Single(handler.Sent);
+        Assert.Equal("/api/v1/user", sent.Path);
+        Assert.Equal("unsaved-new-key", Assert.Single(handler.ApiKeyHeaders));
+    }
+
+    private static string StripComments(string source)
+    {
+        var withoutBlocks = Regex.Replace(source, @"/\*.*?\*/", " ", RegexOptions.Singleline);
+        return Regex.Replace(withoutBlocks, @"//[^\n]*", string.Empty);
+    }
+
+    private static string ExtractMethod(string source, string methodName)
+    {
+        var range = ExtractMethodRange(source, methodName);
+        return source.Substring(range.Start, range.Length);
+    }
+
+    private static IReadOnlyList<string> FindUngatedDelegateCallers(
+        string relative,
+        string source,
+        HashSet<string>? reviewedMethods = null,
+        HashSet<string>? policyDominatedMethods = null)
+    {
+        reviewedMethods ??= ReviewedDelegatedTransportMethods;
+        policyDominatedMethods ??= FindPolicyDominatedMethods(relative, source);
+        var methods = EnumerateMethods(source);
+        var offenders = new List<string>();
+        foreach (var reviewed in reviewedMethods.Where(key => key.StartsWith(relative + ":", StringComparison.Ordinal)))
+        {
+            var separator = reviewed.LastIndexOf(':');
+            var delegateName = reviewed[(separator + 1)..];
+            var invocation = new Regex(
+                @"\b" + Regex.Escape(delegateName) + @"\s*\(",
+                RegexOptions.Compiled);
+            foreach (var caller in methods.Where(method => method.Name != delegateName))
+            {
+                var callerKey = relative + ":" + caller.Name;
+                if (reviewedMethods.Contains(callerKey))
+                {
+                    continue;
+                }
+
+                var bodyOffset = caller.Source.IndexOf(caller.Body, StringComparison.Ordinal);
+                foreach (Match call in invocation.Matches(caller.Body))
+                {
+                    if (!HasExplicitPolicyGateBefore(caller, bodyOffset + call.Index))
+                    {
+                        offenders.Add(reviewed + " <- " + caller.Name);
+                        break;
+                    }
+                }
+            }
+        }
+
+        return offenders;
+    }
+
+    private static HashSet<string> FindPolicyDominatedMethods(string relative, string source)
+    {
+        var methods = EnumerateMethods(source);
+        return methods
+            .Where(HasExplicitPolicyGate)
+            .Select(method => relative + ":" + method.Name)
+            .ToHashSet(StringComparer.Ordinal);
+    }
+
+    private static bool HasExplicitPolicyGate(MethodSource method)
+        => HasExplicitPolicyGateBefore(method, method.Source.Length);
+
+    private static bool HasExplicitPolicyGateBefore(MethodSource method, int boundary)
+    {
+        // Capture is only an immutable snapshot operation. It becomes an
+        // authorization gate when that exact local is checked before transport;
+        // merely mentioning policy, or calling a separately gated helper, cannot
+        // dominate an independent outbound call in this method.
+        foreach (Match capturedSnapshot in Regex.Matches(
+                     method.Source,
+                     @"\bvar\s+(?<snapshot>[A-Za-z_]\w*)\s*=\s*SeerrIntegrationPolicy\.Capture\s*\("))
+        {
+            var snapshotName = capturedSnapshot.Groups["snapshot"].Value;
+            var afterCapture = method.Source[capturedSnapshot.Index..];
+            var check = Regex.Match(
+                afterCapture,
+                @"\b" + Regex.Escape(snapshotName) + @"\.(?:IsActive|IsCurrent)\b");
+            if (check.Success && capturedSnapshot.Index + check.Index + check.Length <= boundary)
+            {
+                return true;
+            }
+        }
+
+        // Some established entry points retain a named boolean because Seerr is
+        // only conditionally needed. Require that boolean to participate in a
+        // later condition; an ignored HasUsableSavedConfiguration call is not a
+        // gate either.
+        foreach (Match savedConfiguration in Regex.Matches(
+                     method.Source,
+                     @"\bvar\s+(?<gate>[A-Za-z_]\w*)\s*=\s*SeerrIntegrationPolicy\.HasUsableSavedConfiguration\s*\("))
+        {
+            var gateName = savedConfiguration.Groups["gate"].Value;
+            var afterCapture = method.Source[savedConfiguration.Index..];
+            var check = Regex.Match(
+                afterCapture,
+                @"\bif\s*\([\s\S]{0,500}?\b" + Regex.Escape(gateName) + @"\b");
+            if (check.Success && savedConfiguration.Index + check.Index + check.Length <= boundary)
+            {
+                return true;
+            }
+        }
+
+        var directCheck = Regex.Match(
+            method.Source,
+            @"\bif\s*\([\s\S]{0,500}?SeerrIntegrationPolicy\.HasUsableSavedConfiguration\s*\(");
+        return directCheck.Success && directCheck.Index + directCheck.Length <= boundary;
+    }
+
+    private static MethodSource? FindContainingMethod(string source, int position)
+    {
+        MethodSource? containing = null;
+        foreach (var candidate in EnumerateMethods(source))
+        {
+            if (candidate.Start > position) break;
+            if (candidate.End < position) continue;
+            if (containing == null || candidate.Source.Length < containing.Source.Length)
+            {
+                containing = candidate;
+            }
+        }
+
+        return containing;
+    }
+
+    private static IReadOnlyList<MethodSource> EnumerateMethods(string source)
+    {
+        var methods = new List<MethodSource>();
+        foreach (Match declaration in MethodDeclaration.Matches(source))
+        {
+            var bodyToken = declaration.Groups["body"];
+            var end = bodyToken.Value == "=>"
+                ? source.IndexOf(';', bodyToken.Index)
+                : FindBalancedBodyEnd(source, bodyToken.Index);
+            if (end < bodyToken.Index) continue;
+            methods.Add(new MethodSource(
+                declaration.Groups["name"].Value,
+                source.Substring(declaration.Index, end - declaration.Index + 1),
+                source.Substring(bodyToken.Index, end - bodyToken.Index + 1),
+                declaration.Index,
+                end));
+        }
+
+        return methods;
+    }
+
+    private static int FindBalancedBodyEnd(string source, int open)
+    {
+        var depth = 0;
+        for (var index = open; index < source.Length; index++)
+        {
+            if (source[index] == '{') depth++;
+            else if (source[index] == '}' && --depth == 0) return index;
+        }
+
+        return -1;
+    }
+
+    private static (int Start, int Length) ExtractMethodRange(string source, string methodName)
+    {
+        var declaration = Regex.Match(
+            source,
+            @"\b" + Regex.Escape(methodName) + @"\s*\([^;{]*\)\s*\{",
+            RegexOptions.Singleline);
+        Assert.True(declaration.Success, $"Could not locate method {methodName}.");
+        var open = source.IndexOf('{', declaration.Index + declaration.Length - 1);
+        var depth = 0;
+        for (var index = open; index < source.Length; index++)
+        {
+            if (source[index] == '{') depth++;
+            else if (source[index] == '}' && --depth == 0)
+            {
+                return (declaration.Index, index - declaration.Index + 1);
+            }
+        }
+
+        throw new Xunit.Sdk.XunitException($"Method {methodName} has no balanced body.");
+    }
+
+    private static IEnumerable<string> SourceFiles()
+        => Directory.EnumerateFiles(PluginSourceRoot(), "*.cs", SearchOption.AllDirectories)
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}")
+                && !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}"));
+
+    private static string Relative(string path)
+        => Path.GetRelativePath(PluginSourceRoot(), path).Replace(Path.DirectorySeparatorChar, '/');
+
+    private static string SourcePath(string relative)
+        => Path.Combine(PluginSourceRoot(), relative.Replace('/', Path.DirectorySeparatorChar));
+
+    private static string PluginSourceRoot([CallerFilePath] string sourceFile = "")
+        => Path.GetFullPath(Path.Combine(
+            Path.GetDirectoryName(sourceFile)!,
+            "..",
+            "..",
+            "Jellyfin.Plugin.JellyfinCanopy"));
+
+    private sealed record MethodSource(
+        string Name,
+        string Source,
+        string Body,
+        int Start,
+        int End);
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrPaginationIntegrationTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrPaginationIntegrationTests.cs
@@ -579,7 +579,7 @@ public class SeerrPaginationIntegrationTests
         var result = await client.ResolveSeerrUser(JellyfinUserId);
 
         Assert.Equal(SeerrUserResolutionStatus.Incomplete, result.Status);
-        Assert.Equal(4, getCount);
+        Assert.Equal(3, getCount);
         Assert.DoesNotContain(handler.Requests, request => request.Method == HttpMethod.Post);
         Assert.DoesNotContain(NormalizedJellyfinUserId, cache.UserCache.Keys);
     }
@@ -968,6 +968,7 @@ public class SeerrPaginationIntegrationTests
             httpClient,
             new[] { "http://seerr:5055" },
             "key",
+            SeerrDispatchFenceTestFactory.Create(),
             CancellationToken.None);
 
         Assert.True(result.IsComplete, result.FailureReason);
@@ -997,6 +998,7 @@ public class SeerrPaginationIntegrationTests
             httpClient,
             new[] { "http://first:5055", "http://second:5055" },
             "key",
+            SeerrDispatchFenceTestFactory.Create(),
             CancellationToken.None);
 
         Assert.True(result.IsComplete, result.FailureReason);
@@ -1026,6 +1028,7 @@ public class SeerrPaginationIntegrationTests
             httpClient,
             new[] { "http://first:5055", "http://second:5055" },
             "key",
+            SeerrDispatchFenceTestFactory.Create(),
             CancellationToken.None);
 
         Assert.False(result.IsComplete);

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrReadGenerationFenceTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrReadGenerationFenceTests.cs
@@ -72,6 +72,34 @@ public sealed class SeerrReadGenerationFenceTests
     }
 
     [Fact]
+    public async Task GenericProxy_PublicFailoverDisabledDuringFirstRequest_DoesNotSendToSecondSource()
+    {
+        var provider = new FakePluginConfigProvider(Configuration($"{SourceA},{SourceB}", "key-a"));
+        var cache = new SeerrCache(provider);
+        var handler = new BlockingFailedReadHandler();
+        var client = CreateClient(handler, provider, cache, new PassthroughParentalFilter());
+
+        var requestTask = client.ProxyRequestAsync(
+            "/api/v1/keyword?query=space",
+            HttpMethod.Get,
+            content: null,
+            new SeerrCaller(JellyfinUserId, IsAdmin: false),
+            BoundUser());
+        await handler.FirstRequestStarted.WaitAsync(TimeSpan.FromSeconds(5));
+
+        provider.Current!.SeerrEnabled = false;
+        handler.ReleaseFirstRequest();
+
+        var conflict = Assert.IsType<ObjectResult>(
+            await requestTask.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.Equal(409, conflict.StatusCode);
+        Assert.Equal(
+            "read_configuration_changed",
+            conflict.Value?.GetType().GetProperty("code")?.GetValue(conflict.Value));
+        Assert.Equal(new[] { "source-a" }, handler.Hosts);
+    }
+
+    [Fact]
     public async Task GenericProxy_UncachedParentalFilterFaultReturnsStructuredUnavailableNotRawBody()
     {
         const string apiPath = "/api/v1/keyword?query=space";
@@ -252,7 +280,7 @@ public sealed class SeerrReadGenerationFenceTests
             cacheLock,
             key,
             stale,
-            () =>
+            SeerrDispatchFenceTestFactory.Create(() =>
             {
                 if (++checks == 1)
                 {
@@ -265,7 +293,7 @@ public sealed class SeerrReadGenerationFenceTests
                 }
 
                 return false;
-            });
+            }));
 
         Assert.False(published);
         Assert.Equal(2, checks);
@@ -381,6 +409,40 @@ public sealed class SeerrReadGenerationFenceTests
     }
 
     private sealed record CapturedRequest(string Host, string Path, string? ApiKey);
+
+    private sealed class BlockingFailedReadHandler : HttpMessageHandler
+    {
+        private readonly TaskCompletionSource _firstRequestStarted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _releaseFirstRequest =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task FirstRequestStarted => _firstRequestStarted.Task;
+
+        public List<string> Hosts { get; } = new();
+
+        public void ReleaseFirstRequest() => _releaseFirstRequest.TrySetResult();
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Hosts.Add(request.RequestUri!.Host);
+            if (Hosts.Count == 1)
+            {
+                _firstRequestStarted.TrySetResult();
+                await _releaseFirstRequest.Task.WaitAsync(cancellationToken);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+            {
+                Content = new StringContent(
+                    "{\"message\":\"unavailable\"}",
+                    Encoding.UTF8,
+                    "application/json"),
+            };
+        }
+    }
 
     private sealed class ChunkedOversizeHandler : HttpMessageHandler
     {

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrScanTriggerServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrScanTriggerServiceTests.cs
@@ -381,39 +381,26 @@ public sealed class SeerrScanTriggerServiceTests
     }
 
     [Fact]
-    public async Task RetiredAutomaticTarget_DoesNotBlockLaterExplicitManualTarget()
+    public async Task ManualTrigger_MasterDisabledWithRetainedCredentials_DoesNotPost()
     {
-        var provider = EnabledProvider();
-        provider.Current!.SeerrUrls = "http://automatic:5055";
-        var clock = new ManualTimeProvider(Epoch);
-        var library = new CountingLibraryManager();
-        var handler = LifecycleHandler.BlockingFirst();
-        using var service = CreateService(provider, handler, library, clock);
-        service.Initialize();
-        library.RaiseItemAdded(Movie());
-        clock.Advance(TimeSpan.FromSeconds(5));
-        await handler.FirstStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
-
-        library.RaiseItemAdded(Movie());
-        var firstManual = service.TriggerNowAsync(new[] { "http://manual-one:5055" }, "key");
-        var secondManual = service.TriggerNowAsync("http://manual-two:5055", "key");
-        provider.Current = new PluginConfiguration
+        var provider = new FakePluginConfigProvider(new PluginConfiguration
         {
-            SeerrEnabled = true,
+            SeerrEnabled = false,
             TriggerSeerrScanOnItemAdded = true,
-            SeerrScanDebounceSeconds = 5,
-            SeerrUrls = "http://replacement:5055",
-            SeerrApiKey = "replacement-key",
-        };
-        handler.ReleaseFirst.TrySetResult();
+            SeerrUrls = "http://retained:5055",
+            SeerrApiKey = "retained-key",
+        });
+        var handler = LifecycleHandler.Immediate();
+        using var service = CreateService(provider, handler);
 
-        var results = await firstManual.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.True((await secondManual.WaitAsync(TimeSpan.FromSeconds(5))).Success);
-        Assert.Equal(new[] { "automatic", "manual-one", "manual-two" },
-            handler.Requests.Select(request => request.Host));
-        Assert.Equal(new[] { true, false, true }, results.Select(result => result.Success));
-        Assert.Equal("ConfigurationChanged", results[1].ErrorCode);
-        Assert.Equal(1, handler.MaximumConcurrency);
+        var result = await service.TriggerNowAsync(
+            "http://retained:5055",
+            "retained-key");
+
+        Assert.False(result.Success);
+        Assert.Equal("SeerrDisabled", result.ErrorCode);
+        Assert.Equal(503, result.StatusCode);
+        Assert.Equal(0, handler.RequestCount);
     }
 
     private static FakePluginConfigProvider EnabledProvider()

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/WatchlistMonitorLifecycleTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/WatchlistMonitorLifecycleTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Collections.Concurrent;
 using System.Text;
 using System.Text.Json;
+using System.Reflection;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
 using Jellyfin.Plugin.JellyfinCanopy.Helpers;
@@ -50,6 +51,8 @@ public sealed class WatchlistMonitorLifecycleTests
         monitor.Initialize();
         library.RaiseItemAdded(Movie(123));
         await readStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        using var throwingRegistration = GetConfigurationCancellation(monitor).Token.Register(
+            static () => throw new InvalidOperationException("synthetic disposal callback failure"));
 
         var disposeTask = Task.Run(monitor.Dispose);
         await WaitUntilAsync(() => library.ItemAddedCount == 0);
@@ -162,6 +165,42 @@ public sealed class WatchlistMonitorLifecycleTests
         await Task.Delay(50);
         Assert.Equal(requestsBeforeDisabledEvent, handler.RequestCount);
         monitor.Dispose();
+    }
+
+    [Fact]
+    public async Task ThrowingCancellationCallback_StillAdvancesGenerationAndClearsOwnedCache()
+    {
+        var library = new CountingLibraryManager();
+        var handler = new BlockingEmptyRequestsHandler();
+        var monitor = CreateEventMonitor(library, handler, out _);
+
+        monitor.Initialize();
+        library.RaiseItemAdded(Movie(123));
+        await handler.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        handler.Release.TrySetResult();
+        await WaitUntilAsync(() => monitor.QueueMetrics.StateCount == 0);
+        Assert.Equal(1, monitor.RequestsCacheCount);
+        var generation = monitor.ConfigurationGenerationNumber;
+
+        var cancellation = GetConfigurationCancellation(monitor);
+        using var registration = cancellation.Token.Register(
+            static () => throw new InvalidOperationException("synthetic cancellation callback failure"));
+
+        monitor.NotifyConfigurationChanged();
+        Assert.Equal(generation + 1, monitor.ConfigurationGenerationNumber);
+        Assert.Equal(0, monitor.RequestsCacheCount);
+        monitor.Dispose();
+    }
+
+    private static CancellationTokenSource GetConfigurationCancellation(WatchlistMonitor monitor)
+    {
+        var generationField = typeof(WatchlistMonitor).GetField(
+            "_configurationGeneration",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        var generation = generationField!.GetValue(monitor);
+        Assert.NotNull(generation);
+        var cancellationProperty = generation.GetType().GetProperty("Cancellation");
+        return Assert.IsType<CancellationTokenSource>(cancellationProperty!.GetValue(generation));
     }
 
     [Fact]

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/WatchlistMonitorLifecycleTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/WatchlistMonitorLifecycleTests.cs
@@ -132,6 +132,71 @@ public sealed class WatchlistMonitorLifecycleTests
     }
 
     [Fact]
+    public async Task DisableNotification_AdvancesGenerationAndClearsOwnedRequestCache()
+    {
+        var library = new CountingLibraryManager();
+        var handler = new BlockingEmptyRequestsHandler();
+        var monitor = CreateEventMonitor(library, handler, out var provider);
+
+        monitor.Initialize();
+        library.RaiseItemAdded(Movie(123));
+        await handler.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        handler.Release.TrySetResult();
+        await WaitUntilAsync(() => monitor.QueueMetrics.StateCount == 0);
+        Assert.Equal(1, monitor.RequestsCacheCount);
+        var generation = monitor.ConfigurationGenerationNumber;
+
+        provider.Current = new PluginConfiguration
+        {
+            AddRequestedMediaToWatchlist = true,
+            SeerrEnabled = false,
+            SeerrUrls = "http://seerr:5055",
+            SeerrApiKey = "retained-key",
+        };
+        monitor.NotifyConfigurationChanged();
+
+        Assert.Equal(generation + 1, monitor.ConfigurationGenerationNumber);
+        Assert.Equal(0, monitor.RequestsCacheCount);
+        var requestsBeforeDisabledEvent = handler.RequestCount;
+        library.RaiseItemAdded(Movie(456));
+        await Task.Delay(50);
+        Assert.Equal(requestsBeforeDisabledEvent, handler.RequestCount);
+        monitor.Dispose();
+    }
+
+    [Fact]
+    public async Task DisableNotification_BlockedOldFlightCannotRepopulateClearedCache()
+    {
+        var library = new CountingLibraryManager();
+        var handler = new IgnoringCancellationBlockingEmptyRequestsHandler();
+        var monitor = CreateEventMonitor(library, handler, out var provider);
+
+        monitor.Initialize();
+        library.RaiseItemAdded(Movie(789));
+        await handler.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        provider.Current = new PluginConfiguration
+        {
+            AddRequestedMediaToWatchlist = true,
+            SeerrEnabled = false,
+            SeerrUrls = "http://seerr:5055",
+            SeerrApiKey = "retained-key",
+        };
+        monitor.NotifyConfigurationChanged();
+        Assert.Equal(0, monitor.RequestsCacheCount);
+
+        handler.Release.TrySetResult();
+        await WaitUntilAsync(() => monitor.QueueMetrics.StateCount == 0);
+
+        Assert.Equal(0, monitor.RequestsCacheCount);
+        Assert.Equal(1, handler.RequestCount);
+        library.RaiseItemAdded(Movie(790));
+        await Task.Delay(50);
+        Assert.Equal(1, handler.RequestCount);
+        monitor.Dispose();
+    }
+
+    [Fact]
     public async Task CompletedOlderFlight_DoesNotDeleteNewerReplacement()
     {
         var olderCompletion = new TaskCompletionSource<int>();
@@ -303,6 +368,50 @@ public sealed class WatchlistMonitorLifecycleTests
                 CancellationObserved.TrySetResult();
                 throw;
             }
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    JsonSerializer.Serialize(new
+                    {
+                        page = 1,
+                        totalPages = 1,
+                        totalResults = 0,
+                        pageInfo = new
+                        {
+                            page = 1,
+                            pages = 1,
+                            pageSize = 0,
+                            results = 0,
+                        },
+                        results = Array.Empty<object>(),
+                    }),
+                    Encoding.UTF8,
+                    "application/json"),
+            };
+        }
+    }
+
+    private sealed class IgnoringCancellationBlockingEmptyRequestsHandler : HttpMessageHandler
+    {
+        private int _requestCount;
+
+        public TaskCompletionSource Started { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Release { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int RequestCount => Volatile.Read(ref _requestCount);
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            _ = request;
+            _ = cancellationToken;
+            Interlocked.Increment(ref _requestCount);
+            Started.TrySetResult();
+            await Release.Task;
             return new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent(

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/ArrRequestsController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/ArrRequestsController.cs
@@ -101,7 +101,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
 
             var configurationRevision = _configProvider.ConfigurationRevision;
             var configStamp = SeerrMutationConfigStamp.Capture(config, configurationRevision);
-            var seerrEnabled = config.SeerrEnabled;
+            var seerrEnabled = SeerrIntegrationPolicy.HasUsableSavedConfiguration(config);
             var seerrApiKey = config.SeerrApiKey;
             var configuredUrls = SeerrClient.GetConfiguredUrls(config.SeerrUrls);
             if (!IsReadConfigurationCurrent(configStamp))
@@ -386,14 +386,44 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             take = Math.Clamp(take, 1, 200);
             skip = Math.Max(0, skip);
 
-            var config = _configProvider.ConfigurationOrNull;
-            if (config == null)
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            if (integration.State == SeerrIntegrationState.Disabled)
+            {
+                return Ok(new
+                {
+                    error = false,
+                    code = "seerr_disabled",
+                    disabled = true,
+                    requests = Array.Empty<object>(),
+                    totalPages = 0,
+                    totalResults = 0,
+                    canApproveRequests = false,
+                });
+            }
+
+            if (!integration.IsActive
+                && integration.State != SeerrIntegrationState.ConfigurationUnavailable)
+            {
+                return Ok(new
+                {
+                    error = false,
+                    code = "seerr_unavailable",
+                    disabled = false,
+                    requests = Array.Empty<object>(),
+                    totalPages = 0,
+                    totalResults = 0,
+                    canApproveRequests = false,
+                });
+            }
+
+            var config = integration.Configuration;
+            if (!integration.IsActive || config == null)
                 return StatusCode(500, "Plugin configuration not available");
 
-            var configurationRevision = _configProvider.ConfigurationRevision;
+            var configurationRevision = integration.ConfigurationRevision;
             var configStamp = SeerrMutationConfigStamp.Capture(config, configurationRevision);
-            var seerrApiKey = config.SeerrApiKey;
-            var configuredUrls = SeerrClient.GetConfiguredUrls(config.SeerrUrls);
+            var seerrApiKey = integration.ApiKey;
+            var configuredUrls = integration.Urls;
             var enrichmentCacheEnabled = !config.SeerrDisableCache;
             var requestApprovalsEnabled = config.RequestApprovalsEnabled;
             if (!IsReadConfigurationCurrent(configStamp))
@@ -1081,7 +1111,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
 
             var configurationRevision = _configProvider.ConfigurationRevision;
             var configStamp = SeerrMutationConfigStamp.Capture(config, configurationRevision);
-            var seerrEnabled = config.SeerrEnabled;
+            var seerrEnabled = SeerrIntegrationPolicy.HasUsableSavedConfiguration(config);
             var seerrApiKey = config.SeerrApiKey;
             var configuredUrls = SeerrClient.GetConfiguredUrls(config.SeerrUrls);
             if (!IsReadConfigurationCurrent(configStamp))
@@ -1615,12 +1645,23 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
         {
             var action = HttpContext.Request.Path.Value?.Contains("/approve", StringComparison.OrdinalIgnoreCase) == true ? "approve" : "decline";
 
-            var config = _configProvider.ConfigurationOrNull;
-            if (config == null
-                || !config.SeerrEnabled
-                || string.IsNullOrWhiteSpace(config.SeerrUrls)
-                || string.IsNullOrWhiteSpace(config.SeerrApiKey))
-                return StatusCode(503, new { error = true, message = "Seerr not configured." });
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            if (!integration.IsActive)
+            {
+                return StatusCode(503, new
+                {
+                    error = true,
+                    code = integration.State == SeerrIntegrationState.Disabled
+                        ? "seerr_disabled"
+                        : "seerr_unavailable",
+                    message = integration.State == SeerrIntegrationState.Disabled
+                        ? "Seerr integration is disabled."
+                        : "Seerr is not configured.",
+                    canApproveRequests = false,
+                });
+            }
+
+            var config = integration.Configuration!;
 
             // The admin feature toggle gates the action server-side too — the
             // client hides the buttons when it's off, but the server still
@@ -1630,7 +1671,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
 
             var mutationConfigStamp = SeerrMutationConfigStamp.Capture(
                 config,
-                _configProvider.ConfigurationRevision);
+                integration.ConfigurationRevision);
 
             var jellyfinUserId = UserHelper.GetCurrentUserId(User)?.ToString();
             if (string.IsNullOrEmpty(jellyfinUserId))
@@ -1653,7 +1694,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 });
             }
 
-            var configuredUrls = SeerrClient.GetConfiguredUrls(config.SeerrUrls);
+            var configuredUrls = integration.Urls;
             var tokenSource = configuredUrls.FirstOrDefault(url => SeerrSourceToken.MatchesSource(
                 sourceClaims!.SourceKey,
                 config.SeerrApiKey,
@@ -1679,10 +1720,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                     currentConfig,
                     _configProvider.ConfigurationRevision)
                 || currentConfig == null
-                || !currentConfig.SeerrEnabled
-                || !currentConfig.RequestApprovalsEnabled
-                || string.IsNullOrWhiteSpace(currentConfig.SeerrUrls)
-                || string.IsNullOrWhiteSpace(currentConfig.SeerrApiKey))
+                || !SeerrIntegrationPolicy.HasUsableSavedConfiguration(currentConfig)
+                || !currentConfig.RequestApprovalsEnabled)
             {
                 return StatusCode(409, new
                 {

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/ArrRequestsController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/ArrRequestsController.cs
@@ -101,6 +101,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
 
             var configurationRevision = _configProvider.ConfigurationRevision;
             var configStamp = SeerrMutationConfigStamp.Capture(config, configurationRevision);
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
             var seerrEnabled = SeerrIntegrationPolicy.HasUsableSavedConfiguration(config);
             var seerrApiKey = config.SeerrApiKey;
             var configuredUrls = SeerrClient.GetConfiguredUrls(config.SeerrUrls);
@@ -507,6 +508,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 }
 
                 var requestUrls = new[] { configuredSource };
+                SeerrDispatchFence dispatchFence = integration
+                    .CreateDispatchFence(_configProvider)
+                    .Restrict(() => IsReadConfigurationCurrent(configStamp));
 
                 // Check if user has permission to view all requests
                 // Jellyfin admins can always view all requests regardless of Seerr permissions
@@ -538,6 +542,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                     seerrApiKey,
                     upstreamFilter,
                     scopeParam,
+                    dispatchFence,
                     HttpContext.RequestAborted).ConfigureAwait(false);
                 if (!IsReadConfigurationCurrent(configStamp))
                     return ReadConfigurationChanged("the request list");
@@ -1097,7 +1102,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
         [Authorize]
         public async Task<IActionResult> GetCompleteUserRequestSnapshot([FromQuery] bool userOnly = false)
         {
-            var config = _configProvider.ConfigurationOrNull;
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            var config = integration.Configuration;
             if (config == null)
             {
                 return StatusCode(500, new
@@ -1109,7 +1115,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 });
             }
 
-            var configurationRevision = _configProvider.ConfigurationRevision;
+            var configurationRevision = integration.ConfigurationRevision;
             var configStamp = SeerrMutationConfigStamp.Capture(config, configurationRevision);
             var seerrEnabled = SeerrIntegrationPolicy.HasUsableSavedConfiguration(config);
             var seerrApiKey = config.SeerrApiKey;
@@ -1203,11 +1209,15 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             var urls = new[] { configuredSource };
             var client = SeerrHttpHelper.CreateClient(_httpClientFactory);
             client.Timeout = TimeSpan.FromSeconds(15);
+            SeerrDispatchFence dispatchFence = integration
+                .CreateDispatchFence(_configProvider)
+                .Restrict(() => IsReadConfigurationCurrent(configStamp));
             var snapshot = await FetchUserRequestSnapshotAsync(
                 client,
                 urls,
                 seerrApiKey,
                 seerrUser.Id.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                dispatchFence,
                 HttpContext.RequestAborted,
                 selfScoped: selfScoped,
                 includeApiUserHeader: selfScoped || !jellyfinAdmin).ConfigureAwait(false);
@@ -1452,6 +1462,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             string apiKey,
             string filter,
             string scopeParam,
+            SeerrDispatchFence dispatchFence,
             CancellationToken cancellationToken,
             int pageSize = ComingSoonPageSize,
             int maxItems = ComingSoonMaxItems,
@@ -1464,6 +1475,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 apiUserId: null,
                 requestedPageSize: pageSize,
                 RequestRowIdentity,
+                dispatchFence,
                 cancellationToken,
                 maximumPages: maxPages,
                 maximumItems: maxItems);
@@ -1473,6 +1485,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             IEnumerable<string> seerrUrls,
             string apiKey,
             string seerrUserId,
+            SeerrDispatchFence dispatchFence,
             CancellationToken cancellationToken,
             bool selfScoped = true,
             int pageSize = RequestKeyPageSize,
@@ -1487,6 +1500,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 includeApiUserHeader ? seerrUserId : null,
                 requestedPageSize: pageSize,
                 RequestRowIdentity,
+                dispatchFence,
                 cancellationToken,
                 maximumPages: maxPages,
                 maximumItems: maxItems);
@@ -1501,6 +1515,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             string seerrUrl,
             string apiKey,
             string scopeParam,
+            SeerrDispatchFence dispatchFence,
             CancellationToken cancellationToken,
             int pageSize = ComingSoonPageSize,
             int maxItems = ComingSoonMaxItems,
@@ -1510,6 +1525,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 new[] { seerrUrl },
                 apiKey,
                 scopeParam,
+                dispatchFence,
                 cancellationToken,
                 pageSize,
                 maxItems,
@@ -1520,6 +1536,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             IEnumerable<string> seerrUrls,
             string apiKey,
             string scopeParam,
+            SeerrDispatchFence dispatchFence,
             CancellationToken cancellationToken,
             int pageSize = ComingSoonPageSize,
             int maxItems = ComingSoonMaxItems,
@@ -1530,6 +1547,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 apiKey,
                 "processing",
                 scopeParam,
+                dispatchFence,
                 cancellationToken,
                 pageSize,
                 maxItems,
@@ -1790,6 +1808,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 return StatusCode(403, new { error = true, message = "You do not have permission to approve or decline requests." });
 
             var requestUri = $"{tokenSource}/api/v1/request/{requestId}/{action}";
+            SeerrDispatchFence dispatchFence = integration
+                .CreateDispatchFence(_configProvider)
+                .Restrict(() => mutationConfigStamp.Matches(
+                    _configProvider.ConfigurationOrNull,
+                    _configProvider.ConfigurationRevision)
+                    && _configProvider.ConfigurationOrNull?.RequestApprovalsEnabled == true);
             var client = Helpers.Seerr.SeerrHttpHelper.CreateClient(_httpClientFactory);
             using var httpRequest = Helpers.Seerr.SeerrHttpHelper.BuildRequest(
                 HttpMethod.Post, requestUri, config.SeerrApiKey, seerrUser.Id.ToString());
@@ -1797,6 +1821,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 client,
                 httpRequest,
                 requestUri,
+                dispatchFence,
                 HttpContext.RequestAborted).ConfigureAwait(false);
 
             if (error != null)
@@ -1855,6 +1880,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            SeerrDispatchFence dispatchFence = integration
+                .CreateDispatchFence(_configProvider)
+                .Restrict(() => IsReadConfigurationCurrent(configStamp));
             if (!IsReadConfigurationCurrent(configStamp))
             {
                 return default;
@@ -1930,6 +1959,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                         client,
                         enrichRequest,
                         enrichUri,
+                        dispatchFence,
                         fetchCancellationToken).ConfigureAwait(false);
 
                     if (!IsReadConfigurationCurrent(configStamp))

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/ItemInfoController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/ItemInfoController.cs
@@ -470,7 +470,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 var avatar = await _avatarFetch.GetAsync(
                     cacheKey,
                     $"{seerrUrl}{avatarPath}",
-                    IsConfigurationCurrent,
+                    integration
+                        .CreateDispatchFence(_configProvider)
+                        .Restrict(IsConfigurationCurrent),
                     HttpContext.RequestAborted).ConfigureAwait(false);
                 if (avatar.Status == AvatarFetchStatus.ConfigurationChanged || !IsConfigurationCurrent())
                 {

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/ItemInfoController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/ItemInfoController.cs
@@ -386,23 +386,22 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             [FromQuery] string path,
             [FromQuery] string? sourceToken = null)
         {
-            var config = _configProvider.ConfigurationOrNull;
-            if (config == null
-                || string.IsNullOrWhiteSpace(config.SeerrUrls)
-                || string.IsNullOrWhiteSpace(config.SeerrApiKey)
-                || string.IsNullOrEmpty(path))
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            var config = integration.Configuration;
+            if (!integration.IsActive || config == null || string.IsNullOrEmpty(path))
             {
                 return NotFound();
             }
 
-            var configurationRevision = _configProvider.ConfigurationRevision;
+            var configurationRevision = integration.ConfigurationRevision;
             var configurationStamp = SeerrMutationConfigStamp.Capture(
                 config,
                 configurationRevision);
-            var seerrApiKey = config.SeerrApiKey;
-            bool IsConfigurationCurrent() => configurationStamp.Matches(
-                _configProvider.ConfigurationOrNull,
-                _configProvider.ConfigurationRevision);
+            var seerrApiKey = integration.ApiKey;
+            bool IsConfigurationCurrent() => integration.IsCurrent(_configProvider)
+                && configurationStamp.Matches(
+                    _configProvider.ConfigurationOrNull,
+                    _configProvider.ConfigurationRevision);
             IActionResult ConfigurationChanged() => StatusCode(409, new
             {
                 error = true,
@@ -436,7 +435,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 });
             }
 
-            var seerrUrl = SeerrClient.GetConfiguredUrls(config.SeerrUrls).FirstOrDefault(url => SeerrSourceToken.MatchesSource(
+            var seerrUrl = integration.Urls.FirstOrDefault(url => SeerrSourceToken.MatchesSource(
                 sourceClaims!.SourceKey,
                 seerrApiKey,
                 url));

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/SeerrProxyController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/SeerrProxyController.cs
@@ -138,7 +138,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             {
                 using var request = Helpers.Seerr.SeerrHttpHelper.BuildRequest(
                     HttpMethod.Get, requestUri, apiKey);
-                var (_, error, _) = await Helpers.Seerr.SeerrHttpHelper.SendAndReadJsonAsync(http, request, requestUri);
+                var (_, error, _) = await Helpers.Seerr.SeerrHttpHelper.SendSetupAndReadJsonAsync(
+                    http,
+                    request,
+                    requestUri);
                 if (error == null) return Ok(new { ok = true });
 
                 _logger.LogWarning($"Seerr validate failed for {url}: code={error.Code} status={error.HttpStatus} cf-ray={error.CfRay} — {error.Message}");
@@ -326,11 +329,27 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
         [Authorize]
         public async Task<IActionResult> GetSeerrQuota()
         {
-            var requestConfig = _configProvider.Configuration;
-            var requestConfigRevision = _configProvider.ConfigurationRevision;
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            if (!integration.IsActive || integration.Configuration == null)
+            {
+                return StatusCode(503, new
+                {
+                    error = true,
+                    code = "seerr_disabled",
+                    message = "Seerr integration is not configured or enabled."
+                });
+            }
+
+            var requestConfig = integration.Configuration;
+            var requestConfigRevision = integration.ConfigurationRevision;
             var requestConfigStamp = SeerrMutationConfigStamp.Capture(
                 requestConfig,
                 requestConfigRevision);
+            SeerrDispatchFence dispatchFence = integration
+                .CreateDispatchFence(_configProvider)
+                .Restrict(() => requestConfigStamp.Matches(
+                    _configProvider.ConfigurationOrNull,
+                    _configProvider.ConfigurationRevision));
             IActionResult ConfigurationChanged() => StatusCode(409, new
             {
                 error = true,
@@ -419,7 +438,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                         quota,
                         seerrUserId,
                         seerrUser.SourceUrl,
-                        requestConfig).ConfigureAwait(false);
+                        requestConfig,
+                        dispatchFence).ConfigureAwait(false);
                     if (!requestConfigStamp.Matches(
                             _configProvider.ConfigurationOrNull,
                             _configProvider.ConfigurationRevision))
@@ -467,7 +487,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             JsonObject quota,
             string seerrUserId,
             string? sourceUrl,
-            PluginConfiguration config)
+            PluginConfiguration config,
+            SeerrDispatchFence dispatchFence)
         {
             // This endpoint owns the projection; never preserve an upstream or
             // cached value that was not computed from this exact snapshot.
@@ -487,6 +508,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                     sourceUrl ?? string.Empty,
                     config.SeerrApiKey,
                     seerrUserId,
+                    dispatchFence,
                     HttpContext.RequestAborted);
             });
             var projectionNow = DateTime.UtcNow;
@@ -827,6 +849,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             string sourceUrl,
             string apiKey,
             string seerrUserId,
+            SeerrDispatchFence dispatchFence,
             CancellationToken cancellationToken,
             int pageSize = 100,
             int maximumPages = SeerrPaginationHelper.DefaultMaximumPages,
@@ -840,6 +863,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 seerrUserId,
                 requestedPageSize: pageSize,
                 static row => SeerrPaginationHelper.CanonicalPositiveIntegerPropertyIdentity(row, "id"),
+                dispatchFence,
                 cancellationToken,
                 maximumPages,
                 maximumItems);
@@ -1162,6 +1186,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 && configStamp.Matches(
                     _configProvider.ConfigurationOrNull,
                     _configProvider.ConfigurationRevision);
+            SeerrDispatchFence dispatchFence = integration
+                .CreateDispatchFence(_configProvider)
+                .Restrict(IsConfigurationCurrent);
 
             if (!IsConfigurationCurrent())
             {
@@ -1228,6 +1255,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                     httpClient,
                     request,
                     requestUri,
+                    dispatchFence,
                     HttpContext.RequestAborted).ConfigureAwait(false);
 
                 if (!IsConfigurationCurrent())

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/SeerrProxyController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/SeerrProxyController.cs
@@ -1135,8 +1135,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
         [Authorize]
         public async Task<IActionResult> GetSeerrPartialRequestsSetting()
         {
-            var config = _configProvider.ConfigurationOrNull;
-            if (config == null || !config.SeerrEnabled || string.IsNullOrEmpty(config.SeerrUrls) || string.IsNullOrEmpty(config.SeerrApiKey))
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            if (!integration.IsActive)
             {
                 // previously returned 200+false, which made the
                 // frontend silently flip the request modal to whole-season
@@ -1146,10 +1146,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 return StatusCode(503, new { error = true, code = "disabled", message = "Seerr integration not configured." });
             }
 
-            var configurationRevision = _configProvider.ConfigurationRevision;
+            var config = integration.Configuration!;
+            var configurationRevision = integration.ConfigurationRevision;
             var configStamp = SeerrMutationConfigStamp.Capture(config, configurationRevision);
-            var apiKey = config.SeerrApiKey;
-            var configuredUrls = SeerrClient.GetConfiguredUrls(config.SeerrUrls);
+            var apiKey = integration.ApiKey;
+            var configuredUrls = integration.Urls;
             IActionResult ConfigurationChanged() => StatusCode(409, new
             {
                 error = true,
@@ -1157,9 +1158,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 message = "Seerr configuration changed while reading request settings. Retry the request."
             });
 
-            bool IsConfigurationCurrent() => configStamp.Matches(
-                _configProvider.ConfigurationOrNull,
-                _configProvider.ConfigurationRevision);
+            bool IsConfigurationCurrent() => integration.IsCurrent(_configProvider)
+                && configStamp.Matches(
+                    _configProvider.ConfigurationOrNull,
+                    _configProvider.ConfigurationRevision);
 
             if (!IsConfigurationCurrent())
             {
@@ -1453,12 +1455,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             var queryString = string.Join("&", queryParts);
             var apiPath = string.IsNullOrWhiteSpace(queryString) ? "/api/v1/issue" : $"/api/v1/issue?{queryString}";
 
-            var config = _configProvider.ConfigurationOrNull;
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            var config = integration.Configuration;
             var caller = SeerrCaller();
-            if (config == null
-                || !config.SeerrEnabled
-                || string.IsNullOrWhiteSpace(config.SeerrUrls)
-                || string.IsNullOrWhiteSpace(config.SeerrApiKey))
+            if (!integration.IsActive || config == null)
             {
                 return StatusCode(503, new { error = true, code = "unavailable", message = "Seerr integration is not available." });
             }
@@ -1468,10 +1468,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 return Forbid();
             }
 
-            var configurationRevision = _configProvider.ConfigurationRevision;
+            var configurationRevision = integration.ConfigurationRevision;
             var configStamp = SeerrMutationConfigStamp.Capture(config, configurationRevision);
-            var apiKey = config.SeerrApiKey;
-            var configuredUrls = SeerrClient.GetConfiguredUrls(config.SeerrUrls);
+            var apiKey = integration.ApiKey;
+            var configuredUrls = integration.Urls;
             bool IsConfigurationCurrent() => configStamp.Matches(
                 _configProvider.ConfigurationOrNull,
                 _configProvider.ConfigurationRevision);

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/SeerrUserController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/SeerrUserController.cs
@@ -88,13 +88,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             // report a typed `reason` so the frontend can display
             // a meaningful banner instead of silently hiding discovery sections.
             // Possible reasons: disabled, no_user, blocked, unlinked, unreachable.
-            var config = _configProvider.ConfigurationOrNull;
-            if (config == null || !config.SeerrEnabled ||
-                string.IsNullOrEmpty(config.SeerrApiKey) ||
-                string.IsNullOrEmpty(config.SeerrUrls))
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            if (!integration.IsActive)
             {
                 return Ok(new { active = false, userFound = false, reason = "disabled" });
             }
+
+            var config = integration.Configuration!;
 
             var jellyfinUserId = UserHelper.GetCurrentUserId(User)?.ToString();
             if (string.IsNullOrEmpty(jellyfinUserId))
@@ -108,6 +108,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             var resolution = await _seerr.ResolveSeerrUser(
                 jellyfinUserId,
                 cancellationToken: HttpContext.RequestAborted).ConfigureAwait(false);
+            if (!integration.IsCurrent(_configProvider))
+            {
+                return Ok(new { active = false, userFound = false, reason = "disabled" });
+            }
+
             if (resolution.IsFound)
             {
                 var seerrUserId = resolution.User!.Id.ToString();
@@ -116,6 +121,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 // 4K permission (degrade-by-hiding), rather than on the admin
                 // toggle alone.
                 var cap = await _seerr.GetSeerr4kCapabilityAsync(jellyfinUserId, IsAdminUser());
+                if (!integration.IsCurrent(_configProvider))
+                {
+                    return Ok(new { active = false, userFound = false, reason = "disabled" });
+                }
+
                 return Ok(new
                 {
                     active = true,
@@ -166,9 +176,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
         public async Task<IActionResult> GetPermissionAudit()
         {
             var config = _configProvider.ConfigurationOrNull;
-            if (config == null || !config.SeerrEnabled ||
-                string.IsNullOrEmpty(config.SeerrApiKey) ||
-                string.IsNullOrEmpty(config.SeerrUrls))
+            if (config == null
+                || !SeerrIntegrationPolicy.HasUsableSavedConfiguration(config))
                 return StatusCode(503, "Seerr integration is not configured or enabled.");
 
             var jellyfinUsers = _userManager.GetUsers()
@@ -367,7 +376,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             try
             {
                 var config = _configProvider.ConfigurationOrNull;
-                if (config == null || !config.SeerrEnabled || !config.SyncSeerrWatchlist)
+                if (config == null
+                    || !config.SyncSeerrWatchlist
+                    || !SeerrIntegrationPolicy.HasUsableSavedConfiguration(config))
                 {
                     return BadRequest(new { error = "Seerr watchlist sync is not enabled" });
                 }
@@ -524,10 +535,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 }
 
                 var commitConfig = _configProvider.ConfigurationOrNull;
-                if (!syncConfigStamp.Matches(
+                if (commitConfig is null
+                    || !syncConfigStamp.Matches(
                         commitConfig,
                         _configProvider.ConfigurationRevision)
-                    || commitConfig?.SeerrEnabled != true
+                    || !SeerrIntegrationPolicy.HasUsableSavedConfiguration(commitConfig)
                     || !commitConfig.SyncSeerrWatchlist)
                 {
                     _logger.LogWarning(
@@ -642,7 +654,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             try
             {
                 var config = _configProvider.ConfigurationOrNull;
-                if (config == null || !config.SeerrEnabled)
+                if (config == null
+                    || !SeerrIntegrationPolicy.HasUsableSavedConfiguration(config))
                 {
                     return BadRequest(new { error = "Seerr integration is not enabled" });
                 }
@@ -690,7 +703,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                         return importConfigStamp.Matches(
                                 current,
                                 _configProvider.ConfigurationRevision)
-                            && current?.SeerrEnabled == true;
+                            && SeerrIntegrationPolicy.HasUsableSavedConfiguration(current);
                     }).ConfigureAwait(false);
 
                 // only flush user caches when at least one user

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/SeerrUserController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/SeerrUserController.cs
@@ -175,10 +175,60 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
         [Authorize(Policy = Policies.RequiresElevation)]
         public async Task<IActionResult> GetPermissionAudit()
         {
-            var config = _configProvider.ConfigurationOrNull;
-            if (config == null
-                || !SeerrIntegrationPolicy.HasUsableSavedConfiguration(config))
-                return StatusCode(503, "Seerr integration is not configured or enabled.");
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            if (!integration.IsActive || integration.Configuration == null)
+            {
+                return StatusCode(503, new
+                {
+                    error = true,
+                    active = false,
+                    code = "seerr_disabled",
+                    message = "Seerr integration is not configured or enabled. No permission audit was published."
+                });
+            }
+
+            var config = integration.Configuration;
+            var auditConfigStamp = SeerrMutationConfigStamp.Capture(
+                config,
+                integration.ConfigurationRevision);
+
+            bool AuditIsCurrent()
+            {
+                try
+                {
+                    return integration.IsCurrent(_configProvider)
+                        && auditConfigStamp.Matches(
+                            _configProvider.ConfigurationOrNull,
+                            _configProvider.ConfigurationRevision);
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+
+            IActionResult ConfigurationChanged()
+            {
+                var current = SeerrIntegrationPolicy.Capture(_configProvider);
+                if (!current.IsActive)
+                {
+                    return StatusCode(503, new
+                    {
+                        error = true,
+                        active = false,
+                        code = "seerr_disabled",
+                        message = "Seerr integration was disabled while preparing the audit. No partial permission audit was published."
+                    });
+                }
+
+                return Conflict(new
+                {
+                    error = true,
+                    active = false,
+                    code = "audit_configuration_changed",
+                    message = "Seerr configuration changed while preparing the audit. No partial permission audit was published."
+                });
+            }
 
             var jellyfinUsers = _userManager.GetUsers()
                 .GroupBy(u => u.Id)
@@ -188,6 +238,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
 
             foreach (var jfUser in jellyfinUsers)
             {
+                if (!AuditIsCurrent())
+                {
+                    return ConfigurationChanged();
+                }
+
                 var userId = jfUser.Id.ToString("N");
                 // allowAutoImport: false — audit must be read-only and must not
                 // create Seerr users as a side effect.
@@ -196,6 +251,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                     bypassCache: true,
                     allowAutoImport: false,
                     cancellationToken: HttpContext.RequestAborted).ConfigureAwait(false);
+                if (!AuditIsCurrent())
+                {
+                    return ConfigurationChanged();
+                }
+
                 var seerrUser = resolution.User;
 
                 if (resolution.Status is SeerrUserResolutionStatus.Incomplete or SeerrUserResolutionStatus.Unavailable)
@@ -303,6 +363,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 });
             }
 
+            if (!AuditIsCurrent())
+            {
+                return ConfigurationChanged();
+            }
+
             return Ok(results);
         }
 
@@ -375,8 +440,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             var cancellationToken = HttpContext.RequestAborted;
             try
             {
-                var config = _configProvider.ConfigurationOrNull;
-                if (config == null
+                var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+                var config = integration.Configuration;
+                if (!integration.IsActive
+                    || config == null
                     || !config.SyncSeerrWatchlist
                     || !SeerrIntegrationPolicy.HasUsableSavedConfiguration(config))
                 {
@@ -391,7 +458,27 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
 
                 var syncConfigStamp = SeerrMutationConfigStamp.Capture(
                     config,
-                    _configProvider.ConfigurationRevision);
+                    integration.ConfigurationRevision);
+                bool CanCommit()
+                {
+                    try
+                    {
+                        var current = _configProvider.ConfigurationOrNull;
+                        return integration.IsCurrent(_configProvider)
+                            && syncConfigStamp.Matches(
+                                current,
+                                _configProvider.ConfigurationRevision)
+                            && current?.SyncSeerrWatchlist == true;
+                    }
+                    catch
+                    {
+                        return false;
+                    }
+                }
+
+                SeerrDispatchFence dispatchFence = integration
+                    .CreateDispatchFence(_configProvider)
+                    .Restrict(CanCommit);
 
                 _logger.LogInformation("[Manual Watchlist Sync] Starting manual Seerr watchlist sync...");
 
@@ -405,10 +492,21 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 // failover replicas. Prove a complete, stable user map for every
                 // normalized distinct domain before resolving any instance-local id.
                 var httpClient = SeerrHttpHelper.CreateClient(_httpClientFactory);
+                if (!integration.IsCurrent(_configProvider))
+                {
+                    return Conflict(new
+                    {
+                        error = true,
+                        code = "sync_configuration_changed",
+                        message = "Seerr configuration changed while staging the sync. No local changes were applied."
+                    });
+                }
+
                 var userSnapshots = await SeerrWatchlistSyncTask.FetchSeerrUserMapSnapshotsAsync(
                     httpClient,
                     urls,
                     config.SeerrApiKey,
+                    dispatchFence,
                     cancellationToken).ConfigureAwait(false);
                 if (!userSnapshots.IsComplete)
                 {
@@ -459,6 +557,16 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                     foreach (var binding in bindings)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
+                        if (!integration.IsCurrent(_configProvider))
+                        {
+                            return Conflict(new
+                            {
+                                error = true,
+                                code = "sync_configuration_changed",
+                                message = "Seerr configuration changed while staging the sync. No local changes were applied."
+                            });
+                        }
+
                         var watchlistItems = await _seerr.GetWatchlistForUser(
                             binding.SeerrUserId,
                             binding.SourceUrl,
@@ -481,6 +589,16 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                         if (!config.AddRequestedMediaToWatchlist)
                         {
                             continue;
+                        }
+
+                        if (!integration.IsCurrent(_configProvider))
+                        {
+                            return Conflict(new
+                            {
+                                error = true,
+                                code = "sync_configuration_changed",
+                                message = "Seerr configuration changed while staging the sync. No local changes were applied."
+                            });
                         }
 
                         var requestItems = await _seerr.GetRequestsForUser(
@@ -511,10 +629,21 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 // that boundary the small local batch runs to completion instead of
                 // leaving a cancellation-created partial prefix.
                 cancellationToken.ThrowIfCancellationRequested();
+                if (!integration.IsCurrent(_configProvider))
+                {
+                    return Conflict(new
+                    {
+                        error = true,
+                        code = "sync_configuration_changed",
+                        message = "Seerr configuration changed while staging the sync. No local changes were applied."
+                    });
+                }
+
                 var commitUserSnapshots = await SeerrWatchlistSyncTask.FetchSeerrUserMapSnapshotsAsync(
                     httpClient,
                     urls,
                     config.SeerrApiKey,
+                    dispatchFence,
                     cancellationToken).ConfigureAwait(false);
                 if (!commitUserSnapshots.IsComplete
                     || !SeerrUserIdentityDomains.TryParse(
@@ -558,6 +687,16 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 var errors = new List<string>();
                 foreach (var user in users)
                 {
+                    if (!CanCommit())
+                    {
+                        return Conflict(new
+                        {
+                            error = true,
+                            code = "sync_configuration_changed",
+                            message = "Seerr configuration changed during the local commit. Remaining changes were stopped."
+                        });
+                    }
+
                     if (!stagedItems.TryGetValue(user.Id, out var items))
                     {
                         continue;
@@ -565,6 +704,16 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
 
                     foreach (var item in items)
                     {
+                        if (!CanCommit())
+                        {
+                            return Conflict(new
+                            {
+                                error = true,
+                                code = "sync_configuration_changed",
+                                message = "Seerr configuration changed during the local commit. Remaining changes were stopped."
+                            });
+                        }
+
                         itemsProcessed++;
 
                         // Find the item in Jellyfin library by TMDB ID
@@ -578,6 +727,16 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                             }
                             else if (userData.Likes != true)
                             {
+                                if (!CanCommit())
+                                {
+                                    return Conflict(new
+                                    {
+                                        error = true,
+                                        code = "sync_configuration_changed",
+                                        message = "Seerr configuration changed during the local commit. Remaining changes were stopped."
+                                    });
+                                }
+
                                 userData.Likes = true;
                                 _userDataManager.SaveUserData(
                                     user,
@@ -585,6 +744,16 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                                     userData,
                                     UserDataSaveReason.UpdateUserRating,
                                     CancellationToken.None);
+                                if (!CanCommit())
+                                {
+                                    return Conflict(new
+                                    {
+                                        error = true,
+                                        code = "sync_configuration_changed",
+                                        message = "Seerr configuration changed during the local commit. Remaining changes were stopped."
+                                    });
+                                }
+
                                 itemsAdded++;
                                 _logger.LogInformation($"[Manual Watchlist Sync] Added '{libraryItem.Name}' to watchlist for {user.Username}");
                             }
@@ -653,9 +822,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
         {
             try
             {
-                var config = _configProvider.ConfigurationOrNull;
-                if (config == null
-                    || !SeerrIntegrationPolicy.HasUsableSavedConfiguration(config))
+                var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+                var config = integration.Configuration;
+                if (!integration.IsActive || config == null)
                 {
                     return BadRequest(new { error = "Seerr integration is not enabled" });
                 }
@@ -667,7 +836,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
 
                 var importConfigStamp = SeerrMutationConfigStamp.Capture(
                     config,
-                    _configProvider.ConfigurationRevision);
+                    integration.ConfigurationRevision);
+                SeerrDispatchFence dispatchFence = integration
+                    .CreateDispatchFence(_configProvider)
+                    .Restrict(() => importConfigStamp.Matches(
+                        _configProvider.ConfigurationOrNull,
+                        _configProvider.ConfigurationRevision));
 
                 // Claim the throttle slot atomically to prevent concurrent imports
                 lock (_seerrCache.ImportThrottleLock)
@@ -696,15 +870,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                     config.SeerrApiKey,
                     _httpClientFactory,
                     _logger,
-                    HttpContext.RequestAborted,
-                    () =>
-                    {
-                        var current = _configProvider.ConfigurationOrNull;
-                        return importConfigStamp.Matches(
-                                current,
-                                _configProvider.ConfigurationRevision)
-                            && SeerrIntegrationPolicy.HasUsableSavedConfiguration(current);
-                    }).ConfigureAwait(false);
+                    dispatchFence,
+                    HttpContext.RequestAborted).ConfigureAwait(false);
 
                 // only flush user caches when at least one user
                 // was actually imported. Previously a 0-imported "success" (all

--- a/Jellyfin.Plugin.JellyfinCanopy/Helpers/Seerr/SeerrHttpHelper.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Helpers/Seerr/SeerrHttpHelper.cs
@@ -141,25 +141,54 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
         internal static Task<HttpResponseMessage> SendResponseHeadersReadAsync(
             HttpClient httpClient,
             HttpRequestMessage request,
+            SeerrDispatchFence dispatchFence,
             CancellationToken ct = default)
-            => httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+            => dispatchFence.CanDispatch(request.RequestUri)
+                ? httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct)
+                : Task.FromException<HttpResponseMessage>(
+                    new InvalidOperationException("The Seerr dispatch fence is no longer current."));
 
         public static Task<(string? Json, SeerrError? Error, int HttpStatus)> SendAndReadJsonAsync(
             HttpClient httpClient,
             HttpRequestMessage request,
             string url,
+            SeerrDispatchFence dispatchFence,
             CancellationToken ct = default)
-            => SendAndReadJsonAsync(httpClient, request, url, MaxBodyBytes, ct);
+            => SendAndReadJsonAsync(httpClient, request, url, MaxBodyBytes, dispatchFence, ct);
 
         internal static async Task<(string? Json, SeerrError? Error, int HttpStatus)> SendAndReadJsonAsync(
             HttpClient httpClient,
             HttpRequestMessage request,
             string url,
             int maxBodyBytes,
+            SeerrDispatchFence dispatchFence,
             CancellationToken ct = default)
         {
-            using var response = await SendResponseHeadersReadAsync(httpClient, request, ct).ConfigureAwait(false);
+            using var response = await SendResponseHeadersReadAsync(
+                httpClient,
+                request,
+                dispatchFence,
+                ct).ConfigureAwait(false);
             var (json, error) = await ReadResponseAsync(response, url, maxBodyBytes, ct).ConfigureAwait(false);
+            return (json, error, (int)response.StatusCode);
+        }
+
+        /// <summary>
+        /// Setup-only transport for an exact elevated endpoint validating
+        /// caller-supplied, not-yet-saved credentials. Normal saved-integration
+        /// traffic must use the fence-requiring overload above.
+        /// </summary>
+        internal static async Task<(string? Json, SeerrError? Error, int HttpStatus)> SendSetupAndReadJsonAsync(
+            HttpClient httpClient,
+            HttpRequestMessage request,
+            string url,
+            CancellationToken ct = default)
+        {
+            using var response = await httpClient.SendAsync(
+                request,
+                HttpCompletionOption.ResponseHeadersRead,
+                ct).ConfigureAwait(false);
+            var (json, error) = await ReadResponseAsync(response, url, MaxBodyBytes, ct).ConfigureAwait(false);
             return (json, error, (int)response.StatusCode);
         }
 

--- a/Jellyfin.Plugin.JellyfinCanopy/Helpers/Seerr/SeerrPaginationHelper.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Helpers/Seerr/SeerrPaginationHelper.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
 
 namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
 {
@@ -150,6 +151,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
             string? apiUserId,
             int requestedPageSize,
             Func<JsonElement, string?> identitySelector,
+            SeerrDispatchFence dispatchFence,
             CancellationToken cancellationToken = default,
             int maximumPages = DefaultMaximumPages,
             int maximumItems = DefaultMaximumItems)
@@ -158,6 +160,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
             ArgumentNullException.ThrowIfNull(baseUrls);
             ArgumentNullException.ThrowIfNull(buildRequestUri);
             ArgumentNullException.ThrowIfNull(identitySelector);
+            ArgumentNullException.ThrowIfNull(dispatchFence);
             if (requestedPageSize <= 0) throw new ArgumentOutOfRangeException(nameof(requestedPageSize));
             if (maximumPages <= 0) throw new ArgumentOutOfRangeException(nameof(maximumPages));
             if (maximumItems <= 0) throw new ArgumentOutOfRangeException(nameof(maximumItems));
@@ -182,6 +185,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
             foreach (var source in sources)
             {
                 cancellationToken.ThrowIfCancellationRequested();
+                if (!dispatchFence.CanDispatch())
+                {
+                    return MultiSourceDispatchDenied(source);
+                }
+
                 var snapshot = await FetchAllAsync(
                     httpClient,
                     new[] { source },
@@ -190,9 +198,15 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
                     apiUserId,
                     requestedPageSize,
                     identitySelector,
+                    dispatchFence,
                     cancellationToken,
                     maximumPages,
                     maximumItems).ConfigureAwait(false);
+                if (!dispatchFence.CanDispatch())
+                {
+                    return MultiSourceDispatchDenied(source);
+                }
+
                 if (!snapshot.IsComplete
                     || !string.Equals(snapshot.SourceUrl, source, StringComparison.Ordinal))
                 {
@@ -223,6 +237,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
             string? apiUserId,
             int requestedPageSize,
             Func<JsonElement, string?> identitySelector,
+            SeerrDispatchFence dispatchFence,
             CancellationToken cancellationToken = default,
             int maximumPages = DefaultMaximumPages,
             int maximumItems = DefaultMaximumItems)
@@ -231,6 +246,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
             ArgumentNullException.ThrowIfNull(baseUrls);
             ArgumentNullException.ThrowIfNull(buildRequestUri);
             ArgumentNullException.ThrowIfNull(identitySelector);
+            ArgumentNullException.ThrowIfNull(dispatchFence);
             if (requestedPageSize <= 0) throw new ArgumentOutOfRangeException(nameof(requestedPageSize));
             if (maximumPages <= 0) throw new ArgumentOutOfRangeException(nameof(maximumPages));
             if (maximumItems <= 0) throw new ArgumentOutOfRangeException(nameof(maximumItems));
@@ -247,6 +263,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
             foreach (var baseUrl in normalizedBaseUrls)
             {
                 cancellationToken.ThrowIfCancellationRequested();
+                if (!dispatchFence.CanDispatch())
+                {
+                    return DispatchDenied(baseUrl);
+                }
 
                 var firstPass = await FetchFromOneUrlAsync(
                     httpClient,
@@ -258,7 +278,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
                     identitySelector,
                     cancellationToken,
                     maximumPages,
-                    maximumItems).ConfigureAwait(false);
+                    maximumItems,
+                    dispatchFence).ConfigureAwait(false);
+
+                if (!dispatchFence.CanDispatch())
+                {
+                    return DispatchDenied(baseUrl);
+                }
 
                 if (!firstPass.IsComplete)
                 {
@@ -284,7 +310,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
                     identitySelector,
                     cancellationToken,
                     maximumPages,
-                    maximumItems).ConfigureAwait(false);
+                    maximumItems,
+                    dispatchFence).ConfigureAwait(false);
+
+                if (!dispatchFence.CanDispatch())
+                {
+                    return DispatchDenied(baseUrl);
+                }
 
                 if (!secondPass.IsComplete)
                 {
@@ -342,7 +374,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
             Func<JsonElement, string?> identitySelector,
             CancellationToken cancellationToken,
             int maximumPages,
-            int maximumItems)
+            int maximumItems,
+            SeerrDispatchFence dispatchFence)
         {
             var items = new List<JsonElement>();
             var identities = new HashSet<string>(StringComparer.Ordinal);
@@ -358,6 +391,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
             while (page <= maximumPages)
             {
                 cancellationToken.ThrowIfCancellationRequested();
+                if (!dispatchFence.CanDispatch())
+                {
+                    return DispatchDenied(baseUrl);
+                }
+
                 var requestUri = buildRequestUri(baseUrl, page, skip);
                 SeerrError? responseError = null;
                 string? json = null;
@@ -372,6 +410,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
                         httpClient,
                         request,
                         requestUri,
+                        dispatchFence,
                         cancellationToken).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -595,6 +634,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
                 if (completeByPages && completeByResults)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
+                    if (!dispatchFence.CanDispatch())
+                    {
+                        return DispatchDenied(baseUrl);
+                    }
+
                     return new SeerrPagedCollectionResult(
                         isComplete: true,
                         items,
@@ -719,5 +763,16 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
                 sourceUrl,
                 error: null,
                 failureReason: reason);
+
+        private static SeerrPagedCollectionResult DispatchDenied(string sourceUrl)
+            => Incomplete(sourceUrl, "The Seerr configuration changed before collection dispatch completed.");
+
+        private static SeerrMultiSourceCollectionResult MultiSourceDispatchDenied(string sourceUrl)
+            => new(
+                isComplete: false,
+                Array.Empty<SeerrPagedCollectionResult>(),
+                sourceUrl,
+                error: null,
+                failureReason: "The Seerr configuration changed before collection dispatch completed.");
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/Helpers/Seerr/SeerrUserImportHelper.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Helpers/Seerr/SeerrUserImportHelper.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
@@ -41,9 +42,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
             string apiKey,
             IHttpClientFactory httpClientFactory,
             ILogger logger,
-            CancellationToken cancellationToken = default,
-            Func<bool>? canDispatch = null)
+            SeerrDispatchFence dispatchFence,
+            CancellationToken cancellationToken = default)
         {
+            ArgumentNullException.ThrowIfNull(dispatchFence);
             cancellationToken.ThrowIfCancellationRequested();
             var result = new BulkImportResult();
             var httpClient = SeerrHttpHelper.CreateClient(httpClientFactory);
@@ -94,6 +96,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
                 apiUserId: null,
                 requestedPageSize: 1000,
                 UserCollectionIdentity,
+                dispatchFence,
                 cancellationToken).ConfigureAwait(false);
             if (!userSnapshots.IsComplete)
             {
@@ -134,6 +137,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
                 apiUserId: null,
                 requestedPageSize: 1000,
                 UserCollectionIdentity,
+                dispatchFence,
                 cancellationToken).ConfigureAwait(false);
             if (!dispatchSnapshots.IsComplete)
             {
@@ -161,7 +165,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
             }
 
             cancellationToken.ThrowIfCancellationRequested();
-            if (canDispatch != null && !canDispatch())
+            if (!dispatchFence.CanDispatch())
             {
                 const string message = "User import authorization or configuration changed during preparation; no users were imported.";
                 logger.LogWarning(message);
@@ -183,6 +187,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
                 using var response = await SeerrHttpHelper.SendResponseHeadersReadAsync(
                     httpClient,
                     request,
+                    dispatchFence,
                     cancellationToken).ConfigureAwait(false);
                 result.Reached = true;
 
@@ -238,6 +243,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
                 return result;
             }
         }
+
 
         private static string? UserCollectionIdentity(JsonElement item)
         {

--- a/Jellyfin.Plugin.JellyfinCanopy/ScheduledTasks/JellyfinToSeerrWatchlistSyncTask.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/ScheduledTasks/JellyfinToSeerrWatchlistSyncTask.cs
@@ -15,6 +15,7 @@ using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Tasks;
 using Microsoft.Extensions.Logging;
 using Jellyfin.Plugin.JellyfinCanopy.Services;
+using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
 
 namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
 {
@@ -69,9 +70,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
 
         public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
         {
-            var config = _configProvider.ConfigurationOrNull;
-
-            if (config == null)
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            var config = integration.Configuration;
+            if (!integration.IsActive
+                || config == null
+                || !config.SyncJellyfinWatchlistToSeerr)
             {
                 _logger.LogInformation("[Jellyfin→Seerr Watchlist Sync] Sync is disabled in plugin configuration.");
                 progress?.Report(100);
@@ -83,35 +86,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
             // detects a transient A→B→A replacement during staging.
             var mutationConfigStamp = SeerrMutationConfigStamp.Capture(
                 config,
-                _configProvider.ConfigurationRevision);
-            var initialApiKey = config.SeerrApiKey;
-
-            if (!config.SyncJellyfinWatchlistToSeerr || !config.SeerrEnabled)
-            {
-                _logger.LogInformation("[Jellyfin→Seerr Watchlist Sync] Sync is disabled in plugin configuration.");
-                progress?.Report(100);
-                return;
-            }
-
-            if (string.IsNullOrEmpty(config.SeerrUrls) || string.IsNullOrEmpty(initialApiKey))
-            {
-                _logger.LogWarning("[Jellyfin→Seerr Watchlist Sync] Seerr URL or API key not configured.");
-                progress?.Report(100);
-                return;
-            }
+                integration.ConfigurationRevision);
+            var initialApiKey = integration.ApiKey;
 
             _logger.LogInformation("[Jellyfin→Seerr Watchlist Sync] Starting sync task...");
             progress?.Report(0);
 
-            var urls = Jellyfin.Plugin.JellyfinCanopy.Services.Seerr.SeerrClient
-                .GetConfiguredUrls(config.SeerrUrls);
-
-            if (urls.Length == 0)
-            {
-                _logger.LogWarning("[Jellyfin→Seerr Watchlist Sync] No valid Seerr URL found.");
-                progress?.Report(100);
-                return;
-            }
+            var urls = integration.Urls;
 
             var httpClient = Helpers.Seerr.SeerrHttpHelper.CreateClient(_httpClientFactory);
 
@@ -442,7 +423,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
             var revision = _configProvider.ConfigurationRevision;
             if (!mutationConfigStamp.Matches(candidate, revision)
                 || candidate == null
-                || !candidate.SeerrEnabled
+                || !SeerrIntegrationPolicy.HasUsableSavedConfiguration(candidate)
                 || !candidate.SyncJellyfinWatchlistToSeerr
                 || string.IsNullOrWhiteSpace(candidate.SeerrApiKey)
                 || !string.Equals(candidate.SeerrApiKey, initialApiKey, StringComparison.Ordinal))

--- a/Jellyfin.Plugin.JellyfinCanopy/ScheduledTasks/JellyfinToSeerrWatchlistSyncTask.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/ScheduledTasks/JellyfinToSeerrWatchlistSyncTask.cs
@@ -88,6 +88,16 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                 config,
                 integration.ConfigurationRevision);
             var initialApiKey = integration.ApiKey;
+            SeerrDispatchFence dispatchFence = integration
+                .CreateDispatchFence(_configProvider)
+                .Restrict(() =>
+                {
+                    var current = _configProvider.ConfigurationOrNull;
+                    return mutationConfigStamp.Matches(
+                            current,
+                            _configProvider.ConfigurationRevision)
+                        && current?.SyncJellyfinWatchlistToSeerr == true;
+                });
 
             _logger.LogInformation("[Jellyfin→Seerr Watchlist Sync] Starting sync task...");
             progress?.Report(0);
@@ -96,10 +106,17 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
 
             var httpClient = Helpers.Seerr.SeerrHttpHelper.CreateClient(_httpClientFactory);
 
+            if (!integration.IsCurrent(_configProvider))
+            {
+                progress?.Report(100);
+                return;
+            }
+
             var userSnapshots = await FetchSeerrUserMapSnapshotsAsync(
                 httpClient,
                 urls,
                 initialApiKey,
+                dispatchFence,
                 cancellationToken).ConfigureAwait(false);
             if (!userSnapshots.IsComplete)
             {
@@ -207,11 +224,18 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                     {
                         foreach (var binding in seerrBindings)
                         {
+                            if (!integration.IsCurrent(_configProvider))
+                            {
+                                progress?.Report(100);
+                                return;
+                            }
+
                             var seerrWatchlistSnapshot = await FetchSeerrWatchlistSnapshotAsync(
                                 httpClient,
                                 binding.SourceUrl,
                                 binding.SeerrUserId,
                                 initialApiKey,
+                                dispatchFence,
                                 cancellationToken).ConfigureAwait(false);
                             if (!seerrWatchlistSnapshot.IsComplete)
                             {
@@ -335,6 +359,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                                 binding.SeerrUserId,
                                 jellyfinUser.Id,
                                 initialApiKey,
+                                dispatchFence,
                                 cancellationToken).ConfigureAwait(false);
 
                             if (!TryAuthorizeMutationConfiguration(
@@ -373,6 +398,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                                 tmdbId,
                                 mediaType,
                                 item.Name ?? string.Empty,
+                                dispatchFence,
                                 cancellationToken).ConfigureAwait(false);
 
                             if (result == 1)
@@ -448,6 +474,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
             string seerrUserId,
             Guid jellyfinUserId,
             string apiKey,
+            SeerrDispatchFence dispatchFence,
             CancellationToken cancellationToken)
         {
             var canonicalSeerrUserId = CanonicalPositiveIntegerText(seerrUserId);
@@ -461,6 +488,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
             var requestUri = $"{seerrUrl.TrimEnd('/')}/api/v1/user/{canonicalSeerrUserId}";
             try
             {
+                if (!dispatchFence.CanDispatch()) return false;
                 using var request = Helpers.Seerr.SeerrHttpHelper.BuildRequest(
                     HttpMethod.Get,
                     requestUri,
@@ -469,6 +497,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                     httpClient,
                     request,
                     requestUri,
+                    dispatchFence,
                     cancellationToken).ConfigureAwait(false);
                 if (error != null || string.IsNullOrWhiteSpace(content))
                 {
@@ -552,6 +581,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
             HttpClient httpClient,
             IEnumerable<string> seerrUrls,
             string apiKey,
+            SeerrDispatchFence dispatchFence,
             CancellationToken cancellationToken)
         {
             const int pageSize = 1000;
@@ -563,6 +593,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                 apiUserId: null,
                 requestedPageSize: pageSize,
                 JsonIdIdentity,
+                dispatchFence,
                 cancellationToken);
         }
 
@@ -570,6 +601,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
             HttpClient httpClient,
             IEnumerable<string> seerrUrls,
             string apiKey,
+            SeerrDispatchFence dispatchFence,
             CancellationToken cancellationToken)
         {
             const int pageSize = 1000;
@@ -581,6 +613,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                 apiUserId: null,
                 requestedPageSize: pageSize,
                 JsonIdIdentity,
+                dispatchFence,
                 cancellationToken);
         }
 
@@ -589,6 +622,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
             string seerrUrl,
             string seerrUserId,
             string apiKey,
+            SeerrDispatchFence dispatchFence,
             CancellationToken cancellationToken)
         {
             const int pageSize = 100;
@@ -600,6 +634,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                 seerrUserId,
                 requestedPageSize: pageSize,
                 WatchlistIdentity,
+                dispatchFence,
                 cancellationToken);
         }
 
@@ -687,10 +722,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
             int tmdbId,
             string mediaType,
             string title,
+            SeerrDispatchFence dispatchFence,
             CancellationToken cancellationToken)
         {
             try
             {
+                if (!dispatchFence.CanDispatch()) return -1;
                 var requestUri = $"{seerrUrl.TrimEnd('/')}/api/v1/watchlist";
                 var body = JsonSerializer.Serialize(new { tmdbId, mediaType, title });
                 using var request = Helpers.Seerr.SeerrHttpHelper.BuildRequest(HttpMethod.Post, requestUri, apiKey, seerrUserId, body);
@@ -698,6 +735,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                     httpClient,
                     request,
                     requestUri,
+                    dispatchFence,
                     cancellationToken).ConfigureAwait(false);
 
                 if (error != null)

--- a/Jellyfin.Plugin.JellyfinCanopy/ScheduledTasks/SeerrUserImportTask.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/ScheduledTasks/SeerrUserImportTask.cs
@@ -62,7 +62,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
         {
             var config = _configProvider.ConfigurationOrNull;
 
-            if (config == null || !config.SeerrAutoImportUsers || !config.SeerrEnabled)
+            if (config == null
+                || !config.SeerrAutoImportUsers
+                || !SeerrIntegrationPolicy.HasUsableSavedConfiguration(config))
             {
                 _logger.LogInformation("[Seerr User Import] Auto-import is disabled in plugin configuration.");
                 progress?.Report(100);
@@ -105,10 +107,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                 () =>
                 {
                     var current = _configProvider.ConfigurationOrNull;
-                    return importConfigStamp.Matches(
+                    return current is not null
+                        && importConfigStamp.Matches(
                             current,
                             _configProvider.ConfigurationRevision)
-                        && current?.SeerrEnabled == true
+                        && SeerrIntegrationPolicy.HasUsableSavedConfiguration(current)
                         && current.SeerrAutoImportUsers;
                 });
 

--- a/Jellyfin.Plugin.JellyfinCanopy/ScheduledTasks/SeerrUserImportTask.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/ScheduledTasks/SeerrUserImportTask.cs
@@ -60,11 +60,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
 
         public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
         {
-            var config = _configProvider.ConfigurationOrNull;
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            var config = integration.Configuration;
 
-            if (config == null
-                || !config.SeerrAutoImportUsers
-                || !SeerrIntegrationPolicy.HasUsableSavedConfiguration(config))
+            if (!integration.IsActive
+                || config == null
+                || !config.SeerrAutoImportUsers)
             {
                 _logger.LogInformation("[Seerr User Import] Auto-import is disabled in plugin configuration.");
                 progress?.Report(100);
@@ -80,7 +81,17 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
 
             var importConfigStamp = SeerrMutationConfigStamp.Capture(
                 config,
-                _configProvider.ConfigurationRevision);
+                integration.ConfigurationRevision);
+            SeerrDispatchFence dispatchFence = integration
+                .CreateDispatchFence(_configProvider)
+                .Restrict(() =>
+                {
+                    var current = _configProvider.ConfigurationOrNull;
+                    return importConfigStamp.Matches(
+                            current,
+                            _configProvider.ConfigurationRevision)
+                        && current?.SeerrAutoImportUsers == true;
+                });
 
             _logger.LogInformation("[Seerr User Import] Starting Seerr user import task...");
             progress?.Report(0);
@@ -103,17 +114,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                 config.SeerrApiKey,
                 _httpClientFactory,
                 _logger,
-                cancellationToken,
-                () =>
-                {
-                    var current = _configProvider.ConfigurationOrNull;
-                    return current is not null
-                        && importConfigStamp.Matches(
-                            current,
-                            _configProvider.ConfigurationRevision)
-                        && SeerrIntegrationPolicy.HasUsableSavedConfiguration(current)
-                        && current.SeerrAutoImportUsers;
-                });
+                dispatchFence,
+                cancellationToken);
 
             if (importResult.Succeeded && importResult.Imported > 0)
             {

--- a/Jellyfin.Plugin.JellyfinCanopy/ScheduledTasks/SeerrWatchlistSyncTask.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/ScheduledTasks/SeerrWatchlistSyncTask.cs
@@ -74,9 +74,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
 
         public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
         {
-            var config = _configProvider.ConfigurationOrNull;
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            var config = integration.Configuration;
 
-            if (config == null
+            if (!integration.IsActive
+                || config == null
                 || !config.SyncSeerrWatchlist
                 || !SeerrIntegrationPolicy.HasUsableSavedConfiguration(config))
             {
@@ -94,7 +96,27 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
 
             var syncConfigStamp = SeerrMutationConfigStamp.Capture(
                 config,
-                _configProvider.ConfigurationRevision);
+                integration.ConfigurationRevision);
+            bool CanCommit()
+            {
+                try
+                {
+                    var current = _configProvider.ConfigurationOrNull;
+                    return integration.IsCurrent(_configProvider)
+                        && syncConfigStamp.Matches(
+                            current,
+                            _configProvider.ConfigurationRevision)
+                        && current?.SyncSeerrWatchlist == true;
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+
+            SeerrDispatchFence dispatchFence = integration
+                .CreateDispatchFence(_configProvider)
+                .Restrict(CanCommit);
 
             _logger.LogInformation("[Seerr→Jellyfin Watchlist Sync] Starting Seerr watchlist sync task...");
             progress?.Report(0);
@@ -111,10 +133,17 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
 
             var httpClient = Helpers.Seerr.SeerrHttpHelper.CreateClient(_httpClientFactory);
 
+            if (!integration.IsCurrent(_configProvider))
+            {
+                progress?.Report(100);
+                return;
+            }
+
             var userSnapshots = await FetchSeerrUserMapSnapshotsAsync(
                 httpClient,
                 urls,
                 config.SeerrApiKey,
+                dispatchFence,
                 cancellationToken).ConfigureAwait(false);
             if (!userSnapshots.IsComplete)
             {
@@ -170,11 +199,18 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                     var requestItems = new List<WatchlistItem>();
                     foreach (var binding in seerrBindings)
                     {
+                        if (!integration.IsCurrent(_configProvider))
+                        {
+                            progress?.Report(100);
+                            return;
+                        }
+
                         var watchlistSnapshot = await FetchSeerrWatchlistSnapshotAsync(
                             httpClient,
                             binding.SourceUrl,
                             binding.SeerrUserId,
                             config.SeerrApiKey,
+                            dispatchFence,
                             cancellationToken).ConfigureAwait(false);
                         if (!watchlistSnapshot.IsComplete)
                         {
@@ -197,11 +233,18 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                             continue;
                         }
 
+                        if (!integration.IsCurrent(_configProvider))
+                        {
+                            progress?.Report(100);
+                            return;
+                        }
+
                         var requestSnapshot = await FetchSeerrRequestSnapshotAsync(
                             httpClient,
                             binding.SourceUrl,
                             binding.SeerrUserId,
                             config.SeerrApiKey,
+                            dispatchFence,
                             cancellationToken).ConfigureAwait(false);
                         if (!requestSnapshot.IsComplete)
                         {
@@ -245,10 +288,17 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
             // watchlist/request reads and require exact equality immediately
             // before the first local mutation. A source-local id rebound during
             // staging must invalidate the whole run, not apply B's rows to A.
+            if (!integration.IsCurrent(_configProvider))
+            {
+                progress?.Report(100);
+                return;
+            }
+
             var commitUserSnapshots = await FetchSeerrUserMapSnapshotsAsync(
                 httpClient,
                 urls,
                 config.SeerrApiKey,
+                dispatchFence,
                 cancellationToken).ConfigureAwait(false);
             if (!commitUserSnapshots.IsComplete
                 || !SeerrUserIdentityDomains.TryParse(
@@ -307,6 +357,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                     // Seerr collection for the entire run has been proven complete.
                     if (config.PreventWatchlistReAddition)
                     {
+                        if (!CanCommit())
+                        {
+                            _logger.LogWarning(
+                                "[Seerr→Jellyfin Watchlist Sync] Configuration changed during the local commit. Remaining changes were stopped.");
+                            progress?.Report(100);
+                            return;
+                        }
+
                         _userConfigurationManager.CleanupOldProcessedWatchlistItems(jellyfinUser.Id, config.WatchlistMemoryRetentionDays);
                     }
 
@@ -341,11 +399,29 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                             continue;
                         }
 
+                        if (!CanCommit())
+                        {
+                            _logger.LogWarning(
+                                "[Seerr→Jellyfin Watchlist Sync] Configuration changed during the local commit. Remaining changes were stopped.");
+                            progress?.Report(100);
+                            return;
+                        }
+
                         var result = await ProcessWatchlistItem(
                             jellyfinUser,
                             item,
                             config,
+                            dispatchFence,
                             CancellationToken.None).ConfigureAwait(false);
+                        if (result == WatchlistItemResult.ConfigurationChanged
+                            || !CanCommit())
+                        {
+                            _logger.LogWarning(
+                                "[Seerr→Jellyfin Watchlist Sync] Configuration changed during the local commit. Remaining changes were stopped.");
+                            progress?.Report(100);
+                            return;
+                        }
+
                         var itemInfo = $"TMDB: {item.TmdbId}";
 
                         switch (result)
@@ -409,6 +485,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
             HttpClient httpClient,
             IEnumerable<string> seerrUrls,
             string apiKey,
+            SeerrDispatchFence dispatchFence,
             CancellationToken cancellationToken)
         {
             const int pageSize = 1000;
@@ -420,6 +497,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                 apiUserId: null,
                 requestedPageSize: pageSize,
                 JsonIdIdentity,
+                dispatchFence,
                 cancellationToken);
         }
 
@@ -427,6 +505,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
             HttpClient httpClient,
             IEnumerable<string> seerrUrls,
             string apiKey,
+            SeerrDispatchFence dispatchFence,
             CancellationToken cancellationToken)
         {
             const int pageSize = 1000;
@@ -438,6 +517,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                 apiUserId: null,
                 requestedPageSize: pageSize,
                 JsonIdIdentity,
+                dispatchFence,
                 cancellationToken);
         }
 
@@ -446,6 +526,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
             string seerrUrl,
             string seerrUserId,
             string apiKey,
+            SeerrDispatchFence dispatchFence,
             CancellationToken cancellationToken)
         {
             const int pageSize = 100;
@@ -457,6 +538,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                 seerrUserId,
                 requestedPageSize: pageSize,
                 WatchlistIdentity,
+                dispatchFence,
                 cancellationToken);
         }
 
@@ -494,6 +576,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
             string seerrUrl,
             string seerrUserId,
             string apiKey,
+            SeerrDispatchFence dispatchFence,
             CancellationToken cancellationToken)
         {
             const int pageSize = 500;
@@ -505,6 +588,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                 seerrUserId,
                 requestedPageSize: pageSize,
                 JsonIdIdentity,
+                dispatchFence,
                 cancellationToken);
         }
 
@@ -724,6 +808,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
             AlreadyInWatchlist,
             AlreadyProcessed,
             NotInLibrary,
+            ConfigurationChanged,
             Skipped
         }
 
@@ -748,6 +833,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
             JUser user,
             WatchlistItem watchlistItem,
             PluginConfiguration config,
+            SeerrDispatchFence dispatchFence,
             CancellationToken cancellationToken)
         {
             try
@@ -808,6 +894,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                     // Mark as processed if prevention is enabled and not already marked
                     if (config.PreventWatchlistReAddition)
                     {
+                        if (!dispatchFence.CanDispatch())
+                        {
+                            return Task.FromResult(WatchlistItemResult.ConfigurationChanged);
+                        }
+
                         TryMarkProcessed(user.Id, watchlistItem.TmdbId, watchlistItem.MediaType, "existing");
                     }
 
@@ -815,6 +906,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                 }
 
                 // Add to watchlist
+                if (!dispatchFence.CanDispatch())
+                {
+                    return Task.FromResult(WatchlistItemResult.ConfigurationChanged);
+                }
+
                 userData.Likes = true;
                 _userDataManager.SaveUserData(
                     user,
@@ -823,9 +919,19 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                     UserDataSaveReason.UpdateUserRating,
                     cancellationToken);
 
+                if (!dispatchFence.CanDispatch())
+                {
+                    return Task.FromResult(WatchlistItemResult.ConfigurationChanged);
+                }
+
                 // Mark as processed if prevention is enabled
                 if (config.PreventWatchlistReAddition)
                 {
+                    if (!dispatchFence.CanDispatch())
+                    {
+                        return Task.FromResult(WatchlistItemResult.ConfigurationChanged);
+                    }
+
                     TryMarkProcessed(user.Id, watchlistItem.TmdbId, watchlistItem.MediaType, "sync");
                 }
 

--- a/Jellyfin.Plugin.JellyfinCanopy/ScheduledTasks/SeerrWatchlistSyncTask.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/ScheduledTasks/SeerrWatchlistSyncTask.cs
@@ -16,6 +16,7 @@ using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Tasks;
 using Microsoft.Extensions.Logging;
 using Jellyfin.Plugin.JellyfinCanopy.Services;
+using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
 
 namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
 {
@@ -75,7 +76,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
         {
             var config = _configProvider.ConfigurationOrNull;
 
-            if (config == null || !config.SyncSeerrWatchlist || !config.SeerrEnabled)
+            if (config == null
+                || !config.SyncSeerrWatchlist
+                || !SeerrIntegrationPolicy.HasUsableSavedConfiguration(config))
             {
                 _logger.LogInformation("[Seerr→Jellyfin Watchlist Sync] Sync is disabled in plugin configuration.");
                 progress?.Report(100);
@@ -262,10 +265,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
             }
 
             var commitConfig = _configProvider.ConfigurationOrNull;
-            if (!syncConfigStamp.Matches(
+            if (commitConfig is null
+                || !syncConfigStamp.Matches(
                     commitConfig,
                     _configProvider.ConfigurationRevision)
-                || commitConfig?.SeerrEnabled != true
+                || !SeerrIntegrationPolicy.HasUsableSavedConfiguration(commitConfig)
                 || !commitConfig.SyncSeerrWatchlist)
             {
                 _logger.LogWarning(

--- a/Jellyfin.Plugin.JellyfinCanopy/SeerrPolicyAliases.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/SeerrPolicyAliases.cs
@@ -1,0 +1,2 @@
+global using SeerrDispatchFence = Jellyfin.Plugin.JellyfinCanopy.Services.Seerr.SeerrIntegrationPolicy.SeerrDispatchFence;
+global using SeerrIntegrationSnapshot = Jellyfin.Plugin.JellyfinCanopy.Services.Seerr.SeerrIntegrationPolicy.SeerrIntegrationSnapshot;

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/AutoMovieRequestService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/AutoMovieRequestService.cs
@@ -452,6 +452,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         {
             try
             {
+                var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+                SeerrDispatchFence dispatchFence = integration
+                    .CreateDispatchFence(_configProvider)
+                    .Restrict(() => mutationConfigStamp.Matches(
+                        _configProvider.ConfigurationOrNull,
+                        _configProvider.ConfigurationRevision)
+                        && _configProvider.ConfigurationOrNull?.AutoMovieRequestEnabled == true);
                 var pinnedSource = FindConfiguredSource(config.SeerrUrls, seerrSourceUrl);
                 if (pinnedSource == null)
                 {
@@ -480,7 +487,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     var (content, error, _) = await Helpers.Seerr.SeerrHttpHelper.SendAndReadJsonAsync(
                         httpClient,
                         request,
-                        requestUrl);
+                        requestUrl,
+                        dispatchFence).ConfigureAwait(false);
                     if (error != null)
                     {
                         _logger.LogDebug($"[Auto-Movie-Request] Seerr collection fetch failed: code={error.Code} status={error.HttpStatus} cf-ray={error.CfRay}");
@@ -652,6 +660,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             PluginConfiguration config,
             SeerrMutationConfigStamp mutationConfigStamp)
         {
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            SeerrDispatchFence dispatchFence = integration
+                .CreateDispatchFence(_configProvider)
+                .Restrict(() => mutationConfigStamp.Matches(
+                    _configProvider.ConfigurationOrNull,
+                    _configProvider.ConfigurationRevision)
+                    && _configProvider.ConfigurationOrNull?.AutoMovieRequestEnabled == true);
             if (!mutationConfigStamp.Matches(
                     _configProvider.ConfigurationOrNull,
                     _configProvider.ConfigurationRevision))
@@ -676,7 +691,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 var (content, error, _) = await Helpers.Seerr.SeerrHttpHelper.SendAndReadJsonAsync(
                     httpClient,
                     request,
-                    requestUrl);
+                    requestUrl,
+                    dispatchFence).ConfigureAwait(false);
                 if (error != null)
                 {
                     _logger.LogDebug($"[Auto-Movie-Request] Quality profile lookup for movie {tmdbId} failed: code={error.Code} status={error.HttpStatus} cf-ray={error.CfRay}");
@@ -953,6 +969,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             PluginConfiguration config,
             SeerrMutationConfigStamp mutationConfigStamp)
         {
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            SeerrDispatchFence dispatchFence = integration
+                .CreateDispatchFence(_configProvider)
+                .Restrict(() => mutationConfigStamp.Matches(
+                    _configProvider.ConfigurationOrNull,
+                    _configProvider.ConfigurationRevision)
+                    && _configProvider.ConfigurationOrNull?.AutoMovieRequestEnabled == true);
             if (!mutationConfigStamp.Matches(
                     _configProvider.ConfigurationOrNull,
                     _configProvider.ConfigurationRevision)
@@ -1057,7 +1080,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 var (_, error, _) = await Helpers.Seerr.SeerrHttpHelper.SendAndReadJsonAsync(
                     httpClient,
                     request,
-                    requestUri);
+                    requestUri,
+                    dispatchFence).ConfigureAwait(false);
 
                 if (error == null)
                 {

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/AutoMovieRequestService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/AutoMovieRequestService.cs
@@ -70,7 +70,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             Guid userId)
         {
             var config = _configProvider.ConfigurationOrNull;
-            if (config == null || !config.AutoMovieRequestEnabled || !config.SeerrEnabled)
+            if (config == null
+                || !config.AutoMovieRequestEnabled
+                || !SeerrIntegrationPolicy.HasUsableSavedConfiguration(config))
             {
                 return AutoRequestPlaybackOutcome.DefinitiveNoop;
             }
@@ -145,7 +147,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             var qualityResolution = await ResolveQualityProfileAsync(
                 tmdbId,
                 seerrSourceUrl,
-                config);
+                config,
+                mutationConfigStamp);
             if (!qualityResolution.IsComplete)
             {
                 _logger.LogWarning(
@@ -169,7 +172,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 tmdbId,
                 seerrSourceUrl,
                 requestIs4k,
-                config);
+                config,
+                mutationConfigStamp);
             if (nextMovieLookup.Value == null)
             {
                 return nextMovieLookup.Outcome;
@@ -443,19 +447,26 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             string currentTmdbId,
             string seerrSourceUrl,
             bool requestIs4k,
-            PluginConfiguration config)
+            PluginConfiguration config,
+            SeerrMutationConfigStamp mutationConfigStamp)
         {
-            if (string.IsNullOrEmpty(config.SeerrUrls) || string.IsNullOrEmpty(config.SeerrApiKey))
-            {
-                return LookupResult<MovieInfo>.RetryableFailure();
-            }
-
             try
             {
                 var pinnedSource = FindConfiguredSource(config.SeerrUrls, seerrSourceUrl);
                 if (pinnedSource == null)
                 {
                     _logger.LogWarning("[Auto-Movie-Request] The linked Seerr instance is no longer configured; no collection lookup was attempted");
+                    return LookupResult<MovieInfo>.RetryableFailure();
+                }
+
+                // Earlier profile/TMDB reads may have yielded while an admin
+                // disabled Seerr or changed its credentials. Revalidate the
+                // operation's complete generation at the final transport edge;
+                // retained URL/key fields must never revive a stale flight.
+                if (!mutationConfigStamp.Matches(
+                        _configProvider.ConfigurationOrNull,
+                        _configProvider.ConfigurationRevision))
+                {
                     return LookupResult<MovieInfo>.RetryableFailure();
                 }
 
@@ -638,9 +649,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         private async Task<OriginalProfileReadResult> GetOriginalMovieQualityProfileAsync(
             string tmdbId,
             string seerrSourceUrl,
-            PluginConfiguration config)
+            PluginConfiguration config,
+            SeerrMutationConfigStamp mutationConfigStamp)
         {
-            if (string.IsNullOrEmpty(config.SeerrUrls) || string.IsNullOrEmpty(config.SeerrApiKey))
+            if (!mutationConfigStamp.Matches(
+                    _configProvider.ConfigurationOrNull,
+                    _configProvider.ConfigurationRevision))
             {
                 return new OriginalProfileReadResult { Status = OriginalProfileReadStatus.Incomplete };
             }
@@ -851,7 +865,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         private async Task<QualityProfileResolution> ResolveQualityProfileAsync(
             string watchedTmdbId,
             string seerrSourceUrl,
-            PluginConfiguration config)
+            PluginConfiguration config,
+            SeerrMutationConfigStamp mutationConfigStamp)
         {
             var mode = config.AutoMovieRequestQualityMode ?? "default";
 
@@ -860,7 +875,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 var original = await GetOriginalMovieQualityProfileAsync(
                     watchedTmdbId,
                     seerrSourceUrl,
-                    config);
+                    config,
+                    mutationConfigStamp);
                 if (original.Status == OriginalProfileReadStatus.Incomplete)
                 {
                     return QualityProfileResolution.Incomplete();
@@ -937,7 +953,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             PluginConfiguration config,
             SeerrMutationConfigStamp mutationConfigStamp)
         {
-            if (string.IsNullOrEmpty(config.SeerrUrls) || string.IsNullOrEmpty(config.SeerrApiKey))
+            if (!mutationConfigStamp.Matches(
+                    _configProvider.ConfigurationOrNull,
+                    _configProvider.ConfigurationRevision)
+                || !SeerrIntegrationPolicy.HasUsableSavedConfiguration(config))
             {
                 _logger.LogWarning("[Auto-Movie-Request] Seerr configuration is missing");
                 return AutoRequestDispatchOutcome.NotAttempted;
@@ -1018,7 +1037,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                         currentConfig,
                         _configProvider.ConfigurationRevision)
                     || currentConfig == null
-                    || !currentConfig.SeerrEnabled
+                    || !SeerrIntegrationPolicy.HasUsableSavedConfiguration(currentConfig)
                     || !currentConfig.AutoMovieRequestEnabled
                     || (qualitySettings?.Is4k == true && !currentConfig.SeerrEnable4KRequests)
                     || string.IsNullOrEmpty(currentConfig.SeerrApiKey)

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/AutoRequest/PlaybackWatcherBase.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/AutoRequest/PlaybackWatcherBase.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Session;
 using Microsoft.Extensions.Logging;
@@ -80,7 +81,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.AutoRequest
                 return;
             }
 
-            if (!IsFeatureEnabled(config) || !config.SeerrEnabled)
+            if (!IsFeatureEnabled(config)
+                || !SeerrIntegrationPolicy.AllowsDeferredScheduling(config))
             {
                 _logger.LogInformation($"{LogPrefix} {DisabledMonitoringName} monitoring is disabled in configuration - not subscribing to playback events");
                 return;
@@ -106,7 +108,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.AutoRequest
         protected PluginConfiguration? GetEnabledConfiguration()
         {
             var config = _configProvider.ConfigurationOrNull as PluginConfiguration;
-            if (config == null || !IsFeatureEnabled(config) || !config.SeerrEnabled)
+            if (config == null
+                || !IsFeatureEnabled(config)
+                || !SeerrIntegrationPolicy.HasUsableSavedConfiguration(config))
             {
                 return null;
             }

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/AutoSeasonRequestService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/AutoSeasonRequestService.cs
@@ -119,6 +119,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     && SeerrIntegrationPolicy.HasUsableSavedConfiguration(current);
             }
 
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            SeerrDispatchFence dispatchFence = integration
+                .CreateDispatchFence(_configProvider)
+                .Restrict(IsCapturedConfigurationCurrent);
+
             if (!IsCapturedConfigurationCurrent())
             {
                 return null;
@@ -173,7 +178,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     var (content, error, _) = await Helpers.Seerr.SeerrHttpHelper.SendAndReadJsonAsync(
                         httpClient,
                         request,
-                        requestUrl);
+                        requestUrl,
+                        dispatchFence).ConfigureAwait(false);
                     if (error != null)
                     {
                         _logger.LogDebug($"[Auto-Season-Request] Series details fetch for TMDB {tmdbId} failed: code={error.Code} status={error.HttpStatus} cf-ray={error.CfRay}");
@@ -617,6 +623,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         {
             try
             {
+                var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+                SeerrDispatchFence dispatchFence = integration
+                    .CreateDispatchFence(_configProvider)
+                    .Restrict(() => mutationConfigStamp.Matches(
+                        _configProvider.ConfigurationOrNull,
+                        _configProvider.ConfigurationRevision)
+                        && _configProvider.ConfigurationOrNull?.AutoSeasonRequestEnabled == true);
                 var pinnedSource = FindConfiguredSource(config.SeerrUrls, seerrSourceUrl);
                 if (pinnedSource == null)
                 {
@@ -641,7 +654,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 var (content, error, _) = await Helpers.Seerr.SeerrHttpHelper.SendAndReadJsonAsync(
                     httpClient,
                     statusRequest,
-                    requestUrl);
+                    requestUrl,
+                    dispatchFence).ConfigureAwait(false);
                 if (error != null)
                 {
                     _logger.LogDebug($"[Auto-Season-Request] Status check for TMDB {tmdbId} failed: code={error.Code} status={error.HttpStatus} cf-ray={error.CfRay}");
@@ -947,6 +961,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             string seerrSourceUrl,
             SeerrMutationConfigStamp mutationConfigStamp)
         {
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            SeerrDispatchFence dispatchFence = integration
+                .CreateDispatchFence(_configProvider)
+                .Restrict(() => mutationConfigStamp.Matches(
+                    _configProvider.ConfigurationOrNull,
+                    _configProvider.ConfigurationRevision)
+                    && _configProvider.ConfigurationOrNull?.AutoSeasonRequestEnabled == true);
             var config = _configProvider.ConfigurationOrNull;
             if (!mutationConfigStamp.Matches(
                     config,
@@ -1040,7 +1061,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 var (_, error, _) = await Helpers.Seerr.SeerrHttpHelper.SendAndReadJsonAsync(
                     httpClient,
                     request,
-                    requestUri);
+                    requestUri,
+                    dispatchFence).ConfigureAwait(false);
 
                 if (error == null)
                 {

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/AutoSeasonRequestService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/AutoSeasonRequestService.cs
@@ -74,10 +74,27 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             return Seerr.SeerrClient.GetConfiguredUrls(urls);
         }
 
-        internal async Task<string?> GetSeriesDetailsJsonAsync(string tmdbId, string seerrSourceUrl)
+        internal Task<string?> GetSeriesDetailsJsonAsync(string tmdbId, string seerrSourceUrl)
         {
-            var config = _configProvider.ConfigurationOrNull;
-            if (config == null || string.IsNullOrEmpty(config.SeerrUrls) || string.IsNullOrEmpty(config.SeerrApiKey))
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            return !integration.IsActive
+                ? Task.FromResult<string?>(null)
+                : GetSeriesDetailsJsonAsync(
+                    tmdbId,
+                    seerrSourceUrl,
+                    integration.Configuration!,
+                    integration.ConfigurationStamp);
+        }
+
+        private async Task<string?> GetSeriesDetailsJsonAsync(
+            string tmdbId,
+            string seerrSourceUrl,
+            PluginConfiguration config,
+            SeerrMutationConfigStamp operationConfigStamp)
+        {
+            if (!operationConfigStamp.Matches(
+                    _configProvider.ConfigurationOrNull,
+                    _configProvider.ConfigurationRevision))
             {
                 return null;
             }
@@ -94,9 +111,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             var configFingerprint = ComputeConfigurationFingerprint(config);
 
             bool IsCapturedConfigurationCurrent()
-                => configStamp.Matches(
-                    _configProvider.ConfigurationOrNull,
-                    _configProvider.ConfigurationRevision);
+            {
+                var current = _configProvider.ConfigurationOrNull;
+                var revision = _configProvider.ConfigurationRevision;
+                return operationConfigStamp.Matches(current, revision)
+                    && configStamp.Matches(current, revision)
+                    && SeerrIntegrationPolicy.HasUsableSavedConfiguration(current);
+            }
 
             if (!IsCapturedConfigurationCurrent())
             {
@@ -134,6 +155,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
 
             async Task<string?> FetchAsync()
             {
+                // A queued single-flight delegate may start after the operation
+                // that created it has been disabled. Recheck at the transport
+                // edge instead of trusting retained credentials in the closure.
+                if (!IsCapturedConfigurationCurrent())
+                {
+                    return null;
+                }
+
                 var httpClient = Helpers.Seerr.SeerrHttpHelper.CreateClient(_httpClientFactory);
 
                 try
@@ -223,7 +252,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             Guid userId)
         {
             var config = _configProvider.ConfigurationOrNull;
-            if (config == null || !config.AutoSeasonRequestEnabled || !config.SeerrEnabled)
+            if (config == null
+                || !config.AutoSeasonRequestEnabled
+                || !SeerrIntegrationPolicy.HasUsableSavedConfiguration(config))
             {
                 return AutoRequestPlaybackOutcome.DefinitiveNoop;
             }
@@ -263,7 +294,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             JUser user)
         {
             var config = _configProvider.ConfigurationOrNull;
-            if (config == null || !config.AutoSeasonRequestEnabled || !config.SeerrEnabled)
+            if (config == null
+                || !config.AutoSeasonRequestEnabled
+                || !SeerrIntegrationPolicy.HasUsableSavedConfiguration(config))
             {
                 return AutoRequestPlaybackOutcome.DefinitiveNoop;
             }
@@ -295,7 +328,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             var totalEpisodesInSeason = await GetTotalEpisodesInSeasonFromTmdb(
                 tmdbId,
                 currentSeasonNumber,
-                seerrSourceUrl);
+                seerrSourceUrl,
+                config,
+                mutationConfigStamp);
             if (totalEpisodesInSeason == null || totalEpisodesInSeason <= 0)
             {
                 _logger.LogWarning($"[Auto-Season-Request] Could not determine total episodes for '{series.Name}' S{currentSeasonNumber} from TMDB");
@@ -406,7 +441,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 var nextSeasonEpisodeCount = await GetTotalEpisodesInSeasonFromTmdb(
                     tmdbId,
                     nextSeasonNumber,
-                    seerrSourceUrl).ConfigureAwait(false);
+                    seerrSourceUrl,
+                    config,
+                    mutationConfigStamp).ConfigureAwait(false);
 
                 if (nextSeasonEpisodeCount == null || nextSeasonEpisodeCount <= 0)
                 {
@@ -421,7 +458,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 var seerrStatus = await GetSeasonStatusFromSeerr(
                     tmdbId,
                     nextSeasonNumber,
-                    seerrSourceUrl).ConfigureAwait(false);
+                    seerrSourceUrl,
+                    config,
+                    mutationConfigStamp).ConfigureAwait(false);
 
                 if (seerrStatus == null)
                 {
@@ -486,17 +525,24 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         private async Task<int?> GetTotalEpisodesInSeasonFromTmdb(
             string tmdbId,
             int seasonNumber,
-            string seerrSourceUrl)
+            string seerrSourceUrl,
+            PluginConfiguration config,
+            SeerrMutationConfigStamp mutationConfigStamp)
         {
-            var config = _configProvider.ConfigurationOrNull;
-            if (config == null || string.IsNullOrEmpty(config.SeerrUrls) || string.IsNullOrEmpty(config.SeerrApiKey))
+            if (!mutationConfigStamp.Matches(
+                    _configProvider.ConfigurationOrNull,
+                    _configProvider.ConfigurationRevision))
             {
                 return null;
             }
 
             try
             {
-                var content = await GetSeriesDetailsJsonAsync(tmdbId, seerrSourceUrl);
+                var content = await GetSeriesDetailsJsonAsync(
+                    tmdbId,
+                    seerrSourceUrl,
+                    config,
+                    mutationConfigStamp);
                 if (string.IsNullOrEmpty(content))
                 {
                     return null;
@@ -565,20 +611,26 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         private async Task<SeasonStatus?> GetSeasonStatusFromSeerr(
             string tmdbId,
             int seasonNumber,
-            string seerrSourceUrl)
+            string seerrSourceUrl,
+            PluginConfiguration config,
+            SeerrMutationConfigStamp mutationConfigStamp)
         {
-            var config = _configProvider.ConfigurationOrNull;
-            if (config == null || string.IsNullOrEmpty(config.SeerrUrls) || string.IsNullOrEmpty(config.SeerrApiKey))
-            {
-                return null;
-            }
-
             try
             {
                 var pinnedSource = FindConfiguredSource(config.SeerrUrls, seerrSourceUrl);
                 if (pinnedSource == null)
                 {
                     _logger.LogWarning("[Auto-Season-Request] The linked Seerr instance is no longer configured; no season-status lookup was attempted");
+                    return null;
+                }
+
+                // The preceding series-details read can be in flight while the
+                // integration is disabled. Fence this distinct status request
+                // with the original generation immediately before transport.
+                if (!mutationConfigStamp.Matches(
+                        _configProvider.ConfigurationOrNull,
+                        _configProvider.ConfigurationRevision))
+                {
                     return null;
                 }
 
@@ -896,13 +948,16 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             SeerrMutationConfigStamp mutationConfigStamp)
         {
             var config = _configProvider.ConfigurationOrNull;
-            if (config == null || string.IsNullOrEmpty(config.SeerrUrls) || string.IsNullOrEmpty(config.SeerrApiKey))
+            if (!mutationConfigStamp.Matches(
+                    config,
+                    _configProvider.ConfigurationRevision)
+                || !SeerrIntegrationPolicy.HasUsableSavedConfiguration(config))
             {
                 _logger.LogWarning("[Auto-Season-Request] Seerr configuration is missing");
                 return AutoRequestDispatchOutcome.NotAttempted;
             }
 
-            var pinnedSource = FindConfiguredSource(config.SeerrUrls, seerrSourceUrl);
+            var pinnedSource = FindConfiguredSource(config!.SeerrUrls, seerrSourceUrl);
             if (seerrUser.Id <= 0 || pinnedSource == null)
             {
                 _logger.LogWarning(
@@ -966,7 +1021,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                         currentConfig,
                         _configProvider.ConfigurationRevision)
                     || currentConfig == null
-                    || !currentConfig.SeerrEnabled
+                    || !SeerrIntegrationPolicy.HasUsableSavedConfiguration(currentConfig)
                     || !currentConfig.AutoSeasonRequestEnabled
                     || string.IsNullOrEmpty(currentConfig.SeerrApiKey)
                     || !string.Equals(currentPinnedSource, pinnedSource, StringComparison.Ordinal))

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/LiveNotifierService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/LiveNotifierService.cs
@@ -132,15 +132,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         /// </summary>
         internal async Task HandleConfigurationChangedAsync(CancellationToken cancellationToken)
         {
-            _watchlistMonitor.NotifyConfigurationChanged();
-
-            try
+            foreach (var failure in SeerrIntegrationPolicy.InvalidateCachedActiveState(
+                _seerrCache,
+                _watchlistMonitor))
             {
-                _seerrCache.ClearAllSeerrCachesOnConfigChange();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "LiveNotifier: failed to flush Seerr caches on config change.");
+                _logger.LogWarning(
+                    failure.Error,
+                    "LiveNotifier: failed to invalidate {Owner} Seerr state on config change.",
+                    failure.Owner);
             }
 
             try

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/AvatarFetchService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/AvatarFetchService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
@@ -49,6 +50,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
 
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly ISeerrCache _cache;
+        private readonly IPluginConfigProvider _configProvider;
         private readonly ILogger<AvatarFetchService> _logger;
         private readonly TimeProvider _timeProvider;
         private readonly long _maximumAvatarBytes;
@@ -58,14 +60,22 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
         public AvatarFetchService(
             IHttpClientFactory httpClientFactory,
             ISeerrCache cache,
+            IPluginConfigProvider configProvider,
             ILogger<AvatarFetchService> logger)
-            : this(httpClientFactory, cache, logger, TimeProvider.System, DefaultMaximumAvatarBytes)
+            : this(
+                httpClientFactory,
+                cache,
+                configProvider,
+                logger,
+                TimeProvider.System,
+                DefaultMaximumAvatarBytes)
         {
         }
 
         internal AvatarFetchService(
             IHttpClientFactory httpClientFactory,
             ISeerrCache cache,
+            IPluginConfigProvider configProvider,
             ILogger<AvatarFetchService> logger,
             TimeProvider timeProvider,
             long maximumAvatarBytes)
@@ -73,6 +83,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumAvatarBytes);
             _httpClientFactory = httpClientFactory;
             _cache = cache;
+            _configProvider = configProvider;
             _logger = logger;
             _timeProvider = timeProvider;
             _maximumAvatarBytes = maximumAvatarBytes;
@@ -94,6 +105,26 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             Func<bool> isConfigurationCurrent,
             CancellationToken cancellationToken)
         {
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            if (!integration.IsActive
+                || !integration.Urls.Any(url => upstreamUrl.StartsWith(
+                    url + "/",
+                    StringComparison.Ordinal)))
+            {
+                return ConfigurationChanged();
+            }
+
+            bool IsAuthorizedGenerationCurrent()
+                => integration.IsCurrent(_configProvider) && isConfigurationCurrent();
+
+            // Authorization precedes last-good and backoff reads: disabling the
+            // master switch must not keep advertising or serving cached active
+            // integration state.
+            if (!IsAuthorizedGenerationCurrent())
+            {
+                return ConfigurationChanged();
+            }
+
             if (TryGetLastGood(cacheKey, out var cached) && IsFresh(cached))
             {
                 return Available(cached);
@@ -102,11 +133,6 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             if (IsBackedOff(cacheKey))
             {
                 return cached.Content != null ? Available(cached) : Missing();
-            }
-
-            if (!isConfigurationCurrent())
-            {
-                return ConfigurationChanged();
             }
 
             while (true)
@@ -124,7 +150,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                     _ = CompleteFlightAsync(
                         cacheKey,
                         upstreamUrl,
-                        isConfigurationCurrent,
+                        IsAuthorizedGenerationCurrent,
                         candidate);
                 }
 

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/AvatarFetchService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/AvatarFetchService.cs
@@ -102,9 +102,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
         internal async Task<AvatarFetchResult> GetAsync(
             string cacheKey,
             string upstreamUrl,
-            Func<bool> isConfigurationCurrent,
+            SeerrDispatchFence dispatchFence,
             CancellationToken cancellationToken)
         {
+            ArgumentNullException.ThrowIfNull(dispatchFence);
             var integration = SeerrIntegrationPolicy.Capture(_configProvider);
             if (!integration.IsActive
                 || !integration.Urls.Any(url => upstreamUrl.StartsWith(
@@ -114,13 +115,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                 return ConfigurationChanged();
             }
 
-            bool IsAuthorizedGenerationCurrent()
-                => integration.IsCurrent(_configProvider) && isConfigurationCurrent();
+            SeerrDispatchFence authorizedFence = integration
+                .CreateDispatchFence(_configProvider)
+                .Restrict(dispatchFence.CanDispatch);
 
             // Authorization precedes last-good and backoff reads: disabling the
             // master switch must not keep advertising or serving cached active
             // integration state.
-            if (!IsAuthorizedGenerationCurrent())
+            if (!authorizedFence.CanDispatch())
             {
                 return ConfigurationChanged();
             }
@@ -150,7 +152,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                     _ = CompleteFlightAsync(
                         cacheKey,
                         upstreamUrl,
-                        IsAuthorizedGenerationCurrent,
+                        authorizedFence,
                         candidate);
                 }
 
@@ -181,14 +183,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             string cacheKey,
             (byte[] Content, string ContentType, string ETag, DateTime CachedAt) entry,
             TimeSpan retention,
-            Func<bool> isConfigurationCurrent)
+            SeerrDispatchFence dispatchFence)
         {
-            if (!isConfigurationCurrent() || !cache.TrySet(cacheKey, entry, retention, out var publication))
+            if (!dispatchFence.CanDispatch() || !cache.TrySet(cacheKey, entry, retention, out var publication))
             {
                 return false;
             }
 
-            if (isConfigurationCurrent())
+            if (dispatchFence.CanDispatch())
             {
                 return true;
             }
@@ -200,7 +202,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
         private async Task CompleteFlightAsync(
             string cacheKey,
             string upstreamUrl,
-            Func<bool> isConfigurationCurrent,
+            SeerrDispatchFence dispatchFence,
             AvatarFlight flight)
         {
             var flightCancellationToken = flight.CancellationToken;
@@ -209,7 +211,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                 var result = await FetchLeaderAsync(
                     cacheKey,
                     upstreamUrl,
-                    isConfigurationCurrent,
+                    dispatchFence,
                     flightCancellationToken).ConfigureAwait(false);
                 flight.Completion.TrySetResult(result);
             }
@@ -220,7 +222,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Avatar fetch flight failed unexpectedly for key {AvatarKey}.", LogKey(cacheKey));
-                flight.Completion.TrySetResult(FailureResult(cacheKey, "internal fetch failure"));
+                flight.Completion.TrySetResult(FailureResult(
+                    cacheKey,
+                    "internal fetch failure",
+                    dispatchFence));
             }
             finally
             {
@@ -232,7 +237,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
         private async Task<AvatarFetchResult> FetchLeaderAsync(
             string cacheKey,
             string upstreamUrl,
-            Func<bool> isConfigurationCurrent,
+            SeerrDispatchFence dispatchFence,
             CancellationToken cancellationToken)
         {
             TryGetLastGood(cacheKey, out var lastGood);
@@ -246,7 +251,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                 return lastGood.Content != null ? Available(lastGood) : Missing();
             }
 
-            if (!isConfigurationCurrent())
+            if (!dispatchFence.CanDispatch())
             {
                 return ConfigurationChanged();
             }
@@ -261,25 +266,38 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                 using var request = new HttpRequestMessage(HttpMethod.Get, upstreamUrl);
                 request.Headers.UserAgent.ParseAdd(Helpers.Seerr.SeerrHttpHelper.UserAgent);
                 request.Headers.Accept.ParseAdd("image/*");
+                if (!dispatchFence.CanDispatch(request.RequestUri))
+                {
+                    return ConfigurationChanged();
+                }
+
                 using var response = await client.SendAsync(
                     request,
                     HttpCompletionOption.ResponseHeadersRead,
                     fetchToken).ConfigureAwait(false);
 
-                if (!isConfigurationCurrent())
+                if (!dispatchFence.CanDispatch(request.RequestUri))
                 {
                     return ConfigurationChanged();
                 }
 
                 if (!response.IsSuccessStatusCode)
                 {
-                    return FailureResult(cacheKey, $"HTTP {(int)response.StatusCode}", lastGood);
+                    return FailureResult(
+                        cacheKey,
+                        $"HTTP {(int)response.StatusCode}",
+                        dispatchFence,
+                        lastGood);
                 }
 
                 var contentType = response.Content.Headers.ContentType?.MediaType;
                 if (!IsAllowedContentType(contentType))
                 {
-                    return FailureResult(cacheKey, $"disallowed content type '{contentType ?? "missing"}'", lastGood);
+                    return FailureResult(
+                        cacheKey,
+                        $"disallowed content type '{contentType ?? "missing"}'",
+                        dispatchFence,
+                        lastGood);
                 }
 
                 var declaredLength = response.Content.Headers.ContentLength;
@@ -288,6 +306,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                     return FailureResult(
                         cacheKey,
                         $"declared size {declaredLength.Value} exceeds {_maximumAvatarBytes}-byte cap",
+                        dispatchFence,
                         lastGood);
                 }
 
@@ -299,15 +318,23 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
 
                 if (content == null)
                 {
-                    return FailureResult(cacheKey, $"stream exceeds {_maximumAvatarBytes}-byte cap", lastGood);
+                    return FailureResult(
+                        cacheKey,
+                        $"stream exceeds {_maximumAvatarBytes}-byte cap",
+                        dispatchFence,
+                        lastGood);
                 }
 
                 if (!HasMatchingSignature(content, contentType!))
                 {
-                    return FailureResult(cacheKey, $"signature does not match {contentType}", lastGood);
+                    return FailureResult(
+                        cacheKey,
+                        $"signature does not match {contentType}",
+                        dispatchFence,
+                        lastGood);
                 }
 
-                if (!isConfigurationCurrent())
+                if (!dispatchFence.CanDispatch())
                 {
                     return ConfigurationChanged();
                 }
@@ -323,10 +350,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                     cacheKey,
                     entry,
                     LastGoodRetention,
-                    isConfigurationCurrent))
+                    dispatchFence))
                 {
-                    return isConfigurationCurrent()
-                        ? FailureResult(cacheKey, "cache capacity rejected avatar", lastGood)
+                    return dispatchFence.CanDispatch()
+                        ? FailureResult(
+                            cacheKey,
+                            "cache capacity rejected avatar",
+                            dispatchFence,
+                            lastGood)
                         : ConfigurationChanged();
                 }
 
@@ -339,19 +370,33 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             }
             catch (OperationCanceledException)
             {
-                return FailureResult(cacheKey, "upstream timed out", lastGood);
+                return FailureResult(
+                    cacheKey,
+                    "upstream timed out",
+                    dispatchFence,
+                    lastGood);
             }
             catch (Exception ex)
             {
-                return FailureResult(cacheKey, ex.GetType().Name, lastGood);
+                return FailureResult(
+                    cacheKey,
+                    ex.GetType().Name,
+                    dispatchFence,
+                    lastGood);
             }
         }
 
         private AvatarFetchResult FailureResult(
             string cacheKey,
             string reason,
+            SeerrDispatchFence dispatchFence,
             (byte[] Content, string ContentType, string ETag, DateTime CachedAt) lastGood = default)
         {
+            if (!dispatchFence.CanDispatch())
+            {
+                return ConfigurationChanged();
+            }
+
             var failures = 1;
             if (_failures.TryGet(cacheKey, out var previous))
             {
@@ -359,10 +404,17 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             }
 
             var delay = FailureBackoff[Math.Min(failures - 1, FailureBackoff.Length - 1)];
-            _failures.Set(
+            _failures.TrySet(
                 cacheKey,
                 new FailureState(failures, _timeProvider.GetUtcNow().Add(delay)),
-                FailureStateRetention);
+                FailureStateRetention,
+                out var publication);
+            if (!dispatchFence.CanDispatch())
+            {
+                _failures.Remove(publication);
+                return ConfigurationChanged();
+            }
+
             _logger.LogWarning(
                 "Avatar upstream unavailable for key {AvatarKey} ({Reason}); retry in {Delay}. Consecutive failures: {Failures}; last-good: {LastGood}.",
                 LogKey(cacheKey),

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrClient.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrClient.cs
@@ -114,16 +114,30 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
 
             var urls = integration.Urls;
             var apiKey = integration.ApiKey;
+            SeerrDispatchFence dispatchFence = integration.CreateDispatchFence(_configProvider);
             var httpClient = SeerrHttpHelper.CreateClient(_httpClientFactory);
             httpClient.Timeout = TimeSpan.FromSeconds(15);
 
             foreach (var url in urls)
             {
+                // A failed probe may await long enough for an administrator to
+                // disable or replace the integration. Revalidate before every
+                // failover dispatch so retained snapshot credentials are never
+                // used for the next configured URL.
+                if (!integration.IsCurrent(_configProvider))
+                {
+                    return false;
+                }
+
                 var requestUri = $"{url}/api/v1/status";
                 try
                 {
                     using var request = SeerrHttpHelper.BuildRequest(HttpMethod.Get, requestUri, apiKey);
-                    var (_, error, _) = await SeerrHttpHelper.SendAndReadJsonAsync(httpClient, request, requestUri);
+                    var (_, error, _) = await SeerrHttpHelper.SendAndReadJsonAsync(
+                        httpClient,
+                        request,
+                        requestUri,
+                        dispatchFence).ConfigureAwait(false);
                     if (error == null)
                     {
                         return integration.IsCurrent(_configProvider);
@@ -139,28 +153,6 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
 
             _logger.LogWarning("Could not establish a connection with any configured Seerr URL. Status is inactive.");
             return false;
-        }
-
-        // Cached wrapper so a Seerr outage doesn't fan out N status probes from
-        // the negative-user-cache window.
-        private async Task<bool> IsSeerrReachableCached()
-        {
-            lock (_seerrCache.SeerrStatusCacheLock)
-            {
-                if (_seerrCache.SeerrStatusCache.HasValue
-                    && DateTime.UtcNow - _seerrCache.SeerrStatusCache.Value.CachedAt < _seerrCache.SeerrStatusCacheTtl)
-                {
-                    return _seerrCache.SeerrStatusCache.Value.Active;
-                }
-            }
-
-            bool active = await GetStatusActiveAsync();
-            lock (_seerrCache.SeerrStatusCacheLock)
-            {
-                _seerrCache.SeerrStatusCache = (active, DateTime.UtcNow);
-            }
-
-            return active;
         }
 
         // ── 4K capability ────────────────────────────────────────────────────
@@ -265,6 +257,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             bool IsConfigurationCurrent() => configStamp.Matches(
                 _configProvider.ConfigurationOrNull,
                 _configProvider.ConfigurationRevision);
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
             var configuredSource = capturedConfiguredUrls
                 .FirstOrDefault(url => string.Equals(url, sourceUrl, StringComparison.Ordinal));
             var apiKey = capturedApiKey;
@@ -315,7 +308,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                 var (json, error, _) = await SeerrHttpHelper.SendAndReadJsonAsync(
                     httpClient,
                     request,
-                    requestUri).ConfigureAwait(false);
+                    requestUri,
+                    integration
+                        .CreateDispatchFence(_configProvider)
+                        .Restrict(IsConfigurationCurrent)).ConfigureAwait(false);
                 if (!IsConfigurationCurrent())
                 {
                     return (false, false);
@@ -468,6 +464,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                 && importConfigStamp.Matches(
                     _configProvider.ConfigurationOrNull,
                     _configProvider.ConfigurationRevision);
+            SeerrDispatchFence dispatchFence = integration
+                .CreateDispatchFence(_configProvider)
+                .Restrict(ConfigurationIsCurrent);
             static SeerrUserResolution ConfigurationChanged() =>
                 SeerrUserResolution.Incomplete(
                     "Seerr configuration changed during user lookup; retry the request.");
@@ -612,6 +611,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                     apiUserId: null,
                     requestedPageSize: 1000,
                     UserCollectionIdentity,
+                    dispatchFence,
                     cancellationToken).ConfigureAwait(false);
 
                 if (!ConfigurationIsCurrent())
@@ -772,6 +772,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                         httpClient,
                         config,
                         importConfigStamp,
+                        dispatchFence,
                         cancellationToken).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -911,6 +912,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             HttpClient httpClient,
             PluginConfiguration capturedConfig,
             SeerrMutationConfigStamp configStamp,
+            SeerrDispatchFence dispatchFence,
             CancellationToken cancellationToken)
         {
             var apiKey = capturedConfig.SeerrApiKey;
@@ -922,6 +924,17 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                 _logger.LogWarning("Refusing to auto-import a malformed Jellyfin user identity.");
                 return (null, true);
             }
+
+            bool ConfigurationIsCurrent()
+            {
+                var current = _configProvider.ConfigurationOrNull;
+                return current != null
+                    && configStamp.Matches(current, _configProvider.ConfigurationRevision)
+                    && SeerrIntegrationPolicy.HasUsableSavedConfiguration(current)
+                    && current.SeerrAutoImportUsers
+                    && !IsImportBlocked(normalizedUserId, current);
+            }
+            SeerrDispatchFence importDispatchFence = dispatchFence.Restrict(ConfigurationIsCurrent);
 
             var url = urls.FirstOrDefault();
             if (string.IsNullOrWhiteSpace(url))
@@ -944,6 +957,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                 apiUserId: null,
                 requestedPageSize: 1000,
                 UserCollectionIdentity,
+                importDispatchFence,
                 cancellationToken).ConfigureAwait(false);
             if (!dispatchSnapshots.IsComplete)
             {
@@ -993,6 +1007,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             // committed import even though this caller cannot prove it.
             try
             {
+                if (!importDispatchFence.CanDispatch())
+                {
+                    return (null, false);
+                }
+
                 var importUri = $"{url}/api/v1/user/import-from-jellyfin";
                 var requestBody = JsonSerializer.Serialize(new { jellyfinUserIds = new[] { normalizedUserId } });
 
@@ -1001,6 +1020,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                     httpClient,
                     importRequest,
                     importUri,
+                    importDispatchFence,
                     cancellationToken).ConfigureAwait(false);
 
                 if (importError != null)
@@ -1069,6 +1089,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                     apiUserId: null,
                     requestedPageSize: 1000,
                     UserCollectionIdentity,
+                    importDispatchFence,
                     cancellationToken).ConfigureAwait(false);
                 if (freshSnapshot.IsComplete)
                 {
@@ -1381,9 +1402,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             object cacheLock,
             string cacheKey,
             (string Content, DateTime CachedAt, long ConfigurationRevision, string ConfigurationIdentity) entry,
-            Func<bool> isConfigurationCurrent)
+            SeerrDispatchFence dispatchFence)
         {
-            if (!isConfigurationCurrent())
+            if (!dispatchFence.CanDispatch())
             {
                 return false;
             }
@@ -1394,7 +1415,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                 cache.TrySet(cacheKey, entry, out publication);
             }
 
-            if (isConfigurationCurrent())
+            if (dispatchFence.CanDispatch())
             {
                 return true;
             }
@@ -1606,6 +1627,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             var requestConfigStamp = SeerrMutationConfigStamp.Capture(
                 config,
                 requestConfigurationRevision);
+            SeerrDispatchFence requestDispatchFence = integration
+                .CreateDispatchFence(_configProvider)
+                .Restrict(() => requestConfigStamp.Matches(
+                    _configProvider.ConfigurationOrNull,
+                    _configProvider.ConfigurationRevision));
             var mutationConfigStamp = method != HttpMethod.Get
                 ? requestConfigStamp
                 : (SeerrMutationConfigStamp?)null;
@@ -1657,6 +1683,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                         resolvedUser.Id,
                         pinnedSourceUrl,
                         config.SeerrApiKey,
+                        requestDispatchFence,
                         cancellationToken).ConfigureAwait(false);
                     if (freshUser == null
                         || freshUser.Id != resolvedUser.Id
@@ -2061,6 +2088,28 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             foreach (var url in urls)
             {
                 cancellationToken.ThrowIfCancellationRequested();
+
+                // Public reads may fail over across several configured Seerr
+                // instances. Every iteration is a separate authorization point:
+                // a completed failed request must not authorize another send
+                // after the master switch or any configuration field changed.
+                if (!integration.IsCurrent(_configProvider))
+                {
+                    var code = method == HttpMethod.Get
+                        ? "read_configuration_changed"
+                        : "mutation_configuration_changed";
+                    var message = method == HttpMethod.Get
+                        ? "Seerr configuration changed before the next request. Please try again."
+                        : "Seerr configuration changed before dispatch. No mutation was attempted; retry with fresh data.";
+                    return new ObjectResult(new
+                    {
+                        error = true,
+                        code,
+                        message,
+                    })
+                    { StatusCode = 409 };
+                }
+
                 var requestUri = $"{url}{apiPath}";
                 // High-frequency endpoints that don't need a per-call INFO line.
                 // also covers /search/keyword (typeahead) and item-
@@ -2103,6 +2152,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                         httpClient,
                         request,
                         requestUri,
+                        requestDispatchFence,
                         cancellationToken).ConfigureAwait(false);
 
                     if (error == null && json != null)
@@ -2136,9 +2186,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                                     _seerrCache.ResponseCacheLock,
                                     cacheKey,
                                     publishedEntry,
-                                    () => requestConfigStamp.Matches(
-                                        _configProvider.ConfigurationOrNull,
-                                        _configProvider.ConfigurationRevision)))
+                                    requestDispatchFence))
                             {
                                 return new ObjectResult(new
                                 {
@@ -2242,6 +2290,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             int seerrUserId,
             string sourceUrl,
             string apiKey,
+            SeerrDispatchFence dispatchFence,
             CancellationToken cancellationToken)
         {
             if (seerrUserId <= 0) return null;
@@ -2252,6 +2301,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             var requestUri = $"{sourceUrl}/api/v1/user/{seerrUserId}";
             try
             {
+                if (!dispatchFence.CanDispatch()) return null;
                 var httpClient = SeerrHttpHelper.CreateClient(_httpClientFactory);
                 httpClient.Timeout = TimeSpan.FromSeconds(15);
                 using var request = SeerrHttpHelper.BuildRequest(
@@ -2262,6 +2312,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                     httpClient,
                     request,
                     requestUri,
+                    dispatchFence,
                     cancellationToken).ConfigureAwait(false);
                 if (error != null || json == null) return null;
 
@@ -2336,6 +2387,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
 
                 var urls = new[] { configuredSource };
                 var httpClient = SeerrHttpHelper.CreateClient(_httpClientFactory);
+                SeerrDispatchFence dispatchFence = integration.CreateDispatchFence(_configProvider);
                 var snapshot = await SeerrPaginationHelper.FetchAllAsync(
                     httpClient,
                     urls,
@@ -2344,6 +2396,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                     seerrUserId,
                     requestedPageSize: 100,
                     WatchlistCollectionIdentity,
+                    dispatchFence,
                     cancellationToken).ConfigureAwait(false);
 
                 if (!snapshot.IsComplete)
@@ -2443,6 +2496,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                 var configStamp = SeerrMutationConfigStamp.Capture(
                     capturedConfiguration,
                     configurationRevision);
+                var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+                SeerrDispatchFence dispatchFence = integration
+                    .CreateDispatchFence(_configProvider)
+                    .Restrict(() => configStamp.Matches(
+                        _configProvider.ConfigurationOrNull,
+                        _configProvider.ConfigurationRevision));
                 var configuredUrls = capturedConfiguredUrls.ToArray();
                 var apiKey = capturedApiKey;
                 if (!SeerrIntegrationPolicy.HasUsableSavedConfiguration(capturedConfiguration)
@@ -2477,6 +2536,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                     seerrUserId,
                     requestedPageSize: 500,
                     RequestCollectionIdentity,
+                    dispatchFence,
                     cancellationToken).ConfigureAwait(false);
 
                 if (!SeerrIntegrationPolicy.HasUsableSavedConfiguration(

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrClient.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrClient.cs
@@ -106,13 +106,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
 
         public async Task<bool> GetStatusActiveAsync()
         {
-            var config = _configProvider.ConfigurationOrNull;
-            if (config == null || !config.SeerrEnabled || string.IsNullOrEmpty(config.SeerrApiKey) || string.IsNullOrEmpty(config.SeerrUrls))
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            if (!integration.IsActive)
             {
                 return false;
             }
 
-            var urls = GetConfiguredUrls(config.SeerrUrls);
+            var urls = integration.Urls;
+            var apiKey = integration.ApiKey;
             var httpClient = SeerrHttpHelper.CreateClient(_httpClientFactory);
             httpClient.Timeout = TimeSpan.FromSeconds(15);
 
@@ -121,11 +122,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                 var requestUri = $"{url}/api/v1/status";
                 try
                 {
-                    using var request = SeerrHttpHelper.BuildRequest(HttpMethod.Get, requestUri, config.SeerrApiKey);
+                    using var request = SeerrHttpHelper.BuildRequest(HttpMethod.Get, requestUri, apiKey);
                     var (_, error, _) = await SeerrHttpHelper.SendAndReadJsonAsync(httpClient, request, requestUri);
                     if (error == null)
                     {
-                        return true;
+                        return integration.IsCurrent(_configProvider);
                     }
 
                     _logger.LogWarning($"Seerr status check failed at {url}: code={error.Code} status={error.HttpStatus} cf-ray={error.CfRay} — {error.Message}");
@@ -166,25 +167,24 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
 
         public async Task<Seerr4kCapability> GetSeerr4kCapabilityAsync(string jellyfinUserId, bool isAdmin = false)
         {
-            var config = _configProvider.ConfigurationOrNull;
-            if (config == null
-                || !config.SeerrEnabled
-                || string.IsNullOrWhiteSpace(config.SeerrUrls)
-                || string.IsNullOrWhiteSpace(config.SeerrApiKey))
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            if (!integration.IsActive)
             {
                 return new Seerr4kCapability(false, false, false, false);
             }
 
-            var configurationRevision = _configProvider.ConfigurationRevision;
+            var config = integration.Configuration!;
+            var configurationRevision = integration.ConfigurationRevision;
             var configStamp = SeerrMutationConfigStamp.Capture(config, configurationRevision);
-            var configuredUrls = GetConfiguredUrls(config.SeerrUrls);
-            var apiKey = config.SeerrApiKey;
+            var configuredUrls = integration.Urls;
+            var apiKey = integration.ApiKey;
             var cacheDisabled = config.SeerrDisableCache;
             var masterMovie4k = config.SeerrEnable4KRequests;
             var masterTv4k = config.SeerrEnable4KTvRequests;
-            bool IsConfigurationCurrent() => configStamp.Matches(
-                _configProvider.ConfigurationOrNull,
-                _configProvider.ConfigurationRevision);
+            bool IsConfigurationCurrent() => integration.IsCurrent(_configProvider)
+                && configStamp.Matches(
+                    _configProvider.ConfigurationOrNull,
+                    _configProvider.ConfigurationRevision);
             if (!IsConfigurationCurrent())
             {
                 return new Seerr4kCapability(false, false, false, false);
@@ -447,23 +447,27 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var config = _configProvider.ConfigurationOrNull;
-            if (config == null || string.IsNullOrEmpty(config.SeerrUrls) || string.IsNullOrEmpty(config.SeerrApiKey))
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            if (!integration.IsActive)
             {
-                _logger.LogWarning("Seerr configuration is missing. Cannot look up user ID.");
+                _logger.LogWarning("Seerr integration is disabled or unavailable. Cannot look up user ID.");
                 return new SeerrUserResolution(
                     SeerrUserResolutionStatus.Unavailable,
-                    FailureReason: "Seerr integration is not configured.");
+                    FailureReason: integration.State == SeerrIntegrationState.Disabled
+                        ? "Seerr integration is disabled."
+                        : "Seerr integration is not configured.");
             }
 
-            var configurationRevision = _configProvider.ConfigurationRevision;
+            var config = integration.Configuration!;
+            var configurationRevision = integration.ConfigurationRevision;
             var configurationIdentity = BuildConfigurationIdentity(config);
             var importConfigStamp = SeerrMutationConfigStamp.Capture(
                 config,
                 configurationRevision);
-            bool ConfigurationIsCurrent() => importConfigStamp.Matches(
-                _configProvider.ConfigurationOrNull,
-                _configProvider.ConfigurationRevision);
+            bool ConfigurationIsCurrent() => integration.IsCurrent(_configProvider)
+                && importConfigStamp.Matches(
+                    _configProvider.ConfigurationOrNull,
+                    _configProvider.ConfigurationRevision);
             static SeerrUserResolution ConfigurationChanged() =>
                 SeerrUserResolution.Incomplete(
                     "Seerr configuration changed during user lookup; retry the request.");
@@ -498,13 +502,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                 return new SeerrUserResolution(SeerrUserResolutionStatus.Blocked);
             }
 
-            var urls = GetConfiguredUrls(config.SeerrUrls);
-            if (urls.Length == 0)
-            {
-                return new SeerrUserResolution(
-                    SeerrUserResolutionStatus.Unavailable,
-                    FailureReason: "No valid Seerr URL is configured.");
-            }
+            var urls = integration.Urls;
 
             var cacheKey = NormalizeUserId(jellyfinUserId);
             bool cacheEnabled = !config.SeerrDisableCache && !bypassCache;
@@ -975,7 +973,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
 
             var currentConfig = _configProvider.ConfigurationOrNull;
             if (!configStamp.Matches(currentConfig, _configProvider.ConfigurationRevision)
-                || currentConfig?.SeerrEnabled != true
+                || currentConfig == null
+                || !SeerrIntegrationPolicy.HasUsableSavedConfiguration(currentConfig)
                 || !currentConfig.SeerrAutoImportUsers
                 || IsImportBlocked(normalizedUserId, currentConfig))
             {
@@ -1180,18 +1179,20 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
 
         public async Task<string?> GetSeerrUserId(string jellyfinUserId, bool allowAutoImport = true)
         {
-            var config = _configProvider.ConfigurationOrNull;
-            if (config == null)
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            if (!integration.IsActive)
             {
                 return null;
             }
 
-            var configurationRevision = _configProvider.ConfigurationRevision;
+            var config = integration.Configuration!;
+            var configurationRevision = integration.ConfigurationRevision;
             var configurationIdentity = BuildConfigurationIdentity(config);
             var configStamp = SeerrMutationConfigStamp.Capture(config, configurationRevision);
-            bool ConfigurationIsCurrent() => configStamp.Matches(
-                _configProvider.ConfigurationOrNull,
-                _configProvider.ConfigurationRevision);
+            bool ConfigurationIsCurrent() => integration.IsCurrent(_configProvider)
+                && configStamp.Matches(
+                    _configProvider.ConfigurationOrNull,
+                    _configProvider.ConfigurationRevision);
             bool cacheEnabled = !config.SeerrDisableCache;
             var cacheKey = NormalizeUserId(jellyfinUserId);
 
@@ -1592,14 +1593,15 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             bool bypassResponseCache = false)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var config = _configProvider.ConfigurationOrNull;
-            if (config == null || !config.SeerrEnabled || string.IsNullOrEmpty(config.SeerrUrls) || string.IsNullOrEmpty(config.SeerrApiKey))
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            if (!integration.IsActive)
             {
                 _logger.LogWarning("Seerr integration is not configured or enabled.");
                 return new ObjectResult("Seerr integration is not configured or enabled.") { StatusCode = 503 };
             }
 
-            var requestConfigurationRevision = _configProvider.ConfigurationRevision;
+            var config = integration.Configuration!;
+            var requestConfigurationRevision = integration.ConfigurationRevision;
             var requestConfigurationIdentity = BuildConfigurationIdentity(config);
             var requestConfigStamp = SeerrMutationConfigStamp.Capture(
                 config,
@@ -1988,9 +1990,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                         currentMutationConfig,
                         _configProvider.ConfigurationRevision)
                     || currentMutationConfig == null
-                    || !currentMutationConfig.SeerrEnabled
-                    || string.IsNullOrEmpty(currentMutationConfig.SeerrUrls)
-                    || string.IsNullOrEmpty(currentMutationConfig.SeerrApiKey))
+                    || !SeerrIntegrationPolicy.HasUsableSavedConfiguration(currentMutationConfig))
                 {
                     return new ObjectResult(new
                     {
@@ -2301,12 +2301,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
 
         public Task<List<WatchlistItem>?> GetWatchlistForUser(string seerrUserId)
         {
-            var config = _configProvider.ConfigurationOrNull;
-            var configuredUrls = GetConfiguredUrls(config?.SeerrUrls);
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            var configuredUrls = integration.Urls;
             // The legacy overload carries an instance-local user id without its
             // identity domain. It is safe only when configuration proves there
             // is exactly one possible source.
-            return configuredUrls.Length == 1
+            return integration.IsActive && configuredUrls.Length == 1
                 ? GetWatchlistForUser(seerrUserId, configuredUrls[0])
                 : Task.FromResult<List<WatchlistItem>?>(null);
         }
@@ -2318,14 +2318,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
         {
             try
             {
-                var config = _configProvider.ConfigurationOrNull;
-                if (config == null || string.IsNullOrEmpty(config.SeerrUrls) || string.IsNullOrEmpty(config.SeerrApiKey))
+                var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+                if (!integration.IsActive)
                 {
                     return null;
                 }
 
                 var configuredSource = FindConfiguredSource(
-                    GetConfiguredUrls(config.SeerrUrls),
+                    integration.Urls,
                     sourceUrl);
                 if (configuredSource == null)
                 {
@@ -2340,7 +2340,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                     httpClient,
                     urls,
                     (url, page, _) => $"{url}/api/v1/user/{seerrUserId}/watchlist?take=100&page={page}",
-                    config.SeerrApiKey,
+                    integration.ApiKey,
                     seerrUserId,
                     requestedPageSize: 100,
                     WatchlistCollectionIdentity,
@@ -2349,6 +2349,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                 if (!snapshot.IsComplete)
                 {
                     LogIncompleteCollection("watchlist", snapshot);
+                    return null;
+                }
+
+                if (!integration.IsCurrent(_configProvider))
+                {
                     return null;
                 }
 
@@ -2375,7 +2380,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                     });
                 }
 
-                return items;
+                return integration.IsCurrent(_configProvider) ? items : null;
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -2391,16 +2396,16 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
 
         public Task<List<WatchlistItem>?> GetRequestsForUser(string seerrUserId)
         {
-            var config = _configProvider.ConfigurationOrNull;
-            var configurationRevision = _configProvider.ConfigurationRevision;
-            var configuredUrls = GetConfiguredUrls(config?.SeerrUrls);
-            return config != null && configuredUrls.Length == 1
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            var config = integration.Configuration;
+            var configuredUrls = integration.Urls;
+            return integration.IsActive && config != null && configuredUrls.Length == 1
                 ? GetRequestsForUser(
                     seerrUserId,
                     configuredUrls[0],
                     config,
-                    configurationRevision,
-                    config.SeerrApiKey,
+                    integration.ConfigurationRevision,
+                    integration.ApiKey,
                     configuredUrls)
                 : Task.FromResult<List<WatchlistItem>?>(null);
         }
@@ -2410,17 +2415,17 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             string? sourceUrl,
             CancellationToken cancellationToken = default)
         {
-            var config = _configProvider.ConfigurationOrNull;
-            var configurationRevision = _configProvider.ConfigurationRevision;
-            return config == null
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            var config = integration.Configuration;
+            return !integration.IsActive || config == null
                 ? Task.FromResult<List<WatchlistItem>?>(null)
                 : GetRequestsForUser(
                     seerrUserId,
                     sourceUrl,
                     config,
-                    configurationRevision,
-                    config.SeerrApiKey,
-                    GetConfiguredUrls(config.SeerrUrls),
+                    integration.ConfigurationRevision,
+                    integration.ApiKey,
+                    integration.Urls,
                     cancellationToken);
         }
 
@@ -2440,8 +2445,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                     configurationRevision);
                 var configuredUrls = capturedConfiguredUrls.ToArray();
                 var apiKey = capturedApiKey;
-                if (configuredUrls.Length == 0
+                if (!SeerrIntegrationPolicy.HasUsableSavedConfiguration(capturedConfiguration)
+                    || configuredUrls.Length == 0
                     || string.IsNullOrEmpty(apiKey)
+                    || !SeerrIntegrationPolicy.HasUsableSavedConfiguration(
+                        _configProvider.ConfigurationOrNull)
                     || !configStamp.Matches(
                         _configProvider.ConfigurationOrNull,
                         _configProvider.ConfigurationRevision))
@@ -2471,7 +2479,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                     RequestCollectionIdentity,
                     cancellationToken).ConfigureAwait(false);
 
-                if (!configStamp.Matches(
+                if (!SeerrIntegrationPolicy.HasUsableSavedConfiguration(
+                        _configProvider.ConfigurationOrNull)
+                    || !configStamp.Matches(
                         _configProvider.ConfigurationOrNull,
                         _configProvider.ConfigurationRevision))
                 {
@@ -2513,9 +2523,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                     items.Add(parsed);
                 }
 
-                return configStamp.Matches(
-                    _configProvider.ConfigurationOrNull,
-                    _configProvider.ConfigurationRevision)
+                return SeerrIntegrationPolicy.HasUsableSavedConfiguration(
+                        _configProvider.ConfigurationOrNull)
+                    && configStamp.Matches(
+                        _configProvider.ConfigurationOrNull,
+                        _configProvider.ConfigurationRevision)
                     ? items
                     : null;
             }

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrIntegrationPolicy.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrIntegrationPolicy.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
 using Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr;
 
@@ -22,59 +23,6 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
     }
 
     /// <summary>
-    /// One immutable authorization snapshot for a non-setup Seerr operation.
-    /// The complete configuration stamp is retained so callers can re-check the
-    /// same generation immediately before publishing data or dispatching a
-    /// mutation.
-    /// </summary>
-    internal sealed class SeerrIntegrationSnapshot
-    {
-        private readonly SeerrMutationConfigStamp _stamp;
-
-        internal SeerrIntegrationSnapshot(
-            SeerrIntegrationState state,
-            PluginConfiguration? configuration,
-            long configurationRevision,
-            string[] urls,
-            string apiKey,
-            SeerrMutationConfigStamp stamp)
-        {
-            State = state;
-            Configuration = configuration;
-            ConfigurationRevision = configurationRevision;
-            Urls = urls;
-            ApiKey = apiKey;
-            _stamp = stamp;
-        }
-
-        public SeerrIntegrationState State { get; }
-
-        public bool IsActive => State == SeerrIntegrationState.Active;
-
-        public PluginConfiguration? Configuration { get; }
-
-        public long ConfigurationRevision { get; }
-
-        public string[] Urls { get; }
-
-        public string ApiKey { get; }
-
-        internal SeerrMutationConfigStamp ConfigurationStamp => _stamp;
-
-        /// <summary>
-        /// Revalidates the entire configuration generation, including in-place
-        /// changes made by test/custom providers. A master-switch disable can
-        /// therefore fence an already-prepared read or mutation.
-        /// </summary>
-        public bool IsCurrent(IPluginConfigProvider provider)
-        {
-            var current = provider.ConfigurationOrNull;
-            return SeerrIntegrationPolicy.HasUsableSavedConfiguration(current)
-                && _stamp.Matches(current, provider.ConfigurationRevision);
-        }
-    }
-
-    /// <summary>
     /// The single semantic owner of the Seerr master switch and saved-credential
     /// contract. Every active (non-setup) read, background operation, advertised
     /// capability and mutation must enter through <see cref="Capture"/> or use
@@ -85,8 +33,182 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
     /// exact endpoints are pinned as named exemptions by
     /// <c>SeerrIntegrationEntryPointGuardTests</c>.
     /// </summary>
-    internal static class SeerrIntegrationPolicy
+    public static class SeerrIntegrationPolicy
     {
+        /// <summary>
+        /// Opaque, fail-closed capability for a single captured Seerr generation.
+        /// Transport APIs accept this type instead of arbitrary boolean delegates,
+        /// so caller restrictions can only narrow the policy-owned base fence.
+        /// </summary>
+        public sealed class SeerrDispatchFence
+        {
+            private readonly SeerrIntegrationSnapshot _snapshot;
+            private readonly IPluginConfigProvider _provider;
+            private readonly Func<bool>? _restriction;
+
+            private SeerrDispatchFence(
+                SeerrIntegrationSnapshot snapshot,
+                IPluginConfigProvider provider,
+                Func<bool>? restriction)
+            {
+                _snapshot = snapshot;
+                _provider = provider;
+                _restriction = restriction;
+            }
+
+            internal static SeerrDispatchFence Create(
+                SeerrIntegrationSnapshot snapshot,
+                IPluginConfigProvider provider)
+                => new(snapshot, provider, restriction: null);
+
+            internal SeerrDispatchFence Restrict(Func<bool> restriction)
+            {
+                ArgumentNullException.ThrowIfNull(restriction);
+                return new SeerrDispatchFence(
+                    _snapshot,
+                    _provider,
+                    _restriction == null
+                        ? restriction
+                        : () => Invoke(_restriction) && Invoke(restriction));
+            }
+
+            internal bool CanDispatch()
+            {
+                try
+                {
+                    return _snapshot.IsActive
+                        && _snapshot.IsCurrent(_provider)
+                        && (_restriction == null || Invoke(_restriction));
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+
+            internal bool CanDispatch(Uri? target)
+                => CanDispatch() && _snapshot.ContainsTarget(target);
+
+            private static bool Invoke(Func<bool> predicate)
+            {
+                try
+                {
+                    return predicate();
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+        }
+
+        /// <summary>
+        /// One immutable authorization snapshot for a non-setup Seerr operation.
+        /// </summary>
+        public sealed class SeerrIntegrationSnapshot
+        {
+            private readonly SeerrMutationConfigStamp _stamp;
+            private readonly string[] _urls;
+
+            private SeerrIntegrationSnapshot(
+                SeerrIntegrationState state,
+                PluginConfiguration? configuration,
+                long configurationRevision,
+                string[] urls,
+                string apiKey,
+                SeerrMutationConfigStamp stamp)
+            {
+                State = state;
+                Configuration = configuration;
+                ConfigurationRevision = configurationRevision;
+                _urls = (string[])urls.Clone();
+                ApiKey = apiKey;
+                _stamp = stamp;
+            }
+
+            internal SeerrIntegrationState State { get; }
+
+            public bool IsActive => State == SeerrIntegrationState.Active;
+
+            public PluginConfiguration? Configuration { get; }
+
+            public long ConfigurationRevision { get; }
+
+            public string[] Urls => (string[])_urls.Clone();
+
+            public string ApiKey { get; }
+
+            internal SeerrMutationConfigStamp ConfigurationStamp => _stamp;
+
+            internal SeerrDispatchFence CreateDispatchFence(IPluginConfigProvider provider)
+                => SeerrDispatchFence.Create(this, provider);
+
+            internal static SeerrIntegrationSnapshot Capture(IPluginConfigProvider provider)
+            {
+                var configuration = provider.ConfigurationOrNull;
+                var revision = provider.ConfigurationRevision;
+                if (configuration == null)
+                {
+                    return Inactive(SeerrIntegrationState.ConfigurationUnavailable, revision);
+                }
+
+                if (!AllowsDeferredScheduling(configuration))
+                {
+                    return Inactive(SeerrIntegrationState.Disabled, revision);
+                }
+
+                if (string.IsNullOrWhiteSpace(configuration.SeerrApiKey))
+                {
+                    return Inactive(SeerrIntegrationState.CredentialsMissing, revision);
+                }
+
+                var urls = SeerrUrlIdentity.ParseConfigured(configuration.SeerrUrls);
+                if (urls.Length == 0)
+                {
+                    return Inactive(SeerrIntegrationState.UrlsInvalid, revision);
+                }
+
+                var stamp = SeerrMutationConfigStamp.Capture(configuration, revision);
+                var snapshot = new SeerrIntegrationSnapshot(
+                    SeerrIntegrationState.Active,
+                    configuration,
+                    revision,
+                    urls,
+                    configuration.SeerrApiKey,
+                    stamp);
+                return snapshot.IsCurrent(provider)
+                    ? snapshot
+                    : Inactive(SeerrIntegrationState.ConfigurationChanged, provider.ConfigurationRevision);
+            }
+
+            public bool IsCurrent(IPluginConfigProvider provider)
+            {
+                var current = provider.ConfigurationOrNull;
+                return HasUsableSavedConfiguration(current)
+                    && _stamp.Matches(current, provider.ConfigurationRevision);
+            }
+
+            internal bool ContainsTarget(Uri? target)
+            {
+                if (target == null || !target.IsAbsoluteUri) return false;
+                var absolute = target.AbsoluteUri;
+                return _urls.Any(source =>
+                    string.Equals(absolute, source, StringComparison.Ordinal)
+                    || absolute.StartsWith(source + "/", StringComparison.Ordinal));
+            }
+
+            private static SeerrIntegrationSnapshot Inactive(
+                SeerrIntegrationState state,
+                long revision)
+                => new(
+                    state,
+                    configuration: null,
+                    revision,
+                    System.Array.Empty<string>(),
+                    string.Empty,
+                    default);
+        }
+
         /// <summary>
         /// Cheap scheduling-only master check for synchronous library-event
         /// handlers. It authorizes no network traffic: the deferred worker must
@@ -111,46 +233,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
         /// retained credentials after the master switch is turned off.
         /// </summary>
         public static SeerrIntegrationSnapshot Capture(IPluginConfigProvider provider)
-        {
-            var configuration = provider.ConfigurationOrNull;
-            var revision = provider.ConfigurationRevision;
-            if (configuration == null)
-            {
-                return Inactive(SeerrIntegrationState.ConfigurationUnavailable, revision);
-            }
-
-            if (!AllowsDeferredScheduling(configuration))
-            {
-                return Inactive(SeerrIntegrationState.Disabled, revision);
-            }
-
-            if (string.IsNullOrWhiteSpace(configuration.SeerrApiKey))
-            {
-                return Inactive(SeerrIntegrationState.CredentialsMissing, revision);
-            }
-
-            var urls = SeerrUrlIdentity.ParseConfigured(configuration.SeerrUrls);
-            if (urls.Length == 0)
-            {
-                return Inactive(SeerrIntegrationState.UrlsInvalid, revision);
-            }
-
-            var stamp = SeerrMutationConfigStamp.Capture(configuration, revision);
-            var snapshot = new SeerrIntegrationSnapshot(
-                SeerrIntegrationState.Active,
-                configuration,
-                revision,
-                urls,
-                configuration.SeerrApiKey,
-                stamp);
-
-            // Configuration and revision are separate provider reads. Reject a
-            // replacement or in-place mutation that raced this capture instead
-            // of returning credentials from a mixed generation.
-            return snapshot.IsCurrent(provider)
-                ? snapshot
-                : Inactive(SeerrIntegrationState.ConfigurationChanged, provider.ConfigurationRevision);
-        }
+            => SeerrIntegrationSnapshot.Capture(provider);
 
         /// <summary>
         /// Invalidates both cache domains that can retain active Seerr state.
@@ -184,15 +267,5 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             return failures;
         }
 
-        private static SeerrIntegrationSnapshot Inactive(
-            SeerrIntegrationState state,
-            long revision)
-            => new(
-                state,
-                configuration: null,
-                revision,
-                System.Array.Empty<string>(),
-                string.Empty,
-                default);
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrIntegrationPolicy.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrIntegrationPolicy.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
+{
+    /// <summary>
+    /// Why the saved Seerr integration is not currently available.
+    /// <see cref="Disabled"/> is deliberately distinct from incomplete setup so
+    /// callers can report the administrator's master-switch decision without
+    /// treating retained credentials as active.
+    /// </summary>
+    internal enum SeerrIntegrationState
+    {
+        Active,
+        Disabled,
+        ConfigurationUnavailable,
+        CredentialsMissing,
+        UrlsInvalid,
+        ConfigurationChanged,
+    }
+
+    /// <summary>
+    /// One immutable authorization snapshot for a non-setup Seerr operation.
+    /// The complete configuration stamp is retained so callers can re-check the
+    /// same generation immediately before publishing data or dispatching a
+    /// mutation.
+    /// </summary>
+    internal sealed class SeerrIntegrationSnapshot
+    {
+        private readonly SeerrMutationConfigStamp _stamp;
+
+        internal SeerrIntegrationSnapshot(
+            SeerrIntegrationState state,
+            PluginConfiguration? configuration,
+            long configurationRevision,
+            string[] urls,
+            string apiKey,
+            SeerrMutationConfigStamp stamp)
+        {
+            State = state;
+            Configuration = configuration;
+            ConfigurationRevision = configurationRevision;
+            Urls = urls;
+            ApiKey = apiKey;
+            _stamp = stamp;
+        }
+
+        public SeerrIntegrationState State { get; }
+
+        public bool IsActive => State == SeerrIntegrationState.Active;
+
+        public PluginConfiguration? Configuration { get; }
+
+        public long ConfigurationRevision { get; }
+
+        public string[] Urls { get; }
+
+        public string ApiKey { get; }
+
+        internal SeerrMutationConfigStamp ConfigurationStamp => _stamp;
+
+        /// <summary>
+        /// Revalidates the entire configuration generation, including in-place
+        /// changes made by test/custom providers. A master-switch disable can
+        /// therefore fence an already-prepared read or mutation.
+        /// </summary>
+        public bool IsCurrent(IPluginConfigProvider provider)
+        {
+            var current = provider.ConfigurationOrNull;
+            return SeerrIntegrationPolicy.HasUsableSavedConfiguration(current)
+                && _stamp.Matches(current, provider.ConfigurationRevision);
+        }
+    }
+
+    /// <summary>
+    /// The single semantic owner of the Seerr master switch and saved-credential
+    /// contract. Every active (non-setup) read, background operation, advertised
+    /// capability and mutation must enter through <see cref="Capture"/> or use
+    /// <see cref="HasUsableSavedConfiguration"/> for a current-generation fence.
+    ///
+    /// Administrator setup probes intentionally do not use this policy: they
+    /// validate explicitly supplied, potentially unsaved URL/key pairs. Those
+    /// exact endpoints are pinned as named exemptions by
+    /// <c>SeerrIntegrationEntryPointGuardTests</c>.
+    /// </summary>
+    internal static class SeerrIntegrationPolicy
+    {
+        /// <summary>
+        /// Cheap scheduling-only master check for synchronous library-event
+        /// handlers. It authorizes no network traffic: the deferred worker must
+        /// still obtain a full <see cref="Capture"/> before any outbound call.
+        /// </summary>
+        public static bool AllowsDeferredScheduling(PluginConfiguration? configuration)
+            => configuration?.SeerrEnabled == true;
+
+        /// <summary>
+        /// True only when the master is enabled and the saved URL/key material is
+        /// usable by an active feature. This is the only production owner that
+        /// reads <see cref="PluginConfiguration.SeerrEnabled"/> directly.
+        /// </summary>
+        public static bool HasUsableSavedConfiguration(PluginConfiguration? configuration)
+            => configuration?.SeerrEnabled == true
+                && !string.IsNullOrWhiteSpace(configuration.SeerrApiKey)
+                && SeerrUrlIdentity.ParseConfigured(configuration.SeerrUrls).Length > 0;
+
+        /// <summary>
+        /// Captures one active saved-configuration generation. Inactive states
+        /// carry no URL or API key, preventing callers from accidentally using
+        /// retained credentials after the master switch is turned off.
+        /// </summary>
+        public static SeerrIntegrationSnapshot Capture(IPluginConfigProvider provider)
+        {
+            var configuration = provider.ConfigurationOrNull;
+            var revision = provider.ConfigurationRevision;
+            if (configuration == null)
+            {
+                return Inactive(SeerrIntegrationState.ConfigurationUnavailable, revision);
+            }
+
+            if (!AllowsDeferredScheduling(configuration))
+            {
+                return Inactive(SeerrIntegrationState.Disabled, revision);
+            }
+
+            if (string.IsNullOrWhiteSpace(configuration.SeerrApiKey))
+            {
+                return Inactive(SeerrIntegrationState.CredentialsMissing, revision);
+            }
+
+            var urls = SeerrUrlIdentity.ParseConfigured(configuration.SeerrUrls);
+            if (urls.Length == 0)
+            {
+                return Inactive(SeerrIntegrationState.UrlsInvalid, revision);
+            }
+
+            var stamp = SeerrMutationConfigStamp.Capture(configuration, revision);
+            var snapshot = new SeerrIntegrationSnapshot(
+                SeerrIntegrationState.Active,
+                configuration,
+                revision,
+                urls,
+                configuration.SeerrApiKey,
+                stamp);
+
+            // Configuration and revision are separate provider reads. Reject a
+            // replacement or in-place mutation that raced this capture instead
+            // of returning credentials from a mixed generation.
+            return snapshot.IsCurrent(provider)
+                ? snapshot
+                : Inactive(SeerrIntegrationState.ConfigurationChanged, provider.ConfigurationRevision);
+        }
+
+        /// <summary>
+        /// Invalidates both cache domains that can retain active Seerr state.
+        /// Each owner is attempted independently so a cancellation callback
+        /// failure in the watchlist generation cannot preserve the shared
+        /// response/capability caches (or vice versa).
+        /// </summary>
+        public static IReadOnlyList<(string Owner, Exception Error)> InvalidateCachedActiveState(
+            ISeerrCache cache,
+            WatchlistMonitor watchlistMonitor)
+        {
+            var failures = new List<(string Owner, Exception Error)>(2);
+            try
+            {
+                watchlistMonitor.NotifyConfigurationChanged();
+            }
+            catch (Exception ex)
+            {
+                failures.Add(("watchlist", ex));
+            }
+
+            try
+            {
+                cache.ClearAllSeerrCachesOnConfigChange();
+            }
+            catch (Exception ex)
+            {
+                failures.Add(("shared", ex));
+            }
+
+            return failures;
+        }
+
+        private static SeerrIntegrationSnapshot Inactive(
+            SeerrIntegrationState state,
+            long revision)
+            => new(
+                state,
+                configuration: null,
+                revision,
+                System.Array.Empty<string>(),
+                string.Empty,
+                default);
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrParentalFilter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrParentalFilter.cs
@@ -150,7 +150,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             FetchConfiguration FetchConfig,
             long ConfigurationRevision,
             string ConfigurationIdentity,
-            SeerrMutationConfigStamp ConfigurationStamp);
+            SeerrMutationConfigStamp ConfigurationStamp,
+            SeerrIntegrationSnapshot Integration);
 
         public async Task<SeerrParentalResult> ApplyAsync(string json, string apiPath, SeerrCaller caller)
         {
@@ -255,17 +256,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
         // ── Gate resolution (shared fast paths) ───────────────────────────────
         private async Task<GateContext?> ResolveGateAsync(SeerrCaller caller)
         {
-            var config = _configProvider.ConfigurationOrNull;
-            if (config == null || !config.SeerrRespectParentalRatings)
-            {
-                return null;
-            }
-
-            // The gate resolves certifications through Seerr; if Seerr isn't
-            // configured it cannot verify anything, so it stays inactive rather
-            // than fail-closed-blocking every title (which would break the raw
-            // TMDB passthrough for Elsewhere-only setups).
-            if (string.IsNullOrEmpty(config.SeerrUrls) || string.IsNullOrEmpty(config.SeerrApiKey))
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            var config = integration.Configuration;
+            if (!integration.IsActive
+                || config == null
+                || !config.SeerrRespectParentalRatings)
             {
                 return null;
             }
@@ -288,11 +283,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                 return null;
             }
 
-            var revision = _configProvider.ConfigurationRevision;
+            var revision = integration.ConfigurationRevision;
             var configurationStamp = SeerrMutationConfigStamp.Capture(config, revision);
             var fetchConfig = new FetchConfiguration(
-                config.SeerrUrls ?? string.Empty,
-                config.SeerrApiKey ?? string.Empty,
+                string.Join(',', integration.Urls),
+                integration.ApiKey,
                 config.TMDB_API_KEY ?? string.Empty,
                 TimeSpan.FromMinutes(Math.Max(1, config.SeerrParentalRatingCacheTtlMinutes)));
             var configurationIdentity = BuildConfigurationIdentity(config);
@@ -305,13 +300,15 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                 fetchConfig,
                 revision,
                 configurationIdentity,
-                configurationStamp);
+                configurationStamp,
+                integration);
         }
 
         private bool IsCurrentConfiguration(GateContext gate)
-            => gate.ConfigurationStamp.Matches(
-                _configProvider.ConfigurationOrNull,
-                _configProvider.ConfigurationRevision);
+            => gate.Integration.IsCurrent(_configProvider)
+                && gate.ConfigurationStamp.Matches(
+                    _configProvider.ConfigurationOrNull,
+                    _configProvider.ConfigurationRevision);
 
         private static string BuildConfigurationIdentity(PluginConfiguration config)
         {

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrParentalFilter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrParentalFilter.cs
@@ -883,7 +883,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             var (detail, hasTagData) = await FetchDetailAsync(
                 mediaType,
                 tmdbId,
-                gate.FetchConfig,
+                gate,
                 needTags,
                 cts.Token).ConfigureAwait(false);
             if (detail is null || !IsCurrentConfiguration(gate))
@@ -954,10 +954,16 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
         private async Task<(JsonElement? Detail, bool HasTagData)> FetchDetailAsync(
             string mediaType,
             int tmdbId,
-            FetchConfiguration config,
+            GateContext gate,
             bool needTags,
             CancellationToken ct)
         {
+            if (!IsCurrentConfiguration(gate))
+            {
+                return (null, false);
+            }
+
+            var config = gate.FetchConfig;
             if (!needTags && !string.IsNullOrEmpty(config.TmdbApiKey))
             {
                 var fromTmdb = await FetchCertFromTmdbAsync(mediaType, tmdbId, config, ct).ConfigureAwait(false);
@@ -967,7 +973,15 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                 }
             }
 
-            var fromSeerr = await FetchDetailFromSeerrAsync(mediaType, tmdbId, config, ct).ConfigureAwait(false);
+            // The TMDB prerequisite is an await boundary. If the integration
+            // changed while it was in flight, do not fall back using the old
+            // Seerr URL/key snapshot.
+            if (!IsCurrentConfiguration(gate))
+            {
+                return (null, false);
+            }
+
+            var fromSeerr = await FetchDetailFromSeerrAsync(mediaType, tmdbId, gate, ct).ConfigureAwait(false);
             return (fromSeerr, fromSeerr is not null);
         }
 
@@ -1012,9 +1026,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
         private async Task<JsonElement?> FetchDetailFromSeerrAsync(
             string mediaType,
             int tmdbId,
-            FetchConfiguration config,
+            GateContext gate,
             CancellationToken ct)
         {
+            var config = gate.FetchConfig;
             var urls = SeerrClient.GetConfiguredUrls(config.SeerrUrls);
             if (urls.Length == 0 || string.IsNullOrEmpty(config.SeerrApiKey))
             {
@@ -1024,9 +1039,20 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             var relative = $"/api/v1/{(mediaType == "tv" ? "tv" : "movie")}/{tmdbId.ToString(CultureInfo.InvariantCulture)}";
             var httpClient = SeerrHttpHelper.CreateClient(_httpClientFactory);
             httpClient.Timeout = PerFetchTimeout;
+            SeerrDispatchFence dispatchFence = gate.Integration
+                .CreateDispatchFence(_configProvider)
+                .Restrict(() => IsCurrentConfiguration(gate));
 
             foreach (var url in urls)
             {
+                // A failed detail request may be followed by another configured
+                // source. Revalidate the complete gate generation before each
+                // send so disable/config edits fence that failover.
+                if (!IsCurrentConfiguration(gate))
+                {
+                    return null;
+                }
+
                 var requestUri = $"{url}{relative}";
                 try
                 {
@@ -1037,6 +1063,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                         httpClient,
                         request,
                         requestUri,
+                        dispatchFence,
                         ct).ConfigureAwait(false);
                     if (error != null || string.IsNullOrEmpty(body))
                     {

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/SeerrScanTriggerService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/SeerrScanTriggerService.cs
@@ -197,7 +197,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     urls,
                     apiKey,
                     drainedEvents,
-                    integration.ConfigurationStamp,
+                    integration.CreateDispatchFence(_configProvider),
                     integration.ConfigurationRevision);
                 if (drainedEvents > 0)
                 {
@@ -303,7 +303,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 .Select(url => new DispatchTarget(
                     url,
                     integration.ApiKey,
-                    integration.ConfigurationStamp))
+                    integration.CreateDispatchFence(_configProvider)))
                 .ToArray();
             return DispatchPlan.Automatic(
                 batchSize,
@@ -421,10 +421,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             {
                 var target = plan.Targets[targetIndex];
                 cancellationToken.ThrowIfCancellationRequested();
-                if (target.ConfigurationStamp is SeerrMutationConfigStamp stamp
-                    && !stamp.Matches(
-                        _configProvider.ConfigurationOrNull,
-                        _configProvider.ConfigurationRevision))
+                if (target.DispatchFence?.CanDispatch() != true)
                 {
                     _logger.LogWarning(
                         "[SeerrScan] Configuration changed before dispatch to {Url}; that retired automatic target was not triggered",
@@ -436,6 +433,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 var result = await PostScanTrigger(
                     target.Url,
                     target.ApiKey,
+                    target.DispatchFence!,
                     cancellationToken).ConfigureAwait(false);
                 results.Add(result);
                 if (result.Success)
@@ -470,11 +468,18 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         private async Task<DispatchResult> PostScanTrigger(
             string url,
             string apiKey,
+            SeerrDispatchFence dispatchFence,
             CancellationToken cancellationToken)
         {
             var endpoint = $"{url.TrimEnd('/')}/api/v1/settings/jobs/{ScanJobId}/run";
             try
             {
+                if (!dispatchFence.CanDispatch())
+                {
+                    return DispatchResult.ConfigurationChangedResult(
+                        new DispatchTarget(url, apiKey, null));
+                }
+
                 var http = Helpers.Seerr.SeerrHttpHelper.CreateClient(_httpClientFactory);
                 http.Timeout = TimeSpan.FromSeconds(15);
                 using var request = Helpers.Seerr.SeerrHttpHelper.BuildRequest(
@@ -487,6 +492,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     http,
                     request,
                     endpoint,
+                    dispatchFence,
                     cancellationToken).ConfigureAwait(false);
                 return new DispatchResult
                 {
@@ -586,7 +592,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         internal sealed record DispatchTarget(
             string Url,
             string ApiKey,
-            SeerrMutationConfigStamp? ConfigurationStamp);
+            SeerrDispatchFence? DispatchFence);
 
         private static void CompleteAsCancelled(DispatchPlan? plan)
         {
@@ -622,13 +628,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 IEnumerable<string> urls,
                 string apiKey,
                 int batchSize,
-                SeerrMutationConfigStamp configurationStamp,
+                SeerrDispatchFence dispatchFence,
                 long configurationRevision)
                 => new(
                     true,
                     batchSize,
                     urls.Distinct(StringComparer.Ordinal)
-                        .Select(url => new DispatchTarget(url, apiKey, configurationStamp)),
+                        .Select(url => new DispatchTarget(url, apiKey, dispatchFence)),
                     configurationRevision);
 
             public static DispatchPlan Automatic(

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/SeerrScanTriggerService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/SeerrScanTriggerService.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
 using Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr;
+using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
 using MediaBrowser.Controller.Library;
 using Microsoft.Extensions.Logging;
 
@@ -94,7 +95,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             try
             {
                 if (_configProvider.ConfigurationOrNull is not PluginConfiguration config) return;
-                if (!config.TriggerSeerrScanOnItemAdded || !config.SeerrEnabled) return;
+                if (!config.TriggerSeerrScanOnItemAdded
+                    || !SeerrIntegrationPolicy.AllowsDeferredScheduling(config)) return;
 
                 var kind = e.Item?.GetBaseItemKind();
                 if (kind != BaseItemKind.Movie
@@ -170,13 +172,33 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             ArgumentNullException.ThrowIfNull(urls);
             if (urls.Count == 0) throw new ArgumentException("At least one Seerr URL is required.", nameof(urls));
 
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            var allowedUrls = integration.Urls.ToHashSet(StringComparer.Ordinal);
+            if (!integration.IsActive
+                || !string.Equals(apiKey, integration.ApiKey, StringComparison.Ordinal)
+                || urls.Any(url => !allowedUrls.Contains(url)))
+            {
+                return Task.FromResult<IReadOnlyList<DispatchResult>>(
+                    urls.Distinct(StringComparer.Ordinal)
+                        .Select(url => DispatchResult.PolicyDeniedResult(
+                            url,
+                            apiKey,
+                            integration.State))
+                        .ToArray());
+            }
+
             DispatchPlan plan;
             lock (_stateLock)
             {
                 ObjectDisposedException.ThrowIf(_disposed, this);
                 _debounceTimer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
                 var drainedEvents = DrainPendingLocked();
-                var manualPlan = DispatchPlan.Manual(urls, apiKey, drainedEvents);
+                var manualPlan = DispatchPlan.Manual(
+                    urls,
+                    apiKey,
+                    drainedEvents,
+                    integration.ConfigurationStamp,
+                    integration.ConfigurationRevision);
                 if (drainedEvents > 0)
                 {
                     manualPlan.AddTargets(CreateAutomaticPlan(drainedEvents).Targets);
@@ -265,24 +287,28 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
 
         private DispatchPlan CreateAutomaticPlan(int batchSize)
         {
-            if (_configProvider.ConfigurationOrNull is not PluginConfiguration config)
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            var config = integration.Configuration;
+            if (!integration.IsActive
+                || config == null
+                || !config.TriggerSeerrScanOnItemAdded)
             {
-                return DispatchPlan.Automatic(batchSize, Array.Empty<DispatchTarget>(), 0);
+                return DispatchPlan.Automatic(
+                    batchSize,
+                    Array.Empty<DispatchTarget>(),
+                    integration.ConfigurationRevision);
             }
 
-            var revision = _configProvider.ConfigurationRevision;
-            var stamp = SeerrMutationConfigStamp.Capture(config, revision);
-            if (!config.SeerrEnabled || !config.TriggerSeerrScanOnItemAdded)
-            {
-                return DispatchPlan.Automatic(batchSize, Array.Empty<DispatchTarget>(), revision);
-            }
-
-            var apiKey = config.SeerrApiKey;
-            var urls = ParseUrls(config.SeerrUrls);
-            var targets = string.IsNullOrEmpty(apiKey)
-                ? Array.Empty<DispatchTarget>()
-                : urls.Select(url => new DispatchTarget(url, apiKey, stamp)).ToArray();
-            return DispatchPlan.Automatic(batchSize, targets, revision);
+            var targets = integration.Urls
+                .Select(url => new DispatchTarget(
+                    url,
+                    integration.ApiKey,
+                    integration.ConfigurationStamp))
+                .ToArray();
+            return DispatchPlan.Automatic(
+                batchSize,
+                targets,
+                integration.ConfigurationRevision);
         }
 
         private void QueueAutomaticPlanLocked(DispatchPlan plan)
@@ -595,13 +621,15 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             public static DispatchPlan Manual(
                 IEnumerable<string> urls,
                 string apiKey,
-                int batchSize)
+                int batchSize,
+                SeerrMutationConfigStamp configurationStamp,
+                long configurationRevision)
                 => new(
                     true,
                     batchSize,
                     urls.Distinct(StringComparer.Ordinal)
-                        .Select(url => new DispatchTarget(url, apiKey, null)),
-                    0);
+                        .Select(url => new DispatchTarget(url, apiKey, configurationStamp)),
+                    configurationRevision);
 
             public static DispatchPlan Automatic(
                 int batchSize,
@@ -666,6 +694,24 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     ErrorCode = "ConfigurationChanged",
                     Body = "Seerr configuration changed before this trigger was sent; retry with the current settings.",
                     TargetApiKey = target.ApiKey,
+                };
+
+            internal static DispatchResult PolicyDeniedResult(
+                string url,
+                string apiKey,
+                SeerrIntegrationState state)
+                => new()
+                {
+                    Url = url,
+                    Success = false,
+                    StatusCode = 503,
+                    ErrorCode = state == SeerrIntegrationState.Disabled
+                        ? "SeerrDisabled"
+                        : "ConfigurationChanged",
+                    Body = state == SeerrIntegrationState.Disabled
+                        ? "Seerr integration is disabled; no scan trigger was sent."
+                        : "The supplied Seerr target is not the active saved integration; no scan trigger was sent.",
+                    TargetApiKey = apiKey,
                 };
         }
     }

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/WatchlistMonitor.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/WatchlistMonitor.cs
@@ -15,6 +15,7 @@ using Jellyfin.Plugin.JellyfinCanopy.Configuration;
 using Jellyfin.Plugin.JellyfinCanopy.Helpers;
 using Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr;
 using Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks;
+using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
@@ -92,7 +93,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 return;
             }
 
-            if (!config.AddRequestedMediaToWatchlist || !config.SeerrEnabled)
+            if (!config.AddRequestedMediaToWatchlist
+                || !SeerrIntegrationPolicy.AllowsDeferredScheduling(config))
             {
                 _logger.LogInformation("[Watchlist] Watchlist monitoring is disabled in configuration - not subscribing to library events");
                 return;
@@ -129,7 +131,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             var configRevision = _configProvider.ConfigurationRevision;
             var config = _configProvider.ConfigurationOrNull;
             if (_configProvider.ConfigurationRevision != configRevision) return;
-            if (config?.AddRequestedMediaToWatchlist != true || !config.SeerrEnabled) return;
+            if (config?.AddRequestedMediaToWatchlist != true
+                || !SeerrIntegrationPolicy.AllowsDeferredScheduling(config)) return;
 
             long configurationGeneration;
             lock (_configurationCancellationLock)
@@ -200,6 +203,28 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
 
         internal CoalescingWorkerMetrics QueueMetrics => _workQueue.Metrics;
 
+        internal int RequestsCacheCount
+        {
+            get
+            {
+                lock (_requestsCacheLock)
+                {
+                    return _requestsCache.Count;
+                }
+            }
+        }
+
+        internal long ConfigurationGenerationNumber
+        {
+            get
+            {
+                lock (_configurationCancellationLock)
+                {
+                    return _configurationGeneration.Number;
+                }
+            }
+        }
+
         internal void NotifyConfigurationChanged()
         {
             lock (_lifecycleLock)
@@ -220,8 +245,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             // cancellation tokens remain readable after their source is disposed.
             previous.Cancellation.Cancel();
             previous.Cancellation.Dispose();
+            lock (_requestsCacheLock)
+            {
+                _requestsCache.Clear();
+            }
             _logger.LogInformation(
-                "[Watchlist] Configuration changed; cancelled the active generation and invalidated queued work.");
+                "[Watchlist] Configuration changed; cancelled the active generation and invalidated queued work and cached Seerr requests.");
         }
 
         // Deterministic test seam over the same operation scheduled by library events. Keeping
@@ -252,7 +281,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 // _logger.LogInformation($"[Watchlist] {eventType} event triggered for: {e.Item?.Name ?? "Unknown"} (Type: {itemKind})");
 
                 // Check if watchlist feature is enabled
-                var config = _configProvider.ConfigurationOrNull as PluginConfiguration;
+                var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+                var config = integration.Configuration;
                 if (config == null)
                 {
                     _logger.LogWarning("[Watchlist] Configuration is null");
@@ -265,7 +295,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     return;
                 }
 
-                if (!config.SeerrEnabled)
+                if (!integration.IsActive)
                 {
                     _logger.LogDebug("[Watchlist] SeerrEnabled is disabled");
                     return;
@@ -275,7 +305,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 // configuration digest plus monotonic object revision prevents an admin save,
                 // including an A→B→A replacement, from authorizing a local write prepared with
                 // stale URLs, credentials, ownership, blocklists, or feature settings.
-                var configRevision = _configProvider.ConfigurationRevision;
+                var configRevision = integration.ConfigurationRevision;
                 var configStamp = SeerrMutationConfigStamp.Capture(config, configRevision);
 
                 // Check if item has TMDB ID
@@ -302,12 +332,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 // _logger.LogInformation($"[Watchlist] New {mediaType} added to library: '{e.Item.Name}' (TMDB: {tmdbId})");
 
                 // Query Seerr for one complete snapshot of every request.
-                var seerrUrls = Seerr.SeerrClient.GetConfiguredUrls(config.SeerrUrls);
-                if (seerrUrls.Length == 0 || string.IsNullOrEmpty(config.SeerrApiKey))
-                {
-                    _logger.LogWarning("[Watchlist] Seerr URL or API key not configured");
-                    return;
-                }
+                var seerrUrls = integration.Urls;
 
                 var httpClient = Helpers.Seerr.SeerrHttpHelper.CreateClient(_httpClientFactory);
 
@@ -315,7 +340,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 var allRequests = await GetAllSeerrRequests(
                     httpClient,
                     seerrUrls,
-                    config.SeerrApiKey,
+                    integration.ApiKey,
                     configRevision,
                     cancellationToken).ConfigureAwait(false);
                 cancellationToken.ThrowIfCancellationRequested();
@@ -338,7 +363,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 var preparedUserSnapshots = await FetchAllUserSnapshotsAsync(
                     httpClient,
                     seerrUrls,
-                    config.SeerrApiKey,
+                    integration.ApiKey,
                     cancellationToken).ConfigureAwait(false);
                 if (!SeerrUserIdentityDomains.TryParse(preparedUserSnapshots, out var preparedDomains))
                 {
@@ -419,7 +444,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 var dispatchUserSnapshots = await FetchAllUserSnapshotsAsync(
                     httpClient,
                     seerrUrls,
-                    config.SeerrApiKey,
+                    integration.ApiKey,
                     cancellationToken).ConfigureAwait(false);
                 if (!SeerrUserIdentityDomains.TryParse(dispatchUserSnapshots, out var dispatchDomains)
                     || !UserIdentityDomainsMatch(preparedDomains, dispatchDomains))
@@ -615,10 +640,21 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 {
                     // Populate the result cache before the shared task completes.
                     // This closes the completion/removal window in which a new
-                    // caller could otherwise start a duplicate fetch.
-                    lock (_requestsCacheLock)
+                    // caller could otherwise start a duplicate fetch. The
+                    // configuration-generation lock closes the disable/clear
+                    // race: an old worker either publishes before notification
+                    // (and is then cleared) or observes its cancelled token.
+                    lock (_configurationCancellationLock)
                     {
-                        _requestsCache.Set(cacheKey, fetchedSnapshot, cacheTtl);
+                        if (cancellationToken.IsCancellationRequested)
+                        {
+                            return null;
+                        }
+
+                        lock (_requestsCacheLock)
+                        {
+                            _requestsCache.Set(cacheKey, fetchedSnapshot, cacheTtl);
+                        }
                     }
                 }
 
@@ -686,7 +722,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 var current = _configProvider.ConfigurationOrNull;
                 var currentRevision = _configProvider.ConfigurationRevision;
                 return current != null
-                    && current.SeerrEnabled
+                    && SeerrIntegrationPolicy.HasUsableSavedConfiguration(current)
                     && current.AddRequestedMediaToWatchlist
                     && configStamp.Matches(current, currentRevision);
             }

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/WatchlistMonitor.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/WatchlistMonitor.cs
@@ -243,14 +243,47 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             // Cancel outside locks because callbacks can complete the active operation inline.
             // Cancel-before-dispose guarantees already-captured tokens observe cancellation; .NET
             // cancellation tokens remain readable after their source is disposed.
-            previous.Cancellation.Cancel();
-            previous.Cancellation.Dispose();
-            lock (_requestsCacheLock)
+            CancelWithoutThrow(previous.Cancellation, "configuration invalidation");
+            DisposeCancellationWithoutThrow(previous.Cancellation, "configuration invalidation");
+
+            try
             {
-                _requestsCache.Clear();
+                lock (_requestsCacheLock)
+                {
+                    _requestsCache.Clear();
+                }
             }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "[Watchlist] Failed to clear the owned request cache during configuration invalidation.");
+            }
+
             _logger.LogInformation(
                 "[Watchlist] Configuration changed; cancelled the active generation and invalidated queued work and cached Seerr requests.");
+        }
+
+        private void CancelWithoutThrow(CancellationTokenSource cancellation, string operation)
+        {
+            try
+            {
+                cancellation.Cancel();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "[Watchlist] A cancellation callback failed during {Operation}; teardown will continue.", operation);
+            }
+        }
+
+        private void DisposeCancellationWithoutThrow(CancellationTokenSource cancellation, string operation)
+        {
+            try
+            {
+                cancellation.Dispose();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "[Watchlist] Cancellation-source disposal failed during {Operation}; teardown will continue.", operation);
+            }
         }
 
         // Deterministic test seam over the same operation scheduled by library events. Keeping
@@ -307,6 +340,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 // stale URLs, credentials, ownership, blocklists, or feature settings.
                 var configRevision = integration.ConfigurationRevision;
                 var configStamp = SeerrMutationConfigStamp.Capture(config, configRevision);
+                SeerrDispatchFence dispatchFence = integration
+                    .CreateDispatchFence(_configProvider)
+                    .Restrict(() => IsCurrentMutationAuthorized(configStamp));
 
                 // Check if item has TMDB ID
                 if (item.ProviderIds == null)
@@ -342,6 +378,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     seerrUrls,
                     integration.ApiKey,
                     configRevision,
+                    dispatchFence,
                     cancellationToken).ConfigureAwait(false);
                 cancellationToken.ThrowIfCancellationRequested();
                 if (allRequests == null || allRequests.Count == 0)
@@ -364,6 +401,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     httpClient,
                     seerrUrls,
                     integration.ApiKey,
+                    dispatchFence,
                     cancellationToken).ConfigureAwait(false);
                 if (!SeerrUserIdentityDomains.TryParse(preparedUserSnapshots, out var preparedDomains))
                 {
@@ -445,6 +483,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     httpClient,
                     seerrUrls,
                     integration.ApiKey,
+                    dispatchFence,
                     cancellationToken).ConfigureAwait(false);
                 if (!SeerrUserIdentityDomains.TryParse(dispatchUserSnapshots, out var dispatchDomains)
                     || !UserIdentityDomainsMatch(preparedDomains, dispatchDomains))
@@ -560,9 +599,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             IReadOnlyList<string> seerrUrls,
             string apiKey,
             long configRevision,
+            SeerrDispatchFence dispatchFence,
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            if (!dispatchFence.CanDispatch()) return null;
             var cacheKey = BuildRequestsCacheKey(seerrUrls, apiKey, configRevision);
             var cacheTtl = GetRequestsCacheTtl();
 
@@ -570,7 +611,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             {
                 if (_requestsCache.TryGetValue(cacheKey, out var cached))
                 {
-                    return cached;
+                    return dispatchFence.CanDispatch() ? cached : null;
                 }
             }
 
@@ -582,6 +623,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                         httpClient,
                         seerrUrls,
                         apiKey,
+                        dispatchFence,
                         cancellationToken).ConfigureAwait(false);
                     if (!snapshots.IsComplete)
                     {
@@ -651,6 +693,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                             return null;
                         }
 
+                        if (!dispatchFence.CanDispatch()) return null;
+
                         lock (_requestsCacheLock)
                         {
                             _requestsCache.Set(cacheKey, fetchedSnapshot, cacheTtl);
@@ -704,6 +748,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             HttpClient httpClient,
             IEnumerable<string> seerrUrls,
             string apiKey,
+            SeerrDispatchFence dispatchFence,
             CancellationToken cancellationToken)
             => SeerrPaginationHelper.FetchAllSourcesAsync(
                 httpClient,
@@ -713,6 +758,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 apiUserId: null,
                 requestedPageSize: 1000,
                 UserCollectionIdentity,
+                dispatchFence,
                 cancellationToken);
 
         private bool IsCurrentMutationAuthorized(SeerrMutationConfigStamp configStamp)
@@ -791,6 +837,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             HttpClient httpClient,
             IEnumerable<string> seerrUrls,
             string apiKey,
+            SeerrDispatchFence dispatchFence,
             CancellationToken cancellationToken)
             => Helpers.Seerr.SeerrPaginationHelper.FetchAllAsync(
                 httpClient,
@@ -800,12 +847,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 apiUserId: null,
                 requestedPageSize: 1000,
                 RequestCollectionIdentity,
+                dispatchFence,
                 cancellationToken);
 
         internal static Task<Helpers.Seerr.SeerrMultiSourceCollectionResult> FetchAllRequestsSnapshotsAsync(
             HttpClient httpClient,
             IEnumerable<string> seerrUrls,
             string apiKey,
+            SeerrDispatchFence dispatchFence,
             CancellationToken cancellationToken)
             => Helpers.Seerr.SeerrPaginationHelper.FetchAllSourcesAsync(
                 httpClient,
@@ -815,6 +864,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 apiUserId: null,
                 requestedPageSize: 1000,
                 RequestCollectionIdentity,
+                dispatchFence,
                 cancellationToken);
 
         // Parses one request row. A null parsed item with true means a valid
@@ -926,12 +976,18 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 configurationGeneration = _configurationGeneration;
             }
 
-            configurationGeneration.Cancellation.Cancel();
+            CancelWithoutThrow(configurationGeneration.Cancellation, "plugin disposal");
 
             // Complete/cancel and synchronously join the one owned worker so no operation can
             // outlive plugin disposal or perform a late local write.
-            _workQueue.Dispose();
-            configurationGeneration.Cancellation.Dispose();
+            try
+            {
+                _workQueue.Dispose();
+            }
+            finally
+            {
+                DisposeCancellationWithoutThrow(configurationGeneration.Cancellation, "plugin disposal");
+            }
             var metrics = _workQueue.Metrics;
             _logger.LogInformation(
                 "[Watchlist] Worker stopped: capacity={Capacity}, peakDepth={PeakQueueDepth}, enqueued={Enqueued}, coalesced={Coalesced}, dropped={Dropped}, processed={Processed}, failures={Failures}, retries={Retried}, cancelled={Cancelled}.",

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -19,7 +19,7 @@ const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the repeated clean measurements', () => {
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1436, totalLines: 1759 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 16412, totalLines: 25066 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 17188, totalLines: 25800 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);
 });

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -21,12 +21,12 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 16412,
-        "totalLines": 25066
+        "coveredLines": 17188,
+        "totalLines": 25800
       },
       "tolerance": {
         "missingCoveredLines": 2,
-        "rationale": "Two clean reviewed local .NET 10/Coverlet integration runs on 2026-07-16 both measured 16412 covered lines across the identical 25066-line combined scope after adding bounded SearchHint hierarchy resolution with Jellyfin 12 enabled-library TopParentIds and the versioned bookmark logical-identity schema. The bookmark work added 46 instrumented lines beyond the reviewed 16366/25020 hidden-search baseline and covered all 46 through clone, equality, validation, dedicated-add, batch, and golden persistence evidence. The existing two-line tolerance remains narrow and covers only the previously reproduced one-line instrumentation variance (0.0080 percentage points)."
+        "rationale": "Two clean reviewed local .NET 10.0.9/Coverlet integration runs on 2026-07-16 each passed 1510 tests and measured the identical 25800-line assembly scope at 17188 and 17187 covered lines; the reviewed high-water is 17188. This final #163 scope replaces forgeable caller boolean predicates with a policy-owned opaque SeerrDispatchFence whose snapshot and capability constructors are private, whose source set is clone-isolated, whose optional restrictions can only narrow the base policy, and whose lowest-level normal transport checks the actual request URI against the captured normalized sources immediately before sending. The separately named unsaved-setup transport is pinned to its exact elevated owner and call graph. Architecture evidence inventories every normal, setup, raw-helper, non-Seerr, and delegated outbound edge; rejects fail-open predicates, truth-named gates, parameterized raw clients, unfenced helper additions, ordinary-gated setup calls, and post-await dispatches; and confines arbitrary Func<bool> storage to the fence's private AND-only restriction. Deterministic regressions also cover paginator page, confirmation-scan, failover, and identity-domain suppression; user-status and permission-audit publication changes; avatar throw/timeout failure-cache races; status/proxy/parental/scan/auto-request transports; both scheduled directions and manual local commit loops; response/avatar cache publication; and cancellation-callback failures during watchlist generation invalidation and disposal. The existing two-line tolerance is unchanged and covers only the reproduced one-line Coverlet instrumentation variance between otherwise identical clean runs (about 0.0039 percentage points)."
       }
     }
   }


### PR DESCRIPTION
Closes #163

## Summary

- centralize the saved Seerr master-switch contract in one policy-owned immutable snapshot and opaque dispatch fence
- require the target-bound fence at the lowest-level normal Seerr transport APIs, so unfenced calls do not compile
- strip retained credentials while disabled and reject old, arbitrary, or replaced Seerr targets immediately before every send
- fence later pagination pages, stability passes, source/failover loops, background tasks, exact-binding helpers, avatar/status/permission publication, cache writes, and manual/scheduled local commit loops
- retain one separately named setup-only transport, pinned to its exact elevated administrator endpoint and call graph
- make configuration-change cancellation/cache/worker teardown fail closed even when cancellation callbacks throw

## Security evidence

- architecture guard inventories every normal, setup, raw-helper, non-Seerr, and delegated outbound edge
- negative fixtures reject nullable/constant-true/ignored predicates, empty or inverted gates, post-await dispatch, raw parameterized clients, unfenced helper additions, ordinary-gated setup calls, and unpinned setup callers
- deterministic races cover disable/config replacement during user resolution, capabilities, avatar exceptions/timeouts, pagination/failover, permission audit, cached status, watchlist teardown, and first-write commit loops
- disabled responses consistently report no capability and no outbound Seerr traffic

## Verification

- final independent review: APPROVE on exact SHA 75c24ec5c67a25cd88ec8b0808860e8f03994454
- server: 1510/1510 twice; coverage 17188/25800 and 17187/25800
- client: 952/952; coverage 1436/1759 exact
- scripts: 346/346; coverage policy 13/13
- focused transport/security evidence: 290/290; final architecture/security set 120/120
- Release production and test builds: 0 warnings, 0 errors
- type checks, lint policy, syntax, bundle, translations, performance, strict MkDocs, links/assets, NuGet vulnerability audit, and diff checks green

## Risk controls

- opaque snapshot/fence constructors are private under the central policy
- source arrays are clone-isolated; normal sends require captured source-or-descendant URI membership
- caller restrictions can only narrow the non-bypassable base fence
- server coverage tolerance remains unchanged at two lines
- no deployment or port 8099 action performed