### PR TITLE
fix(server): persist Seerr spoiler intent durably

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/ArrRequestsQueueFilterTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/ArrRequestsQueueFilterTests.cs
@@ -94,7 +94,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 userManager: null!,
                 new SeerrCache(provider),
                 provider,
-                parentalFilter: null!);
+                parentalFilter: null!,
+                spoilerPendingService: null!);
 
             var items = await client.GetRequestsForUser("7");
 

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SeerrQuotaSourceAffinityTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SeerrQuotaSourceAffinityTests.cs
@@ -587,7 +587,8 @@ public class SeerrQuotaSourceAffinityTests
             userManager: null!,
             new SeerrCache(provider),
             provider,
-            new PassthroughParentalFilter());
+            new PassthroughParentalFilter(),
+            null!);
         var resolvedUser = new SeerrUser { Id = 7, SourceUrl = SourceA };
 
         var result = await client.ProxyRequestAsync(
@@ -642,7 +643,8 @@ public class SeerrQuotaSourceAffinityTests
             userManager: null!,
             cache,
             provider,
-            new PassthroughParentalFilter());
+            new PassthroughParentalFilter(),
+            null!);
 
         var result = await client.ProxyRequestAsync(
             "/api/v1/user/7/quota",
@@ -670,7 +672,8 @@ public class SeerrQuotaSourceAffinityTests
             userManager: null!,
             new SeerrCache(provider),
             provider,
-            new PassthroughParentalFilter());
+            new PassthroughParentalFilter(),
+            null!);
 
         var result = await client.ProxyRequestAsync(
             "/api/v1/user/7/quota",
@@ -699,7 +702,8 @@ public class SeerrQuotaSourceAffinityTests
             userManager: null!,
             new SeerrCache(provider),
             provider,
-            new PassthroughParentalFilter());
+            new PassthroughParentalFilter(),
+            null!);
 
         var result = await client.ProxyRequestAsync(
             "/api/v1/user/7/quota",

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SeerrUserManualWatchlistSyncTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SeerrUserManualWatchlistSyncTests.cs
@@ -343,7 +343,8 @@ public sealed class SeerrUserManualWatchlistSyncTests
             users,
             cache,
             provider,
-            parentalFilter: null!);
+            parentalFilter: null!,
+            spoilerPendingService: null!);
         var controller = new SeerrUserController(
             factory,
             NullLogger<SeerrUserController>.Instance,

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SpoilerGuardControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SpoilerGuardControllerTests.cs
@@ -37,12 +37,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             public required UserConfigurationManager Mgr { get; init; }
             public required CountingLibraryManager Lib { get; init; }
             public required SpoilerPendingService Pending { get; init; }
+            public required SpoilerSeerrPendingPromoter Promoter { get; init; }
             public required SpoilerGuardController Controller { get; init; }
             public required StubUserDataManager UserData { get; init; }
             public required User User { get; init; }
 
             public void Dispose()
             {
+                Promoter.StopAsync(CancellationToken.None).GetAwaiter().GetResult();
                 try { Directory.Delete(Dir, recursive: true); } catch { /* best-effort */ }
             }
         }
@@ -58,6 +60,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             var userManager = includeUserInManager ? new StubUserManager(user) : new StubUserManager();
             var provider = new FakePluginConfigProvider(cfg);
             var pending = new SpoilerPendingService(mgr, lib, userManager, NullLogger<SpoilerPendingService>.Instance);
+            var promoter = new SpoilerSeerrPendingPromoter(
+                lib,
+                userManager,
+                mgr,
+                provider,
+                pending,
+                NullLogger<SpoilerSeerrPendingPromoter>.Instance);
+            promoter.StartAsync(CancellationToken.None).GetAwaiter().GetResult();
             var sessions = new CountingSessionManager();
             var requestIdentity = new RequestIdentityService(
                 sessions,
@@ -85,7 +95,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) },
             };
 
-            return new Harness { Dir = dir, Mgr = mgr, Lib = lib, Pending = pending, Controller = controller, UserData = userData, User = user };
+            return new Harness { Dir = dir, Mgr = mgr, Lib = lib, Pending = pending, Promoter = promoter, Controller = controller, UserData = userData, User = user };
         }
 
         // ─── Display-name sanitizer ───────────────────────────────────────────────
@@ -157,19 +167,19 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             first.PendingTmdb[keyB] = new SpoilerBlurPendingEntry { MediaType = "movie", TmdbId = "2" };
             var r1 = h.Controller.SaveUserSpoilerBlur(userId.ToString(), first);
             Assert.IsType<OkObjectResult>(r1);
-            Assert.True(SpoilerSeerrPendingPromoter.IsKeyRegisteredForTest(keyA));
-            Assert.True(SpoilerSeerrPendingPromoter.IsKeyRegisteredForTest(keyB));
+            Assert.True(h.Promoter.IsKeyRegisteredForTest(keyA));
+            Assert.True(h.Promoter.IsKeyRegisteredForTest(keyB));
 
             // Second save drops keyB → it is unregistered; keyA survives.
             var second = new UserSpoilerBlur();
             second.PendingTmdb[keyA] = new SpoilerBlurPendingEntry { MediaType = "tv", TmdbId = "1" };
             var r2 = h.Controller.SaveUserSpoilerBlur(userId.ToString(), second);
             Assert.IsType<OkObjectResult>(r2);
-            Assert.True(SpoilerSeerrPendingPromoter.IsKeyRegisteredForTest(keyA));
-            Assert.False(SpoilerSeerrPendingPromoter.IsKeyRegisteredForTest(keyB));
+            Assert.True(h.Promoter.IsKeyRegisteredForTest(keyA));
+            Assert.False(h.Promoter.IsKeyRegisteredForTest(keyB));
 
             // Cleanup so the static gate doesn't leak into other tests.
-            SpoilerSeerrPendingPromoter.UnregisterPending(keyA, userId);
+            h.Promoter.UnregisterPending(keyA, userId);
         }
 
         // ─── Pending cap (429) via the HTTP endpoint ──────────────────────────────
@@ -262,7 +272,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             Assert.Equal("My Show", stored.PendingTmdb["tv:888"].DisplayName);
 
             // The recorded pending key primes the promoter gate; clean it up.
-            SpoilerSeerrPendingPromoter.UnregisterPending("tv:888", h.User.Id);
+            h.Promoter.UnregisterPending("tv:888", h.User.Id);
         }
 
         [Fact]
@@ -284,7 +294,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
 
             Assert.False(SpoilerUserResolver.IsUserStateCachedForTest(userKey));
 
-            SpoilerSeerrPendingPromoter.UnregisterPending("tv:999", h.User.Id);
+            h.Promoter.UnregisterPending("tv:999", h.User.Id);
         }
 
         // ─── Health endpoint: non-admin sees only own corruption events ───────────
@@ -383,11 +393,6 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
         public void PromoteForUser_EventItemInaccessible_PromotesAccessibleTmdbDuplicate()
         {
             using var h = Build();
-            var userManager = new StubUserManager(h.User);
-            var promoter = new SpoilerSeerrPendingPromoter(
-                h.Lib, userManager, h.Mgr, new FakePluginConfigProvider(null), h.Pending,
-                NullLogger<SpoilerSeerrPendingPromoter>.Instance);
-
             const string pendingKey = "tv:555";
             var state = new UserSpoilerBlur();
             state.PendingTmdb[pendingKey] = new SpoilerBlurPendingEntry { MediaType = "tv", TmdbId = "555" };
@@ -398,7 +403,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             h.Lib.GetItemByIdUserHook = (_, _) => null;                                    // event item not visible
             h.Lib.GetItemListHook = _ => new List<BaseItem> { new Series { Id = dupId, Name = "Dup Show" } };
 
-            var outcome = promoter.PromoteForUser(h.User.Id, eventItemId, pendingKey, "Orig", isSeries: true);
+            var outcome = h.Promoter.PromoteForUser(h.User.Id, eventItemId, pendingKey, "Orig", isSeries: true);
 
             Assert.Equal(SpoilerSeerrPendingPromoter.PromotionOutcome.Promoted, outcome);
             var stored = h.Mgr.GetUserConfiguration<UserSpoilerBlur>(h.User.Id.ToString("N"), SpoilerFile);

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/Seerr4kCapabilityTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/Seerr4kCapabilityTests.cs
@@ -39,7 +39,8 @@ public class Seerr4kCapabilityTests
             null!,
             new SeerrCache(provider),
             provider,
-            new PassthroughParentalFilter());
+            new PassthroughParentalFilter(),
+            null!);
         return (client, handler);
     }
 

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/Seerr4kMasterSwitchTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/Seerr4kMasterSwitchTests.cs
@@ -39,7 +39,8 @@ public class Seerr4kMasterSwitchTests
             null!,
             new SeerrCache(provider),
             provider,
-            new PassthroughParentalFilter());
+            new PassthroughParentalFilter(),
+            null!);
         // A resolvable user so the gate is reached; permissions are irrelevant here.
         handler.AddResponse("/api/v1/user", $"{{\"results\":[{{\"id\":42,\"jellyfinUserId\":\"{UserId}\",\"permissions\":2048}}],\"pageInfo\":{{\"page\":1,\"pages\":1,\"results\":1}}}}");
         return (client, handler);

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/Seerr4kRequestGateTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/Seerr4kRequestGateTests.cs
@@ -42,7 +42,8 @@ public class Seerr4kRequestGateTests
             null!,
             new SeerrCache(provider),
             provider,
-            new PassthroughParentalFilter());
+            new PassthroughParentalFilter(),
+            null!);
         return (client, handler);
     }
 

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrClientTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrClientTests.cs
@@ -79,7 +79,7 @@ public class SeerrClientTests
     // ─── IPluginConfigProvider seam ──────────────────────────────────────────
 
     private static SeerrClient NewClient(FakePluginConfigProvider provider)
-        => new(new ThrowingHttpClientFactory(), NullLogger<SeerrClient>.Instance, null!, new SeerrCache(provider), provider, null!);
+        => new(new ThrowingHttpClientFactory(), NullLogger<SeerrClient>.Instance, null!, new SeerrCache(provider), provider, null!, null!);
 
     [Fact]
     public async Task GetSeerrUserId_ReadsConfigThroughInjectedProvider_AndSkipsWorkWhenUnconfigured()
@@ -115,6 +115,7 @@ public class SeerrClientTests
             null!,
             new SeerrCache(provider),
             provider,
+            null!,
             null!);
 
         var resolution = await client.ResolveSeerrUser(
@@ -143,6 +144,7 @@ public class SeerrClientTests
             null!,
             new SeerrCache(provider),
             provider,
+            null!,
             null!);
 
         Assert.Null(await client.GetWatchlistForUser("42"));
@@ -166,6 +168,7 @@ public class SeerrClientTests
             null!,
             new SeerrCache(provider),
             provider,
+            null!,
             null!);
 
         Assert.False(await client.GetStatusActiveAsync());
@@ -188,6 +191,7 @@ public class SeerrClientTests
             null!,
             new SeerrCache(provider),
             provider,
