### PR TITLE
fix(client): contain browser storage and activation faults

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/js/plugin.js
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/plugin.js
@@ -130,6 +130,182 @@
 
     const JC = window.JellyfinCanopy; // Alias for internal use
 
+    /** Classify browser-storage exceptions without depending on DOMException. */
+    function classifyStorageFailure(error) {
+        const name = String(error?.name || '');
+        const code = Number(error?.code);
+        return name === 'QuotaExceededError' || name === 'NS_ERROR_DOM_QUOTA_REACHED'
+            || code === 22 || code === 1014
+            ? 'QuotaFailure'
+            : 'Unavailable';
+    }
+
+    /**
+     * Generation-scoped, bounded boot telemetry. Records intentionally omit raw
+     * keys and exception messages because storage keys may contain user ids.
+     */
+    function createBootDiagnostics(limit = 64) {
+        const maxEntries = Math.max(1, Math.min(256, Number(limit) || 64));
+        let epoch = 0;
+        let entries = [];
+
+        function beginEpoch(nextEpoch) {
+            epoch = Math.max(0, Number(nextEpoch) || 0);
+            entries = [];
+        }
+
+        function record(entry) {
+            const candidate = {
+                epoch,
+                feature: String(entry?.feature || 'unknown'),
+                phase: String(entry?.phase || 'storage'),
+                operation: String(entry?.operation || 'unknown'),
+                state: String(entry?.state || 'Unavailable'),
+                storage: entry?.storage === 'session'
+                    ? 'session'
+                    : (entry?.storage === 'none' ? 'none' : 'local'),
+                key: String(entry?.key || 'owned-key')
+            };
+            const duplicateIndex = entries.findIndex((existing) =>
+                existing.feature === candidate.feature
+                && existing.phase === candidate.phase
+                && existing.operation === candidate.operation
+                && existing.state === candidate.state
+                && existing.storage === candidate.storage
+                && existing.key === candidate.key);
+            if (duplicateIndex >= 0) {
+                const existing = entries[duplicateIndex];
+                const repeated = Object.freeze({ ...candidate, count: existing.count + 1 });
+                entries.splice(duplicateIndex, 1);
+                entries.push(repeated);
+                return repeated;
+            }
+            const safe = Object.freeze({ ...candidate, count: 1 });
+            entries.push(safe);
+            if (entries.length > maxEntries) entries.splice(0, entries.length - maxEntries);
+            return safe;
+        }
+
+        return Object.freeze({
+            beginEpoch,
+            record,
+            snapshot: () => Object.freeze({
+                epoch,
+                degraded: entries.length > 0,
+                entries: Object.freeze(entries.slice())
+            }),
+            get size() { return entries.length; },
+            get limit() { return maxEntries; }
+        });
+    }
+
+    /**
+     * Safe adapter for one browser Storage owner. Every operation reacquires the
+     * object so a throwing `window.localStorage`/`sessionStorage` getter is also
+     * contained. JSON corruption quarantines only the exact caller-owned key.
+     */
+    function createStorageAdapter(storageName, getStorage, diagnostics) {
+        const storage = storageName === 'session' ? 'session' : 'local';
+
+        function report(feature, operation, state, key) {
+            if (state === 'Valid' || state === 'Missing') return;
+            diagnostics?.record?.({ feature, phase: 'storage', operation, state, storage, key });
+        }
+
+        function failure(feature, operation, error, key) {
+            const state = classifyStorageFailure(error);
+            report(feature, operation, state, key);
+            return { state, value: null };
+        }
+
+        function read(feature, key, keyLabel = 'owned-key') {
+            try {
+                const value = getStorage().getItem(key);
+                return value === null
+                    ? { state: 'Missing', value: null }
+                    : { state: 'Valid', value };
+            } catch (error) {
+                return failure(feature, 'read', error, keyLabel);
+            }
+        }
+
+        function write(feature, key, value, keyLabel = 'owned-key') {
+            try {
+                getStorage().setItem(key, String(value));
+                return { state: 'Valid', value: String(value) };
+            } catch (error) {
+                return failure(feature, 'write', error, keyLabel);
+            }
+        }
+
+        function remove(feature, key, keyLabel = 'owned-key') {
+            try {
+                getStorage().removeItem(key);
+                return { state: 'Valid', value: null };
+            } catch (error) {
+                return failure(feature, 'remove', error, keyLabel);
+            }
+        }
+
+        function keys(feature, keyLabel = 'owned-prefix-scan') {
+            try {
+                const target = getStorage();
+                const result = [];
+                // Snapshot first: removals by callers cannot reorder this scan.
+                for (let i = 0; i < target.length; i++) {
+                    const key = target.key(i);
+                    if (typeof key === 'string') result.push(key);
+                }
+                return { state: 'Valid', value: result };
+            } catch (error) {
+                return failure(feature, 'keys', error, keyLabel);
+            }
+        }
+
+        function quarantine(feature, key, keyLabel = 'owned-key') {
+            report(feature, 'parse', 'Corrupt', keyLabel);
+            const recovery = remove(feature, key, keyLabel);
+            return {
+                state: 'Corrupt',
+                value: null,
+                recovery: recovery.state === 'Valid' ? 'Removed' : recovery.state
+            };
+        }
+
+        function readJson(feature, key, validate, keyLabel = 'owned-json') {
+            const result = read(feature, key, keyLabel);
+            if (result.state !== 'Valid') return result;
+            try {
+                const value = JSON.parse(result.value);
+                if (typeof validate === 'function' && !validate(value)) {
+                    return quarantine(feature, key, keyLabel);
+                }
+                return { state: 'Valid', value };
+            } catch (_) {
+                return quarantine(feature, key, keyLabel);
+            }
+        }
+
+        function readNumber(feature, key, validate, keyLabel = 'owned-number') {
+            const result = read(feature, key, keyLabel);
+            if (result.state !== 'Valid') return result;
+            const value = Number(result.value);
+            if (!Number.isFinite(value) || (typeof validate === 'function' && !validate(value))) {
+                return quarantine(feature, key, keyLabel);
+            }
+            return { state: 'Valid', value };
+        }
+
+        return Object.freeze({ read, readJson, readNumber, write, remove, quarantine, keys });
+    }
+
+    const bootDiagnostics = createBootDiagnostics();
+    JC.bootDiagnostics = bootDiagnostics;
+    JC.storage = Object.freeze({
+        local: createStorageAdapter('local', () => window.localStorage, bootDiagnostics),
+        session: createStorageAdapter('session', () => window.sessionStorage, bootDiagnostics)
+    });
+
     /**
      * Create the document-lifetime identity owner. The controller is deliberately
      * defined in this classic loader (rather than only in the later bundle):
@@ -348,6 +524,7 @@
      * shared globals replaced with owner-tagged empty state.
      */
     function finalizeIdentityTransition(change) {
+        bootDiagnostics.beginEpoch(change.epoch);
         // Abort and logically drain every older loader initialization before any
         // B-owned global is published. Raw host ajax implementations sometimes
         // ignore AbortSignal; the registry cancellation race still settles and
@@ -356,11 +533,9 @@
         // Jellyfin's compatibility language key is user-only. Remove A's live
         // projection synchronously; B republishes it from a server+user scoped
         // Canopy key after its settings file is loaded.
-        try {
-            for (const userId of identityStorageUserIdVariants(change.previous)) {
-                localStorage.removeItem(`${userId}-language`);
-            }
-        } catch (_) { /* storage can be disabled */ }
+        for (const userId of identityStorageUserIdVariants(change.previous)) {
+            JC.storage.local.remove('identity-transition', `${userId}-language`, 'compatibility-language');
+        }
         JC._cacheManager?.cancelPending?.();
         JC.initialized = false;
         JC._tagCachePrefetch = null;
@@ -1164,58 +1339,40 @@
             const mode = config && config.LayoutEnforcement;
             if (!mode || mode === 'None') return false;
 
-            let stored = null;
-            try {
-                stored = localStorage.getItem(LAYOUT_STORAGE_KEY);
-            } catch (e) {
-                return false; // storage unavailable — nothing we can safely do
-            }
+            const storedResult = JC.storage.local.read('layout-enforcement', LAYOUT_STORAGE_KEY, 'host-layout');
+            if (storedResult.state !== 'Valid' && storedResult.state !== 'Missing') return false;
+            const stored = storedResult.value;
 
             const decision = resolveLayoutEnforcement(mode, stored);
             if (!decision.changed) {
                 // Converged (or nothing to do): clear the loop marker so a future
                 // divergence can be re-enforced with one reload.
-                try {
-                    sessionStorage.removeItem(LAYOUT_ENFORCED_SESSION_KEY);
-                } catch (e) { /* ignore */ }
+                JC.storage.session.remove('layout-enforcement', LAYOUT_ENFORCED_SESSION_KEY, 'reload-guard');
                 return false;
             }
 
-            try {
-                localStorage.setItem(LAYOUT_STORAGE_KEY, decision.value);
-                // Read-back guard: some environments accept setItem but do not
-                // actually persist (ephemeral/in-memory/quota-broken storage). If
-                // the write did not stick, reloading would land right back here —
-                // an infinite reload loop in the storage's own failing domain
-                // (sessionStorage would fail identically, so the session guard
-                // below could not catch it). Bail without reloading instead.
-                if (localStorage.getItem(LAYOUT_STORAGE_KEY) !== decision.value) {
-                    return false;
-                }
-            } catch (e) {
-                return false; // cannot persist — do not reload into an unchanged state
-            }
+            const writeResult = JC.storage.local.write('layout-enforcement', LAYOUT_STORAGE_KEY, decision.value, 'host-layout');
+            if (writeResult.state !== 'Valid') return false;
+            // Read-back guard: some environments accept setItem but do not
+            // actually persist (ephemeral/in-memory/quota-broken storage). If
+            // the write did not stick, reloading would land right back here.
+            const persisted = JC.storage.local.read('layout-enforcement', LAYOUT_STORAGE_KEY, 'host-layout');
+            if (persisted.state !== 'Valid' || persisted.value !== decision.value) return false;
 
             if (!decision.reload) {
                 // Persisted the target without a reload (device already paints it):
                 // we are at the target, so clear any stale loop marker.
-                try {
-                    sessionStorage.removeItem(LAYOUT_ENFORCED_SESSION_KEY);
-                } catch (e) { /* ignore */ }
+                JC.storage.session.remove('layout-enforcement', LAYOUT_ENFORCED_SESSION_KEY, 'reload-guard');
                 return false;
             }
 
             // Loop guard: bail only if we ALREADY reloaded toward this exact target
             // this session and the value still has not stuck (a write that never
             // persists) — otherwise a genuine new divergence gets its one reload.
-            try {
-                if (sessionStorage.getItem(LAYOUT_ENFORCED_SESSION_KEY) === decision.value) {
-                    return false;
-                }
-                sessionStorage.setItem(LAYOUT_ENFORCED_SESSION_KEY, decision.value);
-            } catch (e) {
-                return false; // no sessionStorage → skip reload rather than risk a loop
-            }
+            const guard = JC.storage.session.read('layout-enforcement', LAYOUT_ENFORCED_SESSION_KEY, 'reload-guard');
+            if (guard.state !== 'Valid' && guard.state !== 'Missing') return false;
+            if (guard.value === decision.value) return false;
+            if (JC.storage.session.write('layout-enforcement', LAYOUT_ENFORCED_SESSION_KEY, decision.value, 'reload-guard').state !== 'Valid') return false;
 
             window.location.reload();
             return true;
@@ -1272,8 +1429,9 @@
         try {
             if (typeof ApiClient === 'undefined') return false;
 
-            const creds = localStorage.getItem('jellyfin_credentials');
-            if (!creds) return false;
+            const credentials = JC.storage.local.read('server-identity-check', 'jellyfin_credentials', 'host-credentials');
+            if (credentials.state !== 'Valid') return false;
+            const creds = credentials.value;
 
             const servers = JSON.parse(creds)?.Servers;
             if (!Array.isArray(servers) || servers.length === 0) return false;
@@ -1516,34 +1674,85 @@
         });
     }
 
