### PR TITLE
docs: enforce least-privilege installation guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -323,6 +323,12 @@ npm run check:docs-assets
 mkdocs build --strict
 ```
 
+The Markdown-link command also runs the installation-permission contract. It
+rejects broad or recursive install-tree write guidance and verifies the docs
+against the middleware defaults, legacy `index.html` target, atomic-rename
+requirements, and plugin-owned `custom_branding` storage in the shipped C#
+source. Update the implementation and its least-privilege guidance together.
+
 `check:docs-assets` treats every tracked visual file anywhere under `docs/` as
 owned content: it must be referenced by the README, documentation, MkDocs
 theme, or this repository's plugin manifest, and both documentation-only and

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Four new pages living right in Jellyfin's navigation, reorderable, native on des
 > **Jellyfin 12 required.** On Jellyfin 10.11, use the original [Jellyfin Enhanced](https://github.com/n00bcodr/Jellyfin-Enhanced) instead.
 
 > [!TIP]
-> If you also use plugins that write to the web folder (such as [Plugin Pages](https://github.com/IAmParadox27/jellyfin-plugin-pages) or [Custom Tabs](https://github.com/IAmParadox27/jellyfin-plugin-custom-tabs)), or you've switched Canopy to its legacy on-disk injection fallback, the [File Transformation plugin](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation) avoids the file-permission issues those setups can hit. Canopy's default request-time injection doesn't need it.
+> Canopy's default request-time script and branding middleware do not need write access to Jellyfin's web or installation tree. [File Transformation](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation), [Plugin Pages](https://github.com/IAmParadox27/jellyfin-plugin-pages), and [Custom Tabs](https://github.com/IAmParadox27/jellyfin-plugin-custom-tabs) are separate optional plugins; Canopy does not use them on Jellyfin 12. See the [least-privilege guidance](https://4eh5xitv6787h645ebv.github.io/Jellyfin-Canopy/getting-started/#permission-issues) before enabling any legacy web-file modification.
 
 Optional integrations — connect what you use, skip what you don't: **Seerr** (requests & discovery), **Sonarr / Radarr / Bazarr** (calendar, queue, item-menu search), a **media-segment provider** like Intro Skipper (auto-skip), and a free **TMDB API key** (Elsewhere, TMDB reviews, release dates, richer cast info).
 
@@ -235,11 +235,11 @@ By [n00bcodr](https://github.com/n00bcodr), the original author of Jellyfin Enha
 - [Jellyfin-JavaScript-Injector](https://github.com/n00bcodr/Jellyfin-JavaScript-Injector) — custom script injection
 - [Jellyfish](https://github.com/n00bcodr/Jellyfish/) — custom Jellyfin theme
 
-Recommended plugins:
+Other optional plugins:
 
-- [File Transformation](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation) — safe file modifications
-- [Custom Tabs](https://github.com/IAmParadox27/jellyfin-plugin-custom-tabs) — custom navigation tabs
-- [Plugin Pages](https://github.com/IAmParadox27/jellyfin-plugin-pages) — helps plugins create custom pages
+- [File Transformation](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation) — supports third-party plugins that deliberately modify web files; Canopy does not require it
+- [Custom Tabs](https://github.com/IAmParadox27/jellyfin-plugin-custom-tabs) — custom navigation tabs; Canopy does not use it on Jellyfin 12
+- [Plugin Pages](https://github.com/IAmParadox27/jellyfin-plugin-pages) — helps plugins create custom pages but does not support Jellyfin 12; Canopy does not use it
 - [Kefin Tweaks](https://github.com/ranaldsgift/KefinTweaks) — watchlist and more
 
 <br>

--- a/docs/about.md
+++ b/docs/about.md
@@ -64,10 +64,10 @@ If you run Jellyfin Canopy, these are the projects worth knowing about: n00bcodr
 
 ### Integrations Canopy works with
 
-Jellyfin Canopy cooperates with a handful of other plugins and services. Some come highly recommended; the rest are optional but pair nicely with it.
+Jellyfin Canopy cooperates with a handful of other plugins and services. They are optional; connect only the ones your chosen features use.
 
 - **[Seerr](https://github.com/seerr-team/seerr)** — the media-request management system. Canopy provides deep Seerr integration; see [Discover & Request](discover.md).
-- **[File Transformation](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation)** — safe file modifications for plugins. Highly recommended for a Jellyfin Canopy install; [Getting Started](getting-started.md) covers it.
+- **[File Transformation](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation)** — an optional third-party foundation for plugins that deliberately modify web files. Canopy's Jellyfin 12 request-time middleware does not use or require it; see the [least-privilege installation guidance](getting-started.md#permission-issues).
 - **[Plugin Pages](https://github.com/IAmParadox27/jellyfin-plugin-pages)** — adds custom pages to the Jellyfin sidebar. Jellyfin Canopy no longer uses it: its Calendar, Requests, Bookmarks, and Hidden Content pages are rendered natively as routed destinations, and Plugin Pages does not support Jellyfin 12.
 - **[Custom Tabs](https://github.com/IAmParadox27/jellyfin-plugin-custom-tabs)** — custom navigation tabs for Jellyfin. Jellyfin Canopy no longer uses it; any Custom Tabs entries earlier versions created are cleaned up automatically on upgrade.
 - **[Kefin Tweaks](https://github.com/ranaldsgift/KefinTweaks)** — watchlist and additional tweaks that complement Canopy.

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -29,11 +29,13 @@ Everything lives on the **Extras** tab, in the **Custom Image Assets** section:
 
 **Image guidance:** PNG or SVG are recommended, logos look best with a transparent background, and each image should use dimensions appropriate to its asset type — keep file sizes reasonable for performance.
 
-Uploaded files are stored alongside the plugin configuration, so they survive Jellyfin server and web updates:
+Uploaded files are stored beneath the directory that contains Canopy's plugin configuration, so they use Jellyfin's existing configuration owner and survive server and web updates without making the web tree writable. For the official container the resolved path is:
 
 ```text
-/plugins/configurations/Jellyfin.Plugin.JellyfinCanopy/custom_branding/
+/config/plugins/configurations/Jellyfin.Plugin.JellyfinCanopy/custom_branding/
 ```
+
+Native installations can place the Jellyfin configuration directory elsewhere; Canopy derives the location from its own configuration file rather than assuming an installation path.
 
 !!! info "Turning the branding middleware off"
     The branding middleware is on by default. If it ever conflicts with another plugin, or you want to fall back to Jellyfin's stock assets, an admin can set the advanced [`DisableBrandingMiddleware`](#advanced-kill-switches) kill-switch (default off). When it is on, the plugin stops serving your uploaded images and Jellyfin's built-in assets are used instead.
@@ -173,7 +175,7 @@ The splash screen override replaces the image Jellyfin shows while it loads, so 
 | **Enable Splash Screen Override** | Enables the custom splash screen |
 | **Splash Screen Image URL** | Full URL or relative path to the image. Defaults to `/web/assets/img/banner-light.png` |
 
-To use your own image, place it somewhere accessible from the web root — for example, drop it in the Jellyfin web directory and reference it as `/web/custom/splash.png` — then save and refresh. Use a PNG, JPG, or SVG sized for full-screen display, and pick something that holds up responsively across screen sizes.
+To use your own image, provide an HTTPS URL already served by your reverse proxy, object store, or another trusted static host, then save and refresh. Do not copy the image into Jellyfin's package-owned web directory. Use a PNG, JPG, or SVG sized for full-screen display, and pick something that holds up responsively across screen sizes.
 
 ## Icons
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -175,7 +175,7 @@ The splash screen override replaces the image Jellyfin shows while it loads, so 
 | **Enable Splash Screen Override** | Enables the custom splash screen |
 | **Splash Screen Image URL** | Full URL or relative path to the image. Defaults to `/web/assets/img/banner-light.png` |
 
-To use your own image, provide an HTTPS URL already served by your reverse proxy, object store, or another trusted static host, then save and refresh. Do not copy the image into Jellyfin's package-owned web directory. Use a PNG, JPG, or SVG sized for full-screen display, and pick something that holds up responsively across screen sizes.
+To use your own image, provide a same-origin relative path, an existing plugin-served URL, or a URL served by your reverse proxy or another trusted static host, then save and refresh. LAN-only HTTP is supported when Jellyfin itself is intentionally served over HTTP on that trusted LAN; use HTTPS for an externally hosted production image. Do not copy the image into Jellyfin's package-owned web directory. Use a PNG, JPG, or SVG sized for full-screen display, and pick something that holds up responsively across screen sizes.
 
 ## Icons
 

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -104,7 +104,7 @@ The v12-only target lets the plugin delete a stack of 10.11 shims and use the su
 | Hand-rolled `IsAdminUser()` + JSON 403 envelopes | **CONVERT** → `[Authorize(Policy = ...)]` |
 | `X-Emby-Token` / `X-MediaBrowser-Token` client header | **DELETED** — the avatar-fetch helper now sends only `Authorization: MediaBrowser Token=…` |
 | Request-time `index.html` injection middleware | **STAYS** (no native hook) |
-| Legacy on-disk `index.html` rewrite | keep `CleanupOldScript` only |
+| Legacy on-disk `index.html` rewrite | **STAYS as an explicit fallback only** when `DisableScriptInjectionMiddleware=true`; `CleanupOldScript` separately remains as best-effort migration cleanup |
 | `BrandingAssetStartupFilter` | **STAYS** (no server API) |
 | `CheckPluginPages` (PluginPages plugin config) | **STAYS (conditional)** |
 | Legacy-layout DOM fallbacks (`.headerRight` etc.) | **STAY** — they serve v12's legacy layout |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -208,21 +208,21 @@ Do not wait for a success log to identify the path: the successful legacy-rewrit
 Run this Bash block from an account with `sudo`. It reads the real systemd service user, then takes the web directory from the running process's `--webdir` argument or `JELLYFIN_WEB_DIR` environment. Only when neither is present does it accept one unambiguous `index.html` from the installed `jellyfin-web` package.
 
 ```bash
