### PR TITLE
Fix locale-independent hidden home row scope

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/remove-home.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/remove-home.identity.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { JC } from '../../globals';
 import type { ApiApi } from '../../types/jc';
-import { installRemoveHome, removeFromHomeSurface } from './remove-home';
+import {
+    addRemoveButton,
+    detectCardSurface,
+    hideEmptyHomeSections,
+    installRemoveHome,
+    removeFromHomeSurface,
+} from './remove-home';
 
 let disposeFeature: (() => void) | null = null;
 
@@ -63,5 +69,101 @@ describe('Continue Watching removal identity ownership', () => {
         JC.identity.transition('test-server-id', 'user-b', 'account-switch');
         expect(card.style.display).toBe('');
         expect(card.dataset.jcHomeRemoved).toBeUndefined();
+    });
+
+    it('fails visible while a localized scoped row is empty/loading, then hides and restores owned rows', () => {
+        const section = document.createElement('div');
+        section.id = 'resumableSection';
+        section.className = 'verticalSection';
+        section.innerHTML = '<h2 class="sectionTitle">Continuar viendo</h2>';
+        document.body.appendChild(section);
+
+        hideEmptyHomeSections();
+        expect(section.style.display).toBe('');
+        expect(section.dataset.jcHomeSectionHidden).toBeUndefined();
+
+        const card = document.createElement('div');
+        card.className = 'card jc-hidden';
+        card.dataset.id = 'late-item';
+        section.appendChild(card);
+        hideEmptyHomeSections();
+        expect(section.style.display).toBe('none');
+        expect(section.dataset.jcHomeSectionHidden).toBe('1');
+
+        card.classList.remove('jc-hidden');
+        hideEmptyHomeSections();
+        expect(section.style.display).toBe('');
+        expect(section.dataset.jcHomeSectionHidden).toBeUndefined();
+    });
+
+    it('restores a plugin-hidden row when Jellyfin inserts a visible replacement card', async () => {
+        window.location.hash = '#/home';
+        const section = document.createElement('div');
+        section.id = 'resumableSection';
+        section.className = 'verticalSection';
+        section.innerHTML = '<div class="card jc-hidden" data-id="HIDDEN"></div>';
+        document.body.appendChild(section);
+        hideEmptyHomeSections();
+        expect(section.style.display).toBe('none');
+
+        const replacement = document.createElement('div');
+        replacement.className = 'card';
+        replacement.dataset.id = 'VISIBLE';
+        section.appendChild(replacement);
+
+        await vi.waitFor(() => expect(section.style.display).toBe(''));
+        expect(section.dataset.jcHomeSectionHidden).toBeUndefined();
+    });
+
+    it('reconciles the first already-open menu when row preferences arrive', async () => {
+        disposeFeature?.();
+        disposeFeature = null;
+        const held = deferred<{ CustomPrefs: Record<string, string> }>();
+        ApiClient.getDisplayPreferences = vi.fn(() => held.promise);
+        disposeFeature = installRemoveHome();
+        JC.state = {
+            activeShortcuts: {},
+            removeContext: null,
+            pauseScreenClickTimer: null,
+        };
+        JC.currentSettings = {
+            ...(JC.currentSettings || {}),
+            removeContinueWatchingEnabled: true,
+        };
+
+        const container = document.createElement('div');
+        container.className = 'homeSectionsContainer';
+        const section = document.createElement('div');
+        section.className = 'verticalSection section1';
+        const card = document.createElement('div');
+        card.className = 'card';
+        card.dataset.id = 'first-menu-item';
+        section.appendChild(card);
+        container.appendChild(section);
+        document.body.appendChild(container);
+
+        const scroller = document.createElement('div');
+        scroller.className = 'actionSheetScroller';
+        scroller.innerHTML = '<button class="actionSheetMenuItem" data-id="play"><span class="actionSheetItemText">Play</span></button>';
+        document.body.appendChild(scroller);
+
+        const initialSurface = detectCardSurface(card);
+        expect(initialSurface).toBeNull();
+        JC.state.removeContext = {
+            itemId: 'first-menu-item',
+            surface: initialSurface,
+            card,
+            ts: Date.now(),
+        };
+        addRemoveButton();
+        expect(scroller.querySelector('[data-id="remove-continue-watching"]')).toBeNull();
+        expect(JC.state.removeContext).not.toBeNull();
+
+        held.resolve({ CustomPrefs: {} });
+        await vi.waitFor(() => {
+            const button = scroller.querySelector<HTMLElement>('[data-id="remove-continue-watching"]');
+            expect(button?.dataset.jcSurface).toBe('continuewatching');
+        });
+        expect(JC.state.removeContext).toBeNull();
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/remove-home.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/remove-home.ts
@@ -7,6 +7,7 @@
 
 import { JC } from '../../globals';
 import { createStableMethodFacade } from '../../core/feature-loader';
+import { onBodyMutation } from '../../core/dom-observer';
 // Shared action-sheet platform helpers live in core (used by Remove, multi-select Remove and arr
 // Search) — one source, so a positioning/close bug is fixed once for every injector.
 import {
@@ -14,6 +15,12 @@ import {
     fitActionSheetItem, closeOpenActionSheet,
 } from '../../core/action-sheet';
 import type { IdentityContext } from '../../types/jc';
+import {
+    acquireHomeRowScopes,
+    createHomeRowScopeResolver,
+    primeHomeRowScopes,
+    resolveHomeRowScope,
+} from '../home-row-scope';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -55,36 +62,15 @@ export const REMOVE_SURFACES: Record<string, RemoveSurfaceConfig> = {
 const REMOVE_CONTEXT_TTL_MS = 5000;
 
 /**
- * Determines which home-screen surface a card belongs to, using locale-independent
- * signals so detection survives translated section titles and custom themes:
- *   • Next Up — the section title is a link to the Next Up list (`?type=nextup`).
- *   • Continue Watching — resume cards carry a `data-positionticks` playback position.
- * A localized section-title text check is kept as a last-resort fallback.
+ * Determines which home-screen surface a card belongs to through the shared,
+ * identity-scoped Jellyfin 12 row resolver. Unresolved rows deliberately
+ * return null so a first interaction cannot target the wrong endpoint.
  * @param el A `.card` element, or any element inside/representing one.
  */
 export function detectCardSurface(el: any): 'continuewatching' | 'nextup' | null {
-    if (!el) return null;
-    const card = (typeof el.closest === 'function' ? el.closest('.card') : null) || el;
-    const section = typeof card.closest === 'function'
-        ? card.closest('.section, .verticalSection, .homeSection')
-        : null;
-
-    // Next Up: the section title links to the Next Up list — present regardless of locale.
-    if (section && section.querySelector('a[href*="type=nextup"]')) return 'nextup';
-
-    // Continue Watching: only resume cards expose a playback position.
-    const ticks = (card.getAttribute && card.getAttribute('data-positionticks'))
-        || (el.getAttribute && el.getAttribute('data-positionticks'));
-    if (ticks) return 'continuewatching';
-
-    // Fallback for markup/themes without the link or ticks: localized section title text.
-    if (section) {
-        const title = (section.querySelector('.sectionTitle, h2, .headerText, .sectionTitle-sectionTitle')?.textContent || '')
-            .toLowerCase().trim();
-        if (title.includes('next up')) return 'nextup';
-        if (title.includes('continue watching')) return 'continuewatching';
-    }
-    return null;
+    if (!(el instanceof Element)) return null;
+    const row = resolveHomeRowScope(el);
+    return row.kind === 'continuewatching' || row.kind === 'nextup' ? row.kind : null;
 }
 
 /**
@@ -177,14 +163,30 @@ export async function removeFromHomeSurface(itemId: string, surface: string, car
 export function hideEmptyHomeSections(): void {
     try {
         const sections = document.querySelectorAll<HTMLElement>('.verticalSection, .section, .homeSection');
+        const resolveRow = createHomeRowScopeResolver();
         for (const section of sections) {
-            const titleEl = section.querySelector('.sectionTitle, h2, .headerText, .sectionTitle-sectionTitle');
-            const title = (titleEl?.textContent || '').toLowerCase().trim();
-            const isCW = title.startsWith('continue watching');
-            const isNextUp = title.startsWith('next up');
-            if (!isCW && !isNextUp) continue;
+            const row = resolveRow(section);
+            const isScoped = row.kind === 'continuewatching' || row.kind === 'nextup';
+            if (!isScoped) {
+                if (section.dataset.jcHomeSectionHidden === '1') {
+                    section.style.removeProperty('display');
+                    delete section.dataset.jcHomeSectionHidden;
+                }
+                continue;
+            }
 
-            const cards = section.querySelectorAll<HTMLElement>('.card[data-positionticks], .card[data-id]');
+            const cards = section.querySelectorAll<HTMLElement>('.card[data-id], .card[data-itemid]');
+            // An empty row is also Jellyfin's normal pre-fetch state. Only
+            // collapse rows whose cards exist and were all hidden by a
+            // completed plugin action/filter pass; otherwise fail visible so
+            // late async cards are never trapped inside display:none.
+            if (cards.length === 0) {
+                if (section.dataset.jcHomeSectionHidden === '1') {
+                    section.style.removeProperty('display');
+                    delete section.dataset.jcHomeSectionHidden;
+                }
+                continue;
+            }
             let visibleCount = 0;
             for (const card of cards) {
                 if (card.classList.contains('jc-hidden')) continue;
@@ -194,6 +196,9 @@ export function hideEmptyHomeSections(): void {
             if (visibleCount === 0) {
                 section.style.display = 'none';
                 section.dataset.jcHomeSectionHidden = '1';
+            } else if (section.dataset.jcHomeSectionHidden === '1') {
+                section.style.removeProperty('display');
+                delete section.dataset.jcHomeSectionHidden;
             }
         }
     } catch (err) {
@@ -296,7 +301,10 @@ export function addRemoveButton(): void {
         }
         existing.remove();
     }
-    if (!wantSurface) { JC.state!.removeContext = null; return; }
+    // Keep an unresolved trigger until its short TTL expires. The shared
+    // preferences-ready callback can then resolve the same source card and
+    // inject into the action sheet that is already open.
+    if (!wantSurface) return;
 
     const removeButton = createRemoveButton(context, scroller, ctx.itemId, wantSurface, ctx.card as HTMLElement | undefined);
     insertionPoint.after(removeButton);
@@ -328,19 +336,45 @@ const stableRemoveHome = createStableMethodFacade<typeof removeHomeApi>({
     detect: () => null,
     hideEmpty() {},
 });
+let removeHomeObserverSequence = 0;
+
+function reconcilePendingRemoveContext(): void {
+    hideEmptyHomeSections();
+    const ctx = JC.state?.removeContext;
+    if (!ctx?.itemId || (Date.now() - (ctx.ts || 0)) > REMOVE_CONTEXT_TTL_MS) return;
+    const card = ctx.card;
+    if (!(card instanceof Element)) return;
+    const surface = detectCardSurface(card);
+    if (!surface) return;
+    ctx.surface = surface;
+    addRemoveButton();
+}
 
 /** Publish frozen compatibility methods for one loader-owned activation. */
 export function installRemoveHome(): () => void {
     const uninstall = stableRemoveHome.install(removeHomeApi);
+    const releaseRowScopes = acquireHomeRowScopes(reconcilePendingRemoveContext);
+    primeHomeRowScopes();
     JC.addRemoveButton = stableRemoveHome.facade.add;
     JC.detectCardSurface = stableRemoveHome.facade.detect;
     JC.hideEmptyHomeSections = stableRemoveHome.facade.hideEmpty;
+    const mutationHandle = onBodyMutation(`remove-home-row-restore-${++removeHomeObserverSequence}`, (mutations) => {
+        for (const mutation of mutations) {
+            const target = mutation.target;
+            const targetElement = target instanceof Element ? target : target.parentElement;
+            if (!targetElement?.closest('[data-jc-home-section-hidden="1"]')) continue;
+            hideEmptyHomeSections();
+            break;
+        }
+    });
     const unregisterReset = JC.identity.registerReset('remove-home', resetRemoveHome);
     let disposed = false;
     return () => {
         if (disposed) return;
         disposed = true;
         resetRemoveHome();
+        mutationHandle.unsubscribe();
+        releaseRowScopes();
         unregisterReset();
         uninstall();
     };

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/buttons.scope.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/buttons.scope.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+import {
+    acquireHomeRowScopes,
+    primeHomeRowScopes,
+    resetHomeRowScopes,
+    resolveHomeRowScope,
+} from '../home-row-scope';
+import { addLibraryHideButtons, resetButtonUi } from './buttons';
+import { resetFromUserConfig } from './data';
+import { resetDialogUi } from './dialogs';
+import { clearFilterIdentityState, setupNativeObserver } from './filter';
+
+function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((done) => { resolve = done; });
+    return { promise, resolve };
+}
+
+describe('home-row hide button scope safety', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        resetHomeRowScopes();
+        JC.identity.transition('button-scope-server', `button-scope-${Date.now()}-${Math.random()}`, 'button-scope-test');
+        JC.t = (key: string) => key;
+        JC.userConfig = {
+            hiddenContent: {
+                items: {},
+                settings: {
+                    showHideButtons: true,
+                    showButtonLibrary: true,
+                    experimentalHideCollections: false,
+                },
+            },
+        };
+        resetFromUserConfig();
+    });
+
+    afterEach(() => {
+        resetButtonUi();
+        clearFilterIdentityState();
+        resetDialogUi();
+        resetHomeRowScopes();
+        vi.restoreAllMocks();
+    });
+
+    it('blocks click-time global fallback and removes a stale button after ordinary-to-collection reuse', async () => {
+        ApiClient.getDisplayPreferences = vi.fn().mockResolvedValue({ CustomPrefs: {} });
+        const release = acquireHomeRowScopes(() => {});
+        primeHomeRowScopes();
+
+        const card = document.createElement('div');
+        card.className = 'card';
+        card.dataset.id = 'collection-item';
+        const box = document.createElement('div');
+        box.className = 'cardBox';
+        card.appendChild(box);
+        document.body.appendChild(card);
+        addLibraryHideButtons();
+        const staleButton = box.querySelector<HTMLButtonElement>('.jc-hide-btn');
+        expect(staleButton).not.toBeNull();
+
+        const container = document.createElement('div');
+        container.className = 'homeSectionsContainer';
+        const collectionRow = document.createElement('div');
+        collectionRow.className = 'verticalSection section0';
+        container.appendChild(collectionRow);
+        document.body.appendChild(container);
+        collectionRow.appendChild(card);
+        await vi.waitFor(() => expect(resolveHomeRowScope(card).kind).toBe('collection'));
+
+        staleButton!.click();
+        await Promise.resolve();
+        expect(document.querySelector('.jc-hide-confirm-overlay')).toBeNull();
+        expect((JC.userConfig!.hiddenContent as { items: Record<string, unknown> }).items).toEqual({});
+
+        addLibraryHideButtons();
+        expect(box.querySelector('.jc-hide-btn')).toBeNull();
+        expect(box.style.position).toBe('');
+        release();
+    });
+
+    it('restores cast-only buttons when an unresolved snapshot becomes ready', async () => {
+        const held = deferred<{ CustomPrefs: Record<string, string> }>();
+        ApiClient.getDisplayPreferences = vi.fn(() => held.promise);
+        JC.userConfig = {
+            hiddenContent: {
+                items: {},
+                settings: {
+                    showHideButtons: true,
+                    showButtonLibrary: false,
+                    showButtonCast: true,
+                },
+            },
+        };
+        resetFromUserConfig();
+
+        const container = document.createElement('div');
+        container.className = 'homeSectionsContainer';
+        const section = document.createElement('div');
+        section.className = 'verticalSection section0';
+        const person = document.createElement('div');
+        person.className = 'card personCard';
+        person.dataset.id = 'person-id';
+        person.dataset.type = 'Person';
+        const box = document.createElement('div');
+        box.className = 'cardBox';
+        person.appendChild(box);
+        section.appendChild(person);
+        container.appendChild(section);
+        document.body.appendChild(container);
+
+        setupNativeObserver();
+        addLibraryHideButtons();
+        expect(box.querySelector('.jc-hide-btn')).toBeNull();
+
+        held.resolve({ CustomPrefs: {} });
+        await vi.waitFor(() => expect(box.querySelector('.jc-hide-btn')).not.toBeNull());
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/buttons.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/buttons.ts
@@ -8,7 +8,8 @@ import { JC } from '../../globals';
 import { getItemCached } from '../helpers';
 import { hiddenIdSet, getSettings, hideItem, unhideItem } from './data';
 import type { HideItemParams } from './data';
-import { getCardSurface, getCardItemId } from './filter';
+import { getCardItemId } from './filter';
+import { createHomeRowScopeResolver, resolveHomeRowScope } from '../home-row-scope';
 import { confirmAndHide } from './dialogs';
 import type { IdentityContext } from '../../types/jc';
 
@@ -36,6 +37,14 @@ function removeButtonsAndRestorePosition(): void {
         }
         btn.remove();
     });
+}
+
+function removeButtonAndRestorePosition(btn: HTMLElement): void {
+    const cardBox = btn.parentElement;
+    if (cardBox && btn.dataset.jcHidePreviousPosition !== undefined) {
+        cardBox.style.position = btn.dataset.jcHidePreviousPosition;
+    }
+    btn.remove();
 }
 
 export function resetButtonUi(): void {
@@ -111,7 +120,15 @@ function createLibraryHideButton(cardBox: HTMLElement, card: HTMLElement, itemId
                 if (!isButtonFenceCurrent(fence)) return;
 
                 const cardName = card.querySelector('.cardText')?.textContent || '';
-                const surface = getCardSurface(card);
+                const row = resolveHomeRowScope(card);
+                if (row.kind === 'unresolved') {
+                    // A pending home-row identity must never silently become a
+                    // durable global hide. The resolver-ready pass will
+                    // reconcile this button against the resolved row.
+                    return;
+                }
+                if (row.kind === 'collection' && !getSettings().experimentalHideCollections) return;
+                const surface = row.kind;
 
                 if (surface === 'nextup' || surface === 'continuewatching') {
                     await handleScopedCardHide(card, itemId, cardName, surface, setHiddenState, fence);
@@ -247,10 +264,11 @@ export function addLibraryHideButtons(): void {
     const skipCollections = !s.experimentalHideCollections;
 
     const cards = document.querySelectorAll<HTMLElement>('.card[data-id] .cardBox, .card[data-itemid] .cardBox');
+    const resolveRow = createHomeRowScopeResolver();
     for (let i = 0; i < cards.length; i++) {
         if (!isButtonFenceCurrent(fence)) return;
         const cardBox = cards[i];
-        if (cardBox.querySelector('.jc-hide-btn')) continue;
+        const existingButton = cardBox.querySelector<HTMLElement>('.jc-hide-btn');
 
         const card = cardBox.closest<HTMLElement>('.card');
         if (!card) continue;
@@ -264,6 +282,12 @@ export function addLibraryHideButtons(): void {
         const itemId = getCardItemId(card);
         if (!itemId) continue;
 
+        const row = resolveRow(card);
+        if (row.kind === 'unresolved') {
+            if (existingButton) removeButtonAndRestorePosition(existingButton);
+            continue;
+        }
+
         const cardType = (card.dataset.type || '').toLowerCase();
         const isPerson = cardType === 'person' || card.classList.contains('personCard');
 
@@ -273,13 +297,13 @@ export function addLibraryHideButtons(): void {
         if (!isPerson && !s.showButtonLibrary) continue;
 
         if (skipCollections && !isPerson) {
-            if (cardType === 'collectionfolder' || cardType === 'userview' || cardType === 'boxset' || cardType === 'playlist' || cardType === 'channel') continue;
-            const section = card.closest('.section, .verticalSection, .homeSection');
-            if (section) {
-                const sTitle = (section.querySelector('.sectionTitle, h2, .headerText, .sectionTitle-sectionTitle')?.textContent || '').toLowerCase();
-                if (sTitle.includes('my media') || sTitle.includes('collections')) continue;
+            if (row.kind === 'collection') {
+                if (existingButton) removeButtonAndRestorePosition(existingButton);
+                continue;
             }
         }
+
+        if (existingButton) continue;
 
         createLibraryHideButton(cardBox, card, itemId, isPerson);
     }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/filter.home-scope.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/filter.home-scope.test.ts
@@ -7,7 +7,12 @@
 // stays visible (page-scope hiding correctly stays off).
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { JC } from '../../globals';
-import { clearFilterIdentityState, filterAllNativeCards, setupNativeObserver } from './filter';
+import {
+    clearFilterIdentityState,
+    filterAllNativeCards,
+    refreshNativeCardVisibility,
+    setupNativeObserver,
+} from './filter';
 import { resetFromUserConfig, shouldProcessNativeSurface } from './data';
 
 type HiddenItems = Record<string, { itemId: string; hideScope: string }>;
@@ -214,6 +219,29 @@ describe('home Continue-Watching filtering independent of Filter Library (ENH-2)
         section.querySelector('a')!.setAttribute('href', '#/list?type=movies');
         await vi.waitFor(() => expect(card('ROUTE').classList.contains('jc-hidden')).toBe(false));
         expect(card('ROUTE').dataset.jcHiddenScopeSignature).toBe('ordinary');
+    });
+
+    it('enrols route observers when filtering activates after the title link appeared', async () => {
+        setHiddenContent(
+            { enabled: true, filterLibrary: false, filterContinueWatching: false, filterNextUp: false },
+            {},
+        );
+        setupNativeObserver();
+        const section = document.createElement('div');
+        section.className = 'section';
+        section.innerHTML = '<a class="sectionTitleTextButton" href="#/list?type=nextup">任意</a><div class="card" data-id="ACTIVATE"></div>';
+        document.body.appendChild(section);
+        await Promise.resolve();
+
+        setHiddenContent(
+            { enabled: true, filterLibrary: false, filterContinueWatching: false, filterNextUp: true },
+            { ACTIVATE: { itemId: 'ACTIVATE', hideScope: 'nextup' } },
+        );
+        refreshNativeCardVisibility();
+        await vi.waitFor(() => expect(card('ACTIVATE').classList.contains('jc-hidden')).toBe(true));
+
+        section.querySelector('a')!.setAttribute('href', '#/list?type=movies');
+        await vi.waitFor(() => expect(card('ACTIVATE').classList.contains('jc-hidden')).toBe(false));
     });
 
     it('invalidates TV slot mapping when Jellyfin removes the section10 sentinel', async () => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/filter.home-scope.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/filter.home-scope.test.ts
@@ -7,19 +7,26 @@
 // stays visible (page-scope hiding correctly stays off).
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { JC } from '../../globals';
-import { filterAllNativeCards } from './filter';
+import { clearFilterIdentityState, filterAllNativeCards, setupNativeObserver } from './filter';
 import { resetFromUserConfig, shouldProcessNativeSurface } from './data';
 
 type HiddenItems = Record<string, { itemId: string; hideScope: string }>;
+
+function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((done) => { resolve = done; });
+    return { promise, resolve };
+}
 
 function setHiddenContent(settings: Record<string, unknown>, items: HiddenItems): void {
     JC.userConfig = { hiddenContent: { items, settings } };
     resetFromUserConfig();
 }
 
-function makeSection(title: string, cardIds: string[]): void {
+function makeSection(surface: 'continuewatching' | 'ordinary', title: string, cardIds: string[]): void {
     const section = document.createElement('div');
     section.className = 'section';
+    if (surface === 'continuewatching') section.id = 'resumableSection';
     const titleEl = document.createElement('div');
     titleEl.className = 'sectionTitle';
     titleEl.textContent = title;
@@ -44,6 +51,7 @@ describe('home Continue-Watching filtering independent of Filter Library (ENH-2)
     });
 
     afterEach(() => {
+        clearFilterIdentityState();
         vi.restoreAllMocks();
     });
 
@@ -55,8 +63,8 @@ describe('home Continue-Watching filtering independent of Filter Library (ENH-2)
                 LIB1: { itemId: 'LIB1', hideScope: 'global' },
             },
         );
-        makeSection('Continue Watching', ['CW1']);
-        makeSection('Latest Movies', ['LIB1']);
+        makeSection('continuewatching', 'Weiterschauen', ['CW1']);
+        makeSection('ordinary', 'Neu hinzugefügt', ['LIB1']);
 
         filterAllNativeCards();
 
@@ -74,8 +82,8 @@ describe('home Continue-Watching filtering independent of Filter Library (ENH-2)
                 LIB1: { itemId: 'LIB1', hideScope: 'global' },
             },
         );
-        makeSection('Continue Watching', ['CW1']);
-        makeSection('Latest Movies', ['LIB1']);
+        makeSection('continuewatching', 'متابعة المشاهدة', ['CW1']);
+        makeSection('ordinary', 'أضيف حديثاً', ['LIB1']);
 
         filterAllNativeCards();
 
@@ -91,5 +99,172 @@ describe('home Continue-Watching filtering independent of Filter Library (ENH-2)
 
         setHiddenContent({ filterLibrary: false, filterContinueWatching: false, filterNextUp: true }, {});
         expect(shouldProcessNativeSurface('library')).toBe(true);
+    });
+
+    it('does not permanently process an unresolved localized home row and retries when preferences arrive', async () => {
+        const held = deferred<{ CustomPrefs: Record<string, string> }>();
+        ApiClient.getDisplayPreferences = vi.fn(() => held.promise);
+        setHiddenContent(
+            { filterLibrary: false, filterContinueWatching: true, filterNextUp: true },
+            { CW1: { itemId: 'CW1', hideScope: 'continuewatching' } },
+        );
+        const container = document.createElement('div');
+        container.className = 'homeSectionsContainer';
+        const section = document.createElement('div');
+        section.className = 'verticalSection section1';
+        section.innerHTML = '<h2 class="sectionTitle">Continuar viendo</h2><div class="card" data-id="CW1"></div>';
+        container.appendChild(section);
+        document.body.appendChild(container);
+
+        setupNativeObserver();
+        filterAllNativeCards();
+        expect(card('CW1').classList.contains('jc-hidden')).toBe(false);
+        expect(card('CW1').hasAttribute('data-jc-hidden-checked')).toBe(false);
+
+        held.resolve({ CustomPrefs: {} });
+        await vi.waitFor(() => expect(card('CW1').classList.contains('jc-hidden')).toBe(true));
+        expect(card('CW1').dataset.jcHiddenScopeSignature).toBe('home:1:resume');
+    });
+
+    it('rechecks a processed card moved from Continue Watching into Next Up', async () => {
+        ApiClient.getDisplayPreferences = vi.fn().mockResolvedValue({ CustomPrefs: {} });
+        setHiddenContent(
+            { filterLibrary: false, filterContinueWatching: true, filterNextUp: true },
+            {
+                ITEM: { itemId: 'ITEM', hideScope: 'continuewatching' },
+                OTHER: { itemId: 'OTHER', hideScope: 'nextup' },
+            },
+        );
+        const container = document.createElement('div');
+        container.className = 'homeSectionsContainer';
+        const resume = document.createElement('div');
+        resume.className = 'verticalSection section1';
+        const nextUp = document.createElement('div');
+        nextUp.className = 'verticalSection section5';
+        const moved = document.createElement('div');
+        moved.className = 'card';
+        moved.dataset.id = 'ITEM';
+        const other = document.createElement('div');
+        other.className = 'card';
+        other.dataset.id = 'OTHER';
+        resume.appendChild(moved);
+        nextUp.appendChild(other);
+        container.append(resume, nextUp);
+        document.body.appendChild(container);
+
+        setupNativeObserver();
+        filterAllNativeCards();
+        await vi.waitFor(() => {
+            expect(moved.classList.contains('jc-hidden')).toBe(true);
+            expect(other.classList.contains('jc-hidden')).toBe(true);
+        });
+
+        nextUp.appendChild(moved);
+        resume.appendChild(other);
+        await vi.waitFor(() => {
+            expect(moved.classList.contains('jc-hidden')).toBe(false);
+            expect(other.classList.contains('jc-hidden')).toBe(false);
+        });
+        expect(moved.dataset.jcHiddenScopeSignature).toBe('home:5:nextup');
+        expect(other.dataset.jcHiddenScopeSignature).toBe('home:1:resume');
+    });
+
+    it('retries a processed generic row when a stable Next-Up link is inserted late', async () => {
+        setHiddenContent(
+            { filterLibrary: false, filterContinueWatching: true, filterNextUp: true },
+            { LATE: { itemId: 'LATE', hideScope: 'nextup' } },
+        );
+        const section = document.createElement('div');
+        section.className = 'section';
+        section.innerHTML = '<h2 class="sectionTitle">Up next, but translated</h2><div class="card" data-id="LATE"></div>';
+        document.body.appendChild(section);
+
+        setupNativeObserver();
+        filterAllNativeCards();
+        expect(card('LATE').classList.contains('jc-hidden')).toBe(false);
+        expect(card('LATE').dataset.jcHiddenScopeSignature).toBe('ordinary');
+
+        const link = document.createElement('a');
+        link.className = 'sectionTitleTextButton';
+        link.href = '#/list?type=nextup';
+        section.prepend(link);
+
+        await vi.waitFor(() => expect(card('LATE').classList.contains('jc-hidden')).toBe(true));
+        expect(card('LATE').dataset.jcHiddenScopeSignature).toBe('route:nextup');
+
+        link.remove();
+        await vi.waitFor(() => expect(card('LATE').classList.contains('jc-hidden')).toBe(false));
+        expect(card('LATE').dataset.jcHiddenScopeSignature).toBe('ordinary');
+    });
+
+    it('rechecks a processed route row when the host changes its title-link href in place', async () => {
+        setHiddenContent(
+            { filterLibrary: false, filterContinueWatching: true, filterNextUp: true },
+            { ROUTE: { itemId: 'ROUTE', hideScope: 'nextup' } },
+        );
+        const section = document.createElement('div');
+        section.className = 'section';
+        section.innerHTML = '<a class="sectionTitleTextButton" href="#/list?type=nextup">任意</a><div class="card" data-id="ROUTE"></div>';
+        document.body.appendChild(section);
+
+        setupNativeObserver();
+        filterAllNativeCards();
+        await vi.waitFor(() => expect(card('ROUTE').classList.contains('jc-hidden')).toBe(true));
+
+        section.querySelector('a')!.setAttribute('href', '#/list?type=movies');
+        await vi.waitFor(() => expect(card('ROUTE').classList.contains('jc-hidden')).toBe(false));
+        expect(card('ROUTE').dataset.jcHiddenScopeSignature).toBe('ordinary');
+    });
+
+    it('invalidates TV slot mapping when Jellyfin removes the section10 sentinel', async () => {
+        ApiClient.getDisplayPreferences = vi.fn().mockResolvedValue({
+            CustomPrefs: { homesection0: 'nextup', homesection1: 'none' },
+        });
+        setHiddenContent(
+            { filterLibrary: false, filterContinueWatching: true, filterNextUp: true },
+            { TVNEXT: { itemId: 'TVNEXT', hideScope: 'nextup' } },
+        );
+        const container = document.createElement('div');
+        container.className = 'homeSectionsContainer';
+        const section = document.createElement('div');
+        section.className = 'verticalSection section1';
+        section.innerHTML = '<div class="card" data-id="TVNEXT"></div>';
+        const sentinel = document.createElement('div');
+        sentinel.className = 'verticalSection section10';
+        container.append(section, sentinel);
+        document.body.appendChild(container);
+
+        setupNativeObserver();
+        filterAllNativeCards();
+        await vi.waitFor(() => expect(card('TVNEXT').classList.contains('jc-hidden')).toBe(true));
+        expect(card('TVNEXT').dataset.jcHiddenScopeSignature).toBe('home:1:nextup');
+
+        sentinel.remove();
+        await vi.waitFor(() => expect(card('TVNEXT').classList.contains('jc-hidden')).toBe(false));
+        expect(card('TVNEXT').dataset.jcHiddenScopeSignature).toBe('home:1:none');
+    });
+
+    it('compares the stored signature when a cached section slot changes in place', async () => {
+        ApiClient.getDisplayPreferences = vi.fn().mockResolvedValue({ CustomPrefs: {} });
+        setHiddenContent(
+            { filterLibrary: false, filterContinueWatching: true, filterNextUp: true },
+            { REUSED: { itemId: 'REUSED', hideScope: 'continuewatching' } },
+        );
+        const container = document.createElement('div');
+        container.className = 'homeSectionsContainer';
+        const section = document.createElement('div');
+        section.className = 'verticalSection section1';
+        section.innerHTML = '<div class="card" data-id="REUSED"></div>';
+        container.appendChild(section);
+        document.body.appendChild(container);
+
+        setupNativeObserver();
+        filterAllNativeCards();
+        await vi.waitFor(() => expect(card('REUSED').classList.contains('jc-hidden')).toBe(true));
+        expect(card('REUSED').dataset.jcHiddenScopeSignature).toBe('home:1:resume');
+
+        section.className = 'verticalSection section5';
+        await vi.waitFor(() => expect(card('REUSED').classList.contains('jc-hidden')).toBe(false));
+        expect(card('REUSED').dataset.jcHiddenScopeSignature).toBe('home:5:nextup');
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/filter.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/filter.ts
@@ -583,6 +583,10 @@ export function refreshNativeCardVisibility(): void {
         return;
     }
     const fence = captureFilterFence();
+    // A stable title link may have appeared while filtering/buttons were off,
+    // when the structural fast path intentionally did no work. Enrol those
+    // sections before this activation pass so later in-place href reuse is seen.
+    syncHomeSectionObservers(fence);
     requestAnimationFrame(() => {
         if (!isFilterFenceCurrent(fence)) return;
         filterAllNativeCards();

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/filter.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/filter.ts
@@ -13,20 +13,28 @@ import { JC } from '../../globals';
 import { onViewPage } from '../../core/navigation';
 import { onBodyMutation } from '../../core/dom-observer';
 import type { BodySubscriberHandle, IdentityContext } from '../../types/jc';
+import {
+    acquireHomeRowScopes,
+    createHomeRowScopeResolver,
+    invalidateHomeRowSection,
+    resolveHomeRowScope,
+} from '../home-row-scope';
 import { hiddenIdSet, getSettings, shouldFilterSurface, shouldProcessNativeSurface, getHiddenData, getHiddenCount } from './data';
-import { addLibraryHideButtons } from './buttons';
+import { addLibraryHideButtons, removeLibraryHideButtons } from './buttons';
 import {
     PARENT_SERIES_ABSENCE_TTL_MS,
     ParentSeriesCache,
 } from './parent-series-cache';
 
 const parentSeriesCache = new ParentSeriesCache();
-let sectionSurfaceCache = new WeakMap<Element, string | null>();
 let filterGeneration = 0;
 let parentSeriesGeneration = 0;
 let viewPageUnsubscribe: (() => void) | null = null;
+let rowScopeRelease: (() => void) | null = null;
 let bodyMutationHandle: BodySubscriberHandle | null = null;
+const homeSectionObservers = new Map<HTMLElement, MutationObserver>();
 const detailRescanHandles = new Set<number>();
+const emptySectionReconcileFrames = new Set<number>();
 let parentInvalidationFrameHandle: number | null = null;
 let parentRetryHandle: number | null = null;
 let parentOverflowRetryHandle: number | null = null;
@@ -74,13 +82,18 @@ export function clearFilterIdentityState(): void {
     filterGeneration += 1;
     parentSeriesGeneration += 1;
     parentSeriesCache.clear();
-    sectionSurfaceCache = new WeakMap<Element, string | null>();
     viewPageUnsubscribe?.();
     viewPageUnsubscribe = null;
+    rowScopeRelease?.();
+    rowScopeRelease = null;
     bodyMutationHandle?.unsubscribe();
     bodyMutationHandle = null;
+    for (const observer of homeSectionObservers.values()) observer.disconnect();
+    homeSectionObservers.clear();
     for (const handle of detailRescanHandles) clearTimeout(handle);
     detailRescanHandles.clear();
+    for (const handle of emptySectionReconcileFrames) cancelAnimationFrame(handle);
+    emptySectionReconcileFrames.clear();
     if (filterDebounceHandle !== null) clearTimeout(filterDebounceHandle);
     if (filterFrameHandle !== null) cancelAnimationFrame(filterFrameHandle);
     if (parentInvalidationFrameHandle !== null) cancelAnimationFrame(parentInvalidationFrameHandle);
@@ -105,6 +118,7 @@ export function clearFilterIdentityState(): void {
     });
     document.querySelectorAll<HTMLElement>(`[${PROCESSED_ATTR}]`).forEach((card) => {
         card.removeAttribute(PROCESSED_ATTR);
+        card.removeAttribute(PROCESSED_SCOPE_ATTR);
     });
 }
 
@@ -217,6 +231,8 @@ const DETAIL_FINAL_RESCAN_DELAY_MS = 1200;
 const NATIVE_FILTER_DEBOUNCE_MS = 50;
 /** Data attribute marking a card as already scanned. */
 const PROCESSED_ATTR = 'data-jc-hidden-checked';
+/** Row signature paired with PROCESSED_ATTR so reused/moved cards are rescanned. */
+const PROCESSED_SCOPE_ATTR = 'data-jc-hidden-scope-signature';
 /** Data attribute storing the parent series ID that caused hiding. */
 const HIDDEN_PARENT_ATTR = 'data-jc-hidden-parent-series-id';
 /** Data attribute marking a directly-hidden card. */
@@ -262,16 +278,10 @@ async function getParentSeriesId(itemId: string): Promise<string | null> {
  * @returns The detected surface or null.
  */
 export function getCardSurface(card: HTMLElement): string | null {
-    const section = card.closest('.section, .verticalSection, .homeSection');
-    if (!section) return null;
-    if (sectionSurfaceCache.has(section)) return sectionSurfaceCache.get(section)!;
-    const titleEl = section.querySelector('.sectionTitle, h2, .headerText, .sectionTitle-sectionTitle');
-    const title = (titleEl?.textContent || '').toLowerCase();
-    let surface: string | null = null;
-    if (title.includes('next up')) surface = 'nextup';
-    else if (title.includes('continue watching')) surface = 'continuewatching';
-    sectionSurfaceCache.set(section, surface);
-    return surface;
+    const resolution = resolveHomeRowScope(card);
+    return resolution.kind === 'nextup' || resolution.kind === 'continuewatching'
+        ? resolution.kind
+        : null;
 }
 
 /**
@@ -607,16 +617,26 @@ export function filterNativeCards(syncApply = false): void {
     const toShow: HTMLElement[] = [];
     const pendingParentChecks: Array<{ card: HTMLElement; itemId: string }> = [];
     const cards = document.querySelectorAll<HTMLElement>(CARD_SEL_NEW);
+    const resolveRow = createHomeRowScopeResolver();
     for (let i = 0; i < cards.length; i++) {
         const card = cards[i];
         // Skip image editor cards (they have data-imagetype attribute)
         if (card.hasAttribute('data-imagetype')) continue;
         const itemId = getCardItemId(card);
-        card.setAttribute(PROCESSED_ATTR, '1');
         if (!itemId) continue;
 
         // Check scope-aware hiding for cards in Next Up / Continue Watching sections
-        const cardSurface = getCardSurface(card);
+        const row = resolveRow(card);
+        const cardSurface = row.kind === 'nextup' || row.kind === 'continuewatching'
+            ? row.kind
+            : null;
+        if (row.kind === 'unresolved') {
+            card.removeAttribute(PROCESSED_ATTR);
+            card.removeAttribute(PROCESSED_SCOPE_ATTR);
+        } else {
+            card.setAttribute(PROCESSED_ATTR, '1');
+            card.setAttribute(PROCESSED_SCOPE_ATTR, row.signature);
+        }
         if (cardSurface) {
             if (shouldFilterSurface(cardSurface) && isHiddenOnSurface(itemId, cardSurface)) {
                 toHide.push(card);
@@ -628,6 +648,10 @@ export function filterNativeCards(syncApply = false): void {
         }
 
         if (pageFilterable && hiddenIdSet.has(itemId)) {
+            // hiddenIdSet contains only global entries, so this is safe even
+            // while a home row's scoped identity is still unresolved.
+            card.setAttribute(PROCESSED_ATTR, '1');
+            card.setAttribute(PROCESSED_SCOPE_ATTR, row.signature);
             toHide.push(card);
             card.setAttribute(HIDDEN_DIRECT_ATTR, '1');
             card.removeAttribute(HIDDEN_PARENT_ATTR);
@@ -637,6 +661,9 @@ export function filterNativeCards(syncApply = false): void {
                 toShow.push(card);
                 card.removeAttribute(HIDDEN_DIRECT_ATTR);
             }
+            // Never run page/parent fallbacks against a pending home row. It
+            // remains visible and eligible for the preferences-ready rescan.
+            if (row.kind === 'unresolved') continue;
             if (pageFilterable && !isDetailPage) {
                 const cardType = card.dataset.type || '';
                 if (cardType === 'Episode' || cardType === 'Season') {
@@ -682,13 +709,23 @@ export function filterAllNativeCards(): void {
     const toShow: HTMLElement[] = [];
     const pendingParentChecks: Array<{ card: HTMLElement; itemId: string }> = [];
     const cards = document.querySelectorAll<HTMLElement>(CARD_SEL);
+    const resolveRow = createHomeRowScopeResolver();
     for (let i = 0; i < cards.length; i++) {
         const card = cards[i];
         const itemId = getCardItemId(card);
-        card.setAttribute(PROCESSED_ATTR, '1');
         if (!itemId) continue;
 
-        const cardSurface = getCardSurface(card);
+        const row = resolveRow(card);
+        const cardSurface = row.kind === 'nextup' || row.kind === 'continuewatching'
+            ? row.kind
+            : null;
+        if (row.kind === 'unresolved') {
+            card.removeAttribute(PROCESSED_ATTR);
+            card.removeAttribute(PROCESSED_SCOPE_ATTR);
+        } else {
+            card.setAttribute(PROCESSED_ATTR, '1');
+            card.setAttribute(PROCESSED_SCOPE_ATTR, row.signature);
+        }
         let hiddenByScope = false;
         if (cardSurface && shouldFilterSurface(cardSurface) && isHiddenOnSurface(itemId, cardSurface)) {
             toHide.push(card);
@@ -700,6 +737,8 @@ export function filterAllNativeCards(): void {
 
         if (!hiddenByScope) {
             if (pageFilterable && hiddenIdSet.has(itemId)) {
+                card.setAttribute(PROCESSED_ATTR, '1');
+                card.setAttribute(PROCESSED_SCOPE_ATTR, row.signature);
                 toHide.push(card);
                 card.setAttribute(HIDDEN_DIRECT_ATTR, '1');
                 card.removeAttribute(HIDDEN_PARENT_ATTR);
@@ -709,6 +748,7 @@ export function filterAllNativeCards(): void {
                     toShow.push(card);
                     card.removeAttribute(HIDDEN_DIRECT_ATTR);
                 }
+                if (row.kind === 'unresolved') continue;
                 if (pageFilterable && !isDetailPage) {
                     const cardType = card.dataset.type || '';
                     if (cardType === 'Episode' || cardType === 'Season') {
@@ -751,14 +791,148 @@ const debouncedFilterNative = (): void => {
     }, NATIVE_FILTER_DEBOUNCE_MS);
 };
 
+function shouldShowNativeButtons(): boolean {
+    const settings = getSettings();
+    return settings.showHideButtons && (settings.showButtonLibrary || settings.showButtonCast);
+}
+
+function reconcileEmptyHomeSections(): void {
+    if (typeof (JC as any).hideEmptyHomeSections === 'function') {
+        (JC as any).hideEmptyHomeSections();
+    }
+}
+
+function scheduleEmptyHomeSectionReconcile(fence: FilterFence): void {
+    const handle = requestAnimationFrame(() => {
+        emptySectionReconcileFrames.delete(handle);
+        if (isFilterFenceCurrent(fence)) reconcileEmptyHomeSections();
+    });
+    emptySectionReconcileFrames.add(handle);
+}
+
+function clearProcessedScopeMarkers(root: ParentNode = document): void {
+    root.querySelectorAll<HTMLElement>(`[${PROCESSED_ATTR}]`).forEach((card) => {
+        card.removeAttribute(PROCESSED_ATTR);
+        card.removeAttribute(PROCESSED_SCOPE_ATTR);
+    });
+}
+
+function reconcileProcessedScopeSignatures(root: ParentNode): boolean {
+    let changed = false;
+    const resolveRow = createHomeRowScopeResolver();
+    root.querySelectorAll<HTMLElement>(`[${PROCESSED_ATTR}][${PROCESSED_SCOPE_ATTR}]`).forEach((card) => {
+        const current = resolveRow(card).signature;
+        if (card.getAttribute(PROCESSED_SCOPE_ATTR) === current) return;
+        card.removeAttribute(PROCESSED_ATTR);
+        card.removeAttribute(PROCESSED_SCOPE_ATTR);
+        changed = true;
+    });
+    return changed;
+}
+
+function markAddedCardsForRecheck(node: Element): boolean {
+    let found = false;
+    if (node.closest('.homeSectionsContainer')
+        && [...node.classList].some((className) => /^section\d+$/.test(className))) {
+        invalidateHomeRowSection(node);
+        const container = node.closest('.homeSectionsContainer');
+        if (container) {
+            clearProcessedScopeMarkers(container);
+            found = Boolean(container.querySelector(CARD_SEL));
+        }
+    }
+    if (node.matches(CARD_SEL)) {
+        node.removeAttribute(PROCESSED_ATTR);
+        node.removeAttribute(PROCESSED_SCOPE_ATTR);
+        found = true;
+    }
+    const descendants = node.querySelectorAll<HTMLElement>(CARD_SEL);
+    if (descendants.length > 0) found = true;
+    descendants.forEach((card) => {
+        card.removeAttribute(PROCESSED_ATTR);
+        card.removeAttribute(PROCESSED_SCOPE_ATTR);
+    });
+    return found;
+}
+
+function markRemovedHomeStructureForRecheck(node: Element, target: Node): boolean {
+    const removedSection = [...node.classList].some((className) => /^section\d+$/.test(className))
+        || [...node.querySelectorAll('[class]')].some((element) => (
+            [...element.classList].some((className) => /^section\d+$/.test(className))
+        ));
+    if (!removedSection) return false;
+    const targetElement = target instanceof Element ? target : target.parentElement;
+    const container = (targetElement?.matches('.homeSectionsContainer') ? targetElement : null)
+        || targetElement?.closest('.homeSectionsContainer');
+    if (!container) return false;
+    invalidateHomeRowSection(container);
+    clearProcessedScopeMarkers(container);
+    return Boolean(container.querySelector(CARD_SEL));
+}
+
+const ROW_EVIDENCE_SELECTOR = 'a.sectionTitleTextButton[href], .sectionTitleContainer > a[href], .sectionTitle a[href], h2 > a[href]';
+
+function markLateRowEvidenceForRecheck(node: Element, target: Node): boolean {
+    const hasEvidence = node.matches(ROW_EVIDENCE_SELECTOR)
+        || Boolean(node.querySelector(ROW_EVIDENCE_SELECTOR));
+    if (!hasEvidence) return false;
+    const targetElement = target instanceof Element ? target : target.parentElement;
+    const section = (node.matches('.section, .verticalSection, .homeSection') ? node : node.closest('.section, .verticalSection, .homeSection'))
+        || targetElement?.closest('.section, .verticalSection, .homeSection');
+    if (!section) return false;
+    invalidateHomeRowSection(section);
+    clearProcessedScopeMarkers(section);
+    return Boolean(section.querySelector(CARD_SEL));
+}
+
+function syncHomeSectionObservers(fence: FilterFence): void {
+    for (const [section, observer] of [...homeSectionObservers]) {
+        if (section.isConnected) continue;
+        observer.disconnect();
+        homeSectionObservers.delete(section);
+    }
+    const sections = new Set<HTMLElement>(document.querySelectorAll<HTMLElement>(
+        '.homeSectionsContainer > .section, .homeSectionsContainer > .verticalSection, .homeSectionsContainer > .homeSection',
+    ));
+    document.querySelectorAll<HTMLElement>(ROW_EVIDENCE_SELECTOR).forEach((link) => {
+        const section = link.closest<HTMLElement>('.section, .verticalSection, .homeSection');
+        if (section) sections.add(section);
+    });
+    sections.forEach((section) => {
+        if (homeSectionObservers.has(section)) return;
+        const observer = new MutationObserver(() => {
+            if (!isFilterFenceCurrent(fence)) return;
+            invalidateHomeRowSection(section);
+            if (!reconcileProcessedScopeSignatures(section)) return;
+            removeLibraryHideButtons();
+            filterNativeCards(true);
+            if (shouldShowNativeButtons()) addLibraryHideButtons();
+            reconcileEmptyHomeSections();
+        });
+        observer.observe(section, { attributes: true, attributeFilter: ['class', 'href'], subtree: true });
+        homeSectionObservers.set(section, observer);
+    });
+}
+
 /**
  * Sets up page-navigation and MutationObserver hooks to trigger card
  * filtering and button injection when new cards appear in the DOM.
  */
 export function setupNativeObserver(): void {
     viewPageUnsubscribe?.();
+    rowScopeRelease?.();
     bodyMutationHandle?.unsubscribe();
     const setupFence = captureFilterFence();
+    rowScopeRelease = acquireHomeRowScopes(() => {
+        if (!isFilterFenceCurrent(setupFence)) return;
+        clearProcessedScopeMarkers();
+        removeLibraryHideButtons();
+        filterAllNativeCards();
+        if (shouldShowNativeButtons()) addLibraryHideButtons();
+        scheduleEmptyHomeSectionReconcile(setupFence);
+        syncHomeSectionObservers(setupFence);
+    });
+    syncHomeSectionObservers(setupFence);
     // Use onViewPage for page navigation — much cheaper than a body MutationObserver
     viewPageUnsubscribe = onViewPage(() => {
         if (!isFilterFenceCurrent(setupFence)) return;
@@ -767,7 +941,7 @@ export function setupNativeObserver(): void {
             const rescan = (): void => {
                 if (!isFilterFenceCurrent(setupFence)) return;
                 refreshNativeCardVisibility();
-                if (getSettings().showButtonLibrary) addLibraryHideButtons();
+                if (shouldShowNativeButtons()) addLibraryHideButtons();
             };
             const scheduleRescan = (delay: number): void => {
                 const handle = window.setTimeout(() => {
@@ -789,7 +963,8 @@ export function setupNativeObserver(): void {
         const settings = getSettings();
         if (!settings.enabled) return;
         const shouldFilter = getHiddenCount() > 0;
-        const shouldAddButtons = settings.showHideButtons && settings.showButtonLibrary;
+        const shouldAddButtons = settings.showHideButtons
+            && (settings.showButtonLibrary || settings.showButtonCast);
         if (!shouldFilter && !shouldAddButtons) return;
         let hasNewItems = false;
         for (let i = 0; i < mutations.length; i++) {
@@ -797,17 +972,25 @@ export function setupNativeObserver(): void {
             for (let j = 0; j < added.length; j++) {
                 const node = added[j] as Element;
                 if (node.nodeType === 1 && (
-                    node.classList?.contains('card') ||
-                    node.classList?.contains('listItem') ||
-                    node.querySelector?.('.card[data-id], .listItem[data-id]')
+                    markAddedCardsForRecheck(node)
+                    || markLateRowEvidenceForRecheck(node, mutations[i].target)
                 )) {
                     hasNewItems = true;
-                    break;
                 }
             }
-            if (hasNewItems) break;
+            const removed = mutations[i].removedNodes;
+            for (let j = 0; j < removed.length; j++) {
+                const node = removed[j] as Element;
+                if (node.nodeType !== 1) continue;
+                const rowEvidenceChanged = markLateRowEvidenceForRecheck(node, mutations[i].target);
+                const structureChanged = markRemovedHomeStructureForRecheck(node, mutations[i].target);
+                if (rowEvidenceChanged || structureChanged) {
+                    hasNewItems = true;
+                }
+            }
         }
         if (hasNewItems) {
+            syncHomeSectionObservers(setupFence);
             if (shouldFilter) {
                 // PERF(R8): filter SYNCHRONOUSLY inside this mutation batch — the
                 // hidden-ids set is in memory (a Set lookup per new card), so
@@ -820,6 +1003,8 @@ export function setupNativeObserver(): void {
                 debouncedFilterNative();
             }
             if (shouldAddButtons) addLibraryHideButtons();
+            reconcileEmptyHomeSections();
         }
     }, { priority: 10 });
+
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/home-row-scope.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/home-row-scope.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../globals';
+import {
+    acquireHomeRowScopes,
+    createHomeRowScopeResolver,
+    primeHomeRowScopes,
+    resetHomeRowScopes,
+    resolveHomeRowScope,
+} from './home-row-scope';
+
+function deferred<T>(): { promise: Promise<T>; resolve(value: T): void; reject(error: unknown): void } {
+    let resolve!: (value: T) => void;
+    let reject!: (error: unknown) => void;
+    const promise = new Promise<T>((done, fail) => { resolve = done; reject = fail; });
+    return { promise, resolve, reject };
+}
+
+function homeSection(index: number, heading = '任意の見出し'): { container: HTMLElement; section: HTMLElement; card: HTMLElement } {
+    const container = document.createElement('div');
+    container.className = 'homeSectionsContainer';
+    const section = document.createElement('div');
+    section.className = `verticalSection section${index}`;
+    section.innerHTML = `<h2 class="sectionTitle">${heading}</h2>`;
+    const card = document.createElement('div');
+    card.className = 'card';
+    card.dataset.id = `item-${index}`;
+    section.appendChild(card);
+    container.appendChild(section);
+    document.body.appendChild(container);
+    return { container, section, card };
+}
+
+describe('Jellyfin 12 home-row scope resolver', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        resetHomeRowScopes();
+        JC.identity.transition('scope-server', `scope-user-${Date.now()}-${Math.random()}`, 'scope-test');
+    });
+
+    afterEach(() => {
+        resetHomeRowScopes();
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    it('keeps a first scan unresolved, deduplicates the request, then resolves translated default rows', async () => {
+        const held = deferred<{ CustomPrefs: Record<string, string> }>();
+        const getDisplayPreferences = vi.fn(() => held.promise);
+        ApiClient.getDisplayPreferences = getDisplayPreferences;
+        const onChange = vi.fn();
+        const release = acquireHomeRowScopes(onChange);
+        const { card } = homeSection(1, 'متابعة المشاهدة');
+
+        expect(resolveHomeRowScope(card).kind).toBe('unresolved');
+        expect(resolveHomeRowScope(card).kind).toBe('unresolved');
+        expect(getDisplayPreferences).toHaveBeenCalledTimes(1);
+        expect(getDisplayPreferences).toHaveBeenCalledWith(
+            'usersettings',
+            JC.identity.capture()!.userId,
+            'emby',
+        );
+
+        held.resolve({ CustomPrefs: {} });
+        await vi.waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
+        expect(resolveHomeRowScope(card).kind).toBe('continuewatching');
+        release();
+    });
+
+    it('uses custom ordering and Jellyfin TV prepend without reading the heading', async () => {
+        ApiClient.getDisplayPreferences = vi.fn().mockResolvedValue({
+            CustomPrefs: {
+                homesection0: 'nextup',
+                homesection1: 'none',
+                homesection2: 'none',
+                homesection3: 'none',
+                homesection4: 'none',
+                homesection5: 'none',
+                homesection6: 'none',
+                homesection7: 'none',
+                homesection8: 'none',
+                homesection9: 'none',
+            },
+        });
+        const first = homeSection(0, 'Next Up is deliberately misleading');
+        const next = document.createElement('div');
+        next.className = 'verticalSection section1';
+        const nextCard = document.createElement('div');
+        nextCard.className = 'card';
+        next.appendChild(nextCard);
+        first.container.appendChild(next);
+        const extra = document.createElement('div');
+        extra.className = 'verticalSection section10';
+        first.container.appendChild(extra);
+
+        const release = acquireHomeRowScopes(() => {});
+        primeHomeRowScopes();
+        await vi.waitFor(() => expect(resolveHomeRowScope(nextCard).kind).toBe('nextup'));
+        expect(resolveHomeRowScope(first.card).kind).toBe('collection');
+
+        extra.remove();
+        expect(resolveHomeRowScope(first.card).kind).toBe('nextup');
+        expect(resolveHomeRowScope(nextCard).kind).toBe('ordinary');
+        release();
+    });
+
+    it('accepts exact host ids and route values but rejects substring lookalikes', () => {
+        const resume = document.createElement('section');
+        resume.id = 'resumableSection';
+        const resumeCard = document.createElement('div');
+        resumeCard.className = 'card';
+        resume.appendChild(resumeCard);
+        document.body.appendChild(resume);
+        expect(resolveHomeRowScope(resumeCard).kind).toBe('continuewatching');
+
+        const section = document.createElement('section');
+        section.className = 'section';
+        section.innerHTML = '<a class="sectionTitleTextButton" href="#/items?type=nextup-ish">任意</a><div class="card"></div>';
+        document.body.appendChild(section);
+        expect(resolveHomeRowScope(section.querySelector('.card')!).kind).toBe('ordinary');
+        section.querySelector('a')!.setAttribute('href', '#/items?itemTypes=nextup');
+        expect(resolveHomeRowScope(section.querySelector('.card')!).kind).toBe('nextup');
+    });
+
+    it('walks route evidence once per section within a multi-card pass', () => {
+        const section = document.createElement('section');
+        section.className = 'section';
+        section.innerHTML = '<h2>任意</h2><div class="card"></div><div class="card"></div>';
+        document.body.appendChild(section);
+        const cards = section.querySelectorAll('.card');
+        const querySelectorAll = vi.spyOn(section, 'querySelectorAll');
+        const resolveRow = createHomeRowScopeResolver();
+
+        for (const card of cards) resolveRow(card);
+
+        expect(querySelectorAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('classifies collection cards from stable card data only', () => {
+        const card = document.createElement('div');
+        card.className = 'card';
+        card.dataset.type = 'CollectionFolder';
+        document.body.appendChild(card);
+        expect(resolveHomeRowScope(card).kind).toBe('collection');
+
+        card.dataset.type = 'Movie';
+        card.dataset.collectiontype = 'movies';
+        expect(resolveHomeRowScope(card).kind).toBe('collection');
+        delete card.dataset.collectiontype;
+        card.textContent = 'Collections and Continue Watching';
+        expect(resolveHomeRowScope(card).kind).toBe('ordinary');
+    });
+
+    it('contains a future unknown preference value to that row', async () => {
+        ApiClient.getDisplayPreferences = vi.fn().mockResolvedValue({
+            CustomPrefs: { homesection1: 'resume', homesection9: 'future-row-type' },
+        });
+        const known = homeSection(1, '任意');
+        const unknown = document.createElement('div');
+        unknown.className = 'verticalSection section9';
+        const unknownCard = document.createElement('div');
+        unknownCard.className = 'card';
+        unknown.appendChild(unknownCard);
+        known.container.appendChild(unknown);
+        const release = acquireHomeRowScopes(() => {});
+
+        primeHomeRowScopes();
+        await vi.waitFor(() => expect(resolveHomeRowScope(known.card).kind).toBe('continuewatching'));
+        expect(resolveHomeRowScope(unknownCard).kind).toBe('unresolved');
+        release();
+    });
+
+    it('fences a stale identity completion and accepts only the current owner snapshot', async () => {
+        const first = deferred<{ CustomPrefs: Record<string, string> }>();
+        const second = deferred<{ CustomPrefs: Record<string, string> }>();
+        ApiClient.getDisplayPreferences = vi.fn()
+            .mockImplementationOnce(() => first.promise)
+            .mockImplementationOnce(() => second.promise);
+        const release = acquireHomeRowScopes(() => {});
+        const { card } = homeSection(1);
+
+        expect(resolveHomeRowScope(card).kind).toBe('unresolved');
+        JC.identity.transition('scope-server', 'scope-user-b', 'account-switch');
+        expect(resolveHomeRowScope(card).kind).toBe('unresolved');
+
+        first.resolve({ CustomPrefs: { homesection1: 'nextup' } });
+        await Promise.resolve();
+        expect(resolveHomeRowScope(card).kind).toBe('unresolved');
+
+        second.resolve({ CustomPrefs: {} });
+        await vi.waitFor(() => expect(resolveHomeRowScope(card).kind).toBe('continuewatching'));
+        release();
+    });
+
+    it('fails visible while revalidating every Home entry, including after home-layout settings', async () => {
+        const ordinaryRefresh = deferred<{ CustomPrefs: Record<string, string> }>();
+        const settingsRefresh = deferred<{ CustomPrefs: Record<string, string> }>();
+        const getDisplayPreferences = vi.fn()
+            .mockResolvedValueOnce({ CustomPrefs: {} })
+            .mockImplementationOnce(() => ordinaryRefresh.promise)
+            .mockImplementationOnce(() => settingsRefresh.promise);
+        ApiClient.getDisplayPreferences = getDisplayPreferences;
+        const { card } = homeSection(1);
+        const onChange = vi.fn();
+        const release = acquireHomeRowScopes(onChange);
+        primeHomeRowScopes();
+        await vi.waitFor(() => expect(resolveHomeRowScope(card).kind).toBe('continuewatching'));
+
+        history.pushState({}, '', '#/details?id=ordinary-navigation');
+        history.pushState({}, '', '#/home?scope-cached=1');
+        await vi.waitFor(() => expect(getDisplayPreferences).toHaveBeenCalledTimes(2));
+        expect(resolveHomeRowScope(card).kind).toBe('unresolved');
+        ordinaryRefresh.resolve({ CustomPrefs: { homesection1: 'nextup' } });
+        await vi.waitFor(() => expect(resolveHomeRowScope(card).kind).toBe('nextup'));
+
+        history.pushState({}, '', `#/mypreferenceshome?userId=${JC.identity.capture()!.userId}`);
+        history.pushState({}, '', '#/details?id=after-settings');
+        history.pushState({}, '', '#/home?scope-refreshed=1');
+        await vi.waitFor(() => expect(getDisplayPreferences).toHaveBeenCalledTimes(3));
+        expect(resolveHomeRowScope(card).kind).toBe('unresolved');
+
+        settingsRefresh.resolve({ CustomPrefs: {} });
+        await vi.waitFor(() => expect(resolveHomeRowScope(card).kind).toBe('continuewatching'));
+        expect(onChange).toHaveBeenCalledTimes(5);
+        expect(resolveHomeRowScope(card).kind).toBe('continuewatching');
+        release();
+    });
+
+    it('retries a transient preference failure with a bounded backoff', async () => {
+        vi.useFakeTimers();
+        const getDisplayPreferences = vi.fn()
+            .mockRejectedValueOnce(new Error('temporary'))
+            .mockResolvedValueOnce({ CustomPrefs: {} });
+        ApiClient.getDisplayPreferences = getDisplayPreferences;
+        const release = acquireHomeRowScopes(() => {});
+        const { card } = homeSection(5);
+
+        expect(resolveHomeRowScope(card).kind).toBe('unresolved');
+        await vi.advanceTimersByTimeAsync(500);
+        vi.runAllTicks();
+        expect(getDisplayPreferences).toHaveBeenCalledTimes(2);
+        vi.runAllTicks();
+        expect(resolveHomeRowScope(card).kind).toBe('nextup');
+        release();
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/home-row-scope.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/home-row-scope.ts
@@ -1,0 +1,432 @@
+// src/enhanced/home-row-scope.ts
+//
+// Locale-independent ownership for Jellyfin 12 home rows. Jellyfin renders
+// translated headings, so visible text is never a stable row identifier. Home
+// rows are resolved from host-owned component ids, exact route parameters, or
+// the identity-scoped DisplayPreferences snapshot used by jellyfin-web itself.
+
+import { onNavigate } from '../core/navigation';
+import { JC } from '../globals';
+import type { IdentityContext } from '../types/jc';
+
+export type HomeRowKind = 'continuewatching' | 'nextup' | 'collection' | 'ordinary';
+
+export interface HomeRowResolution {
+    readonly kind: HomeRowKind | 'unresolved';
+    /** True when the element belongs to a Jellyfin home-section slot. */
+    readonly isHomeRow: boolean;
+    /** Stable enough to detect a card/section being reused under another row. */
+    readonly signature: string;
+    readonly section: HTMLElement | null;
+}
+
+interface DisplayPreferencesSnapshot {
+    readonly ownerKey: string;
+    readonly customPrefs: Readonly<Record<string, string>>;
+}
+
+interface DisplayPreferencesDto {
+    CustomPrefs?: Record<string, unknown> | null;
+}
+
+interface ResolverPass {
+    readonly routeEvidence: WeakMap<HTMLElement, boolean>;
+    readonly tvLayout: WeakMap<Element, boolean>;
+}
+
+const DEFAULT_SECTIONS = Object.freeze([
+    'smalllibrarytiles',
+    'resume',
+    'resumeaudio',
+    'resumebook',
+    'livetv',
+    'nextup',
+    'latestmedia',
+    'none',
+    'none',
+    'none',
+]);
+const KNOWN_SECTIONS = new Set([
+    'none', 'smalllibrarytiles', 'librarybuttons', 'activerecordings',
+    'resume', 'resumeaudio', 'resumebook', 'latestmedia', 'nextup', 'livetv',
+]);
+const COLLECTION_TYPES = new Set([
+    'collectionfolder', 'userview', 'boxset', 'playlist', 'channel',
+]);
+const MAX_PREF_ATTEMPTS = 3;
+const PREF_RETRY_BASE_MS = 500;
+
+const listeners = new Set<() => void>();
+let snapshot: DisplayPreferencesSnapshot | null = null;
+let ownerKey: string | null = null;
+let requestGeneration = 0;
+let requestAttempts = 0;
+let inFlight: Promise<void> | null = null;
+let retryHandle: number | null = null;
+let navigateUnsubscribe: (() => void) | null = null;
+let lastNavigationRoute: string | null = null;
+let routeEvidenceCache = new WeakMap<HTMLElement, {
+    readonly link: HTMLAnchorElement;
+    readonly href: string;
+}>();
+let configuredSectionsCache = new WeakMap<Element, {
+    readonly isTvLayout: boolean;
+    readonly sections: readonly string[];
+}>();
+
+function contextKey(context: IdentityContext): string {
+    return `${context.serverId}\u0000${context.userId}\u0000${context.epoch}`;
+}
+
+function notifyListeners(): void {
+    for (const listener of [...listeners]) {
+        try { listener(); }
+        catch (error) {
+            console.warn('🪼 Jellyfin Canopy: Home-row resolver listener failed', error);
+        }
+    }
+}
+
+function clearRetry(): void {
+    if (retryHandle !== null) window.clearTimeout(retryHandle);
+    retryHandle = null;
+}
+
+function resetSnapshot(nextOwnerKey: string | null, notify: boolean): void {
+    requestGeneration += 1;
+    clearRetry();
+    snapshot = null;
+    ownerKey = nextOwnerKey;
+    requestAttempts = 0;
+    inFlight = null;
+    routeEvidenceCache = new WeakMap();
+    configuredSectionsCache = new WeakMap();
+    if (notify) notifyListeners();
+}
+
+function currentContext(): IdentityContext | null {
+    const context = JC.identity?.capture?.() || null;
+    const nextOwnerKey = context ? contextKey(context) : null;
+    if (nextOwnerKey !== ownerKey) resetSnapshot(nextOwnerKey, false);
+    return context;
+}
+
+function sanitizeCustomPrefs(value: unknown): Readonly<Record<string, string>> {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return Object.freeze({});
+    const prefs: Record<string, string> = {};
+    for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
+        if (!/^homesection\d+$/.test(key) || typeof raw !== 'string') continue;
+        prefs[key] = raw.toLowerCase().trim();
+    }
+    return Object.freeze(prefs);
+}
+
+function sameCustomPrefs(
+    left: Readonly<Record<string, string>>,
+    right: Readonly<Record<string, string>>,
+): boolean {
+    const leftKeys = Object.keys(left);
+    const rightKeys = Object.keys(right);
+    return leftKeys.length === rightKeys.length && leftKeys.every((key) => left[key] === right[key]);
+}
+
+/** Start one identity-fenced preferences read. Failures remain retryable. */
+function loadHomeRowScopes(): void {
+    const context = currentContext();
+    if (!context || snapshot || inFlight || requestAttempts >= MAX_PREF_ATTEMPTS) return;
+    if (typeof ApiClient?.getDisplayPreferences !== 'function') return;
+
+    requestAttempts += 1;
+    const generation = requestGeneration;
+    const expectedOwnerKey = contextKey(context);
+    inFlight = Promise.resolve(ApiClient.getDisplayPreferences('usersettings', context.userId, 'emby'))
+        .then((result: unknown) => {
+            if (generation !== requestGeneration || ownerKey !== expectedOwnerKey || !JC.identity.isCurrent(context)) return;
+            const dto = result as DisplayPreferencesDto | null;
+            const customPrefs = sanitizeCustomPrefs(dto?.CustomPrefs);
+            const changed = !snapshot || !sameCustomPrefs(snapshot.customPrefs, customPrefs);
+            snapshot = Object.freeze({
+                ownerKey: expectedOwnerKey,
+                customPrefs,
+            });
+            requestAttempts = 0;
+            if (changed) {
+                configuredSectionsCache = new WeakMap();
+                notifyListeners();
+            }
+        })
+        .catch((error: unknown) => {
+            if (generation !== requestGeneration || ownerKey !== expectedOwnerKey || !JC.identity.isCurrent(context)) return;
+            console.warn('🪼 Jellyfin Canopy: Home-row preferences read failed', error);
+            if (requestAttempts < MAX_PREF_ATTEMPTS && listeners.size > 0) {
+                const delay = PREF_RETRY_BASE_MS * requestAttempts;
+                retryHandle = window.setTimeout(() => {
+                    retryHandle = null;
+                    loadHomeRowScopes();
+                }, delay);
+            }
+        })
+        .finally(() => {
+            if (generation === requestGeneration) inFlight = null;
+        });
+}
+
+export function primeHomeRowScopes(): void {
+    loadHomeRowScopes();
+}
+
+function currentNavigationRoute(): string {
+    return `${window.location.pathname}${window.location.search}${window.location.hash}`;
+}
+
+function jellyfinRoute(route: string): { name: string; params: URLSearchParams } {
+    const hashRoute = route.match(/#(\/[^#]*)$/)?.[1];
+    const raw = hashRoute || route.split('#', 1)[0];
+    const parsed = new URL(raw, window.location.origin);
+    const name = parsed.pathname.split('/').filter(Boolean).pop()?.replace(/\.html$/i, '').toLowerCase() || '';
+    return { name, params: parsed.searchParams };
+}
+
+function isHomeNavigation(route = currentNavigationRoute()): boolean {
+    return jellyfinRoute(route).name === 'home';
+}
+
+function isHomePreferencesNavigation(route: string, userId: string): boolean {
+    const parsed = jellyfinRoute(route);
+    const targetUserId = parsed.params.get('userId');
+    return parsed.name === 'mypreferenceshome' && (!targetUserId || targetUserId === userId);
+}
+
+/**
+ * Keep resolver navigation/async ownership active for one feature lifecycle.
+ * The snapshot remains valid for ordinary navigation. Jellyfin's home-layout
+ * editor writes these exact preferences on `mypreferenceshome`; leaving that
+ * route invalidates the snapshot before any scoped action can use stale order.
+ */
+export function acquireHomeRowScopes(onChange: () => void): () => void {
+    // Each acquire owns a distinct token even when two feature activations use
+    // the same exported callback function.
+    const subscription = (): void => onChange();
+    listeners.add(subscription);
+    if (!navigateUnsubscribe) {
+        lastNavigationRoute = currentNavigationRoute();
+        navigateUnsubscribe = onNavigate(() => {
+            const context = currentContext();
+            const route = currentNavigationRoute();
+            const enteredHome = isHomeNavigation(route)
+                && (lastNavigationRoute === null || !isHomeNavigation(lastNavigationRoute));
+            const leftHomePreferences = context !== null
+                && lastNavigationRoute !== null
+                && isHomePreferencesNavigation(lastNavigationRoute, context.userId)
+                && !isHomePreferencesNavigation(route, context.userId);
+            lastNavigationRoute = route;
+            if (leftHomePreferences) resetSnapshot(ownerKey, true);
+            if (!isHomeNavigation(route)) return;
+            // DisplayPreferences are server/user scoped and may have changed in
+            // another client. Every real Home entry discards the old mapping;
+            // consumers fail visible until this authoritative read completes.
+            if (enteredHome && snapshot) resetSnapshot(ownerKey, true);
+            // A new navigation is a new bounded retry stimulus after a prior
+            // exhausted batch; it does not create an unbounded background loop.
+            if (requestAttempts >= MAX_PREF_ATTEMPTS) requestAttempts = 0;
+            loadHomeRowScopes();
+        });
+    }
+    let disposed = false;
+    return () => {
+        if (disposed) return;
+        disposed = true;
+        listeners.delete(subscription);
+        if (listeners.size !== 0) return;
+        navigateUnsubscribe?.();
+        navigateUnsubscribe = null;
+        lastNavigationRoute = null;
+        resetSnapshot(null, false);
+    };
+}
+
+function closestSection(element: Element): HTMLElement | null {
+    const selector = '.section, .verticalSection, .homeSection, #resumableSection, #resumableItems, #nextUpItemsSection, #nextUpItems';
+    if (element.matches(selector)) return element as HTMLElement;
+    return element.closest<HTMLElement>(selector);
+}
+
+function cardFor(element: Element): HTMLElement | null {
+    if (element.matches('.card, .listItem')) return element as HTMLElement;
+    return element.closest<HTMLElement>('.card, .listItem');
+}
+
+function hasExactNextUpRoute(section: HTMLElement, pass?: ResolverPass): boolean {
+    const passResult = pass?.routeEvidence.get(section);
+    if (passResult !== undefined) return passResult;
+    const cached = routeEvidenceCache.get(section);
+    if (cached
+        && cached.link.isConnected
+        && section.contains(cached.link)
+        && cached.link.getAttribute('href') === cached.href) {
+        pass?.routeEvidence.set(section, true);
+        return true;
+    }
+    routeEvidenceCache.delete(section);
+    // Jellyfin owns this title-link class. Restricting the scan to header links
+    // avoids walking every card anchor once per card in a large row.
+    const links = section.querySelectorAll<HTMLAnchorElement>(
+        'a.sectionTitleTextButton[href], .sectionTitleContainer > a[href], .sectionTitle a[href], h2 > a[href]',
+    );
+    for (const link of links) {
+        const href = link.getAttribute('href') || '';
+        const queryIndex = href.indexOf('?');
+        if (queryIndex < 0) continue;
+        const hashIndex = href.indexOf('#', queryIndex);
+        const params = new URLSearchParams(href.slice(queryIndex + 1, hashIndex < 0 ? undefined : hashIndex));
+        const type = (params.get('type') || '').toLowerCase();
+        const itemTypes = (params.get('itemTypes') || '').toLowerCase();
+        if (type === 'nextup' || itemTypes === 'nextup') {
+            routeEvidenceCache.set(section, Object.freeze({ link, href }));
+            pass?.routeEvidence.set(section, true);
+            return true;
+        }
+    }
+    pass?.routeEvidence.set(section, false);
+    return false;
+}
+
+function sectionIndex(section: HTMLElement): number | null {
+    for (const className of section.classList) {
+        const match = /^section(\d+)$/.exec(className);
+        if (match) return Number.parseInt(match[1], 10);
+    }
+    return null;
+}
+
+function configuredSections(
+    container: Element,
+    customPrefs: Readonly<Record<string, string>>,
+    pass?: ResolverPass,
+): readonly string[] {
+    let isTvLayout = pass?.tvLayout.get(container);
+    if (isTvLayout === undefined) {
+        isTvLayout = Boolean(container.querySelector(':scope > .section10'));
+        pass?.tvLayout.set(container, isTvLayout);
+    }
+    const cached = configuredSectionsCache.get(container);
+    if (cached?.isTvLayout === isTvLayout) return cached.sections;
+    const sections: string[] = [];
+    for (let index = 0; index < 10; index += 1) {
+        let value = customPrefs[`homesection${index}`] || DEFAULT_SECTIONS[index] || 'none';
+        if (value === 'folders') value = DEFAULT_SECTIONS[0];
+        if (!KNOWN_SECTIONS.has(value)) {
+            console.warn(`🪼 Jellyfin Canopy: Unknown Jellyfin home-section type at slot ${index}`);
+            value = `unknown:${index}`;
+        }
+        sections.push(value);
+    }
+    if (isTvLayout && !sections.includes('smalllibrarytiles') && !sections.includes('librarybuttons')) {
+        sections.unshift('smalllibrarytiles');
+    }
+    const frozenSections = Object.freeze([...sections]);
+    configuredSectionsCache.set(container, Object.freeze({ isTvLayout, sections: frozenSections }));
+    return frozenSections;
+}
+
+/** Invalidate bounded DOM-derived facts after a relevant section mutation. */
+export function invalidateHomeRowSection(section: Element): void {
+    const owner = closestSection(section);
+    const container = owner?.closest('.homeSectionsContainer')
+        || (section.matches('.homeSectionsContainer') ? section : section.closest('.homeSectionsContainer'));
+    if (container) configuredSectionsCache.delete(container);
+}
+
+function collectionKind(card: HTMLElement | null): boolean {
+    if (!card) return false;
+    const type = (card.dataset.type || '').toLowerCase();
+    if (COLLECTION_TYPES.has(type)) return true;
+    return Boolean((card.dataset.collectiontype || '').trim());
+}
+
+function resolved(
+    kind: HomeRowKind | 'unresolved',
+    isHomeRow: boolean,
+    signature: string,
+    section: HTMLElement | null,
+): HomeRowResolution {
+    return Object.freeze({ kind, isHomeRow, signature, section });
+}
+
+function resolveHomeRowScopeWithPass(
+    element: Element,
+    pass?: ResolverPass,
+): HomeRowResolution {
+    const context = currentContext();
+    const card = cardFor(element);
+    const section = closestSection(element);
+
+    if (card?.closest('#resumableSection, #resumableItems')) {
+        return resolved('continuewatching', false, 'legacy:continuewatching', section);
+    }
+    if (card?.closest('#nextUpItemsSection, #nextUpItems')) {
+        return resolved('nextup', false, 'legacy:nextup', section);
+    }
+    if (section?.matches('#resumableSection, #resumableItems')) {
+        return resolved('continuewatching', false, 'legacy:continuewatching', section);
+    }
+    if (section?.matches('#nextUpItemsSection, #nextUpItems')) {
+        return resolved('nextup', false, 'legacy:nextup', section);
+    }
+    const container = section?.closest('.homeSectionsContainer');
+    const index = section ? sectionIndex(section) : null;
+    if (section && container && index !== null) {
+        if (!context || !snapshot || snapshot.ownerKey !== contextKey(context)) {
+            if (hasExactNextUpRoute(section, pass)) {
+                return resolved('nextup', true, `home:${index}:route-nextup`, section);
+            }
+            primeHomeRowScopes();
+            return resolved('unresolved', true, `home:${index}:pending`, section);
+        }
+        const sections = configuredSections(container, snapshot.customPrefs, pass);
+        const sectionType = sections[index];
+        if (!sectionType) return resolved('unresolved', true, `home:${index}:invalid`, section);
+        if (sectionType.startsWith('unknown:')) {
+            return resolved('unresolved', true, `home:${index}:${sectionType}`, section);
+        }
+        if (sectionType === 'resume') return resolved('continuewatching', true, `home:${index}:resume`, section);
+        if (sectionType === 'nextup') return resolved('nextup', true, `home:${index}:nextup`, section);
+        if (sectionType === 'smalllibrarytiles' || sectionType === 'librarybuttons') {
+            return resolved('collection', true, `home:${index}:${sectionType}`, section);
+        }
+        return resolved(collectionKind(card) ? 'collection' : 'ordinary', true, `home:${index}:${sectionType}`, section);
+    }
+
+    if (section && hasExactNextUpRoute(section, pass)) {
+        return resolved('nextup', false, 'route:nextup', section);
+    }
+
+    if (section?.closest('.homeSectionsContainer')) {
+        primeHomeRowScopes();
+        return resolved('unresolved', true, 'home:unknown', section);
+    }
+    if (collectionKind(card)) return resolved('collection', false, 'card:collection', section);
+    return resolved('ordinary', false, 'ordinary', section);
+}
+
+/** Resolve one card or section without inspecting rendered language. */
+export function resolveHomeRowScope(element: Element): HomeRowResolution {
+    return resolveHomeRowScopeWithPass(element);
+}
+
+/** Share negative route evidence only inside one synchronous DOM pass. */
+export function createHomeRowScopeResolver(): (element: Element) => HomeRowResolution {
+    const pass: ResolverPass = {
+        routeEvidence: new WeakMap<HTMLElement, boolean>(),
+        tvLayout: new WeakMap<Element, boolean>(),
+    };
+    return (element: Element): HomeRowResolution => resolveHomeRowScopeWithPass(element, pass);
+}
+
+/** Test/lifecycle helper: drop all async state without registering anything. */
+export function resetHomeRowScopes(): void {
+    listeners.clear();
+    navigateUnsubscribe?.();
+    navigateUnsubscribe = null;
+    resetSnapshot(null, false);
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/hidden-content-tab.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/hidden-content-tab.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+import type { PanelContext } from './panel';
+import { wireHiddenContentListeners } from './hidden-content-tab';
+
+describe('hidden-content settings controls', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+        vi.restoreAllMocks();
+    });
+
+    it('adds cast buttons when the master button toggle is enabled in cast-only mode', () => {
+        document.body.innerHTML = '<input id="hiddenShowHideButtons" type="checkbox">';
+        const updateSettings = vi.fn();
+        const addLibraryHideButtons = vi.fn();
+        JC.hiddenContent = {
+            updateSettings,
+            getSettings: vi.fn(() => ({ showButtonLibrary: false, showButtonCast: true })),
+            addLibraryHideButtons,
+            removeLibraryHideButtons: vi.fn(),
+        } as unknown as NonNullable<typeof JC.hiddenContent>;
+        const resetAutoCloseTimer = vi.fn();
+        wireHiddenContentListeners({ resetAutoCloseTimer } as unknown as PanelContext);
+
+        const toggle = document.getElementById('hiddenShowHideButtons') as HTMLInputElement;
+        toggle.checked = true;
+        toggle.dispatchEvent(new Event('change'));
+
+        expect(updateSettings).toHaveBeenCalledWith({ showHideButtons: true });
+        expect(addLibraryHideButtons).toHaveBeenCalledTimes(1);
+        expect(resetAutoCloseTimer).toHaveBeenCalledTimes(1);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/hidden-content-tab.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/hidden-content-tab.ts
@@ -71,7 +71,8 @@ export function wireHiddenContentListeners(ctx: PanelContext): void {
             buttonsToggle.addEventListener('change', (e) => {
                 (JC as any).hiddenContent.updateSettings({ showHideButtons: (e.target as HTMLInputElement).checked });
                 if ((e.target as HTMLInputElement).checked) {
-                    if ((JC as any).hiddenContent.getSettings().showButtonLibrary) {
+                    const settings = (JC as any).hiddenContent.getSettings();
+                    if (settings.showButtonLibrary || settings.showButtonCast) {
                         (JC as any).hiddenContent.addLibraryHideButtons();
                     }
                 } else {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/types/global.d.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/types/global.d.ts
@@ -18,6 +18,12 @@ declare global {
         accessToken(): string;
         getCurrentUser(): Promise<unknown>;
         getItem(userId: string, itemId: string): Promise<unknown>;
+        /** Jellyfin 12 home-row ordering (`usersettings`, client `emby`). */
+        getDisplayPreferences?(
+            id: string,
+            userId: string,
+            app: string
+        ): Promise<{ CustomPrefs?: Record<string, unknown> | null }>;
         ajax(options: { type: string; url: string; dataType?: string; data?: unknown; contentType?: string; signal?: AbortSignal }): Promise<unknown>;
         /**
          * v12 SDK socket subscription: register a callback for one or more

--- a/scripts/bundle-budgets.json
+++ b/scripts/bundle-budgets.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "limits": {
-    "maxOutputCount": 162,
+    "maxOutputCount": 163,
     "maxEsmEntryCount": 36,
     "maxEsmOutputCount": 78,
     "maxIndividualEsmRawBytes": 262144,

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -18,7 +18,7 @@ const ROOT = path.join(__dirname, '..');
 const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the repeated clean measurements', () => {
-    assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1915, totalLines: 2253 });
+    assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1932, totalLines: 2253 });
     assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 18748, totalLines: 27276 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -9,12 +9,12 @@
       "scope": "Jellyfin.Plugin.JellyfinCanopy/src/core/**",
       "report": "coverage/coverage-summary.json",
       "measured": {
-        "coveredLines": 1915,
+        "coveredLines": 1932,
         "totalLines": 2253
       },
       "tolerance": {
         "missingCoveredLines": 1,
-        "rationale": "Clean local Node 22/V8 validation on 2026-07-17 passed 1228 tests and measured the complete 2253-line core scope at 1915 covered lines (84.998%). Issue #123's live hidden-content invalidation subscription covers one previously uncovered core live-event line over the reviewed 1914/2253 baseline, increasing rather than diluting line coverage. The existing one-line tolerance is unchanged and permits only the previously reproduced negligible instrumentation variance; coverage-baseline.test.js retains exact below-floor, above-baseline, scope-change, and broad-tolerance negative boundaries."
+        "rationale": "Two clean local Node 22/V8 coverage runs on 2026-07-17 passed 1244 tests, and the final clean run passed 1249 tests; all three measured the identical complete 2253-line core scope at 1932 covered lines (85.752%). Issue #122's localized/late home-row regressions exercise existing navigation and action-sheet paths, advancing 17 covered lines over the reviewed 1915/2253 baseline without changing scope. The existing one-line tolerance is unchanged and permits only the previously reproduced negligible instrumentation variance; coverage-baseline.test.js retains exact below-floor, above-baseline, scope-change, and broad-tolerance negative boundaries."
       }
     },
     "server": {


### PR DESCRIPTION
Fixes #122.

## What changed

- Added one typed, locale-independent Jellyfin 12 home-row resolver using legacy component IDs, exact route parameters, card data, and identity-scoped `usersettings` DisplayPreferences.
- Made unresolved rows explicit and fail-visible; unresolved state is retryable and cannot fall through to a durable global hide.
- Fenced preference reads by identity/generation, bounded retry attempts, and revalidated each real Home entry so another client's reordered layout cannot drive stale destructive scope.
- Reconciled reused/moved rows, late or in-place title links, TV layout changes, scoped filtering, hide buttons, and empty-row restoration.
- Added standalone restoration ownership for Remove from Home and fixed cast-only master-button activation.
- Added focused regressions and ratcheted the exact bundle inventory and client/core coverage evidence without widening tolerances.

## Root cause and impact

The prior implementation inferred ownership from rendered English headings and cached a timing-dependent unresolved result. Localized or late-rendered rows could therefore be misclassified for the node lifetime, and a hide action could use the wrong scope. Row identity now comes only from stable Jellyfin contracts, while missing authoritative data remains visibly unresolved until a fenced retry succeeds.

## Validation

- Focused home-row regressions: 31 passed
- Full client suite with V8 coverage: 204 files, 1,249 tests passed
- Client/core coverage: exact reviewed `1932/2253` lines; one-line instrumentation tolerance unchanged
- Script policy suite: 373 passed
- TypeScript source/full type checks: passed
- Deterministic bundle + syntax inventory: 163 files; build `9933adca12905cb2d965cd27842b45ed566391b33f16883b00c63efdda9d9069`
- Performance rules: 1,032 ms thread CPU, below the 5,000 ms limit
- Repository lint: zero errors (existing warnings only)
- Release build: zero warnings and zero errors
- Independent final review: approved exact head `38e8014d`

Local server coverage could not start because the host has `Microsoft.NETCore.App 10.0.8` while the restored testhost requires `10.0.9`; the Release build is green and CI will run the server coverage gate on its pinned runtime.
