### PR TITLE
fix(server): drain continue watching cleanup safely

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/ContinueWatchingEventWritersTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/ContinueWatchingEventWritersTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
 using Jellyfin.Plugin.JellyfinCanopy.EventHandlers;
 using Jellyfin.Plugin.JellyfinCanopy.Services;
@@ -260,43 +261,602 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
         }
 
         [Fact]
-        public void LibraryHook_Drain_RearmsTimer_WhenRemovalArrivesMidDrain()
+        public async Task LibraryHook_Lifecycle_IsIdempotentAndTerminal()
         {
-            var tempDir = Path.Combine(Path.GetTempPath(), "jc-cw-drain-" + Guid.NewGuid().ToString("N"));
+            var tempDir = Path.Combine(Path.GetTempPath(), "jc-cw-lifecycle-" + Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(tempDir);
             try
             {
                 var ucm = new UserConfigurationManager(new StubAppPaths(tempDir), NullLogger<UserConfigurationManager>.Instance);
-                using var hook = new ContinueWatchingLibraryHook(
-                    new CountingLibraryManager(),
+                var library = new CountingLibraryManager();
+                var hook = new ContinueWatchingLibraryHook(
+                    library,
                     ucm,
-                    new StubUserManager(),   // no users -> DrainBatch is a no-op; we only test the re-arm
+                    new StubUserManager(),
                     NullLogger<ContinueWatchingLibraryHook>.Instance);
 
-                // Item A gives the drain work to snapshot.
-                hook.EnqueueRemovalForTest(Guid.NewGuid());
+                await hook.StartAsync(CancellationToken.None);
+                await hook.StartAsync(CancellationToken.None);
+                Assert.Equal(1, library.ItemRemovedCount);
 
-                // Simulate a removal arriving mid-drain (a concurrent ItemRemoved, or a second timer
-                // tick that bailed on the _draining guard): it lands AFTER this drain snapshotted its
-                // ids, so it is NOT processed by this drain.
-                var b = Guid.NewGuid();
-                hook.OnDrainProcessingForTest = () =>
-                {
-                    hook.OnDrainProcessingForTest = null;
-                    hook.EnqueueRemovalForTest(b);
-                };
+                await hook.StopAsync(CancellationToken.None);
+                await hook.StopAsync(CancellationToken.None);
+                Assert.Equal(0, library.ItemRemovedCount);
 
-                hook.DrainForTest();
+                await hook.StartAsync(CancellationToken.None);
+                Assert.Equal(0, library.ItemRemovedCount);
 
-                // The drain's finally must re-arm because work (B) still remains — otherwise B sits in
-                // _pendingRemovals with no tick to process it until the next unrelated ItemRemoved.
-                // RED against the old finally that only reset _draining.
-                Assert.Equal(1, hook.DrainRearmCountForTest);
-                Assert.False(hook.PendingIsEmptyForTest);
+                hook.Dispose();
+                hook.Dispose();
             }
             finally
             {
                 try { Directory.Delete(tempDir, recursive: true); } catch { /* best-effort */ }
+            }
+        }
+
+        [Fact]
+        public async Task LibraryHook_StopWaitsForActiveDrainAndProcessesRemovalAcceptedAfterSnapshot()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "jc-cw-stop-drain-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+            using var enteredDrain = new ManualResetEventSlim();
+            using var releaseDrain = new ManualResetEventSlim();
+            try
+            {
+                var ucm = new UserConfigurationManager(
+                    new StubAppPaths(tempDir),
+                    NullLogger<UserConfigurationManager>.Instance);
+                var user = new User("cw-worker", "provider", "password-provider");
+                var batches = 0;
+                using var hook = new ContinueWatchingLibraryHook(
+                    new CountingLibraryManager(),
+                    ucm,
+                    new StubUserManager(user),
+                    NullLogger<ContinueWatchingLibraryHook>.Instance,
+                    pendingRemovalCapacity: 32,
+                    drainDebounce: TimeSpan.Zero,
+                    drainRetryDelay: TimeSpan.Zero,
+                    pruneUserForTest: (_, index) =>
+                    {
+                        Assert.Equal(1, index.Count);
+                        Interlocked.Increment(ref batches);
+
+                        if (!enteredDrain.IsSet)
+                        {
+                            enteredDrain.Set();
+                            releaseDrain.Wait();
+                        }
+
+                        return true;
+                    });
+
+                await hook.StartAsync(CancellationToken.None);
+                var first = Guid.NewGuid();
+                var second = Guid.NewGuid();
+                Assert.True(hook.EnqueueRemovalForTest(first));
+                Assert.True(enteredDrain.Wait(TimeSpan.FromSeconds(10)));
+
+                // B is accepted after A left the pending snapshot. Stop must join
+                // the active drain and keep ownership until B is processed too.
+                Assert.True(hook.EnqueueRemovalForTest(second));
+                var stop = hook.StopAsync(CancellationToken.None);
+                var stopWaitedForActiveDrain = !stop.IsCompleted;
+
+                releaseDrain.Set();
+                await stop;
+
+                Assert.True(stopWaitedForActiveDrain);
+                Assert.True(hook.PendingIsEmptyForTest);
+                Assert.False(hook.EnqueueRemovalForTest(Guid.NewGuid()));
+                Assert.Equal(2, batches);
+            }
+            finally
+            {
+                releaseDrain.Set();
+                try { Directory.Delete(tempDir, recursive: true); } catch { /* best-effort */ }
+            }
+        }
+
+        [Fact]
+        public async Task LibraryHook_AlreadyDispatchedHandlerCannotAcceptAfterStopClosesIntake()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "jc-cw-dispatched-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+            using var handlerEntered = new ManualResetEventSlim();
+            using var releaseHandler = new ManualResetEventSlim();
+            try
+            {
+                var library = new CountingLibraryManager();
+                var hook = new ContinueWatchingLibraryHook(
+                    library,
+                    new UserConfigurationManager(new StubAppPaths(tempDir), NullLogger<UserConfigurationManager>.Instance),
+                    new StubUserManager(),
+                    NullLogger<ContinueWatchingLibraryHook>.Instance);
+                await hook.StartAsync(CancellationToken.None);
+                hook.OnBeforeRemovalAcceptanceForTest = () =>
+                {
+                    handlerEntered.Set();
+                    releaseHandler.Wait();
+                };
+
+                var dispatched = Task.Run(() => library.RaiseItemRemoved(new Movie { Id = Guid.NewGuid() }));
+                Assert.True(handlerEntered.Wait(TimeSpan.FromSeconds(10)));
+
+                await hook.StopAsync(CancellationToken.None);
+                releaseHandler.Set();
+                await dispatched;
+
+                Assert.True(hook.PendingIsEmptyForTest);
+                hook.Dispose();
+            }
+            finally
+            {
+                releaseHandler.Set();
+                try { Directory.Delete(tempDir, recursive: true); } catch { }
+            }
+        }
+
+        [Fact]
+        public async Task LibraryHook_CanceledStopIsObservableAndLaterStopJoinsWorker()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "jc-cw-cancel-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+            using var writeEntered = new ManualResetEventSlim();
+            using var releaseWrite = new ManualResetEventSlim();
+            try
+            {
+                var logger = new CollectingLogger<ContinueWatchingLibraryHook>();
+                var user = new User("cw-cancel", "provider", "password-provider");
+                using var hook = new ContinueWatchingLibraryHook(
+                    new CountingLibraryManager(),
+                    new UserConfigurationManager(new StubAppPaths(tempDir), NullLogger<UserConfigurationManager>.Instance),
+                    new StubUserManager(user),
+                    logger,
+                    pendingRemovalCapacity: 32,
+                    drainDebounce: TimeSpan.Zero,
+                    drainRetryDelay: TimeSpan.Zero,
+                    pruneUserForTest: (_, _) =>
+                    {
+                        writeEntered.Set();
+                        releaseWrite.Wait();
+                        return true;
+                    });
+
+                await hook.StartAsync(CancellationToken.None);
+                Assert.True(hook.EnqueueRemovalForTest(Guid.NewGuid()));
+                Assert.True(writeEntered.Wait(TimeSpan.FromSeconds(10)));
+
+                using var canceled = new CancellationTokenSource();
+                canceled.Cancel();
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => hook.StopAsync(canceled.Token));
+                Assert.Contains(logger.Messages, message => message.Contains("shutdown canceled", StringComparison.Ordinal));
+
+                releaseWrite.Set();
+                await hook.StopAsync(CancellationToken.None);
+                Assert.True(hook.PendingIsEmptyForTest);
+            }
+            finally
+            {
+                releaseWrite.Set();
+                try { Directory.Delete(tempDir, recursive: true); } catch { }
+            }
+        }
+
+        [Fact]
+        public async Task LibraryHook_DisposeAfterCanceledStopReportsTerminalUndrainedWork()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "jc-cw-terminal-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+            using var pruneAttempted = new ManualResetEventSlim();
+            try
+            {
+                var logger = new CollectingLogger<ContinueWatchingLibraryHook>();
+                var user = new User("cw-terminal", "provider", "password-provider");
+                var hook = new ContinueWatchingLibraryHook(
+                    new CountingLibraryManager(),
+                    new UserConfigurationManager(new StubAppPaths(tempDir), NullLogger<UserConfigurationManager>.Instance),
+                    new StubUserManager(user),
+                    logger,
+                    pendingRemovalCapacity: 32,
+                    drainDebounce: TimeSpan.Zero,
+                    drainRetryDelay: TimeSpan.FromHours(1),
+                    pruneUserForTest: (_, _) =>
+                    {
+                        pruneAttempted.Set();
+                        return false;
+                    });
+
+                await hook.StartAsync(CancellationToken.None);
+                Assert.True(hook.EnqueueRemovalForTest(Guid.NewGuid()));
+                Assert.True(pruneAttempted.Wait(TimeSpan.FromSeconds(10)));
+
+                using var canceled = new CancellationTokenSource();
+                canceled.Cancel();
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => hook.StopAsync(canceled.Token));
+
+                hook.Dispose();
+
+                Assert.False(hook.PendingIsEmptyForTest);
+                Assert.Contains(
+                    logger.Messages,
+                    message => message.Contains("TERMINAL shutdown failure", StringComparison.Ordinal)
+                        && message.Contains("undrained", StringComparison.Ordinal));
+
+                // All terminal lifecycle combinations remain idempotent after the failure report.
+                hook.Dispose();
+                var terminal = await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => hook.StopAsync(CancellationToken.None));
+                Assert.Contains("TERMINAL shutdown failure", terminal.Message, StringComparison.Ordinal);
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch { }
+            }
+        }
+
+        [Fact]
+        public async Task LibraryHook_TransientPruneFailureRetainsBatchForRetry()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "jc-cw-retry-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var attempts = 0;
+                var user = new User("cw-retry", "provider", "password-provider");
+                using var hook = new ContinueWatchingLibraryHook(
+                    new CountingLibraryManager(),
+                    new UserConfigurationManager(new StubAppPaths(tempDir), NullLogger<UserConfigurationManager>.Instance),
+                    new StubUserManager(user),
+                    NullLogger<ContinueWatchingLibraryHook>.Instance,
+                    pendingRemovalCapacity: 32,
+                    drainDebounce: TimeSpan.Zero,
+                    drainRetryDelay: TimeSpan.Zero,
+                    pruneUserForTest: (_, _) => Interlocked.Increment(ref attempts) >= 2);
+
+                await hook.StartAsync(CancellationToken.None);
+                Assert.True(hook.EnqueueRemovalForTest(Guid.NewGuid()));
+                await hook.StopAsync(CancellationToken.None);
+
+                Assert.Equal(2, attempts);
+                Assert.True(hook.PendingIsEmptyForTest);
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch { }
+            }
+        }
+
+        [Fact]
+        public async Task LibraryHook_CapacityOverflowRejectsNewIdentityWithoutDiscardingAcceptedIds()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "jc-cw-overflow-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var acceptedBatchSize = 0;
+                var logger = new CollectingLogger<ContinueWatchingLibraryHook>();
+                var user = new User("cw-overflow", "provider", "password-provider");
+                using var hook = new ContinueWatchingLibraryHook(
+                    new CountingLibraryManager(),
+                    new UserConfigurationManager(new StubAppPaths(tempDir), NullLogger<UserConfigurationManager>.Instance),
+                    new StubUserManager(user),
+                    logger,
+                    pendingRemovalCapacity: 2,
+                    drainDebounce: TimeSpan.FromHours(1),
+                    drainRetryDelay: TimeSpan.Zero,
+                    pruneUserForTest: (_, index) =>
+                    {
+                        acceptedBatchSize = index.Count;
+                        return true;
+                    });
+
+                await hook.StartAsync(CancellationToken.None);
+                Assert.True(hook.EnqueueRemovalForTest(Guid.NewGuid()));
+                Assert.True(hook.EnqueueRemovalForTest(Guid.NewGuid()));
+                Assert.False(hook.EnqueueRemovalForTest(Guid.NewGuid()));
+                Assert.Equal(1, hook.RejectedRemovalCountForTest);
+
+                await hook.StopAsync(CancellationToken.None);
+
+                Assert.Equal(2, acceptedBatchSize);
+                Assert.True(hook.PendingIsEmptyForTest);
+                Assert.Contains(
+                    logger.Messages,
+                    message => message.Contains("rejected 1 distinct removal", StringComparison.Ordinal));
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch { }
+            }
+        }
+
+        [Fact]
+        public async Task LibraryHook_ImmediateDisposeDuringDebounceReportsRejectedOverflowExactlyOnce()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "jc-cw-overflow-dispose-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+            using var debounceEntered = new ManualResetEventSlim();
+            using var releaseDebounce = new ManualResetEventSlim();
+            using var abortRequested = new ManualResetEventSlim();
+            try
+            {
+                var logger = new CollectingLogger<ContinueWatchingLibraryHook>();
+                var scanChecks = 0;
+                var itemLookups = 0;
+                var library = new CountingLibraryManager
+                {
+                    IsScanRunningHook = () =>
+                    {
+                        Interlocked.Increment(ref scanChecks);
+                        return true;
+                    },
+                    GetItemByIdNonGenericHook = _ =>
+                    {
+                        Interlocked.Increment(ref itemLookups);
+                        return null;
+                    }
+                };
+                var user = new User("cw-overflow-dispose", "provider", "password-provider");
+                var hook = new ContinueWatchingLibraryHook(
+                    library,
+                    new UserConfigurationManager(new StubAppPaths(tempDir), NullLogger<UserConfigurationManager>.Instance),
+                    new StubUserManager(user),
+                    logger,
+                    pendingRemovalCapacity: 1,
+                    drainDebounce: TimeSpan.FromHours(1),
+                    drainRetryDelay: TimeSpan.Zero,
+                    pruneUserForTest: (_, _) =>
+                        throw new Xunit.Sdk.XunitException("Dispose must abort before any config prune"));
+                hook.OnDrainDebounceStartedForTest = () =>
+                {
+                    debounceEntered.Set();
+                    releaseDebounce.Wait();
+                };
+                hook.OnDisposeWaitingForTest = abortRequested.Set;
+
+                await hook.StartAsync(CancellationToken.None);
+                Assert.True(hook.EnqueueRemovalForTest(Guid.NewGuid()));
+                Assert.True(debounceEntered.Wait(TimeSpan.FromSeconds(10)));
+                Assert.False(hook.EnqueueRemovalForTest(Guid.NewGuid()));
+
+                var dispose = Task.Run(hook.Dispose);
+                Assert.True(abortRequested.Wait(TimeSpan.FromSeconds(10)));
+                releaseDebounce.Set();
+                await dispose;
+
+                Assert.Equal(1, hook.RejectedRemovalCountForTest);
+                Assert.Single(
+                    logger.Messages,
+                    message => message.Contains("bounded orphan-cleanup intake rejected 1 distinct removal", StringComparison.Ordinal));
+                Assert.Equal(0, Volatile.Read(ref scanChecks));
+                Assert.Equal(0, Volatile.Read(ref itemLookups));
+                Assert.True(hook.WorkerIsCompletedForTest);
+            }
+            finally
+            {
+                releaseDebounce.Set();
+                try { Directory.Delete(tempDir, recursive: true); } catch { }
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task LibraryHook_OverflowNeverUsesTransientGlobalNullToPruneUnrelatedGuid(bool scanRunning)
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "jc-cw-overflow-null-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var firstRemoved = Guid.NewGuid();
+                var secondRemoved = Guid.NewGuid();
+                var rejectedRemoved = Guid.NewGuid();
+                var unrelated = Guid.NewGuid();
+                var scanChecks = 0;
+                var itemLookups = 0;
+                var library = new CountingLibraryManager
+                {
+                    // Even with no scan reported and every global lookup transiently null, exact-id
+                    // cleanup must never consult this broad negative source.
+                    IsScanRunningHook = () =>
+                    {
+                        Interlocked.Increment(ref scanChecks);
+                        return scanRunning;
+                    },
+                    GetItemByIdNonGenericHook = _ =>
+                    {
+                        Interlocked.Increment(ref itemLookups);
+                        return null;
+                    }
+                };
+                var user = new User("cw-overflow-scan", "provider", "password-provider");
+                var userId = user.Id.ToString("N");
+                var ucm = new UserConfigurationManager(
+                    new StubAppPaths(tempDir),
+                    NullLogger<UserConfigurationManager>.Instance);
+                var seed = new UserHiddenContent();
+                seed.Items["removed-1"] = new HiddenContentItem { ItemId = firstRemoved.ToString("N") };
+                seed.Items["removed-2"] = new HiddenContentItem { ItemId = secondRemoved.ToString("N") };
+                seed.Items["unrelated"] = new HiddenContentItem { ItemId = unrelated.ToString("N") };
+                ucm.SaveUserConfiguration(userId, "hidden-content.json", seed);
+
+                using var hook = new ContinueWatchingLibraryHook(
+                    library,
+                    ucm,
+                    new StubUserManager(user),
+                    NullLogger<ContinueWatchingLibraryHook>.Instance,
+                    pendingRemovalCapacity: 2,
+                    drainDebounce: TimeSpan.FromHours(1),
+                    drainRetryDelay: TimeSpan.Zero,
+                    pruneUserForTest: null);
+
+                await hook.StartAsync(CancellationToken.None);
+                Assert.True(hook.EnqueueRemovalForTest(firstRemoved));
+                Assert.True(hook.EnqueueRemovalForTest(secondRemoved));
+                Assert.False(hook.EnqueueRemovalForTest(rejectedRemoved));
+                await hook.StopAsync(CancellationToken.None);
+
+                var stored = ucm.GetUserConfigurationStrict<UserHiddenContent>(userId, "hidden-content.json");
+                Assert.Equal(new[] { "unrelated" }, stored.Items.Keys);
+                Assert.Equal(0, Volatile.Read(ref scanChecks));
+                Assert.Equal(0, Volatile.Read(ref itemLookups));
+                Assert.Equal(1, hook.RejectedRemovalCountForTest);
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch { }
+            }
+        }
+
+        [Fact]
+        public async Task LibraryHook_ConcurrentDisposeCallersJoinSameWorkerCompletion()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "jc-cw-dispose-join-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+            using var writeEntered = new ManualResetEventSlim();
+            using var releaseWrite = new ManualResetEventSlim();
+            using var bothDisposeCallersWaiting = new ManualResetEventSlim();
+            try
+            {
+                var disposeWaiters = 0;
+                var user = new User("cw-dispose-join", "provider", "password-provider");
+                var hook = new ContinueWatchingLibraryHook(
+                    new CountingLibraryManager(),
+                    new UserConfigurationManager(new StubAppPaths(tempDir), NullLogger<UserConfigurationManager>.Instance),
+                    new StubUserManager(user),
+                    NullLogger<ContinueWatchingLibraryHook>.Instance,
+                    pendingRemovalCapacity: 32,
+                    drainDebounce: TimeSpan.Zero,
+                    drainRetryDelay: TimeSpan.Zero,
+                    pruneUserForTest: (_, _) =>
+                    {
+                        writeEntered.Set();
+                        releaseWrite.Wait();
+                        return true;
+                    });
+                hook.OnDisposeWaitingForTest = () =>
+                {
+                    if (Interlocked.Increment(ref disposeWaiters) == 2)
+                    {
+                        bothDisposeCallersWaiting.Set();
+                    }
+                };
+
+                await hook.StartAsync(CancellationToken.None);
+                Assert.True(hook.EnqueueRemovalForTest(Guid.NewGuid()));
+                Assert.True(writeEntered.Wait(TimeSpan.FromSeconds(10)));
+
+                var firstDispose = Task.Run(hook.Dispose);
+                var secondDispose = Task.Run(hook.Dispose);
+                Assert.True(bothDisposeCallersWaiting.Wait(TimeSpan.FromSeconds(10)));
+                Assert.False(firstDispose.IsCompleted);
+                Assert.False(secondDispose.IsCompleted);
+
+                releaseWrite.Set();
+                await Task.WhenAll(firstDispose, secondDispose);
+
+                Assert.True(hook.WorkerIsCompletedForTest);
+                hook.Dispose();
+            }
+            finally
+            {
+                releaseWrite.Set();
+                try { Directory.Delete(tempDir, recursive: true); } catch { }
+            }
+        }
+
+        [Fact]
+        public async Task LibraryHook_DisposeRacingStopCannotTurnUndrainedAbortIntoSuccessfulStop()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "jc-cw-stop-dispose-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+            using var pruneEntered = new ManualResetEventSlim();
+            using var releasePrune = new ManualResetEventSlim();
+            using var disposeWaiting = new ManualResetEventSlim();
+            try
+            {
+                var logger = new CollectingLogger<ContinueWatchingLibraryHook>();
+                var user = new User("cw-stop-dispose", "provider", "password-provider");
+                var hook = new ContinueWatchingLibraryHook(
+                    new CountingLibraryManager(),
+                    new UserConfigurationManager(new StubAppPaths(tempDir), NullLogger<UserConfigurationManager>.Instance),
+                    new StubUserManager(user),
+                    logger,
+                    pendingRemovalCapacity: 32,
+                    drainDebounce: TimeSpan.Zero,
+                    drainRetryDelay: TimeSpan.FromHours(1),
+                    pruneUserForTest: (_, _) =>
+                    {
+                        pruneEntered.Set();
+                        releasePrune.Wait();
+                        return false;
+                    });
+                hook.OnDisposeWaitingForTest = disposeWaiting.Set;
+
+                await hook.StartAsync(CancellationToken.None);
+                Assert.True(hook.EnqueueRemovalForTest(Guid.NewGuid()));
+                Assert.True(pruneEntered.Wait(TimeSpan.FromSeconds(10)));
+
+                var stop = hook.StopAsync(CancellationToken.None);
+                var dispose = Task.Run(hook.Dispose);
+                Assert.True(disposeWaiting.Wait(TimeSpan.FromSeconds(10)));
+                releasePrune.Set();
+
+                await dispose;
+                var terminal = await Assert.ThrowsAsync<InvalidOperationException>(async () => await stop);
+                Assert.Contains("TERMINAL shutdown failure", terminal.Message, StringComparison.Ordinal);
+                Assert.Contains(logger.Messages, message => message.Contains("undrained", StringComparison.Ordinal));
+                Assert.True(hook.WorkerIsCompletedForTest);
+            }
+            finally
+            {
+                releasePrune.Set();
+                try { Directory.Delete(tempDir, recursive: true); } catch { }
+            }
+        }
+
+        [Fact]
+        public async Task LibraryHook_BurstCoalescesDuplicatesIntoOneWritePerUser()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "jc-cw-burst-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var firstUser = new User("cw-burst-1", "provider", "password-provider");
+                var secondUser = new User("cw-burst-2", "provider", "password-provider");
+                var calls = new Dictionary<Guid, int>();
+                var removed = Enumerable.Range(0, 5).Select(_ => Guid.NewGuid()).ToArray();
+                using var hook = new ContinueWatchingLibraryHook(
+                    new CountingLibraryManager(),
+                    new UserConfigurationManager(new StubAppPaths(tempDir), NullLogger<UserConfigurationManager>.Instance),
+                    new StubUserManager(firstUser, secondUser),
+                    NullLogger<ContinueWatchingLibraryHook>.Instance,
+                    pendingRemovalCapacity: 32,
+                    drainDebounce: TimeSpan.FromHours(1),
+                    drainRetryDelay: TimeSpan.Zero,
+                    pruneUserForTest: (userId, index) =>
+                    {
+                        calls[userId] = calls.GetValueOrDefault(userId) + 1;
+                        Assert.Equal(removed.Length, index.Count);
+                        return true;
+                    });
+
+                await hook.StartAsync(CancellationToken.None);
+                foreach (var id in removed)
+                {
+                    Assert.True(hook.EnqueueRemovalForTest(id));
+                    Assert.True(hook.EnqueueRemovalForTest(id));
+                }
+
+                await hook.StopAsync(CancellationToken.None);
+
+                Assert.Equal(1, calls[firstUser.Id]);
+                Assert.Equal(1, calls[secondUser.Id]);
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch { }
             }
         }
 

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/LibraryScanEventGuardTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/LibraryScanEventGuardTests.cs
@@ -54,7 +54,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             "TagCacheMonitor.cs",             // record id -> TagCacheService debounced flush worker
             "SeerrScanTriggerService.cs",     // cheap config/kind check -> counter + debounce timer
             "WatchlistMonitor.cs",            // constant-time gates -> bounded coalescing channel worker
