### PR TITLE
test(client): make backpressure regressions deterministic

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/filter.parent-series.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/filter.parent-series.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { JC } from '../../globals';
+import { driveOwnedFakeTimersUntil } from '../../test/owned-timer-driver';
 import { resetFromUserConfig } from './data';
 import {
     clearFilterIdentityState,
@@ -136,31 +137,47 @@ describe('hidden-content parent-Series resolution', () => {
     });
 
     it('recovers overflow beyond both 1,000-entry backpressure tables', async () => {
-        const responseItems = Array.from({ length: 1_001 }, (_value, index) => ({
-            Id: `overflow-episode-${index}`,
-            SeriesId: 'hidden-series',
-        }));
-        let calls = 0;
-        const ajax = vi.spyOn(ApiClient, 'ajax').mockImplementation(() => {
-            calls += 1;
-            // The first 20 requests cover the first bounded 1,000 IDs in
-            // 50-item chunks and omit every row. The bounded overflow pass
-            // must later recover all 1,001 cards without retaining card 1,001.
-            return Promise.resolve({ Items: calls <= 20 ? [] : responseItems });
-        });
-        for (let index = 0; index < 1_001; index += 1) {
-            episodeCard(`overflow-episode-${index}`);
-        }
+        vi.useFakeTimers();
+        try {
+            const responseItems = Array.from({ length: 1_001 }, (_value, index) => ({
+                Id: `overflow-episode-${index}`,
+                SeriesId: 'hidden-series',
+            }));
+            let calls = 0;
+            const ajax = vi.spyOn(ApiClient, 'ajax').mockImplementation(() => {
+                calls += 1;
+                // The first 20 requests cover the first bounded 1,000 IDs in
+                // 50-item chunks and omit every row. The bounded overflow pass
+                // must later recover all 1,001 cards without retaining card 1,001.
+                return Promise.resolve({ Items: calls <= 20 ? [] : responseItems });
+            });
+            for (let index = 0; index < 1_001; index += 1) {
+                episodeCard(`overflow-episode-${index}`);
+            }
 
-        filterAllNativeCards();
+            filterAllNativeCards();
 
-        await vi.waitFor(() => {
+            await driveOwnedFakeTimersUntil({
+                label: 'hidden parent-Series overflow recovery',
+                isComplete: () => document.querySelectorAll('.card.jc-hidden').length === 1_001,
+                diagnostics: () => (
+                    `hidden=${document.querySelectorAll('.card.jc-hidden').length}; api calls=${calls}`
+                ),
+            });
             expect(document.querySelectorAll('.card.jc-hidden')).toHaveLength(1_001);
-        }, { timeout: 4_000 });
-        expect(ajax.mock.calls.length).toBeGreaterThan(20);
-        // Initial wave plus at most three capped overflow waves, each no more
-        // than 20 sequential 50-ID requests for the 1,000-ID pending bound.
-        expect(ajax.mock.calls.length).toBeLessThanOrEqual(80);
+            expect(ajax.mock.calls.length).toBeGreaterThan(20);
+            // Initial wave plus at most three capped overflow waves, each no more
+            // than 20 sequential 50-ID requests for the 1,000-ID pending bound.
+            expect(ajax.mock.calls.length).toBeLessThanOrEqual(80);
+        } finally {
+            clearFilterIdentityState();
+            try {
+                expect(vi.getTimerCount()).toBe(0);
+            } finally {
+                vi.clearAllTimers();
+                vi.useRealTimers();
+            }
+        }
     });
 
     it('invalidates an old parent association on a library change', async () => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/filter.parent-series.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/filter.parent-series.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { JC } from '../../globals';
-import { driveOwnedFakeTimersUntil } from '../../test/owned-timer-driver';
+import { driveOwnedFakeTimersUntil, trackOwnedFakeTimers } from '../../test/owned-timer-driver';
 import { resetFromUserConfig } from './data';
 import {
     clearFilterIdentityState,
@@ -138,6 +138,10 @@ describe('hidden-content parent-Series resolution', () => {
 
     it('recovers overflow beyond both 1,000-entry backpressure tables', async () => {
         vi.useFakeTimers();
+        const ownedTimers = trackOwnedFakeTimers({
+            label: 'hidden parent-Series overflow recovery',
+            isOwned: stack => /[\\/]enhanced[\\/]hidden-content[\\/]filter\.ts/.test(stack),
+        });
         try {
             const responseItems = Array.from({ length: 1_001 }, (_value, index) => ({
                 Id: `overflow-episode-${index}`,
@@ -161,7 +165,8 @@ describe('hidden-content parent-Series resolution', () => {
                 label: 'hidden parent-Series overflow recovery',
                 isComplete: () => document.querySelectorAll('.card.jc-hidden').length === 1_001,
                 diagnostics: () => (
-                    `hidden=${document.querySelectorAll('.card.jc-hidden').length}; api calls=${calls}`
+                    `hidden=${document.querySelectorAll('.card.jc-hidden').length}; api calls=${calls}; `
+                    + `owned timers=${ownedTimers.pendingCount()}`
                 ),
             });
             expect(document.querySelectorAll('.card.jc-hidden')).toHaveLength(1_001);
@@ -172,8 +177,9 @@ describe('hidden-content parent-Series resolution', () => {
         } finally {
             clearFilterIdentityState();
             try {
-                expect(vi.getTimerCount()).toBe(0);
+                ownedTimers.assertNoPending();
             } finally {
+                ownedTimers.restore();
                 vi.clearAllTimers();
                 vi.useRealTimers();
             }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.test.ts
@@ -7,6 +7,7 @@
 // card scan selector could otherwise surface — is still caught.
 import { afterAll, describe, expect, it, vi } from 'vitest';
 import { JC } from '../globals';
+import { driveOwnedFakeTimersUntil } from '../test/owned-timer-driver';
 import { getItemCached } from './helpers';
 import {
     applyContentResponse,
@@ -1174,6 +1175,7 @@ describe('watched/privacy projection response ordering (BI-SEC-035)', () => {
     });
 
     it('drains 200 failed-batch cards with six workers and one lookup per duplicate id', async () => {
+        vi.useFakeTimers();
         document.body.innerHTML = '';
         const oldConfig = JC.pluginConfig;
         const oldUi = JC.core.ui;
@@ -1209,7 +1211,7 @@ describe('watched/privacy projection response ordering (BI-SEC-035)', () => {
 
         try {
             resetTagPipelineIdentity();
-            JC.tagPipeline!.initialize?.();
+            await Promise.resolve(JC.tagPipeline!.initialize?.());
             JC.tagPipeline!.clearProcessed?.();
             for (let index = 1; index <= 199; index += 1) {
                 const itemId = index.toString(16).padStart(32, '0');
@@ -1224,7 +1226,15 @@ describe('watched/privacy projection response ordering (BI-SEC-035)', () => {
             }
             JC.tagPipeline!.scheduleScan?.();
 
-            await vi.waitFor(() => expect(renderedTargets.size).toBe(200), { timeout: 5_000 });
+            await driveOwnedFakeTimersUntil({
+                label: 'tag fallback 200-card drain',
+                isComplete: () => renderedTargets.size === 200,
+                diagnostics: () => (
+                    `rendered=${renderedTargets.size}; fallback requests=${fallbackIds.length}; `
+                    + `active=${activeFallbacks}; max active=${maxActiveFallbacks}`
+                ),
+            });
+            expect(renderedTargets.size).toBe(200);
             expect(fallbackIds).toHaveLength(199);
             expect(new Set(fallbackIds).size).toBe(199);
             expect(maxActiveFallbacks).toBe(6);
@@ -1240,6 +1250,13 @@ describe('watched/privacy projection response ordering (BI-SEC-035)', () => {
             JC.pluginConfig = oldConfig;
             JC.core.ui = oldUi;
             document.body.innerHTML = '';
+            resetTagPipelineIdentity();
+            try {
+                expect(vi.getTimerCount()).toBe(0);
+            } finally {
+                vi.clearAllTimers();
+                vi.useRealTimers();
+            }
         }
     });
 
@@ -1379,6 +1396,7 @@ describe('watched/privacy projection response ordering (BI-SEC-035)', () => {
     });
 
     it('bounds failed-batch fallback work and lets navigation preempt all stale requests', async () => {
+        vi.useFakeTimers();
         document.body.innerHTML = '';
         const oldConfig = JC.pluginConfig;
         const oldUi = JC.core.ui;
@@ -1442,7 +1460,7 @@ describe('watched/privacy projection response ordering (BI-SEC-035)', () => {
 
         try {
             resetTagPipelineIdentity();
-            JC.tagPipeline!.initialize?.();
+            await Promise.resolve(JC.tagPipeline!.initialize?.());
             for (let index = 1; index <= 200; index += 1) {
                 const itemId = index.toString(16).padStart(32, '0');
                 const image = gridCardImage();
@@ -1454,7 +1472,15 @@ describe('watched/privacy projection response ordering (BI-SEC-035)', () => {
             JC.tagPipeline!.clearProcessed?.();
             JC.tagPipeline!.scheduleScan?.();
 
-            await vi.waitFor(() => expect(fallbackStarted).toHaveLength(6), { timeout: 2_000 });
+            await driveOwnedFakeTimersUntil({
+                label: 'tag fallback six-worker admission',
+                isComplete: () => fallbackStarted.length === 6,
+                diagnostics: () => (
+                    `started=${fallbackStarted.length}; active=${activeFallbacks}; `
+                    + `max active=${maxActiveFallbacks}; batch calls=${batchCalls}`
+                ),
+            });
+            expect(fallbackStarted).toHaveLength(6);
             expect(maxActiveFallbacks).toBe(6);
             expect(getItem).not.toHaveBeenCalled();
 
@@ -1467,10 +1493,17 @@ describe('watched/privacy projection response ordering (BI-SEC-035)', () => {
             document.body.appendChild(nextCard);
             JC.tagPipeline!.scheduleScan?.();
 
-            await vi.waitFor(() => expect(fallbackSignals.every(signal => signal.aborted)).toBe(true));
-            await vi.waitFor(() => {
-                expect(document.querySelector(`.bounded-fallback-${nextItemId}`)).not.toBeNull();
+            await driveOwnedFakeTimersUntil({
+                label: 'tag fallback navigation preemption and replacement drain',
+                isComplete: () => fallbackSignals.every(signal => signal.aborted)
+                    && document.querySelector(`.bounded-fallback-${nextItemId}`) !== null,
+                diagnostics: () => (
+                    `aborted=${fallbackSignals.filter(signal => signal.aborted).length}/${fallbackSignals.length}; `
+                    + `started=${fallbackStarted.length}; active=${activeFallbacks}; renders=${staleRenders.join(',')}`
+                ),
             });
+            expect(fallbackSignals.every(signal => signal.aborted)).toBe(true);
+            expect(document.querySelector(`.bounded-fallback-${nextItemId}`)).not.toBeNull();
             expect(fallbackStarted).toHaveLength(6);
             expect(activeFallbacks).toBe(0);
             expect(staleRenders).toEqual([nextItemId]);
@@ -1484,6 +1517,13 @@ describe('watched/privacy projection response ordering (BI-SEC-035)', () => {
             JC.pluginConfig = oldConfig;
             JC.core.ui = oldUi;
             document.body.innerHTML = '';
+            resetTagPipelineIdentity();
+            try {
+                expect(vi.getTimerCount()).toBe(0);
+            } finally {
+                vi.clearAllTimers();
+                vi.useRealTimers();
+            }
         }
     });
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.test.ts
@@ -7,7 +7,7 @@
 // card scan selector could otherwise surface — is still caught.
 import { afterAll, describe, expect, it, vi } from 'vitest';
 import { JC } from '../globals';
-import { driveOwnedFakeTimersUntil } from '../test/owned-timer-driver';
+import { driveOwnedFakeTimersUntil, trackOwnedFakeTimers } from '../test/owned-timer-driver';
 import { getItemCached } from './helpers';
 import {
     applyContentResponse,
@@ -1176,6 +1176,10 @@ describe('watched/privacy projection response ordering (BI-SEC-035)', () => {
 
     it('drains 200 failed-batch cards with six workers and one lookup per duplicate id', async () => {
         vi.useFakeTimers();
+        const ownedTimers = trackOwnedFakeTimers({
+            label: 'tag fallback 200-card drain',
+            isOwned: stack => /[\\/]enhanced[\\/]tag-pipeline\.ts/.test(stack),
+        });
         document.body.innerHTML = '';
         const oldConfig = JC.pluginConfig;
         const oldUi = JC.core.ui;
@@ -1231,7 +1235,8 @@ describe('watched/privacy projection response ordering (BI-SEC-035)', () => {
                 isComplete: () => renderedTargets.size === 200,
                 diagnostics: () => (
                     `rendered=${renderedTargets.size}; fallback requests=${fallbackIds.length}; `
-                    + `active=${activeFallbacks}; max active=${maxActiveFallbacks}`
+                    + `active=${activeFallbacks}; max active=${maxActiveFallbacks}; `
+                    + `owned timers=${ownedTimers.pendingCount()}`
                 ),
             });
             expect(renderedTargets.size).toBe(200);
@@ -1252,8 +1257,9 @@ describe('watched/privacy projection response ordering (BI-SEC-035)', () => {
             document.body.innerHTML = '';
             resetTagPipelineIdentity();
             try {
-                expect(vi.getTimerCount()).toBe(0);
+                ownedTimers.assertNoPending();
             } finally {
+                ownedTimers.restore();
                 vi.clearAllTimers();
                 vi.useRealTimers();
             }
@@ -1397,6 +1403,10 @@ describe('watched/privacy projection response ordering (BI-SEC-035)', () => {
 
     it('bounds failed-batch fallback work and lets navigation preempt all stale requests', async () => {
         vi.useFakeTimers();
+        const ownedTimers = trackOwnedFakeTimers({
+            label: 'tag fallback navigation preemption',
+            isOwned: stack => /[\\/]enhanced[\\/]tag-pipeline\.ts/.test(stack),
+        });
         document.body.innerHTML = '';
         const oldConfig = JC.pluginConfig;
         const oldUi = JC.core.ui;
@@ -1477,7 +1487,8 @@ describe('watched/privacy projection response ordering (BI-SEC-035)', () => {
                 isComplete: () => fallbackStarted.length === 6,
                 diagnostics: () => (
                     `started=${fallbackStarted.length}; active=${activeFallbacks}; `
-                    + `max active=${maxActiveFallbacks}; batch calls=${batchCalls}`
+                    + `max active=${maxActiveFallbacks}; batch calls=${batchCalls}; `
+                    + `owned timers=${ownedTimers.pendingCount()}`
                 ),
             });
             expect(fallbackStarted).toHaveLength(6);
@@ -1499,7 +1510,8 @@ describe('watched/privacy projection response ordering (BI-SEC-035)', () => {
                     && document.querySelector(`.bounded-fallback-${nextItemId}`) !== null,
                 diagnostics: () => (
                     `aborted=${fallbackSignals.filter(signal => signal.aborted).length}/${fallbackSignals.length}; `
-                    + `started=${fallbackStarted.length}; active=${activeFallbacks}; renders=${staleRenders.join(',')}`
+                    + `started=${fallbackStarted.length}; active=${activeFallbacks}; `
+                    + `owned timers=${ownedTimers.pendingCount()}; renders=${staleRenders.join(',')}`
                 ),
             });
             expect(fallbackSignals.every(signal => signal.aborted)).toBe(true);
@@ -1519,8 +1531,9 @@ describe('watched/privacy projection response ordering (BI-SEC-035)', () => {
             document.body.innerHTML = '';
             resetTagPipelineIdentity();
             try {
-                expect(vi.getTimerCount()).toBe(0);
+                ownedTimers.assertNoPending();
             } finally {
+                ownedTimers.restore();
                 vi.clearAllTimers();
                 vi.useRealTimers();
             }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/test/owned-timer-driver.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/test/owned-timer-driver.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { driveOwnedFakeTimersUntil } from './owned-timer-driver';
+
+describe('owned fake-timer driver', () => {
+    afterEach(() => {
+        vi.clearAllTimers();
+        vi.useRealTimers();
+    });
+
+    it('advances scheduler-owned timers without elapsed wall time', async () => {
+        vi.useFakeTimers();
+        let complete = false;
+        window.setTimeout(() => { complete = true; }, 10_000);
+
+        await driveOwnedFakeTimersUntil({
+            label: 'owned timer proof',
+            isComplete: () => complete,
+        });
+
+        expect(complete).toBe(true);
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('accepts completion from the final allowed timer step', async () => {
+        vi.useFakeTimers();
+        let complete = false;
+        await Promise.resolve().then(() => {
+            window.setTimeout(() => {
+                void Promise.resolve().then(() => { complete = true; });
+            }, 10_000);
+        });
+
+        await driveOwnedFakeTimersUntil({
+            label: 'final owned timer proof',
+            isComplete: () => complete,
+            maxSteps: 1,
+        });
+
+        expect(complete).toBe(true);
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('fails with ownership diagnostics when no scheduler progress is possible', async () => {
+        vi.useFakeTimers();
+
+        await expect(driveOwnedFakeTimersUntil({
+            label: 'stalled queue proof',
+            isComplete: () => false,
+            diagnostics: () => 'started=0; completed=0',
+            maxSteps: 3,
+        })).rejects.toThrow(
+            'stalled queue proof did not complete after 3 owned scheduler steps; '
+            + 'pending timers=0; started=0; completed=0'
+        );
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/test/owned-timer-driver.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/test/owned-timer-driver.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { driveOwnedFakeTimersUntil } from './owned-timer-driver';
+import { driveOwnedFakeTimersUntil, trackOwnedFakeTimers } from './owned-timer-driver';
+
+function scheduleTrackedTimeout(callback: () => void): number {
+    return window.setTimeout(callback, 25);
+}
+
+function scheduleTrackedFrame(callback: FrameRequestCallback): number {
+    return window.requestAnimationFrame(callback);
+}
 
 describe('owned fake-timer driver', () => {
     afterEach(() => {
@@ -52,5 +60,53 @@ describe('owned fake-timer driver', () => {
             'stalled queue proof did not complete after 3 owned scheduler steps; '
             + 'pending timers=0; started=0; completed=0'
         );
+    });
+
+    it('tracks only matching timer owners and observes run, clear, and cancel retirement', async () => {
+        vi.useFakeTimers();
+        const tracker = trackOwnedFakeTimers({
+            label: 'source-owned timer proof',
+            isOwned: stack => stack.includes('scheduleTracked'),
+        });
+
+        try {
+            const timeout = scheduleTrackedTimeout(() => undefined);
+            const frame = scheduleTrackedFrame(() => undefined);
+            window.setTimeout(() => undefined, 100);
+
+            expect(tracker.pendingCount()).toBe(2);
+            window.clearTimeout(timeout);
+            expect(tracker.pendingCount()).toBe(1);
+            window.cancelAnimationFrame(frame);
+            expect(tracker.pendingCount()).toBe(0);
+            expect(vi.getTimerCount()).toBe(1);
+
+            let ran = false;
+            scheduleTrackedTimeout(() => { ran = true; });
+            await vi.advanceTimersToNextTimerAsync();
+            expect(ran).toBe(true);
+            expect(tracker.pendingCount()).toBe(0);
+        } finally {
+            tracker.restore();
+        }
+    });
+
+    it('reports the owned scheduling callsite when teardown strands a timer', () => {
+        vi.useFakeTimers();
+        const tracker = trackOwnedFakeTimers({
+            label: 'stranded owner proof',
+            isOwned: stack => stack.includes('scheduleTrackedTimeout'),
+        });
+
+        try {
+            const handle = scheduleTrackedTimeout(() => undefined);
+            expect(() => tracker.assertNoPending()).toThrow(
+                /stranded owner proof left 1 owned fake timer pending: timeout \(25ms\).*scheduleTrackedTimeout/
+            );
+            window.clearTimeout(handle);
+            expect(() => tracker.assertNoPending()).not.toThrow();
+        } finally {
+            tracker.restore();
+        }
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/test/owned-timer-driver.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/test/owned-timer-driver.ts
@@ -1,0 +1,46 @@
+import { vi } from 'vitest';
+
+interface OwnedTimerDrainOptions {
+    label: string;
+    isComplete: () => boolean;
+    diagnostics?: () => string;
+    maxSteps?: number;
+}
+
+/**
+ * Advance fake timers and promise continuations until one owned async contract
+ * completes. The step bound detects a real scheduler stall without coupling
+ * correctness to host wall-clock speed.
+ */
+export async function driveOwnedFakeTimersUntil({
+    label,
+    isComplete,
+    diagnostics,
+    maxSteps = 2_000,
+}: OwnedTimerDrainOptions): Promise<void> {
+    for (let step = 0; step < maxSteps; step += 1) {
+        if (isComplete()) return;
+
+        // Awaited API mocks can publish the next owned timer from a promise
+        // continuation. Give that continuation one deterministic turn before
+        // deciding whether there is a timer to advance.
+        await Promise.resolve();
+        if (isComplete()) return;
+
+        if (vi.getTimerCount() > 0) {
+            await vi.advanceTimersToNextTimerAsync();
+        }
+    }
+
+    // The final allowed timer can satisfy the contract in its callback (or a
+    // promise continuation it publishes). Observe that completion before
+    // classifying the bounded drain as stalled.
+    await Promise.resolve();
+    if (isComplete()) return;
+
+    const detail = diagnostics?.();
+    throw new Error(
+        `${label} did not complete after ${maxSteps} owned scheduler steps; `
+        + `pending timers=${vi.getTimerCount()}${detail ? `; ${detail}` : ''}`
+    );
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/src/test/owned-timer-driver.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/test/owned-timer-driver.ts
@@ -7,6 +7,116 @@ interface OwnedTimerDrainOptions {
     maxSteps?: number;
 }
 
+interface OwnedFakeTimerTrackerOptions {
+    label: string;
+    isOwned: (schedulingStack: string) => boolean;
+}
+
+interface PendingOwnedTimer {
+    kind: 'timeout' | 'animation frame';
+    delay?: number;
+    origin: string;
+}
+
+export interface OwnedFakeTimerTracker {
+    pendingCount: () => number;
+    diagnostics: () => string;
+    assertNoPending: () => void;
+    restore: () => void;
+}
+
+/**
+ * Attribute fake timeout/frame handles to one source owner without treating
+ * process-wide timers as leaks. Call this only after `vi.useFakeTimers()`.
+ * Owned callbacks remove themselves when run, while clear/cancel calls remove
+ * them synchronously, so teardown assertions still catch genuine stranded work.
+ */
+export function trackOwnedFakeTimers({
+    label,
+    isOwned,
+}: OwnedFakeTimerTrackerOptions): OwnedFakeTimerTracker {
+    const pending = new Map<unknown, PendingOwnedTimer>();
+    const callSetTimeout = window.setTimeout.bind(window);
+    const callClearTimeout = window.clearTimeout.bind(window);
+    const callRequestAnimationFrame = window.requestAnimationFrame.bind(window);
+    const callCancelAnimationFrame = window.cancelAnimationFrame.bind(window);
+
+    const ownedOrigin = (): string | null => {
+        const stack = new Error().stack || '';
+        if (!isOwned(stack)) return null;
+        return stack.split('\n')
+            .map(line => line.trim())
+            .find(line => isOwned(line)) || 'owned scheduling callsite unavailable';
+    };
+
+    const setTimeoutSpy = vi.spyOn(window, 'setTimeout').mockImplementation((
+        handler: TimerHandler,
+        timeout?: number,
+        ...args: unknown[]
+    ): number => {
+        const origin = ownedOrigin();
+        if (!origin || typeof handler !== 'function') {
+            return callSetTimeout(handler, timeout, ...args);
+        }
+
+        const callback = handler as (...callbackArgs: unknown[]) => void;
+        let handle = 0;
+        const wrapped = (...callbackArgs: unknown[]): void => {
+            pending.delete(handle);
+            callback(...callbackArgs);
+        };
+        handle = callSetTimeout(wrapped, timeout, ...args);
+        pending.set(handle, { kind: 'timeout', delay: timeout, origin });
+        return handle;
+    });
+    const clearTimeoutSpy = vi.spyOn(window, 'clearTimeout').mockImplementation((handle): void => {
+        pending.delete(handle);
+        callClearTimeout(handle);
+    });
+    const requestAnimationFrameSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback): number => {
+        const origin = ownedOrigin();
+        if (!origin) return callRequestAnimationFrame(callback);
+
+        let handle = 0;
+        const wrapped = (timestamp: number): void => {
+            pending.delete(handle);
+            callback(timestamp);
+        };
+        handle = callRequestAnimationFrame(wrapped);
+        pending.set(handle, { kind: 'animation frame', origin });
+        return handle;
+    });
+    const cancelAnimationFrameSpy = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((handle): void => {
+        pending.delete(handle);
+        callCancelAnimationFrame(handle);
+    });
+
+    const diagnostics = (): string => [...pending.values()].slice(0, 5)
+        .map(timer => (
+            `${timer.kind}${timer.delay === undefined ? '' : ` (${timer.delay}ms)`} at ${timer.origin}`
+        ))
+        .join('; ')
+        + (pending.size > 5 ? `; ${pending.size - 5} more owned timers` : '');
+
+    return {
+        pendingCount: () => pending.size,
+        diagnostics,
+        assertNoPending: () => {
+            if (pending.size === 0) return;
+            throw new Error(
+                `${label} left ${pending.size} owned fake timer${pending.size === 1 ? '' : 's'} pending: `
+                + diagnostics()
+            );
+        },
+        restore: () => {
+            cancelAnimationFrameSpy.mockRestore();
+            requestAnimationFrameSpy.mockRestore();
+            clearTimeoutSpy.mockRestore();
+            setTimeoutSpy.mockRestore();
+        },
+    };
+}
+
 /**
  * Advance fake timers and promise continuations until one owned async contract
  * completes. The step bound detects a real scheduler stall without coupling


### PR DESCRIPTION
Fixes #343

## Summary

- Replace wall-clock `vi.waitFor` ownership in the three backpressure regressions with bounded fake-timer drains tied to explicit queue completion predicates.
- Preserve promise-before-timer ordering while proving the 1,001-card overflow, 200-card six-worker drain, and navigation-preemption contracts.
- Attribute teardown timers to their production source so unrelated navigation timers are not misclassified as queue leaks; owned timeouts and animation frames retire on callback, clear, or cancel and report their scheduling callsite when stranded.
- Leave production backpressure, concurrency, deduplication, and navigation code unchanged.

## Repair of the prior CI failure

The earlier head asserted the process-wide `vi.getTimerCount() === 0`. Full CI correctly exposed an unrelated 100 ms navigation timer from `subscribeHistoryUpdate`. This head replaces that global assertion with source-attributed ownership and includes regressions proving an unrelated timer remains allowed while a genuinely stranded owned timer still fails with exact callsite evidence.

## Validation

- Frozen old-behavior failures reproduced for all three acceptance cases.
- Focused affected scope: 46/46.
- Acceptance repetitions: 3/3; constrained stress: 30/30.
- Exact client coverage twice: 235 files / 1,805 tests, 2,327/2,667 lines.
- Script suite: 618/618.
- Toolchain, both typechecks, deterministic bundle, syntax, performance guard, changed-file ESLint, build, and diff checks passed.
- Independent root review: APPROVE.

## Safety

- No timeout increase or failure suppression.
- Bounded step count still fails a genuine scheduler stall with contract diagnostics.
- Test-only change; no deployment requested or performed.
