### PR TITLE
test(e2e): align Discovery readiness with Seerr

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/discovery/feature.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/discovery/feature.test.ts
@@ -65,14 +65,15 @@ beforeEach(() => {
 });
 
 describe('Discovery lazy feature contract', () => {
-    it('gates download eligibility on config and the exact library route', () => {
+    it('gates download eligibility on shared config and the exact library route', () => {
         expect(isDiscoveryEnabled(state())).toBe(true);
         expect(isDiscoveryLibraryRoute(state('/web/#/movies?topParentId=1'))).toBe(true);
         expect(isDiscoveryLibraryRoute(state('/web/#/tvshows'))).toBe(true);
         expect(isDiscoveryLibraryRoute(state('/web/#/home'))).toBe(false);
 
-        window.JellyfinCanopy.pluginConfig.DiscoveryEnabled = false;
+        window.JellyfinCanopy.pluginConfig = { SeerrEnabled: false, TmdbEnabled: true };
         expect(isDiscoveryEnabled(state())).toBe(false);
+        expect(isDiscoveryEnabled({ ...state(), identity: null })).toBe(false);
     });
 
     it('does not activate or register cleanup for a stale scope', async () => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/discovery/index.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/discovery/index.ts
@@ -4,17 +4,15 @@
 // placement-agnostic; this barrel wires the first placement — the Movies/TV library page tab.
 // Follow-up placements (home tab, standalone page, search suggestions) register alongside it.
 import type { FeatureLoaderState, FeatureModule, FeatureScope } from '../core/feature-loader';
+import { isDiscoveryLibraryConfigured } from '../globals';
 import { resetDiscoveryCustomize } from './customize';
 import { resetDiscoveryFeeds } from './feed';
 import { initLibraryTab, resetLibraryTab } from './library-tab';
 
 /** Configuration-only eligibility; route applicability remains independent. */
 export function isDiscoveryEnabled(state: FeatureLoaderState): boolean {
-    const config = window.JellyfinCanopy?.pluginConfig;
     return Boolean(state.identity)
-        && config?.DiscoveryEnabled !== false
-        && config?.DiscoveryLibraryTab !== false
-        && config?.SeerrEnabled === true;
+        && isDiscoveryLibraryConfigured(window.JellyfinCanopy?.pluginConfig);
 }
 
 /** Only library surfaces should download the Discovery feature closure. */

--- a/Jellyfin.Plugin.JellyfinCanopy/src/discovery/library-tab.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/discovery/library-tab.ts
@@ -9,7 +9,7 @@
 // overlay pane over the library content on the stable #moviesPage/#tvshowsPage div. Re-injected on
 // navigation + a scoped body-observer tick so it survives React re-renders; torn down on nav away.
 
-import { JC } from '../globals';
+import { JC, isDiscoveryLibraryConfigured } from '../globals';
 import { onNavigate } from '../core/navigation';
 import { getHeaderRightContainer } from '../enhanced/helpers';
 import { injectCss } from '../core/ui-kit';
@@ -56,10 +56,7 @@ function stateFor(id: string): PaneState {
 }
 
 function enabled(): boolean {
-    if (JC.pluginConfig?.DiscoveryEnabled === false) return false;
-    if (JC.pluginConfig?.DiscoveryLibraryTab === false) return false;
-    // Discovery is Seerr-backed (parental-filtered + request-aware); it needs a Seerr connection.
-    return JC.pluginConfig?.SeerrEnabled === true;
+    return isDiscoveryLibraryConfigured(JC.pluginConfig);
 }
 
 function ensureCss(): void {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/entries/seerr-descriptors.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/entries/seerr-descriptors.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import type { FeatureLoaderState } from '../core/feature-loader';
-import { JC } from '../globals';
+import { JC, isDiscoveryLibraryConfigured } from '../globals';
 import { seerrFeatureDescriptors } from './seerr-descriptors';
 
 function state(routeKey: string, identity = true): FeatureLoaderState {
@@ -45,5 +45,14 @@ describe('Seerr descriptor fragment', () => {
         expect(search.isEnabled(state('/web/#/search'))).toBe(false);
         expect(discovery.isEnabled(state('/web/#/movies'))).toBe(false);
         expect(search.isEnabled(state('/web/#/search', false))).toBe(false);
+    });
+
+    it.each([
+        [{ DiscoveryEnabled: false, DiscoveryLibraryTab: true, SeerrEnabled: true }, false],
+        [{ DiscoveryEnabled: true, DiscoveryLibraryTab: false, SeerrEnabled: true }, false],
+        [{ DiscoveryEnabled: true, DiscoveryLibraryTab: true, SeerrEnabled: false, TmdbEnabled: true }, false],
+        [{ SeerrEnabled: true }, true],
+    ])('owns the Discovery library configuration truth table %#', (config, expected) => {
+        expect(isDiscoveryLibraryConfigured(config)).toBe(expected);
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/entries/seerr-descriptors.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/entries/seerr-descriptors.ts
@@ -1,5 +1,5 @@
 import type { ClientFeatureDescriptor } from '../core/client-runtime';
-import { JC } from '../globals';
+import { JC, isDiscoveryLibraryConfigured } from '../globals';
 
 function enabled(): boolean {
     return JC.pluginConfig?.SeerrEnabled === true;
@@ -58,9 +58,7 @@ export const seerrFeatureDescriptors: readonly ClientFeatureDescriptor[] = Objec
         dependsOn: ['seerr-core'],
         restartOnConfigChange: true,
         isEnabled: (state) => Boolean(state.identity)
-            && enabled()
-            && JC.pluginConfig?.DiscoveryEnabled !== false
-            && JC.pluginConfig?.DiscoveryLibraryTab !== false,
+            && isDiscoveryLibraryConfigured(JC.pluginConfig),
         isApplicable: (state) => /#\/(?:movies|tvshows)(?:[/?#]|$)/i.test(state.routeKey),
     },
 ]);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/globals.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/globals.ts
@@ -6,7 +6,7 @@
 // the global must exist — a missing namespace means the bundle was loaded
 // out of order, which we fail on loudly instead of half-initializing.
 
-import type { JEGlobal } from './types/jc';
+import type { JEGlobal, PluginConfig } from './types/jc';
 
 if (!window.JellyfinCanopy) {
     throw new Error(
@@ -17,3 +17,10 @@ if (!window.JellyfinCanopy) {
 
 /** The shared plugin namespace (window.JellyfinCanopy). */
 export const JC: JEGlobal = window.JellyfinCanopy;
+
+/** One configuration owner for the Seerr-backed Discovery library placement. */
+export function isDiscoveryLibraryConfigured(config: PluginConfig | undefined): boolean {
+    return config?.DiscoveryEnabled !== false
+        && config?.DiscoveryLibraryTab !== false
+        && config?.SeerrEnabled === true;
+}

--- a/e2e/discovery.spec.ts
+++ b/e2e/discovery.spec.ts
@@ -1,18 +1,20 @@
 // E2E for the Discovery / Trending library placement.
 //
-// The Discovery feed needs a data source (Seerr and/or a TMDB key). Required CI
-// supplies both hermetically; the readiness skip is only for exploratory runs
+// The Discovery library placement needs Seerr for parental-filtered, request-aware data. Required CI
+// supplies it hermetically; the readiness skip is only for exploratory runs
 // against arbitrary unconfigured servers. It asserts the library toggle, that the pane renders real shelves, and
 // that the per-user Customize modal opens; it never triggers a request (no indexer/side effects).
 import { test, expect, loginAs } from './fixtures/auth';
 import type { Page } from 'playwright/test';
+import { discoveryLibraryAvailability } from './helpers/discovery-availability.mjs';
 
-/** True when the session's plugin config has a Discovery data source (Seerr or TMDB) configured. */
-async function discoveryAvailable(page: Page): Promise<boolean> {
-    return page.evaluate(() => {
-        const cfg = (window as unknown as { JellyfinCanopy?: { pluginConfig?: Record<string, unknown> } }).JellyfinCanopy?.pluginConfig || {};
-        return cfg.DiscoveryEnabled !== false && (cfg.SeerrEnabled === true || cfg.TmdbEnabled === true);
-    });
+/** Apply the production-owned library eligibility contract to the current session config. */
+async function discoveryAvailability(page: Page) {
+    const config = await page.evaluate(() => (
+        (window as unknown as { JellyfinCanopy?: { pluginConfig?: Record<string, unknown> } })
+            .JellyfinCanopy?.pluginConfig || {}
+    ));
+    return discoveryLibraryAvailability(config);
 }
 
 test.describe('Discovery / Trending — library placement', () => {
@@ -21,7 +23,8 @@ test.describe('Discovery / Trending — library placement', () => {
         await loginAs(page, 'admin', consoleErrors);
         await page.goto('/web/#/movies');
         await page.waitForTimeout(3000);
-        test.skip(!(await discoveryAvailable(page)), 'no Discovery data source configured on this exploratory server');
+        const availability = await discoveryAvailability(page);
+        test.skip(!availability.available, availability.reason || 'Discovery library placement is unavailable');
 
         const toggle = page.locator('#jc-discovery-toggle-movies');
         await expect(toggle).toBeVisible({ timeout: 20_000 });

--- a/e2e/helpers/discovery-availability.d.mts
+++ b/e2e/helpers/discovery-availability.d.mts
@@ -1,0 +1,7 @@
+export type DiscoveryLibraryAvailability =
+    | Readonly<{ available: true; reason: null }>
+    | Readonly<{ available: false; reason: string }>;
+
+export function discoveryLibraryAvailability(
+    config: Readonly<Record<string, unknown>> | null | undefined,
+): DiscoveryLibraryAvailability;

--- a/e2e/helpers/discovery-availability.mjs
+++ b/e2e/helpers/discovery-availability.mjs
@@ -1,0 +1,20 @@
+/**
+ * Mirror the production Discovery library configuration contract for the
+ * Node-side exploratory readiness decision. The source-contract regression
+ * ties this helper to the two real browser consumers.
+ *
+ * @param {Readonly<Record<string, unknown>> | null | undefined} config
+ * @returns {{ available: true, reason: null } | { available: false, reason: string }}
+ */
+export function discoveryLibraryAvailability(config) {
+    if (config?.DiscoveryEnabled === false) {
+        return { available: false, reason: 'Discovery is disabled on this server' };
+    }
+    if (config?.DiscoveryLibraryTab === false) {
+        return { available: false, reason: 'Discovery library placement is disabled on this server' };
+    }
+    if (config?.SeerrEnabled !== true) {
+        return { available: false, reason: 'Discovery library placement requires Seerr' };
+    }
+    return { available: true, reason: null };
+}

--- a/scripts/e2e/discovery-readiness.test.js
+++ b/scripts/e2e/discovery-readiness.test.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+const test = require('node:test');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const spec = fs.readFileSync(path.join(ROOT, 'e2e', 'discovery.spec.ts'), 'utf8');
+const descriptor = fs.readFileSync(
+    path.join(ROOT, 'Jellyfin.Plugin.JellyfinCanopy', 'src', 'entries', 'seerr-descriptors.ts'),
+    'utf8'
+);
+const owner = fs.readFileSync(
+    path.join(ROOT, 'Jellyfin.Plugin.JellyfinCanopy', 'src', 'globals.ts'),
+    'utf8'
+);
+const surface = fs.readFileSync(
+    path.join(ROOT, 'Jellyfin.Plugin.JellyfinCanopy', 'src', 'discovery', 'library-tab.ts'),
+    'utf8'
+);
+const entry = fs.readFileSync(
+    path.join(ROOT, 'Jellyfin.Plugin.JellyfinCanopy', 'src', 'discovery', 'index.ts'),
+    'utf8'
+);
+const helperPath = path.join(ROOT, 'e2e', 'helpers', 'discovery-availability.mjs');
+const helperSource = fs.readFileSync(helperPath, 'utf8');
+
+test('the real production descriptor and visible surface share one eligibility owner', () => {
+    assert.match(owner, /config\?\.DiscoveryEnabled\s*!==\s*false[\s\S]*config\?\.DiscoveryLibraryTab\s*!==\s*false[\s\S]*config\?\.SeerrEnabled\s*===\s*true/);
+    assert.match(descriptor, /isEnabled:\s*\(state\)\s*=>\s*Boolean\(state\.identity\)\s*&&\s*isDiscoveryLibraryConfigured\(JC\.pluginConfig\)/);
+    assert.match(surface, /return isDiscoveryLibraryConfigured\(JC\.pluginConfig\);/);
+    assert.match(entry, /&&\s*isDiscoveryLibraryConfigured\(window\.JellyfinCanopy\?\.pluginConfig\);/);
+    assert.doesNotMatch(descriptor, /TmdbEnabled/);
+    assert.doesNotMatch(surface, /TmdbEnabled/);
+});
+
+test('the exploratory E2E executes the reviewed availability classifier', () => {
+    assert.match(spec, /from '\.\/helpers\/discovery-availability\.mjs';/);
+    assert.match(spec, /return discoveryLibraryAvailability\(config\);/);
+    assert.doesNotMatch(spec, /TmdbEnabled/);
+    assert.doesNotMatch(helperSource, /TmdbEnabled/);
+});
+
+test('the E2E availability classifier enforces the complete production truth table', async () => {
+    const { discoveryLibraryAvailability } = await import(pathToFileURL(helperPath).href);
+    const cases = [
+        [{ DiscoveryEnabled: false, DiscoveryLibraryTab: true, SeerrEnabled: true }, false, 'Discovery is disabled'],
+        [{ DiscoveryEnabled: true, DiscoveryLibraryTab: false, SeerrEnabled: true }, false, 'library placement is disabled'],
+        [{ DiscoveryEnabled: true, DiscoveryLibraryTab: true, SeerrEnabled: false, TmdbEnabled: true }, false, 'requires Seerr'],
+        [{ SeerrEnabled: true }, true, null],
+    ];
+
+    for (const [config, available, reason] of cases) {
+        const result = discoveryLibraryAvailability(config);
+        assert.equal(result.available, available);
+        if (reason === null) assert.equal(result.reason, null);
+        else assert.match(result.reason, new RegExp(reason));
+    }
+});


### PR DESCRIPTION
Closes #329

## Summary

- centralize the real Discovery library eligibility contract across the catalog descriptor, entry predicate, and visible surface
- make exploratory E2E readiness require Seerr instead of accepting TMDB-only configuration
- provide accurate skip reasons and executable truth-table/source-contract regression coverage
- preserve the valid required-CI path and the existing 163-file bundle budget

## Validation

- frozen source-contract regression failed on the previous predicate
- focused Node readiness tests: 3/3
- focused client tests: 10/10
- full script tests: 382/382
- exact two-CPU client coverage: 206/206 files, 1295/1295 tests, 1932/2253 lines; ratchet green
- typecheck:src, syntax, performance guard, deterministic bundle, Playwright listing, ESLint, and diff check passed
- Fable 5 low: APPROVE
- independent Codex re-review: APPROVE

## Deployment

No deployment requested for this E2E-only eligibility correction.