+set -Eeuo pipefail
+
 service_name=jellyfin
 service_user="$(systemctl show "$service_name" --property=User --value)"
 service_pid="$(systemctl show "$service_name" --property=MainPID --value)"
 [ -n "$service_user" ] || service_user=root
 case "$service_pid" in ''|0|*[!0-9]*) echo "Jellyfin must be running for safe path discovery" >&2; exit 1;; esac
 
-web_dir=
-expect_web_dir=false
-while IFS= read -r -d '' argument; do
-    if [ "$expect_web_dir" = true ]; then web_dir="$argument"; expect_web_dir=false; continue; fi
-    case "$argument" in
-        --webdir=*) web_dir="${argument#--webdir=}" ;;
-        --webdir) expect_web_dir=true ;;
-    esac
-done < <(sudo cat "/proc/$service_pid/cmdline")
+web_dir="$(sudo awk '
+    BEGIN { RS = "\0" }
+    expect_web_dir { print; found = 1; exit }
+    $0 == "--webdir" { expect_web_dir = 1; next }
+    index($0, "--webdir=") == 1 { print substr($0, 10); found = 1; exit }
+    END { if (expect_web_dir && !found) exit 2 }
+' "/proc/$service_pid/cmdline")"
 
 if [ -z "$web_dir" ]; then
     web_dir="$(sudo awk 'BEGIN { RS="\0" } /^JELLYFIN_WEB_DIR=/ { sub(/^JELLYFIN_WEB_DIR=/, ""); print; exit }' "/proc/$service_pid/environ")"
@@ -246,29 +246,60 @@ backup_dir="$HOME/jellyfin-canopy-index-backup-$(date +%Y%m%dT%H%M%S)"
 install -d -m 0700 -- "$backup_dir"
 sudo cp --preserve=all -- "$index_path" "$backup_dir/index.html.original"
 sudo getfacl --absolute-names -- "$index_path" "$index_dir" > "$backup_dir/access.acl"
+sudo test -s "$backup_dir/index.html.original"
+test -s "$backup_dir/access.acl"
+sudo cmp --silent -- "$index_path" "$backup_dir/index.html.original"
+sudo setfacl --test --restore="$backup_dir/access.acl" >/dev/null
 sudo stat -c '%U:%G %a %n' -- "$index_path" "$index_dir"
 printf 'Service principal: %s\nResolved index: %s\nRollback data: %s\n' "$service_user" "$index_path" "$backup_dir"
 read -r -p 'Review those values, then type YES to add the narrow ACLs: ' confirmation
 [ "$confirmation" = YES ] || { echo "No permissions changed" >&2; exit 1; }
 
+restore_after_partial_grant() {
+    local original_status="$1"
+    local restore_failed=0
+    trap - ERR INT TERM
+    set +e
+    sudo cp --preserve=all -- "$backup_dir/index.html.original" "$index_path" || restore_failed=1
+    sudo setfacl --restore="$backup_dir/access.acl" || restore_failed=1
+    set -e
+    if [ "$restore_failed" -ne 0 ]; then
+        echo "CRITICAL: an ACL grant failed and automatic restoration was incomplete; keep legacy mode disabled" >&2
+        exit 1
+    fi
+    echo "ACL grant failed; original index.html and ACLs were restored" >&2
+    exit "$original_status"
+}
+trap 'restore_after_partial_grant $?' ERR
+trap 'restore_after_partial_grant 130' INT
+trap 'restore_after_partial_grant 143' TERM
 sudo setfacl -m "u:${service_user}:r" -- "$index_path"
 sudo setfacl -m "u:${service_user}:rwx" -- "$index_dir"
+trap - ERR INT TERM
 ```
 
-`getfacl` and `setfacl` must be available. The file ACE permits the initial read. The non-inherited directory ACE permits the service to create and write the temporary sibling, replace `index.html`, and delete a leftover temporary file. Directory `rwx` also permits manipulating other immediate children, which is the unavoidable Linux directory boundary for an atomic sibling rename; it is not applied recursively.
+`getfacl` and `setfacl` must be available. The block stops before mutation unless the content copy is byte-identical and the saved ACL document passes `setfacl --test`. If either narrow grant fails, its error/signal trap restores both the original content and both ACLs before exiting. The file ACE permits the initial read. The non-inherited directory ACE permits the service to create and write the temporary sibling, replace `index.html`, and delete a leftover temporary file. Directory `rwx` also permits manipulating other immediate children, which is the unavoidable Linux directory boundary for an atomic sibling rename; it is not applied recursively.
 
 Keep the printed backup directory. To roll back, disable the legacy setting first and run:
 
 ```bash
+set -Eeuo pipefail
+
 read -r -p 'Paste the exact Rollback data path: ' backup_dir
 [ -f "$backup_dir/access.acl" ] && [ -f "$backup_dir/index.html.original" ] || { echo "Invalid rollback directory" >&2; exit 1; }
+sudo test -s "$backup_dir/index.html.original"
+test -s "$backup_dir/access.acl"
+sudo setfacl --test --restore="$backup_dir/access.acl" >/dev/null
 index_path="$(awk '/^# file: / { print substr($0, 9); exit }' "$backup_dir/access.acl")"
-sudo systemctl stop jellyfin
-trap 'sudo systemctl start jellyfin' EXIT
+[ -n "$index_path" ] || { echo "Rollback ACL data does not name index.html" >&2; exit 1; }
+was_running=false
+if sudo systemctl is-active --quiet jellyfin; then
+    was_running=true
+    sudo systemctl stop jellyfin
+fi
 sudo cp --preserve=all -- "$backup_dir/index.html.original" "$index_path"
 sudo setfacl --restore="$backup_dir/access.acl"
-sudo systemctl start jellyfin
-trap - EXIT
+if [ "$was_running" = true ]; then sudo systemctl start jellyfin; fi
 ```
 
 ##### Windows native service
@@ -310,39 +341,73 @@ if ($Confirmation -cne 'YES') { throw 'No permissions changed.' }
 
 $WasRunning = $Service.State -eq 'Running'
 if ($WasRunning) { Stop-Service -Name $Service.Name -ErrorAction Stop }
+$SafeToRestart = $true
 try {
-    Copy-Item -LiteralPath $IndexPath -Destination (Join-Path $BackupDirectory 'index.html.original') -ErrorAction Stop
+    $BackupPath = Join-Path $BackupDirectory 'index.html.original'
+    $StatePath = Join-Path $BackupDirectory 'state.json'
+    Copy-Item -LiteralPath $IndexPath -Destination $BackupPath -ErrorAction Stop
+    if ((Get-FileHash -LiteralPath $IndexPath).Hash -ne (Get-FileHash -LiteralPath $BackupPath).Hash) {
+        throw 'The index.html content backup did not verify.'
+    }
+    $IndexSddl = (Get-Acl -LiteralPath $IndexPath).Sddl
+    $DirectorySddl = (Get-Acl -LiteralPath $IndexDirectory).Sddl
     [ordered]@{
         IndexPath = $IndexPath
         IndexDirectory = $IndexDirectory
         ServiceName = $Service.Name
         Principal = $Principal
-        IndexSddl = (Get-Acl -LiteralPath $IndexPath).Sddl
-        DirectorySddl = (Get-Acl -LiteralPath $IndexDirectory).Sddl
-    } | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $BackupDirectory 'state.json') -Encoding utf8
+        WasRunning = $WasRunning
+        IndexSddl = $IndexSddl
+        DirectorySddl = $DirectorySddl
+    } | ConvertTo-Json | Set-Content -LiteralPath $StatePath -Encoding utf8
+    $VerifiedState = Get-Content -LiteralPath $StatePath -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+    if ($VerifiedState.IndexPath -ne $IndexPath -or $VerifiedState.IndexSddl -ne $IndexSddl `
+        -or $VerifiedState.DirectorySddl -ne $DirectorySddl -or $VerifiedState.WasRunning -isnot [bool]) {
+        throw 'The ACL rollback state did not verify.'
+    }
 
