### PR TITLE
chore: add jellyfin-canopy-agentic-loop skill and workflow

### DIFF
--- a/.agents/skills/jellyfin-canopy-agentic-loop/README.md
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/README.md
@@ -1,0 +1,99 @@
+# jellyfin-canopy-agentic-loop
+
+A Bun-inspired, multi-agent execution engine for Jellyfin Canopy work — bug
+fixes, features, refactors, and general changes. It carries a change through
+**parallel explore + plan**, a **single-writer implement**, an **adversarial
+review-until-clean loop**, and **repo-native verification**, then hands a clean
+branch back for PR.
+
+It is a *how*, layered on top of the *what*: every contract, gate, and
+safety/PR rule is owned by
+[`../jellyfin-canopy-engineering/SKILL.md`](../jellyfin-canopy-engineering/SKILL.md)
+and `AGENTS.md`. This skill never restates or overrides them.
+
+## Why
+
+Reading a large AI-authored diff by hand does not build confidence. Bun's
+Zig→Rust rewrite built it three ways instead: a language-independent test suite,
+**adversarial review in split context** (the reviewer never saw the author's
+reasoning and is told to assume the code is wrong), and **fixing the process
+that generated bad code** rather than each bad line. This skill applies the same
+loop to Canopy, using the repo's own Vitest/xUnit/E2E suite as the conformance
+oracle.
+
+## Files
+
+| File | Role |
+| --- | --- |
+| `SKILL.md` | Entry point — method, what runs in the main thread vs. the engine, guardrails. |
+| `references/adversarial-review.md` | The review loop: split-context rules, lenses, finding verification, done criteria. |
+| `workflows/canopy-loop.js` | The Claude Code Workflow script that runs the phases deterministically. |
+| `agents/openai.yaml` | Portable interface metadata. |
+
+## Using it (Claude Code)
+
+1. The main thread establishes scope and safety and creates the isolated
+   worktree + dedicated branch from current `origin/main` (per the engineering
+   skill), and writes the task brief.
+2. From inside that worktree, launch the loop:
+
+   ```
+   Workflow({
+     scriptPath: ".agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js",
+     args: {
+       worktree: "<abs worktree path>",
+       branch:   "<type>/<slug>",
+       task:     "<full task / issue / repro>",
+       brief:    "<path to task-brief.md>",
+       surface:  "client" | "server" | "cross" | "docs",
+       runtime:  true,
+       depth:    "quick" | "standard" | "deep",
+       solVia:   "agent",          // or "codex-cli"
+       solEffort: "high",
+       solReviewers: 1
+     }
+   })
+   ```
+
+3. Monitor with `/workflows`. Read the returned result (`readyForPR`,
+   `residualRisks`, gate/e2e evidence). If `readyForPR`, the main thread verifies
+   the push target, pushes, and opens the PR. Deployment to `:8099` and releases
+   remain separate, explicitly-authorized actions.
+
+### Depth
+
+| depth | explorers | planners | review round cap | verify-fix cap |
+| --- | --- | --- | --- | --- |
+| quick | 2 | 2 | 2 | 1 |
+| standard | 4 | 3 | 3 | 2 |
+| deep | 6 | 3 | 4 | 3 |
+
+`surface` selects which repo-native gates run; `runtime:true` additionally
+builds the Release DLL and runs `npm run e2e:local` (dockerized
+`jellyfin/jellyfin:unstable`).
+
+### Review model mix
+
+Every review round runs **both** the Claude lens reviewers and **≥1
+`gpt-5.6-sol` reviewer at high effort**. The Sol reviewer is obtained one of two
+ways, chosen with `solVia`:
+
+- `"agent"` (default) — requests `gpt-5.6-sol` directly on the subagent. Needs a
+  Sol-capable route for Claude Code, e.g. the CLIProxyAPI router that exposes
+  `gpt-5.6-sol`
+  ([how-to](https://vallettasoftware.com/blog/post/run-gpt-5-6-in-claude-code)).
+  No `codex` dependency.
+- `"codex-cli"` — a harness subagent shells out to the local `codex` CLI
+  (`-a never -s read-only exec -m gpt-5.6-sol`) with
+  `references/codex-review-schema.json`. Use where the router isn't configured.
+
+The Sol pass is best-effort: if the route/CLI is unavailable it degrades to the
+Claude reviewers rather than failing the loop, so treat a missing Sol pass as a
+signal to fix the route, not as a clean review.
+
+## Non–Claude-Code runtimes
+
+The Workflow tool is Claude Code specific. Any capable agent runtime can follow
+the same method by hand: spawn read-only explorer/planner/reviewer sub-agents in
+parallel, keep exactly one writer, and run the loop and gates from
+`references/adversarial-review.md` and the engineering skill.

--- a/.agents/skills/jellyfin-canopy-agentic-loop/README.md
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/README.md
@@ -72,11 +72,20 @@ oracle.
 builds the Release DLL and runs `npm run e2e:local` (dockerized
 `jellyfin/jellyfin:unstable`).
 
-### Review model mix
+### Model routing
 
-Every review round runs **both** the Claude lens reviewers and **≥1
-`gpt-5.6-sol` reviewer at high effort**. The Sol reviewer is obtained one of two
-ways, chosen with `solVia`:
+The loop spreads models by role to spare Claude/Opus budget:
+
+- **Implementation** — the single writer runs on **Fable (high)**, falling back
+  to **Opus (high)** if Fable is exhausted (`implementModel` / `implementFallback`).
+- **Read-only steps except implementation** — with `modelSplit: true` (default),
+  explore, plan, the review lenses, finding-verification, and the gate runner
+  alternate **~50/50 Claude / `gpt-5.6-sol` (high)**; an unroutable Sol slot
+  falls back to Claude.
+- **Fixers** — stay on Claude/Opus (they write code).
+
+Every review round still runs **both** Claude and **≥1 `gpt-5.6-sol` (high)**
+reviewer. The Sol side is obtained one of two ways, chosen with `solVia`:
 
 - `"agent"` (default) — requests `gpt-5.6-sol` directly on the subagent. Needs a
   Sol-capable route for Claude Code, e.g. the CLIProxyAPI router that exposes

--- a/.agents/skills/jellyfin-canopy-agentic-loop/SKILL.md
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/SKILL.md
@@ -79,14 +79,37 @@ Workflow({
     runtime:  true,                                       // true → also run e2e:local
     depth:    "standard",                                 // "quick" | "standard" | "deep"
 
-    // Review model mix (every round runs Claude lenses AND ≥1 gpt-5.6-sol high):
-    solVia:      "agent",        // "agent" (subagent model param) | "codex-cli"
+    // Model routing (see "Model routing" below):
+    modelSplit:  true,           // ~50/50 Claude/Sol on read-only steps to spare Opus budget
+    solVia:      "agent",        // "agent" (subagent model param, needs router) | "codex-cli"
     solModel:    "gpt-5.6-sol",
     solEffort:   "high",
-    solReviewers: 1              // ≥1 Sol reviewer per round
+    solReviewers: 1,             // Sol whole-diff reviewers when modelSplit is off
+    implementModel:    "fable",  // implementer runs on Fable (high) …
+    implementFallback: "opus"    // … falling back to Opus (high) if Fable is exhausted
   }
 })
 ```
+
+### Model routing
+
+To keep a run from burning all of Claude's budget, the loop deliberately spreads
+models by role:
+
+- **Implementation** — the single writer runs on **Fable (high)**, falling back
+  to **Opus (high)** if Fable is exhausted/unavailable. Never split mid-change.
+- **Everything read-only except implementation** — with `modelSplit: true`,
+  explore, plan, the review lenses, finding-verification, and the gate runner
+  alternate **~50/50 Claude / `gpt-5.6-sol` (high)**. A Sol slot that can't be
+  routed falls back to Claude, so no slot is lost.
+- **Fixers** (review fixer, verify fixer) — stay on Claude/Opus. They write code,
+  so they follow the one-writer, single-model rule.
+
+Sol slots run on Sol only when `solVia: "agent"` (the model param) is backed by a
+Sol-capable route — e.g. the CLIProxyAPI router that exposes `gpt-5.6-sol` to
+Claude Code. With `solVia: "codex-cli"`, only the review round uses Sol (via the
+`codex` CLI harness); the other split steps run on Claude. Set `modelSplit: false`
+to run everything on Claude (implementer still uses Fable→Opus).
 
 The script fans out agents per phase, loops the review until a clean round, runs
 the repo-native gates, and returns a structured result (diff stat, findings

--- a/.agents/skills/jellyfin-canopy-agentic-loop/SKILL.md
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: jellyfin-canopy-agentic-loop
+description: Bun-style multi-agent orchestration for Jellyfin Canopy work — bug fixes, features, refactors, and general changes driven by parallel explore/plan phases and an implement → adversarial-review → fix loop, then repo-native verification. Use when you want the change carried by a fan-out of agents with split-context adversarial review rather than a single writer, on any task in 4eh5xitv6787h645ebv/Jellyfin-Canopy. This skill governs HOW the work runs; all repository contracts, safety rules, gates, and PR discipline come from jellyfin-canopy-engineering and AGENTS.md, which it obeys unchanged.
+---
+
+# Jellyfin Canopy agentic loop
+
+This skill is an **execution engine**, not a second rulebook. It runs a Canopy
+change as a set of parallel agent loops modelled on Bun's Zig→Rust rewrite:
+one implementer, two or more adversarial reviewers, a fixer, and a
+verify-driven definition of done. It exists to raise confidence on non-trivial
+changes by making review independent, parallel, and hostile to the code.
+
+**It does not restate contracts.** Every safety rule, architecture contract,
+gate command, coverage/lint policy, and PR/merge/CI rule is owned by:
+
+- [`.agents/skills/jellyfin-canopy-engineering/SKILL.md`](../jellyfin-canopy-engineering/SKILL.md) — the canonical end-to-end workflow;
+- [`AGENTS.md`](../../../AGENTS.md), `CONTRIBUTING.md`, `SECURITY.md`, and the instructions nearest the files in scope.
+
+Read those first. This skill only adds the multi-agent *shape* on top. Where
+this file and the engineering skill ever appear to disagree, the engineering
+skill and the repository documents win.
+
+## The method (why it looks like this)
+
+Day-to-day engineering is a loop: pick a task, write the change, have it
+reviewed for regressions and correctness, apply the feedback. Bun's rewrite
+scaled that loop by splitting the roles across separate agents with separate
+context windows:
+
+- **Split context.** The agent that wrote the code wants it merged; that bias
+  is real for models too. So the reviewer is a *different* agent that never saw
+  the implementer's reasoning — only the diff and the brief — and is told to
+  assume the code is wrong and find out why. **1 implementer, 2+ adversarial
+  reviewers, 1 fixer.** Implementers do not review; reviewers do not implement.
+- **Confidence comes from three things**, not from reading a huge diff by hand:
+  a language-independent test suite (Canopy's Vitest + xUnit + E2E), adversarial
+  review, and — when something is wrong — **fixing the process that produced the
+  code, not just the line**. If a whole class of mistake keeps appearing, edit
+  the implementer/reviewer instructions, don't hand-patch each instance.
+- **Parallelise the read-only work, serialise the writer.** Exploration,
+  planning judgement, review, and finding-verification are read-only and fan out
+  wide. Implementation and fixes mutate the worktree and must be **one writer at
+  a time** — the repository's "one writer per worktree" rule is non-negotiable.
+
+## What runs where
+
+Two things stay in the **main thread** (the human-facing agent), because they
+need authority, judgement, or an outward-facing action:
+
+1. **Scope, safety, and branch setup** — restate the outcome; confirm it isn't
+   already native/implemented/infeasible; establish the isolated worktree and
+   dedicated branch from current `origin/main` exactly as the engineering skill
+   describes. Write the task brief (acceptance criteria, non-goals, owning
+   layer, reuse decisions, risks, reviewer questions).
+2. **Publish and prove** — after the loop returns clean, verify the push target,
+   push the branch, open the PR, watch CI, and report. Never deploy to `:8099`
+   or mutate an external service as an implicit step; those need separate
+   explicit authorization.
+
+Everything between — explore, plan, implement, adversarial review loop, and
+repo-native verification — runs inside the **Workflow engine**.
+
+## Running the loop (Claude Code)
+
+In Claude Code, execute the loop deterministically with the bundled Workflow
+script. Launch it **from inside the prepared worktree** and pass the task
+context as `args`:
+
+```
+Workflow({
+  scriptPath: ".agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js",
+  args: {
+    worktree: "<absolute path to the prepared worktree>",
+    branch:   "<type>/<slug>",
+    task:     "<the full task: issue text / feature contract / bug + repro>",
+    brief:    "<path to the task-brief.md the main thread wrote>",
+    surface:  "client" | "server" | "cross" | "docs",   // drives which gates run
+    runtime:  true,                                       // true → also run e2e:local
+    depth:    "standard",                                 // "quick" | "standard" | "deep"
+
+    // Review model mix (every round runs Claude lenses AND ≥1 gpt-5.6-sol high):
+    solVia:      "agent",        // "agent" (subagent model param) | "codex-cli"
+    solModel:    "gpt-5.6-sol",
+    solEffort:   "high",
+    solReviewers: 1              // ≥1 Sol reviewer per round
+  }
+})
+```
+
+The script fans out agents per phase, loops the review until a clean round, runs
+the repo-native gates, and returns a structured result (diff stat, findings
+resolved, gate evidence, E2E evidence, residual risks). **Monitor it** with
+`/workflows` and read its returned result — its agents' text is not shown to the
+user, so relay what matters. Requirements:
+
+- The Workflow tool is opt-in and billable. Invoking this skill on a real task
+  **is** that opt-in; do not launch the loop speculatively.
+- The loop assumes the worktree already exists on the right branch with the
+  toolchain installed (`npm ci`, `DOTNET_ROOT` on `PATH`). Do that in step 1.
+- The loop writes code and commits inside the one worktree. Do not start a
+  second writer, a deploy, or an E2E run against a shared server while it runs.
+
+If the Workflow tool is unavailable (a non–Claude-Code runtime reading this
+skill), follow the same phases manually: spawn read-only explorer/planner/
+reviewer sub-agents in parallel, keep a single writer, and apply the loop and
+gates described in [`references/adversarial-review.md`](references/adversarial-review.md).
+
+## The phases
+
+The engine ([`workflows/canopy-loop.js`](workflows/canopy-loop.js)) runs:
+
+1. **Explore** (parallel, read-only) — map the owning layer, every producer/
+   consumer, the nearest implemented analogue, existing cross-cutting helpers,
+   the contracts the change touches, and the test seams. No guessing about where
+   code lives.
+2. **Plan** (parallel judge panel) — a few independent plans, each choosing the
+   owning layer, reuse-vs-new decisions, and the simplest state/failure model;
+   adversarially scored and synthesised into one canonical plan. Prefer deleting
+   or delegating state over adding a flag/retry/lock/observer.
+3. **Implement** (single writer) — build the change at its owner, update every
+   affected consumer, add tests that fail before the fix (admin and non-admin,
+   negative/fallback paths, concurrency/cache invalidation where relevant), add
+   every locale key with real translations, and update affected docs. Commit
+   coherent conventional units. No `Co-Authored-By` trailers; keep issue `#N`
+   out of messages.
+4. **Review loop** (parallel adversarial, loop-until-clean) — see
+   [`references/adversarial-review.md`](references/adversarial-review.md). Each
+   round mixes models on purpose: the Claude lens reviewers **and** at least one
+   `gpt-5.6-sol` (high effort) whole-diff reviewer, all in split context (diff +
+   brief only, told to assume the code is wrong). Findings are deduped and
+   adversarially verified to kill false positives; a single fixer applies
+   confirmed findings; re-review until a clean round. Challenge the design before
+   a second fix to the same owner/state model. If a workaround needs a
+   paragraph-long comment to justify it, the code is wrong — fix the code.
+5. **Verify** (single runner) — run the repo-native gates for the surface, and
+   for runtime-relevant work build the Release DLL and run `npm run e2e:local`
+   (exercise admin and non-admin, assert real DOM/server state, zero
+   non-whitelisted console errors, zero unexpected plugin 4xx). Lint is advisory
+   per repo policy; every other gate is blocking. On failure, loop back a
+   bounded number of times to fix, then re-verify.
+
+## Guardrails carried from the repository
+
+- Only `4eh5xitv6787h645ebv/Jellyfin-Canopy`. `n00bcodr/Jellyfin-Enhanced` and
+  `4eh5xitv6787h645ebv/Jellyfin-Enhanced` are strictly read-only.
+- One writer per worktree; parallel agents are read-only. Never let two agents
+  edit the same files.
+- Jellyfin 12 / .NET 10 boundary; modern MUI **and** legacy web layouts both
+  stay valid when UI is touched; native markup, local assets, no jank.
+- Auth/authorization, per-user isolation, escaping, cancellation, disposal,
+  bounded work, and live-config generation ownership fail closed.
+- Coverage and lint caps are ratchets — never lowered or widened to go green.
+- Rebuild and commit generated bundles, manifests, snapshots, and translations
+  from source when the repo expects it.
+- Deployment to `:8099`, releases, and external-service mutations are separate,
+  explicitly-authorized actions — never an implicit step of this loop.
+- Verify the writable push target immediately before any push or merge.
+
+## When to use / when not
+
+**Use** for any real Canopy change where independent, parallel, adversarial
+review earns its cost: non-trivial bug fixes, features, refactors touching a
+state machine or shared owner, and anything security- or concurrency-sensitive.
+
+**Don't** spin up the loop for a one-line typo, a docs-only wording fix, or pure
+questions/audits — the engineering skill's normal single-thread flow is cheaper.
+For read-only review or benchmark requests, run only the review lenses against
+the supplied diff; skip implement, verify, deploy, and PR.

--- a/.agents/skills/jellyfin-canopy-agentic-loop/agents/openai.yaml
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Jellyfin Canopy Agentic Loop"
+  short_description: "Bun-style multi-agent write/adversarial-review loop for Canopy changes"
+  default_prompt: "Use $jellyfin-canopy-agentic-loop to carry this Jellyfin Canopy change through parallel explore/plan, a single-writer implement, an adversarial review-until-clean loop, and repo-native verification."

--- a/.agents/skills/jellyfin-canopy-agentic-loop/references/adversarial-review.md
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/references/adversarial-review.md
@@ -1,0 +1,99 @@
+# Adversarial review loop
+
+The confidence mechanism of this skill. It is deliberately hostile: reviewers
+are not asked "is this good?" — they are told the change is wrong and asked to
+prove how. Modelled on Bun's rewrite, tuned to Canopy's contracts.
+
+## Rules of the loop
+
+1. **Split context.** A reviewer sees the **diff and the task brief only** —
+   never the implementer's chain of thought. It never edits files. The
+   implementer never reviews its own change. Roles do not mix.
+2. **Default to "wrong".** Each reviewer's only job is to find bugs and concrete
+   reasons the change does not work or violates a contract. "Looks fine" is not
+   a finding; a finding needs a file/line and a failure scenario (inputs/state →
+   wrong output/crash/leak).
+3. **Two or more reviewers per round, across distinct lenses** (below), and
+   **across two model families**: the Claude lens reviewers plus at least one
+   `gpt-5.6-sol` reviewer at **high** effort doing a whole-diff pass. Diversity
+   beats redundancy — different angles *and* different models catch failure modes
+   a single model's blind spots would miss. (In `canopy-loop.js`: `solReviewers`
+   ≥ 1, obtained via the subagent model param or the `codex` CLI per `solVia`.)
+4. **Verify before fixing.** Every finding is adversarially checked by an
+   independent verifier that tries to *refute* it. Default to refuted when
+   uncertain. Only confirmed findings reach the fixer — this kills
+   plausible-but-wrong findings before they cost a change.
+5. **One fixer, then re-review.** A single writer applies the confirmed findings
+   at their owner, adds regression evidence, and the round repeats. Stop when a
+   full round produces no confirmed findings (a clean round), or after the round
+   cap — never on "we're probably fine".
+6. **Fix the process, not the instance.** If a class of finding recurs (the same
+   lens keeps catching the same kind of mistake), amend the implementer/fixer
+   instructions for the next round instead of hand-patching each occurrence.
+7. **Challenge the design before a second fix to the same owner.** If a fix would
+   add another state flag, retry, lock, publisher, or lifecycle path — or a
+   second fix touches the same state machine/ownership boundary — restate the
+   required invariant and try deletion, reuse, or single ownership first. Ask the
+   user if simplification would change accepted behavior.
+8. **No paragraph-long justifications.** If a workaround needs a long explanatory
+   comment to argue it is OK, the code is wrong — fix the code. Reviewers reject
+   such comments.
+
+## Review lenses
+
+Assign each reviewer one lens. Skip lenses the diff cannot touch; add
+task-specific reviewer questions from the brief. For Canopy, the standing lenses
+are:
+
+- **Correctness & logic** — does it do what the brief says on the happy path and
+  every branch? Off-by-one, wrong operator, eager vs. lazy evaluation, error
+  paths, `null`/undefined, boundary values.
+- **Security & privacy (fail closed)** — authn/authz, per-user isolation, input
+  validation, output escaping, no credential/media/PII leakage, no
+  exploit-grade detail in logs. Bare 401/403 preserved. Follow `SECURITY.md`.
+- **Lifecycle & concurrency** — ownership of every new cache/flag/timer/retry/
+  observer/lock/background job/writer; cancellation and disposal; races on
+  shared state; live-config generation ownership. Each side effect has exactly
+  one owner.
+- **Bounds & performance** — bounded memory and work; no unbounded growth,
+  polling, or hidden N×; no jank (flicker/reflow/layout shift) on any layout;
+  respects the repo's performance rules.
+- **Compatibility & platform** — Jellyfin 12 / .NET 10 boundary; modern MUI
+  **and** legacy web layouts both remain valid; native Jellyfin markup and local
+  assets; server/runtime API used as it actually exists (verify against the
+  sanctioned reference trees, not memory).
+- **Test strength** — tests fail before the fix and pass after; cover admin and
+  non-admin, negative/fallback paths, and prove the intended lower tier ran
+  (non-vacuous assertions). Deterministic seams over sleeps/broad mocks. No
+  coverage-cap lowering.
+- **Product semantics & scope** — no behavior added merely because it might be
+  useful; no scope creep beyond the brief; shared parity gaps fixed once at the
+  owner, not by making the new consumer uniquely sophisticated.
+- **Docs, locale & generated artifacts** — every affected user/admin/architecture/
+  security doc updated; every locale key present in all locale files with real
+  translations; bundles/manifests/snapshots rebuilt from source and committed.
+
+## Watch for semantically-different-but-syntactically-similar code
+
+Bun's regressions clustered here; Canopy's mixed C#/TS/JS surface has the same
+trap. Flag when a mechanical-looking change hides a semantic shift:
+
+- an assertion/guard whose argument has a **side effect** that a debug-only or
+  stripped build would skip;
+- eager evaluation of a default (`x ?? expensiveOrThrowing()`) that runs even
+  when the value is present — prefer a lazy form;
+- truncation/rounding differences on odd-length buffers or negative values;
+- bounds checks present in one build/config and absent in another;
+- string/byte handling that silently assumes valid UTF-8/UTF-16 where the source
+  is arbitrary bytes (paths, media, network);
+- format/escape passes that run over data they shouldn't (color/markup markers
+  rewritten into user content).
+
+## Definition of done for the loop
+
+A change is loop-clean when: a full review round yields no confirmed findings;
+every repo-native gate for the surface passes (lint advisory, all else
+blocking); runtime-relevant work has green `e2e:local` evidence for admin and
+non-admin with zero non-whitelisted console errors and zero unexpected plugin
+4xx; and residual risks are named, not hidden. Anything less is reported as
+in-progress, never as done.