+            null!,
             null!);
 
         var statusTask = client.GetStatusActiveAsync();

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrIntentDurabilityTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrIntentDurabilityTests.cs
@@ -1,0 +1,489 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Text.Json;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Controllers;
+using Jellyfin.Plugin.JellyfinCanopy.Services;
+using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.TV;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services;
+
+public sealed class SeerrIntentDurabilityTests : IDisposable
+{
+    private const string Source = "http://seerr:5055";
+    private readonly string _directory = Path.Combine(
+        Path.GetTempPath(),
+        "jc-seerr-intent-" + Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+        catch
+        {
+            // Best-effort test cleanup.
+        }
+    }
+
+    [Fact]
+    public async Task SuccessfulRequest_ReturnsOnlyAfterSpoilerIntentIsDurable()
+    {
+        var user = new User("intent-user", "provider", "password-provider");
+        var userId = user.Id.ToString("N");
+        var handler = new RecordingHttpMessageHandler();
+        handler.AddResponse(
+            "/api/v1/user",
+            $"{{\"results\":[{{\"id\":42,\"jellyfinUserId\":\"{userId}\",\"permissions\":2}}],\"pageInfo\":{{\"page\":1,\"pages\":1,\"results\":1}}}}");
+        handler.AddResponse("/api/v1/request", "{\"id\":1}", HttpStatusCode.Created);
+
+        var config = new PluginConfiguration
+        {
+            SeerrEnabled = true,
+            SeerrUrls = Source,
+            SeerrApiKey = "test-key",
+            SpoilerBlurEnabled = true,
+            SpoilerAutoEnableOnSeerrRequest = true,
+        };
+        var provider = new FakePluginConfigProvider(config);
+        var manager = new UserConfigurationManager(
+            new StubAppPaths(_directory),
+            NullLogger<UserConfigurationManager>.Instance);
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = _ => Array.Empty<BaseItem>(),
+        };
+        var users = new StubUserManager(user);
+        var pending = new SpoilerPendingService(
+            manager,
+            library,
+            users,
+            NullLogger<SpoilerPendingService>.Instance);
+        var client = new SeerrClient(
+            new RecordingHttpClientFactory(handler),
+            NullLogger<SeerrClient>.Instance,
+            users,
+            new SeerrCache(provider),
+            provider,
+            new PassthroughParentalFilter(),
+            pending);
+
+        var result = await client.ProxyRequestAsync(
+            "/api/v1/request",
+            HttpMethod.Post,
+            "{\"mediaType\":\"tv\",\"mediaId\":123,\"seasons\":[2]}",
+            new SeerrCaller(userId, IsAdmin: true));
+
+        Assert.IsType<ContentResult>(result);
+        var state = manager.GetUserConfiguration<UserSpoilerBlur>(
+            userId,
+            "spoilerblur.json");
+        Assert.True(state.PendingTmdb.ContainsKey("tv:123"));
+    }
+
+    [Fact]
+    public async Task TvSeasonsRoute_CannotBypassSharedDurableSuccessBoundary()
+    {
+        var setup = CreateClientHarness();
+        var controller = new SeerrUserController(
+            new RecordingHttpClientFactory(setup.Handler),
+            NullLogger<SeerrUserController>.Instance,
+            setup.Users,
+            new SeerrCache(setup.Provider),
+            setup.Provider,
+            null!,
+            setup.Library,
+            setup.Client)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = new ClaimsPrincipal(new ClaimsIdentity(
+                        new[] { new Claim("Jellyfin-UserId", setup.User.Id.ToString()) },
+                        "TestAuth")),
+                },
+            },
+        };
+        using var document = JsonDocument.Parse(
+            "{\"mediaType\":\"tv\",\"mediaId\":321,\"seasons\":[3]}");
+
+        var result = await controller.RequestTvSeasons(321, document.RootElement);
+
+        Assert.IsType<ContentResult>(result);
+        Assert.True(ReadState(setup).PendingTmdb.ContainsKey("tv:321"));
+    }
+
+    [Fact]
+    public async Task UpstreamSuccess_WithUnresolvedFullPendingStore_ReturnsExplicitPartialSuccess()
+    {
+        var setup = CreateClientHarness();
+        SeedPendingCap(setup);
+
+        var result = Assert.IsType<ObjectResult>(await setup.Client.ProxyRequestAsync(
+            "/api/v1/request",
+            HttpMethod.Post,
+            "{\"mediaType\":\"movie\",\"mediaId\":999}",
+            new SeerrCaller(setup.User.Id.ToString("N"), IsAdmin: true)));
+
+        Assert.Equal(500, result.StatusCode);
+        Assert.Equal("seerr_accepted_spoiler_intent_failed", ReadProperty<string>(result.Value, "code"));
+        Assert.True(ReadProperty<bool>(result.Value, "seerrAccepted"));
+        Assert.False(ReadProperty<bool>(result.Value, "spoilerIntentRecorded"));
+        Assert.Equal("pending_cap_exceeded", ReadProperty<string>(result.Value, "reason"));
+        Assert.Equal(SpoilerPendingService.MaxPendingTmdbPerUser, ReadState(setup).PendingTmdb.Count);
+    }
+
+    [Fact]
+    public async Task UpstreamAcceptedUnsupportedMediaType_ReturnsTruthfulPartialSuccess()
+    {
+        var setup = CreateClientHarness();
+
+        var result = Assert.IsType<ObjectResult>(await setup.Client.ProxyRequestAsync(
+            "/api/v1/request",
+            HttpMethod.Post,
+            "{\"mediaType\":\"music\",\"mediaId\":999}",
+            new SeerrCaller(setup.User.Id.ToString("N"), IsAdmin: true)));
+
+        Assert.Equal(500, result.StatusCode);
+        Assert.Equal("seerr_accepted_spoiler_intent_failed", ReadProperty<string>(result.Value, "code"));
+        Assert.Equal("unsupported_request_target", ReadProperty<string>(result.Value, "reason"));
+        Assert.True(ReadProperty<bool>(result.Value, "seerrAccepted"));
+        Assert.False(ReadProperty<bool>(result.Value, "spoilerIntentRecorded"));
+        Assert.Contains("Do not retry", ReadProperty<string>(result.Value, "message"));
+        Assert.Contains("movie/tv", ReadProperty<string>(result.Value, "message"));
+        Assert.Contains("verify", ReadProperty<string>(result.Value, "message"));
+        Assert.Empty(ReadState(setup).PendingTmdb);
+    }
+
+    [Fact]
+    public async Task CapacityOpeningBeforeFallback_ReportsNewPendingRowAsDurable()
+    {
+        var setup = CreateClientHarness();
+        SeedPendingCap(setup);
+        const string removedKey = "movie:100000";
+        setup.Pending.BeforeCapFallbackForTest = () =>
+        {
+            setup.Manager.RmwUserConfiguration<UserSpoilerBlur>(
+                setup.User.Id.ToString("N"),
+                "spoilerblur.json",
+                state => state.PendingTmdb.Remove(removedKey) ? 1 : 0);
+        };
+
+        var result = await setup.Client.ProxyRequestAsync(
+            "/api/v1/request",
+            HttpMethod.Post,
+            "{\"mediaType\":\"movie\",\"mediaId\":999}",
+            new SeerrCaller(setup.User.Id.ToString("N"), IsAdmin: true));
+
+        Assert.IsType<ContentResult>(result);
+        var state = ReadState(setup);
+        Assert.False(state.PendingTmdb.ContainsKey(removedKey));
+        Assert.True(state.PendingTmdb.ContainsKey("movie:999"));
+        Assert.Equal(SpoilerPendingService.MaxPendingTmdbPerUser, state.PendingTmdb.Count);
+    }
+
+    [Fact]
+    public async Task UpstreamSuccess_AtPendingCapWithAccessibleSeries_DurablyPromotes()
+    {
+        var setup = CreateClientHarness();
+        SeedPendingCap(setup);
+        var series = new Series { Id = Guid.NewGuid(), Name = "Already Here" };
+        series.ProviderIds["Tmdb"] = "999";
+        setup.Library.GetItemListHook = _ => new BaseItem[] { series };
+
+        var result = await setup.Client.ProxyRequestAsync(
+            "/api/v1/request",
+            HttpMethod.Post,
+            "{\"mediaType\":\"tv\",\"mediaId\":999}",
+            new SeerrCaller(setup.User.Id.ToString("N"), IsAdmin: true));
+
+        Assert.IsType<ContentResult>(result);
+        var state = ReadState(setup);
+        Assert.Equal(SpoilerPendingService.MaxPendingTmdbPerUser, state.PendingTmdb.Count);
+        Assert.True(state.Series.ContainsKey(series.Id.ToString("N")));
+    }
+
+    [Fact]
+    public async Task RequestSubresourceMutation_IsNotMisclassifiedAsNewMediaIntent()
+    {
+        var setup = CreateClientHarness();
+        setup.Handler.AddResponse("/api/v1/request/7/approve", "{\"id\":7}");
+
+        var result = await setup.Client.ProxyRequestAsync(
+            "/api/v1/request/7/approve",
+            HttpMethod.Post,
+            "{\"mediaType\":\"tv\",\"mediaId\":777}",
+            new SeerrCaller(setup.User.Id.ToString("N"), IsAdmin: true));
+
+        Assert.IsType<ContentResult>(result);
+        Assert.Empty(ReadState(setup).PendingTmdb);
+    }
+
+    [Fact]
+    public async Task UpstreamSuccess_WithCorruptIntentStore_ReturnsExplicitPartialSuccess()
+    {
+        var setup = CreateClientHarness();
+        setup.Manager.SaveUserConfiguration(
+            setup.User.Id.ToString("N"),
+            "spoilerblur.json",
+            new UserSpoilerBlur());
+        var path = Path.Combine(
+            _directory,
+            "configurations",
+            "Jellyfin.Plugin.JellyfinCanopy",
+            setup.User.Id.ToString("N"),
+            "spoilerblur.json");
+        File.WriteAllText(path, "{{{ corrupt intent store");
+
+        var result = Assert.IsType<ObjectResult>(await setup.Client.ProxyRequestAsync(
+            "/api/v1/request",
+            HttpMethod.Post,
+            "{\"mediaType\":\"movie\",\"mediaId\":654}",
+            new SeerrCaller(setup.User.Id.ToString("N"), IsAdmin: true)));
+
+        Assert.Equal(500, result.StatusCode);
+        Assert.Equal("seerr_accepted_spoiler_intent_failed", ReadProperty<string>(result.Value, "code"));
+        Assert.Equal("intent_store_unavailable", ReadProperty<string>(result.Value, "reason"));
+        Assert.True(ReadProperty<bool>(result.Value, "seerrAccepted"));
+    }
+
+    [Fact]
+    public async Task RequestCancellationAfterUpstreamSuccess_CannotAbandonDurableIntent()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var setup = CreateClientHarness(new CancelDuringResponseFilter(cancellation));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => setup.Client.ProxyRequestAsync(
+            "/api/v1/request",
+            HttpMethod.Post,
+            "{\"mediaType\":\"tv\",\"mediaId\":876}",
+            new SeerrCaller(setup.User.Id.ToString("N"), IsAdmin: true),
+            cancellation.Token));
+
+        Assert.True(ReadState(setup).PendingTmdb.ContainsKey("tv:876"));
+    }
+
+    [Fact]
+    public async Task RequestCancellationAfterSuccessHeadersBeforeJsonCompletion_CannotAbandonIntent()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var setup = CreateClientHarness();
+        var body = new BlockingResponseStream();
+        setup.Handler.ResponseFactory = request =>
+        {
+            if (request.RequestUri!.AbsolutePath != "/api/v1/request")
+            {
+                return null;
+            }
+
+            var content = new StreamContent(body);
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+            return new HttpResponseMessage(HttpStatusCode.Created) { Content = content };
+        };
+
+        var requestTask = setup.Client.ProxyRequestAsync(
+            "/api/v1/request",
+            HttpMethod.Post,
+            "{\"mediaType\":\"tv\",\"mediaId\":877}",
+            new SeerrCaller(setup.User.Id.ToString("N"), IsAdmin: true),
+            cancellation.Token);
+        await body.ReadStarted.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.True(ReadState(setup).PendingTmdb.ContainsKey("tv:877"));
+        cancellation.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => requestTask);
+        Assert.True(body.CancellationObserved);
+    }
+
+    [Fact]
+    public async Task AutoEnableDecision_IsFrozenBeforeDispatchDespiteInPlaceDisableAfterAcceptance()
+    {
+        var setup = CreateClientHarness();
+        setup.Handler.BeforeResponse = request =>
+        {
+            if (request.RequestUri!.AbsolutePath == "/api/v1/request")
+            {
+                setup.Provider.Current!.SpoilerAutoEnableOnSeerrRequest = false;
+            }
+        };
+
+        var result = await setup.Client.ProxyRequestAsync(
+            "/api/v1/request",
+            HttpMethod.Post,
+            "{\"mediaType\":\"movie\",\"mediaId\":878}",
+            new SeerrCaller(setup.User.Id.ToString("N"), IsAdmin: true));
+
+        Assert.IsType<ContentResult>(result);
+        Assert.False(setup.Provider.Current!.SpoilerAutoEnableOnSeerrRequest);
+        Assert.True(ReadState(setup).PendingTmdb.ContainsKey("movie:878"));
+    }
+
+    private ClientHarness CreateClientHarness(ISeerrParentalFilter? parentalFilter = null)
+    {
+        var user = new User("intent-harness", "provider", "password-provider");
+        var handler = new RecordingHttpMessageHandler();
+        handler.AddResponse(
+            "/api/v1/user",
+            $"{{\"results\":[{{\"id\":42,\"jellyfinUserId\":\"{user.Id:N}\",\"permissions\":2}}],\"pageInfo\":{{\"page\":1,\"pages\":1,\"results\":1}}}}");
+        handler.AddResponse("/api/v1/request", "{\"id\":1}", HttpStatusCode.Created);
+        var provider = new FakePluginConfigProvider(new PluginConfiguration
+        {
+            SeerrEnabled = true,
+            SeerrUrls = Source,
+            SeerrApiKey = "test-key",
+            SpoilerBlurEnabled = true,
+            SpoilerAutoEnableOnSeerrRequest = true,
+        });
+        var manager = new UserConfigurationManager(
+            new StubAppPaths(_directory),
+            NullLogger<UserConfigurationManager>.Instance);
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = _ => Array.Empty<BaseItem>(),
+        };
+        var users = new StubUserManager(user);
+        var pending = new SpoilerPendingService(
+            manager,
+            library,
+            users,
+            NullLogger<SpoilerPendingService>.Instance);
+        var client = new SeerrClient(
+            new RecordingHttpClientFactory(handler),
+            NullLogger<SeerrClient>.Instance,
+            users,
+            new SeerrCache(provider),
+            provider,
+            parentalFilter ?? new PassthroughParentalFilter(),
+            pending);
+        return new ClientHarness(user, users, handler, provider, manager, library, pending, client);
+    }
+
+    private static void SeedPendingCap(ClientHarness setup)
+    {
+        var state = new UserSpoilerBlur();
+        for (var i = 0; i < SpoilerPendingService.MaxPendingTmdbPerUser; i++)
+        {
+            var key = $"movie:{100_000 + i}";
+            state.PendingTmdb[key] = new SpoilerBlurPendingEntry
+            {
+                MediaType = "movie",
+                TmdbId = (100_000 + i).ToString(System.Globalization.CultureInfo.InvariantCulture),
+            };
+        }
+
+        setup.Manager.SaveUserConfiguration(setup.User.Id.ToString("N"), "spoilerblur.json", state);
+    }
+
+    private static UserSpoilerBlur ReadState(ClientHarness setup)
+        => setup.Manager.GetUserConfiguration<UserSpoilerBlur>(
+            setup.User.Id.ToString("N"),
+            "spoilerblur.json");
+
+    private static T ReadProperty<T>(object? value, string name)
+        => Assert.IsType<T>(value?.GetType().GetProperty(name)?.GetValue(value));
+
+    private sealed record ClientHarness(
+        User User,
+        StubUserManager Users,
+        RecordingHttpMessageHandler Handler,
+        FakePluginConfigProvider Provider,
+        UserConfigurationManager Manager,
+        CountingLibraryManager Library,
+        SpoilerPendingService Pending,
+        SeerrClient Client);
+
+    private sealed class PassthroughParentalFilter : ISeerrParentalFilter
+    {
+        public Task<SeerrParentalResult> ApplyAsync(string json, string apiPath, SeerrCaller caller)
+            => Task.FromResult(new SeerrParentalResult(false, json));
+
+        public Task<bool> IsBlockedAsync(string mediaType, int tmdbId, SeerrCaller caller)
+            => Task.FromResult(false);
+
+        public Task<bool> IsTmdbProxyPathBlockedAsync(string tmdbApiPath, SeerrCaller caller)
+            => Task.FromResult(false);
+    }
+
+    private sealed class CancelDuringResponseFilter : ISeerrParentalFilter
+    {
+        private readonly CancellationTokenSource _cancellation;
+
+        public CancelDuringResponseFilter(CancellationTokenSource cancellation)
+            => _cancellation = cancellation;
+
+        public Task<SeerrParentalResult> ApplyAsync(string json, string apiPath, SeerrCaller caller)
+        {
+            _cancellation.Cancel();
+            return Task.FromResult(new SeerrParentalResult(false, json));
+        }
+
+        public Task<bool> IsBlockedAsync(string mediaType, int tmdbId, SeerrCaller caller)
+            => Task.FromResult(false);
+
+        public Task<bool> IsTmdbProxyPathBlockedAsync(string tmdbApiPath, SeerrCaller caller)
+            => Task.FromResult(false);
+    }
+
+    private sealed class BlockingResponseStream : Stream
+    {
+        private readonly TaskCompletionSource _readStarted = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task ReadStarted => _readStarted.Task;
+
+        public bool CancellationObserved { get; private set; }
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+            => throw new NotSupportedException();
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            _readStarted.TrySetResult();
+            try
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                throw new InvalidOperationException("The blocked response unexpectedly resumed.");
+            }
+            catch (OperationCanceledException)
+            {
+                CancellationObserved = true;
+                throw;
+            }
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        public override void Flush() => throw new NotSupportedException();
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrPaginationIntegrationTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrPaginationIntegrationTests.cs
@@ -1164,7 +1164,8 @@ public class SeerrPaginationIntegrationTests
             userManager: null!,
             cache,
             provider,
