### PR TITLE
test(discovery): freeze generation ownership regression (#126)

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/base.generation.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/base.generation.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+
+function deferred(): { promise: Promise<void>; resolve(): void } {
+    let resolve!: () => void;
+    const promise = new Promise<void>((done) => { resolve = done; });
+    return { promise, resolve };
+}
+
+describe('Seerr discovery render generation ownership', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        JC.identity.transition('server-a', 'user-a', 'discovery-generation-test-start');
+        JC.pluginConfig = {};
+        JC.core.navigation = {
+            onNavigate: () => () => undefined,
+            onViewPage: () => () => undefined,
+        } as unknown as NonNullable<typeof JC.core.navigation>;
+    });
+
+    it.each(['A settles first', 'B settles first'])(
+        'keeps B ownership through triple same-key re-entry when %s',
+        async (completionOrder) => {
+            const gates = [deferred(), deferred(), deferred()];
+            const calls: AbortSignal[] = [];
+            const { installDiscoveryBase } = await import('./base');
+            installDiscoveryBase();
+            const controller = JC.discoveryBase!.createDiscovery({
+                key: 'generation-test',
+                mode: 'one-shot',
+                logLabel: 'Generation Test',
+                configKey: 'GenerationTestEnabled',
+                getIdFromUrl: () => 'same-item',
+                renderOneShot: vi.fn(async ({ signal }: { signal: AbortSignal }) => {
+                    const call = calls.push(signal) - 1;
+                    await gates[call].promise;
+                    if (signal.aborted) return false;
+
+                    const section = document.createElement('div');
+                    section.className = 'seerr-generation-test-discovery-section';
+                    section.textContent = `generation-${call + 1}`;
+                    document.body.appendChild(section);
+                    return true;
+                }),
+            });
+
+            const renderA = controller.render();
+            await vi.waitFor(() => expect(calls).toHaveLength(1));
+
+            // Navigation/re-entry aborts A, releases the page key, and installs B
+            // as the new owner for that exact same key.
+            controller.cleanup();
+            const renderB = controller.render();
+            await vi.waitFor(() => expect(calls).toHaveLength(2));
+            expect(calls[0].aborted).toBe(true);
+            expect(calls[1].aborted).toBe(false);
+
+            if (completionOrder === 'A settles first') {
+                gates[0].resolve();
+                await renderA;
+
+                // A's late finally must compare-and-clear. If it releases B's
+                // ownership, this third call starts and aborts B.
+                const renderC = controller.render();
+                await Promise.resolve();
+                const thirdStarted = calls.length === 3;
+                if (thirdStarted) gates[2].resolve();
+                gates[1].resolve();
+                await Promise.all([renderB, renderC]);
+
+                expect(thirdStarted).toBe(false);
+                expect(calls).toHaveLength(2);
+                expect(calls[1].aborted).toBe(false);
+            } else {
+                gates[1].resolve();
+                await renderB;
+
+                // A remains held while a completed B owns the processed key.
+                await controller.render();
+                expect(calls).toHaveLength(2);
+
+                gates[0].resolve();
+                await renderA;
+            }
+
+            expect(document.querySelectorAll('.seerr-generation-test-discovery-section'))
+                .toHaveLength(1);
+            expect(document.body.textContent).toContain('generation-2');
+            expect(document.body.textContent).not.toContain('generation-1');
+            controller.dispose();
+        },
+    );
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/filter-utils.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/discovery/filter-utils.identity.test.ts
@@ -47,27 +47,36 @@ describe('discovery managed request identity paving', () => {
         expect(fetchWithRetry).not.toHaveBeenCalled();
     });
 
-    it('cancels only the lifecycle waiter and leaves shared transport ownership in core', async () => {
+    it('lets B succeed from the same shared request after A aborts', async () => {
         let resolve!: (value: unknown) => void;
-        jf.mockReturnValue(new Promise(done => { resolve = done; }));
-        const controller = new AbortController();
+        const sharedRequest = new Promise(done => { resolve = done; });
+        jf.mockReturnValue(sharedRequest);
+        const controllerA = new AbortController();
+        const controllerB = new AbortController();
 
-        const waiting = JC.discoveryFilter!.fetchWithManagedRequest(
+        const waitingA = JC.discoveryFilter!.fetchWithManagedRequest(
             '/JellyfinCanopy/tmdb/search/person?query=a',
             'person',
-            { signal: controller.signal },
+            { signal: controllerA.signal },
         );
-        controller.abort();
+        controllerA.abort();
 
-        await expect(waiting).rejects.toMatchObject({ name: 'AbortError' });
-        expect(jf).toHaveBeenCalledWith(
+        await expect(waitingA).rejects.toMatchObject({ name: 'AbortError' });
+
+        const waitingB = JC.discoveryFilter!.fetchWithManagedRequest(
+            '/JellyfinCanopy/tmdb/search/person?query=a',
+            'person',
+            { signal: controllerB.signal },
+        );
+        expect(jf).toHaveBeenNthCalledWith(
+            2,
             '/JellyfinCanopy/tmdb/search/person?query=a',
             expect.not.objectContaining({ signal: expect.anything() }),
         );
 
-        // The underlying shared request remains settleable/cacheable for other
-        // waiters; this aborted lifecycle did not own its transport.
-        resolve({ results: [] });
-        await Promise.resolve();
+        // A's lifecycle abort cannot poison the identity-owned shared transport
+        // that a current B waiter legitimately reuses.
+        resolve({ results: ['current-b'] });
+        await expect(waitingB).resolves.toEqual({ results: ['current-b'] });
     });
 });


### PR DESCRIPTION
Closes #126.

## What changed

- Added an exact Discovery render-generation regression covering A/B/C re-entry, late cleanup, and stale publication.
- Expanded the managed-request identity regression to prove aborting waiter A does not cancel same-key waiter B, while the shared owner request still deduplicates.

## Why

The production ownership fixes requested by #126 are already present on current `main` through #233 and #280: Discovery routes requests through the shared core request owner with per-waiter abort behavior, and render cleanup uses generation compare-and-clear. What remained missing was direct, issue-shaped evidence that freezes both halves of the contract together.

The new generation test is mutation-proven: replacing compare-and-clear with the historical unconditional cleanup makes the A-first completion order fail because stale A releases current ownership and a third render aborts B.

## Impact

This is test-only. It prevents future regressions where an aborted Discovery generation cancels current work, or a late `finally` releases a newer render generation.

## Validation

- Focused Discovery tests: 2 files, 4 tests passed
- Full client coverage: 207 files, 1,298 tests passed; 1,932/2,253 core lines (85.752%)
- TypeScript source and legacy type checks passed
- Syntax inventory passed
- Deterministic bundle passed (163 files)
- Performance rules passed (248 files; 960 ms CPU)
- ESLint invocation and `git diff --check` passed
- Independent Fable 5 low review: APPROVE

One first full-coverage attempt hit the already-tracked #343 fixed-wall-clock parent-series test; that exact unrelated test passed focused (7/7), and the clean full rerun passed completely.