--- a/.agents/skills/jellyfin-canopy-agentic-loop/references/codex-review-schema.json
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/references/codex-review-schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["verdict", "findings"],
+  "properties": {
+    "verdict": { "type": "string", "enum": ["clean", "findings"] },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["file", "summary", "failureScenario"],
+        "properties": {
+          "lens": { "type": "string" },
+          "file": { "type": "string" },
+          "line": { "type": "integer" },
+          "severity": { "type": "string", "enum": ["blocker", "major", "minor"] },
+          "summary": { "type": "string" },
+          "failureScenario": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -69,6 +69,49 @@ const SOL_VIA = a.solVia || 'agent' // 'agent' | 'codex-cli'
 const CODEX_SCHEMA_PATH =
   a.codexSchema || `${WORKTREE}/.agents/skills/jellyfin-canopy-agentic-loop/references/codex-review-schema.json`
 
+// ── multi-model split (token offload) ───────────────────────────────────────
+// Route ~50% of the READ-ONLY reasoning to gpt-5.6-sol so a run doesn't spend
+// all of Claude's budget. The split covers explore, plan, the review lenses,
+// finding-verification, and the verify/gate runner. IMPLEMENTATION and every
+// code-writing fixer always stay Claude — one writer per worktree, and you don't
+// want two models editing the same files. A slot runs on Sol only when it's a
+// split-Sol slot AND the model-param route is available (SOL_VIA==='agent', i.e.
+// the router). Under 'codex-cli' the split degrades to Claude everywhere except
+// the review round (which has a dedicated codex harness), so the router yields
+// the largest saving. Turn the whole thing off with modelSplit:false.
+const MODEL_SPLIT = a.modelSplit !== false
+const SOL_AGENT_OK = SOL_VIA === 'agent'
+const solSlot = (i) => MODEL_SPLIT && i % 2 === 1 // odd indices → Sol (~50/50)
+
+// A read-only phase agent that runs on Sol for split-Sol slots (model-param
+// route), else Claude. If the Sol attempt throws (model not routable) or returns
+// null, it FALLS BACK to Claude so the slot is never simply lost.
+// opts carries schema/agentType/effort/phase/label.
+async function splitAgent(i, prompt, opts) {
+  if (solSlot(i) && SOL_AGENT_OK) {
+    try {
+      const r = await agent(prompt, { ...opts, model: SOL_MODEL, effort: SOL_EFFORT })
+      if (r != null) return r
+    } catch (_) {
+      /* Sol not routable → Claude fallback below */
+    }
+  }
+  return agent(prompt, opts)
+}
+// A singleton read-only step we prefer to offload to Sol (synthesis, gate
+// runner) to spare Claude tokens; falls back to Claude when Sol isn't routable.
+async function soloSolAgent(prompt, opts) {
+  if (MODEL_SPLIT && SOL_AGENT_OK) {
+    try {
+      const r = await agent(prompt, { ...opts, model: SOL_MODEL, effort: SOL_EFFORT })
+      if (r != null) return r
+    } catch (_) {
+      /* fall through to Claude */
+    }
+  }
+  return agent(prompt, opts)
+}
+
 // ── shared prompt preamble ──────────────────────────────────────────────────
 const CONTRACTS = `You are working on the Jellyfin Canopy plugin repository in the worktree at:
   ${WORKTREE}
@@ -238,7 +281,8 @@ const exploreAngles = [
 const explorations = (
   await parallel(
     exploreAngles.map((angle, i) => () =>
-      agent(
+      splitAgent(
+        i,
         `${CONTRACTS}
 
 PHASE: EXPLORE (read-only — do NOT edit any file).
@@ -246,7 +290,7 @@ Your angle: ${angle}.
 Use rg/ls/Read to trace real code. Return a precise map: where the change lives,
 who is affected, the analogue to copy, helpers to reuse (so we don't write new),
 the contracts touched, and the test seams. Cite real paths; never guess.`,
-        { schema: EXPLORE_SCHEMA, agentType: 'Explore', effort: 'medium', phase: 'Explore', label: `explore:${i + 1}` }
+        { schema: EXPLORE_SCHEMA, agentType: 'Explore', effort: 'medium', phase: 'Explore', label: `explore:${i + 1}${solSlot(i) && SOL_AGENT_OK ? ':sol' : ''}` }
       )
     )
   )
@@ -269,7 +313,8 @@ const planAngles = [
 const plans = (
   await parallel(
     planAngles.map((angle, i) => () =>
-      agent(
+      splitAgent(
+        i,
         `${CONTRACTS}
 
 PHASE: PLAN (read-only). Explore maps (JSON):
@@ -281,13 +326,13 @@ model (and explicitly what NOT to add — no speculative flag/retry/lock/observe
 polling/migration), the failing-first tests (admin AND non-admin, negative/
 fallback, concurrency/cache invalidation where relevant), and the locale keys +
 docs to update.`,
-        { schema: PLAN_SCHEMA, effort: 'high', phase: 'Plan', label: `plan:${i + 1}` }
+        { schema: PLAN_SCHEMA, effort: 'high', phase: 'Plan', label: `plan:${i + 1}${solSlot(i) && SOL_AGENT_OK ? ':sol' : ''}` }
       )
     )
   )
 ).filter(Boolean)
 
-const canonicalPlan = await agent(
+const canonicalPlan = await soloSolAgent(
   `${CONTRACTS}
 
 PHASE: PLAN SYNTHESIS (read-only). You are the adversarial judge. Here are ${plans.length}
@@ -307,8 +352,7 @@ log(`Plan: ${plans.length} plans → 1 canonical (${(canonicalPlan && canonicalP
 // ═══════════════════════════════════════════════════════════════════════════
 phase('Implement')
 
-const implemented = await agent(
-  `${CONTRACTS}
+const implementPrompt = `${CONTRACTS}
 
 PHASE: IMPLEMENT. You are the SOLE writer in this worktree. Follow this canonical
 plan exactly (JSON):
@@ -329,9 +373,26 @@ Rules:
   trailers. Keep issue "#N" out of commit messages and comments.
 - Run the directly-affected focused tests as you go. Do not run the full gate.
 Report the changed files, commits, tests added, a diff stat, and an honest
-self-confidence (high/medium/low) with any open TODOs.`,
-  { schema: IMPLEMENT_SCHEMA, agentType: 'general-purpose', effort: 'high', phase: 'Implement', label: 'implement' }
-)
+self-confidence (high/medium/low) with any open TODOs.`
+
+// Implementer runs on Fable (high) to spare Opus budget; if Fable is exhausted
+// or errors (agent returns null), fall back to Opus (high). The single writer is
+// never split across models mid-change. Fixers stay on the session model (Opus).
+const IMPL_MODEL = a.implementModel || 'fable'
+const IMPL_FALLBACK = a.implementFallback || 'opus'
+const implOpts = { schema: IMPLEMENT_SCHEMA, agentType: 'general-purpose', effort: 'high', phase: 'Implement' }
+let implemented = await agent(implementPrompt, { ...implOpts, model: IMPL_MODEL, label: `implement:${IMPL_MODEL}` })
+if (!implemented) {
+  log(`Implement: ${IMPL_MODEL} unavailable/exhausted → falling back to ${IMPL_FALLBACK} (high)`)
+  implemented = await agent(
+    `${implementPrompt}
+
+NOTE: a previous attempt may have left partial changes or commits in the
+worktree. Inspect \`git -C ${WORKTREE} status\` and \`git -C ${WORKTREE} log --oneline ${BASE}..HEAD\`
+and CONTINUE from there rather than restarting from scratch.`,
+    { ...implOpts, model: IMPL_FALLBACK, label: `implement:${IMPL_FALLBACK}-fallback` }
+  )
+}
 log(`Implement: ${(implemented && implemented.changedFiles && implemented.changedFiles.length) || 0} files, confidence ${(implemented && implemented.selfConfidence) || '?'}`)
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -346,19 +407,25 @@ The change is on branch ${BRANCH}. Inspect it with:
   git -C ${WORKTREE} log --oneline ${BASE}..HEAD
 You see ONLY the diff and this brief — never the implementer's reasoning.`
 
-// gpt-5.6-sol whole-diff adversarial reviewer (high effort). One thunk per Sol
-// reviewer; obtained via the subagent model param ('agent') or the codex CLI.
-function solThunk(roundNo, i) {
+// gpt-5.6-sol adversarial reviewer (high effort). One thunk per Sol reviewer;
+// obtained via the subagent model param ('agent') or the codex CLI. With a lens,
+// the review is scoped to that lens (used by the 50/50 split); without one it is
+// a whole-diff pass (used by the dedicated SOL_REVIEWERS when not splitting).
+function solThunk(roundNo, i, lens) {
+  const scope = lens
+    ? `THROUGH THIS LENS ONLY: "${lens}".`
+    : `across correctness, security/privacy (fail-closed), lifecycle/concurrency,
+bounds/perf/no-jank, JF12 + MUI/legacy compatibility, test strength, product
+scope, and docs/locale/generated-artifact gaps.`
   const solPrompt = `${reviewContext}
 
-PHASE: ADVERSARIAL REVIEW (gpt-5.6-sol, whole diff). Assume the change is WRONG and
-prove how. Cover correctness, security/privacy (fail-closed), lifecycle/
-concurrency, bounds/perf/no-jank, JF12 + MUI/legacy compatibility, test strength,
-product scope, and docs/locale/generated-artifact gaps. Every finding needs a
-real file/line and a concrete failure scenario (inputs/state → wrong output /
-crash / leak / contract violation). Reject workarounds that need a paragraph-long
-comment to justify them. Watch for mechanically-similar-but-semantically-
-different code. Return only real findings (empty array if none).`
+PHASE: ADVERSARIAL REVIEW (gpt-5.6-sol). Assume the change is WRONG and prove how,
+${scope}
+Every finding needs a real file/line and a concrete failure scenario (inputs/
+state → wrong output / crash / leak / contract violation). Reject workarounds
+that need a paragraph-long comment to justify them. Watch for
+mechanically-similar-but-semantically-different code. Return only real findings
+(empty array if none).`
 
   if (SOL_VIA === 'codex-cli') {
     return () =>
@@ -391,9 +458,8 @@ let cleanRound = false
 let round = 0
 while (round < SIZING.roundCap && !cleanRound) {
   round++
-  log(`Review round ${round}/${SIZING.roundCap} — ${LENSES.length} Claude lenses + ${SOL_REVIEWERS}× ${SOL_MODEL} (${SOL_VIA}, ${SOL_EFFORT})`)
 
-  const claudeThunks = LENSES.map((lens, i) => () =>
+  const claudeLensThunk = (lens, i) => () =>
     agent(
       `${reviewContext}
 
@@ -408,12 +474,24 @@ over the wrong data). Reject any workaround that needs a paragraph-long comment
 to justify it. Return only real findings (empty array if none this lens).`,
       { schema: FINDINGS_SCHEMA, agentType: 'code-reviewer', effort: 'medium', phase: 'Review', label: `review-r${round}:${i + 1}` }
     )
-  )
-  const solThunks = Array.from({ length: SOL_REVIEWERS }, (_, i) => solThunk(round, i))
 
-  const raw = (await parallel([...claudeThunks, ...solThunks]))
-    .filter(Boolean)
-    .flatMap((r) => (r && r.findings) || [])
+  // Split the lenses ~50/50 across models when modelSplit is on (Sol takes the
+  // odd slots, lens-scoped). Otherwise: all Claude lenses + the dedicated
+  // whole-diff SOL_REVIEWERS. Either way ≥1 Claude and ≥1 Sol reviewer run.
+  let roundThunks
+  if (MODEL_SPLIT) {
+    roundThunks = LENSES.map((lens, i) => (solSlot(i) ? solThunk(round, i, lens) : claudeLensThunk(lens, i)))
+  } else {
+    roundThunks = [
+      ...LENSES.map((lens, i) => claudeLensThunk(lens, i)),
+      ...Array.from({ length: SOL_REVIEWERS }, (_, i) => solThunk(round, i)),
+    ]
+  }
+  const solCount = MODEL_SPLIT ? LENSES.filter((_, i) => solSlot(i)).length : SOL_REVIEWERS
+  const claudeCount = roundThunks.length - solCount
+  log(`Review round ${round}/${SIZING.roundCap} — ${claudeCount} Claude + ${solCount}× ${SOL_MODEL} (${SOL_VIA}, ${SOL_EFFORT})${MODEL_SPLIT ? ' [50/50]' : ''}`)
+
+  const raw = (await parallel(roundThunks)).filter(Boolean).flatMap((r) => (r && r.findings) || [])
 
   const deduped = dedupe(raw)
   if (!deduped.length) {
@@ -425,7 +503,8 @@ to justify it. Return only real findings (empty array if none this lens).`,
   // Adversarially verify each finding — try to REFUTE it; default refuted.
   const verdicts = await parallel(
     deduped.map((f, i) => () =>
-      agent(
+      splitAgent(
+        i,
         `${reviewContext}
 
 PHASE: VERIFY FINDING. Try hard to REFUTE this claimed defect. Default to
@@ -483,7 +562,7 @@ Compose projects this run created. Do NOT touch :8099 or any shared/prod server.
 let verify = null
 let vround = 0
 while (vround <= SIZING.verifyFixCap) {
-  verify = await agent(
+  verify = await soloSolAgent(
     `${CONTRACTS}
 
 PHASE: VERIFY. Run the repository-native gates for surface="${SURFACE}", in order,

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -63,7 +63,11 @@ const SOL_MODEL = a.solModel || 'gpt-5.6-sol'
 const SOL_EFFORT = a.solEffort || 'high' // low|medium|high|xhigh|max|ultra
 const SOL_REVIEWERS = a.solReviewers == null ? 1 : Math.max(0, a.solReviewers)
 const SOL_VIA = a.solVia || 'agent' // 'agent' | 'codex-cli'
-const CODEX_SCHEMA = '.agents/skills/jellyfin-canopy-agentic-loop/references/codex-review-schema.json'
+// Path to the codex --output-schema. Defaults inside the target worktree, but
+// can be overridden (e.g. an absolute path) when the skill files are not yet in
+// the worktree — such as running the loop before this skill is merged to main.
+const CODEX_SCHEMA_PATH =
+  a.codexSchema || `${WORKTREE}/.agents/skills/jellyfin-canopy-agentic-loop/references/codex-review-schema.json`
 
 // ── shared prompt preamble ──────────────────────────────────────────────────
 const CONTRACTS = `You are working on the Jellyfin Canopy plugin repository in the worktree at:
@@ -370,7 +374,7 @@ ${solPrompt}
 SOL_PROMPT
   codex -a never -s read-only exec -C "${WORKTREE}" --ephemeral --ignore-user-config \\
     --color never --json -m "${SOL_MODEL}" -c model_reasoning_effort="${SOL_EFFORT}" \\
-    --output-schema "${WORKTREE}/${CODEX_SCHEMA}" -o "$R" - < "$P" > "$EV" 2> "$ER"
+    --output-schema "${CODEX_SCHEMA_PATH}" -o "$R" - < "$P" > "$EV" 2> "$ER"
 Then read "$R" (JSON conforming to the schema) and RETURN its findings mapped to
 THIS tool's schema (lens="gpt-5.6-sol", file, line, severity, summary,
 failureScenario). If \`codex\` is missing or exits non-zero, RETURN

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -1,0 +1,546 @@
+export const meta = {
+  name: 'canopy-loop',
+  description:
+    'Bun-style multi-agent loop for a Jellyfin Canopy change: parallel explore + plan, single-writer implement, adversarial review-until-clean, repo-native verify.',
+  phases: [
+    { title: 'Explore', detail: 'parallel read-only map of the owning layer, consumers, analogue, helpers, contracts, test seams' },
+    { title: 'Plan', detail: 'independent plans judged and synthesised into one canonical plan' },
+    { title: 'Implement', detail: 'single writer builds the change at its owner with failing-first tests' },
+    { title: 'Review', detail: 'adversarial reviewers (split context) → verify findings → single fixer → repeat until clean' },
+    { title: 'Verify', detail: 'repo-native gates for the surface; e2e:local for runtime-relevant work' },
+  ],
+}
+
+// ── inputs ──────────────────────────────────────────────────────────────────
+const a = args || {}
+const WORKTREE = a.worktree || '.'
+const BRANCH = a.branch || '(current branch)'
+const TASK = a.task || 'No task text supplied.'
+const BRIEF = a.brief || '(no brief path supplied — read AGENTS.md and the task text)'
+const SURFACE = a.surface || 'cross' // client | server | cross | docs
+const RUNTIME = a.runtime !== false && SURFACE !== 'docs'
+const DEPTH = a.depth || 'standard' // quick | standard | deep
+const BASE = a.base || 'origin/main'
+
+const SIZING = {
+  quick: { explorers: 2, planners: 2, roundCap: 2, verifyFixCap: 1 },
+  standard: { explorers: 4, planners: 3, roundCap: 3, verifyFixCap: 2 },
+  deep: { explorers: 6, planners: 3, roundCap: 4, verifyFixCap: 3 },
+}[DEPTH] || { explorers: 4, planners: 3, roundCap: 3, verifyFixCap: 2 }
+
+// Review lenses (see references/adversarial-review.md). Docs surface uses a
+// narrower set; everything else gets the full standing panel.
+const ALL_LENSES = [
+  'Correctness & logic',
+  'Security & privacy (fail closed)',
+  'Lifecycle & concurrency',
+  'Bounds & performance / no-jank',
+  'Compatibility & platform (JF12/.NET10, MUI + legacy)',
+  'Test strength',
+  'Product semantics & scope',
+  'Docs, locale & generated artifacts',
+]
+const LENSES =
+  SURFACE === 'docs'
+    ? ['Correctness & logic', 'Docs, locale & generated artifacts', 'Product semantics & scope']
+    : DEPTH === 'quick'
+    ? ALL_LENSES.slice(0, 5).concat('Docs, locale & generated artifacts')
+    : ALL_LENSES
+
+// Model mix for review (user policy): every review round runs BOTH the Claude
+// lens reviewers above (≥1) AND ≥1 gpt-5.6-sol whole-diff reviewer at high
+// effort. The Sol reviewer is obtained two ways, selected by args.solVia:
+//   'agent'     — request the model directly on the subagent (default). Needs a
+//                 Sol-capable route, e.g. the CLIProxyAPI router that exposes
+//                 gpt-5.6-sol to Claude Code (vallettasoftware.com/blog/post/run-gpt-5-6-in-claude-code).
+//                 No codex dependency.
+//   'codex-cli' — a harness subagent shells out to the local `codex` CLI
+//                 (-a never -s read-only exec -m gpt-5.6-sol) with the bundled
+//                 output schema. Use where the router is not configured.
+// The Sol pass is best-effort: if it errors/returns null the loop still runs on
+// the Claude reviewers rather than failing.
+const SOL_MODEL = a.solModel || 'gpt-5.6-sol'
+const SOL_EFFORT = a.solEffort || 'high' // low|medium|high|xhigh|max|ultra
+const SOL_REVIEWERS = a.solReviewers == null ? 1 : Math.max(0, a.solReviewers)
+const SOL_VIA = a.solVia || 'agent' // 'agent' | 'codex-cli'
+const CODEX_SCHEMA = '.agents/skills/jellyfin-canopy-agentic-loop/references/codex-review-schema.json'
+
+// ── shared prompt preamble ──────────────────────────────────────────────────
+const CONTRACTS = `You are working on the Jellyfin Canopy plugin repository in the worktree at:
+  ${WORKTREE}
+ALWAYS \`cd ${WORKTREE}\` first. The repository documents are the source of truth:
+read AGENTS.md, CONTRIBUTING.md, SECURITY.md, the nearest instructions to the
+files in scope, and .agents/skills/jellyfin-canopy-engineering/SKILL.md. Obey
+every contract there (JF12/.NET10 boundary; MUI + legacy layouts both valid;
+fail-closed auth/isolation/escaping/disposal/bounded work; coverage & lint caps
+are ratchets; rebuild generated bundles/manifests/snapshots/translations from
+source). Only this repository is writable; the Jellyfin-Enhanced repos are
+read-only. Never deploy to :8099, release, or mutate an external service.
+
+TASK:
+${TASK}
+
+TASK BRIEF: ${BRIEF}
+`
+
+const dedupeKey = (f) => `${f.file || '?'}|${f.line || 0}|${String(f.summary || '').slice(0, 60)}`
+function dedupe(findings) {
+  const seen = new Set()
+  const out = []
+  for (const f of findings) {
+    const k = dedupeKey(f)
+    if (seen.has(k)) continue
+    seen.add(k)
+    out.push(f)
+  }
+  return out
+}
+
+// ── schemas ─────────────────────────────────────────────────────────────────
+const EXPLORE_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['owningLayer', 'files', 'consumers', 'contracts', 'testSeams'],
+  properties: {
+    owningLayer: { type: 'string' },
+    files: { type: 'array', items: { type: 'object', properties: { path: { type: 'string' }, role: { type: 'string' } }, required: ['path', 'role'], additionalProperties: false } },
+    consumers: { type: 'array', items: { type: 'string' } },
+    analogue: { type: 'string', description: 'nearest already-implemented analogue to copy the shape of' },
+    helpers: { type: 'array', items: { type: 'string' }, description: 'existing cross-cutting helpers to reuse instead of writing new' },
+    contracts: { type: 'array', items: { type: 'string' }, description: 'repository/security/runtime contracts this change touches' },
+    testSeams: { type: 'array', items: { type: 'string' } },
+    risks: { type: 'array', items: { type: 'string' } },
+    notes: { type: 'string' },
+  },
+}
+const PLAN_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['summary', 'owningLayer', 'steps', 'tests', 'stateModel'],
+  properties: {
+    summary: { type: 'string' },
+    owningLayer: { type: 'string' },
+    reuseDecisions: { type: 'array', items: { type: 'string' } },
+    stateModel: { type: 'string', description: 'the simplest state/failure model; what NOT to add' },
+    steps: { type: 'array', items: { type: 'string' } },
+    tests: { type: 'array', items: { type: 'string' }, description: 'failing-first tests incl. admin/non-admin & negative paths' },
+    localeDocs: { type: 'array', items: { type: 'string' }, description: 'locale keys and docs to update' },
+    risks: { type: 'array', items: { type: 'string' } },
+    nonGoals: { type: 'array', items: { type: 'string' } },
+  },
+}
+const IMPLEMENT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['changedFiles', 'commits', 'selfConfidence'],
+  properties: {
+    changedFiles: { type: 'array', items: { type: 'string' } },
+    commits: { type: 'array', items: { type: 'string' } },
+    testsAdded: { type: 'array', items: { type: 'string' } },
+    diffStat: { type: 'string' },
+    selfConfidence: { type: 'string', enum: ['high', 'medium', 'low'] },
+    openTodos: { type: 'array', items: { type: 'string' } },
+    notes: { type: 'string' },
+  },
+}
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['findings'],
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['file', 'summary', 'failureScenario'],
+        properties: {
+          lens: { type: 'string' },
+          file: { type: 'string' },
+          line: { type: 'integer' },
+          severity: { type: 'string', enum: ['blocker', 'major', 'minor'] },
+          summary: { type: 'string' },
+          failureScenario: { type: 'string', description: 'concrete inputs/state → wrong output/crash/leak/contract violation' },
+        },
+      },
+    },
+  },
+}
+const VERDICT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['real', 'reason'],
+  properties: {
+    real: { type: 'boolean', description: 'true only if the finding genuinely reproduces / violates a contract' },
+    reason: { type: 'string' },
+    severity: { type: 'string', enum: ['blocker', 'major', 'minor'] },
+  },
+}
+const FIX_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['applied', 'commits'],
+  properties: {
+    applied: { type: 'array', items: { type: 'string' } },
+    commits: { type: 'array', items: { type: 'string' } },
+    designChange: { type: 'string', description: 'if a fix simplified/deleted state instead of adding a guard, say how' },
+    unresolved: { type: 'array', items: { type: 'string' } },
+    notes: { type: 'string' },
+  },
+}
+const VERIFY_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['gates', 'allBlockingPassed'],
+  properties: {
+    gates: { type: 'array', items: { type: 'object', additionalProperties: false, required: ['name', 'pass'], properties: { name: { type: 'string' }, pass: { type: 'boolean' }, evidence: { type: 'string' } } } },
+    allBlockingPassed: { type: 'boolean', description: 'true if every BLOCKING gate passed (lint is advisory, not blocking)' },
+    e2e: { type: 'object', additionalProperties: false, properties: { run: { type: 'boolean' }, pass: { type: 'boolean' }, evidence: { type: 'string' } } },
+    failures: { type: 'array', items: { type: 'string' } },
+  },
+}
+
+// ── gate command list by surface ────────────────────────────────────────────
+function gateCommands() {
+  const core = ['npm run check:toolchain', './verify.sh lint   # ADVISORY — findings do not block', 'git diff --check']
+  const client = ['npm run typecheck:src', 'npm run typecheck', 'npm run test:client:coverage', 'npm run build:bundle', 'npm run syntax']
+  const server = ['dotnet build Jellyfin.Plugin.JellyfinCanopy/JellyfinCanopy.csproj -c Release', 'npm run test:server:coverage']
+  const scripts = ['npm run test:scripts']
+  const docs = ['npm run check:docs']
+  let g = [...core]
+  if (SURFACE === 'client' || SURFACE === 'cross') g = g.concat(client)
+  if (SURFACE === 'server' || SURFACE === 'cross') g = g.concat(server)
+  g = g.concat(scripts) // scripts tests are cheap and catch tooling regressions
+  g = g.concat(['npm run validate-translations   # if any locale file changed'])
+  if (SURFACE === 'docs' || SURFACE === 'cross') g = g.concat(docs)
+  return g
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PHASE 1 — EXPLORE (parallel, read-only)
+// ═══════════════════════════════════════════════════════════════════════════
+phase('Explore')
+log(`canopy-loop: ${DEPTH} depth · surface=${SURFACE} · runtime=${RUNTIME} · branch ${BRANCH}`)
+
+const exploreAngles = [
+  'the OWNING module and the exact functions/types that must change',
+  'every PRODUCER and CONSUMER of the affected behavior (grep the whole tree)',
+  'the nearest ALREADY-IMPLEMENTED analogue and the existing cross-cutting helpers to reuse',
+  'the CONTRACTS at risk (auth/isolation/escaping/disposal/bounded-work/live-config) and the TEST SEAMS',
+  'the CLIENT surface: MUI + legacy layouts, native markup, locale keys, docs impacted',
+  'the SERVER surface: controllers/services/scheduled tasks, .NET tests, generated artifacts',
+].slice(0, SIZING.explorers)
+
+const explorations = (
+  await parallel(
+    exploreAngles.map((angle, i) => () =>
+      agent(
+        `${CONTRACTS}
+
+PHASE: EXPLORE (read-only — do NOT edit any file).
+Your angle: ${angle}.
+Use rg/ls/Read to trace real code. Return a precise map: where the change lives,
+who is affected, the analogue to copy, helpers to reuse (so we don't write new),
+the contracts touched, and the test seams. Cite real paths; never guess.`,
+        { schema: EXPLORE_SCHEMA, agentType: 'Explore', effort: 'medium', phase: 'Explore', label: `explore:${i + 1}` }
+      )
+    )
+  )
+).filter(Boolean)
+
+const exploreDigest = JSON.stringify(explorations, null, 1).slice(0, 12000)
+log(`Explore: ${explorations.length} maps returned`)
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PHASE 2 — PLAN (independent plans → adversarial synthesis into one)
+// ═══════════════════════════════════════════════════════════════════════════
+phase('Plan')
+
+const planAngles = [
+  'MINIMAL-CHANGE first: the smallest change at the true owner; delete/delegate state before adding any.',
+  'RISK first: identify the failure modes and design the state/failure model that fails closed with fewest moving parts.',
+  'REUSE first: maximise use of existing helpers/analogue; avoid any parallel implementation of a shared behavior.',
+].slice(0, SIZING.planners)
+
+const plans = (
+  await parallel(
+    planAngles.map((angle, i) => () =>
+      agent(
+        `${CONTRACTS}
+
+PHASE: PLAN (read-only). Explore maps (JSON):
+${exploreDigest}
+
+Produce an implementation plan with this bias: ${angle}
+Choose the owning layer, reuse-vs-new decisions, the SIMPLEST state/failure
+model (and explicitly what NOT to add — no speculative flag/retry/lock/observer/
+polling/migration), the failing-first tests (admin AND non-admin, negative/
+fallback, concurrency/cache invalidation where relevant), and the locale keys +
+docs to update.`,
+        { schema: PLAN_SCHEMA, effort: 'high', phase: 'Plan', label: `plan:${i + 1}` }
+      )
+    )
+  )
+).filter(Boolean)
+
+const canonicalPlan = await agent(
+  `${CONTRACTS}
+
+PHASE: PLAN SYNTHESIS (read-only). You are the adversarial judge. Here are ${plans.length}
+independent plans (JSON):
+${JSON.stringify(plans, null, 1).slice(0, 12000)}
+
+Score them against the brief and the repository contracts. Pick the strongest
+spine and graft the best ideas from the others. Reject scope creep and any
+avoidable new state. Output ONE canonical plan the implementer will follow
+exactly. Prefer the plan that adds the least and reuses the most.`,
+  { schema: PLAN_SCHEMA, effort: 'high', phase: 'Plan', label: 'plan:synthesis' }
+)
+log(`Plan: ${plans.length} plans → 1 canonical (${(canonicalPlan && canonicalPlan.owningLayer) || 'n/a'})`)
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PHASE 3 — IMPLEMENT (single writer)
+// ═══════════════════════════════════════════════════════════════════════════
+phase('Implement')
+
+const implemented = await agent(
+  `${CONTRACTS}
+
+PHASE: IMPLEMENT. You are the SOLE writer in this worktree. Follow this canonical
+plan exactly (JSON):
+${JSON.stringify(canonicalPlan, null, 1).slice(0, 12000)}
+
+Rules:
+- Build the change at its owning layer and update EVERY affected consumer. Fix
+  shared behavior once at its source; do not patch one consumer or copy a helper.
+- Add tests that FAIL before the change and pass after: admin AND non-admin,
+  negative/fallback, concurrency/cache invalidation where relevant, non-vacuous
+  assertions that prove the intended lower tier ran.
+- Add every new locale key to ALL locale files with real translations. Update
+  affected user/admin/architecture/security docs. Rebuild generated
+  bundles/manifests/snapshots from source if the repo expects it.
+- Do NOT add live activation, polling, retries, migrations, config, or startup
+  work unless the plan requires it. Give each side effect exactly one owner.
+- Commit coherent conventional units (feat/fix/chore/docs). NO \`Co-Authored-By\`
+  trailers. Keep issue "#N" out of commit messages and comments.
+- Run the directly-affected focused tests as you go. Do not run the full gate.
+Report the changed files, commits, tests added, a diff stat, and an honest
+self-confidence (high/medium/low) with any open TODOs.`,
+  { schema: IMPLEMENT_SCHEMA, agentType: 'general-purpose', effort: 'high', phase: 'Implement', label: 'implement' }
+)
+log(`Implement: ${(implemented && implemented.changedFiles && implemented.changedFiles.length) || 0} files, confidence ${(implemented && implemented.selfConfidence) || '?'}`)
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PHASE 4 — ADVERSARIAL REVIEW LOOP (parallel review → verify → single fixer)
+// ═══════════════════════════════════════════════════════════════════════════
+phase('Review')
+
+const reviewContext = `${CONTRACTS}
+
+The change is on branch ${BRANCH}. Inspect it with:
+  git -C ${WORKTREE} diff ${BASE}...HEAD
+  git -C ${WORKTREE} log --oneline ${BASE}..HEAD
+You see ONLY the diff and this brief — never the implementer's reasoning.`
+
+// gpt-5.6-sol whole-diff adversarial reviewer (high effort). One thunk per Sol
+// reviewer; obtained via the subagent model param ('agent') or the codex CLI.
+function solThunk(roundNo, i) {
+  const solPrompt = `${reviewContext}
+
+PHASE: ADVERSARIAL REVIEW (gpt-5.6-sol, whole diff). Assume the change is WRONG and
+prove how. Cover correctness, security/privacy (fail-closed), lifecycle/
+concurrency, bounds/perf/no-jank, JF12 + MUI/legacy compatibility, test strength,
+product scope, and docs/locale/generated-artifact gaps. Every finding needs a
+real file/line and a concrete failure scenario (inputs/state → wrong output /
+crash / leak / contract violation). Reject workarounds that need a paragraph-long
+comment to justify them. Watch for mechanically-similar-but-semantically-
+different code. Return only real findings (empty array if none).`
+
+  if (SOL_VIA === 'codex-cli') {
+    return () =>
+      agent(
+        `${reviewContext}
+
+PHASE: gpt-5.6-sol REVIEW via the local \`codex\` CLI. You are a HARNESS — run the
+external reviewer and relay its structured findings; do NOT review yourself.
+Run from ${WORKTREE} (HEAD must be committed and clean):
+  P=$(mktemp); R=$(mktemp); EV=$(mktemp); ER=$(mktemp)
+  cat > "$P" <<'SOL_PROMPT'
+${solPrompt}
+SOL_PROMPT
+  codex -a never -s read-only exec -C "${WORKTREE}" --ephemeral --ignore-user-config \\
+    --color never --json -m "${SOL_MODEL}" -c model_reasoning_effort="${SOL_EFFORT}" \\
+    --output-schema "${WORKTREE}/${CODEX_SCHEMA}" -o "$R" - < "$P" > "$EV" 2> "$ER"
+Then read "$R" (JSON conforming to the schema) and RETURN its findings mapped to
+THIS tool's schema (lens="gpt-5.6-sol", file, line, severity, summary,
+failureScenario). If \`codex\` is missing or exits non-zero, RETURN
+{"findings":[]} — never fail the call.`,
+        { schema: FINDINGS_SCHEMA, agentType: 'general-purpose', effort: 'medium', phase: 'Review', label: `sol-cli-r${roundNo}:${i + 1}` }
+      )
+  }
+  return () =>
+    agent(solPrompt, { schema: FINDINGS_SCHEMA, model: SOL_MODEL, effort: SOL_EFFORT, phase: 'Review', label: `sol-r${roundNo}:${i + 1}` })
+}
+
+const confirmedAll = []
+let cleanRound = false
+let round = 0
+while (round < SIZING.roundCap && !cleanRound) {
+  round++
+  log(`Review round ${round}/${SIZING.roundCap} — ${LENSES.length} Claude lenses + ${SOL_REVIEWERS}× ${SOL_MODEL} (${SOL_VIA}, ${SOL_EFFORT})`)
+
+  const claudeThunks = LENSES.map((lens, i) => () =>
+    agent(
+      `${reviewContext}
+
+PHASE: ADVERSARIAL REVIEW — lens: "${lens}".
+Assume the change is WRONG and prove how, THROUGH THIS LENS ONLY. A finding needs
+a real file/line and a concrete failure scenario (inputs/state → wrong output /
+crash / leak / contract violation). "Looks fine" is not a finding. Watch for
+mechanically-similar-but-semantically-different code (side effects inside
+asserts/guards, eager vs lazy defaults, odd-length buffer truncation, bounds
+checks present in one build only, byte-vs-UTF assumptions, escape/format passes
+over the wrong data). Reject any workaround that needs a paragraph-long comment
+to justify it. Return only real findings (empty array if none this lens).`,
+      { schema: FINDINGS_SCHEMA, agentType: 'code-reviewer', effort: 'medium', phase: 'Review', label: `review-r${round}:${i + 1}` }
+    )
+  )
+  const solThunks = Array.from({ length: SOL_REVIEWERS }, (_, i) => solThunk(round, i))
+
+  const raw = (await parallel([...claudeThunks, ...solThunks]))
+    .filter(Boolean)
+    .flatMap((r) => (r && r.findings) || [])
+
+  const deduped = dedupe(raw)
+  if (!deduped.length) {
+    cleanRound = true
+    log(`Review round ${round}: clean (no findings)`)
+    break
+  }
+
+  // Adversarially verify each finding — try to REFUTE it; default refuted.
+  const verdicts = await parallel(
+    deduped.map((f, i) => () =>
+      agent(
+        `${reviewContext}
+
+PHASE: VERIFY FINDING. Try hard to REFUTE this claimed defect. Default to
+real=false when uncertain — only real=true if it genuinely reproduces or truly
+violates a repository contract on a reachable path.
+FINDING (${f.lens || '?'}) ${f.file}:${f.line || '?'} — ${f.summary}
+SCENARIO: ${f.failureScenario}`,
+        { schema: VERDICT_SCHEMA, agentType: 'code-reviewer', effort: 'medium', phase: 'Review', label: `verify-r${round}:${i + 1}` }
+      )
+    )
+  )
+
+  const confirmed = deduped.filter((f, i) => verdicts[i] && verdicts[i].real)
+  if (!confirmed.length) {
+    cleanRound = true
+    log(`Review round ${round}: ${deduped.length} findings, all refuted → clean`)
+    break
+  }
+  confirmedAll.push(...confirmed.map((f, i) => ({ ...f, round })))
+  log(`Review round ${round}: ${confirmed.length} confirmed → fixing`)
+
+  await agent(
+    `${CONTRACTS}
+
+PHASE: FIX. You are the SOLE writer. Apply ONLY these confirmed findings at their
+owning layer, add regression evidence for each, and commit coherent units.
+Before adding any new state flag/retry/lock/publisher/lifecycle path — or making
+a second fix to the same state machine/owner — STOP and try deletion, reuse, or
+single ownership first; simpler is required over another guard. Do not fix
+anything not listed. NO \`Co-Authored-By\` trailers.
+
+CONFIRMED FINDINGS:
+${JSON.stringify(confirmed, null, 1).slice(0, 10000)}`,
+    { schema: FIX_SCHEMA, agentType: 'general-purpose', effort: 'high', phase: 'Review', label: `fix-r${round}` }
+  )
+}
+if (!cleanRound) log(`Review: hit round cap (${SIZING.roundCap}) with unresolved findings — will report as residual risk`)
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PHASE 5 — VERIFY (single runner; bounded fix-and-reverify)
+// ═══════════════════════════════════════════════════════════════════════════
+phase('Verify')
+
+const gateList = gateCommands()
+const e2eBlock = RUNTIME
+  ? `\nRUNTIME PROOF (this change affects runtime): build the Release DLL if not
+already built, then run the dockerized E2E:
+  dotnet build Jellyfin.Plugin.JellyfinCanopy/JellyfinCanopy.csproj -c Release
+  npm run e2e:local        # dockerized jellyfin/jellyfin:unstable, 4 shards / 2 CPUs
+Exercise BOTH admin and non-admin. Assert real DOM/server state, ZERO
+non-whitelisted console errors, ZERO unexpected plugin 4xx. Tear down only the
+Compose projects this run created. Do NOT touch :8099 or any shared/prod server.`
+  : `\n(No runtime proof required for this surface.)`
+
+let verify = null
+let vround = 0
+while (vround <= SIZING.verifyFixCap) {
+  verify = await agent(
+    `${CONTRACTS}
+
+PHASE: VERIFY. Run the repository-native gates for surface="${SURFACE}", in order,
+from ${WORKTREE}. Lint is ADVISORY (findings never block); every other gate is
+BLOCKING. Do not pipe wrappers through tail/grep/tee in a way that hides exit
+status. Do not run a plain suite right before its coverage variant.
+
+GATES:
+${gateList.map((g) => '  ' + g).join('\n')}
+${e2eBlock}
+
+Report each gate's pass/fail with short evidence (counts/versions), whether
+ALL BLOCKING gates passed, the e2e result if run, and a list of failures.`,
+    { schema: VERIFY_SCHEMA, agentType: 'general-purpose', effort: 'medium', phase: 'Verify', label: vround === 0 ? 'verify' : `verify-retry-${vround}` }
+  )
+
+  const gatesOk = verify && verify.allBlockingPassed
+  const e2eOk = !RUNTIME || (verify && verify.e2e && verify.e2e.pass)
+  if (gatesOk && e2eOk) {
+    log(`Verify: all blocking gates${RUNTIME ? ' + e2e' : ''} green`)
+    break
+  }
+  vround++
+  if (vround > SIZING.verifyFixCap) {
+    log(`Verify: still failing after ${SIZING.verifyFixCap} fix attempts — reporting failures`)
+    break
+  }
+  log(`Verify: failures → fix attempt ${vround}/${SIZING.verifyFixCap}`)
+  await agent(
+    `${CONTRACTS}
+
+PHASE: VERIFY-FIX. You are the SOLE writer. Fix ONLY the real regressions behind
+these gate/e2e failures at their owner — never weaken coverage, timeouts,
+assertions, security policy, or E2E scope to go green, and never lower a ratchet.
+Commit the fix. FAILURES:
+${JSON.stringify((verify && verify.failures) || [], null, 1).slice(0, 8000)}`,
+    { schema: FIX_SCHEMA, agentType: 'general-purpose', effort: 'high', phase: 'Verify', label: `verify-fix-${vround}` }
+  )
+}
+
+// ── return structured result for the main thread to relay + act on ──────────
+const blockingGreen = !!(verify && verify.allBlockingPassed)
+const e2eGreen = !RUNTIME || !!(verify && verify.e2e && verify.e2e.pass)
+const result = {
+  branch: BRANCH,
+  surface: SURFACE,
+  depth: DEPTH,
+  loopClean: cleanRound,
+  reviewRounds: round,
+  confirmedFindingsResolved: confirmedAll.length,
+  implement: implemented || null,
+  canonicalPlan: canonicalPlan || null,
+  verify: verify || null,
+  readyForPR: cleanRound && blockingGreen && e2eGreen,
+  residualRisks: []
+    .concat(cleanRound ? [] : ['review loop hit its round cap with unresolved confirmed findings'])
+    .concat(blockingGreen ? [] : ['one or more BLOCKING gates are failing'])
+    .concat(e2eGreen ? [] : ['e2e:local did not pass'])
+    .concat((implemented && implemented.openTodos) || []),
+}
+log(
+  `canopy-loop done: readyForPR=${result.readyForPR} · rounds=${round} · findings resolved=${confirmedAll.length} · blockingGreen=${blockingGreen}${RUNTIME ? ` · e2e=${e2eGreen}` : ''}`
+)
+return result

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,13 @@ or Project task, read and follow
 [`.agents/skills/jellyfin-canopy-engineering/SKILL.md`](.agents/skills/jellyfin-canopy-engineering/SKILL.md).
 Treat it as the canonical workflow; do not copy it into tool-specific files.
 
+Optionally, to carry a change through a Bun-style multi-agent loop (parallel
+explore/plan, single-writer implement, and a mixed-model adversarial
+review-until-clean loop), use the accelerator at
+[`.agents/skills/jellyfin-canopy-agentic-loop/SKILL.md`](.agents/skills/jellyfin-canopy-agentic-loop/SKILL.md).
+It changes only *how* the work runs and obeys every contract and invariant here
+and in the canonical skill unchanged.
+
 Critical invariants:
 
 - `n00bcodr/Jellyfin-Enhanced` is strictly read-only. Never push, open or edit


### PR DESCRIPTION
## What & why

Adds a **new, optional execution engine** for Canopy work — a Bun-style
multi-agent loop — alongside the canonical `jellyfin-canopy-engineering` skill.
It exists to raise confidence on non-trivial changes by making review
independent, parallel, and adversarial, modelled on Bun's Zig→Rust rewrite
(one implementer, ≥2 adversarial reviewers in split context, a fixer, and a
verify-driven definition of done).

It changes only *how* a change is produced. Every contract, gate, safety rule,
and PR/merge discipline continues to be owned by the engineering skill,
`AGENTS.md`, and `CONTRIBUTING.md`; this skill defers to them and never restates
or overrides them.

## Implementation

New `.agents/skills/jellyfin-canopy-agentic-loop/`:

- `SKILL.md` — method, what runs in the main thread (scope, worktree, push/PR)
  vs. the engine, and guardrails carried from the repo.
- `references/adversarial-review.md` — split-context rules, review lenses,
  finding verification, and the loop's definition of done.
- `workflows/canopy-loop.js` — a Claude Code Workflow script: Explore (parallel
  read-only) → Plan (judge panel → synthesis) → Implement (single writer) →
  adversarial Review-until-clean → Verify. Read-only phases fan out; the writer
  is always singular (honours one-writer-per-worktree).
- `references/codex-review-schema.json`, `agents/openai.yaml`, `README.md`.

`AGENTS.md` gains a single optional pointer to the accelerator; the canonical
skill is untouched.

Design notes:

- All gates are repo-native (`verify.sh lint` advisory; full gate = the
  npm/dotnet sequence; runtime proof = `npm run e2e:local`). No `:8099` deploy —
  that stays a separate, explicitly-authorized action.
- Review runs a deliberate **model mix** each round: Claude lens reviewers plus
  ≥1 `gpt-5.6-sol` (high) whole-diff reviewer, obtained via the subagent model
  param (`solVia: "agent"`) or the local `codex` CLI (`solVia: "codex-cli"`);
  the Sol pass is best-effort and degrades to the Claude reviewers rather than
  failing the loop.

## Limitations

- Tooling/docs only — no plugin runtime code changes, so no unit/E2E suites
  apply to this diff.
- `solVia: "agent"` yields `gpt-5.6-sol` only when Claude Code is routed to a
  Sol-capable endpoint; otherwise use `solVia: "codex-cli"`.

## Validation

- `workflows/canopy-loop.js` parses as a Workflow body (top-level `await`/
  `return` valid in the runtime); brace/paren/backtick balance verified.
- `references/codex-review-schema.json` is valid JSON.
- All intra-repo markdown links resolve; `git diff --check` clean.