-    $FileAcl = Get-Acl -LiteralPath $IndexPath
-    $FileRule = [System.Security.AccessControl.FileSystemAccessRule]::new(
-        $Principal, [System.Security.AccessControl.FileSystemRights]::Read,
-        [System.Security.AccessControl.InheritanceFlags]::None,
-        [System.Security.AccessControl.PropagationFlags]::None,
-        [System.Security.AccessControl.AccessControlType]::Allow)
-    $FileAcl.AddAccessRule($FileRule)
-    Set-Acl -LiteralPath $IndexPath -AclObject $FileAcl
+    $SafeToRestart = $false
+    try {
+        $FileAcl = Get-Acl -LiteralPath $IndexPath
+        $FileRule = [System.Security.AccessControl.FileSystemAccessRule]::new(
+            $Principal, [System.Security.AccessControl.FileSystemRights]::Read,
+            [System.Security.AccessControl.InheritanceFlags]::None,
+            [System.Security.AccessControl.PropagationFlags]::None,
+            [System.Security.AccessControl.AccessControlType]::Allow)
+        $FileAcl.AddAccessRule($FileRule)
+        Set-Acl -LiteralPath $IndexPath -AclObject $FileAcl -ErrorAction Stop
 
-    $DirectoryRights = [System.Security.AccessControl.FileSystemRights]::ReadAndExecute `
-        -bor [System.Security.AccessControl.FileSystemRights]::Write `
-        -bor [System.Security.AccessControl.FileSystemRights]::DeleteSubdirectoriesAndFiles
-    $DirectoryAcl = Get-Acl -LiteralPath $IndexDirectory
-    $DirectoryRule = [System.Security.AccessControl.FileSystemAccessRule]::new(
-        $Principal, $DirectoryRights,
-        [System.Security.AccessControl.InheritanceFlags]::None,
-        [System.Security.AccessControl.PropagationFlags]::None,
-        [System.Security.AccessControl.AccessControlType]::Allow)
-    $DirectoryAcl.AddAccessRule($DirectoryRule)
-    Set-Acl -LiteralPath $IndexDirectory -AclObject $DirectoryAcl
+        $DirectoryRights = [System.Security.AccessControl.FileSystemRights]::ReadAndExecute `
+            -bor [System.Security.AccessControl.FileSystemRights]::Write `
+            -bor [System.Security.AccessControl.FileSystemRights]::DeleteSubdirectoriesAndFiles
+        $DirectoryAcl = Get-Acl -LiteralPath $IndexDirectory
+        $DirectoryRule = [System.Security.AccessControl.FileSystemAccessRule]::new(
+            $Principal, $DirectoryRights,
+            [System.Security.AccessControl.InheritanceFlags]::None,
+            [System.Security.AccessControl.PropagationFlags]::None,
+            [System.Security.AccessControl.AccessControlType]::Allow)
+        $DirectoryAcl.AddAccessRule($DirectoryRule)
+        Set-Acl -LiteralPath $IndexDirectory -AclObject $DirectoryAcl -ErrorAction Stop
+        $SafeToRestart = $true
+    } catch {
+        $GrantFailure = $_
+        try {
+            Copy-Item -LiteralPath $BackupPath -Destination $IndexPath -Force -ErrorAction Stop
+            $FileAcl = Get-Acl -LiteralPath $IndexPath
+            $FileAcl.SetSecurityDescriptorSddlForm($IndexSddl)
+            Set-Acl -LiteralPath $IndexPath -AclObject $FileAcl -ErrorAction Stop
+            $DirectoryAcl = Get-Acl -LiteralPath $IndexDirectory
+            $DirectoryAcl.SetSecurityDescriptorSddlForm($DirectorySddl)
+            Set-Acl -LiteralPath $IndexDirectory -AclObject $DirectoryAcl -ErrorAction Stop
+            $SafeToRestart = $true
+        } catch {
+            Write-Error 'ACL grant failed and automatic restoration was incomplete; keep legacy mode disabled.'
+            throw
+        }
+        throw $GrantFailure
+    }
 } finally {
-    if ($WasRunning) { Start-Service -Name $Service.Name }
+    if ($WasRunning -and $SafeToRestart) { Start-Service -Name $Service.Name }
 }
 ```
 
@@ -351,19 +416,33 @@ The file rule is read-only. The non-inherited parent-directory rule supplies the
 ```powershell
 $BackupDirectory = Read-Host 'Paste the exact Rollback data path printed by the grant block'
 $State = Get-Content -LiteralPath (Join-Path $BackupDirectory 'state.json') -Raw | ConvertFrom-Json
-Stop-Service -Name $State.ServiceName -ErrorAction Stop
+if ($State.WasRunning -isnot [bool]) { throw 'Rollback data does not contain the original service state.' }
+$WasRunning = [bool]$State.WasRunning
+$Service = Get-Service -Name $State.ServiceName -ErrorAction Stop
+if ($Service.Status -eq [System.ServiceProcess.ServiceControllerStatus]::Running) {
+    Stop-Service -Name $State.ServiceName -ErrorAction Stop
+}
+$RestoreSucceeded = $false
 try {
     Copy-Item -LiteralPath (Join-Path $BackupDirectory 'index.html.original') -Destination $State.IndexPath -Force -ErrorAction Stop
     $FileAcl = Get-Acl -LiteralPath $State.IndexPath
     $FileAcl.SetSecurityDescriptorSddlForm($State.IndexSddl)
-    Set-Acl -LiteralPath $State.IndexPath -AclObject $FileAcl
+    Set-Acl -LiteralPath $State.IndexPath -AclObject $FileAcl -ErrorAction Stop
     $DirectoryAcl = Get-Acl -LiteralPath $State.IndexDirectory
     $DirectoryAcl.SetSecurityDescriptorSddlForm($State.DirectorySddl)
-    Set-Acl -LiteralPath $State.IndexDirectory -AclObject $DirectoryAcl
+    Set-Acl -LiteralPath $State.IndexDirectory -AclObject $DirectoryAcl -ErrorAction Stop
+    if ((Get-FileHash -LiteralPath $State.IndexPath).Hash -ne (Get-FileHash -LiteralPath (Join-Path $BackupDirectory 'index.html.original')).Hash `
+        -or (Get-Acl -LiteralPath $State.IndexPath).Sddl -ne $State.IndexSddl `
+        -or (Get-Acl -LiteralPath $State.IndexDirectory).Sddl -ne $State.DirectorySddl) {
+        throw 'Restored content or ACL verification failed.'
+    }
+    $RestoreSucceeded = $true
 } finally {
-    Start-Service -Name $State.ServiceName
+    if ($RestoreSucceeded -and $WasRunning) { Start-Service -Name $State.ServiceName }
 }
 ```
+
+`WasRunning` is captured before the grant block stops anything. Rollback stops a currently running service while it restores, but starts it again only after content and both ACLs verify successfully **and** that saved value was `true`; a service that was originally stopped remains stopped.
 
 ##### Docker and other immutable containers
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -144,13 +144,6 @@ Most install problems come down to a missed restart, a stale browser cache, or a
 2. Verify **Jellyfin Canopy** is listed under **Installed**.
 3. Check that it's enabled (not disabled).
 
-**Run the startup task:**
-
-1. Go to **Dashboard** → **Scheduled Tasks**.
-2. Under **Jellyfin Canopy**, find the task **Jellyfin Canopy Startup**.
-3. Run it manually (click the **▶︎** button).
-4. Refresh your browser (++ctrl+f5++).
-
 **Clear your browser cache:**
 
 1. Open the clear-cache dialog — Windows/Linux: ++ctrl+shift+delete++; macOS: ++command+shift+delete++.
@@ -192,72 +185,33 @@ If an update didn't take, do a clean reinstall:
 
 ### Permission issues
 
-!!! note "Applies only to the legacy on-disk rewrite"
+#### Default Jellyfin 12 permission contract
 
-    On Jellyfin 12, the plugin injects its client script at request time via built-in middleware and does **not** write to `index.html` on disk, so these permission errors do not occur by default. This section applies only if an admin has disabled the script-injection middleware to fall back to the legacy on-disk `index.html` rewrite, which requires a writable web folder. This is not a toggle in the plugin config page — it can only be enabled by setting `DisableScriptInjectionMiddleware` to `true` in the plugin's configuration XML (default `false`).
+Jellyfin Canopy's default script and branding middleware work at request time. They do **not** need write access to Jellyfin's web or installation tree on Docker, Linux, or Windows. Leave `DisableScriptInjectionMiddleware` and `DisableBrandingMiddleware` at their default value, `false`; do not change ownership or permissions on Jellyfin binaries to install Canopy.
 
-If you see an error like this in a log file:
+Uploaded branding is the relevant configuration write here. Canopy stores it in the `custom_branding` directory beside its plugin configuration, under Jellyfin's existing configuration owner. In the official container that is `/config/plugins/configurations/Jellyfin.Plugin.JellyfinCanopy/custom_branding`; native paths follow the Jellyfin configuration directory selected by that installation. Canopy never needs the branding directory to be moved into `jellyfin-web`.
 
-```text
-Access to the path '/jellyfin/jellyfin-web/index.html' is denied.
-```
+If a log reports access denied for `jellyfin-web/index.html`, first open `Jellyfin.Plugin.JellyfinCanopy.xml` in Jellyfin's plugin-configurations directory and confirm `DisableScriptInjectionMiddleware` is `false`, then restart Jellyfin and force-refresh the browser. Canopy can also make one best-effort attempt to remove a stale on-disk Canopy tag left by an earlier legacy setup; an `Error during cleanup of old script` is non-fatal, and the narrow fix is to restore that exact package-owned `index.html`. For any other error with the flag at `false`, identify the component from the surrounding log lines instead of granting Canopy broader access.
 
-The common solution is to install the [File Transformation plugin](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation) (recommended), or apply a platform-specific permission fix below.
+#### Optional plugins that modify jellyfin-web
 
-#### Docker
+[File Transformation](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation), [Custom Tabs](https://github.com/IAmParadox27/jellyfin-plugin-custom-tabs), and [Plugin Pages](https://github.com/IAmParadox27/jellyfin-plugin-pages) are separate third-party components. Canopy does not use them on Jellyfin 12. If you choose a component that modifies `jellyfin-web`, use that component's Jellyfin-12 documentation for its exact target, service principal, permissions, backup, and rollback. A permission error from one of those components is not a reason to make the whole Jellyfin install writable.
 
-A common error looks like this:
+#### Optional legacy on-disk fallback
 
-```text title="Bash"
-System.UnauthorizedAccessException: Access to the path '/jellyfin/jellyfin-web/index.html' is denied.
-```
+Setting `DisableScriptInjectionMiddleware` to `true` is an advanced compatibility escape hatch. It makes the **Jellyfin Canopy Startup** task rewrite the exact `index.html` reported by Jellyfin's resolved web path. The crash-safe writer reads that file, creates and writes a temporary sibling, then atomically replaces the destination. The service principal therefore needs directory traversal plus create/delete/rename access only in the immediate `jellyfin-web` directory; it does not need access to the rest of the installation tree.
 
-If you are **^^not^^ using the [file-transformation](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation) plugin**, you'll need to manually map the `index.html` file:
+Before enabling this fallback:
 
-1. Copy the `index.html` file out of your container:
+1. Record the exact `index.html` path from Canopy's log; paths differ by package and image.
+2. Identify the actual Jellyfin service principal: the container's configured UID/GID, the `User=` in the Linux service unit, or **Log On As** in Windows Services. Do not assume a username such as `jellyfin` or `NETWORK SERVICE`.
+3. Back up that exact file outside the installation tree and record its owner, mode, or ACL.
+4. Add only the file and immediate-directory access described above for that principal. Preserve the package owner and all unrelated entries. If your platform cannot express that narrow access, keep the request-time middleware enabled.
+5. Restart Jellyfin, run **Jellyfin Canopy Startup** once, and confirm the log names the same file.
 
-    ```bash title="Bash"
-    docker cp jellyfin:/jellyfin/jellyfin-web/index.html /path/to/your/jellyfin/config/index.html
-    ```
+The legacy fallback is a poor fit for immutable containers: a bind-mounted `index.html` cannot be replaced reliably by the required temporary-sibling rename. Keep the middleware enabled rather than making the image writable. Recreating the container from its original image removes any accidental image-layer changes.
 
-2. Add a volume mapping:
-
-    ```bash title="Docker Run"
-    -v /path/to/your/jellyfin/config/index.html:/jellyfin/jellyfin-web/index.html
-    ```
-
-    or in Compose:
-
-    ```yaml title="Docker Compose"
-    services:
-      jellyfin:
-        volumes:
-          # volume mapping
-          - /path/to/your/jellyfin/config:/config
-          - /path/to/your/jellyfin/config/index.html:/jellyfin/jellyfin-web/index.html
-    ```
-
-!!! warning
-
-    This method is not recommended and won't survive a `jellyfin-web` upgrade. The recommended method for Docker:
-
-    1. Install the [File Transformation plugin](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation).
-    2. Follow the standard installation process.
-
-#### Windows
-
-1. Navigate to your Jellyfin installation folder (usually `C:\Program Files\Jellyfin\Server`).
-2. Right-click the folder → **Properties** → **Security**.
-3. Grant `NETWORK SERVICE` **Read** and **Write** permissions.
-4. Apply to all subfolders and files.
-5. Restart the Jellyfin service.
-
-#### Linux
-
-```bash title="Bash"
-sudo chown -R jellyfin:jellyfin /usr/lib/jellyfin/
-sudo chmod -R 755 /usr/lib/jellyfin/
-```
+`index.html` is package-owned and can be replaced by a Jellyfin or `jellyfin-web` upgrade. Before an upgrade, set `DisableScriptInjectionMiddleware` back to `false`, restart, restore the backed-up file (or reinstall/verify the owning package), and remove only the temporary ACL entries you added. Those same steps are the rollback procedure if the fallback fails. Never preserve a modified `index.html` across versions.
 
 ### Admin config page tabs not switching
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -199,17 +199,177 @@ If a log reports access denied for `jellyfin-web/index.html`, first open `Jellyf
 
 #### Optional legacy on-disk fallback
 
