### PR TITLE
fix(server): invalidate tag access by policy generation

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/TagCacheProjectionControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/TagCacheProjectionControllerTests.cs
@@ -200,6 +200,38 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 removed.GetProperty("removedIds").EnumerateArray().Select(static id => id.GetString()));
         }
 
+        [Fact]
+        public void PolicyChangeObservedBeforePublication_ReturnsFailClosedCurrentGenerationReset()
+        {
+            using var harness = new Harness();
+            var itemId = Guid.NewGuid().ToString("N");
+            harness.Cache.SeedUserAccessCacheForTest(harness.User.Id.ToString("N"), itemId);
+            harness.Cache.SeedEntryForTest(itemId, new TagCacheEntry { Type = "Movie" });
+            var oldEpoch = harness.Cache.GetCurrentContentControl(harness.User).Epoch;
+
+            harness.Cache.OnAfterUserCacheSnapshotForTest = () =>
+            {
+                harness.Cache.OnAfterUserCacheSnapshotForTest = null;
+                var updated = new User(
+                    harness.User.Username,
+                    harness.User.AuthenticationProviderId,
+                    harness.User.PasswordResetProviderId)
+                {
+                    Id = harness.User.Id,
+                };
+                updated.OnSavingChanges();
+                harness.Users.ReplaceUser(updated);
+            };
+
+            var payload = Payload(harness.Controller.GetTagCache(harness.User.Id));
+
+            Assert.True(payload.GetProperty("contentReset").GetBoolean());
+            Assert.True(payload.GetProperty("reset").GetBoolean());
+            Assert.Equal(0, payload.GetProperty("count").GetInt32());
+            Assert.Empty(payload.GetProperty("items").EnumerateObject());
+            Assert.NotEqual(oldEpoch, payload.GetProperty("contentEpoch").GetString());
+        }
+
         private static JsonElement Payload(IActionResult result)
         {
             var ok = Assert.IsType<OkObjectResult>(result);
@@ -220,7 +252,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 Directory.CreateDirectory(_tempDir);
 
                 User = new User("projection-controller", "Provider", "PasswordProvider");
-                var users = new StubUserManager(User);
+                Users = new StubUserManager(User);
                 Library = new CountingLibraryManager();
                 UserData = new StubUserDataManager();
                 var appPaths = new StubAppPaths(_tempDir);
@@ -234,11 +266,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                     appPaths,
                     NullLogger<UserConfigurationManager>.Instance);
                 var markers = new SpoilerIdentityService(
-                    users,
+                    Users,
                     NullLogger<SpoilerIdentityService>.Instance);
                 var identity = new RequestIdentityService(
                     new CountingSessionManager(),
-                    users,
+                    Users,
                     markers,
                     NullLogger<RequestIdentityService>.Instance);
                 var resolver = new SpoilerUserResolver(
@@ -258,7 +290,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 Controller = new TagCacheController(
                     new RecordingHttpClientFactory(new HttpClientHandler()),
                     NullLogger<TagCacheController>.Instance,
-                    users,
+                    Users,
                     new SeerrCache(configProvider),
                     configProvider,
                     Cache,
@@ -279,6 +311,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             }
 
             public User User { get; }
+
+            public StubUserManager Users { get; }
 
             public TagCacheService Cache { get; }
 

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/TagCacheContentRevisionTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/TagCacheContentRevisionTests.cs
@@ -48,7 +48,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             var a = Guid.NewGuid();
             var b = Guid.NewGuid();
             using var harness = new Harness(new[] { a, b });
-            harness.Service.GetFullContentForUser(harness.User);
+            var full = harness.Service.GetFullContentForUser(harness.User);
 
             harness.Service.SetLegacyTimestampForTest(1_000);
             harness.Service.PublishUpsertForTest(Key(a), Entry("same-millisecond-a"));
@@ -63,7 +63,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             Assert.Equal(1, afterA);
             Assert.Equal(2, afterB);
             Assert.Equal(3, afterRollback);
-            var delta = harness.Service.GetContentDeltaForUser(harness.User, harness.Service.ContentEpoch, 0);
+            var delta = harness.Service.GetContentDeltaForUser(harness.User, full.Epoch, 0);
             Assert.Equal(3, delta.Revision);
             Assert.Equal(3, delta.JournalRowsVisited);
             Assert.Equal("clock-rollback-a", delta.Items[Key(a)].Type);
@@ -92,6 +92,52 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             AssertReset(harness.Service.GetContentDeltaForUser(harness.User, full.Epoch, -1), 3);
             AssertReset(harness.Service.GetContentDeltaForUser(harness.User, full.Epoch, null), 3);
             AssertReset(harness.Service.GetContentDeltaForUser(harness.User, null, 3), 3);
+        }
+
+        [Fact]
+        public void AuthorizationGenerationChange_InvalidatesContentCursorAndServedProof()
+        {
+            var id = Guid.NewGuid();
+            using var harness = new Harness(new[] { id });
+            harness.Service.SeedEntryForTest(Key(id), Entry("Movie"));
+            var full = harness.Service.GetFullContentForUser(harness.User);
+            Assert.Contains(Key(id), full.Items.Keys);
+
+            var updatedUser = new User(
+                harness.User.Username,
+                harness.User.AuthenticationProviderId,
+                harness.User.PasswordResetProviderId)
+            {
+                Id = harness.User.Id,
+            };
+            updatedUser.OnSavingChanges();
+            harness.Library.GetItemIdsHook = _ => Array.Empty<Guid>();
+
+            var delta = harness.Service.GetContentDeltaForUser(
+                updatedUser,
+                full.Epoch,
+                full.Revision);
+
+            Assert.True(delta.ResetRequired);
+            Assert.NotEqual(full.Epoch, delta.Epoch);
+            Assert.Empty(delta.Items);
+            Assert.Empty(delta.RemovedIds);
+
+            var control = harness.Service.GetCurrentContentControl(updatedUser);
+            var proofless = harness.Service.GetContentDeltaForUser(
+                updatedUser,
+                control.Epoch,
+                control.Revision);
+            Assert.True(proofless.ResetRequired);
+
+            var currentFull = harness.Service.GetFullContentForUser(updatedUser);
+            var currentDelta = harness.Service.GetContentDeltaForUser(
+                updatedUser,
+                currentFull.Epoch,
+                currentFull.Revision);
+            Assert.Equal(delta.Epoch, control.Epoch);
+            Assert.Equal(delta.Epoch, currentFull.Epoch);
+            Assert.False(currentDelta.ResetRequired);
         }
 
         [Fact]

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/TagCacheUserAccessCacheTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/TagCacheUserAccessCacheTests.cs
@@ -9,6 +9,123 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services;
 public sealed class TagCacheUserAccessCacheTests
 {
     [Fact]
+    public void AuthorizationGenerationChange_RecomputesOnlyTheAffectedUserBeforeTtl()
+    {
+        var revokedId = Guid.NewGuid();
+        var retainedId = Guid.NewGuid();
+        var otherId = Guid.NewGuid();
+        var user = new User("revoked", "provider", "password-provider");
+        var other = new User("other", "provider", "password-provider");
+        var calls = new Dictionary<Guid, int>();
+        var library = new CountingLibraryManager
+        {
+            GetItemIdsHook = query =>
+            {
+                calls[query.User!.Id] = calls.GetValueOrDefault(query.User.Id) + 1;
+                if (query.User.Id == other.Id)
+                {
+                    return new[] { otherId };
+                }
+
+                return query.User.RowVersion == 0
+                    ? new[] { revokedId, retainedId }
+                    : new[] { retainedId };
+            },
+        };
+        using var service = new TagCacheService(
+            library,
+            new StubAppPaths(Path.GetTempPath()),
+            NullLogger<TagCacheService>.Instance);
+        service.SeedEntryForTest(revokedId.ToString("N"), new() { Type = "Movie" });
+        service.SeedEntryForTest(retainedId.ToString("N"), new() { Type = "Movie" });
+        service.SeedEntryForTest(otherId.ToString("N"), new() { Type = "Movie" });
+
+        Assert.Equal(2, service.GetCacheForUser(user).Count);
+        Assert.Single(service.GetCacheForUser(other));
+
+        var updatedUser = NextGeneration(user);
+        var afterRevoke = service.GetCacheForUser(updatedUser);
+        Assert.DoesNotContain(revokedId.ToString("N"), afterRevoke.Keys);
+        Assert.Contains(retainedId.ToString("N"), afterRevoke.Keys);
+        Assert.Single(service.GetCacheForUser(other));
+        Assert.Equal(2, calls[user.Id]);
+        Assert.Equal(1, calls[other.Id]);
+    }
+
+    [Fact]
+    public void AuthorizationGenerationChange_MakesGrantVisibleBeforeTtl()
+    {
+        var grantedId = Guid.NewGuid();
+        var user = new User("granted", "provider", "password-provider");
+        var calls = 0;
+        var library = new CountingLibraryManager
+        {
+            GetItemIdsHook = query =>
+            {
+                calls++;
+                return query.User!.RowVersion == 0
+                    ? Array.Empty<Guid>()
+                    : new[] { grantedId };
+            },
+        };
+        using var service = new TagCacheService(
+            library,
+            new StubAppPaths(Path.GetTempPath()),
+            NullLogger<TagCacheService>.Instance);
+        service.SeedEntryForTest(grantedId.ToString("N"), new() { Type = "Movie" });
+
+        Assert.Empty(service.GetCacheForUser(user));
+        var afterGrant = service.GetCacheForUser(NextGeneration(user));
+
+        Assert.Contains(grantedId.ToString("N"), afterGrant.Keys);
+        Assert.Equal(2, calls);
+    }
+
+    [Fact]
+    public async Task NewAuthorizationGenerationDoesNotJoinOldGenerationFlight()
+    {
+        using var oldEntered = new ManualResetEventSlim();
+        using var newEntered = new ManualResetEventSlim();
+        using var releaseOld = new ManualResetEventSlim();
+        var oldId = Guid.NewGuid();
+        var newId = Guid.NewGuid();
+        var user = new User("generation-flight", "provider", "password-provider");
+        var updatedUser = NextGeneration(user);
+        var library = new CountingLibraryManager
+        {
+            GetItemIdsHook = query =>
+            {
+                if (query.User!.RowVersion == 0)
+                {
+                    oldEntered.Set();
+                    releaseOld.Wait(TimeSpan.FromSeconds(10));
+                    return new[] { oldId };
+                }
+
+                newEntered.Set();
+                return new[] { newId };
+            },
+        };
+        using var service = new TagCacheService(
+            library,
+            new StubAppPaths(Path.GetTempPath()),
+            NullLogger<TagCacheService>.Instance);
+        service.SeedEntryForTest(oldId.ToString("N"), new() { Type = "Movie" });
+        service.SeedEntryForTest(newId.ToString("N"), new() { Type = "Movie" });
+
+        var stale = Task.Run(() => service.GetCacheForUser(user));
+        Assert.True(oldEntered.Wait(TimeSpan.FromSeconds(10)));
+        var current = Task.Run(() => service.GetCacheForUser(updatedUser));
+        var currentQueriedIndependently = newEntered.Wait(TimeSpan.FromSeconds(2));
+        releaseOld.Set();
+
+        await Task.WhenAll(stale, current);
+        var currentResult = await current;
+        Assert.True(currentQueriedIndependently);
+        Assert.Equal(new[] { newId.ToString("N") }, currentResult.Keys);
+    }
+
+    [Fact]
     public async Task ConcurrentMissesForOneUserShareOneLibraryQuery()
     {
         using var release = new ManualResetEventSlim();
@@ -96,5 +213,15 @@ public sealed class TagCacheUserAccessCacheTests
         await delayed;
 
         Assert.Equal(1, calls);
+    }
+
+    private static User NextGeneration(User user)
+    {
+        var updated = new User(user.Username, user.AuthenticationProviderId, user.PasswordResetProviderId)
+        {
+            Id = user.Id,
+        };
+        updated.OnSavingChanges();
+        return updated;
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/TestDoubles/StubUserManager.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/TestDoubles/StubUserManager.cs
@@ -20,6 +20,19 @@ public sealed class StubUserManager : IUserManager
     /// <summary>Mutates the fixed user set — used by identity-cache invalidation tests.</summary>
     public void AddUser(User user) => _users.Add(user);
 
+    /// <summary>Replaces the current snapshot for one persisted user id.</summary>
+    public void ReplaceUser(User user)
+    {
+        var index = _users.FindIndex(existing => existing.Id == user.Id);
+        if (index < 0)
+        {
+            _users.Add(user);
+            return;
+        }
+
+        _users[index] = user;
+    }
+
     public event EventHandler<GenericEventArgs<User>> OnUserUpdated { add { } remove { } }
 
     public IEnumerable<User> GetUsers() => _users;

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/TagCacheController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/TagCacheController.cs
@@ -137,7 +137,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 return ProjectionResetResponse(
                     effectiveUserId,
                     projection,
-                    _tagCacheService.GetCurrentContentControl(),
+                    _tagCacheService.GetCurrentContentControl(user),
                     contentVersion,
                     contentTimestamp);
             }
@@ -149,7 +149,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             Services.TagCacheService.ContentDelta content;
             if (projectionOnly)
             {
-                content = _tagCacheService.GetCurrentContentControl();
+                content = _tagCacheService.GetCurrentContentControl(user);
             }
             else if (contentEpoch != null || contentRevision.HasValue)
             {
@@ -161,7 +161,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 // bundle: retain its timestamp delta while teaching it the new
                 // content cursor in this response. Current clients send the exact
                 // epoch/revision pair and never take this full-cache-scan path.
-                content = _tagCacheService.GetCurrentContentControl();
+                content = _tagCacheService.GetCurrentContentControl(user);
                 content = new Services.TagCacheService.ContentDelta(
                     content.Epoch,
                     content.Revision,
@@ -246,6 +246,27 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                     effectiveUserId,
                     latest,
                     content,
+                    contentVersion,
+                    contentTimestamp);
+            }
+
+            // Jellyfin 12 increments User.RowVersion when UpdatePolicyAsync saves
+            // folder access and every other user policy field. Re-resolve at the
+            // publication boundary so an access change observed while this request
+            // was selecting/stripping rows returns a fail-closed reset instead of
+            // labelling stale bytes with the old authorization generation.
+            var currentUser = _userManager.GetUserById(effectiveUserId);
+            if (currentUser is null)
+            {
+                return NotFound();
+            }
+
+            if (currentUser.RowVersion != user.RowVersion)
+            {
+                return ContentResetResponse(
+                    effectiveUserId,
+                    projection,
+                    _tagCacheService.GetCurrentContentControl(currentUser),
                     contentVersion,
                     contentTimestamp);
             }

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/TagCacheService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/TagCacheService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
@@ -156,7 +157,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         // starts empty (client falls back to the live/per-batch strip) until rebuild.
         private const int CurrentCacheSchemaVersion = 2;
 
-        // User access cache: avoids expensive GetItemIds query on every request
+        // User access cache: avoids expensive GetItemIds query on every request.
+        // Jellyfin increments User.RowVersion for every persisted policy update,
+        // including EnabledFolders/EnableAllFolders. The authorization generation
+        // must therefore be part of both the cache and singleflight key: a request
+        // under generation R+1 may never join or reuse work started under R.
         private static readonly TimeSpan UserAccessCacheTtl = TimeSpan.FromSeconds(60);
         private readonly BoundedTtlCache<string, (HashSet<string> Ids, DateTime CachedAt)> _userAccessCache = new(
             maximumEntries: 2_048,
@@ -200,7 +205,6 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         public long Version => Interlocked.Read(ref _version);
         public long LastModified => Interlocked.Read(ref _lastModified);
         public int Count => _cache.Count;
-        internal string ContentEpoch => _contentEpoch;
         internal long ContentRevision => Interlocked.Read(ref _contentRevision);
         internal long ServedContentIdsVisited => Interlocked.Read(ref _servedContentIdsVisited);
         internal void SetLegacyTimestampForTest(long timestamp)
@@ -210,7 +214,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         internal int UserAccessCacheCount => _userAccessCache.Count;
 
         internal void SeedUserAccessCacheForTest(string userKey, params string[] itemIds)
-            => _userAccessCache[userKey] = (
+            => _userAccessCache[AuthorizationKey(userKey, 0)] = (
                 new HashSet<string>(itemIds, StringComparer.Ordinal),
                 DateTime.UtcNow);
 
@@ -804,9 +808,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         {
             ArgumentNullException.ThrowIfNull(user);
             ArgumentNullException.ThrowIfNull(visibleIds);
+            var authorizationKey = AuthorizationKey(user);
             lock (_contentGate)
             {
-                PublishServedState(user.Id.ToString("N"), visibleIds);
+                PublishServedState(authorizationKey, visibleIds);
             }
         }
 
@@ -819,6 +824,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         internal ContentDelta GetFullContentForUser(JUser user)
         {
             ArgumentNullException.ThrowIfNull(user);
+            var authorizationKey = AuthorizationKey(user);
+            var contentEpoch = ContentEpochFor(authorizationKey);
             long revision;
             lock (_contentGate)
             {
@@ -828,10 +835,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             var items = GetCacheForUser(user);
             lock (_contentGate)
             {
-                PublishServedState(user.Id.ToString("N"), items.Keys);
+                PublishServedState(authorizationKey, items.Keys);
             }
             return new ContentDelta(
-                _contentEpoch,
+                contentEpoch,
                 revision,
                 resetRequired: false,
                 items,
@@ -851,26 +858,27 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             long? clientRevision)
         {
             ArgumentNullException.ThrowIfNull(user);
-            var userKey = user.Id.ToString("N");
+            var authorizationKey = AuthorizationKey(user);
+            var contentEpoch = ContentEpochFor(authorizationKey);
 
             lock (_contentGate)
             {
                 var currentRevision = _contentRevision;
                 if (string.IsNullOrWhiteSpace(clientEpoch)
                     || !clientRevision.HasValue
-                    || !string.Equals(clientEpoch, _contentEpoch, StringComparison.Ordinal)
+                    || !string.Equals(clientEpoch, contentEpoch, StringComparison.Ordinal)
                     || clientRevision.Value < 0
                     || clientRevision.Value > currentRevision
-                    || !_servedContentStates.TryGetValue(userKey, out var served))
+                    || !_servedContentStates.TryGetValue(authorizationKey, out var served))
                 {
-                    return ContentResetLocked(currentRevision);
+                    return ContentResetLocked(contentEpoch, currentRevision);
                 }
 
                 var requestedRevision = clientRevision.Value;
                 if (requestedRevision == currentRevision)
                 {
                     return new ContentDelta(
-                        _contentEpoch,
+                        contentEpoch,
                         currentRevision,
                         resetRequired: false,
                         new Dictionary<string, TagCacheEntry>(StringComparer.Ordinal),
@@ -881,7 +889,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 var earliestRetained = currentRevision - _contentJournalCount + 1;
                 if (_contentJournalCount == 0 || requestedRevision < earliestRetained - 1)
                 {
-                    return ContentResetLocked(currentRevision);
+                    return ContentResetLocked(contentEpoch, currentRevision);
                 }
 
                 // Each revision maps to exactly one ring row, so start directly at
@@ -918,9 +926,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     }
                 }
 
-                PublishServedState(userKey, items.Keys);
+                PublishServedState(authorizationKey, items.Keys);
                 return new ContentDelta(
-                    _contentEpoch,
+                    contentEpoch,
                     currentRevision,
                     resetRequired: false,
                     items,
@@ -929,12 +937,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             }
         }
 
-        internal ContentDelta GetCurrentContentControl()
+        internal ContentDelta GetCurrentContentControl(JUser user)
         {
+            ArgumentNullException.ThrowIfNull(user);
+            var contentEpoch = ContentEpochFor(AuthorizationKey(user));
             lock (_contentGate)
             {
                 return new ContentDelta(
-                    _contentEpoch,
+                    contentEpoch,
                     _contentRevision,
                     resetRequired: false,
                     new Dictionary<string, TagCacheEntry>(StringComparer.Ordinal),
@@ -943,9 +953,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             }
         }
 
-        private ContentDelta ContentResetLocked(long currentRevision)
+        private static ContentDelta ContentResetLocked(string contentEpoch, long currentRevision)
             => new(
-                _contentEpoch,
+                contentEpoch,
                 currentRevision,
                 resetRequired: true,
                 new Dictionary<string, TagCacheEntry>(StringComparer.Ordinal),
@@ -959,14 +969,15 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         /// </summary>
         public Dictionary<string, TagCacheEntry> GetCacheForUser(JUser user, long? since = null)
         {
+            ArgumentNullException.ThrowIfNull(user);
             // Capture local reference for thread safety (cache reference may be swapped)
             var cache = _cache;
             OnAfterUserCacheSnapshotForTest?.Invoke();
-            var userKey = user.Id.ToString("N");
+            var authorizationKey = AuthorizationKey(user);
 
             // Check user access cache
             HashSet<string> accessibleSet;
-            if (_userAccessCache.TryGetValue(userKey, out var cached) && DateTime.UtcNow - cached.CachedAt < UserAccessCacheTtl)
+            if (_userAccessCache.TryGetValue(authorizationKey, out var cached) && DateTime.UtcNow - cached.CachedAt < UserAccessCacheTtl)
             {
                 accessibleSet = cached.Ids;
             }
@@ -974,11 +985,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             {
                 OnAfterUserAccessCacheMissForTest?.Invoke();
                 var flight = _userAccessInFlight.GetOrAdd(
-                    userKey,
+                    authorizationKey,
                     _ => new Lazy<HashSet<string>>(
                         () =>
                         {
-                            if (_userAccessCache.TryGetValue(userKey, out var published)
+                            if (_userAccessCache.TryGetValue(authorizationKey, out var published)
                                 && DateTime.UtcNow - published.CachedAt < UserAccessCacheTtl)
                             {
                                 return published.Ids;
@@ -992,7 +1003,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                             var result = new HashSet<string>(
                                 accessibleIds.Select(id => id.ToString("N").ToLowerInvariant()));
                             _userAccessCache.Set(
-                                userKey,
+                                authorizationKey,
                                 (result, DateTime.UtcNow),
                                 UserAccessCacheTtl);
                             return result;
@@ -1005,7 +1016,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 finally
                 {
                     ((ICollection<KeyValuePair<string, Lazy<HashSet<string>>>>)_userAccessInFlight)
-                        .Remove(new KeyValuePair<string, Lazy<HashSet<string>>>(userKey, flight));
+                        .Remove(new KeyValuePair<string, Lazy<HashSet<string>>>(authorizationKey, flight));
                 }
             }
 
@@ -1019,6 +1030,15 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
 
             return result;
         }
+
+        private static string AuthorizationKey(JUser user)
+            => AuthorizationKey(user.Id.ToString("N"), user.RowVersion);
+
+        private static string AuthorizationKey(string userKey, uint rowVersion)
+            => string.Concat(userKey, ":", rowVersion.ToString(CultureInfo.InvariantCulture));
+
+        private string ContentEpochFor(string authorizationKey)
+            => $"{_contentEpoch}:{authorizationKey}";
 
         /// <summary>
         /// Select a small, server-generated set of cache entries for one user without

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.test.ts
@@ -11,6 +11,7 @@ import { getItemCached } from './helpers';
 import {
     applyContentResponse,
     decideContentResponse,
+    projectionOnlyContentRequiresReset,
     decideProjectionResponse,
     extractUserDataChangedIds,
     isListViewRow,
@@ -527,6 +528,34 @@ describe('watched/privacy projection response ordering (BI-SEC-035)', () => {
                     projectionReset: false,
                 });
             }
+            if (call === 5) {
+                return Promise.resolve({
+                    version: 1,
+                    timestamp: 275,
+                    contentEpoch: 'nav-content-policy-2',
+                    contentRevision: 3,
+                    items: {},
+                    projectionUserId: userA,
+                    projectionEpoch: 'nav-process',
+                    projectionRevision: 4,
+                    projectionIds: [],
+                    projectionReset: false,
+                });
+            }
+            if (call === 6) {
+                return Promise.resolve({
+                    version: 1,
+                    timestamp: 275,
+                    contentEpoch: 'nav-content-policy-2',
+                    contentRevision: 3,
+                    items: {},
+                    projectionUserId: userA,
+                    projectionEpoch: 'nav-process',
+                    projectionRevision: 4,
+                    projectionIds: [],
+                    projectionReset: false,
+                });
+            }
             return new Promise((resolve) => { navigationResolvers.push(resolve); });
         });
 
@@ -622,6 +651,18 @@ describe('watched/privacy projection response ordering (BI-SEC-035)', () => {
             projectionReset: false,
         });
         await vi.waitFor(() => expect(projectedLabels).toContain('stripped'));
+        expect(document.querySelector('.navigation-projection-secret')).toBeNull();
+
+        // A policy-generation change can first arrive on a watched-state-only
+        // refresh. It must invalidate the old content snapshot and perform one
+        // full reload without advancing that snapshot to the control revision.
+        await JC.tagPipeline!.refreshServerProjection!({
+            UserId: userA,
+            UserDataList: [{ ItemId: itemId }],
+        });
+        await vi.waitFor(() => expect(ajax).toHaveBeenCalledTimes(6));
+        expect(urls[4]).toContain('projectionOnly=true');
+        expect(urls[5]).not.toContain('projectionOnly=true');
         expect(document.querySelector('.navigation-projection-secret')).toBeNull();
 
         ajax.mockRestore();
@@ -1400,5 +1441,15 @@ describe('revisioned tag-cache content protocol (issue 72)', () => {
             contentEpoch: 'content-process-2',
         })).toBe('reset');
         expect(decideContentResponse(current, response(21, {}, [], true))).toBe('reset');
+    });
+
+    it('treats an authorization epoch change in projection-only control as a reset without advancing same-epoch content', () => {
+        const current = readContentIdentity(response(20))!;
+        expect(projectionOnlyContentRequiresReset(current, {
+            ...response(99),
+            contentEpoch: 'content-process-user-policy-2',
+        })).toBe(true);
+        expect(projectionOnlyContentRequiresReset(current, response(99))).toBe(false);
+        expect(current).toEqual({ epoch: 'content-process-1', revision: 20 });
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.ts
@@ -94,6 +94,22 @@ export function decideContentResponse(
     return 'apply';
 }
 
+/**
+ * Projection-only refreshes deliberately do not apply or advance the shared
+ * content cursor. They must still honor its epoch, because the server folds the
+ * current Jellyfin user-policy generation into that identity. Missing control
+ * or a changed epoch therefore requires one authoritative full reload.
+ */
+export function projectionOnlyContentRequiresReset(
+    current: TagContentIdentity | null,
+    response: any,
+): boolean {
+    const incoming = readContentIdentity(response);
+    if (!current || !incoming) return true;
+    if (response?.contentReset === true || response?.reset === true) return true;
+    return incoming.epoch !== current.epoch;
+}
+
 export interface ContentApplyResult {
     decision: ContentResponseDecision;
     identity: TagContentIdentity | null;
@@ -796,6 +812,21 @@ async function refreshServerCache(projectionOnly = false): Promise<void> {
         // A newer watch event, account switch, or reset supersedes this request.
         if (requestGeneration !== projectionRequestGeneration) return;
         if (normalizeProjectionKey(ApiClient.getCurrentUserId()) !== userKey) return;
+
+        // Check authorization ownership before projection ordering. A delayed
+        // projection response can be older than the watched-state cursor while
+        // still carrying the first control identity for a newly-revoked policy;
+        // ignoring it first would leave the old authorized rows renderable.
+        if (requestProjectionOnly && projectionOnlyContentRequiresReset(serverContent, resp)) {
+            console.log(`${logPrefix} Content authorization epoch changed, reloading one full snapshot`);
+            resetServerProjection(true);
+            await loadServerCache();
+            if (serverCache) {
+                processedCards = new WeakSet();
+                runScan();
+            }
+            return;
+        }
 
         const decision = decideProjectionResponse(serverProjection, resp, userId);
         if (decision === 'ignore') {

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -19,7 +19,7 @@ const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the repeated clean measurements', () => {
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1932, totalLines: 2253 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 18841, totalLines: 27308 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 18876, totalLines: 27327 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);
 });

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -21,12 +21,12 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 18841,
-        "totalLines": 27308
+        "coveredLines": 18876,
+        "totalLines": 27327
       },
       "tolerance": {
         "missingCoveredLines": 2,
-        "rationale": "Two clean local .NET 10.0.9/Coverlet integration runs on 2026-07-17 each passed 1685 tests and measured the identical combined 27308-line assembly scope at 18841 covered lines (68.994%). Issue #161 replaces payload-sized public-branding buffers with cancellation-aware fixed-buffer streaming and adds response-ownership, allocation, concurrent-request, validator, fault, and atomic-generation regressions. Relative to the reviewed 18748/27276 baseline, the reviewed assembly scope grows by 32 executable lines and the high-water advances by 93 covered lines while line coverage rises from 68.734% to 68.994%. The existing two-line tolerance is unchanged and covers only the previously reproduced negligible Coverlet variance; coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, and broad-tolerance negative boundaries."
+        "rationale": "Two clean post-rebase local .NET 10.0.9/Coverlet integration runs on 2026-07-17 each passed 1690 tests and measured the identical combined 27327-line assembly scope at 18876 covered lines (69.075%). Issue #97 scopes tag-cache access sets, in-flight work, content cursors, and served-id proof to Jellyfin's persisted User.RowVersion, with immediate revoke/grant, isolation, cursor-reset, and publication-race regressions. Relative to the reviewed 18841/27308 baseline from issue #161, the reviewed assembly scope grows by 19 instrumented lines and the high-water advances by 35 covered lines while line coverage rises from 68.994% to 69.075%. The existing two-line tolerance is unchanged and covers only the previously reproduced negligible Coverlet variance; coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
## Summary

- scope the tag access cache and singleflight work to Jellyfin's persisted `User.RowVersion`
- scope served-ID proof and content epochs to the same per-user authorization generation
- fail closed with a current-generation reset when a policy update races response publication
- make projection-only client refreshes clear stale ownership and perform one authoritative full reload when the authorization epoch changes
- add immediate revoke/grant, user isolation, stale-flight separation, served-proof, publication-race, and browser integration regressions

## Root cause

Jellyfin 12 advances `User.RowVersion` when `UpdatePolicyAsync` persists folder-access policy, but it does not emit the user-updated event this cache previously depended on. The access set was keyed only by user ID, so a revoke or grant could remain stale for the 60-second TTL, and an old client content cursor could retain rows from the previous authorization generation.

## Security and compatibility behavior

The authorization identity is now `userId:RowVersion` across cached access sets, in-flight queries, served proof, and the client-visible content epoch. Old-generation work can finish only into its old bounded key. A publication-boundary user re-read returns an empty reset if policy changed during selection. Current clients detect a changed epoch even on projection-only responses, clear stale cache/DOM ownership, and reload once without skipping same-epoch content revisions.

## Validation

- post-rebase focused server: 20/20 passed
- post-rebase focused client: 28/28 passed
- post-rebase full server suite, two clean runs: 1,690/1,690 passed each
- exact post-rebase server coverage, both runs: 18,876/27,327 (69.075%)
- full client suite: 1,286/1,286 passed
- coverage-baseline policy tests: 13/13 passed; two-line tolerance unchanged
- repository script suite: 379/379 passed
- Release build: 0 warnings, 0 errors
- source + legacy typechecks, bundle, syntax, and performance guard: passed
- independent agent review: APPROVE, including final rebased diff
- Fable low review: APPROVE, including final rebased diff

Fixes #97