### PR TITLE
fix(client): preempt tag fallback work

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.test.ts
@@ -402,10 +402,9 @@ describe('watched/privacy projection response ordering (BI-SEC-035)', () => {
         JC._tagCachePrefetch = null;
         const currentUser = vi.spyOn(ApiClient, 'getCurrentUserId').mockReturnValue(userA);
         const getItem = vi.spyOn(ApiClient, 'getItem')
-            .mockResolvedValueOnce({ Id: itemId, Type: 'Movie', label: 'stale-helper-secret' })
-            .mockResolvedValueOnce({ Id: itemId, Type: 'Movie', label: 'fresh-helper-safe' });
+            .mockResolvedValueOnce({ Id: itemId, Type: 'Movie', label: 'stale-helper-secret' });
         let ajaxCall = 0;
-        const ajax = vi.spyOn(ApiClient, 'ajax').mockImplementation(() => {
+        const ajax = vi.spyOn(ApiClient, 'ajax').mockImplementation((options) => {
             ajaxCall++;
             if (ajaxCall === 1) {
                 return Promise.resolve({
@@ -435,6 +434,9 @@ describe('watched/privacy projection response ordering (BI-SEC-035)', () => {
                     projectionReset: false,
                 });
             }
+            if (options.type === 'GET' && options.url.includes(`/Users/${userA}/Items/${itemId}`)) {
+                return Promise.resolve({ Id: itemId, Type: 'Movie', label: 'fresh-helper-safe' });
+            }
             return Promise.reject(new Error('tag-data unavailable'));
         });
         let enabled = true;
@@ -461,8 +463,12 @@ describe('watched/privacy projection response ordering (BI-SEC-035)', () => {
             UserId: userA,
             UserDataList: [{ ItemId: itemId }],
         });
-        await vi.waitFor(() => expect(getItem).toHaveBeenCalledTimes(2));
+        await vi.waitFor(() => {
+            expect(ajax.mock.calls.some(([options]) => options.type === 'GET'
+                && options.url.includes(`/Users/${userA}/Items/${itemId}`))).toBe(true);
+        });
 
+        expect(getItem).toHaveBeenCalledTimes(1);
         expect(renderedLabels).not.toContain('stale-helper-secret');
         expect(renderedLabels).toContain('fresh-helper-safe');
 
@@ -854,6 +860,489 @@ describe('watched/privacy projection response ordering (BI-SEC-035)', () => {
         ajax.mockRestore();
         currentUser.mockRestore();
         document.body.innerHTML = '';
+    });
+
+    it('drains 200 failed-batch cards with six workers and one lookup per duplicate id', async () => {
+        document.body.innerHTML = '';
+        const oldConfig = JC.pluginConfig;
+        const oldUi = JC.core.ui;
+        JC.pluginConfig = {
+            ...oldConfig,
+            TagCacheServerMode: false,
+            SpoilerBlurEnabled: false,
+        };
+        JC.core.ui = {
+            injectCss: vi.fn(),
+            removeCss: vi.fn(),
+        } as unknown as NonNullable<typeof JC.core.ui>;
+        const currentUser = vi.spyOn(ApiClient, 'getCurrentUserId').mockReturnValue(userA);
+        const fallbackIds: string[] = [];
+        let activeFallbacks = 0;
+        let maxActiveFallbacks = 0;
+        const ajax = vi.spyOn(ApiClient, 'ajax').mockImplementation(async (options) => {
+            if (options.type === 'POST') throw new Error('batch unavailable');
+            const itemId = options.url.split('/').pop()!;
+            fallbackIds.push(itemId);
+            activeFallbacks += 1;
+            maxActiveFallbacks = Math.max(maxActiveFallbacks, activeFallbacks);
+            await new Promise((resolve) => setTimeout(resolve, 1));
+            activeFallbacks -= 1;
+            return { Id: itemId, Type: 'Movie' };
+        });
+        const getItem = vi.spyOn(ApiClient, 'getItem');
+        const renderedTargets = new Set<HTMLElement>();
+        JC.tagPipeline!.registerRenderer('drained-fallback-test', {
+            isEnabled: () => true,
+            render: (target: HTMLElement) => { renderedTargets.add(target); },
+        });
+
+        try {
+            resetTagPipelineIdentity();
+            JC.tagPipeline!.initialize?.();
+            JC.tagPipeline!.clearProcessed?.();
+            for (let index = 1; index <= 199; index += 1) {
+                const itemId = index.toString(16).padStart(32, '0');
+                const copies = index === 1 ? 2 : 1;
+                for (let copy = 0; copy < copies; copy += 1) {
+                    const image = gridCardImage();
+                    const card = image.closest<HTMLElement>('.card')!;
+                    card.dataset.id = itemId;
+                    card.dataset.type = 'Movie';
+                    document.body.appendChild(card);
+                }
+            }
+            JC.tagPipeline!.scheduleScan?.();
+
+            await vi.waitFor(() => expect(renderedTargets.size).toBe(200), { timeout: 5_000 });
+            expect(fallbackIds).toHaveLength(199);
+            expect(new Set(fallbackIds).size).toBe(199);
+            expect(maxActiveFallbacks).toBe(6);
+            expect(activeFallbacks).toBe(0);
+            expect(getItem).not.toHaveBeenCalled();
+        } finally {
+            history.pushState({}, '', `/drained-fallback-cleanup-${Date.now()}`);
+            (JC.tagPipeline as unknown as { unregisterRenderer(name: string): void })
+                .unregisterRenderer('drained-fallback-test');
+            ajax.mockRestore();
+            getItem.mockRestore();
+            currentUser.mockRestore();
+            JC.pluginConfig = oldConfig;
+            JC.core.ui = oldUi;
+            document.body.innerHTML = '';
+        }
+    });
+
+    it('keeps the successful batch path at one POST and renders every duplicate with embedded episode data', async () => {
+        document.body.innerHTML = '';
+        const itemId = 'dddddddddddddddddddddddddddddddd';
+        const firstEpisode = { Id: 'cccccccccccccccccccccccccccccccc', Type: 'Episode' };
+        const oldConfig = JC.pluginConfig;
+        const oldUi = JC.core.ui;
+        JC.pluginConfig = {
+            ...oldConfig,
+            TagCacheServerMode: false,
+            SpoilerBlurEnabled: false,
+        };
+        JC.core.ui = {
+            injectCss: vi.fn(),
+            removeCss: vi.fn(),
+        } as unknown as NonNullable<typeof JC.core.ui>;
+        const currentUser = vi.spyOn(ApiClient, 'getCurrentUserId').mockReturnValue(userA);
+        const ajax = vi.spyOn(ApiClient, 'ajax').mockResolvedValue({
+            Items: [{ Id: itemId, Type: 'Series', FirstEpisode: firstEpisode }],
+        });
+        const renderExtras: unknown[] = [];
+        JC.tagPipeline!.registerRenderer('successful-batch-test', {
+            isEnabled: () => true,
+            render: (_target: HTMLElement, _item: unknown, extras: unknown) => { renderExtras.push(extras); },
+        });
+
+        try {
+            resetTagPipelineIdentity();
+            JC.tagPipeline!.initialize?.();
+            JC.tagPipeline!.clearProcessed?.();
+            for (let copy = 0; copy < 2; copy += 1) {
+                const image = gridCardImage();
+                const card = image.closest<HTMLElement>('.card')!;
+                card.dataset.id = itemId;
+                card.dataset.type = 'Series';
+                document.body.appendChild(card);
+            }
+            JC.tagPipeline!.scheduleScan?.();
+
+            await vi.waitFor(() => expect(renderExtras).toHaveLength(2));
+            expect(ajax).toHaveBeenCalledTimes(1);
+            expect((ajax.mock.calls[0][0] as { type: string }).type).toBe('POST');
+            expect(renderExtras.every((extras) => (
+                extras as { firstEpisode?: unknown }
+            ).firstEpisode === firstEpisode)).toBe(true);
+        } finally {
+            history.pushState({}, '', `/successful-batch-cleanup-${Date.now()}`);
+            (JC.tagPipeline as unknown as { unregisterRenderer(name: string): void })
+                .unregisterRenderer('successful-batch-test');
+            ajax.mockRestore();
+            currentUser.mockRestore();
+            JC.pluginConfig = oldConfig;
+            JC.core.ui = oldUi;
+            document.body.innerHTML = '';
+        }
+    });
+
+    it('skips stale Series supplemental work and renders base data when the episode lookup fails', async () => {
+        document.body.innerHTML = '';
+        const disconnectedId = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa3';
+        const renderedId = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb4';
+        const oldConfig = JC.pluginConfig;
+        const oldUi = JC.core.ui;
+        JC.pluginConfig = {
+            ...oldConfig,
+            TagCacheServerMode: false,
+            SpoilerBlurEnabled: false,
+        };
+        JC.core.ui = {
+            injectCss: vi.fn(),
+            removeCss: vi.fn(),
+        } as unknown as NonNullable<typeof JC.core.ui>;
+        const currentUser = vi.spyOn(ApiClient, 'getCurrentUserId').mockReturnValue(userA);
+        let resolveDisconnected!: (value: unknown) => void;
+        let supplementalRequests = 0;
+        const ajax = vi.spyOn(ApiClient, 'ajax').mockImplementation((options) => {
+            if (options.type === 'POST') return Promise.reject(new Error('batch unavailable'));
+            if (options.url.includes('/Users/') && options.url.endsWith(disconnectedId)) {
+                return new Promise((resolve) => { resolveDisconnected = resolve; });
+            }
+            if (options.url.includes('/Users/') && options.url.endsWith(renderedId)) {
+                return Promise.resolve({ Id: renderedId, Type: 'Series' });
+            }
+            supplementalRequests += 1;
+            return Promise.reject(new Error('episode unavailable'));
+        });
+        const renders: Array<{ id: string; firstEpisode: unknown }> = [];
+        JC.tagPipeline!.registerRenderer('series-fallback-test', {
+            isEnabled: () => true,
+            render: (_target: HTMLElement, rawItem: unknown, rawExtras: unknown) => {
+                renders.push({
+                    id: normalizeProjectionKey((rawItem as { Id: string }).Id)!,
+                    firstEpisode: (rawExtras as { firstEpisode?: unknown }).firstEpisode,
+                });
+            },
+        });
+
+        try {
+            resetTagPipelineIdentity();
+            JC.tagPipeline!.initialize?.();
+            JC.tagPipeline!.clearProcessed?.();
+            const staleImage = gridCardImage();
+            const staleCard = staleImage.closest<HTMLElement>('.card')!;
+            staleCard.dataset.id = disconnectedId;
+            staleCard.dataset.type = 'Series';
+            document.body.appendChild(staleCard);
+            JC.tagPipeline!.scheduleScan?.();
+            await vi.waitFor(() => expect(resolveDisconnected).toBeTypeOf('function'));
+
+            staleCard.remove();
+            resolveDisconnected({ Id: disconnectedId, Type: 'Series' });
+            await new Promise((resolve) => setTimeout(resolve, 30));
+            expect(supplementalRequests).toBe(0);
+            expect(renders).toEqual([]);
+
+            const renderedImage = gridCardImage();
+            const renderedCard = renderedImage.closest<HTMLElement>('.card')!;
+            renderedCard.dataset.id = renderedId;
+            renderedCard.dataset.type = 'Series';
+            document.body.appendChild(renderedCard);
+            JC.tagPipeline!.scheduleScan?.();
+
+            await vi.waitFor(() => expect(renders).toEqual([{ id: renderedId, firstEpisode: null }]));
+            expect(supplementalRequests).toBe(1);
+        } finally {
+            history.pushState({}, '', `/series-fallback-cleanup-${Date.now()}`);
+            (JC.tagPipeline as unknown as { unregisterRenderer(name: string): void })
+                .unregisterRenderer('series-fallback-test');
+            ajax.mockRestore();
+            currentUser.mockRestore();
+            JC.pluginConfig = oldConfig;
+            JC.core.ui = oldUi;
+            document.body.innerHTML = '';
+        }
+    });
+
+    it('bounds failed-batch fallback work and lets navigation preempt all stale requests', async () => {
+        document.body.innerHTML = '';
+        const oldConfig = JC.pluginConfig;
+        const oldUi = JC.core.ui;
+        JC.pluginConfig = {
+            ...oldConfig,
+            TagCacheServerMode: false,
+            SpoilerBlurEnabled: false,
+        };
+        JC.core.ui = {
+            injectCss: vi.fn(),
+            removeCss: vi.fn(),
+        } as unknown as NonNullable<typeof JC.core.ui>;
+        const currentUser = vi.spyOn(ApiClient, 'getCurrentUserId').mockReturnValue(userA);
+        const fallbackStarted: string[] = [];
+        const fallbackSignals: AbortSignal[] = [];
+        let activeFallbacks = 0;
+        let maxActiveFallbacks = 0;
+        let batchCalls = 0;
+        const nextItemId = 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+
+        const beginFallback = (itemId: string, signal?: AbortSignal): Promise<unknown> => {
+            fallbackStarted.push(itemId);
+            activeFallbacks += 1;
+            maxActiveFallbacks = Math.max(maxActiveFallbacks, activeFallbacks);
+            if (signal) fallbackSignals.push(signal);
+            return new Promise((_resolve, reject) => {
+                signal?.addEventListener('abort', () => {
+                    activeFallbacks -= 1;
+                    reject(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+                }, { once: true });
+            });
+        };
+
+        // This spy is the old, non-abortable fallback seam. Keeping it pending
+        // makes the regression fail on the original serial implementation while
+        // the corrected path must use abortable Ajax requests instead.
+        const getItem = vi.spyOn(ApiClient, 'getItem').mockImplementation(
+            (_userId, itemId) => beginFallback(itemId),
+        );
+        const ajax = vi.spyOn(ApiClient, 'ajax').mockImplementation((options) => {
+            if (options.type === 'POST') {
+                batchCalls += 1;
+                if (batchCalls === 1) return Promise.reject(new Error('batch unavailable'));
+                return Promise.resolve({ Items: [{ Id: nextItemId, Type: 'Movie' }] });
+            }
+            const itemId = options.url.split('/').pop()!;
+            return beginFallback(itemId, options.signal);
+        });
+        const staleRenders: string[] = [];
+        JC.tagPipeline!.registerRenderer('bounded-fallback-test', {
+            isEnabled: () => true,
+            render: (target: HTMLElement, rawItem: unknown) => {
+                const item = rawItem as { Id: string };
+                const id = normalizeProjectionKey(item.Id)!;
+                staleRenders.push(id);
+                const marker = document.createElement('span');
+                marker.className = `bounded-fallback-${id}`;
+                target.appendChild(marker);
+            },
+        });
+
+        try {
+            resetTagPipelineIdentity();
+            JC.tagPipeline!.initialize?.();
+            for (let index = 1; index <= 200; index += 1) {
+                const itemId = index.toString(16).padStart(32, '0');
+                const image = gridCardImage();
+                const card = image.closest<HTMLElement>('.card')!;
+                card.dataset.id = itemId;
+                card.dataset.type = 'Movie';
+                document.body.appendChild(card);
+            }
+            JC.tagPipeline!.clearProcessed?.();
+            JC.tagPipeline!.scheduleScan?.();
+
+            await vi.waitFor(() => expect(fallbackStarted).toHaveLength(6), { timeout: 2_000 });
+            expect(maxActiveFallbacks).toBe(6);
+            expect(getItem).not.toHaveBeenCalled();
+
+            history.pushState({}, '', `/bounded-fallback-next-${Date.now()}`);
+            document.body.innerHTML = '';
+            const nextImage = gridCardImage();
+            const nextCard = nextImage.closest<HTMLElement>('.card')!;
+            nextCard.dataset.id = nextItemId;
+            nextCard.dataset.type = 'Movie';
+            document.body.appendChild(nextCard);
+            JC.tagPipeline!.scheduleScan?.();
+
+            await vi.waitFor(() => expect(fallbackSignals.every(signal => signal.aborted)).toBe(true));
+            await vi.waitFor(() => {
+                expect(document.querySelector(`.bounded-fallback-${nextItemId}`)).not.toBeNull();
+            });
+            expect(fallbackStarted).toHaveLength(6);
+            expect(activeFallbacks).toBe(0);
+            expect(staleRenders).toEqual([nextItemId]);
+        } finally {
+            history.pushState({}, '', `/bounded-fallback-cleanup-${Date.now()}`);
+            (JC.tagPipeline as unknown as { unregisterRenderer(name: string): void })
+                .unregisterRenderer('bounded-fallback-test');
+            ajax.mockRestore();
+            getItem.mockRestore();
+            currentUser.mockRestore();
+            JC.pluginConfig = oldConfig;
+            JC.core.ui = oldUi;
+            document.body.innerHTML = '';
+        }
+    });
+
+    it('keeps a replacement claim authoritative when an abort-ignoring old lookup settles', async () => {
+        document.body.innerHTML = '';
+        const itemId = 'fffffffffffffffffffffffffffffff5';
+        const oldConfig = JC.pluginConfig;
+        const oldUi = JC.core.ui;
+        JC.pluginConfig = {
+            ...oldConfig,
+            TagCacheServerMode: false,
+            SpoilerBlurEnabled: false,
+        };
+        JC.core.ui = {
+            injectCss: vi.fn(),
+            removeCss: vi.fn(),
+        } as unknown as NonNullable<typeof JC.core.ui>;
+        const currentUser = vi.spyOn(ApiClient, 'getCurrentUserId').mockReturnValue(userA);
+        let resolveOld!: (value: unknown) => void;
+        let oldSignal: AbortSignal | undefined;
+        let postCalls = 0;
+        const ajax = vi.spyOn(ApiClient, 'ajax').mockImplementation((options) => {
+            if (options.type === 'POST') {
+                postCalls += 1;
+                if (postCalls === 1) return Promise.reject(new Error('batch unavailable'));
+                return Promise.resolve({ Items: [{ Id: itemId, Type: 'Movie', label: 'new' }] });
+            }
+            oldSignal = options.signal;
+            return new Promise((resolve) => { resolveOld = resolve; });
+        });
+        const labels: string[] = [];
+        const claimedTargets: HTMLElement[] = [];
+        JC.tagPipeline!.registerRenderer('fallback-claim-test', {
+            isEnabled: () => true,
+            render: (target: HTMLElement, rawItem: unknown) => {
+                const label = String((rawItem as { label?: string }).label);
+                labels.push(label);
+                target.dataset.fallbackClaim = label;
+                claimedTargets.push(target);
+            },
+        });
+
+        try {
+            resetTagPipelineIdentity();
+            JC.tagPipeline!.initialize?.();
+            const image = gridCardImage();
+            const card = image.closest<HTMLElement>('.card')!;
+            card.dataset.id = itemId;
+            card.dataset.type = 'Movie';
+            document.body.appendChild(card);
+            JC.tagPipeline!.scheduleScan?.();
+            await vi.waitFor(() => expect(oldSignal).toBeDefined());
+
+            history.pushState({}, '', `/fallback-claim-new-${Date.now()}`);
+            expect(oldSignal!.aborted).toBe(true);
+            await vi.waitFor(() => expect(labels).toEqual(['new']));
+            expect(postCalls).toBe(2);
+            expect(claimedTargets[0]?.dataset.fallbackClaim).toBe('new');
+
+            resolveOld({ Id: itemId, Type: 'Movie', label: 'old' });
+            await new Promise((resolve) => setTimeout(resolve, 30));
+            expect(labels).toEqual(['new']);
+            expect(claimedTargets[0]?.dataset.fallbackClaim).toBe('new');
+        } finally {
+            history.pushState({}, '', `/fallback-claim-cleanup-${Date.now()}`);
+            (JC.tagPipeline as unknown as { unregisterRenderer(name: string): void })
+                .unregisterRenderer('fallback-claim-test');
+            ajax.mockRestore();
+            currentUser.mockRestore();
+            JC.pluginConfig = oldConfig;
+            JC.core.ui = oldUi;
+            document.body.innerHTML = '';
+        }
+    });
+
+    it('releases the queue on account switch and rejects an abort-ignoring fallback result', async () => {
+        document.body.innerHTML = '';
+        const originalIdentity = JC.identity.capture()!;
+        const oldConfig = JC.pluginConfig;
+        const oldUi = JC.core.ui;
+        JC.pluginConfig = {
+            ...oldConfig,
+            TagCacheServerMode: false,
+            SpoilerBlurEnabled: false,
+        };
+        JC.core.ui = {
+            injectCss: vi.fn(),
+            removeCss: vi.fn(),
+        } as unknown as NonNullable<typeof JC.core.ui>;
+        const staleItemId = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1';
+        const currentItemId = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb2';
+        let activeUser = userA;
+        const currentUser = vi.spyOn(ApiClient, 'getCurrentUserId').mockImplementation(() => activeUser);
+        let staleSignal: AbortSignal | undefined;
+        let resolveStale!: (value: unknown) => void;
+        let batchCalls = 0;
+        const ajax = vi.spyOn(ApiClient, 'ajax').mockImplementation((options) => {
+            if (options.type === 'POST') {
+                batchCalls += 1;
+                if (batchCalls === 1) return Promise.reject(new Error('batch unavailable'));
+                return Promise.resolve({ Items: [{ Id: currentItemId, Type: 'Movie' }] });
+            }
+            staleSignal = options.signal;
+            // Deliberately ignore AbortSignal and resolve later. The generation
+            // owner, not transport cooperation, must still reject publication.
+            return new Promise((resolve) => { resolveStale = resolve; });
+        });
+        const getItem = vi.spyOn(ApiClient, 'getItem');
+        const renders: string[] = [];
+        JC.tagPipeline!.registerRenderer('account-fallback-test', {
+            isEnabled: () => true,
+            render: (target: HTMLElement, rawItem: unknown) => {
+                const id = normalizeProjectionKey((rawItem as { Id: string }).Id)!;
+                renders.push(id);
+                const marker = document.createElement('span');
+                marker.className = `account-fallback-${id}`;
+                target.appendChild(marker);
+            },
+        });
+
+        try {
+            const identityA = JC.identity.transition('tag-fallback-server-a', userA, 'tag-fallback-account-a')!;
+            await JC.identity.activate(identityA);
+            const staleImage = gridCardImage();
+            const staleCard = staleImage.closest<HTMLElement>('.card')!;
+            staleCard.dataset.id = staleItemId;
+            staleCard.dataset.type = 'Movie';
+            document.body.appendChild(staleCard);
+            JC.tagPipeline!.clearProcessed?.();
+            JC.tagPipeline!.scheduleScan?.();
+            await vi.waitFor(() => expect(staleSignal).toBeDefined());
+
+            activeUser = userB;
+            const identityB = JC.identity.transition('tag-fallback-server-b', userB, 'tag-fallback-account-b')!;
+            expect(staleSignal!.aborted).toBe(true);
+            const currentImage = gridCardImage();
+            const currentCard = currentImage.closest<HTMLElement>('.card')!;
+            currentCard.dataset.id = currentItemId;
+            currentCard.dataset.type = 'Movie';
+            document.body.appendChild(currentCard);
+            await JC.identity.activate(identityB);
+            JC.tagPipeline!.scheduleScan?.();
+
+            await vi.waitFor(() => {
+                expect(document.querySelector(`.account-fallback-${currentItemId}`)).not.toBeNull();
+            });
+            expect(batchCalls).toBe(2);
+            expect(getItem).not.toHaveBeenCalled();
+
+            resolveStale({ Id: staleItemId, Type: 'Movie' });
+            await new Promise((resolve) => setTimeout(resolve, 30));
+            expect(document.querySelector(`.account-fallback-${staleItemId}`)).toBeNull();
+            expect(renders).toEqual([currentItemId]);
+        } finally {
+            (JC.tagPipeline as unknown as { unregisterRenderer(name: string): void })
+                .unregisterRenderer('account-fallback-test');
+            activeUser = originalIdentity.userId;
+            const restored = JC.identity.transition(
+                originalIdentity.serverId,
+                originalIdentity.userId,
+                'tag-fallback-account-restore',
+            );
+            if (restored) await JC.identity.activate(restored);
+            JC.pluginConfig = oldConfig;
+            JC.core.ui = oldUi;
+            ajax.mockRestore();
+            getItem.mockRestore();
+            currentUser.mockRestore();
+            document.body.innerHTML = '';
+        }
     });
 });
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.ts
@@ -377,11 +377,13 @@ interface QueueEntry {
     renderTarget: HTMLElement;
     itemId: string;
     itemType: string | null;
+    claim: object;
 }
 
 /** True only while a queued element/target still belongs to the captured item. */
 function queueEntryStillOwnsItem(entry: QueueEntry, itemId: string): boolean {
-    return document.contains(entry.el)
+    return queuedClaimByElement.get(entry.el) === entry.claim
+        && document.contains(entry.el)
         && entry.renderTarget.isConnected
         && getItemId(entry.el) === itemId;
 }
@@ -389,6 +391,7 @@ function queueEntryStillOwnsItem(entry: QueueEntry, itemId: string): boolean {
 const renderers = new Map<string, RendererEntry>(); // name → { render, isEnabled, needsFirstEpisode, needsParentSeries }
 let processedCards = new WeakSet<Element>(); // let, not const — needs reassignment on reinit
 let renderedItemByElement = new WeakMap<Element, string>();
+const queuedClaimByElement = new WeakMap<Element, object>();
 const pendingProjectionIds = new Set<string>();
 // Batch-mode watched flips bypass every local/helper cache and must be satisfied
 // by a successful fresh /tag-data response before their cards can render again.
@@ -410,6 +413,11 @@ let fetchTimer: number | null = null;
 let isProcessing = false;
 let processingGeneration = 0;
 let batchGeneration = 0; // Incremented on navigation to cancel stale in-flight batches
+interface BatchRunOwner {
+    controller: AbortController;
+    entries: Set<QueueEntry>;
+}
+let activeBatchOwner: BatchRunOwner | null = null;
 let requestQueue: QueueEntry[] = []; // { el, itemId, itemType }
 let firstFetchAfterNav = true; // PERF(R7): shortens the debounce for the first batch of a navigation
 let processWired = false;
@@ -417,6 +425,54 @@ let bodySubscription: ReturnType<typeof onBodyMutation> | null = null;
 let navigationUnsubscribe: (() => void) | null = null;
 let activeIdentityEpoch: number | null = null;
 let identityActivationGeneration = 0;
+
+function enqueueTagRequest(
+    el: HTMLElement,
+    renderTarget: HTMLElement,
+    itemId: string,
+    itemType: string | null,
+): void {
+    const claim = {};
+    queuedClaimByElement.set(el, claim);
+    requestQueue.push({ el, renderTarget, itemId, itemType, claim });
+}
+
+/** Release a queued card only if this exact request still owns its marker. */
+function releaseQueueEntry(entry: QueueEntry): void {
+    if (queuedClaimByElement.get(entry.el) !== entry.claim) return;
+    queuedClaimByElement.delete(entry.el);
+    processedCards.delete(entry.el);
+    renderedItemByElement.delete(entry.el);
+}
+
+/** Retire an accepted request claim without making the card eligible again. */
+function settleQueueEntry(entry: QueueEntry): void {
+    if (queuedClaimByElement.get(entry.el) === entry.claim) {
+        queuedClaimByElement.delete(entry.el);
+    }
+}
+
+/**
+ * Retire the current batch owner and release the queue lock immediately.
+ * The generation fence remains authoritative even if a host transport ignores
+ * AbortSignal; the exact processing-generation check prevents retired work
+ * from clearing a replacement owner's lock in its finally block.
+ */
+function retireBatchGeneration(): void {
+    batchGeneration += 1;
+    const owner = activeBatchOwner;
+    if (!owner) return;
+    activeBatchOwner = null;
+    for (const entry of owner.entries) releaseQueueEntry(entry);
+    owner.controller.abort();
+    processingGeneration += 1;
+    isProcessing = false;
+    // The retired owner had already spliced its cards out of requestQueue.
+    // Rescan releases those exact claims into the new generation, while any
+    // unaffected queued entries resume without waiting for another mutation.
+    scheduleScan();
+    if (requestQueue.length > 0) scheduleFetchIfQueued();
+}
 
 // ── Pipeline-level exclusions ─────────────────────────────────────
 // Elements matching these selectors are skipped before any renderer runs.
@@ -871,10 +927,10 @@ function normalizeIdList(value: unknown): string[] {
  */
 async function refreshUnknownServerProjection(ids: string[]): Promise<void> {
     projectionRequestGeneration++;
-    batchGeneration++;
+    retireBatchGeneration();
     projectionResetPending = true;
     for (const id of normalizeIdList(ids)) pendingProjectionIds.add(id);
-    for (const entry of requestQueue) processedCards.delete(entry.el);
+    for (const entry of requestQueue) releaseQueueEntry(entry);
     requestQueue = [];
     firstEpisodeCache.clear();
     parentSeriesCache.clear();
@@ -1065,6 +1121,7 @@ function clearRenderedCard(el: HTMLElement): void {
     }
     processedCards.delete(el);
     renderedItemByElement.delete(el);
+    queuedClaimByElement.delete(el);
 }
 
 /**
@@ -1077,10 +1134,10 @@ function invalidateRenderedItems(ids: string[], evictServerRows: boolean): void 
 
     // Any pre-invalidation tag-data response is stale. Its generation checks
     // unmark the captured cards rather than repainting them.
-    batchGeneration++;
+    retireBatchGeneration();
     requestQueue = requestQueue.filter((entry) => {
         if (!idSet.has(entry.itemId)) return true;
-        processedCards.delete(entry.el);
+        releaseQueueEntry(entry);
         return false;
     });
 
@@ -1123,8 +1180,8 @@ function clearRendererProjectionState(clearDom: boolean): void {
 
 /** Start a new local privacy generation and retire every pre-generation source. */
 function beginBatchProjectionGeneration(userId: string): void {
-    batchGeneration++;
-    for (const entry of requestQueue) processedCards.delete(entry.el);
+    retireBatchGeneration();
+    for (const entry of requestQueue) releaseQueueEntry(entry);
     requestQueue = [];
     firstEpisodeCache.clear();
     parentSeriesCache.clear();
@@ -1168,7 +1225,7 @@ function armBatchProjectionRefresh(ids: string[], userId: string): void {
 function resetServerProjection(clearDom: boolean): void {
     serverCacheLoadGeneration++;
     projectionRequestGeneration++;
-    batchGeneration++;
+    retireBatchGeneration();
     serverCache = null;
     serverCacheVersion = 0;
     serverCacheTimestamp = 0;
@@ -1181,7 +1238,7 @@ function resetServerProjection(clearDom: boolean): void {
     forceFreshProjectionIds.clear();
     batchForceAllProjectionIds = false;
     batchFreshProjectionIds.clear();
-    for (const entry of requestQueue) processedCards.delete(entry.el);
+    for (const entry of requestQueue) releaseQueueEntry(entry);
     requestQueue = [];
     firstEpisodeCache.clear();
     parentSeriesCache.clear();
@@ -1205,8 +1262,6 @@ function resetTagPipelineIdentity(): void {
     scanScheduleGeneration++;
     scanScheduled = false;
     scanGeneration++;
-    processingGeneration++;
-    isProcessing = false;
     firstFetchAfterNav = true;
     cardFetchFailures = new WeakMap<Element, number>();
     JC._tagCachePrefetch = null;
@@ -1336,7 +1391,7 @@ function processCard(el: HTMLElement, fadeIn: boolean): void {
     }
 
     if (forceFresh) {
-        requestQueue.push({ el, renderTarget, itemId, itemType });
+        enqueueTagRequest(el, renderTarget, itemId, itemType);
         return;
     }
 
@@ -1355,7 +1410,7 @@ function processCard(el: HTMLElement, fadeIn: boolean): void {
     if (fadeIn) withFadeIn(renderTarget, renderCached); else renderCached();
 
     if (!allCacheHits) {
-        requestQueue.push({ el, renderTarget, itemId, itemType });
+        enqueueTagRequest(el, renderTarget, itemId, itemType);
     }
 }
 
@@ -1481,13 +1536,18 @@ function getItemType(el: HTMLElement): string | null {
 // ── Queue Processing ───────────────────────────────────────────────
 
 const SERVER_BATCH_LIMIT = 200;
+/** Maximum owned item/episode requests in the current fallback generation. */
+export const TAG_FALLBACK_CONCURRENCY = 6;
 
 /**
  * Drain the request queue in SERVER_BATCH_LIMIT-sized chunks.
  */
 async function processQueue(): Promise<void> {
     if (isProcessing || requestQueue.length === 0) return;
-    const myProcessingGeneration = processingGeneration;
+    const myProcessingGeneration = ++processingGeneration;
+    const controller = new AbortController();
+    const owner: BatchRunOwner = { controller, entries: new Set() };
+    activeBatchOwner = owner;
     isProcessing = true;
 
     try {
@@ -1495,11 +1555,17 @@ async function processQueue(): Promise<void> {
 
         // Chunk into batches of SERVER_BATCH_LIMIT to avoid 400 errors
         while (requestQueue.length > 0) {
-            if (myGeneration !== batchGeneration) break; // navigation happened
+            if (controller.signal.aborted || myGeneration !== batchGeneration) break;
             const batch = requestQueue.splice(0, SERVER_BATCH_LIMIT);
-            await processBatch(batch, myGeneration);
+            for (const entry of batch) owner.entries.add(entry);
+            await processBatch(batch, myGeneration, controller.signal);
+            for (const entry of batch) {
+                owner.entries.delete(entry);
+                settleQueueEntry(entry);
+            }
         }
     } finally {
+        if (activeBatchOwner === owner) activeBatchOwner = null;
         // Identity reset can allow B to start while an unsignalled ApiClient.ajax
         // from A is still settling. A must not clear B's processing lock.
         if (myProcessingGeneration === processingGeneration) {
@@ -1513,12 +1579,202 @@ async function processQueue(): Promise<void> {
     }
 }
 
+function fallbackRunIsCurrent(
+    userKey: string,
+    generation: number,
+    signal: AbortSignal,
+): boolean {
+    return !signal.aborted
+        && generation === batchGeneration
+        && normalizeProjectionKey(ApiClient.getCurrentUserId()) === userKey
+        && !projectionResetPending;
+}
+
+function releaseFallbackEntries(entries: QueueEntry[]): void {
+    for (const entry of entries) releaseQueueEntry(entry);
+}
+
+/** Fetch one item without publishing it into the shared DTO cache. */
+async function fetchFallbackItem(
+    userId: string,
+    itemId: string,
+    signal: AbortSignal,
+): Promise<any> {
+    return ApiClient.ajax({
+        type: 'GET',
+        url: ApiClient.getUrl(`/Users/${encodeURIComponent(userId)}/Items/${encodeURIComponent(itemId)}`),
+        dataType: 'json',
+        signal,
+    });
+}
+
+/** A fallback worker owns at most one cancellable request at a time. */
+async function fetchFallbackFirstEpisode(
+    userId: string,
+    parentId: string,
+    signal: AbortSignal,
+): Promise<any> {
+    const response: any = await ApiClient.ajax({
+        type: 'GET',
+        url: (ApiClient as { getUrl(path: string, params?: unknown): string }).getUrl('/Items', {
+            ParentId: parentId,
+            IncludeItemTypes: 'Episode',
+            Recursive: true,
+            SortBy: 'PremiereDate',
+            SortOrder: 'Ascending',
+            Limit: 1,
+            Fields: 'MediaStreams,MediaSources,Genres',
+            userId,
+        }),
+        dataType: 'json',
+        signal,
+    });
+    return response?.Items?.[0] || null;
+}
+
+async function processFallbackItem(
+    itemId: string,
+    entries: QueueEntry[],
+    userId: string,
+    userKey: string,
+    generation: number,
+    signal: AbortSignal,
+): Promise<void> {
+    if (!fallbackRunIsCurrent(userKey, generation, signal)
+        || pendingProjectionIds.has(itemId)) {
+        releaseFallbackEntries(entries);
+        return;
+    }
+
+    let liveEntries = entries.filter((entry) => queueEntryStillOwnsItem(entry, itemId));
+    if (liveEntries.length !== entries.length) {
+        for (const entry of entries) {
+            if (!liveEntries.includes(entry)) releaseQueueEntry(entry);
+        }
+        if (entries.some((entry) => entry.el.isConnected)) scheduleScan();
+    }
+    if (liveEntries.length === 0) return;
+
+    // Privacy-forced ids may only be satisfied by /tag-data. A generic item
+    // endpoint could replay pre-policy DTO fields after the authoritative batch
+    // failed, so keep those cards blank for the next fresh batch attempt.
+    if (forceFreshProjectionIds.has(itemId)) {
+        releaseFallbackEntries(liveEntries);
+        return;
+    }
+
+    try {
+        const item: any = await fetchFallbackItem(userId, itemId, signal);
+        if (!fallbackRunIsCurrent(userKey, generation, signal)
+            || pendingProjectionIds.has(itemId)) {
+            releaseFallbackEntries(liveEntries);
+            scheduleScan();
+            return;
+        }
+        if (!item || !MEDIA_TYPES.has(item.Type)) return;
+
+        const stillOwned = liveEntries.filter((entry) => queueEntryStillOwnsItem(entry, itemId));
+        if (stillOwned.length !== liveEntries.length) {
+            for (const entry of liveEntries) {
+                if (!stillOwned.includes(entry)) releaseQueueEntry(entry);
+            }
+            if (liveEntries.some((entry) => entry.el.isConnected)) scheduleScan();
+        }
+        liveEntries = stillOwned;
+        if (liveEntries.length === 0) return;
+
+        let firstEpisode: any = null;
+        if (item.Type === 'Series' || item.Type === 'Season') {
+            try {
+                firstEpisode = await fetchFallbackFirstEpisode(userId, item.Id, signal);
+            } catch {
+                // Supplemental metadata is optional. Preserve the previous
+                // fail-soft render contract for an ordinary endpoint failure,
+                // while cancellation/generation retirement still rejects all
+                // publication through the owner check immediately below.
+                firstEpisode = null;
+            }
+        }
+        if (!fallbackRunIsCurrent(userKey, generation, signal)
+            || pendingProjectionIds.has(itemId)) {
+            releaseFallbackEntries(liveEntries);
+            scheduleScan();
+            return;
+        }
+
+        let recycled = false;
+        for (const entry of liveEntries) {
+            if (!queueEntryStillOwnsItem(entry, itemId)) {
+                releaseQueueEntry(entry);
+                recycled = true;
+                continue;
+            }
+            const { renderTarget } = entry;
+            const extras = { firstEpisode, parentSeries: null, ratingParentSeries: null, renderTarget };
+            // PERF(R7): post-paint fallback render — fade late tags in.
+            withFadeIn(renderTarget, () => {
+                for (const [, renderer] of renderers) {
+                    if (!renderer.isEnabled()) continue;
+                    try { renderer.render(renderTarget, item, extras); } catch {}
+                }
+            });
+        }
+        if (recycled) scheduleScan();
+    } catch {
+        if (!fallbackRunIsCurrent(userKey, generation, signal)) {
+            releaseFallbackEntries(liveEntries);
+            scheduleScan();
+            return;
+        }
+        // PERF(R9): fail open — un-mark each live card (bounded) so a later
+        // mutation/navigation retries it without an immediate request loop.
+        for (const entry of liveEntries) {
+            const failures = (cardFetchFailures.get(entry.el) || 0) + 1;
+            cardFetchFailures.set(entry.el, failures);
+            if (failures < CARD_FETCH_MAX_FAILURES) releaseQueueEntry(entry);
+        }
+    }
+}
+
+/** Drain unique fallback item ids through an explicit fixed-size worker pool. */
+async function processFallbackBatch(
+    entriesByItem: Map<string, QueueEntry[]>,
+    userId: string,
+    userKey: string,
+    generation: number,
+    signal: AbortSignal,
+): Promise<void> {
+    const groups = [...entriesByItem.entries()];
+    let nextGroup = 0;
+    const worker = async (): Promise<void> => {
+        while (fallbackRunIsCurrent(userKey, generation, signal)) {
+            const index = nextGroup;
+            nextGroup += 1;
+            if (index >= groups.length) return;
+            const [itemId, entries] = groups[index];
+            await processFallbackItem(itemId, entries, userId, userKey, generation, signal);
+        }
+    };
+    const workerCount = Math.min(TAG_FALLBACK_CONCURRENCY, groups.length);
+    await Promise.all(Array.from({ length: workerCount }, () => worker()));
+
+    if (!fallbackRunIsCurrent(userKey, generation, signal)) {
+        for (const [, entries] of groups) releaseFallbackEntries(entries);
+        scheduleScan();
+    }
+}
+
 /**
  * Fetch item data for a batch of cards and fan out to all enabled renderers.
  * @param batch - Queued card entries.
  * @param generation - Batch generation counter to detect stale navigations.
+ * @param signal - Exact queue-owner cancellation signal.
  */
-async function processBatch(batch: QueueEntry[], generation: number): Promise<void> {
+async function processBatch(
+    batch: QueueEntry[],
+    generation: number,
+    signal: AbortSignal,
+): Promise<void> {
     const userId = ApiClient.getCurrentUserId();
     const userKey = normalizeProjectionKey(userId);
     if (!userId || !userKey) return;
@@ -1538,7 +1794,8 @@ async function processBatch(batch: QueueEntry[], generation: number): Promise<vo
             url: ApiClient.getUrl(`/JellyfinCanopy/tag-data/${userId}`),
             data: JSON.stringify(ids),
             contentType: 'application/json',
-            dataType: 'json'
+            dataType: 'json',
+            signal,
         });
 
         if (!Array.isArray(response?.Items)
@@ -1556,7 +1813,7 @@ async function processBatch(batch: QueueEntry[], generation: number): Promise<vo
         // able to pick them up again instead of seeing a hollow "processed".
         if (generation !== batchGeneration
             || normalizeProjectionKey(ApiClient.getCurrentUserId()) !== userKey) {
-            for (const b of batch) processedCards.delete(b.el);
+            for (const entry of batch) releaseQueueEntry(entry);
             scheduleScan();
             return;
         }
@@ -1619,7 +1876,7 @@ async function processBatch(batch: QueueEntry[], generation: number): Promise<vo
                 || normalizeProjectionKey(ApiClient.getCurrentUserId()) !== userKey
                 || projectionResetPending
                 || pendingProjectionIds.has(itemId)) {
-                for (const entry of batchEntries) processedCards.delete(entry.el);
+                for (const entry of batchEntries) releaseQueueEntry(entry);
                 scheduleScan();
                 return;
             }
@@ -1641,7 +1898,7 @@ async function processBatch(batch: QueueEntry[], generation: number): Promise<vo
             let recycled = false;
             for (const entry of batchEntries) {
                 if (!queueEntryStillOwnsItem(entry, itemId)) {
-                    processedCards.delete(entry.el);
+                    releaseQueueEntry(entry);
                     recycled = true;
                     continue;
                 }
@@ -1689,66 +1946,15 @@ async function processBatch(batch: QueueEntry[], generation: number): Promise<vo
             await Promise.all(pendingFirstEps);
         }
     } catch (err) {
-        console.warn(`${logPrefix} Batch fetch failed, falling back to individual fetches:`, err);
-        // Fallback: process items individually
-        for (const entry of batch) {
-            const { el, renderTarget, itemId } = entry;
-            try {
-                if (generation !== batchGeneration
-                    || normalizeProjectionKey(ApiClient.getCurrentUserId()) !== userKey
-                    || projectionResetPending
-                    || pendingProjectionIds.has(itemId)) {
-                    processedCards.delete(el);
-                    if (generation !== batchGeneration
-                        || normalizeProjectionKey(ApiClient.getCurrentUserId()) !== userKey) {
-                        scheduleScan();
-                    }
-                    continue;
-                }
-                if (!queueEntryStillOwnsItem(entry, itemId)) {
-                    processedCards.delete(el);
-                    scheduleScan();
-                    continue;
-                }
-                // Privacy-forced ids may only be satisfied by /tag-data. The
-                // generic helper carries its own short-lived DTO cache, so using
-                // it after a batch failure could replay the pre-flip projection.
-                if (forceFreshProjectionIds.has(itemId)) {
-                    processedCards.delete(el);
-                    continue;
-                }
-                const item: any = await getItemCached(itemId, { userId });
-                if (!item || !MEDIA_TYPES.has(item.Type)) continue;
-
-                const firstEpisode = (item.Type === 'Series' || item.Type === 'Season')
-                    ? await getFirstEpisode(userId, item.Id) : null;
-                const extras = { firstEpisode, parentSeries: null, ratingParentSeries: null, renderTarget };
-
-                if (generation !== batchGeneration
-                    || normalizeProjectionKey(ApiClient.getCurrentUserId()) !== userKey
-                    || projectionResetPending
-                    || pendingProjectionIds.has(itemId)
-                    || !queueEntryStillOwnsItem(entry, itemId)) {
-                    processedCards.delete(el);
-                    scheduleScan();
-                    continue;
-                }
-
-                // PERF(R7): post-paint fallback render — fade late tags in.
-                withFadeIn(renderTarget, () => {
-                    for (const [, renderer] of renderers) {
-                        if (!renderer.isEnabled()) continue;
-                        try { renderer.render(renderTarget, item, extras); } catch {}
-                    }
-                });
-            } catch {
-                // PERF(R9): fail open — un-mark the card (bounded) so a later
-                // pass retries its tags instead of leaving it hollow forever.
-                const failures = (cardFetchFailures.get(el) || 0) + 1;
-                cardFetchFailures.set(el, failures);
-                if (failures < CARD_FETCH_MAX_FAILURES) processedCards.delete(el);
-            }
+        if (signal.aborted
+            || generation !== batchGeneration
+            || normalizeProjectionKey(ApiClient.getCurrentUserId()) !== userKey) {
+            for (const entry of batch) releaseQueueEntry(entry);
+            scheduleScan();
+            return;
         }
+        console.warn(`${logPrefix} Batch fetch failed, falling back to individual fetches:`, err);
+        await processFallbackBatch(elMap, userId, userKey, generation, signal);
     }
 }
 
@@ -1831,7 +2037,7 @@ async function initialize(
         navigationUnsubscribe = onNavigate(() => {
         // Invalidate any in-flight batch processing (don't reset isProcessing
         // directly — let stale batches finish naturally and discard results)
-        batchGeneration++;
+        retireBatchGeneration();
         firstEpisodeCache.clear();
         parentSeriesCache.clear();
         // PERF(R9): fail open — queued cards were already marked processed at
@@ -1839,7 +2045,7 @@ async function initialize(
         // that survives navigation (cached legacy page re-show, §6.8) keeps
         // its "processed" mark with no tags rendered, permanently. Un-mark so
         // a later pass over the same elements retries.
-        for (const entry of requestQueue) processedCards.delete(entry.el);
+        for (const entry of requestQueue) releaseQueueEntry(entry);
         requestQueue = [];
         firstFetchAfterNav = true; // PERF(R7): fast-track the next batch fetch
         if (JC.pluginConfig?.TagCacheServerMode) {
@@ -1981,8 +2187,9 @@ const tagPipelineApi = {
     // For reinitialize support
     clearProcessed() {
         processedCards = new WeakSet(); // Create fresh WeakSet so all cards get re-scanned
+        for (const entry of requestQueue) releaseQueueEntry(entry);
         requestQueue = [];
-        batchGeneration++;
+        retireBatchGeneration();
         firstEpisodeCache.clear();
         parentSeriesCache.clear();
     },


### PR DESCRIPTION
## Summary

- replace serial failed-batch fallback draining with a bounded six-worker pool
- retire and abort stale generation work while fencing exact card claims against retained-DOM ABA races
- coalesce duplicate item lookups, preserve fail-soft Series handling, and prevent stale cross-user cache publication
- add regressions for 200-card draining, successful batch behavior, duplicates, Series fallbacks, navigation, and account switches

## Root cause and impact

When the tag batch endpoint failed, fallback requests drained one item at a time. Large pages could remain stale for a long time, and navigation or identity changes could leave old work occupying ownership or publishing late results. The new owner ledger bounds current-generation work at six concurrent requests and releases obsolete claims immediately.

Fixes #129

## Validation

- focused tag pipeline: 27/27 passed
- full client coverage: 206 files, 1,285 tests passed with 4 workers
- coverage ratchet: 1,932/2,253 lines (85.75%), matches reviewed baseline
- source and legacy typecheck passed
- syntax inventory passed
- performance-rules guard passed: 248 files, 816 ms thread CPU
- deterministic bundle: 163 files, build 77b89c528aa2b2ad9af0dd80b9148d3eebcaba41126a46ebadf2960e99ed9482
- diff check passed
- repository lint wrapper completed; its one error is pre-existing in untouched enhanced/helpers.ts, while both modified files have zero lint errors
- independent reviews: two agent APPROVEs and Fable 5 low APPROVE

## AI assistance

Implemented and validated with Codex assistance. Independent review also used Claude Fable 5 at low effort in read-only mode.