### PR TITLE
feat(agentic-loop): stateful review — oscillation halt + honest counts (redesign M1)

### DIFF
--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -330,6 +330,25 @@ function dedupe(findings) {
   return out
 }
 
+// A STABLE, line-shift-resistant semantic identity for a finding, used to detect
+// the same defect being re-confirmed across review rounds (oscillation) even as
+// the fixer shifts line numbers. Prefers the structured design-lock fields
+// (kind/ownerSymbol/invariantId/decisionId — populated once Design Lock lands)
+// and falls back to file + normalized failure scenario / summary. NOT the same as
+// dedupeKey (which is within-round and line-sensitive).
+const _normalizeText = (s) =>
+  String(s || '')
+    .toLowerCase()
+    .replace(/[0-9]+/g, '#') // collapse line numbers / counts so a shifted repeat still matches
+    .replace(/[^a-z#]+/g, ' ')
+    .trim()
+    .slice(0, 120)
+const findingKey = (f) => {
+  const structured = [f.kind, f.ownerSymbol, f.invariantId, f.decisionId].filter(Boolean).join('|')
+  if (structured) return structured
+  return `${f.file || '?'}|${_normalizeText(f.failureScenario || f.summary)}`
+}
+
 // ── schemas ─────────────────────────────────────────────────────────────────
 const EXPLORE_SCHEMA = {
   type: 'object',
@@ -429,10 +448,14 @@ const FIX_SCHEMA = {
   additionalProperties: true,
   required: ['applied', 'commits'],
   properties: {
-    applied: { type: 'array', items: { type: 'string' } },
+    applied: { type: 'array', items: { type: 'string' }, description: 'confirmed findings actually fixed this pass (summaries)' },
     commits: { type: 'array', items: { type: 'string' } },
     designChange: { type: 'string', description: 'if a fix simplified/deleted state instead of adding a guard, say how' },
-    unresolved: { type: 'array', items: { type: 'string' } },
+    unresolved: { type: 'array', items: { type: 'string' }, description: 'confirmed findings you could NOT fix this pass' },
+    revertedPriorFix: { type: 'boolean', description: 'true if fixing these findings required undoing a previous rounds fix (an oscillation signal)' },
+    head: { type: 'string', description: 'git rev-parse --short HEAD after committing' },
+    addedLines: { type: 'integer', description: 'production lines added this pass (git diff --numstat, excluding tests/locales)' },
+    deletedLines: { type: 'integer', description: 'production lines deleted this pass' },
     notes: { type: 'string' },
   },
 }
@@ -754,9 +777,20 @@ let cleanRound = false
 // Set only when a round TERMINATES the loop with incomplete coverage — a reviewer
 // or a finding-verifier failed to return — so we never certify such a round clean.
 let reviewIncomplete = false
+// Stateful review (M1): detect design OSCILLATION so a non-converging change HALTS
+// instead of grinding to the hard cap. A confirmed finding's stable semantic key
+// re-appearing in a LATER round means its fixer's fix did not stick (or was
+// reverted) — the #167 install-once↔track-teardown thrash signal. Also keeps the
+// resolved-count HONEST: only findings a fixer actually applied are "resolved".
+const confirmedKeyRounds = new Map() // findingKey → [rounds it was confirmed in]
+let appliedFindingsResolved = 0 // HONEST: findings a fixer actually applied (not just confirmed)
+let fixerFailures = 0 // fixer threw / returned null → its confirmed findings are UNRESOLVED
+let designRevisions = 0 // times oscillation forced a design re-decision
+let haltReason = null // set when the loop stops early for non-convergence
+const MAX_DESIGN_REVISIONS = a.maxDesignRevisions == null ? 1 : Math.max(0, a.maxDesignRevisions)
 const MIXED_ROUND_CAP = SIZING.roundCap
 let round = 0
-while (round < HARD_ROUND_CAP && !cleanRound) {
+while (round < HARD_ROUND_CAP && !cleanRound && !haltReason) {
   round++
 
   // Rounds 1..MIXED_ROUND_CAP run the mixed panel (Claude lenses + gpt-5.6-sol).
@@ -848,6 +882,26 @@ SCENARIO: ${f.failureScenario}`,
     break
   }
   confirmedAll.push(...confirmed.map((f) => ({ ...f, round })))
+
+  // OSCILLATION DETECTION: a confirmed key already seen in a PRIOR round means an
+  // earlier fixer did not resolve it (or reverted it). Once repeats appear, allow
+  // MAX_DESIGN_REVISIONS re-decisions, then HALT with a truthful haltReason rather
+  // than grinding every remaining round to the hard cap (the #167 8-hour failure).
+  const repeats = confirmed.filter((f) => (confirmedKeyRounds.get(findingKey(f)) || []).length > 0)
+  for (const f of confirmed) {
+    const k = findingKey(f)
+    confirmedKeyRounds.set(k, [...(confirmedKeyRounds.get(k) || []), round])
+  }
+  if (repeats.length) {
+    designRevisions++
+    log(`Review round ${round}: ${repeats.length} finding(s) re-confirmed after a prior fix → design revision ${designRevisions}/${MAX_DESIGN_REVISIONS}`)
+    if (designRevisions > MAX_DESIGN_REVISIONS) {
+      haltReason = 'non-convergent-design'
+      log(`Review: oscillation persists after ${MAX_DESIGN_REVISIONS} design revision(s) — HALTING (non-convergent-design) for a design re-decision instead of grinding to round ${HARD_ROUND_CAP}`)
+      break
+    }
+  }
+
   // A finding whose verifier failed to return is neither confirmed nor refuted:
   // that scope is unresolved even though we DID confirm (and will fix) others in
   // the same batch. Don't let the fixed-confirmed path silently drop it — mark the
@@ -859,9 +913,12 @@ SCENARIO: ${f.failureScenario}`,
   }
   log(`Review round ${round}: ${confirmed.length} confirmed → fixing`)
 
-  // Wrap the code-writing fixer in safely(): a StructuredOutput retry-cap throw
-  // must NOT abort the whole workflow — verify still needs to run and report.
-  await safely(
+  // The fixer is a REQUIRED writer: capture its result so the resolved-count is
+  // HONEST and reverts/oscillation are visible. A throw/null means its confirmed
+  // findings are UNRESOLVED — never silently counted as resolved (fixes #167's
+  // "even a thrown fixer counts as resolved" telemetry lie). safely() still keeps a
+  // throw from aborting the whole workflow so verify can run and report.
+  const fixResult = await safely(
     () =>
       agent(
         `${CONTRACTS}
@@ -874,6 +931,10 @@ finding demands. Before adding any new state flag/retry/lock/publisher/lifecycle
 path — or making a second fix to the same state machine/owner — STOP and try
 deletion, reuse, or single ownership first; simpler is required over another
 guard. Do not fix anything not listed. ${COMMIT_RULE}
+REPORT which confirmed findings you actually applied vs left unresolved, whether
+fixing them required reverting a previous round's fix (revertedPriorFix), the new
+short HEAD, and production addedLines/deletedLines (git diff --numstat, excluding
+tests/locales).
 
 CONFIRMED FINDINGS:
 ${JSON.stringify(confirmed, null, 1).slice(0, 10000)}`,
@@ -882,10 +943,28 @@ ${JSON.stringify(confirmed, null, 1).slice(0, 10000)}`,
     null,
     `Review fixer (round ${round})`
   )
+  const fixerRan = !!(fixResult && Array.isArray(fixResult.commits) && (fixResult.commits.length || (Array.isArray(fixResult.applied) && fixResult.applied.length)))
+  if (fixerRan) {
+    appliedFindingsResolved += Array.isArray(fixResult.applied) && fixResult.applied.length ? fixResult.applied.length : confirmed.length
+    if (fixResult.revertedPriorFix) {
+      designRevisions++
+      log(`Review round ${round}: fixer reverted a prior fix → design revision ${designRevisions}/${MAX_DESIGN_REVISIONS}`)
+      if (designRevisions > MAX_DESIGN_REVISIONS) {
+        haltReason = 'non-convergent-design'
+        log(`Review: fixer reverts persist after ${MAX_DESIGN_REVISIONS} design revision(s) — HALTING (non-convergent-design)`)
+      }
+    }
+  } else {
+    fixerFailures++
+    reviewIncomplete = true
+    log(`Review round ${round}: fixer failed to return — ${confirmed.length} confirmed finding(s) UNRESOLVED (coverage incomplete)`)
+  }
 }
 if (!cleanRound)
   log(
-    reviewIncomplete
+    haltReason
+      ? `Review: HALTED (${haltReason}) after ${round} round(s) — needs a design re-decision; will report as residual risk`
+      : reviewIncomplete
       ? `Review: ended without a certified-clean round — coverage incomplete (reviewer/verifier failure); will report as residual risk`
       : `Review: hit round cap (${HARD_ROUND_CAP}) with unresolved findings — will report as residual risk`
   )
@@ -1039,24 +1118,31 @@ const result = {
   loopClean: cleanRound,
   reviewRounds: round,
   reviewIncomplete,
+  haltReason,
+  designRevisions,
   incidentalBugs,
-  confirmedFindingsResolved: confirmedAll.length,
+  // HONEST: findings a fixer actually applied (a thrown/absent fixer no longer
+  // inflates this). confirmedFindingsTotal keeps the raw confirmed count.
+  confirmedFindingsResolved: appliedFindingsResolved,
+  confirmedFindingsTotal: confirmedAll.length,
+  fixerFailures,
   implement: implemented || null,
   canonicalPlan: canonicalPlan || null,
   verify: verify || null,
   verifyFixCommitted,
-  readyForPR: implementationOk && cleanRound && !reviewIncomplete && !verifyFixCommitted && blockingGreen && e2eGreen,
+  readyForPR: implementationOk && cleanRound && !reviewIncomplete && !haltReason && !verifyFixCommitted && blockingGreen && e2eGreen,
   residualRisks: []
     .concat(implemented ? [] : ['implementation did not complete — both implementer models failed to return a result'])
     .concat(openTodos.length ? ['implementer left open acceptance-criteria TODOs — change is incomplete'] : [])
-    .concat(reviewIncomplete ? ['adversarial review ended with incomplete coverage (a reviewer or finding-verifier failed) — the round could not be certified clean'] : [])
-    .concat(cleanRound || reviewIncomplete ? [] : ['review loop hit its round cap with unresolved confirmed findings'])
+    .concat(haltReason ? [`review HALTED (${haltReason}): the same defect kept re-appearing after fixes (design oscillation) — needs a design re-decision, not more rounds, before a PR`] : [])
+    .concat(reviewIncomplete ? ['adversarial review ended with incomplete coverage (a reviewer, finding-verifier, or fixer failed) — the round could not be certified clean'] : [])
+    .concat(cleanRound || reviewIncomplete || haltReason ? [] : ['review loop hit its round cap with unresolved confirmed findings'])
     .concat(verifyFixCommitted ? ['verify-fix committed code AFTER the clean review round — those commits were never adversarially reviewed; re-run the review loop before opening a PR'] : [])
     .concat(blockingGreen ? [] : ['one or more BLOCKING gates are failing'])
     .concat(e2eGreen ? [] : ['e2e:local did not pass'])
     .concat(openTodos),
 }
 log(
-  `canopy-loop done: readyForPR=${result.readyForPR} · impl=${implementationOk} · rounds=${round} · findings resolved=${confirmedAll.length} · blockingGreen=${blockingGreen}${RUNTIME ? ` · e2e=${e2eGreen}` : ''}`
+  `canopy-loop done: readyForPR=${result.readyForPR} · impl=${implementationOk} · rounds=${round}${haltReason ? ` · HALTED=${haltReason}` : ''} · findings resolved=${appliedFindingsResolved}/${confirmedAll.length} · blockingGreen=${blockingGreen}${RUNTIME ? ` · e2e=${e2eGreen}` : ''}`
 )
 return result

--- a/scripts/canopy-loop.workflow.test.js
+++ b/scripts/canopy-loop.workflow.test.js
@@ -162,15 +162,14 @@ test('readyForPR is false when the implementer leaves open acceptance-criteria T
     assert.ok(r.residualRisks.some((s) => /open acceptance-criteria TODOs/i.test(s)));
 });
 
-test('a throwing review fixer exhausts the round cap and is never ready-for-PR', async () => {
-    // EVERY round surfaces the same real, confirmed finding whose fixer throws
-    // (StructuredOutput retry cap). The loop must run to roundCap WITHOUT a clean
-    // round and report the branch as NOT ready — the sole guard of that safety
-    // property. (Also proves a throwing fixer resolves the workflow, never aborts.)
+test('a persistently-unfixable finding HALTS for a design re-decision, never ready-for-PR', async () => {
+    // EVERY round surfaces the SAME real, confirmed finding whose fixer throws
+    // (StructuredOutput retry cap). Under the stateful review the same defect
+    // re-appearing after a fix attempt is OSCILLATION: the loop must HALT with a
+    // truthful haltReason (non-convergent-design) EARLY — never grind to the hard
+    // cap — never count the thrown fixer as "resolved", and never be ready-for-PR.
     const { agent } = makeAgent((_p, opts) => {
         const l = opts.label || '';
-        // Mixed rounds surface the finding on the Claude lens-0 reviewer; gpt-only
-        // rounds (past the mixed cap) surface it on the Sol lens-0 reviewer.
         if (/^review-r\d+:1$/.test(l)) return finding('needs a fix'); // mixed rounds
         if (/^sol-r\d+:1$/.test(l)) return finding('needs a fix'); // gpt-only rounds (lens 0 on Sol)
         if (/^verify-r\d+:1$/.test(l)) return { real: true, reason: 'confirmed' }; // every round
@@ -178,15 +177,15 @@ test('a throwing review fixer exhausts the round cap and is never ready-for-PR',
         return undefined;
     });
     const r = await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
-    // Workflow resolves with a structured result rather than throwing out.
-    assert.equal(typeof r, 'object');
-    assert.ok(r.confirmedFindingsResolved >= 1);
+    assert.equal(typeof r, 'object'); // resolves with a structured result, never aborts
     assert.equal(r.loopClean, false, 'a round with an unfixed confirmed finding is not clean');
-    assert.equal(r.reviewIncomplete, false, 'coverage was complete — the finding was confirmed, not lost');
+    assert.equal(r.haltReason, 'non-convergent-design', 'oscillation halts the loop for a design re-decision');
+    assert.ok(r.reviewRounds < 10, 'HALTED early — did not grind to the hard cap');
+    assert.equal(r.confirmedFindingsResolved, 0, 'a thrown fixer applied nothing — honest resolved count is 0');
     assert.equal(r.readyForPR, false, 'unresolved confirmed findings must block ready-for-PR');
     assert.ok(
-        r.residualRisks.some((s) => /round cap with unresolved confirmed findings/i.test(s)),
-        'the round-cap residual risk is reported',
+        r.residualRisks.some((s) => /design oscillation|design re-decision|HALTED/i.test(s)),
+        'the non-convergence residual risk is reported',
     );
 });
 
@@ -238,15 +237,23 @@ test('plan Sol slots (incl. synthesis) run at xhigh', async () => {
 });
 
 test('review escalates to gpt-5.6-sol-only after the mixed round cap', async () => {
-    // A confirmed finding every round whose fixer throws → the loop runs to
+    // A DISTINCT confirmed finding every round (a fresh defect, so no oscillation
+    // halt), fixer succeeds → the loop keeps finding new issues and runs to
     // hardRoundCap. Mixed rounds (≤ roundCap) use Claude lens reviewers; every
     // later round is gpt-only (no Claude lens reviewer runs past the mixed cap).
+    // Distinct WORDS (not round numbers) because findingKey collapses digits.
+    const WORDS = ['alpha', 'bravo', 'charlie', 'delta', 'echo', 'foxtrot'];
     const { agent, calls } = makeAgent((_p, opts) => {
         const l = opts.label || '';
-        if (/^review-r\d+:1$/.test(l)) return finding('x'); // mixed rounds
-        if (/^sol-r\d+:1$/.test(l)) return finding('x'); // gpt-only rounds
+        const rm = l.match(/^(?:review|sol)-r(\d+):1$/);
+        if (rm) {
+            const w = WORDS[Number(rm[1]) - 1];
+            // Distinct summary AND failureScenario so findingKey differs each round
+            // (no oscillation halt) — a genuinely fresh defect per round.
+            return { findings: [{ file: 'a.js', line: 1, severity: 'major', summary: 'defect ' + w, failureScenario: 'scenario ' + w }] };
+        }
         if (/^verify-r\d+:1$/.test(l)) return { real: true, reason: 'c' };
-        if (l.startsWith('fix-r')) return { __throw: 'cap' };
+        // fixer uses the happy default (succeeds) — no fixer failure, no oscillation
         return undefined;
     });
     // quick depth → mixed roundCap 2; cap the hard ceiling at 5 to keep it short.
@@ -265,6 +272,42 @@ test('review escalates to gpt-5.6-sol-only after the mixed round cap', async () 
     assert.ok(solReviewRounds.has(3) && solReviewRounds.has(5), 'gpt-5.6-sol reviewers run the gpt-only rounds');
     assert.equal(r.readyForPR, false, 'unresolved confirmed findings across the escalation block PR');
     assert.equal(r.reviewRounds, 5, 'the loop ran to the hard round cap');
+});
+
+test('oscillation: a fix that does not stick (finding persists) halts for a design re-decision', async () => {
+    // The fixer SUCCEEDS every round, but the SAME defect keeps being re-confirmed
+    // (the fix does not resolve it) — the #167 design-thrash shape. The stateful
+    // review must detect the repeat, allow one design revision, then HALT early.
+    const { agent } = makeAgent((_p, opts) => {
+        const l = opts.label || '';
+        if (/^(?:review|sol)-r\d+:1$/.test(l)) return finding('same unresolved defect'); // identical every round
+        if (/^verify-r\d+:1$/.test(l)) return { real: true, reason: 'c' };
+        // fix-r* uses the happy default → succeeds, yet the defect returns next round
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs({ depth: 'quick', hardRoundCap: 10 }), agent, parallel, phase, () => {});
+    assert.equal(r.haltReason, 'non-convergent-design', 'a persistent re-confirmed defect halts');
+    assert.ok(r.reviewRounds < 10, 'halted early, not ground to the hard cap');
+    assert.equal(r.loopClean, false);
+    assert.equal(r.readyForPR, false);
+    assert.equal(typeof r.designRevisions, 'number');
+    assert.ok(r.designRevisions >= 1, 'at least one design revision was recorded before halting');
+});
+
+test('confirmedFindingsResolved counts only what a fixer actually applied', async () => {
+    // One defect in round 1 only; fixer applies it; round 2 is clean.
+    const { agent } = makeAgent((_p, opts) => {
+        const l = opts.label || '';
+        if (/^(?:review|sol)-r1:1$/.test(l)) return finding('one real defect'); // round 1 only
+        if (/^verify-r1:1$/.test(l)) return { real: true, reason: 'c' };
+        return undefined; // round 2 reviewers → happy {findings:[]} → clean
+    });
+    const r = await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
+    assert.equal(r.loopClean, true, 'clean once the single defect is fixed');
+    assert.equal(r.confirmedFindingsResolved, 1, 'honest count = the one applied fix');
+    assert.equal(r.confirmedFindingsTotal, 1, 'one finding was confirmed total');
+    assert.equal(r.haltReason, null);
+    assert.equal(r.fixerFailures, 0);
 });
 
 test('verify enforces a committed, clean handoff as a blocking gate', async () => {


### PR DESCRIPTION
## Summary

**Milestone 1** of the agentic-loop redesign (from the gpt-5.6-sol architecture review): make the review loop **stateful** so a non-converging large change **halts for a design re-decision** instead of grinding to the hard cap — the #167 8-hour / 21M-token failure — and make its telemetry **honest**.

## What changed (`canopy-loop.js` + harness only)

- **`findingKey()`** — a stable, line-shift-resistant semantic identity for a finding (prefers structured `kind`/`ownerSymbol`/`invariantId`/`decisionId` once later milestones populate them; falls back to `file` + digit-collapsed failure scenario). Distinct from the within-round, line-sensitive `dedupeKey`.
- **Oscillation detection** — a confirmed finding whose key re-appears in a later round means the earlier fixer's fix didn't stick (or was reverted). The loop allows `MAX_DESIGN_REVISIONS` (default 1) then **HALTS** with `haltReason='non-convergent-design'`, reporting it for a design re-decision rather than running every remaining round.
- **Honest resolved count** — `confirmedFindingsResolved` now counts only findings a fixer **actually applied**; a thrown/absent fixer no longer inflates it (it previously did — #167 reported 105 "resolved" while thrashing). Adds `confirmedFindingsTotal`, `fixerFailures`, `designRevisions`, `haltReason`; a failed fixer marks coverage incomplete.
- **`FIX_SCHEMA`** now reports `applied` / `unresolved` / `revertedPriorFix` / `head` / `addedLines` / `deletedLines`.
- `readyForPR` now also requires `!haltReason`.

## Tests — 23/23 green

Reworked the throwing-fixer test to assert the new early-halt semantics; made the gpt-only-escalation test use a **fresh** defect per round (so it exercises escalation without tripping oscillation); added a persistent-defect-halt test and an honest-resolved-count test.

## Rollout

Skill-only; takes effect for issues started after merge (leaves clone fresh from main). All thresholds are arg-overridable (`maxDesignRevisions`, `hardRoundCap`). Follow-on milestones (Design Lock, auto-XL decomposed spiral, test-fidelity gate + read-only Verify, diff-envelope/consolidation, gpt-only-tail → diagnostic) will land as stacked PRs.
