### PR TITLE
fix(i18n): align translation workflow with installed builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,11 @@ You can contribute code through:
 
 Help make Jellyfin Canopy accessible to more users by contributing translations. Locale JSON files live in `Jellyfin.Plugin.JellyfinCanopy/js/locales/` (one per language, `en.json` is the base). The exact supported list lives only in [`locale-manifest.json`](Jellyfin.Plugin.JellyfinCanopy/locale-manifest.json). To add or update a language, edit the relevant file and open a pull request; `npm run validate-translations` must pass, and all registered locales must stay in sync with `en.json`.
 
+Locale changes reach users in the plugin build that contains them. Merging a
+translation pull request does not update an already-installed plugin; both edits
+to existing locales and newly registered locales require a subsequent plugin
+update on the server.
+
 See [Translate Jellyfin Canopy](docs/help.md#translate-jellyfin-canopy) for the complete contribution guide.
 
 ### Issue triage and inactivity

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/ar.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/ar.json
@@ -343,7 +343,7 @@
   "panel_settings_language_display": "لغة العرض",
   "panel_settings_language_display_desc": "حدد اللغة لواجهة Jellyfin Canopy. تسري التغييرات بعد تحديث الصفحة.",
   "panel_settings_language_clear_cache": "مسح ذاكرة التخزين المؤقت للترجمة",
-  "panel_settings_language_clear_cache_desc": "يزيل جميع الترجمات المخزنة مؤقتاً. مفيد لجلب ترجمة تم تحديثها مؤخراً من Github.",
+  "panel_settings_language_clear_cache_desc": "يزيل الترجمات المخزنة مؤقتًا ويعيد تحميل ملف اللغة المضمّن في الإضافة المثبّتة.",
   "toast_language_changed": "{{icon:language}} تم تغيير اللغة! جاري تحديث الصفحة…",
   "toast_translation_cache_cleared": "{{icon:trash}} تم مسح ذاكرة التخزين المؤقت للترجمة! تمت إزالة {count} ترجمة مخزنة مؤقتاً. جاري التحديث…",
   "bookmark_add_title": "إضافة إشارة مرجعية",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/bg.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/bg.json
@@ -343,7 +343,7 @@
   "panel_settings_language_display": "Език на интерфейса",
   "panel_settings_language_display_desc": "Изберете език за интерфейса на Jellyfin Canopy. Промените влизат в сила след презареждане на страницата.",
   "panel_settings_language_clear_cache": "Изчистване на кеша за преводи",
-  "panel_settings_language_clear_cache_desc": "Премахва всички кеширани преводи. Полезно за извличане на наскоро актуализиран превод от Github.",
+  "panel_settings_language_clear_cache_desc": "Премахва кешираните преводи и презарежда езиковия файл, включен в инсталирания плъгин.",
   "toast_language_changed": "{{icon:language}} Езикът е променен! Презареждане на страницата…",
   "toast_translation_cache_cleared": "{{icon:trash}} Кешът за преводи е изчистен! Премахнати са {count} кеширани превода. Презареждане…",
   "bookmark_add_title": "Добавяне на отметка",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/ca.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/ca.json
@@ -343,7 +343,7 @@
   "panel_settings_language_display": "Idioma de visualització",
   "panel_settings_language_display_desc": "Seleccioneu l'idioma per a la interfície de Jellyfin Canopy. Els canvis tenen efecte després d'actualitzar la pàgina.",
   "panel_settings_language_clear_cache": "Netejar la memòria cau de traducció",
-  "panel_settings_language_clear_cache_desc": "Elimina totes les traduccions a la memòria cau. Útil per obtenir una traducció recentment actualitzada de Github.",
+  "panel_settings_language_clear_cache_desc": "Elimina les traduccions de la memòria cau i torna a carregar la configuració regional inclosa en el connector instal·lat.",
   "toast_language_changed": "{{icon:language}} Idioma canviat! Recarregant la pàgina…",
   "toast_translation_cache_cleared": "{{icon:trash}} Memòria cau de traducció esborrada! {count} traducció(ons) a la memòria cau eliminades. Recarregant…",
   "bookmark_add_title": "Afegir marcador",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/cs.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/cs.json
@@ -343,7 +343,7 @@
   "panel_settings_language_display": "Jazyk zobrazení",
   "panel_settings_language_display_desc": "Vyberte jazyk pro rozhraní Jellyfin Canopy. Změny se projeví po obnovení stránky.",
   "panel_settings_language_clear_cache": "Vymazat cache překladů",
-  "panel_settings_language_clear_cache_desc": "Odstraní všechny cachované překlady. Užitečné pro získání nedávno aktualizovaného překladu z Githubu.",
+  "panel_settings_language_clear_cache_desc": "Odstraní překlady z mezipaměti a znovu načte lokalizaci dodanou s nainstalovaným pluginem.",
   "toast_language_changed": "{{icon:language}} Jazyk změněn! Obnovuji stránku…",
   "toast_translation_cache_cleared": "{{icon:trash}} Cache překladů vymazána! Odstraněno {count} cachovaných překladů. Obnovuji…",
   "bookmark_add_title": "Přidat záložku",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/da.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/da.json
@@ -343,7 +343,7 @@
   "panel_settings_language_display": "Visningssprog",
   "panel_settings_language_display_desc": "Vælg sproget til Jellyfin Canopy-grænsefladen. Ændringer træder i kraft efter sideopdatering.",
   "panel_settings_language_clear_cache": "Ryd oversættelsescache",
-  "panel_settings_language_clear_cache_desc": "Fjerner alle cachede oversættelser. Nyttigt til at hente en nyligt opdateret oversættelse fra Github.",
+  "panel_settings_language_clear_cache_desc": "Fjerner cachelagrede oversættelser og genindlæser den sprogversion, der følger med det installerede plugin.",
   "toast_language_changed": "{{icon:language}} Sprog ændret! Opdaterer side…",
   "toast_translation_cache_cleared": "{{icon:trash}} Oversættelsescache ryddet! {count} cachede oversættelse(r) fjernet. Opdaterer…",
   "bookmark_add_title": "Tilføj bogmærke",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/de.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/de.json
@@ -343,7 +343,7 @@
   "panel_settings_language_display": "Anzeigesprache",
   "panel_settings_language_display_desc": "Wählen Sie die Sprache für die Jellyfin Canopy-Oberfläche. Änderungen werden nach Seitenaktualisierung wirksam.",
   "panel_settings_language_clear_cache": "Übersetzungscache leeren",
-  "panel_settings_language_clear_cache_desc": "Entfernt alle zwischengespeicherten Übersetzungen. Nützlich zum Abrufen einer kürzlich aktualisierten Übersetzung von Github.",
+  "panel_settings_language_clear_cache_desc": "Entfernt zwischengespeicherte Übersetzungen und lädt die im installierten Plugin enthaltene Sprachversion neu.",
   "toast_language_changed": "{{icon:language}} Sprache geändert! Seite wird neu geladen…",
   "toast_translation_cache_cleared": "{{icon:trash}} Übersetzungscache geleert! {count} zwischengespeicherte Übersetzung(en) entfernt. Wird neu geladen…",
   "bookmark_add_title": "Lesezeichen hinzufügen",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/en-GB.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/en-GB.json
@@ -344,7 +344,7 @@
   "panel_settings_language_display": "Display Language",
   "panel_settings_language_display_desc": "Select the language for Jellyfin Canopy interface. Changes take effect after page refresh.",
   "panel_settings_language_clear_cache": "Clear Translation Cache",
-  "panel_settings_language_clear_cache_desc": "Removes all cached translations. Useful to fetch a recently updated translation from Github.",
+  "panel_settings_language_clear_cache_desc": "Removes cached translations and reloads the locale included with the installed plugin.",
   "toast_language_changed": "{{icon:language}} Language changed! Refreshing page…",
   "toast_translation_cache_cleared": "{{icon:trash}} Translation cache cleared! {count} cached translation(s) removed. Refreshing…",
   "bookmark_add_title": "Add Bookmark",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/en-US.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/en-US.json
@@ -344,7 +344,7 @@
   "panel_settings_language_display": "Display Language",
   "panel_settings_language_display_desc": "Select the language for Jellyfin Canopy interface. Changes take effect after page refresh.",
   "panel_settings_language_clear_cache": "Clear Translation Cache",
-  "panel_settings_language_clear_cache_desc": "Removes all cached translations. Useful to fetch a recently updated translation from Github.",
+  "panel_settings_language_clear_cache_desc": "Removes cached translations and reloads the locale included with the installed plugin.",
   "toast_language_changed": "{{icon:language}} Language changed! Refreshing page…",
   "toast_translation_cache_cleared": "{{icon:trash}} Translation cache cleared! {count} cached translation(s) removed. Refreshing…",
   "bookmark_add_title": "Add Bookmark",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/en.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/en.json
@@ -346,7 +346,7 @@
   "panel_settings_language_display": "Display Language",
   "panel_settings_language_display_desc": "Select the language for Jellyfin Canopy interface. Changes take effect after page refresh.",
   "panel_settings_language_clear_cache": "Clear Translation Cache",
-  "panel_settings_language_clear_cache_desc": "Removes all cached translations. Useful to fetch a recently updated translation from Github.",
+  "panel_settings_language_clear_cache_desc": "Removes cached translations and reloads the locale included with the installed plugin.",
   "toast_language_changed": "{{icon:language}} Language changed! Refreshing page…",
   "toast_translation_cache_cleared": "{{icon:trash}} Translation cache cleared! {count} cached translation(s) removed. Refreshing…",
   "bookmark_add_title": "Add Bookmark",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/es.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/es.json
@@ -343,7 +343,7 @@
   "panel_settings_language_display": "Idioma de visualización",
   "panel_settings_language_display_desc": "Seleccione el idioma para la interfaz de Jellyfin Canopy. Los cambios surten efecto después de actualizar la página.",
   "panel_settings_language_clear_cache": "Limpiar caché de traducción",
-  "panel_settings_language_clear_cache_desc": "Elimina todas las traducciones en caché. Útil para obtener una traducción recientemente actualizada de Github.",
+  "panel_settings_language_clear_cache_desc": "Elimina las traducciones almacenadas en caché y vuelve a cargar la configuración regional incluida en el plugin instalado.",
   "toast_language_changed": "{{icon:language}} ¡Idioma cambiado! Recargando página…",
   "toast_translation_cache_cleared": "{{icon:trash}} ¡Caché de traducción borrado! {count} traducción(es) en caché eliminadas. Recargando…",
   "bookmark_add_title": "Añadir marcador",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/fr.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/fr.json
@@ -343,7 +343,7 @@
   "panel_settings_language_display": "Langue d'affichage",
   "panel_settings_language_display_desc": "Sélectionnez la langue pour l'interface Jellyfin Canopy. Les modifications prennent effet après l'actualisation de la page.",
   "panel_settings_language_clear_cache": "Effacer le cache de traduction",
-  "panel_settings_language_clear_cache_desc": "Supprime toutes les traductions en cache. Utile pour récupérer une traduction récemment mise à jour depuis Github.",
+  "panel_settings_language_clear_cache_desc": "Supprime les traductions mises en cache et recharge la version localisée incluse dans le plugin installé.",
   "toast_language_changed": "{{icon:language}} Langue modifiée ! Actualisation de la page…",
   "toast_translation_cache_cleared": "{{icon:trash}} Cache de traduction effacé ! {count} traduction(s) en cache supprimée(s). Actualisation…",
   "bookmark_add_title": "Ajouter un signet",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/he.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/he.json
@@ -233,7 +233,7 @@
   "panel_settings_spoiler_guard_skip_confirm": "אל תבקש ממני אישור בעת כיבוי מגן הספוילרים",
   "panel_settings_spoiler_guard_skip_confirm_desc": "דילוג על דיאלוג אישור הכיבוי. חוסך לחיצה בעת כיבוי מגן הספוילרים עבור סדרה.",
   "hidden_content_hide_button": "Hide",
-  "panel_settings_language_clear_cache_desc": "Removes all cached translations. Useful to fetch a recently updated translation from Github.",
+  "panel_settings_language_clear_cache_desc": "מסיר את התרגומים השמורים במטמון וטוען מחדש את קובץ השפה הכלול בתוסף המותקן.",
   "downloads_status_downloading": "Downloading",
   "active_streams_count": "{count} Active Stream|{count} Active Streams",
   "active_streams_load_error": "Failed to fetch sessions",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/hu.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/hu.json
@@ -343,7 +343,7 @@
   "panel_settings_language_display": "Megjelenítési nyelv",
   "panel_settings_language_display_desc": "Válassza ki a Jellyfin Canopy felület nyelvét. A módosítások az oldal frissítése után lépnek életbe.",
   "panel_settings_language_clear_cache": "Fordítási gyorsítótár törlése",
-  "panel_settings_language_clear_cache_desc": "Eltávolítja az összes gyorsítótárazott fordítást. Hasznos egy nemrég frissített fordítás letöltéséhez a Githubról.",
+  "panel_settings_language_clear_cache_desc": "Eltávolítja a gyorsítótárazott fordításokat, és újratölti a telepített bővítményben található területi beállítást.",
   "toast_language_changed": "{{icon:language}} Nyelv megváltoztatva! Oldal frissítése…",
   "toast_translation_cache_cleared": "{{icon:trash}} Fordítási gyorsítótár törölve! {count} gyorsítótárazott fordítás eltávolítva. Újratöltés…",
   "bookmark_add_title": "Könyvjelző hozzáadása",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/it.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/it.json
@@ -343,7 +343,7 @@
   "panel_settings_language_display": "Lingua di visualizzazione",
   "panel_settings_language_display_desc": "Seleziona la lingua per l'interfaccia Jellyfin Canopy. Le modifiche hanno effetto dopo l'aggiornamento della pagina.",
   "panel_settings_language_clear_cache": "Cancella cache traduzioni",
-  "panel_settings_language_clear_cache_desc": "Rimuove tutte le traduzioni memorizzate nella cache. Utile per recuperare una traduzione recentemente aggiornata da Github.",
+  "panel_settings_language_clear_cache_desc": "Rimuove le traduzioni memorizzate nella cache e ricarica le impostazioni locali incluse nel plugin installato.",
   "toast_language_changed": "{{icon:language}} Lingua cambiata! Aggiornamento pagina…",
   "toast_translation_cache_cleared": "{{icon:trash}} Cache traduzioni cancellata! {count} traduzione/i in cache rimosse. Aggiornamento…",
   "bookmark_add_title": "Aggiungi segnalibro",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/nl.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/nl.json
@@ -343,7 +343,7 @@
   "panel_settings_language_display": "Weergavetaal",
   "panel_settings_language_display_desc": "Select the language for Jellyfin Canopy interface. Changes take effect after page refresh.",
   "panel_settings_language_clear_cache": "Vertaalcache wissen",
-  "panel_settings_language_clear_cache_desc": "Verwijdert alle opgeslagen vertalingen. Handig om een recent bijgewerkte vertaling van GitHub op te halen.",
+  "panel_settings_language_clear_cache_desc": "Verwijdert vertalingen uit de cache en laadt de met de geïnstalleerde plugin meegeleverde taalversie opnieuw.",
   "toast_language_changed": "{{icon:language}} Taal gewijzigd! Pagina wordt vernieuwd…",
   "toast_translation_cache_cleared": "{{icon:trash}} Vertaalcache gewist! {count} opgeslagen vertaling(en) verwijderd. Vernieuwen…",
   "bookmark_add_title": "Bladwijzer toevoegen",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/no.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/no.json
@@ -343,7 +343,7 @@
   "panel_settings_language_display": "Visningsspråk",
   "panel_settings_language_display_desc": "Velg språk for Jellyfin Canopy-grensesnittet. Endringer trer i kraft etter at siden er oppdatert.",
   "panel_settings_language_clear_cache": "Tøm oversettelsesbuffer",
-  "panel_settings_language_clear_cache_desc": "Fjerner alle bufrede oversettelser. Nyttig for å hente en nylig oppdatert oversettelse fra Github.",
+  "panel_settings_language_clear_cache_desc": "Fjerner bufrede oversettelser og laster inn språkversjonen som følger med den installerte tilleggsmodulen på nytt.",
   "toast_language_changed": "{{icon:language}} Språk endret! Oppdaterer siden…",
   "toast_translation_cache_cleared": "{{icon:trash}} Oversettelsesbuffer tømt! {count} bufrede oversettelse(r) fjernet. Oppdaterer…",
   "bookmark_add_title": "Legg til bokmerke",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/pl.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/pl.json
@@ -342,7 +342,7 @@
   "panel_settings_language_display": "Język wyświetlania",
   "panel_settings_language_display_desc": "Wybierz język interfejsu Jellyfin Canopy. Zmiany wchodzą w życie po odświeżeniu strony.",
   "panel_settings_language_clear_cache": "Wyczyść pamięć podręczną tłumaczeń",
-  "panel_settings_language_clear_cache_desc": "Usuwa wszystkie zapisane tłumaczenia. Przydatne do pobrania niedawno zaktualizowanego tłumaczenia z Github.",
+  "panel_settings_language_clear_cache_desc": "Usuwa tłumaczenia z pamięci podręcznej i ponownie wczytuje wersję językową dołączoną do zainstalowanej wtyczki.",
   "toast_language_changed": "{{icon:language}} Język zmieniony! Odświeżanie strony…",
   "toast_translation_cache_cleared": "{{icon:trash}} Pamięć podręczna tłumaczeń wyczyszczona! Usunięto {count} tłumaczenie(ń). Odświeżanie…",
   "bookmark_add_title": "Dodaj zakładkę",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/pr.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/pr.json
@@ -343,7 +343,7 @@
   "panel_settings_language_display": "Display Tongue",
   "panel_settings_language_display_desc": "Pick th' speakin' tongue fer Jellyfin Canopy interface. Changes take effect after reloadin' th' page.",
   "panel_settings_language_clear_cache": "Clear Translation Hold",
-  "panel_settings_language_clear_cache_desc": "Tosses all cached translations overboard. Useful to fetch a freshly updated translation from Github.",
+  "panel_settings_language_clear_cache_desc": "Tosses cached translations overboard and reloads th' locale shipped with th' installed plugin.",
   "toast_language_changed": "{{icon:language}} Tongue changed! Reloadin' th' page…",
   "toast_translation_cache_cleared": "{{icon:trash}} Translation hold cleared! {count} cached translation(s) thrown overboard. Reloadin'…",
   "bookmark_add_title": "Mark a New Spot",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/pt-BR.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/pt-BR.json
@@ -343,7 +343,7 @@
   "panel_settings_language_display": "Idioma de exibição",
   "panel_settings_language_display_desc": "Selecione o idioma para a interface do Jellyfin Canopy. As alterações entram em vigor após a atualização da página.",
   "panel_settings_language_clear_cache": "Limpar cache de tradução",
-  "panel_settings_language_clear_cache_desc": "Remove todas as traduções em cache. Útil para buscar uma tradução recentemente atualizada do Github.",
+  "panel_settings_language_clear_cache_desc": "Remove as traduções armazenadas em cache e recarrega a configuração regional incluída no plugin instalado.",
   "toast_language_changed": "{{icon:language}} Idioma alterado! Atualizando página…",
   "toast_translation_cache_cleared": "{{icon:trash}} Cache de tradução limpa! {count} tradução(ões) em cache removida(s). A atualizar…",
   "bookmark_add_title": "Adicionar marcador",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/pt.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/pt.json
@@ -343,7 +343,7 @@
   "panel_settings_language_display": "Idioma de exibição",
   "panel_settings_language_display_desc": "Selecione o idioma para a interface do Jellyfin Canopy. As alterações entram em vigor após a atualização da página.",
   "panel_settings_language_clear_cache": "Limpar cache de tradução",
-  "panel_settings_language_clear_cache_desc": "Remove todas as traduções em cache. Útil para buscar uma tradução recentemente atualizada do Github.",
+  "panel_settings_language_clear_cache_desc": "Remove as traduções em cache e recarrega a configuração regional incluída no plugin instalado.",
   "toast_language_changed": "{{icon:language}} Idioma alterado! Atualizando página…",
   "toast_translation_cache_cleared": "{{icon:trash}} Cache de tradução limpa! {count} tradução(ões) em cache removida(s). A atualizar…",
   "bookmark_add_title": "Adicionar marcador",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/ru.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/ru.json
@@ -342,7 +342,7 @@
   "panel_settings_language_display": "Язык интерфейса",
   "panel_settings_language_display_desc": "Выберите язык интерфейса Jellyfin Canopy. Изменения вступают в силу после обновления страницы.",
   "panel_settings_language_clear_cache": "Очистить кеш переводов",
-  "panel_settings_language_clear_cache_desc": "Удаляет все кешированные переводы. Полезно для получения недавно обновленного перевода с Github.",
+  "panel_settings_language_clear_cache_desc": "Удаляет кешированные переводы и заново загружает языковой файл, поставляемый с установленным плагином.",
   "toast_language_changed": "{{icon:language}} Язык изменён! Обновление страницы…",
   "toast_translation_cache_cleared": "{{icon:trash}} Кэш переводов очищен! Удалено {count} сохранённых переводов. Обновление…",
   "bookmark_add_title": "Добавить в закладки",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/sk.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/sk.json
@@ -343,7 +343,7 @@
   "panel_settings_language_display": "Jazyk zobrazenia",
   "panel_settings_language_display_desc": "Vyberte jazyk pre rozhranie Jellyfin Canopy. Zmeny sa prejavia po obnovení stránky.",
   "panel_settings_language_clear_cache": "Vymazať cache prekladov",
-  "panel_settings_language_clear_cache_desc": "Odstráni všetky cacheované preklady. Užitočné na získanie nedávno aktualizovaného prekladu z Githubu.",
+  "panel_settings_language_clear_cache_desc": "Odstráni preklady z vyrovnávacej pamäte a znova načíta lokalizáciu dodanú s nainštalovaným pluginom.",
   "toast_language_changed": "{{icon:language}} Jazyk zmenený! Obnovujem stránku…",
   "toast_translation_cache_cleared": "{{icon:trash}} Cache prekladov vymazaná! Odstránených {count} cacheovaných prekladov. Obnovujem…",
   "bookmark_add_title": "Pridať záložku",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/sv.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/sv.json
@@ -343,7 +343,7 @@
   "panel_settings_language_display": "Visningsspråk",
   "panel_settings_language_display_desc": "Välj språk för Jellyfin Canopy-gränssnittet. Ändringar träder i kraft efter siduppdatering.",
   "panel_settings_language_clear_cache": "Rensa översättningscache",
-  "panel_settings_language_clear_cache_desc": "Tar bort alla cachade översättningar. Användbart för att hämta en nyligen uppdaterad översättning från Github.",
+  "panel_settings_language_clear_cache_desc": "Tar bort cachade översättningar och läser in språkversionen som medföljer det installerade insticksprogrammet på nytt.",
   "toast_language_changed": "{{icon:language}} Språk ändrat! Uppdaterar sida…",
   "toast_translation_cache_cleared": "{{icon:trash}} Översättningscache rensad! {count} cachad(e) översättning(ar) borttagen(a). Uppdaterar…",
   "bookmark_add_title": "Lägg till bokmärke",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/tr.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/tr.json
@@ -343,7 +343,7 @@
   "panel_settings_language_display": "Görüntüleme Dili",
   "panel_settings_language_display_desc": "Jellyfin Canopy arayüzü için dili seçin. Değişiklikler sayfa yenilemesinden sonra geçerli olur.",
   "panel_settings_language_clear_cache": "Çeviri Önbelleğini Temizle",
-  "panel_settings_language_clear_cache_desc": "Önbelleğe alınmış tüm çevirileri kaldırır. Github'dan yakın zamanda güncellenmiş bir çeviri almak için kullanışlıdır.",
+  "panel_settings_language_clear_cache_desc": "Önbelleğe alınmış çevirileri kaldırır ve yüklü eklentiyle birlikte gelen dil dosyasını yeniden yükler.",
   "toast_language_changed": "{{icon:language}} Dil değiştirildi! Sayfa yenileniyor…",
   "toast_translation_cache_cleared": "{{icon:trash}} Çeviri önbelleği temizlendi! {count} önbelleğe alınmış çeviri kaldırıldı. Yenileniyor…",
   "bookmark_add_title": "Yer İmi Ekle",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/zh-CN.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/zh-CN.json
@@ -343,7 +343,7 @@
   "panel_settings_language_display": "显示语言",
   "panel_settings_language_display_desc": "选择 Jellyfin Canopy 介面的显示语言。更改会在重新载入页面后生效。",
   "panel_settings_language_clear_cache": "清除翻译快取",
-  "panel_settings_language_clear_cache_desc": "移除所有已快取的翻译。可用于从 GitHub 取得最近更新的翻译。",
+  "panel_settings_language_clear_cache_desc": "清除缓存的翻译，并重新加载已安装插件自带的语言文件。",
   "toast_language_changed": "{{icon:language}} 语言已更改！正在重新载入页面…",
   "toast_translation_cache_cleared": "{{icon:trash}} 已清除翻译快取！已移除 {count} 个已快取翻译。正在重新载入…",
   "bookmark_add_title": "新增书签",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/zh-HK.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/zh-HK.json
@@ -343,7 +343,7 @@
   "panel_settings_language_display": "顯示語言",
   "panel_settings_language_display_desc": "選擇 Jellyfin Canopy 介面的顯示語言。更改會在重新載入頁面後生效。",
   "panel_settings_language_clear_cache": "清除翻譯快取",
-  "panel_settings_language_clear_cache_desc": "移除所有已快取的翻譯。可用於從 GitHub 取得最近更新的翻譯。",
+  "panel_settings_language_clear_cache_desc": "移除已快取的翻譯，並重新載入已安裝插件隨附的語言檔案。",
   "toast_language_changed": "{{icon:language}} 語言已更改！正在重新載入頁面…",
   "toast_translation_cache_cleared": "{{icon:trash}} 已清除翻譯快取！已移除 {count} 個已快取翻譯。正在重新載入…",
   "bookmark_add_title": "新增書籤",

--- a/Jellyfin.Plugin.JellyfinCanopy/src/bootstrap/translations-loading.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/bootstrap/translations-loading.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import './translations';
+
+const originalFetch = globalThis.fetch;
+const response = (ok: boolean, body: Record<string, string> = {}): Response => new Response(
+    JSON.stringify(body),
+    { status: ok ? 200 : 404, headers: { 'Content-Type': 'application/json' } },
+);
+const requestUrl = (input: RequestInfo | URL): string => {
+    if (typeof input === 'string') return input;
+    return input instanceof URL ? input.href : input.url;
+};
+const loadTranslations = (): Promise<Record<string, string>> => {
+    const load = window.JellyfinCanopy.loadTranslations;
+    if (!load) throw new Error('translations bootstrap did not install loadTranslations');
+    return load();
+};
+
+describe('translation loader deployment ownership', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        document.documentElement.lang = '';
+        window.JellyfinCanopy.pluginVersion = '2.0.0.0';
+        window.JellyfinCanopy.pluginConfig = {};
+        vi.spyOn(console, 'log').mockImplementation(() => undefined);
+        vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-07-17T00:00:00Z'));
+    });
+
+    afterEach(() => {
+        localStorage.clear();
+        globalThis.fetch = originalFetch;
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    it('short-circuits on the installed bundled locale without contacting GitHub', async () => {
+        const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(response(true, { greeting: 'bundled' }));
+        globalThis.fetch = fetchMock;
+
+        await expect(loadTranslations()).resolves.toEqual({ greeting: 'bundled' });
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock.mock.calls.map(([input]) => requestUrl(input))).toEqual([
+            'http://jellyfin.test/JellyfinCanopy/locales/en.json',
+        ]);
+    });
+
+    it('keeps the default failure path offline and permits GitHub only when explicitly enabled', async () => {
+        const offlineFetch = vi.fn<typeof fetch>().mockResolvedValue(response(false));
+        globalThis.fetch = offlineFetch;
+
+        await expect(loadTranslations()).resolves.toEqual({});
+        expect(offlineFetch.mock.calls.some(([input]) => requestUrl(input).includes('raw.githubusercontent.com'))).toBe(false);
+
+        window.JellyfinCanopy.pluginConfig = { AssetCacheEnabled: false };
+        const fallbackFetch = vi.fn<typeof fetch>((input) => Promise.resolve(
+            requestUrl(input).includes('raw.githubusercontent.com')
+                ? response(true, { greeting: 'remote fallback' })
+                : response(false)
+        ));
+        globalThis.fetch = fallbackFetch;
+
+        await expect(loadTranslations()).resolves.toEqual({ greeting: 'remote fallback' });
+        expect(fallbackFetch.mock.calls.map(([input]) => requestUrl(input))).toEqual([
+            'http://jellyfin.test/JellyfinCanopy/locales/en.json',
+            expect.stringContaining('4eh5xitv6787h645ebv/Jellyfin-Canopy/main/'),
+        ]);
+    });
+
+    it('uses a 24-hour plugin-version cache and retires entries from older builds', async () => {
+        localStorage.setItem('JC_translation_en_1.9.0.0', JSON.stringify({ greeting: 'old build' }));
+        localStorage.setItem('JC_translation_ts_en_1.9.0.0', String(Date.now()));
+        const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(response(true, { greeting: 'current build' }));
+        globalThis.fetch = fetchMock;
+
+        await expect(loadTranslations()).resolves.toEqual({ greeting: 'current build' });
+        expect(localStorage.getItem('JC_translation_en_1.9.0.0')).toBeNull();
+        expect(localStorage.getItem('JC_translation_ts_en_1.9.0.0')).toBeNull();
+        expect(JSON.parse(localStorage.getItem('JC_translation_en_2.0.0.0')!)).toEqual({ greeting: 'current build' });
+
+        fetchMock.mockClear();
+        vi.setSystemTime(new Date('2026-07-17T23:59:59Z'));
+        await expect(loadTranslations()).resolves.toEqual({ greeting: 'current build' });
+        expect(fetchMock).not.toHaveBeenCalled();
+
+        vi.setSystemTime(new Date('2026-07-18T00:00:01Z'));
+        fetchMock.mockResolvedValue(response(true, { greeting: 'refreshed' }));
+        await expect(loadTranslations()).resolves.toEqual({ greeting: 'refreshed' });
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/facade.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/facade.ts
@@ -53,6 +53,6 @@ export interface JellyfinCanopyPublicApi {
     hideSplashScreen?: () => void;
     /** login-image: wires the login-page profile-image behaviour. */
     initializeLoginImage?: () => void;
-    /** translations: loads the active language table (GitHub + bundled fallback). */
+    /** translations: loads the bundled language table with a gated remote fallback. */
     loadTranslations?: () => Promise<Record<string, string>>;
 }

--- a/docs/help.md
+++ b/docs/help.md
@@ -408,9 +408,23 @@ Extra keys and extra placeholders (present in the locale but not in `en.json`) s
 
 ### How translations reach users
 
-Translations are synced from repository updates (merged locale-file PRs) and cached for 24 hours. A merged locale is available immediately after merge — no plugin update is needed.
+Translations ship inside the plugin. After a locale-file pull request merges,
+the change reaches users only in a plugin build that contains that commit and
+only after that build is installed on their server. This is true for both edits
+to an existing locale and additions to `locale-manifest.json`; merging alone
+does not change a running installation.
 
 The language selector lists the available translations by asking the plugin's own server endpoint (`/JellyfinCanopy/locales`) which locale files ship with the installed build. The browser does **not** call GitHub to discover languages, so the list is correct on isolated networks and is never affected by GitHub's anonymous rate limits. A newly-merged locale file becomes selectable once it's part of an installed plugin build.
+
+By default, the browser loads those bundled locale files first and can work
+without GitHub. Only when the third-party asset cache is explicitly disabled
+may a failed bundled-locale request fall back to the Canopy repository on
+GitHub; that fallback is not the source for the language selector and is not a
+deployment mechanism. Browser entries are cached for 24 hours and keyed by the
+installed plugin version. Installing a new version retires the old version's
+entries. The **Refresh Translation Cache** scheduled task can tell clients to
+discard their current cached entries, but it cannot add or update locale files
+that are absent from the installed plugin.
 
 ## Community and support
 

--- a/scripts/validate-translations.js
+++ b/scripts/validate-translations.js
@@ -35,8 +35,6 @@ const CODE_DIRS = [
     path.join(__dirname, '../Jellyfin.Plugin.JellyfinCanopy/src'),
     path.join(__dirname, '../Jellyfin.Plugin.JellyfinCanopy/js'),
 ];
-const WEBLATE_URL = 'https://hosted.weblate.org/projects/jellyfincanopy/';
-
 // ANSI color codes for terminal output
 const colors = {
     reset: '\x1b[0m',
@@ -498,7 +496,7 @@ function createTranslationTemplate(lang) {
         }
         logSuccess(`Created translation template: ${filePath}`);
         logInfo(`Now edit ${lang}.json and translate the English values to ${lang.toUpperCase()}`);
-        logInfo(`Preferred workflow for contributors is Weblate: ${WEBLATE_URL}`);
+        logInfo('Run npm run validate-translations, then open a pull request in the Jellyfin Canopy repository.');
     } catch (error) {
         if (error.code === 'EEXIST') {
             logError(`Translation file ${lang}.json already exists!`);
@@ -612,7 +610,7 @@ ${colors.cyan}Commands:${colors.reset}
 
 ${colors.cyan}Examples:${colors.reset}
     # Preferred translator workflow
-    Translate in Weblate: ${WEBLATE_URL}
+    Edit the locale JSON file, run npm run validate-translations, and open a pull request
 
   # Validate all translations
   node scripts/validate-translations.js validate

--- a/scripts/validate-translations.test.js
+++ b/scripts/validate-translations.test.js
@@ -106,6 +106,31 @@ test('all shipped locales validate clean against en.json', () => {
     }
 });
 
+test('clear-cache copy reloads the installed locale instead of promising a remote update', () => {
+    const inventory = readLocaleInventory();
+    const expectedEnglish = 'Removes cached translations and reloads the locale included with the installed plugin.';
+    for (const locale of inventory.locales) {
+        const translation = JSON.parse(
+            fs.readFileSync(path.join(LOCALES_DIR, `${locale}.json`), 'utf8')
+        );
+        const description = translation.panel_settings_language_clear_cache_desc;
+        assert.ok(
+            typeof description === 'string' && description.trim() !== '',
+            `${locale}.json must describe translation cache clearing`
+        );
+        assert.doesNotMatch(
+            description,
+            /github|weblate/i,
+            `${locale}.json must not present cache clearing as a remote deployment path`
+        );
+    }
+    assert.strictEqual(
+        JSON.parse(fs.readFileSync(path.join(LOCALES_DIR, 'en.json'), 'utf8'))
+            .panel_settings_language_clear_cache_desc,
+        expectedEnglish
+    );
+});
+
 test('canonical inventory is the exact source for all 26 shipped locale files', () => {
     const inventory = readLocaleInventory();
     assert.strictEqual(inventory.baseLocale, 'en');
@@ -208,6 +233,116 @@ test('server loader, workflow, and contributor docs consume the canonical invent
         new RegExp(`${readLocaleInventory().locales.length} synchronized language catalogs`)
     );
     assert.ok(fs.existsSync(INVENTORY_PATH));
+});
+
+test('translation deployment docs stay aligned with the bundled-first runtime contract', () => {
+    const root = path.join(__dirname, '..');
+    const read = relativePath => fs.readFileSync(path.join(root, relativePath), 'utf8');
+    const loader = read('Jellyfin.Plugin.JellyfinCanopy/src/bootstrap/translations.ts');
+    const validator = read('scripts/validate-translations.js');
+    const project = read('Jellyfin.Plugin.JellyfinCanopy/JellyfinCanopy.csproj');
+    const controller = read('Jellyfin.Plugin.JellyfinCanopy/Controllers/ConfigController.cs');
+    const task = read('Jellyfin.Plugin.JellyfinCanopy/ScheduledTasks/ClearTranslationCacheTask.cs');
+    const contributing = read('CONTRIBUTING.md');
+    const help = read('docs/help.md');
+    const customization = read('docs/customization.md');
+    const section = (source, startHeading, endHeading) => {
+        const start = source.indexOf(startHeading);
+        const end = source.indexOf(endHeading, start + startHeading.length);
+        assert.ok(start >= 0 && end > start, `missing section ${startHeading}`);
+        return source.slice(start, end);
+    };
+    const contributingTranslations = section(
+        contributing,
+        '### 2. Translation Contributions',
+        '### Issue triage and inactivity'
+    );
+    const helpTranslations = section(help, '## Translate Jellyfin Canopy', '## Community and support');
+    const customizationTranslations = section(customization, '## Internationalization', '## Server controls');
+
+    const bundledFetch = loader.indexOf('/JellyfinCanopy/locales/${code}.json');
+    const fallbackGate = loader.indexOf('AssetCacheEnabled === false', bundledFetch);
+    const remoteFetch = loader.indexOf('fetch(`${GITHUB_RAW_BASE}/${code}.json`');
+    assert.ok(bundledFetch >= 0, 'runtime must request the installed bundled locale');
+    assert.ok(fallbackGate > bundledFetch, 'remote fallback gate must follow bundled loading');
+    assert.ok(remoteFetch > fallbackGate, 'GitHub must remain a gated last-resort fallback');
+    assert.match(loader, /JC_translation_\$\{code\}_\$\{pluginVersion\}/);
+    assert.match(loader, /const CACHE_DURATION = 24 \* 60 \* 60 \* 1000/);
+    assert.match(loader, /cleanOldTranslationCache\(pluginVersion\)/);
+    assert.match(loader, /Jellyfin-Canopy\/main\/Jellyfin\.Plugin\.JellyfinCanopy\/js\/locales/);
+    assert.doesNotMatch(loader, /n00bcodr\/Jellyfin-Enhanced/);
+
+    assert.match(project, /EmbeddedResource Include="js\\\*\*"/);
+    assert.match(project, /EmbeddedResource Include="locale-manifest\.json"/);
+    assert.match(controller, /HttpGet\("locales"\)/);
+    assert.match(controller, /HttpGet\("locales\/\{lang\}\.json"\)/);
+    assert.match(task, /public string Name => "Refresh Translation Cache"/);
+    assert.match(task, /ClearTranslationCacheTimestamp\s*=/);
+    assert.doesNotMatch(task, /HttpClient|WebRequest|Download|File\./);
+    assert.match(validator, /npm run validate-translations[\s\S]*open a pull request/i);
+    assert.doesNotMatch(
+        validator,
+        /hosted\.weblate\.org|Translate in Weblate|workflow[^\n]*Weblate|n00bcodr\/Jellyfin-Enhanced/i
+    );
+
+    const contributionContract = `${contributingTranslations}\n${helpTranslations}`;
+    assert.match(contributionContract, /plain pull request/i);
+    assert.match(contributionContract, /both edits[\s\S]*newly registered locales require a subsequent plugin[\s\S]*update/i);
+    assert.match(helpTranslations, /merging alone[\s\S]*does not change a running installation/i);
+    assert.match(helpTranslations, /asset cache is explicitly disabled[\s\S]*failed bundled-locale request/i);
+    assert.match(helpTranslations, /scheduled task[\s\S]*cannot add or update locale files/i);
+    assert.match(customizationTranslations, /loads the matching translation from the plugin's bundled locale files/i);
+    assert.match(customizationTranslations, /There is no config-page button for clearing translation caches/i);
+
+    const deploymentDocs = `${contributingTranslations}\n${helpTranslations}\n${customizationTranslations}`;
+    assert.doesNotMatch(deploymentDocs, /available immediately after merge/i);
+    assert.doesNotMatch(deploymentDocs, /no plugin update is needed/i);
+    assert.doesNotMatch(deploymentDocs, /hosted\.weblate\.org/i);
+    assert.doesNotMatch(deploymentDocs, /n00bcodr\/Jellyfin-Enhanced/i);
+});
+
+test('locale contribution fixtures validate content edits and newly registered locales', t => {
+    const existing = inventoryFixture(t);
+    fs.writeFileSync(path.join(existing.localeDir, 'en.json'), '{"greeting":"Hello {name}"}\n');
+    fs.writeFileSync(path.join(existing.localeDir, 'fr.json'), '{"greeting":"Bonjour {name}"}\n');
+    assert.deepStrictEqual(
+        validateLocaleInventory(existing.localeDir, existing.inventoryPath).errors,
+        [],
+        'editing a registered locale must not require an inventory change'
+    );
+    assert.deepStrictEqual(
+        validateEntries(
+            JSON.parse(fs.readFileSync(path.join(existing.localeDir, 'en.json'), 'utf8')),
+            JSON.parse(fs.readFileSync(path.join(existing.localeDir, 'fr.json'), 'utf8'))
+        ).errors,
+        [],
+        'an existing-locale edit must pass full key and placeholder validation'
+    );
+
+    fs.writeFileSync(path.join(existing.localeDir, 'it.json'), '{"greeting":"Ciao {name}"}\n');
+    assert.match(
+        validateLocaleInventory(existing.localeDir, existing.inventoryPath).errors.join('\n'),
+        /Unregistered locale file: it\.json/,
+        'a new locale must be registered before it can ship'
+    );
+
+    fs.writeFileSync(
+        existing.inventoryPath,
+        `${JSON.stringify({ baseLocale: 'en', locales: ['en', 'fr', 'it'] }, null, 2)}\n`
+    );
+    assert.deepStrictEqual(
+        validateLocaleInventory(existing.localeDir, existing.inventoryPath).errors,
+        [],
+        'adding the locale file and canonical inventory entry completes the contribution path'
+    );
+    assert.deepStrictEqual(
+        validateEntries(
+            JSON.parse(fs.readFileSync(path.join(existing.localeDir, 'en.json'), 'utf8')),
+            JSON.parse(fs.readFileSync(path.join(existing.localeDir, 'it.json'), 'utf8'))
+        ).errors,
+        [],
+        'a registered new locale must also pass full key and placeholder validation'
+    );
 });
 
 // --- Presence of the localized nav/calendar labels ---


### PR DESCRIPTION
## Summary

- document that translation changes ship only when a plugin build containing them is installed
- describe the existing bundled-first, default-offline loader and its gated GitHub failure fallback accurately
- replace stale GitHub-fetch wording across all 26 canonical locale catalogs
- add behavioral and contract tests for loader ordering, fallback gating, versioned 24-hour caching, contribution ownership, existing-locale edits, and new-locale registration

## Root cause

The contribution and help text described an immediate/Weblate-style deployment path that does not exist. The plugin actually embeds locale catalogs at build time, loads bundled assets first, and uses the Canopy GitHub repository only as an explicit failure fallback when asset caching is disabled.

## User impact

Contributors and administrators now get an accurate explanation of when translations become available and what the cache refresh task does. Runtime behavior is unchanged.

## Validation

- `node scripts/validate-translations.test.js` (20/20)
- focused loader Vitest (3/3)
- `npm run validate-translations` (26 catalogs, 709/709 keys each)
- `npm run test:scripts` (376/376)
- `npm run typecheck:src`
- `npm run typecheck`
- changed-file ESLint
- `npm run syntax`
- `npm run build:bundle` (163 deterministic files; budgets pass)
- Markdown links, docs assets, and strict MkDocs build
- focused `LocaleManifestTests` (7/7)
- independent repository review: APPROVE
- Fable 5 low review: APPROVE

The full local client coverage suite reached 1,263/1,264. Its sole failure was the unrelated #123 1,001-entry overflow timing test under V8 instrumentation; the relevant implementation/test/config are byte-identical to `main`, and that case subsequently passed under coverage on both `main` and this branch. GitHub CI remains the clean full-suite merge gate.

Closes #144