-            parentalFilter: null!);
+            parentalFilter: null!,
+            spoilerPendingService: null!);
         return (client, cache);
     }
 
@@ -1178,7 +1179,8 @@ public class SeerrPaginationIntegrationTests
             userManager: null!,
             cache,
             provider,
-            parentalFilter: null!);
+            parentalFilter: null!,
+            spoilerPendingService: null!);
 
     private static object UserRow(int id, string jellyfinUserId) => new
     {

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrPublicScopeHeaderTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrPublicScopeHeaderTests.cs
@@ -42,7 +42,8 @@ public class SeerrPublicScopeHeaderTests
             null!,
             new SeerrCache(provider),
             provider,
-            new PassthroughParentalFilter());
+            new PassthroughParentalFilter(),
+            null!);
         return (client, handler);
     }
 
@@ -238,7 +239,8 @@ public class SeerrPublicScopeHeaderTests
             null!,
             new SeerrCache(provider),
             provider,
-            new PassthroughParentalFilter());
+            new PassthroughParentalFilter(),
+            null!);
         var caller = new SeerrCaller(UserId, IsAdmin: true);
 
         await client.ProxyRequestAsync(
@@ -281,7 +283,8 @@ public class SeerrPublicScopeHeaderTests
             null!,
             new SeerrCache(provider),
             provider,
-            new PassthroughParentalFilter());
+            new PassthroughParentalFilter(),
+            null!);
         var caller = new SeerrCaller(UserId, IsAdmin: true);
 
         await client.ProxyRequestAsync(
@@ -335,7 +338,8 @@ public class SeerrPublicScopeHeaderTests
             null!,
             cache,
             provider,
-            new PassthroughParentalFilter());
+            new PassthroughParentalFilter(),
+            null!);
 
         var result = Assert.IsType<ObjectResult>(await client.ProxyRequestAsync(
             "/api/v1/issue",

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrReadGenerationFenceTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrReadGenerationFenceTests.cs
@@ -313,7 +313,8 @@ public sealed class SeerrReadGenerationFenceTests
             userManager: null!,
             cache,
             provider,
-            parentalFilter);
+            parentalFilter,
+            spoilerPendingService: null!);
 
     private static PluginConfiguration Configuration(string source, string apiKey) => new()
     {

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SpoilerGuardTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SpoilerGuardTests.cs
@@ -225,40 +225,60 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             }
         }
 
