### PR TITLE
fix(ci): authenticate stable ruleset-history verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,10 +110,13 @@ jobs:
     uses: ./.github/workflows/security-scan.yml
     with:
       verify_repository_policy: true
+    secrets:
+      REPOSITORY_POLICY_TOKEN: ${{ secrets.REPOSITORY_POLICY_TOKEN }}
     permissions:
-      # The called policy-verifier job needs write-level repository identity
-      # so GitHub returns bypass actors; its other jobs stay contents:read.
-      contents: write
+      # The built-in token stays read-only. The called verifier receives its
+      # separately scoped ruleset token through the explicit secret mapping.
+      actions: read
+      contents: read
 
   release:
     name: Build, test, package & publish

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -12,10 +12,13 @@ on:
         required: false
         type: boolean
         default: false
+    secrets:
+      REPOSITORY_POLICY_TOKEN:
+        description: Fine-grained token scoped to this repository with Administration read and write
+        required: true
   schedule:
     # Run every day at 2:00 AM UTC
     - cron: '0 2 * * *'
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -29,10 +32,11 @@ jobs:
     if: github.event_name == 'schedule' || inputs.verify_repository_policy
     runs-on: ubuntu-latest
     permissions:
-      # GitHub omits ruleset bypass actors unless the caller has repository
-      # write access. This trusted main/tag job executes no repository writes;
-      # write scope is used only to make the complete policy readable.
-      contents: write
+      # Contents permission does not grant access to complete ruleset actor
+      # evidence. Keep the built-in token read-only and give only the verifier
+      # step the separately scoped repository secret below.
+      actions: read
+      contents: read
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -55,6 +59,7 @@ jobs:
       - name: Verify live release policy matches the committed contract
         env:
           GH_TOKEN: ${{ github.token }}
+          RULESET_TOKEN: ${{ secrets.REPOSITORY_POLICY_TOKEN }}
         run: node scripts/release/verify-repository-policy.js
 
   # Scan the FULL git history for committed secrets. TruffleHog runs with --json

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -87,6 +87,19 @@ ruleset details, bypass actors, required checks, environment reviewers/admin
 bypass, and tag deployment policies with that declaration. The daily Security
 Scan runs it from reviewed `main`, and every release runs it again on the exact
 tag SHA. API denial or any missing/weakened/different control is blocking.
