### PR TITLE
fix(server): stream branding assets safely

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/BrandingAssetStreamingTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/BrandingAssetStreamingTests.cs
@@ -1,0 +1,427 @@
+using System.Diagnostics;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Services;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class BrandingAssetStreamingCollection
+{
+    public const string Name = "Branding asset streaming";
+}
+
+/// <summary>
+/// Pins the public-branding response lifecycle. A custom asset is a stable file
+/// generation owned by one response: it is streamed through a fixed buffer,
+/// cancellation stops the copy, and an owned response never falls through to
+/// Jellyfin's static-file middleware after a partial write.
+/// </summary>
+[Collection(BrandingAssetStreamingCollection.Name)]
+public sealed class BrandingAssetStreamingTests : IDisposable
+{
+    private const int MaximumUploadBytes = 10 * 1024 * 1024;
+    private static readonly IServiceProvider Services = new ServiceCollection().BuildServiceProvider();
+    private readonly string _directory;
+    private readonly ITestOutputHelper _output;
+
+    public BrandingAssetStreamingTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _directory = Path.Combine(Path.GetTempPath(), "jc-branding-stream-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_directory);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+        catch
+        {
+            // Best effort: a failed assertion must not hide the original failure.
+        }
+    }
+
+    [Fact]
+    public async Task MaximumSizeGets_DoNotAllocateOnePayloadArrayPerRequest()
+    {
+        var path = AssetPath();
+        using (var file = new FileStream(path, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+        {
+            file.SetLength(MaximumUploadBytes);
+        }
+
+        var filter = CreateFilter();
+        var pipeline = BuildPipeline(filter, _ => Task.CompletedTask);
+
+        // Warm JIT, middleware construction, FileStream internals and the shared copy buffer pool.
+        await pipeline(CreateContext(Stream.Null));
+
+        const int requests = 4;
+        var allocatedBefore = GC.GetTotalAllocatedBytes(precise: true);
+        var timer = Stopwatch.StartNew();
+        for (var index = 0; index < requests; index++)
+        {
+            await pipeline(CreateContext(Stream.Null));
+        }
+
+        timer.Stop();
+        var allocated = GC.GetTotalAllocatedBytes(precise: true) - allocatedBefore;
+        _output.WriteLine(
+            "requests={0} payloadBytes={1} allocatedBytes={2} elapsedMs={3:F3}",
+            requests,
+            MaximumUploadBytes,
+            allocated,
+            timer.Elapsed.TotalMilliseconds);
+
+        // The old ReadAllBytesAsync path allocates at least 40 MiB here. Leave a
+        // generous 2 MiB/request envelope for async/runtime noise while forbidding
+        // a payload-sized allocation from returning.
+        Assert.True(
+            allocated < requests * 2L * 1024 * 1024,
+            $"Four {MaximumUploadBytes}-byte responses allocated {allocated} bytes.");
+    }
+
+    [Fact]
+    public async Task ConcurrentMaximumSizeGets_UseFixedPerResponseBuffersAndReleaseHandles()
+    {
+        var path = AssetPath();
+        using (var file = new FileStream(path, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+        {
+            file.SetLength(MaximumUploadBytes);
+        }
+
+        var pipeline = BuildPipeline(CreateFilter(), _ => Task.CompletedTask);
+        await pipeline(CreateContext(Stream.Null));
+        const int requests = 16;
+        var allocatedBefore = GC.GetTotalAllocatedBytes(precise: true);
+        await Task.WhenAll(Enumerable.Range(0, requests).Select(_ => pipeline(CreateContext(Stream.Null))));
+        var allocated = GC.GetTotalAllocatedBytes(precise: true) - allocatedBefore;
+
+        _output.WriteLine(
+            "concurrentRequests={0} payloadBytes={1} allocatedBytes={2}",
+            requests,
+            MaximumUploadBytes,
+            allocated);
+        Assert.True(
+            allocated < requests * 2L * 1024 * 1024,
+            $"{requests} concurrent responses allocated {allocated} bytes.");
+
+        // Every response must dispose its generation handle. An exclusive reopen
+        // catches a retained handle on platforms that enforce FileShare in-process.
+        using var exclusive = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+        Assert.Equal(MaximumUploadBytes, exclusive.Length);
+    }
+
+    [Fact]
+    public async Task Get_StreamsExactBodyAndValidatorsWithoutDownstreamFallback()
+    {
+        var payload = "canopy-branding"u8.ToArray();
+        await File.WriteAllBytesAsync(AssetPath(), payload);
+        File.SetLastWriteTimeUtc(AssetPath(), new DateTime(2026, 7, 17, 1, 2, 3, DateTimeKind.Utc));
+        var downstreamCalls = 0;
+        var filter = CreateFilter();
+        var pipeline = BuildPipeline(filter, _ =>
+        {
+            Interlocked.Increment(ref downstreamCalls);
+            return Task.CompletedTask;
+        });
+        using var body = new MemoryStream();
+        var context = CreateContext(body);
+
+        await pipeline(context);
+
+        Assert.Equal(0, downstreamCalls);
+        Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+        Assert.Equal("image/png", context.Response.ContentType);
+        Assert.Equal(payload.Length, context.Response.ContentLength);
+        Assert.Equal("no-cache", context.Response.Headers.CacheControl.ToString());
+        Assert.False(string.IsNullOrWhiteSpace(context.Response.Headers.ETag));
+        Assert.False(string.IsNullOrWhiteSpace(context.Response.Headers.LastModified));
+        Assert.Equal(payload, body.ToArray());
+    }
+
+    [Fact]
+    public async Task HeadAndMatchingConditionalGet_ReadNoBody()
+    {
+        await File.WriteAllBytesAsync(AssetPath(), "validator-body"u8.ToArray());
+        var filter = CreateFilter();
+        var pipeline = BuildPipeline(filter, _ => throw new Xunit.Sdk.XunitException("Unexpected downstream fallback"));
+
+        var head = CreateContext(new ThrowOnWriteStream(), HttpMethods.Head);
+        await pipeline(head);
+        Assert.Equal(StatusCodes.Status200OK, head.Response.StatusCode);
+        Assert.True(head.Response.ContentLength > 0);
+        Assert.False(string.IsNullOrWhiteSpace(head.Response.Headers.ETag));
+
+        var conditional = CreateContext(new ThrowOnWriteStream());
+        conditional.Request.Headers.IfNoneMatch = head.Response.Headers.ETag;
+        await pipeline(conditional);
+        Assert.Equal(StatusCodes.Status304NotModified, conditional.Response.StatusCode);
+        Assert.Null(conditional.Response.ContentLength);
+    }
+
+    [Fact]
+    public async Task RequestCancellation_StopsBlockedCopyPromptlyAndDoesNotFallThrough()
+    {
+        using (var file = new FileStream(AssetPath(), FileMode.CreateNew, FileAccess.Write, FileShare.None))
+        {
+            file.SetLength(MaximumUploadBytes);
+        }
+
+        var downstreamCalls = 0;
+        var sink = new BlockingWriteStream();
+        using var aborted = new CancellationTokenSource();
+        var context = CreateContext(sink);
+        context.RequestAborted = aborted.Token;
+        var pipeline = BuildPipeline(CreateFilter(), _ =>
+        {
+            Interlocked.Increment(ref downstreamCalls);
+            return Task.CompletedTask;
+        });
+
+        var response = pipeline(context);
+        await sink.WriteStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        aborted.Cancel();
+        var completedPromptly = await Task.WhenAny(response, Task.Delay(TimeSpan.FromSeconds(1))) == response;
+        sink.Release.TrySetResult();
+        await response;
+
+        Assert.True(completedPromptly, "RequestAborted did not stop the blocked response copy within one second.");
+        Assert.True(sink.ObservedCancellationToken.CanBeCanceled);
+        Assert.Equal(0, downstreamCalls);
+    }
+
+    [Fact]
+    public async Task AtomicReplacementDuringCopy_ServesOneCoherentOpenGeneration()
+    {
+        var original = Enumerable.Repeat((byte)'A', 256 * 1024).ToArray();
+        var replacement = Enumerable.Repeat((byte)'B', original.Length + 17).ToArray();
+        await File.WriteAllBytesAsync(AssetPath(), original);
+        File.SetLastWriteTimeUtc(AssetPath(), new DateTime(2026, 7, 17, 2, 0, 0, DateTimeKind.Utc));
+
+        var sink = new PausingCaptureStream();
+        var pipeline = BuildPipeline(CreateFilter(), _ => throw new Xunit.Sdk.XunitException("Unexpected downstream fallback"));
+        var head = CreateContext(Stream.Null, HttpMethods.Head);
+        await pipeline(head);
+        var originalEtag = head.Response.Headers.ETag.ToString();
+        var context = CreateContext(sink);
+        var response = pipeline(context);
+        await sink.FirstWrite.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await AtomicFile.WriteViaAsync(AssetPath(), stream => stream.WriteAsync(replacement).AsTask());
+        sink.Resume.TrySetResult();
+        await response;
+
+        Assert.Equal(original.Length, context.Response.ContentLength);
+        Assert.Equal(originalEtag, context.Response.Headers.ETag.ToString());
+        Assert.Equal(original, sink.ToArray());
+        Assert.Equal(replacement, await File.ReadAllBytesAsync(AssetPath()));
+
+        var replacementHead = CreateContext(Stream.Null, HttpMethods.Head);
+        await pipeline(replacementHead);
+        Assert.Equal(replacement.Length, replacementHead.Response.ContentLength);
+        Assert.NotEqual(originalEtag, replacementHead.Response.Headers.ETag.ToString());
+    }
+
+    [Fact]
+    public async Task OwnedResponseWriteFailure_NeverInvokesStockMiddleware()
+    {
+        await File.WriteAllBytesAsync(AssetPath(), "partial-response"u8.ToArray());
+        var downstreamCalls = 0;
+        var context = CreateContext(new ThrowOnWriteStream());
+        var pipeline = BuildPipeline(CreateFilter(), _ =>
+        {
+            Interlocked.Increment(ref downstreamCalls);
+            return Task.CompletedTask;
+        });
+
+        await pipeline(context);
+
+        Assert.Equal(0, downstreamCalls);
+        Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+    }
+
+    [Fact]
+    public void OpenGeneration_AllowsAtomicReplacementWhileReaderIsAlive()
+    {
+        Assert.Equal(
+            FileShare.Read | FileShare.Delete,
+            BrandingAssetStartupFilter.BrandingFileShare);
+    }
+
+    [Theory]
+    [InlineData("GET", "/api/icon-transparent.hash.png", false, true)]
+    [InlineData("POST", "/web/icon-transparent.hash.png", false, true)]
+    [InlineData("GET", "/web/icon-transparent.hash.png", true, true)]
+    [InlineData("GET", "/proxy/base/web/icon-transparent.hash.png", false, false)]
+    public async Task PathMethodAndDisabledContracts_FallThroughOnlyWhenExpected(
+        string method,
+        string path,
+        bool disabled,
+        bool expectedFallthrough)
+    {
+        await File.WriteAllBytesAsync(AssetPath(), "path-contract"u8.ToArray());
+        var downstreamCalls = 0;
+        var pipeline = BuildPipeline(CreateFilter(disabled), context =>
+        {
+            Interlocked.Increment(ref downstreamCalls);
+            context.Response.StatusCode = StatusCodes.Status418ImATeapot;
+            return Task.CompletedTask;
+        });
+        using var body = new MemoryStream();
+        var context = CreateContext(body, method, path);
+
+        await pipeline(context);
+
+        Assert.Equal(expectedFallthrough ? 1 : 0, downstreamCalls);
+        Assert.Equal(
+            expectedFallthrough ? StatusCodes.Status418ImATeapot : StatusCodes.Status200OK,
+            context.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task MissingCustomFile_FallsThroughExactlyOnce()
+    {
+        var downstreamCalls = 0;
+        var pipeline = BuildPipeline(CreateFilter(), context =>
+        {
+            Interlocked.Increment(ref downstreamCalls);
+            context.Response.StatusCode = StatusCodes.Status204NoContent;
+            return Task.CompletedTask;
+        });
+        var context = CreateContext(Stream.Null);
+
+        await pipeline(context);
+
+        Assert.Equal(1, downstreamCalls);
+        Assert.Equal(StatusCodes.Status204NoContent, context.Response.StatusCode);
+    }
+
+    private string AssetPath() => Path.Combine(_directory, "icon-transparent.png");
+
+    private BrandingAssetStartupFilter CreateFilter(bool disabled = false)
+        => new(
+            NullLogger<BrandingAssetStartupFilter>.Instance,
+            new FakePluginConfigProvider(new PluginConfiguration { DisableBrandingMiddleware = disabled }),
+            () => _directory);
+
+    private static RequestDelegate BuildPipeline(
+        BrandingAssetStartupFilter filter,
+        RequestDelegate downstream)
+    {
+        var builder = new ApplicationBuilder(Services);
+        filter.Configure(app => app.Run(downstream))(builder);
+        return builder.Build();
+    }
+
+    private static DefaultHttpContext CreateContext(
+        Stream responseBody,
+        string method = "GET",
+        string path = "/web/icon-transparent.hash.png")
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Method = method;
+        context.Request.Path = path;
+        context.Response.Body = responseBody;
+        return context;
+    }
+
+    private sealed class ThrowOnWriteStream : Stream
+    {
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => 0;
+        public override long Position { get => 0; set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new IOException("simulated client write failure");
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => Task.FromException(new IOException("simulated client write failure"));
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+            => ValueTask.FromException(new IOException("simulated client write failure"));
+    }
+
+    private sealed class BlockingWriteStream : Stream
+    {
+        public TaskCompletionSource WriteStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource Release { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public CancellationToken ObservedCancellationToken { get; private set; }
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => 0;
+        public override long Position { get => 0; set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => WriteCoreAsync(cancellationToken);
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+            => new(WriteCoreAsync(cancellationToken));
+
+        private async Task WriteCoreAsync(CancellationToken cancellationToken)
+        {
+            ObservedCancellationToken = cancellationToken;
+            WriteStarted.TrySetResult();
+            await Release.Task.WaitAsync(cancellationToken);
+        }
+    }
+
+    private sealed class PausingCaptureStream : Stream
+    {
+        private readonly MemoryStream _captured = new();
+        private int _pauseClaimed;
+        public TaskCompletionSource FirstWrite { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource Resume { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => _captured.Length;
+        public override long Position { get => _captured.Position; set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => WriteCoreAsync(buffer.AsMemory(offset, count), cancellationToken);
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+            => new(WriteCoreAsync(buffer, cancellationToken));
+
+        public byte[] ToArray() => _captured.ToArray();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing) _captured.Dispose();
+            base.Dispose(disposing);
+        }
+
+        private async Task WriteCoreAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+        {
+            await _captured.WriteAsync(buffer, cancellationToken);
+            if (Interlocked.Exchange(ref _pauseClaimed, 1) == 0)
+            {
+                FirstWrite.TrySetResult();
+                await Resume.Task.WaitAsync(cancellationToken);
+            }
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/BrandingAssetStartupFilter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/BrandingAssetStartupFilter.cs
@@ -30,13 +30,18 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
     /// request and streams those bytes directly (no buffering, no de/recompression —
     /// PNG/ICO are already compressed). When it does not, it calls next() and the
     /// stock asset is served, preserving the original "no custom image = no change"
-    /// behaviour. Any error falls through to next(). Disable via
-    /// DisableBrandingMiddleware.
+    /// behaviour. Errors before a custom response is claimed fall through; after
+    /// response ownership begins they terminate that response and never invoke a
+    /// second body producer. Disable via DisableBrandingMiddleware.
     /// </summary>
     public class BrandingAssetStartupFilter : IStartupFilter
     {
+        internal const FileShare BrandingFileShare = FileShare.Read | FileShare.Delete;
+        internal const int CopyBufferSize = 64 * 1024;
+
         private readonly ILogger<BrandingAssetStartupFilter> _logger;
         private readonly IPluginConfigProvider _configProvider;
+        private readonly Func<string> _brandingDirectoryProvider;
         private int _loggedOnce;
 
         private static readonly RegexOptions Opts = RegexOptions.IgnoreCase | RegexOptions.Compiled;
@@ -68,9 +73,18 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         };
 
         public BrandingAssetStartupFilter(ILogger<BrandingAssetStartupFilter> logger, IPluginConfigProvider configProvider)
+            : this(logger, configProvider, () => JellyfinCanopy.BrandingDirectory)
+        {
+        }
+
+        internal BrandingAssetStartupFilter(
+            ILogger<BrandingAssetStartupFilter> logger,
+            IPluginConfigProvider configProvider,
+            Func<string> brandingDirectoryProvider)
         {
             _logger = logger;
             _configProvider = configProvider;
+            _brandingDirectoryProvider = brandingDirectoryProvider;
         }
 
         public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
@@ -105,33 +119,56 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 return;
             }
 
+            var responseOwned = false;
             try
             {
-                var brandingDir = JellyfinCanopy.BrandingDirectory;
+                var brandingDir = _brandingDirectoryProvider();
                 if (!string.IsNullOrWhiteSpace(brandingDir))
                 {
                     // Resolve under BrandingDirectory and confirm the candidate stays
                     // inside it (defence in depth; OnDiskFileName is a constant).
                     var fullDir = Path.GetFullPath(brandingDir);
                     var filePath = Path.GetFullPath(Path.Join(fullDir, onDiskFileName));
-                    if (string.Equals(Path.GetDirectoryName(filePath), fullDir, StringComparison.OrdinalIgnoreCase)
-                        && File.Exists(filePath))
+                    if (string.Equals(Path.GetDirectoryName(filePath), fullDir, StringComparison.OrdinalIgnoreCase))
                     {
-                        var fileInfo = new FileInfo(filePath);
-                        if (fileInfo.Length > 0)
+                        // FileStream construction has no cancellable overload, so reject
+                        // an already-aborted request immediately before acquiring the
+                        // response-owned handle. CopyToAsync owns all later file reads and
+                        // response writes under the same RequestAborted token.
+                        context.RequestAborted.ThrowIfCancellationRequested();
+                        await using var stream = new FileStream(
+                            filePath,
+                            new FileStreamOptions
+                            {
+                                Mode = FileMode.Open,
+                                Access = FileAccess.Read,
+                                Share = BrandingFileShare,
+                                BufferSize = 4096,
+                                Options = FileOptions.Asynchronous | FileOptions.SequentialScan,
+                            });
+                        context.RequestAborted.ThrowIfCancellationRequested();
+
+                        var length = stream.Length;
+                        if (length > 0)
                         {
+                            // Metadata comes from the exact open handle whose bytes will be
+                            // copied. AtomicFile can rename a replacement over the path while
+                            // this handle remains alive (FileShare.Delete is required on
+                            // Windows); this response still serves one coherent old generation.
+                            var lastWriteTimeUtc = File.GetLastWriteTimeUtc(stream.SafeFileHandle);
                             // Validator from size + mtime so unchanged assets revalidate
                             // cheaply (304, no body). Cache-Control stays no-cache because
                             // the URL hash reflects the stock asset, not the custom file —
                             // so a re-uploaded image (new mtime -> new ETag) is picked up
                             // immediately on the next revalidation.
-                            var etag = "\"" + (fileInfo.LastWriteTimeUtc.Ticks ^ fileInfo.Length)
+                            var etag = "\"" + (lastWriteTimeUtc.Ticks ^ length)
                                 .ToString("x", CultureInfo.InvariantCulture) + "\"";
-                            var lastModified = fileInfo.LastWriteTimeUtc.ToString("R", CultureInfo.InvariantCulture);
+                            var lastModified = lastWriteTimeUtc.ToString("R", CultureInfo.InvariantCulture);
 
                             if (context.Request.Headers.TryGetValue("If-None-Match", out var inm)
                                 && IfNoneMatchSatisfied(inm, etag))
                             {
+                                responseOwned = true;
                                 context.Response.StatusCode = 304;
                                 context.Response.Headers["Cache-Control"] = "no-cache";
                                 context.Response.Headers["ETag"] = etag;
@@ -146,9 +183,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                             }
 
                             var isHead = HttpMethods.IsHead(context.Request.Method);
-                            byte[]? bytes = isHead ? null : await File.ReadAllBytesAsync(filePath).ConfigureAwait(false);
-                            var length = isHead ? fileInfo.Length : bytes!.Length;
-
+                            responseOwned = true;
                             context.Response.StatusCode = 200;
                             context.Response.ContentType = contentType;
                             context.Response.ContentLength = length;
@@ -164,7 +199,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                             // HEAD: headers only, no body.
                             if (!isHead)
                             {
-                                await context.Response.Body.WriteAsync(bytes!, 0, bytes!.Length).ConfigureAwait(false);
+                                await stream.CopyToAsync(
+                                    context.Response.Body,
+                                    CopyBufferSize,
+                                    context.RequestAborted).ConfigureAwait(false);
                             }
 
                             return; // short-circuit: do not fall through to the static-file handler
@@ -172,9 +210,36 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     }
                 }
             }
+            catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)
+            {
+                // The client owns cancellation. Dispose the exact file generation and
+                // stop immediately; a disconnected request must never start the stock
+                // static-file producer or emit a warning as if the server had failed.
+                return;
+            }
+            catch (FileNotFoundException)
+            {
+                // A missing override is the normal stock-branding path. The file can
+                // also disappear between path resolution and open when an admin
+                // deletes it; neither case is a middleware failure worth logging.
+            }
+            catch (DirectoryNotFoundException)
+            {
+                // The custom-branding directory is optional and may not exist yet.
+            }
             catch (Exception ex)
             {
-                // Never break asset serving — fall through to the stock asset below.
+                if (responseOwned)
+                {
+                    // Headers/body now describe the custom generation. Falling through
+                    // could append a stock asset to a partial custom body or attempt a
+                    // second response. Abort the owned response instead.
+                    _logger.LogWarning($"Branding middleware error after response ownership (response terminated): {ex.Message}");
+                    context.Abort();
+                    return;
+                }
+
+                // No custom response was claimed, so the host can safely serve stock.
                 _logger.LogWarning($"Branding middleware error (serving stock asset): {ex.Message}");
             }
 

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -19,7 +19,7 @@ const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the repeated clean measurements', () => {
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1932, totalLines: 2253 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 18748, totalLines: 27276 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 18841, totalLines: 27308 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);
 });

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -21,12 +21,12 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 18748,
-        "totalLines": 27276
+        "coveredLines": 18841,
+        "totalLines": 27308
       },
       "tolerance": {
         "missingCoveredLines": 2,
-        "rationale": "Two clean local .NET 10.0.9/Coverlet integration runs on 2026-07-16 each passed 1672 tests and measured the identical combined 27276-line assembly scope at 18748 and 18747 covered lines. Issue #318's final graph-wide retry delivery adds bounded path namespaces and controller regressions for missing, malformed, out-of-range, duplicate, queried, stale, traversal, unknown, and valid static/dynamic asset graphs. Relative to the reviewed 18744/27277 baseline, the reviewed assembly scope decreases by one instrumented line and the high-water advances by four covered lines while line coverage rises from 68.717% to 68.734%. The existing two-line tolerance is unchanged and covers the reproduced one-line Coverlet variance; coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, and broad-tolerance negative boundaries."
+        "rationale": "Two clean local .NET 10.0.9/Coverlet integration runs on 2026-07-17 each passed 1685 tests and measured the identical combined 27308-line assembly scope at 18841 covered lines (68.994%). Issue #161 replaces payload-sized public-branding buffers with cancellation-aware fixed-buffer streaming and adds response-ownership, allocation, concurrent-request, validator, fault, and atomic-generation regressions. Relative to the reviewed 18748/27276 baseline, the reviewed assembly scope grows by 32 executable lines and the high-water advances by 93 covered lines while line coverage rises from 68.734% to 68.994%. The existing two-line tolerance is unchanged and covers only the previously reproduced negligible Coverlet variance; coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
## Summary

- stream custom branding assets from one stable file handle instead of buffering each entire payload
- keep response validators, length, and bytes coherent during atomic file replacement
- propagate request cancellation and prevent stock middleware from writing after a custom response is owned
- add adversarial allocation, concurrency, cancellation, replacement, HEAD/304, and fault-path coverage

## Root cause

The branding middleware read every asset into a payload-sized managed byte array before writing it. It also did not propagate `RequestAborted`, and a write failure after custom headers/body ownership could fall through to the stock response producer.

## Performance impact

For four sequential 10 MiB responses, measured managed allocation fell from **42,045,264 bytes** to **124,088 bytes** (about **99.705% lower**). Sixteen concurrent maximum-size responses allocated **1,482,208 bytes** total while retaining one fixed 64 KiB copy buffer and one file handle per active response.

## Validation

- focused branding suite: 13/13 passed
- full server suite: 1,685/1,685 passed on two clean runs
- exact server coverage: 18,841/27,308 (68.994%) on both runs
- Release build: 0 warnings, 0 errors
- repository script suite: 379/379 passed
- vulnerability audit: clean
- independent agent review: APPROVE, no blocking findings
- Fable low review: APPROVE, no blocking findings

Fixes #161