-            "ContinueWatchingPlaybackEvents.cs", // record id -> debounced timer drain (GetUsers + per-user prune off-thread, coalesced)
+            "ContinueWatchingPlaybackEvents.cs", // bounded id intake -> lifecycle-owned drain worker (GetUsers + per-user prune off-thread)
             "SpoilerSeerrPendingPromoter.cs", // cheap gate ContainsKey -> coalesced Task.Run sweep (GetItemById + RMW off-thread)
         };
 
@@ -69,9 +69,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             // ScheduleWatchlistCheck (sync handler) performs a non-blocking bounded enqueue;
             // ProcessQueuedItemAsync / ProcessItemForWatchlist run on the owned channel worker.
             ["WatchlistMonitor.cs"] = new[] { "ProcessQueuedItemAsync", "ProcessItemForWatchlist" },
-            // OnItemRemoved (sync handler) only records ids + arms a debounce Timer; Drain is the
-            // timer callback and DrainBatch/PruneOrphans are its per-user workers (GetUsers + prune).
-            ["ContinueWatchingPlaybackEvents.cs"] = new[] { "Drain", "DrainBatch", "PruneOrphans" },
+            // OnItemRemoved (sync handler) only records an id + signals a bounded channel;
+            // RunDrainWorkerAsync/ProcessBatch and their prune paths own all heavy work off-thread.
+            ["ContinueWatchingPlaybackEvents.cs"] = new[]
+            {
+                "RunDrainWorkerAsync", "ProcessBatch", "DrainBatch", "PruneOrphans"
+            },
             // OnItemAdded (sync handler) bumps a counter + arms a debounce Timer; OnDebounceElapsed
             // is the timer callback dispatching the scan HTTP POSTs off-thread.
             ["SeerrScanTriggerService.cs"] = new[] { "OnDebounceElapsed", "DispatchAsync", "PostScanTrigger", "TriggerNowAsync" },

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/TestDoubles/CountingLibraryManager.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/TestDoubles/CountingLibraryManager.cs
@@ -64,6 +64,10 @@ public sealed class CountingLibraryManager : ILibraryManager
     public void RaiseItemAdded(BaseItem item)
         => _itemAdded?.Invoke(this, new ItemChangeEventArgs { Item = item });
 
