### PR TITLE
fix(hidden-content): preserve typed provider identities

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Configuration/PersistedPayloadPolicyTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Configuration/PersistedPayloadPolicyTests.cs
@@ -254,6 +254,43 @@ public sealed class PersistedPayloadPolicyTests
     }
 
     [Fact]
+    public void HiddenContent_VersionedIdentity_IsValidatedAndClonedWithoutAliasing()
+    {
+        var identity = new HiddenContentIdentity
+        {
+            Version = 1,
+            Provider = "tmdb",
+            MediaType = "movie",
+            Id = "550"
+        };
+        var payload = new UserHiddenContent
+        {
+            Items = new Dictionary<string, HiddenContentItem>
+            {
+                ["hc1:tmdb:movie:550"] = new HiddenContentItem { TmdbId = "550", Identity = identity }
+            }
+        };
+
+        Assert.True(PersistedPayloadPolicy.Validate(payload).IsValid);
+        var clone = PersistedPayloadPolicy.CloneValidated(payload);
+        Assert.NotSame(identity, clone.Items["hc1:tmdb:movie:550"].Identity);
+        Assert.Equal("movie", clone.Items["hc1:tmdb:movie:550"].Identity?.MediaType);
+
+        identity.MediaType = "tv";
+        Assert.True(PersistedPayloadPolicy.Validate(payload).IsValid);
+        identity.Provider = "other";
+        AssertHiddenInvalid("key", new HiddenContentItem { TmdbId = "550", Identity = identity });
+        identity.Provider = "tmdb";
+        identity.Version = 2;
+        AssertHiddenInvalid("key", new HiddenContentItem { TmdbId = "550", Identity = identity });
+        identity.Version = 1;
+        identity.Id = "movie-550";
+        AssertHiddenInvalid("key", new HiddenContentItem { TmdbId = "movie-550", Identity = identity });
+        identity.Id = "551";
+        AssertHiddenInvalid("key", new HiddenContentItem { TmdbId = "550", Identity = identity });
+    }
+
+    [Fact]
     public void AggregateByteBudget_AcceptsExactBoundaryAndRejectsNPlusOne()
     {
         Assert.True(PersistedPayloadPolicy.ValidateByteCount(1024, 1024).IsValid);

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Configuration/UserFileFormatGoldenTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Configuration/UserFileFormatGoldenTests.cs
@@ -196,6 +196,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Configuration
                         Name = "Inception",
                         Type = "Movie",
                         TmdbId = "27205",
+                        Identity = new HiddenContentIdentity
+                        {
+                            Version = 1,
+                            Provider = "tmdb",
+                            MediaType = "movie",
+                            Id = "27205"
+                        },
                         HiddenAt = "2024-06-01T08:00:00.000Z",
                         PosterPath = "/poster.jpg",
                         HideScope = "global",
@@ -227,6 +234,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Configuration
 
             var back = _manager.GetUserConfiguration<UserHiddenContent>(UserId, "hidden-content.json");
             Assert.Null(back.Items["movie-27205"].SeasonNumber);
+            Assert.Equal("movie", back.Items["movie-27205"].Identity?.MediaType);
             Assert.Equal(2, back.Items["episode-42"].SeasonNumber);
             Assert.True(back.Settings.FilterSearch);
             Assert.False(back.Settings.ShowHideConfirmation);

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/HiddenContentPayloadControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/HiddenContentPayloadControllerTests.cs
@@ -143,6 +143,46 @@ public sealed class HiddenContentPayloadControllerTests : IDisposable
         Assert.Contains("items=1", fileText, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void AdminHide_UsesTypedProviderKeysAndNeverCreatesAnAmbiguousBareTmdbRow()
+    {
+        _manager.SaveUserConfiguration(UserId, "hidden-content.json", new UserHiddenContent
+        {
+            Items = new Dictionary<string, HiddenContentItem>
+            {
+                ["tmdb-549"] = new() { Name = "Legacy movie", Type = "Movie", TmdbId = "549" }
+            }
+        });
+        var controller = Controller(NullLogger<HiddenContentController>.Instance);
+        var result = controller.AdminHideForUser(UserId, new List<HiddenContentItem>
+        {
+            new() { Name = "Legacy movie", Type = "Movie", TmdbId = "549" },
+            new() { Name = "Movie 550", Type = "Movie", TmdbId = "550" },
+            new() { Name = "TV 550", Type = "Series", TmdbId = "550" },
+            new() { Name = "Ambiguous 551", TmdbId = "551" },
+            new() { ItemId = "jf-exact", Name = "Local", TmdbId = "552" }
+        });
+
+        Assert.IsType<OkObjectResult>(result);
+        var stored = _manager.GetUserConfigurationStrict<UserHiddenContent>(UserId, "hidden-content.json");
+        Assert.Equal(4, stored.Items.Count);
+        Assert.True(stored.Items.ContainsKey("tmdb-549"));
+        Assert.False(stored.Items.ContainsKey("hc1:tmdb:movie:549"));
+        Assert.Equal("movie", stored.Items["hc1:tmdb:movie:550"].Identity?.MediaType);
+        Assert.Equal("tv", stored.Items["hc1:tmdb:tv:550"].Identity?.MediaType);
+        Assert.True(stored.Items.ContainsKey("jf-exact"));
+        Assert.Equal(
+            new[] { "tmdb-549" },
+            stored.Items.Keys.Where(static key => key.StartsWith("tmdb-", StringComparison.Ordinal)));
+
+        Assert.IsType<OkObjectResult>(controller.AdminUnhideForUser(
+            UserId,
+            new List<string> { "hc1:tmdb:movie:550" }));
+        stored = _manager.GetUserConfigurationStrict<UserHiddenContent>(UserId, "hidden-content.json");
+        Assert.False(stored.Items.ContainsKey("hc1:tmdb:movie:550"));
+        Assert.True(stored.Items.ContainsKey("hc1:tmdb:tv:550"));
+    }
+
     private HiddenContentController Controller(ILogger<HiddenContentController> logger)
     {
         var controller = new HiddenContentController(

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/HiddenContentPayloadControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/HiddenContentPayloadControllerTests.cs
@@ -6,6 +6,7 @@ using Jellyfin.Plugin.JellyfinCanopy.Logging;
 using Jellyfin.Plugin.JellyfinCanopy.Services;
 using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
 using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using MediaBrowser.Controller.Entities.Movies;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -183,7 +184,220 @@ public sealed class HiddenContentPayloadControllerTests : IDisposable
         Assert.True(stored.Items.ContainsKey("hc1:tmdb:tv:550"));
     }
 
-    private HiddenContentController Controller(ILogger<HiddenContentController> logger)
+    [Fact]
+    public void AdminHide_SkipsInvalidExplicitIdentitiesAndPreservesDistinctExactItems()
+    {
+        var controller = Controller(NullLogger<HiddenContentController>.Instance);
+        var result = controller.AdminHideForUser(UserId, new List<HiddenContentItem>
+        {
+            new()
+            {
+                ItemId = "jf-1",
+                Name = "Edition one",
+                Type = "Movie",
+                TmdbId = "550",
+                Identity = new HiddenContentIdentity
+                {
+                    Version = 1,
+                    Provider = "tmdb",
+                    MediaType = "movie",
+                    Id = "550"
+                }
+            },
+            new()
+            {
+                ItemId = "jf-2",
+                Name = "Edition two",
+                Type = "Movie",
+                TmdbId = "550",
+                Identity = new HiddenContentIdentity
+                {
+                    Version = 1,
+                    Provider = "tmdb",
+                    MediaType = "movie",
+                    Id = "550"
+                }
+            },
+            new()
+            {
+                ItemId = "future",
+                Type = "Movie",
+                TmdbId = "551",
+                Identity = new HiddenContentIdentity
+                {
+                    Version = 2,
+                    Provider = "tmdb",
+                    MediaType = "movie",
+                    Id = "551"
+                }
+            },
+            new()
+            {
+                ItemId = "malformed",
+                Type = "Movie",
+                TmdbId = "552",
+                Identity = new HiddenContentIdentity
+                {
+                    Version = 1,
+                    Provider = "tmdb",
+                    MediaType = "movie",
+                    Id = "not-decimal"
+                }
+            }
+        });
+
+        Assert.IsType<OkObjectResult>(result);
+        var stored = _manager.GetUserConfigurationStrict<UserHiddenContent>(UserId, "hidden-content.json");
+        Assert.Equal(new[] { "jf-1", "jf-2" }, stored.Items.Keys.Order(StringComparer.Ordinal));
+        Assert.All(stored.Items.Values, item =>
+        {
+            Assert.Equal("550", item.TmdbId);
+            Assert.Equal("movie", item.Identity?.MediaType);
+        });
+    }
+
+    [Fact]
+    public void ScopedHide_AtomicallyPrefersAlternateTypedMetadataOverCanonicalLegacyMetadata()
+    {
+        var itemId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+        var dashed = itemId.ToString();
+        var compact = itemId.ToString("N");
+        _manager.SaveUserConfiguration(UserId, "hidden-content.json", new UserHiddenContent
+        {
+            Items = new Dictionary<string, HiddenContentItem>
+            {
+                [dashed] = new()
+                {
+                    ItemId = dashed,
+                    Name = "Legacy Movie 550",
+                    TmdbId = "550",
+                    HideScope = "continuewatching"
+                },
+                [compact] = new()
+                {
+                    ItemId = compact,
+                    Name = "Movie 551",
+                    Type = "Movie",
+                    TmdbId = "551",
+                    Identity = new HiddenContentIdentity
+                    {
+                        Version = 1,
+                        Provider = "tmdb",
+                        MediaType = "movie",
+                        Id = "551"
+                    },
+                    HideScope = "nextup"
+                }
+            }
+        });
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdUserHook = (id, _) => id == itemId
+                ? new Movie { Id = itemId, Name = "Movie 550" }
+                : null
+        };
+
+        var result = Controller(NullLogger<HiddenContentController>.Instance, library)
+            .HideFromContinueWatching(compact);
+
+        Assert.IsType<OkObjectResult>(result);
+        var stored = _manager.GetUserConfigurationStrict<UserHiddenContent>(UserId, "hidden-content.json");
+        var item = Assert.Single(stored.Items, pair => pair.Key == dashed).Value;
+        Assert.Equal(dashed, item.ItemId);
+        Assert.Equal("551", item.TmdbId);
+        Assert.Equal("movie", item.Identity?.MediaType);
+        Assert.Equal("551", item.Identity?.Id);
+        Assert.Equal("homesections", item.HideScope);
+    }
+
+    [Fact]
+    public void ScopedHide_ReconcilesFreshTypedIdentityWithLegacyTmdbMetadata()
+    {
+        var itemId = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+        var dashed = itemId.ToString();
+        var compact = itemId.ToString("N");
+        _manager.SaveUserConfiguration(UserId, "hidden-content.json", new UserHiddenContent
+        {
+            Items = new Dictionary<string, HiddenContentItem>
+            {
+                [compact] = new()
+                {
+                    ItemId = compact,
+                    Name = "Legacy Movie 550",
+                    Type = "Movie",
+                    TmdbId = "550",
+                    HideScope = "continuewatching"
+                }
+            }
+        });
+        var movie = new Movie { Id = itemId, Name = "Movie 551" };
+        movie.ProviderIds["Tmdb"] = "551";
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdUserHook = (id, _) => id == itemId ? movie : null
+        };
+
+        var result = Controller(NullLogger<HiddenContentController>.Instance, library)
+            .HideFromNextUp(dashed);
+
+        Assert.IsType<OkObjectResult>(result);
+        var stored = _manager.GetUserConfigurationStrict<UserHiddenContent>(UserId, "hidden-content.json");
+        var item = Assert.Single(stored.Items, pair => pair.Key == dashed).Value;
+        Assert.Equal("551", item.TmdbId);
+        Assert.Equal("tmdb", item.Identity?.Provider);
+        Assert.Equal("movie", item.Identity?.MediaType);
+        Assert.Equal("551", item.Identity?.Id);
+        Assert.Equal("homesections", item.HideScope);
+    }
+
+    [Fact]
+    public void ScopedHide_PreservesUnsupportedIdentityAndTmdbAsAnOpaquePair()
+    {
+        var itemId = Guid.Parse("99999999-8888-7777-6666-555555555555");
+        var dashed = itemId.ToString();
+        _manager.SaveUserConfiguration(UserId, "hidden-content.json", new UserHiddenContent
+        {
+            Items = new Dictionary<string, HiddenContentItem>
+            {
+                [dashed] = new()
+                {
+                    ItemId = dashed,
+                    Name = "Future identity",
+                    Type = "Movie",
+                    TmdbId = "550",
+                    Identity = new HiddenContentIdentity
+                    {
+                        Version = 2,
+                        Provider = "imdb",
+                        MediaType = "movie",
+                        Id = "tt123"
+                    },
+                    HideScope = "continuewatching"
+                }
+            }
+        });
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdUserHook = (id, _) => id == itemId
+                ? new Movie { Id = itemId, Name = "Future identity" }
+                : null
+        };
+
+        var result = Controller(NullLogger<HiddenContentController>.Instance, library)
+            .HideFromContinueWatching(dashed);
+
+        Assert.IsType<OkObjectResult>(result);
+        var stored = _manager.GetUserConfigurationStrict<UserHiddenContent>(UserId, "hidden-content.json");
+        var item = Assert.Single(stored.Items).Value;
+        Assert.Equal("550", item.TmdbId);
+        Assert.Equal(2, item.Identity?.Version);
+        Assert.Equal("imdb", item.Identity?.Provider);
+        Assert.Equal("tt123", item.Identity?.Id);
+    }
+
+    private HiddenContentController Controller(
+        ILogger<HiddenContentController> logger,
+        CountingLibraryManager? libraryManager = null)
     {
         var controller = new HiddenContentController(
             new RecordingHttpClientFactory(new HttpClientHandler()),
@@ -192,7 +406,7 @@ public sealed class HiddenContentPayloadControllerTests : IDisposable
             new SeerrCache(_provider),
             _provider,
             _manager,
-            new CountingLibraryManager());
+            libraryManager ?? new CountingLibraryManager());
         controller.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Snapshots/UserFiles/hidden-content.write.json
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Snapshots/UserFiles/hidden-content.write.json
@@ -5,6 +5,12 @@
       "Name": "Inception",
       "Type": "Movie",
       "TmdbId": "27205",
