### PR TITLE
fix(client): preserve tag reset first-fetch fast path

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.test.ts
@@ -250,6 +250,102 @@ describe('idle scan lifecycle (BI-QA-129)', () => {
 
 });
 
+describe('hard identity reset fetch ownership (issue 336)', () => {
+    it('retires an active owner and queued follower without consuming the next 50 ms fetch', async () => {
+        vi.useFakeTimers();
+        document.body.innerHTML = '';
+        const userId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+        const oldConfig = JC.pluginConfig;
+        const oldUi = JC.core.ui;
+        JC.pluginConfig = {
+            ...oldConfig,
+            TagCacheServerMode: false,
+            SpoilerBlurEnabled: false,
+        };
+        JC.core.ui = {
+            injectCss: vi.fn(),
+            removeCss: vi.fn(),
+        } as unknown as NonNullable<typeof JC.core.ui>;
+        const currentUser = vi.spyOn(ApiClient, 'getCurrentUserId').mockReturnValue(userId);
+        const timeout = vi.spyOn(window, 'setTimeout');
+        let postCalls = 0;
+        const ajax = vi.spyOn(ApiClient, 'ajax').mockImplementation((options) => {
+            postCalls += 1;
+            if (postCalls === 1) {
+                return new Promise((_resolve, reject) => {
+                    options.signal?.addEventListener('abort', () => {
+                        reject(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+                    }, { once: true });
+                });
+            }
+            return Promise.resolve({ Items: [] });
+        });
+        JC.tagPipeline!.registerRenderer('identity-reset-fetch-test', {
+            render: () => undefined,
+            isEnabled: () => true,
+        });
+        const appendCard = (itemId: string): void => {
+            const image = gridCardImage();
+            const card = image.closest<HTMLElement>('.card')!;
+            card.dataset.id = itemId;
+            card.dataset.type = 'Movie';
+            document.body.appendChild(card);
+        };
+        const appendObservedCard = async (itemId: string): Promise<void> => {
+            await new Promise<void>((resolve) => {
+                const observer = new MutationObserver(() => {
+                    observer.disconnect();
+                    resolve();
+                });
+                observer.observe(document.body, { childList: true, subtree: true });
+                appendCard(itemId);
+            });
+        };
+
+        try {
+            resetTagPipelineIdentity();
+            await Promise.resolve(JC.tagPipeline!.initialize?.());
+            await appendObservedCard('11111111111111111111111111111111');
+            JC.tagPipeline!.scheduleScan?.();
+            await vi.runAllTimersAsync();
+            expect(ajax).toHaveBeenCalledTimes(1);
+
+            await appendObservedCard('22222222222222222222222222222222');
+            JC.tagPipeline!.scheduleScan?.();
+            await vi.advanceTimersByTimeAsync(16);
+            expect(ajax).toHaveBeenCalledTimes(1);
+
+            timeout.mockClear();
+            resetTagPipelineIdentity();
+            await Promise.resolve();
+            expect(timeout.mock.calls.map((call) => call[1])).not.toContain(50);
+            document.body.innerHTML = '';
+            await Promise.resolve();
+            await Promise.resolve(JC.tagPipeline!.initialize?.());
+            timeout.mockClear();
+            await appendObservedCard('33333333333333333333333333333333');
+            expect(timeout.mock.calls.map((call) => call[1])).toContain(50);
+            expect(timeout.mock.calls.map((call) => call[1])).not.toContain(150);
+            await vi.advanceTimersByTimeAsync(49);
+            expect(ajax).toHaveBeenCalledTimes(1);
+            await vi.advanceTimersByTimeAsync(1);
+            expect(ajax).toHaveBeenCalledTimes(2);
+        } finally {
+            (JC.tagPipeline as unknown as { unregisterRenderer(name: string): void })
+                .unregisterRenderer('identity-reset-fetch-test');
+            resetTagPipelineIdentity();
+            ajax.mockRestore();
+            currentUser.mockRestore();
+            timeout.mockRestore();
+            JC.pluginConfig = oldConfig;
+            JC.core.ui = oldUi;
+            document.body.innerHTML = '';
+            vi.clearAllTimers();
+            vi.useRealTimers();
+        }
+    });
+});
+
 describe('isListViewRow — the single list-view gate (issue 34)', () => {
     it('treats a .cardImageContainer nested in a .listItem row as a list row (skipped)', () => {
         expect(isListViewRow(listRowImage())).toBe(true);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.ts
@@ -474,7 +474,7 @@ function settleQueueEntry(entry: QueueEntry): void {
  * AbortSignal; the exact processing-generation check prevents retired work
  * from clearing a replacement owner's lock in its finally block.
  */
-function retireBatchGeneration(): void {
+function retireBatchGeneration(resumeQueued = true): void {
     batchGeneration += 1;
     const owner = activeBatchOwner;
     if (!owner) return;
@@ -483,11 +483,13 @@ function retireBatchGeneration(): void {
     owner.controller.abort();
     processingGeneration += 1;
     isProcessing = false;
-    // The retired owner had already spliced its cards out of requestQueue.
-    // Rescan releases those exact claims into the new generation, while any
-    // unaffected queued entries resume without waiting for another mutation.
-    scheduleScan();
-    if (requestQueue.length > 0) scheduleFetchIfQueued();
+    if (resumeQueued) {
+        // The retired owner had already spliced its cards out of requestQueue.
+        // Rescan releases those exact claims into the new generation, while any
+        // unaffected queued entries resume without waiting for another mutation.
+        scheduleScan();
+        if (requestQueue.length > 0) scheduleFetchIfQueued();
+    }
 }
 
 // ── Pipeline-level exclusions ─────────────────────────────────────
@@ -1334,10 +1336,10 @@ function armBatchProjectionRefresh(ids: string[], userId: string): void {
 }
 
 /** Clear all visible tag projections and all cache ownership/cursor state. */
-function resetServerProjection(clearDom: boolean): void {
+function resetServerProjection(clearDom: boolean, resumeRetiredQueue = true): void {
     serverCacheLoadGeneration++;
     projectionRequestGeneration++;
-    retireBatchGeneration();
+    retireBatchGeneration(resumeRetiredQueue);
     serverCache = null;
     serverCacheVersion = 0;
     serverCacheTimestamp = 0;
@@ -1378,7 +1380,10 @@ function resetTagPipelineIdentity(): void {
     firstFetchAfterNav = true;
     cardFetchFailures = new WeakMap<Element, number>();
     JC._tagCachePrefetch = null;
-    resetServerProjection(true);
+    // The hard identity reset releases and discards the complete queue.
+    // Do not arm replacement work for entries that cannot survive it or consume
+    // the new identity generation's 50 ms first-fetch fast path.
+    resetServerProjection(true, false);
     document.querySelectorAll(
         '.jc-tag-host, .genre-overlay-container, .quality-overlay-container, ' +
         '.language-overlay-container, .rating-overlay-container'


### PR DESCRIPTION
Closes #336

## Summary

- retire the active tag batch during an identity reset without resuming its queued followers
- preserve the 50 ms first-fetch path for the next valid identity instead of consuming it on discarded reset work
- keep the existing queue-resume behavior for non-identity reset callers
- add a deterministic regression covering an active owner plus queued follower across identity reset

## Validation

- frozen regression: old behavior schedules `[16, 50]`; fixed behavior schedules no reset-time `50`, then the next real fetch schedules `50` (not `150`) and fires at `49 + 1 ms`
- focused tag-pipeline tests: 34/34, twice
- exact two-CPU full coverage: 206/206 files, 1296/1296 tests, 1932/2253 covered lines
- TypeScript, syntax, bundle (163 outputs), performance policy, changed-file lint, and diff hygiene: green
- independent Fable 5 low review: APPROVE
- independent Codex review: APPROVE
