### PR TITLE
fix(client): own settings panel lifecycle

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/entry-points.lazy.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/entry-points.lazy.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { JC } from '../../globals';
+import { handleHistoryUpdate } from '../../core/navigation';
 
 const mocks = vi.hoisted(() => {
     let release!: () => void;
@@ -32,7 +33,7 @@ afterEach(() => {
 });
 
 describe('settings panel dynamic import fence', () => {
-    it('singleflights the graph and rejects a completion from an obsolete identity', async () => {
+    it('singleflights the graph and rejects navigation or identity-obsolete completions', async () => {
         JC.identity.transition('', '', 'settings-lazy-test-logout');
         JC.identity.transition('server', 'user-a', 'settings-lazy-test-a');
         dispose = installSettingsLauncher();
@@ -42,11 +43,24 @@ describe('settings panel dynamic import fence', () => {
         await vi.waitFor(() => expect(mocks.loadCount).toBe(1));
         expect(mocks.show).not.toHaveBeenCalled();
 
-        JC.identity.transition('server', 'user-b', 'settings-lazy-test-b');
+        history.pushState({}, '', `#/settings-lazy-nav-${Date.now()}`);
         mocks.release();
         await Promise.all([first, second]);
 
         expect(mocks.loadCount).toBe(1);
+        expect(mocks.show).not.toHaveBeenCalled();
+        expect(mocks.reset).not.toHaveBeenCalled();
+
+        await openEnhancedPanel();
+        expect(mocks.show).toHaveBeenCalledTimes(1);
+        mocks.show.mockClear();
+        history.pushState({}, '', `#/settings-lazy-active-${Date.now()}`);
+        handleHistoryUpdate();
+        expect(mocks.reset).toHaveBeenCalledTimes(1);
+
+        const obsoleteIdentity = openEnhancedPanel();
+        JC.identity.transition('server', 'user-b', 'settings-lazy-test-b');
+        await obsoleteIdentity;
         expect(mocks.show).not.toHaveBeenCalled();
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/entry-points.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/entry-points.ts
@@ -260,10 +260,19 @@ export function installSettingsLauncher(): () => void {
     JC.isVideoPage = stableSettingsLauncher.facade.videoPage;
     JC.showEnhancedPanel = stableSettingsLauncher.facade.show;
     const unregisterReset = JC.identity.registerReset('settings-launcher', resetSettingsLauncher);
+    // A settings panel belongs to the exact page on which the user opened it.
+    // Retire both a pending dynamic import/settings refresh and an active panel
+    // on same-identity SPA navigation. This subscription is activation-owned,
+    // so importing the lazy panel graph remains side-effect free.
+    const unregisterNavigation = onNavigate(() => {
+        launcherGeneration += 1;
+        panelModule?.resetSettingsPanel();
+    });
     let disposed = false;
     return () => {
         if (disposed) return;
         disposed = true;
+        unregisterNavigation();
         resetSettingsLauncher();
         unregisterReset();
         uninstall();

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/panel.lifecycle.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/panel.lifecycle.test.ts
@@ -1,0 +1,447 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+import { isAnyModalOpen } from '../../core/modal-a11y';
+import { handleHistoryUpdate } from '../../core/navigation';
+import { installSettingsLauncher } from './entry-points';
+import type { ApiApi, CoreFetchOptions } from '../../types/jc';
+
+const mocks = vi.hoisted(() => ({
+    resetLanguageControls: vi.fn(),
+    resetReleaseNotes: vi.fn(),
+    wireHiddenContentListeners: vi.fn(),
+    wireLanguageControls: vi.fn(),
+    wireMiscSettingsControls: vi.fn(),
+    wireSettingsListeners: vi.fn(),
+    wireShortcutEditor: vi.fn(),
+    wireSpoilerGuardListeners: vi.fn(),
+}));
+
+vi.mock('./template', () => ({
+    buildPanelHtml: () => `
+        <button id="closeSettingsPanel" type="button">close</button>
+        <div class="jc-panel-body">
+            <div class="jc-panel-nav"><div class="jc-panel-nav-items"></div></div>
+            <div class="jc-panel-main">
+                <button id="jcPanelBack" type="button">back</button>
+                <section class="jc-pane" data-pane="general">
+                    <h2 class="jc-pane-title">General</h2>
+                    <details id="lifecycleDetails"><summary>details</summary></details>
+                </section>
+            </div>
+        </div>`,
+}));
+vi.mock('./shortcut-editor', () => ({ wireShortcutEditor: mocks.wireShortcutEditor }));
+vi.mock('./settings', () => ({
+    wireSettingsListeners: mocks.wireSettingsListeners,
+    wireMiscSettingsControls: mocks.wireMiscSettingsControls,
+}));
+vi.mock('./hidden-content-tab', () => ({
+    wireHiddenContentListeners: mocks.wireHiddenContentListeners,
+}));
+vi.mock('../spoiler-guard/settings-tab', () => ({
+    wireSpoilerGuardListeners: mocks.wireSpoilerGuardListeners,
+}));
+vi.mock('./language', () => ({
+    resetLanguageControls: mocks.resetLanguageControls,
+    wireLanguageControls: mocks.wireLanguageControls,
+}));
+vi.mock('./release-notes', () => ({
+    resetReleaseNotes: mocks.resetReleaseNotes,
+}));
+
+interface Deferred<T> {
+    promise: Promise<T>;
+    resolve(value: T): void;
+}
+
+function deferred<T>(): Deferred<T> {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((done) => { resolve = done; });
+    return { promise, resolve };
+}
+
+function trackPanelTimers(): Map<number, number> {
+    const active = new Map<number, number>();
+    const realSetTimeout = window.setTimeout.bind(window);
+    const realClearTimeout = globalThis.clearTimeout.bind(globalThis);
+    vi.spyOn(window, 'setTimeout').mockImplementation(((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
+        let timer = 0;
+        const wrapped = () => {
+            active.delete(timer);
+            if (typeof handler !== 'function') throw new TypeError('Expected a function timer handler');
+            Reflect.apply(handler, window, args);
+        };
+        timer = realSetTimeout(wrapped, timeout);
+        if (timeout === 10 || timeout === 20 || timeout === 150) active.set(timer, timeout);
+        return timer;
+    }) as typeof window.setTimeout);
+    vi.spyOn(globalThis, 'clearTimeout').mockImplementation((timer?: number) => {
+        if (timer !== undefined) active.delete(timer);
+        realClearTimeout(timer);
+    });
+    return active;
+}
+
+interface TrackedListener {
+    target: EventTarget;
+    type: string;
+    listener: EventListenerOrEventListenerObject;
+    capture: boolean;
+}
+
+function captureOption(options?: boolean | AddEventListenerOptions | EventListenerOptions): boolean {
+    return typeof options === 'boolean' ? options : options?.capture === true;
+}
+
+function trackExternalListeners(mediaTargets: Set<EventTarget>): TrackedListener[] {
+    const active: TrackedListener[] = [];
+    // The original methods are intentionally invoked through `.call(this, …)`
+    // below so the ledger can wrap every external EventTarget instance.
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const realAdd = EventTarget.prototype.addEventListener;
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const realRemove = EventTarget.prototype.removeEventListener;
+    const isExternal = (target: EventTarget) => target === document
+        || target === window
+        || mediaTargets.has(target);
+
+    vi.spyOn(EventTarget.prototype, 'addEventListener').mockImplementation(function (
+        this: EventTarget,
+        type: string,
+        listener: EventListenerOrEventListenerObject | null,
+        options?: boolean | AddEventListenerOptions
+    ): void {
+        realAdd.call(this, type, listener, options);
+        if (!listener || !isExternal(this)) return;
+        const capture = captureOption(options);
+        if (!active.some(entry => entry.target === this && entry.type === type
+            && entry.listener === listener && entry.capture === capture)) {
+            active.push({ target: this, type, listener, capture });
+        }
+    });
+    vi.spyOn(EventTarget.prototype, 'removeEventListener').mockImplementation(function (
+        this: EventTarget,
+        type: string,
+        listener: EventListenerOrEventListenerObject | null,
+        options?: boolean | EventListenerOptions
+    ): void {
+        realRemove.call(this, type, listener, options);
+        if (!listener || !isExternal(this)) return;
+        const capture = captureOption(options);
+        const index = active.findIndex(entry => entry.target === this && entry.type === type
+            && entry.listener === listener && entry.capture === capture);
+        if (index >= 0) active.splice(index, 1);
+    });
+    return active;
+}
+
+const originalApi = JC.core.api;
+const originalLoadSettings = JC.loadSettings;
+const originalSaveUserSettings = JC.saveUserSettings;
+let showPanel: (() => Promise<void>) | null = null;
+let resetPanel: (() => void) | null = null;
+let disposeLauncher: (() => void) | null = null;
+const mediaTargets = new Set<EventTarget>();
+
+describe('settings panel lifecycle owner', () => {
+    beforeEach(async () => {
+        vi.useFakeTimers();
+        vi.clearAllMocks();
+        mediaTargets.clear();
+        vi.stubGlobal('matchMedia', vi.fn((query: string): MediaQueryList => {
+            const target = new EventTarget();
+            mediaTargets.add(target);
+            return Object.assign(target, {
+                matches: false,
+                media: query,
+                onchange: null,
+                addListener(listener: (event: MediaQueryListEvent) => void) {
+                    target.addEventListener('change', listener as EventListener);
+                },
+                removeListener(listener: (event: MediaQueryListEvent) => void) {
+                    target.removeEventListener('change', listener as EventListener);
+                },
+            }) as MediaQueryList;
+        }));
+        mocks.wireShortcutEditor.mockImplementation((ctx: { trackTimer(timer: number): void }) => {
+            ctx.trackTimer(window.setTimeout(() => undefined, 20));
+        });
+        mocks.wireSettingsListeners.mockImplementation((ctx: { registerCleanup(cleanup: () => void): void }) => {
+            const onTouchMove = () => undefined;
+            document.addEventListener('touchmove', onTouchMove);
+            ctx.registerCleanup(() => document.removeEventListener('touchmove', onTouchMove));
+        });
+        document.body.innerHTML = '<button id="returnFocus" type="button">before</button>';
+        document.body.className = '';
+        JC.identity.transition('', '', 'settings-panel-lifecycle-logout');
+        const identity = JC.identity.transition('server-a', 'user-a', 'settings-panel-lifecycle-login')!;
+        JC.pluginConfig = { Shortcuts: [], DisableAllShortcuts: false };
+        JC.userConfig = JC.identity.own({ settings: JC.identity.own({}, identity) }, identity);
+        JC.currentSettings = JC.identity.own({}, identity);
+        JC.core.api = {
+            plugin: vi.fn().mockResolvedValue({}),
+        } as unknown as ApiApi;
+        JC.loadSettings = vi.fn(() => JC.identity.own({}, identity));
+        JC.saveUserSettings = vi.fn().mockResolvedValue(undefined);
+        JC.CONFIG = { ...JC.CONFIG, HELP_PANEL_AUTOCLOSE_DELAY: 10 };
+        JC.state = {
+            ...JC.state,
+            activeShortcuts: { GoToHome: 'H' },
+            removeContext: JC.state?.removeContext ?? null,
+            pauseScreenClickTimer: JC.state?.pauseScreenClickTimer ?? null,
+        };
+        JC.t = (key: string) => key;
+        JC.initializeShortcuts = vi.fn();
+        (window.JellyfinCanopy as typeof JC & { toCamelCase(value: unknown): unknown }).toCamelCase = value => value;
+        (JC as typeof JC & { themer: { getThemeVariables(): Record<string, string> } }).themer = {
+            getThemeVariables: () => ({
+                panelBg: '#181818', secondaryBg: '#222', altAccent: '#333',
+                blur: '0px', textColor: '#fff', logo: '',
+            }),
+        };
+        const panel = await import('./panel');
+        showPanel = panel.showEnhancedPanel;
+        resetPanel = panel.resetSettingsPanel;
+        resetPanel();
+    });
+
+    afterEach(() => {
+        disposeLauncher?.();
+        disposeLauncher = null;
+        resetPanel?.();
+        showPanel = null;
+        resetPanel = null;
+        JC.core.api = originalApi;
+        JC.loadSettings = originalLoadSettings;
+        JC.saveUserSettings = originalSaveUserSettings;
+        document.body.innerHTML = '';
+        document.body.className = '';
+        vi.unstubAllGlobals();
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    it('singleflights simultaneous opens while the settings refresh is pending', async () => {
+        const response = deferred<unknown>();
+        const plugin = vi.fn(() => response.promise);
+        JC.core.api = { plugin } as unknown as ApiApi;
+
+        const openings = Array.from({ length: 100 }, () => showPanel!());
+
+        expect(plugin).toHaveBeenCalledTimes(1);
+        expect(document.querySelectorAll('#jellyfin-canopy-panel')).toHaveLength(0);
+
+        response.resolve({});
+        await Promise.all(openings);
+
+        expect(document.querySelectorAll('#jellyfin-canopy-panel')).toHaveLength(1);
+        expect(isAnyModalOpen()).toBe(true);
+
+        plugin.mockClear();
+        await showPanel!();
+        expect(plugin).not.toHaveBeenCalled();
+        expect(document.getElementById('jellyfin-canopy-panel')).toBeNull();
+    });
+
+    it('cancels an opening reservation during launcher/navigation teardown', async () => {
+        const response = deferred<unknown>();
+        let options: CoreFetchOptions | undefined;
+        JC.core.api = {
+            plugin: vi.fn((_path: string, requestOptions?: CoreFetchOptions) => {
+                options = requestOptions;
+                return response.promise;
+            }),
+        } as unknown as ApiApi;
+
+        const opening = showPanel!();
+        expect(options?.signal?.aborted).toBe(false);
+
+        resetPanel!();
+        expect(options?.signal?.aborted).toBe(true);
+
+        response.resolve({});
+        await opening;
+        expect(document.getElementById('jellyfin-canopy-panel')).toBeNull();
+        expect(isAnyModalOpen()).toBe(false);
+    });
+
+    it('prevents a retired opening from publishing over a replacement owner', async () => {
+        const firstResponse = deferred<unknown>();
+        const secondResponse = deferred<unknown>();
+        const responses = [firstResponse, secondResponse];
+        const signals: AbortSignal[] = [];
+        JC.core.api = {
+            plugin: vi.fn((_path: string, options?: CoreFetchOptions) => {
+                signals.push(options!.signal!);
+                return responses[signals.length - 1].promise;
+            }),
+        } as unknown as ApiApi;
+
+        const first = showPanel!();
+        resetPanel!();
+        expect(signals[0].aborted).toBe(true);
+
+        const second = showPanel!();
+        secondResponse.resolve({ owner: 'second' });
+        await second;
+        const replacement = document.getElementById('jellyfin-canopy-panel');
+        expect(replacement).not.toBeNull();
+        expect(signals[1].aborted).toBe(false);
+
+        firstResponse.resolve({ owner: 'first' });
+        await first;
+        expect(document.getElementById('jellyfin-canopy-panel')).toBe(replacement);
+        expect(isAnyModalOpen()).toBe(true);
+    });
+
+    it('disposes partially installed resources when a panel wire step throws', async () => {
+        const activeTimers = trackPanelTimers();
+        const activeListeners = trackExternalListeners(mediaTargets);
+        const baselineBody = Array.from(document.body.children);
+        mocks.wireSettingsListeners.mockImplementationOnce(() => {
+            throw new Error('wire failed');
+        });
+
+        await expect(showPanel!()).rejects.toThrow('wire failed');
+
+        expect(document.getElementById('jellyfin-canopy-panel')).toBeNull();
+        expect(document.getElementById('jellyfin-canopy-panel-backdrop')).toBeNull();
+        expect(Array.from(document.body.children)).toEqual(baselineBody);
+        expect(isAnyModalOpen()).toBe(false);
+        expect(activeTimers.size).toBe(0);
+        expect(activeListeners).toEqual([]);
+    });
+
+    it('restores focus and accessibility exactly once when disposal is repeated', async () => {
+        const returnFocus = document.getElementById('returnFocus') as HTMLButtonElement;
+        returnFocus.focus();
+        const focus = vi.spyOn(returnFocus, 'focus');
+
+        await showPanel!();
+        resetPanel!();
+        resetPanel!();
+
+        expect(focus).toHaveBeenCalledTimes(1);
+        expect(isAnyModalOpen()).toBe(false);
+        expect(document.body.classList.contains('jc-modal-open')).toBe(false);
+    });
+
+    it('continues disposing resources after one child cleanup throws', async () => {
+        const beforeThrow = vi.fn();
+        const throws = vi.fn(() => { throw new Error('cleanup failed'); });
+        mocks.wireSettingsListeners.mockImplementationOnce((ctx: { registerCleanup(cleanup: () => void): void }) => {
+            ctx.registerCleanup(beforeThrow);
+            ctx.registerCleanup(throws);
+        });
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+        await showPanel!();
+        resetPanel!();
+        resetPanel!();
+
+        expect(throws).toHaveBeenCalledTimes(1);
+        expect(beforeThrow).toHaveBeenCalledTimes(1);
+        expect(warn).toHaveBeenCalledWith(
+            '🪼 Jellyfin Canopy: Settings panel cleanup failed:',
+            expect.any(Error)
+        );
+        expect(document.getElementById('jellyfin-canopy-panel')).toBeNull();
+        expect(isAnyModalOpen()).toBe(false);
+    });
+
+    it.each(['navigation', 'account'] as const)(
+        'retires real pending and mounted panel owners on %s teardown',
+        async (boundary) => {
+            disposeLauncher = installSettingsLauncher();
+            const pendingResponse = deferred<unknown>();
+            let pendingSignal: AbortSignal | undefined;
+            const plugin = vi.fn((_path: string, options?: CoreFetchOptions) => {
+                pendingSignal = options?.signal;
+                return pendingResponse.promise;
+            });
+            JC.core.api = { plugin } as unknown as ApiApi;
+
+            const pending = JC.showEnhancedPanel!();
+            await vi.waitFor(() => expect(plugin).toHaveBeenCalledTimes(1));
+            expect(pendingSignal?.aborted).toBe(false);
+
+            if (boundary === 'navigation') {
+                history.pushState({}, '', `#/panel-pending-${Date.now()}`);
+                handleHistoryUpdate();
+            } else {
+                JC.identity.transition('server-a', 'user-b', 'panel-pending-account');
+            }
+            expect(pendingSignal?.aborted).toBe(true);
+            pendingResponse.resolve({});
+            await pending;
+            expect(document.getElementById('jellyfin-canopy-panel')).toBeNull();
+            expect(isAnyModalOpen()).toBe(false);
+
+            const identity = JC.identity.capture()!;
+            JC.userConfig = JC.identity.own({ settings: JC.identity.own({}, identity) }, identity);
+            JC.currentSettings = JC.identity.own({}, identity);
+            JC.loadSettings = vi.fn(() => JC.identity.own({}, identity));
+            JC.core.api = { plugin: vi.fn().mockResolvedValue({}) } as unknown as ApiApi;
+            const baselineBody = Array.from(document.body.children);
+            const activeTimers = trackPanelTimers();
+            const activeListeners = trackExternalListeners(mediaTargets);
+            const returnFocus = document.getElementById('returnFocus') as HTMLButtonElement;
+            returnFocus.focus();
+
+            await JC.showEnhancedPanel!();
+            expect(document.getElementById('jellyfin-canopy-panel')).not.toBeNull();
+            if (boundary === 'navigation') {
+                history.pushState({}, '', `#/panel-active-${Date.now()}`);
+                handleHistoryUpdate();
+            } else {
+                JC.identity.transition('server-a', 'user-c', 'panel-active-account');
+            }
+
+            expect(document.getElementById('jellyfin-canopy-panel')).toBeNull();
+            expect(document.getElementById('jellyfin-canopy-panel-backdrop')).toBeNull();
+            expect(Array.from(document.body.children)).toEqual(baselineBody);
+            expect(activeTimers).toEqual(new Map());
+            expect(activeListeners).toEqual([]);
+            expect(isAnyModalOpen()).toBe(false);
+            expect(document.activeElement).toBe(returnFocus);
+        }
+    );
+
+    it.each(['toggle', 'button', 'backdrop', 'escape', 'question', 'auto-close', 'teardown'] as const)(
+        'leaves baseline resources after 100 %s close cycles',
+        async (closePath) => {
+            const activeTimers = trackPanelTimers();
+            const activeListeners = trackExternalListeners(mediaTargets);
+            const baselineBody = Array.from(document.body.children);
+
+            for (let cycle = 0; cycle < 100; cycle += 1) {
+                await showPanel!();
+                expect(document.querySelectorAll('#jellyfin-canopy-panel')).toHaveLength(1);
+                const details = document.getElementById('lifecycleDetails') as HTMLDetailsElement;
+                details.open = true;
+                details.dispatchEvent(new Event('toggle'));
+
+                if (closePath === 'toggle') await showPanel!();
+                else if (closePath === 'button') document.getElementById('closeSettingsPanel')!.click();
+                else if (closePath === 'backdrop') {
+                    document.getElementById('jellyfin-canopy-panel-backdrop')!.click();
+                }
+                else if (closePath === 'escape') {
+                    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+                } else if (closePath === 'question') {
+                    document.dispatchEvent(new KeyboardEvent('keydown', { key: '?', bubbles: true }));
+                } else if (closePath === 'auto-close') {
+                    await vi.advanceTimersByTimeAsync(10);
+                } else resetPanel!();
+
+                expect(document.getElementById('jellyfin-canopy-panel')).toBeNull();
+                expect(document.getElementById('jellyfin-canopy-panel-backdrop')).toBeNull();
+                expect(Array.from(document.body.children)).toEqual(baselineBody);
+                expect(isAnyModalOpen()).toBe(false);
+                expect(activeTimers.size).toBe(0);
+                expect(activeListeners).toEqual([]);
+            }
+        },
+        60_000
+    );
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/panel.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/panel.ts
@@ -7,7 +7,7 @@
 // (Converted from js/enhanced/ui-panel.js — bodies semantically identical.)
 
 import { JC } from '../../globals';
-import { installModalA11y, type ModalA11yHandle } from '../../core/modal-a11y';
+import { installModalA11y } from '../../core/modal-a11y';
 import { buildPanelHtml } from './template';
 import { wireShortcutEditor } from './shortcut-editor';
 import { wireSettingsListeners, wireMiscSettingsControls } from './settings';
@@ -49,13 +49,114 @@ export interface PanelContext {
 const CANOPY_ACCENT = '#00D4FF';
 const CANOPY_ACCENT_FILL = '#2F80FF';
 const CANOPY_GRADIENT = 'linear-gradient(135deg, #00D4FF 0%, #2F80FF 52%, #7B4CFF 100%)';
+const PANEL_ID = 'jellyfin-canopy-panel';
+const BACKDROP_ID = 'jellyfin-canopy-panel-backdrop';
 
-/**
- * Toggles the main settings and help panel for the plugin.
- */
-export async function showEnhancedPanel(): Promise<void> {
+type PanelPhase = 'opening' | 'open' | 'disposed';
+
+interface PanelOwner {
+    readonly identityContext: IdentityContext;
+    readonly abortController: AbortController;
+    phase: PanelPhase;
+    root: HTMLElement | null;
+    isCurrent(): boolean;
+    registerCleanup(cleanup: () => void): void;
+    trackTimer(timer: number): void;
+    forgetTimer(timer: number): void;
+    dispose(): void;
+}
+
+let currentPanelOwner: PanelOwner | null = null;
+let openingPromise: Promise<void> | null = null;
+
+function createPanelOwner(identityContext: IdentityContext): PanelOwner {
+    const cleanups: Array<() => void> = [];
+    const timers = new Set<number>();
+    const owner: PanelOwner = {
+        identityContext,
+        abortController: new AbortController(),
+        phase: 'opening',
+        root: null,
+        isCurrent: () => owner.phase !== 'disposed'
+            && currentPanelOwner === owner
+            && JC.identity.isCurrent(identityContext),
+        registerCleanup(cleanup) {
+            if (owner.phase === 'disposed') {
+                try { cleanup(); } catch (error) {
+                    console.warn('🪼 Jellyfin Canopy: Settings panel late cleanup failed:', error);
+                }
+                return;
+            }
+            cleanups.push(cleanup);
+        },
+        trackTimer(timer) {
+            if (owner.phase === 'disposed') clearTimeout(timer);
+            else timers.add(timer);
+        },
+        forgetTimer(timer) {
+            timers.delete(timer);
+        },
+        dispose() {
+            if (owner.phase === 'disposed') return;
+            owner.phase = 'disposed';
+            if (currentPanelOwner === owner) currentPanelOwner = null;
+            owner.abortController.abort();
+            for (const timer of timers) clearTimeout(timer);
+            timers.clear();
+            for (const cleanup of cleanups.splice(0).reverse()) {
+                try { cleanup(); } catch (error) {
+                    // One faulty child cleanup must not strand later listeners,
+                    // the modal gate, focus restoration, or the exact panel DOM.
+                    console.warn('🪼 Jellyfin Canopy: Settings panel cleanup failed:', error);
+                }
+            }
+            owner.root = null;
+        },
+    };
+    return owner;
+}
+
+type OwnedPanelElement = HTMLElement & { _identityCleanup?: () => void };
+
+/** Toggle the main settings panel, joining calls made during the same open. */
+export function showEnhancedPanel(): Promise<void> {
+    if (currentPanelOwner?.phase === 'open') {
+        currentPanelOwner.dispose();
+        return Promise.resolve();
+    }
+    if (currentPanelOwner?.phase === 'opening' && openingPromise) return openingPromise;
+
+    // A DOM node from an obsolete bundle cannot be a valid owner. Retire its
+    // full stored disposer before any network work; raw removal is defensive
+    // only for foreign/stale markup that never acquired resources here.
+    const existing: OwnedPanelElement | null = document.getElementById(PANEL_ID);
+    if (existing) {
+        if (existing._identityCleanup) existing._identityCleanup();
+        else existing.remove();
+        document.getElementById(BACKDROP_ID)?.remove();
+        return Promise.resolve();
+    }
+    document.getElementById(BACKDROP_ID)?.remove();
+
     const identityContext = JC.identity.capture();
-    if (!identityContext) return;
+    if (!identityContext) return Promise.resolve();
+    const owner = createPanelOwner(identityContext);
+    currentPanelOwner = owner;
+
+    const opening = openPanel(owner).catch((error: unknown) => {
+        owner.dispose();
+        throw error;
+    }).finally(() => {
+        if (openingPromise === opening) openingPromise = null;
+        // Every early/stale return leaves the reservation in opening state.
+        if (owner.phase === 'opening') owner.dispose();
+    });
+    openingPromise = opening;
+    return opening;
+}
+
+async function openPanel(owner: PanelOwner): Promise<void> {
+    const { identityContext } = owner;
     // Refresh user settings when panel opens to ensure correct user's settings are displayed
     const currentUserId = identityContext.userId;
     if (currentUserId) {
@@ -64,14 +165,15 @@ export async function showEnhancedPanel(): Promise<void> {
             const settingsResponse = JC.core.api?.plugin
                 ? await JC.core.api.plugin(
                     `/user-settings/${currentUserId}/settings.json?_=${Date.now()}`,
-                    { skipCache: true }
+                    { skipCache: true, signal: owner.abortController.signal }
                 )
                 : await ApiClient.ajax({
                     type: 'GET',
                     url: ApiClient.getUrl(`/JellyfinCanopy/user-settings/${currentUserId}/settings.json?_=${Date.now()}`),
-                    dataType: 'json'
+                    dataType: 'json',
+                    signal: owner.abortController.signal
                 });
-            if (!JC.identity.isCurrent(identityContext)) return;
+            if (!owner.isCurrent()) return;
 
             // Update the userConfig with fresh data
             if (settingsResponse) {
@@ -87,34 +189,18 @@ export async function showEnhancedPanel(): Promise<void> {
                 }
             }
         } catch (e) {
-            if (!JC.identity.isCurrent(identityContext) || (e as Error)?.name === 'AbortError') return;
+            if (!owner.isCurrent() || (e as Error)?.name === 'AbortError') return;
             console.warn("🪼 Jellyfin Canopy: Could not refresh settings for panel display:", e);
         }
     }
 
-    if (!JC.identity.isCurrent(identityContext)) return;
+    if (!owner.isCurrent()) return;
 
     // Re-initialize shortcuts to ensure they're populated before building the panel
     if (typeof JC.initializeShortcuts === 'function') {
         JC.initializeShortcuts();
     }
 
-    const panelId = 'jellyfin-canopy-panel';
-    const existing = document.getElementById(panelId);
-    if (existing) {
-        // Toggle-close: release the modal-a11y handle BEFORE removal so the
-        // jc-modal-open gate drops, focus is restored and the capture-phase
-        // keydown listener is torn down — otherwise all JC shortcuts stay
-        // suppressed for the rest of the session (the normal close paths below
-        // already release; this early-return branch used to skip it).
-        const owned = existing as unknown as { _a11y?: ModalA11yHandle; _identityCleanup?: () => void };
-        if (owned._identityCleanup) owned._identityCleanup();
-        else {
-            owned._a11y?.release();
-            existing.remove();
-        }
-        return;
-    }
     // Get theme-appropriate styles
     const themeVars: any = (JC as any).themer.getThemeVariables();
 
@@ -138,9 +224,11 @@ export async function showEnhancedPanel(): Promise<void> {
     const logoUrl = themeVars.logo;
 
     const help = document.createElement('div');
-    help.id = panelId;
+    help.id = PANEL_ID;
     help.setAttribute('data-jc-identity-owned', 'true');
     JC.identity.own(help, identityContext);
+    owner.root = help;
+    owner.registerCleanup(() => help.remove());
     Object.assign(help.style, {
         position: 'fixed',
         top: '50%',
@@ -166,6 +254,22 @@ export async function showEnhancedPanel(): Promise<void> {
         flexDirection: 'column'
     });
 
+    const backdrop = document.createElement('div');
+    backdrop.id = BACKDROP_ID;
+    backdrop.setAttribute('data-jc-identity-owned', 'true');
+    backdrop.setAttribute('aria-hidden', 'true');
+    JC.identity.own(backdrop, identityContext);
+    Object.assign(backdrop.style, {
+        position: 'fixed',
+        inset: '0',
+        zIndex: 999998,
+        background: 'rgba(0, 0, 0, 0.45)',
+    });
+    backdrop.addEventListener('click', () => {
+        if (owner.isCurrent()) owner.dispose();
+    });
+    owner.registerCleanup(() => backdrop.remove());
+
     const pluginShortcuts = Array.isArray(JC.pluginConfig.Shortcuts) ? JC.pluginConfig.Shortcuts : [];
 
     // Ensure activeShortcuts is initialized before building the panel
@@ -181,11 +285,7 @@ export async function showEnhancedPanel(): Promise<void> {
     let offset = { x: 0, y: 0 };
     let autoCloseTimer: number | null = null;
     let isMouseInside = false;
-    let a11y: ModalA11yHandle | null = null;
-    let panelClosed = false;
     let closeHelp: (ev: any) => void = () => undefined;
-    const panelTimers = new Set<number>();
-    const panelCleanupCallbacks: Array<() => void> = [];
 
     // Every descendant listener installed by the split panel modules is
     // authorization-gated at the panel root. This also protects a retained,
@@ -195,45 +295,47 @@ export async function showEnhancedPanel(): Promise<void> {
         'mousedown', 'mouseup', 'touchstart', 'touchend'
     ];
     const guardStalePanelEvent = (event: Event) => {
-        if (JC.identity.isCurrent(identityContext)) return;
+        if (owner.isCurrent()) return;
         event.preventDefault();
         event.stopImmediatePropagation();
     };
     guardedEvents.forEach((type) => help.addEventListener(type, guardStalePanelEvent, true));
-    // Deliberately do not unregister this root fence in cleanupPanel(). The
+    // Deliberately do not unregister this root fence during owner disposal. The
     // panel subtree itself is removed, so it is collectible normally; if a host
     // or extension retains an A descendant, however, the capture listener must
     // remain on that detached ancestry and keep its existing child handlers
     // inert after B becomes current.
 
-    const cleanupPanel = () => {
-        if (panelClosed) return;
-        panelClosed = true;
-        if (autoCloseTimer) clearTimeout(autoCloseTimer);
+    const clearAutoCloseTimer = () => {
+        if (autoCloseTimer === null) return;
+        clearTimeout(autoCloseTimer);
+        owner.forgetTimer(autoCloseTimer);
         autoCloseTimer = null;
-        for (const timer of panelTimers) clearTimeout(timer);
-        panelTimers.clear();
-        help.remove();
-        document.removeEventListener('keydown', closeHelp);
-        document.removeEventListener('mousemove', handleMouseMove);
-        document.removeEventListener('mouseup', handleMouseUp);
-        for (const cleanup of panelCleanupCallbacks.splice(0)) cleanup();
-        a11y?.release();
-        a11y = null;
     };
+    owner.registerCleanup(() => {
+        clearAutoCloseTimer();
+        isDragging = false;
+        isMouseInside = false;
+        offset = { x: 0, y: 0 };
+        help.style.cursor = '';
+    });
 
     const resetAutoCloseTimer = () => {
-        if (!JC.identity.isCurrent(identityContext)) return;
-        if (autoCloseTimer) clearTimeout(autoCloseTimer);
-        autoCloseTimer = window.setTimeout(() => {
-            if (!isMouseInside && document.getElementById(panelId)) {
-                cleanupPanel();
+        if (!owner.isCurrent()) return;
+        clearAutoCloseTimer();
+        const timer = window.setTimeout(() => {
+            owner.forgetTimer(timer);
+            if (autoCloseTimer === timer) autoCloseTimer = null;
+            if (!isMouseInside && owner.isCurrent()) {
+                owner.dispose();
             }
         }, JC.CONFIG!.HELP_PANEL_AUTOCLOSE_DELAY as number);
+        autoCloseTimer = timer;
+        owner.trackTimer(timer);
     };
 
     const handleMouseDown = (e: MouseEvent) => {
-        if (!JC.identity.isCurrent(identityContext)) return;
+        if (!owner.isCurrent()) return;
         // Drag only from the header bar: the panes host interactive surfaces
         // (subtitle position grid, selects, sliders) that must own their own
         // pointer gestures — a blanket panel-drag stole them once the old
@@ -248,7 +350,7 @@ export async function showEnhancedPanel(): Promise<void> {
     };
 
     const handleMouseMove = (e: MouseEvent) => {
-        if (!JC.identity.isCurrent(identityContext)) return;
+        if (!owner.isCurrent()) return;
         if (isDragging) {
             help.style.left = `${e.clientX - offset.x}px`;
             help.style.top = `${e.clientY - offset.y}px`;
@@ -258,7 +360,7 @@ export async function showEnhancedPanel(): Promise<void> {
     };
 
     const handleMouseUp = () => {
-        if (!JC.identity.isCurrent(identityContext)) return;
+        if (!owner.isCurrent()) return;
         isDragging = false;
         help.style.cursor = 'grab';
         resetAutoCloseTimer();
@@ -266,9 +368,11 @@ export async function showEnhancedPanel(): Promise<void> {
 
     help.addEventListener('mousedown', handleMouseDown);
     document.addEventListener('mousemove', handleMouseMove);
+    owner.registerCleanup(() => document.removeEventListener('mousemove', handleMouseMove));
     document.addEventListener('mouseup', handleMouseUp);
+    owner.registerCleanup(() => document.removeEventListener('mouseup', handleMouseUp));
     // Reset the auto-close timer when the mouse enters or leaves the panel.
-    help.addEventListener('mouseenter', () => { isMouseInside = true; if (autoCloseTimer) clearTimeout(autoCloseTimer); });
+    help.addEventListener('mouseenter', () => { isMouseInside = true; clearAutoCloseTimer(); });
     help.addEventListener('mouseleave', () => { isMouseInside = false; resetAutoCloseTimer(); });
     help.addEventListener('click', resetAutoCloseTimer);
     help.addEventListener('wheel', (e) => { e.stopPropagation(); resetAutoCloseTimer(); });
@@ -278,8 +382,8 @@ export async function showEnhancedPanel(): Promise<void> {
     const ctx: PanelContext = {
         help,
         identityContext,
-        registerCleanup: (cleanup) => panelCleanupCallbacks.push(cleanup),
-        trackTimer: (timer) => panelTimers.add(timer),
+        registerCleanup: (cleanup) => owner.registerCleanup(cleanup),
+        trackTimer: (timer) => owner.trackTimer(timer),
         pluginShortcuts,
         resetAutoCloseTimer,
         panelBgColor,
@@ -297,7 +401,7 @@ export async function showEnhancedPanel(): Promise<void> {
 
     help.innerHTML = buildPanelHtml(ctx);
 
-    document.body.appendChild(help);
+    document.body.append(backdrop, help);
 
     wireShortcutEditor(ctx);
     resetAutoCloseTimer();
@@ -341,7 +445,7 @@ export async function showEnhancedPanel(): Promise<void> {
         };
         const handlePhoneMediaChange = () => syncLayerFocus(false);
         phoneMedia.addEventListener('change', handlePhoneMediaChange);
-        panelCleanupCallbacks.push(() => phoneMedia.removeEventListener('change', handlePhoneMediaChange));
+        owner.registerCleanup(() => phoneMedia.removeEventListener('change', handlePhoneMediaChange));
 
         const activate = (pane: HTMLElement, persist: boolean) => {
             panes.forEach(p => p.classList.toggle('active', p === pane));
@@ -413,11 +517,11 @@ export async function showEnhancedPanel(): Promise<void> {
         details.addEventListener('toggle', () => {
             if (details.open) {
                 const timer = window.setTimeout(() => {
-                    panelTimers.delete(timer);
-                    if (panelClosed || !JC.identity.isCurrent(identityContext)) return;
+                    owner.forgetTimer(timer);
+                    if (!owner.isCurrent()) return;
                     details.scrollIntoView({ behavior: 'smooth', block: index === 0 ? 'center' : 'nearest' });
                 }, 150);
-                panelTimers.add(timer);
+                owner.trackTimer(timer);
             }
             resetAutoCloseTimer();
         });
@@ -431,7 +535,7 @@ export async function showEnhancedPanel(): Promise<void> {
             // absent — guard it. Calling it unconditionally threw a TypeError
             // here, aborting the close so Escape never dismissed the panel.
             ev.stopPropagation?.();
-            cleanupPanel();
+            owner.dispose();
         }
     };
 
@@ -441,21 +545,20 @@ export async function showEnhancedPanel(): Promise<void> {
         return JC.t!('toast_feature_status', { feature, status });
     };
     document.addEventListener('keydown', closeHelp);
-    document.getElementById('closeSettingsPanel')!.addEventListener('click', closeHelp);
+    owner.registerCleanup(() => document.removeEventListener('keydown', closeHelp));
+    help.querySelector<HTMLElement>('#closeSettingsPanel')!.addEventListener('click', closeHelp);
 
     // Make the panel an accessible modal dialog: dialog role, focus trap +
     // restore, and the jc-modal-open gate that suppresses JC.keyListener while
     // it is open (INT-1) — replacing the former manual remove/re-add dance.
-    a11y = installModalA11y(help, {
+    const a11y = installModalA11y(help, {
         label: JC.t!('panel_settings_tab'),
         onEscape: () => closeHelp({ type: 'keydown', key: 'Escape' }),
     });
-    // Stash the handle on the panel element so the toggle-close early-return
-    // branch (top of this function) can release it without re-entering this
-    // closure. The close paths that DO reach this closure use `a11y` directly.
-    const ownedPanel = help as unknown as { _a11y?: ModalA11yHandle; _identityCleanup?: () => void };
-    ownedPanel._a11y = a11y;
-    ownedPanel._identityCleanup = cleanupPanel;
+    owner.registerCleanup(() => a11y.release());
+    // DOM consumers retain only the exact owner's full idempotent disposer;
+    // there is no partial a11y-only close path.
+    (help as OwnedPanelElement)._identityCleanup = () => owner.dispose();
     ctx.createToast = createToast;
 
     wireSettingsListeners(ctx);
@@ -463,15 +566,16 @@ export async function showEnhancedPanel(): Promise<void> {
     wireSpoilerGuardListeners(ctx.resetAutoCloseTimer);
     wireMiscSettingsControls(ctx);
     wireLanguageControls(ctx);
+    if (!owner.isCurrent()) return;
+    owner.phase = 'open';
 }
 
 export function resetSettingsPanel(): void {
-    const panel = document.getElementById('jellyfin-canopy-panel');
-    const cleanup = panel
-        ? (panel as unknown as { _identityCleanup?: () => void })._identityCleanup
-        : undefined;
-    if (cleanup) cleanup();
+    currentPanelOwner?.dispose();
+    const panel: OwnedPanelElement | null = document.getElementById(PANEL_ID);
+    if (panel?._identityCleanup) panel._identityCleanup();
     else panel?.remove();
+    document.getElementById(BACKDROP_ID)?.remove();
     resetReleaseNotes();
     resetLanguageControls();
 }


### PR DESCRIPTION
## Summary

- give the settings panel one authoritative lifecycle owner across opening, mounted, and disposed states
- singleflight concurrent opens, abort pending settings requests, and fence stale completions
- dispose panel DOM, backdrop, timers, listeners, accessibility state, and child cleanups on every close/navigation/account boundary
- add 100-cycle lifecycle stress coverage for all close paths plus real launcher navigation/account integration coverage

## Root cause

Panel resources were installed and retired through several independent paths. A pending settings fetch was not itself owned, same-identity navigation did not reset the panel, and a partial initialization failure could leave resources behind. That made teardown dependent on where opening or closing happened.

## User impact

Repeatedly opening and closing the settings panel no longer accumulates handlers or timers. Pending or stale opens cannot publish a panel after navigation/account change, and failed initialization restores the original page and accessibility state.

Fixes #124

## Validation

- focused panel lifecycle/lazy tests: 16/16 passed
- full settings-panel tests: 38/38 passed
- full client coverage with 8 bounded workers: 1,279/1,279 passed; 85.752% lines, coverage ratchet passed
- `npm run typecheck:src`
- `npm run typecheck`
- `npm run syntax`
- `npm run check:performance-rules` (248 files, 856 ms)
- `npm run build:bundle` (163 deterministic files; ESM boot 116.1 KB raw / 40.3 KB gzip)
- changed-file ESLint: zero errors
- independent agent reviews: approved
- Fable 5 low read-only review: approved

The canonical unbounded local coverage wrapper was also attempted twice. On this busy 24-CPU host it produced unrelated timeout flakes under excessive worker contention; the exact coverage test step passed cleanly with `--maxWorkers=8`, and GitHub CI remains authoritative.

## AI assistance

Implementation and tests were developed with AI assistance and independently reviewed by multiple agents plus Fable. A separate input-shortcut issue discovered during review was filed as #332 and added to Project 4.
