### PR TITLE
fix(seerr): fence capability status and rendered controls

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/api.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/api.ts
@@ -120,6 +120,11 @@ const api = {} as SeerrApi;
 let cachedUserStatus: SeerrUserStatus | null = null;
 let cachedUserStatusAt = 0;
 let cachedUserStatusEpoch: number | null = null;
+// Identity changes are not the only boundary that retires capability work.
+// A live config refresh can replace the Seerr source, credentials and 4K
+// switches without changing the Jellyfin user. Fence pending status reads by a
+// local generation so an old-source answer cannot repopulate the new cache.
+let userStatusGeneration = 0;
 const NEGATIVE_USER_STATUS_TTL_MS = 60 * 1000;
 // PERF(R9): a TRANSIENT transport failure (no answer from the server at all)
 // is remembered even more briefly than a genuine negative answer — one blip
@@ -148,11 +153,26 @@ function assertCurrentIdentity(context: IdentityContext): void {
     if (!JC.identity.isCurrent(context)) throw identityChangedError();
 }
 
-function resetIdentityCaches(): void {
+function statusGenerationChangedError(): Error {
+    const error = new Error('Seerr user status belongs to a stale configuration');
+    error.name = 'AbortError';
+    return error;
+}
+
+function assertCurrentUserStatusGeneration(generation: number): void {
+    if (generation !== userStatusGeneration) throw statusGenerationChangedError();
+}
+
+function retireUserStatusCache(): void {
+    userStatusGeneration += 1;
     cachedUserStatus = null;
     cachedUserStatusAt = 0;
     cachedUserStatusEpoch = null;
     cachedUserStatusTtl = NEGATIVE_USER_STATUS_TTL_MS;
+}
+
+function resetIdentityCaches(): void {
+    retireUserStatusCache();
     cachedOverrideRules = null;
     overrideRulesCachedAt = 0;
     overrideRulesEpoch = null;
@@ -268,6 +288,7 @@ function emitMediaRequested(tmdbId: any, mediaType: any, is4k = false): void {
  */
 api.checkUserStatus = async function() {
     const context = captureIdentity();
+    const generation = userStatusGeneration;
     if (cachedUserStatus !== null && cachedUserStatusEpoch === context.epoch) {
         // Successful result is sticky for the SPA session.
         if (cachedUserStatus.active && cachedUserStatus.userFound) {
@@ -284,6 +305,7 @@ api.checkUserStatus = async function() {
     try {
         const status = await get('/user-status', { skipCache: true }) as unknown as SeerrUserStatus;
         assertCurrentIdentity(context);
+        assertCurrentUserStatusGeneration(generation);
         cachedUserStatus = status;
         cachedUserStatusAt = Date.now();
         cachedUserStatusEpoch = context.epoch;
@@ -294,6 +316,12 @@ api.checkUserStatus = async function() {
         return status;
     } catch (error: unknown) {
         assertCurrentIdentity(context);
+        assertCurrentUserStatusGeneration(generation);
+        // Navigation and config/identity teardown intentionally abort managed
+        // requests. Cancellation is not evidence that Seerr is unavailable:
+        // publishing a negative TTL here strands the newly rendered page on a
+        // false capability even when the next status request succeeds.
+        if ((error as Error | null)?.name === 'AbortError') throw error;
         console.warn(`${logPrefix} Status check failed:`, error);
         const errorShape = error && typeof error === 'object'
             ? error as { responseJSON?: unknown }
@@ -365,9 +393,7 @@ api.surfaceUserStatusBanner = function(status) {
  * don't outlive the page they happened on.
  */
 api.clearUserStatusCache = function() {
-    cachedUserStatus = null;
-    cachedUserStatusAt = 0;
-    cachedUserStatusEpoch = null;
+    retireUserStatusCache();
 };
 
 /**
@@ -1185,3 +1211,8 @@ api.resolveSeerrBaseUrl = function() {
 // Expose the API module on the global JC object
 JC.seerrAPI = api;
 JC.identity.registerReset('seerr-api', resetIdentityCaches);
+// live-config publishes this only after the replacement config is current and
+// old managed requests have been aborted. Retire the module-local capability
+// cache at the same boundary; the generation fence also rejects an old request
+// whose transport ignores or narrowly outruns abort.
+window.addEventListener('jc:config-changed', retireUserStatusCache);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/canrequest4k.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/canrequest4k.test.ts
@@ -69,4 +69,66 @@ describe('seerr api.canRequest4k gating', () => {
         fetchMock.mockResolvedValue({ active: true, userFound: true, canRequest4kMovie: true });
         expect(api().canRequest4k('movie')).toBe(false);
     });
+
+    it('does not memoize a navigation cancellation as an unavailable capability', async () => {
+        setConfig({ SeerrEnable4KRequests: true });
+        const cancellation = new Error('Request was aborted');
+        cancellation.name = 'AbortError';
+        fetchMock
+            .mockRejectedValueOnce(cancellation)
+            .mockResolvedValueOnce({
+                active: true,
+                userFound: true,
+                canRequest4kMovie: true,
+            });
+
+        await expect(api().checkUserStatus()).rejects.toMatchObject({ name: 'AbortError' });
+
+        await expect(api().checkUserStatus()).resolves.toMatchObject({
+            active: true,
+            userFound: true,
+            canRequest4kMovie: true,
+        });
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(api().canRequest4k('movie')).toBe(true);
+    });
+
+    it('retires pending and cached capability work when live config changes', async () => {
+        setConfig({ SeerrEnable4KRequests: true });
+        let resolveOld!: (value: unknown) => void;
+        fetchMock
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises -- deterministic config-generation race
+            .mockImplementationOnce(() => new Promise((resolve) => { resolveOld = resolve; }))
+            .mockResolvedValueOnce({
+                active: true,
+                userFound: true,
+                canRequest4kMovie: false,
+            })
+            .mockResolvedValueOnce({
+                active: true,
+                userFound: true,
+                canRequest4kMovie: true,
+            });
+
+        const oldStatus = api().checkUserStatus();
+        window.dispatchEvent(new CustomEvent('jc:config-changed'));
+        resolveOld({ active: true, userFound: true, canRequest4kMovie: true });
+
+        await expect(oldStatus).rejects.toThrow(/stale configuration/i);
+        await expect(api().checkUserStatus()).resolves.toMatchObject({
+            canRequest4kMovie: false,
+        });
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(api().canRequest4k('movie')).toBe(false);
+
+        // A settled positive/negative status is sticky until this same config
+        // boundary; after it, the next caller must resolve the replacement
+        // source instead of reusing B's cached capability.
+        window.dispatchEvent(new CustomEvent('jc:config-changed'));
+        await expect(api().checkUserStatus()).resolves.toMatchObject({
+            canRequest4kMovie: true,
+        });
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+        expect(api().canRequest4k('movie')).toBe(true);
+    });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/modal.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/modal.ts
@@ -28,6 +28,7 @@ export interface SeerrModalApi {
     create: (options: SeerrModalOptions) => SeerrModalHandle;
     createAdvancedOptionsHTML: (idPrefix: string) => string;
     populateAdvancedOptions: (modalElement: HTMLElement, data: any, idPrefix: string) => void;
+    closeAll: () => void;
 }
 
 declare module '../types/jc' {
@@ -336,9 +337,15 @@ modal.populateAdvancedOptions = function(modalElement, data, idPrefix) {
     cleanups?.add(() => clearInterval(interval));
 };
 
-JC.identity.registerReset('seerr-request-modal', () => {
+modal.closeAll = function(): void {
     for (const active of [...activeModals]) active.destroy();
-});
+};
+
+JC.identity.registerReset('seerr-request-modal', modal.closeAll);
+// Advanced movie/TV/collection modals snapshot the 4K gate in their markup.
+// Close them at a config boundary so no prior-source action remains clickable;
+// reopening after the replacement status settles renders the current gate.
+window.addEventListener('jc:config-changed', modal.closeAll);
 
 // Expose the modal module on the global JC object
 JC.seerrModal = modal;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/more-info-modal/init.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/more-info-modal/init.ts
@@ -316,6 +316,11 @@ JC.identity.registerReset('seerr-more-info-modal', () => {
     moreInfoModal.close(true);
 });
 
+window.addEventListener('jc:config-changed', () => {
+    state.openGeneration += 1;
+    moreInfoModal.close(true);
+});
+
 // Expose helpers used by other modules (e.g., item-details.js for the
 // Series page "Request More" button) so the unrequested-seasons check
 // logic does not need to be duplicated.

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/buttons-capability-refresh.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/buttons-capability-refresh.test.ts
@@ -1,0 +1,90 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+
+describe('rendered Seerr 4K controls across config generations', () => {
+    let capable = true;
+    let resolveStatus!: (status: { active: boolean; userFound: boolean }) => void;
+
+    beforeAll(async () => {
+        document.body.replaceChildren();
+        JC.t = (key: string) => key;
+        JC.escapeHtml = (value: unknown) => String(value);
+        JC.pluginConfig = {
+            SeerrEnable4KRequests: true,
+            SeerrEnable4KTvRequests: true,
+        };
+        await import('../seerr-status');
+        const { internal } = await import('./internal');
+        internal.icons = new Proxy({}, { get: () => '' });
+        internal.analyzeSeasonStatuses = vi.fn(() => null);
+        internal.addDownloadProgressHover = vi.fn();
+        internal.hide4KPopup = vi.fn();
+        internal.show4KPopup = vi.fn();
+        await import('./buttons');
+    });
+
+    beforeEach(() => {
+        document.body.replaceChildren();
+        capable = true;
+        JC.pluginConfig.SeerrEnable4KRequests = true;
+        JC.pluginConfig.SeerrEnable4KTvRequests = true;
+        JC.seerrAPI = {
+            canRequest4k: () => capable,
+            checkUserStatus: vi.fn(() => new Promise((resolve) => { resolveStatus = resolve; })),
+        } as unknown as NonNullable<typeof JC.seerrAPI>;
+    });
+
+    function renderCard(mediaType: 'movie' | 'tv'): HTMLElement {
+        const identity = JC.identity.capture()!;
+        const card = document.createElement('div');
+        card.className = 'seerr-card';
+        card.dataset.jcIdentityOwned = 'true';
+        JC.identity.own(card, identity);
+        const button = document.createElement('button');
+        button.className = 'seerr-request-button';
+        JC.identity.own(button, identity);
+        card.appendChild(button);
+        document.body.appendChild(card);
+        JC.seerrUI!.configureRequestButton(button, {
+            id: mediaType === 'movie' ? 550 : 1399,
+            mediaType,
+            title: `${mediaType} fixture`,
+            mediaInfo: { status: 1, status4k: 1, seasons: [] },
+        }, true, true);
+        return card;
+    }
+
+    function has4k(card: HTMLElement): boolean {
+        return !!card.querySelector('.seerr-split-arrow[data-toggle4k="true"]');
+    }
+
+    async function settle(status: { active: boolean; userFound: boolean }): Promise<void> {
+        resolveStatus(status);
+        await Promise.resolve();
+        await Promise.resolve();
+    }
+
+    it('rebuilds retained movie and TV controls visible-to-hidden then hidden-to-visible', async () => {
+        const movie = renderCard('movie');
+        const tv = renderCard('tv');
+        expect(has4k(movie)).toBe(true);
+        expect(has4k(tv)).toBe(true);
+
+        capable = false;
+        window.dispatchEvent(new CustomEvent('jc:config-changed'));
+        // Prior-generation affordances retire synchronously, before status B.
+        expect(has4k(movie)).toBe(false);
+        expect(has4k(tv)).toBe(false);
+        await settle({ active: true, userFound: true });
+        expect(has4k(movie)).toBe(false);
+        expect(has4k(tv)).toBe(false);
+
+        capable = true;
+        window.dispatchEvent(new CustomEvent('jc:config-changed'));
+        expect(has4k(movie)).toBe(false);
+        expect(has4k(tv)).toBe(false);
+        await settle({ active: true, userFound: true });
+        expect(has4k(movie)).toBe(true);
+        expect(has4k(tv)).toBe(true);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/buttons-capability-refresh.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/buttons-capability-refresh.test.ts
@@ -3,7 +3,7 @@ import { JC } from '../../globals';
 
 describe('rendered Seerr 4K controls across config generations', () => {
     let capable = true;
-    let resolveStatus!: (status: { active: boolean; userFound: boolean }) => void;
+    let statusResolvers: Array<(status: { active: boolean; userFound: boolean }) => void>;
 
     beforeAll(async () => {
         document.body.replaceChildren();
@@ -28,9 +28,10 @@ describe('rendered Seerr 4K controls across config generations', () => {
         capable = true;
         JC.pluginConfig.SeerrEnable4KRequests = true;
         JC.pluginConfig.SeerrEnable4KTvRequests = true;
+        statusResolvers = [];
         JC.seerrAPI = {
             canRequest4k: () => capable,
-            checkUserStatus: vi.fn(() => new Promise((resolve) => { resolveStatus = resolve; })),
+            checkUserStatus: vi.fn(() => new Promise((resolve) => { statusResolvers.push(resolve); })),
         } as unknown as NonNullable<typeof JC.seerrAPI>;
     });
 
@@ -59,7 +60,9 @@ describe('rendered Seerr 4K controls across config generations', () => {
     }
 
     async function settle(status: { active: boolean; userFound: boolean }): Promise<void> {
-        resolveStatus(status);
+        const resolveStatus = statusResolvers.shift();
+        expect(resolveStatus).toBeTypeOf('function');
+        resolveStatus!(status);
         await Promise.resolve();
         await Promise.resolve();
     }
@@ -83,6 +86,32 @@ describe('rendered Seerr 4K controls across config generations', () => {
         window.dispatchEvent(new CustomEvent('jc:config-changed'));
         expect(has4k(movie)).toBe(false);
         expect(has4k(tv)).toBe(false);
+        await settle({ active: true, userFound: true });
+        expect(has4k(movie)).toBe(true);
+        expect(has4k(tv)).toBe(true);
+    });
+
+    it('does not let a settled prior generation repaint after the next config event', async () => {
+        const movie = renderCard('movie');
+        const tv = renderCard('tv');
+
+        window.dispatchEvent(new CustomEvent('jc:config-changed'));
+        expect(has4k(movie)).toBe(false);
+        expect(has4k(tv)).toBe(false);
+
+        // Resolve B, but dispatch C in the same turn before B's fulfillment
+        // microtask can repaint. C must remain the sole render owner.
+        const resolveB = statusResolvers.shift();
+        expect(resolveB).toBeTypeOf('function');
+        resolveB!({ active: true, userFound: true });
+        window.dispatchEvent(new CustomEvent('jc:config-changed'));
+        expect(has4k(movie)).toBe(false);
+        expect(has4k(tv)).toBe(false);
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(has4k(movie)).toBe(false);
+        expect(has4k(tv)).toBe(false);
+
         await settle({ active: true, userFound: true });
         expect(has4k(movie)).toBe(true);
         expect(has4k(tv)).toBe(true);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/buttons.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/buttons.ts
@@ -27,6 +27,71 @@ function isLive(node: unknown, identity: IdentityContext | null | undefined): bo
         && (JC.identity.isOwned(node, identity) || (!!card && JC.identity.isOwned(card, identity)));
 }
 
+interface CapabilityStatus {
+    active: boolean;
+    userFound: boolean;
+}
+
+/**
+ * Rebuild request controls already owned by the current identity. A 4K arrow
+ * is a snapshot of both config and user-status, so leaving that node in place
+ * across a live config generation would retain an authorization affordance
+ * from the prior Seerr source. Replacing the control also retires all listeners
+ * closed over the old capability decision.
+ */
+export function reconcileRenderedCapabilityControls(status: CapabilityStatus): void {
+    const identity = JC.identity.capture();
+    if (!identity || !JC.identity.isCurrent(identity)) return;
+    internal.hide4KPopup?.();
+
+    document.querySelectorAll<HTMLElement>('.seerr-card').forEach((card) => {
+        if (!JC.identity.isOwned(card, identity)) return;
+        const current = card.querySelector<HTMLElement>('.seerr-button-group')
+            || card.querySelector<HTMLButtonElement>('.seerr-request-button');
+        if (!current) return;
+        const dataOwner = current.classList.contains('seerr-button-group')
+            ? current.querySelector<HTMLElement>('.seerr-split-main')
+            : current;
+        const rawItem = dataOwner?.dataset.searchResultItem;
+        if (!rawItem) return;
+
+        let item: any;
+        try {
+            item = JSON.parse(rawItem);
+        } catch {
+            return;
+        }
+        if (!item || (item.mediaType !== 'movie' && item.mediaType !== 'tv')) return;
+
+        const replacement = document.createElement('button');
+        replacement.type = 'button';
+        replacement.className = 'seerr-request-button';
+        replacement.dataset.tmdbId = String(item.id ?? '');
+        replacement.dataset.mediaType = item.mediaType;
+        // Offline/no-user branches return before the ordinary configurators
+        // stamp this data. Retain it so a later settled generation can rebuild
+        // the same control without refetching the card payload.
+        replacement.dataset.searchResultItem = JSON.stringify(item);
+        JC.identity.own(replacement, identity);
+        current.replaceWith(replacement);
+        configureRequestButton(replacement, item, status.active, status.userFound);
+    });
+}
+
+function refreshRenderedCapabilitiesForConfig(): void {
+    const identity = JC.identity.capture();
+    if (!identity || !JC.identity.isCurrent(identity)) return;
+    // Fail closed synchronously while the replacement source/status resolves.
+    reconcileRenderedCapabilityControls({ active: false, userFound: false });
+    void JC.seerrAPI!.checkUserStatus().then((status) => {
+        if (!JC.identity.isCurrent(identity)) return;
+        reconcileRenderedCapabilityControls(status);
+    }).catch(() => {
+        // Cancellation means a newer identity/config/navigation owns the next
+        // render. The synchronous fail-closed controls remain safe meanwhile.
+    });
+}
+
 /**
  * Configures the request button based on item status and type.
  * @param {HTMLElement} button - Button element to configure.
@@ -355,3 +420,5 @@ internal.configureRequestButton = configureRequestButton;
 internal.configureCollectionButton = configureCollectionButton;
 internal.configureTvShowButton = configureTvShowButton;
 internal.configureMovieButton = configureMovieButton;
+
+window.addEventListener('jc:config-changed', refreshRenderedCapabilitiesForConfig);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/buttons.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/buttons.ts
@@ -32,6 +32,13 @@ interface CapabilityStatus {
     userFound: boolean;
 }
 
+// The API cache owns its own config generation, but a status promise can
+// settle after validating generation B and before this module's fulfillment
+// handler runs. Fence the rendered continuation as well so a synchronous
+// config-C event cannot be followed by a stale B repaint in the next
+// microtask.
+let renderedCapabilityRefreshGeneration = 0;
+
 /**
  * Rebuild request controls already owned by the current identity. A 4K arrow
  * is a snapshot of both config and user-status, so leaving that node in place
@@ -79,12 +86,14 @@ export function reconcileRenderedCapabilityControls(status: CapabilityStatus): v
 }
 
 function refreshRenderedCapabilitiesForConfig(): void {
+    const refreshGeneration = ++renderedCapabilityRefreshGeneration;
     const identity = JC.identity.capture();
     if (!identity || !JC.identity.isCurrent(identity)) return;
     // Fail closed synchronously while the replacement source/status resolves.
     reconcileRenderedCapabilityControls({ active: false, userFound: false });
     void JC.seerrAPI!.checkUserStatus().then((status) => {
-        if (!JC.identity.isCurrent(identity)) return;
+        if (refreshGeneration !== renderedCapabilityRefreshGeneration
+            || !JC.identity.isCurrent(identity)) return;
         reconcileRenderedCapabilityControls(status);
     }).catch(() => {
         // Cancellation means a newer identity/config/navigation owns the next

--- a/e2e/seerr-4k-collections.spec.ts
+++ b/e2e/seerr-4k-collections.spec.ts
@@ -31,14 +31,29 @@ async function fetchUserStatus(page: any): Promise<UserStatus> {
     });
 }
 
-/** Resolve user-status, force the admin master switch, then read the gate. */
-async function gateWithAdminToggle(page: any, mediaType: 'movie' | 'tv', adminToggle: boolean): Promise<boolean> {
+/** Resolve status, force the master switch, then render the real split-button owner. */
+async function rendered4kToggle(page: any, mediaType: 'movie' | 'tv', adminToggle: boolean): Promise<boolean> {
     return page.evaluate(async (args: { mediaType: string; adminToggle: boolean }) => {
         const jc = (window as any).JellyfinCanopy;
         await jc.seerrAPI.checkUserStatus(); // ensure capability is resolved
         jc.pluginConfig.SeerrEnable4KRequests = args.adminToggle;
         jc.pluginConfig.SeerrEnable4KTvRequests = args.adminToggle;
-        return jc.seerrAPI.canRequest4k(args.mediaType) as boolean;
+        const identity = jc.identity.capture();
+        const card = document.createElement('div');
+        card.className = 'seerr-card';
+        jc.identity.own(card, identity);
+        const button = document.createElement('button');
+        card.appendChild(button);
+        jc.identity.own(button, identity);
+        jc.seerrUI.configureRequestButton(button, {
+            id: args.mediaType === 'tv' ? 1399 : 550,
+            mediaType: args.mediaType,
+            title: '4K lifecycle fixture',
+            mediaInfo: { status: 1, status4k: 1, seasons: [] },
+        }, true, true);
+        const rendered = !!card.querySelector('.seerr-split-arrow[data-toggle4k="true"]');
+        card.remove();
+        return rendered;
     }, { mediaType, adminToggle });
 }
 
@@ -60,8 +75,8 @@ for (const role of ['admin', 'user'] as Role[]) {
             expect(surface.hasCollectionModal, 'showCollectionRequestModal exposed').toBe(true);
 
             // With the admin master switch OFF, the 4K option is always hidden.
-            expect(await gateWithAdminToggle(page, 'movie', false)).toBe(false);
-            expect(await gateWithAdminToggle(page, 'tv', false)).toBe(false);
+            expect(await rendered4kToggle(page, 'movie', false)).toBe(false);
+            expect(await rendered4kToggle(page, 'tv', false)).toBe(false);
 
             // The user-status endpoint always answers with a typed reason.
             const status = await fetchUserStatus(page);
@@ -69,8 +84,8 @@ for (const role of ['admin', 'user'] as Role[]) {
 
             // With the admin master switch ON, the option follows the server-
             // reported capability + permission — never the toggle alone.
-            const movieOn = await gateWithAdminToggle(page, 'movie', true);
-            const tvOn = await gateWithAdminToggle(page, 'tv', true);
+            const movieOn = await rendered4kToggle(page, 'movie', true);
+            const tvOn = await rendered4kToggle(page, 'tv', true);
 
             if (status.userFound) {
                 // Linked user: the capability fields are present and are booleans,


### PR DESCRIPTION
## Outcome

Fixes #310 by removing the race between Seerr capability status and the rendered movie/TV 4K controls.

## Root cause

A navigation abort was caught as an ordinary status failure and cached as `active:false/userFound:false` for 10 seconds. Later direct status reads could already report the correct user capability while the request-button path continued to consume the cached false result. Configuration transitions also needed independent API and rendered-control generation ownership so settled prior work could not repaint after a newer config had failed controls closed.

## Changes

- never cache cancelled capability reads
- fence status publication by current identity and configuration generation
- synchronously fail existing Seerr request controls closed at every config transition
- rebuild retained movie/TV controls through the real `configureRequestButton` lifecycle
- fence rendered reconciliation with its own monotonic generation
- detach prior DOM/listeners and close 4K, generic-request, collection, and more-info modal snapshots at the transition boundary
- strengthen the browser regression to compare real rendered movie/TV split controls against live current-user status without sleeps or retries
- add deterministic abort, identity/config, retained-control, and same-turn B/C microtask regressions

## Validation

- focused lifecycle regressions: 15/15
- all Seerr tests: 101/101
- full client coverage: 989/989; core 1,439/1,762, required floor 1,438
- script tests: 346/346
- strict source and legacy typechecks
- performance guard: 197 files, 881 ms
- production bundle and syntax checks
- Release build: zero warnings/errors
- lint: zero errors; 5,602 advisory warnings below the reviewed cap
- disposable Jellyfin 12 unstable E2E: admin + user repeated three times, 6/6; exact 2-CPU quota verified; stack torn down

Independent review required two material fix rounds and then APPROVED exact SHA `f506f0e6912ca4329796c43e555bccbe10b0a580`.

This change was developed with AI assistance and independently reviewed.