-Setting `DisableScriptInjectionMiddleware` to `true` is an advanced compatibility escape hatch. It makes the **Jellyfin Canopy Startup** task rewrite the exact `index.html` reported by Jellyfin's resolved web path. The crash-safe writer reads that file, creates and writes a temporary sibling, then atomically replaces the destination. The service principal therefore needs directory traversal plus create/delete/rename access only in the immediate `jellyfin-web` directory; it does not need access to the rest of the installation tree.
+Setting `DisableScriptInjectionMiddleware` to `true` is an advanced compatibility escape hatch. It makes the **Jellyfin Canopy Startup** task rewrite the `index.html` under Jellyfin's resolved web path. The crash-safe writer reads that file, creates and writes a temporary sibling, then atomically replaces the destination. The service principal therefore needs read access to `index.html` plus create, write, delete, and rename access in its immediate parent directory. It does not need access to the rest of the installation tree.
 
-Before enabling this fallback:
+Do not wait for a success log to identify the path: the successful legacy-rewrite message does not include it. Discover the path and service principal from the running native service, and refuse to continue if discovery is ambiguous. The following procedures deliberately preserve the package owner and unrelated ACL entries.
 
-1. Record the exact `index.html` path from Canopy's log; paths differ by package and image.
-2. Identify the actual Jellyfin service principal: the container's configured UID/GID, the `User=` in the Linux service unit, or **Log On As** in Windows Services. Do not assume a username such as `jellyfin` or `NETWORK SERVICE`.
-3. Back up that exact file outside the installation tree and record its owner, mode, or ACL.
-4. Add only the file and immediate-directory access described above for that principal. Preserve the package owner and all unrelated entries. If your platform cannot express that narrow access, keep the request-time middleware enabled.
-5. Restart Jellyfin, run **Jellyfin Canopy Startup** once, and confirm the log names the same file.
+##### Linux native service
 
