### PR TITLE
fix(bookmarks): key detail cache by identity

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/bookmarks.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/bookmarks.identity.test.ts
@@ -229,6 +229,118 @@ describe('bookmark player identity ownership', () => {
     expect(document.querySelector('.jc-bookmark-hero-subtitle')?.textContent).toBe('Movie Two');
   });
 
+  it('keeps the current B marker and modal after B completes before a late A', async () => {
+    const api = await loadModule({
+      one: bookmark('item-one', 'One'),
+      two: bookmark('item-two', 'Two')
+    });
+    const first = deferred<unknown>();
+    const second = deferred<unknown>();
+    ajax.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+    const rating = document.querySelector<HTMLElement>('.btnUserRating')!;
+
+    rating.dataset.id = 'item-one';
+    const markersA = api.updateMarkers();
+    await vi.waitFor(() => expect(ajax).toHaveBeenCalledTimes(1));
+
+    rating.dataset.id = 'item-two';
+    const markersB = api.updateMarkers();
+    await vi.waitFor(() => expect(ajax).toHaveBeenCalledTimes(2));
+    second.resolve({ Items: [{
+      Id: 'item-two',
+      Name: 'Movie Two',
+      Type: 'Movie',
+      ProviderIds: { Tmdb: 'tmdb-two' }
+    }] });
+    await markersB;
+
+    expect(document.querySelectorAll('.jc-bookmark-marker')).toHaveLength(1);
+    expect(document.querySelector<HTMLElement>('.jc-bookmark-marker')?.title).toContain('Two');
+
+    first.resolve({ Items: [{
+      Id: 'item-one',
+      Name: 'Movie One',
+      Type: 'Movie',
+      ProviderIds: { Tmdb: 'tmdb-one' }
+    }] });
+    await markersA;
+
+    expect(document.querySelectorAll('.jc-bookmark-marker')).toHaveLength(1);
+    expect(document.querySelector<HTMLElement>('.jc-bookmark-marker')?.title).toContain('Two');
+    await api.showModal('view');
+    expect(ajax).toHaveBeenCalledTimes(2);
+    expect(document.querySelector('.jc-bookmark-hero-subtitle')?.textContent).toBe('Movie Two');
+  });
+
+  it('does not reuse the same item cache entry after a server/account switch', async () => {
+    const api = await loadModule({ existing: bookmark('item-a', 'A') });
+    await api.showModal('view');
+    expect(document.querySelector('.jc-bookmark-hero-subtitle')?.textContent).toBe('Movie A');
+    document.querySelector<HTMLElement>('.jc-bm-player-modal-overlay')?.remove();
+
+    switchToB({ existing: { ...bookmark('item-a', 'B'), tmdbId: 'tmdb-b' } });
+    ajax.mockResolvedValueOnce({ Items: [{
+      Id: 'item-a',
+      Name: 'Movie B',
+      Type: 'Movie',
+      ProviderIds: { Tmdb: 'tmdb-b' }
+    }] });
+    await api.showModal('view');
+
+    expect(ajax).toHaveBeenCalledTimes(2);
+    expect(document.querySelector('.jc-bookmark-hero-subtitle')?.textContent).toBe('Movie B');
+  });
+
+  it('retries a short-lived detail failure without publishing stale navigation output', async () => {
+    let now = 10_000;
+    vi.spyOn(Date, 'now').mockImplementation(() => now);
+    const api = await loadModule({
+      a: bookmark('item-a', 'A'),
+      b: bookmark('item-b', 'B')
+    });
+    const rating = document.querySelector<HTMLElement>('.btnUserRating')!;
+    ajax.mockReset();
+    ajax.mockRejectedValueOnce(new Error('temporary outage'));
+
+    rating.dataset.id = 'item-a';
+    await api.updateMarkers();
+    expect(document.querySelector('.jc-bookmark-marker')).toBeNull();
+    expect(ajax).toHaveBeenCalledTimes(1);
+
+    // The typed failure is briefly cached for this exact key only.
+    await api.updateMarkers();
+    expect(ajax).toHaveBeenCalledTimes(1);
+
+    const heldRetry = deferred<unknown>();
+    now += 500;
+    ajax.mockReturnValueOnce(heldRetry.promise);
+    const staleRetry = api.updateMarkers();
+    await vi.waitFor(() => expect(ajax).toHaveBeenCalledTimes(2));
+
+    rating.dataset.id = 'item-b';
+    ajax.mockResolvedValueOnce({ Items: [{
+      Id: 'item-b',
+      Name: 'Movie B',
+      Type: 'Movie',
+      ProviderIds: { Tmdb: 'tmdb-a' }
+    }] });
+    const currentB = api.updateMarkers();
+    await vi.waitFor(() => expect(ajax).toHaveBeenCalledTimes(3));
+    await currentB;
+    expect(document.querySelector<HTMLElement>('.jc-bookmark-marker')?.title).toContain('B');
+
+    heldRetry.resolve({ Items: [{
+      Id: 'item-a',
+      Name: 'Movie A retry',
+      Type: 'Movie',
+      ProviderIds: { Tmdb: 'tmdb-a' }
+    }] });
+    await staleRetry;
+
+    expect(document.querySelectorAll('.jc-bookmark-marker')).toHaveLength(1);
+    expect(document.querySelector<HTMLElement>('.jc-bookmark-marker')?.title).toContain('B');
+  });
+
   it('drops item-one marker and modal continuations after same-identity navigation to item two', async () => {
     const api = await loadModule({
       one: bookmark('item-one', 'One'),
@@ -270,6 +382,53 @@ describe('bookmark player identity ownership', () => {
     expect(document.querySelectorAll('.jc-bookmark-marker')).toHaveLength(1);
     expect(document.querySelector<HTMLElement>('.jc-bookmark-marker')?.title).toContain('Two');
     expect(document.querySelector('.jc-bm-player-modal-overlay')).toBeNull();
+  });
+
+  it('aborts unresolved detail ownership on viewshow before rendering the next item', async () => {
+    const api = await loadModule({
+      one: bookmark('item-one', 'One'),
+      two: bookmark('item-two', 'Two')
+    });
+    JC.initializeBookmarks();
+    const first = deferred<unknown>();
+    const second = deferred<unknown>();
+    ajax.mockReset();
+    ajax.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+    const rating = document.querySelector<HTMLElement>('.btnUserRating')!;
+
+    rating.dataset.id = 'item-one';
+    const retiredMarkers = api.updateMarkers();
+    await vi.waitFor(() => expect(ajax).toHaveBeenCalledTimes(1));
+    const firstSignal = (ajax.mock.calls[0][0] as { signal?: AbortSignal }).signal;
+    expect(firstSignal?.aborted).toBe(false);
+
+    rating.dataset.id = 'item-two';
+    document.dispatchEvent(new Event('viewshow'));
+    await retiredMarkers;
+    expect(firstSignal?.aborted).toBe(true);
+
+    const currentMarkers = api.updateMarkers();
+    await vi.waitFor(() => expect(ajax).toHaveBeenCalledTimes(2));
+    second.resolve({ Items: [{
+      Id: 'item-two',
+      Name: 'Movie Two',
+      Type: 'Movie',
+      ProviderIds: { Tmdb: 'tmdb-two' }
+    }] });
+    await currentMarkers;
+
+    expect(document.querySelectorAll('.jc-bookmark-marker')).toHaveLength(1);
+    expect(document.querySelector<HTMLElement>('.jc-bookmark-marker')?.title).toContain('Two');
+    first.resolve({ Items: [{
+      Id: 'item-one',
+      Name: 'Movie One',
+      Type: 'Movie',
+      ProviderIds: { Tmdb: 'tmdb-one' }
+    }] });
+    await Promise.resolve();
+    expect(document.querySelectorAll('.jc-bookmark-marker')).toHaveLength(1);
+    expect(document.querySelector<HTMLElement>('.jc-bookmark-marker')?.title).toContain('Two');
+    JC.cleanupBookmarks();
   });
 
   it('makes an already-open item-one modal and marker inert after playback advances to item two', async () => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/bookmarks.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/bookmarks.ts
@@ -15,6 +15,10 @@ import {
   persistedBookmarkIdentity,
   type BookmarkIdentityRecord
 } from './bookmark-identity';
+import {
+  createItemDetailsCache,
+  type ItemDetailsCacheOutcome
+} from './item-details-cache';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -375,48 +379,45 @@ import {
       && isMediaItemCurrent(captured, mediaItemId);
   }
 
-  interface ItemDetailsCache {
-    itemId: string | null;
-    data: any;
-    pending: Promise<any> | null;
-    epoch: number;
-    requestId: number;
+  interface BookmarkItemDetails extends BookmarkIdentityRecord {
+    readonly itemId: string;
+    readonly identityVersion: 1;
+    readonly itemType: string;
+    readonly tmdbId: string | null;
+    readonly tvdbId: string | null;
+    readonly seriesTmdbId: string | null;
+    readonly seriesTvdbId: string | null;
+    readonly mediaType: string;
+    readonly seasonNumber: number | null;
+    readonly episodeNumber: number | null;
+    readonly episodeEndNumber: number | null;
+    readonly name: string;
+    readonly type: string;
   }
-  const itemDetailsCache: ItemDetailsCache = {
-    itemId: null,
-    data: null,
-    pending: null,
-    epoch: -1,
-    requestId: 0
-  };
+
+  const itemDetailsCache = createItemDetailsCache<BookmarkItemDetails>({
+    maxEntries: 32,
+    successTtlMs: 15_000,
+    negativeTtlMs: 1_000,
+    failureTtlMs: 500
+  });
 
   /**
    * Fetch full item details including TMDB/TVDB IDs (cached per item for a few seconds)
    */
-  async function fetchItemDetails(itemId: string): Promise<any> {
+  async function fetchItemDetails(itemId: string): Promise<BookmarkItemDetails | null> {
     const captured = captureIdentity();
     const context = captured.context;
     if (!context) return null;
-    if (itemDetailsCache.epoch === context.epoch && itemDetailsCache.itemId === itemId && itemDetailsCache.data) {
-      return itemDetailsCache.data;
-    }
 
-    if (itemDetailsCache.epoch === context.epoch && itemDetailsCache.pending && itemDetailsCache.itemId === itemId) {
-      return itemDetailsCache.pending;
-    }
-
-    const requestId = itemDetailsCache.requestId + 1;
-    itemDetailsCache.itemId = itemId;
-    itemDetailsCache.data = null;
-    itemDetailsCache.epoch = context.epoch;
-    itemDetailsCache.requestId = requestId;
-
-    // Begin on the next microtask so the cache owns the request before even a
-    // synchronously-throwing host ApiClient can reach the finally block.
-    const fetchPromise = Promise.resolve().then(async () => {
+    const outcome = await itemDetailsCache.getOrLoad({
+      serverId: context.serverId,
+      userId: context.userId,
+      itemId
+    }, context.epoch, async (signal): Promise<ItemDetailsCacheOutcome<BookmarkItemDetails>> => {
       try {
         const userId = context.userId;
-        if (!isIdentityCurrent(captured)) return null;
+        if (signal.aborted || !isIdentityCurrent(captured)) return { kind: 'aborted' };
 
         const result: any = await ApiClient.ajax({
           type: 'GET',
@@ -424,16 +425,22 @@ import {
             Ids: itemId,
             Fields: 'ProviderIds,Type,Name,SeriesId,ParentIndexNumber,IndexNumber,IndexNumberEnd'
           }),
-          dataType: 'json'
+          dataType: 'json',
+          signal
         });
 
         const item = result?.Items?.[0];
-        if (!item || !isIdentityCurrent(captured)) return null;
+        if (signal.aborted || !isIdentityCurrent(captured)) return { kind: 'aborted' };
+        if (!item) return { kind: 'negative', reason: 'not-found' };
+        if (typeof item.Id !== 'string' || item.Id !== itemId) {
+          return { kind: 'negative', reason: 'invalid-response' };
+        }
 
         // Episode/season provider IDs identify that concrete item. Keep them in
         // their namespace and fetch the parent series IDs into separate fields.
         let seriesItem: any = null;
         if ((item.Type === 'Season' || item.Type === 'Episode') && item.SeriesId) {
+          if (signal.aborted || !isIdentityCurrent(captured)) return { kind: 'aborted' };
           try {
             const seriesResult: any = await ApiClient.ajax({
               type: 'GET',
@@ -441,11 +448,12 @@ import {
                 Ids: item.SeriesId,
                 Fields: 'ProviderIds,Type,Name'
               }),
-              dataType: 'json'
+              dataType: 'json',
+              signal
             });
             seriesItem = seriesResult?.Items?.[0] || null;
           } catch (e) {
-            if (!isIdentityCurrent(captured)) return null;
+            if (signal.aborted || !isIdentityCurrent(captured)) return { kind: 'aborted' };
             console.warn(`${logPrefix} Failed to fetch series info:`, e);
           }
         }
@@ -457,7 +465,7 @@ import {
         const isSeason = item.Type === 'Season';
         const episodeNumber = isEpisode && Number.isSafeInteger(item.IndexNumber) ? item.IndexNumber : null;
 
-        const details = {
+        const details: BookmarkItemDetails = {
           itemId: item.Id,
           identityVersion: 1,
           itemType: String(item.Type || 'other').toLowerCase(),
@@ -477,25 +485,15 @@ import {
           type: item.Type
         };
 
-        if (!isIdentityCurrent(captured)) return null;
-        if (itemDetailsCache.epoch === context.epoch
-          && itemDetailsCache.requestId === requestId
-          && itemDetailsCache.itemId === itemId) {
-          itemDetailsCache.data = details;
-        }
-        return details;
+        if (signal.aborted || !isIdentityCurrent(captured)) return { kind: 'aborted' };
+        return { kind: 'success', value: details };
       } catch (e) {
-        if (!isIdentityCurrent(captured)) return null;
+        if (signal.aborted || !isIdentityCurrent(captured)) return { kind: 'aborted' };
         console.warn(`${logPrefix} Error fetching item details:`, e);
-        return null;
-      } finally {
-        if (itemDetailsCache.epoch === context.epoch
-          && itemDetailsCache.requestId === requestId) itemDetailsCache.pending = null;
+        return { kind: 'failure', reason: 'transport' };
       }
     });
-
-    itemDetailsCache.pending = fetchPromise;
-    return fetchPromise;
+    return outcome.kind === 'success' ? outcome.value : null;
   }
 
   /**
@@ -511,8 +509,8 @@ import {
    */
   function findBookmarksForItem(
     itemId: string,
-    tmdbId?: string,
-    tvdbId?: string,
+    tmdbId?: string | null,
+    tvdbId?: string | null,
     mediaType?: unknown,
     identity?: BookmarkIdentityRecord
   ): { bookmarks: any[]; hasIdMismatch: boolean; exactMatches: any[]; providerMatches: any[] } {
@@ -631,7 +629,7 @@ import {
     if (startingBookmark.identityVersion !== 1 && typeof startingBookmark.itemId === 'string') {
       const details = await fetchItemDetails(startingBookmark.itemId);
       if (!isBookmarkRootCurrent(captured, root)) return false;
-      if (details?.itemId === startingBookmark.itemId) {
+      if (details && details.itemId === startingBookmark.itemId) {
         identityUpgrade = persistedBookmarkIdentity(details);
         identityUpgradeMediaType = details.mediaType;
       }
@@ -1740,6 +1738,10 @@ import {
 
       const handleViewShow = () => {
         if (!isActivationCurrent()) return;
+        // A host navigation retires unresolved detail work immediately. The
+        // settled keyed entries remain reusable within this identity epoch,
+        // while every continuation still carries the exact current item fence.
+        itemDetailsCache.cancelPending();
         if ((JC as any).isVideoPage()) {
           lastInjectedOsdKey = null; // Reset for new page
           ensureOsdObserver();
@@ -1818,11 +1820,7 @@ import {
     for (const timer of bookmarkTimers) clearTimeout(timer);
     bookmarkTimers.clear();
     disposeActiveModals();
-    itemDetailsCache.itemId = null;
-    itemDetailsCache.data = null;
-    itemDetailsCache.pending = null;
-    itemDetailsCache.epoch = -1;
-    itemDetailsCache.requestId += 1;
+    itemDetailsCache.clear();
     forceCleanupBookmarks?.();
     forceCleanupBookmarks = null;
     removeOwnedBookmarkButtons();

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/item-details-cache.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/item-details-cache.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+    createItemDetailsCache,
+    type ItemDetailsCacheOutcome,
+    type ItemDetailsIdentityKey
+} from './item-details-cache';
+
+function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((done) => { resolve = done; });
+    return { promise, resolve };
+}
+
+function identity(itemId: string, serverId = 'server-a', userId = 'user-a'): ItemDetailsIdentityKey {
+    return { serverId, userId, itemId };
+}
+
+function success(value: string): ItemDetailsCacheOutcome<string> {
+    return { kind: 'success', value };
+}
+
+describe('bookmark item-details cache ownership', () => {
+    it.each([
+        ['A then B', ['a', 'b']],
+        ['B then A', ['b', 'a']]
+    ] as const)('keeps both keys correct when %s completes', async (_label, completionOrder) => {
+        const cache = createItemDetailsCache<string>({
+            maxEntries: 8,
+            successTtlMs: 10_000,
+            negativeTtlMs: 500,
+            failureTtlMs: 100
+        });
+        const held = { a: deferred<ItemDetailsCacheOutcome<string>>(), b: deferred<ItemDetailsCacheOutcome<string>>() };
+        const loaders = { a: vi.fn(() => held.a.promise), b: vi.fn(() => held.b.promise) };
+        const requestA = cache.getOrLoad(identity('a'), 1, loaders.a);
+        const requestB = cache.getOrLoad(identity('b'), 1, loaders.b);
+
+        for (const key of completionOrder) held[key].resolve(success(key.toUpperCase()));
+
+        await expect(requestA).resolves.toEqual(success('A'));
+        await expect(requestB).resolves.toEqual(success('B'));
+        await expect(cache.getOrLoad(identity('a'), 1, loaders.a)).resolves.toEqual(success('A'));
+        await expect(cache.getOrLoad(identity('b'), 1, loaders.b)).resolves.toEqual(success('B'));
+        expect(loaders.a).toHaveBeenCalledTimes(1);
+        expect(loaders.b).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not let A completion clear or replace B pending ownership', async () => {
+        const cache = createItemDetailsCache<string>({
+            maxEntries: 8,
+            successTtlMs: 10_000,
+            negativeTtlMs: 500,
+            failureTtlMs: 100
+        });
+        const a = deferred<ItemDetailsCacheOutcome<string>>();
+        const b = deferred<ItemDetailsCacheOutcome<string>>();
+        const loadB = vi.fn(() => b.promise);
+        const requestA = cache.getOrLoad(identity('a'), 1, () => a.promise);
+        const requestB = cache.getOrLoad(identity('b'), 1, loadB);
+        a.resolve(success('A'));
+        await requestA;
+
+        const duplicateB = cache.getOrLoad(identity('b'), 1, loadB);
+        expect(duplicateB).toBe(requestB);
+        expect(loadB).toHaveBeenCalledTimes(1);
+        b.resolve(success('B'));
+        await expect(duplicateB).resolves.toEqual(success('B'));
+    });
+
+    it('separates server and user identities even when item ids match', async () => {
+        const cache = createItemDetailsCache<string>({
+            maxEntries: 8,
+            successTtlMs: 10_000,
+            negativeTtlMs: 500,
+            failureTtlMs: 100
+        });
+        const loader = vi.fn()
+            .mockResolvedValueOnce(success('server-a/user-a'))
+            .mockResolvedValueOnce(success('server-b/user-a'))
+            .mockResolvedValueOnce(success('server-a/user-b'));
+
+        await expect(cache.getOrLoad(identity('same'), 1, loader)).resolves.toEqual(success('server-a/user-a'));
+        await expect(cache.getOrLoad(identity('same', 'server-b'), 2, loader)).resolves.toEqual(success('server-b/user-a'));
+        await expect(cache.getOrLoad(identity('same', 'server-a', 'user-b'), 3, loader)).resolves.toEqual(success('server-a/user-b'));
+        expect(loader).toHaveBeenCalledTimes(3);
+    });
+
+    it('uses short typed negative/failure TTLs and a longer success TTL', async () => {
+        let now = 1_000;
+        const cache = createItemDetailsCache<string>({
+            maxEntries: 8,
+            successTtlMs: 1_000,
+            negativeTtlMs: 100,
+            failureTtlMs: 20,
+            now: () => now
+        });
+        const failure = vi.fn().mockResolvedValue({ kind: 'failure', reason: 'transport' });
+        const missing = vi.fn().mockResolvedValue({ kind: 'negative', reason: 'not-found' });
+        const found = vi.fn().mockResolvedValue(success('found'));
+
+        await cache.getOrLoad(identity('failure'), 1, failure);
+        now += 19;
+        await cache.getOrLoad(identity('failure'), 1, failure);
+        expect(failure).toHaveBeenCalledTimes(1);
+        now += 1;
+        await cache.getOrLoad(identity('failure'), 1, failure);
+        expect(failure).toHaveBeenCalledTimes(2);
+
+        await cache.getOrLoad(identity('missing'), 1, missing);
+        now += 99;
+        await cache.getOrLoad(identity('missing'), 1, missing);
+        expect(missing).toHaveBeenCalledTimes(1);
+        now += 1;
+        await cache.getOrLoad(identity('missing'), 1, missing);
+        expect(missing).toHaveBeenCalledTimes(2);
+
+        await cache.getOrLoad(identity('found'), 1, found);
+        now += 999;
+        await cache.getOrLoad(identity('found'), 1, found);
+        expect(found).toHaveBeenCalledTimes(1);
+    });
+
+    it('caps settled and pending entries, aborting evicted and cleared work', async () => {
+        const cache = createItemDetailsCache<string>({
+            maxEntries: 2,
+            successTtlMs: 10_000,
+            negativeTtlMs: 500,
+            failureTtlMs: 100
+        });
+        const signals: AbortSignal[] = [];
+        const never = (_signal: AbortSignal): Promise<ItemDetailsCacheOutcome<string>> => {
+            signals.push(_signal);
+            return new Promise(() => undefined);
+        };
+        const first = cache.getOrLoad(identity('one'), 1, never);
+        const second = cache.getOrLoad(identity('two'), 1, never);
+        const third = cache.getOrLoad(identity('three'), 1, never);
+
+        await expect(first).resolves.toEqual({ kind: 'aborted' });
+        expect(signals[0].aborted).toBe(true);
+        expect(cache.pendingSize).toBe(2);
+        cache.clear();
+        await expect(Promise.all([second, third])).resolves.toEqual([{ kind: 'aborted' }, { kind: 'aborted' }]);
+        expect(signals.slice(1)).toHaveLength(2);
+        expect(signals.slice(1).every((signal) => signal.aborted)).toBe(true);
+        expect(cache.pendingSize).toBe(0);
+
+        for (const key of ['a', 'b', 'c']) {
+            await cache.getOrLoad(identity(key), 1, () => Promise.resolve(success(key)));
+        }
+        expect(cache.size).toBe(2);
+    });
+
+    it('retires a prior epoch owner without letting its late completion publish', async () => {
+        const cache = createItemDetailsCache<string>({
+            maxEntries: 8,
+            successTtlMs: 10_000,
+            negativeTtlMs: 500,
+            failureTtlMs: 100
+        });
+        const old = deferred<ItemDetailsCacheOutcome<string>>();
+        const current = deferred<ItemDetailsCacheOutcome<string>>();
+        const oldRequest = cache.getOrLoad(identity('same'), 1, () => old.promise);
+        const currentRequest = cache.getOrLoad(identity('same'), 2, () => current.promise);
+        await expect(oldRequest).resolves.toEqual({ kind: 'aborted' });
+
+        old.resolve(success('old'));
+        current.resolve(success('current'));
+        await expect(currentRequest).resolves.toEqual(success('current'));
+        await expect(cache.getOrLoad(identity('same'), 2, vi.fn())).resolves.toEqual(success('current'));
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/item-details-cache.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/item-details-cache.ts
@@ -1,0 +1,172 @@
+// src/enhanced/bookmarks/item-details-cache.ts
+//
+// Bounded, identity-keyed ownership for the bookmark player's item-detail
+// requests. Cached outcomes and live requests deliberately use separate maps:
+// an older completion may return to its own caller, but only the exact request
+// which still owns a key may publish or clear that key.
+
+export type ItemDetailsCacheOutcome<T> =
+    | { readonly kind: 'success'; readonly value: T }
+    | { readonly kind: 'negative'; readonly reason: 'not-found' | 'invalid-response' }
+    | { readonly kind: 'failure'; readonly reason: 'transport' }
+    | { readonly kind: 'aborted' };
+
+export interface ItemDetailsIdentityKey {
+    readonly serverId: string;
+    readonly userId: string;
+    readonly itemId: string;
+}
+
+export interface ItemDetailsCacheOptions {
+    readonly maxEntries: number;
+    readonly successTtlMs: number;
+    readonly negativeTtlMs: number;
+    readonly failureTtlMs: number;
+    readonly now?: () => number;
+}
+
+interface CachedOutcome<T> {
+    readonly outcome: Exclude<ItemDetailsCacheOutcome<T>, { readonly kind: 'aborted' }>;
+    readonly expiresAt: number;
+    readonly identityEpoch: number;
+}
+
+interface InFlight<T> {
+    readonly identityEpoch: number;
+    readonly owner: symbol;
+    readonly controller: AbortController;
+    readonly promise: Promise<ItemDetailsCacheOutcome<T>>;
+}
+
+export interface ItemDetailsCache<T> {
+    getOrLoad(
+        identity: ItemDetailsIdentityKey,
+        identityEpoch: number,
+        loader: (signal: AbortSignal) => Promise<ItemDetailsCacheOutcome<T>>
+    ): Promise<ItemDetailsCacheOutcome<T>>;
+    cancelPending(): void;
+    clear(): void;
+    readonly size: number;
+    readonly pendingSize: number;
+}
+
+/** Collision-free key: JSON string escaping preserves every identity component. */
+function identityKey(identity: ItemDetailsIdentityKey): string {
+    return JSON.stringify([identity.serverId, identity.userId, identity.itemId]);
+}
+
+/**
+ * Create the bookmark-detail cache. Both settled and pending work are capped;
+ * evicting pending work aborts its caller immediately even when the host's
+ * underlying transport ignores AbortSignal.
+ */
+export function createItemDetailsCache<T>(options: ItemDetailsCacheOptions): ItemDetailsCache<T> {
+    const maxEntries = Math.max(1, Math.floor(options.maxEntries));
+    const successTtlMs = Math.max(1, Math.floor(options.successTtlMs));
+    const negativeTtlMs = Math.max(1, Math.floor(options.negativeTtlMs));
+    const failureTtlMs = Math.max(1, Math.floor(options.failureTtlMs));
+    const now = options.now || Date.now;
+    const settled = new Map<string, CachedOutcome<T>>();
+    const pending = new Map<string, InFlight<T>>();
+
+    function liveSettled(key: string, identityEpoch: number): ItemDetailsCacheOutcome<T> | undefined {
+        const entry = settled.get(key);
+        if (!entry) return undefined;
+        if (entry.identityEpoch !== identityEpoch || entry.expiresAt <= now()) {
+            settled.delete(key);
+            return undefined;
+        }
+        settled.delete(key);
+        settled.set(key, entry);
+        return entry.outcome;
+    }
+
+    function ttlFor(outcome: Exclude<ItemDetailsCacheOutcome<T>, { readonly kind: 'aborted' }>): number {
+        if (outcome.kind === 'success') return successTtlMs;
+        if (outcome.kind === 'negative') return negativeTtlMs;
+        return failureTtlMs;
+    }
+
+    function trimSettled(): void {
+        while (settled.size > maxEntries) {
+            const oldest = settled.keys().next().value;
+            if (oldest === undefined) break;
+            settled.delete(oldest);
+        }
+    }
+
+    function trimPending(): void {
+        while (pending.size >= maxEntries) {
+            const oldest = pending.keys().next().value;
+            if (oldest === undefined) break;
+            const request = pending.get(oldest);
+            pending.delete(oldest);
+            request?.controller.abort();
+        }
+    }
+
+    function cancelPending(): void {
+        for (const request of pending.values()) request.controller.abort();
+        pending.clear();
+    }
+
+    return {
+        getOrLoad(identity, identityEpoch, loader) {
+            const key = identityKey(identity);
+            const cached = liveSettled(key, identityEpoch);
+            if (cached) return Promise.resolve(cached);
+
+            const existing = pending.get(key);
+            if (existing?.identityEpoch === identityEpoch) {
+                // Refresh recency without changing exact ownership.
+                pending.delete(key);
+                pending.set(key, existing);
+                return existing.promise;
+            }
+            if (existing) {
+                pending.delete(key);
+                existing.controller.abort();
+            }
+
+            trimPending();
+            const controller = new AbortController();
+            const owner = Symbol(key);
+
+            // Resolve cancellation independently of the host transport. The
+            // loader promise still has rejection handlers, so a late failure
+            // after cancellation cannot become an unhandled rejection.
+            const loaded = Promise.resolve()
+                .then(() => loader(controller.signal))
+                .catch((): ItemDetailsCacheOutcome<T> => ({ kind: 'failure', reason: 'transport' }));
+            const aborted = new Promise<ItemDetailsCacheOutcome<T>>((resolve) => {
+                if (controller.signal.aborted) resolve({ kind: 'aborted' });
+                else controller.signal.addEventListener('abort', () => resolve({ kind: 'aborted' }), { once: true });
+            });
+            const promise = Promise.race([loaded, aborted]).then((outcome) => {
+                const current = pending.get(key);
+                if (current?.owner !== owner || current.identityEpoch !== identityEpoch) return outcome;
+                pending.delete(key);
+                if (outcome.kind !== 'aborted') {
+                    settled.delete(key);
+                    settled.set(key, { outcome, expiresAt: now() + ttlFor(outcome), identityEpoch });
+                    trimSettled();
+                }
+                return outcome;
+            });
+
+            pending.set(key, { identityEpoch, owner, controller, promise });
+            return promise;
+        },
+        cancelPending,
+        clear() {
+            settled.clear();
+            cancelPending();
+        },
+        get size() {
+            return settled.size;
+        },
+        get pendingSize() {
+            return pending.size;
+        }
+    };
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/src/types/global.d.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/types/global.d.ts
@@ -18,7 +18,7 @@ declare global {
         accessToken(): string;
         getCurrentUser(): Promise<unknown>;
         getItem(userId: string, itemId: string): Promise<unknown>;
-        ajax(options: { type: string; url: string; dataType?: string; data?: unknown; contentType?: string }): Promise<unknown>;
+        ajax(options: { type: string; url: string; dataType?: string; data?: unknown; contentType?: string; signal?: AbortSignal }): Promise<unknown>;
         /**
          * v12 SDK socket subscription: register a callback for one or more
          * SessionMessageType names, receiving `{ MessageType, Data }` envelopes.

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -18,7 +18,7 @@ const ROOT = path.join(__dirname, '..');
 const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the repeated clean measurements', () => {
-    assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1438, totalLines: 1762 });
+    assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1439, totalLines: 1762 });
     assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 17593, totalLines: 26188 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -9,12 +9,12 @@
       "scope": "Jellyfin.Plugin.JellyfinCanopy/src/core/**",
       "report": "coverage/coverage-summary.json",
       "measured": {
-        "coveredLines": 1438,
+        "coveredLines": 1439,
         "totalLines": 1762
       },
       "tolerance": {
         "missingCoveredLines": 1,
-        "rationale": "Two clean local Node 22/V8 runs on 2026-07-16 each passed 959 tests and measured the identical 1762-line core scope at 1438 covered lines after the independently reviewed issue #130 correction. The reviewed high-water is unchanged: routing tag-renderer storage through the fault-containing browser-storage adapter added three executable core lines, two covered and one recovery branch outside the existing tag-renderer tests; the follow-up registered-activation, canonical-integer, and pre-auth-diagnostic fixes live in the classic loader and test harness and therefore do not alter this core scope. The existing one-line tolerance is unchanged and permits only negligible instrumentation variance."
+        "rationale": "Two clean local Node 22/V8 runs on 2026-07-16 each passed 970 tests and measured the unchanged 1762-line core scope at 1439 covered lines. The deterministic issue #87 viewshow regression now drives bookmark detail-request retirement through the real lifecycle and covers the existing dom-observer replacement diagnostic; no production core line was added. The reviewed high-water therefore advances by one covered line. The existing one-line tolerance is unchanged and permits only the previously reproduced negligible instrumentation variance; coverage-baseline.test.js retains exact below-floor, above-baseline, scope-change, and broad-tolerance negative boundaries."
       }
     },
     "server": {


### PR DESCRIPTION
Closes #87

## Outcome

Replaces the single bookmark item-detail cache slot with bounded, identity-owned settled and in-flight caches. A late request for item A can no longer overwrite, clear, or publish into item B's marker or modal after navigation, server change, or account change.

## Implementation

- keys ownership by `{serverId, userId, itemId}` plus the current identity epoch;
- separates bounded settled and pending LRU maps, coalesces same-key flights, and uses exact symbol ownership on completion;
- applies 15-second success, 1-second negative, and 500ms failure TTLs with a 32-entry bound;
- aborts evicted/retired work, passes `AbortSignal` through item and parent-series reads, and validates returned item IDs;
- fences marker/modal publication by exact current media, video, identity, epoch, and navigation generation;
- clears all cache state on identity reset and retires old view work on `viewshow`.

## Validation

- focused bookmark cache/identity/navigation regressions: 35/35 passed;
- full client coverage: 148 files, 970/970 tests, exact 1439/1762 reviewed core lines;
- coverage policy guards: 13/13; existing one-line tolerance unchanged;
- scripts: 346/346;
- source and legacy typechecks, bundle, syntax, and performance guard passed;
- lint: 0 errors, advisory warnings under the existing cap;
- `git diff --check`: passed.

## Independent review

A separate Codex agent APPROVED the original exact commit and then freshly APPROVED rebased exact commit `0ba3f5517f6127668cfb2ec727e523484a10cc97`. It independently reran 35 focused tests and the 13 coverage-policy guards, verified semantic range equivalence, bounds, cache/in-flight ownership, abort behavior, A/B completion orders, identity/navigation fences, and the merged #73 baseline resolution. The requested Fabel/Claude reviewer was unavailable in this environment, so an independent Codex agent was used as the disclosed substitute.
