### PR TITLE
docs: freeze Theme Studio research and design contract

### DIFF
--- a/research/theme-studio-design-contract.md
+++ b/research/theme-studio-design-contract.md
@@ -1,0 +1,409 @@
+# Theme Studio design contract
+
+Project: [Jellyfin Canopy — themes](https://github.com/users/4eh5xitv6787h645ebv/projects/8)
+
+Parent: [#382](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/382)
+
+Research issue: [#383](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/383)
+
+Baseline: Jellyfin Canopy [`b66ea64`](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/tree/b66ea646bd1cd6d371248ce737e7f61439b9b44f)
+
+## User outcome
+
+An administrator can enable Theme Studio and choose safe server defaults. Each
+authenticated user can select a curated preset or build a personal theme through
+a responsive editor. Changes preview immediately, can be undone or reset, and
+are saved to that user's server-backed configuration only after confirmation.
+
+The same theme expresses itself coherently across supported Jellyfin Web views,
+legacy/modern surfaces, and every enabled Canopy feature. It adapts to phone,
+tablet, desktop, ultrawide, touch, keyboard, and TV/remote contexts without
+changing application behavior or accessible reading/focus order.
+
+## Official Jellyfin compatibility boundary
+
+Jellyfin Web 12 is the primary contract. At inspected commit
+[`3d7adb5`](https://github.com/jellyfin/jellyfin-web/tree/3d7adb53480f02164041fdd983b3f7abc28d0fd9/src/themes):
+
+- [`theme.ts`](https://github.com/jellyfin/jellyfin-web/blob/3d7adb53480f02164041fdd983b3f7abc28d0fd9/src/themes/_base/theme.ts)
+  creates a Material UI theme with CSS variables, the `jf` prefix, and the
+  `[data-theme="%s"]` color-scheme selector.
+- [`_palette.scss`](https://github.com/jellyfin/jellyfin-web/blob/3d7adb53480f02164041fdd983b3f7abc28d0fd9/src/themes/_base/_palette.scss)
+  and [`_theme.scss`](https://github.com/jellyfin/jellyfin-web/blob/3d7adb53480f02164041fdd983b3f7abc28d0fd9/src/themes/_base/_theme.scss)
+  bridge `--jf-*` roles into both modern MUI and legacy Jellyfin surfaces.
+- [`themeStorageManager.ts`](https://github.com/jellyfin/jellyfin-web/blob/3d7adb53480f02164041fdd983b3f7abc28d0fd9/src/themes/themeStorageManager.ts)
+  owns the root `data-theme` value and theme-change notification.
+- [`index.ts`](https://github.com/jellyfin/jellyfin-web/blob/3d7adb53480f02164041fdd983b3f7abc28d0fd9/src/themes/index.ts)
+  exposes the dark, light, Apple TV, Blue Radiance, Purple Haze, and WMC built-ins.
+- [`DisplayPreferences.tsx`](https://github.com/jellyfin/jellyfin-web/blob/3d7adb53480f02164041fdd983b3f7abc28d0fd9/src/apps/modern/features/preferences/components/DisplayPreferences.tsx)
+  keeps user theme, custom CSS, animations, and layout preferences in Jellyfin's
+  display model.
+
+Canopy must therefore:
+
+1. select a compatible Jellyfin base scheme and map Canopy semantic roles onto
+   supported `--jf-*` variables;
+2. observe `data-theme`, Jellyfin's theme-change event, identity changes,
+   navigation, and Canopy config generations through one lifecycle owner;
+3. use small, named, versioned adapters only for a surface that cannot be
+   expressed through official roles; and
+4. fail back to the selected Jellyfin theme by removing all Canopy-owned style,
+   attributes, classes, listeners, observers, requests, and cached identity data.
+
+The core bridge includes, at minimum, background/default/paper, text
+primary/secondary/disabled, primary/main/light/dark/contrast, error, divider,
+action active/hover/selected/disabled/focus, AppBar, card radius, and background
+image roles. Exact emitted names are guarded against the pinned official source
+and updated deliberately when Jellyfin changes them.
+
+### Dashboard safe space
+
+Jellyfin 10.11 intentionally stopped applying user custom CSS to the dashboard so
+an administrator retains a recovery UI and private dashboard content is not
+accidentally exposed through externally loaded CSS. The official discussion is
+[jellyfin-web #7220](https://github.com/jellyfin/jellyfin-web/issues/7220).
+
+Theme Studio preserves that boundary:
+
+- user raw snippets never apply to the dashboard;
+- curated Canopy dashboard tokens are bounded and separately enabled by an
+  administrator;
+- an independent dashboard base-theme setting remains available; and
+- safe mode can disable every Canopy dashboard adapter without reading a user's
+  custom theme.
+
+## Current Canopy baseline
+
+At the baseline commit:
+
+- `theme-selector.ts` offers Default plus fifteen Jellyfish palette files,
+  stores an `@import` in browser local storage, mirrors a Jellyfish compatibility
+  key, and reloads the page after selection;
+- `theme-selector.feature.ts` correctly uses an identity-owned feature scope and
+  bounded lifecycle, but the UI is injected into a legacy preference selector;
+- `themer.ts` detects Jellyfish, ElegantFin, or Zesty variables and derives a
+  small panel palette; and
+- `AssetCacheManifest` mirrors Jellyfish theme CSS locally, with a kill switch
+  that can fall back to the upstream CDN.
+
+This is a migration input, not the Theme Studio architecture. Existing Jellyfish
+choices must resolve to equivalent versioned presets on first use. Theme Studio
+must not persist CSS imports, require a reload, depend on Jellyfish's boot code,
+or detect its own active theme by probing third-party variables.
+
+## Architecture
+
+```text
+admin policy + built-in presets + per-user theme.json
+                         │
+                         ▼
+             validated ThemeDocument v1
+                         │
+                  resolve + normalize
+                         │
+        ┌────────────────┼────────────────┐
+        ▼                ▼                ▼
+ official --jf bridge  Canopy tokens  bounded adapters
+        │                │                │
+        └────────────────┼────────────────┘
+                         ▼
+          one identity-owned style layer
+                         │
+             data-jc-theme-* attributes
+                         │
+        modern MUI + legacy + Canopy surfaces
+```
+
+The runtime is an import-pure client feature. Importing its entry performs no
+DOM reads/writes, storage reads, subscriptions, or network activity. Activation
+requires an authenticated identity and the administrator master switch. One
+feature scope owns:
+
+- the preview and committed style layers;
+- root `data-jc-theme-*` attributes;
+- theme/identity/navigation/config subscriptions;
+- media-query listeners for color scheme, contrast, motion, transparency,
+  pointer, hover, and viewport changes;
+- per-user configuration requests and abort controllers; and
+- bounded caches derived only from the current identity and schema revision.
+
+Preview is a second, higher-priority Canopy-owned style layer. Cancel removes it
+synchronously. Apply validates and persists the complete document using the
+existing optimistic-revision protocol, then promotes the acknowledged document.
+Identity change, logout, feature disable, or read failure removes preview and
+committed user layers before another identity can render.
+
+## Persistence and schema
+
+Theme state belongs in a dedicated per-user `theme.json`, not extension data in
+the already crowded `settings.json`. The file uses Canopy's complete-payload,
+optimistic-concurrency model, evidence endpoint, atomic write, last-known-good,
+quarantine, authorization, and identity ownership rules.
+
+Initial bounds:
+
+- serialized size: 128 KiB, below the general 1 MiB user-file ceiling;
+- named profiles: 24;
+- profile name: 80 Unicode scalar values after trimming;
+- token overrides: only schema-enumerated keys, one value per key;
+- schedules: 32 ordered entries;
+- no URLs, HTML, JavaScript, CSS `@import`, `url()`, or free-form selectors in
+  the typed document; and
+- unknown fields retained only through a separately bounded extension envelope
+  and ignored by the resolver until their schema version is supported.
+
+Conceptual wire shape:
+
+```json
+{
+  "Revision": 4,
+  "SchemaVersion": 1,
+  "ActiveProfileId": "my-cinema",
+  "Profiles": [
+    {
+      "Id": "my-cinema",
+      "Name": "My cinema",
+      "BasePreset": "cinematic",
+      "Palette": "canopy-night",
+      "Accent": "violet",
+      "Mode": "system",
+      "Tokens": {
+        "shape.radiusScale": "rounded",
+        "layout.density": "cozy",
+        "effects.material": "glass"
+      },
+      "Responsive": {
+        "phone": { "layout.navigation": "bottom" },
+        "tv": { "effects.level": "minimal" }
+      },
+      "Accessibility": {
+        "motion": "system",
+        "contrast": "system",
+        "transparency": "system"
+      }
+    }
+  ],
+  "Schedule": [],
+  "LegacyMigration": {
+    "JellyfishTheme": "Ocean",
+    "Completed": true
+  }
+}
+```
+
+The actual server and TypeScript models use explicit properties and validated
+enums. Dictionary-shaped token overrides are accepted only after checking each
+key against the schema and parsing its value into the declared type. No token
+value is interpolated into CSS without a type-specific serializer.
+
+### Migration rules
+
+1. Missing `theme.json` creates a default inheriting the administrator's preset.
+2. A known Canopy/Jellyfish selection maps to a bundled palette/preset ID and is
+   recorded once in `LegacyMigration`.
+3. Unknown or malformed legacy imports are not executed; Canopy stays on the
+   Jellyfin base theme and reports a local, non-sensitive migration notice.
+4. Schema migrations are pure, ordered, idempotent, and tested from every
+   released version. The original file remains recoverable through the existing
+   atomic backup/quarantine mechanism.
+5. Export omits server identity, user identity, revision evidence, secrets, and
+   migration diagnostics. Import creates a staged preview and never overwrites
+   a profile without explicit confirmation.
+
+## Token taxonomy
+
+Token names are stable product roles, not DOM selectors or colors disguised as
+component names. Each token descriptor declares type, default, allowed range or
+enum, inheritance, affected surfaces, responsive capability, and whether it is
+safe on the dashboard.
+
+| Namespace | Representative roles |
+|---|---|
+| `color.*` | canvas, surface, elevated, overlay, text, textMuted, primary, onPrimary, secondary, positive, caution, negative, info, divider, focus |
+| `type.*` | familyUi, familyDisplay, familyReading, scale, weight, lineHeight, tracking, maxReadingWidth |
+| `shape.*` | radiusScale, cardRadius, controlRadius, dialogRadius, avatarShape, borderWidth |
+| `elevation.*` | surfaceShadow, cardShadow, dialogShadow, focusRing, glowIntensity |
+| `space.*` | scale, pageGutter, sectionGap, cardGap, controlGap, safeAreaMode |
+| `layout.*` | density, maxContentWidth, navigation, homeHero, details, seasons, cardActions, posterRatio, castShape |
+| `effects.*` | level, material, blur, saturation, backdropOpacity, imageTreatment, noise, glow |
+| `motion.*` | profile, durationScale, easing, hoverLift, pageTransition, stagger |
+| `progress.*` | position, thickness, watchedIndicator, unwatchedIndicator, playedTreatment |
+| `player.*` | osdDensity, controlMaterial, subtitleBackdrop, pauseScreenMaterial, trickplayShape |
+| `icon.*` | family, weight, sizeScale, multicolorMetadata |
+| `accessibility.*` | contrast, motion, transparency, focusEmphasis, underlineLinks, textScale |
+
+Breakpoints are named capabilities—`phone`, `tablet`, `desktop`, `wide`, and
+`tv`—rather than user-entered pixel values. The runtime resolves input mode and
+available space together; a touch-enabled laptop is not forced into the phone
+layout, and a narrow remote client retains focus affordances.
+
+## Preset model
+
+Presets are immutable, versioned data shipped with Canopy. A saved profile
+references a preset and stores only differences, so bug fixes and new surface
+coverage can flow forward while a user can freeze a preset version when exact
+appearance matters.
+
+Initial cohesive presets:
+
+| Preset | Intended character | Main research lineage |
+|---|---|---|
+| Canopy | Balanced default, clear hierarchy, restrained depth | Official Jellyfin, Better Styles, ElegantFin |
+| Minimal | Stock-respecting, dense, low motion/effects | Better Styles, finimalism, Monochromic |
+| Cinematic | Backdrop/hero emphasis and immersive detail pages | NetFin, Flow, Media Bar, ijelly |
+| Glass | Layered translucent material with automatic capability fallback | Abyss, Jamfin, GlassFin, JellySkin |
+| Material | Semantic Material 3 surfaces, pills, FAB/action hierarchy | GNAT, SpookyFin, dynamic-color clients |
+| Studio | Polished neutral dark/light production UI | ElegantFin, NeutralFin, jellygray |
+| TV Focus | Large remote targets, centered browsing, compact OSD | infinitv, ijelly |
+| OLED | True-black low-effects surface profile | scyfin and OLED collections |
+| High Contrast | Explicit borders/focus/text separation | Official roles and accessibility requirements |
+
+Palette families—Canopy, Catppuccin-inspired/attributed where licensing permits,
+Dracula-attributed, seasonal, neutral, vivid, and migrated Jellyfish choices—are
+orthogonal to layout presets. A palette must pass light/dark contrast tests
+before it is exposed as supported.
+
+## Studio interaction contract
+
+The editor uses a desktop split view when space permits and a mobile staged flow
+on small screens. Both operate on the same form model and offer:
+
+- preset gallery with text descriptions and local preview thumbnails;
+- search by token/purpose and beginner/expert modes;
+- visible dirty state, undo/redo, reset section/profile/all, and before/after;
+- palette, typography, shape, density, navigation, cards, details, player,
+  effects, motion, icons, accessibility, and responsive overrides;
+- keyboard navigation, correctly associated labels/descriptions/errors, and no
+  color-only state;
+- debounced, frame-coalesced preview updates with no network write per control;
+- explicit Apply and Cancel; and
+- import/export with validation results and a diff before acceptance.
+
+Phone requirements include a non-obscuring preview toggle, bottom-sheet controls
+that avoid the virtual keyboard, sticky Apply/Cancel above safe-area insets,
+44-by-44 CSS-pixel targets, and no horizontal page scroll at 320 CSS pixels.
+
+## Canopy compatibility contract
+
+Theme Studio exposes `--jc-*` semantic variables and stable
+`data-jc-theme-surface`/`data-jc-theme-component` hooks. Existing Canopy features
+must consume these roles rather than hard-coded colors or trying to identify a
+third-party theme. Feature enablement, authorization, and business state remain
+their existing owners' responsibility.
+
+| Canopy surface group | Required themed states |
+|---|---|
+| Enhanced launcher, native tabs, settings panel | rest/hover/focus/selected/dirty/error/loading; desktop dialog and mobile full-height sheet |
+| Spoiler Guard and hidden content | blurred/protected/reveal, hide actions, confirmation, admin editor, fail-closed state |
+| Card tags and filler warnings | all positions, long values, overlaps, focus/hover visibility, spoiler interaction |
+| Active streams | header badge, panel, posters, progress, transcode/direct badges, forms, destructive confirmation, empty/error |
+| Calendar, requests/downloads, bookmarks | list/grid/agenda/month, filters, navigation, progress, empty/error/loading, phone reflow |
+| Seerr discovery/search/details | available/requested/pending/declined/error, hero/row/modal, permission-specific actions |
+| Sonarr/Radarr/Bazarr | links, search action sheet, release list, rejection reasons, progress and controls |
+| Details, reviews, elsewhere, Letterboxd, ratings | metadata, chips, external links, expansion, empty/error and RTL ordering |
+| Player enhancements | playback controls, subtitle editor/output, OSD rating, bookmarks, pause screen, long-press/frame overlays |
+| Admin/customization | configuration tabs/forms, branding, activity/plugin/metadata icons, diagnostics, safe dashboard mode |
+
+A generated guard inventories stable `jc-*` hooks and requires every owned
+surface group to reference only declared semantic roles. Visual E2E covers
+representative combinatorial interactions rather than every mathematical token
+combination.
+
+## Accessibility and localization
+
+- WCAG contrast is checked for text, icons, focus, controls, status chips, and
+  content over images in every supported light/dark palette.
+- `prefers-reduced-motion` disables non-essential animation regardless of the
+  selected profile; a user may choose an even calmer mode but cannot force
+  essential safety feedback to disappear.
+- `forced-colors` uses system colors and preserves control/focus boundaries.
+- reduced-transparency/high-contrast capability removes blur and supplies solid
+  surfaces without collapsing hierarchy.
+- Layout uses logical properties, mirrors intentionally in RTL, and is tested
+  with Arabic/Hebrew direction plus long German/Finnish-style labels.
+- 200% text zoom and 400% browser zoom must reflow without losing actions.
+- Images, swatches, and presets have localized text alternatives; decorative
+  docs images use empty alt text, informative ones use concise alt text.
+
+## Performance contract
+
+- One generated style layer for committed state and one for preview; no style
+  tag or rule per card.
+- No per-node computed-style loop. Resolve tokens once per generation, write in
+  one batch, and let inheritance carry values.
+- Media/palette analysis is optional, local, bounded, cancellable, cached by
+  non-user media identity, and never delays first usable paint.
+- DOM adapters are route-scoped, mutation-coalesced, bounded, and idempotent.
+- Effects expose `full`, `balanced`, and `minimal`; capability preferences can
+  only reduce cost.
+- Blur, large shadows, filters, background images, and motion are measured on
+  representative low-end mobile and TV emulation, not only desktop.
+- Runtime and bundle budgets, long-task checks, layout-shift checks, and bounded
+  subscription/observer counts are release gates.
+
+## Security and privacy contract
+
+- Every user-file route authenticates, authorizes caller-or-admin access, and
+  returns identical missing/inaccessible behavior where disclosure matters.
+- Theme values are typed and serialized by allowlist. Visible text uses
+  `textContent`/safe component rendering; no theme value reaches `innerHTML`.
+- No credentials, user IDs, server URLs, paths, history, or private media data
+  appear in exports, logs, analytics, screenshots, or external requests.
+- Built-in assets are embedded or served through Canopy's allowlisted local asset
+  path. A cache kill switch must not silently turn a bundled Theme Studio asset
+  into a remote dependency.
+- Raw custom CSS, if delivered as a separate advanced feature, is local-only,
+  excluded from the dashboard, prominently risk-labelled, size bounded, and
+  never eligible for the curated gallery. It is not part of the typed theme
+  document.
+
+## Testing and release evidence
+
+Each implementation slice adds the closest unit/behavioral tests plus the
+following cross-cutting evidence before the umbrella closes:
+
+- schema parser, serializer, migration, invalid-value, size/capacity, optimistic
+  revision, identity handoff, quarantine, import/export, and defaults tests;
+- import-purity, lifecycle, media-query, official-variable bridge, preview/apply/
+  cancel/rollback, legacy migration, and feature-disable tests;
+- token/selector/provenance/local-asset guards and Canopy surface inventory;
+- Playwright across modern and legacy layouts with phone portrait/landscape,
+  tablet, desktop, ultrawide, touch, keyboard, TV focus, reduced motion, forced
+  colors, RTL, zoom, and long labels;
+- accessibility scans plus keyboard and screen-reader-oriented assertions;
+- screenshot comparisons at stable seeded fixtures, with intentional baseline
+  review rather than automatic acceptance;
+- performance measurements on balanced/minimal and full-effects profiles; and
+- offline documentation build/link validation.
+
+## Documentation image contract
+
+Documentation images are generated only after the corresponding view passes its
+behavioral and visual checks. Capture scripts use deterministic demo media or
+clearly licensed fixtures, fixed locale/time/seed, hidden personal/server data,
+and named viewport/device configuration.
+
+Required final set:
+
+- preset overview contact sheet at desktop and phone widths;
+- Theme Studio preset gallery and editor on desktop;
+- Theme Studio staged editor and preview on phone portrait;
+- one tablet and one phone-landscape responsive example;
+- Canopy home/details/player/feature-surface examples;
+- high-contrast, reduced-effects/OLED, and TV-focus examples; and
+- before/after migration from the current Jellyfish selector.
+
+Each docs reference includes meaningful alt text. A machine-readable capture
+manifest records source commit, preset/profile, viewport, device scale, locale,
+color scheme, motion/contrast settings, fixture, and output path.
+
+## Non-goals
+
+- Reimplementing Jellyfin navigation, media data, player behavior, permissions,
+  or Canopy feature policy inside the theme engine.
+- Pixel-identical clones of commercial streaming services.
+- Native theming of clients that do not embed Jellyfin Web or Canopy's bundle.
+- An unmoderated marketplace or automatic execution of downloaded themes.
+- Guaranteeing compatibility with arbitrary third-party custom CSS.
+- Shipping broad implementation before the tracked research and schema contract
+  are reviewed and the issue decomposition is present in Project 8.

--- a/research/theme-studio-ecosystem.md
+++ b/research/theme-studio-ecosystem.md
@@ -1,0 +1,198 @@
+# Theme Studio ecosystem inventory
+
+Project: [Jellyfin Canopy — themes](https://github.com/users/4eh5xitv6787h645ebv/projects/8)
+
+Tracking: [#382](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/382), [#383](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/383)
+
+Snapshot date: **2026-07-19**
+
+## Scope and method
+
+There is no central registry of every Jellyfin theme, and personal stylesheets can
+exist without a public repository. “Every theme” is therefore defined here as a
+reproducible discovery snapshot, not a claim about the entire Internet. The sweep
+covered:
+
+- the [GitHub `jellyfin-theme` topic](https://github.com/topics/jellyfin-theme);
+- the pinned [awesome-jellyfin theme list](https://github.com/awesome-jellyfin/awesome-jellyfin/blob/3938da69c0577e6e0bd933fc52291e13e9964857/THEMES.md);
+- broad GitHub repository searches for Jellyfin theme, skin, CSS, mobile, TV,
+  glass, Material, Apple TV, Netflix, icon, seasonal, and theme-manager terms;
+- repositories linked by the discovered projects; and
+- official Jellyfin Web theme sources at commit
+  [`3d7adb5`](https://github.com/jellyfin/jellyfin-web/tree/3d7adb53480f02164041fdd983b3f7abc28d0fd9/src/themes).
+
+Fifty-one representative repositories were cloned shallowly without checkout or
+execution and inspected as text. Third-party installers, scripts, build systems,
+webhooks, and network calls were not run. GitHub repository metadata supplied the
+archived state, last push, and detected license. `Unresolved` below means GitHub
+did not resolve an SPDX license; it does **not** grant reuse permission. Any later
+code or asset reuse requires an explicit compatibility and attribution review.
+
+This inventory extracts product ideas. It does not copy third-party CSS. That
+boundary is important for provenance, maintainability, Jellyfin 12 compatibility,
+and the differing licenses in the ecosystem.
+
+## Source inventory
+
+### Full themes and theme families
+
+| Project | Status at snapshot | GitHub license metadata | Distinctive contribution | Responsive evidence / main limitation |
+|---|---|---|---|---|
+| [Abyss](https://github.com/AumGupta/abyss-jellyfin) | Active | MIT | Cohesive dark glass system, floating navigation, spring-like motion, broad player/admin/form coverage | Desktop, ultrawide, and breakpoints documented; dark-only and motion/blur need accessibility tiers |
+| [ElegantFin](https://github.com/lscambo13/ElegantFin) | Active | GPL-2.0 | Exceptional surface breadth: login, home, libraries, details, seasons, player, cast, music, books, Live TV, settings, and dashboard | Desktop, mobile, and TV examples; broad selector surface needs a supported-token translation |
+| [Flow](https://github.com/LitCastVlog/Flow) | Active | GPL-3.0 | Plex-inspired composition, optional drawer/logo/episode/cast modules, backdrop-aware detail presentation | Mobile fixes exist; inherits selector and version sensitivity from its theme lineage |
+| [Finity](https://github.com/prism2001/finity) | Active | GPL-3.0 | Large semantic variable set for color, alpha, blur, type, spacing, card sizes, visibility, and complete/minimal presets | Mobile and music are documented gaps; some features rely on an external script |
+| [infinitv](https://github.com/buesche87/infinitv) | Active | GPL-3.0 | TV-first focus, compact OSD, centered composition, remote/keyboard navigation, configurable HSL color and card glow | TV, desktop, and mobile screenshots; TV affordances must not become the phone layout |
+| [Jamfin](https://github.com/JamsRepos/Jamfin) | Active | MIT | Modular base/complete packages, glass surfaces, configurable color/roundness/blur | Useful module precedent; visual effects need a no-blur performance mode |
+| [Jellyfish](https://github.com/n00bcodr/Jellyfish) | Active | NOASSERTION | Palette files, ratings/indicator/icon/logo modules, existing Canopy compatibility and current selector presets | Broad client use; current Canopy integration reloads and stores CSS imports locally |
+| [JellyFlix](https://github.com/prayag17/JellyFlix) | Infrequent | Unresolved | Familiar Netflix-style hierarchy, hero/detail emphasis, streaming-library density | Older/fixed-layout assumptions make it inspiration only |
+| [JellySkin](https://github.com/prayag17/JellySkin) | Infrequent | GPL-3.0 | Gradient accents, horizontal media row, custom icon system, optional performance stylesheet | External fonts/assets and CSP sensitivity; performance add-on is a good tier precedent |
+| [NetFin](https://github.com/ya0903/NetFin) | Active | MIT | Cinematic dark preset, poster-first browsing, metadata clarity, mobile touch-size option | Phone, desktop, and TV examples; brand mimicry must become a neutral Canopy preset |
+| [NeutralFin](https://github.com/KartoffelChipss/NeutralFin) | Active | GPL-2.0 | Neutral black/gray adaptation with media-bar compatibility and per-user installation path | Broad ElegantFin lineage; compatibility must use tokens rather than a copied selector set |
+| [Ultrachromic](https://github.com/CTalvio/Ultrachromic) | Active | MIT | Strongest modular reference: layout, login, title, input, progress, indicator, hover, palette, rounding, and TV-performance modules | Explicit mobile/TV adaptations; many independently composable imports can conflict without a schema |
+| [Monochromic](https://github.com/CTalvio/Monochromic) | Historical | Unresolved | Muted/minimal axis and compact options that informed Ultrachromic | Superseded; retain ideas, not an extra compatibility target |
+| [Kaleidochromic](https://github.com/CTalvio/Kaleidochromic) | Historical | Unresolved | Colorful axis that informed Ultrachromic | Superseded |
+| [Novachromic](https://github.com/CTalvio/Novachromic) | Historical | Unresolved | Light/alternate chromic axis and modular lineage | Superseded |
+| [scyfin](https://github.com/loof2736/scyfin) | Active | GPL-3.0 | Base/options split, static drawer, backdrop navigation, identify-list option, Seafoam/Coral/Snow/OLED palettes | Useful responsive modules; selectors remain web-version coupled |
+| [ZestyTheme](https://github.com/stpnwf/ZestyTheme) | Active | MIT | Minimal structure, many simple accent palettes, two login modes | Mobile/tablet support; documented Live TV and music gaps become required Canopy coverage |
+| [Zombie](https://github.com/MakD/zombie-release) | Active | Unresolved | Explicit synthesis of public themes, streaming-service color presets, mobile alternative layout, featured bar | API-key/file-mutation patterns are rejected; use only the preset and layout ideas |
+| [GlassFin](https://github.com/KBH-Reeper/GlassFin) | Active | Unresolved | Transparent glass hierarchy, responsive states, themeable badges, Media Bar and Enhanced styling | Desktop/mobile claims; unresolved license means no CSS or asset reuse |
+| [JellyfinGlassTheme](https://github.com/MadhavKrishanGoswami/JellyfinGlassTheme) | Active | MIT | Apple-inspired glass, responsive typography and plugin-card treatment | Desktop/tablet/mobile examples; locally bundle any allowed type assets |
+| [JellyThemes](https://github.com/kingchenc/JellyThemes) | Active | GPL-3.0 | Six dark palette personalities—Obsidian, Solaris, Nebula, Ember, Void, Phantom—with shared glass and easing | Responsive claims; palettes should be data, not duplicated stylesheets |
+| [JellyMoon](https://github.com/trple-sss/JellyMoon) | Active | GPL-3.0 | Personal synthesis of Zesty/StrawJelly ideas and colorful detail styling | Treat as visual evidence, not a new architecture |
+| [jellygray](https://github.com/pratimes/jellygray) | Infrequent | MIT | Quiet neutral gray treatment extending through plugins, people, player, and dashboard | Older client baseline; good neutral preset reference |
+| [DarkFlix](https://github.com/DevilsDesigns/Jellyfin-DarkFlix-Theme) | Infrequent | GPL-3.0 | Dense dark streaming-service composition and red accent hierarchy | Fixed/older assumptions; reject brand assets and brittle dimensions |
+| [FossFlix](https://github.com/PaleCache/FossFlix) | Active | GPL-3.0 | Contemporary streaming-style layout with its own visual identity | Validate all breakpoints rather than accepting a desktop screenshot |
+| [Dark Field](https://github.com/pointless-existence/jellyfin-dark-field-theme) | Infrequent | GPL-3.0 | Dark transparent green palette | Narrow style reference |
+| [Friday Fin](https://github.com/az4if/friday_fin) | Archived | Unresolved | Ultrachromic/Zombie-derived personal combination | Archived and derivative; no direct reuse |
+| [Medusa](https://github.com/Arrow420/Medusa) | Active | Unresolved | Modern coverage of home, library, detail, dashboard, player, and subtitles | Unresolved license; use as coverage evidence only |
+| [JellyTheme](https://github.com/DanielHalevi/JellyTheme) | Archived | Unresolved | RTL work, revamped player, compact seasons, settings cleanup, Apple TV-like library | Webroot/bundle modification is rejected; RTL and compact-season outcomes are adopted |
+| [GNAT / SethStyle](https://github.com/JSethCreates/jellyfin-theme-sethstyle) | Active | MIT | Material Design 3 semantics, nine-token palette, clear action hierarchy, FABs, forms, sliders, placeholders | Existing small-screen fallback removes much of the theme; Canopy must adapt instead |
+| [SpookyFin](https://github.com/endoflineservice/SpookyFin---Material-Theme-for-JellyFin) | Active | MIT | Material You, pills/FABs, palette controls, explicit Enhanced tabs/calendar/watchlist/remote/music coverage | Strong Canopy-surface reference; seasonal art remains optional and local |
+| [ijelly](https://github.com/safiyu/ijelly) | Active | Unresolved | Apple TV composition, spring motion, cinematic heroes, TV sizing, pill navigation, text-layer isolation from blur | Desktop/Samsung TV focus; phone layout needs separate verification |
+| [Apple TV+ theme](https://github.com/mfaizanatiq/jellyfin-appletvplus-theme) | Active | MIT | Modular Apple TV+-style presentation and redistribution-oriented packaging | Convert brand-specific expression into a generic cinematic preset |
+| [better-jellyfin-ui](https://github.com/tromoSM/better-jellyfin-ui) | Active | Apache-2.0 | Optional floating header, contrast, hover, border, navigation/logo, and Trickplay modules with user variables | Desktop/mobile; custom CSS is not applied by native TV clients |
+| [Jellyfin Better Styles](https://github.com/Tetrax-10/jellyfin-better-styles) | Infrequent | MIT | Stock-preserving polish, better layout, animation, and card hover | Ideal low-disruption preset; still requires current-client verification |
+| [finimalism](https://github.com/tedhinklater/finimalism) | Active | GPL-3.0 | Jellyfin 11/12 variants, classic/modded layout, accent/blur/rounding, aspect-ratio test discipline | Good compatibility matrix; avoid maintaining two full CSS forks |
+| [alexyle/jellyfin-theme](https://github.com/alexyle/jellyfin-theme) | Active | GPL-3.0 | Current personal theme with a broad aggregate stylesheet | Secondary evidence; evaluate each adopted idea against primary modules |
+| [SethStyle-adjacent personal themes](https://github.com/JSethCreates/jellyfin-theme-sethstyle/network/dependents) | Mixed | Mixed | Shows demand for editable Material palettes and compact surfaces | Not a bounded source set; no individual completeness claim |
+
+### Palette systems
+
+| Project | License | Adoptable outcome |
+|---|---|---|
+| [Catppuccin](https://github.com/catppuccin/jellyfin) | MIT | Four named flavors plus independently selectable accents, represented as semantic palette data |
+| [Evergarden](https://github.com/everviolet/jellyfin) | EUPL-1.2 | Seasonal summer/spring/fall/winter palette families without forcing seasonal animation |
+| [Dracula](https://github.com/dracula/jellyfin) | MIT | Recognizable, accessible dark palette offered with attribution |
+| [theme.park](https://github.com/themepark-dev/theme.park) | MIT | Shared cross-app palette naming and a clean custom-option distribution model |
+| [Jellyfish colors](https://github.com/n00bcodr/Jellyfish/tree/main/colors) | NOASSERTION | Backward-compatible migration for Canopy's Aurora, Banana, Coal, Coral, Forest, Grass, Jellyblue, Jellyflix, Jellypurple, Lavender, Midnight, Mint, Ocean, Peach, and Watermelon choices |
+| [OLED theme collections](https://github.com/artur0sky/jellyfin-oled-themes) | Verify before reuse | True-black surface tier separated from accent selection |
+
+### Companion systems and targeted adaptations
+
+| Project | Kind | Contribution / decision |
+|---|---|---|
+| [Jellyfin Seasonals](https://github.com/CodeDevMLH/Jellyfin-Seasonals) | Plugin | Scheduled or manual seasonal themes, per-user toggle, holiday precedence, configurable particles, and TV-safe defaults. Adopt scheduling and bounded effects as optional modules. |
+| [Skin Manager](https://github.com/Jellyfin-PG/Skin-Manager) | Archived plugin | Gallery/manager interaction model for Jellyfin 10.11+. Adopt safe curated discovery; do not depend on the archived implementation. |
+| [jellyfin-plugin-skin-manager](https://github.com/danieladov/jellyfin-plugin-skin-manager) | Plugin | Install/download workflow. Remote arbitrary CSS remains outside the default safe path. |
+| [KefinTweaks](https://github.com/ranaldsgift/KefinTweaks) | UI extension | Existing skin-manager/tweak UX and many Canopy-adjacent surfaces. Theme Studio replaces only appearance configuration, not unrelated feature policy. |
+| [Jellyfin Media Bar](https://github.com/MakD/Jellyfin-Media-Bar) | UI extension | Featured-content hero behavior and cross-theme compatibility requirements. |
+| [Jellyfin Lucide](https://github.com/KartoffelChipss/Jellyfin-Lucide) | Icon theme | Optional icon family with inherited/current-color semantics and accessible labels. |
+| [icon-metadata](https://github.com/Druidblack/jellyfin-icon-metadata) | Icon theme | Provider icon treatment already integrated by Canopy; requires monochrome/multicolor theme contracts. |
+| [JellyfinMobileTweaks](https://github.com/Oniicode/JellyfinMobileTweaks) | Mobile patch set | Mobile-specific density, tap-target, wrapping, and navigation failures that a theme-agnostic responsive layer must cover. |
+| [Void for Jellyfin](https://github.com/hritwikjohri/Void-for-jellyfin) | Native Android client | Material 3 dynamic color, ambient backgrounds, and truly mobile-native composition. It is inspiration, not a web CSS theme or compatibility target. |
+| [NovaUI](https://github.com/Sakaii-Project/NovaUI-theme) | Archived theme/extension | Glass, hover glow, Smart TV clock/greeting, and plugin compatibility. Discord webhook/global-script patterns are rejected. |
+
+### Additional publicly discoverable repositories
+
+The topic/search sweep also found the following smaller, personal, partial, or
+special-purpose projects. They remain in the provenance log even when they did
+not add a distinct architecture requirement:
+
+- [amirehsan/Jellyfin-CSS](https://github.com/amirehsan/Jellyfin-CSS)
+- [JoeSaf/jellyfin-customui](https://github.com/JoeSaf/jellyfin-customui)
+- [huttflix](https://github.com/topics/jellyfin-theme)
+- [gelee-de-mure](https://github.com/topics/jellyfin-theme)
+- [Jellyfin play-button fixes](https://github.com/topics/jellyfin-theme)
+- [Jellyfin custom themes and collections](https://github.com/search?q=jellyfin+themes&type=repositories)
+- [Automationsxperts/jellyflix](https://github.com/Automationsxperts/jellyflix)
+- [krlsantcard/jellyfin-themes](https://github.com/krlsantcard/jellyfin-themes)
+- [mbcooper83/jellyfin-css-darkandgreen](https://github.com/mbcooper83/jellyfin-css-darkandgreen)
+- [Red-M/jellyfin_seymour](https://github.com/Red-M/jellyfin_seymour)
+
+Search-result pages are intentionally recorded for repeatability where a small
+repository can be renamed or removed. A future inventory refresh must repeat the
+same queries and append additions rather than silently rewriting the snapshot.
+
+## Synthesis matrix
+
+| Theme dimension | Strong evidence | Canopy outcome |
+|---|---|---|
+| Semantic palette | Jellyfin 12, Finity, GNAT, Catppuccin, Ultrachromic | Versioned role-based tokens mapped to `--jf-*`; palette and accent can change independently |
+| Light/dark/OLED | Jellyfin built-ins, chromic family, scyfin, Catppuccin | All presets declare supported color schemes; OLED is a surface tier, not a separate implementation |
+| Typography | Abyss, Glass themes, Apple-style themes | Local/system font stacks, scale, weight, line height, and reading-width tokens; never blur a text layer |
+| Surface/glass | Abyss, Jamfin, GlassFin, JellySkin | Solid, translucent, and glass material tiers; blur automatically reduces for capability/performance preferences |
+| Shape/elevation | ElegantFin, GNAT, SpookyFin, Ultrachromic | Independent radius, border, shadow, and focus-ring scales |
+| Cards/density | infinitv, Finity, finimalism, NetFin | Poster/backdrop/square ratios, compact/cozy/spacious density, bounded hover/focus actions |
+| Navigation | Abyss, Ultrachromic, ijelly, infinitv | Header/sidebar/pill presentations chosen per breakpoint and input mode, with stable destinations |
+| Home/hero | Media Bar, Zombie, NetFin, ijelly | Optional accessible hero module with predictable layout reservation and a reduced-data mode |
+| Details/seasons | ElegantFin, Flow, JellyTheme, NetFin | Hero/compact detail modes, episode list/grid choice, readable metadata, no fixed 1080p assumptions |
+| Player/OSD | infinitv, ElegantFin, Medusa, JellyTheme | Compact/cinematic OSD options that preserve controls, focus order, captions, Trickplay, and Canopy overlays |
+| Music/Live TV/books | ElegantFin and documented gaps elsewhere | Explicit required surfaces, never an untested “best effort” |
+| Motion | Abyss, JellyThemes, ijelly, JellySkin | Calm/expressive/off profiles with reduced-motion override and bounded transition properties |
+| Seasonal/dynamic | Evergarden, Seasonals, dynamic Material clients | Optional palette scheduling and local media-derived accent; no remote assets or unbounded particles |
+| Icons | Lucide, metadata icons, GNAT | Optional local icon packs using current color, stable labels, and no semantic meaning conveyed by icon alone |
+| Mobile/touch | MobileTweaks, NetFin, ElegantFin | Mobile is a first-class layout profile with safe areas, keyboard, wrapping, tap targets, and orientation checks |
+| TV/remote | infinitv, ijelly, ElegantFin | Focus-visible scale/outline, remote-safe navigation, overscan spacing, and low-effects defaults |
+| Accessibility/i18n | JellyTheme RTL, Material semantics, official Jellyfin | Contrast and forced-color checks, zoom/reflow, RTL/logical properties, long labels, reduced motion/transparency |
+| Performance | JellySkin performance add-on, Ultrachromic TV mode, Seasonals | Automatic effects budget plus user-selectable full/balanced/minimal modes |
+
+## Adopt, adapt, and reject
+
+### Adopt as outcomes
+
+- Semantic palette roles and separately selectable accent, brightness, OLED,
+  density, shape, effects, and motion dimensions.
+- Curated cohesive presets plus expert-level composable controls.
+- Live preview with staged changes, undo, reset, and per-control defaults.
+- Multiple card, navigation, details, season, progress, indicator, and login
+  presentations without changing their behavior or accessible order.
+- Optional seasonal scheduling, local dynamic color, local icon families, and
+  performance tiers.
+- Explicit coverage of Canopy surfaces and historically neglected music, Live
+  TV, books, dashboard, mobile, and TV states.
+
+### Adapt behind stable contracts
+
+- Brand-inspired looks become generic presets such as **Cinematic**, **Studio**,
+  **Material**, **Glass**, **Minimal**, and **TV Focus**. Canopy does not ship
+  third-party service marks or claim pixel identity.
+- Selector-heavy techniques become semantic tokens or small versioned adapters.
+- Remote fonts, images, and icon CSS become permitted local/system assets with
+  a provenance manifest.
+- Daily/seasonal changes operate on a saved palette/preset schedule, not an
+  injected `@import` string.
+
+### Reject
+
+- Editing Jellyfin webroot files or generated JavaScript bundles.
+- Arbitrary remote scripts, webhooks, API keys in client CSS/JavaScript, or
+  executable theme packages.
+- Runtime reliance on third-party CDNs for the default experience.
+- Copying unresolved-license CSS or assets.
+- Fixed-resolution layouts, desktop-only completion, or mobile rules that simply
+  turn the theme off.
+- Global unversioned selector overrides without ownership, cleanup, tests, or a
+  compatibility boundary.
+- Theme controls that weaken authentication, elevation, feature policy, privacy,
+  player accessibility, or dashboard recovery behavior.
+
+## Refresh procedure
+
+1. Record the date and current commits for Jellyfin Web and awesome-jellyfin.
+2. Export the GitHub `jellyfin-theme` topic and repeat the search terms in this
+   document.
+3. Compare repository URLs, archived states, last pushes, and license metadata.
+4. Read new projects without executing third-party code.
+5. Append sources and map genuinely new behavior into the synthesis matrix.
+6. Open or update a Theme Studio issue for every newly discovered requirement.

--- a/research/theme-studio-roadmap.md
+++ b/research/theme-studio-roadmap.md
@@ -1,0 +1,80 @@
+# Theme Studio implementation roadmap
+
+Project: [themes — Project 8](https://github.com/users/4eh5xitv6787h645ebv/projects/8)
+
+Milestone: [Theme & Skin Studio](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/milestone/76)
+
+Umbrella: [#382](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/382)
+
+All rows are linked sub-issues of #382, assigned to the milestone, present in
+Project 8, and labelled `no-stale`. Project status is the authoritative live
+state; the waves below describe dependencies, not a promise that independent
+work must be serialized.
+
+## Wave 0 — contract
+
+| Issue | Outcome | Exit dependency |
+|---|---|---|
+| [#383](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/383) | Ecosystem research, official compatibility contract, schema/tokens, surface and responsive matrices, roadmap | Research documents reviewed and docs checks pass |
+
+## Wave 1 — foundation
+
+| Issue | Outcome | Main dependencies |
+|---|---|---|
+| [#384](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/384) | Versioned per-user `theme.json`, admin policy, validation, migrations, import/export model | #383 |
+| [#385](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/385) | Identity-owned runtime, official `--jf-*` bridge, semantic `--jc-*` roles, bounded adapters | #383, then #384 for persistence wiring |
+| [#398](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/398) | Shared contract, lifecycle, responsive, visual, accessibility, and performance gates | Starts with the foundation and expands with every slice |
+
+## Wave 2 — product shell
+
+| Issue | Outcome | Main dependencies |
+|---|---|---|
+| [#386](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/386) | Responsive gallery/editor, staged live preview, undo/reset, profile/import flows | #384, #385 |
+| [#387](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/387) | Curated presets, palettes, icons, thumbnails, provenance | #385 |
+| [#388](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/388) | Jellyfin shell/navigation/cards/home/details/seasons/dialog/form modules | #385, #387 |
+| [#397](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/397) | Jellyfish migration and modern/legacy/version compatibility | #384, #385, #387 |
+
+## Wave 3 — responsive and experience depth
+
+| Issue | Outcome | Main dependencies |
+|---|---|---|
+| [#389](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/389) | Phone/tablet/touch/safe-area adaptations and low-end mobile evidence | #385, #388 |
+| [#390](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/390) | TV/remote, player, music, Live TV, and reader surfaces | #385, #388 |
+| [#391](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/391) | Bounded effects/motion, dynamic color, seasonal schedules, performance tiers | #384, #385, #387 |
+| [#392](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/392) | Accessibility, localization, RTL, zoom, forced colors, high contrast | Cross-cuts #384–#391 and blocks their final acceptance |
+
+Mobile is not isolated to #389. That issue owns reusable phone/tablet mechanics
+and the complete device sweep; every UI issue still has its own applicable phone
+portrait/landscape, tablet, desktop, and ultrawide acceptance.
+
+## Wave 4 — every Canopy surface
+
+| Issue | Outcome | Main dependencies |
+|---|---|---|
+| [#393](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/393) | Enhanced panels/tabs, protection/hidden content, tags, warnings, ratings, and overlays | #385 and component-role contract |
+| [#394](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/394) | Active streams, calendar, requests/downloads, bookmarks | #385 and component-role contract |
+| [#395](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/395) | Discovery, Seerr, ARR, reviews, Elsewhere, and external links | #385 and component-role contract |
+| [#396](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/396) | Safe profile sharing, curated gallery foundation, separately gated raw snippets | #384, #386, #387 |
+
+The grouping is about review size and fixture reuse. If implementation reveals a
+surface that cannot be reviewed safely within one row, create a narrower linked
+sub-issue immediately and add it to Project 8 rather than silently widening the
+pull request.
+
+## Wave 5 — proof and handoff
+
+| Issue | Outcome | Main dependencies |
+|---|---|---|
+| [#399](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/399) | User/admin/developer docs and verified mobile/desktop image set | Verified implementations plus capture infrastructure |
+| [#400](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/400) | Real-browser matrix and final security/privacy/performance/accessibility/provenance audit | All implementation and docs issues |
+
+## Program completion rule
+
+#382 remains open until all child outcomes are complete, the release audit has no
+untracked material finding, and the verified changes are reachable from the
+writable repository's default branch. Closing an issue requires evidence in its
+completion template; a passing desktop screenshot cannot substitute for mobile,
+behavioral, accessibility, or lifecycle proof.
+
+Merge, deployment, and release remain separately authorized actions even after
+the technical evidence is green.

--- a/research/theme-studio-verification-matrix.md
+++ b/research/theme-studio-verification-matrix.md
@@ -1,0 +1,200 @@
+# Theme Studio responsive and visual verification matrix
+
+Tracking: [#382](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/382), [#383](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/383)
+
+This is the minimum evidence matrix. A row may add devices or browsers, but an
+implementation issue cannot remove a required class without recording why the
+behavior is impossible or outside Jellyfin Web/Canopy's supported boundary.
+
+## Viewport and input classes
+
+| ID | CSS viewport | Primary input | Required orientation / capability | Purpose |
+|---|---:|---|---|---|
+| P-S | 320 × 568 | touch | portrait, coarse pointer, no hover | Minimum supported phone width, wrapping and overflow |
+| P | 390 × 844 | touch | portrait, safe-area emulation | Main phone editor and content baseline |
+| P-L | 844 × 390 | touch | landscape, short viewport, safe areas | OSD, hero, dialogs, keyboard avoidance, horizontal navigation |
+| T-S | 600 × 960 | touch | portrait | Small tablet and two-column transition |
+| T | 820 × 1180 | touch + keyboard | portrait and landscape | Tablet editor/detail composition and hybrid input |
+| D | 1440 × 900 | mouse + keyboard | fine pointer, hover | Main desktop baseline |
+| D-L | 1920 × 1080 | mouse + keyboard | fine pointer, hover | Dense library, player, dashboard, documentation captures |
+| W | 2560 × 1080 | mouse + keyboard | ultrawide | Content max-width, hero cropping, line length, empty side space |
+| TV | 1920 × 1080 | remote + keyboard | 10-foot focus, overscan inset, reduced effects | Remote navigation, focus visibility, OSD and grid density |
+
+Phone checks must include a virtual-keyboard-sized visual viewport and an iOS-like
+bottom safe-area inset. Tablet/desktop checks include 125% and 200% OS/browser text
+scaling where automation can represent it. Real-browser evidence is required for
+engine-specific failures that emulation cannot prove.
+
+## Browser/client classes
+
+| Class | Required evidence |
+|---|---|
+| Chromium current | Full automated matrix and screenshots |
+| Firefox current | Core editor/apply/rollback, grid/layout, focus, filters, forced colors where supported |
+| WebKit current | Phone/tablet safe areas, sticky actions, backdrop/filter fallback, form controls |
+| Jellyfin modern MUI | Theme variables, preferences, dashboard safe space, dialogs/forms, Canopy routes |
+| Jellyfin legacy desktop/mobile | Existing class bridge and bounded adapters |
+| Jellyfin TV web layout | Focus/remote flow, effects budget, overscan, player OSD |
+| Jellyfin 12 / .NET 10 server | API, persistence, configuration, asset, and E2E baseline |
+
+Native clients that do not embed Jellyfin Web are documented as unsupported by
+the client theme runtime. They may use server theme-profile APIs in a later native
+adapter, but cannot be counted as visually verified in this milestone.
+
+## Core state matrix
+
+Every Theme Studio control is tested in normal, hover (where available), focus,
+active, disabled, dirty, saving, saved, validation-error, save-error, conflict,
+offline/cancelled, and read/quarantine states. The following flows receive full
+viewport coverage:
+
+1. open studio, choose preset, preview, cancel;
+2. edit tokens, undo/redo, reset section, apply and reload;
+3. change responsive override and cross the relevant viewport boundary;
+4. import valid profile, inspect diff, rename, apply;
+5. reject malformed/oversized/unknown-version import without changing output;
+6. migrate a current Jellyfish palette and preserve a usable fallback;
+7. switch user/logout while preview/save/read is pending;
+8. disable Theme Studio live and remove every owned style/hook; and
+9. change Jellyfin's base theme while Canopy is active.
+
+## Jellyfin surface matrix
+
+| Surface | Required fixture/states | P-S/P | P-L | T | D/D-L | W | TV |
+|---|---|:---:|:---:|:---:|:---:|:---:|:---:|
+| Login/manual login | logo, user image/text fallback, error, keyboard | ✓ | ✓ | ✓ | ✓ | — | ✓ |
+| Home | hero on/off, horizontal rows, long titles, progress, no backdrop | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Movie/series details | backdrop/no backdrop, long metadata, actions, cast | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Seasons/episodes | list/grid, specials, long translated title, progress | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Library/search | poster/backdrop/square, filters, empty/loading/error | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Dialogs/forms/preferences | select, slider, switch, textarea, validation, virtual keyboard | ✓ | ✓ | ✓ | ✓ | — | ✓ |
+| Video player/OSD | playing, paused, Trickplay, subtitles, short height | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Music | album/artist/playlist/now playing, long track text | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Live TV/guide | guide grid, channel list, current program, focus | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Books/readers | cover/detail/list/reader controls | ✓ | ✓ | ✓ | ✓ | — | ✓ |
+| Dashboard | separate admin theme, safe mode, no raw user CSS | ✓ | ✓ | ✓ | ✓ | ✓ | — |
+| Notifications/action sheets | success/warning/error, stacked, long text | ✓ | ✓ | ✓ | ✓ | — | ✓ |
+
+`—` means no distinct visual claim is needed for that exact combination; it does
+not permit an overflow or runtime error when the view is opened there.
+
+## Canopy surface matrix
+
+| Group | Representative interaction | Required viewports |
+|---|---|---|
+| Enhanced panel/settings/native tabs | open, change tab, dirty control, save conflict, mobile sheet | P-S, P, P-L, T, D, TV |
+| Theme Studio | gallery, search, editor, preview, undo, import diff, apply/error | all |
+| Spoiler Guard/hidden content | protected card/detail, reveal, hide dialog, admin edit, fail closed | P, P-L, T, D, TV |
+| Tags/filler/rating overlays | all corners, multiple tags, hover-hide, long value, stacked overlays | P-S, P, T, D, TV |
+| Active streams | badge, panel, cards, progress, message, stop confirm, empty/error | P-S, P-L, T, D |
+| Calendar | agenda/list/grid/month, filters/sidebar, touch navigation | P-S, P-L, T, D, W |
+| Requests/downloads | tabs, search, poster/list, progress, empty/error | P-S, P-L, T, D |
+| Bookmarks | timeline/player dialog/library grid, orphaned item, controls | P-S, P-L, T, D, TV |
+| Seerr/discovery | search result, hero, feed row, request states/modal | P-S, P-L, T, D, W, TV |
+| Sonarr/Radarr/Bazarr | action sheet, instance switch, releases/rejections, progress | P-S, P-L, T, D |
+| Details/reviews/elsewhere/links | expanded/collapsed, external chips, RTL order, empty/error | P-S, P-L, T, D, TV |
+| Player enhancements | subtitle editor/output, rating, pause screen, bookmarks, overlays | P, P-L, T, D, W, TV |
+| Admin customization/icons | config form, activity/plugin/metadata icons, branding and safe mode | P-S, P-L, T, D |
+
+## Accessibility, localization, and capability permutations
+
+The full Cartesian product would hide gaps behind an impractical test count.
+Instead, every baseline viewport runs its primary flow, and the following
+pairwise set spans the cross-cutting risks:
+
+| Profile | Viewport | Scheme/preset | Capability / locale |
+|---|---|---|---|
+| A11Y-1 | P | Canopy light | 200% text, long German labels, reduced motion |
+| A11Y-2 | D | High Contrast dark | forced colors, keyboard only |
+| A11Y-3 | T | Material light | RTL Arabic, coarse pointer, reduced transparency |
+| A11Y-4 | P-L | Cinematic dark | screen-reader semantics, virtual keyboard, safe areas |
+| A11Y-5 | W | Minimal system | 400% zoom/reflow test at equivalent narrow CSS viewport |
+| A11Y-6 | TV | TV Focus dark | remote only, strong focus, minimal effects |
+| PERF-1 | P-S | Glass dark | balanced auto-fallback, low-end CPU/GPU emulation |
+| PERF-2 | TV | OLED | minimal effects, no blur/animation |
+
+No preset can suppress the platform's reduced-motion, forced-colors, or focus
+requirements. Contrast tests use the final composited colors, including media
+scrims and translucent surfaces.
+
+## Visual-regression policy
+
+- Screenshots use deterministic fixtures, locale, time, seed, viewport, device
+  scale, font availability, animation clock, and image responses.
+- Dynamic content has reserved dimensions and stable substitutes; masks are used
+  only for inherently variable text/time, never to hide a layout regression.
+- Baselines are reviewed and committed intentionally. A changed screenshot is
+  not auto-approved because the pixel count is small.
+- Behavior assertions remain authoritative for focus, labels, visibility,
+  clipping, overflow, hit targets, and cleanup; image diffs supplement them.
+- Phone and desktop baselines are mandatory for every primary preset. Secondary
+  palette variants can use token/contrast tests plus a representative contact
+  sheet rather than duplicating every surface screenshot.
+
+## Documentation capture manifest
+
+The final capture command emits image files under `docs/images/theme-studio/` and
+a manifest with this shape:
+
+```json
+{
+  "schemaVersion": 1,
+  "sourceCommit": "<verified commit>",
+  "captures": [
+    {
+      "path": "docs/images/theme-studio/studio-editor-phone.webp",
+      "page": "theme-studio",
+      "state": "editing-cinematic",
+      "preset": "cinematic",
+      "viewport": { "width": 390, "height": 844 },
+      "deviceScaleFactor": 1,
+      "input": "touch",
+      "locale": "en-AU",
+      "colorScheme": "dark",
+      "reducedMotion": true,
+      "forcedColors": false,
+      "fixture": "theme-studio-demo-v1"
+    }
+  ]
+}
+```
+
+Required documentation outputs:
+
+| Image | Desktop | Mobile | Notes |
+|---|:---:|:---:|---|
+| Preset overview/contact sheet | ✓ | ✓ | Same preset order and fixture for comparison |
+| Gallery/select preset | ✓ | ✓ | Show text descriptions, not color alone |
+| Expert editor | ✓ | ✓ | Desktop split view; mobile staged sheet |
+| Before/after preview | ✓ | ✓ | Same media fixture and crop |
+| Home and details | ✓ | ✓ | Demonstrate responsive composition |
+| Player/OSD | ✓ | landscape | Include subtitles/Canopy overlay coexistence |
+| Canopy feature surfaces | ✓ | ✓ | At least panel, tags, calendar, request state, and active streams |
+| Accessibility/effects | ✓ | ✓ | High contrast and low-effects/OLED examples |
+| TV focus | ✓ | not applicable | Visible focus and overscan-safe layout |
+| Jellyfish migration | ✓ | ✓ | Old selection to equivalent Theme Studio preset |
+
+All informative images receive concise alt text in documentation. Contact sheets
+must remain legible when opened at their native dimensions and have adjacent text
+summarizing the differences so the image is not the only source of information.
+
+## Completion evidence template
+
+Every implementation issue records:
+
+```text
+Unit/behavioral tests:
+Server/API tests:
+Modern MUI E2E:
+Legacy E2E:
+Mobile portrait:
+Mobile landscape:
+Tablet:
+Desktop/ultrawide:
+TV/remote:
+Accessibility/i18n:
+Performance:
+Visual baselines:
+Documentation images:
+Known unsupported boundary:
+```


### PR DESCRIPTION
## Summary

- inventories the publicly discoverable Jellyfin theme ecosystem as a reproducible 2026-07-19 snapshot, including provenance/license boundaries and adopted/rejected ideas
- pins the official Jellyfin 12 CSS-variable compatibility boundary and defines the Theme Studio schema, lifecycle, persistence, token, preset, security, accessibility, and performance contracts
- defines explicit phone portrait/landscape, tablet, desktop, ultrawide, touch, keyboard, and TV verification plus the final documentation-image capture manifest
- records the complete Project 8 roadmap and dependencies for issues #382–#400

## Tracking

Closes #383
Parent: #382
Project: https://github.com/users/4eh5xitv6787h645ebv/projects/8
Milestone: Theme & Skin Studio

## Validation

- `git diff --cached --check`
- `npm run check:markdown-links`
- `npm run check:docs-assets`
- `node scripts/check-docs.js`
- `node scripts/check-installation-permissions.js`
- `.venv/bin/python -m mkdocs build --strict -d site`

No third-party theme code, installers, or scripts were executed.