-The legacy fallback is a poor fit for immutable containers: a bind-mounted `index.html` cannot be replaced reliably by the required temporary-sibling rename. Keep the middleware enabled rather than making the image writable. Recreating the container from its original image removes any accidental image-layer changes.
+Run this Bash block from an account with `sudo`. It reads the real systemd service user, then takes the web directory from the running process's `--webdir` argument or `JELLYFIN_WEB_DIR` environment. Only when neither is present does it accept one unambiguous `index.html` from the installed `jellyfin-web` package.
+
+```bash
+service_name=jellyfin
+service_user="$(systemctl show "$service_name" --property=User --value)"
+service_pid="$(systemctl show "$service_name" --property=MainPID --value)"
+[ -n "$service_user" ] || service_user=root
+case "$service_pid" in ''|0|*[!0-9]*) echo "Jellyfin must be running for safe path discovery" >&2; exit 1;; esac
+
+web_dir=
+expect_web_dir=false
+while IFS= read -r -d '' argument; do
+    if [ "$expect_web_dir" = true ]; then web_dir="$argument"; expect_web_dir=false; continue; fi
+    case "$argument" in
+        --webdir=*) web_dir="${argument#--webdir=}" ;;
+        --webdir) expect_web_dir=true ;;
+    esac
+done < <(sudo cat "/proc/$service_pid/cmdline")
+
+if [ -z "$web_dir" ]; then
+    web_dir="$(sudo awk 'BEGIN { RS="\0" } /^JELLYFIN_WEB_DIR=/ { sub(/^JELLYFIN_WEB_DIR=/, ""); print; exit }' "/proc/$service_pid/environ")"
+fi
+
+if [ -n "$web_dir" ]; then
+    index_path="${web_dir%/}/index.html"
+else
+    mapfile -t package_indexes < <(
+        if command -v dpkg-query >/dev/null 2>&1; then dpkg-query -L jellyfin-web 2>/dev/null; fi
+        if command -v rpm >/dev/null 2>&1; then rpm -ql jellyfin-web 2>/dev/null; fi
+    )
+    mapfile -t package_indexes < <(printf '%s\n' "${package_indexes[@]}" | awk '/\/index\.html$/ && !seen[$0]++')
+    [ "${#package_indexes[@]}" -eq 1 ] || { echo "Could not identify exactly one package-owned index.html" >&2; exit 1; }
+    index_path="${package_indexes[0]}"
+fi
+
+[ -f "$index_path" ] || { echo "Resolved index.html does not exist: $index_path" >&2; exit 1; }
+index_dir="$(dirname -- "$index_path")"
+backup_dir="$HOME/jellyfin-canopy-index-backup-$(date +%Y%m%dT%H%M%S)"
+install -d -m 0700 -- "$backup_dir"
+sudo cp --preserve=all -- "$index_path" "$backup_dir/index.html.original"
+sudo getfacl --absolute-names -- "$index_path" "$index_dir" > "$backup_dir/access.acl"
+sudo stat -c '%U:%G %a %n' -- "$index_path" "$index_dir"
+printf 'Service principal: %s\nResolved index: %s\nRollback data: %s\n' "$service_user" "$index_path" "$backup_dir"
+read -r -p 'Review those values, then type YES to add the narrow ACLs: ' confirmation
+[ "$confirmation" = YES ] || { echo "No permissions changed" >&2; exit 1; }
+
+sudo setfacl -m "u:${service_user}:r" -- "$index_path"
+sudo setfacl -m "u:${service_user}:rwx" -- "$index_dir"
+```
+
+`getfacl` and `setfacl` must be available. The file ACE permits the initial read. The non-inherited directory ACE permits the service to create and write the temporary sibling, replace `index.html`, and delete a leftover temporary file. Directory `rwx` also permits manipulating other immediate children, which is the unavoidable Linux directory boundary for an atomic sibling rename; it is not applied recursively.
+
+Keep the printed backup directory. To roll back, disable the legacy setting first and run:
+
+```bash
+read -r -p 'Paste the exact Rollback data path: ' backup_dir
+[ -f "$backup_dir/access.acl" ] && [ -f "$backup_dir/index.html.original" ] || { echo "Invalid rollback directory" >&2; exit 1; }
+index_path="$(awk '/^# file: / { print substr($0, 9); exit }' "$backup_dir/access.acl")"
+sudo systemctl stop jellyfin
+trap 'sudo systemctl start jellyfin' EXIT
+sudo cp --preserve=all -- "$backup_dir/index.html.original" "$index_path"
+sudo setfacl --restore="$backup_dir/access.acl"
+sudo systemctl start jellyfin
+trap - EXIT
+```
+
+##### Windows native service
+
+Run the whole block in an elevated Windows PowerShell session. It accepts exactly one Windows service whose executable is Jellyfin, records that service's actual **Log On As** principal, resolves an explicit `--webdir` or otherwise requires exactly one `index.html` below the service executable, and saves the original content and SDDL outside the installation tree.
+
+```powershell
+$Services = @(Get-CimInstance Win32_Service | Where-Object {
+    $_.PathName -match '(?i)(^|[\\/])jellyfin(?:\.exe)?(?:["\s]|$)'
+})
+if ($Services.Count -ne 1) { throw "Expected exactly one Jellyfin service; found $($Services.Count)." }
+$Service = $Services[0]
+$Principal = $Service.StartName
+
+if ($Service.PathName -match '^\s*"([^"]+\.exe)"') { $Executable = $Matches[1] }
+elseif ($Service.PathName -match '^\s*(\S+\.exe)') { $Executable = $Matches[1] }
+else { throw "Could not resolve the Jellyfin service executable." }
+$Executable = [Environment]::ExpandEnvironmentVariables($Executable)
+$InstallRoot = Split-Path -Parent $Executable
+
+if ($Service.PathName -match '(?i)--webdir(?:=|\s+)(?:"([^"]+)"|(\S+))') {
+    $WebDirectory = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
+    $WebDirectory = [Environment]::ExpandEnvironmentVariables($WebDirectory)
+    if (-not [IO.Path]::IsPathRooted($WebDirectory)) { throw "The service's --webdir is not an absolute path." }
+    $Candidates = @(Get-Item -LiteralPath (Join-Path $WebDirectory 'index.html') -ErrorAction Stop)
+} else {
+    $Candidates = @(Get-ChildItem -LiteralPath $InstallRoot -Filter index.html -File -Recurse -ErrorAction Stop)
+}
+if ($Candidates.Count -ne 1) { throw "Expected exactly one index.html; found $($Candidates.Count)." }
+$IndexPath = $Candidates[0].FullName
+$IndexDirectory = $Candidates[0].DirectoryName
+$BackupDirectory = Join-Path ([Environment]::GetFolderPath('MyDocuments')) ("JellyfinCanopyIndexBackup-" + (Get-Date -Format 'yyyyMMddTHHmmss'))
+New-Item -ItemType Directory -Path $BackupDirectory -ErrorAction Stop | Out-Null
+Write-Host "Service principal: $Principal"
+Write-Host "Resolved index: $IndexPath"
+Write-Host "Rollback data: $BackupDirectory"
+$Confirmation = Read-Host 'Review those values, then type YES to add the narrow ACLs'
+if ($Confirmation -cne 'YES') { throw 'No permissions changed.' }
+
+$WasRunning = $Service.State -eq 'Running'
+if ($WasRunning) { Stop-Service -Name $Service.Name -ErrorAction Stop }
+try {
+    Copy-Item -LiteralPath $IndexPath -Destination (Join-Path $BackupDirectory 'index.html.original') -ErrorAction Stop
+    [ordered]@{
+        IndexPath = $IndexPath
+        IndexDirectory = $IndexDirectory
+        ServiceName = $Service.Name
+        Principal = $Principal
+        IndexSddl = (Get-Acl -LiteralPath $IndexPath).Sddl
+        DirectorySddl = (Get-Acl -LiteralPath $IndexDirectory).Sddl
+    } | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $BackupDirectory 'state.json') -Encoding utf8
+
+    $FileAcl = Get-Acl -LiteralPath $IndexPath
+    $FileRule = [System.Security.AccessControl.FileSystemAccessRule]::new(
+        $Principal, [System.Security.AccessControl.FileSystemRights]::Read,
+        [System.Security.AccessControl.InheritanceFlags]::None,
+        [System.Security.AccessControl.PropagationFlags]::None,
+        [System.Security.AccessControl.AccessControlType]::Allow)
+    $FileAcl.AddAccessRule($FileRule)
+    Set-Acl -LiteralPath $IndexPath -AclObject $FileAcl
+
+    $DirectoryRights = [System.Security.AccessControl.FileSystemRights]::ReadAndExecute `
+        -bor [System.Security.AccessControl.FileSystemRights]::Write `
+        -bor [System.Security.AccessControl.FileSystemRights]::DeleteSubdirectoriesAndFiles
+    $DirectoryAcl = Get-Acl -LiteralPath $IndexDirectory
+    $DirectoryRule = [System.Security.AccessControl.FileSystemAccessRule]::new(
+        $Principal, $DirectoryRights,
+        [System.Security.AccessControl.InheritanceFlags]::None,
+        [System.Security.AccessControl.PropagationFlags]::None,
+        [System.Security.AccessControl.AccessControlType]::Allow)
+    $DirectoryAcl.AddAccessRule($DirectoryRule)
+    Set-Acl -LiteralPath $IndexDirectory -AclObject $DirectoryAcl
+} finally {
+    if ($WasRunning) { Start-Service -Name $Service.Name }
+}
+```
+
+The file rule is read-only. The non-inherited parent-directory rule supplies the create/write/delete-child operations that the temporary-sibling replace needs, without propagating rights into subdirectories. To roll back, disable the legacy setting, paste the printed backup directory into the first line below, and run the block elevated:
+
+```powershell
+$BackupDirectory = Read-Host 'Paste the exact Rollback data path printed by the grant block'
+$State = Get-Content -LiteralPath (Join-Path $BackupDirectory 'state.json') -Raw | ConvertFrom-Json
+Stop-Service -Name $State.ServiceName -ErrorAction Stop
+try {
+    Copy-Item -LiteralPath (Join-Path $BackupDirectory 'index.html.original') -Destination $State.IndexPath -Force -ErrorAction Stop
+    $FileAcl = Get-Acl -LiteralPath $State.IndexPath
+    $FileAcl.SetSecurityDescriptorSddlForm($State.IndexSddl)
+    Set-Acl -LiteralPath $State.IndexPath -AclObject $FileAcl
+    $DirectoryAcl = Get-Acl -LiteralPath $State.IndexDirectory
+    $DirectoryAcl.SetSecurityDescriptorSddlForm($State.DirectorySddl)
+    Set-Acl -LiteralPath $State.IndexDirectory -AclObject $DirectoryAcl
+} finally {
+    Start-Service -Name $State.ServiceName
+}
+```
+
+##### Docker and other immutable containers
+
+Docker has no supported legacy fallback. Do not copy the package-owned `index.html` out of a container and bind-mount that single file back in: a file mount cannot accept the temporary sibling's atomic rename, and the copied file also drifts from the image on upgrade. Keep `DisableScriptInjectionMiddleware=false` and recreate the container from its original image to discard accidental image-layer changes.
+
+If discovery is ambiguous, an ACL command fails, or the platform cannot express these exact non-recursive rights, leave the request-time middleware enabled.
 
 `index.html` is package-owned and can be replaced by a Jellyfin or `jellyfin-web` upgrade. Before an upgrade, set `DisableScriptInjectionMiddleware` back to `false`, restart, restore the backed-up file (or reinstall/verify the owning package), and remove only the temporary ACL entries you added. Those same steps are the rollback procedure if the fallback fails. Never preserve a modified `index.html` across versions.
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -52,12 +52,12 @@ If you're moving up from a 10.11 setup, [Getting Started](getting-started.md) wa
 
 #### The plugin, scripts, or an update didn't show up
 
-These are all installation-environment issues rather than plugin bugs, and [Getting Started](getting-started.md) has the step-by-step fixes:
+These symptoms can come from installation state, configuration, another plugin, or a Canopy bug. [Getting Started](getting-started.md) has the first checks:
 
 - **Plugin not appearing after installation** — check the plugin repository and restart steps.
 - **Scripts not loading** — scripts are injected at request time by the built-in middleware in the default configuration; see the scripts-not-loading fix.
 - **Update not applying** — clear the plugin cache and force a browser refresh with ++ctrl+f5++.
-- **"Permission denied" errors in the logs** — a file-permission problem on the Jellyfin install directory; see the permissions section.
+- **"Permission denied" errors in the logs** — default Canopy does not write the Jellyfin install directory; use the surrounding log lines to identify the component, then see the least-privilege permissions section.
 
 ### Features not behaving
 
@@ -310,8 +310,7 @@ When you write up the report, include: the plugin version, Jellyfin version, bro
 
 | Error | Solution |
 |-------|----------|
