### PR TITLE
feat(agentic-loop): dedicated cheap Localize phase for translations

### DIFF
--- a/.agents/skills/jellyfin-canopy-agentic-loop/SKILL.md
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/SKILL.md
@@ -168,7 +168,16 @@ The engine ([`workflows/canopy-loop.js`](workflows/canopy-loop.js)) runs:
    confirmed findings; re-review until a clean round. Challenge the design before
    a second fix to the same owner/state model. If a workaround needs a
    paragraph-long comment to justify it, the code is wrong — fix the code.
-5. **Verify** (single runner) — run the repo-native gates for the surface, and
+5. **Localize** (single cheap agent, low effort) — translation busywork, kept off
+   the expensive path. The implementer adds new i18n keys only to the base
+   `en.json`; this step runs **after** the review loop (so the other 25 locale
+   files never consume adversarial review) and **before** verify (so
+   `validate-translations` passes at parity). It fans the base keys out to every
+   locale on a low-effort model (gpt/opus on `low`, `localizeEffort`), commits one
+   `chore(i18n)` unit, and no-ops when no keys changed. Skipped for `server`
+   surfaces. Not adversarially reviewed — translations are mechanical and the
+   `validate-translations` gate enforces parity.
+6. **Verify** (single runner) — run the repo-native gates for the surface, and
    for runtime-relevant work build the Release DLL and run `npm run e2e:local`
    (exercise admin and non-admin, assert real DOM/server state, zero
    non-whitelisted console errors, zero unexpected plugin 4xx). Lint is advisory

--- a/.agents/skills/jellyfin-canopy-agentic-loop/references/adversarial-review.md
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/references/adversarial-review.md
@@ -70,8 +70,11 @@ are:
   useful; no scope creep beyond the brief; shared parity gaps fixed once at the
   owner, not by making the new consumer uniquely sophisticated.
 - **Docs, locale & generated artifacts** — every affected user/admin/architecture/
-  security doc updated; every locale key present in all locale files with real
-  translations; bundles/manifests/snapshots rebuilt from source and committed.
+  security doc updated; new i18n keys present in the base `en.json` and referenced
+  in code; bundles/manifests/snapshots rebuilt from source and committed. Do NOT
+  deep-review the other 25 locale translations — those are fanned out afterward by
+  the cheap Localize phase and enforced by the `validate-translations` gate, so
+  reviewing them here is wasted effort.
 
 ## Watch for semantically-different-but-syntactically-similar code
 

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -7,6 +7,7 @@ export const meta = {
     { title: 'Plan', detail: 'independent plans judged and synthesised into one canonical plan' },
     { title: 'Implement', detail: 'single writer builds the change at its owner with failing-first tests' },
     { title: 'Review', detail: 'adversarial reviewers (split context) → verify findings → single fixer → repeat until clean' },
+    { title: 'Localize', detail: 'cheap low-effort agent fans base-locale keys out to all locales — not reviewed' },
     { title: 'Verify', detail: 'repo-native gates for the surface; e2e:local for runtime-relevant work' },
   ],
 }
@@ -136,6 +137,9 @@ const solSlot = (i) => MODEL_SPLIT && i % 2 === 1 // odd indices → Sol (~50/50
 // codex effort × many calls gets very slow, so these default to medium; the
 // review round keeps SOL_EFFORT (high). Override with args.solLightEffort.
 const SOL_LIGHT_EFFORT = a.solLightEffort || 'medium'
+// Effort for the LOCALIZE phase — mechanical translation busywork kept cheap/fast
+// (gpt or opus on low, inheriting the session model). Override with args.localizeEffort.
+const LOCALIZE_EFFORT = a.localizeEffort || 'low'
 
 // codex forwards --output-schema to OpenAI Structured Outputs in STRICT mode,
 // which requires every object to set additionalProperties:false and list EVERY
@@ -551,8 +555,10 @@ Rules:
 - Add tests that FAIL before the change and pass after: admin AND non-admin,
   negative/fallback, concurrency/cache invalidation where relevant, non-vacuous
   assertions that prove the intended lower tier ran.