-        // ─── SpoilerSeerrPendingPromoter static gate atomicity ───────────────────
+        // ─── SpoilerSeerrPendingPromoter instance gate atomicity ─────────────────
 
         [Fact]
         public void PromoterGate_RegisterUnregister_TracksUsersAndRemovesEmptyKey()
         {
+            var directory = Path.Combine(Path.GetTempPath(), "jc-promoter-gate-" + Guid.NewGuid().ToString("N"));
+            var manager = new UserConfigurationManager(
+                new StubAppPaths(directory),
+                NullLogger<UserConfigurationManager>.Instance);
+            var library = new CountingLibraryManager();
+            var users = new StubUserManager();
+            var pending = new SpoilerPendingService(
+                manager,
+                library,
+                users,
+                NullLogger<SpoilerPendingService>.Instance);
+            var promoter = new SpoilerSeerrPendingPromoter(
+                library,
+                users,
+                manager,
+                new FakePluginConfigProvider(null),
+                pending,
+                NullLogger<SpoilerSeerrPendingPromoter>.Instance);
             var key = "tv:" + Guid.NewGuid().ToString("N");
             var userA = Guid.NewGuid();
             var userB = Guid.NewGuid();
 
-            Assert.False(SpoilerSeerrPendingPromoter.IsKeyRegisteredForTest(key));
+            Assert.False(promoter.IsKeyRegisteredForTest(key));
 
-            SpoilerSeerrPendingPromoter.RegisterPending(key, userA);
-            SpoilerSeerrPendingPromoter.RegisterPending(key, userB);
-            Assert.True(SpoilerSeerrPendingPromoter.IsKeyRegisteredForTest(key));
-            Assert.Equal(2, SpoilerSeerrPendingPromoter.RegisteredUserCountForTest(key));
+            promoter.RegisterPending(key, userA);
+            promoter.RegisterPending(key, userB);
+            Assert.True(promoter.IsKeyRegisteredForTest(key));
+            Assert.Equal(2, promoter.RegisteredUserCountForTest(key));
 
             // Re-register is idempotent (set semantics).
-            SpoilerSeerrPendingPromoter.RegisterPending(key, userA);
-            Assert.Equal(2, SpoilerSeerrPendingPromoter.RegisteredUserCountForTest(key));
+            promoter.RegisterPending(key, userA);
+            Assert.Equal(2, promoter.RegisteredUserCountForTest(key));
 
-            SpoilerSeerrPendingPromoter.UnregisterPending(key, userA);
-            Assert.Equal(1, SpoilerSeerrPendingPromoter.RegisteredUserCountForTest(key));
-            Assert.True(SpoilerSeerrPendingPromoter.IsKeyRegisteredForTest(key));
+            promoter.UnregisterPending(key, userA);
+            Assert.Equal(1, promoter.RegisteredUserCountForTest(key));
+            Assert.True(promoter.IsKeyRegisteredForTest(key));
 
             // Removing the last user drops the key entirely.
-            SpoilerSeerrPendingPromoter.UnregisterPending(key, userB);
-            Assert.False(SpoilerSeerrPendingPromoter.IsKeyRegisteredForTest(key));
+            promoter.UnregisterPending(key, userB);
+            Assert.False(promoter.IsKeyRegisteredForTest(key));
 
             // Unregistering a gone key + empty inputs are no-ops (no throw).
-            SpoilerSeerrPendingPromoter.UnregisterPending(key, userB);
-            SpoilerSeerrPendingPromoter.RegisterPending(string.Empty, userA);
-            SpoilerSeerrPendingPromoter.RegisterPending(key, Guid.Empty);
-            Assert.False(SpoilerSeerrPendingPromoter.IsKeyRegisteredForTest(key));
-            Assert.False(SpoilerSeerrPendingPromoter.IsKeyRegisteredForTest(string.Empty));
+            promoter.UnregisterPending(key, userB);
+            promoter.RegisterPending(string.Empty, userA);
+            promoter.RegisterPending(key, Guid.Empty);
+            Assert.False(promoter.IsKeyRegisteredForTest(key));
+            Assert.False(promoter.IsKeyRegisteredForTest(string.Empty));
+
+            try { Directory.Delete(directory, recursive: true); } catch { /* best-effort cleanup */ }
         }
 
         // ─── ImageBlurService ─────────────────────────────────────────────────────

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SpoilerPendingPromoterLifecycleTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SpoilerPendingPromoterLifecycleTests.cs
@@ -1,0 +1,314 @@
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Services;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.TV;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services;
+
+public sealed class SpoilerPendingPromoterLifecycleTests : IDisposable
+{
+    private const string SpoilerFile = "spoilerblur.json";
+    private readonly string _directory = Path.Combine(
+        Path.GetTempPath(),
+        "jc-promoter-lifecycle-" + Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+        catch
+        {
+            // Best-effort test cleanup.
+        }
+    }
+
+    [Fact]
+    public async Task StopAsync_DrainsAcceptedPromotion_AndNoWorkerWriteSurvivesStop()
+    {
+        var harness = CreateHarness();
+        const string pendingKey = "tv:123";
+        var series = VisibleSeries("123");
+        SavePending(harness.Manager, harness.User.Id, pendingKey);
+        harness.Library.GetItemListHook = _ => new BaseItem[] { series };
+        harness.Library.GetItemByIdUserHook = (_, _) => series;
+
+        var entered = NewSignal();
+        var release = NewSignal();
+        harness.Promoter.BeforePromotionForTest = _ =>
+        {
+            entered.TrySetResult();
+            return release.Task;
+        };
+
+        await harness.Promoter.StartAsync(CancellationToken.None);
+        await entered.Task;
+
+        var stop = harness.Promoter.StopAsync(CancellationToken.None);
+        Assert.False(stop.IsCompleted);
+
+        release.TrySetResult();
+        await stop;
+
+        var state = ReadState(harness.Manager, harness.User.Id);
+        Assert.Empty(state.PendingTmdb);
+        Assert.True(state.Series.ContainsKey(series.Id.ToString("N")));
+
+        // The completed owner has unsubscribed. A later matching event cannot
+        // launch detached work or mutate the already-drained generation.
+        harness.Library.RaiseItemAdded(series);
+        Assert.Empty(ReadState(harness.Manager, harness.User.Id).PendingTmdb);
+    }
+
+    [Fact]
+    public async Task ConcurrentStart_WaitsForBlockedStopBeforeCreatingNextGeneration()
+    {
+        var harness = CreateHarness();
+        const string pendingKey = "tv:234";
+        SavePending(harness.Manager, harness.User.Id, pendingKey);
+        harness.Library.GetItemListHook = _ => Array.Empty<BaseItem>();
+        var firstEntered = NewSignal();
+        var releaseFirst = NewSignal();
+        var secondEntered = NewSignal();
+        var sweepCount = 0;
+        harness.Promoter.BeforePromotionForTest = _ =>
+        {
+            if (Interlocked.Increment(ref sweepCount) == 1)
+            {
+                firstEntered.TrySetResult();
+                return releaseFirst.Task;
+            }
+
+            secondEntered.TrySetResult();
+            return Task.CompletedTask;
+        };
+
+        await harness.Promoter.StartAsync(CancellationToken.None);
+        await firstEntered.Task;
+        var stop = harness.Promoter.StopAsync(CancellationToken.None);
+        var restart = harness.Promoter.StartAsync(CancellationToken.None);
+
+        Assert.False(stop.IsCompleted);
+        Assert.False(restart.IsCompleted);
+        Assert.True(harness.Promoter.IsUserRegisteredForTest(pendingKey, harness.User.Id));
+
+        releaseFirst.TrySetResult();
+        await stop;
+        await restart;
+        await secondEntered.Task;
+
+        Assert.True(harness.Promoter.IsUserRegisteredForTest(pendingKey, harness.User.Id));
+        Assert.Equal(2, Volatile.Read(ref sweepCount));
+        await harness.Promoter.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task RegisterPending_RetriesWhenLastUserRemovalDetachesObtainedDictionary()
+    {
+        var harness = CreateHarness();
+        const string pendingKey = "tv:345";
+        var existingUser = harness.User.Id;
+        var registeringUser = Guid.NewGuid();
+        harness.Promoter.RegisterPending(pendingKey, existingUser);
+        var dictionaryObtained = NewSignal();
+        var allowAdd = NewSignal();
+        harness.Promoter.PendingDictionaryAcquiredForTest = (key, userId) =>
+        {
+            if (key == pendingKey && userId == registeringUser)
+            {
+                dictionaryObtained.TrySetResult();
+                allowAdd.Task.GetAwaiter().GetResult();
+            }
+        };
+
+        var register = Task.Run(() => harness.Promoter.RegisterPending(pendingKey, registeringUser));
+        await dictionaryObtained.Task;
+        harness.Promoter.UnregisterPending(pendingKey, existingUser);
+        Assert.False(harness.Promoter.IsKeyRegisteredForTest(pendingKey));
+
+        allowAdd.TrySetResult();
+        await register;
+
+        Assert.True(harness.Promoter.IsUserRegisteredForTest(pendingKey, registeringUser));
+        Assert.Equal(1, harness.Promoter.RegisteredUserCountForTest(pendingKey));
+    }
+
+    [Fact]
+    public async Task FreshInstance_ReplaysDurableRowWithoutAnotherLibraryEvent()
+    {
+        var harness = CreateHarness();
+        const string pendingKey = "tv:456";
+        SavePending(harness.Manager, harness.User.Id, pendingKey);
+        harness.Library.GetItemListHook = _ => Array.Empty<BaseItem>();
+
+        var firstSweep = NewSignal();
+        harness.Promoter.AfterPromotionForTest = _ => firstSweep.TrySetResult();
+        await harness.Promoter.StartAsync(CancellationToken.None);
+        await firstSweep.Task;
+        await harness.Promoter.StopAsync(CancellationToken.None);
+        Assert.True(ReadState(harness.Manager, harness.User.Id).PendingTmdb.ContainsKey(pendingKey));
+
+        var series = VisibleSeries("456");
+        harness.Library.GetItemListHook = _ => new BaseItem[] { series };
+        harness.Library.GetItemByIdUserHook = (_, _) => series;
+        var restarted = NewPromoter(harness, queueCapacity: 2);
+        var replayed = NewSignal();
+        restarted.AfterPromotionForTest = _ => replayed.TrySetResult();
+
+        await restarted.StartAsync(CancellationToken.None);
+        await replayed.Task;
+        await restarted.StopAsync(CancellationToken.None);
+
+        var state = ReadState(harness.Manager, harness.User.Id);
+        Assert.Empty(state.PendingTmdb);
+        Assert.True(state.Series.ContainsKey(series.Id.ToString("N")));
+    }
+
+    [Fact]
+    public async Task DuplicateBurst_Coalesces_AndSaturationLeavesEveryIntentDurable()
+    {
+        var harness = CreateHarness(queueCapacity: 1);
+        harness.Library.GetItemListHook = _ => Array.Empty<BaseItem>();
+        var entered = NewSignal();
+        var release = NewSignal();
+        harness.Promoter.BeforePromotionForTest = key =>
+        {
+            if (string.Equals(key, "tv:100", StringComparison.OrdinalIgnoreCase))
+            {
+                entered.TrySetResult();
+            }
+
+            return release.Task;
+        };
+        await harness.Promoter.StartAsync(CancellationToken.None);
+
+        Assert.True(harness.Pending.RegisterSeerrIntent(
+            harness.User.Id,
+            "{\"mediaType\":\"tv\",\"mediaId\":100}").IsDurable);
+        await entered.Task;
+        for (var i = 0; i < 64; i++)
+        {
+            Assert.True(harness.Pending.RegisterSeerrIntent(
+                harness.User.Id,
+                "{\"mediaType\":\"tv\",\"mediaId\":100}").IsDurable);
+        }
+
+        Assert.True(harness.Pending.RegisterSeerrIntent(
+            harness.User.Id,
+            "{\"mediaType\":\"tv\",\"mediaId\":101}").IsDurable);
+        Assert.True(harness.Pending.RegisterSeerrIntent(
+            harness.User.Id,
+            "{\"mediaType\":\"tv\",\"mediaId\":102}").IsDurable);
+
+        var durable = ReadState(harness.Manager, harness.User.Id);
+        Assert.Equal(3, durable.PendingTmdb.Count);
+        Assert.Equal(1, harness.Promoter.RegisteredUserCountForTest("tv:100"));
+        Assert.InRange(harness.Promoter.ScheduledKeyCountForTest, 1, 2);
+
+        release.TrySetResult();
+        await harness.Promoter.StopAsync(CancellationToken.None);
+        Assert.Equal(3, ReadState(harness.Manager, harness.User.Id).PendingTmdb.Count);
+    }
+
+    [Fact]
+    public async Task SharedTmdbKey_PromotesEveryUserInOneCoalescedSweep()
+    {
+        var userA = new User("shared-a", "provider", "password-provider");
+        var userB = new User("shared-b", "provider", "password-provider");
+        var harness = CreateHarness(new[] { userA, userB });
+        const string pendingKey = "tv:789";
+        SavePending(harness.Manager, userA.Id, pendingKey);
+        SavePending(harness.Manager, userB.Id, pendingKey);
+        var series = VisibleSeries("789");
+        harness.Library.GetItemListHook = _ => new BaseItem[] { series };
+        harness.Library.GetItemByIdUserHook = (_, _) => series;
+        var swept = NewSignal();
+        harness.Promoter.AfterPromotionForTest = _ => swept.TrySetResult();
+
+        await harness.Promoter.StartAsync(CancellationToken.None);
+        await swept.Task;
+        await harness.Promoter.StopAsync(CancellationToken.None);
+
+        Assert.True(ReadState(harness.Manager, userA.Id).Series.ContainsKey(series.Id.ToString("N")));
+        Assert.True(ReadState(harness.Manager, userB.Id).Series.ContainsKey(series.Id.ToString("N")));
+    }
+
+    private Harness CreateHarness(int queueCapacity = 4)
+        => CreateHarness(new[] { new User("lifecycle-user", "provider", "password-provider") }, queueCapacity);
+
+    private Harness CreateHarness(IReadOnlyList<User> users, int queueCapacity = 4)
+    {
+        var manager = new UserConfigurationManager(
+            new StubAppPaths(_directory),
+            NullLogger<UserConfigurationManager>.Instance);
+        var library = new CountingLibraryManager();
+        var userManager = new StubUserManager(users.ToArray());
+        var provider = new FakePluginConfigProvider(new PluginConfiguration
+        {
+            SpoilerBlurEnabled = true,
+        });
+        var pending = new SpoilerPendingService(
+            manager,
+            library,
+            userManager,
+            NullLogger<SpoilerPendingService>.Instance);
+        var harness = new Harness(
+            manager,
+            library,
+            userManager,
+            provider,
+            pending,
+            null!,
+            users[0]);
+        return harness with { Promoter = NewPromoter(harness, queueCapacity) };
+    }
+
+    private static SpoilerSeerrPendingPromoter NewPromoter(Harness harness, int queueCapacity)
+        => new(
+            harness.Library,
+            harness.Users,
+            harness.Manager,
+            harness.Provider,
+            harness.Pending,
+            NullLogger<SpoilerSeerrPendingPromoter>.Instance,
+            queueCapacity);
+
+    private static void SavePending(UserConfigurationManager manager, Guid userId, string pendingKey)
+    {
+        var separator = pendingKey.IndexOf(':');
+        var state = new UserSpoilerBlur();
+        state.PendingTmdb[pendingKey] = new SpoilerBlurPendingEntry
+        {
+            MediaType = pendingKey.Substring(0, separator),
+            TmdbId = pendingKey.Substring(separator + 1),
+        };
+        manager.SaveUserConfiguration(userId.ToString("N"), SpoilerFile, state);
+    }
+
+    private static UserSpoilerBlur ReadState(UserConfigurationManager manager, Guid userId)
+        => manager.GetUserConfiguration<UserSpoilerBlur>(userId.ToString("N"), SpoilerFile);
+
+    private static Series VisibleSeries(string tmdbId)
+    {
+        var series = new Series { Id = Guid.NewGuid(), Name = "Series " + tmdbId };
+        series.ProviderIds["Tmdb"] = tmdbId;
+        return series;
+    }
+
+    private static TaskCompletionSource NewSignal()
+        => new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private sealed record Harness(
+        UserConfigurationManager Manager,
+        CountingLibraryManager Library,
+        StubUserManager Users,
+        FakePluginConfigProvider Provider,
+        SpoilerPendingService Pending,
+        SpoilerSeerrPendingPromoter Promoter,
+        User User);
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/TestDoubles/RecordingHttpClientFactory.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/TestDoubles/RecordingHttpClientFactory.cs
@@ -46,6 +46,10 @@ public sealed class RecordingHttpMessageHandler : HttpMessageHandler
     /// disposed by the caller's <c>using</c> once SendAsync returns, so the body must be read here).</summary>
     public List<CapturedRequest> Sent { get; } = new();
 
+    public Action<HttpRequestMessage>? BeforeResponse { get; set; }
+
+    public Func<HttpRequestMessage, HttpResponseMessage?>? ResponseFactory { get; set; }
+
     public sealed record CapturedRequest(HttpMethod Method, string Path, string Body);
 
     public void AddResponse(string pathSuffix, string body, HttpStatusCode status = HttpStatusCode.OK)
@@ -66,6 +70,13 @@ public sealed class RecordingHttpMessageHandler : HttpMessageHandler
         Sent.Add(new CapturedRequest(request.Method, request.RequestUri!.AbsolutePath, body));
 
         var path = request.RequestUri!.AbsolutePath;
+        BeforeResponse?.Invoke(request);
+        var customResponse = ResponseFactory?.Invoke(request);
+        if (customResponse != null)
+        {
+            return Task.FromResult(customResponse);
+        }
+
         foreach (var (suffix, response) in _responses)
         {
             if (path.EndsWith(suffix, StringComparison.Ordinal))

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/SeerrProxyController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/SeerrProxyController.cs
@@ -56,7 +56,6 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
 
         private readonly ISeerrClient _seerr;
         private readonly ISeerrParentalFilter _parentalFilter;
-        private readonly SpoilerPendingService _spoilerPending;
 
         internal Action? BeforeIssueProjectionPublishForTest { get; set; }
 
@@ -73,7 +72,6 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
         {
             _seerr = seerr;
             _parentalFilter = parentalFilter;
-            _spoilerPending = spoilerPending;
         }
 
         // Thin delegation kept so the ~35 proxy endpoints below read unchanged;
@@ -242,77 +240,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
         [Authorize]
         public async Task<IActionResult> SeerrRequest([FromBody] JsonElement requestBody)
         {
-            var result = await ProxySeerrRequest("/api/v1/request", HttpMethod.Post, requestBody.ToString());
-
-            // Auto-on-request Spoiler Guard pending — best-effort, never blocks the
-            // request. Gated by SpoilerBlurEnabled + SpoilerAutoEnableOnSeerrRequest.
-            // Only a 2xx counts as user intent; anything else fails closed.
-            try
-            {
-                var cfg = _configProvider.ConfigurationOrNull;
-                if (cfg?.SpoilerBlurEnabled == true
-                    && cfg?.SpoilerAutoEnableOnSeerrRequest == true
-                    && IsSeerrRequestResultSuccessful(result))
-                {
-                    // Snapshot identity + body BEFORE Task.Run — HttpContext/User are
-                    // invalid after we return; clone the request-scoped JsonElement.
-                    var userId = UserHelper.GetCurrentUserId(User);
-                    if (userId != null && userId != Guid.Empty)
-                    {
-                        var capturedUserId = userId.Value;
-                        JsonElement bodyClone;
-                        try { bodyClone = requestBody.Clone(); }
-                        catch { bodyClone = default; }
-
-                        if (bodyClone.ValueKind == JsonValueKind.Object)
-                        {
-                            _ = Task.Run(() => _spoilerPending.TryAutoEnableFromSeerrRequest(capturedUserId, bodyClone));
-                        }
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning($"Spoiler Guard auto-on-request hook threw {ex.GetType().Name}: {ex.Message}");
-            }
-
-            return result;
-        }
-
-        // True only for a 2xx proxy result. 409 fails closed: it's an ambiguous Seerr
-        // conflict (MEDIA_EXISTS vs quota/permission denial) whose body SeerrHttpHelper
-        // has already replaced, so we can't distinguish. Null StatusCode counts as OK
-        // only for ContentResult (the success path defaults to 200); a null on
-        // ObjectResult/StatusCodeResult is failure.
-        private static bool IsSeerrRequestResultSuccessful(IActionResult result)
-        {
-            int? status;
-            bool allowNullAsOk = false;
-            if (result is ContentResult cr)
-            {
-                status = cr.StatusCode;
-                allowNullAsOk = true;
-            }
-            else if (result is ObjectResult or)
-            {
-                status = or.StatusCode;
-            }
-            else if (result is StatusCodeResult sr)
-            {
-                status = sr.StatusCode;
-            }
-            else
-            {
-                return false;
-            }
-
-            if (status is null)
-            {
-                if (!allowNullAsOk) return false;
-                status = 200;
-            }
-            int sc = status.Value;
-            return sc >= 200 && sc < 300;
+            // The shared SeerrClient owns the success boundary.  It durably
+            // records any configured Spoiler Guard intent before returning the
+            // upstream 2xx, which also covers the TV-seasons controller route.
+            return await ProxySeerrRequest("/api/v1/request", HttpMethod.Post, requestBody.ToString());
         }
 
         [HttpGet("seerr/request")]

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/SpoilerGuardController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/SpoilerGuardController.cs
@@ -196,13 +196,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 {
                     foreach (var key in userConfiguration.PendingTmdb.Keys)
                     {
-                        SpoilerSeerrPendingPromoter.RegisterPending(key, gateUserId);
+                        _pendingService.NotifyPendingRegistered(key, gateUserId);
                     }
                     foreach (var stale in priorPending)
                     {
                         if (!userConfiguration.PendingTmdb.ContainsKey(stale))
                         {
-                            SpoilerSeerrPendingPromoter.UnregisterPending(stale, gateUserId);
+                            _pendingService.NotifyPendingRemoved(stale, gateUserId);
                         }
                     }
                 }
@@ -896,7 +896,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 SpoilerUserResolver.InvalidateUser(userKey);
                 // Either way the key is no longer pending for this user — keep the
                 // promoter's gate consistent so it stops sweeping this user.
-                SpoilerSeerrPendingPromoter.UnregisterPending(pendingKey, userId.Value);
+                _pendingService.NotifyPendingRemoved(pendingKey, userId.Value);
                 var (removedAnything, removedFrom, removedJellyfinId) = resultBox[0];
                 if (!removedAnything)
                 {

--- a/Jellyfin.Plugin.JellyfinCanopy/Helpers/Seerr/SeerrHttpHelper.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Helpers/Seerr/SeerrHttpHelper.cs
@@ -154,21 +154,70 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
             string url,
             SeerrDispatchFence dispatchFence,
             CancellationToken ct = default)
-            => SendAndReadJsonAsync(httpClient, request, url, MaxBodyBytes, dispatchFence, ct);
+            => SendAndReadJsonCoreAsync(
+                httpClient,
+                request,
+                url,
+                MaxBodyBytes,
+                dispatchFence,
+                responseHeadersObserved: null,
+                ct);
 
-        internal static async Task<(string? Json, SeerrError? Error, int HttpStatus)> SendAndReadJsonAsync(
+        internal static Task<(string? Json, SeerrError? Error, int HttpStatus)> SendAndReadJsonAsync(
+            HttpClient httpClient,
+            HttpRequestMessage request,
+            string url,
+            SeerrDispatchFence dispatchFence,
+            Func<HttpResponseMessage, bool> responseHeadersObserved,
+            CancellationToken ct = default)
+            => SendAndReadJsonCoreAsync(
+                httpClient,
+                request,
+                url,
+                MaxBodyBytes,
+                dispatchFence,
+                responseHeadersObserved,
+                ct);
+
+        internal static Task<(string? Json, SeerrError? Error, int HttpStatus)> SendAndReadJsonAsync(
             HttpClient httpClient,
             HttpRequestMessage request,
             string url,
             int maxBodyBytes,
             SeerrDispatchFence dispatchFence,
             CancellationToken ct = default)
+            => SendAndReadJsonCoreAsync(
+                httpClient,
+                request,
+                url,
+                maxBodyBytes,
+                dispatchFence,
+                responseHeadersObserved: null,
+                ct);
+
+        private static async Task<(string? Json, SeerrError? Error, int HttpStatus)> SendAndReadJsonCoreAsync(
+            HttpClient httpClient,
+            HttpRequestMessage request,
+            string url,
+            int maxBodyBytes,
+            SeerrDispatchFence dispatchFence,
+            Func<HttpResponseMessage, bool>? responseHeadersObserved,
+            CancellationToken ct)
         {
             using var response = await SendResponseHeadersReadAsync(
                 httpClient,
                 request,
                 dispatchFence,
                 ct).ConfigureAwait(false);
+            // This synchronous boundary runs immediately after the upstream
+            // response headers arrive and before RequestAborted is observed by
+            // the bounded body reader. Mutation owners can durably record a
+            // confirmed 2xx side effect here without bypassing the shared
+            // timeout, cancellation, content-type, and body-size protections.
+            if (responseHeadersObserved?.Invoke(response) == false)
+            {
+                return (null, null, (int)response.StatusCode);
+            }
             var (json, error) = await ReadResponseAsync(response, url, maxBodyBytes, ct).ConfigureAwait(false);
             return (json, error, (int)response.StatusCode);
         }

--- a/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
@@ -162,8 +162,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy
             serviceCollection.AddSingleton<SpoilerBlurImageFilter>();
             serviceCollection.AddSingleton<SpoilerFieldStripFilter>();
             // Shared pre-acquisition ("pending") pending-add core used by BOTH the
-            // SpoilerGuardController HTTP endpoints and the Seerr auto-request hook on
-            // SeerrProxyController. Depends only on the config store + library +
+            // SpoilerGuardController HTTP endpoints and SeerrClient's durable
+            // auto-request success boundary. Depends only on the config store + library +
             // user managers (never ISeerrClient), so it stays cycle-free.
             serviceCollection.AddSingleton<SpoilerPendingService>();
             serviceCollection.AddHostedService<SpoilerSeerrPendingPromoter>();

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrClient.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrClient.cs
@@ -11,6 +11,7 @@ using Jellyfin.Plugin.JellyfinCanopy.Configuration;
 using Jellyfin.Plugin.JellyfinCanopy.Helpers;
 using Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr;
 using Jellyfin.Plugin.JellyfinCanopy.Model.Seerr;
+using Jellyfin.Plugin.JellyfinCanopy.Services;
 using MediaBrowser.Controller.Library;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -39,6 +40,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
         private readonly ISeerrCache _seerrCache;
         private readonly IPluginConfigProvider _configProvider;
         private readonly ISeerrParentalFilter _parentalFilter;
+        private readonly SpoilerPendingService _spoilerPendingService;
         private readonly ConcurrentDictionary<string, SemaphoreSlim> _userResolutionGates = new(
             StringComparer.OrdinalIgnoreCase);
 
@@ -48,7 +50,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             IUserManager userManager,
             ISeerrCache seerrCache,
             IPluginConfigProvider configProvider,
-            ISeerrParentalFilter parentalFilter)
+            ISeerrParentalFilter parentalFilter,
+            SpoilerPendingService spoilerPendingService)
         {
             _httpClientFactory = httpClientFactory;
             _logger = logger;
@@ -56,6 +59,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             _seerrCache = seerrCache;
             _configProvider = configProvider;
             _parentalFilter = parentalFilter;
+            _spoilerPendingService = spoilerPendingService;
         }
 
         // ── URL / id helpers (hoisted from SeerrUserResolver) ───────────
@@ -2121,6 +2125,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                 urls = new[] { boundSourceUrl! };
             }
 
+            // Freeze this mutation's local durability obligation after the final
+            // pre-dispatch configuration/identity proof. PluginConfiguration is
+            // mutable, so reading the live object again after a Seerr 2xx could
+            // let an in-place true→false change silently abandon an obligation
+            // that was enabled when the request was sent.
+            var persistSpoilerIntentOnSuccess = config.SpoilerBlurEnabled
+                && config.SpoilerAutoEnableOnSeerrRequest
+                && IsCreateMediaRequest(apiPath, method);
             var httpClient = SeerrHttpHelper.CreateClient(_httpClientFactory);
             httpClient.Timeout = TimeSpan.FromSeconds(15);
 
@@ -2190,12 +2202,37 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                     using var request = SeerrHttpHelper.BuildRequest(method, requestUri, config.SeerrApiKey, requestUserId, content);
                     if (content != null) _logger.LogDebug($"Request body: {content}");
 
+                    IActionResult? spoilerIntentFailure = null;
                     var (json, error, _) = await SeerrHttpHelper.SendAndReadJsonAsync(
                         httpClient,
                         request,
                         requestUri,
                         requestDispatchFence,
+                        response =>
+                        {
+                            if (persistSpoilerIntentOnSuccess
+                                && response.IsSuccessStatusCode
+                                && SeerrHttpHelper.IsJsonContentType(response))
+                            {
+                                // ResponseHeadersRead has confirmed the upstream
+                                // mutation before the caller cancellation token is
+                                // next observed by the bounded JSON body reader.
+                                spoilerIntentFailure = RecordSpoilerIntent(
+                                    jellyfinUserId,
+                                    content);
+                            }
+
+                            // A combined-failure result is already complete at
+                            // this boundary; do not let a slow/cancelled response
+                            // body hide the explicit remediation from the caller.
+                            return spoilerIntentFailure == null;
+                        },
                         cancellationToken).ConfigureAwait(false);
+
+                    if (spoilerIntentFailure != null)
+                    {
+                        return spoilerIntentFailure;
+                    }
 
                     if (error == null && json != null)
                     {
@@ -2311,6 +2348,71 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             }
 
             return new ObjectResult(lastErrorBody) { StatusCode = lastStatusCode };
+        }
+
+        private static bool IsCreateMediaRequest(string apiPath, HttpMethod method)
+        {
+            if (method != HttpMethod.Post)
+            {
+                return false;
+            }
+
+            var queryIndex = apiPath.IndexOf('?', StringComparison.Ordinal);
+            var pathOnly = queryIndex >= 0 ? apiPath.Substring(0, queryIndex) : apiPath;
+            pathOnly = pathOnly.TrimEnd('/');
+            return string.Equals(pathOnly, "/api/v1/request", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private IActionResult? RecordSpoilerIntent(string jellyfinUserId, string? content)
+        {
+            string failureCode;
+            try
+            {
+                if (_spoilerPendingService == null)
+                {
+                    failureCode = "intent_service_unavailable";
+                }
+                else if (!Guid.TryParse(jellyfinUserId, out var userId) || userId == Guid.Empty)
+                {
+                    failureCode = "jellyfin_user_unavailable";
+                }
+                else
+                {
+                    var registration = _spoilerPendingService.RegisterSeerrIntent(userId, content);
+                    if (registration.IsDurable)
+                    {
+                        return null;
+                    }
+
+                    failureCode = registration.Code;
+                }
+            }
+            catch (Exception ex)
+            {
+                failureCode = "intent_store_unavailable";
+                _logger.LogError(
+                    ex,
+                    "Seerr accepted a media request for {User}, but its Spoiler Guard intent could not be persisted.",
+                    ResolveUserDisplay(jellyfinUserId));
+            }
+
+            _logger.LogWarning(
+                "Seerr accepted a media request for {User}, but Spoiler Guard intent registration failed: {FailureCode}",
+                ResolveUserDisplay(jellyfinUserId),
+                failureCode);
+            var message = failureCode == "unsupported_request_target"
+                ? "Seerr accepted a request target outside its supported movie/tv contract, so Spoiler Guard cannot auto-protect it. Do not retry the request; verify the accepted request in Seerr and manually protect a supported movie or series if needed."
+                : "Seerr accepted the request, but Spoiler Guard could not record its pending intent. Do not retry the Seerr request; add the title to Spoiler Guard manually.";
+            return new ObjectResult(new
+            {
+                error = true,
+                code = "seerr_accepted_spoiler_intent_failed",
+                message,
+                seerrAccepted = true,
+                spoilerIntentRecorded = false,
+                reason = failureCode,
+            })
+            { StatusCode = 500 };
         }
 
         public void InvalidateUserIdentityCache(string jellyfinUserId)

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/SpoilerPendingService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/SpoilerPendingService.cs
@@ -16,8 +16,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
     /// Shared core for the pre-acquisition ("pending") Spoiler Guard flow. Owns the
     /// TMDB→library lookup, the pending-entry cap, the display-name sanitizer and the
     /// RMW promote/record logic so BOTH the HTTP endpoint (SpoilerGuardController's
-    /// POST/DELETE spoiler-blur/pending) AND the fire-and-forget Seerr auto-request
-    /// hook (SeerrProxyController) reuse one implementation.
+    /// POST/DELETE spoiler-blur/pending) and the synchronous SeerrClient success
+    /// boundary reuse one implementation.
     ///
     /// Registered as a singleton. Deliberately depends only on the config store,
     /// ILibraryManager and IUserManager — never on ISeerrClient — so it can be
@@ -36,6 +36,16 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         private readonly IUserManager _userManager;
         private readonly ILogger<SpoilerPendingService> _logger;
 
+        /// <summary>
+        /// Raised after the durable store has changed (or an existing durable row
+        /// has been re-observed).  The hosted promoter treats this only as a
+        /// bounded acceleration signal; <c>spoilerblur.json</c> remains the replay
+        /// authority when no worker is running or its queue is saturated.
+        /// </summary>
+        internal event Action<string, Guid, bool>? PendingRegistrationChanged;
+
+        internal Action? BeforeCapFallbackForTest { get; set; }
+
         public SpoilerPendingService(
             UserConfigurationManager userConfigurationManager,
             ILibraryManager libraryManager,
@@ -49,15 +59,191 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         }
 
         /// <summary>
-        /// Structured outcome shared by the HTTP layer and the fire-and-forget log layer.
+        /// Structured outcome shared by the HTTP layer and Seerr intent registration.
         /// <c>Promoted</c> is one of "series", "movie", "pending" or "cap-exceeded".
         /// </summary>
         public sealed record SpoilerBlurPendingResult(string Promoted, string? JellyfinId, string? Name, bool WroteSomething);
 
-        // ─── Shared core (manual POST + auto-on-Seerr-request) ───────────────────
+        /// <summary>
+        /// Result of synchronously recording the local half of a successful Seerr
+        /// media request.  A successful result means either PendingTmdb or the
+        /// final Series/Movies collection was atomically persisted before the
+        /// caller received the Seerr acknowledgment.
+        /// </summary>
+        internal sealed record SeerrIntentRegistration(bool IsDurable, string Code, string? PendingKey = null);
+
+        /// <summary>
+        /// Persists the smallest replayable Spoiler Guard intent without doing a
+        /// library query first.  Promotion is signalled only after the strict RMW
+        /// returns, so an accepted worker item can never outrun its durable row.
+        /// </summary>
+        internal SeerrIntentRegistration RegisterSeerrIntent(Guid userId, string? requestBody)
+        {
+            if (!TryParseSeerrRequestTarget(
+                    requestBody,
+                    out var mediaType,
+                    out var canonicalTmdb,
+                    out var parseFailureCode))
+            {
+                return new SeerrIntentRegistration(false, parseFailureCode);
+            }
+
+            var jUser = _userManager.GetUserById(userId);
+            if (jUser == null)
+            {
+                return new SeerrIntentRegistration(false, "jellyfin_user_unavailable");
+            }
+
+            var pendingKey = $"{mediaType}:{canonicalTmdb}";
+            var userKey = userId.ToString("N");
+            var capExceeded = false;
+            _userConfigurationManager.RmwUserConfiguration<UserSpoilerBlur>(
+                userKey,
+                SpoilerBlurImageFilter.SpoilerBlurFileName,
+                state =>
+                {
+                    if (state.PendingTmdb.ContainsKey(pendingKey))
+                    {
+                        return 0;
+                    }
+
+                    if (state.PendingTmdb.Count >= MaxPendingTmdbPerUser)
+                    {
+                        capExceeded = true;
+                        return 0;
+                    }
+
+                    state.PendingTmdb[pendingKey] = new SpoilerBlurPendingEntry
+                    {
+                        MediaType = mediaType,
+                        TmdbId = canonicalTmdb,
+                        DisplayName = string.Empty,
+                        RequestedAt = DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture),
+                    };
+                    return 1;
+                });
+
+            SpoilerUserResolver.InvalidateUser(userKey);
+            if (!capExceeded)
+            {
+                NotifyPendingRegistered(pendingKey, userId);
+                return new SeerrIntentRegistration(true, "recorded", pendingKey);
+            }
+
+            // Preserve the pre-existing cap contract: an already-present,
+            // accessible title can still be protected directly even when all 500
+            // pre-acquisition slots are occupied.  This synchronous fallback is
+            // also durable before acknowledgment; only unresolved titles fail with
+            // the explicit partial-success contract at the Seerr boundary.
+            BeforeCapFallbackForTest?.Invoke();
+            var promoted = AddPending(userId, jUser, mediaType, canonicalTmdb, displayName: null);
+            return promoted.Promoted switch
+            {
+                "series" or "movie" => new SeerrIntentRegistration(true, "promoted", pendingKey),
+                // Capacity may open between the first strict cap check and the
+                // compatibility fallback. AddPending's `pending` result proves
+                // the target row is now durable, whether this invocation wrote it
+                // or re-observed a concurrent writer.
+                "pending" => new SeerrIntentRegistration(true, "recorded", pendingKey),
+                _ => new SeerrIntentRegistration(false, "pending_cap_exceeded", pendingKey),
+            };
+        }
+
+        private static bool TryParseSeerrRequestTarget(
+            string? requestBody,
+            out string mediaType,
+            out string canonicalTmdb,
+            out string failureCode)
+        {
+            mediaType = string.Empty;
+            canonicalTmdb = string.Empty;
+            failureCode = "invalid_request_target";
+            if (string.IsNullOrWhiteSpace(requestBody))
+            {
+                return false;
+            }
+
+            try
+            {
+                using var document = JsonDocument.Parse(requestBody);
+                var root = document.RootElement;
+                if (root.ValueKind != JsonValueKind.Object
+                    || !root.TryGetProperty("mediaType", out var mediaTypeElement)
+                    || mediaTypeElement.ValueKind != JsonValueKind.String
+                    || !root.TryGetProperty("mediaId", out var mediaIdElement))
+                {
+                    return false;
+                }
+
+                mediaType = mediaTypeElement.GetString()?.Trim().ToLowerInvariant() ?? string.Empty;
+                if (mediaType is not ("tv" or "movie"))
+                {
+                    failureCode = "unsupported_request_target";
+                    return false;
+                }
+
+                int tmdbId;
+                if (mediaIdElement.ValueKind == JsonValueKind.Number)
+                {
+                    if (!mediaIdElement.TryGetInt32(out tmdbId))
+                    {
+                        return false;
+                    }
+                }
+                else if (mediaIdElement.ValueKind == JsonValueKind.String)
+                {
+                    if (!int.TryParse(
+                            mediaIdElement.GetString(),
+                            NumberStyles.Integer,
+                            CultureInfo.InvariantCulture,
+                            out tmdbId))
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    return false;
+                }
+
+                if (tmdbId <= 0)
+                {
+                    return false;
+                }
+
+                canonicalTmdb = tmdbId.ToString(CultureInfo.InvariantCulture);
+                return true;
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+        }
+
+        internal void NotifyPendingRegistered(string pendingKey, Guid userId)
+        {
+            if (string.IsNullOrEmpty(pendingKey) || userId == Guid.Empty)
+            {
+                return;
+            }
+
+            PendingRegistrationChanged?.Invoke(pendingKey, userId, true);
+        }
+
+        internal void NotifyPendingRemoved(string pendingKey, Guid userId)
+        {
+            if (string.IsNullOrEmpty(pendingKey) || userId == Guid.Empty)
+            {
+                return;
+            }
+
+            PendingRegistrationChanged?.Invoke(pendingKey, userId, false);
+        }
+
+        // ─── Shared core (manual POST + cap-full Seerr fallback) ─────────────────
         // Library lookup + RMW. Strict-read corruption (InvalidDataException /
         // JsonException) propagates to the caller so the HTTP endpoint can 503; the
-        // Seerr hook wraps this in a log-and-swallow.
+        // SeerrClient converts this into an explicit partial-success response.
         public SpoilerBlurPendingResult AddPending(
             Guid userId,
             JUser jUser,
@@ -86,7 +272,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                         };
                         return 1;
                     });
-                SpoilerSeerrPendingPromoter.UnregisterPending(pendingKey, userId);
+                NotifyPendingRemoved(pendingKey, userId);
                 SpoilerUserResolver.InvalidateUser(userKey); // F7: state changed (Series/Movies)
                 _logger.LogInformation($"Spoiler Guard pending resolved to existing series '{existingSeries.Name}' ({seriesKey}) for {ResolveUserDisplay(userKey)}");
                 return new SpoilerBlurPendingResult("series", seriesKey, existingSeries.Name, changed > 0);
@@ -107,7 +293,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                         };
                         return 1;
                     });
