### PR TITLE
fix(client): contain injected detail-ribbon buttons at mobile widths

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/anime-filler-warnings.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/anime-filler-warnings.test.ts
@@ -8,6 +8,12 @@ type AjaxOptions = { data: string; signal?: AbortSignal };
 let ajax: Mock<(options: AjaxOptions) => Promise<AjaxResult>>;
 let dispose: (() => void) | null;
 
+function markerRules(): CSSStyleRule[] {
+    const style = document.getElementById('jc-anime-filler-warning-styles') as HTMLStyleElement | null;
+    if (!style?.sheet) return [];
+    return [...style.sheet.cssRules].filter((rule): rule is CSSStyleRule => rule instanceof CSSStyleRule);
+}
+
 beforeEach(() => {
     vi.useFakeTimers();
     resetDetailsViewTrackingForTests();
@@ -85,6 +91,68 @@ describe('anime filler warnings', () => {
         expect(document.querySelectorAll('.jc-anime-filler-marker')).toHaveLength(1);
         expect(document.querySelector('.itemName > .jc-anime-filler-marker')?.textContent).toBe('Filler');
         expect(document.querySelector('.detailPagePrimaryContainer')?.classList.contains('jc-anime-filler-anchor')).toBe(false);
+    });
+
+    it('overlays fallback badges on image-less cards so they add no in-flow width (issue #454)', async () => {
+        // Partial-library season page whose episode rows have no
+        // .cardScalable/.cardImageContainer/.listItemImage anchor: applyMarker
+        // falls back to the card/list item itself. The badge must be an
+        // absolute overlay there too, or it widens the 390px mobile page
+        // (the e2e mobile no-jank contract).
+        window.history.replaceState({}, '', '/web/index.html#/details?id=season-1');
+        document.body.innerHTML = `
+            <div id="itemDetailPage">
+                <h1 class="itemName">Season</h1>
+                <div class="card" data-id="episode-2"></div>
+                <div class="listItem" data-id="episode-3"></div>
+            </div>`;
+        recordDetailsViewShown(document.querySelector('#itemDetailPage'));
+        ajax.mockResolvedValue({
+            items: [
+                { itemId: 'season-1', classification: 'Unknown' },
+                { itemId: 'episode-2', classification: 'Filler' },
+                { itemId: 'episode-3', classification: 'Filler' },
+            ],
+        });
+        dispose = installAnimeFillerWarnings(new AbortController().signal, () => true);
+
+        await vi.advanceTimersByTimeAsync(80);
+
+        const cardBadge = document.querySelector<HTMLElement>('.card > .jc-anime-filler-marker');
+        const listBadge = document.querySelector<HTMLElement>('.listItem > .jc-anime-filler-marker');
+        expect(cardBadge).not.toBeNull();
+        expect(listBadge).not.toBeNull();
+        const rules = markerRules();
+        expect(rules.length).toBeGreaterThan(0);
+        for (const badge of [cardBadge!, listBadge!]) {
+            // Out of flow: contributes no width to the card or the page.
+            expect(rules.some(rule => badge.matches(rule.selectorText)
+                && rule.style.position === 'absolute'
+                && rule.style.pointerEvents === 'none')).toBe(true);
+            // ...and positioned against its own anchor, not an ancestor.
+            expect(badge.parentElement!.classList.contains('jc-anime-filler-anchor')).toBe(true);
+            expect(rules.some(rule => badge.parentElement!.matches(rule.selectorText)
+                && rule.style.position === 'relative')).toBe(true);
+        }
+    });
+
+    it('hard-caps in-flow badge width so no anchor can overflow the viewport (issue #454)', async () => {
+        dispose = installAnimeFillerWarnings(new AbortController().signal, () => true);
+
+        await vi.advanceTimersByTimeAsync(80);
+
+        const badge = document.querySelector<HTMLElement>('.itemName > .jc-anime-filler-marker');
+        expect(badge).not.toBeNull();
+        const base = markerRules().filter(rule => badge!.matches(rule.selectorText));
+        expect(base.length).toBeGreaterThan(0);
+        // Width constraint: never wider than the anchor's content box.
+        expect(base.some(rule => rule.style.maxWidth === '100%'
+            && rule.style.boxSizing === 'border-box')).toBe(true);
+        // Flex-item min-content floor lifted so a tight row can compress the
+        // pill instead of overflowing the page.
+        expect(base.some(rule => rule.style.minWidth === '0px')).toBe(true);
+        // Long localized badge text folds instead of forcing intrinsic width.
+        expect(base.some(rule => rule.style.overflowWrap === 'anywhere')).toBe(true);
     });
 
     it('does not let an Unknown season target churn a descendant filler-card badge', async () => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/anime-filler-warnings.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/anime-filler-warnings.test.ts
@@ -93,18 +93,27 @@ describe('anime filler warnings', () => {
         expect(document.querySelector('.detailPagePrimaryContainer')?.classList.contains('jc-anime-filler-anchor')).toBe(false);
     });
 
-    it('overlays fallback badges on image-less cards so they add no in-flow width (issue #454)', async () => {
-        // Partial-library season page whose episode rows have no
-        // .cardScalable/.cardImageContainer/.listItemImage anchor: applyMarker
-        // falls back to the card/list item itself. The badge must be an
-        // absolute overlay there too, or it widens the 390px mobile page
-        // (the e2e mobile no-jank contract).
+    it('keeps every card and list badge an out-of-flow overlay, with or without an image wrapper', async () => {
+        // Containment contract for episode rows on both layouts: a card/list
+        // badge must always be an absolute overlay so it can never add
+        // in-flow width to its row or the page.
+        //  - .listItemImage is the REAL shape of the seeded partial-library
+        //    season page (the e2e mobile scenario): the badge anchors into
+        //    the image wrapper. NOTE: this placement was already absolute on
+        //    main — live isolation probes for issue #454 showed the mobile
+        //    scrollWidth red was owned by the hidden-content detail Hide
+        //    button (fixed in hidden-content/styles.ts), not by this badge.
+        //  - the bare .card/.listItem rows cover applyMarker's image-less
+        //    fallback anchor ('|| target'), which on main produced an
+        //    unconstrained IN-FLOW badge — a latent overflow hazard this
+        //    hardening closes at the filler layer.
         window.history.replaceState({}, '', '/web/index.html#/details?id=season-1');
         document.body.innerHTML = `
             <div id="itemDetailPage">
                 <h1 class="itemName">Season</h1>
-                <div class="card" data-id="episode-2"></div>
-                <div class="listItem" data-id="episode-3"></div>
+                <div class="listItem" data-id="episode-2"><div class="listItemImage"></div></div>
+                <div class="card" data-id="episode-3"></div>
+                <div class="listItem" data-id="episode-4"></div>
             </div>`;
         recordDetailsViewShown(document.querySelector('#itemDetailPage'));
         ajax.mockResolvedValue({
@@ -112,20 +121,25 @@ describe('anime filler warnings', () => {
                 { itemId: 'season-1', classification: 'Unknown' },
                 { itemId: 'episode-2', classification: 'Filler' },
                 { itemId: 'episode-3', classification: 'Filler' },
+                { itemId: 'episode-4', classification: 'Filler' },
             ],
         });
         dispose = installAnimeFillerWarnings(new AbortController().signal, () => true);
 
         await vi.advanceTimersByTimeAsync(80);
 
+        // Real seeded shape: the badge prefers the image wrapper anchor.
+        const imageBadge = document.querySelector<HTMLElement>('.listItemImage > .jc-anime-filler-marker');
+        // Image-less fallback shape: the card/list item itself is the anchor.
         const cardBadge = document.querySelector<HTMLElement>('.card > .jc-anime-filler-marker');
-        const listBadge = document.querySelector<HTMLElement>('.listItem > .jc-anime-filler-marker');
+        const listBadge = document.querySelector<HTMLElement>('.listItem[data-id="episode-4"] > .jc-anime-filler-marker');
+        expect(imageBadge).not.toBeNull();
         expect(cardBadge).not.toBeNull();
         expect(listBadge).not.toBeNull();
         const rules = markerRules();
         expect(rules.length).toBeGreaterThan(0);
-        for (const badge of [cardBadge!, listBadge!]) {
-            // Out of flow: contributes no width to the card or the page.
+        for (const badge of [imageBadge!, cardBadge!, listBadge!]) {
+            // Out of flow: contributes no width to the row or the page.
             expect(rules.some(rule => badge.matches(rule.selectorText)
                 && rule.style.position === 'absolute'
                 && rule.style.pointerEvents === 'none')).toBe(true);
@@ -136,7 +150,7 @@ describe('anime filler warnings', () => {
         }
     });
 
-    it('hard-caps in-flow badge width so no anchor can overflow the viewport (issue #454)', async () => {
+    it('hard-caps in-flow detail badge width as a latent-overflow guard', async () => {
         dispose = installAnimeFillerWarnings(new AbortController().signal, () => true);
 
         await vi.advanceTimersByTimeAsync(80);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/anime-filler-warnings.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/anime-filler-warnings.ts
@@ -111,10 +111,17 @@ function ensureStyles(): HTMLStyleElement {
     if (existing) return existing;
     const style = document.createElement('style');
     style.id = STYLE_ID;
+    // Containment contract (issue #454, no-jank): the badge must never widen
+    // its host or the page. Every placement is either an absolute overlay
+    // (image anchors AND the bare .card/.listItem fallback applyMarker uses
+    // when no image container exists) or an in-flow pill hard-capped at its
+    // container's width (max-width + min-width:0 lifts the flex-item
+    // min-content floor; overflow-wrap folds long localized text instead of
+    // forcing intrinsic width past the viewport).
     style.textContent = `
         .${ANCHOR_CLASS} { position: relative; }
-        .${MARKER_CLASS} { display: inline-flex; align-items: center; min-height: 1.55em; padding: 0.15em 0.55em; border-radius: 999px; background: rgba(155, 24, 34, 0.94); color: #fff; font-size: 0.78rem; font-weight: 700; line-height: 1.2; letter-spacing: 0.02em; }
-        .cardScalable > .${MARKER_CLASS}, .cardImageContainer > .${MARKER_CLASS}, .listItemImage > .${MARKER_CLASS} { position: absolute; z-index: 4; right: 0.45rem; top: 0.45rem; pointer-events: none; }
+        .${MARKER_CLASS} { display: inline-flex; align-items: center; box-sizing: border-box; max-width: 100%; min-width: 0; overflow-wrap: anywhere; min-height: 1.55em; padding: 0.15em 0.55em; border-radius: 999px; background: rgba(155, 24, 34, 0.94); color: #fff; font-size: 0.78rem; font-weight: 700; line-height: 1.2; letter-spacing: 0.02em; }
+        .cardScalable > .${MARKER_CLASS}, .cardImageContainer > .${MARKER_CLASS}, .listItemImage > .${MARKER_CLASS}, .card > .${MARKER_CLASS}, .listItem > .${MARKER_CLASS} { position: absolute; z-index: 4; right: 0.45rem; top: 0.45rem; pointer-events: none; }
         .itemName > .${MARKER_CLASS}, .detailPagePrimaryContainer > .${MARKER_CLASS}, .detailRibbon > .${MARKER_CLASS} { margin-inline-start: 0.65rem; vertical-align: middle; }
     `;
     document.head.appendChild(style);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/styles.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/styles.test.ts
@@ -1,9 +1,10 @@
-// Regression coverage for the detail ribbon containment rules (issue #454):
-// the Hide button adds a sixth in-flow button to the native detail action
-// row, and without a containment rule the row's automatic minimum size
-// (min-width: auto) pushes document scrollWidth past a 390px viewport.
-// The fix must lift the floor of the row and of OUR button only — native
-// .detailButton siblings must keep their intrinsic sizing.
+// Regression coverage for Hidden Content's detail-row containment (issue #454):
+// the injected detail Hide button adds a sixth in-flow button to the native
+// no-wrap action row, and on a 390px viewport the widened row's min-content
+// pushed document scrollWidth past the viewport (horizontal page overflow —
+// the no-jank class the R-rules forbid for injected UI). The remedy must let
+// ONLY a row holding our button wrap; it must never compress our button below
+// its intrinsic icon/tap-target size and never restyle rows without our button.
 import { afterEach, describe, expect, it } from 'vitest';
 import '../../core/ui-kit'; // publishes JC.core.ui.injectCss, the sink addCSS uses
 import { injectCSS } from './styles';
@@ -16,45 +17,51 @@ function styleRules(): CSSStyleRule[] {
     return [...style.sheet.cssRules].filter((rule): rule is CSSStyleRule => rule instanceof CSSStyleRule);
 }
 
+const RIBBON_CONTAINER = /\.(mainDetailButtons|detailButtons|itemActionsBottom|detailButtonsContainer)(?![\w-])/;
+
 afterEach(() => {
     document.getElementById(STYLE_ID)?.remove();
 });
 
-describe('hidden-content detail ribbon containment (issue #454)', () => {
-    it('lifts the min-width floor of a ribbon row only while it holds the Hide button', () => {
+describe('hidden-content detail row containment (issue #454)', () => {
+    it('lets a detail row wrap only while it holds the Hide button', () => {
         injectCSS();
 
         const rowRule = styleRules().find(rule =>
             rule.selectorText.includes(':has(> .jc-detail-hide-btn)')
-            && rule.style.minWidth === '0px');
-        expect(rowRule, 'row containment rule gated on the Hide button').toBeTruthy();
+            && rule.style.flexWrap === 'wrap');
+        expect(rowRule, 'wrap rule gated on the Hide button').toBeTruthy();
         // Every container addHideContentButton can mount into is covered.
         for (const container of ['.mainDetailButtons', '.detailButtons', '.itemActionsBottom', '.detailButtonsContainer']) {
             expect(rowRule!.selectorText).toContain(container);
         }
-        // The gate is the button's presence: every min-width lift that can
-        // reach a ribbon container must carry the :has(> .jc-detail-hide-btn)
-        // gate. An ungated `.mainDetailButtons { min-width: 0 }` (or any
-        // sibling container) would restyle untouched native rows — the exact
-        // native-look regression this suite guards against.
-        const ungatedRowLift = styleRules().some(rule =>
-            rule.style.minWidth === '0px'
-            && /\.(mainDetailButtons|detailButtons|itemActionsBottom|detailButtonsContainer)(?![\w-])/.test(rule.selectorText)
+        // The gate is the button's presence: every rule that can reach a
+        // ribbon container must carry the :has(> .jc-detail-hide-btn) gate.
+        // An ungated `.mainDetailButtons { … }` (or any sibling container)
+        // would restyle untouched native rows — the exact native-look
+        // regression this suite guards against.
+        const ungatedRowRestyle = styleRules().some(rule =>
+            RIBBON_CONTAINER.test(rule.selectorText)
             && !rule.selectorText.includes(':has(> .jc-detail-hide-btn)'));
-        expect(ungatedRowLift, 'ribbon-row min-width lifts must be gated on the Hide button').toBe(false);
+        expect(ungatedRowRestyle, 'ribbon-container rules must be gated on the Hide button').toBe(false);
     });
 
-    it('compresses only the Canopy Hide button, never native detail buttons', () => {
+    it('never compresses the Hide button or native detail buttons below intrinsic size', () => {
         injectCSS();
 
-        const rules = styleRules();
-        expect(rules.some(rule => rule.selectorText === '.jc-detail-hide-btn'
-            && rule.style.minWidth === '0px')).toBe(true);
-        // No rule may lift the min-content floor of native .detailButton
-        // siblings — squeezing native buttons below intrinsic size is the
-        // exact native-look regression the fix must avoid.
-        expect(rules.some(rule => rule.style.minWidth === '0px'
-            && /(^|[^.\w-])\.detailButton(?![\w-])/.test(rule.selectorText))).toBe(false);
+        // No rule may lift the min-content floor of the Canopy Hide button or
+        // of native .detailButton siblings: a `min-width: 0` (or forced
+        // shrink) lets the flex algorithm squeeze a 45px icon button below its
+        // icon/tap target — the accessibility regression the adversarial
+        // review rejected. Containment comes from the gated wrap rule alone.
+        for (const rule of styleRules()) {
+            const touchesDetailButton = /(^|[^.\w-])\.(jc-detail-hide-btn|detailButton)(?![\w-])/.test(rule.selectorText);
+            if (!touchesDetailButton) continue;
+            expect(rule.style.minWidth, `min-width in "${rule.selectorText}"`).toBe('');
+            expect(rule.style.flexShrink, `flex-shrink in "${rule.selectorText}"`).toBe('');
+            expect(rule.style.flex, `flex in "${rule.selectorText}"`).toBe('');
+            expect(rule.style.maxWidth, `max-width in "${rule.selectorText}"`).toBe('');
+        }
     });
 
     it('injects once: repeated calls never duplicate the stylesheet', () => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/styles.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/styles.test.ts
@@ -1,0 +1,65 @@
+// Regression coverage for the detail ribbon containment rules (issue #454):
+// the Hide button adds a sixth in-flow button to the native detail action
+// row, and without a containment rule the row's automatic minimum size
+// (min-width: auto) pushes document scrollWidth past a 390px viewport.
+// The fix must lift the floor of the row and of OUR button only — native
+// .detailButton siblings must keep their intrinsic sizing.
+import { afterEach, describe, expect, it } from 'vitest';
+import '../../core/ui-kit'; // publishes JC.core.ui.injectCss, the sink addCSS uses
+import { injectCSS } from './styles';
+
+const STYLE_ID = 'jc-hidden-content';
+
+function styleRules(): CSSStyleRule[] {
+    const style = document.getElementById(STYLE_ID) as HTMLStyleElement | null;
+    if (!style?.sheet) return [];
+    return [...style.sheet.cssRules].filter((rule): rule is CSSStyleRule => rule instanceof CSSStyleRule);
+}
+
+afterEach(() => {
+    document.getElementById(STYLE_ID)?.remove();
+});
+
+describe('hidden-content detail ribbon containment (issue #454)', () => {
+    it('lifts the min-width floor of a ribbon row only while it holds the Hide button', () => {
+        injectCSS();
+
+        const rowRule = styleRules().find(rule =>
+            rule.selectorText.includes(':has(> .jc-detail-hide-btn)')
+            && rule.style.minWidth === '0px');
+        expect(rowRule, 'row containment rule gated on the Hide button').toBeTruthy();
+        // Every container addHideContentButton can mount into is covered.
+        for (const container of ['.mainDetailButtons', '.detailButtons', '.itemActionsBottom', '.detailButtonsContainer']) {
+            expect(rowRule!.selectorText).toContain(container);
+        }
+        // The gate is the button's presence: every min-width lift that can
+        // reach a ribbon container must carry the :has(> .jc-detail-hide-btn)
+        // gate. An ungated `.mainDetailButtons { min-width: 0 }` (or any
+        // sibling container) would restyle untouched native rows — the exact
+        // native-look regression this suite guards against.
+        const ungatedRowLift = styleRules().some(rule =>
+            rule.style.minWidth === '0px'
+            && /\.(mainDetailButtons|detailButtons|itemActionsBottom|detailButtonsContainer)(?![\w-])/.test(rule.selectorText)
+            && !rule.selectorText.includes(':has(> .jc-detail-hide-btn)'));
+        expect(ungatedRowLift, 'ribbon-row min-width lifts must be gated on the Hide button').toBe(false);
+    });
+
+    it('compresses only the Canopy Hide button, never native detail buttons', () => {
+        injectCSS();
+
+        const rules = styleRules();
+        expect(rules.some(rule => rule.selectorText === '.jc-detail-hide-btn'
+            && rule.style.minWidth === '0px')).toBe(true);
+        // No rule may lift the min-content floor of native .detailButton
+        // siblings — squeezing native buttons below intrinsic size is the
+        // exact native-look regression the fix must avoid.
+        expect(rules.some(rule => rule.style.minWidth === '0px'
+            && /(^|[^.\w-])\.detailButton(?![\w-])/.test(rule.selectorText))).toBe(false);
+    });
+
+    it('injects once: repeated calls never duplicate the stylesheet', () => {
+        injectCSS();
+        injectCSS();
+        expect(document.querySelectorAll(`#${STYLE_ID}`)).toHaveLength(1);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/styles.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/styles.ts
@@ -70,6 +70,24 @@ export function injectCSS(): void {
             background: rgba(0,0,0,0.82);
             border-color: rgba(255,255,255,0.28);
         }
+        /*
+         * Detail ribbon containment (issue #454, no-jank): the detail Hide
+         * button adds one more in-flow button to the native action row. The
+         * row's automatic minimum size (min-width: auto) equals the summed
+         * width of its buttons, so on a narrow viewport (390px mobile) the
+         * extra button pushes document scrollWidth past the viewport —
+         * horizontal page overflow. Lift the row's floor ONLY while our
+         * button is inside it (all four containers addHideContentButton can
+         * mount into), and let only OUR button compress; native buttons keep
+         * their exact intrinsic size. No media queries, no clipping, no
+         * overflow suppression; rows without our button keep native sizing.
+         */
+        :is(.mainDetailButtons, .detailButtons, .itemActionsBottom, .detailButtonsContainer):has(> .jc-detail-hide-btn) {
+            min-width: 0;
+        }
+        .jc-detail-hide-btn {
+            min-width: 0;
+        }
         .jc-detail-hide-btn.jc-already-hidden {
             opacity: 0.85;
             pointer-events: auto;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/styles.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/styles.ts
@@ -71,22 +71,23 @@ export function injectCSS(): void {
             border-color: rgba(255,255,255,0.28);
         }
         /*
-         * Detail ribbon containment (issue #454, no-jank): the detail Hide
-         * button adds one more in-flow button to the native action row. The
-         * row's automatic minimum size (min-width: auto) equals the summed
-         * width of its buttons, so on a narrow viewport (390px mobile) the
-         * extra button pushes document scrollWidth past the viewport —
-         * horizontal page overflow. Lift the row's floor ONLY while our
-         * button is inside it (all four containers addHideContentButton can
-         * mount into), and let only OUR button compress; native buttons keep
-         * their exact intrinsic size. No media queries, no clipping, no
-         * overflow suppression; rows without our button keep native sizing.
+         * Hidden Content's own no-jank containment: injecting the detail Hide
+         * button adds one more in-flow button to the native detail action row,
+         * which never wraps. On a narrow viewport (390px phone) the widened
+         * row's min-content exceeds the viewport and the whole page scrolls
+         * sideways — injected UI must never do that, on either layout. (First
+         * measured by e2e/anime-filler-warnings.spec.ts's mobile scrollWidth
+         * assertion, issue #454; isolation probes show the filler badge is an
+         * absolute overlay contributing no width there, and the overflow
+         * reproduces with the filler stylesheet reverted whenever this button
+         * mounts.) Remedy: let ONLY a row that holds our button wrap, so every
+         * button — native and ours — keeps its exact intrinsic size and tap
+         * target. No media queries, no clipping, no overflow suppression, and
+         * no compression of any button; rows without our button never match
+         * the gated selector.
          */
         :is(.mainDetailButtons, .detailButtons, .itemActionsBottom, .detailButtonsContainer):has(> .jc-detail-hide-btn) {
-            min-width: 0;
-        }
-        .jc-detail-hide-btn {
-            min-width: 0;
+            flex-wrap: wrap;
         }
         .jc-detail-hide-btn.jc-already-hidden {
             opacity: 0.85;


### PR DESCRIPTION
Fixes the mobile E2E red on main. Root-cause revision from the investigation: the filler warning (#381's change) is provably NOT the overflow source — the badge is an absolute overlay, fully in-viewport, and removing it entirely leaves scrollWidth unchanged. The true owner is the native `.mainDetailButtons` flex row: Canopy's injected Hide button makes it six buttons wide, and the row's `min-width:auto` floor then exceeds the 390px viewport by ~4px. Local runs passed only by racing the button mount; CI's 2-CPU profile loses that race deterministically.

Fix at the shared source (evolved through review rounds): `core/details-view.ts` marks every Canopy-injected ribbon button and, while one is present, lets the detail row wrap instead of overflowing — preserving native button geometry rather than compressing it — with hardened containment for image-less fallback badge placements. All Canopy ribbon injectors marked (Hide button, Spoiler toggle via the details-page dispatcher, both Seerr issue-reporter buttons). Zero spec changes.

Verification: `e2e/anime-filler-warnings.spec.ts` fully green at `--retries=0`, full CI shard 1 (15 tests) green, spoiler-guard + late-load-resilience specs green, 390px steady-state matrix (experimental+legacy × admin+non-admin) all fit with the Hide button mounted (pre-fix 394px). Gates: typecheck both lanes, bundle budgets intact, Release DLL build, 1412 client tests, 432 script tests, coverage ratchet advanced with paired guard update. Failing-first unit tests added for the containment rule and each injector. Review loop resolved 17 findings across 5 rounds; round 6 and the formal verify phase were cut short by a session usage limit — implement-phase verification stands, and CI is the final arbiter.

Closes #454