### PR TITLE
fix(client): bound TTL caches and guard regressions

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/helpers.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/helpers.test.ts
@@ -2,9 +2,12 @@
 // getHeaderRightContainer (PERF(R4) fix: offsetParent is a forced layout read and
 // used to be re-read on every observer tick; it must now be read at most once
 // per navigation).
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { JC } from '../globals';
-import { clearItemCache, getHeaderRightContainer, getItemCached } from './helpers';
+import {
+    clearItemCache, getHeaderRightContainer, getItemCached,
+    ITEM_CACHE_MAX_ENTRIES, ITEM_CACHE_MAX_IN_FLIGHT,
+} from './helpers';
 import { insertHeaderTrayButton, HeaderTrayOrder } from './header-tray';
 
 /** Builds a `.headerRight` whose offsetParent getter counts layout reads. */
@@ -126,6 +129,74 @@ describe('privacy reset item-cache invalidation (BI-SEC-035)', () => {
             .resolves.toEqual({ server: 'b' });
         expect(getItem).toHaveBeenCalledTimes(2);
         getItem.mockRestore();
+    });
+});
+
+describe('shared item DTO cache bounds', () => {
+    beforeEach(() => {
+        clearItemCache();
+        vi.useFakeTimers();
+        vi.setSystemTime(0);
+    });
+
+    afterEach(() => {
+        clearItemCache();
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    it('drops an expired DTO before publishing its replacement', async () => {
+        const getItem = vi.spyOn(ApiClient, 'getItem')
+            .mockResolvedValueOnce({ version: 1 })
+            .mockResolvedValueOnce({ version: 2 });
+
+        await expect(getItemCached('ttl-item', { userId: 'ttl-user' }))
+            .resolves.toEqual({ version: 1 });
+        await expect(getItemCached('ttl-item', { userId: 'ttl-user' }))
+            .resolves.toEqual({ version: 1 });
+        expect(getItem).toHaveBeenCalledTimes(1);
+
+        vi.advanceTimersByTime(30_001);
+        await expect(getItemCached('ttl-item', { userId: 'ttl-user' }))
+            .resolves.toEqual({ version: 2 });
+        expect(getItem).toHaveBeenCalledTimes(2);
+    });
+
+    it('evicts the least-recently-used DTO at one over the hard cap', async () => {
+        const getItem = vi.spyOn(ApiClient, 'getItem')
+            .mockImplementation((_userId, itemId) => Promise.resolve({ itemId }));
+
+        for (let index = 0; index <= ITEM_CACHE_MAX_ENTRIES; index += 1) {
+            await getItemCached(`bounded-${index}`, { userId: 'bounded-user' });
+        }
+        expect(getItem).toHaveBeenCalledTimes(ITEM_CACHE_MAX_ENTRIES + 1);
+
+        await getItemCached(`bounded-${ITEM_CACHE_MAX_ENTRIES}`, { userId: 'bounded-user' });
+        expect(getItem).toHaveBeenCalledTimes(ITEM_CACHE_MAX_ENTRIES + 1);
+        await getItemCached('bounded-0', { userId: 'bounded-user' });
+        expect(getItem).toHaveBeenCalledTimes(ITEM_CACHE_MAX_ENTRIES + 2);
+    });
+
+    it('keeps in-flight deduplication independent from resolved-cache eviction', async () => {
+        const resolvers: Array<(value: unknown) => void> = [];
+        const getItem = vi.spyOn(ApiClient, 'getItem').mockImplementation(
+            (_userId, itemId) => new Promise((resolve) => {
+                resolvers.push(() => resolve({ itemId }));
+            }),
+        );
+        const pending = Array.from(
+            { length: ITEM_CACHE_MAX_IN_FLIGHT },
+            (_, index) => getItemCached(`pending-${index}`, { userId: 'pending-user' }),
+        );
+        const duplicateOldest = getItemCached('pending-0', { userId: 'pending-user' });
+
+        expect(getItem).toHaveBeenCalledTimes(ITEM_CACHE_MAX_IN_FLIGHT);
+        await expect(getItemCached('pending-overflow', { userId: 'pending-user' }))
+            .rejects.toThrow(/capacity exceeded/i);
+        expect(getItem).toHaveBeenCalledTimes(ITEM_CACHE_MAX_IN_FLIGHT);
+        resolvers.forEach((resolve) => resolve({}));
+        await Promise.all([...pending, duplicateOldest]);
+        expect(getItem).toHaveBeenCalledTimes(ITEM_CACHE_MAX_IN_FLIGHT);
     });
 });
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/helpers.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/helpers.ts
@@ -34,8 +34,22 @@ interface ItemCacheEntry {
 }
 
 // Shared cache for item payloads to deduplicate cross-module ApiClient.getItem calls
+export const ITEM_CACHE_MAX_ENTRIES = 500;
+export const ITEM_CACHE_MAX_IN_FLIGHT = 500;
 const itemCache = new Map<string, ItemCacheEntry>();
+const inFlightItems = new Map<string, ItemCacheEntry>();
 const ITEM_CACHE_TTL_MS = 30000; // 30s -- long enough for batch prefetch to warm cache before tag systems scan
+
+/** Boot-local resolved-value LRU; avoids adding a split request to cold boot. */
+function setItemCache(key: string, entry: ItemCacheEntry): void {
+    itemCache.delete(key);
+    itemCache.set(key, entry);
+    while (itemCache.size > ITEM_CACHE_MAX_ENTRIES) {
+        const oldest = itemCache.keys().next().value;
+        if (oldest === undefined) break;
+        itemCache.delete(oldest);
+    }
+}
 
 /**
  * Drop short-lived native item DTOs for one account (or every account).
@@ -45,6 +59,7 @@ const ITEM_CACHE_TTL_MS = 30000; // 30s -- long enough for batch prefetch to war
 export function clearItemCache(userId?: string, itemIds?: string[]): void {
     if (!userId) {
         itemCache.clear();
+        inFlightItems.clear();
         return;
     }
     const normalizedUserId = userId.replace(/-/g, '').toLowerCase();
@@ -54,6 +69,10 @@ export function clearItemCache(userId?: string, itemIds?: string[]): void {
     for (const [key, entry] of itemCache) {
         if (entry.userId !== normalizedUserId) continue;
         if (!selected || selected.has(entry.itemId)) itemCache.delete(key);
+    }
+    for (const [key, entry] of inFlightItems) {
+        if (entry.userId !== normalizedUserId) continue;
+        if (!selected || selected.has(entry.itemId)) inFlightItems.delete(key);
     }
 }
 
@@ -81,21 +100,34 @@ export async function getItemCached(itemId: string, options: GetItemCachedOption
     const entry = itemCache.get(key);
 
     if (!options.forceRefresh && entry && JC.identity.isCurrent(entry.owner)) {
-        if (entry.promise) {
-            return entry.promise;
-        }
         if (entry.item && (now - entry.ts) < ttlMs) {
+            // Refresh recency only for a live hit.
+            itemCache.delete(key);
+            itemCache.set(key, entry);
             return entry.item;
         }
     }
+    // TTL limits freshness, while the hard LRU cap limits cardinality. Drop a
+    // stale value immediately so a failed replacement request cannot leave the
+    // full DTO retained until the next identity reset.
+    if (entry) itemCache.delete(key);
 
+    const active = inFlightItems.get(key);
+    if (!options.forceRefresh && active && JC.identity.isCurrent(active.owner) && active.promise) {
+        return active.promise;
+    }
+    if (inFlightItems.size >= ITEM_CACHE_MAX_IN_FLIGHT) {
+        throw new Error(`Shared item lookup capacity exceeded (${ITEM_CACHE_MAX_IN_FLIGHT} active requests)`);
+    }
+
+    let token: ItemCacheEntry;
     const promise = ApiClient.getItem(userId, itemId)
         .then((item) => {
             if (!JC.identity.isCurrent(context)) return null;
             // A privacy reset or newer forced fetch may retire this request while
             // it is in flight. Only the promise that still owns the key may publish.
-            if (itemCache.get(key)?.promise === promise) {
-                itemCache.set(key, {
+            if (inFlightItems.get(key) === token) {
+                setItemCache(key, {
                     item,
                     ts: Date.now(),
                     promise: null,
@@ -103,28 +135,33 @@ export async function getItemCached(itemId: string, options: GetItemCachedOption
                     userId: normalizedUserId,
                     itemId: normalizedItemId
                 });
+                inFlightItems.delete(key);
             }
             return item;
         })
         .catch((err: unknown) => {
             // Likewise, an older rejection must not delete a newer request/value.
-            if (itemCache.get(key)?.promise === promise) itemCache.delete(key);
+            if (inFlightItems.get(key) === token) inFlightItems.delete(key);
             if (!JC.identity.isCurrent(context)) return null;
             throw err;
         });
 
-    itemCache.set(key, {
+    token = {
         item: null,
         ts: now,
         promise,
         owner: context,
         userId: normalizedUserId,
         itemId: normalizedItemId
-    });
+    };
+    inFlightItems.set(key, token);
     return promise;
 }
 
-JC.identity.registerReset('enhanced-item-cache', () => itemCache.clear());
+JC.identity.registerReset('enhanced-item-cache', () => {
+    itemCache.clear();
+    inFlightItems.clear();
+});
 
 /**
  * Debounce a function call

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/state.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/state.test.ts
@@ -2,8 +2,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { JC } from '../../globals';
 import {
-    applyPromoteResponse, applyRemoveResponse, enableForSeries, isEnabledFor,
-    loadState, resetState, type SpoilerCaches,
+    applyPromoteResponse, applyRemoveResponse, disableForCollection, enableForCollection,
+    enableForSeries, fetchMovieScope, isEnabledFor, loadState, resetState,
+    SCOPE_CACHE_MAX_ENTRIES, SCOPE_CACHE_TTL_MS, type SpoilerCaches,
 } from './state';
 
 function emptyCaches(): SpoilerCaches {
@@ -130,5 +131,143 @@ describe('spoiler-guard identity fencing', () => {
         await expect(pending).rejects.toThrow(/stale identity/i);
         expect(isEnabledFor('aaaa')).toBe(false);
         JC.identity.transition(original.serverId, original.userId, 'spoiler-mutation-test-restore');
+    });
+});
+
+describe('spoiler-guard movie scope cache bounds', () => {
+    const originalApi = JC.core.api;
+    let originalIdentity = JC.identity.capture();
+    let unregisterReset: (() => void) | undefined;
+
+    beforeEach(() => {
+        originalIdentity = JC.identity.capture();
+        unregisterReset = JC.identity.registerReset('spoiler-scope-cache-test', resetState);
+        vi.useFakeTimers();
+        vi.setSystemTime(0);
+        resetState();
+    });
+
+    afterEach(() => {
+        JC.core.api = originalApi;
+        resetState();
+        unregisterReset?.();
+        unregisterReset = undefined;
+        if (originalIdentity) {
+            JC.identity.transition(
+                originalIdentity.serverId,
+                originalIdentity.userId,
+                'spoiler-scope-cache-test-restore',
+            );
+        }
+        vi.useRealTimers();
+    });
+
+    it('expires a cached scope answer and removes it on the next lookup', async () => {
+        const plugin = vi.fn().mockResolvedValue({ inScope: true, played: false });
+        JC.core.api = { plugin } as unknown as NonNullable<typeof JC.core.api>;
+
+        await expect(fetchMovieScope('AB-CD')).resolves.toEqual({ inScope: true, played: false });
+        await expect(fetchMovieScope('AB-CD')).resolves.toEqual({ inScope: true, played: false });
+        expect(plugin).toHaveBeenCalledTimes(1);
+
+        vi.advanceTimersByTime(SCOPE_CACHE_TTL_MS);
+        await expect(fetchMovieScope('AB-CD')).resolves.toEqual({ inScope: true, played: false });
+        expect(plugin).toHaveBeenCalledTimes(2);
+    });
+
+    it('keeps high-cardinality scope traffic within the hard LRU cap', async () => {
+        const plugin = vi.fn().mockResolvedValue({ inScope: false, played: false });
+        JC.core.api = { plugin } as unknown as NonNullable<typeof JC.core.api>;
+
+        for (let index = 0; index <= SCOPE_CACHE_MAX_ENTRIES; index += 1) {
+            await fetchMovieScope(`movie-${index}`);
+        }
+        expect(plugin).toHaveBeenCalledTimes(SCOPE_CACHE_MAX_ENTRIES + 1);
+
+        // The newest answer remains cached, while the oldest was evicted at one over the cap.
+        await fetchMovieScope(`movie-${SCOPE_CACHE_MAX_ENTRIES}`);
+        expect(plugin).toHaveBeenCalledTimes(SCOPE_CACHE_MAX_ENTRIES + 1);
+        await fetchMovieScope('movie-0');
+        expect(plugin).toHaveBeenCalledTimes(SCOPE_CACHE_MAX_ENTRIES + 2);
+    });
+
+    it('clears cached scope answers on the state lifecycle reset', async () => {
+        const plugin = vi.fn().mockResolvedValue({ inScope: true, played: true });
+        JC.core.api = { plugin } as unknown as NonNullable<typeof JC.core.api>;
+
+        await fetchMovieScope('scope-reset');
+        await fetchMovieScope('scope-reset');
+        expect(plugin).toHaveBeenCalledTimes(1);
+
+        resetState();
+        await fetchMovieScope('scope-reset');
+        expect(plugin).toHaveBeenCalledTimes(2);
+    });
+
+    it.each([
+        ['server', 'scope-server-b', 'scope-user'],
+        ['user', 'scope-server', 'scope-user-b'],
+    ])('does not reuse a scope answer after a %s identity transition', async (_kind, serverId, userId) => {
+        JC.identity.transition('scope-server', 'scope-user', 'spoiler-scope-cache-a');
+        const plugin = vi.fn()
+            .mockResolvedValueOnce({ inScope: true, played: false })
+            .mockResolvedValueOnce({ inScope: false, played: true });
+        JC.core.api = { plugin } as unknown as NonNullable<typeof JC.core.api>;
+
+        await expect(fetchMovieScope('same-movie')).resolves.toEqual({ inScope: true, played: false });
+        JC.identity.transition(serverId, userId, 'spoiler-scope-cache-b');
+        await expect(fetchMovieScope('same-movie')).resolves.toEqual({ inScope: false, played: true });
+        expect(plugin).toHaveBeenCalledTimes(2);
+    });
+
+    it('invalidates movie scope answers after collection enable and disable', async () => {
+        const plugin = vi.fn((path: string) => Promise.resolve(
+            path.includes('/scope/movie/') ? { inScope: true, played: false } : {},
+        ));
+        JC.core.api = { plugin } as unknown as NonNullable<typeof JC.core.api>;
+
+        await fetchMovieScope('collection-movie');
+        await fetchMovieScope('collection-movie');
+        await enableForCollection('collection-a');
+        await fetchMovieScope('collection-movie');
+        await disableForCollection('collection-a');
+        await fetchMovieScope('collection-movie');
+
+        expect(plugin.mock.calls.filter(([path]) => String(path).includes('/scope/movie/'))).toHaveLength(3);
+    });
+
+    it('prevents a pre-mutation scope request from repopulating after collection invalidation', async () => {
+        let resolveOldScope!: (value: unknown) => void;
+        const oldScope = new Promise<unknown>((resolve) => { resolveOldScope = resolve; });
+        const plugin = vi.fn((path: string) => {
+            if (path.includes('/collections/')) return Promise.resolve({});
+            if (plugin.mock.calls.filter(([called]) => String(called).includes('/scope/movie/')).length === 1) {
+                return oldScope;
+            }
+            return Promise.resolve({ inScope: true, played: false });
+        });
+        JC.core.api = { plugin } as unknown as NonNullable<typeof JC.core.api>;
+
+        const pendingScope = fetchMovieScope('collection-race-movie');
+        await enableForCollection('collection-race');
+        resolveOldScope({ inScope: false, played: false });
+        await expect(pendingScope).resolves.toBeNull();
+
+        await expect(fetchMovieScope('collection-race-movie'))
+            .resolves.toEqual({ inScope: true, played: false });
+        expect(plugin.mock.calls.filter(([path]) => String(path).includes('/scope/movie/'))).toHaveLength(2);
+    });
+
+    it('does not cache a transient scope failure', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        const plugin = vi.fn()
+            .mockRejectedValueOnce(new Error('temporary'))
+            .mockResolvedValueOnce({ inScope: true, played: false });
+        JC.core.api = { plugin } as unknown as NonNullable<typeof JC.core.api>;
+
+        await expect(fetchMovieScope('retry-movie')).resolves.toBeNull();
+        await expect(fetchMovieScope('retry-movie')).resolves.toEqual({ inScope: true, played: false });
+        expect(plugin).toHaveBeenCalledTimes(2);
+        warn.mockRestore();
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/state.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/state.ts
@@ -8,6 +8,7 @@
 // used (the v12 server keeps identical /spoiler-blur/* paths).
 
 import { JC } from '../../globals';
+import { createBoundedCache } from '../../core/bounded-cache';
 import { normalizeId, pendingKey } from './ids';
 import type { IdentityContext } from '../../types/jc';
 
@@ -72,8 +73,24 @@ const caches: SpoilerCaches = {
  * every re-render / navigation within the TTL window.
  */
 interface MovieScopeResult { inScope: boolean; played: boolean; }
-const SCOPE_TTL_MS = 30_000;
-const scopeCache = new Map<string, { value: MovieScopeResult; ts: number }>();
+export const SCOPE_CACHE_TTL_MS = 30_000;
+// More than eight distinct movie details per second for the full TTL would be
+// required to reach this cap during ordinary browsing.
+export const SCOPE_CACHE_MAX_ENTRIES = 256;
+const scopeCache = createBoundedCache<string, MovieScopeResult>({
+    maxEntries: SCOPE_CACHE_MAX_ENTRIES,
+    ttlMs: SCOPE_CACHE_TTL_MS,
+});
+let scopeCacheGeneration = 0;
+
+function scopeCacheKey(context: IdentityContext, movieId: string): string {
+    return JSON.stringify([context.serverId, context.userId, context.epoch, movieId]);
+}
+
+function clearScopeCache(): void {
+    scopeCacheGeneration += 1;
+    scopeCache.clear();
+}
 
 let userPrefs: SpoilerUserPrefs = {};
 
@@ -119,7 +136,7 @@ export function resetState(): void {
     caches.collections.clear();
     caches.pendingTmdb.clear();
     caches.tmdbToJellyfin.clear();
-    scopeCache.clear();
+    clearScopeCache();
     userPrefs = {};
     loaded = false;
     loadOk = false;
@@ -229,13 +246,18 @@ export function hasEnabledCollections(): boolean {
 export function fetchMovieScope(movieId: string): Promise<MovieScopeResult | null> {
     const n = normalizeId(movieId);
     if (!n) return Promise.resolve(null);
-    const hit = scopeCache.get(n);
-    if (hit && Date.now() - hit.ts < SCOPE_TTL_MS) return Promise.resolve(hit.value);
+    const context = JC.identity.capture();
+    if (!context || !JC.identity.isCurrent(context)) return Promise.resolve(null);
+    const key = scopeCacheKey(context, n);
+    const cacheGeneration = scopeCacheGeneration;
+    const hit = scopeCache.get(key);
+    if (hit) return Promise.resolve(hit);
     return runOwned(() => JC.core.api!.plugin(`/spoiler-blur/scope/movie/${encodeURIComponent(n)}`))
         .then((resp: unknown) => {
             const r = (resp ?? {}) as Partial<MovieScopeResult>;
             const value: MovieScopeResult = { inScope: r.inScope === true, played: r.played === true };
-            scopeCache.set(n, { value, ts: Date.now() });
+            if (scopeCacheGeneration !== cacheGeneration) return null;
+            scopeCache.set(key, value);
             return value;
         })
         .catch((err: unknown) => {
@@ -273,9 +295,9 @@ export function enableForCollection(collectionId: string, collectionName?: strin
         method: 'POST', body: JC.identity.own({ CollectionName: collectionName || '' }, context),
     })).then(() => {
         caches.collections.add(n);
-        // Collection membership changes movie scope — cached scope answers
-        // (keyed by movie id only) are now stale, so drop them all.
-        scopeCache.clear();
+        // Collection membership changes movie scope — every identity-owned
+        // cached movie answer is now stale, so drop them all.
+        clearScopeCache();
     });
 }
 export function disableForCollection(collectionId: string): Promise<void> {
@@ -283,7 +305,7 @@ export function disableForCollection(collectionId: string): Promise<void> {
     return runOwned(() => JC.core.api!.plugin(`/spoiler-blur/collections/${encodeURIComponent(n)}`, { method: 'DELETE' }))
         .then(() => {
             caches.collections.delete(n);
-            scopeCache.clear();
+            clearScopeCache();
         });
 }
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/test/leak-guard.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/test/leak-guard.test.ts
@@ -41,9 +41,21 @@ interface AllowlistEntry {
     rule: RuleId;
     /** One-line justification. */
     why: string;
+    /** Raw Map binding for rules that can report multiple owners per file. */
+    owner?: string;
 }
 
-const ALLOWLIST: AllowlistEntry[] = [];
+const ALLOWLIST: AllowlistEntry[] = [{
+    file: 'core/api-client.ts',
+    rule: 'ttl-map',
+    owner: 'responseCache',
+    why: 'Weighted response LRU is independently capped at 200 entries and 16 MiB with dedicated budget tests.',
+}, {
+    file: 'enhanced/helpers.ts',
+    rule: 'ttl-map',
+    owner: 'itemCache',
+    why: 'Boot-local resolved DTO LRU is capped at 500; sharing the split primitive exceeds cold-output budgets.',
+}];
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Scanner
@@ -56,6 +68,7 @@ interface Violation {
     line: number;
     rule: RuleId;
     detail: string;
+    owner?: string;
 }
 
 interface ScanStats {
@@ -65,10 +78,6 @@ interface ScanStats {
 }
 
 const UPPER_SNAKE_RE = /^[A-Z][A-Z0-9_]*$/;
-
-// A read-time TTL comparison: `now - x.ts < FOO_TTL` / `Date.now() - x.timestamp < CACHE_TTL`
-// (an optional `)` from `(now - x.ts)` is tolerated; the RHS identifier must end in TTL).
-const TTL_READ_RE = /\b(?:now|Date\.now\(\))\s*-\s*\w+\.(?:ts|timestamp)\s*\)?\s*<\s*\w*(?:CACHE_)?TTL\b/;
 
 const REL_OPS = new Set<ts.SyntaxKind>([
     ts.SyntaxKind.LessThanToken,
@@ -348,33 +357,140 @@ function scanTextRules(sf: ts.SourceFile, rel: string, text: string): Violation[
         });
     }
 
-    // Rule 3: hand-rolled TTL cache — module-scope `new Map` + a read-time TTL check,
-    // not routed through core/bounded-cache.
-    if (TTL_READ_RE.test(text) && hasModuleScopeNewMap(sf) && !text.includes('createBoundedCache')) {
-        const m = TTL_READ_RE.exec(text);
+    // Rule 3: hand-rolled TTL cache — module-scope `new Map` + an AST-recognized
+    // read-time TTL comparison, not routed through core/bounded-cache. Identifier
+    // spelling is deliberately not the contract: FOO_TTL, SCOPE_TTL_MS and
+    // CACHE_TTL_SECONDS all describe the same cache semantics.
+    for (const ttlRead of findTtlReadComparisons(sf)) {
         violations.push({
             file: rel,
-            line: m ? text.slice(0, m.index).split('\n').length : 1,
+            line: lineOf(sf, ttlRead.node),
             rule: 'ttl-map',
-            detail: 'module-scope `new Map` cache with a read-time TTL check must route through core/bounded-cache',
+            owner: ttlRead.owner,
+            detail: `module-scope raw Map '${ttlRead.owner}' with a read-time TTL check must route through core/bounded-cache`,
         });
     }
 
     return violations;
 }
 
-/** A top-level `const/let X = new Map(...)` declaration. */
-function hasModuleScopeNewMap(sf: ts.SourceFile): boolean {
+/** True for a Date.now() call (the canonical wall-clock source). */
+function isDateNowCall(node: ts.Node): boolean {
+    return ts.isCallExpression(node)
+        && ts.isPropertyAccessExpression(node.expression)
+        && ts.isIdentifier(node.expression.expression)
+        && node.expression.expression.text === 'Date'
+        && node.expression.name.text === 'now';
+}
+
+/** A TTL identifier in snake/camel variants, including unit suffixes. */
+function isTtlIdentifier(node: ts.Node): boolean {
+    if (!ts.isIdentifier(node)) return false;
+    return /(?:^|_)ttl(?:_|$)|ttl(?:ms|msec|seconds?|secs?|minutes?|mins?)?$/i.test(node.text);
+}
+
+/** Module-scope raw Map binding names. */
+function moduleScopeMapNames(sf: ts.SourceFile): Set<string> {
+    const names = new Set<string>();
     for (const stmt of sf.statements) {
         if (!ts.isVariableStatement(stmt)) continue;
         for (const decl of stmt.declarationList.declarations) {
             const init = decl.initializer;
-            if (init && ts.isNewExpression(init) && ts.isIdentifier(init.expression) && init.expression.text === 'Map') {
-                return true;
+            if (ts.isIdentifier(decl.name) && init && ts.isNewExpression(init)
+                && ts.isIdentifier(init.expression) && init.expression.text === 'Map') {
+                names.add(decl.name.text);
             }
         }
     }
+    return names;
+}
+
+function isAncestor(ancestor: ts.Node, node: ts.Node): boolean {
+    for (let current: ts.Node | undefined = node; current; current = current.parent) {
+        if (current === ancestor) return true;
+    }
     return false;
+}
+
+function lexicalContainer(node: ts.Node): ts.Node {
+    for (let current: ts.Node | undefined = node.parent; current; current = current.parent) {
+        if (ts.isBlock(current) || ts.isSourceFile(current)) return current;
+    }
+    return node.getSourceFile();
+}
+
+/** Resolve one `.ts` receiver to the nearest lexical `const hit = rawMap.get(...)`. */
+function rawMapReadOwner(
+    sf: ts.SourceFile,
+    receiver: ts.Identifier,
+    mapNames: Set<string>,
+): string | null {
+    const useFunction = immediateEnclosingFunction(receiver);
+    let best: { position: number; owner: string | null } | null = null;
+    const walk = (node: ts.Node): void => {
+        if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)
+            && node.name.text === receiver.text
+            && node.getStart(sf) <= receiver.getStart(sf)
+            && immediateEnclosingFunction(node) === useFunction
+            && isAncestor(lexicalContainer(node), receiver)) {
+            const init = node.initializer;
+            const owner = init && ts.isCallExpression(init)
+                && ts.isPropertyAccessExpression(init.expression)
+                && init.expression.name.text === 'get'
+                && ts.isIdentifier(init.expression.expression)
+                && mapNames.has(init.expression.expression.text)
+                ? init.expression.expression.text
+                : null;
+            const candidate = {
+                position: node.getStart(sf),
+                owner,
+            };
+            if (!best || candidate.position > best.position) best = candidate;
+        }
+        ts.forEachChild(node, walk);
+    };
+    walk(sf);
+    return best ? (best as { position: number; owner: string | null }).owner : null;
+}
+
+/**
+ * Locate a relational cache-age comparison by meaning rather than source text:
+ * it must combine a wall-clock read (`now` or `Date.now()`), a `.ts`/`.timestamp`
+ * slot, and a TTL-named bound. Parentheses, direction and unit suffixes do not
+ * affect recognition.
+ */
+function findTtlReadComparisons(sf: ts.SourceFile): Array<{ node: ts.BinaryExpression; owner: string }> {
+    const mapNames = moduleScopeMapNames(sf);
+    if (mapNames.size === 0) return [];
+    const matches = new Map<string, ts.BinaryExpression>();
+    const walk = (node: ts.Node): void => {
+        if (ts.isBinaryExpression(node) && REL_OPS.has(node.operatorToken.kind)) {
+            let hasClock = false;
+            let hasTtl = false;
+            const owners = new Set<string>();
+            const inspect = (part: ts.Node): void => {
+                if (isDateNowCall(part)
+                    || (ts.isIdentifier(part) && part.text.toLowerCase() === 'now')) hasClock = true;
+                if (ts.isPropertyAccessExpression(part)
+                    && /^(?:ts|timestamp)$/i.test(part.name.text)
+                    && ts.isIdentifier(part.expression)) {
+                    const owner = rawMapReadOwner(sf, part.expression, mapNames);
+                    if (owner) owners.add(owner);
+                }
+                if (isTtlIdentifier(part)) hasTtl = true;
+                ts.forEachChild(part, inspect);
+            };
+            inspect(node);
+            if (hasClock && hasTtl) {
+                for (const owner of owners) {
+                    if (!matches.has(owner)) matches.set(owner, node);
+                }
+            }
+        }
+        ts.forEachChild(node, walk);
+    };
+    walk(sf);
+    return [...matches].map(([owner, node]) => ({ node, owner }));
 }
 
 function scanFile(rel: string, text: string, stats: ScanStats): Violation[] {
@@ -413,6 +529,12 @@ function formatViolations(violations: Violation[]): string {
     return violations.map((v) => `  [${v.rule}] ${v.file}:${v.line}  ${v.detail}`).join('\n');
 }
 
+function isAllowlisted(violation: Violation): boolean {
+    return ALLOWLIST.some((entry) => entry.file === violation.file
+        && entry.rule === violation.rule
+        && entry.owner === violation.owner);
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // The guard
 // ─────────────────────────────────────────────────────────────────────────────
@@ -437,7 +559,7 @@ describe('leak-guard: observers, object URLs, TTL caches and retry loops are bou
 
     it('every leak is torn down / bounded, or allowlisted', () => {
         const unmatched = result.violations.filter(
-            (v) => !ALLOWLIST.some((e) => e.file === v.file && e.rule === v.rule)
+            (violation) => !isAllowlisted(violation)
         );
         expect(
             unmatched,
@@ -451,7 +573,9 @@ describe('leak-guard: observers, object URLs, TTL caches and retry loops are bou
 
     it('allowlist entries are current and still needed', () => {
         const stale = ALLOWLIST.filter(
-            (e) => !result.violations.some((v) => v.file === e.file && v.rule === e.rule)
+            (entry) => !result.violations.some((violation) => entry.file === violation.file
+                && entry.rule === violation.rule
+                && entry.owner === violation.owner)
         );
         expect(
             stale.map((e) => `[${e.rule}] ${e.file}`),
@@ -466,6 +590,10 @@ describe('leak-guard: observers, object URLs, TTL caches and retry loops are bou
 
 function scanFixture(source: string): Violation[] {
     return scanFile('fixture.ts', source, { files: 0, observers: 0, selfReschedulers: 0 });
+}
+
+function scanFixtureAt(file: string, source: string): Violation[] {
+    return scanFile(file, source, { files: 0, observers: 0, selfReschedulers: 0 });
 }
 
 describe('leak-guard classifier self-tests', () => {
@@ -487,8 +615,31 @@ describe('leak-guard classifier self-tests', () => {
     it('ttl-map: flags a module-scope Map+TTL cache without bounded-cache, accepts the routed form', () => {
         const raw = 'const c = new Map();\nfunction f(){ const cached = c.get(id); if (cached && now - cached.ts < FOO_TTL) return; }';
         expect(scanFixture(raw).map((v) => v.rule)).toEqual(['ttl-map']);
+        const productionShape = 'const SCOPE_TTL_MS = 30_000;\nconst scopeCache = new Map();\nfunction f(){ const hit = scopeCache.get(id); if (hit && Date.now() - hit.ts < SCOPE_TTL_MS) return hit.value; }';
+        expect(scanFixture(productionShape).map((v) => v.rule)).toEqual(['ttl-map']);
+        const secondsSuffix = 'const CACHE_TTL_SECONDS = 30;\nconst c = new Map();\nfunction f(){ const hit = c.get(id); if (CACHE_TTL_SECONDS > now - hit.timestamp) return hit; }';
+        expect(scanFixture(secondsSuffix).map((v) => v.rule)).toEqual(['ttl-map']);
+        const perEntryTtl = 'const c = new Map();\nfunction f(){ const entry = c.get(id); if (entry && Date.now() - entry.timestamp < entry.ttlMs) return entry.data; }';
+        expect(scanFixture(perEntryTtl).map((v) => v.rule)).toEqual(['ttl-map']);
         const routed = 'import { createBoundedCache } from \'../core/bounded-cache\';\nconst c = createBoundedCache({ maxEntries: 5, ttlMs: 1 });\nfunction f(){ const cached = c.get(id); if (cached && now - cached.ts < FOO_TTL) return; }';
         expect(scanFixture(routed)).toEqual([]);
+        const mixed = `${routed}\nconst raw = new Map();\nfunction leak(){ const hit = raw.get(id); if (hit && now - hit.ts < RAW_TTL_MS) return hit; }`;
+        expect(scanFixture(mixed).map((v) => v.rule)).toEqual(['ttl-map']);
+        const allowlistedAndLeaking = [
+            'const responseCache = new Map();',
+            'function safe(){ const entry = responseCache.get(id); if (entry && Date.now() - entry.timestamp < entry.ttlMs) return entry; }',
+            'const surpriseCache = new Map();',
+            'function leak(){ const hit = surpriseCache.get(id); if (hit && now - hit.ts < SURPRISE_TTL_MS) return hit; }',
+        ].join('\n');
+        const granular = scanFixtureAt('core/api-client.ts', allowlistedAndLeaking);
+        expect(granular.map((v) => v.owner).sort()).toEqual(['responseCache', 'surpriseCache']);
+        expect(granular.filter((v) => !isAllowlisted(v)).map((v) => v.owner)).toEqual(['surpriseCache']);
+        const unrelated = 'const labels = new Map();\nfunction f(){ if (Date.now() - state.ts < STATE_TTL_MS) return labels.get(id); }';
+        expect(scanFixture(unrelated)).toEqual([]);
+        const lexicalNames = 'const c = new Map();\nfunction a(){ const hit = c.get(id); return hit; }\nfunction b(){ const hit = state; if (now - hit.ts < STATE_TTL_MS) return hit; }';
+        expect(scanFixture(lexicalNames)).toEqual([]);
+        const nestedShadow = 'const c = new Map();\nfunction f(){ const hit = c.get(id); { const hit = state; if (now - hit.ts < STATE_TTL_MS) return hit; } }';
+        expect(scanFixture(nestedShadow)).toEqual([]);
         // A function-local Map (not module scope) is not flagged.
         expect(scanFixture('function f(){ const c = new Map(); if (now - x.ts < FOO_TTL) return; }')).toEqual([]);
     });


### PR DESCRIPTION
## Summary

- replace Spoiler Guard's raw movie-scope TTL map with an identity-keyed 256-entry bounded cache
- make collection mutations invalidate both settled and in-flight scope answers with a fail-closed generation fence
- cap the boot-critical shared item DTO LRU and its separately owned in-flight request table at 500 entries each
- replace the TTL-name regex guard with owner-granular AST analysis and precise cache-owner allowlists

## Root cause

The previous TTL architecture guard recognized only identifiers ending in `TTL`, so it missed unit-suffixed names such as `SCOPE_TTL_MS`. Both affected production caches treated expired entries as misses without bounding retained distinct keys. Collection mutations could also clear a settled scope cache and then have an older request republish pre-mutation state.

## Impact

Expired scope/item DTO entries can no longer accumulate through a long authenticated session. Cache and outstanding lookup ownership now have explicit caps, cross-identity reuse is fenced, collection changes fail closed against older responses, and future unit-suffixed raw TTL maps are detected per cache owner.

Cold-start budgets remain unchanged at 163 deterministic outputs and 17 ESM boot requests.

## Validation

- focused Vitest: 37/37
- full client coverage gate: passed (clean rerun)
- source and legacy typechecks: passed
- lint and syntax inventory: passed
- performance-rules guard: 248 files in 1107 ms CPU (under 5000 ms)
- script tests: 373/373
- deterministic bundle: 163 outputs, 17 boot requests
- Release build: zero warnings/errors
- independent agent review: APPROVE
- Opus 4.8 xhigh review: APPROVE (Fable 5 low was attempted twice but its service returned HTTP 529 overload)

Closes #118
Closes #326