-                SpoilerSeerrPendingPromoter.UnregisterPending(pendingKey, userId);
+                NotifyPendingRemoved(pendingKey, userId);
                 SpoilerUserResolver.InvalidateUser(userKey); // F7: state changed (Series/Movies)
                 _logger.LogInformation($"Spoiler Guard pending resolved to existing movie '{existingMovie.Name}' ({movieKey}) for {ResolveUserDisplay(userKey)}");
                 return new SpoilerBlurPendingResult("movie", movieKey, existingMovie.Name, changed > 0);
@@ -153,7 +339,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             }
             // Prime the promoter's fast-path gate so the next ItemAdded matching this
             // TMDB id sweeps THIS user instead of bailing.
-            SpoilerSeerrPendingPromoter.RegisterPending(pendingKey, userId);
+            NotifyPendingRegistered(pendingKey, userId);
             _logger.LogInformation($"Spoiler Guard pending recorded {pendingKey} for {ResolveUserDisplay(userKey)} (not yet in library)");
 
             // TOCTOU recovery: the scanner may have added the item between the
@@ -196,7 +382,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     };
                     return 1;
                 });
-            SpoilerSeerrPendingPromoter.UnregisterPending(pendingKey, userId);
+            NotifyPendingRemoved(pendingKey, userId);
             SpoilerUserResolver.InvalidateUser(userKey); // F7: state changed (Series)
             _logger.LogInformation($"Spoiler Guard pending TOCTOU-promoted to series '{series.Name}' ({seriesKey}) for {ResolveUserDisplay(userKey)}");
             return new SpoilerBlurPendingResult("series", seriesKey, series.Name, true);