-| `Access to the path '/jellyfin/jellyfin-web/index.html' is denied.` | Install the [File Transformation plugin](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation) or follow the Docker workaround in [Getting Started](getting-started.md). |
-| `Access to the path 'C:\Program Files\Jellyfin\Server\jellyfin-web\index.html' is denied.` | Grant "NETWORK SERVICE" Read/Write permissions to the Jellyfin folder. |
+| `Access to ... jellyfin-web/index.html ... is denied.` | Default Canopy does not need write access to this file. Confirm `DisableScriptInjectionMiddleware` is `false`; if the log names Canopy's stale-script cleanup, restore that exact package file, otherwise identify the component from the surrounding lines. Do not broaden install-tree permissions. See [Permission issues](getting-started.md#permission-issues). |
 | Plugin installed but scripts don't load | Scripts are injected at request time by the built-in middleware in the default config — see the scripts-not-loading fix in [Getting Started](getting-started.md). The "Jellyfin Canopy Startup" task only matters in the legacy on-disk `index.html` rewrite mode. |
 | Reviews / Elsewhere / Seerr icons not working | TMDB API may be blocked in your region — see [Seerr's TMDB troubleshooting](https://docs.seerr.dev/troubleshooting#tmdb-failed-to-retrievefetch-xxx). |
 | Seerr search not working | Enable "Jellyfin Sign-In" in Seerr, then either enable plugin auto-import and run "Import Users Now" or import users manually in Seerr. Also verify the user isn't on the blocked-users list. |

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "check:toolchain": "node scripts/check-node-toolchain.js",
     "check:performance-rules": "node scripts/check-performance-rules.js",
-    "check:markdown-links": "node scripts/check-markdown-links.js",
+    "check:markdown-links": "node scripts/check-markdown-links.js && node scripts/check-installation-permissions.js",
     "check:docs-assets": "node scripts/check-doc-assets.js",
     "lint": "eslint --exit-on-fatal-error --max-warnings 6586 \"Jellyfin.Plugin.JellyfinCanopy/js/**/*.js\" \"Jellyfin.Plugin.JellyfinCanopy/src/**/*.ts\" \"Jellyfin.Plugin.JellyfinCanopy/Configuration/*.js\" \"scripts/**/*.js\"",
     "lint:fix": "eslint --fix \"Jellyfin.Plugin.JellyfinCanopy/js/**/*.js\" \"Jellyfin.Plugin.JellyfinCanopy/src/**/*.ts\" \"Jellyfin.Plugin.JellyfinCanopy/Configuration/*.js\" \"scripts/**/*.js\"",

--- a/scripts/check-installation-permissions.js
+++ b/scripts/check-installation-permissions.js
@@ -18,8 +18,16 @@ const UNSAFE_GUIDANCE = [
         pattern: /\b(?:chown|chmod)\b[^\n]*(?:\s-R\b|\s--recursive\b)[^\n]*(?:jellyfin|web)/giu,
     },
     {
+        name: 'recursive Linux ACL grant on a Jellyfin package tree',
+        pattern: /\bsetfacl\b(?=[^\n]*(?:\s--recursive\b|\s-[^\s]*R[^\s]*))(?=[^\n]*(?:\s--(?:modify|modify-file|set|set-file)\b|\s-[a-z]*[mM][a-z]*\b))(?=[^\n]*(?:\bjellyfin-web\b|\/(?:usr\/(?:lib|share)|opt|app)\/jellyfin(?:\/|$)|\/jellyfin\/(?:jellyfin-web|web)(?:\/|$)))[^\n]*/giu,
+    },
+    {
         name: 'recursive Windows permission inheritance',
         pattern: /apply\s+(?:the change\s+)?to\s+all\s+subfolders\s+and\s+files/giu,
+    },
+    {
+        name: 'recursive Windows ACL grant on a Jellyfin package tree',
+        pattern: /\bicacls\b(?=[^\n]*\/grant(?::r)?\b)(?=[^\n]*\/t\b)(?=[^\n]*(?:program files[\\/]+jellyfin|jellyfin-web|[\\/]jellyfin[\\/]+server\b))[^\n]*/giu,
     },
     {
         name: 'broad write grant on the Jellyfin install folder',
@@ -50,7 +58,7 @@ function lineNumber(source, index) {
 function collectGuidanceFiles(root = ROOT) {
     const files = [];
     const excludedDirectories = new Set(['.git', 'bin', 'coverage', 'node_modules', 'obj', 'site']);
-    const guidanceExtensions = new Set(['.md', '.sh', '.yaml', '.yml']);
+    const guidanceExtensions = new Set(['.bash', '.bat', '.cmd', '.md', '.ps1', '.sh', '.yaml', '.yml']);
     const visit = (directory) => {
         for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
             if (entry.isDirectory() && excludedDirectories.has(entry.name)) continue;
@@ -171,7 +179,9 @@ function checkDocumentationContract(root = ROOT) {
         ['docs/getting-started.md', /creates and writes a temporary sibling, then atomically replaces the destination/, 'explain the exact legacy directory operations'],
         ['docs/getting-started.md', /Do not wait for a success log to identify the path/, 'use deterministic legacy-path discovery instead of a nonexistent success-path log'],
         ['docs/getting-started.md', /systemctl show[\s\S]*setfacl -m/, 'provide concrete Linux service discovery and narrow ACL commands'],
+        ['docs/getting-started.md', /set -Eeuo pipefail[\s\S]*cmp --silent[\s\S]*setfacl --test --restore[\s\S]*restore_after_partial_grant/, 'make Linux backup verification and partial-grant rollback fail closed'],
         ['docs/getting-started.md', /Get-CimInstance Win32_Service[\s\S]*FileSystemAccessRule/, 'provide concrete Windows service discovery and narrow ACL commands'],
+        ['docs/getting-started.md', /WasRunning = \$WasRunning[\s\S]*\$RestoreSucceeded = \$false[\s\S]*\$RestoreSucceeded -and \$WasRunning/, 'preserve the original Windows service state through successful rollback'],
         ['docs/getting-started.md', /Docker has no supported legacy fallback/, 'prohibit unsupported container copy and bind-mount workarounds'],
         ['docs/getting-started.md', /best-effort attempt to remove a stale on-disk Canopy tag/, 'explain the non-fatal migration cleanup attempt'],
         ['docs/getting-started.md', /`index\.html` is package-owned/, 'explain upgrade and package ownership semantics'],

--- a/scripts/check-installation-permissions.js
+++ b/scripts/check-installation-permissions.js
@@ -1,0 +1,202 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..');
+const REQUIRED_DOCS = ['README.md', 'docs/getting-started.md', 'docs/customization.md', 'docs/help.md', 'docs/about.md'];
+const RUNTIME_FILES = {
+    atomic: 'Jellyfin.Plugin.JellyfinCanopy/Configuration/AtomicFile.cs',
+    config: 'Jellyfin.Plugin.JellyfinCanopy/Configuration/PluginConfiguration.cs',
+    plugin: 'Jellyfin.Plugin.JellyfinCanopy/JellyfinCanopy.cs',
+    startup: 'Jellyfin.Plugin.JellyfinCanopy/Services/StartupService.cs',
+};
+
+const UNSAFE_GUIDANCE = [
+    {
+        name: 'recursive ownership or mode change on a Jellyfin tree',
+        pattern: /\b(?:chown|chmod)\b[^\n]*(?:\s-R\b|\s--recursive\b)[^\n]*(?:jellyfin|web)/giu,
+    },
+    {
+        name: 'recursive Windows permission inheritance',
+        pattern: /apply\s+(?:the change\s+)?to\s+all\s+subfolders\s+and\s+files/giu,
+    },
+    {
+        name: 'broad write grant on the Jellyfin install folder',
+        pattern: /grant[^\n]*(?:read\s*(?:and|\/)\s*write|modify|full control)[^\n]*(?:jellyfin|install(?:ation)?)[^\n]*(?:folder|directory|tree)/giu,
+    },
+    {
+        name: 'copying a custom asset into the package-owned web tree',
+        pattern: /\b(?:place|drop|copy)\b[^\n]*(?:web root|jellyfin web (?:directory|folder)|jellyfin-web)/giu,
+    },
+    {
+        name: 'blanket File Transformation recommendation for Canopy',
+        pattern: /file transformation[^\n]*(?:highly\s+recommended|required|common solution)[^\n]*(?:canopy|install)/giu,
+    },
+];
+
+function lineNumber(source, index) {
+    return source.slice(0, index).split('\n').length;
+}
+
+function collectGuidanceFiles(root = ROOT) {
+    const files = [];
+    const excludedDirectories = new Set(['.git', 'bin', 'coverage', 'node_modules', 'obj', 'site']);
+    const guidanceExtensions = new Set(['.md', '.sh', '.yaml', '.yml']);
+    const visit = (directory) => {
+        for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+            if (entry.isDirectory() && excludedDirectories.has(entry.name)) continue;
+            const absolute = path.join(directory, entry.name);
+            if (entry.isDirectory()) visit(absolute);
+            else if (entry.isFile() && guidanceExtensions.has(path.extname(entry.name).toLowerCase())) {
+                files.push(path.relative(root, absolute));
+            }
+        }
+    };
+    visit(root);
+    return files;
+}
+
+function checkUnsafeGuidance(files, root = ROOT) {
+    const selected = files || collectGuidanceFiles(root);
+    const problems = [];
+    for (const file of selected) {
+        const absolute = path.join(root, file);
+        if (!fs.existsSync(absolute)) {
+            problems.push(`${file}: required installation document is missing`);
+            continue;
+        }
+        const source = fs.readFileSync(absolute, 'utf8');
+        for (const rule of UNSAFE_GUIDANCE) {
+            rule.pattern.lastIndex = 0;
+            for (const match of source.matchAll(rule.pattern)) {
+                problems.push(`${file}:${lineNumber(source, match.index)}: ${rule.name}`);
+            }
+        }
+    }
+    return problems;
+}
+
+function requirePattern(problems, source, file, pattern, description) {
+    if (!pattern.test(source)) problems.push(`${file}: ${description}`);
+}
+
+function readRuntimeSources(root, problems) {
+    const sources = {};
+    for (const [name, file] of Object.entries(RUNTIME_FILES)) {
+        const absolute = path.join(root, file);
+        if (!fs.existsSync(absolute)) {
+            problems.push(`${file}: runtime permission-contract source is missing`);
+            sources[name] = '';
+        } else {
+            sources[name] = fs.readFileSync(absolute, 'utf8');
+        }
+    }
+    return sources;
+}
+
+function checkRuntimeContract(root = ROOT) {
+    const problems = [];
+    const sources = readRuntimeSources(root, problems);
+    requirePattern(
+        problems,
+        sources.config,
+        RUNTIME_FILES.config,
+        /DisableScriptInjectionMiddleware\s*=\s*false\s*;/,
+        'script middleware must remain enabled by default',
+    );
+    requirePattern(
+        problems,
+        sources.config,
+        RUNTIME_FILES.config,
+        /DisableBrandingMiddleware\s*=\s*false\s*;/,
+        'branding middleware must remain enabled by default',
+    );
+    requirePattern(
+        problems,
+        sources.startup,
+        RUNTIME_FILES.startup,
+        /config\s*!=\s*null\s*&&\s*config\.DisableScriptInjectionMiddleware/,
+        'legacy on-disk startup rewrite must remain opt-in',
+    );
+    requirePattern(
+        problems,
+        sources.plugin,
+        RUNTIME_FILES.plugin,
+        /IndexHtmlPath\s*=>\s*Path\.Combine\(_applicationPaths\.WebPath,\s*"index\.html"\)/,
+        'legacy rewrite target must remain the resolved web-path index.html',
+    );
+    requirePattern(
+        problems,
+        sources.plugin,
+        RUNTIME_FILES.plugin,
+        /BrandingDirectory\s*=>\s*GetPluginDataSubdirectory\("custom_branding"\)/,
+        'branding storage must remain beside the plugin configuration',
+    );
+    requirePattern(
+        problems,
+        sources.plugin,
+        RUNTIME_FILES.plugin,
+        /CleanupOldScript\(\)\s*;/,
+        'best-effort stale legacy-tag cleanup must remain represented in the docs',
+    );
+    requirePattern(
+        problems,
+        sources.atomic,
+        RUNTIME_FILES.atomic,
+        /var temp = path \+ "\.tmp\."[\s\S]*File\.Move\(temp, path, overwrite: true\)/,
+        'legacy writes must retain their temporary-sibling atomic rename semantics',
+    );
+    return problems;
+}
+
+function checkDocumentationContract(root = ROOT) {
+    const problems = checkUnsafeGuidance(undefined, root);
+    for (const file of REQUIRED_DOCS) {
+        if (!fs.existsSync(path.join(root, file))) {
+            problems.push(`${file}: required installation document is missing`);
+        }
+    }
+    const expectations = [
+        ['README.md', /do(?:es)? not need write access to Jellyfin's web or installation tree/, 'state the default no-install-tree-write contract'],
+        ['docs/getting-started.md', /Default Jellyfin 12 permission contract/, 'contain the canonical permission contract'],
+        ['docs/getting-started.md', /creates and writes a temporary sibling, then atomically replaces the destination/, 'explain the exact legacy directory operations'],
+        ['docs/getting-started.md', /best-effort attempt to remove a stale on-disk Canopy tag/, 'explain the non-fatal migration cleanup attempt'],
+        ['docs/getting-started.md', /`index\.html` is package-owned/, 'explain upgrade and package ownership semantics'],
+        ['docs/getting-started.md', /Those same steps are the rollback procedure/, 'document legacy rollback'],
+        ['docs/customization.md', /directory that contains Canopy's plugin configuration/, 'identify the actual branding storage owner boundary'],
+        ['docs/customization.md', /Do not copy the image into Jellyfin's package-owned web directory/, 'keep splash assets out of the web tree'],
+        ['docs/help.md', /Default Canopy does not need write access to this file/, 'route permission errors through the default contract'],
+        ['docs/about.md', /does not use or require it/, 'keep File Transformation explicitly optional'],
+    ];
+    for (const [file, pattern, description] of expectations) {
+        const absolute = path.join(root, file);
+        if (!fs.existsSync(absolute)) continue;
+        requirePattern(problems, fs.readFileSync(absolute, 'utf8'), file, pattern, description);
+    }
+    return problems;
+}
+
+function checkInstallationPermissions(root = ROOT) {
+    return [...checkDocumentationContract(root), ...checkRuntimeContract(root)];
+}
+
+function main() {
+    const problems = checkInstallationPermissions();
+    if (problems.length > 0) {
+        console.error(`Installation permission contract failed:\n${problems.map(problem => `- ${problem}`).join('\n')}`);
+        process.exitCode = 1;
+        return;
+    }
+    console.log('Installation permission contract OK');
+}
+
+if (require.main === module) main();
+
+module.exports = {
+    checkDocumentationContract,
+    checkInstallationPermissions,
+    checkRuntimeContract,
+    checkUnsafeGuidance,
+    collectGuidanceFiles,
+};

--- a/scripts/check-installation-permissions.js
+++ b/scripts/check-installation-permissions.js
@@ -4,7 +4,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const ROOT = path.join(__dirname, '..');
-const REQUIRED_DOCS = ['README.md', 'docs/getting-started.md', 'docs/customization.md', 'docs/help.md', 'docs/about.md'];
+const REQUIRED_DOCS = ['README.md', 'docs/getting-started.md', 'docs/customization.md', 'docs/help.md', 'docs/about.md', 'docs/developers.md'];
 const RUNTIME_FILES = {
     atomic: 'Jellyfin.Plugin.JellyfinCanopy/Configuration/AtomicFile.cs',
     config: 'Jellyfin.Plugin.JellyfinCanopy/Configuration/PluginConfiguration.cs',
@@ -32,6 +32,14 @@ const UNSAFE_GUIDANCE = [
     {
         name: 'blanket File Transformation recommendation for Canopy',
         pattern: /file transformation[^\n]*(?:highly\s+recommended|required|common solution)[^\n]*(?:canopy|install)/giu,
+    },
+    {
+        name: 'Docker copy-out workaround for package-owned index.html',
+        pattern: /\bdocker\s+cp\b[^\n]*\bjellyfin-web\/index\.html\b/giu,
+    },
+    {
+        name: 'single-file Docker bind mount over package-owned index.html',
+        pattern: /^\s*-\s*[^\n#]*index\.html\s*:\s*[^\n#]*(?:jellyfin-web|\/web)\/index\.html(?:\s*:\s*(?:ro|rw))?\s*$/gimu,
     },
 ];
 
@@ -161,13 +169,19 @@ function checkDocumentationContract(root = ROOT) {
         ['README.md', /do(?:es)? not need write access to Jellyfin's web or installation tree/, 'state the default no-install-tree-write contract'],
         ['docs/getting-started.md', /Default Jellyfin 12 permission contract/, 'contain the canonical permission contract'],
         ['docs/getting-started.md', /creates and writes a temporary sibling, then atomically replaces the destination/, 'explain the exact legacy directory operations'],
+        ['docs/getting-started.md', /Do not wait for a success log to identify the path/, 'use deterministic legacy-path discovery instead of a nonexistent success-path log'],
+        ['docs/getting-started.md', /systemctl show[\s\S]*setfacl -m/, 'provide concrete Linux service discovery and narrow ACL commands'],
+        ['docs/getting-started.md', /Get-CimInstance Win32_Service[\s\S]*FileSystemAccessRule/, 'provide concrete Windows service discovery and narrow ACL commands'],
+        ['docs/getting-started.md', /Docker has no supported legacy fallback/, 'prohibit unsupported container copy and bind-mount workarounds'],
         ['docs/getting-started.md', /best-effort attempt to remove a stale on-disk Canopy tag/, 'explain the non-fatal migration cleanup attempt'],
         ['docs/getting-started.md', /`index\.html` is package-owned/, 'explain upgrade and package ownership semantics'],
         ['docs/getting-started.md', /Those same steps are the rollback procedure/, 'document legacy rollback'],
         ['docs/customization.md', /directory that contains Canopy's plugin configuration/, 'identify the actual branding storage owner boundary'],
         ['docs/customization.md', /Do not copy the image into Jellyfin's package-owned web directory/, 'keep splash assets out of the web tree'],
+        ['docs/customization.md', /LAN-only HTTP is supported[\s\S]*use HTTPS for an externally hosted production image/, 'preserve supported splash URL forms and scope the HTTPS requirement'],
         ['docs/help.md', /Default Canopy does not need write access to this file/, 'route permission errors through the default contract'],
         ['docs/about.md', /does not use or require it/, 'keep File Transformation explicitly optional'],
+        ['docs/developers.md', /Legacy on-disk `index\.html` rewrite \| \*\*STAYS as an explicit fallback only\*\* when `DisableScriptInjectionMiddleware=true`; `CleanupOldScript` separately remains as best-effort migration cleanup/, 'keep the developer fallback matrix aligned with runtime'],
     ];
     for (const [file, pattern, description] of expectations) {
         const absolute = path.join(root, file);

--- a/scripts/check-installation-permissions.test.js
+++ b/scripts/check-installation-permissions.test.js
@@ -47,6 +47,21 @@ test('rejects broad recursive grants and package web-tree asset copies', () => {
     });
 });
 
+test('rejects Docker copy-out and single-file bind-mount legacy workarounds', () => {
+    fixture({
+        'docs/docker-bad.md': [
+            'docker cp jellyfin:/jellyfin/jellyfin-web/index.html /srv/jellyfin/index.html',
+            'volumes:',
+            '  - /srv/jellyfin/index.html:/jellyfin/jellyfin-web/index.html:rw',
+        ].join('\n'),
+    }, (root) => {
+        const problems = checkUnsafeGuidance(['docs/docker-bad.md'], root);
+        assert.equal(problems.length, 2);
+        assert.match(problems.join('\n'), /Docker copy-out workaround/);
+        assert.match(problems.join('\n'), /single-file Docker bind mount/);
+    });
+});
+
 test('accepts narrowly scoped legacy and default-middleware explanations', () => {
     fixture({
         'docs/good.md': [

--- a/scripts/check-installation-permissions.test.js
+++ b/scripts/check-installation-permissions.test.js
@@ -47,6 +47,37 @@ test('rejects broad recursive grants and package web-tree asset copies', () => {
     });
 });
 
+test('rejects recursive Linux and Windows ACL grants on package trees', () => {
+    fixture({
+        'docs/recursive-acls.md': [
+            'sudo setfacl -R -m u:jellyfin:rwx /usr/share/jellyfin/web',
+            'setfacl --recursive --modify u:jellyfin:rwx /opt/jellyfin/jellyfin-web',
+            'setfacl -Rm u:jellyfin:rwx /jellyfin/jellyfin-web',
+            'icacls "C:\\Program Files\\Jellyfin\\Server" /grant "NT SERVICE\\Jellyfin:(OI)(CI)M" /T',
+            'icacls C:\\Jellyfin\\Server /T /grant:r "NETWORK SERVICE:(CI)(OI)F"',
+        ].join('\n'),
+    }, (root) => {
+        const problems = checkUnsafeGuidance(['docs/recursive-acls.md'], root);
+        assert.equal(problems.length, 5);
+        assert.equal(problems.filter(problem => /recursive Linux ACL grant/.test(problem)).length, 3);
+        assert.equal(problems.filter(problem => /recursive Windows ACL grant/.test(problem)).length, 2);
+    });
+});
+
+test('scans common shell and Windows command-script guidance files', () => {
+    fixture({
+        'ops/linux.bash': 'setfacl -R -m u:jellyfin:rwx /usr/lib/jellyfin',
+        'ops/windows.ps1': 'icacls "C:\\Program Files\\Jellyfin\\Server" /grant "Users:(OI)(CI)M" /T',
+        'ops/windows.cmd': 'icacls C:\\Jellyfin\\Server /T /grant:r Users:F',
+    }, (root) => {
+        const problems = checkUnsafeGuidance(undefined, root);
+        assert.equal(problems.length, 3);
+        assert.match(problems.join('\n'), /ops\/linux\.bash/);
+        assert.match(problems.join('\n'), /ops\/windows\.ps1/);
+        assert.match(problems.join('\n'), /ops\/windows\.cmd/);
+    });
+});
+
 test('rejects Docker copy-out and single-file bind-mount legacy workarounds', () => {
     fixture({
         'docs/docker-bad.md': [
@@ -67,6 +98,8 @@ test('accepts narrowly scoped legacy and default-middleware explanations', () =>
         'docs/good.md': [
             'Default Canopy does not write Jellyfin binaries.',
             'For optional legacy mode, back up the exact index.html and grant only its service principal.',
+            'sudo setfacl -m "u:${service_user}:rwx" -- "$index_dir"',
+            'icacls "C:\\Program Files\\Jellyfin\\Server\\jellyfin-web" /grant "NT SERVICE\\Jellyfin:(M)"',
             'Restore the backup and remove only the temporary ACL during rollback.',
         ].join('\n'),
     }, root => assert.deepEqual(checkUnsafeGuidance(['docs/good.md'], root), []));

--- a/scripts/check-installation-permissions.test.js
+++ b/scripts/check-installation-permissions.test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const {
+    checkInstallationPermissions,
+    checkRuntimeContract,
+    checkUnsafeGuidance,
+} = require('./check-installation-permissions');
+
+function fixture(files, callback) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'jc-install-permissions-'));
+    try {
+        for (const [name, contents] of Object.entries(files)) {
+            const destination = path.join(root, name);
+            fs.mkdirSync(path.dirname(destination), { recursive: true });
+            fs.writeFileSync(destination, contents);
+        }
+        callback(root);
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+}
+
+test('live installation guidance matches the runtime permission contract', () => {
+    assert.deepEqual(checkInstallationPermissions(), []);
+});
+
+test('rejects broad recursive grants and package web-tree asset copies', () => {
+    fixture({
+        'docs/bad.md': [
+            'sudo chown -R jellyfin:jellyfin /usr/lib/jellyfin/',
+            'Grant NETWORK SERVICE Read and Write to the Jellyfin installation folder.',
+            'Apply to all subfolders and files.',
+            'Drop the image in the Jellyfin web directory.',
+        ].join('\n'),
+    }, (root) => {
+        const problems = checkUnsafeGuidance(['docs/bad.md'], root);
+        assert.equal(problems.length, 4);
+        assert.match(problems.join('\n'), /recursive ownership or mode change/);
+        assert.match(problems.join('\n'), /broad write grant/);
+        assert.match(problems.join('\n'), /recursive Windows permission inheritance/);
+        assert.match(problems.join('\n'), /package-owned web tree/);
+    });
+});
+
+test('accepts narrowly scoped legacy and default-middleware explanations', () => {
+    fixture({
+        'docs/good.md': [
+            'Default Canopy does not write Jellyfin binaries.',
+            'For optional legacy mode, back up the exact index.html and grant only its service principal.',
+            'Restore the backup and remove only the temporary ACL during rollback.',
+        ].join('\n'),
+    }, root => assert.deepEqual(checkUnsafeGuidance(['docs/good.md'], root), []));
+});
+
+test('runtime check fails when a middleware default drifts to disabled', () => {
+    const files = {
+        'Jellyfin.Plugin.JellyfinCanopy/Configuration/AtomicFile.cs': 'var temp = path + ".tmp."; File.Move(temp, path, overwrite: true);',
+        'Jellyfin.Plugin.JellyfinCanopy/Configuration/PluginConfiguration.cs': 'DisableScriptInjectionMiddleware = true; DisableBrandingMiddleware = false;',
+        'Jellyfin.Plugin.JellyfinCanopy/JellyfinCanopy.cs': 'CleanupOldScript(); IndexHtmlPath => Path.Combine(_applicationPaths.WebPath, "index.html"); BrandingDirectory => GetPluginDataSubdirectory("custom_branding");',
+        'Jellyfin.Plugin.JellyfinCanopy/Services/StartupService.cs': 'if (config != null && config.DisableScriptInjectionMiddleware) {}',
+    };
+    fixture(files, (root) => {
+        const problems = checkRuntimeContract(root);
+        assert.equal(problems.length, 1);
+        assert.match(problems[0], /script middleware must remain enabled by default/);
+    });
+});
+
+test('the blocking Markdown gate cannot omit the installation contract', () => {
+    const root = path.join(__dirname, '..');
+    const scripts = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8')).scripts;
+    assert.match(
+        scripts['check:markdown-links'],
+        /node scripts\/check-markdown-links\.js && node scripts\/check-installation-permissions\.js/,
+    );
+});


### PR DESCRIPTION
## Summary

Replace unsafe broad Jellyfin installation-tree write guidance with an enforceable least-privilege installation contract.

Closes #140.

## What changes

- Makes request-time middleware injection the documented default: normal Docker, Linux, and Windows installs do not write Jellyfin's packaged web tree.
- Separates that default from the explicitly enabled legacy on-disk fallback.
- Adds deterministic, ambiguity-rejecting path and Jellyfin service-principal discovery.
- Provides copy-safe Linux and Windows inspection, backup, narrow grant, validation, and rollback flows scoped to the exact `index.html` file and its immediate parent—the permissions required by atomic sibling create/rename/delete.
- Linux uses strict mode, verifies both content and ACL backups, and automatically restores after a partial grant failure.
- Windows records the original service state, restores content and ACLs before restart, and restarts only after successful restoration when the service was originally running.
- Explicitly rejects package-tree copies, Docker copy-out/single-file bind-mount fallbacks, recursive chmod/chown/setfacl grants, and recursive inherited `icacls /T` grants.
- Preserves supported same-origin relative/plugin/reverse-proxy splash URLs and LAN HTTP while requiring HTTPS for externally hosted production assets.
- Adds a source↔documentation contract so runtime defaults and permission guidance cannot drift.

## Validation

- Independent final review: **APPROVE**, no findings.
- Rebase onto current main is patch-identical across all three commits.
- Installation contract tests: **8/8**.
- Full script suite: **357/357**.
- Markdown links, permission contract, documentation assets, strict MkDocs build, syntax inventory, focused ESLint, Bash syntax, PowerShell static structure, and diff hygiene passed.
- Additional false-positive probes confirm read-only recursive ACL inspection/backup remains allowed while package-tree mutation is blocked.

## AI assistance

Implemented, repaired, independently reviewed, and validated with Codex assistance.