+    /// <summary>Raise Jellyfin's synchronous item-removed event.</summary>
+    public void RaiseItemRemoved(BaseItem item)
+        => _itemRemoved?.Invoke(this, new ItemChangeEventArgs { Item = item });
+
     // ---- Optional query hooks (default null = throw, per convention). Set by tests that need
     //      BuildFullCache's full scan (GetItemList) and per-id resolve (GetItemById<T>). ----
 
@@ -86,7 +90,11 @@ public sealed class CountingLibraryManager : ILibraryManager
 
     public AggregateFolder RootFolder => throw new NotImplementedException();
 
-    public bool IsScanRunning => throw new NotImplementedException();
+    /// <summary>When set, backs <see cref="IsScanRunning"/>.</summary>
+    public Func<bool>? IsScanRunningHook { get; set; }
+
+    public bool IsScanRunning
+        => IsScanRunningHook is null ? throw new NotImplementedException() : IsScanRunningHook();
 
     public BaseItem? ResolvePath(FileSystemMetadata fileInfo, Folder? parent = null, IDirectoryService? directoryService = null, CollectionType? collectionType = null) => throw new NotImplementedException();
 

--- a/Jellyfin.Plugin.JellyfinCanopy/EventHandlers/ContinueWatchingPlaybackEvents.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/EventHandlers/ContinueWatchingPlaybackEvents.cs
@@ -1,9 +1,9 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
 using MediaBrowser.Controller.Entities.TV;