+      "Identity": {
+        "Version": 1,
+        "Provider": "tmdb",
+        "MediaType": "movie",
+        "Id": "27205"
+      },
       "HiddenAt": "2024-06-01T08:00:00.000Z",
       "PosterPath": "/poster.jpg",
       "SeriesId": "",

--- a/Jellyfin.Plugin.JellyfinCanopy/Configuration/PersistedPayloadPolicy.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Configuration/PersistedPayloadPolicy.cs
@@ -122,6 +122,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Configuration
                     Name = item.Name ?? string.Empty,
                     Type = item.Type ?? string.Empty,
                     TmdbId = item.TmdbId ?? string.Empty,
+                    Identity = item.Identity == null ? null : new HiddenContentIdentity
+                    {
+                        Version = item.Identity.Version,
+                        Provider = item.Identity.Provider ?? string.Empty,
+                        MediaType = item.Identity.MediaType ?? string.Empty,
+                        Id = item.Identity.Id ?? string.Empty
+                    },
                     HiddenAt = item.HiddenAt ?? string.Empty,
                     PosterPath = item.PosterPath ?? string.Empty,
                     SeriesId = item.SeriesId ?? string.Empty,
@@ -257,6 +264,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Configuration
                 && IsOptionalBoundedString(item.Name, 512)
                 && IsOptionalBoundedString(item.Type, 64)
                 && IsOptionalBoundedString(item.TmdbId, 32)
+                && IsValidHiddenIdentity(item.Identity)
+                && (item.Identity == null || string.IsNullOrEmpty(item.TmdbId)
+                    || string.Equals(item.Identity.Id, item.TmdbId, StringComparison.Ordinal))
                 && IsOptionalBoundedString(item.HiddenAt, 64)
                 && IsOptionalBoundedString(item.PosterPath, 512)
                 && IsOptionalBoundedString(item.SeriesId, 128)
@@ -264,6 +274,26 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Configuration
                 && IsOptionalNonNegativeRange(item.SeasonNumber, 100_000)
                 && IsOptionalNonNegativeRange(item.EpisodeNumber, 100_000)
                 && item.HideScope is null or "" or "global" or "series" or "continuewatching" or "nextup" or "homesections";
+
+        private static bool IsValidHiddenIdentity(HiddenContentIdentity? identity)
+            => identity == null
+                || (identity.Version == 1
+                    && string.Equals(identity.Provider, "tmdb", StringComparison.Ordinal)
+                    && (string.Equals(identity.MediaType, "movie", StringComparison.Ordinal)
+                        || string.Equals(identity.MediaType, "tv", StringComparison.Ordinal))
+                    && IsPositiveDecimalId(identity.Id));
+
+        private static bool IsPositiveDecimalId(string? value)
+        {
+            if (string.IsNullOrEmpty(value) || value.Length > 32) return false;
+            var nonZero = false;
+            foreach (var c in value)
+            {
+                if (c < '0' || c > '9') return false;
+                if (c != '0') nonZero = true;
+            }
+            return nonZero;
+        }
 
         private static bool HasValidExtensionData(Dictionary<string, JsonElement>? extensionData)
         {

--- a/Jellyfin.Plugin.JellyfinCanopy/Configuration/UserConfiguration.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Configuration/UserConfiguration.cs
@@ -304,12 +304,22 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Configuration
         public List<ProcessedWatchlistItem> Items { get; set; } = new List<ProcessedWatchlistItem>();
     }
 