+    function recordFeatureFailure(context, name, error) {
+        // A late rejection from an old generation belongs to teardown, not the
+        // current boot's diagnostics. Identity cancellation is expected too.
+        if (error?.name === 'IdentityChangedError' || error?.name === 'AbortError'
+            || !identity.isCurrent(context)) return;
+        bootDiagnostics.record({
+            feature: name,
+            phase: 'feature-initialization',
+            operation: 'initialize',
+            state: 'FeatureFailure',
+            storage: 'none',
+            key: 'none'
+        });
+        console.error(`🪼 Jellyfin Canopy: feature "${name}" initialized in degraded mode`, error);
+    }
+
+    /** Contain one feature owner without downgrading identity/auth/config failures. */
+    function activateFeature(context, name, enabled, initializer) {
+        if (!enabled || typeof initializer !== 'function') return;
+        requireCurrentIdentity(context);
+        try {
+            // Preserve the historical root-namespace receiver for feature
+            // methods that consult `this`; nested owners use explicit wrappers.
+            const produced = initializer.call(JC);
+            if (produced && typeof produced.then === 'function') {
+                Promise.resolve(produced).catch((error) => {
+                    recordFeatureFailure(context, name, error);
+                });
+            }
+        } catch (error) {
+            if (error?.name === 'IdentityChangedError' || !identity.isCurrent(context)) throw error;
+            recordFeatureFailure(context, name, error);
+        }
+        requireCurrentIdentity(context);
+    }
+
     /** Stage-6 activation. Old-epoch teardown always ran before these gates. */
     function activateFeatures(context) {
-        requireCurrentIdentity(context);
-        if (typeof JC.initializeCanopyScript === 'function') JC.initializeCanopyScript();
-        if (typeof JC.initializeElsewhereScript === 'function' && JC.pluginConfig?.ElsewhereEnabled) JC.initializeElsewhereScript();
-        if (typeof JC.initializeSeerrScript === 'function' && JC.pluginConfig?.SeerrEnabled && JC.pluginConfig?.SeerrShowSearchResults !== false) JC.initializeSeerrScript();
-        if (typeof JC.seerrIssueReporter?.initialize === 'function' && JC.pluginConfig?.SeerrEnabled && JC.pluginConfig?.SeerrShowReportButton) JC.seerrIssueReporter.initialize();
-        if (typeof JC.initializePauseScreen === 'function') JC.initializePauseScreen();
-        if (typeof JC.initializeBookmarks === 'function') JC.initializeBookmarks();
-        if (typeof JC.initializeQualityTags === 'function' && JC.currentSettings?.qualityTagsEnabled) JC.initializeQualityTags();
-        if (typeof JC.initializeGenreTags === 'function' && JC.currentSettings?.genreTagsEnabled) JC.initializeGenreTags();
-        if (typeof JC.initializeRatingTags === 'function' && JC.currentSettings?.ratingTagsEnabled) JC.initializeRatingTags();
-        if (typeof JC.initializeUserReviewTags === 'function' && JC.pluginConfig?.ShowUserReviews && JC.pluginConfig?.ShowUserRatingOnPosters && JC.currentSettings?.ratingTagsEnabled) JC.initializeUserReviewTags();
-        if (typeof JC.initializeArrLinksScript === 'function' && JC.pluginConfig?.ArrLinksEnabled) JC.initializeArrLinksScript();
-        if (typeof JC.initializeArrTagLinksScript === 'function' && JC.pluginConfig?.ArrTagsShowAsLinks) JC.initializeArrTagLinksScript();
-        if (typeof JC.initializeLetterboxdLinksScript === 'function' && JC.pluginConfig?.LetterboxdEnabled) JC.initializeLetterboxdLinksScript();
-        if (typeof JC.initializeReviewsScript === 'function' && (JC.pluginConfig?.ShowReviews || JC.pluginConfig?.ShowUserReviews)) JC.initializeReviewsScript();
-        if (typeof JC.initializeLanguageTags === 'function' && JC.currentSettings?.languageTagsEnabled) JC.initializeLanguageTags();
-        if (typeof JC.initializePeopleTags === 'function' && JC.currentSettings?.peopleTagsEnabled) JC.initializePeopleTags();
-        if (typeof JC.tagPipeline?.initialize === 'function') JC.tagPipeline.initialize();
-        if (typeof JC.initializeOsdRating === 'function') JC.initializeOsdRating();
-        if (typeof JC.initializeHiddenContent === 'function' && JC.pluginConfig?.HiddenContentEnabled) JC.initializeHiddenContent();
-        if (JC.pluginConfig?.ColoredRatingsEnabled && typeof JC.initializeColoredRatings === 'function') JC.initializeColoredRatings();
-        if (JC.pluginConfig?.ThemeSelectorEnabled && typeof JC.initializeThemeSelector === 'function') JC.initializeThemeSelector();
-        if (JC.pluginConfig?.ColoredActivityIconsEnabled && typeof JC.initializeActivityIcons === 'function') JC.initializeActivityIcons();
-        if (JC.pluginConfig?.PluginIconsEnabled && typeof JC.initializePluginIcons === 'function') JC.initializePluginIcons();
-        if (JC.pluginConfig?.ActiveStreamsEnabled && typeof JC.activeStreams?.initialize === 'function') JC.activeStreams.initialize();
-        if (typeof JC.initializePagesFramework === 'function') JC.initializePagesFramework();
+        activateFeature(context, 'canopy', typeof JC.initializeCanopyScript === 'function', JC.initializeCanopyScript);
+        activateFeature(context, 'elsewhere', JC.pluginConfig?.ElsewhereEnabled, JC.initializeElsewhereScript);
+        activateFeature(context, 'seerr', JC.pluginConfig?.SeerrEnabled && JC.pluginConfig?.SeerrShowSearchResults !== false, JC.initializeSeerrScript);
+        activateFeature(
+            context,
+            'seerr-issue-reporter',
+            JC.pluginConfig?.SeerrEnabled && JC.pluginConfig?.SeerrShowReportButton
+                && typeof JC.seerrIssueReporter?.initialize === 'function',
+            () => JC.seerrIssueReporter.initialize()
+        );
+        activateFeature(context, 'pause-screen', typeof JC.initializePauseScreen === 'function', JC.initializePauseScreen);
+        activateFeature(context, 'bookmarks', typeof JC.initializeBookmarks === 'function', JC.initializeBookmarks);
+        activateFeature(context, 'quality-tags', JC.currentSettings?.qualityTagsEnabled, JC.initializeQualityTags);
+        activateFeature(context, 'genre-tags', JC.currentSettings?.genreTagsEnabled, JC.initializeGenreTags);
+        activateFeature(context, 'rating-tags', JC.currentSettings?.ratingTagsEnabled, JC.initializeRatingTags);
+        activateFeature(context, 'user-review-tags', JC.pluginConfig?.ShowUserReviews && JC.pluginConfig?.ShowUserRatingOnPosters && JC.currentSettings?.ratingTagsEnabled, JC.initializeUserReviewTags);
+        activateFeature(context, 'arr-links', JC.pluginConfig?.ArrLinksEnabled, JC.initializeArrLinksScript);
+        activateFeature(context, 'arr-tag-links', JC.pluginConfig?.ArrTagsShowAsLinks, JC.initializeArrTagLinksScript);
+        activateFeature(context, 'letterboxd-links', JC.pluginConfig?.LetterboxdEnabled, JC.initializeLetterboxdLinksScript);
+        activateFeature(context, 'reviews', JC.pluginConfig?.ShowReviews || JC.pluginConfig?.ShowUserReviews, JC.initializeReviewsScript);
+        activateFeature(context, 'language-tags', JC.currentSettings?.languageTagsEnabled, JC.initializeLanguageTags);
+        activateFeature(context, 'people-tags', JC.currentSettings?.peopleTagsEnabled, JC.initializePeopleTags);
+        activateFeature(
+            context,
+            'tag-pipeline',
+            typeof JC.tagPipeline?.initialize === 'function',
+            () => JC.tagPipeline.initialize()
+        );
+        activateFeature(context, 'osd-rating', typeof JC.initializeOsdRating === 'function', JC.initializeOsdRating);
+        activateFeature(context, 'hidden-content', JC.pluginConfig?.HiddenContentEnabled, JC.initializeHiddenContent);
+        activateFeature(context, 'colored-ratings', JC.pluginConfig?.ColoredRatingsEnabled, JC.initializeColoredRatings);
+        activateFeature(context, 'theme-selector', JC.pluginConfig?.ThemeSelectorEnabled, JC.initializeThemeSelector);
+        activateFeature(context, 'activity-icons', JC.pluginConfig?.ColoredActivityIconsEnabled, JC.initializeActivityIcons);
+        activateFeature(context, 'plugin-icons', JC.pluginConfig?.PluginIconsEnabled, JC.initializePluginIcons);
+        activateFeature(
+            context,
+            'active-streams',
+            JC.pluginConfig?.ActiveStreamsEnabled && typeof JC.activeStreams?.initialize === 'function',
+            () => JC.activeStreams.initialize()
+        );
+        activateFeature(context, 'pages-framework', typeof JC.initializePagesFramework === 'function', JC.initializePagesFramework);
     }
 
     async function runInitialization(context, client, scope) {
@@ -1581,15 +1790,21 @@
 
             let nextTranslations = translations || {};
             const serverTranslationClearTs = pluginConfig.ClearTranslationCacheTimestamp || 0;
-            const localTranslationClearTs = parseInt(localStorage.getItem('JC_translation_clear_ts') || '0', 10);
+            const translationClear = JC.storage.local.readNumber(
+                'translations',
+                'JC_translation_clear_ts',
+                (value) => value >= 0,
+                'clear-timestamp'
+            );
+            const localTranslationClearTs = translationClear.state === 'Valid' ? translationClear.value : 0;
             if (serverTranslationClearTs > localTranslationClearTs) {
-                for (let i = localStorage.length - 1; i >= 0; i--) {
-                    const key = localStorage.key(i);
+                const storedKeys = JC.storage.local.keys('translations', 'translation-cache-prefix');
+                for (const key of storedKeys.value || []) {
                     if (key && (key.startsWith('JC_translation_') || key.startsWith('JC_translation_ts_'))) {
-                        localStorage.removeItem(key);
+                        JC.storage.local.remove('translations', key, 'translation-cache-entry');
                     }
                 }
-                localStorage.setItem('JC_translation_clear_ts', serverTranslationClearTs.toString());
+                JC.storage.local.write('translations', 'JC_translation_clear_ts', serverTranslationClearTs.toString(), 'clear-timestamp');
                 nextTranslations = await scope.race(loadTranslations()) || {};
                 requireCurrentIdentity(context);
             }
@@ -1648,8 +1863,8 @@
                 : (parts.length === 1
                     ? parts[0].toLowerCase()
                     : (parts.length === 2 ? `${parts[0].toLowerCase()}-${parts[1].toUpperCase()}` : desiredLanguage));
-            localStorage.setItem(scopedLanguageKey, normalizedLanguage);
-            localStorage.setItem(languageKey, normalizedLanguage);
+            JC.storage.local.write('display-language', scopedLanguageKey, normalizedLanguage, 'scoped-language');
+            JC.storage.local.write('display-language', languageKey, normalizedLanguage, 'compatibility-language');
 
             if (typeof JC.themer?.init === 'function') JC.themer.init();
             installCacheUnloadOnce();
@@ -1665,7 +1880,11 @@
             JC.initialized = true;
             document.dispatchEvent(new CustomEvent('jc:identityactivated', { detail: context }));
             JC.hideSplashScreen?.();
-            console.log(`🪼 Jellyfin Canopy: identity epoch ${context.epoch} initialized successfully.`);
+            const diagnostics = bootDiagnostics.snapshot();
+            if (diagnostics.degraded) {
+                console.warn('🪼 Jellyfin Canopy: initialization completed with degraded feature/storage state', diagnostics);
+            }
+            console.log(`🪼 Jellyfin Canopy: identity epoch ${context.epoch} initialization completed.`);
         } catch (error) {
             if (error?.name === 'IdentityChangedError') return;
             if (identity.isCurrent(context)) {

--- a/Jellyfin.Plugin.JellyfinCanopy/js/plugin.js
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/plugin.js
@@ -150,8 +150,15 @@
         let entries = [];
 
         function beginEpoch(nextEpoch) {
+            const previousEpoch = epoch;
             epoch = Math.max(0, Number(nextEpoch) || 0);
-            entries = [];
+            // Storage can fail before Jellyfin publishes an authenticated
+            // identity (layout enforcement and credential probing both run in
+            // epoch 0). Carry that bounded/redacted evidence into the first
+            // real boot; later identity transitions start a clean generation.
+            entries = previousEpoch === 0 && epoch > 0
+                ? entries.map((entry) => Object.freeze({ ...entry, epoch }))
+                : [];
         }
 
         function record(entry) {
@@ -289,8 +296,11 @@
         function readNumber(feature, key, validate, keyLabel = 'owned-number') {
             const result = read(feature, key, keyLabel);
             if (result.state !== 'Valid') return result;
+            if (!/^(?:0|-?[1-9]\d*)$/.test(result.value)) {
+                return quarantine(feature, key, keyLabel);
+            }
             const value = Number(result.value);
-            if (!Number.isFinite(value) || (typeof validate === 'function' && !validate(value))) {
+            if (!Number.isSafeInteger(value) || (typeof validate === 'function' && !validate(value))) {
                 return quarantine(feature, key, keyLabel);
             }
             return { state: 'Valid', value };
@@ -447,8 +457,27 @@
                         if (record.lastEpoch < context.epoch) record.lastEpoch = context.epoch;
                     })
                     .catch((error) => {
-                        console.error(`🪼 Jellyfin Canopy: identity activate handler "${name}" failed`, error);
-                        throw error;
+                        // A failed participant stays unmarked and therefore
+                        // retryable, but it cannot abort its peers or the
+                        // legacy activation tier for this current epoch.
+                        if (error?.name === 'IdentityChangedError' || error?.name === 'AbortError'
+                            || !isCurrent(context)) return;
+                        try {
+                            if (typeof diagnostics?.recordFeatureFailure === 'function') {
+                                diagnostics.recordFeatureFailure(context, name, error);
+                            } else {
+                                console.error(
+                                    `🪼 Jellyfin Canopy: identity activate handler "${name}" failed`,
+                                    error
+                                );
+                            }
+                        } catch (reportError) {
+                            console.error(
+                                `🪼 Jellyfin Canopy: identity activate handler "${name}" failed`,
+                                error,
+                                reportError
+                            );
+                        }
                     })
                     .finally(() => {
                         if (record.pending === invocation) {
@@ -460,17 +489,7 @@
                 record.pending = invocation;
                 work.push(invocation);
             }
-            const results = await Promise.allSettled(work);
-            let failure = null;
-            for (const result of results) {
-                if (result.status === 'rejected') {
-                    console.error('🪼 Jellyfin Canopy: identity activate handler rejected', result.reason);
-                    failure ||= result.reason instanceof Error
-                        ? result.reason
-                        : new Error('Identity activation failed', { cause: result.reason });
-                }
-            }
-            if (failure) throw failure;
+            await Promise.all(work);
         }
 
         function getRawUserId(context = current) {
@@ -505,7 +524,8 @@
     let initializationRegistry = null;
     const loaderDiagnostics = {
         getPendingInitializationCount: () => initializationRegistry?.getPendingCount?.() || 0,
-        getInitializationControllerCount: () => initializationRegistry?.getControllerCount?.() || 0
+        getInitializationControllerCount: () => initializationRegistry?.getControllerCount?.() || 0,
+        recordFeatureFailure: (context, name, error) => recordFeatureFailure(context, name, error)
     };
 
     function emptyUserConfig() {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/calendar/data.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/calendar/data.ts
@@ -111,38 +111,40 @@ function showUnmonitoredStorageKey(context: IdentityContext): string {
 function getStoredShowUnmonitored(): boolean | null {
     const context = currentIdentity();
     if (!context) return null;
-    try {
-        const storage = window.localStorage;
-        const key = showUnmonitoredStorageKey(context);
-        let stored = storage?.getItem(key);
+    const key = showUnmonitoredStorageKey(context);
+    let stored = JC.storage.local.read('arr-calendar', key, 'show-unmonitored');
 
-        // Upgrade the old process-global preference exactly once. It has no
-        // identity metadata, so the only safe compatibility choice is to give
-        // it to the first authenticated identity that reads it, then remove it
-        // before another account/server can inherit the same value.
-        if (stored === null) {
-            const legacy = storage?.getItem(LEGACY_SHOW_UNMONITORED_KEY);
-            if (legacy === 'true' || legacy === 'false') {
-                storage?.setItem(key, legacy);
-                stored = legacy;
+    // Upgrade the old process-global preference exactly once. It has no
+    // identity metadata, so the only safe compatibility choice is to give
+    // it to the first authenticated identity that reads it, then remove it
+    // before another account/server can inherit the same value.
+    if (stored.state === 'Missing') {
+        const legacy = JC.storage.local.read('arr-calendar', LEGACY_SHOW_UNMONITORED_KEY, 'legacy-show-unmonitored');
+        if (legacy.state === 'Valid' && (legacy.value === 'true' || legacy.value === 'false')) {
+            if (JC.storage.local.write('arr-calendar', key, legacy.value, 'show-unmonitored').state === 'Valid') {
+                stored = { state: 'Valid', value: legacy.value };
+                JC.storage.local.remove('arr-calendar', LEGACY_SHOW_UNMONITORED_KEY, 'legacy-show-unmonitored');
             }
+        } else if (legacy.state === 'Valid') {
+            JC.storage.local.quarantine('arr-calendar', LEGACY_SHOW_UNMONITORED_KEY, 'legacy-show-unmonitored');
+        } else if (legacy.state === 'Missing') {
+            JC.storage.local.remove('arr-calendar', LEGACY_SHOW_UNMONITORED_KEY, 'legacy-show-unmonitored');
         }
-        storage?.removeItem(LEGACY_SHOW_UNMONITORED_KEY);
-        if (stored === null) return null;
-        return stored === 'true';
-    } catch {
+    } else if (stored.state === 'Valid') {
+        JC.storage.local.remove('arr-calendar', LEGACY_SHOW_UNMONITORED_KEY, 'legacy-show-unmonitored');
+    }
+    if (stored.state !== 'Valid') return null;
+    if (stored.value !== 'true' && stored.value !== 'false') {
+        JC.storage.local.quarantine('arr-calendar', key, 'show-unmonitored');
         return null;
     }
+    return stored.value === 'true';
 }
 
 export function setStoredShowUnmonitored(value: boolean): void {
     const context = currentIdentity();
     if (!context) return;
-    try {
-        window.localStorage?.setItem(showUnmonitoredStorageKey(context), String(!!value));
-    } catch {
-        // ignore storage errors
-    }
+    JC.storage.local.write('arr-calendar', showUnmonitoredStorageKey(context), String(!!value), 'show-unmonitored');
 }
 
 /**

--- a/Jellyfin.Plugin.JellyfinCanopy/src/bootstrap/translations.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/bootstrap/translations.ts
@@ -23,6 +23,11 @@ import localeManifest from '../../locale-manifest.json';
 
     type LangResult = { translations: Record<string, string>; usedLang: string };
 
+    function isTranslationRecord(value: unknown): value is Record<string, string> {
+        return value !== null && typeof value === 'object' && !Array.isArray(value)
+            && Object.values(value as Record<string, unknown>).every((entry) => typeof entry === 'string');
+    }
+
     function normalizeLangCode(code: string | null | undefined): string {
         if (!code) return '';
         const parts = code.split('-');
@@ -74,36 +79,32 @@ import localeManifest from '../../locale-manifest.json';
     }
 
     function cleanOldTranslationCache(pluginVersion: string): void {
-        try {
-            for (let i = localStorage.length - 1; i >= 0; i--) {
-                const key = localStorage.key(i);
-                if (key && (key.startsWith('JC_translation_') || key.startsWith('JC_translation_ts_'))) {
-                    if (!key.includes(`_${pluginVersion}`)) {
-                        localStorage.removeItem(key);
-                        console.log(`🪼 Jellyfin Canopy: Removed old translation cache: ${key}`);
-                    }
+        const storedKeys = JC.storage.local.keys('translations', 'translation-cache-prefix');
+        for (const key of storedKeys.value || []) {
+            if (key.startsWith('JC_translation_') || key.startsWith('JC_translation_ts_')) {
+                if (!key.includes(`_${pluginVersion}`)) {
+                    JC.storage.local.remove('translations', key, 'translation-cache-entry');
+                    console.log(`🪼 Jellyfin Canopy: Removed old translation cache: ${key}`);
                 }
             }
-        } catch (e) {
-            console.warn('🪼 Jellyfin Canopy: Failed to clean up old translation caches', e);
         }
     }
 
     async function tryLoadSingleLanguage(code: string, pluginVersion: string): Promise<LangResult> {
         const cacheKey = `JC_translation_${code}_${pluginVersion}`;
         const timestampKey = `JC_translation_ts_${code}_${pluginVersion}`;
-        const cachedTranslations = localStorage.getItem(cacheKey);
-        const cachedTimestamp = localStorage.getItem(timestampKey);
+        const cachedTranslations = JC.storage.local.readJson(
+            'translations', cacheKey, isTranslationRecord, 'translation-cache-payload',
+        );
+        const cachedTimestamp = JC.storage.local.readNumber(
+            'translations', timestampKey, (value) => value >= 0, 'translation-cache-timestamp',
+        );
 
-        if (cachedTranslations && cachedTimestamp) {
-            const age = Date.now() - parseInt(cachedTimestamp, 10);
+        if (cachedTranslations.state === 'Valid' && cachedTimestamp.state === 'Valid') {
+            const age = Date.now() - cachedTimestamp.value;
             if (age < CACHE_DURATION) {
                 console.log(`🪼 Jellyfin Canopy: Using cached translations for ${code} (age: ${Math.round(age / 1000 / 60)} minutes, version: ${pluginVersion})`);
-                try {
-                    return { translations: JSON.parse(cachedTranslations) as Record<string, string>, usedLang: code };
-                } catch (e) {
-                    console.warn('🪼 Jellyfin Canopy: Failed to parse cached translations, will fetch fresh', e);
-                }
+                return { translations: cachedTranslations.value, usedLang: code };
             }
         }
 
@@ -112,11 +113,9 @@ import localeManifest from '../../locale-manifest.json';
             const bundledResponse = await fetch(ApiClient.getUrl(`/JellyfinCanopy/locales/${code}.json`));
             if (bundledResponse.ok) {
                 const translations = await bundledResponse.json() as Record<string, string>;
-                try {
-                    localStorage.setItem(cacheKey, JSON.stringify(translations));
-                    localStorage.setItem(timestampKey, Date.now().toString());
-                    console.log(`🪼 Jellyfin Canopy: Successfully loaded and cached bundled translations for ${code} (version: ${pluginVersion})`);
-                } catch (e) { /* ignore */ }
+                JC.storage.local.write('translations', cacheKey, JSON.stringify(translations), 'translation-cache-payload');
+                JC.storage.local.write('translations', timestampKey, Date.now().toString(), 'translation-cache-timestamp');
+                console.log(`🪼 Jellyfin Canopy: Successfully loaded and cached bundled translations for ${code} (version: ${pluginVersion})`);
                 return { translations, usedLang: code };
             }
         } catch (bundledError) {
@@ -144,12 +143,10 @@ import localeManifest from '../../locale-manifest.json';
 
             if (githubResponse.ok) {
                 const translations = await githubResponse.json() as Record<string, string>;
-                try {
-                    localStorage.setItem(cacheKey, JSON.stringify(translations));
-                    localStorage.setItem(timestampKey, Date.now().toString());
+                const payloadWrite = JC.storage.local.write('translations', cacheKey, JSON.stringify(translations), 'translation-cache-payload');
+                const timestampWrite = JC.storage.local.write('translations', timestampKey, Date.now().toString(), 'translation-cache-timestamp');
+                if (payloadWrite.state === 'Valid' && timestampWrite.state === 'Valid') {
                     console.log(`🪼 Jellyfin Canopy: Successfully fetched and cached translations for ${code} from GitHub (version: ${pluginVersion})`);
-                } catch (storageError) {
-                    console.warn('🪼 Jellyfin Canopy: Failed to cache translations (localStorage full?)', storageError);
                 }
                 return { translations, usedLang: code };
             }
@@ -164,12 +161,10 @@ import localeManifest from '../../locale-manifest.json';
 
                 if (englishResponse.ok) {
                     const translations = await englishResponse.json() as Record<string, string>;
-                    try {
-                        const enCacheKey = `JC_translation_en_${pluginVersion}`;
-                        const enTimestampKey = `JC_translation_ts_en_${pluginVersion}`;
-                        localStorage.setItem(enCacheKey, JSON.stringify(translations));
-                        localStorage.setItem(enTimestampKey, Date.now().toString());
-                    } catch (e) { /* ignore */ }
+                    const enCacheKey = `JC_translation_en_${pluginVersion}`;
+                    const enTimestampKey = `JC_translation_ts_en_${pluginVersion}`;
+                    JC.storage.local.write('translations', enCacheKey, JSON.stringify(translations), 'translation-cache-payload');
+                    JC.storage.local.write('translations', enTimestampKey, Date.now().toString(), 'translation-cache-timestamp');
                     return { translations, usedLang: 'en' };
                 }
             }
@@ -190,10 +185,8 @@ import localeManifest from '../../locale-manifest.json';
 
         if (response.ok) {
             const translations = await response.json() as Record<string, string>;
-            try {
-                localStorage.setItem(cacheKey, JSON.stringify(translations));
-                localStorage.setItem(timestampKey, Date.now().toString());
-            } catch (e) { /* ignore */ }
+            JC.storage.local.write('translations', cacheKey, JSON.stringify(translations), 'translation-cache-payload');
+            JC.storage.local.write('translations', timestampKey, Date.now().toString(), 'translation-cache-timestamp');
             return { translations, usedLang: code };
         }
 
@@ -219,9 +212,9 @@ import localeManifest from '../../locale-manifest.json';
             let lang = 'en';
             if (userId) {
                 const storageKey = `${userId}-language`;
-                const storedLang = localStorage.getItem(storageKey);
-                if (storedLang) {
-                    lang = normalizeLangCode(storedLang);
+                const storedLang = JC.storage.local.read('translations', storageKey, 'host-language');
+                if (storedLang.state === 'Valid' && storedLang.value) {
+                    lang = normalizeLangCode(storedLang.value);
                 } else {
                     // Fall back to the HTML lang attribute set by Jellyfin's web client.
                     // This covers the Android app and other clients where the localStorage

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/locale.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/locale.ts
@@ -33,8 +33,8 @@ export function getDisplayLocale(): string {
         const userId = (typeof ApiClient !== 'undefined' && ApiClient.getCurrentUserId)
             ? ApiClient.getCurrentUserId() : null;
         if (userId) {
-            const stored = window.localStorage?.getItem(`${userId}-language`);
-            if (stored) return normalize(stored);
+            const stored = JC.storage.local.read('locale', `${userId}-language`, 'host-language');
+            if (stored.state === 'Valid' && stored.value) return normalize(stored.value);
         }
 
         const docLang = document.documentElement.lang;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/tag-renderer-base.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/tag-renderer-base.ts
@@ -104,6 +104,10 @@ interface CacheEntry {
     [key: string]: unknown;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
 /**
  * Build a tag instance (state + ctx + lifecycle) for one renderer.
  * @param name - Pipeline renderer name (e.g. 'genre').
@@ -203,18 +207,20 @@ function createTag(name: string, spec: TagSpec): TagInstance {
         }
         if (state.localStorageEnabled) {
             const expectedOwner = ownerValue(context);
-            if (localStorage.getItem(ownerStorageKey) !== expectedOwner) {
+            const owner = JC.storage.local.read(`${name}-tags`, ownerStorageKey, 'cache-owner');
+            if (owner.state !== 'Valid' || owner.value !== expectedOwner) {
                 // Legacy entries had no owner. Treat them as untrusted rather
                 // than exposing one user's projection to the next login.
-                localStorage.removeItem(spec.cache.key);
-                localStorage.setItem(ownerStorageKey, expectedOwner);
+                JC.storage.local.remove(`${name}-tags`, spec.cache.key, 'cache-payload');
+                JC.storage.local.write(`${name}-tags`, ownerStorageKey, expectedOwner, 'cache-owner');
             }
-            try {
-                state.cache = (JSON.parse(localStorage.getItem(spec.cache.key) || '{}') || {}) as Record<string, unknown>;
-            } catch {
-                state.cache = {};
-                localStorage.removeItem(spec.cache.key);
-            }
+            const cached = JC.storage.local.readJson(
+                `${name}-tags`,
+                spec.cache.key,
+                isRecord,
+                'cache-payload',
+            );
+            state.cache = cached.state === 'Valid' ? cached.value : {};
         } else {
             state.cache = {};
         }
@@ -239,8 +245,14 @@ function createTag(name: string, spec: TagSpec): TagInstance {
                     }
                 }
             }
-            localStorage.setItem(ownerStorageKey, ownerValue(context));
-            localStorage.setItem(spec.cache.key, JSON.stringify(state.cache));
+            JC.storage.local.write(`${name}-tags`, ownerStorageKey, ownerValue(context), 'cache-owner');
+            const saved = JC.storage.local.write(
+                `${name}-tags`,
+                spec.cache.key,
+                JSON.stringify(state.cache),
+                'cache-payload',
+            );
+            if (saved.state !== 'Valid') throw new Error(`browser storage ${saved.state}`);
         } catch (e) {
             console.warn(`${logPrefix} Failed to save cache`, e);
         }
@@ -277,8 +289,8 @@ function createTag(name: string, spec: TagSpec): TagInstance {
         const legacy = spec.cache.legacyPrefix;
 
         const stale: string[] = [];
-        for (let i = 0; i < localStorage.length; i++) {
-            const key = localStorage.key(i);
+        const storedKeys = JC.storage.local.keys(`${name}-tags`, 'legacy-cache-prefix');
+        for (const key of storedKeys.value || []) {
             if (key &&
                 (key.startsWith(`${legacy}-`) || key === legacy || key === `${legacy}Timestamp`) &&
                 key !== CACHE_KEY && key !== TIMESTAMP_KEY) {
@@ -287,15 +299,21 @@ function createTag(name: string, spec: TagSpec): TagInstance {
         }
         for (const key of stale) {
             console.log(`${logPrefix} Removing old cache: ${key}`);
-            localStorage.removeItem(key);
+            JC.storage.local.remove(`${name}-tags`, key, 'legacy-cache-entry');
         }
 
         const serverClearTimestamp = JC.pluginConfig?.ClearLocalStorageTimestamp || 0;
-        const localCacheTimestamp = parseInt(localStorage.getItem(TIMESTAMP_KEY) || '0', 10);
+        const timestamp = JC.storage.local.readNumber(
+            `${name}-tags`,
+            TIMESTAMP_KEY,
+            (value) => value >= 0,
+            'cache-timestamp',
+        );
+        const localCacheTimestamp = timestamp.state === 'Valid' ? timestamp.value : 0;
         if (serverClearTimestamp > localCacheTimestamp) {
             console.log(`${logPrefix} Server triggered cache clear (${new Date(serverClearTimestamp).toISOString()})`);
-            localStorage.removeItem(CACHE_KEY);
-            localStorage.setItem(TIMESTAMP_KEY, serverClearTimestamp.toString());
+            JC.storage.local.remove(`${name}-tags`, CACHE_KEY, 'cache-payload');
+            JC.storage.local.write(`${name}-tags`, TIMESTAMP_KEY, serverClearTimestamp.toString(), 'cache-timestamp');
             state.cache = {};
             if (state.hot) state.hot.clear();
         }
@@ -522,8 +540,8 @@ function createTag(name: string, spec: TagSpec): TagInstance {
         if (spec.cache) {
             // The frozen cache key stays unchanged, but an unscoped snapshot is
             // never allowed to survive an authenticated identity transition.
-            localStorage.removeItem(spec.cache.key);
-            localStorage.removeItem(ownerStorageKey);
+            JC.storage.local.remove(`${name}-tags`, spec.cache.key, 'cache-payload');
+            JC.storage.local.remove(`${name}-tags`, ownerStorageKey, 'cache-owner');
         }
         document.querySelectorAll(`.${containerClass}`).forEach((el) => el.remove());
         document.querySelectorAll<HTMLElement>(`[data-${toKebab(TAGGED_ATTR)}]`).forEach((el) => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/discovery/prefs.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/discovery/prefs.ts
@@ -8,6 +8,10 @@
 import type { DiscoveryMediaType } from './rows';
 import { JC } from '../globals';
 
+function isStringArray(value: unknown): value is string[] {
+    return Array.isArray(value) && value.every((entry) => typeof entry === 'string');
+}
+
 function storageOwner(): { serverId: string; userId: string; legacyUserId: string } | null {
     const uid = (typeof ApiClient !== 'undefined' && ApiClient.getCurrentUserId?.()) || '';
     if (!uid) return null;
@@ -38,37 +42,42 @@ function storageKey(mt: DiscoveryMediaType): string | null {
  * "customized to empty" round-trips instead of silently reverting to the admin defaults.
  */
 export function getUserRowIds(mt: DiscoveryMediaType): string[] | null {
-    try {
-        const key = storageKey(mt);
-        const owner = storageOwner();
-        if (!key || !owner) return null;
-        // One-time adoption of the pre-server-scope key. It can belong to only
-        // one server, so remove it immediately after assigning it to the first
-        // authenticated server that reads it.
-        const legacyKey = `jc-discovery-rows:${owner.legacyUserId}:${mt}`;
-        if (localStorage.getItem(key) === null) {
-            const legacy = localStorage.getItem(legacyKey);
-            if (legacy !== null) localStorage.setItem(key, legacy);
+    const key = storageKey(mt);
+    const owner = storageOwner();
+    if (!key || !owner) return null;
+    // One-time adoption of the pre-server-scope key. It can belong to only
+    // one server, so remove it immediately after assigning it to the first
+    // authenticated server that reads it.
+    const legacyKey = `jc-discovery-rows:${owner.legacyUserId}:${mt}`;
+    const current = JC.storage.local.read('discovery-preferences', key, 'row-order');
+    if (current.state === 'Missing') {
+        const legacy = JC.storage.local.read('discovery-preferences', legacyKey, 'legacy-row-order');
+        if (legacy.state === 'Valid') {
+            if (JC.storage.local.write('discovery-preferences', key, legacy.value, 'row-order').state === 'Valid') {
+                JC.storage.local.remove('discovery-preferences', legacyKey, 'legacy-row-order');
+            }
+        } else if (legacy.state === 'Missing') {
+            JC.storage.local.remove('discovery-preferences', legacyKey, 'legacy-row-order');
         }
-        localStorage.removeItem(legacyKey);
-        const raw = localStorage.getItem(key);
-        if (!raw) return null;
-        const parsed: unknown = JSON.parse(raw);
-        if (!Array.isArray(parsed)) return null;
-        return parsed.filter((x): x is string => typeof x === 'string');
-    } catch { return null; }
+    } else if (current.state === 'Valid') {
+        JC.storage.local.remove('discovery-preferences', legacyKey, 'legacy-row-order');
+    }
+    const parsed = JC.storage.local.readJson(
+        'discovery-preferences', key, isStringArray, 'row-order',
+    );
+    return parsed.state === 'Valid' ? parsed.value : null;
 }
 
 /** Persists the user's row-id order for a media type. */
 export function setUserRowIds(mt: DiscoveryMediaType, ids: string[]): void {
     const key = storageKey(mt);
     if (!key) return;
-    try { localStorage.setItem(key, JSON.stringify(ids)); } catch { /* quota / private mode */ }
+    JC.storage.local.write('discovery-preferences', key, JSON.stringify(ids), 'row-order');
 }
 
 /** Clears the user's customization so the feed reverts to the admin/default rows. */
 export function clearUserRowIds(mt: DiscoveryMediaType): void {
     const key = storageKey(mt);
     if (!key) return;
-    try { localStorage.removeItem(key); } catch { /* ignore */ }
+    JC.storage.local.remove('discovery-preferences', key, 'row-order');
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/events.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/events.ts
@@ -458,10 +458,16 @@ JC.initializeCanopyScript = function() {
 
     // Check if local storage needs to be cleared by admin request
     const serverClearTimestamp = JC.pluginConfig.ClearLocalStorageTimestamp || 0;
-    const localClearedTimestamp = parseInt(localStorage.getItem('jellyfinCanopyLastCleared') || '0', 10);
+    const clearTimestamp = JC.storage.local.readNumber(
+        'canopy',
+        'jellyfinCanopyLastCleared',
+        (value) => value >= 0,
+        'clear-timestamp',
+    );
+    const localClearedTimestamp = clearTimestamp.state === 'Valid' ? clearTimestamp.value : 0;
     if (serverClearTimestamp > localClearedTimestamp) {
-        localStorage.removeItem('jellyfinCanopySettings');
-        localStorage.setItem('jellyfinCanopyLastCleared', serverClearTimestamp.toString());
+        JC.storage.local.remove('canopy', 'jellyfinCanopySettings', 'legacy-settings');
+        JC.storage.local.write('canopy', 'jellyfinCanopyLastCleared', serverClearTimestamp.toString(), 'clear-timestamp');
     }
 
     // Initial UI setup

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/dialogs.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/dialogs.ts
@@ -200,9 +200,15 @@ function isConfirmationSuppressed(context: IdentityContext | null): boolean {
     if (settings.showHideConfirmation === false) return true;
     // The legacy unscoped value must never flow into an authenticated session.
     // Removing it is safer than guessing which server/user originally owned it.
-    if (context) localStorage.removeItem(SUPPRESS_STORAGE_KEY);
-    const until = localStorage.getItem(suppressionStorageKey(context));
-    if (until && new Date(until) > new Date()) return true;
+    if (context) JC.storage.local.remove('hidden-content', SUPPRESS_STORAGE_KEY, 'legacy-suppression');
+    const key = suppressionStorageKey(context);
+    const stored = JC.storage.local.read('hidden-content', key, 'suppression-expiry');
+    if (stored.state === 'Valid') {
+        const until = Date.parse(stored.value);
+        if (Number.isFinite(until) && until > Date.now()) return true;
+        if (!Number.isFinite(until)) JC.storage.local.quarantine('hidden-content', key, 'suppression-expiry');
+        else JC.storage.local.remove('hidden-content', key, 'suppression-expiry');
+    }
     return false;
 }
 
@@ -381,7 +387,7 @@ function createStandardConfirmButtons(closeDialog: () => void, onConfirm: () => 
         }
         if (suppress15Check.checked) {
             const until = new Date(Date.now() + SUPPRESS_DURATION_MS).toISOString();
-            localStorage.setItem(suppressionStorageKey(fence.context), until);
+            JC.storage.local.write('hidden-content', suppressionStorageKey(fence.context), until, 'suppression-expiry');
         }
         closeDialog();
         onConfirm();

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/legacy-storage-migration.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/legacy-storage-migration.ts
@@ -6,7 +6,9 @@
  * storage under a dead identity.
  *
  * Idempotent: once the legacy keys are gone this is a no-op.
- */
+*/
+
+import { JC } from '../globals';
 
 /** Durable pref prefixes: adopt value under the new prefix, then drop the old key. */
 const ADOPT_PREFIXES: ReadonlyArray<readonly [legacy: string, current: string]> = [
@@ -23,51 +25,45 @@ const DROP_PREFIXES: readonly string[] = [
 ];
 
 export function migrateLegacyClientStorage(): void {
-    try {
-        if (localStorage.getItem('jellyfinCanopyLastCleared') === null) {
-            const legacyCleared = localStorage.getItem('jellyfinElevateLastCleared');
-            if (legacyCleared !== null) {
-                localStorage.setItem('jellyfinCanopyLastCleared', legacyCleared);
-            }
+    const storage = JC.storage.local;
+    const adopt = (currentKey: string, legacyKey: string, keyLabel: string): void => {
+        const current = storage.read('legacy-storage-migration', currentKey, keyLabel);
+        if (current.state !== 'Missing' && current.state !== 'Valid') return;
+        if (current.state === 'Missing') {
+            const legacy = storage.read('legacy-storage-migration', legacyKey, `legacy-${keyLabel}`);
+            if (legacy.state !== 'Valid') return;
+            if (storage.write('legacy-storage-migration', currentKey, legacy.value, keyLabel).state !== 'Valid') return;
         }
-        localStorage.removeItem('jellyfinElevateLastCleared');
-        localStorage.removeItem('jellyfinElevateSettings');
+        storage.remove('legacy-storage-migration', legacyKey, `legacy-${keyLabel}`);
+    };
+
+    adopt('jellyfinCanopyLastCleared', 'jellyfinElevateLastCleared', 'clear-timestamp');
+    storage.remove('legacy-storage-migration', 'jellyfinElevateSettings', 'legacy-settings');
 
         // Hide-confirm "don't ask again" suppression window (15 min): adopt an
         // active legacy timestamp so the user's explicit choice survives the
         // upgrade, and drop the stale key either way.
-        if (localStorage.getItem('jc_hide_confirm_suppressed_until') === null) {
-            const legacySuppressed = localStorage.getItem('je_hide_confirm_suppressed_until');
-            if (legacySuppressed !== null) {
-                localStorage.setItem('jc_hide_confirm_suppressed_until', legacySuppressed);
-            }
-        }
-        localStorage.removeItem('je_hide_confirm_suppressed_until');
+    adopt('jc_hide_confirm_suppressed_until', 'je_hide_confirm_suppressed_until', 'hide-suppression');
 
         // Prefix-keyed state: snapshot the key list first — removing while
         // indexing through localStorage.length re-orders the remaining keys.
-        const keys: string[] = [];
-        for (let i = 0; i < localStorage.length; i++) {
-            const key = localStorage.key(i);
-            if (key !== null) keys.push(key);
-        }
-        for (const key of keys) {
-            const adoption = ADOPT_PREFIXES.find(([legacy]) => key.startsWith(legacy));
-            if (adoption) {
-                const newKey = adoption[1] + key.slice(adoption[0].length);
-                if (localStorage.getItem(newKey) === null) {
-                    const value = localStorage.getItem(key);
-                    if (value !== null) localStorage.setItem(newKey, value);
-                }
-                localStorage.removeItem(key);
-                continue;
+    const keys = storage.keys('legacy-storage-migration', 'legacy-prefix-scan');
+    for (const key of keys.value || []) {
+        const adoption = ADOPT_PREFIXES.find(([legacy]) => key.startsWith(legacy));
+        if (adoption) {
+            const newKey = adoption[1] + key.slice(adoption[0].length);
+            const current = storage.read('legacy-storage-migration', newKey, 'prefixed-preference');
+            if (current.state !== 'Missing' && current.state !== 'Valid') continue;
+            if (current.state === 'Missing') {
+                const legacy = storage.read('legacy-storage-migration', key, 'legacy-prefixed-preference');
+                if (legacy.state !== 'Valid') continue;
+                if (storage.write('legacy-storage-migration', newKey, legacy.value, 'prefixed-preference').state !== 'Valid') continue;
             }
-            if (DROP_PREFIXES.some((prefix) => key.startsWith(prefix))) {
-                localStorage.removeItem(key);
-            }
+            storage.remove('legacy-storage-migration', key, 'legacy-prefixed-preference');
+            continue;
         }
-    } catch {
-        // Storage can be blocked (private mode, embedded webviews); every
-        // consumer already tolerates missing keys, so silently skip.
+        if (DROP_PREFIXES.some((prefix) => key.startsWith(prefix))) {
+            storage.remove('legacy-storage-migration', key, 'legacy-cache-entry');
+        }
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/hidden-content-tab.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/hidden-content-tab.ts
@@ -93,7 +93,7 @@ export function wireHiddenContentListeners(ctx: PanelContext): void {
         if (confirmToggle) {
             confirmToggle.addEventListener('change', (e) => {
                 (JC as any).hiddenContent.updateSettings({ showHideConfirmation: (e.target as HTMLInputElement).checked });
-                localStorage.removeItem('jc_hide_confirm_suppressed_until');
+                JC.storage.local.remove('hidden-content-settings', 'jc_hide_confirm_suppressed_until', 'legacy-suppression');
                 resetAutoCloseTimer();
             });
         }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/language.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/language.ts
@@ -40,7 +40,8 @@ export function wireLanguageControls(ctx: PanelContext): void {
         const scopedLanguageKey = `jc-display-language:${context.serverId}:${context.userId}`;
 
         // Get saved language from localStorage as well
-        const localStorageLang = localStorage.getItem(scopedLanguageKey);
+        const storedLanguage = JC.storage.local.read('settings-language', scopedLanguageKey, 'scoped-language');
+        const localStorageLang = storedLanguage.state === 'Valid' ? storedLanguage.value : null;
         const savedLanguage = (JC.currentSettings as any).displayLanguage || localStorageLang || '';
         let acknowledgedDisplayLanguage = String(savedLanguage);
 
@@ -166,12 +167,12 @@ export function wireLanguageControls(ctx: PanelContext): void {
 
             // Save to localStorage (use the same code)
             if (fullCultureCode) {
-                localStorage.setItem(scopedLanguageKey, fullCultureCode);
-                localStorage.setItem(languageKey, fullCultureCode);
+                JC.storage.local.write('settings-language', scopedLanguageKey, fullCultureCode, 'scoped-language');
+                JC.storage.local.write('settings-language', languageKey, fullCultureCode, 'compatibility-language');
             } else {
                 // Set empty value instead of removing key
-                localStorage.setItem(scopedLanguageKey, '');
-                localStorage.setItem(languageKey, '');
+                JC.storage.local.write('settings-language', scopedLanguageKey, '', 'scoped-language');
+                JC.storage.local.write('settings-language', languageKey, '', 'compatibility-language');
             }
 
             if (newLang && !translationExists) {
@@ -192,16 +193,23 @@ export function wireLanguageControls(ctx: PanelContext): void {
             const CACHE_PREFIX = 'JC_translation_';
             const CACHE_TIMESTAMP_PREFIX = 'JC_translation_ts_';
 
-            for (let i = 0; i < localStorage.length; i++) {
-                const key = localStorage.key(i);
+            const storedKeys = JC.storage.local.keys('settings-language', 'translation-cache-prefix');
+            for (const key of storedKeys.value || []) {
                 if (key && (key.startsWith(CACHE_PREFIX) || key.startsWith(CACHE_TIMESTAMP_PREFIX))) {
                     cacheKeys.push(key);
                 }
             }
 
-            cacheKeys.forEach(key => localStorage.removeItem(key));
+            let clearedCount = 0;
+            for (const key of cacheKeys) {
+                if (JC.storage.local.remove(
+                    'settings-language', key, 'translation-cache-entry',
+                ).state === 'Valid') {
+                    clearedCount += 1;
+                }
+            }
 
-            toast(JC.t!('toast_translation_cache_cleared', { count: cacheKeys.length }));
+            toast(JC.t!('toast_translation_cache_cleared', { count: Number(clearedCount) || 0 }));
             scheduleReload(context, 2000);
             resetAutoCloseTimer();
         });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/snooze.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/snooze.ts
@@ -72,22 +72,32 @@ export function isDisableSnoozed(): boolean {
     const uid = snoozeUid();
     if (!uid) return false;
     const key = snoozeStorageKey(uid);
-    try {
-        const legacyKey = `jc-spoiler-disable-snooze:${uid}`;
-        if (localStorage.getItem(key) === null) {
-            const legacy = localStorage.getItem(legacyKey);
-            if (legacy !== null) localStorage.setItem(key, legacy);
+    const legacyKey = `jc-spoiler-disable-snooze:${uid}`;
+    const current = JC.storage.local.read('spoiler-guard', key, 'snooze-expiry');
+    if (current.state === 'Missing') {
+        const legacy = JC.storage.local.read('spoiler-guard', legacyKey, 'legacy-snooze-expiry');
+        if (legacy.state === 'Valid') {
+            if (JC.storage.local.write('spoiler-guard', key, legacy.value, 'snooze-expiry').state === 'Valid') {
+                JC.storage.local.remove('spoiler-guard', legacyKey, 'legacy-snooze-expiry');
+            }
+        } else if (legacy.state === 'Missing') {
+            JC.storage.local.remove('spoiler-guard', legacyKey, 'legacy-snooze-expiry');
         }
-        localStorage.removeItem(legacyKey);
-        const raw = localStorage.getItem(key);
-        if (!raw) return false;
-        const verdict = classifySnoozeExpiry(Number(raw), Date.now());
-        if (verdict === 'active') return true;
-        // 'expired' or 'invalid' — drop the stale key.
-        localStorage.removeItem(key);
-    } catch (e) {
-        console.warn(`${logPrefix} snooze read failed:`, e);
+    } else if (current.state === 'Valid') {
+        JC.storage.local.remove('spoiler-guard', legacyKey, 'legacy-snooze-expiry');
     }
+    const now = Date.now();
+    const expiry = JC.storage.local.readNumber(
+        'spoiler-guard',
+        key,
+        (value) => classifySnoozeExpiry(value, now) !== 'invalid',
+        'snooze-expiry',
+    );
+    if (expiry.state !== 'Valid') return false;
+    const verdict = classifySnoozeExpiry(expiry.value, now);
+    if (verdict === 'active') return true;
+    // 'expired' or 'invalid' — drop the stale key.
+    JC.storage.local.remove('spoiler-guard', key, 'snooze-expiry');
     return false;
 }
 
@@ -95,9 +105,7 @@ export function isDisableSnoozed(): boolean {
 export function setDisableSnooze(): void {
     const uid = snoozeUid();
     if (!uid) return;
-    try {
-        localStorage.setItem(snoozeStorageKey(uid), String(Date.now() + SNOOZE_MS));
-    } catch (e) {
-        console.warn(`${logPrefix} snooze persist failed:`, e);
-    }
+    JC.storage.local.write(
+        'spoiler-guard', snoozeStorageKey(uid), String(Date.now() + SNOOZE_MS), 'snooze-expiry',
+    );
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/theme-selector.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/theme-selector.ts
@@ -58,39 +58,30 @@ const getStorageKey = (context: IdentityContext, key: string): string =>
 const getCompatibilityKey = (context: IdentityContext, key: string): string => `${context.userId}-${key}`;
 
 const getLocalStorageValue = (context: IdentityContext, key: string, defaultValue: string | null = null): string | null => {
-    try {
-        const value = localStorage.getItem(getStorageKey(context, key));
-        return value === null ? defaultValue : value;
-    } catch (e) {
-        console.error('🪼 Jellyfin Canopy: Theme selector storage read error', e);
-        return defaultValue;
-    }
+    const result = JC.storage.local.read('theme-selector', getStorageKey(context, key), `theme-${key}`);
+    return result.state === 'Valid' ? result.value : defaultValue;
 };
 
 const setLocalStorageValue = (context: IdentityContext, key: string, value: string): boolean => {
-    try {
-        localStorage.setItem(getStorageKey(context, key), value);
-        if (key === 'customCss' && JC.identity.isCurrent(context)) {
-            localStorage.setItem(getCompatibilityKey(context, key), value);
-        }
-        return true;
-    } catch (e) {
-        console.error('🪼 Jellyfin Canopy: Theme selector storage write error', e);
-        return false;
+    const canonical = JC.storage.local.write('theme-selector', getStorageKey(context, key), value, `theme-${key}`);
+    if (canonical.state !== 'Valid') return false;
+    if (key === 'customCss' && JC.identity.isCurrent(context)) {
+        return JC.storage.local.write(
+            'theme-selector', getCompatibilityKey(context, key), value, 'compatibility-theme',
+        ).state === 'Valid';
     }
+    return true;
 };
 
 const removeLocalStorageValue = (context: IdentityContext, key: string): boolean => {
-    try {
-        localStorage.removeItem(getStorageKey(context, key));
-        if (key === 'customCss' && JC.identity.isCurrent(context)) {
-            localStorage.removeItem(getCompatibilityKey(context, key));
-        }
-        return true;
-    } catch (e) {
-        console.error('🪼🎨Jellyfish Theme Selector : localStorage remove error:', e);
-        return false;
+    const canonical = JC.storage.local.remove('theme-selector', getStorageKey(context, key), `theme-${key}`);
+    if (key === 'customCss' && JC.identity.isCurrent(context)) {
+        const compatibility = JC.storage.local.remove(
+            'theme-selector', getCompatibilityKey(context, key), 'compatibility-theme',
+        );
+        return canonical.state === 'Valid' && compatibility.state === 'Valid';
     }
+    return canonical.state === 'Valid';
 };
 
 // --- Random Theme Functions ---
@@ -195,28 +186,33 @@ const getNotificationKey = (context: IdentityContext): string =>
  * to match across servers.
  */
 const migrateLegacyStorageOnce = (context: IdentityContext): void => {
-    try {
-        if (localStorage.getItem(STORAGE_MIGRATION_KEY) !== 'true') {
-            for (const key of ['customCss', 'randomThemeEnabled', 'lastRandomThemeDate']) {
-                const scopedKey = getStorageKey(context, key);
-                const legacyKey = getCompatibilityKey(context, key);
-                if (localStorage.getItem(scopedKey) === null) {
-                    const legacyValue = localStorage.getItem(legacyKey);
-                    if (legacyValue !== null) localStorage.setItem(scopedKey, legacyValue);
-                }
-            }
-            localStorage.setItem(STORAGE_MIGRATION_KEY, 'true');
+    const migration = JC.storage.local.read('theme-selector', STORAGE_MIGRATION_KEY, 'migration-marker');
+    if (migration.state === 'Missing' || (migration.state === 'Valid' && migration.value !== 'true')) {
+        let complete = true;
+        for (const key of ['customCss', 'randomThemeEnabled', 'lastRandomThemeDate']) {
+            const scopedKey = getStorageKey(context, key);
+            const scoped = JC.storage.local.read('theme-selector', scopedKey, `theme-${key}`);
+            if (scoped.state === 'Missing') {
+                const legacy = JC.storage.local.read(
+                    'theme-selector', getCompatibilityKey(context, key), `legacy-theme-${key}`,
+                );
+                if (legacy.state === 'Valid') {
+                    complete = JC.storage.local.write(
+                        'theme-selector', scopedKey, legacy.value, `theme-${key}`,
+                    ).state === 'Valid' && complete;
+                } else if (legacy.state !== 'Missing') complete = false;
+            } else if (scoped.state !== 'Valid') complete = false;
         }
-
-        // Keep Jellyfish's boot-time compatibility key synchronized with the
-        // current canonical value. A missing B value removes A's old mirror.
-        const currentTheme = getCurrentTheme(context);
-        const compatibilityKey = getCompatibilityKey(context, 'customCss');
-        if (currentTheme) localStorage.setItem(compatibilityKey, currentTheme);
-        else localStorage.removeItem(compatibilityKey);
-    } catch (e) {
-        console.error('Jellyfin Canopy: Theme selector storage migration error', e);
+        if (complete) JC.storage.local.write('theme-selector', STORAGE_MIGRATION_KEY, 'true', 'migration-marker');
     }
+
+    if (migration.state !== 'Valid' && migration.state !== 'Missing') return;
+    // Keep Jellyfish's boot-time compatibility key synchronized with the
+    // current canonical value. A missing B value removes A's old mirror.
+    const currentTheme = getCurrentTheme(context);
+    const compatibilityKey = getCompatibilityKey(context, 'customCss');
+    if (currentTheme) JC.storage.local.write('theme-selector', compatibilityKey, currentTheme, 'compatibility-theme');
+    else JC.storage.local.remove('theme-selector', compatibilityKey, 'compatibility-theme');
 };
 
 // --- Notifications ---
@@ -236,24 +232,26 @@ const showNotification = (message: string): void => {
 };
 
 const checkPostRefreshNotification = (context: IdentityContext, expectedGeneration: number): void => {
-    try {
-        const notificationKey = getNotificationKey(context);
-        let pendingNotification = sessionStorage.getItem(notificationKey);
-        // Compatibility with a reload initiated by a pre-upgrade bundle. The
-        // unscoped value is consumed once and cannot survive an SPA switch.
-        if (!pendingNotification) pendingNotification = sessionStorage.getItem('jellyfin-theme-applied');
-        sessionStorage.removeItem(LEGACY_NOTIFICATION_KEY);
-        if (pendingNotification) {
-            sessionStorage.removeItem(notificationKey);
-            notificationTimer = window.setTimeout(() => {
-                notificationTimer = null;
-                if (isActive(context, expectedGeneration)) {
-                    showNotification(`Theme applied: ${escapeHtml(pendingNotification)}`);
-                }
-            }, NOTIFICATION_DELAY);
-        }
-    } catch (e) {
-        console.error('🪼🎨Jellyfish Theme Selector :  Session storage error:', e);
+    const notificationKey = getNotificationKey(context);
+    let pendingNotification = JC.storage.session.read(
+        'theme-selector', notificationKey, 'pending-notification',
+    ).value;
+    // Compatibility with a reload initiated by a pre-upgrade bundle. The
+    // unscoped value is consumed once and cannot survive an SPA switch.
+    if (!pendingNotification) {
+        pendingNotification = JC.storage.session.read(
+            'theme-selector', LEGACY_NOTIFICATION_KEY, 'legacy-notification',
+        ).value;
+    }
+    JC.storage.session.remove('theme-selector', LEGACY_NOTIFICATION_KEY, 'legacy-notification');
+    if (pendingNotification) {
+        JC.storage.session.remove('theme-selector', notificationKey, 'pending-notification');
+        notificationTimer = window.setTimeout(() => {
+            notificationTimer = null;
+            if (isActive(context, expectedGeneration)) {
+                showNotification(`Theme applied: ${escapeHtml(pendingNotification)}`);
+            }
+        }, NOTIFICATION_DELAY);
     }
 };
 
@@ -273,11 +271,12 @@ const applyRandomThemeIfNeeded = (context: IdentityContext, expectedGeneration: 
         setTheme(context, randomThemeFilename, randomThemeName);
         setLastRandomDate(context, today);
 
-        try {
-            sessionStorage.setItem(getNotificationKey(context), `Random Daily (${randomThemeName})`);
-        } catch (e) {
-            console.error('🪼🎨Jellyfish Theme Selector :  Could not set session storage:', e);
-        }
+        JC.storage.session.write(
+            'theme-selector',
+            getNotificationKey(context),
+            `Random Daily (${randomThemeName})`,
+            'pending-notification',
+        );
         if (isActive(context, expectedGeneration)) window.location.reload();
     } else {
         console.log('🪼🎨Jellyfish Theme Selector :  Random theme already applied for today.');
@@ -342,11 +341,9 @@ const createThemeSelect = (
         setTheme(context, newThemeFilename, newThemeName);
 
         // Store notification for after reload
-        try {
-            sessionStorage.setItem(getNotificationKey(context), newThemeName);
-        } catch (e) {
-            console.error('🪼🎨Jellyfish Theme Selector :  Session storage error:', e);
-        }
+        JC.storage.session.write(
+            'theme-selector', getNotificationKey(context), newThemeName, 'pending-notification',
+        );
 
         // Wait for fade-out transition, then reload
         if (reloadTimer) clearTimeout(reloadTimer);
@@ -560,18 +557,16 @@ const initialize = (attempt = 0): void => {
 
 JC.identity.registerReset('theme-selector', (change) => {
     reset();
-    try {
-        if (change.previous) {
-            localStorage.removeItem(getCompatibilityKey(change.previous, 'customCss'));
-            sessionStorage.removeItem(getNotificationKey(change.previous));
-        }
-        if (change.current) {
-            const currentTheme = getCurrentTheme(change.current);
-            const compatibilityKey = getCompatibilityKey(change.current, 'customCss');
-            if (currentTheme) localStorage.setItem(compatibilityKey, currentTheme);
-            else localStorage.removeItem(compatibilityKey);
-        }
-        sessionStorage.removeItem(LEGACY_NOTIFICATION_KEY);
-    } catch { /* storage may be blocked */ }
+    if (change.previous) {
+        JC.storage.local.remove('theme-selector', getCompatibilityKey(change.previous, 'customCss'), 'compatibility-theme');
+        JC.storage.session.remove('theme-selector', getNotificationKey(change.previous), 'pending-notification');
+    }
+    if (change.current) {
+        const currentTheme = getCurrentTheme(change.current);
+        const compatibilityKey = getCompatibilityKey(change.current, 'customCss');
+        if (currentTheme) JC.storage.local.write('theme-selector', compatibilityKey, currentTheme, 'compatibility-theme');
+        else JC.storage.local.remove('theme-selector', compatibilityKey, 'compatibility-theme');
+    }
+    JC.storage.session.remove('theme-selector', LEGACY_NOTIFICATION_KEY, 'legacy-notification');
 });
 JC.initializeThemeSelector = initialize;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/facade.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/facade.ts
@@ -35,7 +35,7 @@ export interface JellyfinCanopyPublicApi {
     translations: Record<string, string>;
     /** Plugin version string (cache-buster + display). */
     pluginVersion: string;
-    /** Boot-complete marker: true once every enabled feature has initialized. */
+    /** Boot-complete marker: true once every enabled feature was independently attempted. */
     initialized?: boolean;
     /** Escapes HTML special characters for safe interpolation. */
     escapeHtml: (value: unknown) => string;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.ts
@@ -20,15 +20,22 @@ interface PersonData {
     birthPlace?: string | null;
 }
 
-function parseRecord<T>(raw: string): Record<string, T> {
-    const parsed: unknown = JSON.parse(raw);
-    return parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
-        ? parsed as Record<string, T>
-        : {};
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
 function isPersonData(value: unknown): value is PersonData {
     return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isPersonCache(value: unknown): value is Record<string, PersonData> {
+    return isRecord(value) && Object.values(value).every(isPersonData);
+}
+
+function isTimestampCache(value: unknown): value is Record<string, number> {
+    return isRecord(value) && Object.values(value).every(
+        (timestamp) => typeof timestamp === 'number' && Number.isFinite(timestamp) && timestamp >= 0,
+    );
 }
 
 /**
@@ -158,22 +165,24 @@ JC.initializePeopleTags = function() {
     };
 
     const expectedCacheOwner = `${context.serverId}:${context.userId}`;
-    if (localStorage.getItem(CACHE_OWNER_KEY) !== expectedCacheOwner) {
+    const owner = JC.storage.local.read('people-tags', CACHE_OWNER_KEY, 'cache-owner');
+    if (owner.state !== 'Valid' || owner.value !== expectedCacheOwner) {
         // Older builds stored an unowned cache. It cannot safely be replayed
         // after login as a different Jellyfin user.
-        localStorage.removeItem(CACHE_KEY);
-        localStorage.removeItem(CACHE_TIMESTAMP_KEY);
-        localStorage.setItem(CACHE_OWNER_KEY, expectedCacheOwner);
+        JC.storage.local.remove('people-tags', CACHE_KEY, 'cache-payload');
+        JC.storage.local.remove('people-tags', CACHE_TIMESTAMP_KEY, 'cache-timestamps');
+        JC.storage.local.write('people-tags', CACHE_OWNER_KEY, expectedCacheOwner, 'cache-owner');
     }
-    let peopleCache: Record<string, PersonData> = {};
-    let peopleCacheTimestamp: Record<string, number> = {};
-    try {
-        peopleCache = parseRecord<PersonData>(localStorage.getItem(CACHE_KEY) || '{}');
-        peopleCacheTimestamp = parseRecord<number>(localStorage.getItem(CACHE_TIMESTAMP_KEY) || '{}');
-    } catch {
-        localStorage.removeItem(CACHE_KEY);
-        localStorage.removeItem(CACHE_TIMESTAMP_KEY);
-    }
+    const cachedPeople = JC.storage.local.readJson('people-tags', CACHE_KEY, isPersonCache, 'cache-payload');
+    const cachedTimestamps = JC.storage.local.readJson(
+        'people-tags', CACHE_TIMESTAMP_KEY, isTimestampCache, 'cache-timestamps',
+    );
+    let peopleCache: Record<string, PersonData> = cachedPeople.state === 'Valid'
+        ? cachedPeople.value
+        : {};
+    let peopleCacheTimestamp: Record<string, number> = cachedTimestamps.state === 'Valid'
+        ? cachedTimestamps.value
+        : {};
     const Hot = (JC._hotCache = JC._hotCache || { ttl: CACHE_TTL });
     const previousHot = Hot.peopleTags as BoundedCache<string, unknown> | undefined;
     previousHot?.clear?.();
@@ -199,9 +208,9 @@ JC.initializePeopleTags = function() {
         peopleCache = {};
         peopleCacheTimestamp = {};
         if (clearPersistent) {
-            localStorage.removeItem(CACHE_KEY);
-            localStorage.removeItem(CACHE_TIMESTAMP_KEY);
-            localStorage.removeItem(CACHE_OWNER_KEY);
+            JC.storage.local.remove('people-tags', CACHE_KEY, 'cache-payload');
+            JC.storage.local.remove('people-tags', CACHE_TIMESTAMP_KEY, 'cache-timestamps');
+            JC.storage.local.remove('people-tags', CACHE_OWNER_KEY, 'cache-owner');
         }
     };
 
@@ -328,9 +337,9 @@ JC.initializePeopleTags = function() {
                 hotPeopleTags.set(cacheKey, { data: ownedData, timestamp: now });
 
                 if (!isCurrent()) return null;
-                localStorage.setItem(CACHE_OWNER_KEY, expectedCacheOwner);
-                localStorage.setItem(CACHE_KEY, JSON.stringify(peopleCache));
-                localStorage.setItem(CACHE_TIMESTAMP_KEY, JSON.stringify(peopleCacheTimestamp));
+                JC.storage.local.write('people-tags', CACHE_OWNER_KEY, expectedCacheOwner, 'cache-owner');
+                JC.storage.local.write('people-tags', CACHE_KEY, JSON.stringify(peopleCache), 'cache-payload');
+                JC.storage.local.write('people-tags', CACHE_TIMESTAMP_KEY, JSON.stringify(peopleCacheTimestamp), 'cache-timestamps');
 
                 return ownedData;
             }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/test/plugin-loader.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/test/plugin-loader.test.ts
@@ -70,9 +70,229 @@ type InitializationRegistry = {
     getControllerCount(): number;
 };
 
+type StorageState = 'Missing' | 'Valid' | 'Corrupt' | 'Unavailable' | 'QuotaFailure';
+type StorageResult<T> = { state: StorageState; value: T | null; recovery?: string };
+type SafeStorage = {
+    read(feature: string, key: string, label?: string): StorageResult<string>;
+    readJson<T>(feature: string, key: string, validate?: (value: unknown) => value is T, label?: string): StorageResult<T>;
+    readNumber(feature: string, key: string, validate?: (value: number) => boolean, label?: string): StorageResult<number>;
+    write(feature: string, key: string, value: string, label?: string): StorageResult<string>;
+    remove(feature: string, key: string, label?: string): StorageResult<null>;
+    quarantine(feature: string, key: string, label?: string): StorageResult<null>;
+    keys(feature: string, label?: string): StorageResult<string[]>;
+};
+
+function memoryStorage(): Storage {
+    const values = new Map<string, string>();
+    return {
+        get length() { return values.size; },
+        clear: () => values.clear(),
+        getItem: (key) => values.get(key) ?? null,
+        key: (index) => [...values.keys()][index] ?? null,
+        removeItem: (key) => { values.delete(key); },
+        setItem: (key, value) => { values.set(key, String(value)); },
+    };
+}
+
 describe('plugin.js loader guards', () => {
     it('loaded the loader source', () => {
         expect(SRC.length).toBeGreaterThan(0);
+    });
+
+    it('classifies every storage fault and quarantines only the corrupt owned key', () => {
+        const diagnosticsSource = extractFunctionSource('createBootDiagnostics');
+        const classifySource = extractFunctionSource('classifyStorageFailure');
+        const adapterSource = extractFunctionSource('createStorageAdapter');
+        expect(diagnosticsSource, 'createBootDiagnostics not found').toBeTruthy();
+        expect(classifySource, 'classifyStorageFailure not found').toBeTruthy();
+        expect(adapterSource, 'createStorageAdapter not found').toBeTruthy();
+
+        const createDiagnostics = eval(`(${diagnosticsSource})`) as (limit?: number) => {
+            beginEpoch(epoch: number): void;
+            snapshot(): { epoch: number; degraded: boolean; entries: Array<Record<string, unknown>> };
+            readonly size: number;
+            readonly limit: number;
+        };
+        const classify = eval(`(${classifySource})`) as (error: unknown) => StorageState;
+        const makeAdapter = eval(
+            `(function(classifyStorageFailure) { ${adapterSource}; return createStorageAdapter; })`,
+        ) as (
+            classifyStorageFailure: (error: unknown) => StorageState,
+        ) => (name: string, getStorage: () => Storage, diagnostics: unknown) => SafeStorage;
+        const diagnostics = createDiagnostics(4);
+        diagnostics.beginEpoch(9);
+        const storage = memoryStorage();
+        storage.setItem('owned', '{not-json');
+        storage.setItem('unrelated-private-key', 'leave-me');
+        const adapter = makeAdapter(classify)('local', () => storage, diagnostics);
+
+        expect(adapter.read('probe', 'missing', 'probe-payload')).toEqual({ state: 'Missing', value: null });
+        expect(adapter.readJson('probe', 'owned', Array.isArray, 'probe-payload')).toEqual({
+            state: 'Corrupt', value: null, recovery: 'Removed',
+        });
+        expect(storage.getItem('owned')).toBeNull();
+        expect(storage.getItem('unrelated-private-key')).toBe('leave-me');
+
+        // Every JSON-backed runtime family shares this exact owner path. One
+        // malformed entry cannot poison the next family or unrelated storage.
+        const ownedJsonKeys = [
+            'JC_translation_en_test',
+            'JellyfinCanopy-qualityTagsCache',
+            'JellyfinCanopy-genreTagsCache',
+            'JellyfinCanopy-languageTagsCache',
+            'JellyfinCanopy-ratingTagsCache',
+            'JellyfinCanopy-peopleTagsCache',
+            'JellyfinCanopy-peopleTagsCacheTimestamp',
+            'jc-discovery-rows:server:user:movie',
+        ];
+        for (const key of ownedJsonKeys) storage.setItem(key, '{malformed');
+        for (const key of ownedJsonKeys) {
+            expect(adapter.readJson('owned-cache-inventory', key, undefined, 'owned-json').state)
+                .toBe('Corrupt');
+            expect(storage.getItem(key)).toBeNull();
+        }
+        expect(storage.getItem('unrelated-private-key')).toBe('leave-me');
+
+        const security = Object.assign(new Error('blocked'), { name: 'SecurityError' });
+        const quota = Object.assign(new Error('full'), { name: 'QuotaExceededError' });
+        expect(makeAdapter(classify)('local', () => { throw security; }, diagnostics)
+            .read('getter-probe', 'secret-user-id', 'redacted-key').state).toBe('Unavailable');
+        expect(makeAdapter(classify)('local', () => ({
+            ...memoryStorage(),
+            setItem: () => { throw quota; },
+        }), diagnostics).write('writer', 'secret-user-id', 'x', 'redacted-key').state)
+            .toBe('QuotaFailure');
+
+        const removeFails = memoryStorage();
+        removeFails.setItem('owned', '{');
+        removeFails.removeItem = () => { throw quota; };
+        expect(makeAdapter(classify)('local', () => removeFails, diagnostics)
+            .readJson('remove-probe', 'owned', undefined, 'owned-json')).toEqual({
+                state: 'Corrupt', value: null, recovery: 'QuotaFailure',
+            });
+
+        // The ring is bounded and diagnostics contain only the caller's logical
+        // label, never the raw key or exception message.
+        const snapshot = diagnostics.snapshot();
+        expect(snapshot.epoch).toBe(9);
+        expect(snapshot.degraded).toBe(true);
+        expect(snapshot.entries.length).toBeLessThanOrEqual(4);
+        expect(JSON.stringify(snapshot)).not.toContain('secret-user-id');
+        expect(JSON.stringify(snapshot)).not.toContain('full');
+        expect(snapshot.entries.some((entry) => entry.state === 'Corrupt')).toBe(true);
+        expect(snapshot.entries.some((entry) => entry.state === 'QuotaFailure')).toBe(true);
+        diagnostics.beginEpoch(10);
+        expect(diagnostics.snapshot()).toMatchObject({ epoch: 10, degraded: false, entries: [] });
+    });
+
+    it('contains throwing get/set/remove/length paths with deterministic states', () => {
+        const classifySource = extractFunctionSource('classifyStorageFailure')!;
+        const adapterSource = extractFunctionSource('createStorageAdapter')!;
+        const classify = eval(`(${classifySource})`) as (error: unknown) => StorageState;
+        const makeAdapter = eval(
+            `(function(classifyStorageFailure) { ${adapterSource}; return createStorageAdapter; })`,
+        ) as (
+            classifyStorageFailure: (error: unknown) => StorageState,
+        ) => (name: string, getStorage: () => Storage, diagnostics?: unknown) => SafeStorage;
+        const security = Object.assign(new Error('blocked'), { name: 'SecurityError' });
+        const quota = Object.assign(new Error('full'), { name: 'QuotaExceededError' });
+
+        const throwing = memoryStorage();
+        throwing.getItem = () => { throw security; };
+        throwing.setItem = () => { throw quota; };
+        throwing.removeItem = () => { throw security; };
+        Object.defineProperty(throwing, 'length', { get: () => { throw security; } });
+        const adapter = makeAdapter(classify)('session', () => throwing);
+
+        expect(adapter.read('probe', 'x').state).toBe('Unavailable');
+        expect(adapter.write('probe', 'x', 'y').state).toBe('QuotaFailure');
+        expect(adapter.remove('probe', 'x').state).toBe('Unavailable');
+        expect(adapter.keys('probe').state).toBe('Unavailable');
+    });
+
+    it('continues later feature owners after sync/async degradation and still reaches the boot marker', async () => {
+        const recordSource = extractFunctionSource('recordFeatureFailure');
+        const oneSource = extractFunctionSource('activateFeature');
+        const allSource = extractFunctionSource('activateFeatures');
+        expect(recordSource, 'recordFeatureFailure not found').toBeTruthy();
+        expect(oneSource, 'activateFeature not found').toBeTruthy();
+        expect(allSource, 'activateFeatures not found').toBeTruthy();
+        const later = vi.fn();
+        const records: Array<Record<string, unknown>> = [];
+        const context = { serverId: 'server', userId: 'user', epoch: 3 };
+        const jc: Record<string, unknown> = {
+            pluginConfig: {},
+            currentSettings: {},
+            initializeCanopyScript: () => { throw new Error('corrupt owned cache'); },
+            initializeBookmarks: later,
+            initializePagesFramework: () => Promise.reject(new Error('late feature failure')),
+        };
+        const identity = { isCurrent: () => true };
+        const activate = eval(
+            `(function(JC, identity, bootDiagnostics, requireCurrentIdentity) {`
+            + recordSource + oneSource + allSource + '; return activateFeatures; })',
+        ) as (
+            jc: Record<string, unknown>,
+            identity: { isCurrent(context: IdentityContext): boolean },
+            diagnostics: { record(entry: Record<string, unknown>): void },
+            requireCurrent: (context: IdentityContext) => void,
+        ) => (context: IdentityContext) => void;
+        const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        expect(() => activate(jc, identity, { record: (entry) => records.push(entry) }, () => undefined)(context))
+            .not.toThrow();
+        jc.initialized = true; // the next runInitialization statement remains reachable
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(later).toHaveBeenCalledTimes(1);
+        expect(jc.initialized).toBe(true);
+        expect(records).toEqual([
+            expect.objectContaining({
+                feature: 'canopy', phase: 'feature-initialization', state: 'FeatureFailure',
+            }),
+            expect.objectContaining({
+                feature: 'pages-framework', phase: 'feature-initialization', state: 'FeatureFailure',
+            }),
+        ]);
+        expect(error).toHaveBeenCalledTimes(2);
+
+        const run = extractFunctionSource('runInitialization') || '';
+        expect(run.indexOf('activateFeatures(context)')).toBeGreaterThanOrEqual(0);
+        expect(run.indexOf('JC.initialized = true')).toBeGreaterThan(run.indexOf('activateFeatures(context)'));
+    });
+
+    it('routes every runtime TypeScript storage access through the loader-owned adapter', () => {
+        const files = ts.sys.readDirectory(
+            SRC_ROOT,
+            ['.ts'],
+            ['**/*.test.ts', '**/*.d.ts', '**/test/setup.ts'],
+        );
+        const direct: string[] = [];
+        for (const file of files) {
+            const text = ts.sys.readFile(file) || '';
+            const scanner = ts.createScanner(ts.ScriptTarget.Latest, true, ts.LanguageVariant.Standard, text);
+            for (let token = scanner.scan(); token !== ts.SyntaxKind.EndOfFileToken; token = scanner.scan()) {
+                if (token !== ts.SyntaxKind.Identifier) continue;
+                const name = scanner.getTokenText();
+                if (name === 'localStorage' || name === 'sessionStorage' || name === 'indexedDB') {
+                    const line = text.slice(0, scanner.getTokenPos()).split('\n').length;
+                    direct.push(`${file}:${line}:${name}`);
+                }
+            }
+        }
+        expect(direct).toEqual([]);
+        const loaderStorageIdentifiers: string[] = [];
+        const loaderScanner = ts.createScanner(ts.ScriptTarget.Latest, true, ts.LanguageVariant.Standard, SRC);
+        for (let token = loaderScanner.scan(); token !== ts.SyntaxKind.EndOfFileToken; token = loaderScanner.scan()) {
+            if (token === ts.SyntaxKind.Identifier) {
+                const name = loaderScanner.getTokenText();
+                if (name === 'localStorage' || name === 'sessionStorage') loaderStorageIdentifiers.push(name);
+            }
+        }
+        expect(loaderStorageIdentifiers.filter((name) => name === 'localStorage')).toHaveLength(1);
+        expect(loaderStorageIdentifiers.filter((name) => name === 'sessionStorage')).toHaveLength(1);
+        expect(SRC).toContain("createStorageAdapter('local', () => window.localStorage");
+        expect(SRC).toContain("createStorageAdapter('session', () => window.sessionStorage");
     });
 
     it('owns one immutable server/user epoch and resets synchronously on every real transition', () => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/test/plugin-loader.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/test/plugin-loader.test.ts
@@ -210,6 +210,94 @@ describe('plugin.js loader guards', () => {
         expect(adapter.keys('probe').state).toBe('Unavailable');
     });
 
+    it('accepts only canonical base-10 safe integers and quarantines each exact invalid key', () => {
+        const classifySource = extractFunctionSource('classifyStorageFailure')!;
+        const adapterSource = extractFunctionSource('createStorageAdapter')!;
+        const classify = eval(`(${classifySource})`) as (error: unknown) => StorageState;
+        const makeAdapter = eval(
+            `(function(classifyStorageFailure) { ${adapterSource}; return createStorageAdapter; })`,
+        ) as (
+            classifyStorageFailure: (error: unknown) => StorageState,
+        ) => (name: string, getStorage: () => Storage, diagnostics?: unknown) => SafeStorage;
+        const storage = memoryStorage();
+        const adapter = makeAdapter(classify)('local', () => storage);
+
+        const healthy = [
+            ['zero', '0', 0],
+            ['positive', '42', 42],
+            ['negative', '-42', -42],
+            ['max-safe', String(Number.MAX_SAFE_INTEGER), Number.MAX_SAFE_INTEGER],
+            ['min-safe', String(Number.MIN_SAFE_INTEGER), Number.MIN_SAFE_INTEGER],
+        ] as const;
+        for (const [key, raw, expected] of healthy) {
+            storage.setItem(key, raw);
+            expect(adapter.readNumber('number-probe', key, undefined, 'numeric-value'))
+                .toEqual({ state: 'Valid', value: expected });
+            expect(storage.getItem(key)).toBe(raw);
+        }
+
+        storage.setItem('unrelated-private-key', 'leave-me');
+        const corrupt = [
+            ['', 'empty'],
+            ['   ', 'whitespace'],
+            ['0x10', 'hex'],
+            ['1e3', 'exponent'],
+            ['NaN', 'nan'],
+            ['Infinity', 'infinity'],
+            ['01', 'leading-zero'],
+            ['-0', 'negative-zero'],
+            [String(Number.MAX_SAFE_INTEGER + 1), 'over-max-safe'],
+            [String(Number.MIN_SAFE_INTEGER - 1), 'under-min-safe'],
+        ] as const;
+        for (const [raw, key] of corrupt) {
+            storage.setItem(key, raw);
+            expect(adapter.readNumber('number-probe', key, undefined, 'numeric-value'))
+                .toEqual({ state: 'Corrupt', value: null, recovery: 'Removed' });
+            expect(storage.getItem(key)).toBeNull();
+            expect(storage.getItem('unrelated-private-key')).toBe('leave-me');
+        }
+    });
+
+    it('rolls bounded redacted pre-auth storage faults into the first identity epoch only', () => {
+        const diagnosticsSource = extractFunctionSource('createBootDiagnostics')!;
+        const classifySource = extractFunctionSource('classifyStorageFailure')!;
+        const adapterSource = extractFunctionSource('createStorageAdapter')!;
+        const createDiagnostics = eval(`(${diagnosticsSource})`) as (limit?: number) => {
+            beginEpoch(epoch: number): void;
+            snapshot(): { epoch: number; degraded: boolean; entries: Array<Record<string, unknown>> };
+        };
+        const classify = eval(`(${classifySource})`) as (error: unknown) => StorageState;
+        const makeAdapter = eval(
+            `(function(classifyStorageFailure) { ${adapterSource}; return createStorageAdapter; })`,
+        ) as (
+            classifyStorageFailure: (error: unknown) => StorageState,
+        ) => (name: string, getStorage: () => Storage, diagnostics?: unknown) => SafeStorage;
+        const diagnostics = createDiagnostics(4);
+        const secret = 'raw-user-storage-key';
+        const security = Object.assign(new Error('private browser denial'), { name: 'SecurityError' });
+        const adapter = makeAdapter(classify)('local', () => { throw security; }, diagnostics);
+
+        expect(adapter.read('pre-auth-layout', secret, 'host-layout').state).toBe('Unavailable');
+        expect(diagnostics.snapshot()).toMatchObject({
+            epoch: 0,
+            degraded: true,
+            entries: [expect.objectContaining({ epoch: 0, feature: 'pre-auth-layout', key: 'host-layout' })],
+        });
+
+        diagnostics.beginEpoch(1);
+        const firstBoot = diagnostics.snapshot();
+        expect(firstBoot).toMatchObject({
+            epoch: 1,
+            degraded: true,
+            entries: [expect.objectContaining({ epoch: 1, feature: 'pre-auth-layout', key: 'host-layout' })],
+        });
+        expect(JSON.stringify(firstBoot)).not.toContain(secret);
+        expect(JSON.stringify(firstBoot)).not.toContain('private browser denial');
+
+        diagnostics.beginEpoch(2);
+        expect(diagnostics.snapshot()).toMatchObject({ epoch: 2, degraded: false, entries: [] });
+    });
+
     it('continues later feature owners after sync/async degradation and still reaches the boot marker', async () => {
         const recordSource = extractFunctionSource('recordFeatureFailure');
         const oneSource = extractFunctionSource('activateFeature');
@@ -259,6 +347,153 @@ describe('plugin.js loader guards', () => {
         const run = extractFunctionSource('runInitialization') || '';
         expect(run.indexOf('activateFeatures(context)')).toBeGreaterThanOrEqual(0);
         expect(run.indexOf('JC.initialized = true')).toBeGreaterThan(run.indexOf('activateFeatures(context)'));
+    });
+
+    it('completes the real loader marker, event, splash, and legacy tier after a registered owner fails', async () => {
+        const loaderDocument = document.implementation.createHTMLDocument('loader-containment');
+        const local = memoryStorage();
+        const session = memoryStorage();
+        const registeredFailure = vi.fn()
+            .mockRejectedValueOnce(new Error('registered owner failed'))
+            .mockResolvedValue(undefined);
+        const legacyActivation = vi.fn();
+        const laterLegacyActivation = vi.fn();
+        const hideSplash = vi.fn();
+        const initializeSplash = vi.fn();
+        const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+        const client = {
+            getCurrentUserId: () => 'loader-user',
+            getCurrentUser: () => Promise.resolve({ Id: 'loader-user' }),
+            serverId: () => 'loader-server',
+            serverAddress: () => 'http://loader.test',
+            getUrl: (path: string) => `http://loader.test${path}`,
+            setAuthenticationInfo(_token: string | null, _userId: string | null) { return undefined; },
+            ajax: (options: { url: string }) => {
+                const path = new URL(options.url).pathname;
+                if (path.endsWith('/public-config')) return Promise.resolve({ AssetCacheEnabled: false });
+                if (path.endsWith('/private-config')) return Promise.resolve({});
+                if (path.endsWith('/version')) return Promise.resolve('test-version');
+                if (path.endsWith('/bookmark.json')) return Promise.resolve({ Revision: 0, Bookmarks: {} });
+                if (path.endsWith('/shortcuts.json')) return Promise.resolve({ Shortcuts: [] });
+                if (path.includes('/user-settings/')) return Promise.resolve({});
+                throw new Error(`Unexpected loader request: ${path}`);
+            },
+        };
+        const fakeWindow: {
+            ApiClient: typeof client;
+            JellyfinCanopy?: unknown;
+            localStorage: Storage;
+            sessionStorage: Storage;
+            location: { href: string; protocol: string; reload(): void };
+            addEventListener: ReturnType<typeof vi.fn>;
+            setInterval: ReturnType<typeof vi.fn>;
+        } = {
+            ApiClient: client,
+            localStorage: local,
+            sessionStorage: session,
+            location: { href: 'http://loader.test/web/', protocol: 'http:', reload: vi.fn() },
+            addEventListener: vi.fn(),
+            setInterval: vi.fn(() => 1),
+        };
+        Object.defineProperty(fakeWindow, 'ApiClient', {
+            configurable: true,
+            enumerable: true,
+            writable: true,
+            value: client,
+        });
+
+        type LoaderGlobal = {
+            initialized?: boolean;
+            identity: IdentitySession;
+            bootDiagnostics: {
+                snapshot(): { entries: Array<Record<string, unknown>> };
+            };
+            loadTranslations?: () => Promise<Record<string, string>>;
+            loadSettings?: () => Record<string, unknown>;
+            initializeShortcuts?: () => void;
+            initializeCanopyScript?: () => void;
+            initializePagesFramework?: () => void;
+            initializeSplashScreen?: () => void;
+            hideSplashScreen?: () => void;
+        };
+        const originalAppend = loaderDocument.head.appendChild.bind(loaderDocument.head);
+        vi.spyOn(loaderDocument.head, 'appendChild').mockImplementation((node: Node) => {
+            const appended = originalAppend(node);
+            if (!(node instanceof HTMLScriptElement)) return appended;
+            queueMicrotask(() => {
+                const jc = fakeWindow.JellyfinCanopy as LoaderGlobal;
+                if (node.src.includes('/dist/splashscreen.js')) {
+                    jc.initializeSplashScreen = initializeSplash;
+                    jc.hideSplashScreen = hideSplash;
+                } else if (node.src.includes('/dist/translations.js')) {
+                    jc.loadTranslations = () => Promise.resolve({});
+                } else if (node.src.includes('/dist/jc.bundle.js')) {
+                    jc.loadSettings = () => ({ displayLanguage: '' });
+                    jc.initializeShortcuts = vi.fn();
+                    jc.initializeCanopyScript = legacyActivation;
+                    jc.initializePagesFramework = laterLegacyActivation;
+                    jc.identity.registerActivate('registered-owner', registeredFailure);
+                }
+                node.onload?.call(node, new Event('load'));
+            });
+            return appended;
+        });
+
+        const activated = new Promise<CustomEvent<IdentityContext>>((resolve) => {
+            loaderDocument.addEventListener('jc:identityactivated', (event) => {
+                resolve(event as CustomEvent<IdentityContext>);
+            }, { once: true });
+        });
+        const execute = eval(
+            '(function(window, document, ApiClient, CustomEvent, setTimeout, clearTimeout, URL, console) {'
+            + SRC
+            + '\n})',
+        ) as (...args: unknown[]) => void;
+
+        execute(
+            fakeWindow,
+            loaderDocument,
+            client,
+            CustomEvent,
+            vi.fn(() => 1),
+            vi.fn(),
+            URL,
+            console,
+        );
+        const event = await activated;
+        const jc = fakeWindow.JellyfinCanopy as LoaderGlobal;
+
+        expect(registeredFailure).toHaveBeenCalledTimes(1);
+        expect(legacyActivation).toHaveBeenCalledTimes(1);
+        expect(laterLegacyActivation).toHaveBeenCalledTimes(1);
+        expect(jc.initialized).toBe(true);
+        expect(event.detail).toEqual({ serverId: 'loaderserver', userId: 'loaderuser', epoch: 1 });
+        // Early script load paints immediately; authenticated boot refreshes it
+        // once more after publishing the owner snapshot.
+        expect(initializeSplash).toHaveBeenCalledTimes(2);
+        expect(hideSplash).toHaveBeenCalledTimes(1);
+        expect(jc.bootDiagnostics.snapshot().entries).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                feature: 'registered-owner',
+                phase: 'feature-initialization',
+                state: 'FeatureFailure',
+            }),
+        ]));
+        expect(error).toHaveBeenCalledWith(
+            expect.stringContaining('registered-owner'),
+            expect.any(Error),
+        );
+
+        // The failed registered participant remains retryable without replaying
+        // the already-completed legacy tier or disturbing the boot marker.
+        await expect(jc.identity.activate(event.detail)).resolves.toBeUndefined();
+        await expect(jc.identity.activate(event.detail)).resolves.toBeUndefined();
+        expect(registeredFailure).toHaveBeenCalledTimes(2);
+        expect(legacyActivation).toHaveBeenCalledTimes(1);
+        expect(jc.initialized).toBe(true);
     });
 
     it('routes every runtime TypeScript storage access through the loader-owned adapter', () => {
@@ -391,7 +626,7 @@ describe('plugin.js loader guards', () => {
         session.registerActivate('successful', successful);
         session.registerActivate('flaky', flaky);
 
-        await expect(session.activate(context)).rejects.toThrow('first activation failed');
+        await expect(session.activate(context)).resolves.toBeUndefined();
         expect(successful).toHaveBeenCalledTimes(1);
         expect(flaky).toHaveBeenCalledTimes(1);
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/test/setup-identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/test/setup-identity.test.ts
@@ -15,11 +15,13 @@ describe('shared test identity activation contract', () => {
             .mockResolvedValue(undefined);
         unregister.push(JC.identity.registerActivate('setup-retry-probe', flaky));
 
-        await expect(JC.identity.activate(context)).rejects.toThrow('first activation failed');
+        const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        await expect(JC.identity.activate(context)).resolves.toBeUndefined();
         await expect(JC.identity.activate(context)).resolves.toBeUndefined();
         await expect(JC.identity.activate(context)).resolves.toBeUndefined();
 
         expect(flaky).toHaveBeenCalledTimes(2);
+        expect(error).toHaveBeenCalledTimes(1);
     });
 
     it('deduplicates concurrent activation for the same handler and epoch', async () => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/test/setup.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/test/setup.ts
@@ -4,7 +4,14 @@
 // bundle loads — the window.JellyfinCanopy bootstrap namespace and the
 // jellyfin-web globals the core modules touch at import time.
 
-import type { IdentityApi, IdentityChange, IdentityContext, JEGlobal } from '../types/jc';
+import type {
+    BootDiagnosticsApi,
+    BrowserStorageAdapter,
+    IdentityApi,
+    IdentityChange,
+    IdentityContext,
+    JEGlobal,
+} from '../types/jc';
 
 let testIdentity: IdentityContext | null = Object.freeze({
     serverId: 'test-server-id',
@@ -116,6 +123,93 @@ const identity: IdentityApi = {
     getInitializationControllerCount: () => 0,
 };
 
+const diagnosticEntries: ReturnType<BootDiagnosticsApi['snapshot']>['entries'][number][] = [];
+let diagnosticEpoch = testEpoch;
+const bootDiagnostics: BootDiagnosticsApi = {
+    beginEpoch(epoch) {
+        diagnosticEpoch = epoch;
+        diagnosticEntries.length = 0;
+    },
+    record(entry) {
+        const value = Object.freeze({ epoch: diagnosticEpoch, count: 1, ...entry });
+        diagnosticEntries.push(value);
+        if (diagnosticEntries.length > 64) diagnosticEntries.shift();
+        return value;
+    },
+    snapshot: () => Object.freeze({
+        epoch: diagnosticEpoch,
+        degraded: diagnosticEntries.length > 0,
+        entries: Object.freeze([...diagnosticEntries]),
+    }),
+    get size() { return diagnosticEntries.length; },
+    get limit() { return 64; },
+};
+
+function testStorageAdapter(getStorage: () => Storage): BrowserStorageAdapter {
+    const classify = (error: unknown): 'QuotaFailure' | 'Unavailable' =>
+        (error as { name?: string } | null)?.name === 'QuotaExceededError' ? 'QuotaFailure' : 'Unavailable';
+    return {
+        read(_feature, key) {
+            try {
+                const value = getStorage().getItem(key);
+                return value === null ? { state: 'Missing', value: null } : { state: 'Valid', value };
+            } catch (error) { return { state: classify(error), value: null }; }
+        },
+        readJson<T>(feature: string, key: string, validate?: (value: unknown) => value is T) {
+            const raw = this.read(feature, key);
+            if (raw.state !== 'Valid') return raw;
+            try {
+                const value: unknown = JSON.parse(raw.value);
+                if (validate && !validate(value)) throw new Error('invalid');
+                return { state: 'Valid', value: value as T };
+            } catch {
+                const recovery = this.remove(feature, key);
+                return {
+                    state: 'Corrupt',
+                    value: null,
+                    recovery: recovery.state === 'Valid' ? 'Removed' : recovery.state,
+                };
+            }
+        },
+        readNumber(feature, key, validate) {
+            const raw = this.read(feature, key);
+            if (raw.state !== 'Valid') return raw;
+            const value = Number(raw.value);
+            if (Number.isFinite(value) && (!validate || validate(value))) return { state: 'Valid', value };
+            const recovery = this.remove(feature, key);
+            return {
+                state: 'Corrupt',
+                value: null,
+                recovery: recovery.state === 'Valid' ? 'Removed' : recovery.state,
+            };
+        },
+        write(_feature, key, value) {
+            try { getStorage().setItem(key, value); return { state: 'Valid', value }; }
+            catch (error) { return { state: classify(error), value: null }; }
+        },
+        remove(_feature, key) {
+            try { getStorage().removeItem(key); return { state: 'Valid', value: null }; }
+            catch (error) { return { state: classify(error), value: null }; }
+        },
+        quarantine(feature, key) {
+            const recovery = this.remove(feature, key);
+            return {
+                state: 'Corrupt',
+                value: null,
+                recovery: recovery.state === 'Valid' ? 'Removed' : recovery.state,
+            };
+        },
+        keys() {
+            try {
+                const storage = getStorage();
+                const value = Array.from({ length: storage.length }, (_, index) => storage.key(index))
+                    .filter((key): key is string => key !== null);
+                return { state: 'Valid', value };
+            } catch (error) { return { state: classify(error), value: null }; }
+        },
+    };
+}
+
 const bootstrapJE = {
     core: { identity },
     identity,
@@ -123,6 +217,11 @@ const bootstrapJE = {
     translations: {},
     pluginVersion: 'test',
     escapeHtml: (value: unknown) => (typeof value === 'string' ? value : ''),
+    storage: {
+        local: testStorageAdapter(() => window.localStorage),
+        session: testStorageAdapter(() => window.sessionStorage),
+    },
+    bootDiagnostics,
 } as unknown as JEGlobal;
 
 window.JellyfinCanopy = bootstrapJE;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/test/setup.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/test/setup.ts
@@ -83,7 +83,7 @@ const identity: IdentityApi = {
     async activate(context = testIdentity) {
         if (!context || !this.isCurrent(context)) return;
         const work: Promise<void>[] = [];
-        for (const record of activateHandlers.values()) {
+        for (const [name, record] of activateHandlers.entries()) {
             if (record.epoch === context.epoch) continue;
             if (record.pendingEpoch === context.epoch && record.pending) {
                 work.push(record.pending);
@@ -97,6 +97,20 @@ const identity: IdentityApi = {
                     // retryable, and late older success cannot replace newer.
                     if (record.epoch < context.epoch) record.epoch = context.epoch;
                 })
+                .catch((error: unknown) => {
+                    const errorName = (error as { name?: string } | null)?.name;
+                    if (errorName === 'IdentityChangedError' || errorName === 'AbortError'
+                        || !this.isCurrent(context)) return;
+                    bootDiagnostics.record({
+                        feature: name,
+                        phase: 'feature-initialization',
+                        operation: 'initialize',
+                        state: 'FeatureFailure',
+                        storage: 'none',
+                        key: 'none',
+                    });
+                    console.error(`Test identity activate handler "${name}" failed`, error);
+                })
                 .finally(() => {
                     if (record.pending === invocation) {
                         record.pending = null;
@@ -108,13 +122,7 @@ const identity: IdentityApi = {
             work.push(invocation);
         }
 
-        const results = await Promise.allSettled(work);
-        const failure = results.find((result): result is PromiseRejectedResult => result.status === 'rejected');
-        if (failure) {
-            throw failure.reason instanceof Error
-                ? failure.reason
-                : new Error('Test identity activation failed', { cause: failure.reason });
-        }
+        await Promise.all(work);
     },
     getEpoch: () => testEpoch,
     getResetHandlerCount: () => resetHandlers.size,
@@ -127,8 +135,14 @@ const diagnosticEntries: ReturnType<BootDiagnosticsApi['snapshot']>['entries'][n
 let diagnosticEpoch = testEpoch;
 const bootDiagnostics: BootDiagnosticsApi = {
     beginEpoch(epoch) {
+        const previousEpoch = diagnosticEpoch;
         diagnosticEpoch = epoch;
-        diagnosticEntries.length = 0;
+        if (previousEpoch === 0 && epoch > 0) {
+            const carried = diagnosticEntries.map((entry) => Object.freeze({ ...entry, epoch }));
+            diagnosticEntries.splice(0, diagnosticEntries.length, ...carried);
+        } else {
+            diagnosticEntries.length = 0;
+        }
     },
     record(entry) {
         const value = Object.freeze({ epoch: diagnosticEpoch, count: 1, ...entry });
@@ -174,8 +188,16 @@ function testStorageAdapter(getStorage: () => Storage): BrowserStorageAdapter {
         readNumber(feature, key, validate) {
             const raw = this.read(feature, key);
             if (raw.state !== 'Valid') return raw;
+            if (!/^(?:0|-?[1-9]\d*)$/.test(raw.value)) {
+                const recovery = this.remove(feature, key);
+                return {
+                    state: 'Corrupt',
+                    value: null,
+                    recovery: recovery.state === 'Valid' ? 'Removed' : recovery.state,
+                };
+            }
             const value = Number(raw.value);
-            if (Number.isFinite(value) && (!validate || validate(value))) return { state: 'Valid', value };
+            if (Number.isSafeInteger(value) && (!validate || validate(value))) return { state: 'Valid', value };
             const recovery = this.remove(feature, key);
             return {
                 state: 'Corrupt',

--- a/Jellyfin.Plugin.JellyfinCanopy/src/types/jc.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/types/jc.ts
@@ -73,6 +73,7 @@ export interface BrowserStorageAdapter {
         validate?: (value: unknown) => value is T,
         keyLabel?: string,
     ): BrowserStorageResult<T>;
+    /** Read one canonical base-10 safe integer; other spellings are corrupt. */
     readNumber(
         feature: string,
         key: string,

--- a/Jellyfin.Plugin.JellyfinCanopy/src/types/jc.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/types/jc.ts
@@ -51,6 +51,75 @@ export interface CacheManager {
     cancelPending(): void;
 }
 
+/** Typed result states for every browser-storage operation. */
+export type BrowserStorageState = 'Missing' | 'Valid' | 'Corrupt' | 'Unavailable' | 'QuotaFailure';
+export type BrowserStorageRecovery = 'Removed' | 'Unavailable' | 'QuotaFailure';
+
+export type BrowserStorageResult<T> =
+    | Readonly<{ state: 'Valid'; value: T }>
+    | Readonly<{ state: 'Missing' | 'Unavailable' | 'QuotaFailure'; value: null }>
+    | Readonly<{ state: 'Corrupt'; value: null; recovery: BrowserStorageRecovery }>;
+
+export type BrowserStorageMutationResult<T> =
+    | Readonly<{ state: 'Valid'; value: T }>
+    | Readonly<{ state: 'Unavailable' | 'QuotaFailure'; value: null }>;
+
+/** Safe access to one Storage object; implemented by the classic boot loader. */
+export interface BrowserStorageAdapter {
+    read(feature: string, key: string, keyLabel?: string): BrowserStorageResult<string>;
+    readJson<T>(
+        feature: string,
+        key: string,
+        validate?: (value: unknown) => value is T,
+        keyLabel?: string,
+    ): BrowserStorageResult<T>;
+    readNumber(
+        feature: string,
+        key: string,
+        validate?: (value: number) => boolean,
+        keyLabel?: string,
+    ): BrowserStorageResult<number>;
+    write(feature: string, key: string, value: string, keyLabel?: string): BrowserStorageMutationResult<string>;
+    remove(feature: string, key: string, keyLabel?: string): BrowserStorageMutationResult<null>;
+    /** Record corruption and remove only this exact caller-owned key. */
+    quarantine(
+        feature: string,
+        key: string,
+        keyLabel?: string,
+    ): Readonly<{ state: 'Corrupt'; value: null; recovery: BrowserStorageRecovery }>;
+    keys(feature: string, keyLabel?: string): BrowserStorageMutationResult<string[]>;
+}
+
+export interface BrowserStorageApi {
+    readonly local: BrowserStorageAdapter;
+    readonly session: BrowserStorageAdapter;
+}
+
+export interface BootDiagnosticEntry {
+    readonly epoch: number;
+    readonly feature: string;
+    readonly phase: string;
+    readonly operation: string;
+    readonly state: BrowserStorageState | 'FeatureFailure';
+    readonly storage: 'local' | 'session' | 'none';
+    /** Non-identifying logical key label, never the raw browser-storage key. */
+    readonly key: string;
+    /** Number of identical faults coalesced into this bounded record. */
+    readonly count: number;
+}
+
+export interface BootDiagnosticsApi {
+    beginEpoch(epoch: number): void;
+    record(entry: Omit<BootDiagnosticEntry, 'epoch' | 'count'>): BootDiagnosticEntry;
+    snapshot(): Readonly<{
+        epoch: number;
+        degraded: boolean;
+        entries: readonly BootDiagnosticEntry[];
+    }>;
+    readonly size: number;
+    readonly limit: number;
+}
+
 /**
  * The Map subset every in-memory item cache uses, backed by a size-capped +
  * lazily-TTL-swept LRU (src/core/bounded-cache.ts). Drop-in for the raw
@@ -630,6 +699,10 @@ export interface JEGlobal extends JellyfinCanopyPublicApi {
     escapeHtml: (value: unknown) => string;
     toast?: (html: string, duration?: number) => void;
     requestManager?: RequestManagerApi;
+    /** Fail-open browser-storage owner installed before any feature code runs. */
+    storage: BrowserStorageApi;
+    /** Generation-scoped bounded degraded-boot telemetry (no raw keys/errors). */
+    bootDiagnostics: BootDiagnosticsApi;
     _cacheManager?: CacheManager;
     _hotCache?: HotCache;
     /**

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -18,7 +18,7 @@ const ROOT = path.join(__dirname, '..');
 const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the repeated clean measurements', () => {
-    assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1436, totalLines: 1759 });
+    assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1438, totalLines: 1762 });
     assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 17260, totalLines: 25874 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -9,12 +9,12 @@
       "scope": "Jellyfin.Plugin.JellyfinCanopy/src/core/**",
       "report": "coverage/coverage-summary.json",
       "measured": {
-        "coveredLines": 1436,
-        "totalLines": 1759
+        "coveredLines": 1438,
+        "totalLines": 1762
       },
       "tolerance": {
         "missingCoveredLines": 1,
-        "rationale": "A clean GitHub Actions Node 22/V8 run on 2026-07-16 measured 1436 covered lines across the 1759-line core scope after adding the shared document-relative Jellyfin SPA route builders. Focused V8 evidence exercised every new executable line, including encoded parameters, invalid routes, and the parameter-free path. One line permits only negligible instrumentation variance."
+        "rationale": "Two clean local Node 22/V8 runs on 2026-07-16 each passed 956 tests and measured the identical 1762-line core scope at 1438 covered lines after issue #130 routed tag-renderer storage through the fault-containing browser-storage adapter. The three-line scope increase is reviewed: two new executable lines are covered and one recovery branch remains outside the existing tag-renderer tests. The existing one-line tolerance is unchanged and permits only negligible instrumentation variance."
       }
     },
     "server": {

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -14,7 +14,7 @@
       },
       "tolerance": {
         "missingCoveredLines": 1,
-        "rationale": "Two clean local Node 22/V8 runs on 2026-07-16 each passed 956 tests and measured the identical 1762-line core scope at 1438 covered lines after issue #130 routed tag-renderer storage through the fault-containing browser-storage adapter. The three-line scope increase is reviewed: two new executable lines are covered and one recovery branch remains outside the existing tag-renderer tests. The existing one-line tolerance is unchanged and permits only negligible instrumentation variance."
+        "rationale": "Two clean local Node 22/V8 runs on 2026-07-16 each passed 959 tests and measured the identical 1762-line core scope at 1438 covered lines after the independently reviewed issue #130 correction. The reviewed high-water is unchanged: routing tag-renderer storage through the fault-containing browser-storage adapter added three executable core lines, two covered and one recovery branch outside the existing tag-renderer tests; the follow-up registered-activation, canonical-integer, and pre-auth-diagnostic fixes live in the classic loader and test harness and therefore do not alter this core scope. The existing one-line tolerance is unchanged and permits only negligible instrumentation variance."
       }
     },
     "server": {


### PR DESCRIPTION
## What changed

- add a typed, fault-containing browser-storage adapter for missing, valid, corrupt, unavailable, and quota-failure states
- quarantine only the exact corrupt Canopy-owned key with bounded, redacted diagnostics
- route the affected feature storage and migration paths through that adapter
- independently contain registered feature activation so one failing participant cannot abort later features or the final initialization marker
- retry only failed activation participants while retaining successful peers
- preserve bounded pre-auth diagnostics into the first authenticated identity epoch
- enforce canonical base-10 safe-integer storage values
- add malformed-data, throwing-storage, activation-fault, retry, identity-epoch, and key-isolation regressions

## Why

A malformed owned value or browser storage exception could escape a feature initializer and abort the shared Stage 6 loader. Later features would never activate and the client initialization marker could remain unset. Broad recovery also risked touching unrelated storage instead of isolating the failing owned key.

## Validation

- independent implementation review: approved
- independent exact rebased-commit review: approved
- full client coverage: 147 files, 959/959 tests, 1,438/1,762 core lines
- focused loader/setup tests: 35/35
- script-policy tests: 346/346
- coverage baseline tests: 13/13
- strict TypeScript checks, legacy typecheck, syntax inventory, bundle, and performance guard: green
- lint advisory: 0 errors
- rebased non-baseline implementation blobs: byte-identical to reviewed version
- diff checks and worktree: clean

Fixes #130
