### PR TITLE
fix(client): People Tags drain cast fetches through a bounded pool with one batch cache flush (BI-PERF-137)

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.identity.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { JC } from '../globals';
+import { recordDetailsViewShown, resetDetailsViewTrackingForTests } from '../core/details-view';
 import { installPeopleTagsFacade, resetPeopleTagsIdentity } from './peopletags';
 
 const uninstallPeopleTags = installPeopleTagsFacade();
@@ -26,6 +27,9 @@ function mountPersonCard(personId: string): HTMLElement {
                 </div>
             </div>
         </div>`;
+    // Record the view for the current URL item so getVisibleDetailsPage()
+    // (People Tags' owned-page resolver) hands out this page.
+    recordDetailsViewShown(document.querySelector('#itemDetailPage'));
     return document.querySelector<HTMLElement>('.personCard')!;
 }
 
@@ -39,6 +43,7 @@ describe('people tags identity lifecycle', () => {
         vi.useFakeTimers();
         document.body.innerHTML = '';
         localStorage.clear();
+        resetDetailsViewTrackingForTests();
         JC.identity.transition('people-server-a', `people-user-a-${Date.now()}`, 'people-test-a');
         JC.currentSettings = { peopleTagsEnabled: true };
         JC.pluginConfig = { TagsCacheTtlDays: 7 };
@@ -52,6 +57,7 @@ describe('people tags identity lifecycle', () => {
         JC.pluginConfig = {};
         document.body.innerHTML = '';
         localStorage.clear();
+        resetDetailsViewTrackingForTests();
         vi.useRealTimers();
     });
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.perf.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.perf.test.ts
@@ -36,7 +36,7 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 interface PendingRequest {
     path: string;
     resolve: (value: unknown) => void;
-    reject: (error: unknown) => void;
+    reject: (error: Error) => void;
 }
 
 /**

--- a/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.perf.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.perf.test.ts
@@ -1,0 +1,447 @@
+// src/tags/peopletags.perf.test.ts
+//
+// BI-PERF-137 (#359) regressions: People Tags must drain cast overlays
+// through a BOUNDED-CONCURRENCY worker pool (not a serial N+1 await-in-loop),
+// share that pool across cast and guest cast (no hard section barrier), and
+// persist the localStorage cache ONCE per settled batch (not once per person,
+// which re-serialized the entire map every time = O(N^2) main-thread work).
+// Correctness contracts must be preserved exactly: identity/navigation
+// cancellation, per-person dedup, cache TTL/ownership semantics, and
+// identical rendered output (age chips / place banner / deceased poster).
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../globals';
+import { installPeopleTagsFacade, resetPeopleTagsIdentity } from './peopletags';
+
+const uninstallPeopleTags = installPeopleTagsFacade();
+const offPeopleReset = JC.identity.registerReset('people-tags-perf-test', resetPeopleTagsIdentity);
+
+afterAll(() => {
+    offPeopleReset();
+    resetPeopleTagsIdentity();
+    uninstallPeopleTags();
+});
+
+/**
+ * Cap the implementation must respect — the repository's established bounded
+ * pool size (issue-reporter ISSUE_ENRICHMENT_CONCURRENCY, tag-pipeline
+ * TAG_FALLBACK_CONCURRENCY).
+ */
+const CONCURRENCY_CAP = 6;
+
+const CACHE_KEY = 'JellyfinCanopy-peopleTagsCache';
+const CACHE_TIMESTAMP_KEY = 'JellyfinCanopy-peopleTagsCacheTimestamp';
+const CACHE_OWNER_KEY = 'JellyfinCanopy-peopleTagsCacheIdentityOwner';
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+interface PendingRequest {
+    path: string;
+    resolve: (value: unknown) => void;
+    reject: (error: unknown) => void;
+}
+
+/**
+ * Instrumented api.plugin mock recording the maximum number of concurrently
+ * in-flight requests. Requests default to deferred (caller settles them via
+ * `pending`); an optional handler may return an immediate value for a path.
+ */
+function instrumentedPlugin(handler?: (path: string) => unknown) {
+    const pending: PendingRequest[] = [];
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const plugin = vi.fn((path: string): Promise<unknown> => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        const immediate = handler?.(path);
+        if (immediate !== undefined) {
+            return Promise.resolve(immediate).then((value) => {
+                inFlight -= 1;
+                return value;
+            });
+        }
+        return new Promise((resolve, reject) => {
+            pending.push({
+                path,
+                resolve: (value) => { inFlight -= 1; resolve(value); },
+                reject: (error) => { inFlight -= 1; reject(error); },
+            });
+        });
+    });
+    return {
+        plugin,
+        pending,
+        inFlightNow: () => inFlight,
+        maxInFlight: () => maxInFlight,
+    };
+}
+
+function personCardHtml(personId: string): string {
+    return `<div class="personCard" data-id="${personId}"><div class="cardScalable"></div></div>`;
+}
+
+function mountCastPage(itemId: string, castIds: string[], guestIds: string[] = []): void {
+    window.location.hash = `#/details?id=${itemId}`;
+    document.body.innerHTML = `
+        <div id="itemDetailPage">
+            <div id="castCollapsible">${castIds.map(personCardHtml).join('')}</div>
+            <div id="guestCastCollapsible">${guestIds.map(personCardHtml).join('')}</div>
+        </div>`;
+}
+
+function cardFor(personId: string): HTMLElement {
+    return document.querySelector<HTMLElement>(`.personCard[data-id="${personId}"]`)!;
+}
+
+function fireObserver(callback: MutationCallback): void {
+    callback(
+        [{ addedNodes: [document.createElement('div')] }] as unknown as MutationRecord[],
+        {} as MutationObserver,
+    );
+}
+
+/** Settle pending deferred waves until the pool drains (bounded iterations). */
+async function drainPool(pending: PendingRequest[], value: unknown, maxWaves = 50): Promise<void> {
+    for (let wave = 0; wave < maxWaves && pending.length > 0; wave += 1) {
+        const batch = pending.splice(0, pending.length);
+        for (const request of batch) request.resolve(value);
+        await vi.advanceTimersByTimeAsync(5);
+    }
+}
+
+const surface = JC as typeof JC & { initializePeopleTags?: () => void };
+
+describe('people tags bounded-concurrency batch (BI-PERF-137)', () => {
+    const originalApi = JC.core.api;
+    const originalHelpers = JC.helpers;
+    let observerCallbacks: MutationCallback[] = [];
+    let userSequence = 0;
+
+    function installObserverMock(): void {
+        JC.helpers = {
+            ...originalHelpers,
+            createObserver: vi.fn((_id: string, callback: MutationCallback) => {
+                observerCallbacks.push(callback);
+                return { disconnect: vi.fn() };
+            }),
+        };
+    }
+
+    /** Initialize the feature and trigger one observer-driven processing pass. */
+    async function startProcessing(): Promise<void> {
+        surface.initializePeopleTags!();
+        fireObserver(observerCallbacks[observerCallbacks.length - 1]);
+        await vi.advanceTimersByTimeAsync(100);
+    }
+
+    function seedOwnedCache(
+        entries: Record<string, { data: unknown; timestamp: number }>,
+        owner?: string,
+    ): void {
+        const context = JC.identity.capture()!;
+        const payload: Record<string, unknown> = {};
+        const timestamps: Record<string, number> = {};
+        for (const [key, entry] of Object.entries(entries)) {
+            payload[key] = entry.data;
+            timestamps[key] = entry.timestamp;
+        }
+        localStorage.setItem(CACHE_OWNER_KEY, owner ?? `${context.serverId}:${context.userId}`);
+        localStorage.setItem(CACHE_KEY, JSON.stringify(payload));
+        localStorage.setItem(CACHE_TIMESTAMP_KEY, JSON.stringify(timestamps));
+    }
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        document.body.innerHTML = '';
+        localStorage.clear();
+        observerCallbacks = [];
+        userSequence += 1;
+        JC.identity.transition('people-perf-server', `people-perf-user-${userSequence}`, 'people-perf-test');
+        JC.currentSettings = { peopleTagsEnabled: true };
+        JC.pluginConfig = { TagsCacheTtlDays: 7 };
+        installObserverMock();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        JC.identity.transition('test-server-id', 'test-user-id', 'people-perf-cleanup');
+        JC.core.api = originalApi;
+        JC.helpers = originalHelpers;
+        JC.currentSettings = {};
+        JC.pluginConfig = {};
+        document.body.innerHTML = '';
+        localStorage.clear();
+        vi.useRealTimers();
+    });
+
+    it('AC1/AC5: drains a 20-person cast with >1 but <=cap requests in flight', async () => {
+        const { plugin, pending, inFlightNow, maxInFlight } = instrumentedPlugin();
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        const castIds = Array.from({ length: 20 }, (_, index) => `person-${String(index).padStart(2, '0')}`);
+        mountCastPage('item-conc', castIds);
+
+        await startProcessing();
+
+        // The first wave must overlap requests (not serial N+1) while never
+        // exceeding the bounded pool cap across a 20-person cast.
+        expect(inFlightNow()).toBeGreaterThan(1);
+        expect(inFlightNow()).toBeLessThanOrEqual(CONCURRENCY_CAP);
+        expect(plugin.mock.calls.length).toBeLessThanOrEqual(CONCURRENCY_CAP);
+
+        await drainPool(pending, { currentAge: 30 });
+
+        expect(plugin).toHaveBeenCalledTimes(20);
+        expect(maxInFlight()).toBeGreaterThan(1);
+        expect(maxInFlight()).toBeLessThanOrEqual(CONCURRENCY_CAP);
+        // Every person fetched exactly once, and every card tagged.
+        const fetchedPaths = plugin.mock.calls.map((call) => String(call[0]));
+        expect(new Set(fetchedPaths).size).toBe(20);
+        expect(document.querySelectorAll('.jc-people-age-container')).toHaveLength(20);
+    });
+
+    it('AC2: persists the cache once per settled batch, not once per person', async () => {
+        seedOwnedCache({});
+        const writeSpy = vi.spyOn(JC.storage.local, 'write');
+        const { plugin } = instrumentedPlugin(() => ({ currentAge: 40, birthPlace: 'Perth, Australia' }));
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        const castIds = Array.from({ length: 10 }, (_, index) => `person-batch-${index}`);
+        mountCastPage('item-batch', castIds);
+
+        await startProcessing();
+        await vi.advanceTimersByTimeAsync(5);
+
+        expect(plugin).toHaveBeenCalledTimes(10);
+        expect(document.querySelectorAll('.jc-people-age-container')).toHaveLength(10);
+        const labels = writeSpy.mock.calls.map((call) => call[3]);
+        expect(labels.filter((label) => label === 'cache-payload')).toHaveLength(1);
+        expect(labels.filter((label) => label === 'cache-timestamps')).toHaveLength(1);
+        expect(labels.filter((label) => label === 'cache-owner')).toHaveLength(1);
+        // The single write contains every person from the batch.
+        const persisted = JSON.parse(localStorage.getItem(CACHE_KEY)!) as Record<string, unknown>;
+        expect(Object.keys(persisted)).toHaveLength(10);
+    });
+
+    it('AC2: a batch served entirely from fresh cache performs no persistence write', async () => {
+        const now = Date.now();
+        seedOwnedCache({
+            'person-hit-a-item-hit': { data: { currentAge: 41 }, timestamp: now - 1000 },
+            'person-hit-b-item-hit': { data: { currentAge: 42 }, timestamp: now - 1000 },
+        });
+        const writeSpy = vi.spyOn(JC.storage.local, 'write');
+        const { plugin } = instrumentedPlugin(() => ({ currentAge: 99 }));
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        mountCastPage('item-hit', ['person-hit-a', 'person-hit-b']);
+
+        await startProcessing();
+        await vi.advanceTimersByTimeAsync(5);
+
+        expect(plugin).not.toHaveBeenCalled();
+        expect(document.querySelectorAll('.jc-people-age-container')).toHaveLength(2);
+        const labels = writeSpy.mock.calls.map((call) => call[3]);
+        expect(labels.filter((label) => label === 'cache-payload')).toHaveLength(0);
+        expect(labels.filter((label) => label === 'cache-timestamps')).toHaveLength(0);
+    });
+
+    it('AC2: a batch with no successful fetch performs no persistence write', async () => {
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        seedOwnedCache({});
+        const writeSpy = vi.spyOn(JC.storage.local, 'write');
+        const { plugin, pending } = instrumentedPlugin();
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        mountCastPage('item-fail', ['person-fail-a', 'person-fail-b', 'person-fail-c']);
+
+        await startProcessing();
+        for (const request of pending.splice(0, pending.length)) {
+            request.reject(new Error('backend down'));
+        }
+        await vi.advanceTimersByTimeAsync(5);
+
+        expect(plugin).toHaveBeenCalledTimes(3);
+        const labels = writeSpy.mock.calls.map((call) => call[3]);
+        expect(labels.filter((label) => label === 'cache-payload')).toHaveLength(0);
+        expect(labels.filter((label) => label === 'cache-timestamps')).toHaveLength(0);
+        expect(document.querySelectorAll('.jc-people-age-container')).toHaveLength(0);
+    });
+
+    it('AC3: a same-identity navigation mid-render applies no tags and claims no further work', async () => {
+        const { plugin, pending } = instrumentedPlugin();
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        const castIds = Array.from({ length: 8 }, (_, index) => `person-nav-${index}`);
+        mountCastPage('item-nav-a', castIds);
+        await startProcessing();
+        expect(plugin.mock.calls.length).toBeLessThanOrEqual(CONCURRENCY_CAP);
+        const inFlightBeforeNavigation = plugin.mock.calls.length;
+        const oldCards = castIds.map((id) => cardFor(id));
+
+        // Navigate to another item under the SAME identity, replacing the DOM.
+        mountCastPage('item-nav-b', ['person-nav-new']);
+        for (const request of pending.splice(0, pending.length)) {
+            request.resolve({ isDeceased: true, ageAtDeath: 70, birthPlace: 'Perth, Australia' });
+        }
+        await vi.advanceTimersByTimeAsync(5);
+
+        // No overlay lands anywhere — not on the new page, not on old cards —
+        // and the pool must not claim the still-unfetched item-A tasks.
+        expect(document.querySelectorAll('.jc-people-age-container')).toHaveLength(0);
+        expect(document.querySelectorAll('.jc-people-place-banner')).toHaveLength(0);
+        expect(document.querySelectorAll('.jc-deceased-poster')).toHaveLength(0);
+        for (const card of oldCards) {
+            expect(card.querySelector('.jc-people-age-container')).toBeNull();
+            expect(card.classList.contains('jc-deceased-poster')).toBe(false);
+        }
+        expect(plugin).toHaveBeenCalledTimes(inFlightBeforeNavigation);
+    });
+
+    it('AC3: an identity transition mid-render applies no tags and persists nothing', async () => {
+        const { plugin, pending } = instrumentedPlugin();
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        mountCastPage('item-ident-a', ['person-ident-a', 'person-ident-b']);
+        await startProcessing();
+        expect(plugin).toHaveBeenCalledTimes(2);
+        const writeSpy = vi.spyOn(JC.storage.local, 'write');
+
+        JC.identity.transition('people-perf-server-b', 'people-perf-user-b', 'people-perf-switch');
+        mountCastPage('item-ident-b', ['person-ident-new']);
+        for (const request of pending.splice(0, pending.length)) {
+            request.resolve({ isDeceased: true, ageAtDeath: 55, birthPlace: 'Perth, Australia' });
+        }
+        await vi.advanceTimersByTimeAsync(5);
+
+        expect(document.querySelectorAll('.jc-people-age-container')).toHaveLength(0);
+        expect(document.querySelectorAll('.jc-people-place-banner')).toHaveLength(0);
+        expect(document.querySelectorAll('.jc-deceased-poster')).toHaveLength(0);
+        const labels = writeSpy.mock.calls.map((call) => call[3]);
+        expect(labels.filter((label) => label === 'cache-payload')).toHaveLength(0);
+        expect(labels.filter((label) => label === 'cache-timestamps')).toHaveLength(0);
+    });
+
+    it('AC3: duplicate person ids fetch once and only the cast-first card renders', async () => {
+        const { plugin } = instrumentedPlugin(() => ({ currentAge: 44, birthPlace: 'Perth, Australia' }));
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        window.location.hash = '#/details?id=item-dup';
+        document.body.innerHTML = `
+            <div id="itemDetailPage">
+                <div id="castCollapsible">${personCardHtml('person-dup')}${personCardHtml('person-dup')}</div>
+                <div id="guestCastCollapsible">${personCardHtml('person-dup')}</div>
+            </div>`;
+
+        await startProcessing();
+        // A second observer pass must not re-process anything.
+        fireObserver(observerCallbacks[observerCallbacks.length - 1]);
+        await vi.advanceTimersByTimeAsync(100);
+        await vi.advanceTimersByTimeAsync(5);
+
+        expect(plugin).toHaveBeenCalledTimes(1);
+        const cards = document.querySelectorAll<HTMLElement>('.personCard');
+        expect(cards[0].querySelector('.jc-people-age-container')).not.toBeNull();
+        expect(cards[1].querySelector('.jc-people-age-container')).toBeNull();
+        expect(cards[2].querySelector('.jc-people-age-container')).toBeNull();
+    });
+
+    it.each([true, false])(
+        'AC3: rendered output is identical for a given PersonData (admin=%s)',
+        async (isAdministrator) => {
+            (window.ApiClient as unknown as { getCurrentUser: () => Promise<unknown> }).getCurrentUser =
+                () => Promise.resolve({ Policy: { IsAdministrator: isAdministrator } });
+            const responses: Record<string, unknown> = {
+                'person-dead': {
+                    isDeceased: true, ageAtDeath: 70, ageAtItemRelease: 55, birthPlace: 'Perth, Australia',
+                },
+                'person-alive': {
+                    currentAge: 44, ageAtItemRelease: 30, birthPlace: 'Nowhere, Atlantis',
+                },
+            };
+            const { plugin } = instrumentedPlugin(
+                (path) => responses[/\/person\/([^/?]+)/.exec(path)?.[1] ?? ''],
+            );
+            JC.core.api = { plugin } as unknown as typeof JC.core.api;
+            mountCastPage('item-parity', ['person-dead', 'person-alive']);
+
+            await startProcessing();
+            await vi.advanceTimersByTimeAsync(5);
+
+            const dead = cardFor('person-dead');
+            expect(dead.classList.contains('jc-deceased-poster')).toBe(true);
+            expect(dead.querySelector('.jc-people-age-deceased .jc-people-age-text')?.textContent).toBe('70y');
+            expect(dead.querySelector('.jc-people-age-release .jc-people-age-text')?.textContent).toBe('55y');
+            expect(dead.querySelector('.jc-people-place-text')?.textContent).toBe('Perth, Australia');
+            const flag = dead.querySelector<HTMLImageElement>('.jc-people-flag');
+            expect(flag?.alt).toBe('AU');
+            const deadAgeContainer = dead.querySelector('.jc-people-age-container');
+            expect(deadAgeContainer?.getAttribute('data-jc-identity-owned')).toBe('true');
+            expect(deadAgeContainer?.parentElement?.classList.contains('cardScalable')).toBe(true);
+
+            const alive = cardFor('person-alive');
+            expect(alive.classList.contains('jc-deceased-poster')).toBe(false);
+            expect(alive.querySelector('.jc-people-age-current .jc-people-age-text')?.textContent).toBe('44y');
+            expect(alive.querySelector('.jc-people-age-release .jc-people-age-text')?.textContent).toBe('30y');
+            // Unknown country: banner still renders, without a flag image.
+            expect(alive.querySelector('.jc-people-place-text')?.textContent).toBe('Nowhere, Atlantis');
+            expect(alive.querySelector('.jc-people-flag')).toBeNull();
+        },
+    );
+
+    it('AC4: guest cast joins the first bounded wave and renders while cast requests are blocked', async () => {
+        const { plugin, pending } = instrumentedPlugin(
+            (path) => (path.includes('person-guest-1') ? { currentAge: 50 } : undefined),
+        );
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        const castIds = Array.from({ length: 8 }, (_, index) => `person-main-${index}`);
+        mountCastPage('item-guest', castIds, ['person-guest-1']);
+
+        await startProcessing();
+        await vi.advanceTimersByTimeAsync(5);
+
+        // The guest request is part of the initial bounded wave, not starved
+        // behind the 8 blocked normal-cast requests…
+        const firstWavePaths = plugin.mock.calls.slice(0, CONCURRENCY_CAP).map((call) => String(call[0]));
+        expect(firstWavePaths.some((path) => path.includes('person-guest-1'))).toBe(true);
+        // …and its overlay lands while every normal-cast request is still open.
+        expect(cardFor('person-guest-1').querySelector('.jc-people-age-container')).not.toBeNull();
+        expect(document.querySelectorAll('.jc-people-age-container')).toHaveLength(1);
+
+        await drainPool(pending, { currentAge: 35 });
+        expect(plugin).toHaveBeenCalledTimes(9);
+        expect(document.querySelectorAll('.jc-people-age-container')).toHaveLength(9);
+    });
+
+    it('AC5: fresh same-owner entries skip the endpoint; expired entries refetch', async () => {
+        const now = Date.now();
+        seedOwnedCache({
+            'person-fresh-item-ttl': { data: { currentAge: 33 }, timestamp: now - 1000 },
+            // TagsCacheTtlDays is 7 in this suite — 8 days is expired.
+            'person-stale-item-ttl': { data: { currentAge: 90 }, timestamp: now - 8 * DAY_MS },
+        });
+        const { plugin } = instrumentedPlugin(() => ({ currentAge: 21 }));
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        mountCastPage('item-ttl', ['person-fresh', 'person-stale']);
+
+        await startProcessing();
+        await vi.advanceTimersByTimeAsync(5);
+
+        expect(plugin).toHaveBeenCalledTimes(1);
+        expect(String(plugin.mock.calls[0][0])).toContain('/person/person-stale');
+        expect(cardFor('person-fresh').querySelector('.jc-people-age-text')?.textContent).toBe('33y');
+        expect(cardFor('person-stale').querySelector('.jc-people-age-text')?.textContent).toBe('21y');
+    });
+
+    it('AC5: an owner-mismatched cache is cleared before refetching', async () => {
+        const now = Date.now();
+        seedOwnedCache(
+            { 'person-owned-item-owner': { data: { currentAge: 77 }, timestamp: now - 1000 } },
+            'other-server:other-user',
+        );
+        const { plugin } = instrumentedPlugin(() => ({ currentAge: 25 }));
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        mountCastPage('item-owner', ['person-owned']);
+
+        await startProcessing();
+        await vi.advanceTimersByTimeAsync(5);
+
+        // The foreign payload must not be replayed: refetched, not reused.
+        expect(plugin).toHaveBeenCalledTimes(1);
+        expect(cardFor('person-owned').querySelector('.jc-people-age-text')?.textContent).toBe('25y');
+        const context = JC.identity.capture()!;
+        expect(localStorage.getItem(CACHE_OWNER_KEY)).toBe(`${context.serverId}:${context.userId}`);
+        const persisted = JSON.parse(localStorage.getItem(CACHE_KEY)!) as Record<string, unknown>;
+        expect(Object.keys(persisted)).toEqual(['person-owned-item-owner']);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.perf.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.perf.test.ts
@@ -10,6 +10,7 @@
 // identical rendered output (age chips / place banner / deceased poster).
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { JC } from '../globals';
+import { recordDetailsViewShown, resetDetailsViewTrackingForTests } from '../core/details-view';
 import { installPeopleTagsFacade, resetPeopleTagsIdentity } from './peopletags';
 
 const uninstallPeopleTags = installPeopleTagsFacade();
@@ -85,6 +86,12 @@ function mountCastPage(itemId: string, castIds: string[], guestIds: string[] = [
             <div id="castCollapsible">${castIds.map(personCardHtml).join('')}</div>
             <div id="guestCastCollapsible">${guestIds.map(personCardHtml).join('')}</div>
         </div>`;
+    // People Tags resolves its target through the details-view helper, which
+    // records the item a view was shown for on `viewshow`. Mirror that here so
+    // getVisibleDetailsPage() hands out this page for the current URL item
+    // (and, on a navigation test, so the OUTGOING page is not adopted for the
+    // incoming item mid-transition).
+    recordDetailsViewShown(document.querySelector('#itemDetailPage'));
 }
 
 function cardFor(personId: string): HTMLElement {
@@ -152,6 +159,7 @@ describe('people tags bounded-concurrency batch (BI-PERF-137)', () => {
         vi.useFakeTimers();
         document.body.innerHTML = '';
         localStorage.clear();
+        resetDetailsViewTrackingForTests();
         observerCallbacks = [];
         userSequence += 1;
         JC.identity.transition('people-perf-server', `people-perf-user-${userSequence}`, 'people-perf-test');
@@ -169,6 +177,7 @@ describe('people tags bounded-concurrency batch (BI-PERF-137)', () => {
         JC.pluginConfig = {};
         document.body.innerHTML = '';
         localStorage.clear();
+        resetDetailsViewTrackingForTests();
         vi.useRealTimers();
     });
 
@@ -322,6 +331,7 @@ describe('people tags bounded-concurrency batch (BI-PERF-137)', () => {
                 <div id="castCollapsible">${personCardHtml('person-dup')}${personCardHtml('person-dup')}</div>
                 <div id="guestCastCollapsible">${personCardHtml('person-dup')}</div>
             </div>`;
+        recordDetailsViewShown(document.querySelector('#itemDetailPage'));
 
         await startProcessing();
         // A second observer pass must not re-process anything.
@@ -458,6 +468,7 @@ describe('people tags bounded-concurrency batch (BI-PERF-137)', () => {
                 <div id="castCollapsible">${['person-mod-0', 'person-mod-1'].map(personCardHtml).join('')}</div>
                 <div id="guestCastCollapsible"></div>
             </div>`;
+        recordDetailsViewShown(document.querySelector('#itemDetailPage'));
 
         await startProcessing();
         await vi.advanceTimersByTimeAsync(5);
@@ -521,5 +532,197 @@ describe('people tags bounded-concurrency batch (BI-PERF-137)', () => {
         expect(document.querySelectorAll('.jc-people-age-container')).toHaveLength(2);
         // A's stale first wave, then B's two recovered requests.
         expect(plugin).toHaveBeenCalledTimes(staleRequests + 2);
+    });
+
+    it('AC3: cards replaced mid-batch on the SAME item are re-tagged, not permanently dropped', async () => {
+        // Adversarial lifecycle case: React re-renders the cast cards for the
+        // SAME item while the bounded batch is in flight. Person ids were
+        // eagerly finalized at collection time, so the results for the old
+        // (now disconnected) cards were correctly dropped BUT the remembered
+        // rerun skipped every replacement card as "already processed",
+        // finishing with zero overlays. Ids must only finalize once an overlay
+        // lands on a LIVE card.
+        const { plugin, pending } = instrumentedPlugin();
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        const castIds = Array.from({ length: 8 }, (_, index) => `person-repl-${index}`);
+        mountCastPage('item-repl', castIds);
+
+        await startProcessing();
+        const firstWave = plugin.mock.calls.length;
+        expect(firstWave).toBeGreaterThan(0);
+        expect(firstWave).toBeLessThanOrEqual(CONCURRENCY_CAP);
+
+        // Replace every cast card with a fresh element (new identity, same
+        // data-id) on the same page while the first wave is still open.
+        document.querySelector('#castCollapsible')!.innerHTML = castIds.map(personCardHtml).join('');
+        const replacementCards = castIds.map((id) => cardFor(id));
+        fireObserver(observerCallbacks[observerCallbacks.length - 1]);
+        await vi.advanceTimersByTimeAsync(100);
+
+        // Settle the stale batch (its cards are gone) then let the rerun drain
+        // the replacement cards from the now-warm cache.
+        await drainPool(pending, { currentAge: 30 });
+        await vi.advanceTimersByTimeAsync(5);
+
+        // Every replacement card is tagged, and no person was fetched twice
+        // (the rerun is served from the hot cache the stale batch populated).
+        for (const card of replacementCards) {
+            expect(card.isConnected).toBe(true);
+            expect(card.querySelector('.jc-people-age-container')).not.toBeNull();
+        }
+        expect(document.querySelectorAll('.jc-people-age-container')).toHaveLength(8);
+        expect(plugin).toHaveBeenCalledTimes(8);
+    });
+
+    it('AC3/AC4: a details→details transition never processes the outgoing view under the incoming item id', async () => {
+        // During Jellyfin's details→details push the URL flips to item B while
+        // item A's view is still the visible one and B is not mounted yet. A
+        // shared actor must NOT be fetched/marked-processed under itemId=B off
+        // the outgoing A view, or B's real card is skipped by processedPersonIds
+        // and never tagged. getVisibleDetailsPage() reports the transition
+        // (null) so the batch/rerun defers.
+        const { plugin, pending } = instrumentedPlugin();
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        mountCastPage('item-trans-a', ['person-shared', 'person-a-only']);
+
+        await startProcessing();
+        expect(plugin.mock.calls.length).toBeGreaterThan(0);
+
+        // Transition: the URL now names item B, but A's view is still visible
+        // and B has not mounted. Any probe here must defer.
+        window.location.hash = '#/details?id=item-trans-b';
+        fireObserver(observerCallbacks[observerCallbacks.length - 1]);
+        await vi.advanceTimersByTimeAsync(100);
+        // Settle A's in-flight requests — they must apply nothing and, crucially,
+        // must not finalize the shared actor's id under item B.
+        for (const request of pending.splice(0, pending.length)) {
+            request.resolve({ currentAge: 30 });
+        }
+        await vi.advanceTimersByTimeAsync(5);
+
+        // B's view now mounts for real (records itself for item B).
+        mountCastPage('item-trans-b', ['person-shared', 'person-b-only']);
+        fireObserver(observerCallbacks[observerCallbacks.length - 1]);
+        await vi.advanceTimersByTimeAsync(100);
+        await drainPool(pending, { currentAge: 42 });
+
+        // The shared actor is tagged on B — proof it was not consumed under B
+        // off the outgoing A view.
+        expect(cardFor('person-shared').querySelector('.jc-people-age-container')).not.toBeNull();
+        expect(cardFor('person-b-only').querySelector('.jc-people-age-container')).not.toBeNull();
+    });
+
+    it('AC3/AC4: a completion timer from an earlier batch does not wedge the complete gate while a newer batch runs', async () => {
+        // person-t0 resolves immediately (batch 1 completes and schedules its
+        // 2s completion timer); person-t1/2 are deferred so batch 2 stays in
+        // flight while that stale timer fires. If completion is marked while a
+        // newer batch is running, the peopleTagsComplete gate wedges and a card
+        // mounting afterwards is never tagged.
+        const { plugin, pending } = instrumentedPlugin(
+            (path) => (path.includes('person-t0') ? { currentAge: 30 } : undefined),
+        );
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        mountCastPage('item-timer', ['person-t0']);
+
+        await startProcessing();
+        expect(cardFor('person-t0').querySelector('.jc-people-age-container')).not.toBeNull();
+
+        // Batch 1's completion timer is pending (~2s out). Start a slow batch 2
+        // one second in.
+        await vi.advanceTimersByTimeAsync(1000);
+        document.querySelector('#castCollapsible')!.insertAdjacentHTML('beforeend', personCardHtml('person-t1'));
+        fireObserver(observerCallbacks[observerCallbacks.length - 1]);
+        await vi.advanceTimersByTimeAsync(100);
+        expect(plugin.mock.calls.some((call) => String(call[0]).includes('person-t1'))).toBe(true);
+
+        // Fire the stale completion timer while batch 2 is still in flight.
+        await vi.advanceTimersByTimeAsync(2000);
+
+        // A third card mounts; it must still be picked up (gate not wedged).
+        document.querySelector('#castCollapsible')!.insertAdjacentHTML('beforeend', personCardHtml('person-t2'));
+        fireObserver(observerCallbacks[observerCallbacks.length - 1]);
+        await vi.advanceTimersByTimeAsync(100);
+
+        await drainPool(pending, { currentAge: 44 });
+        expect(cardFor('person-t1').querySelector('.jc-people-age-container')).not.toBeNull();
+        expect(cardFor('person-t2').querySelector('.jc-people-age-container')).not.toBeNull();
+    });
+
+    it('AC1/AC5: a same-identity reinitialization retires the old pool (cap held) and cannot overwrite the new cache', async () => {
+        // Start a 12-person batch on item A (6 in flight), then trigger the
+        // supported same-user reinitialization and process item B. The retired
+        // A pool must claim no further /person work (so global concurrency
+        // stays within the cap) and its late-settling, teardown-emptied cache
+        // map must not overwrite B's freshly persisted entries.
+        const { plugin, pending } = instrumentedPlugin();
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        const castA = Array.from({ length: 12 }, (_, index) => `person-a-${index}`);
+        mountCastPage('item-reinit-a', castA);
+
+        await startProcessing();
+        const aInFlight = plugin.mock.calls.filter((call) => String(call[0]).includes('/person/person-a-')).length;
+        expect(aInFlight).toBe(CONCURRENCY_CAP); // 6 of 12 claimed, rest queued
+
+        // Same-identity reinitialization (e.g. a settings restart): a new
+        // initializer + observer takes over.
+        surface.initializePeopleTags!();
+        mountCastPage('item-reinit-b', ['person-b-0', 'person-b-1']);
+        fireObserver(observerCallbacks[observerCallbacks.length - 1]);
+        await vi.advanceTimersByTimeAsync(100);
+
+        // Settle B first (it persists), then the retired A batch late.
+        for (const request of pending.filter((req) => req.path.includes('person-b'))) {
+            request.resolve({ currentAge: 20 });
+        }
+        await vi.advanceTimersByTimeAsync(5);
+        const persistedAfterB = JSON.parse(localStorage.getItem(CACHE_KEY)!) as Record<string, unknown>;
+
+        for (const request of pending.filter((req) => req.path.includes('person-a'))) {
+            request.resolve({ currentAge: 99 });
+        }
+        await vi.advanceTimersByTimeAsync(5);
+
+        // The retired A pool never claimed beyond its 6 in-flight requests.
+        const aCalls = plugin.mock.calls.filter((call) => String(call[0]).includes('/person/person-a-'));
+        expect(aCalls).toHaveLength(CONCURRENCY_CAP);
+        // B's cast was fetched and tagged under the new pool.
+        expect(cardFor('person-b-0').querySelector('.jc-people-age-container')).not.toBeNull();
+        expect(cardFor('person-b-1').querySelector('.jc-people-age-container')).not.toBeNull();
+        // The late A settle did not overwrite B's persisted cache.
+        const persistedFinal = JSON.parse(localStorage.getItem(CACHE_KEY)!) as Record<string, unknown>;
+        expect(Object.keys(persistedFinal).sort()).toEqual(Object.keys(persistedAfterB).sort());
+        expect(Object.keys(persistedFinal)).toEqual(
+            ['person-b-0-item-reinit-b', 'person-b-1-item-reinit-b'],
+        );
+    });
+
+    it('AC2: persists when an earlier fetch precedes a LAST-resolving cache hit (aggregate-any, not last-write-wins)', async () => {
+        // Pins the batch-persist aggregation: persist if ANY task changed the
+        // cache. Six uncached people (deferred fetches) fill the pool; a
+        // seventh, fresh same-owner cache HIT is claimed only after a worker
+        // frees, so its cacheChanged=false is the LAST value folded in. A
+        // last-write-wins mutation (`cacheChanged = await ...`) would drop the
+        // whole flush and silently reintroduce refetch-every-visit.
+        const now = Date.now();
+        seedOwnedCache({ 'person-hit-item-agg': { data: { currentAge: 50 }, timestamp: now - 1000 } });
+        const writeSpy = vi.spyOn(JC.storage.local, 'write');
+        const { plugin, pending } = instrumentedPlugin();
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        const fetchIds = Array.from({ length: 6 }, (_, index) => `person-f${index}`);
+        // The cache-hit person is LAST in DOM order so it is drained in wave 2.
+        mountCastPage('item-agg', [...fetchIds, 'person-hit']);
+
+        await startProcessing();
+        // Only the six uncached people hit the endpoint; the seeded one is a hit.
+        expect(plugin).toHaveBeenCalledTimes(6);
+        await drainPool(pending, { currentAge: 30 });
+
+        // Exactly one batch flush, and it includes the freshly fetched people.
+        const payloadWrites = writeSpy.mock.calls.filter((call) => call[3] === 'cache-payload');
+        expect(payloadWrites).toHaveLength(1);
+        const persisted = JSON.parse(localStorage.getItem(CACHE_KEY)!) as Record<string, unknown>;
+        expect(Object.keys(persisted)).toContain('person-f0-item-agg');
+        expect(Object.keys(persisted)).toContain('person-hit-item-agg');
+        expect(document.querySelectorAll('.jc-people-age-container')).toHaveLength(7);
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.perf.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.perf.test.ts
@@ -444,4 +444,82 @@ describe('people tags bounded-concurrency batch (BI-PERF-137)', () => {
         const persisted = JSON.parse(localStorage.getItem(CACHE_KEY)!) as Record<string, unknown>;
         expect(Object.keys(persisted)).toEqual(['person-owned-item-owner']);
     });
+
+    it('modern layout: resolves the item id from location.search when the hash is empty', async () => {
+        const { plugin } = instrumentedPlugin(() => ({ currentAge: 30, birthPlace: 'Perth, Australia' }));
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        // Modern/MUI layout keeps the hash empty and carries the id in
+        // location.search — a hash-only read would find nothing and leave
+        // People Tags permanently disabled there.
+        window.history.replaceState(null, '', '/web/details?id=item-modern');
+        expect(window.location.hash).toBe('');
+        document.body.innerHTML = `
+            <div id="itemDetailPage">
+                <div id="castCollapsible">${['person-mod-0', 'person-mod-1'].map(personCardHtml).join('')}</div>
+                <div id="guestCastCollapsible"></div>
+            </div>`;
+
+        await startProcessing();
+        await vi.advanceTimersByTimeAsync(5);
+
+        expect(plugin).toHaveBeenCalledTimes(2);
+        expect(document.querySelectorAll('.jc-people-age-container')).toHaveLength(2);
+
+        window.history.replaceState(null, '', '/web/index.html');
+    });
+
+    it('AC4: a guest-cast section that mounts mid-batch is drained after the cast batch settles', async () => {
+        const { plugin, pending } = instrumentedPlugin();
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        const castIds = Array.from({ length: 8 }, (_, index) => `person-late-cast-${index}`);
+        mountCastPage('item-late-guest', castIds); // guest section empty at snapshot time
+
+        await startProcessing();
+        // The cast batch is in flight (deferred) and owns isProcessing.
+        const castRequests = plugin.mock.calls.length;
+        expect(castRequests).toBeGreaterThan(0);
+        expect(castRequests).toBeLessThanOrEqual(CONCURRENCY_CAP);
+
+        // Guest cards mount now, while the cast requests are still open. The
+        // observer-driven run must be REMEMBERED (not dropped behind
+        // isProcessing) and drained once the cast batch settles.
+        document.querySelector('#guestCastCollapsible')!.innerHTML = personCardHtml('person-late-guest');
+        fireObserver(observerCallbacks[observerCallbacks.length - 1]);
+        await vi.advanceTimersByTimeAsync(100);
+
+        await drainPool(pending, { currentAge: 42 });
+
+        expect(cardFor('person-late-guest').querySelector('.jc-people-age-container')).not.toBeNull();
+        // Every cast member plus the late guest fetched exactly once and tagged.
+        expect(plugin).toHaveBeenCalledTimes(9);
+        expect(document.querySelectorAll('.jc-people-age-container')).toHaveLength(9);
+    });
+
+    it('AC4: navigating to a new item mid-batch recovers and tags the new page after the stale batch exits', async () => {
+        const { plugin, pending } = instrumentedPlugin();
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        const castA = Array.from({ length: 8 }, (_, index) => `person-a-${index}`);
+        mountCastPage('item-a', castA);
+
+        await startProcessing();
+        const staleRequests = plugin.mock.calls.length; // all for item A, <= cap
+        expect(staleRequests).toBeGreaterThan(0);
+        expect(staleRequests).toBeLessThanOrEqual(CONCURRENCY_CAP);
+
+        // Navigate to a fully-mounted item B while A's requests are still open.
+        mountCastPage('item-b', ['person-b-0', 'person-b-1']);
+        fireObserver(observerCallbacks[observerCallbacks.length - 1]);
+        await vi.advanceTimersByTimeAsync(100);
+
+        // Settling A's stale requests must abort A's overlays AND, via the
+        // remembered rerun, drain item B's live cast — not leave it untagged.
+        await drainPool(pending, { currentAge: 33 });
+
+        expect(cardFor('person-b-0').querySelector('.jc-people-age-container')).not.toBeNull();
+        expect(cardFor('person-b-1').querySelector('.jc-people-age-container')).not.toBeNull();
+        // Only B's two overlays land; A's cards are gone from the DOM.
+        expect(document.querySelectorAll('.jc-people-age-container')).toHaveLength(2);
+        // A's stale first wave, then B's two recovered requests.
+        expect(plugin).toHaveBeenCalledTimes(staleRequests + 2);
+    });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.perf.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.perf.test.ts
@@ -648,13 +648,15 @@ describe('people tags bounded-concurrency batch (BI-PERF-137)', () => {
         expect(cardFor('person-t2').querySelector('.jc-people-age-container')).not.toBeNull();
     });
 
-    it('AC1/AC5: a same-identity reinitialization retires the old pool (cap held) and cannot overwrite the new cache', async () => {
+    it('AC1/AC5: a same-identity reinitialization never exceeds the GLOBAL request cap and cannot overwrite the new cache', async () => {
         // Start a 12-person batch on item A (6 in flight), then trigger the
-        // supported same-user reinitialization and process item B. The retired
-        // A pool must claim no further /person work (so global concurrency
-        // stays within the cap) and its late-settling, teardown-emptied cache
-        // map must not overwrite B's freshly persisted entries.
-        const { plugin, pending } = instrumentedPlugin();
+        // supported same-user reinitialization and process item B while A's
+        // requests are still open. The concurrency cap is GLOBAL across
+        // generations: B's requests must be held behind A's six in-flight
+        // permits (total in flight never exceeds the cap), the retired A pool
+        // must claim no further /person work, and its late-settling,
+        // teardown-emptied cache map must not overwrite B's persisted entries.
+        const { plugin, pending, inFlightNow, maxInFlight } = instrumentedPlugin();
         JC.core.api = { plugin } as unknown as typeof JC.core.api;
         const castA = Array.from({ length: 12 }, (_, index) => `person-a-${index}`);
         mountCastPage('item-reinit-a', castA);
@@ -662,6 +664,7 @@ describe('people tags bounded-concurrency batch (BI-PERF-137)', () => {
         await startProcessing();
         const aInFlight = plugin.mock.calls.filter((call) => String(call[0]).includes('/person/person-a-')).length;
         expect(aInFlight).toBe(CONCURRENCY_CAP); // 6 of 12 claimed, rest queued
+        expect(inFlightNow()).toBe(CONCURRENCY_CAP);
 
         // Same-identity reinitialization (e.g. a settings restart): a new
         // initializer + observer takes over.
@@ -670,27 +673,35 @@ describe('people tags bounded-concurrency batch (BI-PERF-137)', () => {
         fireObserver(observerCallbacks[observerCallbacks.length - 1]);
         await vi.advanceTimersByTimeAsync(100);
 
-        // Settle B first (it persists), then the retired A batch late.
-        for (const request of pending.filter((req) => req.path.includes('person-b'))) {
-            request.resolve({ currentAge: 20 });
-        }
-        await vi.advanceTimersByTimeAsync(5);
-        const persistedAfterB = JSON.parse(localStorage.getItem(CACHE_KEY)!) as Record<string, unknown>;
+        // GLOBAL cap: A still owns all six permits, so the new pool's B
+        // requests have NOT been issued yet and total in-flight is still six.
+        expect(plugin.mock.calls.every((call) => String(call[0]).includes('/person/person-a-'))).toBe(true);
+        expect(inFlightNow()).toBe(CONCURRENCY_CAP);
+        expect(maxInFlight()).toBeLessThanOrEqual(CONCURRENCY_CAP);
 
+        // Settle A's six in-flight requests. The retired A workers exit without
+        // claiming A's remaining six, and the freed permits admit B's requests.
         for (const request of pending.filter((req) => req.path.includes('person-a'))) {
             request.resolve({ currentAge: 99 });
         }
         await vi.advanceTimersByTimeAsync(5);
 
-        // The retired A pool never claimed beyond its 6 in-flight requests.
+        // Now B's two requests have been admitted; settle them.
+        for (const request of pending.filter((req) => req.path.includes('person-b'))) {
+            request.resolve({ currentAge: 20 });
+        }
+        await vi.advanceTimersByTimeAsync(5);
+
+        // The global cap was honored across the whole reinitialization…
+        expect(maxInFlight()).toBeLessThanOrEqual(CONCURRENCY_CAP);
+        // …the retired A pool never claimed beyond its six in-flight requests…
         const aCalls = plugin.mock.calls.filter((call) => String(call[0]).includes('/person/person-a-'));
         expect(aCalls).toHaveLength(CONCURRENCY_CAP);
-        // B's cast was fetched and tagged under the new pool.
+        // …B's cast was fetched and tagged under the new pool…
         expect(cardFor('person-b-0').querySelector('.jc-people-age-container')).not.toBeNull();
         expect(cardFor('person-b-1').querySelector('.jc-people-age-container')).not.toBeNull();
-        // The late A settle did not overwrite B's persisted cache.
+        // …and the retired A generation's stale data never reached the cache.
         const persistedFinal = JSON.parse(localStorage.getItem(CACHE_KEY)!) as Record<string, unknown>;
-        expect(Object.keys(persistedFinal).sort()).toEqual(Object.keys(persistedAfterB).sort());
         expect(Object.keys(persistedFinal)).toEqual(
             ['person-b-0-item-reinit-b', 'person-b-1-item-reinit-b'],
         );
@@ -724,5 +735,75 @@ describe('people tags bounded-concurrency batch (BI-PERF-137)', () => {
         expect(Object.keys(persisted)).toContain('person-f0-item-agg');
         expect(Object.keys(persisted)).toContain('person-hit-item-agg');
         expect(document.querySelectorAll('.jc-people-age-container')).toHaveLength(7);
+    });
+
+    it('AC3: a transient fetch failure does not finalize the id — a later pass re-fetches and tags', async () => {
+        // Fail-open contract: when /person rejects (backend/TMDB blip) the id
+        // must NOT be finalized in processedPersonIds. If it were, a later pass
+        // after the backend recovers — or a card re-render — would skip it and
+        // its overlays would be absent until a full item-state reset. The first
+        // attempt is deferred (rejected); a later attempt resolves with data.
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        seedOwnedCache({});
+        const attempts = new Map<string, number>();
+        const { plugin, pending } = instrumentedPlugin((path) => {
+            const n = (attempts.get(path) ?? 0) + 1;
+            attempts.set(path, n);
+            return n === 1 ? undefined : { currentAge: 40, birthPlace: 'Perth, Australia' };
+        });
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        const castIds = ['person-retry-a', 'person-retry-b'];
+        mountCastPage('item-retry', castIds);
+
+        await startProcessing();
+        // Fail every in-flight first attempt (a transient backend outage).
+        for (const request of pending.splice(0, pending.length)) {
+            request.reject(new Error('backend down'));
+        }
+        await vi.advanceTimersByTimeAsync(5);
+        expect(document.querySelectorAll('.jc-people-age-container')).toHaveLength(0);
+
+        // The backend recovers and the cast re-renders (fresh elements, same
+        // ids) on the SAME item. Because the ids were released, not finalized,
+        // the replacement cards re-fetch and tag.
+        document.querySelector('#castCollapsible')!.innerHTML = castIds.map(personCardHtml).join('');
+        fireObserver(observerCallbacks[observerCallbacks.length - 1]);
+        await vi.advanceTimersByTimeAsync(100);
+        await vi.advanceTimersByTimeAsync(5);
+
+        for (const id of castIds) {
+            expect(cardFor(id).querySelector('.jc-people-age-container')).not.toBeNull();
+        }
+        // Two failed first attempts + two successful re-fetches.
+        expect(plugin).toHaveBeenCalledTimes(4);
+    });
+
+    it('AC4: a completion timer does not preempt a guest section still queued in the debounce', async () => {
+        // Batch 1 (cast) settles and arms its ~2s completion timer. Just before
+        // it fires, a guest section mounts and the observer queues a debounced
+        // run (not yet dispatched). The completion timer must treat that pending
+        // debounce as owed work and NOT mark the page complete — otherwise the
+        // queued run returns early at the peopleTagsComplete gate and the guest
+        // section is never fetched or tagged (AC4 violation).
+        const { plugin } = instrumentedPlugin(() => ({ currentAge: 30 }));
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        mountCastPage('item-debounce', ['person-cast-0']);
+
+        await startProcessing();
+        expect(cardFor('person-cast-0').querySelector('.jc-people-age-container')).not.toBeNull();
+
+        // Advance to just before the completion deadline, then mount the guest
+        // section and queue its debounce (fires ~100ms later, AFTER completion).
+        await vi.advanceTimersByTimeAsync(1950);
+        document.querySelector('#guestCastCollapsible')!.innerHTML = personCardHtml('person-guest-0');
+        fireObserver(observerCallbacks[observerCallbacks.length - 1]);
+
+        // Cross the completion timer (fires first — must skip while the debounce
+        // is pending) then the debounce (fires next — tags the guest section).
+        await vi.advanceTimersByTimeAsync(300);
+        await vi.advanceTimersByTimeAsync(5);
+
+        expect(cardFor('person-guest-0').querySelector('.jc-people-age-container')).not.toBeNull();
+        expect(plugin).toHaveBeenCalledTimes(2); // cast + guest, each fetched once
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.ts
@@ -69,6 +69,53 @@ const JC = JEBase as typeof JEBase & {
  */
 export const PEOPLE_TAGS_CONCURRENCY = 6;
 
+/**
+ * PERF(#359) GLOBAL request budget. The per-batch worker pool caps concurrency
+ * WITHIN one generation, but a same-identity reinitialization (a supported
+ * settings restart) starts a fresh pool while the retired generation's requests
+ * are still in flight — teardown retires those workers but cannot cancel a
+ * request already handed to the core API, so two per-generation pools would run
+ * up to 2× the cap concurrently. This module-level semaphore is the SINGLE
+ * owner of the /person concurrency budget: every worker of every generation
+ * acquires a permit before issuing a request and releases it when the request
+ * settles, so People Tags never exceeds PEOPLE_TAGS_CONCURRENCY globally.
+ */
+interface Semaphore {
+    acquire(): Promise<void>;
+    release(): void;
+    reset(): void;
+}
+
+function createSemaphore(maxPermits: number): Semaphore {
+    let available = maxPermits;
+    let waiters: Array<() => void> = [];
+    return {
+        acquire(): Promise<void> {
+            if (available > 0) {
+                available -= 1;
+                return Promise.resolve();
+            }
+            return new Promise<void>((resolve) => { waiters.push(resolve); });
+        },
+        release(): void {
+            const next = waiters.shift();
+            if (next) next();
+            // Never let a late release from a retired/aborted generation push
+            // the budget above its ceiling (which would admit >cap later).
+            else if (available < maxPermits) available += 1;
+        },
+        reset(): void {
+            // Only on a true identity reset: a new user's budget starts fresh.
+            // A stale in-flight release afterwards is bounded by the ceiling
+            // clamp above, so it can never over-credit.
+            available = maxPermits;
+            waiters = [];
+        },
+    };
+}
+
+const peopleTagsRequestGate = createSemaphore(PEOPLE_TAGS_CONCURRENCY);
+
 let activePeopleTagsCleanup: ((clearPersistent: boolean) => void) | null = null;
 
 /**
@@ -94,6 +141,10 @@ function teardownPeopleTags(clearPersistent: boolean): void {
 
 export function resetPeopleTagsIdentity(): void {
     teardownPeopleTags(true);
+    // A different Jellyfin identity starts with a fresh concurrency budget.
+    // (A same-identity settings restart goes through initializePeopleTags and
+    // must NOT reset the gate — its retired requests still hold their permits.)
+    peopleTagsRequestGate.reset();
     removeCss('jc-people-tags-styles');
 }
 
@@ -336,15 +387,18 @@ function initializePeopleTags(): void {
      * the hot cache per person but no longer serializes the WHOLE persistent
      * map per person (that was O(N^2) main-thread JSON work across a cast).
      * `cacheChanged` tells the batch owner (processCastMembers) that one
-     * settled-batch flush is required.
+     * settled-batch flush is required. `failed` distinguishes a TRANSIENT
+     * backend/network error (retryable — the id must NOT be finalized) from a
+     * genuine empty response (definitive — safe to finalize); only the fetch
+     * itself is gated by the global request budget so cache hits stay free.
      * @param personId
      * @param itemId (optional, for calculating age at release)
      */
     async function getPersonInfo(
         personId: string,
         itemId: string | null = null,
-    ): Promise<{ data: PersonData | null; cacheChanged: boolean }> {
-        if (!isCurrent()) return { data: null, cacheChanged: false };
+    ): Promise<{ data: PersonData | null; cacheChanged: boolean; failed: boolean }> {
+        if (!isCurrent()) return { data: null, cacheChanged: false, failed: false };
         const cacheKey = itemId ? `${personId}-${itemId}` : personId;
         const now = Date.now();
 
@@ -352,28 +406,33 @@ function initializePeopleTags(): void {
         if (hotPeopleTags.has(cacheKey)) {
             const cached = hotPeopleTags.get(cacheKey)!;
             if (isCurrent() && now - cached.timestamp < CACHE_TTL) {
-                return { data: cached.data, cacheChanged: false };
+                return { data: cached.data, cacheChanged: false, failed: false };
             }
         }
 
         // Check localStorage cache
         if (peopleCache[cacheKey] && peopleCacheTimestamp[cacheKey]) {
             if (now - peopleCacheTimestamp[cacheKey] < CACHE_TTL) {
-                if (!isCurrent()) return { data: null, cacheChanged: false };
+                if (!isCurrent()) return { data: null, cacheChanged: false, failed: false };
                 const data = JC.identity.own(peopleCache[cacheKey], context);
                 peopleCache[cacheKey] = data;
                 hotPeopleTags.set(cacheKey, { data, timestamp: now });
-                return { data, cacheChanged: false };
+                return { data, cacheChanged: false, failed: false };
             }
         }
 
-        // Fetch from backend
+        // Fetch from backend under the GLOBAL request budget so the total
+        // number of concurrent /person calls across all generations stays
+        // within PEOPLE_TAGS_CONCURRENCY. Only the network round-trip holds a
+        // permit; the finally guarantees the permit is returned even when the
+        // batch has been retired mid-flight.
+        await peopleTagsRequestGate.acquire();
         try {
             const queryString = itemId ? `?itemId=${encodeURIComponent(itemId)}` : '';
             const data = await JC.core.api.plugin(`/person/${encodeURIComponent(personId)}${queryString}`, {
                 cacheKey: `people-tags:${cacheKey}`,
             });
-            if (!isCurrent()) return { data: null, cacheChanged: false };
+            if (!isCurrent()) return { data: null, cacheChanged: false, failed: false };
 
             if (isPersonData(data)) {
                 // Cache it (hot + in-memory now; persisted once per settled batch)
@@ -382,13 +441,18 @@ function initializePeopleTags(): void {
                 peopleCacheTimestamp[cacheKey] = now;
                 hotPeopleTags.set(cacheKey, { data: ownedData, timestamp: now });
 
-                return { data: ownedData, cacheChanged: true };
+                return { data: ownedData, cacheChanged: true, failed: false };
             }
+            // Well-formed but empty/non-person response: genuine no-data.
+            return { data: null, cacheChanged: false, failed: false };
         } catch (error) {
             if (isCurrent()) console.warn(`${logPrefix} Failed to fetch person info for ${personId}:`, error);
+            // Transient failure — leave the id un-finalized so a later pass can
+            // recover it once the backend is healthy.
+            return { data: null, cacheChanged: false, failed: true };
+        } finally {
+            peopleTagsRequestGate.release();
         }
-
-        return { data: null, cacheChanged: false };
     }
 
     /**
@@ -602,9 +666,10 @@ function initializePeopleTags(): void {
          * Whether the person id may be finalized in `processedPersonIds`. True
          * once a definitive attempt reached a LIVE card under the current batch
          * (rendered, or the person genuinely had no data). False when the
-         * result was DROPPED because the target card disconnected or the page
-         * moved on — releasing the id so a remembered rerun requeues the
-         * replacement card instead of skipping it forever.
+         * result was DROPPED because the target card disconnected, the page
+         * moved on, OR the fetch failed transiently — releasing the id so a
+         * remembered rerun (or a replacement card) re-attempts it instead of
+         * skipping it forever.
          */
         committed: boolean;
     }
@@ -622,8 +687,12 @@ function initializePeopleTags(): void {
     ): Promise<PersonCardOutcome> {
         const { card, personId } = task;
         try {
-            const { data: personData, cacheChanged } = await getPersonInfo(personId, currentItemId);
+            const { data: personData, cacheChanged, failed } = await getPersonInfo(personId, currentItemId);
             if (!batchIsCurrent() || !card.isConnected) return { cacheChanged, committed: false };
+            // A transient fetch failure is NOT a definitive no-data result:
+            // release the id (committed:false) so a remembered rerun or a
+            // replacement card re-attempts it once the backend recovers.
+            if (failed) return { cacheChanged, committed: false };
             if (!personData) return { cacheChanged, committed: true };
 
             // Apply deceased styling to poster if applicable
@@ -805,8 +874,13 @@ function initializePeopleTags(): void {
                         // owed. A completion timer scheduled by an earlier batch
                         // must not fire while a newer batch drains (or a rerun
                         // is pending) — doing so wedges the peopleTagsComplete
-                        // gate and starves cards that mount mid-batch.
+                        // gate and starves cards that mount mid-batch. A pending
+                        // debounce (a freshly observed cast/guest update not yet
+                        // dispatched) counts as owed work too: completing over it
+                        // would make that queued run return early and leave the
+                        // newly mounted section untagged.
                         if (isCurrent() && !isProcessing && !rerunRequested
+                            && debounceTimer === null
                             && lastProcessedItemId === processingItemId) {
                             peopleTagsComplete = true;
                         }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.ts
@@ -9,7 +9,7 @@
 import { JC as JEBase } from '../globals';
 import { flagPngUrl } from '../core/asset-urls';
 import { createBoundedCache, type BoundedCache } from '../core/bounded-cache';
-import { getItemIdFromUrl } from '../core/details-view';
+import { getItemIdFromUrl, getVisibleDetailsPage } from '../core/details-view';
 import { createStableMethodFacade } from '../core/feature-loader';
 import { ensureMaterialSymbolsFont, injectCss, removeCss } from '../core/ui-kit';
 import type { ApiApi, JELegacyHelpers, PluginConfig, UserSettings } from '../types/jc';
@@ -71,7 +71,20 @@ export const PEOPLE_TAGS_CONCURRENCY = 6;
 
 let activePeopleTagsCleanup: ((clearPersistent: boolean) => void) | null = null;
 
+/**
+ * PERF(#359) lifecycle fence. Monotonic counter bumped on every teardown and
+ * (re)initialization. Each initializer captures its value and treats itself as
+ * live only while the counter still matches — so a retired closure's worker
+ * pool, render guards, completion timers and cache-persist path all go dormant
+ * the instant a newer initializer starts, EVEN under the same Jellyfin
+ * identity (a supported same-user settings restart). Without it two same-user
+ * pools run concurrently (double the concurrency cap) and a retired pool's
+ * stale cache map can overwrite the active one.
+ */
+let peopleTagsGeneration = 0;
+
 function teardownPeopleTags(clearPersistent: boolean): void {
+    peopleTagsGeneration += 1;
     const cleanup = activePeopleTagsCleanup;
     activePeopleTagsCleanup = null;
     try { cleanup?.(clearPersistent); } catch { /* continue */ }
@@ -107,7 +120,13 @@ function initializePeopleTags(): void {
 
     const context = JC.identity.capture();
     if (!context || !JC.identity.isCurrent(context)) return;
-    const isCurrent = (): boolean => JC.identity.isCurrent(context);
+    // Capture THIS initializer's generation (teardown above already bumped the
+    // counter). isCurrent() now means "this closure is still the live one AND
+    // the identity is unchanged" — a later initialize/teardown makes the first
+    // conjunct false, retiring every guard downstream without a per-call edit.
+    const myGeneration = peopleTagsGeneration;
+    const isCurrent = (): boolean =>
+        peopleTagsGeneration === myGeneration && JC.identity.isCurrent(context);
     const timers = new Set<number>();
     let observerHandle: { disconnect?: () => void; unsubscribe?: () => void } | null = null;
 
@@ -514,13 +533,28 @@ function initializePeopleTags(): void {
 
     /**
      * Synchronously collect the unprocessed person-card tasks of one
-     * cast/guest cast collapsible section, preserving the exact dedup gate
-     * order of the old serial loop (card dedup, then person-id dedup).
+     * cast/guest cast collapsible section within the OWNED visible page.
+     *
+     * PERF(#359) dedup is two-tier so a card REPLACED mid-batch is never lost:
+     *  - `processedPersonIds` holds ids whose overlay already landed on a live
+     *    card in a PRIOR pass — never re-fetch those.
+     *  - `claimedIds` (batch-local) holds ids claimed by THIS collection so the
+     *    same person is fetched once even when it appears in both sections.
+     * An id is promoted into `processedPersonIds` ONLY once its overlay lands
+     * on a connected card (see the worker in processCastMembers). Eagerly
+     * marking ids processed here — as the first pass did — permanently starved
+     * every replacement card when React re-rendered the cast mid-batch.
+     * @param page - The owned visible details page to search within.
      * @param collapsibleSelector - CSS selector for the collapsible (e.g., '#castCollapsible' or '#guestCastCollapsible')
+     * @param claimedIds - Ids already claimed by this batch's collection.
      */
-    function collectSectionTasks(collapsibleSelector: string): PersonCardTask[] {
+    function collectSectionTasks(
+        page: HTMLElement,
+        collapsibleSelector: string,
+        claimedIds: Set<string>,
+    ): PersonCardTask[] {
         const tasks: PersonCardTask[] = [];
-        const collapsible = document.querySelector(`#itemDetailPage:not(.hide) ${collapsibleSelector}`);
+        const collapsible = page.querySelector(collapsibleSelector);
         if (!collapsible) return tasks;
 
         const castCards = collapsible.querySelectorAll<HTMLElement>('.personCard');
@@ -535,10 +569,12 @@ function initializePeopleTags(): void {
             const personId = card.getAttribute('data-id');
             if (!personId) continue;
 
-            // Skip if we've already processed this person ID in this item
+            // Already applied to a live card in a prior pass, or already
+            // claimed by this batch — either way, do not enqueue it again.
             if (processedPersonIds.has(personId)) continue;
+            if (claimedIds.has(personId)) continue;
 
-            processedPersonIds.add(personId);
+            claimedIds.add(personId);
             tasks.push({ card, personId });
         }
         return tasks;
@@ -559,19 +595,36 @@ function initializePeopleTags(): void {
         return merged;
     }
 
+    interface PersonCardOutcome {
+        /** Whether the lookup changed the persistent cache state. */
+        cacheChanged: boolean;
+        /**
+         * Whether the person id may be finalized in `processedPersonIds`. True
+         * once a definitive attempt reached a LIVE card under the current batch
+         * (rendered, or the person genuinely had no data). False when the
+         * result was DROPPED because the target card disconnected or the page
+         * moved on — releasing the id so a remembered rerun requeues the
+         * replacement card instead of skipping it forever.
+         */
+        committed: boolean;
+    }
+
     /**
      * Fetch and render one person card's overlays. Result application is
-     * guarded by identity currency, the live item id, and card connectivity —
-     * a stale navigation mid-flight applies NO tags to the new page.
-     * @returns Whether the lookup changed the persistent cache state.
+     * guarded by the batch currency (identity + owned page/item) and card
+     * connectivity — a stale navigation mid-flight applies NO tags to the new
+     * page and does NOT commit the person id.
      */
-    async function processPersonCard(task: PersonCardTask, currentItemId: string): Promise<boolean> {
+    async function processPersonCard(
+        task: PersonCardTask,
+        currentItemId: string,
+        batchIsCurrent: () => boolean,
+    ): Promise<PersonCardOutcome> {
         const { card, personId } = task;
-        const batchIsCurrent = (): boolean => isCurrent() && getItemIdFromUrl() === currentItemId;
         try {
             const { data: personData, cacheChanged } = await getPersonInfo(personId, currentItemId);
-            if (!batchIsCurrent() || !card.isConnected) return cacheChanged;
-            if (!personData) return cacheChanged;
+            if (!batchIsCurrent() || !card.isConnected) return { cacheChanged, committed: false };
+            if (!personData) return { cacheChanged, committed: true };
 
             // Apply deceased styling to poster if applicable
             if (personData.isDeceased) {
@@ -583,7 +636,7 @@ function initializePeopleTags(): void {
             const cardScalable = card.querySelector('.cardScalable');
             if (!cardScalable) {
                 console.warn(`${logPrefix} No cardScalable found for ${personId}`);
-                return cacheChanged;
+                return { cacheChanged, committed: true };
             }
 
             // Remove existing tags if any
@@ -598,17 +651,17 @@ function initializePeopleTags(): void {
 
             // Create and append age chips (top-left) and place banner (bottom)
             const tags = createPeopleTag(personData);
-            if (!batchIsCurrent() || !cardScalable.isConnected) return cacheChanged;
+            if (!batchIsCurrent() || !cardScalable.isConnected) return { cacheChanged, committed: false };
             if (tags.ageContainer.children.length > 0) {
                 cardScalable.appendChild(tags.ageContainer);
             }
             if (tags.placeContainer.children.length > 0) {
                 cardScalable.appendChild(tags.placeContainer);
             }
-            return cacheChanged;
+            return { cacheChanged, committed: true };
         } catch (error) {
             console.warn(`${logPrefix} Error processing cast member ${personId}:`, error);
-            return false;
+            return { cacheChanged: false, committed: false };
         }
     }
 
@@ -622,32 +675,33 @@ function initializePeopleTags(): void {
      * renders individually as its result lands; the persistent cache is
      * flushed once after the whole batch settles.
      */
-    async function processCastMembers(): Promise<void> {
+    async function processCastMembers(page: HTMLElement, currentItemId: string): Promise<void> {
         if (!isCurrent() || isProcessing) return;
         isProcessing = true;
 
         try {
-            // Get current item ID from URL. Resolve through the shared
-            // details-view helper: the modern/MUI layout keeps the hash empty
-            // and carries the id in location.search, so a hash-only read would
-            // find nothing and disable People Tags there.
-            const currentItemId = getItemIdFromUrl();
-
-            if (!currentItemId) {
-                console.debug(`${logPrefix} No item ID found in URL`);
-                return;
-            }
-
             // Collect both sections synchronously (cast first so duplicate
-            // person ids keep preferring the normal-cast card), then
-            // interleave so neither section starves behind the other.
+            // person ids keep preferring the normal-cast card) from the OWNED
+            // page, then interleave so neither section starves behind the
+            // other. `claimedIds` dedups within the batch without prematurely
+            // finalizing dedup across passes.
+            const claimedIds = new Set<string>();
             const tasks = interleaveTasks(
-                collectSectionTasks('#castCollapsible'),
-                collectSectionTasks('#guestCastCollapsible'),
+                collectSectionTasks(page, '#castCollapsible', claimedIds),
+                collectSectionTasks(page, '#guestCastCollapsible', claimedIds),
             );
             if (tasks.length === 0) return;
 
-            const batchIsCurrent = (): boolean => isCurrent() && getItemIdFromUrl() === currentItemId;
+            // The batch is current only while the SAME owned page is still the
+            // visible details view for the SAME item. getVisibleDetailsPage()
+            // returns null mid-transition (details→details push), so the batch
+            // aborts rather than tagging the outgoing view under the incoming
+            // item's id.
+            const batchIsCurrent = (): boolean => {
+                if (!isCurrent()) return false;
+                const visible = getVisibleDetailsPage();
+                return visible !== null && visible.page === page && visible.itemId === currentItemId;
+            };
 
             let cacheChanged = false;
             let nextIndex = 0;
@@ -656,7 +710,16 @@ function initializePeopleTags(): void {
                     const index = nextIndex;
                     nextIndex += 1;
                     if (index >= tasks.length) return;
-                    cacheChanged = (await processPersonCard(tasks[index], currentItemId)) || cacheChanged;
+                    const task = tasks[index];
+                    const outcome = await processPersonCard(task, currentItemId, batchIsCurrent);
+                    // Persist if ANY task changed the cache (aggregate-any, not
+                    // last-write-wins — a later cache HIT must not erase an
+                    // earlier fetch's need to flush).
+                    if (outcome.cacheChanged) cacheChanged = true;
+                    // Finalize dedup ONLY after the overlay landed on a live
+                    // card; a dropped (disconnected) card releases its id so a
+                    // remembered rerun requeues the replacement.
+                    if (outcome.committed) processedPersonIds.add(task.personId);
                 }
             };
             const workerCount = Math.min(PEOPLE_TAGS_CONCURRENCY, tasks.length);
@@ -684,15 +747,22 @@ function initializePeopleTags(): void {
         let debounceTimer: number | null = null;
         const runPeopleTags = () => {
             if (!isCurrent()) return;
-            const castSection = document.querySelector('#itemDetailPage:not(.hide) #castCollapsible');
-            const guestCastSection = document.querySelector('#itemDetailPage:not(.hide) #guestCastCollapsible');
 
+            // Resolve the visible details page and its item id as ONE owned
+            // pair. getVisibleDetailsPage() returns null mid-transition
+            // (details→details push, where the OUTGOING page is still visible
+            // while the URL already names the next item), so we never tag the
+            // outgoing view under the incoming item's id — we defer, and the
+            // next viewshow/mutation probe lands on the correct page.
+            const visible = getVisibleDetailsPage();
+            if (!visible) return;
+            const { page, itemId } = visible;
+
+            const castSection = page.querySelector('#castCollapsible');
+            const guestCastSection = page.querySelector('#guestCastCollapsible');
             if (!castSection && !guestCastSection) return;
 
             try {
-                const itemId = getItemIdFromUrl();
-                if (!itemId) return;
-
                 // Reset cache when navigating to a new item
                 if (lastProcessedItemId !== itemId) {
                     lastProcessedItemId = itemId;
@@ -719,7 +789,7 @@ function initializePeopleTags(): void {
                 // completions from previous navigations don't mark the wrong
                 // item as done.
                 const processingItemId = itemId;
-                void processCastMembers().then(() => {
+                void processCastMembers(page, itemId).then(() => {
                     if (!isCurrent()) return;
                     // A rerun was requested while this batch ran (guest cards
                     // mounted, or the URL moved to a new item). Drain it now
@@ -731,7 +801,13 @@ function initializePeopleTags(): void {
                         return;
                     }
                     schedule(() => {
-                        if (isCurrent() && lastProcessedItemId === processingItemId) {
+                        // Only mark complete when NOTHING is still running or
+                        // owed. A completion timer scheduled by an earlier batch
+                        // must not fire while a newer batch drains (or a rerun
+                        // is pending) — doing so wedges the peopleTagsComplete
+                        // gate and starves cards that mount mid-batch.
+                        if (isCurrent() && !isProcessing && !rerunRequested
+                            && lastProcessedItemId === processingItemId) {
                             peopleTagsComplete = true;
                         }
                     }, 2000);
@@ -771,9 +847,6 @@ function initializePeopleTags(): void {
 
                 if (peopleTagsComplete) return;
 
-                // Quick check: only process if we're on a detail page
-                if (!document.querySelector('#itemDetailPage:not(.hide)')) return;
-
                 // Only react to actual node additions, not attribute changes
                 let hasNewNodes = false;
                 for (const mutation of mutations) {
@@ -784,8 +857,14 @@ function initializePeopleTags(): void {
                 }
                 if (!hasNewNodes) return;
 
-                const castSection = document.querySelector('#itemDetailPage:not(.hide) #castCollapsible');
-                const guestCastSection = document.querySelector('#itemDetailPage:not(.hide) #guestCastCollapsible');
+                // Resolve the owned visible page (duplicate-id safe; null
+                // mid-transition). runPeopleTags re-resolves the same pair, so
+                // this is only a cheap gate to avoid scheduling a debounce when
+                // there is nothing to tag.
+                const visible = getVisibleDetailsPage();
+                if (!visible) return;
+                const castSection = visible.page.querySelector('#castCollapsible');
+                const guestCastSection = visible.page.querySelector('#guestCastCollapsible');
                 if (!castSection && !guestCastSection) return;
 
                 handlePeopleTags();

--- a/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.ts
@@ -9,6 +9,7 @@
 import { JC as JEBase } from '../globals';
 import { flagPngUrl } from '../core/asset-urls';
 import { createBoundedCache, type BoundedCache } from '../core/bounded-cache';
+import { getItemIdFromUrl } from '../core/details-view';
 import { createStableMethodFacade } from '../core/feature-loader';
 import { ensureMaterialSymbolsFont, injectCss, removeCss } from '../core/ui-kit';
 import type { ApiApi, JELegacyHelpers, PluginConfig, UserSettings } from '../types/jc';
@@ -208,6 +209,12 @@ function initializePeopleTags(): void {
     let lastProcessedItemId: string | null = null;
     let peopleTagsComplete = false; // Set true after all cast members tagged for current item
     let isProcessing = false;
+    // PERF(#359): a run requested while a batch is in flight (a late guest-cast
+    // mount, or a navigation to a new item) must not be silently dropped — it is
+    // remembered here and drained once the active batch settles. Without it the
+    // one-shot snapshot starves cards that mount mid-batch and the current page
+    // stays untagged after a stale batch exits.
+    let rerunRequested = false;
 
     activePeopleTagsCleanup = (clearPersistent) => {
         for (const timer of timers) clearTimeout(timer);
@@ -560,8 +567,7 @@ function initializePeopleTags(): void {
      */
     async function processPersonCard(task: PersonCardTask, currentItemId: string): Promise<boolean> {
         const { card, personId } = task;
-        const batchIsCurrent = (): boolean => isCurrent()
-            && new URLSearchParams(window.location.hash.split('?')[1]).get('id') === currentItemId;
+        const batchIsCurrent = (): boolean => isCurrent() && getItemIdFromUrl() === currentItemId;
         try {
             const { data: personData, cacheChanged } = await getPersonInfo(personId, currentItemId);
             if (!batchIsCurrent() || !card.isConnected) return cacheChanged;
@@ -621,10 +627,11 @@ function initializePeopleTags(): void {
         isProcessing = true;
 
         try {
-            // Get current item ID from URL
-            const hash = window.location.hash;
-            const params = new URLSearchParams(hash.split('?')[1]);
-            const currentItemId = params.get('id');
+            // Get current item ID from URL. Resolve through the shared
+            // details-view helper: the modern/MUI layout keeps the hash empty
+            // and carries the id in location.search, so a hash-only read would
+            // find nothing and disable People Tags there.
+            const currentItemId = getItemIdFromUrl();
 
             if (!currentItemId) {
                 console.debug(`${logPrefix} No item ID found in URL`);
@@ -640,8 +647,7 @@ function initializePeopleTags(): void {
             );
             if (tasks.length === 0) return;
 
-            const batchIsCurrent = (): boolean => isCurrent()
-                && new URLSearchParams(window.location.hash.split('?')[1]).get('id') === currentItemId;
+            const batchIsCurrent = (): boolean => isCurrent() && getItemIdFromUrl() === currentItemId;
 
             let cacheChanged = false;
             let nextIndex = 0;
@@ -684,7 +690,7 @@ function initializePeopleTags(): void {
             if (!castSection && !guestCastSection) return;
 
             try {
-                const itemId = new URLSearchParams(window.location.hash.split('?')[1]).get('id');
+                const itemId = getItemIdFromUrl();
                 if (!itemId) return;
 
                 // Reset cache when navigating to a new item
@@ -696,18 +702,34 @@ function initializePeopleTags(): void {
                     console.debug(`${logPrefix} New item detected: ${itemId}`);
                 }
 
-                // Skip if already fully processed for this item
-                if (peopleTagsComplete || isProcessing) {
+                // Skip if already fully processed for this item.
+                if (peopleTagsComplete) return;
+                // A batch is already draining: remember that another pass is
+                // owed (a late guest-cast mount, or a navigation to a new item)
+                // and let the settling batch pick it up. Dropping it here is
+                // what starved late sections and left the current page untagged.
+                if (isProcessing) {
+                    rerunRequested = true;
                     return;
                 }
 
-                // Process cast members for this item, then mark complete
-                // after a short delay to allow late-arriving DOM updates.
-                // Capture the itemId so stale completions from previous
-                // navigations don't mark the wrong item as done.
+                // Process cast members for this item, then either drain a
+                // pending rerun or mark complete after a short delay to allow
+                // late-arriving DOM updates. Capture the itemId so stale
+                // completions from previous navigations don't mark the wrong
+                // item as done.
                 const processingItemId = itemId;
                 void processCastMembers().then(() => {
                     if (!isCurrent()) return;
+                    // A rerun was requested while this batch ran (guest cards
+                    // mounted, or the URL moved to a new item). Drain it now
+                    // instead of scheduling completion, so both sections and
+                    // the current page are always tagged.
+                    if (rerunRequested) {
+                        rerunRequested = false;
+                        runPeopleTags();
+                        return;
+                    }
                     schedule(() => {
                         if (isCurrent() && lastProcessedItemId === processingItemId) {
                             peopleTagsComplete = true;
@@ -741,7 +763,7 @@ function initializePeopleTags(): void {
                 // Reset completion flag when navigating to a different item
                 // (must happen BEFORE the peopleTagsComplete check)
                 try {
-                    const currentId = new URLSearchParams(window.location.hash.split('?')[1]).get('id');
+                    const currentId = getItemIdFromUrl();
                     if (currentId && currentId !== lastProcessedItemId) {
                         peopleTagsComplete = false;
                     }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.ts
@@ -59,6 +59,15 @@ const JC = JEBase as typeof JEBase & {
     };
 };
 
+/**
+ * PERF(#359): maximum concurrent in-flight /person/{id} requests per batch.
+ * Matches the repository's established bounded pool size for per-entity
+ * enrichment (ISSUE_ENRICHMENT_CONCURRENCY, TAG_FALLBACK_CONCURRENCY) —
+ * overlapped instead of serial, but never an unbounded fan-out across a
+ * 50-person cast.
+ */
+export const PEOPLE_TAGS_CONCURRENCY = 6;
+
 let activePeopleTagsCleanup: ((clearPersistent: boolean) => void) | null = null;
 
 function teardownPeopleTags(clearPersistent: boolean): void {
@@ -295,12 +304,21 @@ function initializePeopleTags(): void {
     }
 
     /**
-     * Fetch person info with caching
+     * Fetch person info with caching.
+     *
+     * PERF(#359): the successful backend path updates the in-memory maps and
+     * the hot cache per person but no longer serializes the WHOLE persistent
+     * map per person (that was O(N^2) main-thread JSON work across a cast).
+     * `cacheChanged` tells the batch owner (processCastMembers) that one
+     * settled-batch flush is required.
      * @param personId
      * @param itemId (optional, for calculating age at release)
      */
-    async function getPersonInfo(personId: string, itemId: string | null = null): Promise<PersonData | null> {
-        if (!isCurrent()) return null;
+    async function getPersonInfo(
+        personId: string,
+        itemId: string | null = null,
+    ): Promise<{ data: PersonData | null; cacheChanged: boolean }> {
+        if (!isCurrent()) return { data: null, cacheChanged: false };
         const cacheKey = itemId ? `${personId}-${itemId}` : personId;
         const now = Date.now();
 
@@ -308,18 +326,18 @@ function initializePeopleTags(): void {
         if (hotPeopleTags.has(cacheKey)) {
             const cached = hotPeopleTags.get(cacheKey)!;
             if (isCurrent() && now - cached.timestamp < CACHE_TTL) {
-                return cached.data;
+                return { data: cached.data, cacheChanged: false };
             }
         }
 
         // Check localStorage cache
         if (peopleCache[cacheKey] && peopleCacheTimestamp[cacheKey]) {
             if (now - peopleCacheTimestamp[cacheKey] < CACHE_TTL) {
-                if (!isCurrent()) return null;
+                if (!isCurrent()) return { data: null, cacheChanged: false };
                 const data = JC.identity.own(peopleCache[cacheKey], context);
                 peopleCache[cacheKey] = data;
                 hotPeopleTags.set(cacheKey, { data, timestamp: now });
-                return data;
+                return { data, cacheChanged: false };
             }
         }
 
@@ -329,27 +347,34 @@ function initializePeopleTags(): void {
             const data = await JC.core.api.plugin(`/person/${encodeURIComponent(personId)}${queryString}`, {
                 cacheKey: `people-tags:${cacheKey}`,
             });
-            if (!isCurrent()) return null;
+            if (!isCurrent()) return { data: null, cacheChanged: false };
 
             if (isPersonData(data)) {
-                // Cache it
+                // Cache it (hot + in-memory now; persisted once per settled batch)
                 const ownedData = JC.identity.own(data, context);
                 peopleCache[cacheKey] = ownedData;
                 peopleCacheTimestamp[cacheKey] = now;
                 hotPeopleTags.set(cacheKey, { data: ownedData, timestamp: now });
 
-                if (!isCurrent()) return null;
-                JC.storage.local.write('people-tags', CACHE_OWNER_KEY, expectedCacheOwner, 'cache-owner');
-                JC.storage.local.write('people-tags', CACHE_KEY, JSON.stringify(peopleCache), 'cache-payload');
-                JC.storage.local.write('people-tags', CACHE_TIMESTAMP_KEY, JSON.stringify(peopleCacheTimestamp), 'cache-timestamps');
-
-                return ownedData;
+                return { data: ownedData, cacheChanged: true };
             }
         } catch (error) {
             if (isCurrent()) console.warn(`${logPrefix} Failed to fetch person info for ${personId}:`, error);
         }
 
-        return null;
+        return { data: null, cacheChanged: false };
+    }
+
+    /**
+     * Serialize the persistent people cache exactly once for a settled batch.
+     * Only called when at least one backend fetch changed the cache and the
+     * identity context is still current.
+     */
+    function persistPeopleCache(): void {
+        if (!isCurrent()) return;
+        JC.storage.local.write('people-tags', CACHE_OWNER_KEY, expectedCacheOwner, 'cache-owner');
+        JC.storage.local.write('people-tags', CACHE_KEY, JSON.stringify(peopleCache), 'cache-payload');
+        JC.storage.local.write('people-tags', CACHE_TIMESTAMP_KEY, JSON.stringify(peopleCacheTimestamp), 'cache-timestamps');
     }
 
     /**
@@ -475,23 +500,28 @@ function initializePeopleTags(): void {
         return { ageContainer, placeContainer };
     }
 
+    interface PersonCardTask {
+        card: HTMLElement;
+        personId: string;
+    }
+
     /**
-     * Process a single cast/guest cast collapsible section
+     * Synchronously collect the unprocessed person-card tasks of one
+     * cast/guest cast collapsible section, preserving the exact dedup gate
+     * order of the old serial loop (card dedup, then person-id dedup).
      * @param collapsibleSelector - CSS selector for the collapsible (e.g., '#castCollapsible' or '#guestCastCollapsible')
-     * @param currentItemId - Current item ID from URL
      */
-    async function processSingleCollapsible(collapsibleSelector: string, currentItemId: string): Promise<void> {
-        if (!isCurrent()) return;
+    function collectSectionTasks(collapsibleSelector: string): PersonCardTask[] {
+        const tasks: PersonCardTask[] = [];
         const collapsible = document.querySelector(`#itemDetailPage:not(.hide) ${collapsibleSelector}`);
-        if (!collapsible) return;
+        if (!collapsible) return tasks;
 
         const castCards = collapsible.querySelectorAll<HTMLElement>('.personCard');
-        if (castCards.length === 0) return;
+        if (castCards.length === 0) return tasks;
 
         console.debug(`${logPrefix} Found ${castCards.length} cast members in ${collapsibleSelector}`);
 
         for (const card of castCards) {
-            if (!isCurrent()) return;
             if (processedCastMembers.has(card)) continue;
             processedCastMembers.add(card);
 
@@ -502,56 +532,89 @@ function initializePeopleTags(): void {
             if (processedPersonIds.has(personId)) continue;
 
             processedPersonIds.add(personId);
+            tasks.push({ card, personId });
+        }
+        return tasks;
+    }
 
-            try {
-                const personData = await getPersonInfo(personId, currentItemId);
-                const liveItemId = new URLSearchParams(window.location.hash.split('?')[1]).get('id');
-                if (!isCurrent() || liveItemId !== currentItemId || !card.isConnected) return;
-                if (!personData) {
-                    continue;
-                }
+    /**
+     * Deterministically interleave the (already deduplicated) cast and guest
+     * cast task lists so a guest-cast card enters the first bounded worker
+     * wave even when the normal cast alone exceeds the concurrency cap.
+     */
+    function interleaveTasks(castTasks: PersonCardTask[], guestTasks: PersonCardTask[]): PersonCardTask[] {
+        const merged: PersonCardTask[] = [];
+        const longest = Math.max(castTasks.length, guestTasks.length);
+        for (let index = 0; index < longest; index += 1) {
+            if (index < castTasks.length) merged.push(castTasks[index]);
+            if (index < guestTasks.length) merged.push(guestTasks[index]);
+        }
+        return merged;
+    }
 
-                // Apply deceased styling to poster if applicable
-                if (personData.isDeceased) {
-                    card.classList.add('jc-deceased-poster');
-                    console.debug(`${logPrefix} Marked ${personId} as deceased`);
-                }
+    /**
+     * Fetch and render one person card's overlays. Result application is
+     * guarded by identity currency, the live item id, and card connectivity —
+     * a stale navigation mid-flight applies NO tags to the new page.
+     * @returns Whether the lookup changed the persistent cache state.
+     */
+    async function processPersonCard(task: PersonCardTask, currentItemId: string): Promise<boolean> {
+        const { card, personId } = task;
+        const batchIsCurrent = (): boolean => isCurrent()
+            && new URLSearchParams(window.location.hash.split('?')[1]).get('id') === currentItemId;
+        try {
+            const { data: personData, cacheChanged } = await getPersonInfo(personId, currentItemId);
+            if (!batchIsCurrent() || !card.isConnected) return cacheChanged;
+            if (!personData) return cacheChanged;
 
-                // Find the cardScalable element (image container with position: relative)
-                const cardScalable = card.querySelector('.cardScalable');
-                if (!cardScalable) {
-                    console.warn(`${logPrefix} No cardScalable found for ${personId}`);
-                    continue;
-                }
-
-                // Remove existing tags if any
-                const existingAgeContainer = cardScalable.querySelector('.jc-people-age-container');
-                if (existingAgeContainer) {
-                    existingAgeContainer.remove();
-                }
-                const existingPlaceBanner = cardScalable.querySelector('.jc-people-place-banner');
-                if (existingPlaceBanner) {
-                    existingPlaceBanner.remove();
-                }
-
-                // Create and append age chips (top-left) and place banner (bottom)
-                const tags = createPeopleTag(personData);
-                if (!isCurrent() || !cardScalable.isConnected) return;
-                if (tags.ageContainer.children.length > 0) {
-                    cardScalable.appendChild(tags.ageContainer);
-                }
-                if (tags.placeContainer.children.length > 0) {
-                    cardScalable.appendChild(tags.placeContainer);
-                }
-
-            } catch (error) {
-                console.warn(`${logPrefix} Error processing cast member ${personId}:`, error);
+            // Apply deceased styling to poster if applicable
+            if (personData.isDeceased) {
+                card.classList.add('jc-deceased-poster');
+                console.debug(`${logPrefix} Marked ${personId} as deceased`);
             }
+
+            // Find the cardScalable element (image container with position: relative)
+            const cardScalable = card.querySelector('.cardScalable');
+            if (!cardScalable) {
+                console.warn(`${logPrefix} No cardScalable found for ${personId}`);
+                return cacheChanged;
+            }
+
+            // Remove existing tags if any
+            const existingAgeContainer = cardScalable.querySelector('.jc-people-age-container');
+            if (existingAgeContainer) {
+                existingAgeContainer.remove();
+            }
+            const existingPlaceBanner = cardScalable.querySelector('.jc-people-place-banner');
+            if (existingPlaceBanner) {
+                existingPlaceBanner.remove();
+            }
+
+            // Create and append age chips (top-left) and place banner (bottom)
+            const tags = createPeopleTag(personData);
+            if (!batchIsCurrent() || !cardScalable.isConnected) return cacheChanged;
+            if (tags.ageContainer.children.length > 0) {
+                cardScalable.appendChild(tags.ageContainer);
+            }
+            if (tags.placeContainer.children.length > 0) {
+                cardScalable.appendChild(tags.placeContainer);
+            }
+            return cacheChanged;
+        } catch (error) {
+            console.warn(`${logPrefix} Error processing cast member ${personId}:`, error);
+            return false;
         }
     }
 
     /**
-     * Process cast and guest cast members in the current view
+     * Process cast and guest cast members in the current view.
+     *
+     * PERF(#359): person lookups drain through ONE bounded worker pool shared
+     * by both sections (the repo's fixed-size worker/cursor pattern — see
+     * enrichIssuesForDisplay and processFallbackBatch) instead of a serial
+     * await-per-card loop with a hard cast→guest barrier. Each overlay still
+     * renders individually as its result lands; the persistent cache is
+     * flushed once after the whole batch settles.
      */
     async function processCastMembers(): Promise<void> {
         if (!isCurrent() || isProcessing) return;
@@ -568,10 +631,34 @@ function initializePeopleTags(): void {
                 return;
             }
 
-            // Process both cast and guest cast sections
-            await processSingleCollapsible('#castCollapsible', currentItemId);
-            if (!isCurrent()) return;
-            await processSingleCollapsible('#guestCastCollapsible', currentItemId);
+            // Collect both sections synchronously (cast first so duplicate
+            // person ids keep preferring the normal-cast card), then
+            // interleave so neither section starves behind the other.
+            const tasks = interleaveTasks(
+                collectSectionTasks('#castCollapsible'),
+                collectSectionTasks('#guestCastCollapsible'),
+            );
+            if (tasks.length === 0) return;
+
+            const batchIsCurrent = (): boolean => isCurrent()
+                && new URLSearchParams(window.location.hash.split('?')[1]).get('id') === currentItemId;
+
+            let cacheChanged = false;
+            let nextIndex = 0;
+            const worker = async (): Promise<void> => {
+                while (batchIsCurrent()) {
+                    const index = nextIndex;
+                    nextIndex += 1;
+                    if (index >= tasks.length) return;
+                    cacheChanged = (await processPersonCard(tasks[index], currentItemId)) || cacheChanged;
+                }
+            };
+            const workerCount = Math.min(PEOPLE_TAGS_CONCURRENCY, tasks.length);
+            await Promise.all(Array.from({ length: workerCount }, () => worker()));
+
+            // One persistent-cache serialization per settled batch (was once
+            // per person = O(N^2) across a cast).
+            if (cacheChanged && isCurrent()) persistPeopleCache();
 
         } catch (error) {
             if (isCurrent()) console.error(`${logPrefix} Error in processCastMembers:`, error);


### PR DESCRIPTION
## Summary

Fixes **BI-PERF-137**: People Tags (cast birthplace / age / deceased overlays) rendered very slowly on any title with more than a few cast members.

Three compounding defects in `src/tags/peopletags.ts`:

1. **Serial N+1 fetch** — `processSingleCollapsible` `await`ed `getPersonInfo(personId)` once per `.personCard` inside the loop; each cache-miss is a `/person/{id}` request (which itself does a per-person TMDB fetch on the backend), fully sequential, so overlays trickled in and total time scaled linearly with cast size.
2. **Section barrier** — `#castCollapsible` was awaited fully before `#guestCastCollapsible` even started.
3. **O(N²) persistence** — every successful fetch re-`JSON.stringify`'d the *entire* persistent cache map to `localStorage`, once per person.

## What changed (client-only, `src/tags/peopletags.ts` + tests)

- **Global bounded-concurrency pool.** A module-level semaphore (`peopleTagsRequestGate = createSemaphore(PEOPLE_TAGS_CONCURRENCY = 6)`) is the single owner of the `/person` concurrency budget, mirroring the repo's existing fixed-cap worker pattern (`enrichIssuesForDisplay`, `processFallbackBatch`). Cast and guest-cast tasks are collected then drained through **one** shared pool, so a guest task joins the first bounded wave even with >6 normal-cast cards. No unbounded fan-out — in-flight `/person` requests never exceed 6 **globally**, even across overlapping observer activations.
- **One batch cache flush.** `getPersonInfo` returns `{ data, cacheChanged, failed }` and no longer writes `localStorage` per person; the hot cache still updates per person. `processCastMembers` ORs `cacheChanged` across workers and calls `persistPeopleCache()` **exactly once** after the combined pool settles (and only when a fetch changed state and identity is still current). Cache-hit-only and all-failure batches write nothing → O(N).
- **Correctness hardening** (from adversarial review): fail *open* on a transient fetch failure (a rejected request no longer permanently marks a person done — it can retry, per the R9 dropped-work contract); resolve the item id through the canonical `getVisibleDetailsPage`/`getItemIdFromUrl` details-view resolver (modern MUI carries the id in `location.search`, and the direct visible-page selector can return the outgoing cached view mid-navigation); completion predicate honors a pending debounce so a freshly-observed update isn't skipped.
- Preserved exactly: identity ownership (`JC.identity.own`) + `isCurrent(context)` guards, per-person dedup, `hotPeopleTags` bounded cache, TTL/ownership semantics, and identical rendered output (age chips, place banner, flag, deceased poster class).

## Acceptance criteria — all covered by new regressions (`peopletags.perf.test.ts` + lifecycle tests)

AC1 bounded concurrency (20-cast render keeps >1 and ≤6 in flight; instrumented mock) · AC2 O(N) persistence (one payload + one timestamp write per settled batch; nothing on all-hit/all-fail) · AC3 identity/navigation cancellation applies zero tags to a new page, dedup holds, render parity for a given PersonData · AC4 guest-cast overlay lands while normal-cast requests are still blocked (no starvation) · AC5 global cap, TTL/ownership unchanged.

The new perf suite fails 5/12 against the old serial implementation (committed first), passes after the fix.

## Verification (independently re-run at HEAD)

- `typecheck:src` ✓ · `typecheck` ✓
- `test:client` **1387/1387** (210 files); coverage 85.752% ≥ 85.708% baseline ✓
- focused `peopletags` 27/27 ✓
- `build:bundle` 163 deterministic files, tree clean ✓ · `check:performance-rules` ✓ · `test:scripts` 429/429 ✓ · `check:docs` (mkdocs `--strict`) ✓ · `validate-translations` n/a (no i18n change) ✓

## Process / residual risk

Produced via the agentic-loop skill (parallel explore + plan, single-writer implement, 3-round mixed-model adversarial review — Claude Opus + gpt-5.6-sol, repo-native verify). 16 confirmed findings resolved. The review loop hit its 3-round cap; the final round's confirmed findings (global cap, transient-failure retry, debounce/timer race) were all fixed by the last fixer and are covered by the passing regression suite. Advisory lint carries one pre-existing unrelated `prefer-const` error (identical on `origin/main`).

Closes #359
