### PR TITLE
fix(client): cancel tag pipeline idle work

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.test.ts
@@ -18,6 +18,7 @@ import {
     normalizeProjectionKey,
     readProjectionIdentity,
     readContentIdentity,
+    disposeTagPipeline,
     installTagPipeline,
     resetTagPipelineIdentity,
     TagProjectionDependencyIndex,
@@ -30,16 +31,13 @@ const offPipelineActivate = JC.identity.registerActivate(
     () => JC.tagPipeline?.initialize?.()
 );
 
-afterAll(async () => {
-    // Retire identity-owned scans while jsdom is still alive, then let the
-    // uncancellable requestIdleCallback fallback drain its generation guard.
-    // Otherwise a real 16 ms timer can reach runScan() after environment
-    // teardown and turn an entirely passing suite into an unhandled failure.
+afterAll(() => {
+    // Production teardown synchronously cancels every owned idle handle; no
+    // real-time drain/sleep is needed before jsdom removes the document.
     JC.identity.transition('', '', 'tag-pipeline-test-teardown');
     offPipelineActivate();
     offPipelineReset();
     uninstallTagPipeline();
-    await new Promise((resolve) => setTimeout(resolve, 25));
     document.body.innerHTML = '';
 });
 
@@ -75,6 +73,182 @@ function legacyNoImageRow(): HTMLElement {
     row.appendChild(img);
     return img;
 }
+
+describe('idle scan lifecycle (BI-QA-129)', () => {
+    const restoreGlobal = (name: 'requestIdleCallback' | 'cancelIdleCallback', descriptor?: PropertyDescriptor): void => {
+        if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+        else Reflect.deleteProperty(globalThis, name);
+    };
+
+    it('cancels timeout-fallback scans on repeated reset and runs a fresh generation normally', () => {
+        vi.useFakeTimers();
+        JC.tagPipeline!.registerRenderer('idle-timeout-lifecycle-test', {
+            render: () => undefined,
+            isEnabled: () => true,
+        });
+
+        try {
+            resetTagPipelineIdentity();
+            JC.tagPipeline!.scheduleScan?.();
+            expect(vi.getTimerCount()).toBe(1);
+
+            resetTagPipelineIdentity();
+            expect(vi.getTimerCount()).toBe(0);
+            expect(() => resetTagPipelineIdentity()).not.toThrow();
+            expect(vi.getTimerCount()).toBe(0);
+
+            const query = vi.spyOn(document, 'querySelectorAll');
+            JC.tagPipeline!.scheduleScan?.();
+            expect(vi.getTimerCount()).toBe(1);
+            vi.advanceTimersByTime(16);
+            expect(query).toHaveBeenCalledWith('.cardImageContainer');
+            expect(vi.getTimerCount()).toBe(0);
+            query.mockRestore();
+        } finally {
+            (JC.tagPipeline as unknown as { unregisterRenderer(name: string): void })
+                .unregisterRenderer('idle-timeout-lifecycle-test');
+            resetTagPipelineIdentity();
+            vi.clearAllTimers();
+            vi.useRealTimers();
+        }
+    });
+
+    it('cancels native idle scans and rejects an abort-ignoring stale callback', () => {
+        const requestDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'requestIdleCallback');
+        const cancelDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'cancelIdleCallback');
+        const callbacks = new Map<number, IdleRequestCallback>();
+        let handle = 0;
+        const request = vi.fn((callback: IdleRequestCallback): number => {
+            const id = ++handle;
+            callbacks.set(id, callback);
+            return id;
+        });
+        const cancel = vi.fn((id: number): void => { callbacks.delete(id); });
+        Object.defineProperty(globalThis, 'requestIdleCallback', { configurable: true, writable: true, value: request });
+        Object.defineProperty(globalThis, 'cancelIdleCallback', { configurable: true, writable: true, value: cancel });
+        JC.tagPipeline!.registerRenderer('idle-native-lifecycle-test', {
+            render: () => undefined,
+            isEnabled: () => true,
+        });
+
+        try {
+            JC.tagPipeline!.scheduleScan?.();
+            const staleCallback = callbacks.get(1)!;
+            expect(request).toHaveBeenCalledTimes(1);
+
+            resetTagPipelineIdentity();
+            expect(cancel).toHaveBeenCalledWith(1);
+            expect(callbacks.size).toBe(0);
+
+            const query = vi.spyOn(document, 'querySelectorAll');
+            staleCallback({ didTimeout: false, timeRemaining: () => 50 });
+            expect(query).not.toHaveBeenCalled();
+
+            JC.tagPipeline!.scheduleScan?.();
+            const freshCallback = callbacks.get(2)!;
+            callbacks.delete(2);
+            freshCallback({ didTimeout: false, timeRemaining: () => 50 });
+            expect(query).toHaveBeenCalledWith('.cardImageContainer');
+            query.mockRestore();
+        } finally {
+            (JC.tagPipeline as unknown as { unregisterRenderer(name: string): void })
+                .unregisterRenderer('idle-native-lifecycle-test');
+            resetTagPipelineIdentity();
+            restoreGlobal('requestIdleCallback', requestDescriptor);
+            restoreGlobal('cancelIdleCallback', cancelDescriptor);
+        }
+    });
+
+    it('uses the cancellable timeout fallback when native idle has no cancel API', () => {
+        vi.useFakeTimers();
+        const requestDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'requestIdleCallback');
+        const cancelDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'cancelIdleCallback');
+        const request = vi.fn(() => 1);
+        Object.defineProperty(globalThis, 'requestIdleCallback', { configurable: true, writable: true, value: request });
+        Reflect.deleteProperty(globalThis, 'cancelIdleCallback');
+        JC.tagPipeline!.registerRenderer('idle-unpaired-native-test', {
+            render: () => undefined,
+            isEnabled: () => true,
+        });
+
+        try {
+            JC.tagPipeline!.scheduleScan?.();
+            expect(request).not.toHaveBeenCalled();
+            expect(vi.getTimerCount()).toBe(1);
+            resetTagPipelineIdentity();
+            expect(vi.getTimerCount()).toBe(0);
+        } finally {
+            (JC.tagPipeline as unknown as { unregisterRenderer(name: string): void })
+                .unregisterRenderer('idle-unpaired-native-test');
+            resetTagPipelineIdentity();
+            restoreGlobal('requestIdleCallback', requestDescriptor);
+            restoreGlobal('cancelIdleCallback', cancelDescriptor);
+            vi.clearAllTimers();
+            vi.useRealTimers();
+        }
+    });
+
+    it('cancels a queued native chunk continuation before it processes the final card', () => {
+        vi.useFakeTimers();
+        const requestDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'requestIdleCallback');
+        const cancelDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'cancelIdleCallback');
+        const callbacks = new Map<number, IdleRequestCallback>();
+        const retainedCallbacks = new Map<number, IdleRequestCallback>();
+        let handle = 0;
+        const request = vi.fn((callback: IdleRequestCallback): number => {
+            const id = ++handle;
+            callbacks.set(id, callback);
+            retainedCallbacks.set(id, callback);
+            return id;
+        });
+        const cancel = vi.fn((id: number): void => { callbacks.delete(id); });
+        Object.defineProperty(globalThis, 'requestIdleCallback', { configurable: true, writable: true, value: request });
+        Object.defineProperty(globalThis, 'cancelIdleCallback', { configurable: true, writable: true, value: cancel });
+        const ajax = vi.spyOn(ApiClient, 'ajax');
+        JC.tagPipeline!.registerRenderer('idle-chunk-lifecycle-test', {
+            render: () => undefined,
+            isEnabled: () => true,
+        });
+
+        try {
+            for (let index = 1; index <= 21; index += 1) {
+                const image = gridCardImage();
+                const card = image.closest<HTMLElement>('.card')!;
+                card.dataset.id = index.toString(16).padStart(32, '0');
+                card.dataset.type = 'Movie';
+                document.body.appendChild(card);
+            }
+
+            JC.tagPipeline!.scheduleScan?.();
+            const firstScan = callbacks.get(1)!;
+            callbacks.delete(1);
+            firstScan({ didTimeout: false, timeRemaining: () => 50 });
+            expect(callbacks.has(2)).toBe(true);
+            expect(vi.getTimerCount()).toBe(0);
+
+            const staleContinuation = retainedCallbacks.get(2)!;
+            resetTagPipelineIdentity();
+            expect(cancel).toHaveBeenCalledWith(2);
+            expect(callbacks.size).toBe(0);
+            expect(vi.getTimerCount()).toBe(0);
+
+            staleContinuation({ didTimeout: false, timeRemaining: () => 50 });
+            vi.runAllTimers();
+            expect(ajax).not.toHaveBeenCalled();
+        } finally {
+            (JC.tagPipeline as unknown as { unregisterRenderer(name: string): void })
+                .unregisterRenderer('idle-chunk-lifecycle-test');
+            resetTagPipelineIdentity();
+            ajax.mockRestore();
+            document.body.innerHTML = '';
+            restoreGlobal('requestIdleCallback', requestDescriptor);
+            restoreGlobal('cancelIdleCallback', cancelDescriptor);
+            vi.clearAllTimers();
+            vi.useRealTimers();
+        }
+    });
+
+});
 
 describe('isListViewRow — the single list-view gate (issue 34)', () => {
     it('treats a .cardImageContainer nested in a .listItem row as a list row (skipped)', () => {
@@ -1451,5 +1625,31 @@ describe('revisioned tag-cache content protocol (issue 72)', () => {
         })).toBe(true);
         expect(projectionOnlyContentRequiresReset(current, response(99))).toBe(false);
         expect(current).toEqual({ epoch: 'content-process-1', revision: 20 });
+    });
+});
+
+// Keep the destructive full-dispose proof last: disposeTagPipeline clears the
+// renderer registry by contract, so running it earlier would weaken unrelated
+// tests that share this file's installed facade.
+describe('tag pipeline final teardown (BI-QA-129)', () => {
+    it('cancels queued idle work synchronously during full pipeline disposal', () => {
+        vi.useFakeTimers();
+        JC.tagPipeline!.registerRenderer('idle-dispose-lifecycle-test', {
+            render: () => undefined,
+            isEnabled: () => true,
+        });
+
+        try {
+            resetTagPipelineIdentity();
+            JC.tagPipeline!.scheduleScan?.();
+            expect(vi.getTimerCount()).toBe(1);
+            disposeTagPipeline();
+            expect(vi.getTimerCount()).toBe(0);
+            vi.runAllTimers();
+        } finally {
+            resetTagPipelineIdentity();
+            vi.clearAllTimers();
+            vi.useRealTimers();
+        }
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.ts
@@ -1054,23 +1054,104 @@ let scanScheduleGeneration = 0;
 const CARDS_PER_CHUNK = 20;
 let scanGeneration = 0; // Incremented on each new scan to cancel stale chunk chains
 
+type IdleTaskId = number;
+
+interface PendingIdleTask {
+    cancel: () => void;
+}
+
+// One lifecycle owner covers both scan-start jobs and chunk continuations. The
+// old scheduler discarded browser handles, so generation guards could prevent
+// stale DOM writes but could not stop callbacks from reaching a torn-down
+// jsdom/window. Retaining every handle makes reset/dispose synchronous while
+// the generation remains a second fence for callbacks a hostile scheduler
+// invokes after cancellation.
+const pendingIdleTasks = new Map<IdleTaskId, PendingIdleTask>();
+let nextIdleTaskId = 0;
+let idleLifecycleGeneration = 0;
+let scanStartIdleTask: IdleTaskId | null = null;
+let chunkIdleTask: IdleTaskId | null = null;
+
+/** Schedule cancellable idle work against the currently available browser backend. */
+function scheduleIdle(fn: () => void): IdleTaskId | null {
+    const taskId = ++nextIdleTaskId;
+    const generation = idleLifecycleGeneration;
+    let registered = false;
+    let ranBeforeRegistration = false;
+
+    const run = (): void => {
+        if (!registered) {
+            // Defensive support for deterministic/synthetic schedulers that
+            // invoke inline. Real requestIdleCallback/setTimeout are async.
+            ranBeforeRegistration = true;
+        } else if (!pendingIdleTasks.delete(taskId)) {
+            return;
+        }
+        if (generation !== idleLifecycleGeneration) return;
+        fn();
+    };
+
+    let cancel: () => void;
+    if (typeof requestIdleCallback === 'function' && typeof cancelIdleCallback === 'function') {
+        const cancelNativeIdle = cancelIdleCallback;
+        const handle = requestIdleCallback(run, { timeout: 100 });
+        cancel = () => cancelNativeIdle(handle);
+    } else {
+        const handle = setTimeout(run, 16);
+        cancel = () => clearTimeout(handle);
+    }
+
+    registered = true;
+    if (!ranBeforeRegistration && generation === idleLifecycleGeneration) {
+        pendingIdleTasks.set(taskId, { cancel });
+        return taskId;
+    }
+
+    // The callback either completed inline or retired this lifecycle before
+    // registration. Do not publish a phantom pending handle.
+    if (!ranBeforeRegistration) {
+        try { cancel(); } catch { /* generation fencing still retires the job */ }
+    }
+    return null;
+}
+
+/** Cancel one queued idle job; a late callback is rejected by map ownership. */
+function cancelIdleTask(taskId: IdleTaskId | null): void {
+    if (taskId === null) return;
+    const task = pendingIdleTasks.get(taskId);
+    if (!task) return;
+    pendingIdleTasks.delete(taskId);
+    try { task.cancel(); } catch { /* cancellation remains generation-fenced */ }
+}
+
+/** Retire every queued scan job before its DOM/window owner is torn down. */
+function retireIdleTasks(): void {
+    idleLifecycleGeneration++;
+    const tasks = Array.from(pendingIdleTasks.values());
+    pendingIdleTasks.clear();
+    for (const task of tasks) {
+        try { task.cancel(); } catch { /* continue retiring the remaining jobs */ }
+    }
+    scanStartIdleTask = null;
+    chunkIdleTask = null;
+}
+
 /**
  * Schedule scan. Coalesces multiple mutations into a single scan start.
  */
 // Use requestIdleCallback for all tag work so it never competes with
 // user interactions (hover, scroll, click). Falls back to setTimeout
 // for browsers without requestIdleCallback support.
-// PERF(R8): idle timeout 100ms (was 500ms) — the first scan after cards mount must
-// not sit behind half a second of idle waiting while the posters are visible.
-const scheduleIdle: (fn: () => void) => unknown = typeof requestIdleCallback === 'function'
-    ? (fn: () => void) => requestIdleCallback(fn, { timeout: 100 })
-    : (fn: () => void) => setTimeout(fn, 16);
+// PERF(R8): native idle timeout 100ms (was 500ms); the 16ms cancellable
+// fallback keeps the first scan prompt in browsers without the paired native
+// request/cancel contract.
 
 function scheduleScan(): void {
     if (scanScheduled) return;
     scanScheduled = true;
     const scheduledGeneration = scanScheduleGeneration;
-    scheduleIdle(() => {
+    scanStartIdleTask = scheduleIdle(() => {
+        scanStartIdleTask = null;
         if (scheduledGeneration !== scanScheduleGeneration) return;
         scanScheduled = false;
         runScan();
@@ -1290,6 +1371,7 @@ function resetTagPipelineIdentity(): void {
         clearTimeout(fetchTimer);
         fetchTimer = null;
     }
+    retireIdleTasks();
     scanScheduleGeneration++;
     scanScheduled = false;
     scanGeneration++;
@@ -1495,6 +1577,15 @@ function syncScanAddedCards(mutations: MutationRecord[]): void {
  * are cancelled when a new scan starts (e.g., rapid page changes).
  */
 function runScan(): void {
+    // A direct scan (initialization/live invalidation) supersedes any queued
+    // scan start, and every new scan supersedes the prior chunk continuation.
+    cancelIdleTask(scanStartIdleTask);
+    scanStartIdleTask = null;
+    scanScheduled = false;
+    cancelIdleTask(chunkIdleTask);
+    chunkIdleTask = null;
+    const myGeneration = ++scanGeneration;
+
     if (!hasAnyEnabledRenderer()) return;
     if (typeof ApiClient === 'undefined') return;
 
@@ -1510,8 +1601,6 @@ function runScan(): void {
     }
     if (unprocessed.length === 0) return;
 
-    // Cancel any in-progress chunk chain from a previous scan
-    const myGeneration = ++scanGeneration;
     let index = 0;
 
     function processChunk(): void {
@@ -1527,7 +1616,10 @@ function runScan(): void {
 
         if (index < unprocessed.length) {
             // More cards to process — yield and continue when browser is idle
-            scheduleIdle(processChunk);
+            chunkIdleTask = scheduleIdle(() => {
+                chunkIdleTask = null;
+                processChunk();
+            });
         } else {
             // All cards processed — schedule batch fetch for cache misses
             scheduleFetchIfQueued();


### PR DESCRIPTION
Fixes #236

## Summary
- retain and cancel tag-pipeline scan-start and chunk-continuation idle handles
- fall back to cancellable timers when the native idle API is unpaired
- fence late or cancellation-ignoring callbacks by lifecycle generation and task ownership
- remove the timing-based 25 ms test teardown workaround

## Validation
- frozen regression: 1 pending timer after identity reset on main
- focused tag pipeline: 33/33
- affected V8 scope: 40/40
- full client aggregate: 206 files, 1291/1291 tests
- line coverage: 1932/2253 (85.752%), exact reviewed baseline
- source and full typechecks
- deterministic bundle, syntax, performance rules, changed-file ESLint, diff check
- independent Codex review: APPROVE
- Fable 5 low review: APPROVE

## Safety
- preserves single-start coalescing and the 20-card chunk bound
- no timeout increases or unhandled-error suppression
- no deployment requested for this PR