### PR TITLE
Fix hidden parent lookup lifecycle and bounds

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/filter.parent-series.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/filter.parent-series.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+import { resetFromUserConfig } from './data';
+import {
+    clearFilterIdentityState,
+    filterAllNativeCards,
+    filterNativeCards,
+    invalidateParentSeriesAssociations,
+    restoreNativeCardsForIds,
+} from './filter';
+
+function installHiddenSeries(seriesId = 'hidden-series'): void {
+    const context = JC.identity.capture()!;
+    const hiddenContent = JC.identity.own({
+        items: { [seriesId]: { itemId: seriesId, type: 'Series', hideScope: 'global' } },
+        settings: { enabled: true, filterLibrary: true },
+    }, context);
+    JC.userConfig = JC.identity.own({ hiddenContent }, context);
+    resetFromUserConfig();
+}
+
+function episodeCard(itemId = 'episode-1'): HTMLElement {
+    const card = document.createElement('div');
+    card.className = 'card';
+    card.dataset.id = itemId;
+    card.dataset.type = 'Episode';
+    document.body.appendChild(card);
+    return card;
+}
+
+describe('hidden-content parent-Series resolution', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        window.location.hash = '#/library';
+        installHiddenSeries();
+    });
+
+    afterEach(() => {
+        clearFilterIdentityState();
+        document.body.innerHTML = '';
+        vi.restoreAllMocks();
+    });
+
+    it('retries an omitted batch row and later restores parent hiding', async () => {
+        const ajax = vi.spyOn(ApiClient, 'ajax')
+            .mockResolvedValueOnce({ Items: [] })
+            .mockResolvedValueOnce({ Items: [{ Id: 'episode-1', SeriesId: 'hidden-series' }] });
+        const card = episodeCard();
+
+        filterAllNativeCards();
+        await vi.waitFor(() => expect(ajax).toHaveBeenCalledTimes(1));
+        await vi.waitFor(() => expect(card.hasAttribute('data-jc-hidden-checked')).toBe(false));
+
+        await vi.waitFor(() => {
+            expect(ajax).toHaveBeenCalledTimes(2);
+            expect(card.classList.contains('jc-hidden')).toBe(true);
+            expect(card.getAttribute('data-jc-hidden-parent-series-id')).toBe('hidden-series');
+        }, { timeout: 2_000 });
+    });
+
+    it('does not make a transient batch and individual failure sticky', async () => {
+        const ajax = vi.spyOn(ApiClient, 'ajax')
+            .mockRejectedValueOnce(new Error('temporary batch failure'))
+            .mockRejectedValueOnce(new Error('temporary item failure'))
+            .mockResolvedValueOnce({ Items: [{ Id: 'episode-1', SeriesId: 'hidden-series' }] });
+        vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        const card = episodeCard();
+
+        filterAllNativeCards();
+
+        await vi.waitFor(() => {
+            expect(ajax).toHaveBeenCalledTimes(3);
+            expect(card.classList.contains('jc-hidden')).toBe(true);
+            expect(card.getAttribute('data-jc-hidden-parent-series-id')).toBe('hidden-series');
+        }, { timeout: 2_000 });
+    });
+
+    it('keeps the old parent marker until a replacement result can unhide atomically', async () => {
+        let resolveReplacement!: (value: unknown) => void;
+        const replacement = new Promise((resolve) => { resolveReplacement = resolve; });
+        const ajax = vi.spyOn(ApiClient, 'ajax')
+            .mockResolvedValueOnce({ Items: [{ Id: 'episode-1', SeriesId: 'hidden-series' }] })
+            .mockReturnValueOnce(replacement);
+        const card = episodeCard();
+
+        filterAllNativeCards();
+        await vi.waitFor(() => expect(card.classList.contains('jc-hidden')).toBe(true));
+
+        const afterPositiveTtl = Date.now() + 6 * 60 * 1_000;
+        vi.spyOn(Date, 'now').mockReturnValue(afterPositiveTtl);
+        restoreNativeCardsForIds(new Set(['unrelated-item']));
+        filterNativeCards();
+        await vi.waitFor(() => expect(ajax).toHaveBeenCalledTimes(2));
+        expect(card.classList.contains('jc-hidden')).toBe(true);
+        expect(card.getAttribute('data-jc-hidden-parent-series-id')).toBe('hidden-series');
+
+        resolveReplacement({ Items: [{ Id: 'episode-1', SeriesId: 'visible-series' }] });
+        await vi.waitFor(() => {
+            expect(card.classList.contains('jc-hidden')).toBe(false);
+            expect(card.hasAttribute('data-jc-hidden-parent-series-id')).toBe(false);
+        });
+    });
+
+    it('deduplicates duplicate visible cards while applying the cached result to both', async () => {
+        const ajax = vi.spyOn(ApiClient, 'ajax')
+            .mockResolvedValue({ Items: [{ Id: 'episode-1', SeriesId: 'hidden-series' }] });
+        const first = episodeCard();
+        const second = episodeCard();
+
+        filterAllNativeCards();
+        await vi.waitFor(() => {
+            expect(first.classList.contains('jc-hidden')).toBe(true);
+            expect(second.classList.contains('jc-hidden')).toBe(true);
+        }, { timeout: 2_000 });
+        expect(ajax).toHaveBeenCalledTimes(1);
+    });
+
+    it('stops automatic retry work after the per-card attempt cap', async () => {
+        vi.useFakeTimers();
+        try {
+            const ajax = vi.spyOn(ApiClient, 'ajax').mockRejectedValue(new Error('offline'));
+            vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+            const card = episodeCard();
+
+            filterAllNativeCards();
+            await vi.advanceTimersByTimeAsync(2_500);
+            expect(ajax).toHaveBeenCalledTimes(8);
+            expect(card.hasAttribute('data-jc-hidden-checked')).toBe(true);
+
+            filterNativeCards();
+            await vi.advanceTimersByTimeAsync(1_000);
+            expect(ajax).toHaveBeenCalledTimes(8);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('recovers overflow beyond both 1,000-entry backpressure tables', async () => {
+        const responseItems = Array.from({ length: 1_001 }, (_value, index) => ({
+            Id: `overflow-episode-${index}`,
+            SeriesId: 'hidden-series',
+        }));
+        let calls = 0;
+        const ajax = vi.spyOn(ApiClient, 'ajax').mockImplementation(() => {
+            calls += 1;
+            // The first 20 requests cover the first bounded 1,000 IDs in
+            // 50-item chunks and omit every row. The bounded overflow pass
+            // must later recover all 1,001 cards without retaining card 1,001.
+            return Promise.resolve({ Items: calls <= 20 ? [] : responseItems });
+        });
+        for (let index = 0; index < 1_001; index += 1) {
+            episodeCard(`overflow-episode-${index}`);
+        }
+
+        filterAllNativeCards();
+
+        await vi.waitFor(() => {
+            expect(document.querySelectorAll('.card.jc-hidden')).toHaveLength(1_001);
+        }, { timeout: 4_000 });
+        expect(ajax.mock.calls.length).toBeGreaterThan(20);
+        // Initial wave plus at most three capped overflow waves, each no more
+        // than 20 sequential 50-ID requests for the 1,000-ID pending bound.
+        expect(ajax.mock.calls.length).toBeLessThanOrEqual(80);
+    });
+
+    it('invalidates an old parent association on a library change', async () => {
+        const ajax = vi.spyOn(ApiClient, 'ajax')
+            .mockResolvedValueOnce({ Items: [{ Id: 'episode-1', SeriesId: 'hidden-series' }] })
+            .mockResolvedValueOnce({ Items: [{ Id: 'episode-1', SeriesId: 'visible-series' }] });
+        const card = episodeCard();
+
+        filterAllNativeCards();
+        await vi.waitFor(() => expect(card.classList.contains('jc-hidden')).toBe(true));
+
+        invalidateParentSeriesAssociations();
+        await vi.waitFor(() => {
+            expect(ajax).toHaveBeenCalledTimes(2);
+            expect(card.classList.contains('jc-hidden')).toBe(false);
+            expect(card.hasAttribute('data-jc-hidden-parent-series-id')).toBe(false);
+        });
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/filter.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/filter.ts
@@ -15,18 +15,47 @@ import { onBodyMutation } from '../../core/dom-observer';
 import type { BodySubscriberHandle, IdentityContext } from '../../types/jc';
 import { hiddenIdSet, getSettings, shouldFilterSurface, shouldProcessNativeSurface, getHiddenData, getHiddenCount } from './data';
 import { addLibraryHideButtons } from './buttons';
+import {
+    PARENT_SERIES_ABSENCE_TTL_MS,
+    ParentSeriesCache,
+} from './parent-series-cache';
 
-const parentSeriesCache = new Map<string, string | null>();
-const parentSeriesRequestMap = new Map<string, Promise<string | null>>();
+const parentSeriesCache = new ParentSeriesCache();
 let sectionSurfaceCache = new WeakMap<Element, string | null>();
 let filterGeneration = 0;
+let parentSeriesGeneration = 0;
 let viewPageUnsubscribe: (() => void) | null = null;
 let bodyMutationHandle: BodySubscriberHandle | null = null;
 const detailRescanHandles = new Set<number>();
+let parentInvalidationFrameHandle: number | null = null;
+let parentRetryHandle: number | null = null;
+let parentOverflowRetryHandle: number | null = null;
+let parentOverflowRetryAttempts = 0;
+const parentRetryEntries = new Map<HTMLElement, { dueAt: number }>();
+let parentRetryAttempts = new WeakMap<HTMLElement, number>();
+const parentBatchOwners = new Map<string, symbol>();
+let activeParentBatchRequests = 0;
+
+const PARENT_RETRY_DELAY_MS = 500;
+const PARENT_RETRY_MAX_ATTEMPTS = 3;
+const PARENT_RETRY_MAX_CARDS = 1_000;
+const PARENT_OVERFLOW_RETRY_MAX_ATTEMPTS = 3;
+const PARENT_BATCH_SIZE = 50;
+const PARENT_BATCH_MAX_ACTIVE_REQUESTS = 4;
+const PARENT_BATCH_MAX_PENDING_IDS = 1_000;
 
 interface FilterFence {
     generation: number;
     context: IdentityContext | null;
+}
+
+interface ParentSeriesItemResponse {
+    Id?: string;
+    SeriesId?: string | null;
+}
+
+interface ParentSeriesBatchResponse {
+    Items?: ParentSeriesItemResponse[];
 }
 
 function captureFilterFence(): FilterFence {
@@ -43,8 +72,8 @@ let filterFrameHandle: number | null = null;
 
 export function clearFilterIdentityState(): void {
     filterGeneration += 1;
+    parentSeriesGeneration += 1;
     parentSeriesCache.clear();
-    parentSeriesRequestMap.clear();
     sectionSurfaceCache = new WeakMap<Element, string | null>();
     viewPageUnsubscribe?.();
     viewPageUnsubscribe = null;
@@ -54,8 +83,18 @@ export function clearFilterIdentityState(): void {
     detailRescanHandles.clear();
     if (filterDebounceHandle !== null) clearTimeout(filterDebounceHandle);
     if (filterFrameHandle !== null) cancelAnimationFrame(filterFrameHandle);
+    if (parentInvalidationFrameHandle !== null) cancelAnimationFrame(parentInvalidationFrameHandle);
+    if (parentRetryHandle !== null) clearTimeout(parentRetryHandle);
+    if (parentOverflowRetryHandle !== null) clearTimeout(parentOverflowRetryHandle);
     filterDebounceHandle = null;
     filterFrameHandle = null;
+    parentInvalidationFrameHandle = null;
+    parentRetryHandle = null;
+    parentOverflowRetryHandle = null;
+    parentOverflowRetryAttempts = 0;
+    parentRetryEntries.clear();
+    parentRetryAttempts = new WeakMap<HTMLElement, number>();
+    parentBatchOwners.clear();
 
     // Remove only visibility markers owned by this feature. Other users of the
     // generic jc-hidden class are left untouched.
@@ -67,6 +106,107 @@ export function clearFilterIdentityState(): void {
     document.querySelectorAll<HTMLElement>(`[${PROCESSED_ATTR}]`).forEach((card) => {
         card.removeAttribute(PROCESSED_ATTR);
     });
+}
+
+function armParentRetryTimer(): void {
+    if (parentRetryHandle !== null || parentRetryEntries.size === 0) return;
+    let earliest = Number.POSITIVE_INFINITY;
+    for (const entry of parentRetryEntries.values()) earliest = Math.min(earliest, entry.dueAt);
+    const delay = Math.max(0, earliest - Date.now());
+    const fence = captureFilterFence();
+    parentRetryHandle = window.setTimeout(() => {
+        parentRetryHandle = null;
+        if (!isFilterFenceCurrent(fence)) return;
+        const now = Date.now();
+        let retryReady = false;
+        for (const [card, entry] of [...parentRetryEntries]) {
+            if (!card.isConnected) {
+                parentRetryEntries.delete(card);
+                continue;
+            }
+            if (entry.dueAt > now) continue;
+            parentRetryEntries.delete(card);
+            card.removeAttribute(PROCESSED_ATTR);
+            retryReady = true;
+        }
+        if (retryReady) filterNativeCards();
+        armParentRetryTimer();
+    }, delay);
+}
+
+/**
+ * Queue one bounded whole-surface pass when a per-card table is saturated.
+ * This keeps memory capped without making overflow cards permanently sticky.
+ */
+function scheduleParentOverflowRetry(): void {
+    if (parentOverflowRetryHandle !== null
+        || parentOverflowRetryAttempts >= PARENT_OVERFLOW_RETRY_MAX_ATTEMPTS) return;
+    parentOverflowRetryAttempts += 1;
+    const fence = captureFilterFence();
+    parentOverflowRetryHandle = window.setTimeout(() => {
+        parentOverflowRetryHandle = null;
+        if (isFilterFenceCurrent(fence)) filterAllNativeCards();
+    }, PARENT_RETRY_DELAY_MS);
+}
+
+/** Coalesce bounded, navigation-owned retries for transient/incomplete lookups. */
+function scheduleParentRetry(card: HTMLElement, delayMs = PARENT_RETRY_DELAY_MS): void {
+    if (!card.isConnected) return;
+    const prior = parentRetryEntries.get(card);
+    const dueAt = Date.now() + Math.max(0, delayMs);
+    if (prior) {
+        // Repeated scans before the queued retry fires are the same attempt.
+        // Preserve the earliest deadline instead of consuming the retry cap or
+        // postponing an authoritative-absence revalidation indefinitely.
+        prior.dueAt = Math.min(prior.dueAt, dueAt);
+        if (parentRetryHandle !== null) clearTimeout(parentRetryHandle);
+        parentRetryHandle = null;
+        armParentRetryTimer();
+        return;
+    }
+    const attempts = (parentRetryAttempts.get(card) || 0) + 1;
+    if (attempts > PARENT_RETRY_MAX_ATTEMPTS) {
+        parentRetryEntries.delete(card);
+        return;
+    }
+    if (parentRetryEntries.size >= PARENT_RETRY_MAX_CARDS) {
+        scheduleParentOverflowRetry();
+        return;
+    }
+    card.removeAttribute(PROCESSED_ATTR);
+    parentRetryAttempts.set(card, attempts);
+    parentRetryEntries.set(card, {
+        dueAt,
+    });
+    // A newly queued transient retry may be earlier than an existing 30-second
+    // absence revalidation; always re-arm against the true earliest deadline.
+    if (parentRetryHandle !== null) clearTimeout(parentRetryHandle);
+    parentRetryHandle = null;
+    armParentRetryTimer();
+}
+
+function clearParentRetry(card: HTMLElement): void {
+    parentRetryEntries.delete(card);
+    parentRetryAttempts.delete(card);
+}
+
+function parentBatchKey(context: IdentityContext, itemId: string): string {
+    return `${encodeURIComponent(context.serverId)}:${encodeURIComponent(context.userId)}:${context.epoch}:${encodeURIComponent(itemId)}`;
+}
+
+/** Apply one authoritative parent result without dropping ownership mid-flight. */
+function applyResolvedParentVisibility(card: HTMLElement, seriesId: string | null): void {
+    if (!card.isConnected) return;
+    if (seriesId && hiddenIdSet.has(seriesId)) {
+        card.classList.add('jc-hidden');
+        card.setAttribute(HIDDEN_PARENT_ATTR, seriesId);
+        card.removeAttribute(HIDDEN_DIRECT_ATTR);
+        return;
+    }
+    if (card.hasAttribute(HIDDEN_PARENT_ATTR)) {
+        card.classList.remove('jc-hidden');
+        card.removeAttribute(HIDDEN_PARENT_ATTR);
+    }
 }
 
 /** Delay for first detail-page rescan (async episode loading). */
@@ -88,45 +228,28 @@ const CARD_SEL_NEW = '.card[data-id]:not([data-jc-hidden-checked]), .card[data-i
 
 /**
  * Fetches the parent series ID for an episode/season item from the API.
- * Results are cached in `parentSeriesCache`; in-flight requests are
- * de-duplicated via `parentSeriesRequestMap`.
+ * Results are kept in the bounded, identity-scoped parent-Series cache;
+ * in-flight requests are de-duplicated by that cache as well.
  * @param itemId Jellyfin item ID (episode or season).
  * @returns The series ID, or `null` if unavailable.
  */
 async function getParentSeriesId(itemId: string): Promise<string | null> {
-    if (parentSeriesCache.has(itemId)) {
-        return parentSeriesCache.get(itemId)!;
-    }
-    if (parentSeriesRequestMap.has(itemId)) {
-        return parentSeriesRequestMap.get(itemId)!;
-    }
     const fence = captureFilterFence();
-    const request = (async () => {
-        try {
-            const userId = fence.context?.userId || ApiClient.getCurrentUserId();
-            const item: any = await ApiClient.ajax({
-                type: 'GET',
-                url: (ApiClient as { getUrl(path: string, params?: unknown): string }).getUrl(`/Users/${userId}/Items/${itemId}`, { Fields: 'SeriesId' }),
-                dataType: 'json'
-            });
-            if (!isFilterFenceCurrent(fence)) return null;
-            const seriesId = item?.SeriesId || null;
-            parentSeriesCache.set(itemId, seriesId);
-            return seriesId;
-        } catch (e) {
-            if (!isFilterFenceCurrent(fence)) return null;
-            console.warn('🪼 Jellyfin Canopy: Failed to fetch parent series for', itemId, e);
-            parentSeriesCache.set(itemId, null);
-            return null;
-        }
-    })();
-    parentSeriesRequestMap.set(itemId, request);
-    void request.finally(() => {
-        if (parentSeriesRequestMap.get(itemId) === request) {
-            parentSeriesRequestMap.delete(itemId);
-        }
-    });
-    return request;
+    const parentGeneration = parentSeriesGeneration;
+    const isCurrent = (): boolean => isFilterFenceCurrent(fence)
+        && parentGeneration === parentSeriesGeneration;
+    if (!fence.context) return null;
+    return parentSeriesCache.resolve(fence.context, itemId, async () => {
+        const item = await ApiClient.ajax({
+            type: 'GET',
+            url: (ApiClient as { getUrl(path: string, params?: unknown): string }).getUrl(`/Users/${fence.context!.userId}/Items/${itemId}`, { Fields: 'SeriesId' }),
+            dataType: 'json'
+        }) as ParentSeriesItemResponse | null;
+        if (!isCurrent()) return undefined;
+        // A returned item with no SeriesId is authoritative but short-lived.
+        // Transport/authorization/abort failures reject and remain retryable.
+        return item?.SeriesId || null;
+    }, isCurrent);
 }
 
 // ============================================================
@@ -218,21 +341,23 @@ function checkAndHideByParentSeries(card: HTMLElement, itemId: string): void {
     if (hiddenIdSet.size === 0) return;
 
     const fence = captureFilterFence();
+    const parentGeneration = parentSeriesGeneration;
     getParentSeriesId(itemId).then((seriesId) => {
-        if (!isFilterFenceCurrent(fence)) return;
-        if (!seriesId) return;
+        if (!isFilterFenceCurrent(fence) || parentGeneration !== parentSeriesGeneration) return;
+        if (!seriesId) {
+            applyResolvedParentVisibility(card, null);
+            scheduleParentRetry(card, PARENT_SERIES_ABSENCE_TTL_MS);
+            return;
+        }
         if (!card.isConnected) return;
+        clearParentRetry(card);
         if (!getSettings().enabled || !shouldFilterSurface(getCurrentNativeSurface())) return;
 
-        if (hiddenIdSet.has(seriesId)) {
-            card.classList.add('jc-hidden');
-            card.setAttribute(HIDDEN_PARENT_ATTR, seriesId);
-            card.removeAttribute(HIDDEN_DIRECT_ATTR);
-        } else if (card.getAttribute(HIDDEN_PARENT_ATTR) === seriesId && card.classList.contains('jc-hidden')) {
-            card.classList.remove('jc-hidden');
-            card.removeAttribute(HIDDEN_PARENT_ATTR);
-        }
+        applyResolvedParentVisibility(card, seriesId);
     }).catch((e) => {
+        // PERF(R9): a transient failure must leave this card eligible for the
+        // next bounded observer/navigation pass instead of becoming sticky.
+        scheduleParentRetry(card);
         console.warn('🪼 Jellyfin Canopy: Parent series check failed for', itemId, e);
     });
 }
@@ -247,31 +372,49 @@ async function batchCheckParentSeries(cardEntries: Array<{ card: HTMLElement; it
     if (!getSettings().enabled || !shouldFilterSurface(getCurrentNativeSurface())) return;
     if (hiddenIdSet.size === 0) return;
     const fence = captureFilterFence();
+    const parentGeneration = parentSeriesGeneration;
+    const isCurrent = (): boolean => isFilterFenceCurrent(fence)
+        && parentGeneration === parentSeriesGeneration;
 
     // Separate cached from uncached
     const cached: Array<{ card: HTMLElement; itemId: string; seriesId: string | null }> = [];
-    const uncached: Array<{ card: HTMLElement; itemId: string }> = [];
+    const uncached: Array<{ card: HTMLElement; itemId: string; batchKey: string }> = [];
+    if (!fence.context) return;
+    const batchOwner = Symbol('hidden-parent-batch');
     for (let i = 0; i < cardEntries.length; i++) {
         const entry = cardEntries[i];
-        if (parentSeriesCache.has(entry.itemId)) {
-            cached.push({ ...entry, seriesId: parentSeriesCache.get(entry.itemId)! });
-        } else {
-            uncached.push(entry);
+        const seriesId = parentSeriesCache.get(fence.context, entry.itemId);
+        if (seriesId !== undefined) {
+            cached.push({ ...entry, seriesId });
+            continue;
         }
+        const batchKey = parentBatchKey(fence.context, entry.itemId);
+        if (parentBatchOwners.has(batchKey)) {
+            scheduleParentRetry(entry.card);
+            continue;
+        }
+        if (parentBatchOwners.size >= PARENT_BATCH_MAX_PENDING_IDS) {
+            scheduleParentOverflowRetry();
+            continue;
+        }
+        parentBatchOwners.set(batchKey, batchOwner);
+        uncached.push({ ...entry, batchKey });
     }
 
     // Process cached entries immediately
     if (cached.length > 0) {
         requestAnimationFrame(() => {
-            if (!isFilterFenceCurrent(fence)) return;
+            if (!isCurrent()) return;
             for (let i = 0; i < cached.length; i++) {
                 const { card, seriesId } = cached[i];
-                if (!card.isConnected || !seriesId) continue;
-                if (hiddenIdSet.has(seriesId)) {
-                    card.classList.add('jc-hidden');
-                    card.setAttribute(HIDDEN_PARENT_ATTR, seriesId);
-                    card.removeAttribute(HIDDEN_DIRECT_ATTR);
+                if (!card.isConnected) continue;
+                if (!seriesId) {
+                    applyResolvedParentVisibility(card, null);
+                    scheduleParentRetry(card, PARENT_SERIES_ABSENCE_TTL_MS);
+                    continue;
                 }
+                clearParentRetry(card);
+                applyResolvedParentVisibility(card, seriesId);
             }
         });
     }
@@ -279,59 +422,120 @@ async function batchCheckParentSeries(cardEntries: Array<{ card: HTMLElement; it
     // Fetch uncached entries in batches of 50
     if (uncached.length === 0) return;
 
-    const BATCH_SIZE = 50;
     const userId = fence.context?.userId || ApiClient.getCurrentUserId();
 
-    for (let start = 0; start < uncached.length; start += BATCH_SIZE) {
-        const chunk = uncached.slice(start, start + BATCH_SIZE);
-        const ids = chunk.map(e => e.itemId).join(',');
+    try {
+        for (let start = 0; start < uncached.length; start += PARENT_BATCH_SIZE) {
+            const chunk = uncached.slice(start, start + PARENT_BATCH_SIZE);
+            const ids = chunk.map(e => e.itemId).join(',');
 
-        try {
-            const result: any = await ApiClient.ajax({
-                type: 'GET',
-                url: (ApiClient as { getUrl(path: string, params?: unknown): string }).getUrl(`/Users/${userId}/Items`, { Ids: ids, Fields: 'SeriesId' }),
-                dataType: 'json'
-            });
-            if (!isFilterFenceCurrent(fence)) return;
-
-            const itemsById = new Map<string, string | null>();
-            const responseItems = result?.Items || [];
-            for (let i = 0; i < responseItems.length; i++) {
-                const item = responseItems[i];
-                itemsById.set(item.Id, item.SeriesId || null);
-                parentSeriesCache.set(item.Id, item.SeriesId || null);
-            }
-
-            // Also cache items that weren't in the response (deleted, etc.)
-            for (let i = 0; i < chunk.length; i++) {
-                if (!itemsById.has(chunk[i].itemId)) {
-                    parentSeriesCache.set(chunk[i].itemId, null);
+            try {
+                if (activeParentBatchRequests >= PARENT_BATCH_MAX_ACTIVE_REQUESTS) {
+                    for (const entry of chunk) scheduleParentRetry(entry.card);
+                    continue;
                 }
-            }
+                activeParentBatchRequests += 1;
+                let result: ParentSeriesBatchResponse | null;
+                try {
+                    result = await ApiClient.ajax({
+                        type: 'GET',
+                        url: (ApiClient as { getUrl(path: string, params?: unknown): string }).getUrl(`/Users/${userId}/Items`, { Ids: ids, Fields: 'SeriesId' }),
+                        dataType: 'json'
+                    }) as ParentSeriesBatchResponse | null;
+                } finally {
+                    activeParentBatchRequests -= 1;
+                }
+                if (!isCurrent()) return;
 
-            // Batch apply hiding
-            requestAnimationFrame(() => {
-                if (!isFilterFenceCurrent(fence)) return;
+                const itemsById = new Map<string, string | null>();
+                const responseItems: ParentSeriesItemResponse[] = result?.Items || [];
+                for (let i = 0; i < responseItems.length; i++) {
+                    const item = responseItems[i];
+                    if (!item?.Id) continue;
+                    itemsById.set(item.Id, item.SeriesId || null);
+                    parentSeriesCache.set(fence.context, item.Id, item.SeriesId || null);
+                }
+
+                // An omitted row is not authoritative absence. Leave it retryable
+                // and remove the processed marker so a later scan can recover.
                 for (let i = 0; i < chunk.length; i++) {
-                    const { card, itemId } = chunk[i];
-                    if (!card.isConnected) continue;
-                    const seriesId = parentSeriesCache.get(itemId);
-                    if (seriesId && hiddenIdSet.has(seriesId)) {
-                        card.classList.add('jc-hidden');
-                        card.setAttribute(HIDDEN_PARENT_ATTR, seriesId);
-                        card.removeAttribute(HIDDEN_DIRECT_ATTR);
+                    if (!itemsById.has(chunk[i].itemId)) {
+                        scheduleParentRetry(chunk[i].card);
                     }
                 }
-            });
-        } catch (e) {
-            if (!isFilterFenceCurrent(fence)) return;
-            console.warn('🪼 Jellyfin Canopy: Batch parent series check failed', e);
-            // Fall back to individual lookups for this chunk
-            for (let i = 0; i < chunk.length; i++) {
-                checkAndHideByParentSeries(chunk[i].card, chunk[i].itemId);
+
+                // Batch apply hiding
+                requestAnimationFrame(() => {
+                    if (!isCurrent()) return;
+                    for (let i = 0; i < chunk.length; i++) {
+                        const { card, itemId } = chunk[i];
+                        if (!card.isConnected) continue;
+                        const seriesId = itemsById.get(itemId);
+                        if (seriesId === null) {
+                            applyResolvedParentVisibility(card, null);
+                            scheduleParentRetry(card, PARENT_SERIES_ABSENCE_TTL_MS);
+                            continue;
+                        }
+                        if (seriesId) {
+                            clearParentRetry(card);
+                            applyResolvedParentVisibility(card, seriesId);
+                        }
+                    }
+                });
+            } catch (e) {
+                if (!isCurrent()) return;
+                console.warn('🪼 Jellyfin Canopy: Batch parent series check failed', e);
+                // Fall back to individual lookups for this chunk.
+                for (let i = 0; i < chunk.length; i++) {
+                    scheduleParentRetry(chunk[i].card);
+                    checkAndHideByParentSeries(chunk[i].card, chunk[i].itemId);
+                }
+            }
+        }
+    } finally {
+        for (const entry of uncached) {
+            if (parentBatchOwners.get(entry.batchKey) === batchOwner) {
+                parentBatchOwners.delete(entry.batchKey);
             }
         }
     }
+}
+
+/**
+ * Library association changes retire every cached parent mapping for the
+ * current identity and re-check visible Episode/Season cards. A broad clear is
+ * intentional: Jellyfin can report only the changed parent, not every child
+ * whose SeriesId projection changed.
+ */
+export function invalidateParentSeriesAssociations(): void {
+    const context = JC.identity?.capture?.() || null;
+    if (!context) return;
+    parentSeriesGeneration += 1;
+    parentSeriesCache.invalidate(context);
+    if (parentRetryHandle !== null) clearTimeout(parentRetryHandle);
+    if (parentOverflowRetryHandle !== null) clearTimeout(parentOverflowRetryHandle);
+    parentRetryHandle = null;
+    parentOverflowRetryHandle = null;
+    parentOverflowRetryAttempts = 0;
+    parentRetryEntries.clear();
+    parentRetryAttempts = new WeakMap<HTMLElement, number>();
+    parentBatchOwners.clear();
+
+    document.querySelectorAll<HTMLElement>(CARD_SEL).forEach((card) => {
+        if (card.getAttribute(HIDDEN_PARENT_ATTR) && card.classList.contains('jc-hidden')) {
+            card.classList.remove('jc-hidden');
+        }
+        card.removeAttribute(HIDDEN_PARENT_ATTR);
+        const cardType = card.dataset.type || '';
+        if (cardType === 'Episode' || cardType === 'Season') card.removeAttribute(PROCESSED_ATTR);
+    });
+
+    if (parentInvalidationFrameHandle !== null) cancelAnimationFrame(parentInvalidationFrameHandle);
+    const fence = captureFilterFence();
+    parentInvalidationFrameHandle = requestAnimationFrame(() => {
+        parentInvalidationFrameHandle = null;
+        if (isFilterFenceCurrent(fence)) filterNativeCards();
+    });
 }
 
 /**
@@ -409,7 +613,6 @@ export function filterNativeCards(syncApply = false): void {
         if (card.hasAttribute('data-imagetype')) continue;
         const itemId = getCardItemId(card);
         card.setAttribute(PROCESSED_ATTR, '1');
-        card.removeAttribute(HIDDEN_PARENT_ATTR);
         if (!itemId) continue;
 
         // Check scope-aware hiding for cards in Next Up / Continue Watching sections
@@ -418,6 +621,8 @@ export function filterNativeCards(syncApply = false): void {
             if (shouldFilterSurface(cardSurface) && isHiddenOnSurface(itemId, cardSurface)) {
                 toHide.push(card);
                 card.setAttribute(HIDDEN_DIRECT_ATTR, '1');
+                card.removeAttribute(HIDDEN_PARENT_ATTR);
+                clearParentRetry(card);
                 continue;
             }
         }
@@ -425,6 +630,8 @@ export function filterNativeCards(syncApply = false): void {
         if (pageFilterable && hiddenIdSet.has(itemId)) {
             toHide.push(card);
             card.setAttribute(HIDDEN_DIRECT_ATTR, '1');
+            card.removeAttribute(HIDDEN_PARENT_ATTR);
+            clearParentRetry(card);
         } else {
             if (card.getAttribute(HIDDEN_DIRECT_ATTR) === '1' && card.classList.contains('jc-hidden')) {
                 toShow.push(card);
@@ -479,7 +686,6 @@ export function filterAllNativeCards(): void {
         const card = cards[i];
         const itemId = getCardItemId(card);
         card.setAttribute(PROCESSED_ATTR, '1');
-        card.removeAttribute(HIDDEN_PARENT_ATTR);
         if (!itemId) continue;
 
         const cardSurface = getCardSurface(card);
@@ -487,6 +693,8 @@ export function filterAllNativeCards(): void {
         if (cardSurface && shouldFilterSurface(cardSurface) && isHiddenOnSurface(itemId, cardSurface)) {
             toHide.push(card);
             card.setAttribute(HIDDEN_DIRECT_ATTR, '1');
+            card.removeAttribute(HIDDEN_PARENT_ATTR);
+            clearParentRetry(card);
             hiddenByScope = true;
         }
 
@@ -494,8 +702,10 @@ export function filterAllNativeCards(): void {
             if (pageFilterable && hiddenIdSet.has(itemId)) {
                 toHide.push(card);
                 card.setAttribute(HIDDEN_DIRECT_ATTR, '1');
+                card.removeAttribute(HIDDEN_PARENT_ATTR);
+                clearParentRetry(card);
             } else {
-                if (card.classList.contains('jc-hidden')) {
+                if (card.getAttribute(HIDDEN_DIRECT_ATTR) === '1' && card.classList.contains('jc-hidden')) {
                     toShow.push(card);
                     card.removeAttribute(HIDDEN_DIRECT_ATTR);
                 }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/parent-series-cache.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/parent-series-cache.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import type { IdentityContext } from '../../types/jc';
+import {
+    ParentSeriesCache,
+    ParentSeriesCapacityError,
+} from './parent-series-cache';
+
+const ownerA: IdentityContext = Object.freeze({ serverId: 'server-a', userId: 'user-a', epoch: 1 });
+const ownerB: IdentityContext = Object.freeze({ serverId: 'server-b', userId: 'user-a', epoch: 2 });
+const ownerC: IdentityContext = Object.freeze({ serverId: 'server-a', userId: 'user-b', epoch: 3 });
+
+describe('ParentSeriesCache', () => {
+    it('does not negative-cache a transient failure and succeeds on retry', async () => {
+        const cache = new ParentSeriesCache();
+        let attempts = 0;
+        const loader = (): Promise<string> => {
+            attempts += 1;
+            if (attempts === 1) return Promise.reject(new Error('temporary 429'));
+            return Promise.resolve('series-1');
+        };
+
+        await expect(cache.resolve(ownerA, 'episode-1', loader)).rejects.toThrow('temporary 429');
+        await expect(cache.resolve(ownerA, 'episode-1', loader)).resolves.toBe('series-1');
+        await expect(cache.resolve(ownerA, 'episode-1', loader)).resolves.toBe('series-1');
+        expect(attempts).toBe(2);
+    });
+
+    it('does not cache an omitted batch-style result', async () => {
+        const cache = new ParentSeriesCache();
+        let attempts = 0;
+
+        await expect(cache.resolve(ownerA, 'episode-1', () => {
+            attempts += 1;
+            return Promise.resolve(undefined);
+        })).resolves.toBeNull();
+        await expect(cache.resolve(ownerA, 'episode-1', () => {
+            attempts += 1;
+            return Promise.resolve('series-late');
+        })).resolves.toBe('series-late');
+
+        expect(attempts).toBe(2);
+    });
+
+    it('expires authoritative absence sooner than a successful association', () => {
+        let now = 1_000;
+        const cache = new ParentSeriesCache({
+            positiveTtlMs: 100,
+            absenceTtlMs: 10,
+            now: () => now,
+        });
+
+        cache.set(ownerA, 'missing-parent', null);
+        cache.set(ownerA, 'known-parent', 'series-1');
+        expect(cache.get(ownerA, 'missing-parent')).toBeNull();
+        expect(cache.get(ownerA, 'known-parent')).toBe('series-1');
+
+        now += 11;
+        expect(cache.get(ownerA, 'missing-parent')).toBeUndefined();
+        expect(cache.get(ownerA, 'known-parent')).toBe('series-1');
+
+        now += 90;
+        expect(cache.get(ownerA, 'known-parent')).toBeUndefined();
+    });
+
+    it('keeps retained entries and in-flight work within hard bounds', async () => {
+        const cache = new ParentSeriesCache({ maxEntries: 3, maxInFlight: 2 });
+        for (let index = 0; index < 20; index += 1) {
+            cache.set(ownerA, `episode-${index}`, `series-${index}`);
+        }
+        expect(cache.size).toBe(3);
+        expect(cache.get(ownerA, 'episode-0')).toBeUndefined();
+        expect(cache.get(ownerA, 'episode-19')).toBe('series-19');
+
+        let resolveFirst!: (value: string) => void;
+        let resolveSecond!: (value: string) => void;
+        const first = cache.resolve(ownerA, 'held-1', () => new Promise((resolve) => { resolveFirst = resolve; }));
+        const second = cache.resolve(ownerA, 'held-2', () => new Promise((resolve) => { resolveSecond = resolve; }));
+        await expect(cache.resolve(ownerA, 'held-3', () => Promise.resolve('series-3')))
+            .rejects.toBeInstanceOf(ParentSeriesCapacityError);
+        expect(cache.inFlightSize).toBe(2);
+
+        resolveFirst('series-1');
+        resolveSecond('series-2');
+        await Promise.all([first, second]);
+        expect(cache.inFlightSize).toBe(0);
+    });
+
+    it('isolates identical item ids by server, user, and identity epoch', () => {
+        const cache = new ParentSeriesCache();
+        cache.set(ownerA, 'same-episode', 'series-a');
+        cache.set(ownerB, 'same-episode', 'series-b');
+        cache.set(ownerC, 'same-episode', 'series-c');
+
+        expect(cache.get(ownerA, 'same-episode')).toBe('series-a');
+        expect(cache.get(ownerB, 'same-episode')).toBe('series-b');
+        expect(cache.get(ownerC, 'same-episode')).toBe('series-c');
+    });
+
+    it('invalidates changed associations and blocks late retired publication', async () => {
+        const cache = new ParentSeriesCache();
+        cache.set(ownerA, 'changed', 'old-series');
+        cache.set(ownerA, 'unchanged', 'stable-series');
+        cache.invalidate(ownerA, new Set(['changed']));
+
+        expect(cache.get(ownerA, 'changed')).toBeUndefined();
+        expect(cache.get(ownerA, 'unchanged')).toBe('stable-series');
+
+        let resolveLate!: (value: string) => void;
+        const late = cache.resolve(ownerA, 'in-flight', () => new Promise((resolve) => { resolveLate = resolve; }));
+        cache.invalidate(ownerA);
+        resolveLate('retired-series');
+
+        await expect(late).resolves.toBeNull();
+        expect(cache.get(ownerA, 'in-flight')).toBeUndefined();
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/parent-series-cache.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/parent-series-cache.ts
@@ -1,0 +1,155 @@
+import { createBoundedCache, type BoundedCache } from '../../core/bounded-cache';
+import type { IdentityContext } from '../../types/jc';
+
+export const PARENT_SERIES_CACHE_MAX_ENTRIES = 1_000;
+export const PARENT_SERIES_POSITIVE_TTL_MS = 5 * 60 * 1_000;
+export const PARENT_SERIES_ABSENCE_TTL_MS = 30 * 1_000;
+export const PARENT_SERIES_MAX_IN_FLIGHT = 16;
+
+interface ParentSeriesSlot {
+    ownerKey: string;
+    itemId: string;
+    seriesId: string | null;
+    expiresAt: number;
+}
+
+export interface ParentSeriesCacheOptions {
+    maxEntries?: number;
+    positiveTtlMs?: number;
+    absenceTtlMs?: number;
+    maxInFlight?: number;
+    now?: () => number;
+}
+
+/** Raised when callers outrun the bounded parent-resolution request budget. */
+export class ParentSeriesCapacityError extends Error {
+    constructor() {
+        super('Parent-series resolution queue is full');
+        this.name = 'ParentSeriesCapacityError';
+    }
+}
+
+function ownerKey(owner: IdentityContext): string {
+    return `${encodeURIComponent(owner.serverId)}:${encodeURIComponent(owner.userId)}:${owner.epoch}`;
+}
+
+function itemKey(owner: IdentityContext, itemId: string): string {
+    return `${ownerKey(owner)}:${encodeURIComponent(itemId)}`;
+}
+
+/**
+ * Typed, identity-scoped parent-Series cache shared by the native-card filter.
+ * Transient failures and incomplete batch rows never enter the cache; only a
+ * returned item with no SeriesId is a short-lived authoritative absence.
+ */
+export class ParentSeriesCache {
+    private readonly values: BoundedCache<string, ParentSeriesSlot>;
+    private readonly inFlight = new Map<string, Promise<string | null>>();
+    private readonly positiveTtlMs: number;
+    private readonly absenceTtlMs: number;
+    private readonly maxInFlight: number;
+    private readonly now: () => number;
+    private generation = 0;
+
+    constructor(options: ParentSeriesCacheOptions = {}) {
+        const maxEntries = Math.max(1, Math.floor(options.maxEntries ?? PARENT_SERIES_CACHE_MAX_ENTRIES));
+        this.positiveTtlMs = Math.max(1, options.positiveTtlMs ?? PARENT_SERIES_POSITIVE_TTL_MS);
+        this.absenceTtlMs = Math.max(1, options.absenceTtlMs ?? PARENT_SERIES_ABSENCE_TTL_MS);
+        this.maxInFlight = Math.max(1, Math.floor(options.maxInFlight ?? PARENT_SERIES_MAX_IN_FLIGHT));
+        this.now = options.now ?? Date.now;
+        this.values = createBoundedCache<string, ParentSeriesSlot>({
+            maxEntries,
+            ttlMs: Math.max(this.positiveTtlMs, this.absenceTtlMs),
+        });
+    }
+
+    /** Return undefined for a miss/expiry; null is a cached authoritative absence. */
+    get(owner: IdentityContext, itemId: string): string | null | undefined {
+        const key = itemKey(owner, itemId);
+        const slot = this.values.get(key);
+        if (!slot) return undefined;
+        if (slot.expiresAt <= this.now()) {
+            this.values.delete(key);
+            return undefined;
+        }
+        return slot.seriesId;
+    }
+
+    /** Cache a successful association, or a short-lived authoritative absence. */
+    set(owner: IdentityContext, itemId: string, seriesId: string | null): void {
+        const normalizedSeriesId = typeof seriesId === 'string' && seriesId.trim() !== ''
+            ? seriesId
+            : null;
+        const ttlMs = normalizedSeriesId === null ? this.absenceTtlMs : this.positiveTtlMs;
+        const key = itemKey(owner, itemId);
+        this.values.set(key, {
+            ownerKey: ownerKey(owner),
+            itemId,
+            seriesId: normalizedSeriesId,
+            expiresAt: this.now() + ttlMs,
+        });
+    }
+
+    /**
+     * Resolve one item with same-owner de-duplication. Loader rejection is a
+     * transient failure and remains retryable; undefined means an incomplete
+     * response and is likewise deliberately not cached.
+     */
+    resolve(
+        owner: IdentityContext,
+        itemId: string,
+        loader: () => Promise<string | null | undefined>,
+        isCurrent: () => boolean = () => true,
+    ): Promise<string | null> {
+        const cached = this.get(owner, itemId);
+        if (cached !== undefined) return Promise.resolve(cached);
+
+        const key = itemKey(owner, itemId);
+        const existing = this.inFlight.get(key);
+        if (existing) return existing;
+        if (this.inFlight.size >= this.maxInFlight) {
+            return Promise.reject(new ParentSeriesCapacityError());
+        }
+
+        const generation = this.generation;
+        const request = loader().then((seriesId) => {
+            if (!isCurrent() || generation !== this.generation) return null;
+            if (seriesId !== undefined) this.set(owner, itemId, seriesId);
+            return seriesId ?? null;
+        }).finally(() => {
+            if (this.inFlight.get(key) === request) this.inFlight.delete(key);
+        });
+        this.inFlight.set(key, request);
+        return request;
+    }
+
+    /** Invalidate selected associations for one identity, or its whole cache. */
+    invalidate(owner: IdentityContext, itemIds?: ReadonlySet<string>): void {
+        this.generation += 1;
+        const selectedOwner = ownerKey(owner);
+        // Snapshot before get(): BoundedCache.get refreshes LRU recency by
+        // reinserting the key, which must not mutate the iterator we traverse.
+        for (const key of [...this.values.keys()]) {
+            const slot = this.values.get(key);
+            if (!slot || slot.ownerKey !== selectedOwner) continue;
+            if (!itemIds || itemIds.has(slot.itemId)) this.values.delete(key);
+        }
+        this.inFlight.clear();
+    }
+
+    clear(): void {
+        this.generation += 1;
+        this.values.clear();
+        this.inFlight.clear();
+    }
+
+    get size(): number {
+        // Iteration lazily removes entries whose outer TTL has elapsed.
+        for (const _slot of this.values.values()) { /* sweep */ }
+        return this.values.size;
+    }
+
+    get inFlightSize(): number {
+        return this.inFlight.size;
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/src/entries/hidden-content-runtime.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/entries/hidden-content-runtime.test.ts
@@ -1,6 +1,9 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LIVE } from '../core/live';
 import { JC } from '../globals';
 import { createTestFeatureScope } from '../test/feature-scope';
+
+let liveOnSpy: ReturnType<typeof vi.spyOn>;
 
 const mocks = vi.hoisted(() => ({
     cancelInitial: vi.fn(),
@@ -8,8 +11,10 @@ const mocks = vi.hoisted(() => ({
     clearFilter: vi.fn(),
     disposeFacade: vi.fn(),
     initialize: vi.fn(),
+    invalidateParentSeries: vi.fn(),
     install: vi.fn(),
     installPersistence: vi.fn(),
+    liveDispose: vi.fn(),
     persistenceDispose: vi.fn(),
     resetButtons: vi.fn(),
     resetDialogs: vi.fn(),
@@ -20,7 +25,10 @@ const mocks = vi.hoisted(() => ({
 vi.mock('../enhanced/hidden-content/buttons', () => ({ resetButtonUi: mocks.resetButtons }));
 vi.mock('../enhanced/hidden-content/data', () => ({ clearIdentityData: mocks.clearData }));
 vi.mock('../enhanced/hidden-content/dialogs', () => ({ resetDialogUi: mocks.resetDialogs }));
-vi.mock('../enhanced/hidden-content/filter', () => ({ clearFilterIdentityState: mocks.clearFilter }));
+vi.mock('../enhanced/hidden-content/filter', () => ({
+    clearFilterIdentityState: mocks.clearFilter,
+    invalidateParentSeriesAssociations: mocks.invalidateParentSeries,
+}));
 vi.mock('../enhanced/hidden-content/init', () => ({
     cancelInitialFilter: mocks.cancelInitial,
     initializeHiddenContent: mocks.initialize,
@@ -41,7 +49,12 @@ beforeEach(() => {
     vi.clearAllMocks();
     mocks.install.mockReturnValue(mocks.disposeFacade);
     mocks.installPersistence.mockReturnValue(mocks.persistenceDispose);
+    liveOnSpy = vi.spyOn(JC.core.live!, 'on').mockReturnValue(mocks.liveDispose);
     JC.pluginConfig = { HiddenContentEnabled: true };
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
 });
 
 describe('Hidden Content lazy runtime contract', () => {
@@ -73,6 +86,10 @@ describe('Hidden Content lazy runtime contract', () => {
         expect(mocks.install).toHaveBeenCalledTimes(1);
         expect(mocks.installPersistence).toHaveBeenCalledTimes(1);
         expect(mocks.initialize).toHaveBeenCalledTimes(1);
+        expect(liveOnSpy).toHaveBeenCalledWith(
+            LIVE.LIBRARY_CHANGED,
+            mocks.invalidateParentSeries,
+        );
 
         await harness.dispose();
         await harness.dispose();
@@ -85,6 +102,7 @@ describe('Hidden Content lazy runtime contract', () => {
             mocks.resetDialogs,
             mocks.resetPanel,
             mocks.resetPersistence,
+            mocks.liveDispose,
         ]) expect(cleanup).toHaveBeenCalledTimes(1);
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/entries/hidden-content-runtime.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/entries/hidden-content-runtime.ts
@@ -1,8 +1,12 @@
 import type { FeatureLoaderState, FeatureModule, FeatureScope } from '../core/feature-loader';
+import { LIVE } from '../core/live';
 import { resetButtonUi } from '../enhanced/hidden-content/buttons';
 import { clearIdentityData } from '../enhanced/hidden-content/data';
 import { resetDialogUi } from '../enhanced/hidden-content/dialogs';
-import { clearFilterIdentityState } from '../enhanced/hidden-content/filter';
+import {
+    clearFilterIdentityState,
+    invalidateParentSeriesAssociations,
+} from '../enhanced/hidden-content/filter';
 import {
     initializeHiddenContent,
     installHiddenContent,
@@ -46,6 +50,9 @@ export const hiddenContentRuntimeFeature: FeatureModule = Object.freeze({
         cleanups.push(clearFilterIdentityState);
         cleanups.push(() => document.getElementById('jc-hidden-content')?.remove());
         cleanups.push(installPersistenceLifecycle());
+        if (JC.core.live) {
+            cleanups.push(JC.core.live.on(LIVE.LIBRARY_CHANGED, invalidateParentSeriesAssociations));
+        }
         cleanups.push(JC.identity.registerReset('hidden-content-runtime', dispose));
 
         if (!scope.isCurrent()) {

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -18,7 +18,7 @@ const ROOT = path.join(__dirname, '..');
 const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the repeated clean measurements', () => {
-    assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1914, totalLines: 2253 });
+    assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1915, totalLines: 2253 });
     assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 18748, totalLines: 27276 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -9,12 +9,12 @@
       "scope": "Jellyfin.Plugin.JellyfinCanopy/src/core/**",
       "report": "coverage/coverage-summary.json",
       "measured": {
-        "coveredLines": 1914,
+        "coveredLines": 1915,
         "totalLines": 2253
       },
       "tolerance": {
         "missingCoveredLines": 1,
-        "rationale": "Final clean local Node 22/V8 validation on 2026-07-16 passed 1215 tests and measured the complete 2253-line core scope at 1914 covered lines (84.953%). Issue #318's post-CI settings reconciliation coverage adds three instrumented lines and six covered lines over the reviewed 1908/2250 baseline, increasing rather than diluting line coverage. The existing one-line tolerance is unchanged and permits only the previously reproduced negligible instrumentation variance; coverage-baseline.test.js retains exact below-floor, above-baseline, scope-change, and broad-tolerance negative boundaries."
+        "rationale": "Clean local Node 22/V8 validation on 2026-07-17 passed 1228 tests and measured the complete 2253-line core scope at 1915 covered lines (84.998%). Issue #123's live hidden-content invalidation subscription covers one previously uncovered core live-event line over the reviewed 1914/2253 baseline, increasing rather than diluting line coverage. The existing one-line tolerance is unchanged and permits only the previously reproduced negligible instrumentation variance; coverage-baseline.test.js retains exact below-floor, above-baseline, scope-change, and broad-tolerance negative boundaries."
       }
     },
     "server": {


### PR DESCRIPTION
Closes #123.

## What changed

- replaces the module-lifetime raw parent-Series maps with a typed bounded cache keyed by Jellyfin server, user, identity epoch, and item;
- caches successful associations for five minutes and authoritative absence for 30 seconds, while transient failures and omitted batch rows remain retryable;
- bounds individual in-flight resolution, 50-ID batches, active batch transports, pending IDs, per-card retries, and overflow retries;
- deduplicates overlapping/duplicate batch work and fences late identity, library-generation, and request completions;
- invalidates parent mappings on live library changes and atomically preserves/unwinds parent-owned hidden DOM state;
- advances the client coverage ratchet from 1914/2253 to 1915/2253 without widening tolerance.

## User impact

An Episode or Season no longer remains incorrectly visible for the rest of the SPA session after a temporary 401/429/network failure or incomplete batch response. Parent changes and confirmed absences also revalidate, while large libraries stay within explicit memory and request bounds.

## Validation

- `npm run check:toolchain`
- focused owner/import tests: 17/17, plus the final overflow regression set
- `npm run test:client:coverage`: 1228/1228; 1915/2253 core lines, exact reviewed ratchet
- `npm run check:performance-rules`: 247 files, 807 ms current-thread CPU
- `npm run build:bundle`: 161 deterministic files; build `7cd09d5f91699fa9ae95e3539336c9db40bc611d143090c1897504cfa280876e`
- `npm run syntax`
- `npm run typecheck:src`
- `npm run typecheck`
- `npm run test:scripts`: 373/373
- `git diff --check`

## Independent review

Fable 5 at low effort reviewed the local exact diff. Two review rounds produced actionable lifecycle/backpressure findings; all were fixed with regressions. The final fresh verdict was `APPROVE`.

## AI assistance

This PR was developed with AI assistance. The implementation, tests, and generated evidence were reviewed and validated before publication.