+    public class HiddenContentIdentity
+    {
+        public int Version { get; set; }
+        public string Provider { get; set; } = string.Empty;
+        public string MediaType { get; set; } = string.Empty;
+        public string Id { get; set; } = string.Empty;
+    }
+
     public class HiddenContentItem
     {
         public string ItemId { get; set; } = string.Empty;
         public string Name { get; set; } = string.Empty;
         public string Type { get; set; } = string.Empty;
         public string TmdbId { get; set; } = string.Empty;
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public HiddenContentIdentity? Identity { get; set; }
         public string HiddenAt { get; set; } = string.Empty;
         public string PosterPath { get; set; } = string.Empty;
         public string SeriesId { get; set; } = string.Empty;

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/HiddenContentController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/HiddenContentController.cs
@@ -479,6 +479,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                     {
                         if (it == null) continue;
                         var identity = ResolveIdentity(it);
+                        // An explicit identity is authoritative. Unknown versions and malformed
+                        // values must not be silently downgraded to an exact-only or legacy row.
+                        if (it.Identity != null && identity == null) continue;
                         // Exact local identity wins. Provider-only rows use the same
                         // versioned key as the browser; ambiguous legacy rows are refused.
                         var key = !string.IsNullOrEmpty(it.ItemId)
@@ -486,7 +489,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                             : (identity != null ? $"hc1:tmdb:{identity.MediaType}:{identity.Id}" : null);
                         if (string.IsNullOrEmpty(key) || key.Length > 256) continue;
                         if (cfg.Items.ContainsKey(key)) continue; // never clobber the user's own hide
-                        if (identity != null && cfg.Items.Values.Any(existing =>
+                        if (identity != null && string.IsNullOrEmpty(it.ItemId) && cfg.Items.Values.Any(existing =>
                         {
                             if (existing == null) return false;
                             var current = ResolveIdentity(existing);
@@ -629,6 +632,26 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             int? seasonNumber = null;
             int? episodeNumber = null;
             string typeName = jfItem.GetType().Name;
+            var tmdbId = jfItem.ProviderIds.TryGetValue("Tmdb", out var providerTmdbId)
+                ? providerTmdbId
+                : string.Empty;
+            var mediaType = string.Equals(typeName, "Movie", StringComparison.Ordinal) ? "movie"
+                : (string.Equals(typeName, "Series", StringComparison.Ordinal) ? "tv" : null);
+            HiddenContentIdentity? providerIdentity = null;
+            if (mediaType != null
+                && !string.IsNullOrEmpty(tmdbId)
+                && tmdbId.Length <= 32
+                && tmdbId.All(static c => c >= '0' && c <= '9')
+                && tmdbId.Any(static c => c != '0'))
+            {
+                providerIdentity = new HiddenContentIdentity
+                {
+                    Version = 1,
+                    Provider = "tmdb",
+                    MediaType = mediaType,
+                    Id = tmdbId
+                };
+            }
 
             if (jfItem is MediaBrowser.Controller.Entities.TV.Episode ep)
             {
@@ -643,7 +666,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 ItemId = itemGuid.ToString(),
                 Name = jfItem.Name ?? string.Empty,
                 Type = typeName,
-                TmdbId = string.Empty,
+                TmdbId = providerIdentity?.Id ?? string.Empty,
+                Identity = providerIdentity,
                 HiddenAt = DateTime.UtcNow.ToString("o", System.Globalization.CultureInfo.InvariantCulture),
                 PosterPath = string.Empty,
                 SeriesId = seriesId ?? string.Empty,
@@ -678,6 +702,40 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                         // Merge with existing entries (under either hyphenated or N-format key) — pick the wider scope.
                         h.Items.TryGetValue(key, out var hyphenEntry);
                         h.Items.TryGetValue(keyN, out var nEntry);
+
+                        // Reconcile provider metadata as one atomic pair. A stored typed identity
+                        // outranks fresh library metadata, which outranks an untyped legacy TMDB id.
+                        // This prevents one GUID variant's legacy id from masking the other's typed
+                        // identity or producing a mismatched Identity/TmdbId pair.
+                        var identityEntry = hyphenEntry?.Identity != null
+                            ? hyphenEntry
+                            : (nEntry?.Identity != null ? nEntry : null);
+                        if (identityEntry?.Identity != null)
+                        {
+                            entry.Identity = new HiddenContentIdentity
+                            {
+                                Version = identityEntry.Identity.Version,
+                                Provider = identityEntry.Identity.Provider ?? string.Empty,
+                                MediaType = identityEntry.Identity.MediaType ?? string.Empty,
+                                Id = identityEntry.Identity.Id ?? string.Empty
+                            };
+                            var supportedTmdbIdentity = entry.Identity.Version == 1
+                                && string.Equals(entry.Identity.Provider, "tmdb", StringComparison.Ordinal)
+                                && (string.Equals(entry.Identity.MediaType, "movie", StringComparison.Ordinal)
+                                    || string.Equals(entry.Identity.MediaType, "tv", StringComparison.Ordinal))
+                                && entry.Identity.Id.Length <= 32
+                                && entry.Identity.Id.All(static c => c >= '0' && c <= '9')
+                                && entry.Identity.Id.Any(static c => c != '0');
+                            entry.TmdbId = supportedTmdbIdentity
+                                ? entry.Identity.Id
+                                : (identityEntry.TmdbId ?? string.Empty);
+                        }
+                        else if (providerIdentity == null)
+                        {
+                            entry.TmdbId = !string.IsNullOrEmpty(hyphenEntry?.TmdbId)
+                                ? hyphenEntry.TmdbId
+                                : (nEntry?.TmdbId ?? string.Empty);
+                        }
 
                         var existingScope = WiderScope(
                             hyphenEntry?.HideScope,

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/HiddenContentController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/HiddenContentController.cs
@@ -409,7 +409,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
         /// <summary>
         /// Admin-only: hides one or more items on behalf of another user (admin adding).
         /// The body is a list of hidden-content items (the same shape the client stores). Each is keyed
-        /// by its item id (or tmdb-{id}) and RMW-merged into the user's hidden-content.json without
+        /// by its exact Jellyfin item id (or versioned provider identity) and RMW-merged into the user's hidden-content.json without
         /// overwriting an item the user already hid. Returns how many were newly added.
         /// </summary>
         [HttpPost("admin/hidden-content/{userId}/hide")]
@@ -439,6 +439,36 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             static string Clamp(string? s, int max) =>
                 string.IsNullOrEmpty(s) ? string.Empty : (s.Length <= max ? s : s.Substring(0, max));
 
+            static HiddenContentIdentity? ResolveIdentity(HiddenContentItem item)
+            {
+                var mediaType = item.Identity?.MediaType;
+                var provider = item.Identity?.Provider;
+                var id = item.Identity?.Id;
+                if (item.Identity != null)
+                {
+                    if (item.Identity.Version != 1
+                        || !string.Equals(provider, "tmdb", StringComparison.Ordinal)
+                        || (mediaType != "movie" && mediaType != "tv")
+                        || string.IsNullOrEmpty(id)
+                        || id.Length > 32
+                        || id.Any(static c => c < '0' || c > '9')
+                        || id.All(static c => c == '0')
+                        || (!string.IsNullOrEmpty(item.TmdbId) && !string.Equals(item.TmdbId, id, StringComparison.Ordinal))) return null;
+
+                    return new HiddenContentIdentity { Version = 1, Provider = "tmdb", MediaType = mediaType, Id = id };
+                }
+
+                mediaType = string.Equals(item.Type, "Movie", StringComparison.OrdinalIgnoreCase) ? "movie"
+                    : (string.Equals(item.Type, "Series", StringComparison.OrdinalIgnoreCase) ? "tv" : null);
+                id = item.TmdbId;
+                if ((mediaType != "movie" && mediaType != "tv")
+                    || string.IsNullOrEmpty(id)
+                    || id.Length > 32
+                    || id.Any(static c => c < '0' || c > '9')
+                    || id.All(static c => c == '0')) return null;
+                return new HiddenContentIdentity { Version = 1, Provider = "tmdb", MediaType = mediaType, Id = id };
+            }
+
             try
             {
                 var added = 0;
@@ -448,12 +478,23 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                     foreach (var it in items)
                     {
                         if (it == null) continue;
-                        // Mirror the client's key scheme: item id, else tmdb-{id}.
+                        var identity = ResolveIdentity(it);
+                        // Exact local identity wins. Provider-only rows use the same
+                        // versioned key as the browser; ambiguous legacy rows are refused.
                         var key = !string.IsNullOrEmpty(it.ItemId)
                             ? it.ItemId
-                            : (!string.IsNullOrEmpty(it.TmdbId) ? $"tmdb-{it.TmdbId}" : null);
+                            : (identity != null ? $"hc1:tmdb:{identity.MediaType}:{identity.Id}" : null);
                         if (string.IsNullOrEmpty(key) || key.Length > 256) continue;
                         if (cfg.Items.ContainsKey(key)) continue; // never clobber the user's own hide
+                        if (identity != null && cfg.Items.Values.Any(existing =>
+                        {
+                            if (existing == null) return false;
+                            var current = ResolveIdentity(existing);
+                            return current != null
+                                && string.Equals(current.Provider, identity.Provider, StringComparison.Ordinal)
+                                && string.Equals(current.MediaType, identity.MediaType, StringComparison.Ordinal)
+                                && string.Equals(current.Id, identity.Id, StringComparison.Ordinal);
+                        })) continue;
                         // Cross-user write path: bound the admin-supplied free-text fields and constrain
                         // HideScope to the known set, so a compromised admin token can't persist multi-MB
                         // strings or an unrecognised scope into another user's store.
@@ -463,6 +504,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                         it.SeriesId = Clamp(it.SeriesId, 128);
                         it.Type = Clamp(it.Type, 64);
                         it.TmdbId = Clamp(it.TmdbId, 32);
+                        it.Identity = identity;
                         it.HiddenAt = string.IsNullOrEmpty(it.HiddenAt) ? DateTime.UtcNow.ToString("o") : Clamp(it.HiddenAt, 64);
                         it.HideScope = it.HideScope is "global" or "continuewatching" or "nextup" or "homesections" ? it.HideScope : "global";
                         cfg.Items[key] = it;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content-page/admin.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content-page/admin.ts
@@ -17,6 +17,7 @@ import {
 } from './state';
 import type { HiddenContentPageFence } from './state';
 import { isCssColor } from '../../core/css-safe';
+import { createTmdbIdentity, hiddenIdentityKey, identityFromSource } from '../hidden-content/media-identity';
 // Cross-module reference (defined in hidden-content-page/render.ts). ES-module
 // cyclic edge — only ever invoked at call time, never during module evaluation.
 import { renderPage } from './render';
@@ -284,11 +285,13 @@ async function adminUnhide(keys: string[], fence: HiddenContentPageFence): Promi
  */
 async function adminAddItem(targetUserId: string, result: any, fence: HiddenContentPageFence): Promise<boolean> {
     if (!isPageFenceCurrent(fence) || state.selectedAdminUserId !== targetUserId) return false;
+    const identity = createTmdbIdentity(result.tmdbId, result.type);
     const item = {
         itemId: result.itemId || '',
         name: result.name || '',
         type: result.type || '',
         tmdbId: result.tmdbId ? String(result.tmdbId) : '',
+        ...(identity ? { identity } : {}),
         // Store the TMDB poster path for Seerr-sourced items (not in the library) so the hidden card
         // can render a poster; library items render from their Jellyfin image, so leave it blank.
         posterPath: result.source === 'seerr' ? (result.posterPath || '') : '',
@@ -305,7 +308,7 @@ async function adminAddItem(targetUserId: string, result: any, fence: HiddenCont
     // The server returns the number of items it newly added; 0 means the user already had it hidden.
     // Only update the local cache + dropdown count for a real add, so the count can't drift upward.
     const didAdd = typeof added === 'number' ? added > 0 : true;
-    const key = item.itemId || ('tmdb-' + item.tmdbId);
+    const key = item.itemId || (identity ? hiddenIdentityKey(identity) : '');
     if (didAdd && Array.isArray(state.adminItems) && !state.adminItems.some((i) => (i._key || i.itemId) === key)) {
         state.adminItems = state.adminItems.concat([{ ...item, _key: key }]);
     }
@@ -401,8 +404,12 @@ export function openAdminAddModal(): void {
     document.addEventListener('keydown', esc);
 
     const buildResultCard = (n: any): HTMLElement => {
-        const key = n.itemId || ('tmdb-' + n.tmdbId);
-        const alreadyHidden = (state.adminItems || []).some((i) => (i._key || i.itemId) === key);
+        const identity = createTmdbIdentity(n.tmdbId, n.type);
+        const alreadyHidden = (state.adminItems || []).some((i) => {
+            if (n.itemId && (i.itemId === n.itemId || i._key === n.itemId)) return true;
+            const current = identityFromSource(i);
+            return !!identity && !!current && hiddenIdentityKey(current) === hiddenIdentityKey(identity);
+        });
         const card = document.createElement('div');
         card.className = 'jc-hidden-item-card';
         card.dataset.jcIdentityOwned = 'true';

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content-page/admin.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content-page/admin.ts
@@ -516,18 +516,21 @@ export function openAdminAddModal(): void {
         if (!isModalCurrent() || token !== searchToken) return;
 
         const normalized: any[] = [];
-        const seenTmdb = new Set<string>();
+        const seenProviderIdentities = new Set<string>();
         for (const r of libItems) {
             const tmdb = (r.ProviderIds && (r.ProviderIds.Tmdb || r.ProviderIds.tmdb)) || '';
-            if (tmdb) seenTmdb.add(String(tmdb));
+            const identity = createTmdbIdentity(tmdb, r.Type);
+            if (identity) seenProviderIdentities.add(hiddenIdentityKey(identity));
             normalized.push({ source: 'library', itemId: r.Id, name: r.Name, type: r.Type,
                 tmdbId: tmdb ? String(tmdb) : '', posterPath: '', year: r.ProductionYear || '' });
         }
         for (const r of seerrItems) {
             if (r.mediaType !== 'movie' && r.mediaType !== 'tv') continue; // skip people
             const tmdb = String(r.id);
-            if (seenTmdb.has(tmdb)) continue; // already shown from the library
-            seenTmdb.add(tmdb);
+            const identity = createTmdbIdentity(tmdb, r.mediaType);
+            const identityKey = identity && hiddenIdentityKey(identity);
+            if (identityKey && seenProviderIdentities.has(identityKey)) continue; // already shown from the library
+            if (identityKey) seenProviderIdentities.add(identityKey);
             normalized.push({ source: 'seerr', itemId: '', name: r.title || r.name || '',
                 type: r.mediaType === 'tv' ? 'Series' : 'Movie', tmdbId: tmdb,
                 posterPath: r.posterPath || r.poster_path || '',

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content-page/identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content-page/identity.test.ts
@@ -6,6 +6,7 @@ import { createGroupCard } from './cards';
 import { state } from './state';
 
 const originalApi = JC.core.api;
+const originalSeerrApi = JC.seerrAPI;
 
 function startSession(serverId = 'server-a', userId = 'user-a'): IdentityContext {
     JC.identity.transition('', '', 'test-logout');
@@ -24,6 +25,7 @@ describe('hidden-content page identity lifecycle', () => {
     afterEach(() => {
         JC.identity.transition('', '', 'test-cleanup');
         JC.core.api = originalApi;
+        JC.seerrAPI = originalSeerrApi;
         vi.restoreAllMocks();
         vi.useRealTimers();
         document.body.innerHTML = '';
@@ -109,5 +111,41 @@ describe('hidden-content page identity lifecycle', () => {
 
         expect(fetch).toHaveBeenCalledTimes(1);
         expect(document.body.textContent).not.toContain('A result');
+    });
+
+    it('keeps movie and TV admin search results with the same TMDB number', async () => {
+        JC.core.api = {
+            fetch: vi.fn().mockResolvedValue({
+                Items: [{
+                    Id: 'jf-movie-550',
+                    Name: 'Library Movie 550',
+                    Type: 'Movie',
+                    ProviderIds: { Tmdb: '550' },
+                }],
+            }),
+        } as unknown as NonNullable<typeof JC.core.api>;
+        JC.seerrAPI = {
+            search: vi.fn().mockResolvedValue({
+                results: [
+                    { id: 550, mediaType: 'movie', title: 'Movie 550' },
+                    { id: 550, mediaType: 'tv', name: 'TV 550' },
+                ],
+            }),
+        } as unknown as NonNullable<typeof JC.seerrAPI>;
+        state.selectedAdminUserId = 'target-a';
+        state.adminUserName = 'Target A';
+        state.adminItems = [];
+
+        openAdminAddModal();
+        const input = document.querySelector<HTMLInputElement>('.jc-hidden-admin-add-overlay input')!;
+        input.value = '550';
+        input.dispatchEvent(new Event('input'));
+        await vi.advanceTimersByTimeAsync(300);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const names = [...document.querySelectorAll('.jc-hidden-admin-add-overlay .jc-hidden-item-name')]
+            .map((element) => element.textContent);
+        expect(names).toEqual(['Library Movie 550', 'TV 550']);
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/data.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/data.ts
@@ -19,6 +19,7 @@ import {
     hiddenIdentityStatus,
     identityFromSource,
     normalizeHiddenMediaType,
+    sameHiddenIdentity,
 } from './media-identity';
 import type { HiddenContentIdentity, HiddenIdentityStatus, HiddenMediaType } from './media-identity';
 
@@ -91,7 +92,9 @@ function emptyHiddenData(): HiddenContentData {
 
 function upgradeSafeLegacyIdentities(data: HiddenContentData): { data: HiddenContentData; changed: boolean } {
     let changed = false;
-    const items: Record<string, HiddenItem> = {};
+    // Storage keys are opaque user data. A normal object plus assignment would
+    // invoke Object.prototype.__proto__ and silently lose that tracked row.
+    const items = { __proto__: null } as unknown as HiddenContentData['items'];
     for (const [key, item] of Object.entries(data.items || {})) {
         const identity = identityFromSource(item);
         if (!item.identity && identity) {
@@ -342,6 +345,44 @@ function widestScope(a: string, b: string | undefined): string {
     return ra >= rb ? la : lb;
 }
 
+/** Merge duplicate storage rows without discarding exact ids or typed provider metadata. */
+function mergeHiddenRows(preferred: HiddenItem, additional: HiddenItem): HiddenItem {
+    const merged: HiddenItem = { ...additional, ...preferred };
+    merged.itemId = preferred.itemId || additional.itemId || '';
+    merged.name = preferred.name || additional.name || '';
+    merged.type = preferred.type || additional.type || '';
+    // Select identity + TMDB as one pair. Explicit typed metadata outranks a
+    // derivable legacy row, so one GUID variant cannot contribute identity 551
+    // while another contributes a stale TMDB 550.
+    const identitySource = preferred.identity
+        ? preferred
+        : (additional.identity ? additional : null);
+    const explicitIdentity = identitySource ? identityFromSource(identitySource) : null;
+    if (explicitIdentity) {
+        merged.identity = { ...explicitIdentity };
+        merged.tmdbId = explicitIdentity.id;
+    } else if (identitySource?.identity) {
+        // Preserve unsupported explicit schemas atomically; never reinterpret
+        // them as legacy metadata during a scoped-key collapse.
+        merged.identity = { ...identitySource.identity };
+        merged.tmdbId = identitySource.tmdbId || '';
+    } else {
+        const derivedIdentity = identityFromSource(preferred) || identityFromSource(additional);
+        merged.identity = derivedIdentity ? { ...derivedIdentity } : undefined;
+        merged.tmdbId = derivedIdentity?.id || preferred.tmdbId || additional.tmdbId || '';
+    }
+    merged.hiddenAt = !preferred.hiddenAt
+        ? (additional.hiddenAt || '')
+        : (!additional.hiddenAt || preferred.hiddenAt <= additional.hiddenAt ? preferred.hiddenAt : additional.hiddenAt);
+    merged.posterPath = preferred.posterPath || additional.posterPath || '';
+    merged.seriesId = preferred.seriesId || additional.seriesId || '';
+    merged.seriesName = preferred.seriesName || additional.seriesName || '';
+    merged.seasonNumber = preferred.seasonNumber ?? additional.seasonNumber ?? null;
+    merged.episodeNumber = preferred.episodeNumber ?? additional.episodeNumber ?? null;
+    merged.hideScope = widestScope(preferred.hideScope || '', additional.hideScope) || 'global';
+    return merged;
+}
+
 // Local-cache mirror of a server-side hide write — preserves existing metadata + merges scopes via mergeCwScope.
 // Looks up under hyphenated AND N-format keys (server canonical is hyphenated; some callers pass N-format from data-id).
 export function markScopedHidden(itemId: string, scope?: string): void {
@@ -369,18 +410,16 @@ export function markScopedHidden(itemId: string, scope?: string): void {
         if (!v?.hiddenAt) continue;
         if (!earliestHiddenAt || v.hiddenAt < earliestHiddenAt) earliestHiddenAt = v.hiddenAt;
     }
+    const reconciled = variants.reduce<HiddenItem | null>(
+        (current, variant) => current ? mergeHiddenRows(current, variant) : { ...variant },
+        null,
+    );
     const merged: HiddenItem = {
+        ...(reconciled || {}),
         itemId,
-        name: existing?.name || '',
-        type: existing?.type || '',
-        tmdbId: existing?.tmdbId || '',
         hiddenAt: earliestHiddenAt || new Date().toISOString(),
-        posterPath: existing?.posterPath || '',
-        seriesId: existing?.seriesId || '',
-        seriesName: existing?.seriesName || '',
-        seasonNumber: existing?.seasonNumber ?? null,
-        episodeNumber: existing?.episodeNumber ?? null,
         hideScope: finalScope,
+        ...(reconciled?.identity ? { identity: { ...reconciled.identity } } : {}),
     };
     const nextItems = { ...items, [itemId]: merged };
     if (hyphenated !== itemId) delete nextItems[hyphenated];
@@ -496,18 +535,27 @@ export interface HideItemParams {
  */
 export function hideItem({ itemId, name, type, tmdbId, identity: suppliedIdentity, posterPath, seriesId, seriesName, seasonNumber, episodeNumber, hideScope }: HideItemParams): void {
     const data = getHiddenData();
-    const identity = identityFromSource({ identity: suppliedIdentity, tmdbId, type });
+    const explicitIdentity = suppliedIdentity
+        ? identityFromSource({ identity: suppliedIdentity })
+        : null;
+    if (suppliedIdentity && (!explicitIdentity
+        || (tmdbId != null && String(tmdbId).trim() !== explicitIdentity.id))) return;
+    const identity = explicitIdentity || identityFromSource({ tmdbId, type });
     if (!itemId && !identity) return;
-    const existingIdentityKey = identity && Object.entries(data.items).find(([, item]) => {
+    const existingIdentityEntry = identity && Object.entries(data.items).find(([, item]) => {
         const current = identityFromSource(item);
-        return current && hiddenIdentityKey(current) === hiddenIdentityKey(identity);
-    })?.[0];
+        return current
+            && hiddenIdentityKey(current) === hiddenIdentityKey(identity)
+            && (!itemId || !item.itemId || item.itemId === itemId);
+    });
+    const existingIdentityKey = existingIdentityEntry?.[0];
+    const existingIdentityItem = existingIdentityEntry?.[1];
     const key = existingIdentityKey || itemId || hiddenIdentityKey(identity!);
     const newItem: HiddenItem = {
-        itemId: itemId || '',
+        itemId: itemId || existingIdentityItem?.itemId || '',
         name: name || '',
         type: type || '',
-        tmdbId: tmdbId ? String(tmdbId) : '',
+        tmdbId: identity?.id || (tmdbId ? String(tmdbId) : ''),
         ...(identity ? { identity } : {}),
         hiddenAt: new Date().toISOString(),
         posterPath: posterPath || '',
@@ -611,7 +659,22 @@ export function resolveLegacyIdentity(storageKey: string, mediaType: HiddenMedia
         identity,
         type: normalizedType === 'tv' ? 'Series' : 'Movie',
     };
-    if (!commitHiddenData({ ...data, items: { ...data.items, [storageKey]: nextItem } }, data)) return false;
+    const nextItems = { ...data.items, [storageKey]: nextItem };
+    const matchingEntries = Object.entries(nextItems).filter(([key, candidate]) =>
+        key !== storageKey && sameHiddenIdentity(identityFromSource(candidate), identity));
+    const candidates = [[storageKey, nextItem], ...matchingEntries] as Array<[string, HiddenItem]>;
+    const survivor = candidates.find(([, candidate]) => !!candidate.itemId) || candidates[0];
+    let merged: HiddenItem = { ...survivor[1], identity: { ...identity } };
+    for (const [key, candidate] of candidates) {
+        if (key === survivor[0]) continue;
+        const mergeable = !candidate.itemId || !merged.itemId || candidate.itemId === merged.itemId;
+        if (!mergeable) continue;
+        merged = mergeHiddenRows(merged, candidate);
+        merged.identity = { ...identity };
+        delete nextItems[key];
+    }
+    nextItems[survivor[0]] = merged;
+    if (!commitHiddenData({ ...data, items: nextItems }, data)) return false;
     rebuildSets();
     debouncedSave();
     emitChange();

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/data.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/data.ts
@@ -16,10 +16,11 @@ import { refreshNativeCardVisibility, restoreNativeCardsForIds } from './filter'
 import {
     createTmdbIdentity,
     hiddenIdentityKey,
+    hiddenIdentityStatus,
     identityFromSource,
     normalizeHiddenMediaType,
 } from './media-identity';
-import type { HiddenContentIdentity, HiddenMediaType } from './media-identity';
+import type { HiddenContentIdentity, HiddenIdentityStatus, HiddenMediaType } from './media-identity';
 
 // ============================================================
 // Shared shapes
@@ -42,7 +43,7 @@ export interface HiddenItem {
     /** Storage key attached by getAllHiddenItems / admin fetches. */
     _key?: string;
     /** Derived management state; never persisted. */
-    _identityStatus?: 'resolved' | 'legacy-unresolved' | 'local-only';
+    _identityStatus?: HiddenIdentityStatus;
     /** Cross-user admin rows can be reviewed but not resolved in the current user's store. */
     _identityReadOnly?: boolean;
     [key: string]: unknown;
@@ -593,9 +594,7 @@ export function getAllHiddenItems(): HiddenItem[] {
     return Object.entries(items).map(([key, item]) => ({
         ...item,
         _key: key,
-        _identityStatus: identityFromSource(item)
-            ? 'resolved'
-            : (item.tmdbId ? 'legacy-unresolved' : 'local-only'),
+        _identityStatus: hiddenIdentityStatus(item),
     }));
 }
 
@@ -603,7 +602,7 @@ export function getAllHiddenItems(): HiddenItem[] {
 export function resolveLegacyIdentity(storageKey: string, mediaType: HiddenMediaType): boolean {
     const data = getHiddenData();
     const item = data.items[storageKey];
-    if (!item?.tmdbId || identityFromSource(item)) return false;
+    if (!item?.tmdbId || item.identity || identityFromSource(item)) return false;
     const normalizedType = normalizeHiddenMediaType(mediaType);
     const identity = createTmdbIdentity(item.tmdbId, normalizedType);
     if (!identity) return false;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/data.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/data.ts
@@ -13,6 +13,13 @@ import type { IdentityContext } from '../../types/jc';
 import { debouncedSave } from './save';
 import { showUndoToast } from './dialogs';
 import { refreshNativeCardVisibility, restoreNativeCardsForIds } from './filter';
+import {
+    createTmdbIdentity,
+    hiddenIdentityKey,
+    identityFromSource,
+    normalizeHiddenMediaType,
+} from './media-identity';
+import type { HiddenContentIdentity, HiddenMediaType } from './media-identity';
 
 // ============================================================
 // Shared shapes
@@ -24,6 +31,7 @@ export interface HiddenItem {
     name?: string;
     type?: string;
     tmdbId?: string;
+    identity?: HiddenContentIdentity;
     hiddenAt?: string;
     posterPath?: string;
     seriesId?: string;
@@ -33,6 +41,10 @@ export interface HiddenItem {
     hideScope?: string;
     /** Storage key attached by getAllHiddenItems / admin fetches. */
     _key?: string;
+    /** Derived management state; never persisted. */
+    _identityStatus?: 'resolved' | 'legacy-unresolved' | 'local-only';
+    /** Cross-user admin rows can be reviewed but not resolved in the current user's store. */
+    _identityReadOnly?: boolean;
     [key: string]: unknown;
 }
 
@@ -69,11 +81,26 @@ export interface HiddenContentSettings {
 // ============================================================
 
 export const hiddenIdSet = new Set<string>();
-const hiddenTmdbIdSet = new Set<string>();
+const hiddenProviderIdentitySet = new Set<string>();
 let hiddenData: HiddenContentData | null = null;
 
 function emptyHiddenData(): HiddenContentData {
     return { items: {}, settings: {} };
+}
+
+function upgradeSafeLegacyIdentities(data: HiddenContentData): { data: HiddenContentData; changed: boolean } {
+    let changed = false;
+    const items: Record<string, HiddenItem> = {};
+    for (const [key, item] of Object.entries(data.items || {})) {
+        const identity = identityFromSource(item);
+        if (!item.identity && identity) {
+            items[key] = { ...item, identity };
+            changed = true;
+        } else {
+            items[key] = item;
+        }
+    }
+    return changed ? { data: { ...data, items }, changed } : { data, changed };
 }
 
 function contextFor(data: HiddenContentData): IdentityContext | null {
@@ -110,7 +137,7 @@ function commitHiddenData(data: HiddenContentData, previous: HiddenContentData):
 function clearIdentityData(): void {
     hiddenData = null;
     hiddenIdSet.clear();
-    hiddenTmdbIdSet.clear();
+    hiddenProviderIdentitySet.clear();
 }
 
 JC.identity?.registerReset?.('hidden-content-data', clearIdentityData);
@@ -182,7 +209,7 @@ export function getSettings(): HiddenContentSettings {
  */
 export function rebuildSets(): void {
     hiddenIdSet.clear();
-    hiddenTmdbIdSet.clear();
+    hiddenProviderIdentitySet.clear();
     const data = getHiddenData();
     const items = data.items || {};
     for (const key of Object.keys(items)) {
@@ -190,7 +217,8 @@ export function rebuildSets(): void {
         const scope = item.hideScope || 'global';
         if (scope !== 'global') continue;
         if (item.itemId) hiddenIdSet.add(item.itemId);
-        if (item.tmdbId) hiddenTmdbIdSet.add(String(item.tmdbId));
+        const identity = identityFromSource(item);
+        if (identity) hiddenProviderIdentitySet.add(hiddenIdentityKey(identity));
     }
 }
 
@@ -267,9 +295,11 @@ export async function refresh(): Promise<boolean> {
         const camelCased = typeof JC.transformUserFileCase === 'function'
             ? JC.transformUserFileCase('hidden-content.json', fresh, 'load')
             : (typeof JC.toCamelCase === 'function' ? JC.toCamelCase(fresh) : fresh);
-        const next = camelCased && typeof camelCased === 'object'
+        const loaded = camelCased && typeof camelCased === 'object'
             ? camelCased as HiddenContentData
             : emptyHiddenData();
+        const upgraded = upgradeSafeLegacyIdentities(loaded);
+        const next = upgraded.data;
         if (context) {
             if (!replaceHiddenData(next, context)) return false;
         } else {
@@ -278,6 +308,7 @@ export async function refresh(): Promise<boolean> {
             hiddenData = next;
         }
         rebuildSets();
+        if (upgraded.changed) debouncedSave();
         emitChange();
         return true;
     } catch (e) {
@@ -379,11 +410,55 @@ export function isHidden(jellyfinItemId: string): boolean {
  * @param tmdbId The TMDB ID.
  * @returns `true` if the item is hidden.
  */
-export function isHiddenByTmdbId(tmdbId: string | number): boolean {
-    if (!tmdbId) return false;
+export function isHiddenByTmdbId(tmdbId: string | number, mediaType?: string): boolean {
+    const identity = createTmdbIdentity(tmdbId, mediaType);
+    if (!identity) return false;
     const settings = getSettings();
     if (!settings.enabled) return false;
-    return hiddenTmdbIdSet.has(String(tmdbId));
+    return hiddenProviderIdentitySet.has(hiddenIdentityKey(identity));
+}
+
+export interface HiddenMediaCandidate {
+    itemId?: string | null;
+    jellyfinMediaId?: string | null;
+    itemEpisodeId?: string | null;
+    tmdbId?: string | number | null;
+    id?: string | number | null;
+    mediaType?: string | null;
+    type?: string | null;
+}
+
+/** One comparator shared by cards, requests, calendar and management lookups. */
+export function isHiddenMedia(candidate: HiddenMediaCandidate): boolean {
+    const settings = getSettings();
+    if (!settings.enabled) return false;
+    const localIds = [candidate.itemId, candidate.jellyfinMediaId, candidate.itemEpisodeId];
+    if (localIds.some((id) => !!id && hiddenIdSet.has(String(id)))) return true;
+    const identity = createTmdbIdentity(
+        candidate.tmdbId || candidate.id,
+        candidate.mediaType || candidate.type,
+    );
+    return !!identity && hiddenProviderIdentitySet.has(hiddenIdentityKey(identity));
+}
+
+/** Returns the exact persisted row owned by a media candidate, if any. */
+export function getHiddenStorageKey(candidate: HiddenMediaCandidate): string | null {
+    const items = getHiddenData().items || {};
+    const localIds = [candidate.itemId, candidate.jellyfinMediaId, candidate.itemEpisodeId]
+        .filter((id): id is string => typeof id === 'string' && !!id);
+    for (const [key, item] of Object.entries(items)) {
+        if (localIds.includes(item.itemId || '') || localIds.includes(key)) return key;
+    }
+    const wanted = createTmdbIdentity(
+        candidate.tmdbId || candidate.id,
+        candidate.mediaType || candidate.type,
+    );
+    if (!wanted) return null;
+    const wantedKey = hiddenIdentityKey(wanted);
+    return Object.entries(items).find(([, item]) => {
+        const current = identityFromSource(item);
+        return !!current && hiddenIdentityKey(current) === wantedKey;
+    })?.[0] || null;
 }
 
 /** Item data accepted by hideItem. */
@@ -396,6 +471,8 @@ export interface HideItemParams {
     type?: string;
     /** TMDB ID. */
     tmdbId?: string | number;
+    /** Optional explicit provider identity. Normally derived from type + tmdbId. */
+    identity?: HiddenContentIdentity;
     /** TMDB poster path. */
     posterPath?: string;
     /** Parent series Jellyfin ID. */
@@ -416,14 +493,21 @@ export interface HideItemParams {
  * shows an undo toast, and refreshes native card visibility.
  * @param params Item data to hide.
  */
-export function hideItem({ itemId, name, type, tmdbId, posterPath, seriesId, seriesName, seasonNumber, episodeNumber, hideScope }: HideItemParams): void {
+export function hideItem({ itemId, name, type, tmdbId, identity: suppliedIdentity, posterPath, seriesId, seriesName, seasonNumber, episodeNumber, hideScope }: HideItemParams): void {
     const data = getHiddenData();
-    const key = itemId || `tmdb-${tmdbId}`;
+    const identity = identityFromSource({ identity: suppliedIdentity, tmdbId, type });
+    if (!itemId && !identity) return;
+    const existingIdentityKey = identity && Object.entries(data.items).find(([, item]) => {
+        const current = identityFromSource(item);
+        return current && hiddenIdentityKey(current) === hiddenIdentityKey(identity);
+    })?.[0];
+    const key = existingIdentityKey || itemId || hiddenIdentityKey(identity!);
     const newItem: HiddenItem = {
         itemId: itemId || '',
         name: name || '',
         type: type || '',
         tmdbId: tmdbId ? String(tmdbId) : '',
+        ...(identity ? { identity } : {}),
         hiddenAt: new Date().toISOString(),
         posterPath: posterPath || '',
         seriesId: seriesId || '',
@@ -455,7 +539,7 @@ export function unhideItem(itemId: string): void {
     const newItems = { ...data.items };
     let restoredJellyfinId = '';
 
-    // Try direct key match first (covers storage keys like "tmdb-12345")
+    // Try direct key match first (covers legacy and versioned provider keys).
     if (newItems[itemId]) {
         restoredJellyfinId = newItems[itemId].itemId || '';
         delete newItems[itemId];
@@ -475,7 +559,9 @@ export function unhideItem(itemId: string): void {
 
     const idsToRestore = new Set<string>();
     if (restoredJellyfinId) idsToRestore.add(restoredJellyfinId);
-    else if (itemId && !String(itemId).startsWith('tmdb-')) idsToRestore.add(itemId);
+    else if (itemId
+        && !String(itemId).startsWith('tmdb-')
+        && !String(itemId).startsWith('hc1:')) idsToRestore.add(itemId);
     restoreNativeCardsForIds(idsToRestore);
     refreshNativeCardVisibility();
 }
@@ -504,7 +590,34 @@ export function updateSettings(partial: Record<string, unknown>): void {
 export function getAllHiddenItems(): HiddenItem[] {
     const data = getHiddenData();
     const items = data.items || {};
-    return Object.entries(items).map(([key, item]) => ({ ...item, _key: key }));
+    return Object.entries(items).map(([key, item]) => ({
+        ...item,
+        _key: key,
+        _identityStatus: identityFromSource(item)
+            ? 'resolved'
+            : (item.tmdbId ? 'legacy-unresolved' : 'local-only'),
+    }));
+}
+
+/** Explicitly resolves an ambiguous legacy TMDB row selected in management UI. */
+export function resolveLegacyIdentity(storageKey: string, mediaType: HiddenMediaType): boolean {
+    const data = getHiddenData();
+    const item = data.items[storageKey];
+    if (!item?.tmdbId || identityFromSource(item)) return false;
+    const normalizedType = normalizeHiddenMediaType(mediaType);
+    const identity = createTmdbIdentity(item.tmdbId, normalizedType);
+    if (!identity) return false;
+    const nextItem: HiddenItem = {
+        ...item,
+        identity,
+        type: normalizedType === 'tv' ? 'Series' : 'Movie',
+    };
+    if (!commitHiddenData({ ...data, items: { ...data.items, [storageKey]: nextItem } }, data)) return false;
+    rebuildSets();
+    debouncedSave();
+    emitChange();
+    refreshNativeCardVisibility();
+    return true;
 }
 
 /**
@@ -525,15 +638,11 @@ export function getHiddenCount(): number {
 export function filterSeerrResults(results: any[], surface: string): any[] {
     if (!shouldFilterSurface(surface)) return results;
     if (!Array.isArray(results)) return results;
-    return results.filter((item) => {
-        const tmdbId = item.id || item.tmdbId;
-        return !hiddenTmdbIdSet.has(String(tmdbId));
-    });
+    return results.filter((item) => !isHiddenMedia(item));
 }
 
 /**
- * Filters calendar events, removing hidden items by TMDB ID, Jellyfin ID,
- * or normalised name match (for Sonarr events without TMDB IDs).
+ * Filters calendar events by the shared exact local/provider comparator.
  * @param events Array of calendar event objects.
  * @returns Filtered array.
  */
@@ -541,27 +650,7 @@ export function filterCalendarEvents(events: any[]): any[] {
     if (!shouldFilterSurface('calendar')) return events;
     if (!Array.isArray(events)) return events;
 
-    // Build a set of normalised hidden-item names for fuzzy matching
-    const hiddenNames = new Set<string>();
-    const items = (getHiddenData().items) || {};
-    for (const key of Object.keys(items)) {
-        const name = items[key].name;
-        if (name) {
-            const lower = name.toLowerCase();
-            hiddenNames.add(lower);
-            // Also store without trailing parenthetical qualifier
-            // so "Hell's Kitchen (US)" matches "Hell's Kitchen" and vice-versa.
-            const stripped = lower.replace(/\s*\([^)]*\)\s*$/, '');
-            if (stripped !== lower) hiddenNames.add(stripped);
-        }
-    }
-
-    return events.filter((event) => {
-        if (event.tmdbId && hiddenTmdbIdSet.has(String(event.tmdbId))) return false;
-        if (event.itemId && hiddenIdSet.has(event.itemId)) return false;
-        if (event.title && hiddenNames.has(event.title.toLowerCase())) return false;
-        return true;
-    });
+    return events.filter((event) => !isHiddenMedia(event));
 }
 
 /**
@@ -572,12 +661,7 @@ export function filterCalendarEvents(events: any[]): any[] {
 export function filterRequestItems(items: any[]): any[] {
     if (!shouldFilterSurface('requests')) return items;
     if (!Array.isArray(items)) return items;
-    return items.filter((item) => {
-        const tmdbId = item.tmdbId || item.id;
-        if (tmdbId && hiddenTmdbIdSet.has(String(tmdbId))) return false;
-        if (item.jellyfinMediaId && hiddenIdSet.has(item.jellyfinMediaId)) return false;
-        return true;
-    });
+    return items.filter((item) => !isHiddenMedia(item));
 }
 
 /**
@@ -602,15 +686,18 @@ export function unhideAll(): void {
 export function resetFromUserConfig(): void {
     const context = JC.identity?.capture?.() || null;
     const configured = (JC.userConfig?.hiddenContent as HiddenContentData | undefined) || emptyHiddenData();
+    const upgraded = upgradeSafeLegacyIdentities(configured);
     if (context) {
         const owner = JC.identity.ownerOf(configured);
         hiddenData = owner && !JC.identity.isOwned(configured, context)
             ? emptyHiddenData()
-            : configured;
+            : upgraded.data;
         JC.identity.own(hiddenData, context);
         if (JC.userConfig) JC.userConfig.hiddenContent = hiddenData;
     } else {
-        hiddenData = configured;
+        hiddenData = upgraded.data;
+        if (JC.userConfig) JC.userConfig.hiddenContent = hiddenData;
     }
     rebuildSets();
+    if (upgraded.changed && hiddenData === upgraded.data) debouncedSave();
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/identity.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { JC } from '../../globals';
 import type { IdentityContext } from '../../types/jc';
+import { loadUserFileCaseTransform } from '../../test/plugin-loader-harness';
 import { getHiddenData, hiddenIdSet, refresh, resetFromUserConfig, updateSettings } from './data';
 
 const originalTransformUserFileCase = JC.transformUserFileCase;
@@ -189,5 +190,50 @@ describe('hidden-content identity fencing', () => {
         expect(Object.keys(sent.Items)).toEqual(['Movie-A', 'movie-a', '映画-1']);
         expect(sent.Items['Movie-A'].ItemId).toBe('upper');
         expect(sent.Settings.FilterSearch).toBe(true);
+    });
+
+    it('migrates and saves hazardous opaque keys through the real schema bridge', async () => {
+        const transformUserFileCase = loadUserFileCaseTransform();
+        JC.transformUserFileCase = transformUserFileCase;
+        const wire = JSON.parse(`{
+            "Items": {
+                "__proto__": { "ItemId": "proto-id", "Type": "Movie", "TmdbId": "550" },
+                "constructor": { "ItemId": "constructor-id", "Type": "Series", "TmdbId": "551" },
+                "toString": { "ItemId": "to-string-id", "Type": "Movie", "TmdbId": "552" }
+            },
+            "Settings": { "Enabled": true }
+        }`) as unknown;
+        const transformed = transformUserFileCase(
+            'hidden-content.json',
+            wire,
+            'load',
+        ) as { items: Record<string, { itemId?: string; identity?: { id?: string } }>; settings: Record<string, unknown> };
+        const context = JC.identity.capture()!;
+        const hiddenContent = JC.identity.own(transformed, context);
+        JC.userConfig = JC.identity.own({ hiddenContent }, context);
+        const ajax = vi.spyOn(ApiClient, 'ajax').mockResolvedValue({});
+
+        resetFromUserConfig();
+
+        const items = getHiddenData().items;
+        expect(Object.getPrototypeOf(items)).toBeNull();
+        expect(Object.keys(items)).toEqual(['__proto__', 'constructor', 'toString']);
+        expect(items['__proto__'].itemId).toBe('proto-id');
+        expect(items['__proto__'].identity?.id).toBe('550');
+        expect(items['constructor'].identity?.id).toBe('551');
+        expect(items['toString'].identity?.id).toBe('552');
+
+        await vi.advanceTimersByTimeAsync(500);
+
+        expect(ajax).toHaveBeenCalledTimes(1);
+        const request = ajax.mock.calls[0][0] as { data: string };
+        const sent = JSON.parse(request.data) as {
+            Items: Record<string, { ItemId?: string; Identity?: { Id?: string } }>;
+        };
+        expect(Object.keys(sent.Items)).toEqual(['__proto__', 'constructor', 'toString']);
+        expect(sent.Items['__proto__'].ItemId).toBe('proto-id');
+        expect(sent.Items['__proto__'].Identity?.Id).toBe('550');
+        expect(sent.Items['constructor'].Identity?.Id).toBe('551');
+        expect(sent.Items['toString'].Identity?.Id).toBe('552');
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/init.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/init.ts
@@ -12,6 +12,8 @@ import {
     resetFromUserConfig,
     isHidden,
     isHiddenByTmdbId,
+    isHiddenMedia,
+    getHiddenStorageKey,
     hideItem,
     unhideItem,
     getSettings,
@@ -24,6 +26,7 @@ import {
     unhideAll,
     refresh,
     markScopedHidden,
+    resolveLegacyIdentity,
 } from './data';
 import {
     flushPendingSave,
@@ -82,6 +85,8 @@ JC.initializeHiddenContent = function (): void {
     JC.hiddenContent = {
         isHidden,
         isHiddenByTmdbId,
+        isHiddenMedia,
+        getHiddenStorageKey,
         isHiddenOnSurface,
         hideItem,
         unhideItem,
@@ -102,6 +107,7 @@ JC.initializeHiddenContent = function (): void {
         removeLibraryHideButtons,
         refresh,
         markScopedHidden,
+        resolveLegacyIdentity,
         flushPendingSave,
         // Admin-only cross-user visibility + editing
         fetchHiddenContentUsers,

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/media-identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/media-identity.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+import type { HiddenItem } from './data';
+import { createItemCard } from './panel';
+
+vi.mock('./save', () => ({ debouncedSave: vi.fn() }));
+vi.mock('./dialogs', () => ({ showUndoToast: vi.fn() }));
+vi.mock('./filter', () => ({
+    refreshNativeCardVisibility: vi.fn(),
+    restoreNativeCardsForIds: vi.fn(),
+}));
+
+import {
+    filterCalendarEvents,
+    filterRequestItems,
+    filterSeerrResults,
+    getAllHiddenItems,
+    getHiddenData,
+    getHiddenStorageKey,
+    hideItem,
+    isHiddenByTmdbId,
+    isHiddenMedia,
+    resetFromUserConfig,
+    unhideItem,
+} from './data';
+
+function install(items: Record<string, HiddenItem> = {}): void {
+    JC.identity.transition('', '', 'hidden-media-test-reset');
+    JC.userConfig = {
+        hiddenContent: {
+            items,
+            settings: {
+                enabled: true,
+                filterDiscovery: true,
+                filterCalendar: true,
+                filterRequests: true,
+            },
+        },
+    };
+    resetFromUserConfig();
+}
+
+describe('versioned hidden-content media identity', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        document.body.innerHTML = '';
+        JC.t = (key: string) => key;
+        install();
+    });
+
+    it('keeps TMDB movie 550 and TV 550 independent through hide-both and unhide-one', () => {
+        hideItem({ name: 'Movie 550', type: 'Movie', tmdbId: 550 });
+        hideItem({ name: 'TV 550', type: 'Series', tmdbId: 550 });
+
+        expect(Object.keys(getHiddenData().items).sort()).toEqual([
+            'hc1:tmdb:movie:550',
+            'hc1:tmdb:tv:550',
+        ]);
+        expect(filterSeerrResults([
+            { id: 550, mediaType: 'movie' },
+            { id: 550, mediaType: 'tv' },
+            { id: 551, mediaType: 'movie' },
+        ], 'discovery')).toEqual([{ id: 551, mediaType: 'movie' }]);
+
+        unhideItem('hc1:tmdb:movie:550');
+
+        expect(isHiddenByTmdbId(550, 'movie')).toBe(false);
+        expect(isHiddenByTmdbId(550, 'tv')).toBe(true);
+        expect(isHiddenByTmdbId(550)).toBe(false);
+        expect(getHiddenStorageKey({ tmdbId: 550, mediaType: 'tv' })).toBe('hc1:tmdb:tv:550');
+        expect(filterSeerrResults([
+            { id: 550, mediaType: 'movie' },
+            { id: 550, mediaType: 'tv' },
+        ], 'discovery')).toEqual([{ id: 550, mediaType: 'movie' }]);
+    });
+
+    it('uses the same exact comparator for cards, requests, calendar and management', () => {
+        hideItem({ itemId: 'jf-movie-550', name: 'Movie 550', type: 'Movie', tmdbId: 550 });
+
+        const candidates = [
+            { tmdbId: 550, type: 'Movie' },
+            { tmdbId: 550, type: 'Series' },
+            { jellyfinMediaId: 'jf-movie-550', tmdbId: 999, type: 'tv' },
+        ];
+        expect(candidates.map(isHiddenMedia)).toEqual([true, false, true]);
+        expect(filterRequestItems(candidates)).toEqual([candidates[1]]);
+        expect(filterCalendarEvents([
+            { itemId: 'other', tmdbId: 550, type: 'Movie' },
+            { itemId: 'other', tmdbId: 550, type: 'Series' },
+            { itemEpisodeId: 'jf-movie-550', tmdbId: 999, type: 'Series' },
+        ])).toEqual([{ itemId: 'other', tmdbId: 550, type: 'Series' }]);
+        expect(getAllHiddenItems()).toEqual([
+            expect.objectContaining({
+                _key: 'jf-movie-550',
+                _identityStatus: 'resolved',
+                identity: { version: 1, provider: 'tmdb', mediaType: 'movie', id: '550' },
+            }),
+        ]);
+    });
+
+    it('never cross-hides same-title media of another type, year, or provider id', () => {
+        hideItem({ name: 'The Same Title', type: 'Movie', tmdbId: 700 });
+        const events = [
+            { title: 'The Same Title', year: 2000, tmdbId: 700, type: 'Movie' },
+            { title: 'The Same Title', year: 2000, tmdbId: 700, type: 'Series' },
+            { title: 'The Same Title', year: 2024, tmdbId: 701, type: 'Movie' },
+            { title: 'The Same Title', year: 2024, type: 'Movie' },
+        ];
+
+        expect(filterCalendarEvents(events)).toEqual(events.slice(1));
+    });
+
+    it('migrates typed legacy rows but surfaces ambiguous bare IDs without applying them', () => {
+        install({
+            'tmdb-551': { name: 'Known movie', type: 'Movie', tmdbId: '551', hideScope: 'global' },
+            'tmdb-550': { name: 'Unknown legacy item', tmdbId: '550', hideScope: 'global' },
+            future: {
+                name: 'Future identity',
+                type: 'Movie',
+                tmdbId: '552',
+                hideScope: 'global',
+                identity: { version: 2, provider: 'tmdb', mediaType: 'movie', id: '552' } as unknown as HiddenItem['identity'],
+            },
+        });
+
+        expect(getHiddenData().items['tmdb-551'].identity).toEqual({
+            version: 1,
+            provider: 'tmdb',
+            mediaType: 'movie',
+            id: '551',
+        });
+        expect(isHiddenByTmdbId(551, 'movie')).toBe(true);
+        expect(isHiddenByTmdbId(551, 'tv')).toBe(false);
+        hideItem({ itemId: 'jf-known-551', name: 'Known movie', type: 'Movie', tmdbId: 551 });
+        expect(Object.keys(getHiddenData().items)).toEqual(['tmdb-551', 'tmdb-550', 'future']);
+        expect(getHiddenData().items['tmdb-551'].itemId).toBe('jf-known-551');
+        expect(isHiddenByTmdbId(550, 'movie')).toBe(false);
+        expect(isHiddenByTmdbId(550, 'tv')).toBe(false);
+        expect(isHiddenByTmdbId(552, 'movie')).toBe(false);
+        expect(getAllHiddenItems()).toEqual(expect.arrayContaining([
+            expect.objectContaining({ _key: 'tmdb-550', _identityStatus: 'legacy-unresolved' }),
+        ]));
+
+        const unresolved = getAllHiddenItems().find((item) => item._key === 'tmdb-550')!;
+        const card = createItemCard(unresolved);
+        expect(card.querySelector('.jc-hidden-item-meta')?.textContent).toContain('review required');
+        expect(card.querySelector('.jc-hidden-item-name')?.getAttribute('href')).toBeNull();
+        const resolutionButtons = card.querySelectorAll<HTMLButtonElement>('.jc-hidden-item-identity-resolution button');
+        expect([...resolutionButtons].map((button) => button.textContent)).toEqual(['Movie', 'TV']);
+
+        resolutionButtons[1].click();
+        expect(isHiddenByTmdbId(550, 'movie')).toBe(false);
+        expect(isHiddenByTmdbId(550, 'tv')).toBe(true);
+        expect(getHiddenData().items['tmdb-550']).toEqual(expect.objectContaining({
+            type: 'Series',
+            identity: { version: 1, provider: 'tmdb', mediaType: 'tv', id: '550' },
+        }));
+    });
+
+    it('retains exact Jellyfin IDs even when a legacy provider identity is ambiguous', () => {
+        install({
+            legacy: { itemId: 'jf-exact', name: 'Episode', type: 'Episode', tmdbId: '550', hideScope: 'global' },
+        });
+
+        expect(isHiddenMedia({ itemId: 'jf-exact' })).toBe(true);
+        expect(getHiddenData().items.legacy.identity).toBeUndefined();
+        expect(isHiddenMedia({ tmdbId: 550, mediaType: 'movie' })).toBe(false);
+        expect(isHiddenMedia({ tmdbId: 550, mediaType: 'tv' })).toBe(false);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/media-identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/media-identity.test.ts
@@ -21,6 +21,7 @@ import {
     isHiddenByTmdbId,
     isHiddenMedia,
     resetFromUserConfig,
+    resolveLegacyIdentity,
     unhideItem,
 } from './data';
 
@@ -139,7 +140,20 @@ describe('versioned hidden-content media identity', () => {
         expect(isHiddenByTmdbId(552, 'movie')).toBe(false);
         expect(getAllHiddenItems()).toEqual(expect.arrayContaining([
             expect.objectContaining({ _key: 'tmdb-550', _identityStatus: 'legacy-unresolved' }),
+            expect.objectContaining({ _key: 'future', _identityStatus: 'unsupported' }),
         ]));
+
+        const future = getAllHiddenItems().find((item) => item._key === 'future')!;
+        const futureCard = createItemCard(future);
+        expect(futureCard.querySelector('.jc-hidden-item-meta')?.textContent).toContain('Unsupported identity');
+        expect(futureCard.querySelector('.jc-hidden-item-identity-resolution')).toBeNull();
+        expect(resolveLegacyIdentity('future', 'tv')).toBe(false);
+        expect(getHiddenData().items.future.identity).toEqual({
+            version: 2,
+            provider: 'tmdb',
+            mediaType: 'movie',
+            id: '552',
+        });
 
         const unresolved = getAllHiddenItems().find((item) => item._key === 'tmdb-550')!;
         const card = createItemCard(unresolved);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/media-identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/media-identity.test.ts
@@ -20,6 +20,7 @@ import {
     hideItem,
     isHiddenByTmdbId,
     isHiddenMedia,
+    markScopedHidden,
     resetFromUserConfig,
     resolveLegacyIdentity,
     unhideItem,
@@ -75,6 +76,41 @@ describe('versioned hidden-content media identity', () => {
         ], 'discovery')).toEqual([{ id: 550, mediaType: 'movie' }]);
     });
 
+    it('rejects unsupported or mismatched explicit identities and persists valid pairs atomically', () => {
+        hideItem({
+            itemId: 'jf-mismatch',
+            name: 'Mismatched',
+            type: 'Movie',
+            tmdbId: 550,
+            identity: { version: 1, provider: 'tmdb', mediaType: 'movie', id: '551' },
+        });
+        hideItem({
+            itemId: 'jf-future',
+            name: 'Future',
+            type: 'Movie',
+            tmdbId: 552,
+            identity: {
+                version: 2,
+                provider: 'tmdb',
+                mediaType: 'movie',
+                id: '552',
+            } as unknown as HiddenItem['identity'],
+        });
+        expect(getHiddenData().items).toEqual({});
+
+        hideItem({
+            itemId: 'jf-valid',
+            name: 'Valid',
+            type: 'Movie',
+            identity: { version: 1, provider: 'tmdb', mediaType: 'movie', id: '551' },
+        });
+        expect(getHiddenData().items['jf-valid']).toEqual(expect.objectContaining({
+            itemId: 'jf-valid',
+            tmdbId: '551',
+            identity: { version: 1, provider: 'tmdb', mediaType: 'movie', id: '551' },
+        }));
+    });
+
     it('uses the same exact comparator for cards, requests, calendar and management', () => {
         hideItem({ itemId: 'jf-movie-550', name: 'Movie 550', type: 'Movie', tmdbId: 550 });
 
@@ -99,6 +135,23 @@ describe('versioned hidden-content media identity', () => {
         ]);
     });
 
+    it('preserves distinct exact Jellyfin ids that share one provider identity', () => {
+        hideItem({ itemId: 'jf-1', name: 'Edition one', type: 'Movie', tmdbId: 550 });
+        hideItem({ itemId: 'jf-2', name: 'Edition two', type: 'Movie', tmdbId: 550 });
+
+        expect(Object.keys(getHiddenData().items).sort()).toEqual(['jf-1', 'jf-2']);
+        expect(getHiddenData().items['jf-1'].itemId).toBe('jf-1');
+        expect(getHiddenData().items['jf-2'].itemId).toBe('jf-2');
+        expect(isHiddenMedia({ itemId: 'jf-1' })).toBe(true);
+        expect(isHiddenMedia({ itemId: 'jf-2' })).toBe(true);
+
+        unhideItem('jf-1');
+        expect(Object.keys(getHiddenData().items)).toEqual(['jf-2']);
+        expect(isHiddenMedia({ itemId: 'jf-1' })).toBe(false);
+        expect(isHiddenMedia({ itemId: 'jf-2' })).toBe(true);
+        expect(isHiddenByTmdbId(550, 'movie')).toBe(true);
+    });
+
     it('never cross-hides same-title media of another type, year, or provider id', () => {
         hideItem({ name: 'The Same Title', type: 'Movie', tmdbId: 700 });
         const events = [
@@ -119,6 +172,7 @@ describe('versioned hidden-content media identity', () => {
                 name: 'Future identity',
                 type: 'Movie',
                 tmdbId: '552',
+                posterPath: '/future.jpg',
                 hideScope: 'global',
                 identity: { version: 2, provider: 'tmdb', mediaType: 'movie', id: '552' } as unknown as HiddenItem['identity'],
             },
@@ -144,9 +198,35 @@ describe('versioned hidden-content media identity', () => {
         ]));
 
         const future = getAllHiddenItems().find((item) => item._key === 'future')!;
+        const open = vi.fn();
+        const fetchMovieDetails = vi.fn();
+        const search = vi.fn();
+        (JC as any).seerrMoreInfo = { open };
+        (JC as any).seerrAPI = { fetchMovieDetails, search };
         const futureCard = createItemCard(future);
         expect(futureCard.querySelector('.jc-hidden-item-meta')?.textContent).toContain('Unsupported identity');
         expect(futureCard.querySelector('.jc-hidden-item-identity-resolution')).toBeNull();
+        expect(futureCard.querySelector('img')).toBeNull();
+        expect(futureCard.innerHTML).not.toContain('image.tmdb.org');
+        for (const selector of ['.jc-hidden-item-poster-link', '.jc-hidden-item-name']) {
+            const link = futureCard.querySelector<HTMLAnchorElement>(selector)!;
+            expect(link.getAttribute('href')).toBeNull();
+            expect(link.dataset.tmdbId).toBeUndefined();
+            expect(link.dataset.mediaType).toBeUndefined();
+            link.click();
+        }
+        expect(open).not.toHaveBeenCalled();
+
+        const exactFutureCard = createItemCard({ ...future, itemId: 'jf-future' });
+        const exactFutureImage = exactFutureCard.querySelector<HTMLImageElement>('.jc-hidden-item-poster')!;
+        expect(exactFutureImage.src).not.toContain('image.tmdb.org');
+        exactFutureImage.dispatchEvent(new Event('error'));
+        expect(fetchMovieDetails).not.toHaveBeenCalled();
+        expect(search).not.toHaveBeenCalled();
+        expect(exactFutureCard.dataset.jellyfinRemoved).toBeUndefined();
+        expect(exactFutureCard.dataset.resolvedTmdbId).toBeUndefined();
+        exactFutureCard.querySelector<HTMLAnchorElement>('.jc-hidden-item-name')!.click();
+        expect(open).not.toHaveBeenCalled();
         expect(resolveLegacyIdentity('future', 'tv')).toBe(false);
         expect(getHiddenData().items.future.identity).toEqual({
             version: 2,
@@ -180,5 +260,74 @@ describe('versioned hidden-content media identity', () => {
         expect(getHiddenData().items.legacy.identity).toBeUndefined();
         expect(isHiddenMedia({ tmdbId: 550, mediaType: 'movie' })).toBe(false);
         expect(isHiddenMedia({ tmdbId: 550, mediaType: 'tv' })).toBe(false);
+    });
+
+    it('atomically prefers alternate typed metadata over conflicting canonical legacy metadata', () => {
+        const dashed = '11111111-2222-3333-4444-555555555555';
+        const compact = dashed.replace(/-/g, '');
+        install({
+            [dashed]: {
+                itemId: dashed,
+                name: 'Legacy Movie 550',
+                type: '',
+                tmdbId: '550',
+                hideScope: 'continuewatching',
+            },
+            [compact]: {
+                itemId: compact,
+                name: 'Movie 551',
+                type: 'Movie',
+                tmdbId: '551',
+                identity: { version: 1, provider: 'tmdb', mediaType: 'movie', id: '551' },
+                hideScope: 'nextup',
+            },
+        });
+
+        markScopedHidden(dashed, 'continuewatching');
+
+        expect(Object.keys(getHiddenData().items)).toEqual([dashed]);
+        expect(getHiddenData().items[dashed]).toEqual(expect.objectContaining({
+            itemId: dashed,
+            tmdbId: '551',
+            identity: { version: 1, provider: 'tmdb', mediaType: 'movie', id: '551' },
+            hideScope: 'homesections',
+        }));
+    });
+
+    it('deduplicates a resolved provider-only legacy row without removing distinct exact ids', () => {
+        install({
+            legacy: { name: 'Legacy 550', tmdbId: '550', hideScope: 'global' },
+            'jf-1': {
+                itemId: 'jf-1',
+                name: 'Edition one',
+                type: 'Movie',
+                tmdbId: '550',
+                identity: { version: 1, provider: 'tmdb', mediaType: 'movie', id: '550' },
+                hideScope: 'nextup',
+            },
+            'jf-2': {
+                itemId: 'jf-2',
+                name: 'Edition two',
+                type: 'Movie',
+                tmdbId: '550',
+                identity: { version: 1, provider: 'tmdb', mediaType: 'movie', id: '550' },
+                hideScope: 'continuewatching',
+            },
+        });
+
+        expect(resolveLegacyIdentity('legacy', 'movie')).toBe(true);
+        expect(Object.keys(getHiddenData().items).sort()).toEqual(['jf-1', 'jf-2']);
+        expect(getHiddenData().items['jf-1'].hideScope).toBe('global');
+
+        unhideItem('jf-1');
+        expect(isHiddenByTmdbId(550, 'movie')).toBe(false);
+        expect(getHiddenData().items['jf-2']).toEqual(expect.objectContaining({
+            itemId: 'jf-2',
+            hideScope: 'continuewatching',
+        }));
+
+        unhideItem('jf-2');
+        expect(isHiddenByTmdbId(550, 'movie')).toBe(false);
+        expect(Object.keys(getHiddenData().items)).toEqual([]);
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/media-identity.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/media-identity.ts
@@ -1,0 +1,83 @@
+/** Versioned provider identity persisted with hidden-content rows. */
+export interface HiddenContentIdentity {
+    version: 1;
+    provider: 'tmdb';
+    mediaType: 'movie' | 'tv';
+    id: string;
+}
+
+export type HiddenMediaType = HiddenContentIdentity['mediaType'];
+
+export interface HiddenIdentitySource {
+    identity?: Partial<HiddenContentIdentity> | null;
+    tmdbId?: string | number | null;
+    mediaType?: string | null;
+    type?: string | null;
+}
+
+export const HIDDEN_CONTENT_IDENTITY_VERSION = 1 as const;
+
+export function normalizeHiddenMediaType(value: unknown): HiddenMediaType | null {
+    if (typeof value !== 'string') return null;
+    switch (value.trim().toLowerCase()) {
+        case 'movie': return 'movie';
+        case 'tv':
+        case 'series': return 'tv';
+        default: return null;
+    }
+}
+
+function normalizeProviderId(value: unknown): string | null {
+    if (typeof value !== 'string' && typeof value !== 'number') return null;
+    const id = String(value).trim();
+    return /^(?=.*[1-9])\d{1,32}$/.test(id) ? id : null;
+}
+
+export function createTmdbIdentity(
+    id: string | number | null | undefined,
+    mediaType: unknown,
+): HiddenContentIdentity | null {
+    const normalizedId = normalizeProviderId(id);
+    const normalizedType = normalizeHiddenMediaType(mediaType);
+    if (!normalizedId || !normalizedType) return null;
+    return {
+        version: HIDDEN_CONTENT_IDENTITY_VERSION,
+        provider: 'tmdb',
+        mediaType: normalizedType,
+        id: normalizedId,
+    };
+}
+
+/**
+ * Reads a persisted identity, or conservatively upgrades a legacy TMDB row
+ * only when its old Type field unambiguously identifies movie versus TV.
+ */
+export function identityFromSource(source: HiddenIdentitySource | null | undefined): HiddenContentIdentity | null {
+    if (!source) return null;
+    const identity = source.identity;
+    if (identity) {
+        if (identity.version === HIDDEN_CONTENT_IDENTITY_VERSION
+            && String(identity.provider || '').toLowerCase() === 'tmdb') {
+            return createTmdbIdentity(identity.id, identity.mediaType);
+        }
+        // Unknown or malformed explicit versions are not legacy rows. Leave
+        // them unresolved rather than silently downgrading future semantics.
+        return null;
+    }
+    return createTmdbIdentity(source.tmdbId, source.mediaType || source.type);
+}
+
+export function hiddenIdentityKey(identity: HiddenContentIdentity): string {
+    return `hc${identity.version}:${identity.provider}:${identity.mediaType}:${encodeURIComponent(identity.id)}`;
+}
+
+export function sameHiddenIdentity(
+    left: HiddenContentIdentity | null | undefined,
+    right: HiddenContentIdentity | null | undefined,
+): boolean {
+    return !!left && !!right
+        && left.version === right.version
+        && left.provider === right.provider
+        && left.mediaType === right.mediaType
+        && left.id === right.id;
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/media-identity.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/media-identity.ts
@@ -7,6 +7,7 @@ export interface HiddenContentIdentity {
 }
 
 export type HiddenMediaType = HiddenContentIdentity['mediaType'];
+export type HiddenIdentityStatus = 'resolved' | 'legacy-unresolved' | 'unsupported' | 'local-only';
 
 export interface HiddenIdentitySource {
     identity?: Partial<HiddenContentIdentity> | null;
@@ -65,6 +66,13 @@ export function identityFromSource(source: HiddenIdentitySource | null | undefin
         return null;
     }
     return createTmdbIdentity(source.tmdbId, source.mediaType || source.type);
+}
+
+/** Classifies management rows without treating unknown explicit schemas as legacy. */
+export function hiddenIdentityStatus(source: HiddenIdentitySource | null | undefined): HiddenIdentityStatus {
+    if (identityFromSource(source)) return 'resolved';
+    if (source?.identity) return 'unsupported';
+    return source?.tmdbId ? 'legacy-unresolved' : 'local-only';
 }
 
 export function hiddenIdentityKey(identity: HiddenContentIdentity): string {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/panel.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/panel.ts
@@ -5,9 +5,10 @@
 // (Converted from js/enhanced/hidden-content-panel.js — bodies semantically identical.)
 
 import { JC } from '../../globals';
-import { getHiddenData, unhideItem, unhideAll } from './data';
+import { getAllHiddenItems, resolveLegacyIdentity, unhideItem, unhideAll } from './data';
 import type { HiddenItem } from './data';
 import type { IdentityContext } from '../../types/jc';
+import { identityFromSource } from './media-identity';
 
 /** Max poster width when loading images from TMDB / Jellyfin. */
 const POSTER_MAX_WIDTH = 300;
@@ -93,14 +94,15 @@ export function createItemCard(item: HiddenItem, onNavigate?: () => void): HTMLE
 
     const hasJellyfinId = !!item.itemId;
     const hasTmdbId = !!item.tmdbId;
-    const mediaType = item.type === 'Series' ? 'tv' : 'movie';
+    const hasResolvedTmdbId = hasTmdbId && item._identityStatus !== 'legacy-unresolved';
+    const mediaType = identityFromSource(item)?.mediaType || (item.type === 'Series' ? 'tv' : 'movie');
 
     // Clickable poster area that navigates to item detail
     const posterLink = document.createElement('a');
     posterLink.className = 'jc-hidden-item-poster-link';
     if (hasJellyfinId) {
         posterLink.href = `#/details?id=${item.itemId}`;
-    } else if (hasTmdbId) {
+    } else if (hasResolvedTmdbId) {
         posterLink.href = '#';
         posterLink.dataset.tmdbId = String(item.tmdbId);
         posterLink.dataset.mediaType = mediaType;
@@ -123,16 +125,16 @@ export function createItemCard(item: HiddenItem, onNavigate?: () => void): HTMLE
             if (!isPanelFenceCurrent(fence)) return;
             const self = img;
             // Switch card to Seerr navigation
-            if (hasTmdbId && (JC as any).seerrMoreInfo) {
+            if (hasResolvedTmdbId && (JC as any).seerrMoreInfo) {
                 card.dataset.jellyfinRemoved = '1';
             }
             // Item removed from Jellyfin — fall back to TMDB poster
-            if (hasTmdbId && item.posterPath) {
+            if (hasResolvedTmdbId && item.posterPath) {
                 self.src = `https://image.tmdb.org/t/p/w${POSTER_MAX_WIDTH}${item.posterPath}`;
                 self.onerror = function(this: HTMLImageElement) {
                     if (isPanelFenceCurrent(fence)) this.style.display = 'none';
                 };
-            } else if (hasTmdbId && (JC as any).seerrAPI) {
+            } else if (hasResolvedTmdbId && (JC as any).seerrAPI) {
                 // No posterPath stored — fetch it from Seerr
                 self.onerror = function(this: HTMLImageElement) {
                     if (isPanelFenceCurrent(fence)) this.style.display = 'none';
@@ -196,7 +198,7 @@ export function createItemCard(item: HiddenItem, onNavigate?: () => void): HTMLE
     nameLink.textContent = item.name || 'Unknown';
     if (hasJellyfinId) {
         nameLink.href = `#/details?id=${item.itemId}`;
-    } else if (hasTmdbId) {
+    } else if (hasResolvedTmdbId) {
         nameLink.href = '#';
         nameLink.dataset.tmdbId = String(item.tmdbId);
         nameLink.dataset.mediaType = mediaType;
@@ -214,15 +216,15 @@ export function createItemCard(item: HiddenItem, onNavigate?: () => void): HTMLE
             // If item was removed from Jellyfin, fall back to the Seerr modal — using the
             // stored TMDB id, or one resolved at render time by a Seerr search.
             const removedId = (card.dataset.jellyfinRemoved === '1')
-                ? (hasTmdbId ? item.tmdbId : card.dataset.resolvedTmdbId)
+                ? (hasResolvedTmdbId ? item.tmdbId : card.dataset.resolvedTmdbId)
                 : '';
             if (hasJellyfinId && removedId && (JC as any).seerrMoreInfo) {
                 e.preventDefault();
-                (JC as any).seerrMoreInfo.open(parseInt(String(removedId), 10), hasTmdbId ? mediaType : (card.dataset.resolvedMediaType || mediaType));
+                (JC as any).seerrMoreInfo.open(parseInt(String(removedId), 10), hasResolvedTmdbId ? mediaType : (card.dataset.resolvedMediaType || mediaType));
                 if (onNavigate) onNavigate();
             } else if (hasJellyfinId) {
                 if (onNavigate) onNavigate();
-            } else if (hasTmdbId && (JC as any).seerrMoreInfo) {
+            } else if (hasResolvedTmdbId && (JC as any).seerrMoreInfo) {
                 e.preventDefault();
                 (JC as any).seerrMoreInfo.open(parseInt(String(item.tmdbId), 10), mediaType);
                 if (onNavigate) onNavigate();
@@ -241,8 +243,33 @@ export function createItemCard(item: HiddenItem, onNavigate?: () => void): HTMLE
         _scope === 'nextup'           ? JC.t!('hidden_content_scope_nextup_label') :
         _scope === 'homesections'     ? JC.t!('hidden_content_scope_homesections_label') :
         '';
-    metaDiv.textContent = [item.type, _scopeText, hiddenDate].filter(Boolean).join(' · ');
+    const identityText = item._identityStatus === 'legacy-unresolved' ? 'Legacy identity — review required' : '';
+    metaDiv.textContent = [item.type, identityText, _scopeText, hiddenDate].filter(Boolean).join(' · ');
     info.appendChild(metaDiv);
+
+    if (item._identityStatus === 'legacy-unresolved' && item._key && !item._identityReadOnly) {
+        const resolution = document.createElement('div');
+        resolution.className = 'jc-hidden-item-identity-resolution';
+        const prompt = document.createElement('span');
+        prompt.textContent = 'Treat this TMDB item as: ';
+        resolution.appendChild(prompt);
+        for (const [mediaType, label] of [['movie', 'Movie'], ['tv', 'TV']] as const) {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.textContent = label;
+            button.addEventListener('click', () => {
+                if (!isPanelFenceCurrent(fence)) return;
+                if (resolveLegacyIdentity(item._key!, mediaType)) {
+                    item._identityStatus = 'resolved';
+                    item.type = mediaType === 'tv' ? 'Series' : 'Movie';
+                    metaDiv.textContent = [item.type, _scopeText, hiddenDate].filter(Boolean).join(' · ');
+                    resolution.remove();
+                }
+            });
+            resolution.appendChild(button);
+        }
+        info.appendChild(resolution);
+    }
 
     const unhideBtn = document.createElement('button');
     unhideBtn.className = 'jc-hidden-item-unhide';
@@ -264,8 +291,7 @@ export function showManagementPanel(): void {
     if (!isPanelFenceCurrent(fence)) return;
     activeManagementClose?.();
 
-    const data = getHiddenData();
-    const items = Object.entries(data.items || {}).map(([key, item]) => ({ ...item, _key: key }));
+    const items = getAllHiddenItems();
 
     const overlay = document.createElement('div');
     overlay.className = 'jc-hidden-management-overlay';

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/panel.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/panel.ts
@@ -243,7 +243,9 @@ export function createItemCard(item: HiddenItem, onNavigate?: () => void): HTMLE
         _scope === 'nextup'           ? JC.t!('hidden_content_scope_nextup_label') :
         _scope === 'homesections'     ? JC.t!('hidden_content_scope_homesections_label') :
         '';
-    const identityText = item._identityStatus === 'legacy-unresolved' ? 'Legacy identity — review required' : '';
+    const identityText = item._identityStatus === 'legacy-unresolved'
+        ? 'Legacy identity — review required'
+        : (item._identityStatus === 'unsupported' ? 'Unsupported identity — update required' : '');
     metaDiv.textContent = [item.type, identityText, _scopeText, hiddenDate].filter(Boolean).join(' · ');
     info.appendChild(metaDiv);
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/panel.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/panel.ts
@@ -94,7 +94,7 @@ export function createItemCard(item: HiddenItem, onNavigate?: () => void): HTMLE
 
     const hasJellyfinId = !!item.itemId;
     const hasTmdbId = !!item.tmdbId;
-    const hasResolvedTmdbId = hasTmdbId && item._identityStatus !== 'legacy-unresolved';
+    const hasResolvedTmdbId = hasTmdbId && item._identityStatus === 'resolved';
     const mediaType = identityFromSource(item)?.mediaType || (item.type === 'Series' ? 'tv' : 'movie');
 
     // Clickable poster area that navigates to item detail
@@ -108,7 +108,7 @@ export function createItemCard(item: HiddenItem, onNavigate?: () => void): HTMLE
         posterLink.dataset.mediaType = mediaType;
     }
 
-    if (item.posterPath) {
+    if (item.posterPath && hasResolvedTmdbId) {
         const img = document.createElement('img');
         img.className = 'jc-hidden-item-poster';
         img.src = `https://image.tmdb.org/t/p/w${POSTER_MAX_WIDTH}${item.posterPath}`;
@@ -153,7 +153,8 @@ export function createItemCard(item: HiddenItem, onNavigate?: () => void): HTMLE
                 }).catch(function() {
                     if (isPanelFenceCurrent(fence)) self.style.display = 'none';
                 });
-            } else if (item.type !== 'Person' && item.name && (JC as any).seerrAPI && (JC as any).seerrMoreInfo) {
+            } else if (item._identityStatus !== 'unsupported'
+                && item.type !== 'Person' && item.name && (JC as any).seerrAPI && (JC as any).seerrMoreInfo) {
                 // No TMDB id stored and the Jellyfin media is gone — resolve via a Seerr search
                 // so the card opens the more-info modal instead of a blank poster + dead link.
                 self.style.display = 'none';

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/save.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/save.ts
@@ -9,6 +9,7 @@ import type { IdentityContext } from '../../types/jc';
 import { toast } from '../../core/ui-kit';
 import { getHiddenData } from './data';
 import type { HiddenItem } from './data';
+import { identityFromSource } from './media-identity';
 
 let saveTimeout: number | null = null;
 let pendingDebounceContext: IdentityContext | null = null;
@@ -123,7 +124,14 @@ export async function fetchUserHiddenItemsForAdmin(targetUserId: string): Promis
                 ? JC.toCamelCase(res && res.hiddenContent)
                 : (res && res.hiddenContent));
         const items: Record<string, HiddenItem> = (hc && hc.items) || {};
-        return Object.entries(items).map(([key, item]) => ({ ...item, _key: key }));
+        return Object.entries(items).map(([key, item]) => ({
+            ...item,
+            _key: key,
+            _identityStatus: identityFromSource(item)
+                ? 'resolved'
+                : (item.tmdbId ? 'legacy-unresolved' : 'local-only'),
+            _identityReadOnly: true,
+        }));
     } catch (e: any) {
         if (e && e.status === 403) console.warn('🪼 Jellyfin Canopy: Hidden Content admin read denied (not an admin).');
         return null;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/save.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/save.ts
@@ -9,7 +9,7 @@ import type { IdentityContext } from '../../types/jc';
 import { toast } from '../../core/ui-kit';
 import { getHiddenData } from './data';
 import type { HiddenItem } from './data';
-import { identityFromSource } from './media-identity';
+import { hiddenIdentityStatus } from './media-identity';
 
 let saveTimeout: number | null = null;
 let pendingDebounceContext: IdentityContext | null = null;
@@ -127,9 +127,7 @@ export async function fetchUserHiddenItemsForAdmin(targetUserId: string): Promis
         return Object.entries(items).map(([key, item]) => ({
             ...item,
             _key: key,
-            _identityStatus: identityFromSource(item)
-                ? 'resolved'
-                : (item.tmdbId ? 'legacy-unresolved' : 'local-only'),
+            _identityStatus: hiddenIdentityStatus(item),
             _identityReadOnly: true,
         }));
     } catch (e: any) {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/surface.d.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/surface.d.ts
@@ -4,7 +4,8 @@
 // user scripts keep reading JC.hiddenContent / calling JC.initializeHiddenContent
 // by these exact names.
 import type {} from '../../types/jc';
-import type { HiddenItem, HideItemParams, HiddenContentSettings } from './data';
+import type { HiddenItem, HideItemParams, HiddenContentSettings, HiddenMediaCandidate } from './data';
+import type { HiddenMediaType } from './media-identity';
 import type { HideDialogOptions } from './dialogs';
 import type { HiddenContentUser } from './save';
 
@@ -12,7 +13,9 @@ declare module '../../types/jc' {
     /** The frozen public JC.hiddenContent surface. */
     interface HiddenContentApi {
         isHidden(jellyfinItemId: string): boolean;
-        isHiddenByTmdbId(tmdbId: string | number): boolean;
+        isHiddenByTmdbId(tmdbId: string | number, mediaType?: string): boolean;
+        isHiddenMedia(candidate: HiddenMediaCandidate): boolean;
+        getHiddenStorageKey(candidate: HiddenMediaCandidate): string | null;
         isHiddenOnSurface(itemId: string, surface: string): boolean;
         hideItem(params: HideItemParams): void;
         unhideItem(itemId: string): void;
@@ -33,6 +36,7 @@ declare module '../../types/jc' {
         removeLibraryHideButtons(): void;
         refresh(): Promise<boolean>;
         markScopedHidden(itemId: string, scope?: string): void;
+        resolveLegacyIdentity(storageKey: string, mediaType: HiddenMediaType): boolean;
         flushPendingSave(): Promise<void>;
         // Admin-only cross-user visibility + editing
         fetchHiddenContentUsers(): Promise<HiddenContentUser[] | null>;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/cards.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/cards.identity.test.ts
@@ -39,6 +39,44 @@ describe('Seerr card identity ownership', () => {
         JC.identity.transition('card-server-a', `card-user-a-${Math.random()}`, 'test setup');
     });
 
+    it('keeps the Seerr button hidden when another exact row still owns the provider identity', () => {
+        const unhideItem = vi.fn();
+        const getHiddenStorageKey = vi.fn(() => 'jf-1');
+        const isHiddenMedia = vi.fn(() => true);
+        JC.hiddenContent = {
+            getSettings: () => ({ enabled: true, showHideButtons: true, showButtonSeerr: true }),
+            isHiddenMedia,
+            getHiddenStorageKey,
+            unhideItem,
+            confirmAndHide: vi.fn(),
+        } as unknown as NonNullable<typeof JC.hiddenContent>;
+        const createCard = ui.createSeerrCard as unknown as (
+            item: Record<string, unknown>,
+            active: boolean,
+            userFound: boolean,
+        ) => HTMLElement;
+        const card = createCard({
+            id: 550,
+            mediaType: 'movie',
+            title: 'Another edition',
+            overview: '',
+            mediaInfo: { jellyfinMediaId: 'jf-2', status: 5 },
+        }, true, true);
+        const button = card.querySelector<HTMLButtonElement>('.jc-hide-btn')!;
+
+        expect(button.classList.contains('jc-already-hidden')).toBe(true);
+        button.click();
+
+        expect(getHiddenStorageKey).toHaveBeenCalledWith(expect.objectContaining({
+            jellyfinMediaId: 'jf-2',
+            tmdbId: 550,
+        }));
+        expect(unhideItem).toHaveBeenCalledWith('jf-1');
+        expect(isHiddenMedia).toHaveBeenCalledTimes(2);
+        expect(button.classList.contains('jc-already-hidden')).toBe(true);
+        expect(button.title).toBe('Hidden');
+    });
+
     it('removes A cards synchronously and retained direct controls cannot open under B', () => {
         const createCard = ui.createSeerrCard as unknown as (
             item: { id: number; mediaType: string; title: string; overview: string },

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/cards.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/cards.ts
@@ -348,7 +348,11 @@ function createSeerrCard(item: any, isSeerrActive: any, seerrUserFound: any) {
             const hiddenLabel = JC.t!('hidden_content_already_hidden') !== 'hidden_content_already_hidden' ? JC.t!('hidden_content_already_hidden') : 'Hidden';
             const unhideLabel = JC.t!('hidden_content_unhide') !== 'hidden_content_unhide' ? JC.t!('hidden_content_unhide') : 'Unhide';
             const hideLabel = JC.t!('hidden_content_hide_button') !== 'hidden_content_hide_button' ? JC.t!('hidden_content_hide_button') : 'Hide';
-            const unhideKey = jellyfinMediaId || `tmdb-${item.id}`;
+            const mediaCandidate = {
+                jellyfinMediaId: jellyfinMediaId || '',
+                tmdbId: item.id,
+                mediaType: item.mediaType,
+            };
 
             /**
              * Replaces the hide button's content with a material icon.
@@ -380,7 +384,8 @@ function createSeerrCard(item: any, isSeerrActive: any, seerrUserFound: any) {
                     e.preventDefault();
                     e.stopPropagation();
                     if (!isCurrent()) return;
-                    JC.hiddenContent?.unhideItem(unhideKey);
+                    const unhideKey = JC.hiddenContent?.getHiddenStorageKey(mediaCandidate);
+                    if (unhideKey) JC.hiddenContent?.unhideItem(unhideKey);
                     setHideState();
                 };
             }
@@ -413,7 +418,7 @@ function createSeerrCard(item: any, isSeerrActive: any, seerrUserFound: any) {
                 };
             }
 
-            if (JC.hiddenContent.isHiddenByTmdbId(item.id)) {
+            if (JC.hiddenContent.isHiddenMedia(mediaCandidate)) {
                 setHiddenState();
             } else {
                 setHideState();

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/cards.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/cards.ts
@@ -386,7 +386,8 @@ function createSeerrCard(item: any, isSeerrActive: any, seerrUserFound: any) {
                     if (!isCurrent()) return;
                     const unhideKey = JC.hiddenContent?.getHiddenStorageKey(mediaCandidate);
                     if (unhideKey) JC.hiddenContent?.unhideItem(unhideKey);
-                    setHideState();
+                    if (JC.hiddenContent?.isHiddenMedia(mediaCandidate)) setHiddenState();
+                    else setHideState();
                 };
             }
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/test/plugin-loader-harness.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/test/plugin-loader-harness.ts
@@ -1,0 +1,39 @@
+import * as ts from 'typescript';
+
+const TEST_FILE_PATH = decodeURIComponent(new URL(import.meta.url).pathname);
+const SRC_ROOT = TEST_FILE_PATH.replace(/\/test\/[^/]+$/, '/');
+const PLUGIN_JS_PATH = SRC_ROOT.replace(/src\/$/, 'js/') + 'plugin.js';
+const SOURCE = ts.sys.readFile(PLUGIN_JS_PATH) ?? '';
+
+function extractFunctionSource(name: string): string {
+    const start = SOURCE.indexOf(`function ${name}(`);
+    if (start < 0) throw new Error(`${name} not found in plugin.js`);
+    const braceStart = SOURCE.indexOf('{', start);
+    if (braceStart < 0) throw new Error(`${name} body not found in plugin.js`);
+    let depth = 0;
+    for (let i = braceStart; i < SOURCE.length; i++) {
+        const ch = SOURCE[i];
+        if (ch === '{') depth++;
+        else if (ch === '}' && --depth === 0) return SOURCE.slice(start, i + 1);
+    }
+    throw new Error(`${name} body is unterminated in plugin.js`);
+}
+
+export type UserFileCaseTransform = (
+    fileName: string,
+    value: unknown,
+    direction: 'load' | 'save',
+) => unknown;
+
+/** Evaluates the exact schema-transform implementation shipped in plugin.js. */
+export function loadUserFileCaseTransform(): UserFileCaseTransform {
+    const sources = [
+        'transformObjectKeys',
+        'toCamelCase',
+        'toPascalCase',
+        'userFileCaseOptions',
+        'transformUserFileCase',
+    ].map(extractFunctionSource).join('\n');
+    const evaluated: unknown = eval(`(() => { ${sources}\nreturn transformUserFileCase; })()`);
+    return evaluated as UserFileCaseTransform;
+}

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -19,7 +19,7 @@ const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the repeated clean measurements', () => {
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1439, totalLines: 1762 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 18049, totalLines: 26648 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 18168, totalLines: 26709 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);
 });

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -19,7 +19,7 @@ const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the repeated clean measurements', () => {
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1439, totalLines: 1762 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 18168, totalLines: 26709 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 18321, totalLines: 26765 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);
 });

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -21,12 +21,12 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 18168,
-        "totalLines": 26709
+        "coveredLines": 18321,
+        "totalLines": 26765
       },
       "tolerance": {
         "missingCoveredLines": 2,
-        "rationale": "Two clean local .NET 10.0.9/Coverlet integration runs on 2026-07-16 each passed 1595 tests and measured the identical 26709-line assembly scope at 18168 covered lines. Issue #121 adds the validated, cloned v1 hidden-content provider identity and typed admin mutation owner while retaining exact Jellyfin item keys. Deterministic regressions cover movie 550 and TV 550 coexisting, typed legacy deduplication, refusal of new ambiguous bare TMDB rows, exact local identity retention, and unhide-one isolation. The reviewed high-water advances to 18168 covered lines; the existing two-line tolerance is unchanged and remains the previously reviewed narrow Coverlet instrumentation allowance."
+        "rationale": "Two clean post-rebase local .NET 10.0.9/Coverlet integration runs on 2026-07-16 each passed 1606 tests and measured the identical 26765-line assembly scope at 18321 and 18320 covered lines. Issue #121 adds validated v1 hidden-content provider identities while retaining exact Jellyfin keys; its review successor rejects unsupported explicit admin identities, preserves distinct exact rows sharing one provider identity, deduplicates only merge-compatible legacy rows, and reconciles typed identity plus TMDB metadata as one atomic pair across canonical/compact scoped-hide variants and fresh library metadata. Unsupported future/non-TMDB scoped metadata remains an opaque Identity/TmdbId pair rather than being reinterpreted. Deterministic regressions cover conflicting legacy 550 versus typed/fresh 551 metadata, future IMDb metadata beside TMDB 550, same-TMDB exact rows, typed legacy deduplication, ambiguous-row refusal, and unhide isolation. Relative to main's reviewed 18049/26648 issue #84 baseline, the reviewed assembly scope grows by 117 instrumented lines and the high-water advances to 18321 covered lines while preserving opaque-key/null-prototype protections. The existing two-line tolerance is unchanged and covers the reproduced one-line Coverlet variance; coverage-baseline.test.js retains the negative boundaries."
       }
     }
   }

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -21,12 +21,12 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 18049,
-        "totalLines": 26648
+        "coveredLines": 18168,
+        "totalLines": 26709
       },
       "tolerance": {
         "missingCoveredLines": 2,
-        "rationale": "Two clean local .NET 10.0.9/Coverlet integration runs on 2026-07-16 each passed 1594 tests and measured the identical 26648-line assembly scope at 18049 covered lines. Issue #84's real revisioned bookmark replacement/GET/file regression newly covers eight existing controller lines while proving generated, case-distinct, punctuation, Unicode, numeric-looking, and prototype-shaped dictionary keys remain exact and BookmarkItem DTO properties remain PascalCase. The reviewed high-water therefore advances from 18041 to 18049; the existing two-line tolerance is unchanged. The combined scope retains issue #151's page-independent filtered-total contract, source-pinned title issue owner, bounded enrichment and modal retrieval, fresh authorization/configuration gates, and deterministic pagination and ownership regressions. Issue #72 replaces wall-clock, upsert-only tag-cache deltas with a process-epoch monotonic revision journal whose bounded rows carry upserts and authorization-filtered tombstones. Full snapshots establish per-user disclosure proof, projection-only rows extend that proof, retained-history gaps and invalid cursors reset deterministically, and the client advances removal-only cursors, clears authoritative empty snapshots, and rejects stale out-of-order responses. The per-user disclosure proof is updated and reweighed in place so one-row deltas do not copy all 15000 previously served ids. Deterministic regressions cover deletion and zero-upsert advancement, same-millisecond mutations and clock rollback, repeated-id last-state wins, retention boundaries and invalid cursors, real multi-user tombstone isolation, projection-only introduction followed by deletion, 15000-entry one/no-change bounded journal and disclosure-proof work plus payload size, full non-empty to empty healing, and both N/N+1 completion orders. The tolerance remains the previously reviewed narrow Coverlet instrumentation allowance; coverage-baseline.test.js retains exact below-floor, above-baseline, scope-change, and broad-tolerance negative boundaries."
+        "rationale": "Two clean local .NET 10.0.9/Coverlet integration runs on 2026-07-16 each passed 1595 tests and measured the identical 26709-line assembly scope at 18168 covered lines. Issue #121 adds the validated, cloned v1 hidden-content provider identity and typed admin mutation owner while retaining exact Jellyfin item keys. Deterministic regressions cover movie 550 and TV 550 coexisting, typed legacy deduplication, refusal of new ambiguous bare TMDB rows, exact local identity retention, and unhide-one isolation. The reviewed high-water advances to 18168 covered lines; the existing two-line tolerance is unchanged and remains the previously reviewed narrow Coverlet instrumentation allowance."
       }
     }
   }


### PR DESCRIPTION
Closes #121.

## Root cause

Hidden Content treated bare TMDB IDs as globally unique. Movie and TV identities could collide, exact Jellyfin rows could be merged incorrectly, and scoped updates could pair identity metadata from different records.

## What changed

- Introduce versioned typed TMDB identities for movie and TV content while retaining exact Jellyfin item IDs.
- Migrate only unambiguous legacy rows; ambiguous and unsupported future identities remain review-only and fail closed.
- Reconcile Identity and TmdbId as one atomic pair across admin, scoped-hide, persistence, and client mutation paths.
- Preserve distinct exact Jellyfin rows, opaque future identity pairs, and null-prototype hazardous storage keys.
- Prevent unsupported identities from producing TMDB or Seerr navigation, API calls, searches, or poster requests.
- Re-evaluate Seerr card state after removing one of multiple matching rows.

## Validation

- Client: 151 files, 1,008/1,008 tests; core coverage 1,439/1,762
- Server: 1,606/1,606 tests; 18,320/26,765 within the unchanged two-line tolerance of repeated reviewed high-water 18,321
- Focused overlap: client 52/52; server 15/15
- Repository scripts: 349/349
- Both TypeScript checks, deterministic bundle, syntax inventory, translations, performance guard
- Release build: 0 warnings, 0 errors
- NuGet transitive vulnerability audit: clean
- ESLint advisory: 0 errors
- Two independent exact-SHA reviews: APPROVE at 0616a1df8d69a49d107430860f1d18ebd08c3a4a
- Diff hygiene: clean

GitHub Actions supplies the official six-shard dockerized Jellyfin 12 unstable evidence.