### PR TITLE
feat: add Theme Studio runtime bridge

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/entries/feature-catalog.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/entries/feature-catalog.test.ts
@@ -23,6 +23,23 @@ beforeEach(() => {
 });
 
 describe('built-in detail integration catalog', () => {
+    it('gives Theme Studio exclusive ownership over the legacy Jellyfish selector', () => {
+        const studio = descriptor('theme-studio');
+        const legacy = descriptor('theme-selector');
+        expect(studio.scope).toBe('identity');
+        expect(studio.restartOnConfigChange).toBe(true);
+        expect(studio.isApplicable(state)).toBe(true);
+
+        JC.pluginConfig = { ThemeStudioEnabled: true, ThemeSelectorEnabled: true };
+        expect(studio.isEnabled(state)).toBe(true);
+        expect(legacy.isEnabled(state)).toBe(false);
+        expect(studio.isEnabled({ ...state, identity: null })).toBe(false);
+
+        JC.pluginConfig.ThemeStudioEnabled = false;
+        expect(studio.isEnabled(state)).toBe(false);
+        expect(legacy.isEnabled(state)).toBe(true);
+    });
+
     it('activates the event shell after its settings-launcher dependency', () => {
         const settingsIndex = builtInFeatureDescriptors.findIndex((item) => item.id === 'settings-launcher');
         const eventsIndex = builtInFeatureDescriptors.findIndex((item) => item.id === 'enhanced-events');

--- a/Jellyfin.Plugin.JellyfinCanopy/src/entries/feature-catalog.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/entries/feature-catalog.ts
@@ -254,12 +254,22 @@ export const builtInFeatureDescriptors: readonly ClientFeatureDescriptor[] = Obj
         isApplicable: isVideoPlaybackRoute,
     },
     {
+        id: 'theme-studio',
+        entry: 'theme-studio',
+        scope: 'identity',
+        restartOnConfigChange: true,
+        isEnabled: (state) => Boolean(state.identity)
+            && JC.pluginConfig?.ThemeStudioEnabled === true,
+        isApplicable: () => true,
+    },
+    {
         id: 'theme-selector',
         entry: 'theme-selector',
         scope: 'identity',
         restartOnConfigChange: true,
         isEnabled: (state) => Boolean(state.identity)
-            && JC.pluginConfig?.ThemeSelectorEnabled === true,
+            && JC.pluginConfig?.ThemeSelectorEnabled === true
+            && JC.pluginConfig?.ThemeStudioEnabled !== true,
         isApplicable: () => true,
     },
     {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/appearance-features.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/appearance-features.test.ts
@@ -130,6 +130,9 @@ describe('appearance lazy-feature lifecycle', () => {
         JC.pluginConfig = { ThemeSelectorEnabled: true, ColoredRatingsEnabled: true };
         expect(isThemeSelectorEnabled()).toBe(true);
         expect(isColoredRatingsEnabled()).toBe(true);
+        JC.pluginConfig.ThemeStudioEnabled = true;
+        expect(isThemeSelectorEnabled()).toBe(false);
+        expect(isColoredRatingsEnabled()).toBe(true);
     });
 
     it('does nothing when stale scopes reach either entry', () => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/theme-selector.feature.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/theme-selector.feature.ts
@@ -8,7 +8,8 @@ import {
 
 /** Base-runtime descriptor gate. Keep equivalent logic outside this lazy chunk. */
 export function isThemeSelectorEnabled(): boolean {
-    return JC.pluginConfig?.ThemeSelectorEnabled === true;
+    return JC.pluginConfig?.ThemeSelectorEnabled === true
+        && JC.pluginConfig?.ThemeStudioEnabled !== true;
 }
 
 /**

--- a/Jellyfin.Plugin.JellyfinCanopy/src/test/theme-studio-fixture.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/test/theme-studio-fixture.ts
@@ -1,0 +1,30 @@
+import type { UserThemeConfiguration } from '../types/jc';
+
+export function themeConfiguration(): UserThemeConfiguration {
+    return {
+        Revision: 3,
+        SchemaVersion: 1,
+        ActiveProfileId: 'default',
+        Profiles: [{
+            Id: 'default',
+            Name: 'Default',
+            BasePreset: 'canopy',
+            PresetVersion: null,
+            FreezePresetVersion: false,
+            Palette: 'canopy-night',
+            Accent: 'violet',
+            Mode: 'system',
+            Tokens: {},
+            Responsive: { Phone: null, Tablet: null, Desktop: null, Wide: null, Tv: null },
+            Accessibility: {
+                Motion: 'system',
+                Contrast: 'system',
+                Transparency: 'system',
+                FocusEmphasis: 'system',
+                UnderlineLinks: false,
+            },
+        }],
+        Schedule: [],
+        LegacyMigration: { JellyfishTheme: '', Completed: false },
+    };
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/color.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/color.ts
@@ -42,9 +42,15 @@ function luminance(color: Rgba): number {
     return 0.2126 * linear(color.red) + 0.7152 * linear(color.green) + 0.0722 * linear(color.blue);
 }
 
-/** WCAG contrast after alpha-compositing both colors over the supplied surface. */
-export function contrastRatio(foreground: string, background: string, surface = '#000000'): number {
-    const surfaceColor = opaque(surface, BLACK);
+/** WCAG contrast after alpha-compositing foreground, background, surface, then canvas. */
+export function contrastRatio(
+    foreground: string,
+    background: string,
+    surface = '#000000',
+    canvas = '#000000',
+): number {
+    const canvasColor = opaque(canvas, BLACK);
+    const surfaceColor = opaque(surface, canvasColor);
     const backgroundColor = opaque(background, surfaceColor);
     const foregroundColor = opaque(foreground, backgroundColor);
     const foregroundLuminance = luminance(foregroundColor);
@@ -58,10 +64,12 @@ export function readableForeground(
     background: string,
     preferred: string,
     surface = '#000000',
+    canvas = '#000000',
     minimumRatio = 4.5,
 ): string {
-    if (contrastRatio(preferred, background, surface) >= minimumRatio) return preferred;
-    return contrastRatio('#000000', background, surface) >= contrastRatio('#FFFFFF', background, surface)
+    if (contrastRatio(preferred, background, surface, canvas) >= minimumRatio) return preferred;
+    return contrastRatio('#000000', background, surface, canvas)
+        >= contrastRatio('#FFFFFF', background, surface, canvas)
         ? '#000000'
         : '#FFFFFF';
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/color.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/color.ts
@@ -1,0 +1,67 @@
+interface Rgba {
+    readonly red: number;
+    readonly green: number;
+    readonly blue: number;
+    readonly alpha: number;
+}
+
+const BLACK: Rgba = Object.freeze({ red: 0, green: 0, blue: 0, alpha: 1 });
+
+function parseHex(value: string): Rgba | null {
+    if (!/^#[0-9a-fA-F]{6}(?:[0-9a-fA-F]{2})?$/.test(value)) return null;
+    return {
+        red: Number.parseInt(value.slice(1, 3), 16) / 255,
+        green: Number.parseInt(value.slice(3, 5), 16) / 255,
+        blue: Number.parseInt(value.slice(5, 7), 16) / 255,
+        alpha: value.length === 9 ? Number.parseInt(value.slice(7, 9), 16) / 255 : 1,
+    };
+}
+
+function composite(foreground: Rgba, background: Rgba): Rgba {
+    const alpha = foreground.alpha + background.alpha * (1 - foreground.alpha);
+    if (alpha <= 0) return BLACK;
+    return {
+        red: (foreground.red * foreground.alpha
+            + background.red * background.alpha * (1 - foreground.alpha)) / alpha,
+        green: (foreground.green * foreground.alpha
+            + background.green * background.alpha * (1 - foreground.alpha)) / alpha,
+        blue: (foreground.blue * foreground.alpha
+            + background.blue * background.alpha * (1 - foreground.alpha)) / alpha,
+        alpha,
+    };
+}
+
+function opaque(value: string, background: Rgba): Rgba {
+    return composite(parseHex(value) ?? BLACK, background);
+}
+
+function luminance(color: Rgba): number {
+    const linear = (channel: number): number => channel <= 0.04045
+        ? channel / 12.92
+        : ((channel + 0.055) / 1.055) ** 2.4;
+    return 0.2126 * linear(color.red) + 0.7152 * linear(color.green) + 0.0722 * linear(color.blue);
+}
+
+/** WCAG contrast after alpha-compositing both colors over the supplied surface. */
+export function contrastRatio(foreground: string, background: string, surface = '#000000'): number {
+    const surfaceColor = opaque(surface, BLACK);
+    const backgroundColor = opaque(background, surfaceColor);
+    const foregroundColor = opaque(foreground, backgroundColor);
+    const foregroundLuminance = luminance(foregroundColor);
+    const backgroundLuminance = luminance(backgroundColor);
+    return (Math.max(foregroundLuminance, backgroundLuminance) + 0.05)
+        / (Math.min(foregroundLuminance, backgroundLuminance) + 0.05);
+}
+
+/** Retains a readable preferred color, otherwise chooses the stronger black/white foreground. */
+export function readableForeground(
+    background: string,
+    preferred: string,
+    surface = '#000000',
+    minimumRatio = 4.5,
+): string {
+    if (contrastRatio(preferred, background, surface) >= minimumRatio) return preferred;
+    return contrastRatio('#000000', background, surface) >= contrastRatio('#FFFFFF', background, surface)
+        ? '#000000'
+        : '#FFFFFF';
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/feature.import.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/feature.import.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+import { JC } from '../globals';
+
+describe('Theme Studio feature import purity', () => {
+    it('acquires no styles, observers, subscriptions, timers, requests, or facade on import', async () => {
+        const before = {
+            styles: document.querySelectorAll('style, link[rel="stylesheet"]').length,
+            resets: JC.identity.getResetHandlerCount(),
+            api: JC.core.themeStudio,
+        };
+        const documentListener = vi.spyOn(document, 'addEventListener');
+        const windowListener = vi.spyOn(window, 'addEventListener');
+        const timer = vi.spyOn(window, 'setTimeout');
+        const interval = vi.spyOn(window, 'setInterval');
+        const observe = vi.spyOn(MutationObserver.prototype, 'observe');
+        const reset = vi.spyOn(JC.identity, 'registerReset');
+        const request = JC.core.api ? vi.spyOn(JC.core.api, 'plugin') : null;
+
+        const module = await import('./feature');
+
+        expect(typeof module.activate).toBe('function');
+        expect(typeof module.themeStudioFeature.activate).toBe('function');
+        expect(documentListener).not.toHaveBeenCalled();
+        expect(windowListener).not.toHaveBeenCalled();
+        expect(timer).not.toHaveBeenCalled();
+        expect(interval).not.toHaveBeenCalled();
+        expect(observe).not.toHaveBeenCalled();
+        expect(reset).not.toHaveBeenCalled();
+        if (request) expect(request).not.toHaveBeenCalled();
+        expect({
+            styles: document.querySelectorAll('style, link[rel="stylesheet"]').length,
+            resets: JC.identity.getResetHandlerCount(),
+            api: JC.core.themeStudio,
+        }).toEqual(before);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/feature.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/feature.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createTestFeatureScope } from '../test/feature-scope';
+import { COMMITTED_STYLE_ID } from './styles';
+
+afterEach(() => {
+    document.getElementById(COMMITTED_STYLE_ID)?.remove();
+    document.documentElement.removeAttribute('data-jc-theme-active');
+    vi.unstubAllGlobals();
+});
+
+describe('Theme Studio feature activation boundary', () => {
+    it('clears presentation and acquired resources when activation throws', async () => {
+        const stale = document.createElement('style');
+        stale.id = COMMITTED_STYLE_ID;
+        document.head.append(stale);
+        document.documentElement.setAttribute('data-jc-theme-active', 'true');
+        vi.stubGlobal('matchMedia', undefined);
+        vi.stubGlobal('MutationObserver', class {
+            constructor() { throw new Error('observer unavailable'); }
+        });
+        const harness = createTestFeatureScope();
+        const { themeStudioFeature } = await import('./feature');
+
+        await expect(themeStudioFeature.activate(harness.scope)).rejects.toThrow('observer unavailable');
+        expect(document.getElementById(COMMITTED_STYLE_ID)).toBeNull();
+        expect(document.documentElement.hasAttribute('data-jc-theme-active')).toBe(false);
+        await harness.dispose();
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/feature.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/feature.ts
@@ -1,0 +1,36 @@
+import type { FeatureLoaderState, FeatureModule, FeatureScope } from '../core/feature-loader';
+import { JC } from '../globals';
+import { ThemeStudioRuntime } from './runtime';
+
+export function isThemeStudioEnabled(state: FeatureLoaderState): boolean {
+    return Boolean(state.identity) && JC.pluginConfig?.ThemeStudioEnabled === true;
+}
+
+let activeRuntime: ThemeStudioRuntime | null = null;
+
+export const themeStudioFeature: FeatureModule = Object.freeze({
+    async activate(scope: FeatureScope): Promise<void> {
+        if (!scope.isCurrent()) return;
+        activeRuntime?.dispose();
+        const runtime = new ThemeStudioRuntime(scope);
+        activeRuntime = runtime;
+        scope.track(() => {
+            runtime.dispose();
+            if (activeRuntime === runtime) activeRuntime = null;
+        });
+        try {
+            runtime.install();
+            if (!scope.isCurrent()) {
+                runtime.dispose();
+                return;
+            }
+            await runtime.load();
+            if (!scope.isCurrent()) runtime.dispose();
+        } catch (error) {
+            runtime.dispose();
+            throw error;
+        }
+    },
+});
+
+export const activate: FeatureModule['activate'] = (scope) => themeStudioFeature.activate(scope);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/resolver.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/resolver.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { ThemeMediaState } from './resolver';
 import { resolveBreakpoint, resolveTheme } from './resolver';
 import { themeConfiguration } from '../test/theme-studio-fixture';
+import { contrastRatio } from './color';
 
 function media(overrides: Partial<ThemeMediaState> = {}): ThemeMediaState {
     return {
@@ -64,6 +65,8 @@ describe('Theme Studio resolver', () => {
 
     it('can only reduce motion/transparency and strengthens focus for system contrast', () => {
         const configuration = themeConfiguration();
+        configuration.Profiles[0].Accessibility.Motion = 'on';
+        configuration.Profiles[0].Accessibility.Transparency = 'on';
         const resolved = resolveTheme(configuration, media({
             reducedMotion: true,
             reducedTransparency: true,
@@ -86,6 +89,47 @@ describe('Theme Studio resolver', () => {
             'effects.blur': 0,
             'layout.card-actions': 'always',
         });
+    });
+
+    it('also reduces effects when the profile requests it without an OS preference', () => {
+        const configuration = themeConfiguration();
+        configuration.Profiles[0].Accessibility.Motion = 'off';
+        configuration.Profiles[0].Accessibility.Transparency = 'off';
+        const resolved = resolveTheme(configuration, media());
+        expect(resolved).toMatchObject({ reducedMotion: true, reducedTransparency: true });
+    });
+
+    it('pairs every bundled accent with a WCAG-readable primary foreground', () => {
+        for (const accent of [
+            'violet', 'blue', 'cyan', 'teal', 'green', 'amber', 'orange', 'red', 'pink', 'neutral',
+        ]) {
+            for (const mode of ['dark', 'light'] as const) {
+                const configuration = themeConfiguration();
+                configuration.Profiles[0].Accent = accent;
+                configuration.Profiles[0].Mode = mode;
+                const resolved = resolveTheme(configuration, media());
+                expect(contrastRatio(
+                    String(resolved.tokens['color.on-primary']),
+                    String(resolved.tokens['color.primary']),
+                    String(resolved.tokens['color.surface']),
+                ), `${accent}/${mode}`).toBeGreaterThanOrEqual(4.5);
+            }
+        }
+    });
+
+    it('corrects an unreadable custom primary foreground after alpha composition', () => {
+        const configuration = themeConfiguration();
+        configuration.Profiles[0].Tokens = {
+            'color.primary': '#FFFFFF80',
+            'color.on-primary': '#FFFFFF',
+        };
+        const resolved = resolveTheme(configuration, media({ jellyfinTheme: 'light' }));
+        expect(resolved.tokens['color.on-primary']).toBe('#000000');
+        expect(contrastRatio(
+            String(resolved.tokens['color.on-primary']),
+            String(resolved.tokens['color.primary']),
+            String(resolved.tokens['color.surface']),
+        )).toBeGreaterThanOrEqual(4.5);
     });
 
     it('selects the highest-priority seasonal profile across a year boundary', () => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/resolver.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/resolver.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import type { ThemeMediaState } from './resolver';
+import { resolveBreakpoint, resolveTheme } from './resolver';
+import { themeConfiguration } from '../test/theme-studio-fixture';
+
+function media(overrides: Partial<ThemeMediaState> = {}): ThemeMediaState {
+    return {
+        viewportWidth: 1280,
+        viewportHeight: 800,
+        tv: false,
+        darkScheme: true,
+        reducedMotion: false,
+        moreContrast: false,
+        reducedTransparency: false,
+        forcedColors: false,
+        hover: true,
+        coarsePointer: false,
+        jellyfinTheme: 'dark',
+        ...overrides,
+    };
+}
+
+describe('Theme Studio resolver', () => {
+    it('uses named phone, tablet, desktop, wide and TV scopes at exact boundaries', () => {
+        expect(resolveBreakpoint(media({ viewportWidth: 390 }))).toBe('phone');
+        expect(resolveBreakpoint(media({ viewportWidth: 599 }))).toBe('phone');
+        expect(resolveBreakpoint(media({ viewportWidth: 600 }))).toBe('tablet');
+        expect(resolveBreakpoint(media({ viewportWidth: 1023 }))).toBe('tablet');
+        expect(resolveBreakpoint(media({ viewportWidth: 1024 }))).toBe('desktop');
+        expect(resolveBreakpoint(media({ viewportWidth: 1599 }))).toBe('desktop');
+        expect(resolveBreakpoint(media({ viewportWidth: 1600 }))).toBe('wide');
+        expect(resolveBreakpoint(media({ viewportWidth: 390, tv: true }))).toBe('tv');
+        expect(resolveBreakpoint(media({
+            viewportWidth: 844, viewportHeight: 390, coarsePointer: true,
+        }))).toBe('phone');
+        expect(resolveBreakpoint(media({
+            viewportWidth: 1024, viewportHeight: 768, coarsePointer: true,
+        }))).toBe('tablet');
+        expect(resolveBreakpoint(media({
+            viewportWidth: 1366, viewportHeight: 768, coarsePointer: true,
+        }))).toBe('desktop');
+    });
+
+    it('merges the active responsive scope after profile tokens', () => {
+        const configuration = themeConfiguration();
+        configuration.Profiles[0].Tokens = { 'space.page-gutter': 2, 'layout.navigation': 'header' };
+        configuration.Profiles[0].Responsive.Phone = {
+            Tokens: { 'space.page-gutter': 0.5, 'layout.navigation': 'bottom' },
+        };
+        const phone = resolveTheme(configuration, media({ viewportWidth: 390 }));
+        const desktop = resolveTheme(configuration, media({ viewportWidth: 1440 }));
+        expect(phone.tokens['space.page-gutter']).toBe(0.5);
+        expect(phone.tokens['layout.navigation']).toBe('bottom');
+        expect(desktop.tokens['space.page-gutter']).toBe(2);
+        expect(desktop.tokens['layout.navigation']).toBe('header');
+    });
+
+    it('follows Jellyfin data-theme for system mode without owning it', () => {
+        const configuration = themeConfiguration();
+        expect(resolveTheme(configuration, media({ jellyfinTheme: 'light', darkScheme: true })).mode).toBe('light');
+        expect(resolveTheme(configuration, media({ jellyfinTheme: 'dark', darkScheme: false })).mode).toBe('dark');
+        expect(resolveTheme(configuration, media({ jellyfinTheme: '', darkScheme: false })).mode).toBe('light');
+    });
+
+    it('can only reduce motion/transparency and strengthens focus for system contrast', () => {
+        const configuration = themeConfiguration();
+        const resolved = resolveTheme(configuration, media({
+            reducedMotion: true,
+            reducedTransparency: true,
+            moreContrast: true,
+            hover: false,
+            coarsePointer: true,
+        }));
+        expect(resolved).toMatchObject({
+            reducedMotion: true,
+            reducedTransparency: true,
+            highContrast: true,
+            focus: 'strong',
+            coarsePointer: true,
+        });
+        expect(resolved.tokens).toMatchObject({
+            'motion.profile': 'off',
+            'motion.duration-scale': 0,
+            'motion.hover-lift': 0,
+            'effects.material': 'solid',
+            'effects.blur': 0,
+            'layout.card-actions': 'always',
+        });
+    });
+
+    it('selects the highest-priority seasonal profile across a year boundary', () => {
+        const configuration = themeConfiguration();
+        configuration.Profiles.push({
+            ...structuredClone(configuration.Profiles[0]),
+            Id: 'winter',
+            Name: 'Winter',
+            BasePreset: 'oled',
+        });
+        configuration.Schedule = [{
+            Id: 'winter-run',
+            ProfileId: 'winter',
+            StartMonthDay: '12-15',
+            EndMonthDay: '01-10',
+            Priority: 80,
+            Enabled: true,
+        }];
+        expect(resolveTheme(configuration, media(), { now: new Date(2026, 0, 2) }).profileId).toBe('winter');
+        expect(resolveTheme(configuration, media(), {
+            now: new Date(2026, 0, 2), allowScheduling: false,
+        }).profileId).toBe('default');
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/resolver.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/resolver.test.ts
@@ -112,6 +112,7 @@ describe('Theme Studio resolver', () => {
                     String(resolved.tokens['color.on-primary']),
                     String(resolved.tokens['color.primary']),
                     String(resolved.tokens['color.surface']),
+                    String(resolved.tokens['color.canvas']),
                 ), `${accent}/${mode}`).toBeGreaterThanOrEqual(4.5);
             }
         }
@@ -129,6 +130,25 @@ describe('Theme Studio resolver', () => {
             String(resolved.tokens['color.on-primary']),
             String(resolved.tokens['color.primary']),
             String(resolved.tokens['color.surface']),
+            String(resolved.tokens['color.canvas']),
+        )).toBeGreaterThanOrEqual(4.5);
+    });
+
+    it('composites translucent custom surfaces over the canvas before choosing a foreground', () => {
+        const configuration = themeConfiguration();
+        configuration.Profiles[0].Tokens = {
+            'color.canvas': '#FFFFFF',
+            'color.surface': '#FFFFFF00',
+            'color.primary': '#00000080',
+            'color.on-primary': '#FFFFFF',
+        };
+        const resolved = resolveTheme(configuration, media());
+        expect(resolved.tokens['color.on-primary']).toBe('#000000');
+        expect(contrastRatio(
+            String(resolved.tokens['color.on-primary']),
+            String(resolved.tokens['color.primary']),
+            String(resolved.tokens['color.surface']),
+            String(resolved.tokens['color.canvas']),
         )).toBeGreaterThanOrEqual(4.5);
     });
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/resolver.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/resolver.ts
@@ -1,0 +1,309 @@
+import type { ThemeProfile, ThemeTokenValue, UserThemeConfiguration } from '../types/jc';
+
+export type ThemeBreakpoint = 'phone' | 'tablet' | 'desktop' | 'wide' | 'tv';
+export type ResolvedThemeMode = 'dark' | 'light';
+
+export interface ThemeMediaState {
+    readonly viewportWidth: number;
+    readonly viewportHeight: number;
+    readonly tv: boolean;
+    readonly darkScheme: boolean;
+    readonly reducedMotion: boolean;
+    readonly moreContrast: boolean;
+    readonly reducedTransparency: boolean;
+    readonly forcedColors: boolean;
+    readonly hover: boolean;
+    readonly coarsePointer: boolean;
+    readonly jellyfinTheme: string;
+}
+
+export interface ResolveThemeOptions {
+    readonly allowScheduling?: boolean;
+    readonly now?: Date;
+}
+
+export interface ResolvedTheme {
+    readonly profileId: string;
+    readonly preset: string;
+    readonly palette: string;
+    readonly mode: ResolvedThemeMode;
+    readonly breakpoint: ThemeBreakpoint;
+    readonly reducedMotion: boolean;
+    readonly highContrast: boolean;
+    readonly reducedTransparency: boolean;
+    readonly forcedColors: boolean;
+    readonly hover: boolean;
+    readonly coarsePointer: boolean;
+    readonly focus: 'standard' | 'strong';
+    readonly underlineLinks: boolean;
+    readonly tokens: Readonly<Record<string, ThemeTokenValue>>;
+}
+
+const DARK_COLORS: Readonly<Record<string, ThemeTokenValue>> = Object.freeze({
+    'color.canvas': '#0B0B12',
+    'color.surface': '#171722',
+    'color.elevated': '#222232',
+    'color.overlay': '#0C0C12E6',
+    'color.text': '#F6F4FF',
+    'color.text-muted': '#B7B3C7',
+    'color.primary': '#8F76FF',
+    'color.on-primary': '#FFFFFF',
+    'color.secondary': '#45D6C2',
+    'color.positive': '#58D68D',
+    'color.caution': '#F6C85F',
+    'color.negative': '#FF6B79',
+    'color.info': '#62A9FF',
+    'color.divider': '#FFFFFF24',
+    'color.focus': '#C7B8FF',
+});
+
+const LIGHT_COLORS: Readonly<Record<string, ThemeTokenValue>> = Object.freeze({
+    'color.canvas': '#F6F5FA',
+    'color.surface': '#FFFFFF',
+    'color.elevated': '#ECEAF3',
+    'color.overlay': '#F8F7FBEF',
+    'color.text': '#1C1A24',
+    'color.text-muted': '#625E70',
+    'color.primary': '#6048D8',
+    'color.on-primary': '#FFFFFF',
+    'color.secondary': '#087F73',
+    'color.positive': '#147D45',
+    'color.caution': '#8A5A00',
+    'color.negative': '#B42335',
+    'color.info': '#145DA0',
+    'color.divider': '#1C1A2429',
+    'color.focus': '#4C32C3',
+});
+
+const BASE_TOKENS: Readonly<Record<string, ThemeTokenValue>> = Object.freeze({
+    'type.family-ui': 'system',
+    'type.family-display': 'system',
+    'type.family-reading': 'system',
+    'type.scale': 1,
+    'type.line-height': 1.45,
+    'type.tracking': 0,
+    'type.max-reading-width': 68,
+    'shape.radius-scale': 'rounded',
+    'shape.card-radius': 'rounded',
+    'shape.control-radius': 'rounded',
+    'shape.dialog-radius': 'rounded',
+    'shape.avatar-shape': 'circle',
+    'shape.border-width': 1,
+    'elevation.glow-intensity': 0.15,
+    'elevation.surface-shadow': 'soft',
+    'elevation.card-shadow': 'soft',
+    'elevation.dialog-shadow': 'medium',
+    'elevation.focus-ring': 'medium',
+    'space.scale': 'cozy',
+    'space.page-gutter': 1,
+    'space.section-gap': 1,
+    'space.card-gap': 1,
+    'space.control-gap': 1,
+    'layout.density': 'cozy',
+    'layout.navigation': 'auto',
+    'layout.home-hero': 'compact',
+    'layout.details': 'classic',
+    'layout.seasons': 'auto',
+    'layout.card-actions': 'hover',
+    'layout.poster-ratio': 'auto',
+    'layout.cast-shape': 'circle',
+    'effects.level': 'balanced',
+    'effects.material': 'translucent',
+    'effects.blur': 12,
+    'effects.saturation': 1,
+    'effects.backdrop-opacity': 0.82,
+    'effects.glow': 0.15,
+    'effects.image-treatment': 'gradient',
+    'motion.profile': 'system',
+    'motion.duration-scale': 1,
+    'motion.easing': 'smooth',
+    'motion.hover-lift': 3,
+    'motion.page-transition': true,
+    'motion.stagger': true,
+    'progress.position': 'bottom',
+    'progress.thickness': 4,
+    'progress.watched-indicator': 'check',
+    'progress.unwatched-indicator': 'corner',
+    'player.osd-density': 'standard',
+    'player.control-material': 'translucent',
+    'player.pause-screen-material': 'translucent',
+    'player.subtitle-backdrop': 'shadow',
+    'player.trickplay-shape': 'rounded',
+    'icon.family': 'system',
+    'icon.weight': 'regular',
+    'icon.size-scale': 1,
+    'icon.multicolor-metadata': true,
+    'accessibility.underline-links': false,
+    'accessibility.contrast': 'system',
+    'accessibility.motion': 'system',
+    'accessibility.transparency': 'system',
+    'accessibility.focus-emphasis': 'system',
+    'accessibility.text-scale': 1,
+});
+
+const ACCENTS: Readonly<Record<string, string>> = Object.freeze({
+    violet: '#8F76FF', blue: '#4B9DFF', cyan: '#35C5E8', teal: '#31BFAE',
+    green: '#58C878', amber: '#E4A93A', orange: '#F08043', red: '#EF6371',
+    pink: '#E76AAA', neutral: '#9290A0',
+});
+
+function presetTokens(name: string, mode: ResolvedThemeMode): Record<string, ThemeTokenValue> {
+    switch (name) {
+        case 'minimal': return {
+            'effects.level': 'minimal', 'effects.material': 'solid', 'effects.blur': 0,
+            'effects.glow': 0, 'elevation.card-shadow': 'none', 'motion.profile': 'calm',
+        };
+        case 'cinematic': return {
+            'layout.home-hero': 'cinematic', 'layout.details': 'cinematic',
+            'effects.level': 'full', 'effects.image-treatment': 'gradient',
+            'elevation.card-shadow': 'strong', 'motion.profile': 'expressive',
+        };
+        case 'glass': return {
+            'effects.level': 'full', 'effects.material': 'glass', 'effects.blur': 24,
+            'effects.saturation': 1.2, 'effects.backdrop-opacity': 0.66,
+        };
+        case 'material': return {
+            'shape.card-radius': 'subtle', 'shape.control-radius': 'subtle',
+            'effects.material': 'solid', 'elevation.card-shadow': 'medium',
+        };
+        case 'studio': return {
+            'layout.density': 'compact', 'space.scale': 'compact',
+            'effects.level': 'minimal', 'effects.material': 'solid', 'effects.blur': 0,
+        };
+        case 'tv-focus': return {
+            'layout.density': 'spacious', 'space.scale': 'spacious',
+            'layout.card-actions': 'always', 'elevation.focus-ring': 'strong',
+            'accessibility.focus-emphasis': 'strong', 'icon.size-scale': 1.2,
+        };
+        case 'oled': return mode === 'dark' ? {
+            'color.canvas': '#000000', 'color.surface': '#080808', 'color.elevated': '#121212',
+            'effects.material': 'solid', 'effects.blur': 0,
+        } : {};
+        case 'high-contrast': return {
+            'effects.material': 'solid', 'effects.blur': 0, 'effects.glow': 0,
+            'shape.border-width': 2, 'elevation.focus-ring': 'strong',
+            'accessibility.contrast': 'on', 'accessibility.focus-emphasis': 'strong',
+        };
+        default: return {};
+    }
+}
+
+export function resolveBreakpoint(media: Pick<ThemeMediaState,
+    'viewportWidth' | 'viewportHeight' | 'tv' | 'coarsePointer'>): ThemeBreakpoint {
+    if (media.tv) return 'tv';
+    if (media.viewportWidth < 600
+        || (media.coarsePointer && media.viewportHeight < 600 && media.viewportWidth < 1000)) return 'phone';
+    if (media.viewportWidth < 1024
+        || (media.coarsePointer && media.viewportWidth <= 1180 && media.viewportHeight >= 600)) return 'tablet';
+    if (media.viewportWidth < 1600) return 'desktop';
+    return 'wide';
+}
+
+function scheduledProfile(configuration: UserThemeConfiguration, now: Date): ThemeProfile | null {
+    const current = `${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+    const eligible = configuration.Schedule.filter((entry) => {
+        if (!entry.Enabled) return false;
+        return entry.StartMonthDay <= entry.EndMonthDay
+            ? current >= entry.StartMonthDay && current <= entry.EndMonthDay
+            : current >= entry.StartMonthDay || current <= entry.EndMonthDay;
+    }).sort((left, right) => right.Priority - left.Priority || left.Id.localeCompare(right.Id));
+    const selected = eligible[0];
+    return selected ? configuration.Profiles.find((item) => item.Id === selected.ProfileId) ?? null : null;
+}
+
+function selectProfile(configuration: UserThemeConfiguration, options: ResolveThemeOptions): ThemeProfile {
+    const scheduled = options.allowScheduling === false
+        ? null
+        : scheduledProfile(configuration, options.now ?? new Date());
+    return scheduled ?? configuration.Profiles.find((item) => item.Id === configuration.ActiveProfileId)
+        ?? configuration.Profiles[0];
+}
+
+function systemChoice(value: 'system' | 'on' | 'off', system: boolean): boolean {
+    return value === 'on' || (value === 'system' && system);
+}
+
+function responsiveTokens(profile: ThemeProfile, breakpoint: ThemeBreakpoint): Record<string, ThemeTokenValue> {
+    const scope = breakpoint === 'phone' ? profile.Responsive.Phone
+        : breakpoint === 'tablet' ? profile.Responsive.Tablet
+            : breakpoint === 'desktop' ? profile.Responsive.Desktop
+                : breakpoint === 'wide' ? profile.Responsive.Wide : profile.Responsive.Tv;
+    return scope?.Tokens ?? {};
+}
+
+/** Pure, deterministic profile + capability resolution. */
+export function resolveTheme(
+    configuration: UserThemeConfiguration,
+    media: ThemeMediaState,
+    options: ResolveThemeOptions = {},
+): ResolvedTheme {
+    const profile = selectProfile(configuration, options);
+    const mode: ResolvedThemeMode = profile.Mode === 'light' ? 'light'
+        : profile.Mode === 'dark' ? 'dark'
+            : media.jellyfinTheme.toLowerCase().includes('light') || (!media.jellyfinTheme && !media.darkScheme)
+                ? 'light' : 'dark';
+    const breakpoint = resolveBreakpoint(media);
+    const tokens: Record<string, ThemeTokenValue> = {
+        ...BASE_TOKENS,
+        ...(mode === 'dark' ? DARK_COLORS : LIGHT_COLORS),
+        ...(ACCENTS[profile.Accent] ? { 'color.primary': ACCENTS[profile.Accent] } : {}),
+        ...presetTokens(profile.BasePreset, mode),
+        ...profile.Tokens,
+        ...responsiveTokens(profile, breakpoint),
+    };
+
+    const reducedMotion = systemChoice(profile.Accessibility.Motion === 'off' ? 'on'
+        : profile.Accessibility.Motion === 'on' ? 'off' : 'system', media.reducedMotion);
+    const highContrast = profile.BasePreset === 'high-contrast'
+        || systemChoice(profile.Accessibility.Contrast, media.moreContrast);
+    const reducedTransparency = systemChoice(profile.Accessibility.Transparency === 'off' ? 'on'
+        : profile.Accessibility.Transparency === 'on' ? 'off' : 'system', media.reducedTransparency);
+    const focus = profile.Accessibility.FocusEmphasis === 'strong'
+        || (profile.Accessibility.FocusEmphasis === 'system' && highContrast) ? 'strong' : 'standard';
+    const underlineLinks = profile.Accessibility.UnderlineLinks
+        || tokens['accessibility.underline-links'] === true;
+
+    tokens['accessibility.motion'] = reducedMotion ? 'off' : 'on';
+    tokens['accessibility.contrast'] = highContrast ? 'on' : 'off';
+    tokens['accessibility.transparency'] = reducedTransparency ? 'off' : 'on';
+    tokens['accessibility.focus-emphasis'] = focus;
+    tokens['accessibility.underline-links'] = underlineLinks;
+    if (reducedMotion) {
+        tokens['motion.profile'] = 'off';
+        tokens['motion.duration-scale'] = 0;
+        tokens['motion.hover-lift'] = 0;
+        tokens['motion.page-transition'] = false;
+        tokens['motion.stagger'] = false;
+    }
+    if (reducedTransparency) {
+        tokens['effects.material'] = 'solid';
+        tokens['effects.blur'] = 0;
+        tokens['effects.saturation'] = 1;
+        tokens['effects.backdrop-opacity'] = 1;
+    }
+    if (media.coarsePointer || !media.hover) {
+        tokens['layout.card-actions'] = 'always';
+        tokens['motion.hover-lift'] = 0;
+    }
+    if (highContrast) {
+        tokens['shape.border-width'] = Math.max(2, Number(tokens['shape.border-width']) || 0);
+        tokens['elevation.focus-ring'] = 'strong';
+    }
+
+    return Object.freeze({
+        profileId: profile.Id,
+        preset: profile.BasePreset,
+        palette: profile.Palette,
+        mode,
+        breakpoint,
+        reducedMotion,
+        highContrast,
+        reducedTransparency,
+        forcedColors: media.forcedColors,
+        hover: media.hover,
+        coarsePointer: media.coarsePointer,
+        focus,
+        underlineLinks,
+        tokens: Object.freeze(tokens),
+    });
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/resolver.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/resolver.ts
@@ -256,6 +256,7 @@ export function resolveTheme(
         String(tokens['color.primary']),
         String(tokens['color.on-primary']),
         String(tokens['color.surface']),
+        String(tokens['color.canvas']),
     );
 
     const reducedMotion = media.reducedMotion || profile.Accessibility.Motion === 'off';

--- a/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/resolver.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/resolver.ts
@@ -1,4 +1,5 @@
 import type { ThemeProfile, ThemeTokenValue, UserThemeConfiguration } from '../types/jc';
+import { readableForeground } from './color';
 
 export type ThemeBreakpoint = 'phone' | 'tablet' | 'desktop' | 'wide' | 'tv';
 export type ResolvedThemeMode = 'dark' | 'light';
@@ -251,13 +252,17 @@ export function resolveTheme(
         ...profile.Tokens,
         ...responsiveTokens(profile, breakpoint),
     };
+    tokens['color.on-primary'] = readableForeground(
+        String(tokens['color.primary']),
+        String(tokens['color.on-primary']),
+        String(tokens['color.surface']),
+    );
 
-    const reducedMotion = systemChoice(profile.Accessibility.Motion === 'off' ? 'on'
-        : profile.Accessibility.Motion === 'on' ? 'off' : 'system', media.reducedMotion);
+    const reducedMotion = media.reducedMotion || profile.Accessibility.Motion === 'off';
     const highContrast = profile.BasePreset === 'high-contrast'
         || systemChoice(profile.Accessibility.Contrast, media.moreContrast);
-    const reducedTransparency = systemChoice(profile.Accessibility.Transparency === 'off' ? 'on'
-        : profile.Accessibility.Transparency === 'on' ? 'off' : 'system', media.reducedTransparency);
+    const reducedTransparency = media.reducedTransparency
+        || profile.Accessibility.Transparency === 'off';
     const focus = profile.Accessibility.FocusEmphasis === 'strong'
         || (profile.Accessibility.FocusEmphasis === 'system' && highContrast) ? 'strong' : 'standard';
     const underlineLinks = profile.Accessibility.UnderlineLinks

--- a/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/runtime.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/runtime.test.ts
@@ -1,0 +1,274 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../globals';
+import { createTestFeatureScope, type TestFeatureScope } from '../test/feature-scope';
+import { themeConfiguration } from '../test/theme-studio-fixture';
+import type { ApiApi } from '../types/jc';
+import { ThemeStudioRuntime } from './runtime';
+import { COMMITTED_STYLE_ID, PREVIEW_STYLE_ID } from './styles';
+
+interface MutableMediaQueryList extends MediaQueryList {
+    setMatches(value: boolean): void;
+}
+
+function mediaHarness(): {
+    matchMedia: (query: string) => MediaQueryList;
+    set(query: string, matches: boolean): void;
+} {
+    const lists = new Map<string, MutableMediaQueryList>();
+    const matchMedia = (query: string): MediaQueryList => {
+        const existing = lists.get(query);
+        if (existing) return existing;
+        let matches = query === '(prefers-color-scheme: dark)' || query === '(hover: hover)';
+        const listeners = new Set<(event: MediaQueryListEvent) => void>();
+        const list = {
+            media: query,
+            get matches() { return matches; },
+            onchange: null,
+            addEventListener: (_name: string, listener: EventListenerOrEventListenerObject) => {
+                listeners.add(listener as (event: MediaQueryListEvent) => void);
+            },
+            removeEventListener: (_name: string, listener: EventListenerOrEventListenerObject) => {
+                listeners.delete(listener as (event: MediaQueryListEvent) => void);
+            },
+            addListener: (listener: (event: MediaQueryListEvent) => void) => listeners.add(listener),
+            removeListener: (listener: (event: MediaQueryListEvent) => void) => listeners.delete(listener),
+            dispatchEvent: () => true,
+            setMatches(value: boolean) {
+                matches = value;
+                const event = { matches, media: query } as MediaQueryListEvent;
+                for (const listener of listeners) listener(event);
+            },
+        } as unknown as MutableMediaQueryList;
+        lists.set(query, list);
+        return list;
+    };
+    return {
+        matchMedia,
+        set(query, matches) { (matchMedia(query) as MutableMediaQueryList).setMatches(matches); },
+    };
+}
+
+function eventsHarness(): JellyfinEvents {
+    const handlers = new Map<string, Set<(...args: unknown[]) => void>>();
+    return {
+        on(_target, name, handler) {
+            const set = handlers.get(name) ?? new Set();
+            set.add(handler);
+            handlers.set(name, set);
+        },
+        off(_target, name, handler) { handlers.get(name)?.delete(handler); },
+        trigger(_target, name, args = []) {
+            for (const handler of handlers.get(name) ?? []) handler(...args);
+        },
+    };
+}
+
+const scopes: TestFeatureScope[] = [];
+let originalApi: ApiApi | undefined;
+let originalEvents: JellyfinEvents | undefined;
+let originalRemember: typeof JC.rememberUserSettingsSnapshot;
+
+beforeEach(() => {
+    originalApi = JC.core.api;
+    originalEvents = window.Events;
+    originalRemember = JC.rememberUserSettingsSnapshot;
+    window.Events = eventsHarness();
+    const media = mediaHarness();
+    vi.stubGlobal('matchMedia', media.matchMedia);
+    Object.defineProperty(window, 'innerWidth', { value: 390, configurable: true, writable: true });
+    Object.defineProperty(window, 'innerHeight', { value: 844, configurable: true, writable: true });
+    history.replaceState({}, '', '/web/#/home');
+    document.documentElement.setAttribute('data-theme', 'dark');
+    document.documentElement.classList.remove('layout-tv');
+    document.body.className = '';
+    JC.pluginConfig = {
+        ThemeStudioEnabled: true,
+        ThemeStudioDashboardEnabled: false,
+        ThemeStudioAllowSeasonalScheduling: true,
+    };
+    JC.rememberUserSettingsSnapshot = vi.fn();
+    (window as unknown as { __themeMedia: ReturnType<typeof mediaHarness> }).__themeMedia = media;
+});
+
+afterEach(async () => {
+    while (scopes.length > 0) await scopes.pop()?.dispose();
+    JC.core.api = originalApi;
+    window.Events = originalEvents;
+    JC.rememberUserSettingsSnapshot = originalRemember;
+    delete (window as unknown as { __themeMedia?: unknown }).__themeMedia;
+    delete JC.core.themeStudio;
+    document.getElementById(COMMITTED_STYLE_ID)?.remove();
+    document.getElementById(PREVIEW_STYLE_ID)?.remove();
+    for (const name of [...document.documentElement.attributes].map((item) => item.name)) {
+        if (name.startsWith('data-jc-theme-')) document.documentElement.removeAttribute(name);
+    }
+    document.documentElement.removeAttribute('data-theme');
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+function apiReturning(value: unknown): ReturnType<typeof vi.fn> {
+    const plugin = vi.fn().mockResolvedValue(value);
+    JC.core.api = { plugin } as unknown as ApiApi;
+    return plugin;
+}
+
+function createRuntime(): { runtime: ThemeStudioRuntime; harness: TestFeatureScope } {
+    const harness = createTestFeatureScope();
+    scopes.push(harness);
+    const runtime = new ThemeStudioRuntime(harness.scope);
+    harness.scope.track(runtime);
+    runtime.install();
+    return { runtime, harness };
+}
+
+describe('Theme Studio identity-owned runtime', () => {
+    it('loads once, applies one committed layer, and follows host theme/media changes live', async () => {
+        const plugin = apiReturning(themeConfiguration());
+        const { runtime } = createRuntime();
+        await runtime.load();
+
+        const expectedRequestOptions: Record<string, unknown> = {
+            skipCache: true,
+            timeoutMs: 10_000,
+            signal: expect.any(AbortSignal),
+        };
+        expect(plugin).toHaveBeenCalledOnce();
+        expect(plugin).toHaveBeenCalledWith(
+            '/user-settings/user-a/theme.json',
+            expect.objectContaining(expectedRequestOptions),
+        );
+        expect(document.querySelectorAll(`#${COMMITTED_STYLE_ID}`)).toHaveLength(1);
+        expect(document.getElementById(PREVIEW_STYLE_ID)).toBeNull();
+        expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+        expect(document.documentElement.getAttribute('data-jc-theme-active')).toBe('true');
+        expect(document.documentElement.getAttribute('data-jc-theme-breakpoint')).toBe('phone');
+        expect(document.documentElement.getAttribute('data-jc-theme-route')).toBe('home');
+        expect(document.getElementById(COMMITTED_STYLE_ID)?.textContent)
+            .toContain('--jf-palette-background-default: #0B0B12');
+        expect(JC.rememberUserSettingsSnapshot).toHaveBeenCalledWith(
+            'theme.json', expect.objectContaining({ Revision: 3 }),
+        );
+
+        document.documentElement.setAttribute('data-theme', 'light');
+        window.Events?.trigger(document, 'THEME_CHANGE');
+        expect(document.documentElement.getAttribute('data-jc-theme-mode')).toBe('light');
+        expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+
+        const media = (window as unknown as { __themeMedia: ReturnType<typeof mediaHarness> }).__themeMedia;
+        media.set('(prefers-reduced-motion: reduce)', true);
+        expect(document.documentElement.getAttribute('data-jc-theme-motion')).toBe('reduced');
+        expect(document.getElementById(COMMITTED_STYLE_ID)?.textContent)
+            .toContain('animation-duration: 0.01ms !important');
+
+        window.innerWidth = 800;
+        window.innerHeight = 600;
+        media.set('(min-width: 600px) and (max-width: 1023px)', true);
+        expect(document.documentElement.getAttribute('data-jc-theme-breakpoint')).toBe('tablet');
+        expect(runtime.getDiagnostics()).toMatchObject({ status: 'active', breakpoint: 'tablet', revision: 3 });
+
+        window.innerWidth = 844;
+        window.innerHeight = 390;
+        media.set('(pointer: coarse)', true);
+        media.set('(orientation: landscape) and (max-height: 599px) and (max-width: 999px) and (pointer: coarse)', true);
+        expect(document.documentElement.getAttribute('data-jc-theme-breakpoint')).toBe('phone');
+    });
+
+    it('owns a later preview layer and cancels it without disturbing committed state', async () => {
+        apiReturning(themeConfiguration());
+        const { runtime } = createRuntime();
+        await runtime.load();
+        const currentApi = JC.core.themeStudio;
+        const preview = themeConfiguration();
+        preview.Profiles[0].Tokens = { 'shape.card-radius': 'pill' };
+        expect(JC.core.themeStudio?.preview(preview)).toBe(true);
+        expect(document.querySelectorAll(`#${PREVIEW_STYLE_ID}`)).toHaveLength(1);
+        expect(document.documentElement.getAttribute('data-jc-theme-preview')).toBe('true');
+        expect(document.getElementById(PREVIEW_STYLE_ID)?.textContent)
+            .toContain('--jf-card-borderRadius: 999px');
+        expect(JC.core.themeStudio?.getDiagnostics().status).toBe('preview');
+
+        JC.core.themeStudio?.cancelPreview();
+        expect(document.getElementById(PREVIEW_STYLE_ID)).toBeNull();
+        expect(document.documentElement.hasAttribute('data-jc-theme-preview')).toBe(false);
+        expect(document.getElementById(COMMITTED_STYLE_ID)).not.toBeNull();
+        expect(JC.core.themeStudio?.getDiagnostics().status).toBe('active');
+        expect(currentApi).toBe(JC.core.themeStudio);
+    });
+
+    it('keeps the dashboard as an unthemed recovery space unless explicitly enabled', async () => {
+        history.replaceState({}, '', '/web/#/dashboard');
+        apiReturning(themeConfiguration());
+        const { runtime } = createRuntime();
+        await runtime.load();
+        expect(document.getElementById(COMMITTED_STYLE_ID)).toBeNull();
+        expect(document.documentElement.hasAttribute('data-jc-theme-active')).toBe(false);
+        expect(runtime.getDiagnostics().status).toBe('inactive');
+
+        JC.pluginConfig.ThemeStudioDashboardEnabled = true;
+        runtime.refresh();
+        expect(document.getElementById(COMMITTED_STYLE_ID)).not.toBeNull();
+        expect(document.documentElement.getAttribute('data-jc-theme-active')).toBe('true');
+    });
+
+    it('removes presentation synchronously on identity reset and read/validation failure', async () => {
+        apiReturning(themeConfiguration());
+        const first = createRuntime();
+        await first.runtime.load();
+        const hostTheme = document.documentElement.getAttribute('data-theme');
+        JC.identity.transition('runtime-server', `runtime-user-${Math.random()}`, 'runtime-test');
+        expect(document.getElementById(COMMITTED_STYLE_ID)).toBeNull();
+        expect(document.documentElement.hasAttribute('data-jc-theme-active')).toBe(false);
+        expect(document.documentElement.getAttribute('data-theme')).toBe(hostTheme);
+        expect(JC.core.themeStudio).toBeUndefined();
+
+        const stale = document.createElement('style');
+        stale.id = COMMITTED_STYLE_ID;
+        document.head.append(stale);
+        document.documentElement.setAttribute('data-jc-theme-active', 'true');
+        apiReturning({ ...themeConfiguration(), RawCss: '*{}' });
+        const second = createRuntime();
+        expect(document.getElementById(COMMITTED_STYLE_ID)).toBeNull();
+        await second.runtime.load();
+        expect(second.runtime.getDiagnostics().status).toBe('error');
+        expect(document.getElementById(COMMITTED_STYLE_ID)).toBeNull();
+        expect(document.documentElement.hasAttribute('data-jc-theme-active')).toBe(false);
+        expect(document.documentElement.getAttribute('data-theme')).toBe(hostTheme);
+    });
+
+    it('rejects late obsolete responses without applying user presentation', async () => {
+        let resolveRequest: (value: unknown) => void = () => undefined;
+        const plugin = vi.fn(() => new Promise<unknown>((resolve) => { resolveRequest = resolve; }));
+        JC.core.api = { plugin } as unknown as ApiApi;
+        const { runtime, harness } = createRuntime();
+        const load = runtime.load();
+        harness.setCurrent(false);
+        resolveRequest(themeConfiguration());
+        await load;
+        expect(document.getElementById(COMMITTED_STYLE_ID)).toBeNull();
+        expect(document.documentElement.hasAttribute('data-jc-theme-active')).toBe(false);
+        expect(JC.core.themeStudio).toBeUndefined();
+    });
+
+    it('prevents a retained obsolete API from clearing its successor presentation', async () => {
+        apiReturning(themeConfiguration());
+        const first = createRuntime();
+        await first.runtime.load();
+        const staleApi = JC.core.themeStudio;
+        first.runtime.dispose();
+
+        const second = createRuntime();
+        await second.runtime.load();
+        const successorCss = document.getElementById(COMMITTED_STYLE_ID)?.textContent;
+        expect(successorCss).toBeTruthy();
+        expect(JC.core.themeStudio).not.toBe(staleApi);
+
+        staleApi?.refresh();
+        staleApi?.cancelPreview();
+        first.runtime.dispose();
+
+        expect(document.getElementById(COMMITTED_STYLE_ID)?.textContent).toBe(successorCss);
+        expect(document.documentElement.getAttribute('data-jc-theme-active')).toBe('true');
+        expect(second.runtime.getDiagnostics().status).toBe('active');
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/runtime.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/runtime.test.ts
@@ -235,6 +235,34 @@ describe('Theme Studio identity-owned runtime', () => {
         expect(currentApi).toBe(JC.core.themeStudio);
     });
 
+    it('suspends committed reduced-motion adapters while a full-motion preview is active', async () => {
+        const committed = themeConfiguration();
+        committed.Profiles[0].Accessibility.Motion = 'off';
+        apiReturning(committed);
+        const { runtime } = createRuntime();
+        await runtime.load();
+
+        const committedCss = document.getElementById(COMMITTED_STYLE_ID)?.textContent ?? '';
+        expect(committedCss).toContain('animation-duration: 0.01ms !important');
+        expect(committedCss).toContain(':not([data-jc-theme-preview="true"])');
+
+        const preview = themeConfiguration();
+        preview.Profiles[0].Accessibility.Motion = 'on';
+        expect(JC.core.themeStudio?.preview(preview)).toBe(true);
+        expectRootThemeState({ motion: 'full' });
+        expect(document.getElementById(PREVIEW_STYLE_ID)?.textContent)
+            .not.toContain('animation-duration: 0.01ms !important');
+        expect(document.documentElement.matches(
+            ':root[data-jc-theme-active="true"]:not([data-jc-theme-preview="true"])',
+        )).toBe(false);
+
+        JC.core.themeStudio?.cancelPreview();
+        expectRootThemeState({ motion: 'reduced' });
+        expect(document.documentElement.matches(
+            ':root[data-jc-theme-active="true"]:not([data-jc-theme-preview="true"])',
+        )).toBe(true);
+    });
+
     it('keeps the dashboard as an unthemed recovery space unless explicitly enabled', async () => {
         history.replaceState({}, '', '/web/#/dashboard');
         apiReturning(themeConfiguration());

--- a/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/runtime.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/runtime.test.ts
@@ -113,6 +113,12 @@ function apiReturning(value: unknown): ReturnType<typeof vi.fn> {
     return plugin;
 }
 
+function expectRootThemeState(expected: Readonly<Record<string, string>>): void {
+    for (const [name, value] of Object.entries(expected)) {
+        expect(document.documentElement.getAttribute(`data-jc-theme-${name}`), name).toBe(value);
+    }
+}
+
 function createRuntime(): { runtime: ThemeStudioRuntime; harness: TestFeatureScope } {
     const harness = createTestFeatureScope();
     scopes.push(harness);
@@ -180,18 +186,51 @@ describe('Theme Studio identity-owned runtime', () => {
         await runtime.load();
         const currentApi = JC.core.themeStudio;
         const preview = themeConfiguration();
-        preview.Profiles[0].Tokens = { 'shape.card-radius': 'pill' };
+        preview.Profiles.push({
+            ...structuredClone(preview.Profiles[0]),
+            Id: 'preview',
+            Name: 'Preview',
+            BasePreset: 'minimal',
+            Palette: 'preview-palette',
+            Mode: 'light',
+            Tokens: { 'shape.card-radius': 'pill' },
+            Accessibility: {
+                ...preview.Profiles[0].Accessibility,
+                Motion: 'off',
+                Contrast: 'on',
+                Transparency: 'off',
+            },
+        });
+        preview.ActiveProfileId = 'preview';
         expect(JC.core.themeStudio?.preview(preview)).toBe(true);
         expect(document.querySelectorAll(`#${PREVIEW_STYLE_ID}`)).toHaveLength(1);
         expect(document.documentElement.getAttribute('data-jc-theme-preview')).toBe('true');
         expect(document.getElementById(PREVIEW_STYLE_ID)?.textContent)
             .toContain('--jf-card-borderRadius: 999px');
+        expectRootThemeState({
+            profile: 'preview',
+            preset: 'minimal',
+            palette: 'preview-palette',
+            mode: 'light',
+            motion: 'reduced',
+            contrast: 'more',
+            transparency: 'reduced',
+        });
         expect(JC.core.themeStudio?.getDiagnostics().status).toBe('preview');
 
         JC.core.themeStudio?.cancelPreview();
         expect(document.getElementById(PREVIEW_STYLE_ID)).toBeNull();
         expect(document.documentElement.hasAttribute('data-jc-theme-preview')).toBe(false);
         expect(document.getElementById(COMMITTED_STYLE_ID)).not.toBeNull();
+        expectRootThemeState({
+            profile: 'default',
+            preset: 'canopy',
+            palette: 'canopy-night',
+            mode: 'dark',
+            motion: 'full',
+            contrast: 'standard',
+            transparency: 'full',
+        });
         expect(JC.core.themeStudio?.getDiagnostics().status).toBe('active');
         expect(currentApi).toBe(JC.core.themeStudio);
     });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/runtime.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/runtime.ts
@@ -1,0 +1,350 @@
+import type { FeatureScope } from '../core/feature-loader';
+import { JC } from '../globals';
+import type {
+    ThemeStudioDiagnostics,
+    ThemeStudioRuntimeApi,
+    UserThemeConfiguration,
+} from '../types/jc';
+import { resolveTheme, type ResolvedTheme, type ThemeMediaState } from './resolver';
+import { parseUserThemeConfiguration } from './schema';
+import {
+    COMMITTED_STYLE_ID,
+    PREVIEW_STYLE_ID,
+    serializeThemeStyles,
+    type ThemeStyleLayer,
+} from './styles';
+
+const THEME_CHANGE = 'THEME_CHANGE';
+const ROOT_ATTRIBUTES = Object.freeze([
+    'data-jc-theme-active',
+    'data-jc-theme-preview',
+    'data-jc-theme-profile',
+    'data-jc-theme-preset',
+    'data-jc-theme-palette',
+    'data-jc-theme-mode',
+    'data-jc-theme-breakpoint',
+    'data-jc-theme-motion',
+    'data-jc-theme-contrast',
+    'data-jc-theme-transparency',
+    'data-jc-theme-pointer',
+    'data-jc-theme-hover',
+    'data-jc-theme-forced-colors',
+    'data-jc-theme-route',
+]);
+
+const MEDIA_QUERIES = Object.freeze({
+    darkScheme: '(prefers-color-scheme: dark)',
+    reducedMotion: '(prefers-reduced-motion: reduce)',
+    moreContrast: '(prefers-contrast: more)',
+    reducedTransparency: '(prefers-reduced-transparency: reduce)',
+    forcedColors: '(forced-colors: active)',
+    hover: '(hover: hover)',
+    coarsePointer: '(pointer: coarse)',
+    phone: '(max-width: 599px)',
+    tablet: '(min-width: 600px) and (max-width: 1023px)',
+    wide: '(min-width: 1600px)',
+    handsetLandscape: '(orientation: landscape) and (max-height: 599px) and (max-width: 999px) and (pointer: coarse)',
+    tabletLandscape: '(orientation: landscape) and (min-height: 600px) and (max-width: 1180px) and (pointer: coarse)',
+});
+
+type MediaName = keyof typeof MEDIA_QUERIES;
+
+// Presentation is global DOM state, so teardown must be generation-aware.
+// A retained API from an obsolete feature generation must never clear the
+// styles and root attributes installed by its successor.
+let presentationOwner: ThemeStudioRuntime | null = null;
+
+function claimPresentation(owner: ThemeStudioRuntime): void {
+    presentationOwner = owner;
+}
+
+function dashboardRoute(): boolean {
+    const route = `${window.location.pathname}${window.location.search}${window.location.hash}`.toLowerCase();
+    return /#\/(?:dashboard|configurationpage)(?:[/?#]|$)/.test(route)
+        || /(?:^|\/)(?:dashboard|configurationpage)(?:[/?#]|$)/.test(route);
+}
+
+function routeScope(): 'dashboard' | 'player' | 'details' | 'home' | 'browse' | 'other' {
+    const route = `${window.location.pathname}${window.location.search}${window.location.hash}`.toLowerCase();
+    if (dashboardRoute()) return 'dashboard';
+    if (/(?:#\/|\/)(?:video|livetv)(?:[/?#]|$)/.test(route)) return 'player';
+    if (/(?:#\/|\/)details(?:[/?#]|$)/.test(route)) return 'details';
+    if (/(?:#\/|\/)home(?:[/?#]|$)/.test(route)) return 'home';
+    if (/(?:#\/|\/)(?:movies|tv|music|artists|collections|playlists|library)(?:[/?#]|$)/.test(route)) return 'browse';
+    return 'other';
+}
+
+function themeStyle(layer: ThemeStyleLayer): HTMLStyleElement {
+    const id = layer === 'committed' ? COMMITTED_STYLE_ID : PREVIEW_STYLE_ID;
+    const existing = document.getElementById(id);
+    if (existing instanceof HTMLStyleElement) return existing;
+    existing?.remove();
+    const style = document.createElement('style');
+    style.id = id;
+    style.dataset.jcOwner = 'theme-studio';
+    style.dataset.jcLayer = layer;
+    document.head.append(style);
+    return style;
+}
+
+function updateStyle(layer: ThemeStyleLayer, theme: ResolvedTheme): void {
+    const style = themeStyle(layer);
+    const css = serializeThemeStyles(theme, layer);
+    if (style.textContent !== css) style.textContent = css;
+}
+
+function removeStyle(id: string): void {
+    document.getElementById(id)?.remove();
+}
+
+function rootThemeName(): string {
+    return document.documentElement.getAttribute('data-theme')?.trim() ?? '';
+}
+
+function tvLayout(): boolean {
+    return document.documentElement.classList.contains('layout-tv')
+        || document.body?.classList.contains('layout-tv') === true
+        || document.documentElement.getAttribute('data-layout') === 'tv';
+}
+
+export class ThemeStudioRuntime {
+    readonly #scope: FeatureScope;
+    readonly #media = new Map<MediaName, MediaQueryList>();
+    readonly #cleanups: Array<() => void> = [];
+    #configuration: UserThemeConfiguration | null = null;
+    #previewConfiguration: UserThemeConfiguration | null = null;
+    #disposed = false;
+    #installed = false;
+    #diagnostics: ThemeStudioDiagnostics = Object.freeze({
+        status: 'inactive', revision: null, profileId: null, breakpoint: null, mode: null,
+    });
+    #api: ThemeStudioRuntimeApi | null = null;
+
+    constructor(scope: FeatureScope) {
+        this.#scope = scope;
+    }
+
+    install(): void {
+        if (this.#installed || this.#disposed || !this.#scope.isCurrent()) return;
+        this.#installed = true;
+        // Remove orphaned presentation from an interrupted older generation
+        // before this identity acquires any asynchronous work.
+        this.#clearPresentation(true);
+
+        const refresh = (): void => this.refresh();
+        if (typeof window.matchMedia === 'function') {
+            for (const [name, query] of Object.entries(MEDIA_QUERIES) as Array<[MediaName, string]>) {
+                const media = window.matchMedia(query);
+                this.#media.set(name, media);
+                if (typeof media.addEventListener === 'function') {
+                    media.addEventListener('change', refresh);
+                    this.#cleanups.push(() => media.removeEventListener('change', refresh));
+                } else {
+                    media.addListener(refresh);
+                    this.#cleanups.push(() => media.removeListener(refresh));
+                }
+            }
+        }
+
+        const observer = new MutationObserver(refresh);
+        observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+        this.#cleanups.push(() => observer.disconnect());
+
+        const events = window.Events;
+        if (events) {
+            events.on(document, THEME_CHANGE, refresh);
+            this.#cleanups.push(() => events.off(document, THEME_CHANGE, refresh));
+        }
+        if (JC.core.navigation) this.#cleanups.push(JC.core.navigation.onNavigate(refresh));
+        this.#cleanups.push(JC.identity.registerReset('theme-studio-runtime', () => this.dispose()));
+
+        const api: ThemeStudioRuntimeApi = Object.freeze({
+            preview: (configuration: unknown) => this.preview(configuration),
+            cancelPreview: () => this.cancelPreview(),
+            refresh: () => this.refresh(),
+            getDiagnostics: () => this.getDiagnostics(),
+        });
+        this.#api = api;
+        JC.core.themeStudio = api;
+    }
+
+    async load(): Promise<void> {
+        if (this.#disposed || !this.#scope.isCurrent()) return;
+        this.#setDiagnostics('loading', null);
+        try {
+            const api = JC.core.api;
+            if (!api) throw new Error('Theme Studio API is unavailable');
+            const raw = await api.plugin(
+                `/user-settings/${encodeURIComponent(this.#scope.userId)}/theme.json`,
+                { signal: this.#scope.signal, skipCache: true, timeoutMs: 10_000 },
+            );
+            if (this.#disposed) return;
+            if (!this.#scope.isCurrent()) {
+                this.dispose();
+                return;
+            }
+            const configuration = parseUserThemeConfiguration(raw);
+            if (!configuration) throw new Error('Theme Studio response failed validation');
+            this.#configuration = JC.identity.own(configuration);
+            JC.rememberUserSettingsSnapshot?.('theme.json', this.#configuration);
+            this.refresh();
+        } catch (error) {
+            if (this.#disposed || this.#scope.signal.aborted || !this.#scope.isCurrent()
+                || (error as { name?: string } | null)?.name === 'AbortError') return;
+            this.#configuration = null;
+            this.#previewConfiguration = null;
+            this.#clearPresentation();
+            this.#setDiagnostics('error', null);
+            JC.bootDiagnostics.record({
+                feature: 'theme-studio',
+                phase: 'feature-initialization',
+                operation: 'read-theme',
+                state: 'FeatureFailure',
+                storage: 'none',
+                key: 'theme.json',
+            });
+        }
+    }
+
+    preview(value: unknown): boolean {
+        if (this.#disposed || !this.#scope.isCurrent() || !this.#configuration) return false;
+        const configuration = parseUserThemeConfiguration(value);
+        if (!configuration) return false;
+        this.#previewConfiguration = configuration;
+        this.refresh();
+        return document.documentElement.getAttribute('data-jc-theme-preview') === 'true';
+    }
+
+    cancelPreview(): void {
+        if (this.#disposed || !this.#scope.isCurrent() || presentationOwner !== this) return;
+        this.#previewConfiguration = null;
+        removeStyle(PREVIEW_STYLE_ID);
+        document.documentElement.removeAttribute('data-jc-theme-preview');
+        if (!this.#disposed && this.#configuration && this.#scope.isCurrent() && !this.#dashboardBlocked()) {
+            this.#applyCommitted();
+        }
+    }
+
+    refresh(): void {
+        if (this.#disposed) return;
+        if (!this.#scope.isCurrent()) {
+            this.dispose();
+            return;
+        }
+        if (!this.#configuration) {
+            this.#clearPresentation();
+            return;
+        }
+        if (this.#dashboardBlocked()) {
+            this.#clearPresentation();
+            this.#setDiagnostics('inactive', null);
+            return;
+        }
+        this.#applyCommitted();
+        if (this.#previewConfiguration) this.#applyPreview();
+        else {
+            removeStyle(PREVIEW_STYLE_ID);
+            document.documentElement.removeAttribute('data-jc-theme-preview');
+        }
+    }
+
+    getDiagnostics(): ThemeStudioDiagnostics {
+        return this.#diagnostics;
+    }
+
+    dispose(): void {
+        if (this.#disposed) return;
+        this.#disposed = true;
+        this.#configuration = null;
+        this.#previewConfiguration = null;
+        this.#clearPresentation();
+        for (let index = this.#cleanups.length - 1; index >= 0; index -= 1) {
+            try { this.#cleanups[index]?.(); } catch { /* exact teardown continues */ }
+        }
+        this.#cleanups.length = 0;
+        this.#media.clear();
+        if (this.#api && JC.core.themeStudio === this.#api) delete JC.core.themeStudio;
+        this.#api = null;
+        this.#setDiagnostics('inactive', null);
+    }
+
+    #dashboardBlocked(): boolean {
+        return dashboardRoute() && JC.pluginConfig?.ThemeStudioDashboardEnabled !== true;
+    }
+
+    #matches(name: MediaName): boolean {
+        return this.#media.get(name)?.matches === true;
+    }
+
+    #captureMedia(): ThemeMediaState {
+        return {
+            viewportWidth: Math.max(0, window.innerWidth || document.documentElement.clientWidth || 0),
+            viewportHeight: Math.max(0, window.innerHeight || document.documentElement.clientHeight || 0),
+            tv: tvLayout(),
+            darkScheme: this.#matches('darkScheme'),
+            reducedMotion: this.#matches('reducedMotion'),
+            moreContrast: this.#matches('moreContrast'),
+            reducedTransparency: this.#matches('reducedTransparency'),
+            forcedColors: this.#matches('forcedColors'),
+            hover: this.#matches('hover'),
+            coarsePointer: this.#matches('coarsePointer'),
+            jellyfinTheme: rootThemeName(),
+        };
+    }
+
+    #resolve(configuration: UserThemeConfiguration): ResolvedTheme {
+        return resolveTheme(configuration, this.#captureMedia(), {
+            allowScheduling: JC.pluginConfig?.ThemeStudioAllowSeasonalScheduling !== false,
+        });
+    }
+
+    #applyCommitted(): void {
+        if (!this.#configuration) return;
+        const theme = this.#resolve(this.#configuration);
+        claimPresentation(this);
+        updateStyle('committed', theme);
+        const root = document.documentElement;
+        root.setAttribute('data-jc-theme-active', 'true');
+        root.setAttribute('data-jc-theme-profile', theme.profileId);
+        root.setAttribute('data-jc-theme-preset', theme.preset);
+        root.setAttribute('data-jc-theme-palette', theme.palette);
+        root.setAttribute('data-jc-theme-mode', theme.mode);
+        root.setAttribute('data-jc-theme-breakpoint', theme.breakpoint);
+        root.setAttribute('data-jc-theme-motion', theme.reducedMotion ? 'reduced' : 'full');
+        root.setAttribute('data-jc-theme-contrast', theme.highContrast ? 'more' : 'standard');
+        root.setAttribute('data-jc-theme-transparency', theme.reducedTransparency ? 'reduced' : 'full');
+        root.setAttribute('data-jc-theme-pointer', theme.coarsePointer ? 'coarse' : 'fine');
+        root.setAttribute('data-jc-theme-hover', theme.hover ? 'hover' : 'none');
+        root.setAttribute('data-jc-theme-forced-colors', theme.forcedColors ? 'active' : 'none');
+        root.setAttribute('data-jc-theme-route', routeScope());
+        this.#setDiagnostics('active', theme);
+    }
+
+    #applyPreview(): void {
+        if (!this.#previewConfiguration) return;
+        const theme = this.#resolve(this.#previewConfiguration);
+        claimPresentation(this);
+        updateStyle('preview', theme);
+        document.documentElement.setAttribute('data-jc-theme-preview', 'true');
+        this.#setDiagnostics('preview', theme);
+    }
+
+    #clearPresentation(force = false): void {
+        if (!force && presentationOwner !== this) return;
+        removeStyle(COMMITTED_STYLE_ID);
+        removeStyle(PREVIEW_STYLE_ID);
+        const root = document.documentElement;
+        for (const name of ROOT_ATTRIBUTES) root.removeAttribute(name);
+        presentationOwner = null;
+    }
+
+    #setDiagnostics(status: ThemeStudioDiagnostics['status'], theme: ResolvedTheme | null): void {
+        this.#diagnostics = Object.freeze({
+            status,
+            revision: this.#configuration?.Revision ?? null,
+            profileId: theme?.profileId ?? null,
+            breakpoint: theme?.breakpoint ?? null,
+            mode: theme?.mode ?? null,
+        });
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/runtime.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/runtime.ts
@@ -303,6 +303,11 @@ export class ThemeStudioRuntime {
         const theme = this.#resolve(this.#configuration);
         claimPresentation(this);
         updateStyle('committed', theme);
+        this.#applyRootAttributes(theme);
+        this.#setDiagnostics('active', theme);
+    }
+
+    #applyRootAttributes(theme: ResolvedTheme): void {
         const root = document.documentElement;
         root.setAttribute('data-jc-theme-active', 'true');
         root.setAttribute('data-jc-theme-profile', theme.profileId);
@@ -317,7 +322,6 @@ export class ThemeStudioRuntime {
         root.setAttribute('data-jc-theme-hover', theme.hover ? 'hover' : 'none');
         root.setAttribute('data-jc-theme-forced-colors', theme.forcedColors ? 'active' : 'none');
         root.setAttribute('data-jc-theme-route', routeScope());
-        this.#setDiagnostics('active', theme);
     }
 
     #applyPreview(): void {
@@ -325,6 +329,7 @@ export class ThemeStudioRuntime {
         const theme = this.#resolve(this.#previewConfiguration);
         claimPresentation(this);
         updateStyle('preview', theme);
+        this.#applyRootAttributes(theme);
         document.documentElement.setAttribute('data-jc-theme-preview', 'true');
         this.#setDiagnostics('preview', theme);
     }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/schema.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/schema.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { isUserThemeConfiguration, parseUserThemeConfiguration, THEME_TOKEN_RULES } from './schema';
+import { themeConfiguration } from '../test/theme-studio-fixture';
+
+describe('Theme Studio browser schema boundary', () => {
+    it('accepts the server-shaped v1 document and returns an isolated clone', () => {
+        const source = themeConfiguration();
+        const parsed = parseUserThemeConfiguration(source);
+        expect(parsed).toEqual(source);
+        expect(parsed).not.toBe(source);
+        expect(parsed?.Profiles[0]).not.toBe(source.Profiles[0]);
+
+        source.Profiles[0].Name = 'Changed after validation';
+        expect(parsed?.Profiles[0]?.Name).toBe('Default');
+    });
+
+    it('mirrors the full server token vocabulary and rejects arbitrary CSS-bearing keys', () => {
+        expect(THEME_TOKEN_RULES.size).toBeGreaterThan(70);
+        const valid = themeConfiguration();
+        valid.Profiles[0].Tokens = {
+            'color.primary': '#AABBCCDD',
+            'shape.card-radius': 'pill',
+            'effects.blur': 48,
+            'motion.page-transition': false,
+        };
+        expect(isUserThemeConfiguration(valid)).toBe(true);
+
+        for (const [name, value] of [
+            ['raw.css', 'body{display:none}'],
+            ['background.url', 'url(https://example.invalid/x)'],
+            ['color.primary', 'red;--owned:1'],
+            ['shape.card-radius', '1px}body{display:none'],
+        ] as const) {
+            const attack = themeConfiguration();
+            attack.Profiles[0].Tokens = { [name]: value };
+            expect(parseUserThemeConfiguration(attack), name).toBeNull();
+        }
+    });
+
+    it('rejects unknown fields at every envelope and invalid migration evidence', () => {
+        const cases: unknown[] = [];
+        const root = themeConfiguration() as unknown as Record<string, unknown>;
+        root.RawCss = '*{}';
+        cases.push(root);
+        const profile = themeConfiguration();
+        (profile.Profiles[0] as unknown as Record<string, unknown>).Url = 'https://example.invalid';
+        cases.push(profile);
+        const responsive = themeConfiguration();
+        (responsive.Profiles[0].Responsive as unknown as Record<string, unknown>).Watch = {};
+        cases.push(responsive);
+        const migration = themeConfiguration();
+        migration.LegacyMigration = { JellyfishTheme: 'UnknownTheme', Completed: true };
+        cases.push(migration);
+        const inconsistent = themeConfiguration();
+        inconsistent.LegacyMigration = { JellyfishTheme: '', Completed: true };
+        cases.push(inconsistent);
+        for (const value of cases) expect(parseUserThemeConfiguration(value)).toBeNull();
+
+        const migrated = themeConfiguration();
+        migrated.LegacyMigration = { JellyfishTheme: 'Ocean', Completed: true };
+        expect(parseUserThemeConfiguration(migrated)).not.toBeNull();
+    });
+
+    it('enforces identifiers, references, capacities, finite numbers, and the byte ceiling', () => {
+        const duplicate = themeConfiguration();
+        duplicate.Profiles.push(structuredClone(duplicate.Profiles[0]));
+        expect(parseUserThemeConfiguration(duplicate)).toBeNull();
+
+        const missing = themeConfiguration();
+        missing.ActiveProfileId = 'missing';
+        expect(parseUserThemeConfiguration(missing)).toBeNull();
+
+        const invalidNumber = themeConfiguration();
+        invalidNumber.Profiles[0].Tokens = { 'effects.blur': Number.NaN };
+        expect(parseUserThemeConfiguration(invalidNumber)).toBeNull();
+
+        const tooMany = themeConfiguration();
+        tooMany.Profiles = Array.from({ length: 25 }, (_, index) => ({
+            ...structuredClone(tooMany.Profiles[0]),
+            Id: `profile-${index}`,
+        }));
+        expect(parseUserThemeConfiguration(tooMany)).toBeNull();
+
+        const oversized = themeConfiguration();
+        oversized.Profiles[0].Name = 'x'.repeat(129 * 1024);
+        expect(parseUserThemeConfiguration(oversized)).toBeNull();
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/schema.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/schema.ts
@@ -1,0 +1,233 @@
+import type {
+    ThemeAccessibilitySettings,
+    ThemeBreakpointOverrides,
+    ThemeLegacyMigration,
+    ThemeProfile,
+    ThemeResponsiveSettings,
+    ThemeScheduleEntry,
+    ThemeTokenValue,
+    UserThemeConfiguration,
+} from '../types/jc';
+
+const MAXIMUM_PERSISTED_BYTES = 128 * 1024;
+const MAXIMUM_PROFILES = 24;
+const MAXIMUM_SCHEDULE_ENTRIES = 32;
+const MAXIMUM_PROFILE_NAME_RUNES = 80;
+const MAXIMUM_TOKEN_OVERRIDES_PER_SCOPE = 128;
+
+type TokenRule = (value: unknown) => value is ThemeTokenValue;
+
+const choice = (...values: readonly string[]): TokenRule => {
+    const allowed = new Set(values);
+    return (value: unknown): value is string => typeof value === 'string' && allowed.has(value);
+};
+
+const number = (minimum: number, maximum: number): TokenRule =>
+    (value: unknown): value is number => typeof value === 'number'
+        && Number.isFinite(value) && value >= minimum && value <= maximum;
+
+const color: TokenRule = (value: unknown): value is string =>
+    typeof value === 'string' && /^#[0-9a-fA-F]{6}(?:[0-9a-fA-F]{2})?$/.test(value);
+
+const boolean: TokenRule = (value: unknown): value is boolean => typeof value === 'boolean';
+
+function assign(target: Map<string, TokenRule>, rule: TokenRule, ...names: readonly string[]): void {
+    for (const name of names) target.set(name, rule);
+}
+
+function buildTokenRules(): ReadonlyMap<string, TokenRule> {
+    const rules = new Map<string, TokenRule>();
+    assign(rules, color,
+        'color.canvas', 'color.surface', 'color.elevated', 'color.overlay',
+        'color.text', 'color.text-muted', 'color.primary', 'color.on-primary',
+        'color.secondary', 'color.positive', 'color.caution', 'color.negative',
+        'color.info', 'color.divider', 'color.focus');
+    assign(rules, choice('system', 'inter', 'serif', 'rounded', 'monospace'),
+        'type.family-ui', 'type.family-display', 'type.family-reading');
+    assign(rules, number(0.75, 1.5), 'type.scale');
+    assign(rules, number(1, 2), 'type.line-height');
+    assign(rules, number(-0.05, 0.2), 'type.tracking');
+    assign(rules, number(30, 100), 'type.max-reading-width');
+    assign(rules, choice('square', 'subtle', 'rounded', 'pill'),
+        'shape.radius-scale', 'shape.card-radius', 'shape.control-radius', 'shape.dialog-radius');
+    assign(rules, choice('circle', 'rounded', 'square'), 'shape.avatar-shape');
+    assign(rules, number(0, 4), 'shape.border-width');
+    assign(rules, number(0, 1), 'elevation.glow-intensity');
+    assign(rules, choice('none', 'soft', 'medium', 'strong'),
+        'elevation.surface-shadow', 'elevation.card-shadow', 'elevation.dialog-shadow',
+        'elevation.focus-ring');
+    assign(rules, choice('compact', 'cozy', 'spacious'), 'space.scale', 'layout.density');
+    assign(rules, number(0.5, 3),
+        'space.page-gutter', 'space.section-gap', 'space.card-gap', 'space.control-gap');
+    assign(rules, choice('auto', 'header', 'sidebar', 'pills', 'bottom'), 'layout.navigation');
+    assign(rules, choice('off', 'compact', 'cinematic'), 'layout.home-hero');
+    assign(rules, choice('classic', 'compact', 'cinematic'), 'layout.details');
+    assign(rules, choice('list', 'grid', 'auto'), 'layout.seasons');
+    assign(rules, choice('hover', 'always', 'menu'), 'layout.card-actions');
+    assign(rules, choice('poster', 'backdrop', 'square', 'auto'), 'layout.poster-ratio');
+    assign(rules, choice('circle', 'rounded', 'square'), 'layout.cast-shape');
+    assign(rules, choice('full', 'balanced', 'minimal'), 'effects.level');
+    assign(rules, choice('solid', 'translucent', 'glass'), 'effects.material');
+    assign(rules, number(0, 48), 'effects.blur');
+    assign(rules, number(0, 2), 'effects.saturation');
+    assign(rules, number(0, 1), 'effects.backdrop-opacity', 'effects.glow');
+    assign(rules, choice('none', 'dim', 'gradient', 'blur'), 'effects.image-treatment');
+    assign(rules, choice('off', 'calm', 'expressive', 'system'), 'motion.profile');
+    assign(rules, number(0, 2), 'motion.duration-scale');
+    assign(rules, choice('standard', 'smooth', 'spring'), 'motion.easing');
+    assign(rules, number(0, 12), 'motion.hover-lift');
+    assign(rules, boolean, 'motion.page-transition', 'motion.stagger');
+    assign(rules, choice('overlay', 'bottom', 'floating'), 'progress.position');
+    assign(rules, number(1, 12), 'progress.thickness');
+    assign(rules, choice('corner', 'floating', 'check', 'none'),
+        'progress.watched-indicator', 'progress.unwatched-indicator');
+    assign(rules, choice('compact', 'standard', 'cinematic'), 'player.osd-density');
+    assign(rules, choice('solid', 'translucent', 'glass'),
+        'player.control-material', 'player.pause-screen-material');
+    assign(rules, choice('none', 'shadow', 'solid', 'box'), 'player.subtitle-backdrop');
+    assign(rules, choice('rounded', 'square', 'pill'), 'player.trickplay-shape');
+    assign(rules, choice('material', 'lucide', 'system'), 'icon.family');
+    assign(rules, choice('light', 'regular', 'bold'), 'icon.weight');
+    assign(rules, number(0.75, 1.5), 'icon.size-scale');
+    assign(rules, boolean, 'icon.multicolor-metadata', 'accessibility.underline-links');
+    assign(rules, choice('system', 'on', 'off'),
+        'accessibility.contrast', 'accessibility.motion', 'accessibility.transparency');
+    assign(rules, choice('system', 'standard', 'strong'), 'accessibility.focus-emphasis');
+    assign(rules, number(0.75, 2), 'accessibility.text-scale');
+    return rules;
+}
+
+export const THEME_TOKEN_RULES = buildTokenRules();
+
+const BASE_PRESETS = new Set([
+    'canopy', 'minimal', 'cinematic', 'glass', 'material', 'studio',
+    'tv-focus', 'oled', 'high-contrast',
+]);
+const MODES = new Set(['system', 'dark', 'light']);
+const SYSTEM_CHOICES = new Set(['system', 'on', 'off']);
+const FOCUS_CHOICES = new Set(['system', 'standard', 'strong']);
+const JELLYFISH_THEMES = new Set([
+    'Aurora', 'Banana', 'Coal', 'Coral', 'Forest', 'Grass', 'Jellyblue', 'Jellyflix',
+    'Jellypurple', 'Lavender', 'Midnight', 'Mint', 'Ocean', 'Peach', 'Watermelon',
+]);
+
+function record(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function exactKeys(value: Record<string, unknown>, required: readonly string[], optional: readonly string[] = []): boolean {
+    const allowed = new Set([...required, ...optional]);
+    return required.every((key) => Object.prototype.hasOwnProperty.call(value, key))
+        && Object.keys(value).every((key) => allowed.has(key));
+}
+
+function identifier(value: unknown): value is string {
+    return typeof value === 'string' && /^[a-z][a-z0-9-]{0,63}$/.test(value);
+}
+
+function displayName(value: unknown): value is string {
+    return typeof value === 'string' && value.length > 0 && value === value.trim()
+        && [...value].length <= MAXIMUM_PROFILE_NAME_RUNES && !/[\u0000-\u001f\u007f]/.test(value);
+}
+
+function tokenMap(value: unknown): value is Record<string, ThemeTokenValue> {
+    if (!record(value) || Object.keys(value).length > MAXIMUM_TOKEN_OVERRIDES_PER_SCOPE) return false;
+    return Object.entries(value).every(([name, token]) => THEME_TOKEN_RULES.get(name)?.(token) === true);
+}
+
+function breakpoint(value: unknown): value is ThemeBreakpointOverrides | null | undefined {
+    return value === null || value === undefined
+        || (record(value) && exactKeys(value, ['Tokens']) && tokenMap(value.Tokens));
+}
+
+function responsive(value: unknown): value is ThemeResponsiveSettings {
+    if (!record(value) || !exactKeys(value, [], ['Phone', 'Tablet', 'Desktop', 'Wide', 'Tv'])) return false;
+    return breakpoint(value.Phone) && breakpoint(value.Tablet) && breakpoint(value.Desktop)
+        && breakpoint(value.Wide) && breakpoint(value.Tv);
+}
+
+function accessibility(value: unknown): value is ThemeAccessibilitySettings {
+    return record(value)
+        && exactKeys(value, ['Motion', 'Contrast', 'Transparency', 'FocusEmphasis', 'UnderlineLinks'])
+        && typeof value.Motion === 'string' && SYSTEM_CHOICES.has(value.Motion)
+        && typeof value.Contrast === 'string' && SYSTEM_CHOICES.has(value.Contrast)
+        && typeof value.Transparency === 'string' && SYSTEM_CHOICES.has(value.Transparency)
+        && typeof value.FocusEmphasis === 'string' && FOCUS_CHOICES.has(value.FocusEmphasis)
+        && typeof value.UnderlineLinks === 'boolean';
+}
+
+function profile(value: unknown): value is ThemeProfile {
+    if (!record(value) || !exactKeys(value, [
+        'Id', 'Name', 'BasePreset', 'FreezePresetVersion', 'Palette', 'Accent', 'Mode',
+        'Tokens', 'Responsive', 'Accessibility',
+    ], ['PresetVersion'])) return false;
+    const presetVersion = value.PresetVersion;
+    return identifier(value.Id) && displayName(value.Name)
+        && typeof value.BasePreset === 'string' && BASE_PRESETS.has(value.BasePreset)
+        && typeof value.FreezePresetVersion === 'boolean'
+        && (presetVersion === null || presetVersion === undefined
+            || (Number.isInteger(presetVersion) && Number(presetVersion) > 0 && Number(presetVersion) <= 10_000))
+        && (!value.FreezePresetVersion || (typeof presetVersion === 'number' && presetVersion > 0))
+        && identifier(value.Palette) && identifier(value.Accent)
+        && typeof value.Mode === 'string' && MODES.has(value.Mode)
+        && tokenMap(value.Tokens) && responsive(value.Responsive) && accessibility(value.Accessibility);
+}
+
+function monthDay(value: unknown): value is string {
+    if (typeof value !== 'string') return false;
+    const match = /^(\d{2})-(\d{2})$/.exec(value);
+    if (!match) return false;
+    const month = Number(match[1]);
+    const day = Number(match[2]);
+    const date = new Date(Date.UTC(2000, month - 1, day));
+    return date.getUTCMonth() === month - 1 && date.getUTCDate() === day;
+}
+
+function scheduleEntry(value: unknown, profileIds: ReadonlySet<string>): value is ThemeScheduleEntry {
+    return record(value)
+        && exactKeys(value, ['Id', 'ProfileId', 'StartMonthDay', 'EndMonthDay', 'Priority', 'Enabled'])
+        && identifier(value.Id) && typeof value.ProfileId === 'string' && profileIds.has(value.ProfileId)
+        && monthDay(value.StartMonthDay) && monthDay(value.EndMonthDay)
+        && Number.isInteger(value.Priority) && Number(value.Priority) >= 0 && Number(value.Priority) <= 100
+        && typeof value.Enabled === 'boolean';
+}
+
+function legacyMigration(value: unknown): value is ThemeLegacyMigration {
+    if (!record(value) || !exactKeys(value, ['JellyfishTheme', 'Completed'])
+        || typeof value.JellyfishTheme !== 'string' || typeof value.Completed !== 'boolean') return false;
+    return value.JellyfishTheme.length === 0
+        ? value.Completed === false
+        : value.Completed === true && JELLYFISH_THEMES.has(value.JellyfishTheme);
+}
+
+/** Strictly validates the server DTO before any value can enter a stylesheet. */
+export function isUserThemeConfiguration(value: unknown): value is UserThemeConfiguration {
+    if (!record(value) || !exactKeys(value, [
+        'Revision', 'SchemaVersion', 'ActiveProfileId', 'Profiles', 'Schedule', 'LegacyMigration',
+    ]) || !Number.isInteger(value.Revision) || Number(value.Revision) < 0
+        || value.SchemaVersion !== 1 || !identifier(value.ActiveProfileId)
+        || !Array.isArray(value.Profiles) || value.Profiles.length < 1
+        || value.Profiles.length > MAXIMUM_PROFILES || !Array.isArray(value.Schedule)
+        || value.Schedule.length > MAXIMUM_SCHEDULE_ENTRIES || !legacyMigration(value.LegacyMigration)) return false;
+
+    const profiles = value.Profiles as unknown[];
+    if (!profiles.every(profile)) return false;
+    const profileIds = new Set(profiles.map((item) => (item).Id));
+    if (profileIds.size !== profiles.length || !profileIds.has(value.ActiveProfileId)) return false;
+    const schedule = value.Schedule as unknown[];
+    if (!schedule.every((entry) => scheduleEntry(entry, profileIds))) return false;
+    return new Set(schedule.map((entry) => (entry).Id)).size === schedule.length;
+}
+
+/** Returns an isolated JSON clone, or null for oversized/malformed data. */
+export function parseUserThemeConfiguration(value: unknown): UserThemeConfiguration | null {
+    try {
+        const serialized = JSON.stringify(value);
+        if (new TextEncoder().encode(serialized).byteLength > MAXIMUM_PERSISTED_BYTES
+            || !isUserThemeConfiguration(value)) return null;
+        const clone: unknown = JSON.parse(serialized);
+        return isUserThemeConfiguration(clone) ? clone : null;
+    } catch {
+        return null;
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/styles.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/styles.test.ts
@@ -35,6 +35,7 @@ describe('Theme Studio CSS serialization', () => {
             '--jf-card-borderRadius',
         ]) expect(first, role).toContain(`${role}:`);
         expect(first).toContain(':root[data-jc-theme-active="true"]');
+        expect(first).toContain(':not([data-jc-theme-preview="true"])');
         expect(first).not.toContain('@layer');
         expect(first).toContain('Adapter legacy-v12-base-surfaces');
         expect(first).toContain('.jc-legacy-layout[data-jc-theme-route]');
@@ -55,11 +56,24 @@ describe('Theme Studio CSS serialization', () => {
         expect(css).toContain('text-decoration: underline');
         expect(css).toContain('@media (forced-colors: active)');
         expect(css).toContain('--jf-palette-primary-main: Highlight');
+        expect(css).not.toContain(':not([data-jc-theme-preview="true"])');
     });
 
     it('keeps a readable white error foreground for the darker light-mode negative color', () => {
         const theme = resolveTheme(themeConfiguration(), { ...media, jellyfinTheme: 'light' });
         expect(serializeThemeStyles(theme, 'committed'))
             .toContain('--jf-palette-error-contrastText: #FFFFFF');
+    });
+
+    it('composites translucent error surfaces over the canvas before choosing its foreground', () => {
+        const configuration = themeConfiguration();
+        configuration.Profiles[0].Tokens = {
+            'color.canvas': '#FFFFFF',
+            'color.surface': '#FFFFFF00',
+            'color.negative': '#00000080',
+        };
+        const theme = resolveTheme(configuration, media);
+        expect(serializeThemeStyles(theme, 'committed'))
+            .toContain('--jf-palette-error-contrastText: #000000');
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/styles.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/styles.test.ts
@@ -39,6 +39,7 @@ describe('Theme Studio CSS serialization', () => {
         expect(first).toContain('Adapter legacy-v12-base-surfaces');
         expect(first).toContain('.jc-legacy-layout[data-jc-theme-route]');
         expect(first).toContain('Adapter focus-v12');
+        expect(first).toContain('--jf-palette-error-contrastText: #000000');
         expect(first).not.toContain('url(');
         expect(first).not.toContain('@import');
     });
@@ -54,5 +55,11 @@ describe('Theme Studio CSS serialization', () => {
         expect(css).toContain('text-decoration: underline');
         expect(css).toContain('@media (forced-colors: active)');
         expect(css).toContain('--jf-palette-primary-main: Highlight');
+    });
+
+    it('keeps a readable white error foreground for the darker light-mode negative color', () => {
+        const theme = resolveTheme(themeConfiguration(), { ...media, jellyfinTheme: 'light' });
+        expect(serializeThemeStyles(theme, 'committed'))
+            .toContain('--jf-palette-error-contrastText: #FFFFFF');
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/styles.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/styles.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { resolveTheme, type ThemeMediaState } from './resolver';
+import { serializeThemeStyles } from './styles';
+import { themeConfiguration } from '../test/theme-studio-fixture';
+
+const media: ThemeMediaState = {
+    viewportWidth: 390,
+    viewportHeight: 844,
+    tv: false,
+    darkScheme: true,
+    reducedMotion: false,
+    moreContrast: false,
+    reducedTransparency: false,
+    forcedColors: false,
+    hover: false,
+    coarsePointer: true,
+    jellyfinTheme: 'dark',
+};
+
+describe('Theme Studio CSS serialization', () => {
+    it('is deterministic and bridges stable Canopy tokens to pinned Jellyfin roles', () => {
+        const theme = resolveTheme(themeConfiguration(), media);
+        const first = serializeThemeStyles(theme, 'committed');
+        expect(serializeThemeStyles(theme, 'committed')).toBe(first);
+        for (const role of [
+            '--jc-color-canvas',
+            '--jc-safe-area-bottom',
+            '--jf-palette-background-default',
+            '--jf-palette-background-paper',
+            '--jf-palette-text-primary',
+            '--jf-palette-primary-main',
+            '--jf-palette-primary-mainChannel',
+            '--jf-palette-action-selectedOpacity',
+            '--jf-palette-AppBar-defaultBg',
+            '--jf-card-borderRadius',
+        ]) expect(first, role).toContain(`${role}:`);
+        expect(first).toContain(':root[data-jc-theme-active="true"]');
+        expect(first).not.toContain('@layer');
+        expect(first).toContain('Adapter legacy-v12-base-surfaces');
+        expect(first).toContain('.jc-legacy-layout[data-jc-theme-route]');
+        expect(first).toContain('Adapter focus-v12');
+        expect(first).not.toContain('url(');
+        expect(first).not.toContain('@import');
+    });
+
+    it('keeps preview in the later cascade layer and emits bounded accessibility adapters', () => {
+        const configuration = themeConfiguration();
+        configuration.Profiles[0].Accessibility.Motion = 'off';
+        configuration.Profiles[0].Accessibility.UnderlineLinks = true;
+        const theme = resolveTheme(configuration, { ...media, forcedColors: true });
+        const css = serializeThemeStyles(theme, 'preview');
+        expect(css).toContain(':root[data-jc-theme-preview="true"]');
+        expect(css).toContain('animation-duration: 0.01ms !important');
+        expect(css).toContain('text-decoration: underline');
+        expect(css).toContain('@media (forced-colors: active)');
+        expect(css).toContain('--jf-palette-primary-main: Highlight');
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/styles.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/styles.ts
@@ -1,0 +1,210 @@
+import type { ThemeTokenValue } from '../types/jc';
+import type { ResolvedTheme } from './resolver';
+
+export const COMMITTED_STYLE_ID = 'jc-theme-studio-committed';
+export const PREVIEW_STYLE_ID = 'jc-theme-studio-preview';
+
+const RADIUS: Readonly<Record<string, string>> = Object.freeze({
+    square: '0px', subtle: '0.35rem', rounded: '0.75rem', pill: '999px',
+    circle: '50%',
+});
+const FONT: Readonly<Record<string, string>> = Object.freeze({
+    system: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+    inter: 'Inter, system-ui, sans-serif',
+    serif: 'Georgia, "Times New Roman", serif',
+    rounded: 'ui-rounded, "Arial Rounded MT Bold", system-ui, sans-serif',
+    monospace: 'ui-monospace, "Cascadia Code", Consolas, monospace',
+});
+const SHADOW: Readonly<Record<string, string>> = Object.freeze({
+    none: 'none',
+    soft: '0 0.25rem 1rem rgb(0 0 0 / 0.18)',
+    medium: '0 0.5rem 1.75rem rgb(0 0 0 / 0.28)',
+    strong: '0 0.75rem 2.5rem rgb(0 0 0 / 0.42)',
+});
+const DENSITY: Readonly<Record<string, string>> = Object.freeze({
+    compact: '0.875', cozy: '1', spacious: '1.18',
+});
+
+function token(theme: ResolvedTheme, name: string): ThemeTokenValue {
+    const value = theme.tokens[name];
+    if (value === undefined) throw new Error(`Resolved Theme Studio token is missing: ${name}`);
+    return value;
+}
+
+function stringToken(theme: ResolvedTheme, name: string): string {
+    return String(token(theme, name));
+}
+
+function numberToken(theme: ResolvedTheme, name: string): number {
+    return Number(token(theme, name));
+}
+
+function hexChannels(value: string): readonly [number, number, number, number] {
+    const red = Number.parseInt(value.slice(1, 3), 16);
+    const green = Number.parseInt(value.slice(3, 5), 16);
+    const blue = Number.parseInt(value.slice(5, 7), 16);
+    const alpha = value.length === 9 ? Number.parseInt(value.slice(7, 9), 16) / 255 : 1;
+    return [red, green, blue, alpha];
+}
+
+function rgba(value: string, opacity = 1): string {
+    const [red, green, blue, alpha] = hexChannels(value);
+    return `rgb(${red} ${green} ${blue} / ${Math.min(1, alpha * opacity).toFixed(3)})`;
+}
+
+function cssTokenValue(name: string, value: ThemeTokenValue): string {
+    if (typeof value === 'boolean') return value ? '1' : '0';
+    if (typeof value === 'number') {
+        if (name.startsWith('shape.') && name.endsWith('width')) return `${value}px`;
+        if (name === 'effects.blur' || name === 'motion.hover-lift' || name === 'progress.thickness') return `${value}px`;
+        if (name === 'type.tracking') return `${value}em`;
+        if (name === 'type.max-reading-width') return `${value}ch`;
+        return String(value);
+    }
+    if (name.startsWith('type.family-')) return FONT[value] ?? FONT.system;
+    if (name.startsWith('shape.') && (name.includes('radius') || name.includes('shape'))) return RADIUS[value] ?? value;
+    if (name.startsWith('elevation.') && name.endsWith('shadow')) return SHADOW[value] ?? SHADOW.none;
+    if (name === 'elevation.focus-ring') {
+        return value === 'none' ? '0px' : value === 'soft' ? '2px' : value === 'medium' ? '3px' : '4px';
+    }
+    if (name === 'space.scale' || name === 'layout.density') return DENSITY[value] ?? '1';
+    return value;
+}
+
+function customDeclarations(theme: ResolvedTheme): Record<string, string> {
+    const declarations: Record<string, string> = {};
+    for (const [name, value] of Object.entries(theme.tokens)) {
+        declarations[`--jc-${name.replaceAll('.', '-')}`] = cssTokenValue(name, value);
+    }
+    declarations['--jc-safe-area-top'] = 'env(safe-area-inset-top, 0px)';
+    declarations['--jc-safe-area-right'] = 'env(safe-area-inset-right, 0px)';
+    declarations['--jc-safe-area-bottom'] = 'env(safe-area-inset-bottom, 0px)';
+    declarations['--jc-safe-area-left'] = 'env(safe-area-inset-left, 0px)';
+    declarations['--jc-density-factor'] = DENSITY[stringToken(theme, 'layout.density')] ?? '1';
+    declarations['--jc-page-gutter'] = `calc(${numberToken(theme, 'space.page-gutter')}rem * var(--jc-density-factor))`;
+    declarations['--jc-section-gap'] = `calc(${numberToken(theme, 'space.section-gap')}rem * var(--jc-density-factor))`;
+    declarations['--jc-card-gap'] = `calc(${numberToken(theme, 'space.card-gap')}rem * var(--jc-density-factor))`;
+    declarations['--jc-control-gap'] = `calc(${numberToken(theme, 'space.control-gap')}rem * var(--jc-density-factor))`;
+    declarations['--jc-motion-duration'] = `${Math.round(180 * numberToken(theme, 'motion.duration-scale'))}ms`;
+    return declarations;
+}
+
+/** Exact Jellyfin 12/MUI roles pinned by the Theme Studio design contract. */
+function jellyfinDeclarations(theme: ResolvedTheme): Record<string, string> {
+    const canvas = stringToken(theme, 'color.canvas');
+    const surface = stringToken(theme, 'color.surface');
+    const elevated = stringToken(theme, 'color.elevated');
+    const text = stringToken(theme, 'color.text');
+    const textMuted = stringToken(theme, 'color.text-muted');
+    const primary = stringToken(theme, 'color.primary');
+    const onPrimary = stringToken(theme, 'color.on-primary');
+    const negative = stringToken(theme, 'color.negative');
+    const divider = stringToken(theme, 'color.divider');
+    const [primaryRed, primaryGreen, primaryBlue] = hexChannels(primary);
+    return {
+        '--jf-palette-background-default': canvas,
+        '--jf-palette-background-paper': surface,
+        '--jf-palette-background-defaultImage': 'none',
+        '--jf-palette-text-primary': text,
+        '--jf-palette-text-secondary': textMuted,
+        '--jf-palette-text-disabled': rgba(text, 0.38),
+        '--jf-palette-primary-main': primary,
+        '--jf-palette-primary-light': primary,
+        '--jf-palette-primary-dark': primary,
+        '--jf-palette-primary-contrastText': onPrimary,
+        '--jf-palette-primary-mainChannel': `${primaryRed} ${primaryGreen} ${primaryBlue}`,
+        '--jf-palette-error-main': negative,
+        '--jf-palette-error-light': negative,
+        '--jf-palette-error-dark': negative,
+        '--jf-palette-error-contrastText': '#FFFFFF',
+        '--jf-palette-divider': divider,
+        '--jf-palette-action-active': rgba(text, 0.56),
+        '--jf-palette-action-hover': rgba(text, 0.08),
+        '--jf-palette-action-hoverOpacity': '0.08',
+        '--jf-palette-action-selected': rgba(primary, 0.20),
+        '--jf-palette-action-selectedOpacity': '0.20',
+        '--jf-palette-action-disabled': rgba(text, 0.38),
+        '--jf-palette-action-disabledBackground': rgba(text, 0.12),
+        '--jf-palette-action-disabledOpacity': '0.38',
+        '--jf-palette-action-focus': rgba(text, 0.12),
+        '--jf-palette-action-focusOpacity': '0.12',
+        '--jf-palette-action-activatedOpacity': '0.12',
+        '--jf-palette-AppBar-defaultBg': surface,
+        '--jf-palette-AppBar-transparentBg': rgba(canvas, 0.72),
+        '--jf-card-borderRadius': cssTokenValue('shape.card-radius', token(theme, 'shape.card-radius')),
+        '--jf-palette-Button-inheritContainedBg': elevated,
+        '--jf-palette-Button-inheritContainedHoverBg': rgba(text, 0.12),
+        '--jf-palette-SnackbarContent-bg': elevated,
+        '--jf-palette-SnackbarContent-color': text,
+        '--jf-palette-FilledInput-bg': rgba(text, 0.08),
+        '--jf-palette-FilledInput-borderColor': divider,
+    };
+}
+
+function declarationBlock(declarations: Record<string, string>): string {
+    return Object.entries(declarations).sort(([left], [right]) => left.localeCompare(right))
+        .map(([name, value]) => `  ${name}: ${value};`).join('\n');
+}
+
+function adapters(selector: string, theme: ResolvedTheme): string {
+    const focusWidth = cssTokenValue('elevation.focus-ring', token(theme, 'elevation.focus-ring'));
+    const textDecoration = theme.underlineLinks ? 'underline' : 'none';
+    const routeSelector = `${selector}[data-jc-theme-route]`;
+    const legacySelector = `${selector}.jc-legacy-layout[data-jc-theme-route]`;
+    const motion = theme.reducedMotion ? `
+${routeSelector} *, ${routeSelector} *::before, ${routeSelector} *::after {
+  animation-duration: 0.01ms !important;
+  animation-iteration-count: 1 !important;
+  scroll-behavior: auto !important;
+  transition-duration: 0.01ms !important;
+}` : '';
+    return `
+/* Adapter legacy-v12-base-surfaces: Jellyfin 12 legacy layout, route-scoped. */
+${legacySelector} body,
+${legacySelector} .backgroundContainer,
+${legacySelector} .mainAnimatedPage {
+  background-color: var(--jc-color-canvas);
+  color: var(--jc-color-text);
+}
+${legacySelector} .skinHeader,
+${legacySelector} .dialog,
+${legacySelector} .cardContent,
+${legacySelector} .cardBox:not(.visualCardBox) {
+  background-color: var(--jc-color-surface);
+}
+/* Adapter focus-v12: keyboard focus across both Jellyfin 12 layouts. */
+${routeSelector} :is(a, button, input, select, textarea, [tabindex]):focus-visible {
+  outline: ${focusWidth} solid var(--jc-color-focus);
+  outline-offset: 2px;
+}
+${routeSelector} a:not(.emby-button) {
+  text-decoration: ${textDecoration};
+  text-underline-offset: 0.16em;
+}
+${routeSelector} {
+  forced-color-adjust: auto;
+}${motion}
+@media (forced-colors: active) {
+  ${routeSelector} {
+    --jc-color-focus: Highlight;
+    --jf-palette-primary-main: Highlight;
+    --jf-palette-primary-contrastText: HighlightText;
+  }
+}`;
+}
+
+export type ThemeStyleLayer = 'committed' | 'preview';
+
+/** Serializes only values produced by the validated resolver. */
+export function serializeThemeStyles(theme: ResolvedTheme, layer: ThemeStyleLayer): string {
+    const attribute = layer === 'committed' ? 'data-jc-theme-active' : 'data-jc-theme-preview';
+    const selector = `:root[${attribute}="true"]`;
+    const declarations = { ...customDeclarations(theme), ...jellyfinDeclarations(theme) };
+    // Jellyfin's own MUI variables are unlayered. An @layer declaration here
+    // would always lose to them; the two owner style elements instead use
+    // equal specificity and deterministic committed-then-preview source order.
+    return `${selector} {
+${declarationBlock(declarations)}
+}
+${adapters(selector, theme)}`;
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/styles.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/styles.ts
@@ -1,4 +1,5 @@
 import type { ThemeTokenValue } from '../types/jc';
+import { readableForeground } from './color';
 import type { ResolvedTheme } from './resolver';
 
 export const COMMITTED_STYLE_ID = 'jc-theme-studio-committed';
@@ -116,7 +117,7 @@ function jellyfinDeclarations(theme: ResolvedTheme): Record<string, string> {
         '--jf-palette-error-main': negative,
         '--jf-palette-error-light': negative,
         '--jf-palette-error-dark': negative,
-        '--jf-palette-error-contrastText': '#FFFFFF',
+        '--jf-palette-error-contrastText': readableForeground(negative, '#FFFFFF', surface),
         '--jf-palette-divider': divider,
         '--jf-palette-action-active': rgba(text, 0.56),
         '--jf-palette-action-hover': rgba(text, 0.08),

--- a/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/styles.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/theme-studio/styles.ts
@@ -117,7 +117,7 @@ function jellyfinDeclarations(theme: ResolvedTheme): Record<string, string> {
         '--jf-palette-error-main': negative,
         '--jf-palette-error-light': negative,
         '--jf-palette-error-dark': negative,
-        '--jf-palette-error-contrastText': readableForeground(negative, '#FFFFFF', surface),
+        '--jf-palette-error-contrastText': readableForeground(negative, '#FFFFFF', surface, canvas),
         '--jf-palette-divider': divider,
         '--jf-palette-action-active': rgba(text, 0.56),
         '--jf-palette-action-hover': rgba(text, 0.08),
@@ -199,7 +199,11 @@ export type ThemeStyleLayer = 'committed' | 'preview';
 /** Serializes only values produced by the validated resolver. */
 export function serializeThemeStyles(theme: ResolvedTheme, layer: ThemeStyleLayer): string {
     const attribute = layer === 'committed' ? 'data-jc-theme-active' : 'data-jc-theme-preview';
-    const selector = `:root[${attribute}="true"]`;
+    // Preview is a complete resolved theme. Suspend the committed layer while
+    // it is active so omitted adapters (for example full motion) cannot leak
+    // stricter committed behavior into the preview.
+    const previewGate = layer === 'committed' ? ':not([data-jc-theme-preview="true"])' : '';
+    const selector = `:root[${attribute}="true"]${previewGate}`;
     const declarations = { ...customDeclarations(theme), ...jellyfinDeclarations(theme) };
     // Jellyfin's own MUI variables are unlayered. An @layer declaration here
     // would always lose to them; the two owner style elements instead use

--- a/Jellyfin.Plugin.JellyfinCanopy/src/types/jc.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/types/jc.ts
@@ -112,6 +112,22 @@ export interface ThemeLegacyJellyfishSelection {
     Theme: string;
 }
 
+export interface ThemeStudioDiagnostics {
+    readonly status: 'inactive' | 'loading' | 'active' | 'preview' | 'error';
+    readonly revision: number | null;
+    readonly profileId: string | null;
+    readonly breakpoint: 'phone' | 'tablet' | 'desktop' | 'wide' | 'tv' | null;
+    readonly mode: 'dark' | 'light' | null;
+}
+
+/** Identity-owned seam consumed by the later Theme Studio editor chunk. */
+export interface ThemeStudioRuntimeApi {
+    preview(configuration: unknown): boolean;
+    cancelPreview(): void;
+    refresh(): void;
+    getDiagnostics(): ThemeStudioDiagnostics;
+}
+
 /** The unified localStorage write scheduler created by js/plugin.js. */
 export interface CacheManager {
     register(saveCallback: () => void): void;
@@ -741,6 +757,8 @@ export interface JECore {
     clientRuntime?: {
         reconcileUserSettings(context: IdentityContext): Promise<readonly unknown[]>;
     };
+    /** Present only while the authenticated Theme Studio feature owns a scope. */
+    themeStudio?: ThemeStudioRuntimeApi;
 }
 
 /**

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -283,6 +283,34 @@ Schema 1 persists PascalCase names exactly as represented by the TypeScript inte
 
 Export omits the revision and legacy-migration evidence and deep-clones the shareable data. Both `/validate` and `/migrate-jellyfish` are non-mutating staging operations; callers must show the result and explicitly save it through the revisioned POST. Jellyfish migration accepts only a bundled canonical theme name such as `Ocean`, never a CSS import, filename, or URL.
 
+### Theme Studio client runtime
+
+Theme Studio is an import-pure, identity-scoped lazy feature. When the administrator enables it, one feature generation performs one authenticated `theme.json` read, validates the complete response against the browser copy of schema 1, and then resolves one active profile. An oversized response, unknown field, unsupported token, read failure, obsolete identity, or activation failure removes the Theme Studio presentation and leaves Jellyfin's selected base theme in control. The runtime never stores CSS, walks components for computed styles, or creates a style element per component.
+
+The integration boundary is pinned to Jellyfin Web commit `3d7adb53480f02164041fdd983b3f7abc28d0fd9`: `src/themes/index.ts` configures MUI CSS variables with prefix `jf` and selector `[data-theme="%s"]`, while `src/themes/_base/_theme.scss` exposes the classic-layout bridge. Jellyfin alone owns root `data-theme` and the document `THEME_CHANGE` event. Canopy observes both and recomputes its bounded layer without writing `data-theme` or reloading the page.
+
+The committed and preview style layers have stable IDs `jc-theme-studio-committed` and `jc-theme-studio-preview`. Preview is appended later with equal selector specificity and can be removed independently. They deliberately do not use the CSS `@layer` at-rule: Jellyfin's own MUI variables are unlayered, and an author cascade layer would always lose to those declarations. The runtime publishes semantic `--jc-*` variables and bridges the pinned Jellyfin roles for background/default image/paper, text, primary/error, divider, action states and opacities, AppBar, filled inputs, buttons, snackbar, and `--jf-card-borderRadius`. Guard tests name those variables exactly so an upstream rename requires an explicit compatibility review.
+
+Two versioned adapters cover gaps not represented by official variables:
+
+- `legacy-v12-base-surfaces` targets only `.jc-legacy-layout` under an active `data-jc-theme-route` scope.
+- `focus-v12` supplies keyboard focus and optional link-underlining behavior under the same bounded route scope in both Jellyfin 12 layouts.
+
+Both adapters are serialized once into the generation-owned layer and are therefore idempotent. Route scope is one of `home`, `browse`, `details`, `player`, `dashboard`, or `other`. The administrator dashboard is a recovery space by default: the runtime removes committed and preview layers on dashboard/configuration routes unless `ThemeStudioDashboardEnabled` is explicitly enabled. Even when enabled, only the typed token bridge and the two bounded adapters apply.
+
+Responsive selection is capability-aware and uses the following tested boundaries:
+
+| Scope | Selection evidence |
+| --- | --- |
+| Phone portrait | Width below 600 px; tested at 390 × 844 |
+| Phone landscape | Coarse pointer, height below 600 px, width below 1000 px; tested at 844 × 390 |
+| Tablet | 600–1023 px, plus coarse-pointer landscape up to 1180 px; tested at 600/1023 and 1024 × 768 |
+| Desktop | 1024–1599 px outside the tablet/handset exception; a 1366 × 768 touch laptop remains desktop |
+| Wide | 1600 px and wider |
+| TV | Jellyfin's TV layout marker takes precedence over viewport width |
+
+The root capability attributes record the resolved breakpoint, pointer/hover state, light/dark mode, contrast, transparency, reduced motion, forced colors, profile, preset, palette, and route. Media-query listeners update those attributes and the same two style layers live. Reduced-motion and reduced-transparency preferences can only remove effects; coarse/no-hover input disables hover-only actions; high contrast strengthens focus. No Theme Studio runtime layout contains user text, so long localized labels and RTL do not introduce a runtime-owned layout direction or truncation surface in this slice.
+
 ### Bookmark API
 
 Bookmarks are stored **per user** under the plugin's configurations directory. The user id is normalized (dashes stripped, lowercased) to form the folder name, and the file is named `bookmark.json` (singular):

--- a/e2e/required-test-inventory.json
+++ b/e2e/required-test-inventory.json
@@ -89,6 +89,9 @@
     "e2e/spoiler-identity-tags.spec.ts › spoiler guard identity tags (reverse-proxy-safe attribution) › anonymous image fetches resolve per-user by marker on a shared IP",
     "e2e/spoiler-identity-tags.spec.ts › spoiler guard identity tags (reverse-proxy-safe attribution) › authenticated DTO responses carry per-user markers (distinct per user, blurhashes re-keyed)",
     "e2e/spoiler-identity-tags.spec.ts › spoiler guard identity tags (reverse-proxy-safe attribution) › unknown or absent markers fail safe (legacy ladder, no errors)",
+    "e2e/theme-studio-runtime.spec.ts › Theme Studio runtime bridge › legacy adapter is version-scoped and dashboard navigation restores the base theme",
+    "e2e/theme-studio-runtime.spec.ts › Theme Studio runtime bridge › modern desktop bridges official variables and follows Jellyfin theme changes live",
+    "e2e/theme-studio-runtime.spec.ts › Theme Studio runtime bridge › phone portrait and coarse-pointer landscape stay bounded without duplicate layers",
     "e2e/tags.spec.ts › tags › hide-on-hover fades the detail-page primary poster tags",
     "e2e/tags.spec.ts › tags › home library cards get data-jc-*-tagged markers per enabled family"
   ]

--- a/e2e/theme-studio-runtime.spec.ts
+++ b/e2e/theme-studio-runtime.spec.ts
@@ -1,0 +1,206 @@
+import type { Page } from 'playwright/test';
+import { assertNoRuntimeErrors, expect, loginAs, test, USERS } from './fixtures/auth';
+import { api, authenticate, PLUGIN_ID, type Session } from './fixtures/api';
+
+const CONFIG_PATH = `/Plugins/${PLUGIN_ID}/Configuration`;
+const COMMITTED_STYLE = '#jc-theme-studio-committed';
+const PREVIEW_STYLE = '#jc-theme-studio-preview';
+
+async function seedLayout(page: Page, layout: 'experimental' | 'desktop'): Promise<void> {
+    await page.addInitScript((value) => localStorage.setItem('layout', value), layout);
+}
+
+async function waitForThemeRuntime(page: Page, breakpoint: string): Promise<void> {
+    await page.waitForFunction((expected) => {
+        const root = document.documentElement;
+        return root.getAttribute('data-jc-theme-active') === 'true'
+            && root.getAttribute('data-jc-theme-breakpoint') === expected
+            && document.querySelectorAll('#jc-theme-studio-committed').length === 1;
+    }, breakpoint);
+}
+
+async function themeOverflowEvidence(page: Page): Promise<{ active: number; baseline: number }> {
+    return page.evaluate(async () => {
+        const style = document.querySelector<HTMLStyleElement>('#jc-theme-studio-committed');
+        if (!style) throw new Error('Theme Studio committed style is missing');
+        const overflow = () => document.documentElement.scrollWidth - window.innerWidth;
+        const active = overflow();
+        style.media = 'not all';
+        await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+        const baseline = overflow();
+        style.removeAttribute('media');
+        await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+        return { active, baseline };
+    });
+}
+
+test.describe.serial('Theme Studio runtime bridge', () => {
+    let admin: Session;
+    let original: Record<string, unknown>;
+
+    test.beforeAll(async ({ baseURL }) => {
+        admin = await authenticate(baseURL!, USERS.admin.username, USERS.admin.password);
+        const configuration = await api<Record<string, unknown>>(baseURL!, CONFIG_PATH, admin.token);
+        expect(configuration, 'plugin configuration must be readable').toBeTruthy();
+        original = configuration!;
+    });
+
+    test.beforeEach(async ({ baseURL }) => {
+        await api(baseURL!, CONFIG_PATH, admin.token, {
+            method: 'POST',
+            body: JSON.stringify({
+                ...original,
+                ThemeStudioEnabled: true,
+                ThemeStudioDashboardEnabled: false,
+                ThemeStudioAllowSeasonalScheduling: true,
+                ThemeSelectorEnabled: false,
+                LayoutEnforcement: 'None',
+            }),
+        });
+    });
+
+    test.afterEach(async ({ baseURL }) => {
+        await api(baseURL!, CONFIG_PATH, admin.token, {
+            method: 'POST',
+            body: JSON.stringify(original),
+        });
+    });
+
+    test.afterAll(async ({ baseURL }) => {
+        await api(baseURL!, CONFIG_PATH, admin.token, {
+            method: 'POST',
+            body: JSON.stringify(original),
+        });
+    });
+
+    test('modern desktop bridges official variables and follows Jellyfin theme changes live', async ({
+        page,
+        consoleErrors,
+    }) => {
+        await page.setViewportSize({ width: 1440, height: 900 });
+        await seedLayout(page, 'experimental');
+        await loginAs(page, 'admin', consoleErrors);
+        await waitForThemeRuntime(page, 'desktop');
+
+        const initial = await page.evaluate(() => {
+            const root = document.documentElement;
+            const styles = getComputedStyle(root);
+            return {
+                hostTheme: root.getAttribute('data-theme') || '',
+                mode: root.getAttribute('data-jc-theme-mode'),
+                route: root.getAttribute('data-jc-theme-route'),
+                canvas: styles.getPropertyValue('--jc-color-canvas').trim(),
+                officialCanvas: styles.getPropertyValue('--jf-palette-background-default').trim(),
+                officialPrimary: styles.getPropertyValue('--jf-palette-primary-main').trim(),
+                layers: document.querySelectorAll('#jc-theme-studio-committed').length,
+                previews: document.querySelectorAll('#jc-theme-studio-preview').length,
+            };
+        });
+        expect(initial).toMatchObject({ route: 'home', layers: 1, previews: 0 });
+        expect(initial.canvas).toMatch(/^#[0-9A-F]{6}$/i);
+        expect(initial.officialCanvas).toBe(initial.canvas);
+        expect(initial.officialPrimary).toMatch(/^#[0-9A-F]{6}$/i);
+
+        const changed = await page.evaluate(() => {
+            const root = document.documentElement;
+            const originalTheme = root.getAttribute('data-theme') || 'dark';
+            const target = originalTheme.toLowerCase().includes('light') ? 'dark' : 'light';
+            root.setAttribute('data-theme', target);
+            window.Events?.trigger(document, 'THEME_CHANGE');
+            return { originalTheme, target };
+        });
+        await expect.poll(() => page.evaluate(() =>
+            document.documentElement.getAttribute('data-jc-theme-mode'))).toBe(changed.target);
+        expect(await page.evaluate(() => document.documentElement.getAttribute('data-theme'))).toBe(changed.target);
+        await page.evaluate((value) => {
+            document.documentElement.setAttribute('data-theme', value);
+            window.Events?.trigger(document, 'THEME_CHANGE');
+        }, changed.originalTheme);
+        await expect.poll(() => page.evaluate(() =>
+            document.documentElement.getAttribute('data-jc-theme-mode'))).toBe(initial.mode);
+        assertNoRuntimeErrors(consoleErrors);
+    });
+
+    test('phone portrait and coarse-pointer landscape stay bounded without duplicate layers', async ({
+        page,
+        consoleErrors,
+    }) => {
+        await page.addInitScript(() => {
+            const nativeMatchMedia = window.matchMedia.bind(window);
+            window.matchMedia = ((query: string): MediaQueryList => {
+                const list = nativeMatchMedia(query);
+                if (query !== '(pointer: coarse)') return list;
+                return new Proxy(list, {
+                    get(target, property, receiver) {
+                        if (property === 'matches') return true;
+                        const value = Reflect.get(target, property, receiver) as unknown;
+                        return typeof value === 'function' ? value.bind(target) : value;
+                    },
+                });
+            }) as typeof window.matchMedia;
+        });
+        await page.setViewportSize({ width: 390, height: 844 });
+        await seedLayout(page, 'experimental');
+        await loginAs(page, 'admin', consoleErrors);
+        await waitForThemeRuntime(page, 'phone');
+        const portraitOverflow = await themeOverflowEvidence(page);
+        expect(portraitOverflow.active).toBeLessThanOrEqual(portraitOverflow.baseline + 1);
+
+        await page.setViewportSize({ width: 844, height: 390 });
+        await waitForThemeRuntime(page, 'phone');
+        const landscape = await page.evaluate(() => ({
+            layers: document.querySelectorAll('#jc-theme-studio-committed').length,
+            previews: document.querySelectorAll('#jc-theme-studio-preview').length,
+            pointer: document.documentElement.getAttribute('data-jc-theme-pointer'),
+            safeBottom: getComputedStyle(document.documentElement)
+                .getPropertyValue('--jc-safe-area-bottom').trim(),
+        }));
+        expect(landscape).toMatchObject({ layers: 1, previews: 0, pointer: 'coarse' });
+        expect(landscape.safeBottom).not.toBe('');
+        const landscapeOverflow = await themeOverflowEvidence(page);
+        expect(landscapeOverflow.active).toBeLessThanOrEqual(landscapeOverflow.baseline + 1);
+
+        await page.keyboard.press('Tab');
+        expect(await page.evaluate(() => document.activeElement !== document.body)).toBe(true);
+        assertNoRuntimeErrors(consoleErrors);
+    });
+
+    test('legacy adapter is version-scoped and dashboard navigation restores the base theme', async ({
+        page,
+        consoleErrors,
+    }) => {
+        await seedLayout(page, 'desktop');
+        await loginAs(page, 'admin', consoleErrors);
+        await waitForThemeRuntime(page, 'desktop');
+        const committedCss = await page.locator(COMMITTED_STYLE)
+            .evaluate((style) => style.textContent ?? '');
+        expect(committedCss).toContain('Adapter legacy-v12-base-surfaces');
+        expect(committedCss).toContain('.jc-legacy-layout[data-jc-theme-route]');
+        const adapterBackground = await page.evaluate(() => {
+            const root = document.documentElement;
+            const wasModern = root.classList.contains('jc-modern-layout');
+            root.classList.remove('jc-modern-layout');
+            root.classList.add('jc-legacy-layout');
+            const surface = document.createElement('div');
+            surface.className = 'backgroundContainer';
+            document.body.append(surface);
+            const background = getComputedStyle(surface).backgroundColor;
+            surface.remove();
+            root.classList.remove('jc-legacy-layout');
+            root.classList.toggle('jc-modern-layout', wasModern);
+            return background;
+        });
+        expect(adapterBackground).toBe('rgb(11, 11, 18)');
+        const hostTheme = await page.evaluate(() => document.documentElement.getAttribute('data-theme'));
+
+        await page.evaluate(() => { window.location.hash = '#/dashboard'; });
+        await page.waitForFunction(() => window.location.hash.startsWith('#/dashboard'));
+        await expect(page.locator(COMMITTED_STYLE)).toHaveCount(0);
+        await expect(page.locator(PREVIEW_STYLE)).toHaveCount(0);
+        expect(await page.evaluate(() => ({
+            active: document.documentElement.hasAttribute('data-jc-theme-active'),
+            hostTheme: document.documentElement.getAttribute('data-theme'),
+        }))).toEqual({ active: false, hostTheme });
+        assertNoRuntimeErrors(consoleErrors);
+    });
+});

--- a/scripts/build-bundle.js
+++ b/scripts/build-bundle.js
@@ -70,6 +70,7 @@ const ESM_ENTRIES = Object.freeze({
     'subtitle-styles': path.join(SRC_ROOT, 'entries', 'subtitle-styles.ts'),
     'spoiler-guard': path.join(SRC_ROOT, 'enhanced', 'spoiler-guard', 'feature.ts'),
     'theme-selector': path.join(SRC_ROOT, 'extras', 'theme-selector.feature.ts'),
+    'theme-studio': path.join(SRC_ROOT, 'theme-studio', 'feature.ts'),
     'anime-filler-warnings': path.join(SRC_ROOT, 'entries', 'anime-filler-warnings.ts'),
 });
 

--- a/scripts/bundle-budgets.json
+++ b/scripts/bundle-budgets.json
@@ -1,9 +1,9 @@
 {
   "schemaVersion": 1,
   "limits": {
-    "maxOutputCount": 165,
-    "maxEsmEntryCount": 36,
-    "maxEsmOutputCount": 79,
+    "maxOutputCount": 167,
+    "maxEsmEntryCount": 37,
+    "maxEsmOutputCount": 81,
     "maxIndividualEsmRawBytes": 262144,
     "maxBootRequests": 17,
     "maxBootRawBytes": 524288,


### PR DESCRIPTION
## Outcome

Adds the import-pure, identity-owned Theme Studio runtime bridge for Jellyfin 12. It resolves one validated per-user profile, publishes stable `--jc-*` tokens plus the pinned official `--jf-*` roles, scopes the smallest legacy adapters, follows Jellyfin theme/media/navigation changes live, and removes presentation synchronously on disable, identity reset, dashboard recovery, stale generation, or failure.

This is a stacked draft. It depends on:

- #401 for the researched design/compatibility contract
- #402 for the versioned server schema and per-user API

Closes #385 when the dependency stack is merged.

## Compatibility and safety

- modern Jellyfin 12/MUI, version-scoped legacy layout, dashboard recovery, TV capability, desktop/wide, tablet, phone portrait, and coarse-pointer landscape resolution
- no mutation of Jellyfin's `data-theme`; `THEME_CHANGE` is observed live
- one GET per runtime generation; no per-node resolution loop
- bounded strict browser schema with unknown-key rejection
- one presentation owner for styles, attributes, media subscriptions, navigation, identity, request cancellation, and teardown
- OS reduced-motion/transparency preferences can only reduce effects
- bundled/custom primary and error foregrounds are WCAG-selected after alpha composition through surface and canvas
- preview is a complete selector-gated layer, so committed accessibility adapters cannot leak into preview state
- no remote assets, raw CSS, `@import`, or `url()` inputs

## Validation at `4050a5bc`

- focused Theme Studio Vitest: 3 files, 20 tests passed
- full client coverage: 217 files, 1,429 tests passed; client/core 1,932/2,253 lines = 85.752%, exact reviewed baseline
- `./verify.sh lint`: passed (0 errors; repository advisory warnings remain below the existing cap)
- `npm run typecheck:src`: passed
- `npm run typecheck`: passed
- `npm run build:bundle`: 167 deterministic files; 17 boot requests, 116.6 KB raw / 40.4 KB gzip; cold Home 22 requests, 153.4 KB raw / 52.6 KB gzip
- `npm run syntax`: passed
- `dotnet build Jellyfin.Plugin.JellyfinCanopy/JellyfinCanopy.csproj -c Release --no-restore`: passed, 0 warnings / 0 errors
- disposable digest-pinned Jellyfin 12 Playwright: 3/3 passed (modern desktop; phone portrait + coarse-pointer landscape; version-scoped legacy adapter + dashboard recovery)
- `git diff --check`: passed

Local xUnit execution was not claimed: this workstation currently has .NET runtime 10.0.8 while the restored testhost requests 10.0.9. The release build passed, and the stacked schema dependency's GitHub Unit tests plus all six Jellyfin E2E shards are green.

## Independent review

Independent read-only review found four accessibility/preview issues in the first pass and two alpha-composition/preview-cascade edge cases in the second. All six were fixed with regressions. The final review of `4050a5bc` traced every call site and reported no actionable regression.

## AI assistance

AI assistance was used for implementation, testing, and review. All changes were locally inspected and validated with the evidence above.