+GitHub's ordinary ruleset-detail response can omit bypass actors without
+marking the response incomplete, so the verifier also reads a stable current
+ruleset-history version and fails closed if complete evidence is unavailable.
+
+The workflow requires an Actions repository secret named
+`REPOSITORY_POLICY_TOKEN`. Create it from a fine-grained personal access token
+limited to this repository with only **Administration: Read and write** (plus
+GitHub's automatic Metadata read permission), set an expiry/rotation owner, and
+do not add Contents or Actions access. Administration write is unavoidable:
+GitHub requires it for both ruleset-history endpoints, even though this verifier
+performs only reads. Ordinary policy and environment reads use the separate,
+ephemeral `GITHUB_TOKEN` with `actions: read` and `contents: read`; the external
+token enters only the verifier step as `RULESET_TOKEN`.
 
 ## Emergency procedure
 
@@ -151,8 +164,9 @@ The release tools are dependency-free Node and can be run locally:
   required checks, default-branch PR protection, release-tag creation and
   immutability, and the approval environment.
 - `node scripts/release/verify-repository-policy.js` — compares that source of
-  truth with GitHub's live ruleset and environment APIs; requires an
-  authenticated `GH_TOKEN` that can read full ruleset bypass details.
+  truth with GitHub's live ruleset and environment APIs; requires read-only
+  `GH_TOKEN` plus `RULESET_TOKEN` with repository Administration read/write so
+  stable current history supplies complete bypass-actor evidence.
 
 - `node scripts/release/validate-manifest.js manifest.json` — validates the
   manifest: JSON shape, required fields, 4-part versions, MD5 checksum and

--- a/scripts/release/repository-policy.test.js
+++ b/scripts/release/repository-policy.test.js
@@ -97,8 +97,12 @@ test('release reuses exact-SHA Build/Test and Security gates after ancestry proo
     assert.match(release, /needs: \[provenance, quality-gates, security-gates\]/);
     assert.match(security, /pull_request:[\s\S]*?workflow_call:[\s\S]*?verify_repository_policy:/);
     assert.match(release, /security-gates:[\s\S]*?with:\n\s+verify_repository_policy: true/);
-    assert.match(security, /repository-policy:\n\s+name: Repository Policy[\s\S]*?if: github\.event_name == 'schedule' \|\| inputs\.verify_repository_policy[\s\S]*?contents: write[\s\S]*?verify-repository-policy\.js/);
+    assert.match(security, /workflow_call:[\s\S]*?secrets:\n\s+REPOSITORY_POLICY_TOKEN:[\s\S]*?required: true/);
+    assert.doesNotMatch(security, /workflow_dispatch/);
+    assert.match(security, /repository-policy:\n\s+name: Repository Policy[\s\S]*?if: github\.event_name == 'schedule' \|\| inputs\.verify_repository_policy[\s\S]*?actions: read\n\s+contents: read[\s\S]*?verify-repository-policy\.js/);
     assert.match(security, /Checkout reviewed source[\s\S]*?persist-credentials: false/);
+    assert.match(security, /Verify live release policy matches the committed contract\n\s+env:\n\s+GH_TOKEN: \$\{\{ github\.token \}\}\n\s+RULESET_TOKEN: \$\{\{ secrets\.REPOSITORY_POLICY_TOKEN \}\}/);
+    assert.match(release, /security-gates:[\s\S]*?secrets:\n\s+REPOSITORY_POLICY_TOKEN: \$\{\{ secrets\.REPOSITORY_POLICY_TOKEN \}\}[\s\S]*?actions: read\n\s+contents: read/);
     assert.match(release, /actions: write # dispatch required checks for the generated manifest PR/);
     assert.match(release, /gh workflow run "\$workflow" --ref "\$BRANCH"/);
     assert.match(release, /node scripts\/release\/check-dispatch\.js/);

--- a/scripts/release/verify-repository-policy.js
+++ b/scripts/release/verify-repository-policy.js
@@ -8,6 +8,22 @@ const util = require('node:util');
 
 const DEFAULT_POLICY = path.join(__dirname, 'repository-policy.json');
 const API_VERSION = '2026-03-10';
+const RULESET_HISTORY_ATTEMPTS = 3;
+const BYPASS_ACTOR_TYPES = new Set([
+    'Integration',
+    'OrganizationAdmin',
+    'RepositoryRole',
+    'Team',
+    'DeployKey',
+    'User',
+]);
+const BYPASS_MODES = new Set(['always', 'pull_request', 'exempt']);
+const ACTOR_TYPES_REQUIRING_ID = new Set([
+    'Integration',
+    'RepositoryRole',
+    'Team',
+    'User',
+]);
 
 function clone(value) {
     return JSON.parse(JSON.stringify(value));
@@ -23,6 +39,15 @@ function projectObject(actual, expected) {
         key,
         projectObject(actual?.[key], expected[key]),
     ]));
+}
+
+function normalizeBypassActors(ruleset) {
+    return sortBy(ruleset?.bypass_actors || [], actor =>
+        `${actor.actor_type}:${actor.actor_id}`).map(actor => ({
+        actor_id: actor.actor_id,
+        actor_type: actor.actor_type,
+        bypass_mode: actor.bypass_mode,
+    }));
 }
 
 function normalizeRuleset(ruleset, expected) {
@@ -76,12 +101,7 @@ function normalizeRuleset(ruleset, expected) {
             name: ruleset.name,
             target: ruleset.target,
             enforcement: ruleset.enforcement,
-            bypass_actors: sortBy(ruleset.bypass_actors || [], actor =>
-                `${actor.actor_type}:${actor.actor_id}`).map(actor => ({
-                actor_id: actor.actor_id,
-                actor_type: actor.actor_type,
-                bypass_mode: actor.bypass_mode,
-            })),
+            bypass_actors: normalizeBypassActors(ruleset),
             conditions: projectObject(ruleset.conditions, expected.conditions),
             rules: sortBy(rules, rule => rule.type),
         },
@@ -145,21 +165,165 @@ async function fetchJson(fetchImpl, url, token) {
     return response.json();
 }
 
-async function verifyLivePolicy({ policy, token, fetchImpl = globalThis.fetch }) {
-    if (!token) throw new Error('GH_TOKEN is required to verify protected policy details');
+function historyHead(value, rulesetName) {
+    const head = Array.isArray(value) ? value[0] : null;
+    if (!Number.isSafeInteger(head?.version_id) || head.version_id <= 0) {
+        throw new Error(`ruleset ${rulesetName} history did not return a current version`);
+    }
+    return head;
+}
+
+function assertCompleteBypassActors(ruleset, rulesetName) {
+    if (!Object.prototype.hasOwnProperty.call(ruleset, 'bypass_actors')
+        || !Array.isArray(ruleset.bypass_actors)) {
+        throw new Error(
+            `ruleset ${rulesetName} history version has no complete bypass_actors array`
+        );
+    }
+    for (const [index, actor] of ruleset.bypass_actors.entries()) {
+        const label = `ruleset ${rulesetName} history bypass_actors[${index}]`;
+        if (!actor || typeof actor !== 'object' || Array.isArray(actor)) {
+            throw new Error(`${label} is not an actor object`);
+        }
+        if (!BYPASS_ACTOR_TYPES.has(actor.actor_type)) {
+            throw new Error(`${label} has invalid actor_type`);
+        }
+        if (!BYPASS_MODES.has(actor.bypass_mode)) {
+            throw new Error(`${label} has invalid bypass_mode`);
+        }
+        if (ACTOR_TYPES_REQUIRING_ID.has(actor.actor_type)
+            && (!Number.isSafeInteger(actor.actor_id) || actor.actor_id <= 0)) {
+            throw new Error(`${label} requires a positive integer actor_id`);
+        }
+        if (actor.actor_type === 'DeployKey' && actor.actor_id !== null) {
+            throw new Error(`${label} requires a null actor_id for DeployKey`);
+        }
+        if (actor.actor_type === 'OrganizationAdmin'
+            && actor.actor_id !== null
+            && (!Number.isSafeInteger(actor.actor_id) || actor.actor_id <= 0)) {
+            throw new Error(`${label} has invalid OrganizationAdmin actor_id`);
+        }
+        if (actor.bypass_mode === 'pull_request'
+            && (ruleset.target !== 'branch' || actor.actor_type === 'DeployKey')) {
+            throw new Error(`${label} has an invalid pull_request bypass_mode`);
+        }
+    }
+}
+
+async function fetchCompleteRulesetState(fetchImpl, root, summary, token) {
+    const historyUrl = `${root}/rulesets/${summary.id}/history?per_page=1`;
+    let observedVersion = null;
+    for (let attempt = 1; attempt <= RULESET_HISTORY_ATTEMPTS; attempt++) {
+        let before;
+        try {
+            before = historyHead(
+                await fetchJson(fetchImpl, historyUrl, token),
+                summary.name
+            );
+        } catch (error) {
+            throw new Error(
+                `complete bypass-actor evidence is unreadable for ruleset ${summary.name}: `
+                + `${error?.message || error}; REPOSITORY_POLICY_TOKEN must be scoped to this `
+                + 'repository with Administration (read and write)'
+            );
+        }
+
+        const version = await fetchJson(
+            fetchImpl,
+            `${root}/rulesets/${summary.id}/history/${before.version_id}`,
+            token
+        );
+        const after = historyHead(
+            await fetchJson(fetchImpl, historyUrl, token),
+            summary.name
+        );
+        observedVersion = after.version_id;
+        if (before.version_id !== after.version_id) continue;
+        if (version?.version_id !== before.version_id
+            || !version.state
+            || typeof version.state !== 'object'
+            || Array.isArray(version.state)) {
+            throw new Error(`ruleset ${summary.name} history version is malformed`);
+        }
+        assertCompleteBypassActors(version.state, summary.name);
+        return {
+            state: version.state,
+            versionId: version.version_id,
+        };
+    }
+    throw new Error(
+        `ruleset ${summary.name} changed while policy evidence was read; `
+        + `no stable version after ${RULESET_HISTORY_ATTEMPTS} attempts `
+        + `(last version ${observedVersion || 'unknown'})`
+    );
+}
+
+async function verifyLivePolicy({
+    policy,
+    token,
+    rulesetToken = token,
+    fetchImpl = globalThis.fetch,
+}) {
+    if (!token) {
+        throw new Error('GH_TOKEN is required for read-only repository policy APIs');
+    }
+    if (!rulesetToken) {
+        throw new Error(
+            'RULESET_TOKEN is required; Actions must provide REPOSITORY_POLICY_TOKEN '
+            + 'scoped only to this repository with Administration (read and write)'
+        );
+    }
     if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(policy.repository)) {
         throw new Error('policy repository must be owner/name');
     }
     const root = `https://api.github.com/repos/${policy.repository}`;
     const summaries = await fetchJson(fetchImpl, `${root}/rulesets`, token);
     if (!Array.isArray(summaries)) throw new Error('GitHub ruleset response must be an array');
+    const rulesetEvidence = [];
     for (const expected of policy.rulesets) {
         const matches = summaries.filter(ruleset => ruleset.name === expected.name);
         if (matches.length !== 1) {
             throw new Error(`expected exactly one live ruleset named ${expected.name}; found ${matches.length}`);
         }
         const detail = await fetchJson(fetchImpl, `${root}/rulesets/${matches[0].id}`, token);
-        assertContract(`ruleset ${expected.name}`, normalizeRuleset(detail, expected));
+        const complete = await fetchCompleteRulesetState(
+            fetchImpl,
+            root,
+            matches[0],
+            rulesetToken
+        );
+        const detailActors = normalizeBypassActors(detail);
+        const completeActors = normalizeBypassActors(complete.state);
+        let actorSource = 'detail-and-history';
+        if (!util.isDeepStrictEqual(detailActors, completeActors)) {
+            if (detailActors.length !== 0 || completeActors.length === 0) {
+                throw new Error(
+                    `ruleset ${expected.name} returned inconsistent bypass-actor evidence; `
+                    + 'refusing to classify the result as policy drift'
+                );
+            }
+            actorSource = 'history-after-detail-redaction';
+        }
+
+        // The ordinary detail endpoint exposes every non-sensitive policy field
+        // to read-only callers but redacts bypass actors without marking the
+        // response incomplete. Repository ruleset history requires Administration
+        // write permission, so its stable latest version is the capability proof
+        // and complete actor source. Verify both views without treating [] from a
+        // redacted detail response as authoritative policy state.
+        assertContract(
+            `ruleset ${expected.name}`,
+            normalizeRuleset({ ...detail, bypass_actors: completeActors }, expected)
+        );
+        assertContract(
+            `ruleset ${expected.name} version ${complete.versionId}`,
+            normalizeRuleset(complete.state, expected)
+        );
+        rulesetEvidence.push({
+            name: expected.name,
+            versionId: complete.versionId,
+            actorSource,
+        });
     }
 
     const encodedEnvironment = encodeURIComponent(policy.environment.name);
@@ -184,6 +348,7 @@ async function verifyLivePolicy({ policy, token, fetchImpl = globalThis.fetch })
     return {
         repository: policy.repository,
         rulesets: policy.rulesets.map(ruleset => ruleset.name),
+        rulesetEvidence,
         environment: policy.environment.name,
     };
 }
@@ -209,14 +374,29 @@ function parseArgs(argv) {
 async function main(argv) {
     const args = parseArgs(argv);
     const policy = JSON.parse(fs.readFileSync(path.resolve(args.policy), 'utf8'));
-    const result = await verifyLivePolicy({ policy, token: process.env.GH_TOKEN });
+    const result = await verifyLivePolicy({
+        policy,
+        token: process.env.GH_TOKEN,
+        rulesetToken: process.env.RULESET_TOKEN,
+    });
+    const recovered = result.rulesetEvidence
+        .filter(evidence => evidence.actorSource === 'history-after-detail-redaction');
     const message = `Verified ${result.rulesets.length} release rulesets and environment ${result.environment}`;
     process.stdout.write(`${message}\n`);
+    if (recovered.length > 0) {
+        process.stdout.write(
+            `::notice title=Ruleset actor evidence::Detailed reads redacted bypass actors for `
+            + `${recovered.map(evidence => evidence.name).join(', ')}; `
+            + 'verified stable current ruleset history instead\n'
+        );
+    }
     if (process.env.GITHUB_STEP_SUMMARY) {
         fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, [
             '### Repository release policy',
             `- Repository: \`${result.repository}\``,
             `- Rulesets: ${result.rulesets.map(name => `\`${name}\``).join(', ')}`,
+            `- Complete bypass-actor evidence: stable current ruleset history (${result.rulesetEvidence.map(evidence => `\`${evidence.name}\` v${evidence.versionId}`).join(', ')})`,
+            `- Detail redaction recovered: ${recovered.length > 0 ? recovered.map(evidence => `\`${evidence.name}\``).join(', ') : 'none'}`,
             `- Approval environment: \`${result.environment}\``,
             '- Result: live GitHub policy matches the committed contract',
             '',

--- a/scripts/release/verify-repository-policy.test.js
+++ b/scripts/release/verify-repository-policy.test.js
@@ -48,6 +48,14 @@ function liveState() {
     return {
         rulesets,
         environment,
+        redactDetailRuleIds: [],
+        historyStatus: 200,
+        historyHeadSequence: {},
+        historyHeadReads: {},
+        malformedHistoryVersionIds: [],
+        omitHistoryBypassActorIds: [],
+        historyBypassActorOverrides: {},
+        requests: [],
         branchPolicies: {
             total_count: policy.environment.deployment_policies.length,
             branch_policies: clone(policy.environment.deployment_policies),
@@ -56,23 +64,64 @@ function liveState() {
 }
 
 function fakeFetch(state) {
-    return async url => {
+    return async (url, options) => {
         const pathname = new URL(url).pathname;
+        state.requests.push({
+            pathname,
+            authorization: options?.headers?.Authorization,
+        });
         let body;
+        let status = 200;
         if (pathname.endsWith('/rulesets')) {
             body = state.rulesets.map(({ id, name, target, enforcement }) =>
                 ({ id, name, target, enforcement }));
+        } else if (/\/rulesets\/\d+\/history\/\d+$/.test(pathname)) {
+            const parts = pathname.split('/');
+            const id = Number(parts.at(-3));
+            const versionId = Number(parts.at(-1));
+            const rulesetState = clone(state.rulesets.find(ruleset => ruleset.id === id));
+            if (state.omitHistoryBypassActorIds.includes(id)) {
+                delete rulesetState.bypass_actors;
+            }
+            if (Object.prototype.hasOwnProperty.call(state.historyBypassActorOverrides, id)) {
+                rulesetState.bypass_actors = clone(state.historyBypassActorOverrides[id]);
+            }
+            body = {
+                version_id: versionId,
+                actor: { id: policy.maintainer.id, type: 'User' },
+                updated_at: '2026-07-15T01:28:18Z',
+                state: rulesetState,
+            };
+            if (state.malformedHistoryVersionIds.includes(id)) body.state = null;
+        } else if (/\/rulesets\/\d+\/history$/.test(pathname)) {
+            const id = Number(pathname.split('/').at(-2));
+            if (state.historyStatus !== 200) {
+                status = state.historyStatus;
+            } else {
+                const reads = state.historyHeadReads[id] || 0;
+                state.historyHeadReads[id] = reads + 1;
+                const sequence = state.historyHeadSequence[id] || [id + 1_000];
+                const versionId = sequence[Math.min(reads, sequence.length - 1)];
+                body = [{
+                    version_id: versionId,
+                    actor: { id: policy.maintainer.id, type: 'User' },
+                    updated_at: '2026-07-15T01:28:18Z',
+                }];
+            }
         } else if (/\/rulesets\/\d+$/.test(pathname)) {
             const id = Number(pathname.split('/').at(-1));
             body = state.rulesets.find(ruleset => ruleset.id === id);
+            if (body && state.redactDetailRuleIds.includes(id)) {
+                body = { ...body, bypass_actors: [] };
+            }
         } else if (pathname.endsWith('/deployment-branch-policies')) {
             body = state.branchPolicies;
         } else if (pathname.endsWith('/environments/release')) {
             body = state.environment;
         }
         return {
-            ok: body !== undefined,
-            status: body === undefined ? 404 : 200,
+            ok: status === 200 && body !== undefined,
+            status: status === 200 && body === undefined ? 404 : status,
             json: async () => clone(body),
         };
     };
@@ -81,16 +130,66 @@ function fakeFetch(state) {
 async function verify(state) {
     return verifyLivePolicy({
         policy,
-        token: 'test-token',
+        token: 'read-token',
+        rulesetToken: 'ruleset-token',
         fetchImpl: fakeFetch(state),
     });
 }
 
 test('exact live policy passes with GitHub-normalized tag update parameters', async () => {
-    const result = await verify(liveState());
+    const state = liveState();
+    const result = await verify(state);
     assert.equal(result.repository, policy.repository);
     assert.equal(result.rulesets.length, 3);
+    assert.equal(result.rulesetEvidence.length, 3);
+    assert.ok(result.rulesetEvidence.every(evidence =>
+        evidence.actorSource === 'detail-and-history'));
     assert.equal(result.environment, 'release');
+    assert.equal(state.requests.filter(request =>
+        /\/rulesets\/\d+\/history(?:\/\d+)?$/.test(request.pathname)).length, 9);
+    for (const request of state.requests) {
+        if (/\/rulesets\/\d+\/history(?:\/\d+)?$/.test(request.pathname)) {
+            assert.equal(request.authorization, 'Bearer ruleset-token');
+        } else {
+            assert.equal(request.authorization, 'Bearer read-token');
+        }
+    }
+});
+
+test('redacted detail actors are recovered from stable privileged history', async () => {
+    const state = liveState();
+    state.redactDetailRuleIds = state.rulesets.map(ruleset => ruleset.id);
+    const result = await verify(state);
+
+    const creation = result.rulesetEvidence
+        .find(evidence => evidence.name === 'Restrict release tag creation');
+    assert.equal(creation.actorSource, 'history-after-detail-redaction');
+    assert.ok(result.rulesetEvidence
+        .filter(evidence => evidence.name !== creation.name)
+        .every(evidence => evidence.actorSource === 'detail-and-history'));
+});
+
+test('genuine actor drift remains blocking when ordinary detail actors are redacted', async () => {
+    const state = liveState();
+    state.redactDetailRuleIds = state.rulesets.map(ruleset => ruleset.id);
+    state.rulesets[0].bypass_actors.push({
+        actor_id: policy.maintainer.id,
+        actor_type: 'User',
+        bypass_mode: 'always',
+    });
+
+    await assert.rejects(verify(state), /drifted from repository-policy/);
+});
+
+test('a ruleset history race retries but never accepts an unstable snapshot', async () => {
+    const recovered = liveState();
+    recovered.historyHeadSequence[100] = [1_100, 1_101, 1_101, 1_101];
+    await verify(recovered);
+    assert.equal(recovered.historyHeadReads[100], 4);
+
+    const unstable = liveState();
+    unstable.historyHeadSequence[100] = [1_100, 1_101, 1_102, 1_103, 1_104, 1_105];
+    await assert.rejects(verify(unstable), /no stable version after 3 attempts/);
 });
 
 test('an explicit false tag-update parameter remains compatible', async () => {
@@ -126,6 +225,14 @@ test('weakened enforcement, status checks, or immutable-tag bypasses are detecte
             };
         },
         state => { state.rulesets[2].bypass_actors.push({ actor_id: 45441845, actor_type: 'User', bypass_mode: 'always' }); },
+        state => {
+            state.redactDetailRuleIds = state.rulesets.map(ruleset => ruleset.id);
+            state.rulesets[0].bypass_actors.push({
+                actor_id: 45441845,
+                actor_type: 'User',
+                bypass_mode: 'always',
+            });
+        },
     ];
     for (const mutate of mutations) {
         const state = liveState();
@@ -151,13 +258,65 @@ test('missing authentication and API failures are blocking', async () => {
     await assert.rejects(verifyLivePolicy({
         policy,
         token: '',
+        rulesetToken: 'test-token',
         fetchImpl: fakeFetch(liveState()),
     }), /GH_TOKEN is required/);
     await assert.rejects(verifyLivePolicy({
         policy,
         token: 'test-token',
+        rulesetToken: '',
+        fetchImpl: fakeFetch(liveState()),
+    }), /RULESET_TOKEN is required.*Administration \(read and write\)/);
+    await assert.rejects(verifyLivePolicy({
+        policy,
+        token: 'test-token',
         fetchImpl: async () => ({ ok: false, status: 403 }),
     }), /GitHub API 403/);
+
+    const unreadable = liveState();
+    unreadable.historyStatus = 403;
+    await assert.rejects(
+        verify(unreadable),
+        /complete bypass-actor evidence is unreadable.*Administration \(read and write\)/
+    );
+
+    const malformedHead = liveState();
+    malformedHead.historyHeadSequence[100] = [null];
+    await assert.rejects(
+        verify(malformedHead),
+        /history did not return a current version/
+    );
+
+    const malformedVersion = liveState();
+    malformedVersion.malformedHistoryVersionIds.push(100);
+    await assert.rejects(
+        verify(malformedVersion),
+        /history version is malformed/
+    );
+
+    const omittedEmptyActors = liveState();
+    omittedEmptyActors.omitHistoryBypassActorIds.push(100);
+    await assert.rejects(
+        verify(omittedEmptyActors),
+        /has no complete bypass_actors array/
+    );
+
+    const invalidActors = [
+        null,
+        { actor_id: policy.maintainer.id, actor_type: 'User' },
+        { actor_id: '45441845', actor_type: 'User', bypass_mode: 'always' },
+        { actor_id: policy.maintainer.id, actor_type: 'Unknown', bypass_mode: 'always' },
+        { actor_id: 1, actor_type: 'DeployKey', bypass_mode: 'always' },
+        { actor_id: null, actor_type: 'DeployKey', bypass_mode: 'pull_request' },
+    ];
+    for (const actor of invalidActors) {
+        const malformedActor = liveState();
+        malformedActor.historyBypassActorOverrides[100] = [actor];
+        await assert.rejects(
+            verify(malformedActor),
+            /history bypass_actors\[0\]/
+        );
+    }
 });
 
 test('policy CLI rejects unknown, duplicate, and flag-shaped values', () => {


### PR DESCRIPTION
## Summary

- split scheduled repository-policy verification between the built-in GitHub token and a narrowly scoped ruleset-history credential
- fail closed when stable history omits or malforms bypass-actor evidence
- keep the privileged path restricted to trusted default-branch schedules and release provenance
- document the required `REPOSITORY_POLICY_TOKEN` permissions and setup

## Validation

- 349 script tests passed
- repository-policy live verifier passed
- workflow YAML parsed successfully
- ESLint completed with 0 errors
- Markdown links passed

Tracks #313

## Deployment note

The code can merge safely, but closing #313 still requires explicit owner authorization to configure the `REPOSITORY_POLICY_TOKEN` repository secret and a subsequent green scheduled verification.