@@ -219,7 +405,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     };
                     return 1;
                 });
-            SpoilerSeerrPendingPromoter.UnregisterPending(pendingKey, userId);
+            NotifyPendingRemoved(pendingKey, userId);
             SpoilerUserResolver.InvalidateUser(userKey); // F7: state changed (Movies)
             _logger.LogInformation($"Spoiler Guard pending TOCTOU-promoted to movie '{movie.Name}' ({movieKey}) for {ResolveUserDisplay(userKey)}");
             return new SpoilerBlurPendingResult("movie", movieKey, movie.Name, true);
@@ -259,54 +445,6 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 _logger.LogWarning($"FindLibraryItemByTmdb({mediaType}, {tmdbId}) threw {ex.GetType().Name}: {ex.Message}");
             }
             return null;
-        }
-
-        // Off-thread continuation for the Seerr auto-request hook — must NOT touch
-        // HttpContext / User (userId is captured by the caller before Task.Run). Parses
-        // the cloned request body, resolves the user, and delegates to AddPending.
-        // Log-and-swallow: a Spoiler Guard failure must never surface on the request.
-        public void TryAutoEnableFromSeerrRequest(Guid userId, JsonElement requestBody)
-        {
-            try
-            {
-                if (requestBody.ValueKind != JsonValueKind.Object) return;
-                if (!requestBody.TryGetProperty("mediaType", out var mtProp) || mtProp.ValueKind != JsonValueKind.String) return;
-                if (!requestBody.TryGetProperty("mediaId", out var miProp)) return;
-
-                var rawType = mtProp.GetString();
-                if (string.IsNullOrEmpty(rawType)) return;
-                var mediaType = rawType.ToLowerInvariant();
-                if (mediaType != "tv" && mediaType != "movie") return;
-
-                int tmdbInt;
-                if (miProp.ValueKind == JsonValueKind.Number)
-                {
-                    if (!miProp.TryGetInt32(out tmdbInt) || tmdbInt <= 0) return;
-                }
-                else if (miProp.ValueKind == JsonValueKind.String)
-                {
-                    if (!int.TryParse(miProp.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out tmdbInt)
-                        || tmdbInt <= 0) return;
-                }
-                else
-                {
-                    return;
-                }
-
-                var jUser = _userManager.GetUserById(userId);
-                if (jUser == null) return;
-
-                var canonicalTmdb = tmdbInt.ToString(CultureInfo.InvariantCulture);
-                var summary = AddPending(userId, jUser, mediaType, canonicalTmdb, displayName: null);
-                if (summary.WroteSomething)
-                {
-                    _logger.LogInformation($"Spoiler Guard auto-on-request {summary.Promoted} for {mediaType}:{canonicalTmdb} by {ResolveUserDisplay(userId.ToString("N"))}");
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning($"Spoiler Guard auto-on-request task threw {ex.GetType().Name}: {ex.Message}");
-            }
         }
 
         // Clamp + strip control / format chars so a poisoned modal payload can't grow

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/SpoilerSeerrPendingPromoter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/SpoilerSeerrPendingPromoter.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
 using MediaBrowser.Controller.Entities;
@@ -15,108 +16,34 @@ using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.JellyfinCanopy.Services
 {
-    // Promotes pending Spoiler Guard entries (UserSpoilerBlur.PendingTmdb) into
-    // real Series/Movies entries when matching library items land via Seerr or
-    // any other source. Hooks ILibraryManager.ItemAdded + ItemUpdated.
-    //
-    // Load discipline: library events fire in rapid bursts while a season is
-    // importing (each episode add refreshes the parent Series, so one download
-    // batch can raise dozens of Series ItemUpdated events in under a minute).
-    // Everything here is therefore designed to stay OFF the scanner's hot path
-    // and OFF the library database during those bursts:
-    //
-    //   1. _pendingUsersByKey maps "tv:{tmdb}"/"movie:{tmdb}" -> the set of
-    //      users who actually have that key pending. A sweep only ever touches
-    //      those users (usually exactly one) — never the whole user table.
-    //   2. Sweeps are coalesced per key: one in-flight sweep at a time, a
-    //      rerun flag for events that arrive mid-sweep, and a short settle
-    //      delay so an import burst collapses into a single sweep instead of
-    //      one library read + file RMW per event.
-    //   3. Keys are UNREGISTERED once no user holds them anymore (promotion,
-    //      user delete, or pending-DELETE endpoint), so a promoted show stops
-    //      costing anything on subsequent library events. The gate is a pure
-    //      performance optimization — per-user spoilerblur.json files remain
-    //      the source of truth, and sweeps re-verify against them.
-    //
-    // Per-user library access is checked via GetItemById(id, user) — a user
-    // who can't see the new item won't get the Spoiler Guard entry promoted
-    // for them (they stay registered and are retried on later events), which
-    // would otherwise be a UX bug (entry shows up in their management UI for
-    // a title they can't access).
+    /// <summary>
+    /// Promotes durable <see cref="UserSpoilerBlur.PendingTmdb"/> rows when the
+    /// corresponding media becomes visible in a user's library.  One bounded,
+    /// instance-owned worker serializes all file writes; library events only
+    /// record a coalesced key and never perform database or file I/O.
+    /// </summary>
     public sealed class SpoilerSeerrPendingPromoter : IHostedService
     {
-        // Populated on StartAsync from the per-user spoilerblur.json files and
-        // kept in sync by the controller endpoints + the sweeps below.
-        private static readonly ConcurrentDictionary<string, ConcurrentDictionary<Guid, byte>> _pendingUsersByKey
+        internal const int DefaultQueueCapacity = 256;
+
+        private readonly ConcurrentDictionary<string, ConcurrentDictionary<Guid, byte>> _pendingUsersByKey
             = new(StringComparer.OrdinalIgnoreCase);
-
-        // Per-key sweep coalescing. _sweepRunning holds keys with an active
-        // background sweep; _sweepRerun holds keys that saw another library
-        // event while their sweep was running (or scheduled) and need one more
-        // pass afterwards.
-        private static readonly ConcurrentDictionary<string, byte> _sweepRunning
+        private readonly ConcurrentDictionary<string, byte> _queuedOrRunning
             = new(StringComparer.OrdinalIgnoreCase);
-        private static readonly ConcurrentDictionary<string, byte> _sweepRerun
+        private readonly ConcurrentDictionary<string, byte> _rerun
             = new(StringComparer.OrdinalIgnoreCase);
-
-        // How long a scheduled sweep waits before running. Two purposes:
-        // lets the burst of ItemAdded/ItemUpdated events a season import
-        // fires coalesce into one sweep, and keeps our library reads away
-        // from the exact moment the scanner is writing the item that raised
-        // the event. Promotion is not latency-sensitive — the entry only
-        // needs to flip before the user next browses the title.
-        private const int SweepSettleDelayMs = 2000;
-
-        // Exposed so the controller's POST/DELETE endpoints can keep the gate
-        // accurate without coupling to the hosted-service instance.
-        public static void RegisterPending(string pendingKey, Guid userId)
-        {
-            if (string.IsNullOrEmpty(pendingKey) || userId == Guid.Empty) return;
-            var users = _pendingUsersByKey.GetOrAdd(
-                pendingKey, _ => new ConcurrentDictionary<Guid, byte>());
-            users.TryAdd(userId, 0);
-        }
-
-        public static void UnregisterPending(string pendingKey, Guid userId)
-        {
-            if (string.IsNullOrEmpty(pendingKey) || userId == Guid.Empty) return;
-            if (!_pendingUsersByKey.TryGetValue(pendingKey, out var users)) return;
-            users.TryRemove(userId, out _);
-            if (users.IsEmpty)
-            {
-                // Remove the key, but atomically: a concurrent RegisterPending
-                // could add a user to `users` between our IsEmpty check and the
-                // removal, which would strand that user's pending row (no sweep
-                // until restart). TryRemove(KeyValuePair) only deletes if the
-                // mapped set is STILL the same (now-empty) instance; if a racer
-                // swapped in a fresh set via GetOrAdd, or repopulated this one,
-                // the delete is refused. Re-check the recovered set and merge
-                // any late arrivals back so nothing is lost.
-                if (((ICollection<KeyValuePair<string, ConcurrentDictionary<Guid, byte>>>)_pendingUsersByKey)
-                        .Remove(new KeyValuePair<string, ConcurrentDictionary<Guid, byte>>(pendingKey, users))
-                    && !users.IsEmpty)
-                {
-                    foreach (var lateUser in users.Keys)
-                    {
-                        RegisterPending(pendingKey, lateUser);
-                    }
-                }
-            }
-        }
-
-        // Test seams (Tests has InternalsVisibleTo) over the static gate.
-        internal static bool IsKeyRegisteredForTest(string pendingKey)
-            => _pendingUsersByKey.ContainsKey(pendingKey);
-
-        internal static int RegisteredUserCountForTest(string pendingKey)
-            => _pendingUsersByKey.TryGetValue(pendingKey, out var users) ? users.Count : 0;
-
+        private readonly SemaphoreSlim _lifecycleGate = new(1, 1);
         private readonly ILibraryManager _libraryManager;
         private readonly IUserManager _userManager;
         private readonly UserConfigurationManager _configManager;
         private readonly IPluginConfigProvider _configProvider;
         private readonly SpoilerPendingService _pendingService;
         private readonly ILogger<SpoilerSeerrPendingPromoter> _logger;
+        private readonly int _queueCapacity;
+
+        private Channel<string>? _channel;
+        private Task? _workerTask;
+        private volatile bool _accepting;
 
         public SpoilerSeerrPendingPromoter(
             ILibraryManager libraryManager,
@@ -124,88 +51,301 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             UserConfigurationManager configManager,
             IPluginConfigProvider configProvider,
             SpoilerPendingService pendingService,
-            ILogger<SpoilerSeerrPendingPromoter> logger)
+            ILogger<SpoilerSeerrPendingPromoter> logger,
+            int queueCapacity = DefaultQueueCapacity)
         {
+            if (queueCapacity <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(queueCapacity));
+            }
+
             _libraryManager = libraryManager;
             _userManager = userManager;
             _configManager = configManager;
             _configProvider = configProvider;
-            // Reused for the F5 user-scoped TMDB duplicate lookup. Depends only
-            // on the config/library/user managers (never ISeerrClient nor
-            // this promoter), so injecting it here introduces no DI cycle.
             _pendingService = pendingService;
             _logger = logger;
+            _queueCapacity = queueCapacity;
         }
 
-        public Task StartAsync(CancellationToken cancellationToken)
+        /// <summary>
+        /// Deterministic barrier used only by concurrency tests.  It runs on the
+        /// single worker immediately before a promotion attempt.
+        /// </summary>
+        internal Func<string, Task>? BeforePromotionForTest { get; set; }
+
+        internal Action<string>? AfterPromotionForTest { get; set; }
+
+        internal Action<string, Guid>? PendingDictionaryAcquiredForTest { get; set; }
+
+        internal bool IsKeyRegisteredForTest(string pendingKey)
+            => _pendingUsersByKey.ContainsKey(pendingKey);
+
+        internal int RegisteredUserCountForTest(string pendingKey)
+            => _pendingUsersByKey.TryGetValue(pendingKey, out var users) ? users.Count : 0;
+
+        internal bool IsUserRegisteredForTest(string pendingKey, Guid userId)
+            => _pendingUsersByKey.TryGetValue(pendingKey, out var users)
+                && users.ContainsKey(userId);
+
+        internal int ScheduledKeyCountForTest => _queuedOrRunning.Count;
+
+        public async Task StartAsync(CancellationToken cancellationToken)
         {
-            // Repopulate the in-memory gate from disk so a restart doesn't
-            // silently break promotion for users with already-pending entries.
+            await _lifecycleGate.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                ScanExistingPendingKeys();
+                if (_accepting)
+                {
+                    return;
+                }
+
+                _pendingUsersByKey.Clear();
+                _queuedOrRunning.Clear();
+                _rerun.Clear();
+                var channel = Channel.CreateBounded<string>(new BoundedChannelOptions(_queueCapacity)
+                {
+                    SingleReader = true,
+                    SingleWriter = false,
+                    FullMode = BoundedChannelFullMode.Wait,
+                    AllowSynchronousContinuations = false,
+                });
+                _channel = channel;
+                _accepting = true;
+                _pendingService.PendingRegistrationChanged += OnPendingRegistrationChanged;
+                _libraryManager.ItemAdded += OnItemAdded;
+                _libraryManager.ItemUpdated += OnItemAdded;
+                _workerTask = RunWorkerAsync(channel.Reader);
+                // Rebuild the instance gate from disk and actively enqueue every
+                // durable key.  Bounded WriteAsync backpressures startup rather than
+                // dropping rows; this closes the old restart gap where rows were only
+                // indexed and then waited forever for another library event.
+                try
+                {
+                    var startupKeys = ScanExistingPendingKeys();
+                    foreach (var key in startupKeys)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        await ScheduleStartupAsync(channel.Writer, key, cancellationToken).ConfigureAwait(false);
+                    }
+                }
+                catch
+                {
+                    // Start already owns the lifecycle gate, so clean this failed
+                    // generation directly rather than recursively waiting on it.
+                    await StopOwnedGenerationAsync().ConfigureAwait(false);
+                    throw;
+                }
             }
