### PR TITLE
test(e2e): source-gate Jellyfin-web pageerror noise

### DIFF
--- a/e2e/admin-theme-contrast.spec.ts
+++ b/e2e/admin-theme-contrast.spec.ts
@@ -8,7 +8,7 @@ import {
 
 const CONFIG_HASH = '#/configurationpage?name=Jellyfin%20Canopy';
 const DASHBOARD_CHROME =
-    /scrollHandler is not a function|\/Users\/[^/]+\/Images\/Primary|\/JellyfinCanopy\/BrandingImage/i;
+    /\/Users\/[^/]+\/Images\/Primary|\/JellyfinCanopy\/BrandingImage/i;
 
 function assertNoConfigPageRuntimeErrors(consoleErrors: ConsoleErrors): void {
     assertNoRuntimeErrors({

--- a/e2e/code-splitting.spec.ts
+++ b/e2e/code-splitting.spec.ts
@@ -109,16 +109,6 @@ function assertOnlyInducedImportFailure(
     ).toEqual([]);
 }
 
-/**
- * Jellyfin-web can emit this dashboard/search transition error from its own
- * hashed chunk while the recovered Seerr route settles. Keep the exception
- * source-gated so an identically worded Canopy error still fails the contract.
- */
-function isKnownJellyfinWebScrollError(text: string): boolean {
-    return /scrollHandler is not a function/.test(text)
-        && /\/web\/[A-Za-z0-9._-]+\.chunk\.js(?::\d+){1,2}/.test(text);
-}
-
 test.describe('manifest-owned code splitting', () => {
     test('cold authenticated home excludes disabled and off-route feature entries', async ({
         page,
@@ -341,7 +331,6 @@ test.describe('manifest-owned code splitting', () => {
         const entryAttempts: number[] = [];
         const implementationAttempts: number[] = [];
         const activationLogs: string[] = [];
-        const pageErrors: string[] = [];
         let releaseRecoveredChild!: () => void;
         const recoveredChildReleased = new Promise<void>((resolve) => {
             releaseRecoveredChild = resolve;
@@ -361,7 +350,6 @@ test.describe('manifest-owned code splitting', () => {
                 activationLogs.push(message.text());
             }
         });
-        page.on('pageerror', (error) => pageErrors.push(error.stack || error.message));
         await page.route(implementation.routePattern, async (route) => {
             const attempt = requestAttempt(route.request().url());
             implementationAttempts.push(attempt);
@@ -415,10 +403,6 @@ test.describe('manifest-owned code splitting', () => {
             implementationAttempts,
             'the dynamic relative child inherits the failed and recovered graph paths'
         ).toEqual([0, 1]);
-        expect(
-            pageErrors.filter((text) => !isKnownJellyfinWebScrollError(text)),
-            `no page errors after recovery\n${pageErrors.join('\n')}`
-        ).toEqual([]);
         assertOnlyInducedImportFailure(consoleErrors, entry.id);
     });
 });

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -69,10 +69,11 @@ const CONSOLE_NOISE: RegExp[] = [
 //   - /JellyfinCanopy/admin/ : RequiresElevation endpoints a non-admin
 //                                 session legitimately hits and degrades on
 //                                 (bare 403 — docs/developers.md#authorization-policies)
-// Config-page-only chrome noise (admin dashboard branding previews, the admin's
-// absent avatar, jellyfin-web's own dashboard pageerror) is NOT listed here — it
-// is scoped locally by each config-page spec so this web-client net stays tight
-// for normal pages.
+// Config-page-only chrome noise (admin dashboard branding previews and the
+// admin's absent avatar) is NOT listed here; each config-page spec scopes those
+// URL exceptions locally. The exact Jellyfin-web dashboard pageerror is instead
+// source- and stack-gated by isKnownJellyfinWebHostNoise below so every spec uses
+// one fail-closed owner without broadening the normal web-client noise list.
 const ALLOWED_4XX_URL: RegExp[] = [
     /\/socket(\?|$)/i,
     /favicon/i,

--- a/e2e/pages-lifecycle.spec.ts
+++ b/e2e/pages-lifecycle.spec.ts
@@ -3,29 +3,9 @@
 // (the ghost-page bug: page content lingering over other views until a
 // refresh), browser back re-opens it, deep links and refreshes render it,
 // and switching directly between two pages tears the first one down.
-import { test, expect, loginAs, type ConsoleErrors } from './fixtures/auth';
+import { test, expect, loginAs, assertNoRuntimeErrors } from './fixtures/auth';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-
-// jellyfin-web's OWN bundles emit two documented noise classes this spec can
-// encounter and must not fail on (neither is plugin code):
-//  - "[Home] failed to get tab controller … reading 'querySelector'"
-//    (hometab.*.chunk.js): a rare home remount race after fast view swaps
-//    under heavy host load — 10 standalone fast round-trips never reproduce
-//    it and the admin variant of the same flow passes in-suite.
-//  - "t.scrollHandler is not a function": a pageerror from jellyfin-web's own
-//    bundles on full page loads (this spec's deep-link/refresh path) — the
-//    same noise settings-persist.spec.ts already classifies; JC's only scroll
-//    feature uses `_scrollHandler` and runs only on Seerr discovery pages.
-// Filtered by exact message, nothing else.
-const KNOWN_WEB_NOISE = /\[Home\] failed to get tab controller|scrollHandler is not a function/;
-function assertNoPageLifecycleRuntimeErrors(consoleErrors: ConsoleErrors): void {
-    expect(consoleErrors.unexpected5xx(), 'unexpected 5xx responses').toEqual([]);
-    expect(
-        consoleErrors.real().filter((text) => !KNOWN_WEB_NOISE.test(text)),
-        'unexpected console errors'
-    ).toEqual([]);
-}
 
 const PAGES = [
     { id: 'calendar', route: '#/calendar', facade: 'calendarPage', marker: '#jc-calendar-container' },
@@ -91,7 +71,7 @@ test.describe('pages lifecycle (shared framework)', () => {
             await page.waitForSelector('#indexPage', { state: 'visible', timeout: 30_000 });
             await expectGone(page, info.marker);
 
-            assertNoPageLifecycleRuntimeErrors(consoleErrors);
+            assertNoRuntimeErrors(consoleErrors);
         });
     }
 
@@ -110,7 +90,7 @@ test.describe('pages lifecycle (shared framework)', () => {
             /page not found/i.test(document.body.innerText));
         expect(notFoundVisible, 'the 404 shell must not remain visible').toBe(false);
 
-        assertNoPageLifecycleRuntimeErrors(consoleErrors);
+        assertNoRuntimeErrors(consoleErrors);
     });
 
     test('page → page direct switch tears the first page down', async ({ page, consoleErrors }) => {
@@ -129,7 +109,7 @@ test.describe('pages lifecycle (shared framework)', () => {
         await page.waitForSelector('#indexPage', { state: 'visible', timeout: 30_000 });
         await expectGone(page, '#jc-downloads-container');
 
-        assertNoPageLifecycleRuntimeErrors(consoleErrors);
+        assertNoRuntimeErrors(consoleErrors);
     });
 
     test('non-admin: pages open and close cleanly too', async ({ page, consoleErrors }) => {
@@ -141,6 +121,6 @@ test.describe('pages lifecycle (shared framework)', () => {
         await page.waitForSelector('#indexPage', { state: 'visible', timeout: 30_000 });
         await expectGone(page, '#jc-calendar-container');
 
-        assertNoPageLifecycleRuntimeErrors(consoleErrors);
+        assertNoRuntimeErrors(consoleErrors);
     });
 });

--- a/e2e/requests-gating.spec.ts
+++ b/e2e/requests-gating.spec.ts
@@ -24,12 +24,11 @@ const CONFIG_HASH = '#/configurationpage?name=Jellyfin%20Canopy';
 // runs against arbitrary servers whose config page cannot meet the precondition.
 const NEEDS_TMDB = 'TMDB not configured on this exploratory server';
 
-// Jellyfin dashboard chrome can lack an admin avatar/branding preview and its
-// host bundle can emit the exact scroll-handler pageerror. Keep that existing
-// config-page exception local; every 5xx and every other console/4xx still
-// flows through the shared runtime assertion.
+// Jellyfin dashboard chrome can lack an admin avatar/branding preview. Keep
+// those config-page exceptions local; every 5xx and every other console/4xx
+// still flows through the shared runtime assertion.
 const DASHBOARD_CHROME =
-    /scrollHandler is not a function|\/Users\/[^/]+\/Images\/Primary|\/JellyfinCanopy\/BrandingImage/i;
+    /\/Users\/[^/]+\/Images\/Primary|\/JellyfinCanopy\/BrandingImage/i;
 
 function assertNoConfigPageRuntimeErrors(consoleErrors: ConsoleErrors): void {
     assertNoRuntimeErrors({

--- a/e2e/reviews-gating.spec.ts
+++ b/e2e/reviews-gating.spec.ts
@@ -29,7 +29,7 @@ const NEEDS_TMDB = 'TMDB not configured on this exploratory server';
 // exceptions. The adapter leaves every 5xx and every unrelated error visible
 // to the shared runtime assertion.
 const DASHBOARD_CHROME =
-    /scrollHandler is not a function|\/Users\/[^/]+\/Images\/Primary|\/JellyfinCanopy\/BrandingImage/i;
+    /\/Users\/[^/]+\/Images\/Primary|\/JellyfinCanopy\/BrandingImage/i;
 
 function assertNoConfigPageRuntimeErrors(consoleErrors: ConsoleErrors): void {
     assertNoRuntimeErrors({

--- a/e2e/settings-persist.spec.ts
+++ b/e2e/settings-persist.spec.ts
@@ -308,9 +308,6 @@ test.describe('per-user settings persistence', () => {
         // The full JF12 admin dashboard is the only place a plugin config page
         // can be shown. Its chrome emits core-Jellyfin noise that has nothing
         // to do with the plugin and does not appear on normal web-client pages:
-        //   - `t.scrollHandler is not a function`: a pageerror from
-        //     jellyfin-web's own dashboard bundle (JC's only scroll feature uses
-        //     `_scrollHandler` and runs only on Seerr discovery pages).
         //   - /Users/{id}/Images/Primary 404: the seeded admin has no avatar.
         //   - /JellyfinCanopy/BrandingImage 404: branding previews for assets
         //     that are not uploaded on the bare seed; config-page.js handles the
@@ -318,7 +315,7 @@ test.describe('per-user settings persistence', () => {
         // Filter exactly those, then assert the PLUGIN itself produced no console
         // errors or HTTP failures on the config page — a real, non-hollow check.
         const DASHBOARD_CHROME =
-            /scrollHandler is not a function|\/Users\/[^/]+\/Images\/Primary|\/JellyfinCanopy\/BrandingImage/i;
+            /\/Users\/[^/]+\/Images\/Primary|\/JellyfinCanopy\/BrandingImage/i;
         const serverErrors = consoleErrors.unexpected5xx();
         const pluginErrors = consoleErrors.real().filter((t) => !DASHBOARD_CHROME.test(t));
         const plugin4xx = consoleErrors.unexpected4xx().filter((r) => !DASHBOARD_CHROME.test(r.url));

--- a/scripts/e2e/jellyfin-host-noise.d.ts
+++ b/scripts/e2e/jellyfin-host-noise.d.ts
@@ -7,7 +7,12 @@ export function hasValidConcurrentLogoutResponses(
     responses: Array<{ requestIndex: number; status: number; bodyBytes: number }>
 ): boolean;
 export function isKnownHiddenContentHostNoise(text: string): boolean;
-export function isKnownJellyfinWebHostNoise(detail: { text: string; stack?: string }): boolean;
+export function isKnownJellyfinWebScrollHandlerError(
+    detail: { text: string; stack?: string; source?: string }
+): boolean;
+export function isKnownJellyfinWebHostNoise(
+    detail: { text: string; stack?: string; source?: string }
+): boolean;
 export function isExpectedSignedOutHostLogout4xx(
     response: { url: string; status: number; method: string },
     evidence: LogoutEvidence

--- a/scripts/e2e/jellyfin-host-noise.js
+++ b/scripts/e2e/jellyfin-host-noise.js
@@ -10,6 +10,7 @@ const HOME_LOGOUT_AXIOS_401 = 'AxiosError: Request failed with status code 401';
 const HOME_TAB_CHUNK = /\/web\/hometab\.[A-Za-z0-9]+\.chunk\.js:\d+:\d+/;
 const HOME_CHUNK = /\/web\/home\.[A-Za-z0-9]+\.chunk\.js:\d+:\d+/;
 const JELLYFIN_WEB_BUNDLE_FRAME = /\/web\/[A-Za-z0-9_.%-]+\.[A-Fa-f0-9]{12,}\.chunk\.js:\d+:\d+/;
+const JELLYFIN_WEB_CHUNK_FRAME = /(?:^|\n)[^\n]*(?:(?:https?:\/\/[^/\s)]+)|(?<![A-Za-z0-9._~!$&'()*+,;=:@%/?#-]))\/web\/[A-Za-z0-9_.%-]+\.[A-Fa-f0-9]{12,}\.chunk\.js:\d+(?::\d+)?(?:\)?\s*$)/m;
 const CANOPY_STACK_FRAME = /(?:^|\n)[^\n]*(?:\bJellyfinCanopy\b|\/JellyfinCanopy(?:\/|[?#]))/i;
 const HOME_TAB_SOURCE = /^\/web\/hometab\.[A-Za-z0-9]{12,}\.chunk\.js$/;
 const AXIOS_BUNDLE_PATH = '/web/node_modules.axios.bundle.js';
@@ -205,11 +206,26 @@ function isExpectedSignedOutHostLogout4xx(response, evidence) {
  * @param {string} text
  */
 function isKnownHiddenContentHostNoise(text) {
-    if (text === SCROLL_HANDLER_ERROR) return true;
     return text.startsWith(HOME_TAB_PREFIX)
         && HOME_TAB_CHUNK.test(text)
         && HOME_CHUNK.test(text)
         && !CANOPY_STACK_FRAME.test(text);
+}
+
+/**
+ * Exact Jellyfin-web scroll cleanup race. The message alone is not evidence of
+ * host ownership: require a pageerror with an immutable hashed stock-web frame,
+ * and fail closed when any Canopy frame appears in the same stack.
+ *
+ * @param {{text: string, stack?: string, source?: string}} detail
+ */
+function isKnownJellyfinWebScrollHandlerError(detail) {
+    const text = String(detail?.text || '');
+    const stack = String(detail?.stack || '');
+    return detail?.source === 'pageerror'
+        && text === SCROLL_HANDLER_ERROR
+        && JELLYFIN_WEB_CHUNK_FRAME.test(stack)
+        && !CANOPY_STACK_FRAME.test(stack);
 }
 
 /**
@@ -218,11 +234,12 @@ function isKnownHiddenContentHostNoise(text) {
  * not sufficient: it is accepted only with a browser stack pointing at the
  * immutable hashed Jellyfin-web chunk and with no Canopy frame.
  *
- * @param {{text: string, stack?: string}} detail
+ * @param {{text: string, stack?: string, source?: string}} detail
  */
 function isKnownJellyfinWebHostNoise(detail) {
     const text = String(detail?.text || '');
     const stack = String(detail?.stack || '');
+    if (isKnownJellyfinWebScrollHandlerError(detail)) return true;
     if (isKnownHiddenContentHostNoise(text)) return true;
     return text === HOME_SELECTED_INDEX_ERROR
         && JELLYFIN_WEB_BUNDLE_FRAME.test(stack)
@@ -285,6 +302,7 @@ module.exports = {
     SCROLL_HANDLER_ERROR,
     hasValidConcurrentLogoutResponses,
     isKnownHiddenContentHostNoise,
+    isKnownJellyfinWebScrollHandlerError,
     isKnownJellyfinWebHostNoise,
     isExpectedSignedOutHostLogout4xx,
     isExpectedSignedOutHomeAxios401,

--- a/scripts/e2e/jellyfin-host-noise.test.js
+++ b/scripts/e2e/jellyfin-host-noise.test.js
@@ -12,6 +12,7 @@ const {
     SCROLL_HANDLER_ERROR,
     hasValidConcurrentLogoutResponses,
     isKnownHiddenContentHostNoise,
+    isKnownJellyfinWebScrollHandlerError,
     isKnownJellyfinWebHostNoise,
     isExpectedSignedOutHostLogout4xx,
     isExpectedSignedOutHomeAxios401,
@@ -22,6 +23,13 @@ const ROOT = path.resolve(__dirname, '../..');
 const OBSERVED_HOME_RACE = `${HOME_TAB_PREFIX}\n`
     + '    at new e (http://localhost:8100/web/hometab.2be9340f81cc7f0987ef.chunk.js:1:1173)\n'
     + '    at http://localhost:8100/web/home.ea733a1f3e4e4f7bee3b.chunk.js:1:2950';
+
+const OBSERVED_SCROLL_HANDLER_RACE = {
+    source: 'pageerror',
+    text: SCROLL_HANDLER_ERROR,
+    stack: 'TypeError: t.scrollHandler is not a function\n'
+        + '    at http://localhost:8100/web/dashboard.2be9340f81cc7f0987ef.chunk.js:1:1173',
+};
 
 const LOGOUT_ORIGIN = 'http://127.0.0.1:8100';
 const OLD_USER_ID = '92bdc95c7381435689451ad246198f74';
@@ -102,10 +110,71 @@ const OBSERVED_SIGNED_OUT_HOME_401S = [
     '/Items/Latest?userId=92bdc95c7381435689451ad246198f74&parentId=f137a2dd21bbc1b99aa5c0f6bf02a805&fields=PrimaryImageAspectRatio&fields=Path&imageTypeLimit=1&enableImageTypes=Primary&enableImageTypes=Backdrop&enableImageTypes=Thumb&limit=16',
 ];
 
-test('accepts only the exact observed scroll-handler host message', () => {
-    assert.equal(isKnownHiddenContentHostNoise(SCROLL_HANDLER_ERROR), true);
-    assert.equal(isKnownHiddenContentHostNoise(`${SCROLL_HANDLER_ERROR} extra`), false);
-    assert.equal(isKnownHiddenContentHostNoise('t.scrollHandler is not a function'), false);
+test('scroll-handler host race requires the exact pageerror and a hashed stock-web frame', () => {
+    assert.equal(isKnownJellyfinWebScrollHandlerError(OBSERVED_SCROLL_HANDLER_RACE), true);
+    assert.equal(isKnownJellyfinWebHostNoise(OBSERVED_SCROLL_HANDLER_RACE), true);
+    assert.equal(
+        isKnownJellyfinWebScrollHandlerError({
+            ...OBSERVED_SCROLL_HANDLER_RACE,
+            stack: OBSERVED_SCROLL_HANDLER_RACE.stack.replace(':1:1173', ':1'),
+        }),
+        true,
+        'a browser frame with a line and no column remains valid'
+    );
+    assert.equal(
+        isKnownHiddenContentHostNoise(SCROLL_HANDLER_ERROR),
+        false,
+        'the legacy string-only predicate cannot establish source ownership'
+    );
+});
+
+test('scroll-handler classifier rejects missing, similar, non-pageerror, and non-stock evidence', () => {
+    const rejected = [
+        { ...OBSERVED_SCROLL_HANDLER_RACE, stack: '' },
+        { ...OBSERVED_SCROLL_HANDLER_RACE, source: 'console' },
+        { ...OBSERVED_SCROLL_HANDLER_RACE, source: undefined },
+        { ...OBSERVED_SCROLL_HANDLER_RACE, text: 't.scrollHandler is not a function' },
+        { ...OBSERVED_SCROLL_HANDLER_RACE, text: `${SCROLL_HANDLER_ERROR} extra` },
+        {
+            ...OBSERVED_SCROLL_HANDLER_RACE,
+            stack: 'TypeError: t.scrollHandler is not a function\n'
+                + '    at http://localhost:8100/web/dashboard.chunk.js:1:1173',
+        },
+        {
+            ...OBSERVED_SCROLL_HANDLER_RACE,
+            stack: 'TypeError: t.scrollHandler is not a function\n'
+                + '    at http://localhost:8100/api/web/dashboard.2be9340f81cc7f0987ef.chunk.js:1:1173',
+        },
+        {
+            ...OBSERVED_SCROLL_HANDLER_RACE,
+            stack: 'TypeError: t.scrollHandler is not a function\n'
+                + '    at http://localhost:8100/dashboard?/web/dashboard.2be9340f81cc7f0987ef.chunk.js:1:1173',
+        },
+        {
+            ...OBSERVED_SCROLL_HANDLER_RACE,
+            stack: 'TypeError: t.scrollHandler is not a function\n'
+                + '    at http://localhost:8100/dashboard#/web/dashboard.2be9340f81cc7f0987ef.chunk.js:1:1173',
+        },
+        {
+            ...OBSERVED_SCROLL_HANDLER_RACE,
+            stack: 'TypeError: t.scrollHandler is not a function\n'
+                + '    at http://localhost:8100/JellyfinCanopy/dist/dashboard.2be9340f81cc7f0987ef.chunk.js:1:1173',
+        },
+    ];
+    for (const detail of rejected) {
+        assert.equal(isKnownJellyfinWebScrollHandlerError(detail), false, JSON.stringify(detail));
+        assert.equal(isKnownJellyfinWebHostNoise(detail), false, JSON.stringify(detail));
+    }
+});
+
+test('scroll-handler classifier rejects a mixed stock-web and Canopy stack', () => {
+    const mixed = {
+        ...OBSERVED_SCROLL_HANDLER_RACE,
+        stack: `${OBSERVED_SCROLL_HANDLER_RACE.stack}\n`
+            + '    at http://localhost:8100/JellyfinCanopy/dist/jc.bundle.js:4:20',
+    };
+    assert.equal(isKnownJellyfinWebScrollHandlerError(mixed), false);
+    assert.equal(isKnownJellyfinWebHostNoise(mixed), false);
 });
 
 test('accepts the observed Home race only with both Jellyfin host chunks', () => {
@@ -372,4 +441,33 @@ test('account switching scopes logout Axios noise to the phase-local response cl
     assert.match(source, /response\.status === 401\s*&& isExpectedSignedOutHostLogout4xx\(response, evidence\)/);
     assert.match(source, /failed\.filter\(\(response\) => !isExpectedSignedOutHostLogout4xx\(response, evidence\)\)/);
     assert.doesNotMatch(source, /HOST_LOGOUT_NOISE[\s\S]*AxiosError/);
+});
+
+test('every former scroll-handler E2E consumer delegates to the shared fixture', () => {
+    const e2eRoot = path.join(ROOT, 'e2e');
+    const e2eTypeScript = fs.readdirSync(e2eRoot, { recursive: true })
+        .filter((relativePath) => relativePath.endsWith('.ts'));
+    for (const relativePath of e2eTypeScript) {
+        const source = fs.readFileSync(path.join(e2eRoot, relativePath), 'utf8');
+        assert.doesNotMatch(source, /scrollHandler is not a function/, relativePath);
+        assert.doesNotMatch(source, /isKnownJellyfinWebScrollError/, relativePath);
+    }
+
+    const consumers = [
+        'e2e/admin-theme-contrast.spec.ts',
+        'e2e/code-splitting.spec.ts',
+        'e2e/pages-lifecycle.spec.ts',
+        'e2e/requests-gating.spec.ts',
+        'e2e/reviews-gating.spec.ts',
+        'e2e/settings-persist.spec.ts',
+    ];
+    for (const relativePath of consumers) {
+        const source = fs.readFileSync(path.join(ROOT, relativePath), 'utf8');
+        assert.match(source, /consoleErrors/);
+    }
+
+    const fixture = fs.readFileSync(path.join(ROOT, 'e2e/fixtures/auth.ts'), 'utf8');
+    assert.match(fixture, /source: 'pageerror'/);
+    assert.match(fixture, /stack: String\(error\.stack \|\| ''\)/);
+    assert.match(fixture, /!isKnownJellyfinWebHostNoise\(detail\)/);
 });


### PR DESCRIPTION
Closes #323.

## Outcome

Centralizes the known Jellyfin-web `t.scrollHandler is not a function` pageerror in the shared E2E host-noise owner and removes duplicated, broader consumer filters.

The classifier now accepts the stock race only when all evidence agrees: Playwright source is `pageerror`, the message is exact, the stack contains a root `/web/<name>.<12+ hex>.chunk.js:<line>[:column]` frame, and the complete stack contains no Jellyfin Canopy frame. Missing, similar, pure-Canopy, mixed, nested-path, query, and fragment impostors remain fatal.

## Changes

- Added the structured shared classifier and declaration.
- Removed the unsafe string-only Hidden Content branch.
- Migrated code-splitting, page lifecycle, settings, theme, requests, and reviews E2E consumers to the shared fixture policy.
- Added deterministic positive, negative, mixed-stack, path-boundary, and source-contract tests.
- Corrected the fixture policy comment to match the shared ownership boundary.

## Validation

- `npm run check:toolchain` — Node 22.20.0 / npm 10.9.3
- focused host-noise contracts — 20/20 passed
- `npm run test:scripts` — 379/379 passed
- `npm run typecheck` — passed
- `npm run syntax` — passed
- affected Playwright inventory — 22 tests across 6 specs listed successfully
- `./verify.sh lint` — advisory signal completed; no changed-file findings
- `git diff --check` — passed
- independent agent final review — APPROVE
- Fable 5 low review — APPROVE; its query/fragment boundary suggestion was implemented and independently re-approved

## Implementation notes

This change was developed with AI assistance. The resulting diff and tests were independently reviewed and locally validated.