@@ -220,116 +220,420 @@ namespace Jellyfin.Plugin.JellyfinCanopy.EventHandlers
     public sealed class ContinueWatchingLibraryHook : IHostedService, IDisposable
     {
         private static readonly TimeSpan DrainDebounce = TimeSpan.FromSeconds(2);
+        private static readonly TimeSpan DrainRetryDelay = TimeSpan.FromSeconds(2);
+        private const int PendingRemovalCapacity = 4096;
 
         private readonly ILibraryManager _libraryManager;
         private readonly UserConfigurationManager _configManager;
         private readonly IUserManager _userManager;
         private readonly ILogger<ContinueWatchingLibraryHook> _logger;
+        private readonly object _lifecycleGate = new();
+        private readonly HashSet<string> _pendingRemovals = new(StringComparer.OrdinalIgnoreCase);
+        private readonly int _pendingRemovalCapacity;
+        private readonly TimeSpan _drainDebounce;
+        private readonly TimeSpan _drainRetryDelay;
+        private readonly Func<Guid, CwRemovedIdIndex, bool>? _pruneUserForTest;
+        private readonly TaskCompletionSource<bool> _disposeCompletion = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        // Coalesce a bulk delete (many ItemRemoved events in one burst) into a single debounced
-        // drain: without this, each removed item started its own Task.Run that enumerated every user
-        // and did a locked per-user disk RMW — O(items × users) file reads on a bulk delete.
-        private readonly ConcurrentDictionary<string, byte> _pendingRemovals = new(StringComparer.OrdinalIgnoreCase);
-        private readonly Timer _drainTimer;
-        // Interlocked flush guard so a StopAsync flush and a concurrent timer tick don't double-drain
-        // (mirrors TagCacheService.FlushPending).
-        private int _draining;
-        private int _drainRearms; // count of times the finally re-armed the timer (test seam)
+        private Channel<byte>? _drainSignals;
+        private CancellationTokenSource? _flushNow;
+        private CancellationTokenSource? _abortWorker;
+        private Task? _workerTask;
+        private bool _started;
+        private bool _subscribed;
+        private bool _accepting;
+        private bool _stopInitiated;
+        private bool _disposed;
+        private bool _disposeStarted;
+        private string? _terminalFailure;
+        private long _rejectedRemovalCount;
+        private long _reportedRejectedRemovalCount;
 
-        // Test seams (Tests has InternalsVisibleTo).
-        internal void EnqueueRemovalForTest(Guid id) => _pendingRemovals.TryAdd(id.ToString(), 0);
+        // Test seams (Tests has InternalsVisibleTo). Both enqueue paths use the production intake
+        // fence, so lifecycle races exercise the same acceptance boundary as ItemRemoved.
+        internal bool EnqueueRemovalForTest(Guid id) => TryAcceptRemoval(id);
 
-        internal void DrainForTest() => Drain();
+        internal Action? OnBeforeRemovalAcceptanceForTest;
 
         internal Action? OnDrainProcessingForTest;
 
-        internal int DrainRearmCountForTest => _drainRearms;
+        internal Action? OnDrainDebounceStartedForTest;
 
-        internal bool PendingIsEmptyForTest => _pendingRemovals.IsEmpty;
+        internal Action? OnDisposeWaitingForTest;
+
+        internal bool PendingIsEmptyForTest
+        {
+            get
+            {
+                lock (_lifecycleGate)
+                {
+                    return _pendingRemovals.Count == 0;
+                }
+            }
+        }
+
+        internal long RejectedRemovalCountForTest => Interlocked.Read(ref _rejectedRemovalCount);
+
+        internal bool WorkerIsCompletedForTest
+        {
+            get
+            {
+                lock (_lifecycleGate)
+                {
+                    return _workerTask?.IsCompleted != false;
+                }
+            }
+        }
 
         public ContinueWatchingLibraryHook(
             ILibraryManager libraryManager,
             UserConfigurationManager configManager,
             IUserManager userManager,
             ILogger<ContinueWatchingLibraryHook> logger)
+            : this(
+                libraryManager,
+                configManager,
+                userManager,
+                logger,
+                PendingRemovalCapacity,
+                DrainDebounce,
+                DrainRetryDelay,
+                null)
         {
+        }
+
+        internal ContinueWatchingLibraryHook(
+            ILibraryManager libraryManager,
+            UserConfigurationManager configManager,
+            IUserManager userManager,
+            ILogger<ContinueWatchingLibraryHook> logger,
+            int pendingRemovalCapacity,
+            TimeSpan drainDebounce,
+            TimeSpan drainRetryDelay,
+            Func<Guid, CwRemovedIdIndex, bool>? pruneUserForTest)
+        {
+            if (pendingRemovalCapacity <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(pendingRemovalCapacity));
+            }
+
             _libraryManager = libraryManager;
             _configManager = configManager;
             _userManager = userManager;
             _logger = logger;
-            _drainTimer = new Timer(_ => Drain(), null, Timeout.Infinite, Timeout.Infinite);
+            _pendingRemovalCapacity = pendingRemovalCapacity;
+            _drainDebounce = drainDebounce;
+            _drainRetryDelay = drainRetryDelay;
+            _pruneUserForTest = pruneUserForTest;
         }
 
         public Task StartAsync(CancellationToken cancellationToken)
         {
-            _libraryManager.ItemRemoved += OnItemRemoved;
+            cancellationToken.ThrowIfCancellationRequested();
+            lock (_lifecycleGate)
+            {
+                // A hosted-service instance has a single terminal lifecycle. Duplicate starts are
+                // harmless, while a start after Stop/Dispose must not reopen closed intake.
+                if (_started || _stopInitiated || _disposed) return Task.CompletedTask;
+
+                _drainSignals = Channel.CreateBounded<byte>(new BoundedChannelOptions(1)
+                {
+                    SingleReader = true,
+                    SingleWriter = false,
+                    FullMode = BoundedChannelFullMode.DropWrite
+                });
+                _flushNow = new CancellationTokenSource();
+                _abortWorker = new CancellationTokenSource();
+                _accepting = true;
+                _started = true;
+                _subscribed = true;
+                _libraryManager.ItemRemoved += OnItemRemoved;
+
+                var signals = _drainSignals;
+                var flushNow = _flushNow;
+                var abortWorker = _abortWorker;
+                _workerTask = Task.Run(() => RunDrainWorkerAsync(signals, flushNow.Token, abortWorker.Token));
+            }
+
             return Task.CompletedTask;
         }
 
