### PR TITLE
fix(arr): collect complete paged queues

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/ArrQueuePaginationTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/ArrQueuePaginationTests.cs
@@ -1,0 +1,297 @@
+using System.Net;
+using System.Text;
+using System.Text.Json.Nodes;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Model.Arr;
+using Jellyfin.Plugin.JellyfinCanopy.Services.Arr;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services;
+
+public sealed class ArrQueuePaginationTests
+{
+    [Theory]
+    [InlineData("sonarr", 4)]
+    [InlineData("radarr", 5)]
+    public async Task SharedPaginator_CollectsExactBoundaryAndPartialFinalPage(string service, int total)
+    {
+        var handler = new QueueHandler(total, id => $$"""{"id":{{id}}}""");
+        var fetch = NewFetch(handler);
+
+        var result = await fetch.FetchQueueCollectionAsync<string>(
+            Instance(service),
+            (page, size) => $"/api/v3/queue?service={service}&page={page}&pageSize={size}",
+            pageSize: 2,
+            identity: row => row["id"]?.ToJsonString(),
+            projector: row => row["id"]!.ToJsonString(),
+            requestTimeout: TimeSpan.FromSeconds(2),
+            contextLabel: $"{service} queue",
+            ct: CancellationToken.None);
+
+        Assert.True(result.IsComplete);
+        Assert.Null(result.Error);
+        Assert.Equal(total, result.Items.Count);
+        Assert.Equal((int)Math.Ceiling(total / 2d), handler.QueueRequests);
+    }
+
+    [Fact]
+    public async Task DownloadsPageSize_IncludesSentinelAfterFirstThousandRows()
+    {
+        var handler = new QueueHandler(1_001, id => $$"""{"id":{{id}}}""");
+        var fetch = NewFetch(handler);
+
+        var result = await fetch.FetchQueueCollectionAsync<string>(
+            Instance("sonarr"),
+            (page, size) => $"/api/v3/queue?page={page}&pageSize={size}",
+            pageSize: 1_000,
+            identity: row => row["id"]?.ToJsonString(),
+            projector: row => row["id"]!.ToJsonString(),
+            requestTimeout: TimeSpan.FromSeconds(2),
+            contextLabel: "download queue",
+            ct: CancellationToken.None);
+
+        Assert.True(result.IsComplete);
+        Assert.Equal("1001", result.Items[^1]);
+        Assert.Equal(2, handler.QueueRequests);
+    }
+
+    [Theory]
+    [InlineData("sonarr", QueueFault.ChangingTotal, "totalRecords changed")]
+    [InlineData("radarr", QueueFault.ChangingTotal, "totalRecords changed")]
+    [InlineData("sonarr", QueueFault.DuplicateSecondPage, "did not advance")]
+    [InlineData("radarr", QueueFault.DuplicateSecondPage, "did not advance")]
+    [InlineData("sonarr", QueueFault.NonAdvancingPage, "non-advancing")]
+    [InlineData("radarr", QueueFault.NonAdvancingPage, "non-advancing")]
+    [InlineData("sonarr", QueueFault.LaterPageFailure, "HTTP 500")]
+    [InlineData("radarr", QueueFault.LaterPageFailure, "HTTP 500")]
+    public async Task InconsistentOrFailedLaterPage_IsExplicitlyIncomplete(string service, QueueFault fault, string reason)
+    {
+        var handler = new QueueHandler(4, id => $$"""{"id":{{id}}}""", fault);
+        var fetch = NewFetch(handler);
+
+        var result = await fetch.FetchQueueCollectionAsync<string>(
+            Instance(service),
+            (page, size) => $"/api/v3/queue?page={page}&pageSize={size}",
+            pageSize: 2,
+            identity: row => row["id"]?.ToJsonString(),
+            projector: row => row["id"]!.ToJsonString(),
+            requestTimeout: TimeSpan.FromSeconds(2),
+            contextLabel: "Radarr queue",
+            ct: CancellationToken.None);
+
+        Assert.False(result.IsComplete);
+        Assert.Contains(reason, result.Error, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(new[] { "1", "2" }, result.Items);
+        Assert.Equal(2, handler.QueueRequests);
+    }
+
+    [Fact]
+    public async Task AggregateRecordLimit_RejectsOversizedQueueBeforeRetainingRows()
+    {
+        var handler = new QueueHandler(ArrFetchService.MaxQueueRecords + 1, id => $$"""{"id":{{id}}}""");
+        var fetch = NewFetch(handler);
+
+        var result = await fetch.FetchQueueCollectionAsync<string>(
+            Instance("sonarr"),
+            (page, size) => $"/api/v3/queue?page={page}&pageSize={size}",
+            pageSize: 1_000,
+            identity: row => row["id"]?.ToJsonString(),
+            projector: row => row["id"]!.ToJsonString(),
+            requestTimeout: TimeSpan.FromSeconds(2),
+            contextLabel: "Sonarr queue",
+            ct: CancellationToken.None);
+
+        Assert.False(result.IsComplete);
+        Assert.Empty(result.Items);
+        Assert.Contains("100000-record safety limit", result.Error, StringComparison.Ordinal);
+        Assert.Equal(1, handler.QueueRequests);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task MalformedRecordOrProjection_IsExplicitlyIncomplete(bool scalarRecord)
+    {
+        var handler = new QueueHandler(
+            1,
+            _ => scalarRecord ? "42" : "{\"id\":1,\"size\":\"not-a-number\"}");
+        var fetch = NewFetch(handler);
+
+        var result = await fetch.FetchQueueCollectionAsync<string>(
+            Instance("radarr"),
+            (page, size) => $"/api/v3/queue?page={page}&pageSize={size}",
+            pageSize: 100,
+            identity: row => row["id"]?.ToJsonString(),
+            projector: row => ((int?)row["size"]).ToString(),
+            requestTimeout: TimeSpan.FromSeconds(2),
+            contextLabel: "Radarr queue",
+            ct: CancellationToken.None);
+
+        Assert.False(result.IsComplete);
+        Assert.Empty(result.Items);
+        Assert.Equal("page 1: invalid response", result.Error);
+        Assert.Equal(1, handler.QueueRequests);
+    }
+
+    [Theory]
+    [InlineData("radarr", 100)]
+    [InlineData("sonarr", 200)]
+    public async Task ActionStatus_FindsTargetBeyondFormerSinglePage(string service, int pageSize)
+    {
+        const int targetArrId = 7;
+        var total = pageSize + 1;
+        var handler = new QueueHandler(
+            total,
+            id => service == "sonarr"
+                ? $$"""{"id":{{id}},"seriesId":{{(id == total ? targetArrId : 99)}},"title":"row {{id}}","size":100,"sizeleft":50}"""
+                : $$"""{"id":{{id}},"title":"row {{id}}","size":100,"sizeleft":50}""");
+        handler.LookupService = service;
+        var fetch = NewFetch(handler);
+        var actions = new ArrActionService(fetch, new ArrTargetResolver(fetch), NullLogger<ArrActionService>.Instance);
+
+        var status = await actions.GetQueueStatusAsync(
+            service == "radarr" ? Movie() : Series(),
+            service == "radarr" ? RadarrConfig() : SonarrConfig(),
+            CancellationToken.None);
+
+        Assert.True(status.IsComplete);
+        Assert.Empty(status.Errors);
+        if (service == "sonarr")
+        {
+            var target = Assert.Single(status.Items);
+            Assert.Equal($"row {total}", target.Title);
+        }
+        else
+        {
+            Assert.Equal(total, status.Items.Count);
+            Assert.Equal($"row {total}", status.Items[^1].Title);
+        }
+        Assert.Equal(2, handler.QueueRequests);
+    }
+
+    [Fact]
+    public async Task ActionStatus_LaterPageFailure_IsNotReportedAsEmptySuccess()
+    {
+        var handler = new QueueHandler(101, id => $$"""{"id":{{id}},"title":"row {{id}}"}""", QueueFault.LaterPageFailure)
+        {
+            LookupService = "radarr",
+        };
+        var fetch = NewFetch(handler);
+        var actions = new ArrActionService(fetch, new ArrTargetResolver(fetch), NullLogger<ArrActionService>.Instance);
+
+        var status = await actions.GetQueueStatusAsync(Movie(), RadarrConfig(), CancellationToken.None);
+
+        Assert.False(status.IsComplete);
+        Assert.Empty(status.Items);
+        Assert.Contains(status.Errors, error => error.Reason.Contains("page 2", StringComparison.Ordinal));
+    }
+
+    private static ArrFetchService NewFetch(HttpMessageHandler handler)
+        => new(new RecordingHttpClientFactory(handler), NullLogger<ArrFetchService>.Instance);
+
+    private static ArrInstance Instance(string service) => new()
+    {
+        Name = service,
+        Url = "http://localhost:8989",
+        ApiKey = "key",
+        Enabled = true,
+    };
+
+    private static PluginConfiguration RadarrConfig() => new()
+    {
+        RadarrInstances = """[{"Name":"movies","Url":"http://localhost:7878","ApiKey":"rk","Enabled":true}]""",
+    };
+
+    private static PluginConfiguration SonarrConfig() => new()
+    {
+        SonarrInstances = """[{"Name":"tv","Url":"http://localhost:8989","ApiKey":"sk","Enabled":true}]""",
+    };
+
+    private static ArrResolvedItem Movie() => new() { Kind = ArrMediaKind.Movie, TmdbId = 27205, Name = "Movie" };
+
+    private static ArrResolvedItem Series() => new() { Kind = ArrMediaKind.Series, SeriesTvdbId = 81189, Name = "Series" };
+
+    public enum QueueFault
+    {
+        None,
+        ChangingTotal,
+        DuplicateSecondPage,
+        NonAdvancingPage,
+        LaterPageFailure,
+    }
+
+    private sealed class QueueHandler : HttpMessageHandler
+    {
+        private readonly int _total;
+        private readonly Func<int, string> _record;
+        private readonly QueueFault _fault;
+
+        public QueueHandler(int total, Func<int, string> record, QueueFault fault = QueueFault.None)
+        {
+            _total = total;
+            _record = record;
+            _fault = fault;
+        }
+
+        public string? LookupService { get; set; }
+
+        public int QueueRequests { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var uri = request.RequestUri!;
+            if (uri.AbsolutePath.EndsWith("/api/v3/movie", StringComparison.Ordinal) && LookupService == "radarr")
+                return Json("[{\"id\":7,\"monitored\":true,\"hasFile\":false}]");
+            if (uri.AbsolutePath.EndsWith("/api/v3/series", StringComparison.Ordinal) && LookupService == "sonarr")
+                return Json("[{\"id\":7,\"monitored\":true,\"statistics\":{\"episodeFileCount\":0}}]");
+
+            if (!uri.AbsolutePath.EndsWith("/api/v3/queue", StringComparison.Ordinal))
+                return Json("{}", HttpStatusCode.NotFound);
+
+            QueueRequests++;
+            var page = QueryInt(uri, "page");
+            var pageSize = QueryInt(uri, "pageSize");
+            if (_fault == QueueFault.LaterPageFailure && page == 2)
+                return Json("{}", HttpStatusCode.InternalServerError);
+
+            var reportedPage = _fault == QueueFault.NonAdvancingPage && page == 2 ? 1 : page;
+            var reportedTotal = _fault == QueueFault.ChangingTotal && page == 2 ? _total + 1 : _total;
+            var firstId = _fault == QueueFault.DuplicateSecondPage && page == 2
+                ? 1
+                : ((page - 1) * pageSize) + 1;
+            var count = Math.Max(0, Math.Min(pageSize, _total - ((page - 1) * pageSize)));
+
+            var body = new StringBuilder();
+            body.Append("{\"page\":").Append(reportedPage)
+                .Append(",\"pageSize\":").Append(pageSize)
+                .Append(",\"totalRecords\":").Append(reportedTotal)
+                .Append(",\"records\":[");
+            for (var offset = 0; offset < count; offset++)
+            {
+                if (offset > 0) body.Append(',');
+                body.Append(_record(firstId + offset));
+            }
+            body.Append("]}");
+            return Json(body.ToString());
+        }
+
+        private static int QueryInt(Uri uri, string name)
+        {
+            foreach (var part in uri.Query.TrimStart('?').Split('&', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var pair = part.Split('=', 2);
+                if (pair.Length == 2 && string.Equals(pair[0], name, StringComparison.Ordinal))
+                    return int.Parse(pair[1], System.Globalization.CultureInfo.InvariantCulture);
+            }
+            return 0;
+        }
+
+        private static Task<HttpResponseMessage> Json(string body, HttpStatusCode status = HttpStatusCode.OK)
+            => Task.FromResult(new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            });
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/ArrRequestsController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/ArrRequestsController.cs
@@ -279,98 +279,96 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             return tmdbOk || tvdbOk;
         }
 
-        private Task<(List<object> Items, string? Error)> FetchSonarrQueue(ArrInstance instance, int instanceIndex, HashSet<(int TmdbId, string MediaType)>? allowedRequests, HashSet<int>? allowedTvTvdb, CancellationToken ct)
+        private async Task<(List<object> Items, string? Error)> FetchSonarrQueue(ArrInstance instance, int instanceIndex, HashSet<(int TmdbId, string MediaType)>? allowedRequests, HashSet<int>? allowedTvTvdb, CancellationToken ct)
         {
-            return _arrFetch.FetchAndMapAsync<List<object>>(
+            var result = await _arrFetch.FetchQueueCollectionAsync<object>(
                 instance,
-                "/api/v3/queue?includeEpisode=true&includeSeries=true&sortKey=timeleft&sortDirection=ascending&pageSize=1000",
-                data =>
+                (page, pageSize) => $"/api/v3/queue?includeEpisode=true&includeSeries=true&sortKey=timeleft&sortDirection=ascending&page={page}&pageSize={pageSize}",
+                pageSize: Services.Arr.ArrFetchService.MaxQueuePageSize,
+                identity: record => record["id"]?.ToJsonString(),
+                projector: record =>
                 {
-                    var items = new List<object>();
-                    if (data?["records"] is not JsonArray records) return items;
-                    foreach (var record in records)
-                    {
-                        var series = record?["series"];
-                        var episode = record?["episode"];
-                        int? tmdbId = ArrIdHelper.ToNullableId((int?)series?["tmdbId"]);
-                        int? tvdbId = ArrIdHelper.ToNullableId((int?)series?["tvdbId"]);
-                        if (!IsSonarrQueueItemAllowed(tmdbId, tvdbId, allowedRequests, allowedTvTvdb))
-                            continue;
+                    var series = record["series"];
+                    var episode = record["episode"];
+                    int? tmdbId = ArrIdHelper.ToNullableId((int?)series?["tmdbId"]);
+                    int? tvdbId = ArrIdHelper.ToNullableId((int?)series?["tvdbId"]);
+                    if (!IsSonarrQueueItemAllowed(tmdbId, tvdbId, allowedRequests, allowedTvTvdb))
+                        return null;
 
-                        var seasonNumber = (int?)episode?["seasonNumber"];
-                        var episodeNumber = (int?)episode?["episodeNumber"];
-                        items.Add(new
-                        {
-                            // Namespace the per-instance queue id by source + the instance's unique
-                            // position so two Sonarr instances that both number queue records from 1 —
-                            // even with an identical or blank display name — can't collide.
-                            id = ArrIdHelper.NamespacedId(nameof(ArrType.Sonarr), instanceIndex, record?["id"]),
-                            source = nameof(ArrType.Sonarr),
-                            instanceName = instance.Name,
-                            title = (string?)series?["title"] ?? "Unknown",
-                            subtitle = $"S{seasonNumber:D2}E{episodeNumber:D2} - {(string?)episode?["title"]}",
-                            seasonNumber = seasonNumber,
-                            episodeNumber = episodeNumber,
-                            status = (string?)record?["status"] ?? "Unknown",
-                            progress = CalculateProgress((double?)record?["size"], (double?)record?["sizeleft"]),
-                            totalSize = (long?)record?["size"],
-                            sizeRemaining = (long?)record?["sizeleft"],
-                            timeRemaining = (string?)record?["timeleft"],
-                            posterUrl = PosterFromImages(series?["images"]),
-                            tmdbId = tmdbId
-                        });
-                    }
-                    return items;
+                    var seasonNumber = (int?)episode?["seasonNumber"];
+                    var episodeNumber = (int?)episode?["episodeNumber"];
+                    return new
+                    {
+                        // Namespace the per-instance queue id by source + the instance's unique
+                        // position so two Sonarr instances that both number queue records from 1 —
+                        // even with an identical or blank display name — can't collide.
+                        id = ArrIdHelper.NamespacedId(nameof(ArrType.Sonarr), instanceIndex, record["id"]),
+                        source = nameof(ArrType.Sonarr),
+                        instanceName = instance.Name,
+                        title = (string?)series?["title"] ?? "Unknown",
+                        subtitle = $"S{seasonNumber:D2}E{episodeNumber:D2} - {(string?)episode?["title"]}",
+                        seasonNumber = seasonNumber,
+                        episodeNumber = episodeNumber,
+                        status = (string?)record["status"] ?? "Unknown",
+                        progress = CalculateProgress((double?)record["size"], (double?)record["sizeleft"]),
+                        totalSize = (long?)record["size"],
+                        sizeRemaining = (long?)record["sizeleft"],
+                        timeRemaining = (string?)record["timeleft"],
+                        posterUrl = PosterFromImages(series?["images"]),
+                        tmdbId = tmdbId
+                    };
                 },
-                emptyResult: new List<object>(),
-                timeout: TimeSpan.FromSeconds(10),
+                requestTimeout: TimeSpan.FromSeconds(10),
                 contextLabel: "Sonarr queue",
-                ct: ct);
+                ct: ct).ConfigureAwait(false);
+
+            return result.IsComplete
+                ? (result.Items, null)
+                : (new List<object>(), result.Error ?? "incomplete queue collection");
         }
 
-        private Task<(List<object> Items, string? Error)> FetchRadarrQueue(ArrInstance instance, int instanceIndex, HashSet<(int TmdbId, string MediaType)>? allowedRequests, CancellationToken ct)
+        private async Task<(List<object> Items, string? Error)> FetchRadarrQueue(ArrInstance instance, int instanceIndex, HashSet<(int TmdbId, string MediaType)>? allowedRequests, CancellationToken ct)
         {
-            return _arrFetch.FetchAndMapAsync<List<object>>(
+            var result = await _arrFetch.FetchQueueCollectionAsync<object>(
                 instance,
-                "/api/v3/queue?includeMovie=true&pageSize=1000",
-                data =>
+                (page, pageSize) => $"/api/v3/queue?includeMovie=true&page={page}&pageSize={pageSize}",
+                pageSize: Services.Arr.ArrFetchService.MaxQueuePageSize,
+                identity: record => record["id"]?.ToJsonString(),
+                projector: record =>
                 {
-                    var items = new List<object>();
-                    if (data?["records"] is not JsonArray records) return items;
-                    foreach (var record in records)
-                    {
-                        var movie = record?["movie"];
-                        int? tmdbId = ArrIdHelper.ToNullableId((int?)movie?["tmdbId"]);
-                        if (allowedRequests != null && (!tmdbId.HasValue || !allowedRequests.Contains((tmdbId.Value, "movie"))))
-                            continue;
+                    var movie = record["movie"];
+                    int? tmdbId = ArrIdHelper.ToNullableId((int?)movie?["tmdbId"]);
+                    if (allowedRequests != null && (!tmdbId.HasValue || !allowedRequests.Contains((tmdbId.Value, "movie"))))
+                        return null;
 
-                        items.Add(new
-                        {
-                            // Namespace the per-instance queue id by source + the instance's unique
-                            // position so two Radarr instances that both number queue records from 1 —
-                            // even with an identical or blank display name — can't collide.
-                            id = ArrIdHelper.NamespacedId(nameof(ArrType.Radarr), instanceIndex, record?["id"]),
-                            source = nameof(ArrType.Radarr),
-                            instanceName = instance.Name,
-                            title = (string?)movie?["title"] ?? "Unknown",
-                            subtitle = movie?["year"]?.ToString(),
-                            seasonNumber = (int?)null,
-                            episodeNumber = (int?)null,
-                            status = (string?)record?["status"] ?? "Unknown",
-                            progress = CalculateProgress((double?)record?["size"], (double?)record?["sizeleft"]),
-                            totalSize = (long?)record?["size"],
-                            sizeRemaining = (long?)record?["sizeleft"],
-                            timeRemaining = (string?)record?["timeleft"],
-                            posterUrl = PosterFromImages(movie?["images"]),
-                            tmdbId = tmdbId
-                        });
-                    }
-                    return items;
+                    return new
+                    {
+                        // Namespace the per-instance queue id by source + the instance's unique
+                        // position so two Radarr instances that both number queue records from 1 —
+                        // even with an identical or blank display name — can't collide.
+                        id = ArrIdHelper.NamespacedId(nameof(ArrType.Radarr), instanceIndex, record["id"]),
+                        source = nameof(ArrType.Radarr),
+                        instanceName = instance.Name,
+                        title = (string?)movie?["title"] ?? "Unknown",
+                        subtitle = movie?["year"]?.ToString(),
+                        seasonNumber = (int?)null,
+                        episodeNumber = (int?)null,
+                        status = (string?)record["status"] ?? "Unknown",
+                        progress = CalculateProgress((double?)record["size"], (double?)record["sizeleft"]),
+                        totalSize = (long?)record["size"],
+                        sizeRemaining = (long?)record["sizeleft"],
+                        timeRemaining = (string?)record["timeleft"],
+                        posterUrl = PosterFromImages(movie?["images"]),
+                        tmdbId = tmdbId
+                    };
                 },
-                emptyResult: new List<object>(),
-                timeout: TimeSpan.FromSeconds(10),
+                requestTimeout: TimeSpan.FromSeconds(10),
                 contextLabel: "Radarr queue",
-                ct: ct);
+                ct: ct).ConfigureAwait(false);
+
+            return result.IsComplete
+                ? (result.Items, null)
+                : (new List<object>(), result.Error ?? "incomplete queue collection");
         }
 
         private static double CalculateProgress(double? size, double? sizeleft)

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/ArrSearchController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/ArrSearchController.cs
@@ -176,11 +176,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
         {
             var config = _configProvider.ConfigurationOrNull;
             if (config == null) return StatusCode(503, new { message = "Plugin configuration unavailable." });
-            if (!config.ArrSearchEnabled) return Ok(new { items = Array.Empty<object>() });
+            if (!config.ArrSearchEnabled) return Ok(new { items = Array.Empty<object>(), errors = Array.Empty<object>(), isComplete = true });
 
             var item = _resolver.Resolve(itemId);
-            var rows = await _actions.GetQueueStatusAsync(item, config, HttpContext.RequestAborted).ConfigureAwait(false);
-            return Ok(new { items = rows });
+            var status = await _actions.GetQueueStatusAsync(item, config, HttpContext.RequestAborted).ConfigureAwait(false);
+            return status.IsComplete ? Ok(status) : StatusCode(502, status);
         }
 
         // ── helpers ──────────────────────────────────────────────────────────

--- a/Jellyfin.Plugin.JellyfinCanopy/Model/Arr/ArrSearchModels.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Model/Arr/ArrSearchModels.cs
@@ -146,6 +146,17 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Model.Arr
         [JsonPropertyName("timeRemaining")] public string? TimeRemaining { get; set; }
     }
 
+    /// <summary>
+    /// Complete queue-status snapshot for post-action feedback. Consumers must treat
+    /// <see cref="IsComplete"/> false as unknown rather than as an empty/completed queue.
+    /// </summary>
+    public sealed class ArrQueueStatusDto
+    {
+        [JsonPropertyName("items")] public List<ArrQueueRowDto> Items { get; set; } = new();
+        [JsonPropertyName("errors")] public List<ArrErrorDto> Errors { get; set; } = new();
+        [JsonPropertyName("isComplete")] public bool IsComplete { get; set; } = true;
+    }
+
     public sealed class ArrErrorDto
     {
         [JsonPropertyName("instanceName")] public string InstanceName { get; set; } = string.Empty;

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Arr/ArrActionService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Arr/ArrActionService.cs
@@ -392,46 +392,61 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Arr
         // ── queue status (reuses the Downloads-page data source; no second UI) ─
 
         /// <summary>Active-download rows for a resolved item, for post-action progress feedback.</summary>
-        public async Task<List<ArrQueueRowDto>> GetQueueStatusAsync(ArrResolvedItem item, PluginConfiguration config, CancellationToken ct)
+        public async Task<ArrQueueStatusDto> GetQueueStatusAsync(ArrResolvedItem item, PluginConfiguration config, CancellationToken ct)
         {
-            var rows = new List<ArrQueueRowDto>();
+            var status = new ArrQueueStatusDto();
             if (item.Kind == ArrMediaKind.Unknown || !item.HasArrIdentity)
-                return rows;
+                return status;
 
             var service = ServiceOf(item);
             var instances = EnabledInstances(item, config);
-            var (matches, _) = await _targets.ResolveMatchesAsync(item, instances, service, ct).ConfigureAwait(false);
+            var (matches, resolutionErrors) = await _targets.ResolveMatchesAsync(item, instances, service, ct).ConfigureAwait(false);
+            status.Errors.AddRange(resolutionErrors);
 
             var perInstance = await Task.WhenAll(matches.Select(m => QueueForInstanceAsync(m, service, ct))).ConfigureAwait(false);
-            foreach (var list in perInstance) rows.AddRange(list);
-            return rows;
+            foreach (var instanceResult in perInstance)
+            {
+                status.Items.AddRange(instanceResult.Items);
+                if (instanceResult.Error != null)
+                {
+                    status.Errors.Add(new ArrErrorDto
+                    {
+                        InstanceName = instanceResult.InstanceName,
+                        Reason = instanceResult.Error,
+                    });
+                }
+            }
+
+            status.IsComplete = status.Errors.Count == 0;
+            return status;
         }
 
-        private async Task<List<ArrQueueRowDto>> QueueForInstanceAsync(ArrInstanceMatch m, string service, CancellationToken ct)
+        private async Task<(List<ArrQueueRowDto> Items, string? Error, string InstanceName)> QueueForInstanceAsync(ArrInstanceMatch m, string service, CancellationToken ct)
         {
-            var path = service == "radarr"
-                ? $"/api/v3/queue?movieIds={m.ArrId}&pageSize=100"
-                : $"/api/v3/queue?includeSeries=false&includeEpisode=false&pageSize=200";
+            var pageSize = service == "radarr" ? 100 : 200;
 
-            var (list, _) = await _fetch.FetchAndMapAsync<List<ArrQueueRowDto>>(
-                m.Instance, path,
-                node =>
+            var result = await _fetch.FetchQueueCollectionAsync<ArrQueueRowDto>(
+                m.Instance,
+                (page, size) => service == "radarr"
+                    ? $"/api/v3/queue?movieIds={m.ArrId}&page={page}&pageSize={size}"
+                    : $"/api/v3/queue?includeSeries=false&includeEpisode=false&page={page}&pageSize={size}",
+                pageSize,
+                identity: record => record["id"]?.ToJsonString(),
+                projector: record =>
                 {
-                    var result = new List<ArrQueueRowDto>();
-                    if (node?["records"] is JsonArray records)
-                    {
-                        foreach (var rec in records)
-                        {
-                            // Sonarr's queue isn't reliably server-filterable by series across versions —
-                            // filter to this series here so we only report the item the user acted on.
-                            if (service == "sonarr" && ArrSearchMapping.IntN(rec?["seriesId"]) != m.ArrId) continue;
-                            result.Add(ArrSearchMapping.MapQueueRow(rec, service, m.Instance.Name));
-                        }
-                    }
-                    return result;
+                    // Sonarr's queue isn't reliably server-filterable by series across versions —
+                    // filter to this series here so we only report the item the user acted on.
+                    if (service == "sonarr" && ArrSearchMapping.IntN(record["seriesId"]) != m.ArrId)
+                        return null;
+                    return ArrSearchMapping.MapQueueRow(record, service, m.Instance.Name);
                 },
-                emptyResult: new List<ArrQueueRowDto>(), QueueTimeout, "queue status", ct).ConfigureAwait(false);
-            return list;
+                requestTimeout: QueueTimeout,
+                contextLabel: $"{service} queue status",
+                ct: ct).ConfigureAwait(false);
+
+            return result.IsComplete
+                ? (result.Items, null, m.Instance.Name)
+                : (new List<ArrQueueRowDto>(), result.Error ?? "incomplete queue collection", m.Instance.Name);
         }
 
         private static JsonNode? Detach(JsonNode? node) => node == null ? null : JsonNode.Parse(node.ToJsonString());

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Arr/ArrFetchService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Arr/ArrFetchService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -10,6 +11,21 @@ using Microsoft.Extensions.Logging;
 namespace Jellyfin.Plugin.JellyfinCanopy.Services.Arr
 {
     /// <summary>
+    /// Result of collecting one complete Sonarr/Radarr QueueResource. Items may contain the
+    /// successfully projected prefix when <see cref="IsComplete"/> is false, but callers must not
+    /// publish that prefix as a complete queue snapshot.
+    /// </summary>
+    public sealed class ArrQueueCollection<T>
+        where T : class
+    {
+        public List<T> Items { get; } = new();
+
+        public bool IsComplete { get; internal set; }
+
+        public string? Error { get; internal set; }
+    }
+
+    /// <summary>
     /// Shared Sonarr/Radarr fetch plumbing (moved verbatim from
     /// <c>JellyfinCanopyControllerBase.FetchAndMapAsync</c>): SSRF-guarded GET
     /// against an instance, per-request API key, per-endpoint timeout, and the
@@ -18,6 +34,15 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Arr
     /// </summary>
     public sealed class ArrFetchService
     {
+        // QueueResource can legitimately be much larger than the default 100/200-row action pages.
+        // These aggregate guards permit up to 100,000 records while bounding retained identities /
+        // projections, HTTP round trips, and wall-clock collection time. A page is capped at 1,000
+        // records so a single response cannot defeat the collection's memory bound.
+        public const int MaxQueueRecords = 100_000;
+        public const int MaxQueuePages = 1_000;
+        public const int MaxQueuePageSize = 1_000;
+        public static readonly TimeSpan MaxQueueCollectionDuration = TimeSpan.FromSeconds(45);
+
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly ILogger<ArrFetchService> _logger;
 
@@ -52,6 +77,211 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Arr
             string contextLabel,
             CancellationToken ct)
             => SendAndMapAsync(instance, HttpMethod.Get, endpointPath, jsonBody: null, mapper, emptyResult, timeout, contextLabel, ct);
+
+        /// <summary>
+        /// Collects a complete typed Arr QueueResource using its page metadata. Stable record ids
+        /// drive deduplication and forward-progress checks; projection happens a page at a time so
+        /// filtered consumers retain only their own rows. Any failed page, changing/non-advancing
+        /// metadata, duplicate-only page, or aggregate limit returns an explicit incomplete result.
+        /// </summary>
+        public async Task<ArrQueueCollection<T>> FetchQueueCollectionAsync<T>(
+            ArrInstance instance,
+            Func<int, int, string> endpointPath,
+            int pageSize,
+            Func<JsonNode, string?> identity,
+            Func<JsonNode, T?> projector,
+            TimeSpan requestTimeout,
+            string contextLabel,
+            CancellationToken ct)
+            where T : class
+        {
+            var result = new ArrQueueCollection<T>();
+            if (pageSize is < 1 or > MaxQueuePageSize)
+            {
+                result.Error = $"invalid queue page size {pageSize}";
+                return result;
+            }
+
+            var identities = new HashSet<string>(StringComparer.Ordinal);
+            int? expectedTotal = null;
+            using var collectionCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            collectionCts.CancelAfter(MaxQueueCollectionDuration);
+
+            try
+            {
+                for (var requestedPage = 1; requestedPage <= MaxQueuePages; requestedPage++)
+                {
+                    var (page, pageError) = await FetchAndMapAsync<ArrQueuePage?>(
+                        instance,
+                        endpointPath(requestedPage, pageSize),
+                        ParseQueuePage,
+                        emptyResult: null,
+                        timeout: requestTimeout,
+                        contextLabel: $"{contextLabel} page {requestedPage}",
+                        ct: collectionCts.Token).ConfigureAwait(false);
+
+                    if (pageError != null)
+                    {
+                        result.Error = $"page {requestedPage}: {pageError}";
+                        return result;
+                    }
+
+                    if (page == null)
+                    {
+                        result.Error = $"page {requestedPage}: invalid queue pagination metadata";
+                        return result;
+                    }
+
+                    if (page.Page != requestedPage || page.PageSize != pageSize)
+                    {
+                        result.Error = $"page {requestedPage}: non-advancing queue pagination metadata";
+                        return result;
+                    }
+
+                    if (page.TotalRecords is < 0 or > MaxQueueRecords)
+                    {
+                        result.Error = $"page {requestedPage}: queue exceeds the {MaxQueueRecords}-record safety limit";
+                        return result;
+                    }
+
+                    if (page.Records.Count > pageSize)
+                    {
+                        result.Error = $"page {requestedPage}: response exceeds its declared page size";
+                        return result;
+                    }
+
+                    if (expectedTotal.HasValue && expectedTotal.Value != page.TotalRecords)
+                    {
+                        result.Error = $"page {requestedPage}: totalRecords changed during queue collection";
+                        return result;
+                    }
+
+                    expectedTotal ??= page.TotalRecords;
+                    var newRecords = 0;
+                    try
+                    {
+                        foreach (var record in page.Records)
+                        {
+                            var recordIdentity = identity(record);
+                            if (string.IsNullOrWhiteSpace(recordIdentity))
+                            {
+                                result.Error = $"page {requestedPage}: queue record has no stable identity";
+                                return result;
+                            }
+
+                            if (!identities.Add(recordIdentity))
+                                continue;
+
+                            newRecords++;
+                            var projected = projector(record);
+                            if (projected != null)
+                                result.Items.Add(projected);
+                        }
+                    }
+                    catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                    {
+                        throw;
+                    }
+                    catch (JsonException ex)
+                    {
+                        _logger.LogError($"Invalid queue record in {contextLabel} from {instance.Name}, page {requestedPage}: {ex.Message}");
+                        result.Error = $"page {requestedPage}: invalid response";
+                        return result;
+                    }
+                    catch (InvalidOperationException ex)
+                    {
+                        _logger.LogError($"Invalid queue record in {contextLabel} from {instance.Name}, page {requestedPage}: {ex.Message}");
+                        result.Error = $"page {requestedPage}: invalid response";
+                        return result;
+                    }
+                    catch (FormatException ex)
+                    {
+                        _logger.LogError($"Invalid queue record in {contextLabel} from {instance.Name}, page {requestedPage}: {ex.Message}");
+                        result.Error = $"page {requestedPage}: invalid response";
+                        return result;
+                    }
+                    catch (OverflowException ex)
+                    {
+                        _logger.LogError($"Invalid queue record in {contextLabel} from {instance.Name}, page {requestedPage}: {ex.Message}");
+                        result.Error = $"page {requestedPage}: invalid response";
+                        return result;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError($"Unexpected queue projection error in {contextLabel} from {instance.Name}, page {requestedPage}: {ex.Message}");
+                        result.Error = $"page {requestedPage}: internal error";
+                        return result;
+                    }
+
+                    if (identities.Count > MaxQueueRecords)
+                    {
+                        result.Error = $"page {requestedPage}: queue exceeds the {MaxQueueRecords}-record safety limit";
+                        return result;
+                    }
+
+                    if (identities.Count == page.TotalRecords)
+                    {
+                        result.IsComplete = true;
+                        return result;
+                    }
+
+                    if (identities.Count > page.TotalRecords)
+                    {
+                        result.Error = $"page {requestedPage}: queue contains more identities than totalRecords";
+                        return result;
+                    }
+
+                    if (page.Records.Count == 0 || newRecords == 0)
+                    {
+                        result.Error = $"page {requestedPage}: queue records did not advance";
+                        return result;
+                    }
+
+                    if (page.Records.Count < pageSize)
+                    {
+                        result.Error = $"page {requestedPage}: partial page ended before totalRecords";
+                        return result;
+                    }
+                }
+
+                result.Error = $"queue exceeds the {MaxQueuePages}-page safety limit";
+                return result;
+            }
+            catch (OperationCanceledException) when (!ct.IsCancellationRequested && collectionCts.IsCancellationRequested)
+            {
+                result.Error = $"queue collection exceeded {MaxQueueCollectionDuration.TotalSeconds:0} seconds";
+                return result;
+            }
+        }
+
+        private static ArrQueuePage? ParseQueuePage(JsonNode? node)
+        {
+            if (node is not JsonObject obj
+                || !TryReadInt(obj["page"], out var page)
+                || !TryReadInt(obj["pageSize"], out var pageSize)
+                || !TryReadInt(obj["totalRecords"], out var totalRecords)
+                || obj["records"] is not JsonArray records)
+            {
+                return null;
+            }
+
+            var rows = new List<JsonNode>(records.Count);
+            foreach (var record in records)
+            {
+                if (record != null)
+                    rows.Add(record);
+            }
+
+            return new ArrQueuePage(page, pageSize, totalRecords, rows);
+        }
+
+        private static bool TryReadInt(JsonNode? node, out int value)
+        {
+            value = 0;
+            return node is JsonValue jsonValue && jsonValue.TryGetValue(out value);
+        }
+
+        private sealed record ArrQueuePage(int Page, int PageSize, int TotalRecords, List<JsonNode> Records);
 
         /// <summary>
         /// Generalized SSRF-guarded arr call for any verb, sharing the exact error taxonomy

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/search/manage-modal.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/search/manage-modal.ts
@@ -31,6 +31,7 @@ export async function openManage(itemId: string): Promise<void> {
 class ManageView {
     private ctx: ArrContext | null = null;
     private queue: ArrQueueRow[] = [];
+    private queueError: string | null = null;
 
     constructor(private modal: ArrModalHandle, private itemId: string) {}
 
@@ -38,10 +39,16 @@ class ManageView {
         if (!this.modal.isActive()) return;
         this.modal.body.replaceChildren(centered(spinner()));
         try {
-            const [ctx, queue] = await Promise.all([fetchContext(this.itemId), fetchStatus(this.itemId).catch(() => [])]);
+            const [ctx, queueResult] = await Promise.all([
+                fetchContext(this.itemId),
+                fetchStatus(this.itemId)
+                    .then(queue => ({ queue, error: null as string | null }))
+                    .catch(error => ({ queue: [] as ArrQueueRow[], error: errorMessage(error) })),
+            ]);
             if (!this.modal.isActive()) return;
             this.ctx = ctx;
-            this.queue = queue;
+            this.queue = queueResult.queue;
+            this.queueError = queueResult.error;
         } catch (e) {
             if (!this.modal.isActive()) return;
             this.modal.body.replaceChildren(centered(message('error', errorMessage(e))));
@@ -67,6 +74,8 @@ class ManageView {
         const frag = document.createDocumentFragment();
 
         // Live download progress (shared with the Downloads page).
+        // An incomplete upstream collection is unknown, not an empty/completed queue.
+        if (this.queueError) frag.appendChild(message('error', this.queueError));
         if (this.queue.length > 0) frag.appendChild(this.buildProgress());
 
         // Tracked instances with a monitor toggle.

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -19,7 +19,7 @@ const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the repeated clean measurements', () => {
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1473, totalLines: 1797 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 18326, totalLines: 26770 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 18443, totalLines: 26889 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);
 });

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -21,12 +21,12 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 18326,
-        "totalLines": 26770
+        "coveredLines": 18443,
+        "totalLines": 26889
       },
       "tolerance": {
         "missingCoveredLines": 2,
-        "rationale": "Two clean post-rebase local .NET 10.0.9/Coverlet integration runs on 2026-07-16 each passed 1606 tests and measured the identical 26770-line assembly scope at 18325 and 18326 covered lines; the reviewed high-water is 18326. Relative to main's reviewed 18321/26765 baseline, Hide Favorites Tab adds five instrumented lines across the PluginConfiguration backing property and constructor initializer, the UserSettings backing property, the SettingDescriptors PublicUser admin-default-to-override pairing, and the UserSettingsController default-build assignment. Golden config-payload, user-file-format, config-control-coverage, and bool-projection tests cover all five lines. The existing two-line tolerance is unchanged and covers the reproduced one-line Coverlet variance; coverage-baseline.test.js retains the negative boundaries."
+        "rationale": "Two clean local .NET 10.0.9/Coverlet integration runs on 2026-07-16 each passed 1623 tests and measured the identical combined 26889-line assembly scope at the reviewed 18443-line high-water. Issue #155 adds the shared typed Arr QueueResource paginator, complete/incomplete status propagation, and deterministic Sonarr/Radarr regressions for the 1001st download row, action targets beyond the former 100/200-row prefixes, exact and partial boundaries, changing totals, duplicate/non-advancing pages, later-page failure, the aggregate record limit, and malformed scalar/projection records. The reviewed successor restores the prior fetch boundary's exception-to-explicit-incomplete behavior without swallowing caller cancellation. Relative to main's reviewed 18326/26770 Hide Favorites Tab baseline, the reviewed assembly scope grows by 119 instrumented lines and the high-water advances by 117 covered lines to 18443. The existing two-line tolerance is unchanged and covers the reproduced one-line Coverlet variance; coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
## Summary

Collect complete paged Sonarr and Radarr queue results instead of silently truncating consumers at their former 100/200/1,000-row prefixes.

Closes #155.

## Implementation

- Adds a shared typed `ArrFetchService.FetchQueueCollectionAsync<T>` paginator.
- Follows upstream `page`, `pageSize`, and `totalRecords` metadata with stable-ID deduplication.
- Applies filtering and projection page-by-page while retaining explicit complete/incomplete status.
- Bounds collection at 100,000 records, 1,000 pages, 1,000 rows per request, and 45 seconds.
- Treats total/page metadata drift, malformed records, duplicate-only/non-advancing pages, premature partial pages, limits, timeouts, and later-page HTTP failures as explicit incomplete results.
- Preserves caller cancellation.
- Download consumers discard incomplete per-instance prefixes rather than returning partial success.
- Sonarr/Radarr action status returns 502 for incomplete queues; the client renders a queue error rather than a false empty state.

## Validation

- Three independent reviews: **APPROVE**, no actionable findings.
- Final post-#306 range review proved identical implementation/test patch IDs; only the expected combined coverage reconciliation changed.
- Two clean final server runs: **1,623/1,623 tests**, both exactly **18,443/26,889** lines.
- The combined delta over #306 is exactly +117 covered / +119 scope; client coverage remains #127's **1,473/1,797** baseline.
- Focused paginator regressions: **17/17**.
- Coverage-policy regressions: **13/13**.
- Toolchain, source typecheck, 349 script tests, plugin/test builds, and diff hygiene passed.
- Regressions cover exact/partial boundaries, changing totals, metadata drift, duplicate/non-advancing pages, malformed scalar/projection records, limits, later failures, the 1,001st download row, Sonarr row 201, and Radarr row 101.
- GitHub's full six-shard Dockerized Jellyfin 12 suite is rerunning on this final rebased head.

## AI assistance

Implemented, repaired, independently reviewed, and validated with Codex assistance.