### PR TITLE
fix(client): reconcile native preferences links across cached pages

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/view-root.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/view-root.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+    recordViewRootShown,
+    resetViewRootTrackingForTests,
+    resolveCurrentViewRoot,
+} from './view-root';
+
+function buildRoot(classes = 'page libraryPage'): HTMLElement {
+    const root = document.createElement('div');
+    root.id = 'myPreferencesMenuPage';
+    root.className = classes;
+    document.body.appendChild(root);
+    return root;
+}
+
+describe('resolveCurrentViewRoot', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        resetViewRootTrackingForTests();
+        history.replaceState({}, '', '/web/#/home');
+    });
+
+    it('enumerates duplicate ids and adopts the only visible boot-time instance', () => {
+        const stale = buildRoot('page libraryPage hide');
+        const current = buildRoot('page libraryPage');
+
+        const resolved = resolveCurrentViewRoot('myPreferencesMenuPage');
+
+        expect(resolved?.root).toBe(current);
+        expect(resolved?.root).not.toBe(stale);
+    });
+
+    it('waits for the current navigation viewshow instead of adopting the outgoing page', () => {
+        history.replaceState({}, '', '/web/#/mypreferencesmenu.html?instance=old');
+        const outgoing = buildRoot();
+        recordViewRootShown(outgoing);
+        expect(resolveCurrentViewRoot('myPreferencesMenuPage')?.root).toBe(outgoing);
+
+        // Jellyfin changes the route before it hides the outgoing cached view.
+        history.replaceState({}, '', '/web/#/mypreferencesmenu.html?instance=new');
+        const incoming = buildRoot('page libraryPage');
+        expect(resolveCurrentViewRoot('myPreferencesMenuPage')).toBeNull();
+
+        incoming.dispatchEvent(new CustomEvent('viewshow', { bubbles: true }));
+        expect(resolveCurrentViewRoot('myPreferencesMenuPage')?.root).toBe(incoming);
+    });
+
+    it('refreshes ownership when POP re-shows an older cached instance', () => {
+        history.replaceState({}, '', '/web/#/mypreferencesmenu.html?instance=a');
+        const cachedA = buildRoot();
+        cachedA.dispatchEvent(new CustomEvent('viewshow', { bubbles: true }));
+
+        history.replaceState({}, '', '/web/#/mypreferencesmenu.html?instance=b');
+        cachedA.classList.add('hide');
+        const cachedB = buildRoot();
+        cachedB.dispatchEvent(new CustomEvent('viewshow', { bubbles: true }));
+        expect(resolveCurrentViewRoot('myPreferencesMenuPage')?.root).toBe(cachedB);
+
+        history.replaceState({}, '', '/web/#/mypreferencesmenu.html?instance=a');
+        cachedB.classList.add('hide');
+        cachedA.classList.remove('hide');
+        cachedA.dispatchEvent(new CustomEvent('viewshow', { bubbles: true }));
+        expect(resolveCurrentViewRoot('myPreferencesMenuPage')?.root).toBe(cachedA);
+    });
+
+    it('supports modern and legacy root class dialects without selector-order ownership', () => {
+        const legacy = buildRoot('page libraryPage hide');
+        const modern = buildRoot('page mainAnimatedPage');
+        modern.dispatchEvent(new CustomEvent('viewbeforeshow', { bubbles: true }));
+
+        expect(resolveCurrentViewRoot('myPreferencesMenuPage')?.root).toBe(modern);
+        expect(resolveCurrentViewRoot('myPreferencesMenuPage')?.root).not.toBe(legacy);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/view-root.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/view-root.ts
@@ -1,0 +1,117 @@
+// src/core/view-root.ts
+//
+// Resolves the current instance of a Jellyfin native page without relying on
+// document.getElementById(). Jellyfin's view cache can keep an old hidden page
+// connected while mounting another page with the same id, and navigation is
+// announced before the incoming view replaces the outgoing visible element.
+//
+// A raw viewbeforeshow/viewshow is the ownership hand-off: stamp its target
+// with the exact pathname/search/hash identity that was current when Jellyfin
+// showed it. `viewbeforeshow` covers React-hosted modern views; `viewshow`
+// covers legacy viewManager mounts and cached POP re-shows. Consumers receive
+// a root only when that stamp still matches the current navigation. That makes
+// early navigation callbacks fail closed until the incoming lifecycle event.
+
+import { navDedupKey } from './navigation';
+
+interface ShownRootRecord {
+    navigationKey: string;
+    sequence: number;
+}
+
+export interface CurrentViewRoot {
+    root: HTMLElement;
+    navigationKey: string;
+    showSequence: number;
+}
+
+let shownRoots = new WeakMap<HTMLElement, ShownRootRecord>();
+let showSequence = 0;
+let everRecordedViewLifecycle = false;
+
+function escapeAttributeValue(value: string): string {
+    if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+        return CSS.escape(value);
+    }
+    return value.replace(/["\\]/g, '\\$&');
+}
+
+/**
+ * Enumerate every element carrying an exact id, including duplicate ids.
+ * Attribute selectors are intentional: selector engines may optimize `#id`
+ * through getElementById() and silently return only the first cached instance.
+ */
+export function queryElementsById(id: string, scope: ParentNode = document): HTMLElement[] {
+    return Array.from(
+        scope.querySelectorAll<HTMLElement>(`[id="${escapeAttributeValue(id)}"]`)
+    );
+}
+
+function isVisibleConnectedRoot(root: HTMLElement): boolean {
+    if (!root.isConnected || root.hidden) return false;
+    if (root.getAttribute('aria-hidden') === 'true') return false;
+    return root.closest('.hide, [hidden], [aria-hidden="true"]') === null;
+}
+
+/** Record one native view instance as shown for the current navigation. */
+export function recordViewRootShown(element: Element | null | undefined): void {
+    if (!(element instanceof HTMLElement)) return;
+    shownRoots.set(element, {
+        navigationKey: navDedupKey(),
+        sequence: ++showSequence,
+    });
+    everRecordedViewLifecycle = true;
+}
+
+/**
+ * Resolve the current visible instance of a native page id.
+ *
+ * Before the bundle has observed any view lifecycle event, one unique visible instance is
+ * safe to adopt: this is the normal "bundle booted on the page" case. After a
+ * lifecycle event has been observed, an unstamped visible element can be the
+ * outgoing half of a navigation transition, so callers wait for the incoming
+ * viewbeforeshow/viewshow.
+ */
+export function resolveCurrentViewRoot(pageId: string): CurrentViewRoot | null {
+    const navigationKey = navDedupKey();
+    const visibleRoots = queryElementsById(pageId).filter(isVisibleConnectedRoot);
+    let winner: { root: HTMLElement; record: ShownRootRecord } | null = null;
+
+    for (const root of visibleRoots) {
+        const record = shownRoots.get(root);
+        if (!record || record.navigationKey !== navigationKey) continue;
+        if (!winner || record.sequence > winner.record.sequence) {
+            winner = { root, record };
+        }
+    }
+
+    if (winner) {
+        return {
+            root: winner.root,
+            navigationKey: winner.record.navigationKey,
+            showSequence: winner.record.sequence,
+        };
+    }
+
+    if (!everRecordedViewLifecycle && visibleRoots.length === 1) {
+        const root = visibleRoots[0];
+        recordViewRootShown(root);
+        const record = shownRoots.get(root)!;
+        return { root, navigationKey: record.navigationKey, showSequence: record.sequence };
+    }
+
+    return null;
+}
+
+/** Test-only reset for the module-level weak ownership ledger. */
+export function resetViewRootTrackingForTests(): void {
+    shownRoots = new WeakMap<HTMLElement, ShownRootRecord>();
+    showSequence = 0;
+    everRecordedViewLifecycle = false;
+}
+
+for (const eventName of ['viewbeforeshow', 'viewshow']) {
+    document.addEventListener(eventName, (event) => {
+        recordViewRootShown(event.target as Element | null);
+    }, true);
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/pages/entry-points.cached-view.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/pages/entry-points.cached-view.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+import { initEntryPoints } from './entry-points';
+import { registerPage } from './registry';
+
+function buildPreferencesPage(hidden: boolean): HTMLElement {
+    const page = document.createElement('div');
+    page.id = 'myPreferencesMenuPage';
+    page.className = 'page libraryPage';
+    if (hidden) page.classList.add('hide');
+    const section = document.createElement('div');
+    section.className = 'verticalSection';
+    page.appendChild(section);
+    document.body.appendChild(page);
+    return page;
+}
+
+describe('page entry points in cached native preferences views', () => {
+    it('removes a stale owned link and mounts exactly once in the current page', async () => {
+        document.body.innerHTML = '';
+        const context = JC.identity.transition('server-a', 'user-a', 'cached-preferences-test');
+        registerPage({
+            id: 'cached-preferences-entry',
+            route: '/cached-preferences-entry',
+            titleKey: 'cached_preferences_entry',
+            titleFallback: 'Cached preferences entry',
+            icon: 'event',
+            isEnabled: () => true,
+            render: vi.fn(),
+        });
+        const stalePage = buildPreferencesPage(true);
+        const staleLink = document.createElement('a');
+        staleLink.id = 'jcPagePrefs-cached-preferences-entry';
+        staleLink.setAttribute('data-jc-identity-owned', 'true');
+        JC.identity.own(staleLink, context);
+        stalePage.querySelector('.verticalSection')!.appendChild(staleLink);
+        const currentPage = buildPreferencesPage(false);
+
+        initEntryPoints();
+        await JC.identity.activate(context);
+
+        expect(stalePage.querySelector('#jcPagePrefs-cached-preferences-entry')).toBeNull();
+        expect(currentPage.querySelectorAll('#jcPagePrefs-cached-preferences-entry')).toHaveLength(1);
+        JC.core.dom!.removeBodySubscriber('jc-pages-entries');
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/pages/entry-points.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/pages/entry-points.ts
@@ -22,6 +22,7 @@
 import { JC } from '../../globals';
 import { onBodyMutation } from '../../core/dom-observer';
 import { onNavigate, onViewPage } from '../../core/navigation';
+import { queryElementsById, resolveCurrentViewRoot } from '../../core/view-root';
 import { getSidebarContainer, getHeaderRightContainer } from '../helpers';
 import { insertHeaderTrayButton } from '../header-tray';
 import { orderedPages, pageAvailable, resolvePage } from './registry';
@@ -194,12 +195,23 @@ function prefsLinkId(descriptor: PageDescriptor): string {
 function reconcilePrefsMenu(): void {
     const context = JC.identity.capture();
     if (!context) return;
-    const page = document.getElementById('myPreferencesMenuPage');
-    if (!page || page.classList.contains('hide')) return;
+    const current = resolveCurrentViewRoot('myPreferencesMenuPage');
+    if (!current) return;
+    const page = current.root;
     const menuContainer = page.querySelector('.verticalSection');
     if (!menuContainer) return;
+
+    // A cached old preferences view may retain identity-owned links with the
+    // same ids. Remove every non-current copy before reconciling this root so
+    // neither selector order nor stale identity can suppress current entries.
+    document.querySelectorAll<HTMLElement>('[id^="jcPagePrefs-"]').forEach((entry) => {
+        if (!page.contains(entry)) entry.remove();
+    });
+
     for (const descriptor of orderedPages()) {
-        let existing = document.getElementById(prefsLinkId(descriptor));
+        const matches = queryElementsById(prefsLinkId(descriptor), page);
+        let existing = matches.shift() ?? null;
+        matches.forEach((duplicate) => duplicate.remove());
         if (existing && !JC.identity.isOwned(existing, context)) {
             existing.remove();
             existing = null;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/entry-points.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/entry-points.test.ts
@@ -4,6 +4,7 @@
 // call made off the preferences page, and never disconnected them).
 import { beforeEach, describe, expect, it } from 'vitest';
 import { JC } from '../../globals';
+import { resetViewRootTrackingForTests } from '../../core/view-root';
 import './entry-points';
 
 const addLink = (): void => (JC as unknown as { addUserPreferencesLink: () => void }).addUserPreferencesLink();
@@ -22,6 +23,7 @@ function buildPrefsPage(hidden = false): HTMLElement {
 describe('JC.addUserPreferencesLink', () => {
     beforeEach(() => {
         document.body.innerHTML = '';
+        resetViewRootTrackingForTests();
     });
 
     it('creates no observers and no link when off the preferences page', () => {
@@ -58,6 +60,19 @@ describe('JC.addUserPreferencesLink', () => {
         expect(document.getElementById('jellyfinCanopyUserPrefsLink')).toBeNull();
     });
 
+    it('reconciles a hidden cached page into the current visible page', () => {
+        const stalePage = buildPrefsPage(true);
+        const staleLink = document.createElement('a');
+        staleLink.id = 'jellyfinCanopyUserPrefsLink';
+        stalePage.querySelector('.verticalSection')!.appendChild(staleLink);
+        const currentPage = buildPrefsPage();
+
+        addLink();
+
+        expect(stalePage.querySelector('#jellyfinCanopyUserPrefsLink')).toBeNull();
+        expect(currentPage.querySelectorAll('#jellyfinCanopyUserPrefsLink')).toHaveLength(1);
+    });
+
     it('adds the link via the navigation hook once the cached page is re-shown', () => {
         const page = buildPrefsPage(true);
         addLink(); // wires the nav hooks; page hidden so no link yet
@@ -69,5 +84,31 @@ describe('JC.addUserPreferencesLink', () => {
         history.pushState({}, '', '/test-prefs-link-reshow');
 
         expect(document.getElementById('jellyfinCanopyUserPrefsLink')).not.toBeNull();
+    });
+
+    it('moves ownership across repeated cached-view re-shows without accumulating links', () => {
+        history.replaceState({}, '', '/web/#/mypreferencesmenu.html?instance=a');
+        const pageA = buildPrefsPage();
+        pageA.dispatchEvent(new CustomEvent('viewshow', { bubbles: true }));
+        addLink();
+
+        history.replaceState({}, '', '/web/#/mypreferencesmenu.html?instance=b');
+        pageA.classList.add('hide');
+        const pageB = buildPrefsPage();
+        pageB.dispatchEvent(new CustomEvent('viewshow', { bubbles: true }));
+        addLink();
+
+        expect(pageA.querySelector('#jellyfinCanopyUserPrefsLink')).toBeNull();
+        expect(pageB.querySelectorAll('#jellyfinCanopyUserPrefsLink')).toHaveLength(1);
+
+        history.replaceState({}, '', '/web/#/mypreferencesmenu.html?instance=a');
+        pageB.classList.add('hide');
+        pageA.classList.remove('hide');
+        pageA.dispatchEvent(new CustomEvent('viewshow', { bubbles: true }));
+        addLink();
+
+        expect(pageB.querySelector('#jellyfinCanopyUserPrefsLink')).toBeNull();
+        expect(pageA.querySelectorAll('#jellyfinCanopyUserPrefsLink')).toHaveLength(1);
+        expect(document.querySelectorAll('#jellyfinCanopyUserPrefsLink')).toHaveLength(1);
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/entry-points.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/entry-points.ts
@@ -8,6 +8,7 @@
 import { JC } from '../../globals';
 import { onBodyMutation } from '../../core/dom-observer';
 import { onNavigate, onViewPage } from '../../core/navigation';
+import { queryElementsById, resolveCurrentViewRoot } from '../../core/view-root';
 import { getSidebarContainer } from '../helpers';
 import { ensureCanopySection, insertSectionEntry } from '../pages/entry-points';
 
@@ -104,14 +105,23 @@ let prefsLinkNavHooksWired = false;
  * @returns True when the link exists (or was just added).
  */
 function addPrefsLinkIfOnPage(): boolean {
-    const page = document.getElementById('myPreferencesMenuPage');
-    if (!page || page.classList.contains('hide')) return false;
+    const current = resolveCurrentViewRoot('myPreferencesMenuPage');
+    if (!current) return false;
+    const page = current.root;
 
     const menuContainer = page.querySelector('.verticalSection');
     if (!menuContainer) return false;
 
-    // Check if link already exists
-    if (document.getElementById('jellyfinCanopyUserPrefsLink')) return true;
+    // Cached native views can retain the same page/link ids. Ownership follows
+    // the current view root: remove stale/duplicate copies, then gate only on a
+    // link inside this root.
+    const links = queryElementsById('jellyfinCanopyUserPrefsLink');
+    let currentLink: HTMLElement | null = null;
+    for (const link of links) {
+        if (page.contains(link) && !currentLink) currentLink = link;
+        else link.remove();
+    }
+    if (currentLink) return true;
 
     // Create the link element matching Jellyfin's structure
     const enhancedLink = document.createElement('a');

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -18,7 +18,7 @@ const ROOT = path.join(__dirname, '..');
 const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the repeated clean measurements', () => {
-    assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1439, totalLines: 1762 });
+    assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1473, totalLines: 1797 });
     assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 18321, totalLines: 26765 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -9,12 +9,12 @@
       "scope": "Jellyfin.Plugin.JellyfinCanopy/src/core/**",
       "report": "coverage/coverage-summary.json",
       "measured": {
-        "coveredLines": 1439,
-        "totalLines": 1762
+        "coveredLines": 1473,
+        "totalLines": 1797
       },
       "tolerance": {
         "missingCoveredLines": 1,
-        "rationale": "Two clean local Node 22/V8 runs on 2026-07-16 each passed 970 tests and measured the unchanged 1762-line core scope at 1439 covered lines. The deterministic issue #87 viewshow regression now drives bookmark detail-request retirement through the real lifecycle and covers the existing dom-observer replacement diagnostic; no production core line was added. The reviewed high-water therefore advances by one covered line. The existing one-line tolerance is unchanged and permits only the previously reproduced negligible instrumentation variance; coverage-baseline.test.js retains exact below-floor, above-baseline, scope-change, and broad-tolerance negative boundaries."
+        "rationale": "Two clean local Node 22/V8 runs on 2026-07-16 each passed 1015 tests and measured the expanded 1797-line core scope at 1473 covered lines. Issue #127 adds the shared current-view root resolver used by native preferences injectors, with deterministic coverage for duplicate cached IDs, URL handoff before an incoming lifecycle event, POP re-show, and modern/legacy view roots. Relative to the reviewed 1439/1762 issue #87 baseline, the reviewed core scope grows by 35 instrumented lines and the high-water advances by 34 covered lines. The existing one-line tolerance is unchanged and permits only the previously reproduced negligible instrumentation variance; coverage-baseline.test.js retains exact below-floor, above-baseline, scope-change, and broad-tolerance negative boundaries."
       }
     },
     "server": {


### PR DESCRIPTION
Closes #127.

## What changed

- add one shared lifecycle-aware, URL-keyed visible view-root resolver for modern and legacy Jellyfin preferences pages
- reconcile stale and duplicate Canopy links root-locally across cached page handoffs, POP re-shows, and duplicate IDs
- migrate both the registered-pages and settings-panel native preference injectors to the shared owner
- add deterministic regressions for outgoing/incoming handoff, duplicate IDs, modern/legacy roots, and cached reactivation
- advance the reviewed client coverage ratchet from two identical clean measurements

## Why

Jellyfin retains and reuses cached page roots. The previous document-wide ID lookup could bind Canopy's native preference link to an outgoing hidden page, suppress insertion into the newly visible page, or leave duplicate stale links behind.

## Validation

- independent review: APPROVE, no actionable findings
- focused lifecycle/injector tests: 11/11
- full client suite: 1,015/1,015
- client coverage: 1,473/1,797 lines, reproduced exactly
- TypeScript source typecheck
- changed-file ESLint
- coverage-policy tests: 13/13
- performance-rules guard
- script suite: 349/349
- bundle/syntax and `git diff --check`
