### PR TITLE
feat(agentic-loop): gpt-weighted explorers, xhigh explore/plan, gpt-only review escalation

### DIFF
--- a/.agents/skills/jellyfin-canopy-agentic-loop/SKILL.md
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/SKILL.md
@@ -97,14 +97,21 @@ Workflow({
 To keep a run from burning all of Claude's budget, the loop deliberately spreads
 models by role:
 
-- **~50/50 Claude / `gpt-5.6-sol` — the whole way, except two roles.** With
+- **Weighted Claude / `gpt-5.6-sol` split — the whole way, except two roles.** With
   `modelSplit: true`, explore, plan (incl. synthesis), the review lenses, and the
-  review's finding-verification alternate roughly half-and-half between Claude and
-  `gpt-5.6-sol`. Under `solVia: "codex-cli"` (default) the Sol slots run through a
-  generalized `codex` harness (`gpt-5.6-sol`, `solLightEffort` = medium for
-  explore/plan/verify-findings, high for review); under `solVia: "agent"` they use
-  the subagent model param via a router. Any Sol slot that can't be routed **falls
-  back to Claude**, so no slot is lost.
+  review's finding-verification are spread across Claude and `gpt-5.6-sol`:
+  - **Explore** runs 8 explorers (standard/deep depth); the first 2 on Claude/Opus
+    and the remaining 6 on `gpt-5.6-sol` (override with `exploreClaudeCount`).
+  - **Explore + plan** (incl. synthesis) run their Sol slots at **`xhigh`** reasoning
+    effort (`solExplorePlanEffort`, default `xhigh`); plan keeps a ~50/50 split.
+  - **Review** runs the mixed panel (Claude lenses + `gpt-5.6-sol`) for the first
+    `roundCap` rounds (standard = 4); if still not clean it CONTINUES with
+    `gpt-5.6-sol` as the ONLY reviewer up to `hardRoundCap` (default 10). Review Sol
+    stays at `solEffort` (high).
+  Under `solVia: "codex-cli"` (default) the Sol slots run through a generalized
+  `codex` harness; under `solVia: "agent"` they use the subagent model param via a
+  router. Any Sol slot that can't be routed **falls back to Claude**, so no slot is
+  lost (even in a gpt-only round).
 - **Implementation (excepted)** — the single writer runs on **Fable (high)**,
   falling back to **Opus (high)** if Fable is exhausted/unavailable. Never split
   mid-change, never gpt.

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -57,11 +57,16 @@ const COMMIT_RULE =
   (ISSUE_REF ? `, and INCLUDE the issue number ${ISSUE_REF} in each commit subject (end the subject with " (${ISSUE_REF})")` : '') +
   '.'
 
+// roundCap here is the MIXED-panel review cap (Claude lenses + gpt-5.6-sol). If
+// the loop still isn't clean after it, review CONTINUES with gpt-5.6-sol as the
+// ONLY reviewer up to HARD_ROUND_CAP (see the review loop). explorers is the
+// TOTAL explorer count; the first EXPLORE_CLAUDE_COUNT run on Claude/Opus and the
+// rest on gpt-5.6-sol (see exploreSol).
 const SIZING = {
   quick: { explorers: 2, planners: 2, roundCap: 2, verifyFixCap: 1 },
-  standard: { explorers: 4, planners: 3, roundCap: 3, verifyFixCap: 2 },
-  deep: { explorers: 6, planners: 3, roundCap: 4, verifyFixCap: 3 },
-}[DEPTH] || { explorers: 4, planners: 3, roundCap: 3, verifyFixCap: 2 }
+  standard: { explorers: 8, planners: 3, roundCap: 4, verifyFixCap: 2 },
+  deep: { explorers: 8, planners: 3, roundCap: 4, verifyFixCap: 3 },
+}[DEPTH] || { explorers: 8, planners: 3, roundCap: 4, verifyFixCap: 2 }
 
 // Review lenses (see references/adversarial-review.md). Docs surface uses a
 // narrower set; everything else gets the full standing panel.
@@ -145,10 +150,24 @@ const MODEL_SPLIT = a.modelSplit !== false
 const SOL_AGENT_OK = SOL_VIA === 'agent'
 const solSlot = (i) => MODEL_SPLIT && i % 2 === 1 // odd indices → Sol (~50/50)
 
+// Explorers are weighted toward gpt-5.6-sol (user policy): the first
+// EXPLORE_CLAUDE_COUNT explorers run on Claude/Opus, every remaining explorer on
+// Sol. With the standard 8 explorers that is 2 Opus + 6 Sol. Override the Opus
+// count with args.exploreClaudeCount.
+const EXPLORE_CLAUDE_COUNT = a.exploreClaudeCount == null ? 2 : Math.max(0, a.exploreClaudeCount)
+const exploreSol = (i) => MODEL_SPLIT && i >= EXPLORE_CLAUDE_COUNT
+// The hard review-round ceiling: after the mixed roundCap, gpt-5.6-sol-only
+// review rounds continue up to here (user policy). Override with args.hardRoundCap.
+const HARD_ROUND_CAP = Math.max(1, a.hardRoundCap == null ? 10 : a.hardRoundCap)
+
 // Effort for the non-review Sol phases (explore/plan/finding-verification). High
 // codex effort × many calls gets very slow, so these default to medium; the
 // review round keeps SOL_EFFORT (high). Override with args.solLightEffort.
 const SOL_LIGHT_EFFORT = a.solLightEffort || 'medium'
+// The EXPLORE and PLAN phases run their gpt-5.6-sol slots at a HIGHER reasoning
+// effort than the review rounds (user policy): default xhigh. Review Sol stays at
+// SOL_EFFORT. Override with args.solExplorePlanEffort.
+const SOL_EXPLORE_PLAN_EFFORT = a.solExplorePlanEffort || 'xhigh'
 // Effort for the LOCALIZE phase — mechanical translation busywork kept cheap/fast
 // (gpt or opus on low, inheriting the session model). Override with args.localizeEffort.
 const LOCALIZE_EFFORT = a.localizeEffort || 'low'
@@ -224,13 +243,17 @@ ${prompt}
 // param ('agent' route) or the codex CLI ('codex-cli') — else Claude. Any Sol
 // failure (unroutable / null / throw) FALLS BACK to Claude so the slot is never
 // lost. opts carries schema/agentType/effort/phase/label.
-async function splitAgent(i, prompt, opts) {
-  if (solSlot(i)) {
+// ctl (optional): { slot?: (i)=>bool overrides solSlot for this call; solEffort?:
+// gpt-5.6-sol reasoning effort for the 'agent' route (default SOL_EFFORT);
+// solLightEffort?: codex-cli effort (default SOL_LIGHT_EFFORT) }.
+async function splitAgent(i, prompt, opts, ctl) {
+  const useSol = ctl && typeof ctl.slot === 'function' ? ctl.slot(i) : solSlot(i)
+  if (useSol) {
     try {
       let r = null
-      if (SOL_AGENT_OK) r = await agent(prompt, { ...opts, model: SOL_MODEL, effort: SOL_EFFORT })
+      if (SOL_AGENT_OK) r = await agent(prompt, { ...opts, model: SOL_MODEL, effort: (ctl && ctl.solEffort) || SOL_EFFORT })
       else if (opts && opts.schema)
-        r = await codexAgent(prompt, opts.schema, { effort: SOL_LIGHT_EFFORT, phase: opts.phase, label: (opts.label || '') + ':sol' })
+        r = await codexAgent(prompt, opts.schema, { effort: (ctl && ctl.solLightEffort) || SOL_LIGHT_EFFORT, phase: opts.phase, label: (opts.label || '') + ':sol' })
       if (r != null) return r
     } catch (_) {
       /* Sol failed → Claude fallback below */
@@ -240,13 +263,13 @@ async function splitAgent(i, prompt, opts) {
 }
 // A singleton read-only step we offload to Sol (plan synthesis) to spare Claude
 // tokens; falls back to Claude when Sol isn't routable/available.
-async function soloSolAgent(prompt, opts) {
+async function soloSolAgent(prompt, opts, solEffort) {
   if (MODEL_SPLIT) {
     try {
       let r = null
-      if (SOL_AGENT_OK) r = await agent(prompt, { ...opts, model: SOL_MODEL, effort: SOL_EFFORT })
+      if (SOL_AGENT_OK) r = await agent(prompt, { ...opts, model: SOL_MODEL, effort: solEffort || SOL_EFFORT })
       else if (opts && opts.schema)
-        r = await codexAgent(prompt, opts.schema, { effort: SOL_LIGHT_EFFORT, phase: opts.phase, label: (opts.label || '') + ':sol' })
+        r = await codexAgent(prompt, opts.schema, { effort: solEffort || SOL_LIGHT_EFFORT, phase: opts.phase, label: (opts.label || '') + ':sol' })
       if (r != null) return r
     } catch (_) {
       /* fall through to Claude */
@@ -465,6 +488,8 @@ const exploreAngles = [
   'the CONTRACTS at risk (auth/isolation/escaping/disposal/bounded-work/live-config) and the TEST SEAMS',
   'the CLIENT surface: MUI + legacy layouts, native markup, locale keys, docs impacted',
   'the SERVER surface: controllers/services/scheduled tasks, .NET tests, generated artifacts',
+  'the DATA/STATE/CONCURRENCY surface: persistence, caches, revisions, invalidation, and the races the change can introduce',
+  'the PERFORMANCE/BOUNDS surface: allocations, N+1 / manager-call counts, unbounded work, and the measurable budgets to assert',
 ].slice(0, SIZING.explorers)
 
 const explorations = (
@@ -483,7 +508,8 @@ Also, while reading, note (do NOT fix, do NOT scope-creep) any UNRELATED
 pre-existing bug you notice in the code you traverse — a genuine defect outside
 this task — in incidentalBugs with a title, severity, area, and file:line
 evidence. Only real defects; leave it empty if you see none.`,
-        { schema: EXPLORE_SCHEMA, agentType: 'Explore', effort: 'medium', phase: 'Explore', label: `explore:${i + 1}${solSlot(i) && SOL_AGENT_OK ? ':sol' : ''}` }
+        { schema: EXPLORE_SCHEMA, agentType: 'Explore', effort: 'medium', phase: 'Explore', label: `explore:${i + 1}${exploreSol(i) && SOL_AGENT_OK ? ':sol' : ''}` },
+        { slot: exploreSol, solEffort: SOL_EXPLORE_PLAN_EFFORT }
       )
     )
   )
@@ -519,7 +545,8 @@ model (and explicitly what NOT to add — no speculative flag/retry/lock/observe
 polling/migration), the failing-first tests (admin AND non-admin, negative/
 fallback, concurrency/cache invalidation where relevant), and the locale keys +
 docs to update.`,
-        { schema: PLAN_SCHEMA, effort: 'high', phase: 'Plan', label: `plan:${i + 1}${solSlot(i) && SOL_AGENT_OK ? ':sol' : ''}` }
+        { schema: PLAN_SCHEMA, effort: 'high', phase: 'Plan', label: `plan:${i + 1}${solSlot(i) && SOL_AGENT_OK ? ':sol' : ''}` },
+        { solEffort: SOL_EXPLORE_PLAN_EFFORT }
       )
     )
   )
@@ -543,7 +570,8 @@ best ideas from the others. Reject scope creep and any avoidable new state.
 Output ONE canonical plan (matching the schema fields only) the implementer will
 follow exactly — it MUST address the real defect and every acceptance criterion,
 and add the least while reusing the most.`,
-      { schema: PLAN_SCHEMA, effort: 'high', phase: 'Plan', label: 'plan:synthesis' }
+      { schema: PLAN_SCHEMA, effort: 'high', phase: 'Plan', label: 'plan:synthesis' },
+      SOL_EXPLORE_PLAN_EFFORT
     ),
   plans[0] || null,
   'Plan synthesis'
@@ -726,18 +754,31 @@ let cleanRound = false
 // Set only when a round TERMINATES the loop with incomplete coverage — a reviewer
 // or a finding-verifier failed to return — so we never certify such a round clean.
 let reviewIncomplete = false
+const MIXED_ROUND_CAP = SIZING.roundCap
 let round = 0
-while (round < SIZING.roundCap && !cleanRound) {
+while (round < HARD_ROUND_CAP && !cleanRound) {
   round++
+
+  // Rounds 1..MIXED_ROUND_CAP run the mixed panel (Claude lenses + gpt-5.6-sol).
+  // If still not clean after that, review CONTINUES with gpt-5.6-sol as the ONLY
+  // reviewer (user policy) for every remaining round up to HARD_ROUND_CAP: all
+  // lenses run on Sol plus the whole-diff Sol reviewer(s), no Claude lens
+  // reviewers. (A Sol slot still falls back to Claude for its scope ONLY if Sol
+  // can't be routed at all — fail closed so no lens is left unreviewed.)
+  const gptOnly = round > MIXED_ROUND_CAP
 
   // Split the lenses ~50/50 across models when modelSplit is on (Sol takes the
   // odd slots, lens-scoped) and ALWAYS add ≥1 whole-diff Sol reviewer so the
   // documented "≥1 gpt-5.6-sol whole-diff reviewer per round" contract holds even
   // under the split. With modelSplit off: all Claude lenses + the whole-diff Sol
-  // reviewers. Either way ≥1 Claude and ≥1 whole-diff Sol reviewer run, and every
-  // Sol slot falls back to Claude for its scope if Sol can't be routed.
+  // reviewers. In a gpt-only round every lens runs on Sol.
   let roundThunks
-  if (MODEL_SPLIT) {
+  if (gptOnly) {
+    roundThunks = [
+      ...LENSES.map((lens, i) => solThunk(round, i, lens)),
+      ...Array.from({ length: Math.max(1, SOL_REVIEWERS) }, (_, i) => solThunk(round, LENSES.length + i)),
+    ]
+  } else if (MODEL_SPLIT) {
     roundThunks = [
       ...LENSES.map((lens, i) => (solSlot(i) ? solThunk(round, i, lens) : () => claudeReview(round, i, lens))),
       ...Array.from({ length: Math.max(1, SOL_REVIEWERS) }, (_, i) => solThunk(round, LENSES.length + i)),
@@ -748,9 +789,9 @@ while (round < SIZING.roundCap && !cleanRound) {
       ...Array.from({ length: Math.max(1, SOL_REVIEWERS) }, (_, i) => solThunk(round, LENSES.length + i)),
     ]
   }
-  const claudeLensCount = MODEL_SPLIT ? LENSES.filter((_, i) => !solSlot(i)).length : LENSES.length
+  const claudeLensCount = gptOnly ? 0 : (MODEL_SPLIT ? LENSES.filter((_, i) => !solSlot(i)).length : LENSES.length)
   const solCount = roundThunks.length - claudeLensCount
-  log(`Review round ${round}/${SIZING.roundCap} — ${claudeLensCount} Claude lens + ${solCount}× ${SOL_MODEL} (${SOL_VIA}, ${SOL_EFFORT})${MODEL_SPLIT ? ' [50/50 + whole-diff]' : ''}`)
+  log(`Review round ${round}/${HARD_ROUND_CAP}${gptOnly ? ' [gpt-only]' : ''} — ${claudeLensCount} Claude lens + ${solCount}× ${SOL_MODEL} (${SOL_VIA}, ${SOL_EFFORT})${MODEL_SPLIT && !gptOnly ? ' [50/50 + whole-diff]' : ''}`)
 
   const results = await parallel(roundThunks)
   const failedWorkers = results.filter((r) => r == null).length
@@ -783,7 +824,11 @@ real=false when uncertain — only real=true if it genuinely reproduces or truly
 violates a repository contract on a reachable path.
 FINDING (${f.lens || '?'}) ${f.file}:${f.line || '?'} — ${f.summary}
 SCENARIO: ${f.failureScenario}`,
-        { schema: VERDICT_SCHEMA, agentType: 'code-reviewer', effort: 'medium', phase: 'Review', label: `verify-r${round}:${i + 1}` }
+        { schema: VERDICT_SCHEMA, agentType: 'code-reviewer', effort: 'medium', phase: 'Review', label: `verify-r${round}:${i + 1}` },
+        // In a gpt-only round, finding-verification runs on Sol too (gpt is the
+        // sole reviewer once past the mixed cap); Sol still falls back to Claude
+        // per finding if unroutable. The code-writing fixer stays Claude/Opus.
+        gptOnly ? { slot: () => MODEL_SPLIT } : undefined
       )
     )
   )
@@ -842,7 +887,7 @@ if (!cleanRound)
   log(
     reviewIncomplete
       ? `Review: ended without a certified-clean round — coverage incomplete (reviewer/verifier failure); will report as residual risk`
-      : `Review: hit round cap (${SIZING.roundCap}) with unresolved findings — will report as residual risk`
+      : `Review: hit round cap (${HARD_ROUND_CAP}) with unresolved findings — will report as residual risk`
   )
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/scripts/canopy-loop.workflow.test.js
+++ b/scripts/canopy-loop.workflow.test.js
@@ -169,7 +169,10 @@ test('a throwing review fixer exhausts the round cap and is never ready-for-PR',
     // property. (Also proves a throwing fixer resolves the workflow, never aborts.)
     const { agent } = makeAgent((_p, opts) => {
         const l = opts.label || '';
-        if (/^review-r\d+:1$/.test(l)) return finding('needs a fix'); // every round
+        // Mixed rounds surface the finding on the Claude lens-0 reviewer; gpt-only
+        // rounds (past the mixed cap) surface it on the Sol lens-0 reviewer.
+        if (/^review-r\d+:1$/.test(l)) return finding('needs a fix'); // mixed rounds
+        if (/^sol-r\d+:1$/.test(l)) return finding('needs a fix'); // gpt-only rounds (lens 0 on Sol)
         if (/^verify-r\d+:1$/.test(l)) return { real: true, reason: 'confirmed' }; // every round
         if (l.startsWith('fix-r')) return { __throw: 'StructuredOutput retry cap' };
         return undefined;
@@ -212,6 +215,56 @@ test('every split review round still runs a whole-diff Sol reviewer', async () =
             /across correctness, security\/privacy \(fail-closed\)/.test(c.prompt),
     );
     assert.ok(wholeDiffSol, 'a whole-diff (unscoped) Sol reviewer runs under modelSplit');
+});
+
+test('explore runs 8 agents weighted 2 Claude/Opus + 6 gpt-5.6-sol at xhigh', async () => {
+    const { agent, calls } = makeAgent(null);
+    await runWorkflow(baseArgs({ depth: 'standard' }), agent, parallel, phase, () => {});
+    const explore = calls.filter((c) => /^explore:\d+/.test(c.opts.label || ''));
+    assert.equal(explore.length, 8, '8 explorers at standard depth');
+    const claude = explore.filter((c) => !c.opts.model);
+    const sol = explore.filter((c) => c.opts.model === 'gpt-5.6-sol');
+    assert.equal(claude.length, 2, 'first 2 explorers run on Claude/Opus');
+    assert.equal(sol.length, 6, 'remaining 6 explorers run on gpt-5.6-sol');
+    assert.ok(sol.every((c) => c.opts.effort === 'xhigh'), 'explore Sol slots run at xhigh');
+});
+
+test('plan Sol slots (incl. synthesis) run at xhigh', async () => {
+    const { agent, calls } = makeAgent(null);
+    await runWorkflow(baseArgs({ depth: 'standard' }), agent, parallel, phase, () => {});
+    const planSol = calls.filter((c) => /^plan:/.test(c.opts.label || '') && c.opts.model === 'gpt-5.6-sol');
+    assert.ok(planSol.length >= 1, 'at least one plan slot runs on Sol');
+    assert.ok(planSol.every((c) => c.opts.effort === 'xhigh'), 'plan Sol slots run at xhigh');
+});
+
+test('review escalates to gpt-5.6-sol-only after the mixed round cap', async () => {
+    // A confirmed finding every round whose fixer throws → the loop runs to
+    // hardRoundCap. Mixed rounds (≤ roundCap) use Claude lens reviewers; every
+    // later round is gpt-only (no Claude lens reviewer runs past the mixed cap).
+    const { agent, calls } = makeAgent((_p, opts) => {
+        const l = opts.label || '';
+        if (/^review-r\d+:1$/.test(l)) return finding('x'); // mixed rounds
+        if (/^sol-r\d+:1$/.test(l)) return finding('x'); // gpt-only rounds
+        if (/^verify-r\d+:1$/.test(l)) return { real: true, reason: 'c' };
+        if (l.startsWith('fix-r')) return { __throw: 'cap' };
+        return undefined;
+    });
+    // quick depth → mixed roundCap 2; cap the hard ceiling at 5 to keep it short.
+    const r = await runWorkflow(baseArgs({ depth: 'quick', hardRoundCap: 5 }), agent, parallel, phase, () => {});
+    const roundsWith = (re) =>
+        new Set(
+            calls
+                .map((c) => c.opts.label || '')
+                .map((l) => l.match(re))
+                .filter(Boolean)
+                .map((m) => Number(m[1])),
+        );
+    const claudeReviewRounds = roundsWith(/^review-r(\d+):/);
+    const solReviewRounds = roundsWith(/^sol-r(\d+):/);
+    assert.ok(![...claudeReviewRounds].some((n) => n > 2), 'no Claude lens reviewer past the mixed cap (2)');
+    assert.ok(solReviewRounds.has(3) && solReviewRounds.has(5), 'gpt-5.6-sol reviewers run the gpt-only rounds');
+    assert.equal(r.readyForPR, false, 'unresolved confirmed findings across the escalation block PR');
+    assert.equal(r.reviewRounds, 5, 'the loop ran to the hard round cap');
 });
 
 test('verify enforces a committed, clean handoff as a blocking gate', async () => {


### PR DESCRIPTION
## Summary

Tunes the `jellyfin-canopy-agentic-loop` model routing and review escalation per updated policy. Skill-only (`.agents/…` + its workflow test); no plugin code.

## Changes

**Explorers weighted toward gpt-5.6-sol**
- Standard/deep depth now run **8 explorers**; the first **2 on Claude/Opus** and the remaining **6 on `gpt-5.6-sol`** (`exploreClaudeCount` override, default 2).
- Added two explore angles (data/state/concurrency, performance/bounds) so all 8 explorers have a distinct focus.

**xhigh reasoning effort for explore + plan Sol**
- Explore, plan, and plan-synthesis run their `gpt-5.6-sol` slots at **`xhigh`** (`solExplorePlanEffort`, default `xhigh`). Review Sol stays at `solEffort` (high).

**gpt-5.6-sol-only review escalation**
- Review runs the mixed panel (Claude lenses + `gpt-5.6-sol`) for the first `roundCap` rounds (standard = **4**). If still not clean, review **continues with `gpt-5.6-sol` as the only reviewer** — all lenses + finding-verification on Sol — up to **`hardRoundCap` (default 10)**.
- The code-writing fixers stay on Claude/Opus (one-writer rule unchanged). Any Sol slot that can't be routed still falls back to Claude, so no lens is ever left unreviewed.

## Tests

`scripts/canopy-loop.workflow.test.js`: **21/21** (added: 8-explorer 2-Claude/6-Sol weighting, explore/plan Sol at xhigh, and the gpt-only escalation past the mixed cap). The 6 unrelated `test:scripts` failures in a bare local checkout are pre-existing (build-artifact/mkdocs-dependent) and identical on `origin/main`.

## Rollout

Takes effect for issues started **after** this merges (loop leaves clone the skill fresh from `main`); in-flight runs use their own leaf copy and are unaffected. All overridable via args (`exploreClaudeCount`, `solExplorePlanEffort`, `hardRoundCap`).