-            catch (Exception ex)
+            finally
             {
-                _logger.LogWarning($"SpoilerSeerrPromoter: startup scan failed (gate may miss already-pending entries until next write): {ex.Message}");
+                _lifecycleGate.Release();
             }
-            _libraryManager.ItemAdded += OnItemAdded;
-            // ItemAdded fires before Jellyfin's TMDB provider has fetched
-            // metadata — ProviderIds.Tmdb is typically empty at that moment.
-            // ItemUpdated fires after metadata refresh, at which point
-            // ProviderIds.Tmdb is populated, so we re-run the same logic.
-            // The sweep is idempotent (gate + ContainsKey checks) so the
-            // double-fire on items that arrive with metadata already in
-            // place is harmless.
-            _libraryManager.ItemUpdated += OnItemAdded;
-            return Task.CompletedTask;
         }
 
-        public Task StopAsync(CancellationToken cancellationToken)
+        public async Task StopAsync(CancellationToken cancellationToken)
         {
+            // A stop owns lifecycle serialization until its worker is completely
+            // drained. A concurrent Start therefore cannot clear or reuse maps
+            // while the old generation is still finishing accepted writes.
+            await _lifecycleGate.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+            try
+            {
+                await StopOwnedGenerationAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                _lifecycleGate.Release();
+            }
+
+            // StopAsync's token is a host deadline, not permission to orphan a
+            // writer. Once stop has begun, drain the finite accepted set and
+            // return only after the worker is gone, even if that deadline fired.
+        }
+
+        private async Task StopOwnedGenerationAsync()
+        {
+            Channel<string>? channel;
+            Task? worker;
+            if (!_accepting && _workerTask == null)
+            {
+                return;
+            }
+
+            _accepting = false;
+            _pendingService.PendingRegistrationChanged -= OnPendingRegistrationChanged;
             _libraryManager.ItemAdded -= OnItemAdded;
             _libraryManager.ItemUpdated -= OnItemAdded;
-            return Task.CompletedTask;
+            channel = _channel;
+            worker = _workerTask;
+            channel?.Writer.TryComplete();
+
+            // Accepted work is finite (bounded channel + coalesced keys), so drain
+            // it before returning.  We deliberately do not abandon the worker when
+            // the host token is cancelled: after this await completes there is no
+            // task left that can write user configuration.
+            if (worker != null)
+            {
+                await worker.ConfigureAwait(false);
+            }
+
+            if (ReferenceEquals(_channel, channel))
+            {
+                _channel = null;
+                _workerTask = null;
+                _queuedOrRunning.Clear();
+                _rerun.Clear();
+                _pendingUsersByKey.Clear();
+            }
         }
 
-        // Best-effort startup scan — corrupt or missing files are skipped on
-        // purpose: the gate is a performance optimization, not a correctness
-        // invariant. Reuses UserConfigurationManager's path + serializer
-        // discipline (GetAllUserIds enumerates the canonical per-user config
-        // dirs under {PluginsPath}/configurations/Jellyfin.Plugin.JellyfinCanopy;
-        // GetUserConfiguration is the lenient System.Text.Json read the store
-        // writes with) instead of a raw file read + separate deserializer.
-        private void ScanExistingPendingKeys()
+        private IReadOnlyList<string> ScanExistingPendingKeys()
         {
-            int users = 0, keys = 0;
+            var keysToSchedule = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var userCount = 0;
+            var rowCount = 0;
             foreach (var userIdN in _configManager.GetAllUserIds())
             {
-                if (!Guid.TryParseExact(userIdN, "N", out var userId)) continue;
+                if (!Guid.TryParseExact(userIdN, "N", out var userId))
+                {
+                    continue;
+                }
 
                 UserSpoilerBlur state;
                 try
                 {
                     state = _configManager.GetUserConfiguration<UserSpoilerBlur>(
-                        userIdN, SpoilerBlurImageFilter.SpoilerBlurFileName);
+                        userIdN,
+                        SpoilerBlurImageFilter.SpoilerBlurFileName);
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogWarning($"SpoilerSeerrPromoter: skipping unreadable state for {userIdN}: {ex.GetType().Name}");
+                    _logger.LogWarning(
+                        "SpoilerSeerrPromoter: skipping unreadable state for {User}: {ExceptionType}",
+                        userIdN,
+                        ex.GetType().Name);
                     continue;
                 }
 
-                if (state?.PendingTmdb == null || state.PendingTmdb.Count == 0) continue;
-                users++;
+                if (state.PendingTmdb.Count == 0)
+                {
+                    continue;
+                }
+
+                userCount++;
                 foreach (var key in state.PendingTmdb.Keys)
                 {
-                    if (string.IsNullOrEmpty(key)) continue;
+                    if (string.IsNullOrEmpty(key))
+                    {
+                        continue;
+                    }
+
                     RegisterPending(key, userId);
-                    keys++;
+                    keysToSchedule.Add(key);
+                    rowCount++;
                 }
             }
