### PR TITLE
fix(seerr): let CREATE_ISSUES users read their own issues (BI-SRV-109)

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SeerrIssueAvatarSourceTokenTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SeerrIssueAvatarSourceTokenTests.cs
@@ -335,15 +335,165 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
         }
 
         [Fact]
-        public async Task TargetedIssueEndpoint_RequiresIssueViewPermissionBeforeDetailDispatch()
+        public async Task TargetedIssueEndpoint_NoIssuePermissionRejectedBeforeAnyDispatch()
         {
+            // REQUEST_MOVIE only — a real permission, none of the issue bits.
             var seerr = new IssueSeerrClient(new SeerrUser
             {
                 Id = 42,
-                Permissions = SeerrPermission.CREATE_ISSUES,
+                Permissions = SeerrPermission.REQUEST_MOVIE,
                 SourceUrl = Source,
             });
             var controller = CreateController(seerr, new PassthroughParentalFilter());
+
+            var result = Assert.IsType<ObjectResult>(await controller.GetSeerrIssues(
+                tmdbId: 42,
+                mediaType: "movie"));
+
+            Assert.Equal(403, result.StatusCode);
+            Assert.Contains("no_issue_view_permission", JsonSerializer.Serialize(result.Value), StringComparison.Ordinal);
+            Assert.Equal(string.Empty, seerr.LastApiPath);
+            Assert.Equal(0, seerr.FreshDetailReads);
+        }
+
+        [Fact]
+        public async Task TargetedIssueEndpoint_CreateOnlyReaderReadsOwnIssuesViaOwnershipScopedListNotMediaDetail()
+        {
+            // The create-refresh case: a CREATE_ISSUES-only reporter opens their
+            // just-created issue. Seerr returns their OWN issues (ownership already
+            // enforced); the requested title is projected and the unrelated owned
+            // title is excluded — without ever touching the unfiltered media detail.
+            var owned = OwnedListBody(2,
+                (7, 42, "movie", 1),
+                (8, 99, "movie", 1));
+            var seerr = new IssueSeerrClient(CreateOnlyUser(), owned);
+            var controller = CreateController(seerr, new PassthroughParentalFilter());
+
+            var result = Assert.IsType<ContentResult>(await controller.GetSeerrIssues(
+                tmdbId: 42,
+                mediaType: "movie",
+                filter: "all"));
+            var body = JsonNode.Parse(result.Content!)!.AsObject();
+            var rows = body["results"]!.AsArray();
+
+            Assert.Single(rows);
+            Assert.Equal(7, (int)rows[0]!["id"]!);
+            Assert.Equal(1, (int)body["pageInfo"]!["results"]!);
+            Assert.True((bool)body["jellyfinCanopyPagination"]!["totalExact"]!);
+            Assert.Equal(0, seerr.FreshDetailReads);
+            Assert.Contains("/api/v1/issue?", seerr.LastApiPath, StringComparison.Ordinal);
+            Assert.Contains("createdBy=42", seerr.LastApiPath, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public async Task TargetedIssueEndpoint_CreateOnlyEmptyOwnedListPublishesAnExactEmptyTitle()
+        {
+            var seerr = new IssueSeerrClient(CreateOnlyUser(), OwnedListBody(0));
+            var controller = CreateController(seerr, new PassthroughParentalFilter());
+
+            var result = Assert.IsType<ContentResult>(await controller.GetSeerrIssues(
+                tmdbId: 42,
+                mediaType: "movie"));
+            var body = JsonNode.Parse(result.Content!)!.AsObject();
+
+            Assert.Empty(body["results"]!.AsArray());
+            Assert.Equal(0, (int)body["pageInfo"]!["results"]!);
+            Assert.Equal(0, seerr.FreshDetailReads);
+        }
+
+        [Fact]
+        public async Task TargetedIssueEndpoint_CreateOnlyIncompletePageFailsClosedNotFalseEmpty()
+        {
+            // pageInfo.results (total) disagrees with the returned page length: the
+            // complete owned set was not seen, so the title projection is unsafe.
+            var owned = @"{ ""pageInfo"": { ""pages"": 2, ""pageSize"": 1000, ""results"": 2, ""page"": 1 },
+                ""results"": [{
+                    ""id"": 7, ""status"": 1,
+                    ""createdAt"": ""2026-01-01T00:00:00Z"", ""updatedAt"": ""2026-01-01T00:00:00Z"",
+                    ""media"": { ""tmdbId"": 42, ""mediaType"": ""movie"" }
+                }] }";
+            var seerr = new IssueSeerrClient(CreateOnlyUser(), owned);
+            var controller = CreateController(seerr, new PassthroughParentalFilter());
+
+            var result = Assert.IsType<ObjectResult>(await controller.GetSeerrIssues(
+                tmdbId: 42,
+                mediaType: "movie"));
+
+            Assert.Equal(502, result.StatusCode);
+            Assert.Contains("issue_relation_incomplete", JsonSerializer.Serialize(result.Value), StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public async Task TargetedIssueEndpoint_CreateOnlyOwnedListBeyondHardBoundFailsClosed()
+        {
+            var results = new JsonArray();
+            for (var id = 1; id <= 1001; id++)
+            {
+                results.Add(new JsonObject
+                {
+                    ["id"] = id,
+                    ["status"] = 1,
+                    ["createdAt"] = "2026-01-01T00:00:00Z",
+                    ["updatedAt"] = "2026-01-01T00:00:00Z",
+                    ["media"] = new JsonObject { ["tmdbId"] = 42, ["mediaType"] = "movie" },
+                });
+            }
+            var owned = new JsonObject
+            {
+                ["pageInfo"] = new JsonObject { ["results"] = 1001, ["page"] = 1 },
+                ["results"] = results,
+            }.ToJsonString();
+            var seerr = new IssueSeerrClient(CreateOnlyUser(), owned);
+            var controller = CreateController(seerr, new PassthroughParentalFilter());
+
+            var result = Assert.IsType<ObjectResult>(await controller.GetSeerrIssues(
+                tmdbId: 42,
+                mediaType: "movie",
+                take: 1000));
+
+            Assert.Equal(502, result.StatusCode);
+            Assert.Contains("issue_relation_incomplete", JsonSerializer.Serialize(result.Value), StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public async Task TargetedIssueEndpoint_CreateOnlyMalformedOwnedRowFailsClosed()
+        {
+            var owned = @"{ ""pageInfo"": { ""results"": 1, ""page"": 1 },
+                ""results"": [{
+                    ""id"": 7, ""status"": 1,
+                    ""createdAt"": ""2026-01-01T00:00:00Z"", ""updatedAt"": ""2026-01-01T00:00:00Z""
+                }] }";
+            var seerr = new IssueSeerrClient(CreateOnlyUser(), owned);
+            var controller = CreateController(seerr, new PassthroughParentalFilter());
+
+            var result = Assert.IsType<ObjectResult>(await controller.GetSeerrIssues(
+                tmdbId: 42,
+                mediaType: "movie"));
+
+            Assert.Equal(502, result.StatusCode);
+            Assert.Contains("issue_relation_incomplete", JsonSerializer.Serialize(result.Value), StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public async Task TargetedIssueEndpoint_CreateOnlyPreservesUpstreamFailureWithoutFalseEmpty()
+        {
+            var upstream = new ObjectResult(new { error = true, code = "seerr_unavailable" }) { StatusCode = 503 };
+            var seerr = new IssueSeerrClient(CreateOnlyUser(), resultOverride: upstream);
+            var controller = CreateController(seerr, new PassthroughParentalFilter());
+
+            var result = await controller.GetSeerrIssues(tmdbId: 42, mediaType: "movie");
+
+            Assert.Same(upstream, result);
+            Assert.Equal(0, seerr.FreshDetailReads);
+            Assert.Contains("/api/v1/issue?", seerr.LastApiPath, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public async Task TargetedIssueEndpoint_CreateOnlyBlockedTitleNeverDispatches()
+        {
+            var seerr = new IssueSeerrClient(CreateOnlyUser(), OwnedListBody(0));
+            var parental = new PassthroughParentalFilter { BlockTarget = true };
+            var controller = CreateController(seerr, parental);
 
             var result = Assert.IsType<ObjectResult>(await controller.GetSeerrIssues(
                 tmdbId: 42,
@@ -359,6 +509,53 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             Permissions = SeerrPermission.VIEW_ISSUES,
             SourceUrl = Source,
         };
+
+        private static SeerrUser CreateOnlyUser() => new()
+        {
+            Id = 42,
+            Permissions = SeerrPermission.CREATE_ISSUES,
+            SourceUrl = Source,
+        };
+
+        // Shapes Seerr's ownership-scoped /api/v1/issue list response: each row is
+        // an owned issue carrying its media identity, exactly as Seerr returns for
+        // a createdBy = self query.
+        private static string OwnedListBody(int total, params (int Id, int TmdbId, string MediaType, int Status)[] rows)
+        {
+            var results = new JsonArray();
+            foreach (var (id, tmdbId, mediaType, status) in rows)
+            {
+                results.Add(new JsonObject
+                {
+                    ["id"] = id,
+                    ["status"] = status,
+                    ["createdAt"] = "2026-01-01T00:00:00Z",
+                    ["updatedAt"] = "2026-01-01T00:00:00Z",
+                    ["media"] = new JsonObject
+                    {
+                        ["tmdbId"] = tmdbId,
+                        ["mediaType"] = mediaType,
+                    },
+                    ["createdBy"] = new JsonObject
+                    {
+                        ["username"] = "reporter",
+                        ["avatar"] = "/avatar/reporter.png",
+                    },
+                });
+            }
+
+            return new JsonObject
+            {
+                ["pageInfo"] = new JsonObject
+                {
+                    ["pages"] = 1,
+                    ["pageSize"] = 1000,
+                    ["results"] = total,
+                    ["page"] = 1,
+                },
+                ["results"] = results,
+            }.ToJsonString();
+        }
 
         private static string DetailBody(int ownerId, int tmdbId, string mediaType, JsonArray issues)
             => new JsonObject

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrIssueViewPolicyTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrIssueViewPolicyTests.cs
@@ -1,0 +1,204 @@
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Model.Seerr;
+using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services;
+
+/// <summary>
+/// Pins the issue-read preflight in <see cref="SeerrClient.ProxyRequestAsyncCore"/>.
+/// Seerr enforces per-issue ownership on the <c>/api/v1/issue</c> list and
+/// <c>/api/v1/issue/{id}</c> detail routes (issue.ts: a caller lacking
+/// VIEW_ISSUES/MANAGE_ISSUES is scoped to <c>createdBy = self</c> on the list and
+/// 403'd on a foreign detail), so a CREATE_ISSUES-only reporter must be admitted
+/// through Canopy's local gate to read THEIR OWN issues — without becoming a
+/// global view. A caller holding none of CREATE/VIEW/MANAGE stays locally 403'd
+/// before any upstream dispatch, and VIEW_ISSUES/MANAGE_ISSUES behavior is
+/// unchanged.
+/// </summary>
+public class SeerrIssueViewPolicyTests
+{
+    private const string UserId = "3f2504e04f8941d39a0c0305e82c3301";
+    private const string ListPath = "/api/v1/issue?take=20&skip=0&filter=all&sort=added";
+    private const string DetailPath = "/api/v1/issue/5";
+
+    private static PluginConfiguration Config() => new()
+    {
+        SeerrEnabled = true,
+        SeerrUrls = "http://seerr:5055",
+        SeerrApiKey = "test-key",
+    };
+
+    private static (SeerrClient client, RecordingHttpMessageHandler handler) NewClient()
+    {
+        var handler = new RecordingHttpMessageHandler();
+        var provider = new FakePluginConfigProvider(Config());
+        var client = new SeerrClient(
+            new RecordingHttpClientFactory(handler),
+            NullLogger<SeerrClient>.Instance,
+            null!,
+            new SeerrCache(provider),
+            provider,
+            new PassthroughParentalFilter());
+        return (client, handler);
+    }
+
+    private static void SeedUser(RecordingHttpMessageHandler handler, long permissions)
+        => handler.AddResponse(
+            "/api/v1/user",
+            $"{{\"results\":[{{\"id\":42,\"jellyfinUserId\":\"{UserId}\",\"permissions\":{permissions}}}],\"pageInfo\":{{\"page\":1,\"pages\":1,\"results\":1}}}}");
+
+    private static string? GetCode(object? value)
+        => value?.GetType().GetProperty("code")?.GetValue(value) as string;
+
+    private static bool DispatchedIssueRead(RecordingHttpMessageHandler handler)
+        => handler.Sent.Any(r =>
+            r.Method == HttpMethod.Get
+            && r.Path.StartsWith("/api/v1/issue", System.StringComparison.Ordinal));
+
+    // ── CREATE_ISSUES-only is admitted so Seerr can enforce ownership ─────────
+
+    [Theory]
+    [InlineData(ListPath)]
+    [InlineData(DetailPath)]
+    public async Task CreateIssuesOnly_IssueRead_PassesPreflightAndDispatches(string apiPath)
+    {
+        var (client, handler) = NewClient();
+        SeedUser(handler, (long)SeerrPermission.CREATE_ISSUES);
+        handler.AddResponse("/api/v1/issue", "{\"results\":[]}");
+        handler.AddResponse("/api/v1/issue/5", "{\"id\":5}");
+
+        var result = await client.ProxyRequestAsync(
+            apiPath, HttpMethod.Get, null, new SeerrCaller(UserId, false));
+
+        // The read reached Seerr (which owns the ownership call) rather than being
+        // stopped by Canopy's local no_issue_view_permission gate.
+        Assert.True(DispatchedIssueRead(handler));
+        Assert.NotEqual("no_issue_view_permission", GetCode((result as ObjectResult)?.Value));
+    }
+
+    [Fact]
+    public async Task CreateIssuesOnly_IssueDetail_CarriesPinnedUserIdentitySoSeerrEnforcesOwnership()
+    {
+        var (client, handler) = NewClient();
+        SeedUser(handler, (long)SeerrPermission.CREATE_ISSUES);
+        // Seerr denies a foreign issue itself; Canopy must surface that, proving
+        // local admission did not turn into a global view.
+        handler.AddResponse("/api/v1/issue/9", "{\"message\":\"forbidden\"}", HttpStatusCode.Forbidden);
+
+        var result = await client.ProxyRequestAsync(
+            "/api/v1/issue/9", HttpMethod.Get, null, new SeerrCaller(UserId, false));
+
+        var dispatched = handler.Requests.Single(r =>
+            r.RequestUri!.AbsolutePath == "/api/v1/issue/9");
+        Assert.True(dispatched.Headers.TryGetValues("X-Api-User", out var apiUser));
+        Assert.Equal("42", apiUser!.Single());
+        // Seerr's 403 is preserved rather than replaced by a local decision.
+        var obj = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(403, obj.StatusCode);
+    }
+
+    // ── None of CREATE/VIEW/MANAGE remains a local 403 before dispatch ────────
+
+    [Theory]
+    [InlineData(ListPath)]
+    [InlineData(DetailPath)]
+    public async Task NoIssuePermission_IssueRead_LocallyRejectedBeforeDispatch(string apiPath)
+    {
+        var (client, handler) = NewClient();
+        // REQUEST_MOVIE only — a real permission, but none of the issue bits.
+        SeedUser(handler, (long)SeerrPermission.REQUEST_MOVIE);
+        handler.AddResponse("/api/v1/issue", "{\"results\":[]}");
+
+        var result = await client.ProxyRequestAsync(
+            apiPath, HttpMethod.Get, null, new SeerrCaller(UserId, false));
+
+        var obj = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(403, obj.StatusCode);
+        Assert.Equal("no_issue_view_permission", GetCode(obj.Value));
+        Assert.False(DispatchedIssueRead(handler));
+    }
+
+    // ── VIEW_ISSUES / MANAGE_ISSUES semantics are unchanged ───────────────────
+
+    [Theory]
+    [InlineData((long)SeerrPermission.VIEW_ISSUES)]
+    [InlineData((long)SeerrPermission.MANAGE_ISSUES)]
+    public async Task ViewOrManageIssues_IssueList_StillDispatches(long permissions)
+    {
+        var (client, handler) = NewClient();
+        SeedUser(handler, permissions);
+        handler.AddResponse("/api/v1/issue", "{\"results\":[]}");
+
+        var result = await client.ProxyRequestAsync(
+            ListPath, HttpMethod.Get, null, new SeerrCaller(UserId, false));
+
+        Assert.IsNotType<ObjectResult>(result);
+        Assert.True(DispatchedIssueRead(handler));
+    }
+
+    // ── The media-detail relation is UNFILTERED, so it stays VIEW/MANAGE-only ──
+
+    [Fact]
+    public async Task CreateIssuesOnly_MediaDetailRelation_StaysLocallyRejectedBeforeDispatch()
+    {
+        var (client, handler) = NewClient();
+        handler.AddResponse(
+            "/api/v1/user/42",
+            $"{{\"id\":42,\"jellyfinUserId\":\"{UserId}\",\"permissions\":{(long)SeerrPermission.CREATE_ISSUES}}}");
+        handler.AddResponse(
+            "/api/v1/movie/100",
+            "{\"mediaInfo\":{\"id\":1,\"tmdbId\":100,\"mediaType\":\"movie\",\"issues\":[]}}");
+
+        var result = await client.ProxyFreshMediaDetailAsync(
+            100,
+            "movie",
+            new SeerrCaller(UserId, false),
+            new SeerrUser { Id = 42, SourceUrl = "http://seerr:5055", Permissions = SeerrPermission.CREATE_ISSUES });
+
+        var obj = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(403, obj.StatusCode);
+        Assert.Equal("no_issue_view_permission", GetCode(obj.Value));
+        Assert.DoesNotContain(handler.Sent, r => r.Path == "/api/v1/movie/100");
+    }
+
+    [Fact]
+    public async Task ViewIssues_MediaDetailRelation_StillDispatches()
+    {
+        var (client, handler) = NewClient();
+        handler.AddResponse(
+            "/api/v1/user/42",
+            $"{{\"id\":42,\"jellyfinUserId\":\"{UserId}\",\"permissions\":{(long)SeerrPermission.VIEW_ISSUES}}}");
+        handler.AddResponse(
+            "/api/v1/movie/100",
+            "{\"mediaInfo\":{\"id\":1,\"tmdbId\":100,\"mediaType\":\"movie\",\"issues\":[]}}");
+
+        var result = await client.ProxyFreshMediaDetailAsync(
+            100,
+            "movie",
+            new SeerrCaller(UserId, false),
+            new SeerrUser { Id = 42, SourceUrl = "http://seerr:5055", Permissions = SeerrPermission.VIEW_ISSUES });
+
+        Assert.IsNotType<ObjectResult>(result);
+        Assert.Contains(handler.Sent, r => r.Path == "/api/v1/movie/100");
+    }
+
+    private sealed class PassthroughParentalFilter : ISeerrParentalFilter
+    {
+        public Task<SeerrParentalResult> ApplyAsync(string json, string apiPath, SeerrCaller caller)
+            => Task.FromResult(new SeerrParentalResult(false, json));
+
+        public Task<bool> IsBlockedAsync(string mediaType, int tmdbId, SeerrCaller caller)
+            => Task.FromResult(false);
+
+        public Task<bool> IsTmdbProxyPathBlockedAsync(string tmdbApiPath, SeerrCaller caller)
+            => Task.FromResult(false);
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/SeerrProxyController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/SeerrProxyController.cs
@@ -1543,11 +1543,20 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             }
 
             var seerrUser = resolution.User!;
-            if (!caller.IsAdmin
-                && !SeerrPermissionHelper.HasPermission(seerrUser.Permissions, SeerrPermission.ADMIN)
-                && !SeerrPermissionHelper.HasAnyPermission(
+
+            // A caller allowed to see OTHERS' issues (Jellyfin admin, Seerr ADMIN,
+            // or VIEW_ISSUES/MANAGE_ISSUES) may consume Seerr's unfiltered relations.
+            // A CREATE_ISSUES-only reporter is admitted too, but only ever reads
+            // their OWN issues through Seerr's ownership-enforced list/detail routes.
+            var canViewOthersIssues = caller.IsAdmin
+                || SeerrPermissionHelper.HasPermission(seerrUser.Permissions, SeerrPermission.ADMIN)
+                || SeerrPermissionHelper.HasAnyPermission(
                     seerrUser.Permissions,
-                    SeerrPermission.VIEW_ISSUES | SeerrPermission.MANAGE_ISSUES))
+                    SeerrPermission.VIEW_ISSUES | SeerrPermission.MANAGE_ISSUES);
+            if (!canViewOthersIssues
+                && !SeerrPermissionHelper.HasPermission(
+                    seerrUser.Permissions,
+                    SeerrPermission.CREATE_ISSUES))
             {
                 return StatusCode(403, new
                 {
@@ -1636,6 +1645,113 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 });
             }
 
+            // A CREATE_ISSUES-only reporter must NOT consume the media detail's
+            // unfiltered issue relation (that would expose other reporters' issues).
+            // Read their OWN issues through Seerr's ownership-enforced list route,
+            // scoped to createdBy = their pinned id, then project just this title.
+            // Seerr stays the ownership authority: it filters the list to the caller
+            // and 403s a foreign createdBy, so admitting them here is not a global
+            // view. The projection is exact only if the caller's complete owned set
+            // fit in one bounded page; anything else fails closed, never false-empty.
+            if (!canViewOthersIssues)
+            {
+                var ownedPath = "/api/v1/issue?"
+                    + $"createdBy={pinnedUser.Id}"
+                    + $"&take={MaximumTitleIssueRows}"
+                    + "&skip=0"
+                    + $"&filter={Uri.EscapeDataString(filterValue)}"
+                    + $"&sort={Uri.EscapeDataString(sortValue)}";
+                var ownedResult = await _seerr.ProxyRequestAsync(
+                    ownedPath,
+                    HttpMethod.Get,
+                    null,
+                    caller,
+                    pinnedUser,
+                    HttpContext.RequestAborted).ConfigureAwait(false);
+                if (!IsConfigurationCurrent())
+                {
+                    return ConfigurationChanged();
+                }
+
+                if (ownedResult is not ContentResult ownedContent
+                    || ownedContent.StatusCode is < 200 or >= 300
+                    || string.IsNullOrWhiteSpace(ownedContent.Content))
+                {
+                    return ownedResult;
+                }
+
+                JsonObject? ownedList;
+                try
+                {
+                    ownedList = JsonNode.Parse(ownedContent.Content) as JsonObject;
+                }
+                catch (JsonException ex)
+                {
+                    _logger.LogWarning(ex, "Seerr owned-issue list was not valid JSON; no issue projection was published.");
+                    return InvalidIssueRelation();
+                }
+
+                if (ownedList == null
+                    || ownedList["pageInfo"] is not JsonObject ownedPageInfo
+                    || !TryReadInt(ownedPageInfo["results"], out var ownedTotal)
+                    || ownedTotal < 0
+                    || ownedTotal > MaximumTitleIssueRows
+                    || ownedList["results"] is not JsonArray ownedResults
+                    || ownedResults.Count != ownedTotal)
+                {
+                    return InvalidIssueRelation();
+                }
+
+                var ownedSeenIds = new HashSet<int>();
+                var ownedRows = new List<(JsonObject Row, int Id, DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt)>();
+                foreach (var node in ownedResults)
+                {
+                    if (node is not JsonObject row
+                        || !TryReadPositiveInt(row["id"], out var issueId)
+                        || !ownedSeenIds.Add(issueId)
+                        || !TryReadInt(row["status"], out var status)
+                        || status is not (1 or 2)
+                        || !TryReadTimestamp(row["createdAt"], out var createdAt)
+                        || !TryReadTimestamp(row["updatedAt"], out var updatedAt)
+                        || row["media"] is not JsonObject rowMedia
+                        || !TryReadPositiveInt(rowMedia["tmdbId"], out var rowTmdbId)
+                        || string.IsNullOrWhiteSpace((string?)rowMedia["mediaType"]))
+                    {
+                        return InvalidIssueRelation();
+                    }
+
+                    // Project only the requested title. Seerr already scoped
+                    // ownership; this is a title filter, not an ownership decision.
+                    if (rowTmdbId != tmdbId.Value
+                        || !string.Equals(
+                            (string?)rowMedia["mediaType"],
+                            normalizedMediaType,
+                            StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    if ((filterValue == "open" && status != 1)
+                        || (filterValue == "resolved" && status != 2))
+                    {
+                        continue;
+                    }
+
+                    ownedRows.Add((row, issueId, createdAt, updatedAt));
+                }
+
+                var ownedProjection = OrderAndPublishTitleRows(
+                    ownedRows,
+                    sortValue,
+                    take,
+                    skip,
+                    apiKey,
+                    caller.JellyfinUserId,
+                    configuredSource);
+                BeforeIssueProjectionPublishForTest?.Invoke();
+                return IsConfigurationCurrent() ? ownedProjection : ConfigurationChanged();
+            }
+
             var detailResult = await _seerr.ProxyFreshMediaDetailAsync(
                 tmdbId.Value,
                 normalizedMediaType!,
@@ -1717,12 +1833,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 rows.Add((row, issueId, createdAt, updatedAt));
             }
 
-            var orderedRows = sortValue == "modified"
-                ? rows.OrderByDescending(row => row.UpdatedAt).ThenByDescending(row => row.Id)
-                : rows.OrderByDescending(row => row.CreatedAt).ThenByDescending(row => row.Id);
-            var matchingRows = orderedRows.Select(row => row.Row).ToArray();
-            var projected = BuildExactTitleIssueResult(
-                matchingRows,
+            var projected = OrderAndPublishTitleRows(
+                rows,
+                sortValue,
                 take,
                 skip,
                 apiKey,
@@ -1737,6 +1850,33 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 code = "issue_relation_incomplete",
                 message = "Seerr did not return a complete title issue relation. No partial result was published."
             });
+        }
+
+        // Orders the validated, title-matched issue rows exactly as the client
+        // contract expects and hands them to the exact-title pagination and
+        // avatar-decoration builder. Shared by the media-detail relation path
+        // (VIEW_ISSUES/MANAGE_ISSUES/admin) and the ownership-scoped owned-issue
+        // list path (CREATE_ISSUES-only) so both publish an identical contract.
+        private IActionResult OrderAndPublishTitleRows(
+            List<(JsonObject Row, int Id, DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt)> rows,
+            string sortValue,
+            int take,
+            int skip,
+            string apiKey,
+            string callerId,
+            string configuredSource)
+        {
+            var orderedRows = sortValue == "modified"
+                ? rows.OrderByDescending(row => row.UpdatedAt).ThenByDescending(row => row.Id)
+                : rows.OrderByDescending(row => row.CreatedAt).ThenByDescending(row => row.Id);
+            var matchingRows = orderedRows.Select(row => row.Row).ToArray();
+            return BuildExactTitleIssueResult(
+                matchingRows,
+                take,
+                skip,
+                apiKey,
+                callerId,
+                configuredSource);
         }
 
         private IActionResult BuildExactTitleIssueResult(

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrClient.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrClient.cs
@@ -1880,17 +1880,34 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                                 return new ObjectResult(new { code = "no_issue_permission", message = "You do not have permission to report issues in Seerr." }) { StatusCode = 403 };
                         }
 
-                        // GET /api/v1/issue — view issues list (any of: ?query, exact, /id)
-                        // The /api/v1/issue/{id} path was previously not gated by this
-                        // check.— non-admin without VIEW_ISSUES could
-                        // fetch any issue by id by guessing.
-                        if (method == HttpMethod.Get && (requireIssueViewPermission
-                            || apiPath.StartsWith("/api/v1/issue?", StringComparison.OrdinalIgnoreCase)
+                        // GET media detail carries an UNFILTERED issue relation
+                        // (every reporter's issue for the title), so it keeps the
+                        // stricter see-others gate: only VIEW_ISSUES / MANAGE_ISSUES
+                        // may consume that relation.
+                        if (method == HttpMethod.Get && requireIssueViewPermission)
+                        {
+                            if (!SeerrPermissionHelper.HasAnyPermission(perms,
+                                SeerrPermission.VIEW_ISSUES | SeerrPermission.MANAGE_ISSUES))
+                                return new ObjectResult(new { code = "no_issue_view_permission", message = "You do not have permission to view issues in Seerr." }) { StatusCode = 403 };
+                        }
+
+                        // GET /api/v1/issue — issue list (any of: ?query, exact) and
+                        // /api/v1/issue/{id} detail. Seerr enforces per-issue
+                        // ownership on these routes (issue.ts: a caller without
+                        // VIEW_ISSUES/MANAGE_ISSUES is scoped to createdBy = self on
+                        // the list and 403'd on a foreign detail). So a CREATE_ISSUES
+                        // reporter may reach them to read THEIR OWN issues; admitting
+                        // them here does not become a global view because Seerr still
+                        // filters/denies by owner. The /api/v1/issue/{id} path was
+                        // previously not gated, so a non-admin could fetch any issue
+                        // by guessing its id — the mask below still closes that.
+                        else if (method == HttpMethod.Get && (
+                            apiPath.StartsWith("/api/v1/issue?", StringComparison.OrdinalIgnoreCase)
                             || apiPath.StartsWith("/api/v1/issue/", StringComparison.OrdinalIgnoreCase)
                             || string.Equals(apiPath, "/api/v1/issue", StringComparison.OrdinalIgnoreCase)))
                         {
                             if (!SeerrPermissionHelper.HasAnyPermission(perms,
-                                SeerrPermission.VIEW_ISSUES | SeerrPermission.MANAGE_ISSUES))
+                                SeerrPermission.CREATE_ISSUES | SeerrPermission.VIEW_ISSUES | SeerrPermission.MANAGE_ISSUES))
                                 return new ObjectResult(new { code = "no_issue_view_permission", message = "You do not have permission to view issues in Seerr." }) { StatusCode = 403 };
                         }
 

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -19,7 +19,7 @@ const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the repeated clean measurements', () => {
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 1932, totalLines: 2253 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 19042, totalLines: 27479 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 19150, totalLines: 27560 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);
 });

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -21,12 +21,12 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 19042,
-        "totalLines": 27479
+        "coveredLines": 19150,
+        "totalLines": 27560
       },
       "tolerance": {
         "missingCoveredLines": 2,
-        "rationale": "Two clean final post-review local .NET 10.0.9/Coverlet integration runs on 2026-07-17 each passed 1702 tests and measured the identical complete 27479-line assembly scope at 19042 covered lines (69.297%). Issue #174 replaces the Continue Watching Timer race with bounded lifecycle-owned exact-id intake, deterministic drain/join, shared concurrent-disposal completion, observable cancellation/forced-terminal failure, retained retries, and exactly-once aggregated overflow rejection evidence on normal and abort exits. Adversarial stop, dispatch, retry, capacity, immediate-dispose, transient-global-null, coalescing, and lifecycle regressions cover the accepted-work contract without broad point-in-time library pruning. Relative to the reviewed 18876/27327 baseline, the reviewed assembly scope grows by 152 instrumented lines and the high-water advances by 166 covered lines while line coverage rises from 69.075% to 69.297%. The existing two-line tolerance is unchanged and covers only previously reproduced negligible Coverlet variance; coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, and broad-tolerance negative boundaries."
+        "rationale": "Repeated clean post-review local .NET 10.0.9/Coverlet integration runs on 2026-07-18 each passed all 1718 tests and measured the complete 27560-line assembly scope, with covered lines oscillating one line between 19149 and 19150 (high-water 19150 = 69.485%) purely from previously reproduced Coverlet instrumentation nondeterminism. Issue #171 (BI-SRV-109) widens the Seerr issue list/detail preflight so a CREATE_ISSUES-only reporter is admitted and reads only their own issues through Seerr's ownership-enforced routes, while the unfiltered media-detail relation stays gated on VIEW_ISSUES/MANAGE_ISSUES and a create-only reporter's targeted refresh is served from Seerr's ownership-scoped list projected to the requested title, failing closed on any incomplete, oversized, or malformed upstream response. New SeerrIssueViewPolicy and avatar-source-token tests exercise the admitted create-only path, the still-rejected no-permission path, the unchanged view/manage semantics, and the fail-closed projection. Relative to the reviewed 19042/27479 baseline, the reviewed assembly scope grows by 81 instrumented lines and the high-water advances by 108 covered lines while line coverage rises from 69.297% to 69.485%. The existing two-line tolerance is unchanged and covers only the reproduced negligible Coverlet variance; coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
## What & why

BI-SRV-109: a Seerr user with only `CREATE_ISSUES` could report an issue but then
got 403 when Canopy's preflight tried to list/read it (it required `VIEW_ISSUES`
or `MANAGE_ISSUES`), so a successful create refreshed into an empty/error modal.
Seerr itself allows a create-only user to list and read **their own** issues and
enforces ownership server-side.

## Implementation (server-only)

Rather than naively widen the shared `VIEW_ISSUES|MANAGE_ISSUES` mask (which would
leak **others'** issues via the unfiltered media-detail relation), the gate is
split at its two owners:

- **`SeerrClient.ProxyRequestAsyncCore`** — the direct `/api/v1/issue` list and
  `/api/v1/issue/{id}` GETs now admit `CREATE_ISSUES` too; Seerr auto-scopes
  non-VIEW/MANAGE callers to `createdBy=self` and 403s a foreign detail. The
  media-detail relation path (unfiltered) stays `VIEW_ISSUES|MANAGE_ISSUES`.
- **`SeerrProxyController.GetSeerrIssues`** — admits `CREATE_ISSUES`; for a
  create-only targeted refresh it does **not** call the media-detail relation
  (which would expose others' issues) and instead reads the caller's own issues
  via `/api/v1/issue?createdBy=<pinned id>`, validates the page is complete and
  within the existing 1000-row bound, filters to the requested title, and reuses
  the existing exact-title pagination + avatar decoration. Malformed/incomplete/
  oversized/failed upstream responses **fail closed** (existing 502), never a
  false empty.

No new permission is invented; no existing gate is weakened beyond letting an
owner read their own. Client (`fetchIssues`/`fetchIssuesForMedia`) has no pre-gate
and needs no change — it just stops getting 403.

## Tests / verification

- 30 new xUnit tests (`SeerrIssueViewPolicyTests`, `SeerrIssueAvatarSourceTokenTests`):
  create-only admitted on list+detail (was 403); ownership carried so Seerr still
  403s a foreign issue; no-permission still rejected before dispatch; VIEW/MANAGE
  unchanged; create-refresh projects the owned title and excludes unrelated titles;
  empty/incomplete/oversized/malformed/blocked all fail closed. Positive tests fail
  before the change.
- Independently re-verified: `dotnet build -c Release` clean (0/0); the 30 new
  tests pass; implementer's full server suite 1718/1718; coverage ratchet **raised**
  (69.297%→69.485%), tolerance unchanged.

## Notes

- **Security-sensitive (permission gate) — please review before merge.** The
  ownership guarantee for criterion 2 relies on Seerr's own `createdBy=self`
  scoping; a reviewer should sanity-check that assumption against the Seerr version
  in use.
- AI-assisted: implemented and adversarially reviewed by a multi-agent loop
  (single-writer implementation on Opus, review incl. `gpt-5.6-sol`, repo-native
  gates). The loop's automated verify reported not-ready only because that agent
  used the host's `.NET 10.0.8` runtime; with `10.0.9` the gates pass.
