### PR TITLE
fix(client): preserve question marks in panel fields

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/panel.lifecycle.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/panel.lifecycle.test.ts
@@ -19,6 +19,13 @@ const mocks = vi.hoisted(() => ({
 vi.mock('./template', () => ({
     buildPanelHtml: () => `
         <button id="closeSettingsPanel" type="button">close</button>
+        <input id="lifecycleEditableInput" type="text">
+        <textarea id="lifecycleEditableTextarea"></textarea>
+        <select id="lifecycleEditableSelect"><option>one</option></select>
+        <div id="lifecycleEditableContent" contenteditable="true" tabindex="0">
+            <span id="lifecycleEditableContentChild">editable</span>
+        </div>
+        <button id="lifecycleStaleKeyTarget" type="button">stale key target</button>
         <div class="jc-panel-body">
             <div class="jc-panel-nav"><div class="jc-panel-nav-items"></div></div>
             <div class="jc-panel-main">
@@ -324,6 +331,57 @@ describe('settings panel lifecycle owner', () => {
         expect(focus).toHaveBeenCalledTimes(1);
         expect(isAnyModalOpen()).toBe(false);
         expect(document.body.classList.contains('jc-modal-open')).toBe(false);
+    });
+
+    it.each([
+        ['input', '#lifecycleEditableInput', '#lifecycleEditableInput'],
+        ['textarea', '#lifecycleEditableTextarea', '#lifecycleEditableTextarea'],
+        ['select', '#lifecycleEditableSelect', '#lifecycleEditableSelect'],
+        ['nested contenteditable', '#lifecycleEditableContentChild', '#lifecycleEditableContent'],
+    ] as const)(
+        'lets a %s own the printable question-mark key',
+        async (_surface, targetSelector, focusSelector) => {
+            await showPanel!();
+            const panel = document.getElementById('jellyfin-canopy-panel')!;
+            const target = panel.querySelector<HTMLElement>(targetSelector)!;
+            panel.querySelector<HTMLElement>(focusSelector)!.focus();
+
+            target.dispatchEvent(new KeyboardEvent('keydown', { key: '?', bubbles: true }));
+
+            expect(document.getElementById('jellyfin-canopy-panel')).toBe(panel);
+            expect(panel.isConnected).toBe(true);
+            expect(isAnyModalOpen()).toBe(true);
+        }
+    );
+
+    it('still closes on Escape from an editable descendant', async () => {
+        await showPanel!();
+        const input = document.getElementById('lifecycleEditableInput') as HTMLInputElement;
+        input.focus();
+
+        input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+        expect(document.getElementById('jellyfin-canopy-panel')).toBeNull();
+        expect(isAnyModalOpen()).toBe(false);
+    });
+
+    it('keeps a replacement owner live when a retained stale subtree emits question mark', async () => {
+        await showPanel!();
+        const stalePanel = document.getElementById('jellyfin-canopy-panel')!;
+        const staleTarget = stalePanel.querySelector<HTMLElement>('#lifecycleStaleKeyTarget')!;
+        resetPanel!();
+
+        await showPanel!();
+        const replacement = document.getElementById('jellyfin-canopy-panel')!;
+        stalePanel.id = 'retained-stale-settings-panel';
+        document.body.appendChild(stalePanel);
+
+        staleTarget.dispatchEvent(new KeyboardEvent('keydown', { key: '?', bubbles: true }));
+
+        expect(document.getElementById('jellyfin-canopy-panel')).toBe(replacement);
+        expect(replacement.isConnected).toBe(true);
+        expect(isAnyModalOpen()).toBe(true);
+        stalePanel.remove();
     });
 
     it('continues disposing resources after one child cleanup throws', async () => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/panel.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/panel.ts
@@ -141,6 +141,26 @@ function createPanelOwner(
 
 type OwnedPanelElement = HTMLElement & { _identityCleanup?: () => void };
 
+interface SyntheticPanelEscapeEvent {
+    readonly type: 'keydown';
+    readonly key: 'Escape';
+    readonly target?: EventTarget | null;
+    stopPropagation?(): void;
+}
+
+type PanelCloseEvent = KeyboardEvent | MouseEvent | SyntheticPanelEscapeEvent;
+
+/** True when a printable keyboard event belongs to an editable surface. */
+function isEditableKeyboardTarget(target: EventTarget | null): boolean {
+    if (!(target instanceof Element)) return false;
+    const editable = target.closest('input, textarea, select, [contenteditable]');
+    if (!editable) return false;
+    if (editable.matches('input, textarea, select')) return true;
+    // The nearest explicit contenteditable boundary owns the inherited state;
+    // a nested `contenteditable="false"` island is deliberately non-editable.
+    return editable.getAttribute('contenteditable') !== 'false';
+}
+
 /** Toggle the main settings panel, joining calls made during the same open. */
 export function showEnhancedPanel(launch: SettingsPanelLaunchContext | null = null): Promise<void> {
     if (currentPanelOwner?.phase === 'open') {
@@ -343,7 +363,7 @@ async function openPanel(owner: PanelOwner): Promise<void> {
     let offset = { x: 0, y: 0 };
     let autoCloseTimer: number | null = null;
     let isMouseInside = false;
-    let closeHelp: (ev: any) => void = () => undefined;
+    let closeHelp: (ev: PanelCloseEvent) => void = () => undefined;
 
     // Every descendant listener installed by the split panel modules is
     // authorization-gated at the panel root. This also protects a retained,
@@ -593,8 +613,14 @@ async function openPanel(owner: PanelOwner): Promise<void> {
     });
 
     // --- Event Handlers for Settings Panel ---
-    closeHelp = (ev: any) => {
-        if ((ev.type === 'keydown' && (ev.key === 'Escape' || ev.key === '?')) || (ev.type === 'click' && ev.target.id === 'closeSettingsPanel')) {
+    closeHelp = (ev) => {
+        const keyboardClose = 'key' in ev && ev.type === 'keydown'
+            && (ev.key === 'Escape'
+                || (ev.key === '?' && !isEditableKeyboardTarget(ev.target ?? null)));
+        const buttonClose = ev.type === 'click'
+            && ev.target instanceof HTMLElement
+            && ev.target.id === 'closeSettingsPanel';
+        if (keyboardClose || buttonClose) {
             // modal-a11y's Escape path invokes this with a synthetic
             // `{ type, key }` object (not a DOM event), so stopPropagation may be
             // absent — guard it. Calling it unconditionally threw a TypeError

--- a/e2e/panel.spec.ts
+++ b/e2e/panel.spec.ts
@@ -44,10 +44,17 @@ test.describe('panel', () => {
         await expect(aboutPane.locator('#releaseNotesBtn')).toBeVisible();
 
         // The section search filters the nav.
-        await panel.locator('#jcPanelSearch').fill('subtitle');
+        const search = panel.locator('#jcPanelSearch');
+        await search.fill('subtitle');
         await expect(subtitlesItem).toBeVisible();
         await expect(panel.locator('.tab-button[data-tab="random-button"]')).toBeHidden();
-        await panel.locator('#jcPanelSearch').fill('');
+        await search.fill('');
+
+        // Printable keys belong to the focused editor: the panel-level `?`
+        // dismissal must not steal the character or destroy the search context.
+        await search.press('Shift+/');
+        await expect(search).toHaveValue('?');
+        await expect(panel).toBeVisible();
 
         // Escape closes the panel.
         await page.keyboard.press('Escape');

--- a/e2e/panel.spec.ts
+++ b/e2e/panel.spec.ts
@@ -52,7 +52,7 @@ test.describe('panel', () => {
 
         // Printable keys belong to the focused editor: the panel-level `?`
         // dismissal must not steal the character or destroy the search context.
-        await search.press('Shift+/');
+        await search.press('?');
         await expect(search).toHaveValue('?');
         await expect(panel).toBeVisible();
 


### PR DESCRIPTION
## Summary

- ignore the document-wide `?` close shortcut when the keyboard event originated from an input, textarea, select, or inherited editable region
- preserve Escape, close-button, backdrop, toggle, and non-editable question-mark close behavior
- retain lifecycle ownership fencing so stale panel descendants cannot close a replacement panel
- add focused lifecycle regressions and a real search-field Playwright scenario

## Root cause and impact

The settings panel document key listener treated every `?` keypress as a close request, including text entered into the panel search field and other editable controls. Users could not type a question mark without losing the panel. The listener now classifies the event origin before applying only the printable shortcut.

Fixes #332

## Validation

Revalidated and rebased onto `main` at `334a1faf3008f9a70e60615427cec39d3a072242`.

- regression-first proof on current `main`: 4 editable-surface cases failed, 17 passed
- patched focused lifecycle suite: 21/21 passed
- settings-panel scope: 16 files, 127 tests passed
- full client suite: 233 files, 1,795 tests passed
- full client coverage: 233 files, 1,795 tests passed; ratchet matched 2,327/2,667 lines (87.252%)
- source and legacy typechecks passed
- syntax inventory passed
- focused lint: zero errors; 32 pre-existing advisory warnings in `panel.ts`
- performance-rules guard: 262 files, 1,079 ms thread CPU
- deterministic bundle built twice with identical hash `434f1f7f1906018c14439d787120c0d87ba8b03c176a7b0ddd4fb2cf15a17abe`
- `git diff --check` passed
- the first CI shard 4 run exposed a Playwright key-mapping portability problem in the new test (`Shift+/` generated `/` on Linux); a local Chromium diagnostic reproduced that mapping and proved literal `?` generates the intended key and value
- after the test-only correction: focused lifecycle 21/21, both typechecks, Playwright discovery, and `git diff --check` passed
- independent read-only Codex review: APPROVE with no findings on exact head `c4a4017771a2c49b0d7eee1231085549dc1e4b82` over `334a1faf3008f9a70e60615427cec39d3a072242`

The real-browser search-field regression is included in `e2e/panel.spec.ts`; dockerized Jellyfin 12 execution is delegated to the required six-shard CI matrix.

## AI assistance

Implemented, revalidated, and reviewed with Codex assistance.