-        public Task StopAsync(CancellationToken cancellationToken)
+        public async Task StopAsync(CancellationToken cancellationToken)
         {
-            _libraryManager.ItemRemoved -= OnItemRemoved;
-            // Flush anything queued mid-window so a shutdown doesn't drop pending prunes.
-            _drainTimer.Change(Timeout.Infinite, Timeout.Infinite);
-            Drain();
-            _drainTimer.Dispose();
-            return Task.CompletedTask;
+            Task? worker;
+            lock (_lifecycleGate)
+            {
+                CloseIntakeLocked();
+                worker = _workerTask;
+            }
+
+            if (worker == null) return;
+
+            try
+            {
+                // Cancellation only cancels this caller's wait. It does not abandon accepted work:
+                // the owned worker remains live, and a later StopAsync can deterministically join it.
+                await worker.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+                string? terminalFailure;
+                lock (_lifecycleGate)
+                {
+                    terminalFailure = _terminalFailure;
+                }
+
+                if (terminalFailure != null)
+                {
+                    throw new InvalidOperationException(terminalFailure);
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                _logger.LogWarning("CW: shutdown canceled before accepted orphan-cleanup work was drained; the worker remains active for a later join.");
+                throw;
+            }
         }
 
         public void Dispose()
         {
-            _drainTimer.Dispose();
-            GC.SuppressFinalize(this);
+            var ownsDisposal = false;
+            Task completion;
+            Task? worker = null;
+            CancellationTokenSource? abortWorker = null;
+            lock (_lifecycleGate)
+            {
+                if (!_disposeStarted)
+                {
+                    _disposeStarted = true;
+                    _disposed = true;
+                    CloseIntakeLocked();
+                    abortWorker = _abortWorker;
+                    worker = _workerTask;
+                    ownsDisposal = true;
+                }
+
+                completion = _disposeCompletion.Task;
+            }
+
+            if (ownsDisposal)
+            {
+                Exception? disposalFailure = null;
+                try
+                {
+                    // StopAsync is the normal drain/join path. Dispose is the final safety fence: if
+                    // host shutdown skipped or canceled StopAsync, abort retries and join any in-flight
+                    // write so no worker can write after any Dispose caller returns.
+                    abortWorker?.Cancel();
+                    OnDisposeWaitingForTest?.Invoke();
+                    worker?.GetAwaiter().GetResult();
+                }
+                catch (OperationCanceledException)
+                {
+                    // RunDrainWorkerAsync observes the abort and publishes the shared terminal result.
+                }
+                catch (Exception ex)
+                {
+                    disposalFailure = ex;
+                }
+                finally
+                {
+                    _flushNow?.Dispose();
+                    _abortWorker?.Dispose();
+                    if (disposalFailure == null)
+                    {
+                        _disposeCompletion.TrySetResult(true);
+                    }
+                    else
+                    {
+                        _disposeCompletion.TrySetException(disposalFailure);
+                    }
+
+                    GC.SuppressFinalize(this);
+                }
+            }
+            else
+            {
+                OnDisposeWaitingForTest?.Invoke();
+            }
+
+            // Every caller, including callers that arrive while the owner is still joining the
+            // worker, observes the same terminal completion before returning.
+            completion.GetAwaiter().GetResult();
         }
 
         private void OnItemRemoved(object? sender, ItemChangeEventArgs e)
         {
             // PERF(S1): ItemRemoved fires synchronously on Jellyfin's library-scan thread. Record only
-            // the id here (O(1)) and (re)arm the debounce timer; the user enumeration and the per-user
-            // hidden-content prune (file I/O) run once, off the scan thread, on the timer thread. See
+            // the id here (bounded O(1)) and signal the worker; user enumeration and the per-user
+            // hidden-content prune (file I/O) run once, off the scan thread, on the owned worker. See
             // docs/developers.md#performance-rules (S1).
             var id = e?.Item?.Id ?? Guid.Empty;
             if (id == Guid.Empty) return;
-            _pendingRemovals.TryAdd(id.ToString(), 0);
-            _drainTimer.Change(DrainDebounce, Timeout.InfiniteTimeSpan);
+            OnBeforeRemovalAcceptanceForTest?.Invoke();
+            TryAcceptRemoval(id);
         }
 
-        // Snapshot + clear the pending removals, then prune each user ONCE for the whole batch.
-        private void Drain()
+        private bool TryAcceptRemoval(Guid id)
         {
-            if (Interlocked.Exchange(ref _draining, 1) == 1) return;
+            if (id == Guid.Empty) return false;
+            lock (_lifecycleGate)
+            {
+                if (!_accepting || _drainSignals == null) return false;
+
+                var identifier = id.ToString();
+                if (_pendingRemovals.Count >= _pendingRemovalCapacity
+                    && !_pendingRemovals.Contains(identifier))
+                {
+                    // Keep every already-accepted exact identity. Broad point-in-time library
+                    // negatives are unsafe during scans, so a new distinct id beyond the hard
+                    // intake bound is explicitly rejected and counted rather than replacing exact
+                    // work with an unrelated full reconciliation.
+                    Interlocked.Increment(ref _rejectedRemovalCount);
+                    return false;
+                }
+
+                _pendingRemovals.Add(identifier);
+                _drainSignals.Writer.TryWrite(0);
+                return true;
+            }
+        }
+
+        private void CloseIntakeLocked()
+        {
+            if (_stopInitiated) return;
+            _stopInitiated = true;
+            _accepting = false;
+            if (_subscribed)
+            {
+                _libraryManager.ItemRemoved -= OnItemRemoved;
+                _subscribed = false;
+            }
+
+            _flushNow?.Cancel();
+            _drainSignals?.Writer.TryComplete();
+        }
+
+        private async Task RunDrainWorkerAsync(
+            Channel<byte> signals,
+            CancellationToken flushNow,
+            CancellationToken abortWorker)
+        {
+            RemovalBatch? activeBatch = null;
             try
             {
-                if (_pendingRemovals.IsEmpty) return;
-                var ids = _pendingRemovals.Keys.ToArray();
-                foreach (var k in ids) _pendingRemovals.TryRemove(k, out _);
+                while (await signals.Reader.WaitToReadAsync(abortWorker).ConfigureAwait(false))
+                {
+                    signals.Reader.TryRead(out _);
+                    OnDrainDebounceStartedForTest?.Invoke();
+                    try
+                    {
+                        await Task.Delay(_drainDebounce, flushNow).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException) when (flushNow.IsCancellationRequested)
+                    {
+                        // Stop closes intake before canceling this debounce, making the final
+                        // snapshot complete. The worker itself is not canceled and drains it below.
+                    }
 
-                OnDrainProcessingForTest?.Invoke();
+                    abortWorker.ThrowIfCancellationRequested();
+                    while (signals.Reader.TryRead(out _)) { }
+                    activeBatch = TakePendingBatch();
+                    if (activeBatch.Value.IsEmpty) continue;
 
-                var userIds = _userManager.GetUsers().Select(u => u.Id);
-                DrainBatch(ids, userIds, PruneOrphans);
+                    OnDrainProcessingForTest?.Invoke();
+                    while (!ProcessBatch(activeBatch.Value))
+                    {
+                        await Task.Delay(_drainRetryDelay, abortWorker).ConfigureAwait(false);
+                    }
+
+                    activeBatch = null;
+                }
             }
-            catch (Exception ex)
+            catch (OperationCanceledException) when (abortWorker.IsCancellationRequested)
             {
-                _logger.LogWarning($"CW: orphan-prune drain failed: {ex.Message}");
+                if (activeBatch.HasValue) RestorePendingBatch(activeBatch.Value);
+                int pendingCount;
+                lock (_lifecycleGate)
+                {
+                    pendingCount = _pendingRemovals.Count;
+                }
+
+                if (pendingCount > 0)
+                {
+                    var failure = $"CW: TERMINAL shutdown failure: disposal aborted with {pendingCount} accepted orphan-cleanup id(s) undrained.";
+                    lock (_lifecycleGate)
+                    {
+                        _terminalFailure ??= failure;
+                    }
+
+                    _logger.LogError(failure);
+                }
             }
             finally
             {
-                Interlocked.Exchange(ref _draining, 0);
-                // Re-arm if work arrived while we were draining (a concurrent ItemRemoved, or a timer
-                // tick that bailed on the _draining guard): those ids weren't in this drain's snapshot,
-                // so without a re-arm they'd sit in _pendingRemovals until the next unrelated event.
-                // Fixed delay, no busy-spin. Guard against ObjectDisposedException: StopAsync may have
-                // disposed the timer (it drains once more itself), so a late re-arm is a harmless no-op.
-                if (!_pendingRemovals.IsEmpty)
+                // Rejections happen on the synchronous event path, where logging would add
+                // unbounded host work. Publish one aggregated delta from the owned worker even if
+                // Dispose aborts before ProcessBatch is reached; a normal batch report makes this
+                // final call a no-op, so each rejected event is reported exactly once.
+                ReportRejectedRemovals();
+            }
+        }
+
+        private RemovalBatch TakePendingBatch()
+        {
+            lock (_lifecycleGate)
+            {
+                if (_pendingRemovals.Count == 0) return default;
+                var ids = _pendingRemovals.ToArray();
+                _pendingRemovals.Clear();
+                return new RemovalBatch(ids);
+            }
+        }
+
+        private void RestorePendingBatch(RemovalBatch batch)
+        {
+            lock (_lifecycleGate)
+            {
+                // Intake is already closed on this terminal path. Restoring the active exact batch
+                // beside a final pending batch remains bounded at twice the fixed intake capacity.
+                foreach (var id in batch.RemovedIds)
                 {
-                    try
-                    {
-                        _drainTimer.Change(DrainDebounce, Timeout.InfiniteTimeSpan);
-                        Interlocked.Increment(ref _drainRearms);
-                    }
-                    catch (ObjectDisposedException) { /* shutting down; StopAsync already drained/stopped */ }
+                    _pendingRemovals.Add(id);
                 }
+            }
+        }
+
+        private bool ProcessBatch(RemovalBatch batch)
+        {
+            ReportRejectedRemovals();
+            Guid[] userIds;
+            try
+            {
+                userIds = _userManager.GetUsers().Select(user => user.Id).ToArray();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"CW: orphan-prune user enumeration failed; batch retained for retry: {ex.Message}");
+                return false;
+            }
+
+            var targetIds = CwRemovedIdIndex.Create(batch.RemovedIds);
+            var allSucceeded = true;
+            foreach (var userId in userIds)
+            {
+                allSucceeded &= PruneOrphans(userId, targetIds);
+            }
+
+            return allSucceeded;
+        }
+
+        private void ReportRejectedRemovals()
+        {
+            var total = Interlocked.Read(ref _rejectedRemovalCount);
+            var previouslyReported = Interlocked.Exchange(ref _reportedRejectedRemovalCount, total);
+            if (total > previouslyReported)
+            {
+                _logger.LogWarning(
+                    $"CW: bounded orphan-cleanup intake rejected {total - previouslyReported} distinct removal(s); {total} total rejection(s) since startup.");
             }
         }
 