-- Add every new locale key to ALL locale files with real translations. Update
-  affected user/admin/architecture/security docs. Rebuild generated
+- Add any NEW i18n key ONLY to the base English locale (js/locales/en.json) and
+  reference it in code. Do NOT translate the other locale files — a dedicated
+  low-cost Localize phase fans them out afterward, so spend no effort there.
+  Update affected user/admin/architecture/security docs. Rebuild generated
   bundles/manifests/snapshots from source if the repo expects it.
 - Do NOT add live activation, polling, retries, migrations, config, or startup
   work unless the plan requires it. Give each side effect exactly one owner.
@@ -832,6 +838,40 @@ if (!cleanRound)
       ? `Review: ended without a certified-clean round — coverage incomplete (reviewer/verifier failure); will report as residual risk`
       : `Review: hit round cap (${SIZING.roundCap}) with unresolved findings — will report as residual risk`
   )
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PHASE 4.5 — LOCALIZE (cheap, low-effort translation busywork; NOT reviewed)
+// Runs AFTER the review loop, so the 25 non-base locale files never consume
+// adversarial review, and BEFORE verify, so validate-translations passes at
+// parity. Implementer/fixers add new i18n keys only to the base en.json; one
+// low-effort agent (gpt/opus on low) fans them out to every locale.
+// ═══════════════════════════════════════════════════════════════════════════
+if (SURFACE !== 'server') {
+  phase('Localize')
+  log(`Localize: fanning base-locale keys out to all locales (effort=${LOCALIZE_EFFORT})`)
+  await safely(
+    () =>
+      agent(
+        `${CONTRACTS}
+
+PHASE: LOCALIZE — cheap, low-effort TRANSLATION BUSYWORK ONLY. No logic, no code,
+no tests. Work from ${WORKTREE}. The implementer/fixers added any NEW i18n keys
+ONLY to the base English locale (js/locales/en.json). Propagate every key that is
+new or changed in en.json to ALL other locale files so
+\`npm run validate-translations\` passes at full parity — REAL translations per each
+locale's language, placeholder tokens ({name}, %s, {count}, etc.) kept
+byte-identical, and follow the repo's existing English-fallback convention for any
+locale file that already uses it. Touch ONLY js/locales/*.json — never code, tests,
+docs, or any other file. Then run \`npm run validate-translations\` until green and
+commit ONE \`chore(i18n): …\` unit (no \`Co-Authored-By\` trailer, no issue #N in the
+message or comments). If en.json has NO new or changed keys versus the other
+locales, do NOTHING and report "no locale work needed".`,
+        { agentType: 'general-purpose', effort: LOCALIZE_EFFORT, phase: 'Localize', label: 'localize' }
+      ),
+    null,
+    'Localize'
+  )
+}
 
 // ═══════════════════════════════════════════════════════════════════════════
 // PHASE 5 — VERIFY (single runner; bounded fix-and-reverify)


### PR DESCRIPTION
## What & why

Locale/translation work was riding the expensive implement + adversarial-review
path, inflating runtime for what is mechanical busywork. This pulls it into a
dedicated **cheap `Localize` phase**.

- The **implementer** now adds new i18n keys **only to the base `en.json`** and
  references them in code — it no longer hand-translates 25 locale files.
- A new **`Localize` phase** runs **after** the review loop (so the other locale
  files never consume adversarial review) and **before** verify (so
  `validate-translations` passes at full parity). A single **low-effort agent**
  (`localizeEffort` = `low`, inheriting the session model — gpt under claudex, opus
  otherwise) fans the base keys out to every locale and commits one `chore(i18n)`
  unit. It is **skipped for `server`** surfaces and **no-ops** when no keys changed.
- Reviewers are told **not** to deep-review the 25 translations — the
  `validate-translations` gate enforces parity, so reviewing them is wasted effort.

Net: translation adds ~no time/tokens to the expensive review cycle.

## Verification

- Workflow script parses; `scripts/canopy-loop.workflow.test.js` → 18/18 pass.
- Skill-only change (SKILL.md, references/adversarial-review.md,
  workflows/canopy-loop.js); no plugin code touched.