-            if (keys > 0)
+
+            if (rowCount > 0)
             {
-                _logger.LogInformation($"SpoilerSeerrPromoter: gate primed with {keys} pending key(s) across {users} user file(s)");
+                _logger.LogInformation(
+                    "SpoilerSeerrPromoter: replaying {Rows} durable pending row(s) across {Users} user file(s)",
+                    rowCount,
+                    userCount);
+            }
+
+            return keysToSchedule.ToArray();
+        }
+
+        private async Task ScheduleStartupAsync(
+            ChannelWriter<string> writer,
+            string pendingKey,
+            CancellationToken cancellationToken)
+        {
+            _rerun[pendingKey] = 0;
+            if (!_queuedOrRunning.TryAdd(pendingKey, 0))
+            {
+                return;
+            }
+
+            try
+            {
+                await writer.WriteAsync(pendingKey, cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                _queuedOrRunning.TryRemove(pendingKey, out _);
+                _rerun.TryRemove(pendingKey, out _);
+                throw;
+            }
+        }
+
+        private void OnPendingRegistrationChanged(string pendingKey, Guid userId, bool registered)
+        {
+            if (registered)
+            {
+                RegisterPending(pendingKey, userId);
+                TrySchedule(pendingKey);
+            }
+            else
+            {
+                UnregisterPending(pendingKey, userId);
+            }
+        }
+
+        internal void RegisterPending(string pendingKey, Guid userId)
+        {
+            if (string.IsNullOrEmpty(pendingKey) || userId == Guid.Empty)
+            {
+                return;
+            }
+
+            while (true)
+            {
+                var users = _pendingUsersByKey.GetOrAdd(
+                    pendingKey,
+                    static _ => new ConcurrentDictionary<Guid, byte>());
+                PendingDictionaryAcquiredForTest?.Invoke(pendingKey, userId);
+                users.TryAdd(userId, 0);
+
+                // An unregister can remove the last old user and detach this
+                // per-key dictionary between GetOrAdd and TryAdd. Publishing to
+                // that detached instance would lose the durable registration.
+                // Accept the add only while the outer map still owns exactly it;
+                // otherwise remove our stale copy and merge into the live map.
+                if (_pendingUsersByKey.TryGetValue(pendingKey, out var current)
+                    && ReferenceEquals(users, current))
+                {
+                    return;
+                }
+
+                users.TryRemove(userId, out _);
+            }
+        }
+
+        internal void UnregisterPending(string pendingKey, Guid userId)
+        {
+            if (string.IsNullOrEmpty(pendingKey)
+                || userId == Guid.Empty
+                || !_pendingUsersByKey.TryGetValue(pendingKey, out var users))
+            {
+                return;
+            }
+
+            users.TryRemove(userId, out _);
+            if (!users.IsEmpty)
+            {
+                return;
+            }
+
+            if (((ICollection<KeyValuePair<string, ConcurrentDictionary<Guid, byte>>>)_pendingUsersByKey)
+                    .Remove(new KeyValuePair<string, ConcurrentDictionary<Guid, byte>>(pendingKey, users))
+                && !users.IsEmpty)
+            {
+                foreach (var lateUser in users.Keys)
+                {
+                    RegisterPending(pendingKey, lateUser);
+                }
             }
         }
 
@@ -213,119 +353,185 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         {
             try
             {
-                var cfg = _configProvider.ConfigurationOrNull;
-                if (cfg?.SpoilerBlurEnabled != true) return;
+                if (!_accepting || _configProvider.ConfigurationOrNull?.SpoilerBlurEnabled != true)
+                {
+                    return;
+                }
 
-                var item = e?.Item;
-                if (item is not Series && item is not Movie) return;
+                var item = e.Item;
+                if (item is not Series && item is not Movie)
+                {
+                    return;
+                }
 
-                if (item.ProviderIds == null
-                    || !item.ProviderIds.TryGetValue("Tmdb", out var tmdbId)
+                if (!item.ProviderIds.TryGetValue("Tmdb", out var tmdbId)
                     || string.IsNullOrEmpty(tmdbId))
                 {
                     return;
                 }
-                var mediaType = item is Series ? "tv" : "movie";
-                var pendingKey = $"{mediaType}:{tmdbId}";
 
-                // Fast-path gate: if NO user has this key pending, we're done —
-                // this is the path every library event for non-pending items
-                // takes, so it must stay allocation- and I/O-free.
-                if (!_pendingUsersByKey.ContainsKey(pendingKey)) return;
+                var pendingKey = $"{(item is Series ? "tv" : "movie")}:{tmdbId}";
+                if (!_pendingUsersByKey.ContainsKey(pendingKey))
+                {
+                    return;
+                }
 
-                // PERF(S1): the scan-thread handler ends here — record the id +
-                // schedule a coalesced off-thread sweep; no DB query or file I/O
-                // runs synchronously. See docs/developers.md#performance-rules (S1).
-                ScheduleSweep(pendingKey, item.Id, item.Name ?? string.Empty, item is Series);
+                // PERF(S1): a constant-time coalescing signal is the end of the
+                // synchronous scan-thread path.  All lookups and RMWs are owned by
+                // the single hosted worker.
+                TrySchedule(pendingKey);
             }
             catch (Exception ex)
             {
-                _logger.LogWarning($"SpoilerSeerrPromoter: handler failed before scheduling: {ex.Message}");
+                _logger.LogWarning(
+                    "SpoilerSeerrPromoter: handler failed before scheduling: {Message}",
+                    ex.Message);
             }
         }
 
-        // Coalesced background sweep scheduler. At most one sweep per key runs
-        // at a time; events that arrive while one is running (or settling) set
-        // the rerun flag and are folded into a single follow-up pass. This is
-        // what keeps a rapid-fire episode import (Series ItemUpdated storms)
-        // from turning into dozens of concurrent library reads + file RMWs
-        // racing the scanner.
-        private void ScheduleSweep(string pendingKey, Guid itemId, string itemName, bool isSeries)
+        private bool TrySchedule(string pendingKey)
         {
-            _sweepRerun[pendingKey] = 0;
-            if (!_sweepRunning.TryAdd(pendingKey, 0)) return; // active sweep picks up the rerun flag
+            var channel = _channel;
+            if (!_accepting || channel == null || !_pendingUsersByKey.ContainsKey(pendingKey))
+            {
+                return false;
+            }
 
-            _ = Task.Run(async () =>
+            _rerun[pendingKey] = 0;
+            if (!_queuedOrRunning.TryAdd(pendingKey, 0))
+            {
+                return true;
+            }
+
+            if (channel.Writer.TryWrite(pendingKey))
+            {
+                return true;
+            }
+
+            _queuedOrRunning.TryRemove(pendingKey, out _);
+            _rerun.TryRemove(pendingKey, out _);
+            _logger.LogWarning(
+                "SpoilerSeerrPromoter: bounded queue is full; {PendingKey} remains durable and will replay on restart or a later library event",
+                pendingKey);
+            return false;
+        }
+
+        private async Task RunWorkerAsync(ChannelReader<string> reader)
+        {
+            await foreach (var pendingKey in reader.ReadAllAsync().ConfigureAwait(false))
             {
                 try
                 {
-                    await Task.Delay(SweepSettleDelayMs).ConfigureAwait(false);
-                    while (_sweepRerun.TryRemove(pendingKey, out _))
+                    do
                     {
-                        SweepPendingUsers(pendingKey, itemId, itemName, isSeries);
+                        _rerun.TryRemove(pendingKey, out _);
+                        if (BeforePromotionForTest != null)
+                        {
+                            await BeforePromotionForTest(pendingKey).ConfigureAwait(false);
+                        }
+
+                        SweepPendingUsers(pendingKey);
+                        AfterPromotionForTest?.Invoke(pendingKey);
                     }
+                    while (_rerun.TryRemove(pendingKey, out _));
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogWarning($"SpoilerSeerrPromoter: sweep for {pendingKey} failed: {ex.Message}");
+                    _logger.LogWarning(
+                        "SpoilerSeerrPromoter: sweep for {PendingKey} failed: {Message}",
+                        pendingKey,
+                        ex.Message);
                 }
                 finally
                 {
-                    _sweepRunning.TryRemove(pendingKey, out _);
-                    // Late-arrival race: an event may have set the rerun flag
-                    // after the loop's last check but before the running flag
-                    // cleared. Reschedule so it isn't lost.
-                    if (_sweepRerun.ContainsKey(pendingKey) && _pendingUsersByKey.ContainsKey(pendingKey))
+                    _queuedOrRunning.TryRemove(pendingKey, out _);
+                    if (_rerun.ContainsKey(pendingKey)
+                        && _pendingUsersByKey.ContainsKey(pendingKey))
                     {
-                        ScheduleSweep(pendingKey, itemId, itemName, isSeries);
+                        TrySchedule(pendingKey);
                     }
                 }
-            });
+            }
         }
 
-        private void SweepPendingUsers(string pendingKey, Guid itemId, string itemName, bool isSeries)
+        private void SweepPendingUsers(string pendingKey)
         {
-            if (!_pendingUsersByKey.TryGetValue(pendingKey, out var users)) return;
+            if (!_pendingUsersByKey.TryGetValue(pendingKey, out var users))
+            {
+                return;
+            }
 
-            // Snapshot: the set can be mutated concurrently by the controller.
             foreach (var userId in users.Keys.ToArray())
             {
                 try
                 {
-                    var outcome = PromoteForUser(userId, itemId, pendingKey, itemName, isSeries);
+                    var outcome = PromoteDurableIntent(userId, pendingKey);
                     if (outcome != PromotionOutcome.StillPending)
                     {
-                        // Promoted, already gone, or user deleted — either way
-                        // this user no longer holds the pending key, so stop
-                        // sweeping them for it.
                         UnregisterPending(pendingKey, userId);
                     }
                 }
                 catch (Exception ex)
                 {
-                    // Keep the user registered so a later event retries them.
-                    _logger.LogWarning($"SpoilerSeerrPromoter: per-user promotion failed for user {userId} on {pendingKey}: {ex.Message}");
+                    _logger.LogWarning(
+                        "SpoilerSeerrPromoter: per-user promotion failed for user {UserId} on {PendingKey}: {Message}",
+                        userId,
+                        pendingKey,
+                        ex.Message);
                 }
             }
         }
 
-        // Internal (Tests has InternalsVisibleTo) so the F5 duplicate-fallback
-        // path can be driven directly without racing the async sweep.
-        internal enum PromotionOutcome
-        {
-            Promoted,      // pending row consumed (or already promoted earlier)
-            NotPending,    // user deleted / file no longer has the key
-            StillPending,  // user can't see the item yet — retry on later events
-        }
-
-        internal PromotionOutcome PromoteForUser(Guid userId, Guid itemId, string pendingKey, string itemName, bool isSeries)
+        private PromotionOutcome PromoteDurableIntent(Guid userId, string pendingKey)
         {
             var jUser = _userManager.GetUserById(userId);
-            if (jUser == null) return PromotionOutcome.NotPending;
+            if (jUser == null)
+            {
+                return PromotionOutcome.NotPending;
+            }
 
-            // Library-access gate: if the user can't see the item (filtered
-            // by library access), don't promote — they'd never see a card
-            // for it but would see a stranded entry in management UI.
+            var separator = pendingKey.IndexOf(':', StringComparison.Ordinal);
+            if (separator <= 0 || separator >= pendingKey.Length - 1)
+            {
+                return PromotionOutcome.StillPending;
+            }
+
+            var mediaType = pendingKey.Substring(0, separator);
+            var tmdbId = pendingKey.Substring(separator + 1);
+            var item = _pendingService.FindLibraryItemByTmdb(jUser, mediaType, tmdbId);
+            if (item == null)
+            {
+                return PromotionOutcome.StillPending;
+            }
+
+            return PromoteForUser(
+                userId,
+                item.Id,
+                pendingKey,
+                item.Name ?? string.Empty,
+                item is Series);
+        }
+
+        internal enum PromotionOutcome
+        {
+            Promoted,
+            NotPending,
+            StillPending,
+        }
+
+        internal PromotionOutcome PromoteForUser(
+            Guid userId,
+            Guid itemId,
+            string pendingKey,
+            string itemName,
+            bool isSeries)
+        {
+            var jUser = _userManager.GetUserById(userId);
+            if (jUser == null)
+            {
+                return PromotionOutcome.NotPending;
+            }
+
             BaseItem? visibleItem;
             try
             {
@@ -333,104 +539,136 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             }
             catch (Exception ex)
             {
-                _logger.LogWarning($"SpoilerSeerrPromoter: GetItemById({itemId},{userId}) threw {ex.GetType().Name}: {ex.Message}");
+                _logger.LogWarning(
+                    "SpoilerSeerrPromoter: GetItemById({ItemId},{UserId}) threw {ExceptionType}: {Message}",
+                    itemId,
+                    userId,
+                    ex.GetType().Name,
+                    ex.Message);
                 return PromotionOutcome.StillPending;
             }
+
             if (visibleItem == null)
             {
-                // F5: the event's itemId may be a library DUPLICATE this user
-                // cannot access (the same TMDB id also exists in a library they
-                // do have access to). Stranding the pending entry in that case
-                // is a bug — try a user-scoped TMDB lookup for an accessible
-                // duplicate of the right type and promote THAT id instead.
-                var dup = TryFindAccessibleDuplicate(jUser, pendingKey, isSeries);
-                if (dup == null) return PromotionOutcome.StillPending;
-                itemId = dup.Id;
-                if (!string.IsNullOrEmpty(dup.Name)) itemName = dup.Name;
+                var duplicate = TryFindAccessibleDuplicate(jUser, pendingKey, isSeries);
+                if (duplicate == null)
+                {
+                    return PromotionOutcome.StillPending;
+                }
+
+                itemId = duplicate.Id;
+                if (!string.IsNullOrEmpty(duplicate.Name))
+                {
+                    itemName = duplicate.Name;
+                }
             }
 
             var userKey = userId.ToString("N");
-            var fileName = SpoilerBlurImageFilter.SpoilerBlurFileName;
             var itemKey = itemId.ToString("N");
-
             try
             {
-                var stillHadPending = new[] { false };
+                var stillHadPending = false;
                 _configManager.RmwUserConfiguration<UserSpoilerBlur>(
-                    userKey, fileName, state =>
+                    userKey,
+                    SpoilerBlurImageFilter.SpoilerBlurFileName,
+                    state =>
                     {
-                        if (!state.PendingTmdb.Remove(pendingKey)) return 0;
-                        stillHadPending[0] = true;
+                        if (!state.PendingTmdb.Remove(pendingKey))
+                        {
+                            return 0;
+                        }
+
+                        stillHadPending = true;
                         if (isSeries)
                         {
-                            if (state.Series.ContainsKey(itemKey)) return 1;
-                            state.Series[itemKey] = new SpoilerBlurSeriesEntry
+                            if (!state.Series.ContainsKey(itemKey))
                             {
-                                SeriesId = itemKey,
-                                SeriesName = itemName,
-                                EnabledAt = DateTime.UtcNow.ToString("o", System.Globalization.CultureInfo.InvariantCulture),
-                            };
+                                state.Series[itemKey] = new SpoilerBlurSeriesEntry
+                                {
+                                    SeriesId = itemKey,
+                                    SeriesName = itemName,
+                                    EnabledAt = DateTime.UtcNow.ToString(
+                                        "o",
+                                        System.Globalization.CultureInfo.InvariantCulture),
+                                };
+                            }
                         }
-                        else
+                        else if (!state.Movies.ContainsKey(itemKey))
                         {
-                            if (state.Movies.ContainsKey(itemKey)) return 1;
                             state.Movies[itemKey] = new SpoilerBlurMovieEntry
                             {
                                 MovieId = itemKey,
                                 MovieName = itemName,
-                                EnabledAt = DateTime.UtcNow.ToString("o", System.Globalization.CultureInfo.InvariantCulture),
+                                EnabledAt = DateTime.UtcNow.ToString(
+                                    "o",
+                                    System.Globalization.CultureInfo.InvariantCulture),
                             };
                         }
+
                         return 1;
                     });
-                if (stillHadPending[0])
+
+                if (!stillHadPending)
                 {
-                    // F7: Series/Movies changed — drop the user's cached state so
-                    // the image/strip filters blur the promoted title immediately.
-                    SpoilerUserResolver.InvalidateUser(userKey);
-                    _logger.LogInformation($"SpoilerSeerrPromoter: promoted {pendingKey} -> {(isSeries ? "series" : "movie")} {itemKey} for user {userId}");
-                    return PromotionOutcome.Promoted;
+                    return PromotionOutcome.NotPending;
                 }
-                // File no longer holds the key (promoted via the controller's
-                // TOCTOU path, or removed by the user) — nothing to do.
-                return PromotionOutcome.NotPending;
+
+                SpoilerUserResolver.InvalidateUser(userKey);
+                _logger.LogInformation(
+                    "SpoilerSeerrPromoter: promoted {PendingKey} -> {MediaType} {ItemKey} for user {UserId}",
+                    pendingKey,
+                    isSeries ? "series" : "movie",
+                    itemKey,
+                    userId);
+                return PromotionOutcome.Promoted;
             }
             catch (UserStoreUnhealthyException)
             {
-                // Keep the registration for a post-repair event, but do not log
-                // every library notification for the same durable generation.
                 return PromotionOutcome.StillPending;
             }
             catch (InvalidDataException ex)
             {
-                _logger.LogWarning($"SpoilerSeerrPromoter: skipping {userId}/{pendingKey} due to corrupt spoilerblur.json: {ex.Message}");
-                // Strict read will keep failing until the file is repaired;
-                // keep the user registered so repair + a later event recovers.
+                _logger.LogWarning(
+                    "SpoilerSeerrPromoter: skipping {UserId}/{PendingKey} due to corrupt spoilerblur.json: {Message}",
+                    userId,
+                    pendingKey,
+                    ex.Message);
                 return PromotionOutcome.StillPending;
             }
         }
 
-        // F5 helper: resolve an accessible library duplicate for the pending key
-        // (parsed as "{tv|movie}:{tmdbId}") scoped to the user, when the event's
-        // own itemId wasn't visible to them. Returns the item only when its type
-        // matches the pending media type. Reuses SpoilerPendingService's indexed
-        // TMDB lookup so the matching happens in the DB, not a client-side scan.
         private BaseItem? TryFindAccessibleDuplicate(JUser jUser, string pendingKey, bool isSeries)
         {
-            var sep = pendingKey.IndexOf(':');
-            if (sep <= 0 || sep >= pendingKey.Length - 1) return null;
-            var mediaType = pendingKey.Substring(0, sep);
-            var tmdb = pendingKey.Substring(sep + 1);
+            var separator = pendingKey.IndexOf(':', StringComparison.Ordinal);
+            if (separator <= 0 || separator >= pendingKey.Length - 1)
+            {
+                return null;
+            }
+
+            var mediaType = pendingKey.Substring(0, separator);
+            var tmdb = pendingKey.Substring(separator + 1);
             try
             {
-                var dup = _pendingService.FindLibraryItemByTmdb(jUser, mediaType, tmdb);
-                if (isSeries && dup is Series) return dup;
-                if (!isSeries && dup is Movie) return dup;
+                var duplicate = _pendingService.FindLibraryItemByTmdb(jUser, mediaType, tmdb);
+                if (isSeries && duplicate is Series)
+                {
+                    return duplicate;
+                }
+
+                if (!isSeries && duplicate is Movie)
+                {
+                    return duplicate;
+                }
             }
             catch (Exception ex)
             {
-                _logger.LogWarning($"SpoilerSeerrPromoter: duplicate TMDB lookup for {pendingKey} threw {ex.GetType().Name}: {ex.Message}");
+                _logger.LogWarning(
+                    "SpoilerSeerrPromoter: duplicate TMDB lookup for {PendingKey} threw {ExceptionType}: {Message}",
+                    pendingKey,
+                    ex.GetType().Name,
+                    ex.Message);
             }
+
             return null;
         }
     }

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -19,7 +19,7 @@ const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the repeated clean measurements', () => {
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1932, totalLines: 2253 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 19042, totalLines: 27479 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 19396, totalLines: 27765 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);
 });

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -21,12 +21,12 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 19042,
-        "totalLines": 27479
+        "coveredLines": 19396,
+        "totalLines": 27765
       },
       "tolerance": {
         "missingCoveredLines": 2,
-        "rationale": "Two clean final post-review local .NET 10.0.9/Coverlet integration runs on 2026-07-17 each passed 1702 tests and measured the identical complete 27479-line assembly scope at 19042 covered lines (69.297%). Issue #174 replaces the Continue Watching Timer race with bounded lifecycle-owned exact-id intake, deterministic drain/join, shared concurrent-disposal completion, observable cancellation/forced-terminal failure, retained retries, and exactly-once aggregated overflow rejection evidence on normal and abort exits. Adversarial stop, dispatch, retry, capacity, immediate-dispose, transient-global-null, coalescing, and lifecycle regressions cover the accepted-work contract without broad point-in-time library pruning. Relative to the reviewed 18876/27327 baseline, the reviewed assembly scope grows by 152 instrumented lines and the high-water advances by 166 covered lines while line coverage rises from 69.075% to 69.297%. The existing two-line tolerance is unchanged and covers only previously reproduced negligible Coverlet variance; coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, and broad-tolerance negative boundaries."
+        "rationale": "Two clean post-rebase local .NET 10.0.9/Coverlet integration runs on 2026-07-17 each passed 1719 tests and measured the identical combined 27765-line assembly scope at 19396 covered lines (69.858%). Issue #165 moves successful Seerr media-request acknowledgment behind an atomic per-user Spoiler Guard intent write and replaces process-static detached promotion tasks with a bounded, instance-owned hosted worker. Independent-review fixes add response-header durability before RequestAborted body reads, a frozen pre-dispatch auto-enable obligation, explicit unsupported-target partial success, cap-opening durability, detached-dictionary registration recovery, and serialized stop/start generations, with deterministic regressions. Relative to #341's reviewed 19042/27479 baseline, the reviewed assembly scope grows by 286 instrumented lines and the high-water advances by 354 covered lines while line coverage rises from 69.297% to 69.858%. The existing two-line tolerance is unchanged and covers only reproduced negligible Coverlet variance; coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
Fixes #165

## Summary
- persist per-user Spoiler Guard intent as soon as an accepted Seerr mutation receives 2xx response headers
- freeze the auto-enable obligation from the final pre-dispatch configuration proof
- add a bounded lifecycle-owned promoter with durable disk fallback, startup replay, coalescing, and serialized start/stop
- report unsupported, malformed, or capacity-constrained accepted targets truthfully as partial success
- preserve existing timeout, cancellation, content-type, body-size, authorization, and duplicate-edition contracts

## Validation
- combined focused durability/lifecycle scope: 40/40
- full server suite: 1719/1719 twice
- line coverage: 19396/27765 twice, exact reviewed baseline
- coverage policy: 13/13
- script tests: 379/379
- performance guard: 248 files, 872 ms CPU under 5000 ms
- source and legacy typechecks, syntax, deterministic bundle, Release builds, diff check: green
- independent Codex review: APPROVE
- fresh Fable 5 low review: APPROVE

## Safety
- durable intent is recorded before request-aborted body reads can cancel the response path
- one bounded worker owns replay and promotion; stop awaits the generation drain
- saturation falls back to disk without claiming protection that was not persisted
- no deployment requested for this PR