@@ -353,8 +657,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.EventHandlers
 
         // One locked RMW per user that removes every batched orphan id, then invalidates the response
         // filter's HideContext cache for that user if anything changed.
-        private void PruneOrphans(Guid userId, CwRemovedIdIndex targetIds)
+        private bool PruneOrphans(Guid userId, CwRemovedIdIndex targetIds)
         {
+            if (_pruneUserForTest != null) return _pruneUserForTest(userId, targetIds);
+
             try
             {
                 var removed = _configManager.RmwUserConfiguration<UserHiddenContent>(
@@ -365,19 +671,24 @@ namespace Jellyfin.Plugin.JellyfinCanopy.EventHandlers
                 {
                     HiddenContentResponseFilter.InvalidateUser(userId.ToString("N"));
                 }
+
+                return true;
             }
             catch (UserStoreUnhealthyException)
             {
                 // The marker transition is already logged centrally. Repeated
-                // library events must remain silent until explicit recovery.
+                // library events remain silent, but the accepted batch stays owned for retry.
+                return false;
             }
             catch (InvalidDataException ex)
             {
-                _logger.LogWarning($"CW: skipping orphan-prune for user {userId} due to corrupt hidden-content.json: {ex.Message}");
+                _logger.LogWarning($"CW: retaining orphan-prune for user {userId} due to corrupt hidden-content.json: {ex.Message}");
+                return false;
             }
             catch (Exception ex)
             {
-                _logger.LogWarning($"CW: orphan-prune failed for user {userId}: {ex.Message}");
+                _logger.LogWarning($"CW: orphan-prune failed for user {userId}; batch retained for retry: {ex.Message}");
+                return false;
             }
         }
 
@@ -398,6 +709,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.EventHandlers
 
             foreach (var key in keysToDrop) hidden.Items.Remove(key);
             return keysToDrop.Count;
+        }
+
+        private readonly record struct RemovalBatch(string[] RemovedIds)
+        {
+            internal bool IsEmpty => RemovedIds == null || RemovedIds.Length == 0;
         }
     }
 }

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -19,7 +19,7 @@ const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the repeated clean measurements', () => {
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1932, totalLines: 2253 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 18876, totalLines: 27327 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 19042, totalLines: 27479 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);
 });

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -21,12 +21,12 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 18876,
-        "totalLines": 27327
+        "coveredLines": 19042,
+        "totalLines": 27479
       },
       "tolerance": {
         "missingCoveredLines": 2,
-        "rationale": "Two clean post-rebase local .NET 10.0.9/Coverlet integration runs on 2026-07-17 each passed 1690 tests and measured the identical combined 27327-line assembly scope at 18876 covered lines (69.075%). Issue #97 scopes tag-cache access sets, in-flight work, content cursors, and served-id proof to Jellyfin's persisted User.RowVersion, with immediate revoke/grant, isolation, cursor-reset, and publication-race regressions. Relative to the reviewed 18841/27308 baseline from issue #161, the reviewed assembly scope grows by 19 instrumented lines and the high-water advances by 35 covered lines while line coverage rises from 68.994% to 69.075%. The existing two-line tolerance is unchanged and covers only the previously reproduced negligible Coverlet variance; coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, and broad-tolerance negative boundaries."
+        "rationale": "Two clean final post-review local .NET 10.0.9/Coverlet integration runs on 2026-07-17 each passed 1702 tests and measured the identical complete 27479-line assembly scope at 19042 covered lines (69.297%). Issue #174 replaces the Continue Watching Timer race with bounded lifecycle-owned exact-id intake, deterministic drain/join, shared concurrent-disposal completion, observable cancellation/forced-terminal failure, retained retries, and exactly-once aggregated overflow rejection evidence on normal and abort exits. Adversarial stop, dispatch, retry, capacity, immediate-dispose, transient-global-null, coalescing, and lifecycle regressions cover the accepted-work contract without broad point-in-time library pruning. Relative to the reviewed 18876/27327 baseline, the reviewed assembly scope grows by 152 instrumented lines and the high-water advances by 166 covered lines while line coverage rises from 69.075% to 69.297%. The existing two-line tolerance is unchanged and covers only previously reproduced negligible Coverlet variance; coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
Fixes #174

## Summary
- replace the timer drain with one lifecycle-owned bounded signal channel and a single worker
- close intake and await every accepted removal before successful stop completion
- preserve exact accepted removal IDs across shutdown and report bounded overflow once
- make concurrent Stop and Dispose callers join the same terminal result
- keep cleanup scoped to exact IDs without broad library reconciliation

## Validation
- focused Continue Watching and scan-guard tests: 23/23
- full server suite: 1702/1702
- line coverage: 19042/27479, exact reviewed baseline
- coverage policy: 13/13
- script tests: 379/379
- Release build: zero warnings and errors
- diff check clean
- independent Codex review: APPROVE
- Fable 5 low review: APPROVE

## Safety
- accepted work is drained or explicitly reported
- no post-stop writes after successful completion
- no broad GetItemById or scan-state orphan sweep
- no deployment requested for this PR