### PR TITLE
chore(workflow): resilience, resumability, and convergence for the agentic dev loop

### DIFF
--- a/.agents/skills/jellyfin-canopy-agentic-loop/README.md
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/README.md
@@ -54,6 +54,8 @@ oracle.
        startPhase: "explore",      // resume a paused/limit-killed run with "review" or "verify"
        reviewedHead: "<sha>",      // verify-resume only: certifies the prior clean review when
                                    // verify reports this exact HEAD (record the paused run's headSha)
+       ledger: [/* paused run's result.ledger */],  // review-resume only: seed prior
+                                   // fix/refute dispositions so they are not re-churned
        envSetup: "<shell prelude run before any build/test, e.g. DOTNET_ROOT exports>",
        reviewMode: "spec",         // opt-in for specification authoring (spec lenses)
        solVia:   "codex-cli",      // default; or "agent" (needs a Sol-capable router)
@@ -102,8 +104,10 @@ The loop serves two envelopes:
   is fail-closed (no review ran) unless the pause followed a clean review round:
   pass `reviewedHead:<the returned headSha>` and it certifies iff verify reports
   that exact HEAD. Campaigns over an issue queue relaunch per issue (`issue: N`
-  self-hydrates the brief) and use the returned resume fields as the per-issue
-  checkpoint.
+  self-hydrates the brief) and use the returned resume fields
+  (`resumeFrom`/`headSha`/`loopClean`/`ledger`) as the per-issue checkpoint —
+  pass the persisted `ledger` back on a `startPhase:"review"` resume so the review
+  loop keeps its prior refutations/fixes suppressed instead of re-churning them.
 
 ### Model routing
 

--- a/.agents/skills/jellyfin-canopy-agentic-loop/README.md
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/README.md
@@ -139,7 +139,10 @@ Every **mixed** review round (up to the mixed cap) runs **both** Claude and
 Each Sol slot is fail-closed: if the route/CLI is unavailable, that slot's scope
 (its lens, or the whole diff) is reviewed by Claude instead — the slot is never
 dropped and a round is never certified clean with a lens left unreviewed. Treat a
-missing Sol pass as a signal to fix the route, not as a clean review.
+missing Sol pass as a signal to fix the route, not as a clean review — and the loop
+enforces it: the round that certifies `loopClean` MUST have **real** cross-family
+coverage. A clean round whose every Sol slot fell back to Claude (dead route) sets
+`reviewIncomplete`, so `readyForPR` stays false until the Sol route is fixed.
 
 ## Non–Claude-Code runtimes
 

--- a/.agents/skills/jellyfin-canopy-agentic-loop/README.md
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/README.md
@@ -116,8 +116,10 @@ The loop spreads models by role to spare Claude/Opus budget:
 - **Implementation** — the single writer runs on **Fable (high)**, falling back
   to **Opus (high)** if Fable is exhausted (`implementModel` / `implementFallback`).
 - **Read-only steps except the gate runner** — with `modelSplit: true` (default):
-  **explore runs 2 Claude + 6 `gpt-5.6-sol`** explorers (`exploreClaudeCount`,
-  Sol slots at `xhigh`); plan (incl. synthesis), the review lenses, and
+  **explore runs 8 explorers on a non-docs standard/deep run — 2 Claude + 6
+  `gpt-5.6-sol`** (`exploreClaudeCount`, Sol slots at `xhigh`; a `quick` run uses 2
+  explorers and a `docs` surface uses its 4 docs-specific angles = 2 Claude + 2
+  Sol); plan (incl. synthesis), the review lenses, and
   finding-verification alternate **~50/50 Claude / `gpt-5.6-sol`**; an
   unroutable Sol slot falls back to Claude. After 3 consecutive Sol failures a
   circuit breaker sends the remaining Sol slots straight to Claude, and the

--- a/.agents/skills/jellyfin-canopy-agentic-loop/README.md
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/README.md
@@ -45,12 +45,18 @@ oracle.
        branch:   "<type>/<slug>",
        task:     "<full task / issue / repro>",
        brief:    "<path to task-brief.md>",
+       briefText: "<the brief CONTENTS inlined — preferred; agents may never open the path>",
+       issue:    123,              // commit-subject ref; with NO briefText, a Phase-0 agent
+                                   // fetches the live issue body as the brief (self-hydration)
        surface:  "client" | "server" | "cross" | "docs",
        runtime:  true,
        depth:    "quick" | "standard" | "deep",
+       startPhase: "explore",      // resume a paused/limit-killed run with "review" or "verify"
+       envSetup: "<shell prelude run before any build/test, e.g. DOTNET_ROOT exports>",
+       reviewMode: "spec",         // opt-in for specification authoring (spec lenses)
        solVia:   "codex-cli",      // default; or "agent" (needs a Sol-capable router)
        solEffort: "high",
-       solReviewers: 1
+       solReviewers: 1             // whole-diff Sol reviewers per round (min 1)
      }
    })
    ```
@@ -62,15 +68,36 @@ oracle.
 
 ### Depth
 
-| depth | explorers | planners | review round cap | verify-fix cap |
+| depth | explorers | planners | mixed review round cap | verify-fix cap |
 | --- | --- | --- | --- | --- |
 | quick | 2 | 2 | 2 | 1 |
-| standard | 4 | 3 | 3 | 2 |
-| deep | 6 | 3 | 4 | 3 |
+| standard | 8 | 3 | 4 | 2 |
+| deep | 8 | 3 | 4 | 3 |
 
-`surface` selects which repo-native gates run; `runtime:true` additionally
+The "mixed" cap is the Claude+Sol panel; if the loop is still not clean after
+it, review **continues with `gpt-5.6-sol` as the only reviewer** up to
+`hardRoundCap` (default 10). Docs surfaces and `reviewMode:"spec"` default the
+hard cap to mixed-cap+1 instead — prose does not converge under a ten-round
+escalation, and unresolved docs findings go back to a human.
+
+`surface` selects which repo-native gates run (docs runs also use 4
+docs-specific explore angles and skip Localize); `runtime:true` additionally
 builds the Release DLL and runs `npm run e2e:local` (dockerized
 `jellyfin/jellyfin:unstable`).
+
+### Operating envelopes
+
+The loop serves two envelopes:
+
+- **FIXES** — contained bug fixes and small changes: `depth:"quick"` plus a
+  patch-sized brief (tight acceptance criteria, narrow surface) keeps the run
+  light: 2 explorers, 2 planners, a 2-round mixed cap, surface-scoped gates.
+- **FEATURES** — large multi-day work: run `standard`/`deep`; the loop survives
+  provider outages by returning `status:"paused"` with `pauseReason` +
+  `resumeFrom` instead of burning retries, and a later session re-enters with
+  `startPhase:"review"`/`"verify"` against the same branch. Campaigns over an
+  issue queue relaunch per issue (`issue: N` self-hydrates the brief) and use
+  the returned resume fields as the per-issue checkpoint.
 
 ### Model routing
 
@@ -78,14 +105,21 @@ The loop spreads models by role to spare Claude/Opus budget:
 
 - **Implementation** — the single writer runs on **Fable (high)**, falling back
   to **Opus (high)** if Fable is exhausted (`implementModel` / `implementFallback`).
-- **Read-only steps except implementation** — with `modelSplit: true` (default),
-  explore, plan, the review lenses, finding-verification, and the gate runner
-  alternate **~50/50 Claude / `gpt-5.6-sol` (high)**; an unroutable Sol slot
-  falls back to Claude.
+- **Read-only steps except the gate runner** — with `modelSplit: true` (default):
+  **explore runs 2 Claude + 6 `gpt-5.6-sol`** explorers (`exploreClaudeCount`,
+  Sol slots at `xhigh`); plan (incl. synthesis), the review lenses, and
+  finding-verification alternate **~50/50 Claude / `gpt-5.6-sol`**; an
+  unroutable Sol slot falls back to Claude. After 3 consecutive Sol failures a
+  circuit breaker sends the remaining Sol slots straight to Claude, and the
+  result's `modelCoverage` records requested-vs-actual models per slot class.
+- **Final verify / gate run** — stays on **Claude** (one authoritative model
+  runs the repo gates; never split to Sol).
 - **Fixers** — stay on Claude/Opus (they write code).
 
-Every review round still runs **both** Claude and **≥1 `gpt-5.6-sol` (high)**
-reviewer. The Sol side is obtained one of two ways, chosen with `solVia`:
+Every **mixed** review round (up to the mixed cap) runs **both** Claude and
+**≥1 `gpt-5.6-sol` (high)** reviewer; escalation rounds past the mixed cap are
+`gpt-5.6-sol`-only. The Sol side is obtained one of two ways, chosen with
+`solVia`:
 
 - `"codex-cli"` (default) — a harness subagent shells out to the local `codex`
   CLI (`-a never -s read-only exec -m gpt-5.6-sol`) with

--- a/.agents/skills/jellyfin-canopy-agentic-loop/README.md
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/README.md
@@ -83,7 +83,8 @@ hard cap to mixed-cap+1 instead — prose does not converge under a ten-round
 escalation, and unresolved docs findings go back to a human.
 
 `surface` selects which repo-native gates run (docs runs also use 4
-docs-specific explore angles and skip Localize); `runtime:true` additionally
+docs-specific explore angles and skip Localize — `server` runs skip Localize too,
+having no client locale surface); `runtime:true` additionally
 builds the Release DLL and runs `npm run e2e:local` (dockerized
 `jellyfin/jellyfin:unstable`).
 

--- a/.agents/skills/jellyfin-canopy-agentic-loop/README.md
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/README.md
@@ -52,6 +52,8 @@ oracle.
        runtime:  true,
        depth:    "quick" | "standard" | "deep",
        startPhase: "explore",      // resume a paused/limit-killed run with "review" or "verify"
+       reviewedHead: "<sha>",      // verify-resume only: certifies the prior clean review when
+                                   // verify reports this exact HEAD (record the paused run's headSha)
        envSetup: "<shell prelude run before any build/test, e.g. DOTNET_ROOT exports>",
        reviewMode: "spec",         // opt-in for specification authoring (spec lenses)
        solVia:   "codex-cli",      // default; or "agent" (needs a Sol-capable router)
@@ -95,9 +97,12 @@ The loop serves two envelopes:
 - **FEATURES** — large multi-day work: run `standard`/`deep`; the loop survives
   provider outages by returning `status:"paused"` with `pauseReason` +
   `resumeFrom` instead of burning retries, and a later session re-enters with
-  `startPhase:"review"`/`"verify"` against the same branch. Campaigns over an
-  issue queue relaunch per issue (`issue: N` self-hydrates the brief) and use
-  the returned resume fields as the per-issue checkpoint.
+  `startPhase:"review"`/`"verify"` against the same branch. A verify-only resume
+  is fail-closed (no review ran) unless the pause followed a clean review round:
+  pass `reviewedHead:<the returned headSha>` and it certifies iff verify reports
+  that exact HEAD. Campaigns over an issue queue relaunch per issue (`issue: N`
+  self-hydrates the brief) and use the returned resume fields as the per-issue
+  checkpoint.
 
 ### Model routing
 

--- a/.agents/skills/jellyfin-canopy-agentic-loop/README.md
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/README.md
@@ -60,7 +60,10 @@ oracle.
        reviewMode: "spec",         // opt-in for specification authoring (spec lenses)
        solVia:   "codex-cli",      // default; or "agent" (needs a Sol-capable router)
        solEffort: "high",
-       solReviewers: 1             // whole-diff Sol reviewers per round (min 1)
+       solReviewers: 1,            // whole-diff Sol reviewers per round (min 1)
+       stallPatience: 2,           // review-loop non-convergence: no-progress rounds → stop (default 2)
+       backstopRounds: 25,         // review-loop absolute ceiling (default ~25; docs/spec roundCap+1)
+       hardRoundCap: 10            // EXPLICIT OVERRIDE: old fixed cap — pins the backstop AND disables the stall detector
      }
    })
    ```
@@ -79,10 +82,27 @@ oracle.
 | deep | 8 | 3 | 4 | 3 |
 
 The "mixed" cap is the Claude+Sol panel; if the loop is still not clean after
-it, review **continues with `gpt-5.6-sol` as the only reviewer** up to
-`hardRoundCap` (default 10). Docs surfaces and `reviewMode:"spec"` default the
-hard cap to mixed-cap+1 instead — prose does not converge under a ten-round
-escalation, and unresolved docs findings go back to a human.
+it, review **continues with `gpt-5.6-sol` as the only reviewer**. The loop then
+terminates on one of three signals, not an arbitrary count:
+
+- **a clean round** (no confirmed findings);
+- **a progress stall** — `stallPatience` consecutive rounds with no progress
+  (default 2), or a round whose confirmed findings are wholly a re-report of
+  ledger-disposed items (pure oscillation). A stall is **non-convergence**: the
+  run stops, does not certify, and returns a "did not converge" residual asking a
+  human to split the change. "Progress" = the confirmed-finding count strictly
+  fell vs the previous round, or ≥1 confirmed finding was newly applied;
+- **a runaway backstop** — an absolute ceiling (`backstopRounds`, default ~25;
+  docs and `reviewMode:"spec"` default mixed-cap+1) so a pathologically entangled
+  file cannot loop forever even while nominally making progress one finding at a
+  time.
+
+This replaces the old fixed 10-round cap: a legitimately-converging change is
+**never** cut off by a count, and a stalled one (the #167 config-page.js case:
+8 h / 21 M tokens / never converged) stops fast and surfaces for a human.
+`hardRoundCap` still works as an explicit override — it pins the backstop to that
+fixed count **and** disables the stall detector, restoring the old fixed-count
+behavior for callers who want it.
 
 `surface` selects which repo-native gates run (docs runs also use 4
 docs-specific explore angles and skip Localize — `server` runs skip Localize too,

--- a/.agents/skills/jellyfin-canopy-agentic-loop/SKILL.md
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/SKILL.md
@@ -76,21 +76,42 @@ Workflow({
     branch:   "<type>/<slug>",
     task:     "<the full task: issue text / feature contract / bug + repro>",
     brief:    "<path to the task-brief.md the main thread wrote>",
+    briefText: "<the brief CONTENTS inlined — preferred; agents may never open the path>",
+    issue:    123,               // commit-subject ref; with NO briefText a Phase-0 agent
+                                 // fetches the live issue body as the brief (self-hydration)
     surface:  "client" | "server" | "cross" | "docs",   // drives which gates run
     runtime:  true,                                       // true → also run e2e:local
     depth:    "standard",                                 // "quick" | "standard" | "deep"
+    startPhase: "explore",       // "review"/"verify" resume a paused run on the same branch
+    envSetup: "<shell prelude every build/test agent runs first (e.g. DOTNET_ROOT exports)>",
+    reviewMode: "spec",          // opt-in spec-authoring lenses (acceptance traceability, …)
 
     // Model routing (see "Model routing" below):
     modelSplit:  true,           // ~50/50 Claude/Sol on read-only steps to spare Opus budget
     solVia:      "codex-cli",    // default; or "agent" (subagent model param, needs a Sol-capable router)
     solModel:    "gpt-5.6-sol",
     solEffort:   "high",
-    solReviewers: 1,             // Sol whole-diff reviewers when modelSplit is off
+    solReviewers: 1,             // whole-diff Sol reviewers per round (min 1, split or not)
     implementModel:    "fable",  // implementer runs on Fable (high) …
     implementFallback: "opus"    // … falling back to Opus (high) if Fable is exhausted
   }
 })
 ```
+
+### Operating envelopes
+
+- **FIXES** (light): for a contained bug fix, use `depth:"quick"` with a
+  patch-sized brief and a narrow `surface` — 2 explorers, 2 planners, 2 mixed
+  review rounds, surface-scoped gates. The safety essentials (requirement
+  fidelity, fail-closed review, gate integrity) stay on.
+- **FEATURES** (multi-day): use `standard`/`deep`. On a terminal provider
+  failure (session/usage limit, quota, credits) the loop STOPS spawning agents
+  and returns `status:"paused"` with `pauseReason` and `resumeFrom`; relaunch
+  later with `startPhase:"review"` (or `"verify"`) on the same branch instead of
+  re-burning explore/plan/implement. A verify-only resume never certifies
+  `readyForPR`. For campaigns over an issue queue, relaunch per issue with
+  `issue: N` (self-hydrating brief) and persist each run's returned
+  `resumeFrom`/`headSha` as the per-issue checkpoint.
 
 ### Model routing
 
@@ -102,12 +123,18 @@ models by role:
   review's finding-verification are spread across Claude and `gpt-5.6-sol`:
   - **Explore** runs 8 explorers (standard/deep depth); the first 2 on Claude/Opus
     and the remaining 6 on `gpt-5.6-sol` (override with `exploreClaudeCount`).
-  - **Explore + plan** (incl. synthesis) run their Sol slots at **`xhigh`** reasoning
-    effort (`solExplorePlanEffort`, default `xhigh`); plan keeps a ~50/50 split.
+  - **Explore + plan** (incl. synthesis) run their Sol slots at **`xhigh`**
+    reasoning effort on the `"agent"` route (`solExplorePlanEffort`, default
+    `xhigh`); on the default `"codex-cli"` route those slots run at
+    `solLightEffort` (default `medium`) — synthesis passes `xhigh` through on
+    either route. Plan keeps a ~50/50 split.
   - **Review** runs the mixed panel (Claude lenses + `gpt-5.6-sol`) for the first
     `roundCap` rounds (standard = 4); if still not clean it CONTINUES with
-    `gpt-5.6-sol` as the ONLY reviewer up to `hardRoundCap` (default 10). Review Sol
-    stays at `solEffort` (high).
+    `gpt-5.6-sol` as the ONLY reviewer up to `hardRoundCap` (default 10; docs
+    surfaces and `reviewMode:"spec"` default to `roundCap`+1 instead). Review Sol
+    stays at `solEffort` (high). Three consecutive Sol failures trip a circuit
+    breaker (remaining Sol slots go straight to Claude); the result's
+    `modelCoverage` shows requested-vs-actual coverage.
   Under `solVia: "codex-cli"` (default) the Sol slots run through a generalized
   `codex` harness; under `solVia: "agent"` they use the subagent model param via a
   router. Any Sol slot that can't be routed **falls back to Claude**, so no slot is
@@ -164,16 +191,22 @@ The engine ([`workflows/canopy-loop.js`](workflows/canopy-loop.js)) runs:
 3. **Implement** (single writer) — build the change at its owner, update every
    affected consumer, add tests that fail before the fix (admin and non-admin,
    negative/fallback paths, concurrency/cache invalidation where relevant), add
-   every locale key with real translations, and update affected docs. Commit
-   coherent conventional units. No `Co-Authored-By` trailers; **include the issue
-   number `#N`** in each commit subject (e.g. end it with ` (#123)`).
+   any new i18n key **only to the base `en.json`** (the Localize phase fans out
+   the translations), and update affected docs. Commit coherent conventional
+   units. No `Co-Authored-By` trailers; **include the issue number `#N`** in
+   each commit subject (e.g. end it with ` (#123)`).
 4. **Review loop** (parallel adversarial, loop-until-clean) — see
    [`references/adversarial-review.md`](references/adversarial-review.md). Each
-   round mixes models on purpose: the Claude lens reviewers **and** at least one
-   `gpt-5.6-sol` (high effort) whole-diff reviewer, all in split context (diff +
-   brief only, told to assume the code is wrong). Findings are deduped and
-   adversarially verified to kill false positives; a single fixer applies
-   confirmed findings; re-review until a clean round. Challenge the design before
+   mixed round runs models on purpose: the Claude lens reviewers **and** at least
+   one `gpt-5.6-sol` (high effort) whole-diff reviewer, all in split context (diff
+   + brief only, told to assume the code is wrong); rounds past the mixed cap are
+   `gpt-5.6-sol`-only up to `hardRoundCap`. Findings are deduped and adversarially
+   verified to kill false positives; a **finding ledger** (fixed + refuted, with
+   verifier reasons) is injected into later rounds so resolved items are not
+   re-reported without new evidence; a single fixer applies confirmed findings;
+   re-review until a clean round. On docs surfaces (and `reviewMode:"spec"`) only
+   confirmed blocker/major findings drive fix rounds — confirmed minors are
+   returned as `advisoryNotes`. Challenge the design before
    a second fix to the same owner/state model. If a workaround needs a
    paragraph-long comment to justify it, the code is wrong — fix the code.
 5. **Localize** (single cheap agent, low effort) — translation busywork, kept off
@@ -182,9 +215,9 @@ The engine ([`workflows/canopy-loop.js`](workflows/canopy-loop.js)) runs:
    files never consume adversarial review) and **before** verify (so
    `validate-translations` passes at parity). It fans the base keys out to every
    locale on a low-effort model (gpt/opus on `low`, `localizeEffort`), commits one
-   `chore(i18n)` unit, and no-ops when no keys changed. Skipped for `server`
-   surfaces. Not adversarially reviewed — translations are mechanical and the
-   `validate-translations` gate enforces parity.
+   `chore(i18n)` unit, and no-ops when no keys changed. Skipped for `server` and
+   `docs` surfaces. Not adversarially reviewed — translations are mechanical and
+   the `validate-translations` gate enforces parity.
 6. **Verify** (single runner) — run the repo-native gates for the surface, and
    for runtime-relevant work build the Release DLL and run `npm run e2e:local`
    (exercise admin and non-admin, assert real DOM/server state, zero

--- a/.agents/skills/jellyfin-canopy-agentic-loop/SKILL.md
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/SKILL.md
@@ -83,6 +83,8 @@ Workflow({
     runtime:  true,                                       // true → also run e2e:local
     depth:    "standard",                                 // "quick" | "standard" | "deep"
     startPhase: "explore",       // "review"/"verify" resume a paused run on the same branch
+    reviewedHead: "<sha>",       // with startPhase:"verify" ONLY: the HEAD the paused run was
+                                 // clean at — certifies the prior review iff verify reports the same HEAD
     envSetup: "<shell prelude every build/test agent runs first (e.g. DOTNET_ROOT exports)>",
     reviewMode: "spec",          // opt-in spec-authoring lenses (acceptance traceability, …)
 
@@ -108,10 +110,16 @@ Workflow({
   failure (session/usage limit, quota, credits) the loop STOPS spawning agents
   and returns `status:"paused"` with `pauseReason` and `resumeFrom`; relaunch
   later with `startPhase:"review"` (or `"verify"`) on the same branch instead of
-  re-burning explore/plan/implement. A verify-only resume never certifies
-  `readyForPR`. For campaigns over an issue queue, relaunch per issue with
-  `issue: N` (self-hydrating brief) and persist each run's returned
-  `resumeFrom`/`headSha` as the per-issue checkpoint.
+  re-burning explore/plan/implement. A verify-only resume normally never certifies
+  `readyForPR` — **except** when the pause came AFTER a certified-clean review
+  round (`resumeFrom.phase==="verify"`, the run's `loopClean` was true): record the
+  paused run's returned `headSha` (or `git -C <worktree> rev-parse HEAD`) and
+  resume with `startPhase:"verify"` **plus** `reviewedHead:<that sha>`. The run
+  certifies iff the verify agent independently reports the same HEAD (proving no
+  commit changed since the clean review); any mismatch stays fail-closed. For
+  campaigns over an issue queue, relaunch per issue with `issue: N` (self-hydrating
+  brief) and persist each run's returned `resumeFrom`/`headSha`/`loopClean` as the
+  per-issue checkpoint.
 
 ### Model routing
 

--- a/.agents/skills/jellyfin-canopy-agentic-loop/SKILL.md
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/SKILL.md
@@ -224,8 +224,11 @@ The engine ([`workflows/canopy-loop.js`](workflows/canopy-loop.js)) runs:
    `validate-translations` passes at parity). It fans the base keys out to every
    locale on a low-effort model (gpt/opus on `low`, `localizeEffort`), commits one
    `chore(i18n)` unit, and no-ops when no keys changed. Skipped for `server` and
-   `docs` surfaces. Not adversarially reviewed — translations are mechanical and
-   the `validate-translations` gate enforces parity.
+   `docs` surfaces. It still runs on a `startPhase:"verify"` resume (a run that
+   paused between the clean review and Localize would otherwise fail
+   `validate-translations` forever). Not adversarially reviewed — translations are
+   mechanical, the commit lands before the first verify, and the
+   `validate-translations` gate enforces parity.
 6. **Verify** (single runner) — run the repo-native gates for the surface, and
    for runtime-relevant work build the Release DLL and run `npm run e2e:local`
    (exercise admin and non-admin, assert real DOM/server state, zero

--- a/.agents/skills/jellyfin-canopy-agentic-loop/SKILL.md
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/SKILL.md
@@ -133,8 +133,11 @@ models by role:
 - **Weighted Claude / `gpt-5.6-sol` split — the whole way, except two roles.** With
   `modelSplit: true`, explore, plan (incl. synthesis), the review lenses, and the
   review's finding-verification are spread across Claude and `gpt-5.6-sol`:
-  - **Explore** runs 8 explorers (standard/deep depth); the first 2 on Claude/Opus
-    and the remaining 6 on `gpt-5.6-sol` (override with `exploreClaudeCount`).
+  - **Explore** runs 8 explorers on a non-docs standard/deep run; the first 2 on
+    Claude/Opus and the remaining 6 on `gpt-5.6-sol` (override with
+    `exploreClaudeCount`). A `quick` run uses 2 explorers, and a `docs` surface uses
+    its 4 docs-specific angles (2 Claude + 2 Sol) — the "6 Sol" figure is the
+    standard/deep code-surface case, not every run.
   - **Explore + plan** (incl. synthesis) run their Sol slots at **`xhigh`**
     reasoning effort on the `"agent"` route (`solExplorePlanEffort`, default
     `xhigh`); on the default `"codex-cli"` route those slots run at
@@ -166,9 +169,13 @@ Fable→Opus; review still gets ≥1 whole-diff `gpt-5.6-sol` reviewer).
 
 While exploring, agents surface **unrelated pre-existing bugs** they notice (they
 do **not** fix them — no scope creep). The loop returns them as
-`result.incidentalBugs`; the main thread dedupes against open issues and files the
-genuinely-new ones to the **Jellyfin Elevate Bug Inventory (Project 4)** with the
-`bug-inventory` + `no-stale` labels.
+`result.incidentalBugs`. **Only when issue creation, labelling, and Project
+mutation are authorized for this run** does the main thread dedupe against open
+issues and file the genuinely-new ones to the **Jellyfin Elevate Bug Inventory
+(Project 4)** with the `bug-inventory` + `no-stale` labels. Absent that
+authorization, surface the deduped list as a **proposed issue payload for the
+user to disposition** — do not mutate GitHub. Filing issues, like deploys and
+releases, is an outward-facing action, not an implicit step of the loop.
 
 The script fans out agents per phase, loops the review until a clean round, runs
 the repo-native gates, and returns a structured result (diff stat, findings

--- a/.agents/skills/jellyfin-canopy-agentic-loop/SKILL.md
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/SKILL.md
@@ -90,6 +90,12 @@ Workflow({
     envSetup: "<shell prelude every build/test agent runs first (e.g. DOTNET_ROOT exports)>",
     reviewMode: "spec",          // opt-in spec-authoring lenses (acceptance traceability, …)
 
+    // Review-loop termination (progress-based; see "Review" below):
+    stallPatience: 2,            // consecutive no-progress review rounds → stop as non-converged (default 2)
+    backstopRounds: 25,          // absolute round ceiling (default ~25; docs/spec default roundCap+1)
+    hardRoundCap: 10,            // EXPLICIT OVERRIDE: old fixed-count behavior — pins the backstop AND
+                                 // disables the stall detector (runs to exactly this many rounds)
+
     // Model routing (see "Model routing" below):
     modelSplit:  true,           // ~50/50 Claude/Sol on read-only steps to spare Opus budget
     solVia:      "codex-cli",    // default; or "agent" (subagent model param, needs a Sol-capable router)
@@ -145,9 +151,17 @@ models by role:
     either route. Plan keeps a ~50/50 split.
   - **Review** runs the mixed panel (Claude lenses + `gpt-5.6-sol`) for the first
     `roundCap` rounds (standard = 4); if still not clean it CONTINUES with
-    `gpt-5.6-sol` as the ONLY reviewer up to `hardRoundCap` (default 10; docs
-    surfaces and `reviewMode:"spec"` default to `roundCap`+1 instead). Review Sol
-    stays at `solEffort` (high). Three consecutive Sol failures trip a circuit
+    `gpt-5.6-sol` as the ONLY reviewer. The loop terminates on **(a)** a clean
+    round, **(b)** a **progress stall** — `stallPatience` consecutive rounds with
+    no progress (default 2), or a round whose confirmed findings are wholly a
+    ledger re-report (pure oscillation) — surfaced for a human as a
+    non-convergence residual, or **(c)** a high runaway **backstop**
+    (`backstopRounds`, default ~25; docs/`reviewMode:"spec"` default `roundCap`+1).
+    This replaces the old fixed 10-round cap: a converging change is never cut off
+    by an arbitrary count, and a stalled one (the #167 config-page.js case) stops
+    fast. `hardRoundCap` still works as an explicit override — it pins the backstop
+    to that fixed count **and** disables the stall detector (old behavior). Review
+    Sol stays at `solEffort` (high). Three consecutive Sol failures trip a circuit
     breaker (remaining Sol slots go straight to Claude); the result's
     `modelCoverage` shows requested-vs-actual coverage.
   Under `solVia: "codex-cli"` (default) the Sol slots run through a generalized
@@ -219,11 +233,13 @@ The engine ([`workflows/canopy-loop.js`](workflows/canopy-loop.js)) runs:
    mixed round runs models on purpose: the Claude lens reviewers **and** at least
    one `gpt-5.6-sol` (high effort) whole-diff reviewer, all in split context (diff
    + brief only, told to assume the code is wrong); rounds past the mixed cap are
-   `gpt-5.6-sol`-only up to `hardRoundCap`. Findings are deduped and adversarially
+   `gpt-5.6-sol`-only. Findings are deduped and adversarially
    verified to kill false positives; a **finding ledger** (fixed + refuted, with
    verifier reasons) is injected into later rounds so resolved items are not
    re-reported without new evidence; a single fixer applies confirmed findings;
-   re-review until a clean round. On docs surfaces (and `reviewMode:"spec"`) only
+   re-review until a clean round, a **progress stall** (non-convergence — default 2
+   no-progress rounds, surfaced for a human), or the runaway **backstop**. On docs
+   surfaces (and `reviewMode:"spec"`) only
    confirmed blocker/major findings drive fix rounds — confirmed minors are
    returned as `advisoryNotes`. Challenge the design before
    a second fix to the same owner/state model. If a workaround needs a

--- a/.agents/skills/jellyfin-canopy-agentic-loop/SKILL.md
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/SKILL.md
@@ -85,6 +85,8 @@ Workflow({
     startPhase: "explore",       // "review"/"verify" resume a paused run on the same branch
     reviewedHead: "<sha>",       // with startPhase:"verify" ONLY: the HEAD the paused run was
                                  // clean at — certifies the prior review iff verify reports the same HEAD
+    ledger: [/* the paused run's returned result.ledger */],  // seed the finding ledger on a
+                                 // startPhase:"review" resume so prior fixes/refutations stay suppressed
     envSetup: "<shell prelude every build/test agent runs first (e.g. DOTNET_ROOT exports)>",
     reviewMode: "spec",          // opt-in spec-authoring lenses (acceptance traceability, …)
 
@@ -118,8 +120,10 @@ Workflow({
   certifies iff the verify agent independently reports the same HEAD (proving no
   commit changed since the clean review); any mismatch stays fail-closed. For
   campaigns over an issue queue, relaunch per issue with `issue: N` (self-hydrating
-  brief) and persist each run's returned `resumeFrom`/`headSha`/`loopClean` as the
-  per-issue checkpoint.
+  brief) and persist each run's returned `resumeFrom`/`headSha`/`loopClean`/`ledger`
+  as the per-issue checkpoint. Pass the persisted `ledger` back as `ledger:` on a
+  `startPhase:"review"` resume so the review loop keeps its prior refutations and
+  fixes suppressed instead of re-churning them.
 
 ### Model routing
 

--- a/.agents/skills/jellyfin-canopy-agentic-loop/references/adversarial-review.md
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/references/adversarial-review.md
@@ -14,11 +14,14 @@ prove how. Modelled on Bun's rewrite, tuned to Canopy's contracts.
    a finding; a finding needs a file/line and a failure scenario (inputs/state →
    wrong output/crash/leak).
 3. **Two or more reviewers per round, across distinct lenses** (below), and
-   **across two model families**: the Claude lens reviewers plus at least one
-   `gpt-5.6-sol` reviewer at **high** effort doing a whole-diff pass. Diversity
-   beats redundancy — different angles *and* different models catch failure modes
-   a single model's blind spots would miss. (In `canopy-loop.js`: `solReviewers`
-   ≥ 1, obtained via the subagent model param or the `codex` CLI per `solVia`.)
+   **across two model families** in every *mixed* round: the Claude lens
+   reviewers plus at least one `gpt-5.6-sol` reviewer at **high** effort doing a
+   whole-diff pass. Diversity beats redundancy — different angles *and* different
+   models catch failure modes a single model's blind spots would miss. (In
+   `canopy-loop.js`: `solReviewers` ≥ 1, obtained via the subagent model param or
+   the `codex` CLI per `solVia`.) *Escalation* rounds past the mixed cap
+   (`roundCap`) run `gpt-5.6-sol` only, up to `hardRoundCap` — a distinct mode,
+   not a mixed round.
 4. **Verify before fixing.** Every finding is adversarially checked by an
    independent verifier that tries to *refute* it. Default to refuted when
    uncertain. Only confirmed findings reach the fixer — this kills
@@ -27,6 +30,12 @@ prove how. Modelled on Bun's rewrite, tuned to Canopy's contracts.
    at their owner, adds regression evidence, and the round repeats. Stop when a
    full round produces no confirmed findings (a clean round), or after the round
    cap — never on "we're probably fine".
+   **Carry a finding ledger between rounds**: what earlier rounds fixed and what
+   the verifier refuted (with reasons) goes into every later reviewer's context,
+   and a resolved item may not be re-reported without NEW evidence. For docs/spec
+   surfaces, gate fixing by severity — confirmed blocker/major findings drive fix
+   rounds; confirmed minors are returned as advisory notes and a minors-only
+   round counts as clean.
 6. **Fix the process, not the instance.** If a class of finding recurs (the same
    lens keeps catching the same kind of mistake), amend the implementer/fixer
    instructions for the next round instead of hand-patching each occurrence.
@@ -45,6 +54,10 @@ Assign each reviewer one lens. Skip lenses the diff cannot touch; add
 task-specific reviewer questions from the brief. For Canopy, the standing lenses
 are:
 
+- **Requirement fidelity** — does it fix the ACTUAL reported defect and satisfy
+  EVERY acceptance criterion in the brief — not an easier semantically-different
+  change primed by the branch name or surrounding code? A change that does not
+  address the reported defect is a blocking finding regardless of its quality.
 - **Correctness & logic** — does it do what the brief says on the happy path and
   every branch? Off-by-one, wrong operator, eager vs. lazy evaluation, error
   paths, `null`/undefined, boundary values.

--- a/.agents/skills/jellyfin-canopy-agentic-loop/references/adversarial-review.md
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/references/adversarial-review.md
@@ -21,7 +21,10 @@ prove how. Modelled on Bun's rewrite, tuned to Canopy's contracts.
    `canopy-loop.js`: `solReviewers` ≥ 1, obtained via the subagent model param or
    the `codex` CLI per `solVia`.) *Escalation* rounds past the mixed cap
    (`roundCap`) run `gpt-5.6-sol` only, up to `hardRoundCap` — a distinct mode,
-   not a mixed round.
+   not a mixed round. The round that **certifies** the branch clean must have
+   **real** cross-family coverage: if its every Sol slot fell back to Claude (dead
+   route), the run fails closed (`reviewIncomplete`) rather than certifying an
+   all-Claude review as mixed.
 4. **Verify before fixing.** Every finding is adversarially checked by an
    independent verifier that tries to *refute* it. Default to refuted when
    uncertain. Only confirmed findings reach the fixer — this kills
@@ -29,7 +32,11 @@ prove how. Modelled on Bun's rewrite, tuned to Canopy's contracts.
 5. **One fixer, then re-review.** A single writer applies the confirmed findings
    at their owner, adds regression evidence, and the round repeats. Stop when a
    full round produces no confirmed findings (a clean round), or after the round
-   cap — never on "we're probably fine".
+   cap — never on "we're probably fine". The fixer reports back which findings it
+   **applied** and which it left **unresolved** (by id); only applied findings are
+   ledgered as fixed, and a fixer that returns nothing, reports any unresolved id,
+   or does not cover every confirmed id blocks certification — a later empty round
+   cannot certify a defect the fixer said is still there.
    **Carry a finding ledger between rounds**: what earlier rounds fixed and what
    the verifier refuted (with reasons) goes into every later reviewer's context,
    and a resolved item may not be re-reported without NEW evidence. For docs/spec

--- a/.agents/skills/jellyfin-canopy-agentic-loop/references/adversarial-review.md
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/references/adversarial-review.md
@@ -20,8 +20,9 @@ prove how. Modelled on Bun's rewrite, tuned to Canopy's contracts.
    models catch failure modes a single model's blind spots would miss. (In
    `canopy-loop.js`: `solReviewers` ≥ 1, obtained via the subagent model param or
    the `codex` CLI per `solVia`.) *Escalation* rounds past the mixed cap
-   (`roundCap`) run `gpt-5.6-sol` only, up to `hardRoundCap` — a distinct mode,
-   not a mixed round. The round that **certifies** the branch clean must have
+   (`roundCap`) run `gpt-5.6-sol` only until the loop terminates (clean / stall /
+   backstop, see rule 5) — a distinct mode, not a mixed round. The round that
+   **certifies** the branch clean must have
    **real** cross-family coverage: if its every Sol slot fell back to Claude (dead
    route), the run fails closed (`reviewIncomplete`) rather than certifying an
    all-Claude review as mixed.
@@ -30,9 +31,29 @@ prove how. Modelled on Bun's rewrite, tuned to Canopy's contracts.
    uncertain. Only confirmed findings reach the fixer — this kills
    plausible-but-wrong findings before they cost a change.
 5. **One fixer, then re-review.** A single writer applies the confirmed findings
-   at their owner, adds regression evidence, and the round repeats. Stop when a
-   full round produces no confirmed findings (a clean round), or after the round
-   cap — never on "we're probably fine". The fixer reports back which findings it
+   at their owner, adds regression evidence, and the round repeats. The loop
+   terminates on one of three signals — **never** on "we're probably fine", and
+   **never** on an arbitrary round count:
+   - **a clean round** (no confirmed blocker/major findings);
+   - **a progress stall** — `stallPatience` consecutive rounds with no progress
+     (default 2), or a round whose confirmed findings are wholly a re-report of
+     ledger-disposed items (pure oscillation). A stall means the review is **not
+     converging**: stop, do not certify, and surface a "did not converge" residual
+     for a human (consider splitting the change). "Progress" = the
+     confirmed-finding count strictly fell vs the previous round, or ≥1 confirmed
+     finding was newly applied this round;
+   - **a runaway backstop** — an absolute ceiling (`backstopRounds`, default ~25;
+     docs/spec default mixed-cap+1) so a pathologically entangled change cannot
+     loop forever even while nominally making progress one finding at a time.
+
+   This replaces the old fixed 10-round cap: a genuinely-converging change is
+   never cut off by a count (the cap's job was non-convergence detection, not
+   budget control — that is now the terminal-failure pause), and a hopeless
+   oscillation stops fast (the #167 config-page.js case). `hardRoundCap` remains
+   an explicit override that pins the backstop to a fixed count **and** disables
+   the stall detector, for callers who want the old behavior.
+
+   The fixer reports back which findings it
    **applied** and which it left **unresolved** (by id); only applied findings are
    ledgered as fixed, and a fixer that returns nothing, reports any unresolved id,
    or does not cover every confirmed id blocks certification — a later empty round

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -176,9 +176,10 @@ const SOL_HEREDOC = 'SOL_PROMPT_' + _fnv1a(TASK + '|' + BRANCH + '|' + WORKTREE)
 // ── multi-model split (token offload) ───────────────────────────────────────
 // Route ~50% of the READ-ONLY reasoning to gpt-5.6-sol so a run doesn't spend
 // all of Claude's budget. The split covers explore, plan, the review lenses,
-// finding-verification, and the verify/gate runner. IMPLEMENTATION and every
-// code-writing fixer always stay Claude — one writer per worktree, and you don't
-// want two models editing the same files. A split-Sol slot runs on Sol under
+// and finding-verification. IMPLEMENTATION and every code-writing fixer always
+// stay Claude — one writer per worktree, and you don't want two models editing
+// the same files — and the FINAL VERIFY/GATE RUN also stays on Claude (one
+// authoritative model runs the repo gates; see the Verify phase). A split-Sol slot runs on Sol under
 // BOTH routes: the 'agent' route uses the subagent model param, and 'codex-cli'
 // runs the slot through the codex harness (codexAgent, requires opts.schema) — so
 // explore/plan/synthesis/finding-verification offload ~50% to Sol on either route,

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -1223,13 +1223,16 @@ let cleanRound = false
 // Set only when a round TERMINATES the loop with incomplete coverage — a reviewer
 // or a finding-verifier failed to return — so we never certify such a round clean.
 let reviewIncomplete = false
-// Set when a fix round does NOT fully apply its confirmed findings (the fixer
-// returned null, reported any `unresolved` id, or failed to apply every confirmed
-// id). Distinct from reviewIncomplete (which is a COVERAGE gap): here coverage was
-// complete but the fixer's OWN report says the defect is still in the diff, so a
-// later — possibly non-deterministically empty — clean round must not certify it.
-// A subsequent fixer that fully applies clears it.
-let unfixedConfirmed = false
+// Confirmed findings a fixer left UNAPPLIED, tracked persistently by stable
+// content fingerprint (dedupeKey: file|line|summary). A single boolean here was
+// unsafe: any later round whose fixer fully applied its OWN (possibly unrelated)
+// findings reset it to false, silently clearing an older still-unresolved finding
+// and certifying a branch that still carries a defect. A fingerprint is removed
+// ONLY when THAT SAME finding is later applied by a fixer or independently refuted
+// by a verifier; readyForPR blocks while the map is non-empty. Distinct from
+// reviewIncomplete (a COVERAGE gap) — here coverage was complete but the fixer's
+// own report says the defect is still in the diff.
+const unresolvedFindings = new Map() // fingerprint → { file, line, summary, round }
 const MIXED_ROUND_CAP = SIZING.roundCap
 let round = 0
 if (START_PHASE === 'verify') {
@@ -1345,10 +1348,14 @@ SCENARIO: ${f.failureScenario}`,
   const unverified = pairs.filter((p) => p.v == null).length
   const confirmedPairs = pairs.filter((p) => p.v && p.v.real)
   // Ledger: refuted findings carry the verifier's reason forward so later
-  // rounds don't re-litigate them.
+  // rounds don't re-litigate them. An independent refutation of a finding also
+  // CLEARS any prior unresolved mark for that same fingerprint — it is no longer
+  // a live defect (the verifier proved it does not reproduce).
   for (const p of pairs)
-    if (p.v && !p.v.real)
+    if (p.v && !p.v.real) {
       ledger.push({ file: p.f.file, line: p.f.line || 0, summary: String(p.f.summary || '').slice(0, 140), status: 'refuted', reason: String(p.v.reason || '').slice(0, 200), round })
+      unresolvedFindings.delete(dedupeKey(p.f))
+    }
   // Severity gate (docs/spec only): confirmed MINORS become advisory notes for
   // the launcher; only blocker/major findings reach the fixer. The severity is
   // the verifier's when it gave one (it re-judged the finding), else the
@@ -1434,24 +1441,26 @@ ${JSON.stringify(confirmedForFixer, null, 1).slice(0, 10000)}`,
   const reportedUnresolved =
     fixResult && Array.isArray(fixResult.unresolved) ? fixResult.unresolved.filter((x) => x != null && String(x).trim()) : []
   // Ledger + resolved-count: ONLY findings the fixer reports applied (by id) count
-  // as fixed/resolved. Everything else stays out of the "fixed" ledger so later
-  // rounds MAY re-report it.
+  // as fixed/resolved and clear their unresolved mark. Every OTHER confirmed
+  // finding — a reported-unresolved id, or one silently dropped by a null/partial
+  // fixer — is recorded in unresolvedFindings by its stable fingerprint and stays
+  // there across rounds until it is itself applied or independently refuted. This
+  // is what stops a later unrelated fully-applied round (or a non-deterministically
+  // empty clean round) from certifying a branch that still carries this defect.
+  let appliedThisRound = 0
   confirmed.forEach((f, i) => {
+    const fp = dedupeKey(f)
     if (fixResult && appliedSet.has(fixIds[i])) {
       ledger.push({ file: f.file, line: f.line || 0, summary: String(f.summary || '').slice(0, 140), status: 'fixed', reason: `applied by the round-${round} fixer`, round })
       confirmedAll.push({ ...f, round })
+      unresolvedFindings.delete(fp)
+      appliedThisRound++
+    } else {
+      unresolvedFindings.set(fp, { file: f.file, line: f.line || 0, summary: String(f.summary || '').slice(0, 140), round })
     }
   })
-  // A fixer that returns null, reports ANY unresolved id, or fails to apply every
-  // confirmed id has NOT resolved the round. Flag the run so a later (possibly
-  // non-deterministically empty) clean round cannot certify still-present defects;
-  // a subsequent fixer that FULLY applies clears the flag.
-  const fullyApplied = !!fixResult && reportedUnresolved.length === 0 && fixIds.every((id) => appliedSet.has(id))
-  if (fullyApplied) unfixedConfirmed = false
-  else {
-    unfixedConfirmed = true
-    log(`Review round ${round}: fixer applied ${appliedSet.size}/${fixIds.length} confirmed finding(s)${reportedUnresolved.length ? `, ${reportedUnresolved.length} unresolved` : ''}${fixResult ? '' : ' (fixer returned nothing)'} → run cannot certify until they are fixed`)
-  }
+  if (appliedThisRound < fixIds.length || reportedUnresolved.length || !fixResult)
+    log(`Review round ${round}: fixer applied ${appliedThisRound}/${fixIds.length} confirmed finding(s)${reportedUnresolved.length ? `, ${reportedUnresolved.length} reported unresolved` : ''}${fixResult ? '' : ' (fixer returned nothing)'} → ${unresolvedFindings.size} finding(s) still unresolved; run cannot certify until they are fixed`)
 }
 if (!cleanRound && START_PHASE !== 'verify')
   log(
@@ -1716,7 +1725,7 @@ const result = {
   // ran, e.g. a paused run) — lets the launcher pin resume/PR actions to the
   // exact commit that was verified.
   headSha: lastVerifyHead,
-  readyForPR: !PAUSED && implementationOk && cleanRound && !reviewIncomplete && !unfixedConfirmed && !verifyFixCommitted && blockingGreen && e2eGreen,
+  readyForPR: !PAUSED && implementationOk && cleanRound && !reviewIncomplete && unresolvedFindings.size === 0 && !verifyFixCommitted && blockingGreen && e2eGreen,
   residualRisks: []
     .concat(
       PAUSED
@@ -1735,7 +1744,13 @@ const result = {
         : []
     )
     .concat(cleanRound || reviewIncomplete ? [] : ['review loop hit its round cap with unresolved confirmed findings'])
-    .concat(unfixedConfirmed ? ['a review fixer left confirmed findings unapplied/unresolved — the branch is NOT certified; re-run the review loop before opening a PR'] : [])
+    .concat(
+      unresolvedFindings.size
+        ? [
+            `${unresolvedFindings.size} confirmed finding(s) were left unapplied/unresolved by a fixer and never later applied or refuted (e.g. ${[...unresolvedFindings.values()].slice(0, 3).map((u) => `${u.file}:${u.line}`).join(', ')}) — the branch is NOT certified; re-run the review loop before opening a PR`,
+          ]
+        : []
+    )
     .concat(verifyFixCommitted ? ['verify-fix committed code AFTER the clean review round — those commits were never adversarially reviewed; re-run the review loop before opening a PR'] : [])
     .concat(blockingGreen ? [] : ['one or more BLOCKING gates are failing'])
     .concat(e2eGreen ? [] : ['e2e:local did not pass'])

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -44,6 +44,16 @@ const SURFACE_COERCED = SURFACE !== SURFACE_INPUT
 const RUNTIME = a.runtime !== false && SURFACE !== 'docs'
 const DEPTH = a.depth || 'standard' // quick | standard | deep
 const BASE = a.base || 'origin/main'
+// Resume support: a run killed mid-flight (e.g. by a session usage limit) has
+// all completed work COMMITTED on the branch, and the review/verify prompts work
+// purely from the committed ${BASE}...HEAD range — so a relaunch can re-enter
+// later instead of re-burning explore/plan/implement:
+//   'explore' (default) — full run, byte-identical to the pre-resume behavior;
+//   'review'  — skip Explore/Plan/Implement, adversarially review the committed
+//               range, then verify (can certify readyForPR — review runs fully);
+//   'verify'  — additionally skip the review loop: gates only. A verify-only
+//               resume can NEVER certify readyForPR (fail closed — no review ran).
+const START_PHASE = ['explore', 'review', 'verify'].includes(a.startPhase) ? a.startPhase : 'explore'
 // User policy: INCLUDE the issue number in commit messages (traceability). Derived
 // from the branch (fix/issue-<N>) or args.issue. The main thread additionally puts
 // "Closes #<N>" in the PR body so a merge auto-closes the issue + moves the board item.
@@ -530,10 +540,12 @@ function gateCommands() {
 // ═══════════════════════════════════════════════════════════════════════════
 // PHASE 1 — EXPLORE (parallel, read-only)
 // ═══════════════════════════════════════════════════════════════════════════
-phase('Explore')
+if (START_PHASE === 'explore') phase('Explore')
 if (SURFACE_COERCED)
   log(`canopy-loop: unknown surface "${SURFACE_INPUT}" → coerced to "cross" (fail closed: runs all surface gates)`)
 log(`canopy-loop: ${DEPTH} depth · surface=${SURFACE} · runtime=${RUNTIME} · branch ${BRANCH}`)
+if (START_PHASE !== 'explore')
+  log(`canopy-loop: RESUME at "${START_PHASE}" — explore/plan/implement skipped; working from the committed ${BASE}...HEAD range`)
 
 const exploreAngles = [
   'the OWNING module and the exact functions/types that must change',
@@ -546,7 +558,9 @@ const exploreAngles = [
   'the PERFORMANCE/BOUNDS surface: allocations, N+1 / manager-call counts, unbounded work, and the measurable budgets to assert',
 ].slice(0, SIZING.explorers)
 
-const exploreResults = await parallel(
+let explorations = []
+if (START_PHASE === 'explore') {
+  const exploreResults = await parallel(
     exploreAngles.map((angle, i) => () =>
       splitAgent(
         i,
@@ -566,11 +580,12 @@ evidence. Only real defects; leave it empty if you see none.`,
       )
     )
   )
-batchOutage(exploreResults, 'Explore')
-const explorations = exploreResults.filter(Boolean)
+  batchOutage(exploreResults, 'Explore')
+  explorations = exploreResults.filter(Boolean)
+  log(`Explore: ${explorations.length} maps returned`)
+}
 
 const exploreDigest = JSON.stringify(explorations, null, 1).slice(0, 12000)
-log(`Explore: ${explorations.length} maps returned`)
 
 // ═══════════════════════════════════════════════════════════════════════════
 // PHASE 2 — PLAN (independent plans → adversarial synthesis into one)
@@ -583,7 +598,7 @@ const planAngles = [
 
 let plans = []
 let canonicalPlan = null
-if (!systemicFailure) {
+if (START_PHASE === 'explore' && !systemicFailure) {
   phase('Plan')
   const planResults = await parallel(
     planAngles.map((angle, i) => () =>
@@ -609,7 +624,7 @@ docs to update.`,
   plans = planResults.filter(Boolean)
 }
 
-if (!systemicFailure) {
+if (START_PHASE === 'explore' && !systemicFailure) {
   canonicalPlan = await safely(
   () =>
     soloSolAgent(
@@ -671,7 +686,12 @@ const IMPL_MODEL = a.implementModel || 'fable'
 const IMPL_FALLBACK = a.implementFallback || 'opus'
 const implOpts = { schema: IMPLEMENT_SCHEMA, agentType: 'general-purpose', effort: 'high', phase: 'Implement' }
 let implemented = null
-if (!systemicFailure) {
+if (START_PHASE !== 'explore') {
+  // Resumed run: the implementation is already COMMITTED on the branch (that is
+  // the premise of resuming). Synthesize a placeholder so the readyForPR logic
+  // works unchanged; reviewers/verify read the real state from BASE...HEAD.
+  implemented = { changedFiles: [], commits: [], selfConfidence: 'medium', openTodos: [], resumed: true }
+} else if (!systemicFailure) {
   phase('Implement')
   implemented = await safely(
     () => agent(implementPrompt, { ...implOpts, model: IMPL_MODEL, label: `implement:${IMPL_MODEL}` }),
@@ -700,7 +720,7 @@ and CONTINUE from there rather than restarting from scratch.`,
 // ═══════════════════════════════════════════════════════════════════════════
 // PHASE 4 — ADVERSARIAL REVIEW LOOP (parallel review → verify → single fixer)
 // ═══════════════════════════════════════════════════════════════════════════
-if (!systemicFailure) phase('Review')
+if (!systemicFailure && START_PHASE !== 'verify') phase('Review')
 
 const reviewContext = `${CONTRACTS}
 
@@ -822,7 +842,14 @@ let cleanRound = false
 let reviewIncomplete = false
 const MIXED_ROUND_CAP = SIZING.roundCap
 let round = 0
-while (round < HARD_ROUND_CAP && !cleanRound && !systemicFailure) {
+if (START_PHASE === 'verify') {
+  // Verify-only resume: the review loop is SKIPPED, so this run can never
+  // certify the branch clean — readyForPR stays false (fail closed). Use
+  // startPhase:'review' (or a full run) to certify.
+  reviewIncomplete = true
+  log('verify-only resume: review loop skipped — this run cannot certify readyForPR (fail closed)')
+}
+while (round < HARD_ROUND_CAP && !cleanRound && !systemicFailure && START_PHASE !== 'verify') {
   round++
 
   // Rounds 1..MIXED_ROUND_CAP run the mixed panel (Claude lenses + gpt-5.6-sol).
@@ -965,7 +992,7 @@ ${JSON.stringify(confirmed, null, 1).slice(0, 10000)}`,
     `Review fixer (round ${round})`
   )
 }
-if (!cleanRound)
+if (!cleanRound && START_PHASE !== 'verify')
   log(
     reviewIncomplete
       ? `Review: ended without a certified-clean round — coverage incomplete (reviewer/verifier failure); will report as residual risk`
@@ -979,7 +1006,7 @@ if (!cleanRound)
 // parity. Implementer/fixers add new i18n keys only to the base en.json; one
 // low-effort agent (gpt/opus on low) fans them out to every locale.
 // ═══════════════════════════════════════════════════════════════════════════
-if (SURFACE !== 'server' && !systemicFailure) {
+if (SURFACE !== 'server' && !systemicFailure && START_PHASE !== 'verify') {
   phase('Localize')
   log(`Localize: fanning base-locale keys out to all locales (effort=${LOCALIZE_EFFORT})`)
   await safely(
@@ -1133,6 +1160,7 @@ const result = {
   status: PAUSED ? 'paused' : 'complete',
   pauseReason: PAUSED ? systemicFailureDetail : null,
   resumeFrom,
+  startPhase: START_PHASE,
   branch: BRANCH,
   surface: SURFACE,
   depth: DEPTH,
@@ -1156,7 +1184,13 @@ const result = {
     )
     .concat(implemented || PAUSED ? [] : ['implementation did not complete — both implementer models failed to return a result'])
     .concat(openTodos.length ? ['implementer left open acceptance-criteria TODOs — change is incomplete'] : [])
-    .concat(reviewIncomplete ? ['adversarial review ended with incomplete coverage (a reviewer or finding-verifier failed) — the round could not be certified clean'] : [])
+    .concat(
+      START_PHASE === 'verify'
+        ? ['verify-only resume: the adversarial review loop was SKIPPED — run startPhase:"review" (or a full run) before opening a PR']
+        : reviewIncomplete
+        ? ['adversarial review ended with incomplete coverage (a reviewer or finding-verifier failed) — the round could not be certified clean']
+        : []
+    )
     .concat(cleanRound || reviewIncomplete ? [] : ['review loop hit its round cap with unresolved confirmed findings'])
     .concat(verifyFixCommitted ? ['verify-fix committed code AFTER the clean review round — those commits were never adversarially reviewed; re-run the review loop before opening a PR'] : [])
     .concat(blockingGreen ? [] : ['one or more BLOCKING gates are failing'])

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -28,7 +28,12 @@ const a = (() => {
 })()
 const WORKTREE = a.worktree || '.'
 const BRANCH = a.branch || '(current branch)'
-const TASK = a.task || 'No task text supplied.'
+// `let` because in the preferred `issue: N`-only launch shape (no task/briefText),
+// a successful Phase-0 issue hydration replaces this placeholder with a real task
+// line derived from the fetched issue title/url — otherwise every agent prompt
+// would open with "TASK: No task text supplied." above the authoritative brief,
+// a confusing signal for the requirement-fidelity reviewers.
+let TASK = a.task || 'No task text supplied.'
 const BRIEF = a.brief || '(no brief path supplied — read AGENTS.md and the task text)'
 // Inlined brief CONTENTS (preferred). The script sandbox cannot read files, so
 // the launcher should read the brief and pass its text here — otherwise agents
@@ -503,6 +508,10 @@ or augment the body. If the command fails, return an empty body.`,
   )
   if (fetched && fetched.body) {
     BRIEF_TEXT = `Issue #${ISSUE_NUM}: ${fetched.title || ''}\n(${fetched.url || 'no url'} · updated ${fetched.updatedAt || 'unknown'})\n\n${fetched.body}`
+    // Give the agent prompts a real TASK line too (only when the launcher supplied
+    // no explicit task) so the requirement-fidelity lens isn't fed the placeholder.
+    if (!a.task)
+      TASK = `Resolve issue #${ISSUE_NUM}: ${fetched.title || '(untitled)'} (${fetched.url || 'no url'}) — full body in the TASK BRIEF below.`
     log(`Brief self-hydrated from live issue #${ISSUE_NUM} (${fetched.body.length} chars)`)
   } else {
     log(`Issue fetch for #${ISSUE_NUM} failed — continuing with the brief path only (existing behavior)`)

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -237,9 +237,16 @@ const TERMINAL_FAILURE_RE =
   /session limit|usage limit|quota exceeded|exceeded your (current )?quota|out of credits?|insufficient credits?|credit balance/i
 let systemicFailure = false
 let systemicFailureDetail = ''
-function noteAgentError(e) {
+// scope (optional): 'sol' — an auxiliary gpt-5.6-sol/codex slot; 'implement' — the
+// primary implement model. Both have their OWN fallback onto a healthy Claude
+// path, so a terminal error THERE must NOT pause the whole run: a Sol/codex quota
+// is a separate provider (the Claude session may be fine) and the primary
+// implementer falls back to Opus. Only exhaustion of the ACTIVE session provider
+// (default/unset scope) trips the global breaker and pauses the run.
+function noteAgentError(e, scope) {
   const msg = String(e && e.message ? e.message : e)
   if (!TERMINAL_FAILURE_RE.test(msg)) return false
+  if (scope === 'sol' || scope === 'implement') return true // terminal for THIS route only; caller falls back
   if (!systemicFailure) log(`TERMINAL provider failure ("${msg.slice(0, 90)}") — halting all further agent spawns`)
   systemicFailure = true
   if (!systemicFailureDetail) systemicFailureDetail = msg.slice(0, 160)
@@ -424,11 +431,11 @@ async function splitAgent(i, prompt, opts, ctl) {
       noteSolFailure('null/unavailable result')
       covNote(cls, false, 'sol returned null/unavailable')
     } catch (e) {
-      noteAgentError(e) /* Sol failed → Claude fallback below (unless terminal) */
+      noteAgentError(e, 'sol') /* Sol quota/limit is a separate provider → Claude fallback below */
       noteSolFailure(e && e.message)
       covNote(cls, false, e && e.message)
     }
-    if (systemicFailure) return null // terminal: the fallback would die the same way
+    if (systemicFailure) return null // terminal on the SESSION provider: the fallback would die the same way
   }
   return classified(() => agent(prompt, opts))
 }
@@ -452,7 +459,7 @@ async function soloSolAgent(prompt, opts, solEffort) {
       noteSolFailure('null/unavailable result')
       covNote(cls, false, 'sol returned null/unavailable')
     } catch (e) {
-      noteAgentError(e) /* fall through to Claude (unless terminal) */
+      noteAgentError(e, 'sol') /* Sol quota/limit is a separate provider → Claude fallback below */
       noteSolFailure(e && e.message)
       covNote(cls, false, e && e.message)
     }
@@ -464,12 +471,12 @@ async function soloSolAgent(prompt, opts, solEffort) {
 // Await a CRITICAL singleton agent; on any throw (e.g. a StructuredOutput retry
 // cap) return the fallback instead of aborting the whole workflow. Parallel
 // phases already null-out throwers; this protects the awaited singletons.
-async function safely(makePromise, fallback, what) {
+async function safely(makePromise, fallback, what, scope) {
   try {
     const r = await makePromise()
     return r == null ? fallback : r
   } catch (e) {
-    noteAgentError(e) // classify terminal (quota/limit) failures before falling back
+    noteAgentError(e, scope) // classify terminal (quota/limit) failures before falling back
     log(`${what} failed (${String(e && e.message ? e.message : e).slice(0, 90)}) → using fallback`)
     return fallback
   }
@@ -991,7 +998,8 @@ if (START_PHASE !== 'explore') {
   implemented = await safely(
     () => agent(implementPrompt, { ...implOpts, model: IMPL_MODEL, label: `implement:${IMPL_MODEL}` }),
     null,
-    `Implement (${IMPL_MODEL})`
+    `Implement (${IMPL_MODEL})`,
+    'implement' // a primary-model quota falls back to Opus below, not a whole-run pause
   )
   if (!implemented && !systemicFailure) {
     log(`Implement: ${IMPL_MODEL} unavailable/exhausted → falling back to ${IMPL_FALLBACK} (high)`)
@@ -1165,8 +1173,8 @@ ${solPrompt}
             )
             return r && !r.solUnavailable ? r : null
           } catch (e) {
-            noteAgentError(e)
-            return null // codex harness threw → Claude fallback below (scope never lost)
+            noteAgentError(e, 'sol') // codex/Sol quota is a separate provider → Claude fallback below (scope never lost)
+            return null
           }
         }
       : async () => {
@@ -1174,8 +1182,8 @@ ${solPrompt}
             const r = await agent(solPrompt, { schema: FINDINGS_SCHEMA, model: SOL_MODEL, effort: SOL_EFFORT, phase: 'Review', label: `sol-r${roundNo}:${i + 1}` })
             return r != null ? r : null
           } catch (e) {
-            noteAgentError(e)
-            return null // Sol not routable → Claude fallback below
+            noteAgentError(e, 'sol') // Sol quota/route error is a separate provider → Claude fallback below
+            return null
           }
         }
 

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -698,16 +698,28 @@ log(`canopy-loop: ${DEPTH} depth · surface=${SURFACE} · runtime=${RUNTIME} · 
 if (START_PHASE !== 'explore')
   log(`canopy-loop: RESUME at "${START_PHASE}" — explore/plan/implement skipped; working from the committed ${BASE}...HEAD range`)
 
-const exploreAngles = [
-  'the OWNING module and the exact functions/types that must change',
-  'every PRODUCER and CONSUMER of the affected behavior (grep the whole tree)',
-  'the nearest ALREADY-IMPLEMENTED analogue and the existing cross-cutting helpers to reuse',
-  'the CONTRACTS at risk (auth/isolation/escaping/disposal/bounded-work/live-config) and the TEST SEAMS',
-  'the CLIENT surface: MUI + legacy layouts, native markup, locale keys, docs impacted',
-  'the SERVER surface: controllers/services/scheduled tasks, .NET tests, generated artifacts',
-  'the DATA/STATE/CONCURRENCY surface: persistence, caches, revisions, invalidation, and the races the change can introduce',
-  'the PERFORMANCE/BOUNDS surface: allocations, N+1 / manager-call counts, unbounded work, and the measurable budgets to assert',
-].slice(0, SIZING.explorers)
+// A docs-surface run gets docs-relevant angles: the standard list's client/
+// server/concurrency/performance explorers have nothing to trace against a
+// markdown-only change (each was also a Sol slot with a codex harness — pure
+// waste on SR-15/#454). Everything else keeps the full standard list.
+const exploreAngles = (SURFACE === 'docs'
+  ? [
+      'the OWNING docs pages and the exact sections/claims that must change',
+      'every PRODUCER and CONSUMER of the documented behavior: the code, gates, and contracts the text describes (grep the whole tree — the docs must not contradict them)',
+      'the nearest ALREADY-WRITTEN analogue page and the repo doc conventions to copy',
+      'the DOCS surface: nav/mkdocs structure, links, code examples, doc-asset policy, and the check:docs / mkdocs gates that validate them',
+    ]
+  : [
+      'the OWNING module and the exact functions/types that must change',
+      'every PRODUCER and CONSUMER of the affected behavior (grep the whole tree)',
+      'the nearest ALREADY-IMPLEMENTED analogue and the existing cross-cutting helpers to reuse',
+      'the CONTRACTS at risk (auth/isolation/escaping/disposal/bounded-work/live-config) and the TEST SEAMS',
+      'the CLIENT surface: MUI + legacy layouts, native markup, locale keys, docs impacted',
+      'the SERVER surface: controllers/services/scheduled tasks, .NET tests, generated artifacts',
+      'the DATA/STATE/CONCURRENCY surface: persistence, caches, revisions, invalidation, and the races the change can introduce',
+      'the PERFORMANCE/BOUNDS surface: allocations, N+1 / manager-call counts, unbounded work, and the measurable budgets to assert',
+    ]
+).slice(0, SIZING.explorers)
 
 let explorations = []
 if (START_PHASE === 'explore') {
@@ -1306,7 +1318,10 @@ if (!cleanRound && START_PHASE !== 'verify')
 // parity. Implementer/fixers add new i18n keys only to the base en.json; one
 // low-effort agent (gpt/opus on low) fans them out to every locale.
 // ═══════════════════════════════════════════════════════════════════════════
-if (SURFACE !== 'server' && !halted() && START_PHASE !== 'verify') {
+// Skipped for 'server' (no client locale surface) and 'docs' (docs-only changes
+// never touch js/locales; the validate-translations gate still runs in Verify,
+// so a docs change that somehow touched en.json still fails closed at the gate).
+if (SURFACE !== 'server' && SURFACE !== 'docs' && !halted() && START_PHASE !== 'verify') {
   phase('Localize')
   log(`Localize: fanning base-locale keys out to all locales (effort=${LOCALIZE_EFFORT})`)
   await safely(

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -242,9 +242,13 @@ function noteAgentError(e) {
   return true
 }
 // An all-null parallel batch means every agent in it failed — a provider outage,
-// not N independent accidents. (results.length === 0 is not a batch at all.)
+// not N independent accidents. Require a REAL batch (>1): a single-element batch
+// returning null is a normal per-agent failure with correct fail-closed handling
+// downstream (unverified→reviewIncomplete, splitAgent Claude fallback), NOT an
+// outage — misclassifying it pauses the whole run on the common late-round case
+// of one finding whose lone verifier flaked. (results.length ≤ 1 is not a batch.)
 function batchOutage(results, what) {
-  if (results.length && results.every((r) => r == null)) {
+  if (results.length > 1 && results.every((r) => r == null)) {
     if (!systemicFailure) log(`${what}: ALL ${results.length} parallel agents failed — treating as provider outage`)
     systemicFailure = true
     if (!systemicFailureDetail) systemicFailureDetail = `${what}: all ${results.length} parallel agents returned null`

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -276,7 +276,13 @@ async function classified(makePromise) {
 // recovery agent also failed; pauses the run BEFORE the writer (same pause
 // contract as systemicFailure, resumable with a fresh full run).
 let quorumFailure = ''
-const halted = () => systemicFailure || !!quorumFailure
+// Input-validity failure: the launcher pointed at an issue as the brief source but
+// the live fetch failed AND no explicit task/briefText/brief path was supplied, so
+// there are NO authoritative requirements. Running agents anyway would implement
+// and (fail-open) certify work with no acceptance criteria — pause BEFORE Explore
+// instead (same pause contract; resume with a real task source or a working fetch).
+let inputFailure = ''
+const halted = () => systemicFailure || !!quorumFailure || !!inputFailure
 
 // Per-phase agent accounting (attempted / succeeded / null) returned as
 // result.agentStats, so silent `.filter(Boolean)` losses are visible.
@@ -513,8 +519,13 @@ or augment the body. If the command fails, return an empty body.`,
     if (!a.task)
       TASK = `Resolve issue #${ISSUE_NUM}: ${fetched.title || '(untitled)'} (${fetched.url || 'no url'}) — full body in the TASK BRIEF below.`
     log(`Brief self-hydrated from live issue #${ISSUE_NUM} (${fetched.body.length} chars)`)
+  } else if (START_PHASE === 'explore' && !a.task && !a.brief) {
+    // The issue WAS the intended brief source, the fetch failed, and nothing else
+    // authoritative was supplied — fail closed rather than implement on placeholders.
+    inputFailure = `issue #${ISSUE_NUM} hydration failed and no explicit task, briefText, or brief path was supplied — refusing to run agents with no authoritative requirements (fail closed)`
+    log(`Input: ${inputFailure}`)
   } else {
-    log(`Issue fetch for #${ISSUE_NUM} failed — continuing with the brief path only (existing behavior)`)
+    log(`Issue fetch for #${ISSUE_NUM} failed — continuing with the supplied task/brief (existing behavior)`)
   }
 }
 
@@ -527,7 +538,7 @@ or augment the body. If the command fails, return an empty body.`,
 // trips the breaker BEFORE any Sol slot spawns. A healthy route costs one tiny
 // agent; only an explicit available:false trips it (a null/ambiguous probe leaves
 // the runtime breaker to catch a mid-run death — fail toward attempting Sol).
-if (SOL_VIA === 'codex-cli' && MODEL_SPLIT && !systemicFailure) {
+if (SOL_VIA === 'codex-cli' && MODEL_SPLIT && !halted()) {
   const probe = await safely(
     () =>
       agent(
@@ -778,7 +789,7 @@ const exploreAngles = (SURFACE === 'docs'
 ).slice(0, SIZING.explorers)
 
 let explorations = []
-if (START_PHASE === 'explore') {
+if (START_PHASE === 'explore' && !halted()) {
   const exploreResults = await parallel(
     exploreAngles.map((angle, i) => () =>
       splitAgent(
@@ -1645,7 +1656,7 @@ const resumeFrom = !PAUSED
   : { phase: 'verify' }
 const result = {
   status: PAUSED ? 'paused' : 'complete',
-  pauseReason: PAUSED ? systemicFailureDetail || quorumFailure : null,
+  pauseReason: PAUSED ? systemicFailureDetail || quorumFailure || inputFailure : null,
   resumeFrom,
   startPhase: START_PHASE,
   branch: BRANCH,
@@ -1682,7 +1693,7 @@ const result = {
     .concat(
       PAUSED
         ? [
-            `run PAUSED (${systemicFailureDetail || quorumFailure}) — do NOT blindly retry; ${systemicFailure ? 'once capacity returns, ' : ''}resume with startPhase:"${resumeFrom.phase}" against the same branch`,
+            `run PAUSED (${systemicFailureDetail || quorumFailure || inputFailure}) — do NOT blindly retry; ${systemicFailure ? 'once capacity returns, ' : inputFailure ? 'supply a task/briefText (or fix the issue fetch), then ' : ''}resume with startPhase:"${resumeFrom.phase}" against the same branch`,
           ]
         : []
     )

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -1064,7 +1064,24 @@ and speculative EXTRA requirements the brief never asked for are NOT findings.`
 // verifier's reasons). Injected into every reviewer prompt from round 2 on so
 // reviewers stop re-reporting resolved items — the main convergence lever on
 // every surface, and the difference between 2 rounds and 10 on prose-heavy ones.
-const ledger = [] // { file, line, summary, status: 'fixed'|'refuted'|'advisory', reason, round }
+// Seed from the launcher (a.ledger) so a startPhase:'review' resume keeps the
+// refutation/fix suppression it earned last session instead of re-churning items
+// earlier rounds already disposed of. The ledger references file:line in the same
+// committed BASE...HEAD range the resume reviews, so seeding only suppresses
+// re-reports — never invents a disposition. Prior-run entries are marked round:0.
+// Persist the returned `ledger` and pass it back on resume (see SKILL.md/README).
+const ledger = Array.isArray(a.ledger)
+  ? a.ledger
+      .filter((e) => e && e.file && e.status)
+      .map((e) => ({
+        file: e.file,
+        line: e.line || 0,
+        summary: String(e.summary || '').slice(0, 140),
+        status: e.status,
+        reason: String(e.reason || '').slice(0, 200),
+        round: 0,
+      }))
+  : [] // { file, line, summary, status: 'fixed'|'refuted'|'advisory', reason, round }
 // Render the ledger as compact ONE-LINE entries with an equal-share budget, so
 // EVERY disposition survives (truncated within its own line) rather than the
 // newest rounds vanishing whole. The old `JSON.stringify(ledger).slice(0,6000)`

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -60,9 +60,10 @@ const BASE = a.base || 'origin/main'
 //   'explore' (default) — full run, byte-identical to the pre-resume behavior;
 //   'review'  — skip Explore/Plan/Implement, adversarially review the committed
 //               range, then verify (can certify readyForPR — review runs fully);
-//   'verify'  — additionally skip the review loop: gates only. A verify-only
-//               resume normally can NEVER certify readyForPR (fail closed — no
-//               review ran), UNLESS the launcher passes reviewedHead (below).
+//   'verify'  — additionally skip the review loop: Localize (parity fan-out, not
+//               reviewed) then gates. A verify-only resume normally can NEVER
+//               certify readyForPR (fail closed — no review ran), UNLESS the
+//               launcher passes reviewedHead (below).
 const START_PHASE = ['explore', 'review', 'verify'].includes(a.startPhase) ? a.startPhase : 'explore'
 // reviewedHead escape hatch (fail-closed sha match). The primary #454 scenario is
 // a run that dies AFTER a certified-clean review round but during Localize/Verify
@@ -1359,7 +1360,15 @@ if (!cleanRound && START_PHASE !== 'verify')
 // Skipped for 'server' (no client locale surface) and 'docs' (docs-only changes
 // never touch js/locales; the validate-translations gate still runs in Verify,
 // so a docs change that somehow touched en.json still fails closed at the gate).
-if (SURFACE !== 'server' && SURFACE !== 'docs' && !halted() && START_PHASE !== 'verify') {
+// RUNS on a verify-resume too: a run that paused between the clean review round
+// and Localize left new en.json keys un-fanned-out, so a verify-only resume that
+// skipped Localize would fail validate-translations forever (or invite the
+// verify-fixer into the mass locale edits the fix prompts forbid). The phase is
+// cheap and self-no-ops when en.json has no new/changed keys, its chore(i18n)
+// commit lands BEFORE the first verify so verifyFixCommitted HEAD tracking is
+// untouched, and it is never adversarially reviewed — so it cannot poison
+// certification. Hence no START_PHASE guard here.
+if (SURFACE !== 'server' && SURFACE !== 'docs' && !halted()) {
   phase('Localize')
   log(`Localize: fanning base-locale keys out to all locales (effort=${LOCALIZE_EFFORT})`)
   await safely(

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -689,7 +689,7 @@ const FINDINGS_SCHEMA = {
       items: {
         type: 'object',
         additionalProperties: true,
-        required: ['file', 'summary', 'failureScenario'],
+        required: ['file', 'summary', 'failureScenario', 'severity'],
         properties: {
           lens: { type: 'string' },
           file: { type: 'string' },
@@ -705,11 +705,11 @@ const FINDINGS_SCHEMA = {
 const VERDICT_SCHEMA = {
   type: 'object',
   additionalProperties: true,
-  required: ['real', 'reason'],
+  required: ['real', 'reason', 'severity'],
   properties: {
     real: { type: 'boolean', description: 'true only if the finding genuinely reproduces / violates a contract' },
     reason: { type: 'string' },
-    severity: { type: 'string', enum: ['blocker', 'major', 'minor'] },
+    severity: { type: 'string', enum: ['blocker', 'major', 'minor'], description: 'your re-judged severity — REQUIRED so the docs/spec severity gate never silently defaults an omitted value to major and churns an extra fix round' },
   },
 }
 const FIX_SCHEMA = {
@@ -1041,7 +1041,15 @@ DOCS/PROSE FINDING BAR: for documentation and specification text, a finding must
 be a FACTUAL defect — a wrong command or code sample, a broken link, a
 contradiction with a repository contract or an acceptance criterion, or an
 invalid example. Wording, tone, style, and restructuring preferences are NOT
-findings.`
+findings.
+SEVERITY (required on EVERY finding — it drives whether a fix round runs):
+  • blocker = following the text causes a wrong/destructive action, or it
+    contradicts a binding repository contract or an acceptance criterion;
+  • major   = a factual error a reader would act on (wrong command/flag/path,
+    broken link, invalid example) but not destructive;
+  • minor   = stale/imprecise phrasing with NO wrong action — reported as an
+    advisory note, never forcing another round.
+Do not inflate a minor to major to force a fix; do not hide a blocker as minor.`
     : ''
 }${
   REVIEW_MODE === 'spec'
@@ -1311,7 +1319,9 @@ while (round < HARD_ROUND_CAP && !cleanRound && !halted() && START_PHASE !== 've
 PHASE: VERIFY FINDING. Try hard to REFUTE this claimed defect. Default to
 real=false when uncertain — only real=true if it genuinely reproduces or truly
 violates a repository contract on a reachable path.
-FINDING (${f.lens || '?'}) ${f.file}:${f.line || '?'} — ${f.summary}
+Return severity (blocker/major/minor) REQUIRED — your own re-judgment of the
+confirmed finding${SEVERITY_GATED ? ' (this surface reports confirmed minors as advisory notes rather than forcing another fix round, so an accurate minor-vs-major call matters)' : ''}.
+FINDING (${f.lens || '?'}) ${f.file}:${f.line || '?'} — ${f.summary} [reviewer severity: ${f.severity || 'unset'}]
 SCENARIO: ${f.failureScenario}`,
         { schema: VERDICT_SCHEMA, agentType: 'code-reviewer', effort: 'medium', phase: 'Review', label: `verify-r${round}:${i + 1}` },
         // In a gpt-only round, finding-verification runs on Sol too (gpt is the

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -172,6 +172,54 @@ const SOL_EXPLORE_PLAN_EFFORT = a.solExplorePlanEffort || 'xhigh'
 // (gpt or opus on low, inheriting the session model). Override with args.localizeEffort.
 const LOCALIZE_EFFORT = a.localizeEffort || 'low'
 
+// ── systemic-failure (quota / usage-limit) circuit breaker ──────────────────
+// A TERMINAL provider failure (Anthropic session/usage limit, exhausted quota
+// or credits) kills every subsequent agent the same way. Without detection the
+// loop keeps spawning doomed reviewers, Localize, Verify, and verify-fix agents
+// (run #454 burned 26 agent errors after "You've hit your session limit").
+// Two triggers set systemic-failure mode:
+//   1. an agent error message matching TERMINAL_FAILURE_RE, or
+//   2. an ENTIRE parallel batch returning null (provider/infrastructure outage —
+//      a single null is a normal per-agent failure and never trips this).
+// Once set, the loop stops spawning agents entirely (no Localize, no Verify, no
+// fixers, no Claude fallbacks) and returns early with status:'paused' plus
+// resumeFrom, so a later run can resume via startPhase instead of re-burning
+// the completed phases. Singleton failures keep the existing fail-closed
+// semantics (reviewIncomplete, verifier-null-is-unresolved, etc.) unchanged.
+const TERMINAL_FAILURE_RE =
+  /session limit|usage limit|quota exceeded|exceeded your (current )?quota|out of credits?|insufficient credits?|credit balance/i
+let systemicFailure = false
+let systemicFailureDetail = ''
+function noteAgentError(e) {
+  const msg = String(e && e.message ? e.message : e)
+  if (!TERMINAL_FAILURE_RE.test(msg)) return false
+  if (!systemicFailure) log(`TERMINAL provider failure ("${msg.slice(0, 90)}") — halting all further agent spawns`)
+  systemicFailure = true
+  if (!systemicFailureDetail) systemicFailureDetail = msg.slice(0, 160)
+  return true
+}
+// An all-null parallel batch means every agent in it failed — a provider outage,
+// not N independent accidents. (results.length === 0 is not a batch at all.)
+function batchOutage(results, what) {
+  if (results.length && results.every((r) => r == null)) {
+    if (!systemicFailure) log(`${what}: ALL ${results.length} parallel agents failed — treating as provider outage`)
+    systemicFailure = true
+    if (!systemicFailureDetail) systemicFailureDetail = `${what}: all ${results.length} parallel agents returned null`
+  }
+  return systemicFailure
+}
+// Await an agent promise, classifying any error before rethrowing. parallel()
+// nulls out throwers, which would otherwise DISCARD the error message — this is
+// how terminal failures inside parallel batches reach the classifier.
+async function classified(makePromise) {
+  try {
+    return await makePromise()
+  } catch (e) {
+    noteAgentError(e)
+    throw e
+  }
+}
+
 // codex forwards --output-schema to OpenAI Structured Outputs in STRICT mode,
 // which requires every object to set additionalProperties:false and list EVERY
 // declared property in `required`. Our workflow schemas are intentionally
@@ -202,6 +250,7 @@ function strictSchema(s) {
 // runs `codex ... exec --output-schema`, then RELAYS the structured result.
 // Returns null when codex is unavailable/errors so the caller falls back to Claude.
 async function codexAgent(prompt, schema, opts) {
+  if (systemicFailure) return null // outage: don't spawn the harness agent
   const eff = (opts && opts.effort) || SOL_LIGHT_EFFORT
   const r = await agent(
     `You are a HARNESS that runs an external gpt-5.6-sol analyst via the codex CLI
@@ -247,6 +296,7 @@ ${prompt}
 // gpt-5.6-sol reasoning effort for the 'agent' route (default SOL_EFFORT);
 // solLightEffort?: codex-cli effort (default SOL_LIGHT_EFFORT) }.
 async function splitAgent(i, prompt, opts, ctl) {
+  if (systemicFailure) return null // outage: no Sol attempt, no Claude fallback
   const useSol = ctl && typeof ctl.slot === 'function' ? ctl.slot(i) : solSlot(i)
   if (useSol) {
     try {
@@ -255,15 +305,17 @@ async function splitAgent(i, prompt, opts, ctl) {
       else if (opts && opts.schema)
         r = await codexAgent(prompt, opts.schema, { effort: (ctl && ctl.solLightEffort) || SOL_LIGHT_EFFORT, phase: opts.phase, label: (opts.label || '') + ':sol' })
       if (r != null) return r
-    } catch (_) {
-      /* Sol failed → Claude fallback below */
+    } catch (e) {
+      noteAgentError(e) /* Sol failed → Claude fallback below (unless terminal) */
     }
+    if (systemicFailure) return null // terminal: the fallback would die the same way
   }
-  return agent(prompt, opts)
+  return classified(() => agent(prompt, opts))
 }
 // A singleton read-only step we offload to Sol (plan synthesis) to spare Claude
 // tokens; falls back to Claude when Sol isn't routable/available.
 async function soloSolAgent(prompt, opts, solEffort) {
+  if (systemicFailure) return null // outage: no Sol attempt, no Claude fallback
   if (MODEL_SPLIT) {
     try {
       let r = null
@@ -271,11 +323,12 @@ async function soloSolAgent(prompt, opts, solEffort) {
       else if (opts && opts.schema)
         r = await codexAgent(prompt, opts.schema, { effort: solEffort || SOL_LIGHT_EFFORT, phase: opts.phase, label: (opts.label || '') + ':sol' })
       if (r != null) return r
-    } catch (_) {
-      /* fall through to Claude */
+    } catch (e) {
+      noteAgentError(e) /* fall through to Claude (unless terminal) */
     }
+    if (systemicFailure) return null
   }
-  return agent(prompt, opts)
+  return classified(() => agent(prompt, opts))
 }
 
 // Await a CRITICAL singleton agent; on any throw (e.g. a StructuredOutput retry
@@ -286,6 +339,7 @@ async function safely(makePromise, fallback, what) {
     const r = await makePromise()
     return r == null ? fallback : r
   } catch (e) {
+    noteAgentError(e) // classify terminal (quota/limit) failures before falling back
     log(`${what} failed (${String(e && e.message ? e.message : e).slice(0, 90)}) → using fallback`)
     return fallback
   }
@@ -492,8 +546,7 @@ const exploreAngles = [
   'the PERFORMANCE/BOUNDS surface: allocations, N+1 / manager-call counts, unbounded work, and the measurable budgets to assert',
 ].slice(0, SIZING.explorers)
 
-const explorations = (
-  await parallel(
+const exploreResults = await parallel(
     exploreAngles.map((angle, i) => () =>
       splitAgent(
         i,
@@ -513,7 +566,8 @@ evidence. Only real defects; leave it empty if you see none.`,
       )
     )
   )
-).filter(Boolean)
+batchOutage(exploreResults, 'Explore')
+const explorations = exploreResults.filter(Boolean)
 
 const exploreDigest = JSON.stringify(explorations, null, 1).slice(0, 12000)
 log(`Explore: ${explorations.length} maps returned`)
@@ -521,16 +575,17 @@ log(`Explore: ${explorations.length} maps returned`)
 // ═══════════════════════════════════════════════════════════════════════════
 // PHASE 2 — PLAN (independent plans → adversarial synthesis into one)
 // ═══════════════════════════════════════════════════════════════════════════
-phase('Plan')
-
 const planAngles = [
   'MINIMAL-CHANGE first: the smallest change at the true owner; delete/delegate state before adding any.',
   'RISK first: identify the failure modes and design the state/failure model that fails closed with fewest moving parts.',
   'REUSE first: maximise use of existing helpers/analogue; avoid any parallel implementation of a shared behavior.',
 ].slice(0, SIZING.planners)
 
-const plans = (
-  await parallel(
+let plans = []
+let canonicalPlan = null
+if (!systemicFailure) {
+  phase('Plan')
+  const planResults = await parallel(
     planAngles.map((angle, i) => () =>
       splitAgent(
         i,
@@ -550,9 +605,12 @@ docs to update.`,
       )
     )
   )
-).filter(Boolean)
+  batchOutage(planResults, 'Plan')
+  plans = planResults.filter(Boolean)
+}
 
-const canonicalPlan = await safely(
+if (!systemicFailure) {
+  canonicalPlan = await safely(
   () =>
     soloSolAgent(
       `${CONTRACTS}
@@ -575,14 +633,13 @@ and add the least while reusing the most.`,
     ),
   plans[0] || null,
   'Plan synthesis'
-)
-log(`Plan: ${plans.length} plans → 1 canonical (${(canonicalPlan && canonicalPlan.owningLayer) || 'n/a'})`)
+  )
+  log(`Plan: ${plans.length} plans → 1 canonical (${(canonicalPlan && canonicalPlan.owningLayer) || 'n/a'})`)
+}
 
 // ═══════════════════════════════════════════════════════════════════════════
 // PHASE 3 — IMPLEMENT (single writer)
 // ═══════════════════════════════════════════════════════════════════════════
-phase('Implement')
-
 const implementPrompt = `${CONTRACTS}
 
 PHASE: IMPLEMENT. You are the SOLE writer in this worktree. Follow this canonical
@@ -613,33 +670,37 @@ self-confidence (high/medium/low) with any open TODOs.`
 const IMPL_MODEL = a.implementModel || 'fable'
 const IMPL_FALLBACK = a.implementFallback || 'opus'
 const implOpts = { schema: IMPLEMENT_SCHEMA, agentType: 'general-purpose', effort: 'high', phase: 'Implement' }
-let implemented = await safely(
-  () => agent(implementPrompt, { ...implOpts, model: IMPL_MODEL, label: `implement:${IMPL_MODEL}` }),
-  null,
-  `Implement (${IMPL_MODEL})`
-)
-if (!implemented) {
-  log(`Implement: ${IMPL_MODEL} unavailable/exhausted → falling back to ${IMPL_FALLBACK} (high)`)
+let implemented = null
+if (!systemicFailure) {
+  phase('Implement')
   implemented = await safely(
-    () =>
-      agent(
-        `${implementPrompt}
+    () => agent(implementPrompt, { ...implOpts, model: IMPL_MODEL, label: `implement:${IMPL_MODEL}` }),
+    null,
+    `Implement (${IMPL_MODEL})`
+  )
+  if (!implemented && !systemicFailure) {
+    log(`Implement: ${IMPL_MODEL} unavailable/exhausted → falling back to ${IMPL_FALLBACK} (high)`)
+    implemented = await safely(
+      () =>
+        agent(
+          `${implementPrompt}
 
 NOTE: a previous attempt may have left partial changes or commits in the
 worktree. Inspect \`git -C ${WORKTREE} status\` and \`git -C ${WORKTREE} log --oneline ${BASE}..HEAD\`
 and CONTINUE from there rather than restarting from scratch.`,
-        { ...implOpts, model: IMPL_FALLBACK, label: `implement:${IMPL_FALLBACK}-fallback` }
-      ),
-    null,
-    `Implement (${IMPL_FALLBACK})`
-  )
+          { ...implOpts, model: IMPL_FALLBACK, label: `implement:${IMPL_FALLBACK}-fallback` }
+        ),
+      null,
+      `Implement (${IMPL_FALLBACK})`
+    )
+  }
+  log(`Implement: ${(implemented && implemented.changedFiles && implemented.changedFiles.length) || 0} files, confidence ${(implemented && implemented.selfConfidence) || '?'}`)
 }
-log(`Implement: ${(implemented && implemented.changedFiles && implemented.changedFiles.length) || 0} files, confidence ${(implemented && implemented.selfConfidence) || '?'}`)
 
 // ═══════════════════════════════════════════════════════════════════════════
 // PHASE 4 — ADVERSARIAL REVIEW LOOP (parallel review → verify → single fixer)
 // ═══════════════════════════════════════════════════════════════════════════
-phase('Review')
+if (!systemicFailure) phase('Review')
 
 const reviewContext = `${CONTRACTS}
 
@@ -655,6 +716,7 @@ You see ONLY the diff and this brief — never the implementer's reasoning.`
 // → a whole-diff pass. Used both as a first-class reviewer AND as the fallback
 // when a Sol slot can't be routed, so no review scope is ever silently lost.
 function claudeReview(roundNo, i, lens) {
+  if (systemicFailure) return null // outage: don't spawn another doomed reviewer
   const scoped = lens
     ? `PHASE: ADVERSARIAL REVIEW — lens: "${lens}".
 Assume the change is WRONG and prove how, THROUGH THIS LENS ONLY.`
@@ -662,8 +724,7 @@ Assume the change is WRONG and prove how, THROUGH THIS LENS ONLY.`
 Assume the change is WRONG and prove how, across correctness, security/privacy
 (fail-closed), lifecycle/concurrency, bounds/perf/no-jank, JF12 + MUI/legacy
 compatibility, test strength, product scope, and docs/locale/generated-artifact gaps.`
-  return agent(
-    `${reviewContext}
+  const prompt = `${reviewContext}
 
 ${scoped}
 A finding needs a real file/line and a concrete failure scenario (inputs/state →
@@ -672,8 +733,9 @@ Watch for mechanically-similar-but-semantically-different code (side effects
 inside asserts/guards, eager vs lazy defaults, odd-length buffer truncation,
 bounds checks present in one build only, byte-vs-UTF assumptions, escape/format
 passes over the wrong data). Reject any workaround that needs a paragraph-long
-comment to justify it. Return only real findings (empty array if none).`,
-    { schema: FINDINGS_SCHEMA, agentType: 'code-reviewer', effort: 'medium', phase: 'Review', label: `review-r${roundNo}:${i + 1}${lens ? '' : ':whole'}` }
+comment to justify it. Return only real findings (empty array if none).`
+  return classified(() =>
+    agent(prompt, { schema: FINDINGS_SCHEMA, agentType: 'code-reviewer', effort: 'medium', phase: 'Review', label: `review-r${roundNo}:${i + 1}${lens ? '' : ':whole'}` })
   )
 }
 
@@ -729,7 +791,8 @@ failure — reserve {"findings": []} for a genuine clean codex run.`,
             { schema: FINDINGS_SCHEMA, agentType: 'general-purpose', effort: 'medium', phase: 'Review', label: `sol-cli-r${roundNo}:${i + 1}` }
             )
             return r && !r.solUnavailable ? r : null
-          } catch (_) {
+          } catch (e) {
+            noteAgentError(e)
             return null // codex harness threw → Claude fallback below (scope never lost)
           }
         }
@@ -737,14 +800,17 @@ failure — reserve {"findings": []} for a genuine clean codex run.`,
           try {
             const r = await agent(solPrompt, { schema: FINDINGS_SCHEMA, model: SOL_MODEL, effort: SOL_EFFORT, phase: 'Review', label: `sol-r${roundNo}:${i + 1}` })
             return r != null ? r : null
-          } catch (_) {
+          } catch (e) {
+            noteAgentError(e)
             return null // Sol not routable → Claude fallback below
           }
         }
 
   return async () => {
+    if (systemicFailure) return null // outage: no Sol attempt, no Claude fallback
     const r = await runSol()
     if (r != null) return r
+    if (systemicFailure) return null // terminal: the fallback would die the same way
     return claudeReview(roundNo, i, lens) // scope never lost
   }
 }
@@ -756,7 +822,7 @@ let cleanRound = false
 let reviewIncomplete = false
 const MIXED_ROUND_CAP = SIZING.roundCap
 let round = 0
-while (round < HARD_ROUND_CAP && !cleanRound) {
+while (round < HARD_ROUND_CAP && !cleanRound && !systemicFailure) {
   round++
 
   // Rounds 1..MIXED_ROUND_CAP run the mixed panel (Claude lenses + gpt-5.6-sol).
@@ -794,6 +860,11 @@ while (round < HARD_ROUND_CAP && !cleanRound) {
   log(`Review round ${round}/${HARD_ROUND_CAP}${gptOnly ? ' [gpt-only]' : ''} — ${claudeLensCount} Claude lens + ${solCount}× ${SOL_MODEL} (${SOL_VIA}, ${SOL_EFFORT})${MODEL_SPLIT && !gptOnly ? ' [50/50 + whole-diff]' : ''}`)
 
   const results = await parallel(roundThunks)
+  if (batchOutage(results, `Review round ${round}`)) {
+    reviewIncomplete = true
+    log(`Review round ${round}: provider outage — pausing instead of spawning more agents`)
+    break
+  }
   const failedWorkers = results.filter((r) => r == null).length
   const raw = results.filter(Boolean).flatMap((r) => (r && r.findings) || [])
 
@@ -833,6 +904,12 @@ SCENARIO: ${f.failureScenario}`,
     )
   )
 
+  if (batchOutage(verdicts, `Review round ${round} finding-verification`)) {
+    reviewIncomplete = true
+    log(`Review round ${round}: provider outage during finding-verification — pausing`)
+    break
+  }
+
   // A missing verdict (verifier agent failed) is NOT a refutation — the finding
   // is unresolved, not cleared. Only a returned real=false counts as refuted.
   const unverified = deduped.filter((_, i) => verdicts[i] == null).length
@@ -856,6 +933,11 @@ SCENARIO: ${f.failureScenario}`,
   if (unverified) {
     reviewIncomplete = true
     log(`Review round ${round}: ${confirmed.length} confirmed but ${unverified} finding(s) unverified (verifier failure) → coverage incomplete, run cannot certify clean`)
+  }
+  if (systemicFailure) {
+    reviewIncomplete = true
+    log(`Review round ${round}: provider outage — not spawning the fixer`)
+    break
   }
   log(`Review round ${round}: ${confirmed.length} confirmed → fixing`)
 
@@ -897,7 +979,7 @@ if (!cleanRound)
 // parity. Implementer/fixers add new i18n keys only to the base en.json; one
 // low-effort agent (gpt/opus on low) fans them out to every locale.
 // ═══════════════════════════════════════════════════════════════════════════
-if (SURFACE !== 'server') {
+if (SURFACE !== 'server' && !systemicFailure) {
   phase('Localize')
   log(`Localize: fanning base-locale keys out to all locales (effort=${LOCALIZE_EFFORT})`)
   await safely(
@@ -926,7 +1008,7 @@ locales, do NOTHING and report "no locale work needed".`,
 // ═══════════════════════════════════════════════════════════════════════════
 // PHASE 5 — VERIFY (single runner; bounded fix-and-reverify)
 // ═══════════════════════════════════════════════════════════════════════════
-phase('Verify')
+if (!systemicFailure) phase('Verify')
 
 const gateList = gateCommands()
 const e2eBlock = RUNTIME
@@ -946,7 +1028,7 @@ let vround = 0
 // stale cleanRound to certify them is unsafe. Track whether any verify-fix
 // actually committed; if so the final diff is unreviewed and NOT ready for PR.
 let verifyFixCommitted = false
-while (vround <= SIZING.verifyFixCap) {
+while (vround <= SIZING.verifyFixCap && !systemicFailure) {
   // FINAL VERIFY stays on Claude (authoritative gate run) — never split to Sol.
   verify = await safely(
     () =>
@@ -984,6 +1066,10 @@ ALL BLOCKING gates passed, the e2e result if run, and a list of failures.`,
   vround++
   if (vround > SIZING.verifyFixCap) {
     log(`Verify: still failing after ${SIZING.verifyFixCap} fix attempts — reporting failures`)
+    break
+  }
+  if (systemicFailure) {
+    log('Verify: provider outage — skipping the verify-fix retry (a code-writing fixer is pointless during an outage)')
     break
   }
   log(`Verify: failures → fix attempt ${vround}/${SIZING.verifyFixCap}`)
@@ -1032,7 +1118,21 @@ const incidentalBugs = (() => {
   }
   return out
 })()
+// A paused run tells the launcher exactly where to re-enter: the committed
+// branch state carries everything the later phases need (they work purely from
+// the BASE...HEAD range), so nothing before resumeFrom.phase is re-run.
+const PAUSED = systemicFailure
+const resumeFrom = !PAUSED
+  ? null
+  : !implemented
+  ? { phase: 'explore' }
+  : !cleanRound
+  ? { phase: 'review', round }
+  : { phase: 'verify' }
 const result = {
+  status: PAUSED ? 'paused' : 'complete',
+  pauseReason: PAUSED ? systemicFailureDetail : null,
+  resumeFrom,
   branch: BRANCH,
   surface: SURFACE,
   depth: DEPTH,
@@ -1045,9 +1145,16 @@ const result = {
   canonicalPlan: canonicalPlan || null,
   verify: verify || null,
   verifyFixCommitted,
-  readyForPR: implementationOk && cleanRound && !reviewIncomplete && !verifyFixCommitted && blockingGreen && e2eGreen,
+  readyForPR: !PAUSED && implementationOk && cleanRound && !reviewIncomplete && !verifyFixCommitted && blockingGreen && e2eGreen,
   residualRisks: []
-    .concat(implemented ? [] : ['implementation did not complete — both implementer models failed to return a result'])
+    .concat(
+      PAUSED
+        ? [
+            `run PAUSED on a systemic provider failure (${systemicFailureDetail}) — do NOT relaunch a full run; once capacity returns, resume with startPhase:"${resumeFrom.phase}" against the same branch`,
+          ]
+        : []
+    )
+    .concat(implemented || PAUSED ? [] : ['implementation did not complete — both implementer models failed to return a result'])
     .concat(openTodos.length ? ['implementer left open acceptance-criteria TODOs — change is incomplete'] : [])
     .concat(reviewIncomplete ? ['adversarial review ended with incomplete coverage (a reviewer or finding-verifier failed) — the round could not be certified clean'] : [])
     .concat(cleanRound || reviewIncomplete ? [] : ['review loop hit its round cap with unresolved confirmed findings'])
@@ -1057,6 +1164,6 @@ const result = {
     .concat(openTodos),
 }
 log(
-  `canopy-loop done: readyForPR=${result.readyForPR} · impl=${implementationOk} · rounds=${round} · findings resolved=${confirmedAll.length} · blockingGreen=${blockingGreen}${RUNTIME ? ` · e2e=${e2eGreen}` : ''}`
+  `canopy-loop ${result.status}: readyForPR=${result.readyForPR} · impl=${implementationOk} · rounds=${round} · findings resolved=${confirmedAll.length} · blockingGreen=${blockingGreen}${RUNTIME ? ` · e2e=${e2eGreen}` : ''}${PAUSED ? ` · resumeFrom=${resumeFrom.phase}` : ''}`
 )
 return result

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -34,6 +34,13 @@ const BRIEF = a.brief || '(no brief path supplied — read AGENTS.md and the tas
 // the launcher should read the brief and pass its text here — otherwise agents
 // may never open the path and will infer the task from weaker signals.
 const BRIEF_TEXT = a.briefText || ''
+// Optional environment prelude every build/test-running agent must execute
+// FIRST (workflow subagents get fresh shells, so the launcher's exports do not
+// propagate — historically the verify agent picked a system dotnet over the
+// $HOME/.dotnet toolchain). Generic hook only: the machine-specific value (e.g.
+// `export DOTNET_ROOT=$HOME/.dotnet; export PATH="$DOTNET_ROOT:$PATH"`) stays
+// on the launcher side.
+const ENV_SETUP = a.envSetup ? String(a.envSetup) : ''
 // client | server | cross | docs. An unknown value (e.g. a launcher typo like
 // "clinet") must NOT silently skip all surface-specific gates — fail closed to
 // 'cross', the superset that runs every surface's verification.
@@ -462,7 +469,7 @@ fail-closed auth/isolation/escaping/disposal/bounded work; coverage & lint caps
 are ratchets; rebuild generated bundles/manifests/snapshots/translations from
 source). Only this repository is writable; the Jellyfin-Enhanced repos are
 read-only. Never deploy to :8099, release, or mutate an external service.
-
+${ENV_SETUP ? `\nENVIRONMENT (run before ANY build/test command in every shell you open):\n  ${ENV_SETUP}\n` : ''}
 REQUIREMENT FIDELITY (binding): The acceptance criteria in the TASK / TASK BRIEF
 below are authoritative. Fix the ACTUAL reported defect and satisfy EVERY
 acceptance criterion. Do NOT infer the intended change from the branch name, and
@@ -1321,6 +1328,9 @@ review. Then run the repository-native gates for surface="${SURFACE}", in order,
 from ${WORKTREE}. Lint is ADVISORY (findings never block); every other gate is
 BLOCKING. Do not pipe wrappers through tail/grep/tee in a way that hides exit
 status. Do not run a plain suite right before its coverage variant.
+Before any dotnet gate, echo the toolchain (\`command -v dotnet && dotnet --version\`)
+as gate evidence; if DOTNET_ROOT is set, ensure $DOTNET_ROOT precedes the system
+dotnet on PATH so the repository's pinned SDK is the one that runs.
 
 HANDOFF: a non-empty \`git status --porcelain\` is a BLOCKING failure. The reviewed
 and pushable change is the committed range ${BASE}..HEAD, so any uncommitted edit

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -91,12 +91,31 @@ const ALL_LENSES = [
   'Product semantics & scope',
   'Docs, locale & generated artifacts',
 ]
+// Review mode: 'standard' reviews code/diff correctness. 'spec' (opt-in, for
+// specification/design-doc authoring) swaps in lenses that judge a SPEC — does
+// it trace to the acceptance criteria, agree with itself, name owners that can
+// build it, and state contracts that are verifiable — instead of hunting prose
+// style. Selected by the launcher with args.reviewMode:'spec'.
+const REVIEW_MODE = a.reviewMode === 'spec' ? 'spec' : 'standard'
+const SPEC_LENSES = [
+  'Acceptance traceability (does every acceptance criterion in the brief map to spec text that satisfies it? cite the criterion per finding)',
+  'Internal consistency (do any two statements in the spec contradict each other, a repository contract, or an existing doc?)',
+  'Implementability (does each requirement name a real owner/mechanism that can actually build and enforce it — no ownerless or impossible mandate?)',
+  'Verifiable contracts (is every stated requirement/safety contract testable or measurable as written?)',
+]
 const LENSES =
-  SURFACE === 'docs'
+  REVIEW_MODE === 'spec'
+    ? SPEC_LENSES
+    : SURFACE === 'docs'
     ? ['Correctness & logic', 'Docs, locale & generated artifacts', 'Product semantics & scope']
     : DEPTH === 'quick'
     ? ALL_LENSES.slice(0, 5).concat('Docs, locale & generated artifacts')
     : ALL_LENSES
+// Docs/prose and spec review gate fixing by SEVERITY: blocker/major confirmed
+// findings drive a fix round; confirmed minors are reported as advisory notes
+// and do NOT force another round (prose minors historically drove SR-15 to the
+// 10-round cap while the same machinery converged in 2 rounds on SR-06).
+const SEVERITY_GATED = SURFACE === 'docs' || REVIEW_MODE === 'spec'
 
 // Model mix for review (user policy): every review round runs BOTH the Claude
 // lens reviewers above (≥1) AND ≥1 gpt-5.6-sol whole-diff reviewer at high
@@ -167,8 +186,12 @@ const solSlot = (i) => MODEL_SPLIT && i % 2 === 1 // odd indices → Sol (~50/50
 const EXPLORE_CLAUDE_COUNT = a.exploreClaudeCount == null ? 2 : Math.max(0, a.exploreClaudeCount)
 const exploreSol = (i) => MODEL_SPLIT && i >= EXPLORE_CLAUDE_COUNT
 // The hard review-round ceiling: after the mixed roundCap, gpt-5.6-sol-only
-// review rounds continue up to here (user policy). Override with args.hardRoundCap.
-const HARD_ROUND_CAP = Math.max(1, a.hardRoundCap == null ? 10 : a.hardRoundCap)
+// review rounds continue up to here (user policy). Docs/spec surfaces default
+// MUCH lower (roundCap+1): prose churn does not converge under a 10-round
+// escalation, and unresolved docs findings should go back to a human instead.
+// Override with args.hardRoundCap.
+const DEFAULT_HARD_CAP = SEVERITY_GATED ? SIZING.roundCap + 1 : 10
+const HARD_ROUND_CAP = Math.max(1, a.hardRoundCap == null ? DEFAULT_HARD_CAP : a.hardRoundCap)
 
 // Effort for the non-review Sol phases (explore/plan/finding-verification). High
 // codex effort × many calls gets very slow, so these default to medium; the
@@ -731,7 +754,42 @@ The change is on branch ${BRANCH}. Inspect it with:
   git -C ${WORKTREE} status --porcelain   # MUST be empty — a non-empty result is a finding
 The reviewed diff is the COMMITTED range ${BASE}...HEAD; any uncommitted change is
 unreviewed and would be lost on push, so treat a dirty worktree as a real finding.
-You see ONLY the diff and this brief — never the implementer's reasoning.`
+You see ONLY the diff and this brief — never the implementer's reasoning.${
+  SURFACE === 'docs' || REVIEW_MODE === 'spec'
+    ? `
+
+DOCS/PROSE FINDING BAR: for documentation and specification text, a finding must
+be a FACTUAL defect — a wrong command or code sample, a broken link, a
+contradiction with a repository contract or an acceptance criterion, or an
+invalid example. Wording, tone, style, and restructuring preferences are NOT
+findings.`
+    : ''
+}${
+  REVIEW_MODE === 'spec'
+    ? `
+SPEC REVIEW MODE: every finding MUST cite the acceptance criterion, repository
+contract, or authoritative platform behavior it violates. Editorial preferences
+and speculative EXTRA requirements the brief never asked for are NOT findings.`
+    : ''
+}`
+
+// Finding LEDGER: what previous rounds already fixed or refuted (with the
+// verifier's reasons). Injected into every reviewer prompt from round 2 on so
+// reviewers stop re-reporting resolved items — the main convergence lever on
+// every surface, and the difference between 2 rounds and 10 on prose-heavy ones.
+const ledger = [] // { file, line, summary, status: 'fixed'|'refuted'|'advisory', reason, round }
+const ledgerBlock = () =>
+  !ledger.length
+    ? ''
+    : `
+
+FINDING LEDGER (already resolved in earlier rounds of THIS review):
+${JSON.stringify(ledger, null, 1).slice(0, 6000)}
+Do NOT re-report a "fixed", "refuted", or "advisory" item — or a trivial
+rewording of one — unless you bring NEW evidence that the verifier's reason is
+wrong or the fix is incomplete. A re-report without new evidence is noise and
+will be refuted.`
+const reviewCtx = () => reviewContext + ledgerBlock()
 
 // A Claude adversarial reviewer for a scope: lens set → that lens only; lens null
 // → a whole-diff pass. Used both as a first-class reviewer AND as the fallback
@@ -745,7 +803,7 @@ Assume the change is WRONG and prove how, THROUGH THIS LENS ONLY.`
 Assume the change is WRONG and prove how, across correctness, security/privacy
 (fail-closed), lifecycle/concurrency, bounds/perf/no-jank, JF12 + MUI/legacy
 compatibility, test strength, product scope, and docs/locale/generated-artifact gaps.`
-  const prompt = `${reviewContext}
+  const prompt = `${reviewCtx()}
 
 ${scoped}
 A finding needs a real file/line and a concrete failure scenario (inputs/state →
@@ -772,7 +830,7 @@ function solThunk(roundNo, i, lens) {
     : `across correctness, security/privacy (fail-closed), lifecycle/concurrency,
 bounds/perf/no-jank, JF12 + MUI/legacy compatibility, test strength, product
 scope, and docs/locale/generated-artifact gaps.`
-  const solPrompt = `${reviewContext}
+  const solPrompt = `${reviewCtx()}
 
 PHASE: ADVERSARIAL REVIEW (gpt-5.6-sol). Assume the change is WRONG and prove how,
 ${scope}
@@ -837,6 +895,9 @@ failure — reserve {"findings": []} for a genuine clean codex run.`,
 }
 
 const confirmedAll = []
+// Confirmed-but-minor docs/spec findings reported to the launcher instead of
+// forcing another fix round (see SEVERITY_GATED above).
+const advisoryNotes = []
 let cleanRound = false
 // Set only when a round TERMINATES the loop with incomplete coverage — a reviewer
 // or a finding-verifier failed to return — so we never certify such a round clean.
@@ -940,8 +1001,27 @@ SCENARIO: ${f.failureScenario}`,
 
   // A missing verdict (verifier agent failed) is NOT a refutation — the finding
   // is unresolved, not cleared. Only a returned real=false counts as refuted.
-  const unverified = deduped.filter((_, i) => verdicts[i] == null).length
-  const confirmed = deduped.filter((f, i) => verdicts[i] && verdicts[i].real)
+  const pairs = deduped.map((f, i) => ({ f, v: verdicts[i] }))
+  const unverified = pairs.filter((p) => p.v == null).length
+  const confirmedPairs = pairs.filter((p) => p.v && p.v.real)
+  // Ledger: refuted findings carry the verifier's reason forward so later
+  // rounds don't re-litigate them.
+  for (const p of pairs)
+    if (p.v && !p.v.real)
+      ledger.push({ file: p.f.file, line: p.f.line || 0, summary: String(p.f.summary || '').slice(0, 140), status: 'refuted', reason: String(p.v.reason || '').slice(0, 200), round })
+  // Severity gate (docs/spec only): confirmed MINORS become advisory notes for
+  // the launcher; only blocker/major findings reach the fixer. The severity is
+  // the verifier's when it gave one (it re-judged the finding), else the
+  // reviewer's, else major (fail closed toward fixing).
+  const sevOf = (p) => (p.v && p.v.severity) || p.f.severity || 'major'
+  let confirmed = confirmedPairs.map((p) => p.f)
+  if (SEVERITY_GATED) {
+    for (const p of confirmedPairs.filter((p) => sevOf(p) === 'minor')) {
+      advisoryNotes.push(`${p.f.file}:${p.f.line || '?'} — ${p.f.summary} [confirmed minor: ${String(p.v.reason || '').slice(0, 120)}]`)
+      ledger.push({ file: p.f.file, line: p.f.line || 0, summary: String(p.f.summary || '').slice(0, 140), status: 'advisory', reason: 'confirmed minor — reported as an advisory note, not fixed', round })
+    }
+    confirmed = confirmedPairs.filter((p) => sevOf(p) !== 'minor').map((p) => p.f)
+  }
   if (!confirmed.length) {
     if (unverified || failedWorkers) {
       reviewIncomplete = true
@@ -949,7 +1029,11 @@ SCENARIO: ${f.failureScenario}`,
       break
     }
     cleanRound = true
-    log(`Review round ${round}: ${deduped.length} findings, all refuted → clean`)
+    log(
+      `Review round ${round}: ${deduped.length} findings, ${
+        advisoryNotes.length ? `no blocker/major confirmed (${advisoryNotes.length} minor(s) reported as advisory) → clean` : 'all refuted → clean'
+      }`
+    )
     break
   }
   confirmedAll.push(...confirmed.map((f) => ({ ...f, round })))
@@ -971,7 +1055,7 @@ SCENARIO: ${f.failureScenario}`,
 
   // Wrap the code-writing fixer in safely(): a StructuredOutput retry-cap throw
   // must NOT abort the whole workflow — verify still needs to run and report.
-  await safely(
+  const fixResult = await safely(
     () =>
       agent(
         `${CONTRACTS}
@@ -992,6 +1076,11 @@ ${JSON.stringify(confirmed, null, 1).slice(0, 10000)}`,
     null,
     `Review fixer (round ${round})`
   )
+  // Ledger: only findings the fixer actually processed count as fixed. A
+  // failed/null fixer leaves them unresolved so later rounds MAY re-report them.
+  if (fixResult)
+    for (const f of confirmed)
+      ledger.push({ file: f.file, line: f.line || 0, summary: String(f.summary || '').slice(0, 140), status: 'fixed', reason: `applied by the round-${round} fixer`, round })
 }
 if (!cleanRound && START_PHASE !== 'verify')
   log(
@@ -1193,6 +1282,12 @@ const result = {
   reviewIncomplete,
   incidentalBugs,
   confirmedFindingsResolved: confirmedAll.length,
+  // Confirmed-but-minor docs/spec findings (severity-gated surfaces only) for
+  // the launcher/human to disposition — they did not force fix rounds.
+  advisoryNotes,
+  // Every finding disposition across rounds (fixed / refuted / advisory, with
+  // verifier reasons) — also the re-report suppressor injected into reviewers.
+  ledger,
   implement: implemented || null,
   canonicalPlan: canonicalPlan || null,
   verify: verify || null,

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -1196,6 +1196,13 @@ let cleanRound = false
 // Set only when a round TERMINATES the loop with incomplete coverage — a reviewer
 // or a finding-verifier failed to return — so we never certify such a round clean.
 let reviewIncomplete = false
+// Set when a fix round does NOT fully apply its confirmed findings (the fixer
+// returned null, reported any `unresolved` id, or failed to apply every confirmed
+// id). Distinct from reviewIncomplete (which is a COVERAGE gap): here coverage was
+// complete but the fixer's OWN report says the defect is still in the diff, so a
+// later — possibly non-deterministically empty — clean round must not certify it.
+// A subsequent fixer that fully applies clears it.
+let unfixedConfirmed = false
 const MIXED_ROUND_CAP = SIZING.roundCap
 let round = 0
 if (START_PHASE === 'verify') {
@@ -1340,7 +1347,6 @@ SCENARIO: ${f.failureScenario}`,
     )
     break
   }
-  confirmedAll.push(...confirmed.map((f) => ({ ...f, round })))
   // A finding whose verifier failed to return is neither confirmed nor refuted:
   // that scope is unresolved even though we DID confirm (and will fix) others in
   // the same batch. Don't let the fixed-confirmed path silently drop it — mark the
@@ -1357,6 +1363,13 @@ SCENARIO: ${f.failureScenario}`,
   }
   log(`Review round ${round}: ${confirmed.length} confirmed → fixing`)
 
+  // Stable per-finding ids the fixer reports back in applied/unresolved, so we
+  // trust the fixer's OWN account of what it fixed rather than assuming a non-null
+  // return resolved everything (a fixer that returns applied:[], unresolved:[…]
+  // otherwise got its findings marked fixed and could be certified by the next
+  // empty round — the reproduced fail-open).
+  const fixIds = confirmed.map((_, i) => `r${round}f${i + 1}`)
+  const confirmedForFixer = confirmed.map((f, i) => ({ id: fixIds[i], ...f }))
   // Wrap the code-writing fixer in safely(): a StructuredOutput retry-cap throw
   // must NOT abort the whole workflow — verify still needs to run and report.
   const fixResult = await safely(
@@ -1373,18 +1386,43 @@ path — or making a second fix to the same state machine/owner — STOP and try
 deletion, reuse, or single ownership first; simpler is required over another
 guard. Do not fix anything not listed. ${COMMIT_RULE}
 
+REPORT HONESTLY: return \`applied\` = the \`id\`s you FULLY fixed and committed, and
+\`unresolved\` = the \`id\`s you could NOT fix. Every confirmed \`id\` below MUST
+appear in exactly one of the two lists — do not claim an id you did not commit a
+real fix for. A finding you leave out or list in \`unresolved\` blocks certification
+(honest is better than a false clean).
+
 CONFIRMED FINDINGS:
-${JSON.stringify(confirmed, null, 1).slice(0, 10000)}`,
+${JSON.stringify(confirmedForFixer, null, 1).slice(0, 10000)}`,
         { schema: FIX_SCHEMA, agentType: 'general-purpose', effort: 'high', phase: 'Review', label: `fix-r${round}` }
       ),
     null,
     `Review fixer (round ${round})`
   )
-  // Ledger: only findings the fixer actually processed count as fixed. A
-  // failed/null fixer leaves them unresolved so later rounds MAY re-report them.
-  if (fixResult)
-    for (const f of confirmed)
+  const appliedSet = new Set(
+    fixResult && Array.isArray(fixResult.applied) ? fixResult.applied.map((x) => String(x).trim()) : []
+  )
+  const reportedUnresolved =
+    fixResult && Array.isArray(fixResult.unresolved) ? fixResult.unresolved.filter((x) => x != null && String(x).trim()) : []
+  // Ledger + resolved-count: ONLY findings the fixer reports applied (by id) count
+  // as fixed/resolved. Everything else stays out of the "fixed" ledger so later
+  // rounds MAY re-report it.
+  confirmed.forEach((f, i) => {
+    if (fixResult && appliedSet.has(fixIds[i])) {
       ledger.push({ file: f.file, line: f.line || 0, summary: String(f.summary || '').slice(0, 140), status: 'fixed', reason: `applied by the round-${round} fixer`, round })
+      confirmedAll.push({ ...f, round })
+    }
+  })
+  // A fixer that returns null, reports ANY unresolved id, or fails to apply every
+  // confirmed id has NOT resolved the round. Flag the run so a later (possibly
+  // non-deterministically empty) clean round cannot certify still-present defects;
+  // a subsequent fixer that FULLY applies clears the flag.
+  const fullyApplied = !!fixResult && reportedUnresolved.length === 0 && fixIds.every((id) => appliedSet.has(id))
+  if (fullyApplied) unfixedConfirmed = false
+  else {
+    unfixedConfirmed = true
+    log(`Review round ${round}: fixer applied ${appliedSet.size}/${fixIds.length} confirmed finding(s)${reportedUnresolved.length ? `, ${reportedUnresolved.length} unresolved` : ''}${fixResult ? '' : ' (fixer returned nothing)'} → run cannot certify until they are fixed`)
+  }
 }
 if (!cleanRound && START_PHASE !== 'verify')
   log(
@@ -1639,7 +1677,7 @@ const result = {
   // ran, e.g. a paused run) — lets the launcher pin resume/PR actions to the
   // exact commit that was verified.
   headSha: lastVerifyHead,
-  readyForPR: !PAUSED && implementationOk && cleanRound && !reviewIncomplete && !verifyFixCommitted && blockingGreen && e2eGreen,
+  readyForPR: !PAUSED && implementationOk && cleanRound && !reviewIncomplete && !unfixedConfirmed && !verifyFixCommitted && blockingGreen && e2eGreen,
   residualRisks: []
     .concat(
       PAUSED
@@ -1658,6 +1696,7 @@ const result = {
         : []
     )
     .concat(cleanRound || reviewIncomplete ? [] : ['review loop hit its round cap with unresolved confirmed findings'])
+    .concat(unfixedConfirmed ? ['a review fixer left confirmed findings unapplied/unresolved — the branch is NOT certified; re-run the review loop before opening a PR'] : [])
     .concat(verifyFixCommitted ? ['verify-fix committed code AFTER the clean review round — those commits were never adversarially reviewed; re-run the review loop before opening a PR'] : [])
     .concat(blockingGreen ? [] : ['one or more BLOCKING gates are failing'])
     .concat(e2eGreen ? [] : ['e2e:local did not pass'])

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -33,7 +33,9 @@ const BRIEF = a.brief || '(no brief path supplied — read AGENTS.md and the tas
 // Inlined brief CONTENTS (preferred). The script sandbox cannot read files, so
 // the launcher should read the brief and pass its text here — otherwise agents
 // may never open the path and will infer the task from weaker signals.
-const BRIEF_TEXT = a.briefText || ''
+// `let` because when args.issue is set and no briefText was passed, a Phase-0
+// agent self-hydrates it from the live issue (see "issue self-hydration").
+let BRIEF_TEXT = a.briefText || ''
 // Optional environment prelude every build/test-running agent must execute
 // FIRST (workflow subagents get fresh shells, so the launcher's exports do not
 // propagate — historically the verify agent picked a system dotnet over the
@@ -64,11 +66,11 @@ const START_PHASE = ['explore', 'review', 'verify'].includes(a.startPhase) ? a.s
 // User policy: INCLUDE the issue number in commit messages (traceability). Derived
 // from the branch (fix/issue-<N>) or args.issue. The main thread additionally puts
 // "Closes #<N>" in the PR body so a merge auto-closes the issue + moves the board item.
-const ISSUE_REF = (() => {
+const ISSUE_NUM = (() => {
   const raw = a.issue != null ? String(a.issue) : ((/issue[-/]?(\d+)/i.exec(BRANCH) || [])[1] || '')
-  const n = String(raw).replace(/[^0-9]/g, '')
-  return n ? '#' + n : ''
+  return String(raw).replace(/[^0-9]/g, '')
 })()
+const ISSUE_REF = ISSUE_NUM ? '#' + ISSUE_NUM : ''
 const COMMIT_RULE =
   'Commit hygiene: NO `Co-Authored-By` trailers' +
   (ISSUE_REF ? `, and INCLUDE the issue number ${ISSUE_REF} in each commit subject (end the subject with " (${ISSUE_REF})")` : '') +
@@ -455,6 +457,51 @@ async function safely(makePromise, fallback, what) {
     noteAgentError(e) // classify terminal (quota/limit) failures before falling back
     log(`${what} failed (${String(e && e.message ? e.message : e).slice(0, 90)}) → using fallback`)
     return fallback
+  }
+}
+
+// ── issue self-hydration (Phase 0) ──────────────────────────────────────────
+// When the launcher passes an issue number but no inlined briefText, ONE cheap
+// agent fetches the LIVE issue and its body becomes the brief — replacing the
+// manual copy-paste that can omit edits or go stale between authoring and
+// launch. Explicit task/briefText always win (the fetch never overrides them);
+// a failed fetch logs a warning and falls back to the existing brief-path
+// behavior unchanged.
+if (a.issue != null && ISSUE_NUM && !BRIEF_TEXT) {
+  const fetched = await safely(
+    () =>
+      agent(
+        `cd ${WORKTREE} first, then run (read-only):
+  gh issue view ${ISSUE_NUM} --json number,title,body,url,updatedAt
+Return the fields VERBATIM in your structured output — do NOT summarize, edit,
+or augment the body. If the command fails, return an empty body.`,
+        {
+          schema: {
+            type: 'object',
+            additionalProperties: true,
+            required: ['title', 'body'],
+            properties: {
+              number: { type: 'integer' },
+              title: { type: 'string' },
+              body: { type: 'string' },
+              url: { type: 'string' },
+              updatedAt: { type: 'string' },
+            },
+          },
+          agentType: 'general-purpose',
+          effort: 'low',
+          phase: 'Explore',
+          label: 'fetch-issue',
+        }
+      ),
+    null,
+    'Issue fetch'
+  )
+  if (fetched && fetched.body) {
+    BRIEF_TEXT = `Issue #${ISSUE_NUM}: ${fetched.title || ''}\n(${fetched.url || 'no url'} · updated ${fetched.updatedAt || 'unknown'})\n\n${fetched.body}`
+    log(`Brief self-hydrated from live issue #${ISSUE_NUM} (${fetched.body.length} chars)`)
+  } else {
+    log(`Issue fetch for #${ISSUE_NUM} failed — continuing with the brief path only (existing behavior)`)
   }
 }
 

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -505,6 +505,7 @@ const VERIFY_SCHEMA = {
   additionalProperties: true,
   required: ['gates', 'allBlockingPassed'],
   properties: {
+    headSha: { type: 'string', description: 'exact output of `git rev-parse HEAD` in the worktree, read BEFORE running any gate' },
     gates: { type: 'array', items: { type: 'object', additionalProperties: true, required: ['name', 'pass'], properties: { name: { type: 'string' }, pass: { type: 'boolean' }, evidence: { type: 'string' } } } },
     allBlockingPassed: { type: 'boolean', description: 'true if every BLOCKING gate passed (lint is advisory, not blocking)' },
     e2e: { type: 'object', additionalProperties: true, properties: { run: { type: 'boolean' }, pass: { type: 'boolean' }, evidence: { type: 'string' } } },
@@ -1054,7 +1055,14 @@ let vround = 0
 // cleanRound. Those commits never appeared in any reviewer's diff, so reusing the
 // stale cleanRound to certify them is unsafe. Track whether any verify-fix
 // actually committed; if so the final diff is unreviewed and NOT ready for PR.
+// Detection is TWO-channel (fail closed): the fixer's own commits report, AND an
+// independent HEAD-sha comparison across verify runs — a fixer that commits and
+// then returns null/throws/omits its commits can not slip unreviewed code past
+// the certification. If HEAD cannot be established after a fix attempt, the loop
+// cannot prove nothing was committed, so it also fails closed.
 let verifyFixCommitted = false
+let lastVerifyHead = null // headSha from the most recent verify run
+let verifyFixAttempted = false // a verify-fix agent ran since that verify
 while (vround <= SIZING.verifyFixCap && !systemicFailure) {
   // FINAL VERIFY stays on Claude (authoritative gate run) — never split to Sol.
   verify = await safely(
@@ -1062,7 +1070,9 @@ while (vround <= SIZING.verifyFixCap && !systemicFailure) {
       agent(
         `${CONTRACTS}
 
-PHASE: VERIFY. Run the repository-native gates for surface="${SURFACE}", in order,
+PHASE: VERIFY. FIRST run \`git -C ${WORKTREE} rev-parse HEAD\` and report the exact
+sha as headSha — the loop uses it to prove no unreviewed commit slipped in after
+review. Then run the repository-native gates for surface="${SURFACE}", in order,
 from ${WORKTREE}. Lint is ADVISORY (findings never block); every other gate is
 BLOCKING. Do not pipe wrappers through tail/grep/tee in a way that hides exit
 status. Do not run a plain suite right before its coverage variant.
@@ -1083,6 +1093,19 @@ ALL BLOCKING gates passed, the e2e result if run, and a list of failures.`,
     { gates: [], allBlockingPassed: false, failures: ['verify agent did not return structured output'] },
     'Verify'
   )
+
+  const reportedHead = verify && typeof verify.headSha === 'string' && verify.headSha.trim() ? verify.headSha.trim() : null
+  if (verifyFixAttempted) {
+    // A fixer ran since the last verify. Any HEAD movement — or an inability to
+    // read HEAD on either side — means possibly-unreviewed commits (fail closed),
+    // regardless of what the fixer itself reported.
+    if (!reportedHead || !lastVerifyHead || reportedHead !== lastVerifyHead) {
+      if (!verifyFixCommitted) log('Verify: HEAD changed (or was unreadable) across a verify-fix attempt — marking the branch as carrying unreviewed commits')
+      verifyFixCommitted = true
+    }
+    verifyFixAttempted = false
+  }
+  if (reportedHead) lastVerifyHead = reportedHead
 
   const gatesOk = verify && verify.allBlockingPassed
   const e2eOk = !RUNTIME || (verify && verify.e2e && verify.e2e.pass)
@@ -1118,6 +1141,7 @@ ${JSON.stringify((verify && verify.failures) || [], null, 1).slice(0, 8000)}`,
     null,
     `Verify fixer (attempt ${vround})`
   )
+  verifyFixAttempted = true
   if (vfix && Array.isArray(vfix.commits) && vfix.commits.length) verifyFixCommitted = true
 }
 
@@ -1173,6 +1197,10 @@ const result = {
   canonicalPlan: canonicalPlan || null,
   verify: verify || null,
   verifyFixCommitted,
+  // Last HEAD sha independently reported by a verify run (null when verify never
+  // ran, e.g. a paused run) — lets the launcher pin resume/PR actions to the
+  // exact commit that was verified.
+  headSha: lastVerifyHead,
   readyForPR: !PAUSED && implementationOk && cleanRound && !reviewIncomplete && !verifyFixCommitted && blockingGreen && e2eGreen,
   residualRisks: []
     .concat(

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -1449,6 +1449,16 @@ if (!cleanRound && START_PHASE !== 'verify')
       ? `Review: ended without a certified-clean round — coverage incomplete (reviewer/verifier failure); will report as residual risk`
       : `Review: hit round cap (${HARD_ROUND_CAP}) with unresolved findings — will report as residual risk`
   )
+// Mixed-model contract enforcement on the CERTIFYING round. Every round always
+// requests ≥1 gpt-5.6-sol reviewer (Math.max(1, SOL_REVIEWERS)); if the round that
+// went clean had NO real Sol coverage — every Sol slot fell back to Claude because
+// the route was down — it is an all-Claude review, not the documented cross-family
+// one, so it must not certify (roundsWithoutSol already records it, but readyForPR
+// ignored that field). round>0 excludes the reviewedHead escape hatch (no round ran).
+if (cleanRound && round > 0 && !solOkThisRound && START_PHASE !== 'verify') {
+  reviewIncomplete = true
+  log(`Review: the clean round ${round} ran with NO real gpt-5.6-sol coverage (Sol route down) — not a certified cross-family review; fail closed`)
+}
 
 // ═══════════════════════════════════════════════════════════════════════════
 // PHASE 4.5 — LOCALIZE (cheap, low-effort translation busywork; NOT reviewed)

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -253,6 +253,24 @@ async function classified(makePromise) {
   }
 }
 
+// Evidence-quorum failure: explore/plan produced too little to implement from,
+// with no terminal provider error to blame. Set only after a consolidated
+// recovery agent also failed; pauses the run BEFORE the writer (same pause
+// contract as systemicFailure, resumable with a fresh full run).
+let quorumFailure = ''
+const halted = () => systemicFailure || !!quorumFailure
+
+// Per-phase agent accounting (attempted / succeeded / null) returned as
+// result.agentStats, so silent `.filter(Boolean)` losses are visible.
+const agentStats = {}
+function statAdd(ph, results) {
+  const s = agentStats[ph] || (agentStats[ph] = { attempted: 0, succeeded: 0, nulls: 0 })
+  s.attempted += results.length
+  const ok = results.filter((r) => r != null).length
+  s.succeeded += ok
+  s.nulls += results.length - ok
+}
+
 // ── Sol route circuit breaker + model-coverage accounting ───────────────────
 // A dead Sol route (codex CLI missing, router down) fails EVERY slot the same
 // way; without a breaker each slot still burns a harness agent plus a Claude
@@ -660,8 +678,40 @@ evidence. Only real defects; leave it empty if you see none.`,
     )
   )
   batchOutage(exploreResults, 'Explore')
+  statAdd('explore', exploreResults)
   explorations = exploreResults.filter(Boolean)
   log(`Explore: ${explorations.length} maps returned`)
+
+  // Evidence quorum: implementing off zero or one map defeats the fan-out's
+  // whole point. Below quorum (and not an outage), spend ONE consolidated
+  // recovery explorer on the direct-Claude route; if still short, pause before
+  // the writer rather than implement on missing evidence.
+  const EXPLORE_QUORUM = Math.min(2, exploreAngles.length)
+  if (!systemicFailure && explorations.length < EXPLORE_QUORUM) {
+    log(`Explore: ${explorations.length}/${exploreAngles.length} maps — below quorum (${EXPLORE_QUORUM}); spawning ONE consolidated recovery explorer (direct Claude)`)
+    const rec = await safely(
+      () =>
+        agent(
+          `${CONTRACTS}
+
+PHASE: EXPLORE (RECOVERY — read-only; do NOT edit any file). Earlier parallel
+explorers failed, so YOU must cover ALL of these angles in ONE consolidated map:
+${exploreAngles.map((s) => '- ' + s).join('\n')}
+Use rg/ls/Read to trace real code. Return where the change lives, who is
+affected, the analogue to copy, helpers to reuse, the contracts touched, and the
+test seams. Cite real paths; never guess.`,
+          { schema: EXPLORE_SCHEMA, agentType: 'Explore', effort: 'high', phase: 'Explore', label: 'explore:recovery' }
+        ),
+      null,
+      'Explore recovery'
+    )
+    statAdd('explore', [rec])
+    if (rec) explorations.push(rec)
+    if (!systemicFailure && explorations.length < EXPLORE_QUORUM) {
+      quorumFailure = `explore produced ${explorations.length}/${EXPLORE_QUORUM} maps even after the recovery agent — refusing to implement on missing evidence`
+      log(`Explore: ${quorumFailure}`)
+    }
+  }
 }
 
 const exploreDigest = JSON.stringify(explorations, null, 1).slice(0, 12000)
@@ -677,7 +727,7 @@ const planAngles = [
 
 let plans = []
 let canonicalPlan = null
-if (START_PHASE === 'explore' && !systemicFailure) {
+if (START_PHASE === 'explore' && !halted()) {
   phase('Plan')
   const planResults = await parallel(
     planAngles.map((angle, i) => () =>
@@ -700,10 +750,43 @@ docs to update.`,
     )
   )
   batchOutage(planResults, 'Plan')
+  statAdd('plan', planResults)
   plans = planResults.filter(Boolean)
+
+  // Plan quorum: a single surviving plan collapses the independent-plans
+  // premise. Below quorum (and not an outage), one consolidated recovery
+  // planner on the direct-Claude route; still short → pause before the writer.
+  const PLAN_QUORUM = Math.min(2, planAngles.length)
+  if (!systemicFailure && plans.length < PLAN_QUORUM) {
+    log(`Plan: ${plans.length}/${planAngles.length} plans — below quorum (${PLAN_QUORUM}); spawning ONE consolidated recovery planner (direct Claude)`)
+    const rec = await safely(
+      () =>
+        agent(
+          `${CONTRACTS}
+
+PHASE: PLAN (RECOVERY — read-only). Earlier parallel planners failed. Explore maps (JSON):
+${exploreDigest}
+
+Produce ONE implementation plan that balances ALL of these biases:
+${planAngles.map((s) => '- ' + s).join('\n')}
+Choose the owning layer, reuse-vs-new decisions, the SIMPLEST state/failure
+model, the failing-first tests (admin AND non-admin, negative/fallback), and the
+locale keys + docs to update.`,
+          { schema: PLAN_SCHEMA, effort: 'high', phase: 'Plan', label: 'plan:recovery' }
+        ),
+      null,
+      'Plan recovery'
+    )
+    statAdd('plan', [rec])
+    if (rec) plans.push(rec)
+    if (!systemicFailure && plans.length < PLAN_QUORUM) {
+      quorumFailure = `plan produced ${plans.length}/${PLAN_QUORUM} plans even after the recovery agent — refusing to implement without a plan quorum`
+      log(`Plan: ${quorumFailure}`)
+    }
+  }
 }
 
-if (START_PHASE === 'explore' && !systemicFailure) {
+if (START_PHASE === 'explore' && !halted()) {
   canonicalPlan = await safely(
   () =>
     soloSolAgent(
@@ -770,7 +853,7 @@ if (START_PHASE !== 'explore') {
   // the premise of resuming). Synthesize a placeholder so the readyForPR logic
   // works unchanged; reviewers/verify read the real state from BASE...HEAD.
   implemented = { changedFiles: [], commits: [], selfConfidence: 'medium', openTodos: [], resumed: true }
-} else if (!systemicFailure) {
+} else if (!halted()) {
   phase('Implement')
   implemented = await safely(
     () => agent(implementPrompt, { ...implOpts, model: IMPL_MODEL, label: `implement:${IMPL_MODEL}` }),
@@ -799,7 +882,7 @@ and CONTINUE from there rather than restarting from scratch.`,
 // ═══════════════════════════════════════════════════════════════════════════
 // PHASE 4 — ADVERSARIAL REVIEW LOOP (parallel review → verify → single fixer)
 // ═══════════════════════════════════════════════════════════════════════════
-if (!systemicFailure && START_PHASE !== 'verify') phase('Review')
+if (!halted() && START_PHASE !== 'verify') phase('Review')
 
 const reviewContext = `${CONTRACTS}
 
@@ -977,7 +1060,7 @@ if (START_PHASE === 'verify') {
   reviewIncomplete = true
   log('verify-only resume: review loop skipped — this run cannot certify readyForPR (fail closed)')
 }
-while (round < HARD_ROUND_CAP && !cleanRound && !systemicFailure && START_PHASE !== 'verify') {
+while (round < HARD_ROUND_CAP && !cleanRound && !halted() && START_PHASE !== 'verify') {
   round++
   solOkThisRound = false
 
@@ -1016,6 +1099,7 @@ while (round < HARD_ROUND_CAP && !cleanRound && !systemicFailure && START_PHASE 
   log(`Review round ${round}/${HARD_ROUND_CAP}${gptOnly ? ' [gpt-only]' : ''} — ${claudeLensCount} Claude lens + ${solCount}× ${SOL_MODEL} (${SOL_VIA}, ${SOL_EFFORT})${MODEL_SPLIT && !gptOnly ? ' [50/50 + whole-diff]' : ''}`)
 
   const results = await parallel(roundThunks)
+  statAdd('review', results)
   if (batchOutage(results, `Review round ${round}`)) {
     reviewIncomplete = true
     log(`Review round ${round}: provider outage — pausing instead of spawning more agents`)
@@ -1064,6 +1148,7 @@ SCENARIO: ${f.failureScenario}`,
     )
   )
 
+  statAdd('findingVerification', verdicts)
   if (batchOutage(verdicts, `Review round ${round} finding-verification`)) {
     reviewIncomplete = true
     log(`Review round ${round}: provider outage during finding-verification — pausing`)
@@ -1167,7 +1252,7 @@ if (!cleanRound && START_PHASE !== 'verify')
 // parity. Implementer/fixers add new i18n keys only to the base en.json; one
 // low-effort agent (gpt/opus on low) fans them out to every locale.
 // ═══════════════════════════════════════════════════════════════════════════
-if (SURFACE !== 'server' && !systemicFailure && START_PHASE !== 'verify') {
+if (SURFACE !== 'server' && !halted() && START_PHASE !== 'verify') {
   phase('Localize')
   log(`Localize: fanning base-locale keys out to all locales (effort=${LOCALIZE_EFFORT})`)
   await safely(
@@ -1196,7 +1281,7 @@ locales, do NOTHING and report "no locale work needed".`,
 // ═══════════════════════════════════════════════════════════════════════════
 // PHASE 5 — VERIFY (single runner; bounded fix-and-reverify)
 // ═══════════════════════════════════════════════════════════════════════════
-if (!systemicFailure) phase('Verify')
+if (!halted()) phase('Verify')
 
 const gateList = gateCommands()
 const e2eBlock = RUNTIME
@@ -1223,7 +1308,7 @@ let vround = 0
 let verifyFixCommitted = false
 let lastVerifyHead = null // headSha from the most recent verify run
 let verifyFixAttempted = false // a verify-fix agent ran since that verify
-while (vround <= SIZING.verifyFixCap && !systemicFailure) {
+while (vround <= SIZING.verifyFixCap && !halted()) {
   // FINAL VERIFY stays on Claude (authoritative gate run) — never split to Sol.
   verify = await safely(
     () =>
@@ -1332,7 +1417,7 @@ const incidentalBugs = (() => {
 // A paused run tells the launcher exactly where to re-enter: the committed
 // branch state carries everything the later phases need (they work purely from
 // the BASE...HEAD range), so nothing before resumeFrom.phase is re-run.
-const PAUSED = systemicFailure
+const PAUSED = halted()
 const resumeFrom = !PAUSED
   ? null
   : !implemented
@@ -1342,7 +1427,7 @@ const resumeFrom = !PAUSED
   : { phase: 'verify' }
 const result = {
   status: PAUSED ? 'paused' : 'complete',
-  pauseReason: PAUSED ? systemicFailureDetail : null,
+  pauseReason: PAUSED ? systemicFailureDetail || quorumFailure : null,
   resumeFrom,
   startPhase: START_PHASE,
   branch: BRANCH,
@@ -1367,6 +1452,9 @@ const result = {
   // rounds that silently lost cross-family coverage — a missing Sol pass is a
   // route problem to FIX, never a healthy mixed review (per README).
   modelCoverage: { slots: modelCoverage, solDead, roundsWithoutSol },
+  // Per-phase attempted/succeeded/null agent accounting (empty results are no
+  // longer silently filtered away without a trace).
+  agentStats,
   // Last HEAD sha independently reported by a verify run (null when verify never
   // ran, e.g. a paused run) — lets the launcher pin resume/PR actions to the
   // exact commit that was verified.
@@ -1376,7 +1464,7 @@ const result = {
     .concat(
       PAUSED
         ? [
-            `run PAUSED on a systemic provider failure (${systemicFailureDetail}) — do NOT relaunch a full run; once capacity returns, resume with startPhase:"${resumeFrom.phase}" against the same branch`,
+            `run PAUSED (${systemicFailureDetail || quorumFailure}) — do NOT blindly retry; ${systemicFailure ? 'once capacity returns, ' : ''}resume with startPhase:"${resumeFrom.phase}" against the same branch`,
           ]
         : []
     )

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -518,6 +518,40 @@ or augment the body. If the command fails, return an empty body.`,
   }
 }
 
+// ── codex-cli route preflight (Phase 0) ─────────────────────────────────────
+// Under the default codex-cli route the Sol slots are only discovered dead at
+// RUNTIME, after each of the first explore batch's Sol slots burns a harness
+// agent that finds `codex` absent plus a Claude fallback (the breaker bounds but
+// does not eliminate that tax — ~6 wasted spawns in explore alone). The route is
+// statically known at launch, so one cheap probe short-circuits it: a missing CLI
+// trips the breaker BEFORE any Sol slot spawns. A healthy route costs one tiny
+// agent; only an explicit available:false trips it (a null/ambiguous probe leaves
+// the runtime breaker to catch a mid-run death — fail toward attempting Sol).
+if (SOL_VIA === 'codex-cli' && MODEL_SPLIT && !systemicFailure) {
+  const probe = await safely(
+    () =>
+      agent(
+        `cd ${WORKTREE} first, then run (read-only, Bash):\n  command -v codex && codex --version\nReport available:true only if BOTH succeed (codex is on PATH and prints a version); otherwise available:false. Return the version string when known.`,
+        {
+          schema: { type: 'object', additionalProperties: true, required: ['available'], properties: { available: { type: 'boolean' }, version: { type: 'string' } } },
+          agentType: 'general-purpose',
+          effort: 'low',
+          phase: 'Explore',
+          label: 'codex-preflight',
+        }
+      ),
+    null,
+    'codex preflight'
+  )
+  if (probe && probe.available === false) {
+    solDead = true
+    covNote('preflight', false, `codex CLI unavailable at launch (${(probe.version && String(probe.version).slice(0, 40)) || 'command -v codex failed'})`)
+    log('codex-cli preflight: `codex` is unavailable — Sol route marked dead up front; all Sol slots run on Claude')
+  } else {
+    log(`codex-cli preflight: codex ${probe && probe.version ? `(${String(probe.version).slice(0, 40)}) ` : ''}available`)
+  }
+}
+
 // ── shared prompt preamble ──────────────────────────────────────────────────
 const CONTRACTS = `You are working on the Jellyfin Canopy plugin repository in the worktree at:
   ${WORKTREE}

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -536,20 +536,33 @@ or augment the body. If the command fails, return an empty body.`,
   }
 }
 
-// ── codex-cli route preflight (Phase 0) ─────────────────────────────────────
-// Under the default codex-cli route the Sol slots are only discovered dead at
-// RUNTIME, after each of the first explore batch's Sol slots burns a harness
-// agent that finds `codex` absent plus a Claude fallback (the breaker bounds but
-// does not eliminate that tax — ~6 wasted spawns in explore alone). The route is
-// statically known at launch, so one cheap probe short-circuits it: a missing CLI
-// trips the breaker BEFORE any Sol slot spawns. A healthy route costs one tiny
-// agent; only an explicit available:false trips it (a null/ambiguous probe leaves
-// the runtime breaker to catch a mid-run death — fail toward attempting Sol).
+// ── Sol route preflight (Phase 0) ───────────────────────────────────────────
+// Under either route the Sol slots are otherwise only discovered dead at RUNTIME,
+// after each of the first explore batch's Sol slots burns a harness/subagent plus
+// a Claude fallback (the breaker bounds but does not eliminate that tax — ~6
+// wasted spawns in explore alone). The route is statically known at launch, so one
+// cheap probe short-circuits it: a dead route trips the breaker BEFORE any Sol slot
+// spawns. A healthy route costs one tiny agent; only an explicit failure trips it
+// (a null/ambiguous probe leaves the runtime breaker to catch a mid-run death —
+// fail toward attempting Sol). The probe exercises the REAL route end-to-end
+// (an actual gpt-5.6-sol round-trip), not just whether a binary is installed — an
+// installed `codex` with a broken auth/model route would still pass an install
+// check yet fail every real request.
 if (SOL_VIA === 'codex-cli' && MODEL_SPLIT && !halted()) {
   const probe = await safely(
     () =>
       agent(
-        `cd ${WORKTREE} first, then run (read-only, Bash):\n  command -v codex && codex --version\nReport available:true only if BOTH succeed (codex is on PATH and prints a version); otherwise available:false. Return the version string when known.`,
+        `cd ${WORKTREE} first (read-only, Bash). Probe whether the configured gpt-5.6-sol
+route actually WORKS, not merely whether the binary is installed:
+1. If \`command -v codex\` fails, report available:false, version:"command -v codex failed".
+2. Otherwise run ONE minimal real request (it exercises auth + model routing):
+     printf 'Reply with exactly the token OK and nothing else.' | \\
+       codex -a never -s read-only exec -C "${WORKTREE}" --ephemeral --ignore-user-config \\
+         --color never -m "${SOL_MODEL}" - 2>&1 | tail -20
+   Report available:true ONLY if codex exited 0 AND produced model output (a line
+   containing OK) — i.e. the route round-tripped. Report available:false on any
+   auth/model/route/quota error, a non-zero exit, or empty output; put a short
+   reason (first error line) in version. Record \`codex --version\` in version on success.`,
         {
           schema: { type: 'object', additionalProperties: true, required: ['available'], properties: { available: { type: 'boolean' }, version: { type: 'string' } } },
           agentType: 'general-purpose',
@@ -559,14 +572,36 @@ if (SOL_VIA === 'codex-cli' && MODEL_SPLIT && !halted()) {
         }
       ),
     null,
-    'codex preflight'
+    'codex preflight',
+    'sol' // a terminal Sol/codex quota at preflight marks the route dead, never pauses the run
   )
   if (probe && probe.available === false) {
     solDead = true
-    covNote('preflight', false, `codex CLI unavailable at launch (${(probe.version && String(probe.version).slice(0, 40)) || 'command -v codex failed'})`)
-    log('codex-cli preflight: `codex` is unavailable — Sol route marked dead up front; all Sol slots run on Claude')
+    covNote('preflight', false, `codex gpt-5.6-sol route unusable at launch (${(probe.version && String(probe.version).slice(0, 60)) || 'command -v codex failed'})`)
+    log('codex-cli preflight: the gpt-5.6-sol route is unusable — Sol route marked dead up front; all Sol slots run on Claude')
   } else {
-    log(`codex-cli preflight: codex ${probe && probe.version ? `(${String(probe.version).slice(0, 40)}) ` : ''}available`)
+    log(`codex-cli preflight: gpt-5.6-sol route ${probe && probe.version ? `(${String(probe.version).slice(0, 40)}) ` : ''}live`)
+  }
+}
+// Agent (router) route mirror: the codex-cli branch above preflights only the
+// codex route, so an unroutable gpt-5.6-sol on the 'agent' route otherwise burned
+// up-to-3 doomed Sol spawns before the runtime breaker tripped. Send one minimal
+// real request through the subagent model param; only a hard null (unroutable)
+// marks the route dead, matching the codex-cli probe's conservative stance. scope
+// 'sol' keeps a terminal Sol quota from pausing the whole Claude run.
+if (SOL_VIA === 'agent' && MODEL_SPLIT && !halted()) {
+  const p = await safely(
+    () => agent('Reply with the single token OK.', { model: SOL_MODEL, effort: 'low', agentType: 'general-purpose', phase: 'Explore', label: 'sol-agent-preflight' }),
+    null,
+    'sol-agent preflight',
+    'sol'
+  )
+  if (p == null) {
+    solDead = true
+    covNote('preflight', false, 'gpt-5.6-sol router unroutable at launch')
+    log('agent-route preflight: gpt-5.6-sol unroutable — Sol route marked dead up front; all Sol slots run on Claude')
+  } else {
+    log('agent-route preflight: gpt-5.6-sol route live')
   }
 }
 

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -994,17 +994,29 @@ and speculative EXTRA requirements the brief never asked for are NOT findings.`
 // reviewers stop re-reporting resolved items — the main convergence lever on
 // every surface, and the difference between 2 rounds and 10 on prose-heavy ones.
 const ledger = [] // { file, line, summary, status: 'fixed'|'refuted'|'advisory', reason, round }
-const ledgerBlock = () =>
-  !ledger.length
-    ? ''
-    : `
+// Render the ledger as compact ONE-LINE entries with an equal-share budget, so
+// EVERY disposition survives (truncated within its own line) rather than the
+// newest rounds vanishing whole. The old `JSON.stringify(ledger).slice(0,6000)`
+// head-slice kept the oldest ~17 entries and silently dropped later rounds on
+// churny (SR-15-scale) runs — re-enabling exactly the re-report noise the ledger
+// exists to suppress (the same defect digest() fixed for explore/plan handoffs).
+const LEDGER_BUDGET = 12000
+const ledgerBlock = () => {
+  if (!ledger.length) return ''
+  const per = Math.max(120, Math.floor(LEDGER_BUDGET / ledger.length))
+  const lines = ledger.map((e) => {
+    const line = `- [${e.status} r${e.round}] ${e.file || '?'}:${e.line || 0} — ${String(e.summary || '')} (${String(e.reason || '')})`
+    return line.length > per ? line.slice(0, per - 1) + '…' : line
+  })
+  return `
 
 FINDING LEDGER (already resolved in earlier rounds of THIS review):
-${JSON.stringify(ledger, null, 1).slice(0, 6000)}
+${lines.join('\n')}
 Do NOT re-report a "fixed", "refuted", or "advisory" item — or a trivial
 rewording of one — unless you bring NEW evidence that the verifier's reason is
 wrong or the fix is incomplete. A re-report without new evidence is noise and
 will be refuted.`
+}
 const reviewCtx = () => reviewContext + ledgerBlock()
 
 // A Claude adversarial reviewer for a scope: lens set → that lens only; lens null

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -96,9 +96,10 @@ const COMMIT_RULE =
 
 // roundCap here is the MIXED-panel review cap (Claude lenses + gpt-5.6-sol). If
 // the loop still isn't clean after it, review CONTINUES with gpt-5.6-sol as the
-// ONLY reviewer up to HARD_ROUND_CAP (see the review loop). explorers is the
-// TOTAL explorer count; the first EXPLORE_CLAUDE_COUNT run on Claude/Opus and the
-// rest on gpt-5.6-sol (see exploreSol).
+// ONLY reviewer until the loop terminates on a clean round, a progress stall, or
+// the runaway backstop (see the review loop). explorers is the TOTAL explorer
+// count; the first EXPLORE_CLAUDE_COUNT run on Claude/Opus and the rest on
+// gpt-5.6-sol (see exploreSol).
 const SIZING = {
   quick: { explorers: 2, planners: 2, roundCap: 2, verifyFixCap: 1 },
   standard: { explorers: 8, planners: 3, roundCap: 4, verifyFixCap: 2 },

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -61,8 +61,20 @@ const BASE = a.base || 'origin/main'
 //   'review'  — skip Explore/Plan/Implement, adversarially review the committed
 //               range, then verify (can certify readyForPR — review runs fully);
 //   'verify'  — additionally skip the review loop: gates only. A verify-only
-//               resume can NEVER certify readyForPR (fail closed — no review ran).
+//               resume normally can NEVER certify readyForPR (fail closed — no
+//               review ran), UNLESS the launcher passes reviewedHead (below).
 const START_PHASE = ['explore', 'review', 'verify'].includes(a.startPhase) ? a.startPhase : 'explore'
+// reviewedHead escape hatch (fail-closed sha match). The primary #454 scenario is
+// a run that dies AFTER a certified-clean review round but during Localize/Verify
+// — it pauses with resumeFrom.phase='verify' and returns headSha. On the resume
+// the launcher passes that exact sha back as reviewedHead; IFF the verify agent
+// INDEPENDENTLY reports HEAD byte-identical to it, the prior clean review still
+// covers this exact commit range and the run certifies without re-reviewing. Any
+// mismatch, absence, or unreadable HEAD keeps the fail-closed default. Launcher
+// protocol: on status:'paused' with resumeFrom.phase==='verify' AND loopClean:true,
+// record `git -C <worktree> rev-parse HEAD` (or reuse the returned headSha) and
+// resume with startPhase:'verify' + reviewedHead:<that sha>.
+const REVIEWED_HEAD = a.reviewedHead ? String(a.reviewedHead).trim() : ''
 // User policy: INCLUDE the issue number in commit messages (traceability). Derived
 // from the branch (fix/issue-<N>) or args.issue. The main thread additionally puts
 // "Closes #<N>" in the PR body so a merge auto-closes the issue + moves the board item.
@@ -1134,11 +1146,14 @@ let reviewIncomplete = false
 const MIXED_ROUND_CAP = SIZING.roundCap
 let round = 0
 if (START_PHASE === 'verify') {
-  // Verify-only resume: the review loop is SKIPPED, so this run can never
-  // certify the branch clean — readyForPR stays false (fail closed). Use
-  // startPhase:'review' (or a full run) to certify.
+  // Verify-only resume: the review loop is SKIPPED, so by default this run can
+  // never certify the branch clean — readyForPR stays false (fail closed). The
+  // reviewedHead escape hatch may flip this AFTER verify establishes HEAD (see
+  // the post-verify block); use startPhase:'review' (or a full run) otherwise.
   reviewIncomplete = true
-  log('verify-only resume: review loop skipped — this run cannot certify readyForPR (fail closed)')
+  if (REVIEWED_HEAD)
+    log(`verify-only resume: review loop skipped — will certify the prior clean review IFF verify reports HEAD === reviewedHead (${REVIEWED_HEAD.slice(0, 12)}…)`)
+  else log('verify-only resume: review loop skipped — this run cannot certify readyForPR (fail closed)')
 }
 while (round < HARD_ROUND_CAP && !cleanRound && !halted() && START_PHASE !== 'verify') {
   round++
@@ -1476,6 +1491,24 @@ ${JSON.stringify((verify && verify.failures) || [], null, 1).slice(0, 8000)}`,
   if (vfix && Array.isArray(vfix.commits) && vfix.commits.length) verifyFixCommitted = true
 }
 
+// reviewedHead escape hatch (resolved here — needs the verify agent's HEAD). A
+// verify-only resume that was paused AFTER a certified-clean review round can now
+// certify IFF the launcher-supplied reviewedHead exactly equals the HEAD the
+// verify agent independently reported: identical shas prove no commit changed
+// since the clean review, so its coverage still holds for this exact range. Any
+// mismatch, missing sha, or unreadable HEAD keeps the fail-closed default above.
+let reviewedHeadCertified = false
+if (START_PHASE === 'verify' && REVIEWED_HEAD) {
+  if (lastVerifyHead && lastVerifyHead === REVIEWED_HEAD) {
+    cleanRound = true
+    reviewIncomplete = false
+    reviewedHeadCertified = true
+    log(`verify-only resume: verify HEAD ${lastVerifyHead.slice(0, 12)}… matches reviewedHead — prior clean review certified, no re-review needed`)
+  } else {
+    log(`verify-only resume: reviewedHead ${REVIEWED_HEAD.slice(0, 12)}… ≠ verify HEAD ${lastVerifyHead ? lastVerifyHead.slice(0, 12) + '…' : '(unreadable)'} — NOT certifying (fail closed)`)
+  }
+}
+
 // ── return structured result for the main thread to relay + act on ──────────
 const blockingGreen = !!(verify && verify.allBlockingPassed)
 const e2eGreen = !RUNTIME || !!(verify && verify.e2e && verify.e2e.pass)
@@ -1557,8 +1590,8 @@ const result = {
     .concat(implemented || PAUSED ? [] : ['implementation did not complete — both implementer models failed to return a result'])
     .concat(openTodos.length ? ['implementer left open acceptance-criteria TODOs — change is incomplete'] : [])
     .concat(
-      START_PHASE === 'verify'
-        ? ['verify-only resume: the adversarial review loop was SKIPPED — run startPhase:"review" (or a full run) before opening a PR']
+      START_PHASE === 'verify' && !reviewedHeadCertified
+        ? ['verify-only resume: the adversarial review loop was SKIPPED — pass reviewedHead:<the paused clean HEAD> to certify, or run startPhase:"review" (or a full run) before opening a PR']
         : reviewIncomplete
         ? ['adversarial review ended with incomplete coverage (a reviewer or finding-verifier failed) — the round could not be certified clean']
         : []

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -531,6 +531,15 @@ TASK BRIEF${BRIEF_TEXT ? ' (authoritative — read in full)' : ` — read this f
 ${BRIEF_TEXT || '(brief text not inlined; open the path above before planning)'}
 `
 
+// Equal-share digest for inter-phase handoffs: every item gets budget/n chars,
+// truncating WITHIN items instead of head-slicing the whole array (which showed
+// planners only the first ~3 of 8 pretty-printed explorer maps and threw the
+// rest — including the xhigh-priced Sol fan-out — away).
+const digest = (arr, budget) =>
+  '[' +
+  arr.map((x) => JSON.stringify(x, null, 1).slice(0, Math.floor(budget / Math.max(1, arr.length)))).join(',\n') +
+  ']'
+
 const dedupeKey = (f) => `${f.file || '?'}|${f.line || 0}|${String(f.summary || '').slice(0, 60)}`
 function dedupe(findings) {
   const seen = new Set()
@@ -780,7 +789,7 @@ test seams. Cite real paths; never guess.`,
   }
 }
 
-const exploreDigest = JSON.stringify(explorations, null, 1).slice(0, 12000)
+const exploreDigest = digest(explorations, 16000)
 
 // ═══════════════════════════════════════════════════════════════════════════
 // PHASE 2 — PLAN (independent plans → adversarial synthesis into one)
@@ -860,7 +869,7 @@ if (START_PHASE === 'explore' && !halted()) {
 
 PHASE: PLAN SYNTHESIS (read-only). You are the adversarial judge. Here are ${plans.length}
 independent plans (JSON):
-${JSON.stringify(plans, null, 1).slice(0, 12000)}
+${digest(plans, 12000)}
 
 Score them against the brief and the repository contracts. First (in your own
 reasoning, not as an extra output field) confirm every acceptance criterion in

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -166,24 +166,10 @@ const SOL_VIA = a.solVia || 'codex-cli' // 'codex-cli' | 'agent'
 // the worktree — such as running the loop before this skill is merged to main.
 const CODEX_SCHEMA_PATH =
   a.codexSchema || `${WORKTREE}/.agents/skills/jellyfin-canopy-agentic-loop/references/codex-review-schema.json`
-// Per-run random heredoc delimiter for the codex harness. The reviewer prompt
-// embeds launcher-supplied (untrusted) TASK/BRIEF text; a fixed delimiter could
-// be closed early by a brief line equal to it, spilling the rest into the shell.
-// A random nonce the brief author cannot predict makes that collision infeasible.
-// NOTE: Math.random()/Date.now() THROW in the workflow sandbox (and would break
-// resume), so the nonce is derived deterministically from the run inputs via a
-// tiny FNV-1a hash. It is still unpredictable to a brief author who does not know
-// the exact TASK/BRANCH/WORKTREE, so an untrusted brief line cannot guess and
-// close the heredoc early.
-const _fnv1a = (s) => {
-  let h = 0x811c9dc5 >>> 0
-  for (let i = 0; i < s.length; i++) {
-    h = (h ^ s.charCodeAt(i)) >>> 0
-    h = Math.imul(h, 0x01000193) >>> 0
-  }
-  return h.toString(36)
-}
-const SOL_HEREDOC = 'SOL_PROMPT_' + _fnv1a(TASK + '|' + BRANCH + '|' + WORKTREE) + _fnv1a(BRIEF + '|' + BRIEF_TEXT)
+// NOTE: the codex review harness writes its prompt to a temp file with the Write
+// tool (see solThunk), NOT a shell heredoc, so there is no delimiter for an
+// untrusted brief line to close and no per-run nonce is needed — the injection
+// channel the old FNV-1a heredoc delimiter guarded against is closed at the source.
 
 // ── multi-model split (token offload) ───────────────────────────────────────
 // Route ~50% of the READ-ONLY reasoning to gpt-5.6-sol so a run doesn't spend
@@ -1081,22 +1067,33 @@ mechanically-similar-but-semantically-different code. Return only real findings
 
 PHASE: gpt-5.6-sol REVIEW via the local \`codex\` CLI. You are a HARNESS — run the
 external reviewer and relay its structured findings; do NOT review yourself.
-Run from ${WORKTREE} (HEAD must be committed and clean):
-  P=$(mktemp); R=$(mktemp); EV=$(mktemp); ER=$(mktemp)
-  trap 'rm -f "$P" "$R" "$EV" "$ER"' EXIT
-  cat > "$P" <<'${SOL_HEREDOC}'
+Work from ${WORKTREE} (HEAD must be committed and clean):
+1. Allocate two unique temp paths P and R by running \`mktemp\` twice (Bash). Do
+   NOT put them under ${WORKTREE}/.git — in a linked worktree (git worktree add)
+   .git is a gitdir POINTER FILE, not a directory, so writing under .git/ fails
+   with ENOTDIR. mktemp's OS-temp paths are outside the worktree and never dirty
+   git status.
+2. Write the REVIEW PROMPT between <<<PROMPT>>> markers VERBATIM to path P with
+   the Write tool (no shell heredoc — so untrusted TASK/BRIEF text embedded in the
+   prompt can never close a delimiter and spill into the shell). Do not paraphrase
+   or summarise it.
+3. Run (Bash), substituting the real P and R paths:
+     codex -a never -s read-only exec -C "${WORKTREE}" --ephemeral --ignore-user-config \\
+       --color never --json -m "${SOL_MODEL}" -c model_reasoning_effort="${SOL_EFFORT}" \\
+       --output-schema "${CODEX_SCHEMA_PATH}" -o R - < P
+4. Read R (JSON conforming to the schema) and RETURN its findings mapped to THIS
+   tool's schema (lens="gpt-5.6-sol", file, line, severity, summary,
+   failureScenario). If \`codex\` is missing OR exits non-zero, the Sol review did
+   NOT run: RETURN {"findings": [], "solUnavailable": true} so the loop covers this
+   scope with Claude instead. Do NOT invent findings and do NOT return a bare empty
+   array on failure — reserve {"findings": []} for a genuine clean codex run.
+5. ALWAYS delete the temp files before you finish — run \`rm -f\` on the real P and
+   R paths whether codex succeeded or failed — so no prompt or result files
+   accumulate in the OS temp directory across runs.
+
+<<<PROMPT>>>
 ${solPrompt}
-${SOL_HEREDOC}
-  codex -a never -s read-only exec -C "${WORKTREE}" --ephemeral --ignore-user-config \\
-    --color never --json -m "${SOL_MODEL}" -c model_reasoning_effort="${SOL_EFFORT}" \\
-    --output-schema "${CODEX_SCHEMA_PATH}" -o "$R" - < "$P" > "$EV" 2> "$ER"
-Then read "$R" (JSON conforming to the schema) and RETURN its findings mapped to
-THIS tool's schema (lens="gpt-5.6-sol", file, line, severity, summary,
-failureScenario). The temp files are cleaned up by the trap on shell exit.
-If \`codex\` is missing OR exits non-zero, the Sol review did NOT run: RETURN
-{"findings": [], "solUnavailable": true} so the loop covers this scope with
-Claude instead. Do NOT invent findings and do NOT return a bare empty array on
-failure — reserve {"findings": []} for a genuine clean codex run.`,
+<<<PROMPT>>>`,
             { schema: FINDINGS_SCHEMA, agentType: 'general-purpose', effort: 'medium', phase: 'Review', label: `sol-cli-r${roundNo}:${i + 1}` }
             )
             return r && !r.solUnavailable ? r : null

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -1729,7 +1729,10 @@ const openTodos = (implemented && implemented.openTodos) || []
 const implementationOk = !!implemented && openTodos.length === 0
 // Incidental (unrelated, pre-existing) bugs surfaced while exploring, deduped by
 // title. The main thread files the genuinely-new ones to the bug inventory
-// (Project 4) after checking they are not already reported.
+// (Project 4) — after checking they are not already reported — ONLY when issue
+// creation/labelling/Project mutation is authorized for the run; otherwise it
+// returns them as a proposed payload for the user and mutates nothing (filing is
+// an outward-facing action, not an implicit loop step). See SKILL.md.
 const incidentalBugs = (() => {
   const seen = new Set()
   const out = []

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -199,13 +199,21 @@ const solSlot = (i) => MODEL_SPLIT && i % 2 === 1 // odd indices → Sol (~50/50
 // count with args.exploreClaudeCount.
 const EXPLORE_CLAUDE_COUNT = a.exploreClaudeCount == null ? 2 : Math.max(0, a.exploreClaudeCount)
 const exploreSol = (i) => MODEL_SPLIT && i >= EXPLORE_CLAUDE_COUNT
-// The hard review-round ceiling: after the mixed roundCap, gpt-5.6-sol-only
-// review rounds continue up to here (user policy). Docs/spec surfaces default
-// MUCH lower (roundCap+1): prose churn does not converge under a 10-round
-// escalation, and unresolved docs findings should go back to a human instead.
-// Override with args.hardRoundCap.
+// The review loop no longer terminates on a fixed round count — a crude count
+// (the old default 10) cannot tell "round 9 of genuine steady progress" from
+// "round 3 of hopeless oscillation" (the #167 config-page.js case: 8h / 21M
+// tokens / never converged). Termination is now PROGRESS-BASED: a clean round,
+// a progress STALL (STALL_PATIENCE consecutive no-progress rounds, or a round
+// whose confirmed findings are wholly a ledger re-report — see the review loop),
+// or a high runaway BACKSTOP. HARD_ROUND_CAP survives only as (a) the floor the
+// default backstop never drops below and (b) the OLD fixed-count behavior when a
+// caller passes args.hardRoundCap explicitly (which pins the backstop to that
+// value AND disables the stall detector's early stop — see STALL_DETECT below).
+// Docs/spec keep the low roundCap+1 default; the stall detector usually fires
+// first there anyway, and unresolved prose still goes back to a human fast.
+const HARD_CAP_SET = a.hardRoundCap != null
 const DEFAULT_HARD_CAP = SEVERITY_GATED ? SIZING.roundCap + 1 : 10
-const HARD_ROUND_CAP = Math.max(1, a.hardRoundCap == null ? DEFAULT_HARD_CAP : a.hardRoundCap)
+const HARD_ROUND_CAP = Math.max(1, HARD_CAP_SET ? a.hardRoundCap : DEFAULT_HARD_CAP)
 
 // Effort for the non-review Sol phases (explore/plan/finding-verification). High
 // codex effort × many calls gets very slow, so these default to medium; the
@@ -1286,6 +1294,49 @@ let reviewIncomplete = false
 // own report says the defect is still in the diff.
 const unresolvedFindings = new Map() // fingerprint → { file, line, summary, round }
 const MIXED_ROUND_CAP = SIZING.roundCap
+
+// ── non-convergence (progress-stall) detector + runaway backstop ─────────────
+// The round loop's real job is non-convergence DETECTION, not budget control
+// (terminal-failure pauses handle budget). A legitimately-converging change must
+// NEVER be cut off by an arbitrary count; a genuinely stalled one must stop ASAP
+// and surface for a human. So, evaluated after each review round from signals
+// already computed:
+//   • PROGRESS = the confirmed-finding count (what survives verification and goes
+//     to the fixer) strictly DECREASED vs the previous round, OR ≥1 confirmed
+//     finding was newly APPLIED this round.
+//   • STALL    = STALL_PATIENCE consecutive rounds with no progress (default 2),
+//     OR a round whose confirmed findings are WHOLLY a re-report of items the
+//     ledger already disposed of in an earlier round (pure oscillation).
+// On a stall the loop stops with the same not-clean / residual-risk shape the old
+// cap-hit produced (loopClean stays false; readyForPR cannot certify) plus a
+// "did not converge" residual so a human can split the change.
+// The BACKSTOP is an absolute ceiling so a pathological entangled file cannot
+// loop forever even while nominally making progress one finding at a time.
+const STALL_PATIENCE = Math.max(1, a.stallPatience != null ? a.stallPatience : 2)
+// An explicit args.hardRoundCap means the caller wants the OLD fixed-count
+// behavior: run up to exactly that many rounds and DISABLE the progress-stall
+// early stop (the backstop IS the hard cap). Otherwise the stall detector is the
+// primary terminator and the backstop is a high ceiling.
+const STALL_DETECT = !HARD_CAP_SET
+// Absolute round ceiling. Explicit hardRoundCap → that fixed count. Else an
+// explicit args.backstopRounds is honored as-is (min 1); the default is a high
+// ceiling floored at the old hard-cap-equivalent (~25 for code, roundCap+1 for
+// docs/spec where the stall detector terminates far sooner anyway).
+const BACKSTOP_ROUNDS = Math.max(
+  1,
+  HARD_CAP_SET
+    ? HARD_ROUND_CAP
+    : a.backstopRounds != null
+    ? a.backstopRounds
+    : SEVERITY_GATED
+    ? HARD_ROUND_CAP
+    : Math.max(HARD_ROUND_CAP, 25)
+)
+// Progress-stall bookkeeping across rounds.
+let prevConfirmedCount = null // confirmed count of the previous fixer round
+let noProgressStreak = 0 // consecutive rounds with no progress
+let reviewStalled = false // the loop stopped on a progress stall (non-convergence)
+let stallOscillation = false // the stall was pure oscillation (all re-reports), not just a streak
 let round = 0
 if (START_PHASE === 'verify') {
   // Verify-only resume: the review loop is SKIPPED, so by default this run can
@@ -1297,14 +1348,15 @@ if (START_PHASE === 'verify') {
     log(`verify-only resume: review loop skipped — will certify the prior clean review IFF verify reports HEAD === reviewedHead (${REVIEWED_HEAD.slice(0, 12)}…)`)
   else log('verify-only resume: review loop skipped — this run cannot certify readyForPR (fail closed)')
 }
-while (round < HARD_ROUND_CAP && !cleanRound && !halted() && START_PHASE !== 'verify') {
+while (round < BACKSTOP_ROUNDS && !cleanRound && !halted() && START_PHASE !== 'verify') {
   round++
   solOkThisRound = false
 
   // Rounds 1..MIXED_ROUND_CAP run the mixed panel (Claude lenses + gpt-5.6-sol).
   // If still not clean after that, review CONTINUES with gpt-5.6-sol as the ONLY
-  // reviewer (user policy) for every remaining round up to HARD_ROUND_CAP: all
-  // lenses run on Sol plus the whole-diff Sol reviewer(s), no Claude lens
+  // reviewer (user policy) for every remaining round until the loop terminates
+  // (clean / stall / backstop): all lenses run on Sol plus the whole-diff Sol
+  // reviewer(s), no Claude lens
   // reviewers. (A Sol slot still falls back to Claude for its scope ONLY if Sol
   // can't be routed at all — fail closed so no lens is left unreviewed.)
   const gptOnly = round > MIXED_ROUND_CAP
@@ -1333,7 +1385,7 @@ while (round < HARD_ROUND_CAP && !cleanRound && !halted() && START_PHASE !== 've
   }
   const claudeLensCount = gptOnly ? 0 : (MODEL_SPLIT ? LENSES.filter((_, i) => !solSlot(i)).length : LENSES.length)
   const solCount = roundThunks.length - claudeLensCount
-  log(`Review round ${round}/${HARD_ROUND_CAP}${gptOnly ? ' [gpt-only]' : ''} — ${claudeLensCount} Claude lens + ${solCount}× ${SOL_MODEL} (${SOL_VIA}, ${SOL_EFFORT})${MODEL_SPLIT && !gptOnly ? ' [50/50 + whole-diff]' : ''}`)
+  log(`Review round ${round}/${BACKSTOP_ROUNDS}${gptOnly ? ' [gpt-only]' : ''}${STALL_DETECT ? ` [stall-patience ${STALL_PATIENCE}]` : ' [fixed-cap]'} — ${claudeLensCount} Claude lens + ${solCount}× ${SOL_MODEL} (${SOL_VIA}, ${SOL_EFFORT})${MODEL_SPLIT && !gptOnly ? ' [50/50 + whole-diff]' : ''}`)
 
   const results = await parallel(roundThunks)
   statAdd('review', results)
@@ -1513,12 +1565,50 @@ ${JSON.stringify(confirmedForFixer, null, 1).slice(0, 10000)}`,
   })
   if (appliedThisRound < fixIds.length || reportedUnresolved.length || !fixResult)
     log(`Review round ${round}: fixer applied ${appliedThisRound}/${fixIds.length} confirmed finding(s)${reportedUnresolved.length ? `, ${reportedUnresolved.length} reported unresolved` : ''}${fixResult ? '' : ' (fixer returned nothing)'} → ${unresolvedFindings.size} finding(s) still unresolved; run cannot certify until they are fixed`)
+
+  // ── progress-stall check (non-convergence detection) ──────────────────────
+  // Reached only when this round confirmed blocker/major findings and ran a
+  // fixer (clean and coverage-incomplete rounds already broke out above). PURE
+  // OSCILLATION: the confirmed set is wholly a re-report of items the ledger
+  // disposed of in an EARLIER round (fixed/refuted/advisory) — the reviewers are
+  // re-litigating settled findings, the clearest non-convergence signal. STREAK:
+  // STALL_PATIENCE consecutive rounds where the confirmed count did not fall and
+  // the fixer applied nothing new. Either way we stop and surface for a human
+  // rather than churn to the backstop.
+  if (STALL_DETECT) {
+    const priorLedgerFps = new Set(
+      ledger
+        .filter((e) => e.round !== round && (e.status === 'fixed' || e.status === 'refuted' || e.status === 'advisory'))
+        .map(dedupeKey)
+    )
+    const pureOscillation = confirmed.length > 0 && confirmed.every((f) => priorLedgerFps.has(dedupeKey(f)))
+    const progressed = (prevConfirmedCount != null && confirmed.length < prevConfirmedCount) || appliedThisRound > 0
+    if (progressed) noProgressStreak = 0
+    else noProgressStreak++
+    prevConfirmedCount = confirmed.length
+    if (pureOscillation || noProgressStreak >= STALL_PATIENCE) {
+      reviewStalled = true
+      stallOscillation = pureOscillation
+      log(
+        `Review round ${round}: STALL — ${
+          pureOscillation
+            ? 'confirmed findings are wholly a re-report of items already disposed of in the ledger (pure oscillation)'
+            : `${noProgressStreak} consecutive round(s) without progress (STALL_PATIENCE=${STALL_PATIENCE})`
+        }; review is not converging → stopping and surfacing for a human`
+      )
+      break
+    }
+  } else {
+    prevConfirmedCount = confirmed.length
+  }
 }
 if (!cleanRound && START_PHASE !== 'verify')
   log(
     reviewIncomplete
       ? `Review: ended without a certified-clean round — coverage incomplete (reviewer/verifier failure); will report as residual risk`
-      : `Review: hit round cap (${HARD_ROUND_CAP}) with unresolved findings — will report as residual risk`
+      : reviewStalled
+      ? `Review: did NOT converge — stopped at round ${round} on a progress ${stallOscillation ? 'oscillation (re-report set)' : `stall (${STALL_PATIENCE} no-progress round(s))`}; surfacing for a human`
+      : `Review: hit the runaway backstop (${BACKSTOP_ROUNDS} rounds) with unresolved findings — will report as residual risk`
   )
 // Mixed-model contract enforcement on the CERTIFYING round. Every round always
 // requests ≥1 gpt-5.6-sol reviewer (Math.max(1, SOL_REVIEWERS)); if the round that
@@ -1768,6 +1858,12 @@ const result = {
   loopClean: cleanRound,
   reviewRounds: round,
   reviewIncomplete,
+  // Non-convergence signals: the loop stopped on a progress stall (reviewStalled)
+  // — optionally pure oscillation (stallOscillation) — rather than a clean round;
+  // and the absolute round ceiling in effect for this run.
+  reviewStalled,
+  stallOscillation,
+  backstopRounds: BACKSTOP_ROUNDS,
   incidentalBugs,
   confirmedFindingsResolved: confirmedAll.length,
   // Confirmed-but-minor docs/spec findings (severity-gated surfaces only) for
@@ -1809,7 +1905,21 @@ const result = {
         ? ['adversarial review ended with incomplete coverage (a reviewer or finding-verifier failed) — the round could not be certified clean']
         : []
     )
-    .concat(cleanRound || reviewIncomplete ? [] : ['review loop hit its round cap with unresolved confirmed findings'])
+    .concat(
+      cleanRound || reviewIncomplete
+        ? []
+        : reviewStalled
+        ? [
+            `review did NOT converge — ${
+              stallOscillation
+                ? 'confirmed findings were wholly a re-report of items already disposed of in the ledger (pure oscillation)'
+                : `${STALL_PATIENCE} consecutive review round(s) made no progress`
+            }; surfacing for a human — consider splitting the change into smaller independent pieces${
+              unresolvedFindings.size ? ` (${unresolvedFindings.size} finding(s) still unresolved)` : ''
+            }`,
+          ]
+        : ['review loop hit the runaway backstop (' + BACKSTOP_ROUNDS + ' rounds) with unresolved confirmed findings — surface for a human']
+    )
     .concat(
       unresolvedFindings.size
         ? [

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -1632,6 +1632,17 @@ ALL BLOCKING gates passed, the e2e result if run, and a list of failures.`,
     log('Verify: provider outage — skipping the verify-fix retry (a code-writing fixer is pointless during an outage)')
     break
   }
+  // Distinguish a runner/infrastructure failure (the verify agent returned no
+  // structured gate evidence — the safely() sentinel, or a report with an empty
+  // gates array) from a returned gate failure. Only the latter names something a
+  // code fixer can act on; spawning a writer against "verify did not return
+  // structured output" burns an agent and can dirty the tree. Re-run Verify
+  // read-only instead, bounded by the same verifyFixCap.
+  const verifyReturnedStructured = !!(verify && Array.isArray(verify.gates) && verify.gates.length > 0)
+  if (!verifyReturnedStructured) {
+    log(`Verify: no structured gate results (runner/infrastructure failure, not a code defect) → re-running verify read-only (attempt ${vround}/${SIZING.verifyFixCap}); NOT spawning a code fixer`)
+    continue
+  }
   log(`Verify: failures → fix attempt ${vround}/${SIZING.verifyFixCap}`)
   // Wrap the code-writing verify-fixer in safely(): a StructuredOutput retry-cap
   // throw must NOT abort the workflow — the loop must still re-verify and return

--- a/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
+++ b/.agents/skills/jellyfin-canopy-agentic-loop/workflows/canopy-loop.js
@@ -253,6 +253,41 @@ async function classified(makePromise) {
   }
 }
 
+// ── Sol route circuit breaker + model-coverage accounting ───────────────────
+// A dead Sol route (codex CLI missing, router down) fails EVERY slot the same
+// way; without a breaker each slot still burns a harness agent plus a Claude
+// fallback (22-23 empty results per production run). After 3 CONSECUTIVE Sol
+// failures the route is declared dead and remaining Sol slots go straight to
+// Claude; any Sol success resets the counter, so a healthy route is unaffected.
+// Fail-closed semantics are preserved — Claude still covers every scope.
+// modelCoverage additionally records requested-vs-actual model per slot class so
+// a run where "mixed-model review" silently became all-Claude is VISIBLE in the
+// result instead of being relabeled as healthy coverage.
+let solConsecutiveFailures = 0
+let solDead = false
+const modelCoverage = {} // per slot class (phase): { requested, ranSol, claudeFallback, reasons[] }
+let solOkThisRound = false // did any Sol reviewer actually run this review round?
+const roundsWithoutSol = [] // review rounds with zero real cross-family coverage
+function covNote(cls, ranSol, reason) {
+  const c = modelCoverage[cls] || (modelCoverage[cls] = { requested: 0, ranSol: 0, claudeFallback: 0, reasons: [] })
+  c.requested++
+  if (ranSol) c.ranSol++
+  else {
+    c.claudeFallback++
+    if (reason && c.reasons.length < 5) c.reasons.push(String(reason).slice(0, 90))
+  }
+}
+function noteSolFailure(reason) {
+  solConsecutiveFailures++
+  if (solConsecutiveFailures >= 3 && !solDead) {
+    solDead = true
+    log(`Sol route DEAD after 3 consecutive failures (${String(reason).slice(0, 60)}) — remaining Sol slots run on Claude`)
+  }
+}
+function noteSolSuccess() {
+  solConsecutiveFailures = 0
+}
+
 // codex forwards --output-schema to OpenAI Structured Outputs in STRICT mode,
 // which requires every object to set additionalProperties:false and list EVERY
 // declared property in `required`. Our workflow schemas are intentionally
@@ -330,16 +365,26 @@ ${prompt}
 // solLightEffort?: codex-cli effort (default SOL_LIGHT_EFFORT) }.
 async function splitAgent(i, prompt, opts, ctl) {
   if (systemicFailure) return null // outage: no Sol attempt, no Claude fallback
-  const useSol = ctl && typeof ctl.slot === 'function' ? ctl.slot(i) : solSlot(i)
-  if (useSol) {
+  const cls = (opts && opts.phase) || 'other'
+  const wantSol = ctl && typeof ctl.slot === 'function' ? ctl.slot(i) : solSlot(i)
+  if (wantSol && solDead) covNote(cls, false, 'sol route dead (circuit breaker)')
+  if (wantSol && !solDead) {
     try {
       let r = null
       if (SOL_AGENT_OK) r = await agent(prompt, { ...opts, model: SOL_MODEL, effort: (ctl && ctl.solEffort) || SOL_EFFORT })
       else if (opts && opts.schema)
         r = await codexAgent(prompt, opts.schema, { effort: (ctl && ctl.solLightEffort) || SOL_LIGHT_EFFORT, phase: opts.phase, label: (opts.label || '') + ':sol' })
-      if (r != null) return r
+      if (r != null) {
+        noteSolSuccess()
+        covNote(cls, true)
+        return r
+      }
+      noteSolFailure('null/unavailable result')
+      covNote(cls, false, 'sol returned null/unavailable')
     } catch (e) {
       noteAgentError(e) /* Sol failed → Claude fallback below (unless terminal) */
+      noteSolFailure(e && e.message)
+      covNote(cls, false, e && e.message)
     }
     if (systemicFailure) return null // terminal: the fallback would die the same way
   }
@@ -349,15 +394,25 @@ async function splitAgent(i, prompt, opts, ctl) {
 // tokens; falls back to Claude when Sol isn't routable/available.
 async function soloSolAgent(prompt, opts, solEffort) {
   if (systemicFailure) return null // outage: no Sol attempt, no Claude fallback
-  if (MODEL_SPLIT) {
+  const cls = (opts && opts.phase) || 'other'
+  if (MODEL_SPLIT && solDead) covNote(cls, false, 'sol route dead (circuit breaker)')
+  if (MODEL_SPLIT && !solDead) {
     try {
       let r = null
       if (SOL_AGENT_OK) r = await agent(prompt, { ...opts, model: SOL_MODEL, effort: solEffort || SOL_EFFORT })
       else if (opts && opts.schema)
         r = await codexAgent(prompt, opts.schema, { effort: solEffort || SOL_LIGHT_EFFORT, phase: opts.phase, label: (opts.label || '') + ':sol' })
-      if (r != null) return r
+      if (r != null) {
+        noteSolSuccess()
+        covNote(cls, true)
+        return r
+      }
+      noteSolFailure('null/unavailable result')
+      covNote(cls, false, 'sol returned null/unavailable')
     } catch (e) {
       noteAgentError(e) /* fall through to Claude (unless terminal) */
+      noteSolFailure(e && e.message)
+      covNote(cls, false, e && e.message)
     }
     if (systemicFailure) return null
   }
@@ -887,8 +942,19 @@ failure — reserve {"findings": []} for a genuine clean codex run.`,
 
   return async () => {
     if (systemicFailure) return null // outage: no Sol attempt, no Claude fallback
+    if (solDead) {
+      covNote('Review', false, 'sol route dead (circuit breaker)')
+      return claudeReview(roundNo, i, lens) // scope never lost
+    }
     const r = await runSol()
-    if (r != null) return r
+    if (r != null) {
+      noteSolSuccess()
+      covNote('Review', true)
+      solOkThisRound = true
+      return r
+    }
+    noteSolFailure('review sol slot failed/unavailable')
+    covNote('Review', false, 'sol review slot failed/unavailable')
     if (systemicFailure) return null // terminal: the fallback would die the same way
     return claudeReview(roundNo, i, lens) // scope never lost
   }
@@ -913,6 +979,7 @@ if (START_PHASE === 'verify') {
 }
 while (round < HARD_ROUND_CAP && !cleanRound && !systemicFailure && START_PHASE !== 'verify') {
   round++
+  solOkThisRound = false
 
   // Rounds 1..MIXED_ROUND_CAP run the mixed panel (Claude lenses + gpt-5.6-sol).
   // If still not clean after that, review CONTINUES with gpt-5.6-sol as the ONLY
@@ -953,6 +1020,10 @@ while (round < HARD_ROUND_CAP && !cleanRound && !systemicFailure && START_PHASE 
     reviewIncomplete = true
     log(`Review round ${round}: provider outage — pausing instead of spawning more agents`)
     break
+  }
+  if (!solOkThisRound) {
+    roundsWithoutSol.push(round)
+    log(`Review round ${round}: NO real gpt-5.6-sol coverage — every Sol slot fell back to Claude (route problem, not a clean mixed review)`)
   }
   const failedWorkers = results.filter((r) => r == null).length
   const raw = results.filter(Boolean).flatMap((r) => (r && r.findings) || [])
@@ -1292,6 +1363,10 @@ const result = {
   canonicalPlan: canonicalPlan || null,
   verify: verify || null,
   verifyFixCommitted,
+  // Requested-vs-actual model per slot class, breaker state, and any review
+  // rounds that silently lost cross-family coverage — a missing Sol pass is a
+  // route problem to FIX, never a healthy mixed review (per README).
+  modelCoverage: { slots: modelCoverage, solDead, roundsWithoutSol },
   // Last HEAD sha independently reported by a verify run (null when verify never
   // ran, e.g. a paused run) — lets the launcher pin resume/PR actions to the
   // exact commit that was verified.
@@ -1318,6 +1393,13 @@ const result = {
     .concat(verifyFixCommitted ? ['verify-fix committed code AFTER the clean review round — those commits were never adversarially reviewed; re-run the review loop before opening a PR'] : [])
     .concat(blockingGreen ? [] : ['one or more BLOCKING gates are failing'])
     .concat(e2eGreen ? [] : ['e2e:local did not pass'])
+    .concat(
+      roundsWithoutSol.length
+        ? [
+            `review round(s) ${roundsWithoutSol.join(', ')} ran WITHOUT real cross-family (gpt-5.6-sol) coverage — every Sol slot fell back to Claude; fix the Sol route (codex CLI / router) before treating this as a fully mixed-model review`,
+          ]
+        : []
+    )
     .concat(openTodos),
 }
 log(

--- a/.agents/skills/jellyfin-canopy-engineering/SKILL.md
+++ b/.agents/skills/jellyfin-canopy-engineering/SKILL.md
@@ -222,6 +222,23 @@ identify the failing assertion/command before changing code or rerunning.
   within scope.
 - Treat the aggregate E2E job as a summary; inspect the failed shard first.
 
+While auto-merge waits, run a bounded post-publication watch: enabled auto-merge
+does **not** update the branch when `main` advances, so alongside the checks
+also inspect the PR's mergeability/behind state (e.g.
+`gh pr view --json mergeable,mergeStateStatus`). When `main` has moved and the
+ruleset requires an up-to-date branch:
+
+1. update the branch from current `origin/main` and resolve semantically;
+2. rerun the affected gates;
+3. reconfirm the independent review still applies to the result (request a fresh
+   verdict if the resolution changed reviewed code);
+4. verify the push URL and push;
+5. continue monitoring the NEW head commit's required checks — do not assume the
+   previous green run carries over.
+
+Keep the watch bounded: recheck on check completion or a `main` advance, not in
+a tight poll, and stop once merged.
+
 Merge only when the latest commit has all required blocking checks green and
 the independent review is still applicable. Inspect the current branch ruleset;
 at minimum expect Plugin, Unit tests, Client checks, the E2E aggregate, Manifest
@@ -231,8 +248,10 @@ required check.
 
 ## 9. Merge and prove closure
 
-Immediately before merging, verify the writable push destination again. After
-merge, independently verify:
+Immediately before merging, verify the writable push destination again. If the
+merge is deferred to auto-merge, keep the section-8 behind-state watch running
+until the merge actually lands — a PR left "behind" waits forever. After merge,
+independently verify:
 
 1. the PR state and exact merge commit;
 2. the merge commit is reachable from current `origin/main`;

--- a/scripts/canopy-loop.workflow.test.js
+++ b/scripts/canopy-loop.workflow.test.js
@@ -403,6 +403,32 @@ test('a fixer that reports a finding unresolved blocks certification even if a l
     assert.ok(!r.ledger.some((e) => e.status === 'fixed'), 'an unfixed finding is never ledgered as fixed');
 });
 
+test('an unresolved finding is NOT cleared by a later fixer fully applying an UNRELATED finding', async () => {
+    // The persistent-unresolved regression: round 1 leaves finding A unresolved;
+    // round 2 fully applies an UNRELATED finding B; round 3 comes back clean. A
+    // single unfixedConfirmed boolean would be reset to false by B's clean apply
+    // and wrongly certify the branch while A is still in the diff. Per-finding
+    // fingerprint tracking must keep A unresolved until A itself is applied or
+    // independently refuted.
+    const { agent } = makeAgent((_p, opts) => {
+        const l = opts.label || '';
+        if (l === 'review-r1:1') return finding('finding A needs a real fix');
+        if (l === 'verify-r1:1') return { real: true, reason: 'A reproduces' };
+        if (l === 'fix-r1') return { applied: [], unresolved: ['r1f1'], commits: [] }; // A left unresolved
+        if (l === 'review-r2:1')
+            return { findings: [{ file: 'other.js', line: 9, severity: 'major', summary: 'finding B unrelated', failureScenario: 'z' }] };
+        if (l === 'verify-r2:1') return { real: true, reason: 'B reproduces' };
+        if (l === 'fix-r2') return { applied: ['r2f1'], unresolved: [], commits: ['c'] }; // B fully applied
+        return undefined; // round 3 reviewers empty → clean round
+    });
+    const r = await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
+    assert.equal(r.loopClean, true, 'round 3 came back clean');
+    assert.equal(r.reviewIncomplete, false, 'coverage was complete throughout');
+    assert.equal(r.confirmedFindingsResolved, 1, 'only B was actually applied');
+    assert.equal(r.readyForPR, false, 'unresolved finding A must still block certification after B is fixed');
+    assert.ok(r.residualRisks.some((s) => /unapplied\/unresolved/i.test(s)));
+});
+
 test('a fixer that applies only SOME confirmed findings does not certify', async () => {
     // Two confirmed findings; the fixer applies one and silently drops the other
     // (neither in applied nor unresolved). Fail closed on the dropped id.

--- a/scripts/canopy-loop.workflow.test.js
+++ b/scripts/canopy-loop.workflow.test.js
@@ -124,6 +124,40 @@ test('a terminal session-limit failure pauses the run instead of spawning more a
     assert.ok(r.residualRisks.some((s) => /PAUSED .*resume/i.test(s)), 'the pause residual carries resume instructions');
 });
 
+test('a terminal quota error on the Sol route falls back to Claude instead of pausing the run', async () => {
+    // A codex/Sol quota is a SEPARATE provider from the Claude session — it must
+    // open the Sol breaker and fall back to Claude, NOT pause the whole run.
+    const { agent, calls } = makeAgent((_p, opts) => {
+        if (opts.model === 'gpt-5.6-sol') return { __throw: 'You have exceeded your current quota' };
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
+    assert.equal(r.status, 'complete', 'a Sol-route quota error does not pause the Claude run');
+    assert.equal(r.resumeFrom, null, 'the run is not paused for resume');
+    assert.ok(calls.some((c) => c.opts.phase === 'Verify'), 'the run proceeds through verify on Claude');
+});
+
+test('a terminal quota on the primary implementer falls back to Opus instead of pausing', async () => {
+    const { agent, calls } = makeAgent((_p, opts) => {
+        if ((opts.label || '').startsWith('implement:fable')) return { __throw: 'You have exceeded your current quota' };
+        return undefined; // the Opus fallback and everything else succeed
+    });
+    const r = await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
+    assert.ok(calls.some((c) => (c.opts.label || '').includes('opus-fallback')), 'Opus fallback attempted after a Fable quota');
+    assert.equal(r.status, 'complete', 'a primary-implementer quota does not pause the run');
+    assert.equal(r.readyForPR, true, 'the Opus fallback produced a certifiable implementation');
+});
+
+test('a terminal quota on BOTH implementers pauses the run (session provider exhausted)', async () => {
+    const { agent } = makeAgent((_p, opts) => {
+        if ((opts.label || '').startsWith('implement')) return { __throw: 'You have exceeded your current quota' };
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
+    assert.equal(r.status, 'paused', 'both implementers exhausted → pause');
+    assert.equal(r.resumeFrom.phase, 'explore');
+});
+
 test('an all-null explore batch is treated as a provider outage and pauses before implement', async () => {
     // Nulls carry no error message, but EVERY agent in a batch failing is an
     // infrastructure outage, not N coincidences — pause instead of burning the

--- a/scripts/canopy-loop.workflow.test.js
+++ b/scripts/canopy-loop.workflow.test.js
@@ -578,6 +578,31 @@ test('issue + no briefText: a Phase-0 agent hydrates the brief from the live iss
     assert.equal(r.readyForPR, true);
 });
 
+test('issue-only launch replaces the placeholder TASK line with the fetched issue title', async () => {
+    // In the preferred issue:N-only shape, hydration must also fill TASK so agents
+    // do not open with "No task text supplied." above the authoritative brief.
+    const { agent, calls } = makeAgent((_p, opts) => {
+        if ((opts.label || '') === 'fetch-issue')
+            return { number: 452, title: 'Fix the widget', body: 'ACCEPTANCE CRITERIA', url: 'https://x/452', updatedAt: '2026-07-20' };
+        return undefined;
+    });
+    await runWorkflow(baseArgs({ issue: 452 }), agent, parallel, phase, () => {});
+    const impl = calls.find((c) => (c.opts.label || '').startsWith('implement'));
+    assert.doesNotMatch(impl.prompt, /No task text supplied/, 'placeholder TASK replaced after hydration');
+    assert.match(impl.prompt, /Resolve issue #452: Fix the widget/, 'TASK line derived from the fetched issue title');
+});
+
+test('an explicit task is NOT overwritten by issue hydration', async () => {
+    const { agent, calls } = makeAgent((_p, opts) => {
+        if ((opts.label || '') === 'fetch-issue')
+            return { number: 452, title: 'Fix the widget', body: 'ACCEPTANCE CRITERIA', url: 'https://x/452', updatedAt: '2026-07-20' };
+        return undefined;
+    });
+    await runWorkflow(baseArgs({ issue: 452, task: 'EXPLICIT LAUNCHER TASK' }), agent, parallel, phase, () => {});
+    const impl = calls.find((c) => (c.opts.label || '').startsWith('implement'));
+    assert.match(impl.prompt, /EXPLICIT LAUNCHER TASK/, 'explicit task wins over the fetched title');
+});
+
 test('an explicit briefText suppresses the issue fetch (launcher brief stays authoritative)', async () => {
     const { agent, calls } = makeAgent(null);
     await runWorkflow(baseArgs({ issue: 452, briefText: 'MANUAL BRIEF' }), agent, parallel, phase, () => {});

--- a/scripts/canopy-loop.workflow.test.js
+++ b/scripts/canopy-loop.workflow.test.js
@@ -193,6 +193,18 @@ test('startPhase:"verify" + reviewedHead that does NOT match the verified HEAD s
     assert.ok(r.residualRisks.some((s) => /review loop was SKIPPED/i.test(s)));
 });
 
+test('startPhase:"verify" resume still runs Localize on a client surface (parity fan-out)', async () => {
+    // A run can pause between the clean review round and Localize. Skipping
+    // Localize on the verify-resume would leave new en.json keys un-fanned-out and
+    // fail validate-translations forever, so the cheap parity fan-out must run.
+    const { agent, calls } = makeAgent(null);
+    const r = await runWorkflow(baseArgs({ surface: 'client', runtime: false, startPhase: 'verify' }), agent, parallel, phase, () => {});
+    assert.ok(!calls.some((c) => c.opts.phase === 'Review'), 'no review agents on a verify-only resume');
+    assert.ok(calls.some((c) => c.opts.phase === 'Localize'), 'Localize still fans out locale keys on a verify-resume');
+    assert.ok(calls.some((c) => c.opts.phase === 'Verify'), 'verify runs');
+    assert.equal(r.readyForPR, false, 'still fail-closed without a reviewedHead match');
+});
+
 test('an unknown startPhase falls back to a full run', async () => {
     const { agent, calls } = makeAgent(null);
     const r = await runWorkflow(baseArgs({ startPhase: 'implment' }), agent, parallel, phase, () => {});

--- a/scripts/canopy-loop.workflow.test.js
+++ b/scripts/canopy-loop.workflow.test.js
@@ -92,6 +92,60 @@ test('happy path returns readyForPR', async () => {
     assert.equal(r.loopClean, true);
     assert.equal(r.readyForPR, true);
     assert.equal(r.reviewIncomplete, false);
+    assert.equal(r.status, 'complete');
+    assert.equal(r.pauseReason, null);
+    assert.equal(r.resumeFrom, null);
+});
+
+test('a terminal session-limit failure pauses the run instead of spawning more agents', async () => {
+    // Every review-phase agent dies on the Anthropic session limit (run #454).
+    // The loop must classify that as TERMINAL and stop spawning: no Claude
+    // fallbacks, no second round, no Localize, no Verify, no fixers — return a
+    // paused result pointing at the phase to resume from.
+    const { agent, calls } = makeAgent((_p, opts) => {
+        if (opts.phase === 'Review') return { __throw: "You've hit your session limit · resets 3am" };
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs({ surface: 'client' }), agent, parallel, phase, () => {});
+    assert.equal(r.status, 'paused');
+    assert.match(r.pauseReason, /session limit/i);
+    assert.equal(r.resumeFrom.phase, 'review');
+    assert.equal(r.readyForPR, false);
+    assert.equal(r.reviewIncomplete, true);
+    assert.equal(r.reviewRounds, 1, 'no second review round is attempted during an outage');
+    assert.ok(!calls.some((c) => c.opts.phase === 'Localize'), 'no Localize agent after terminal failure');
+    assert.ok(!calls.some((c) => c.opts.phase === 'Verify'), 'no Verify agent after terminal failure');
+    assert.ok(!calls.some((c) => (c.opts.label || '').startsWith('fix-r')), 'no fixer after terminal failure');
+    assert.ok(r.residualRisks.some((s) => /PAUSED .*resume/i.test(s)), 'the pause residual carries resume instructions');
+});
+
+test('an all-null explore batch is treated as a provider outage and pauses before implement', async () => {
+    // Nulls carry no error message, but EVERY agent in a batch failing is an
+    // infrastructure outage, not N coincidences — pause instead of burning the
+    // plan/implement/review/verify phases on a dead provider.
+    const { agent, calls } = makeAgent((_p, opts) => {
+        if ((opts.label || '').startsWith('explore')) return null;
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
+    assert.equal(r.status, 'paused');
+    assert.equal(r.resumeFrom.phase, 'explore');
+    assert.equal(r.readyForPR, false);
+    assert.ok(!calls.some((c) => (c.opts.label || '').startsWith('plan')), 'no planner spawned during an outage');
+    assert.ok(!calls.some((c) => (c.opts.label || '').startsWith('implement')), 'no implementer spawned during an outage');
+    assert.ok(!calls.some((c) => c.opts.phase === 'Verify'), 'no verify spawned during an outage');
+});
+
+test('a singleton non-terminal agent failure does NOT trip systemic-failure mode', async () => {
+    // One explorer dying for its own reasons is the existing, expected fallback
+    // path — the run must complete normally (fail-closed semantics unchanged).
+    const { agent } = makeAgent((_p, opts) => {
+        if ((opts.label || '') === 'explore:1') return { __throw: 'transient tool crash' };
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
+    assert.equal(r.status, 'complete');
+    assert.equal(r.readyForPR, true);
 });
 
 test('an unroutable Sol lens slot is reviewed by the Claude fallback, not lost', async () => {

--- a/scripts/canopy-loop.workflow.test.js
+++ b/scripts/canopy-loop.workflow.test.js
@@ -453,6 +453,25 @@ test('a verify-fix that commits after a clean review round is not ready-for-PR',
     assert.ok(r.residualRisks.some((s) => /never adversarially reviewed/i.test(s)));
 });
 
+test('a docs run explores 4 docs-relevant angles and skips Localize', async () => {
+    const { agent, calls } = makeAgent(null);
+    const r = await runWorkflow(baseArgs({ surface: 'docs', runtime: false, depth: 'standard' }), agent, parallel, phase, () => {});
+    const explore = calls.filter((c) => /^explore:\d+/.test(c.opts.label || ''));
+    assert.equal(explore.length, 4, 'docs runs use the 4 docs angles, not 8 code explorers');
+    assert.ok(explore.some((c) => /the DOCS surface: nav\/mkdocs structure/.test(c.prompt)), 'the DOCS-surface angle runs');
+    assert.ok(explore.every((c) => !/DATA\/STATE\/CONCURRENCY/.test(c.prompt)), 'no concurrency explorer for docs');
+    assert.ok(!calls.some((c) => c.opts.phase === 'Localize'), 'no Localize agent for docs');
+    assert.equal(r.readyForPR, true);
+});
+
+test('non-docs surfaces keep the full explorer list and Localize behavior', async () => {
+    const { agent, calls } = makeAgent(null);
+    await runWorkflow(baseArgs({ surface: 'client', depth: 'standard', runtime: false }), agent, parallel, phase, () => {});
+    const explore = calls.filter((c) => /^explore:\d+/.test(c.opts.label || ''));
+    assert.equal(explore.length, 8);
+    assert.ok(calls.some((c) => c.opts.phase === 'Localize'), 'client surface still localizes');
+});
+
 test('issue + no briefText: a Phase-0 agent hydrates the brief from the live issue', async () => {
     const { agent, calls } = makeAgent((_p, opts) => {
         if ((opts.label || '') === 'fetch-issue')

--- a/scripts/canopy-loop.workflow.test.js
+++ b/scripts/canopy-loop.workflow.test.js
@@ -795,6 +795,43 @@ test('the finding ledger reaches round-2 reviewers with fixed and refuted dispos
     assert.ok(r.ledger.some((e) => e.status === 'refuted'), 'result exposes the refuted entry');
 });
 
+test('the finding ledger carries EVERY disposition to later rounds (equal-share, not a head-slice)', async () => {
+    // A churny round-1: 40 findings — #1 confirmed+fixed, #2..#40 refuted with long
+    // reasons — produces 40 ledger entries well past the old 6000-char JSON slice.
+    // The round-2 reviewer prompt must still carry the NEWEST dispositions (which a
+    // head-slice dropped), so reviewers don't re-report them.
+    const N = 40;
+    const { agent, calls } = makeAgent((_p, opts) => {
+        const l = opts.label || '';
+        if (l === 'review-r1:1') {
+            return {
+                findings: Array.from({ length: N }, (_, k) => ({
+                    file: `f${k + 1}.js`, line: k + 1, severity: 'major',
+                    summary: `LEDGER_ENTRY_${k + 1}`, failureScenario: 'x'.repeat(40),
+                })),
+            };
+        }
+        const m = /^verify-r1:(\d+)$/.exec(l);
+        if (m) {
+            const idx = Number(m[1]);
+            return idx === 1
+                ? { real: true, reason: 'CONFIRM_1 ' + 'y'.repeat(260) } // forces round 2 + a fixed entry
+                : { real: false, reason: `REFUTE_${idx} ` + 'z'.repeat(260) };
+        }
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
+    assert.ok(r.ledger.length >= N, `all ${N} dispositions recorded (got ${r.ledger.length})`);
+    const round2 = calls.filter((c) => /^(review|sol)-r2:/.test(c.opts.label || ''));
+    assert.ok(round2.length, 'round 2 ran');
+    for (const c of round2) {
+        assert.match(c.prompt, /FINDING LEDGER/, 'ledger present in round 2');
+        assert.match(c.prompt, /REFUTE_2\b/, 'an EARLY refuted disposition survives');
+        assert.match(c.prompt, /REFUTE_40\b/, 'the NEWEST refuted disposition survives (dropped by the old 6000-char head-slice)');
+        assert.match(c.prompt, /LEDGER_ENTRY_1\b/, 'the fixed disposition survives');
+    }
+});
+
 test('round-1 reviewers see no ledger block (nothing resolved yet)', async () => {
     const { agent, calls } = makeAgent(null);
     await runWorkflow(baseArgs(), agent, parallel, phase, () => {});

--- a/scripts/canopy-loop.workflow.test.js
+++ b/scripts/canopy-loop.workflow.test.js
@@ -160,6 +160,39 @@ test('startPhase:"verify" runs gates only and can NEVER certify readyForPR (fail
     assert.ok(r.residualRisks.some((s) => /review loop was SKIPPED/i.test(s)));
 });
 
+test('startPhase:"verify" + reviewedHead matching the verified HEAD certifies the prior clean review', async () => {
+    // The #454 window: a run died AFTER a clean review round, during Verify. On
+    // resume the launcher passes back the sha it was clean at; the verify agent
+    // independently reports the SAME HEAD → the prior clean review still covers
+    // this exact range, so the run certifies without re-reviewing.
+    const { agent, calls } = makeAgent((_p, opts) => {
+        if (opts.phase === 'Verify' && (opts.label || '').startsWith('verify'))
+            return { gates: [{ name: 'g', pass: true }], allBlockingPassed: true, e2e: { run: false, pass: true }, headSha: 'deadbeefcafe' };
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs({ startPhase: 'verify', reviewedHead: 'deadbeefcafe' }), agent, parallel, phase, () => {});
+    assert.ok(!calls.some((c) => c.opts.phase === 'Review'), 'no review agents on a verify-only resume');
+    assert.equal(r.loopClean, true, 'prior clean review certified via reviewedHead match');
+    assert.equal(r.reviewIncomplete, false);
+    assert.equal(r.readyForPR, true, 'a verified HEAD == reviewedHead certifies without re-running review');
+    assert.ok(!r.residualRisks.some((s) => /review loop was SKIPPED/i.test(s)), 'no skipped-review residual when certified');
+});
+
+test('startPhase:"verify" + reviewedHead that does NOT match the verified HEAD stays fail-closed', async () => {
+    // A commit changed since the clean review (or the sha is stale): the prior
+    // review no longer covers this range, so the run must NOT certify.
+    const { agent } = makeAgent((_p, opts) => {
+        if (opts.phase === 'Verify' && (opts.label || '').startsWith('verify'))
+            return { gates: [{ name: 'g', pass: true }], allBlockingPassed: true, e2e: { run: false, pass: true }, headSha: 'aaaa1111' };
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs({ startPhase: 'verify', reviewedHead: 'bbbb2222' }), agent, parallel, phase, () => {});
+    assert.equal(r.loopClean, false, 'a HEAD mismatch does not certify');
+    assert.equal(r.reviewIncomplete, true);
+    assert.equal(r.readyForPR, false);
+    assert.ok(r.residualRisks.some((s) => /review loop was SKIPPED/i.test(s)));
+});
+
 test('an unknown startPhase falls back to a full run', async () => {
     const { agent, calls } = makeAgent(null);
     const r = await runWorkflow(baseArgs({ startPhase: 'implment' }), agent, parallel, phase, () => {});

--- a/scripts/canopy-loop.workflow.test.js
+++ b/scripts/canopy-loop.workflow.test.js
@@ -453,6 +453,106 @@ test('a verify-fix that commits after a clean review round is not ready-for-PR',
     assert.ok(r.residualRisks.some((s) => /never adversarially reviewed/i.test(s)));
 });
 
+test('docs surface: confirmed minors become advisory notes and the round counts clean', async () => {
+    // A confirmed MINOR wording-adjacent defect on a docs surface must not force
+    // another full fix round: it is reported in advisoryNotes and the round is
+    // clean (SR-15's churn driver).
+    const { agent, calls } = makeAgent((_p, opts) => {
+        const l = opts.label || '';
+        if (l === 'review-r1:1')
+            return { findings: [{ file: 'docs/a.md', line: 3, severity: 'minor', summary: 'stale sentence', failureScenario: 'x' }] };
+        if (l.startsWith('verify-r1')) return { real: true, severity: 'minor', reason: 'true but cosmetic' };
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs({ surface: 'docs', runtime: false }), agent, parallel, phase, () => {});
+    assert.equal(r.loopClean, true, 'a minors-only round counts clean');
+    assert.equal(r.reviewRounds, 1);
+    assert.ok(r.advisoryNotes.some((s) => /stale sentence/.test(s)), 'the confirmed minor is reported as advisory');
+    assert.ok(!calls.some((c) => (c.opts.label || '').startsWith('fix-r')), 'no fixer runs for minors only');
+    assert.equal(r.readyForPR, true);
+});
+
+test('non-docs surfaces still fix confirmed minors (severity gate is docs/spec-scoped)', async () => {
+    const { agent, calls } = makeAgent((_p, opts) => {
+        const l = opts.label || '';
+        if (l === 'review-r1:1')
+            return { findings: [{ file: 'a.js', line: 1, severity: 'minor', summary: 'off by one', failureScenario: 'x' }] };
+        if (l.startsWith('verify-r1')) return { real: true, severity: 'minor', reason: 'reproduces' };
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
+    assert.ok(calls.some((c) => (c.opts.label || '').startsWith('fix-r')), 'code-surface minors still reach the fixer');
+    assert.equal(r.advisoryNotes.length, 0);
+    assert.ok(r.confirmedFindingsResolved >= 1);
+});
+
+test('docs surface: the hard round cap defaults to roundCap+1, not 10', async () => {
+    // quick depth → mixed roundCap 2 → docs hard cap 3. A blocker every round
+    // with a throwing fixer must stop after 3 rounds instead of churning to 10.
+    const { agent } = makeAgent((_p, opts) => {
+        const l = opts.label || '';
+        if (/^review-r\d+:1$/.test(l)) return finding('real blocker'); // mixed rounds
+        if (/^sol-r\d+:1$/.test(l)) return finding('real blocker'); // gpt-only round(s)
+        if (/^verify-r\d+:1$/.test(l)) return { real: true, severity: 'blocker', reason: 'c' };
+        if (l.startsWith('fix-r')) return { __throw: 'cap' };
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs({ surface: 'docs', runtime: false }), agent, parallel, phase, () => {});
+    assert.equal(r.reviewRounds, 3, 'docs hard cap is roundCap+1 (2+1)');
+    assert.equal(r.readyForPR, false);
+});
+
+test('the finding ledger reaches round-2 reviewers with fixed and refuted dispositions', async () => {
+    // Round 1: finding A confirmed+fixed, finding B refuted. Round-2 reviewer
+    // prompts must carry both dispositions and the no-re-report rule.
+    const { agent, calls } = makeAgent((_p, opts) => {
+        const l = opts.label || '';
+        if (l === 'review-r1:1')
+            return {
+                findings: [
+                    { file: 'a.js', line: 1, severity: 'major', summary: 'A real defect', failureScenario: 'x' },
+                    { file: 'b.js', line: 2, severity: 'major', summary: 'B bogus claim', failureScenario: 'y' },
+                ],
+            };
+        if (l === 'verify-r1:1') return { real: true, reason: 'A reproduces' };
+        if (l === 'verify-r1:2') return { real: false, reason: 'B impossible: guarded upstream' };
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
+    assert.equal(r.loopClean, true, 'round 2 is clean');
+    const round2 = calls.filter((c) => /^(review|sol)-r2:/.test(c.opts.label || ''));
+    assert.ok(round2.length, 'round 2 reviewers ran');
+    for (const c of round2) {
+        assert.match(c.prompt, /FINDING LEDGER/, 'ledger block present');
+        assert.match(c.prompt, /A real defect/, 'fixed finding listed');
+        assert.match(c.prompt, /B impossible: guarded upstream/, 'refuted reason carried forward');
+        assert.match(c.prompt, /NEW evidence/, 'no-re-report rule present');
+    }
+    assert.ok(r.ledger.some((e) => e.status === 'fixed'), 'result exposes the fixed entry');
+    assert.ok(r.ledger.some((e) => e.status === 'refuted'), 'result exposes the refuted entry');
+});
+
+test('round-1 reviewers see no ledger block (nothing resolved yet)', async () => {
+    const { agent, calls } = makeAgent(null);
+    await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
+    const round1 = calls.filter((c) => /^(review|sol)-r1:/.test(c.opts.label || ''));
+    assert.ok(round1.length, 'round 1 ran');
+    for (const c of round1) assert.doesNotMatch(c.prompt, /FINDING LEDGER/);
+});
+
+test('reviewMode:"spec" swaps in the spec lenses and the citation rule', async () => {
+    const { agent, calls } = makeAgent(null);
+    await runWorkflow(baseArgs({ surface: 'docs', runtime: false, reviewMode: 'spec' }), agent, parallel, phase, () => {});
+    const reviewPrompts = calls.filter((c) => c.opts.phase === 'Review').map((c) => c.prompt);
+    assert.ok(reviewPrompts.some((p) => /Acceptance traceability/.test(p)), 'spec lens present');
+    assert.ok(reviewPrompts.some((p) => /Implementability/.test(p)), 'spec lens present');
+    assert.ok(reviewPrompts.every((p) => !/Lifecycle & concurrency/.test(p)), 'code lenses are replaced');
+    assert.ok(
+        reviewPrompts.some((p) => /SPEC REVIEW MODE/.test(p) && /NOT findings/.test(p)),
+        'citation + no-editorial-preference rule present',
+    );
+});
+
 test('a verify-fixer that commits but returns null is still caught by the HEAD-sha check', async () => {
     // The fixer commits real code, then dies before reporting (null / throw /
     // omitted commits array). The old commits-array-only detection would leave

--- a/scripts/canopy-loop.workflow.test.js
+++ b/scripts/canopy-loop.workflow.test.js
@@ -453,6 +453,33 @@ test('a verify-fix that commits after a clean review round is not ready-for-PR',
     assert.ok(r.residualRisks.some((s) => /never adversarially reviewed/i.test(s)));
 });
 
+test('envSetup is interpolated into every CONTRACTS prompt and the verify env echo is present', async () => {
+    const { agent, calls } = makeAgent(null);
+    await runWorkflow(
+        baseArgs({ envSetup: 'export DOTNET_ROOT=$HOME/.dotnet; export PATH="$DOTNET_ROOT:$PATH"' }),
+        agent,
+        parallel,
+        phase,
+        () => {},
+    );
+    const impl = calls.find((c) => (c.opts.label || '').startsWith('implement'));
+    const verifyCall = calls.find((c) => c.opts.phase === 'Verify');
+    assert.match(impl.prompt, /ENVIRONMENT \(run before ANY build\/test command/);
+    assert.match(impl.prompt, /DOTNET_ROOT=\$HOME\/\.dotnet/);
+    assert.match(verifyCall.prompt, /DOTNET_ROOT=\$HOME\/\.dotnet/, 'verify inherits the env prelude via CONTRACTS');
+    assert.match(verifyCall.prompt, /command -v dotnet && dotnet --version/, 'verify echoes the toolchain');
+    assert.match(verifyCall.prompt, /\$DOTNET_ROOT precedes the system\ndotnet on PATH/, 'generic PATH-precedence rule');
+});
+
+test('without envSetup no ENVIRONMENT block is injected (default prompts unchanged)', async () => {
+    const { agent, calls } = makeAgent(null);
+    await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
+    assert.ok(
+        calls.every((c) => !/ENVIRONMENT \(run before ANY build\/test command/.test(c.prompt)),
+        'no env block by default',
+    );
+});
+
 test('a below-quorum explore spawns one consolidated recovery explorer and continues', async () => {
     // quick depth = 2 explorers, quorum 2. One fails → recovery explorer covers
     // the gap → the run proceeds normally.

--- a/scripts/canopy-loop.workflow.test.js
+++ b/scripts/canopy-loop.workflow.test.js
@@ -47,7 +47,7 @@ function baseArgs(extra) {
 }
 
 // Canonical "everything succeeds" response for each labelled agent call.
-function happy(opts) {
+function happy(opts, prompt) {
     const label = (opts && opts.label) || '';
     const ph = (opts && opts.phase) || '';
     if (label.startsWith('explore')) return { owningLayer: 'x', files: [{ path: 'a', role: 'r' }], consumers: [], contracts: [], testSeams: [] };
@@ -55,7 +55,12 @@ function happy(opts) {
     if (label.startsWith('implement')) return { changedFiles: ['f'], commits: ['c'], selfConfidence: 'high', openTodos: [] };
     if (ph === 'Review') {
         if (label.startsWith('verify-r')) return { real: false, reason: 'refuted' };
-        if (label.startsWith('fix-r')) return { applied: ['a'], commits: ['c'] };
+        if (label.startsWith('fix-r')) {
+            // A fully-resolving fixer: echo back every confirmed finding id in the
+            // prompt as applied (the loop now trusts applied/unresolved by id).
+            const ids = [...String(prompt || '').matchAll(/"id":\s*"(r\d+f\d+)"/g)].map((m) => m[1]);
+            return { applied: ids, unresolved: [], commits: ['c'] };
+        }
         return { findings: [] }; // reviewers: review-r*, sol-r*, sol-cli-r*
     }
     if (ph === 'Verify') {
@@ -79,7 +84,7 @@ function makeAgent(override) {
                 return r;
             }
         }
-        return happy(opts);
+        return happy(opts, prompt);
     };
     return { agent, calls };
 }
@@ -331,7 +336,7 @@ test('a throwing review fixer exhausts the round cap and is never ready-for-PR',
     const r = await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
     // Workflow resolves with a structured result rather than throwing out.
     assert.equal(typeof r, 'object');
-    assert.ok(r.confirmedFindingsResolved >= 1);
+    assert.equal(r.confirmedFindingsResolved, 0, 'a throwing fixer applies nothing → nothing counts resolved');
     assert.equal(r.loopClean, false, 'a round with an unfixed confirmed finding is not clean');
     assert.equal(r.reviewIncomplete, false, 'coverage was complete — the finding was confirmed, not lost');
     assert.equal(r.readyForPR, false, 'unresolved confirmed findings must block ready-for-PR');
@@ -339,6 +344,62 @@ test('a throwing review fixer exhausts the round cap and is never ready-for-PR',
         r.residualRisks.some((s) => /round cap with unresolved confirmed findings/i.test(s)),
         'the round-cap residual risk is reported',
     );
+});
+
+test('a fixer that reports a finding unresolved blocks certification even if a later round is clean', async () => {
+    // The reproduced fail-open: the fixer explicitly returns applied:[],
+    // unresolved:[id], yet the next round happens to come back empty. Trusting that
+    // empty round would certify a still-present defect — the fixer's own report
+    // must block it.
+    const { agent } = makeAgent((_p, opts) => {
+        const l = opts.label || '';
+        if (l === 'review-r1:1') return finding('needs a real fix');
+        if (l === 'verify-r1:1') return { real: true, reason: 'confirmed' };
+        if (l === 'fix-r1') return { applied: [], unresolved: ['r1f1'], commits: [] }; // fixer admits it could not fix
+        return undefined; // round 2 reviewers return empty (a non-deterministic miss)
+    });
+    const r = await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
+    assert.equal(r.loopClean, true, 'round 2 was clean (reviewers missed the still-present defect)');
+    assert.equal(r.reviewIncomplete, false, 'coverage itself was complete — this is a fixer failure, not a lost scope');
+    assert.equal(r.readyForPR, false, 'an unresolved confirmed finding must block ready-for-PR');
+    assert.equal(r.confirmedFindingsResolved, 0, 'nothing was actually applied');
+    assert.ok(r.residualRisks.some((s) => /unapplied\/unresolved/i.test(s)));
+    assert.ok(!r.ledger.some((e) => e.status === 'fixed'), 'an unfixed finding is never ledgered as fixed');
+});
+
+test('a fixer that applies only SOME confirmed findings does not certify', async () => {
+    // Two confirmed findings; the fixer applies one and silently drops the other
+    // (neither in applied nor unresolved). Fail closed on the dropped id.
+    const { agent } = makeAgent((_p, opts) => {
+        const l = opts.label || '';
+        if (l === 'review-r1:1')
+            return {
+                findings: [
+                    { file: 'a.js', line: 1, severity: 'major', summary: 'A', failureScenario: 'x' },
+                    { file: 'b.js', line: 2, severity: 'major', summary: 'B', failureScenario: 'y' },
+                ],
+            };
+        if (/^verify-r1:\d+$/.test(l)) return { real: true, reason: 'both real' };
+        if (l === 'fix-r1') return { applied: ['r1f1'], unresolved: [], commits: ['c'] }; // r1f2 dropped
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
+    assert.equal(r.readyForPR, false, 'a confirmed finding neither applied nor unresolved blocks certification');
+    assert.equal(r.confirmedFindingsResolved, 1, 'only the applied finding is counted resolved');
+});
+
+test('a fixer that fully applies every confirmed finding certifies (applied ids honored)', async () => {
+    const { agent } = makeAgent((_p, opts) => {
+        const l = opts.label || '';
+        if (l === 'review-r1:1') return finding('fix me');
+        if (l === 'verify-r1:1') return { real: true, reason: 'confirmed' };
+        if (l === 'fix-r1') return { applied: ['r1f1'], unresolved: [], commits: ['c'] };
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
+    assert.equal(r.confirmedFindingsResolved, 1, 'the applied finding counts as resolved');
+    assert.equal(r.readyForPR, true);
+    assert.ok(r.ledger.some((e) => e.status === 'fixed'));
 });
 
 test('a throwing verify fixer does not abort the whole workflow', async () => {

--- a/scripts/canopy-loop.workflow.test.js
+++ b/scripts/canopy-loop.workflow.test.js
@@ -453,6 +453,42 @@ test('a verify-fix that commits after a clean review round is not ready-for-PR',
     assert.ok(r.residualRisks.some((s) => /never adversarially reviewed/i.test(s)));
 });
 
+test('issue + no briefText: a Phase-0 agent hydrates the brief from the live issue', async () => {
+    const { agent, calls } = makeAgent((_p, opts) => {
+        if ((opts.label || '') === 'fetch-issue')
+            return { number: 452, title: 'Fix the widget', body: 'THE LIVE ISSUE BODY with acceptance criteria', url: 'https://x/452', updatedAt: '2026-07-20' };
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs({ issue: 452 }), agent, parallel, phase, () => {});
+    const fetch = calls.find((c) => (c.opts.label || '') === 'fetch-issue');
+    assert.ok(fetch, 'fetch-issue agent spawned');
+    assert.match(fetch.prompt, /gh issue view 452 --json number,title,body,url,updatedAt/);
+    assert.equal(fetch.opts.effort, 'low', 'the fetch is cheap');
+    const impl = calls.find((c) => (c.opts.label || '').startsWith('implement'));
+    assert.match(impl.prompt, /THE LIVE ISSUE BODY with acceptance criteria/, 'hydrated body reaches CONTRACTS');
+    assert.match(impl.prompt, /authoritative — read in full/, 'hydrated brief is treated as inlined brief text');
+    assert.equal(r.readyForPR, true);
+});
+
+test('an explicit briefText suppresses the issue fetch (launcher brief stays authoritative)', async () => {
+    const { agent, calls } = makeAgent(null);
+    await runWorkflow(baseArgs({ issue: 452, briefText: 'MANUAL BRIEF' }), agent, parallel, phase, () => {});
+    assert.ok(!calls.some((c) => (c.opts.label || '') === 'fetch-issue'), 'no fetch when briefText supplied');
+    const impl = calls.find((c) => (c.opts.label || '').startsWith('implement'));
+    assert.match(impl.prompt, /MANUAL BRIEF/);
+});
+
+test('a failed issue fetch falls back to the brief-path behavior', async () => {
+    const { agent, calls } = makeAgent((_p, opts) => {
+        if ((opts.label || '') === 'fetch-issue') return null;
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs({ issue: 452 }), agent, parallel, phase, () => {});
+    const impl = calls.find((c) => (c.opts.label || '').startsWith('implement'));
+    assert.match(impl.prompt, /brief text not inlined; open the path above/, 'existing brief-path fallback preserved');
+    assert.equal(r.readyForPR, true, 'a failed fetch alone never blocks the run');
+});
+
 test('envSetup is interpolated into every CONTRACTS prompt and the verify env echo is present', async () => {
     const { agent, calls } = makeAgent(null);
     await runWorkflow(

--- a/scripts/canopy-loop.workflow.test.js
+++ b/scripts/canopy-loop.workflow.test.js
@@ -619,10 +619,36 @@ test('codex-cli preflight: a healthy codex CLI leaves the Sol route live', async
     assert.ok(calls.some((c) => (c.opts.label || '').startsWith('sol-cli-r')), 'codex harness runs on a live route');
 });
 
-test('the preflight probe does not run on the agent route', async () => {
+test('the codex preflight does not run on the agent route (the agent-route probe does)', async () => {
     const { agent, calls } = makeAgent(null);
     await runWorkflow(baseArgs({ solVia: 'agent' }), agent, parallel, phase, () => {});
     assert.ok(!calls.some((c) => (c.opts.label || '') === 'codex-preflight'), 'no codex preflight when solVia is agent');
+    const probe = calls.find((c) => (c.opts.label || '') === 'sol-agent-preflight');
+    assert.ok(probe, 'the agent route runs its own gpt-5.6-sol probe');
+    assert.equal(probe.opts.model, 'gpt-5.6-sol', 'the probe exercises the real router model');
+});
+
+test('the codex preflight probes the real route (a minimal gpt-5.6-sol request), not just install', async () => {
+    const { agent, calls } = makeAgent(null);
+    await runWorkflow(baseArgs({ solVia: 'codex-cli' }), agent, parallel, phase, () => {});
+    const probe = calls.find((c) => (c.opts.label || '') === 'codex-preflight');
+    assert.ok(probe, 'codex preflight spawned');
+    assert.match(probe.prompt, /codex -a never -s read-only exec/, 'the probe runs a real codex exec');
+    assert.match(probe.prompt, /-m "gpt-5\.6-sol"/, 'the probe uses the configured model');
+    assert.match(probe.prompt, /auth\/model\/route\/quota error/, 'a broken route (not just a missing binary) fails the probe');
+});
+
+test('an unroutable agent-route Sol at preflight marks the route dead without pausing the run', async () => {
+    // The agent route probe returns null (unroutable). Sol is marked dead up front;
+    // the run continues on Claude fallbacks rather than pausing.
+    const { agent, calls } = makeAgent((_p, opts) => {
+        if ((opts.label || '') === 'sol-agent-preflight') return null;
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs({ solVia: 'agent' }), agent, parallel, phase, () => {});
+    assert.equal(r.status, 'complete', 'a dead Sol route at preflight does not pause the Claude run');
+    assert.equal(r.modelCoverage.solDead, true, 'the Sol route is marked dead up front');
+    assert.ok(!calls.some((c) => /^sol-r\d+:/.test(c.opts.label || '') && c.opts.model === 'gpt-5.6-sol'), 'no doomed Sol review spawns after the route is known dead');
 });
 
 test('a non-split round still runs at least one whole-diff Sol reviewer at solReviewers:0', async () => {

--- a/scripts/canopy-loop.workflow.test.js
+++ b/scripts/canopy-loop.workflow.test.js
@@ -453,6 +453,56 @@ test('a verify-fix that commits after a clean review round is not ready-for-PR',
     assert.ok(r.residualRisks.some((s) => /never adversarially reviewed/i.test(s)));
 });
 
+test('three consecutive Sol failures trip the breaker: later rounds spawn no Sol attempts', async () => {
+    // Every Sol-routed agent throws (dead router). Round 1 burns its attempts
+    // (that is where the 3 consecutive failures accrue); a confirmed finding
+    // forces round 2, which must go STRAIGHT to Claude — zero sol-r2 spawns.
+    const { agent, calls } = makeAgent((_p, opts) => {
+        const l = opts.label || '';
+        if (opts.model === 'gpt-5.6-sol') return { __throw: 'router down' };
+        if (l === 'review-r1:1') return finding('real defect');
+        if (l === 'verify-r1:1') return { real: true, reason: 'confirmed' };
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
+    assert.ok(r.reviewRounds >= 2, 'a second round ran');
+    assert.ok(!calls.some((c) => /^sol-r2:/.test(c.opts.label || '')), 'no Sol reviewer spawned after the breaker tripped');
+    assert.ok(calls.some((c) => /^review-r2:/.test(c.opts.label || '')), 'round-2 scopes covered by Claude');
+    assert.equal(r.modelCoverage.solDead, true);
+    assert.ok(r.modelCoverage.roundsWithoutSol.includes(1), 'the Sol-less round is visible');
+    assert.ok(
+        r.residualRisks.some((s) => /WITHOUT real cross-family/i.test(s)),
+        'the lost cross-family coverage is a named residual risk',
+    );
+});
+
+test('modelCoverage reports requested vs actual per slot class on a healthy run', async () => {
+    const { agent } = makeAgent(null);
+    const r = await runWorkflow(baseArgs({ depth: 'standard' }), agent, parallel, phase, () => {});
+    assert.equal(r.modelCoverage.solDead, false);
+    assert.deepEqual(r.modelCoverage.roundsWithoutSol, []);
+    assert.ok(r.modelCoverage.slots.Explore.ranSol >= 1, 'explore Sol slots recorded');
+    assert.ok(r.modelCoverage.slots.Review.ranSol >= 1, 'review Sol slots recorded');
+    assert.equal(r.modelCoverage.slots.Explore.claudeFallback, 0, 'no silent fallbacks on a healthy route');
+});
+
+test('a Sol success resets the breaker counter (two failures never trip it)', async () => {
+    // Sol lens slots fail twice in round 1 but the whole-diff Sol reviewer
+    // succeeds — the counter resets, solDead stays false.
+    let solFails = 0;
+    const { agent } = makeAgent((_p, opts) => {
+        const l = opts.label || '';
+        if (opts.model === 'gpt-5.6-sol' && /^sol-r1:[12]$/.test(l) && solFails < 2) {
+            solFails++;
+            return { __throw: 'transient' };
+        }
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
+    assert.equal(r.modelCoverage.solDead, false, 'two non-consecutive-with-success failures never kill the route');
+    assert.equal(r.readyForPR, true);
+});
+
 test('docs surface: confirmed minors become advisory notes and the round counts clean', async () => {
     // A confirmed MINOR wording-adjacent defect on a docs surface must not force
     // another full fix round: it is reported in advisoryNotes and the round is

--- a/scripts/canopy-loop.workflow.test.js
+++ b/scripts/canopy-loop.workflow.test.js
@@ -471,6 +471,37 @@ test('codex-cli: a THROWING codex harness falls back to Claude, not a lost scope
     assert.ok(r.confirmedFindingsResolved >= 1, 'thrown codex scope covered by the Claude fallback');
 });
 
+test('codex-cli preflight: an unavailable codex CLI trips the breaker before any Sol slot spawns', async () => {
+    // The route is statically known at launch, so one cheap probe short-circuits a
+    // dead codex-cli route instead of burning a harness agent + Claude fallback per
+    // Sol slot before the runtime breaker trips.
+    const { agent, calls } = makeAgent((_p, opts) => {
+        if ((opts.label || '') === 'codex-preflight') return { available: false, version: '' };
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs({ solVia: 'codex-cli' }), agent, parallel, phase, () => {});
+    assert.ok(calls.some((c) => (c.opts.label || '') === 'codex-preflight'), 'preflight probe spawned on the codex-cli route');
+    assert.equal(r.modelCoverage.solDead, true, 'a missing codex CLI marks the Sol route dead up front');
+    assert.ok(!calls.some((c) => (c.opts.label || '').startsWith('sol-cli-r')), 'no codex harness spawned once the route is known dead');
+    assert.ok(calls.some((c) => (c.opts.label || '').startsWith('explore')), 'explore still runs (on Claude)');
+});
+
+test('codex-cli preflight: a healthy codex CLI leaves the Sol route live', async () => {
+    const { agent, calls } = makeAgent((_p, opts) => {
+        if ((opts.label || '') === 'codex-preflight') return { available: true, version: 'codex 1.2.3' };
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs({ solVia: 'codex-cli' }), agent, parallel, phase, () => {});
+    assert.equal(r.modelCoverage.solDead, false, 'a healthy probe does not trip the breaker');
+    assert.ok(calls.some((c) => (c.opts.label || '').startsWith('sol-cli-r')), 'codex harness runs on a live route');
+});
+
+test('the preflight probe does not run on the agent route', async () => {
+    const { agent, calls } = makeAgent(null);
+    await runWorkflow(baseArgs({ solVia: 'agent' }), agent, parallel, phase, () => {});
+    assert.ok(!calls.some((c) => (c.opts.label || '') === 'codex-preflight'), 'no codex preflight when solVia is agent');
+});
+
 test('a non-split round still runs at least one whole-diff Sol reviewer at solReviewers:0', async () => {
     // modelSplit:false + solReviewers:0 must NOT yield a Sol-less round: the
     // Math.max(1, SOL_REVIEWERS) floor keeps the "≥1 whole-diff Sol reviewer per

--- a/scripts/canopy-loop.workflow.test.js
+++ b/scripts/canopy-loop.workflow.test.js
@@ -949,6 +949,23 @@ test('non-docs surfaces still fix confirmed minors (severity gate is docs/spec-s
     assert.ok(r.confirmedFindingsResolved >= 1);
 });
 
+test('docs/spec reviews carry a severity rubric and verifiers are required to return severity', async () => {
+    // The docs/spec severity gate defaults an omitted severity to major and churns
+    // an extra fix round; the finding bar now ships an explicit rubric and the
+    // verifier prompt (and schema) require severity so it is never omitted.
+    const { agent, calls } = makeAgent((_p, opts) => {
+        if (opts.label === 'review-r1:1')
+            return { findings: [{ file: 'docs/a.md', line: 3, severity: 'minor', summary: 's', failureScenario: 'x' }] };
+        if ((opts.label || '').startsWith('verify-r1')) return { real: true, severity: 'minor', reason: 'cosmetic' };
+        return undefined;
+    });
+    await runWorkflow(baseArgs({ surface: 'docs', runtime: false }), agent, parallel, phase, () => {});
+    const review = calls.find((c) => (c.opts.label || '').startsWith('review-r1'));
+    assert.match(review.prompt, /SEVERITY \(required on EVERY finding/, 'docs finding bar ships the severity rubric');
+    const verify = calls.find((c) => (c.opts.label || '').startsWith('verify-r1'));
+    assert.match(verify.prompt, /Return severity \(blocker\/major\/minor\) REQUIRED/, 'verifier is required to return severity');
+});
+
 test('docs surface: the hard round cap defaults to roundCap+1, not 10', async () => {
     // quick depth → mixed roundCap 2 → docs hard cap 3. A blocker every round
     // with a throwing fixer must stop after 3 rounds instead of churning to 10.

--- a/scripts/canopy-loop.workflow.test.js
+++ b/scripts/canopy-loop.workflow.test.js
@@ -211,6 +211,26 @@ test('a fully-failed reviewer slot does not certify a clean round (fail closed)'
     assert.ok(r.residualRisks.some((s) => /incomplete coverage/i.test(s)));
 });
 
+test('a single confirmed finding whose lone verifier flakes does NOT pause the run as an outage', async () => {
+    // Late review rounds routinely carry exactly ONE finding. Its verifier batch
+    // has a single element; a lone null verdict there is a per-agent flake, not a
+    // provider outage. It must NOT trip batchOutage (which would pause the whole
+    // run, skipping the fixer/Localize/Verify). The finding stays unresolved
+    // (reviewIncomplete), the run COMPLETES, and Verify still runs.
+    const { agent, calls } = makeAgent((_p, opts) => {
+        const l = opts.label || '';
+        if (l === 'review-r1:1') return finding('lone late-round defect');
+        if (l.startsWith('verify-r')) return null; // the single verifier returns null
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
+    assert.equal(r.status, 'complete', 'a 1-finding/1-null-verifier round is NOT a provider outage');
+    assert.notEqual(r.resumeFrom && r.resumeFrom.phase, 'review', 'the run is not paused for resume');
+    assert.equal(r.reviewIncomplete, true, 'the unverified finding leaves coverage incomplete');
+    assert.equal(r.readyForPR, false);
+    assert.ok(calls.some((c) => c.opts.phase === 'Verify'), 'verify still runs after a lone verifier flake');
+});
+
 test('a finding whose verifier fails is treated as unresolved, not refuted', async () => {
     const { agent } = makeAgent((_p, opts) => {
         const l = opts.label || '';

--- a/scripts/canopy-loop.workflow.test.js
+++ b/scripts/canopy-loop.workflow.test.js
@@ -453,6 +453,26 @@ test('a verify-fix that commits after a clean review round is not ready-for-PR',
     assert.ok(r.residualRisks.some((s) => /never adversarially reviewed/i.test(s)));
 });
 
+test('every explorer contributes to the plan digest (equal-share, not head-slice)', async () => {
+    // 8 large explorer maps: a 12KB head-slice only ever showed the first ~3.
+    // With the per-item budget, the FIRST and the LAST explorer's identifying
+    // marker must both reach the planners.
+    const { agent, calls } = makeAgent((_p, opts) => {
+        const m = /^explore:(\d+)/.exec(opts.label || '');
+        if (m)
+            return {
+                owningLayer: `MARKER_EXPLORER_${m[1]}`,
+                files: [{ path: 'a', role: 'x'.repeat(3000) }],
+                consumers: [], contracts: [], testSeams: [],
+            };
+        return undefined;
+    });
+    await runWorkflow(baseArgs({ depth: 'standard' }), agent, parallel, phase, () => {});
+    const plan = calls.find((c) => (c.opts.label || '').startsWith('plan:'));
+    assert.match(plan.prompt, /MARKER_EXPLORER_1\b/, 'first explorer present');
+    assert.match(plan.prompt, /MARKER_EXPLORER_8\b/, 'last explorer present (was dropped by the head-slice)');
+});
+
 test('a docs run explores 4 docs-relevant angles and skips Localize', async () => {
     const { agent, calls } = makeAgent(null);
     const r = await runWorkflow(baseArgs({ surface: 'docs', runtime: false, depth: 'standard' }), agent, parallel, phase, () => {});

--- a/scripts/canopy-loop.workflow.test.js
+++ b/scripts/canopy-loop.workflow.test.js
@@ -703,15 +703,34 @@ test('an explicit briefText suppresses the issue fetch (launcher brief stays aut
     assert.match(impl.prompt, /MANUAL BRIEF/);
 });
 
-test('a failed issue fetch falls back to the brief-path behavior', async () => {
+test('a failed issue fetch with no other task source pauses before the writer (fail closed)', async () => {
+    // issue:N was the intended brief source; the fetch failed and nothing else
+    // authoritative was supplied. Running agents on placeholders would implement
+    // AND certify with no acceptance criteria — pause instead.
     const { agent, calls } = makeAgent((_p, opts) => {
         if ((opts.label || '') === 'fetch-issue') return null;
         return undefined;
     });
     const r = await runWorkflow(baseArgs({ issue: 452 }), agent, parallel, phase, () => {});
+    assert.equal(r.status, 'paused');
+    assert.equal(r.resumeFrom.phase, 'explore');
+    assert.match(r.pauseReason, /hydration failed|authoritative requirements/i);
+    assert.ok(!calls.some((c) => (c.opts.label || '').startsWith('explore')), 'no explorers without authoritative requirements');
+    assert.ok(!calls.some((c) => (c.opts.label || '').startsWith('implement')), 'no writer without authoritative requirements');
+    assert.equal(r.readyForPR, false);
+    assert.ok(r.residualRisks.some((s) => /PAUSED .*resume/i.test(s)));
+});
+
+test('a failed issue fetch still runs when an explicit task was supplied (brief-path fallback preserved)', async () => {
+    const { agent, calls } = makeAgent((_p, opts) => {
+        if ((opts.label || '') === 'fetch-issue') return null;
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs({ issue: 452, task: 'EXPLICIT TASK, no fetch needed' }), agent, parallel, phase, () => {});
     const impl = calls.find((c) => (c.opts.label || '').startsWith('implement'));
     assert.match(impl.prompt, /brief text not inlined; open the path above/, 'existing brief-path fallback preserved');
-    assert.equal(r.readyForPR, true, 'a failed fetch alone never blocks the run');
+    assert.match(impl.prompt, /EXPLICIT TASK, no fetch needed/);
+    assert.equal(r.readyForPR, true, 'a failed fetch does not block when a task was supplied');
 });
 
 test('envSetup is interpolated into every CONTRACTS prompt and the verify env echo is present', async () => {

--- a/scripts/canopy-loop.workflow.test.js
+++ b/scripts/canopy-loop.workflow.test.js
@@ -1075,6 +1075,28 @@ test('the finding ledger carries EVERY disposition to later rounds (equal-share,
     }
 });
 
+test('a seeded ledger (args.ledger) reaches round-1 reviewers on a review resume', async () => {
+    // A limit-killed run persists its ledger; the launcher passes it back on the
+    // startPhase:"review" resume. Round-1 reviewers must see those prior
+    // dispositions so they do not re-litigate items an earlier session already
+    // fixed or refuted. Only {file,status} entries are seeded, marked round:0.
+    const seeded = [
+        { file: 'x.js', line: 5, summary: 'SEEDED_REFUTED item', status: 'refuted', reason: 'guarded upstream' },
+        { file: 'y.js', line: 8, summary: 'SEEDED_FIXED item', status: 'fixed', reason: 'applied last session' },
+        { garbage: true }, // no file/status → filtered out, never reaches a reviewer
+    ];
+    const { agent, calls } = makeAgent(null);
+    const r = await runWorkflow(baseArgs({ startPhase: 'review', ledger: seeded }), agent, parallel, phase, () => {});
+    const round1 = calls.filter((c) => /^(review|sol)-r1:/.test(c.opts.label || ''));
+    assert.ok(round1.length, 'round 1 reviewers ran on resume');
+    for (const c of round1) {
+        assert.match(c.prompt, /FINDING LEDGER/, 'seeded ledger present in round 1 on resume');
+        assert.match(c.prompt, /SEEDED_REFUTED item/, 'seeded refuted disposition carried to round 1');
+        assert.match(c.prompt, /SEEDED_FIXED item/, 'seeded fixed disposition carried to round 1');
+    }
+    assert.ok(r.ledger.some((e) => /SEEDED_REFUTED/.test(e.summary) && e.round === 0), 'seeded entries persist in the returned ledger marked round:0');
+});
+
 test('round-1 reviewers see no ledger block (nothing resolved yet)', async () => {
     const { agent, calls } = makeAgent(null);
     await runWorkflow(baseArgs(), agent, parallel, phase, () => {});

--- a/scripts/canopy-loop.workflow.test.js
+++ b/scripts/canopy-loop.workflow.test.js
@@ -658,6 +658,41 @@ test('a verifier failure alongside a confirmed finding marks coverage incomplete
     assert.ok(r.residualRisks.some((s) => /incomplete coverage/i.test(s)));
 });
 
+test('an infrastructure-empty Verify result re-verifies read-only instead of spawning a code fixer', async () => {
+    // The verify AGENT returns nothing (runner/infra failure), so safely() yields
+    // the sentinel { gates: [], allBlockingPassed: false, failures: ['…did not
+    // return structured output'] }. That is not a code defect a fixer can act on —
+    // the loop must re-run Verify read-only rather than launch a code-writing
+    // verify-fixer against an empty failures list.
+    let verifyRuns = 0;
+    const { agent, calls } = makeAgent((_p, opts) => {
+        const l = opts.label || '';
+        if (opts.phase === 'Verify' && l.startsWith('verify') && !l.startsWith('verify-fix')) {
+            verifyRuns++;
+            return null; // no structured output — infrastructure failure
+        }
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
+    assert.ok(verifyRuns >= 2, 'Verify is retried read-only on an infrastructure failure');
+    assert.ok(!calls.some((c) => (c.opts.label || '').startsWith('verify-fix')), 'no code-writing verify-fixer for an infrastructure-empty result');
+    assert.equal(r.readyForPR, false, 'an unverifiable branch is not ready for PR');
+    assert.equal(r.verifyFixCommitted, false, 'no fixer ran, so nothing is marked as an unreviewed verify-fix commit');
+});
+
+test('a real failed gate (structured evidence) still spawns the verify-fixer', async () => {
+    // Distinct from the infra case: verify returns structured gates naming a
+    // failed blocking gate → a code fixer is the right response.
+    const { agent, calls } = makeAgent((_p, opts) => {
+        const l = opts.label || '';
+        if (l === 'verify') return { gates: [{ name: 'g', pass: false }], allBlockingPassed: false, failures: ['g failed'] };
+        if (l.startsWith('verify-retry')) return { gates: [{ name: 'g', pass: true }], allBlockingPassed: true, e2e: { run: false, pass: true } };
+        return undefined;
+    });
+    await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
+    assert.ok(calls.some((c) => (c.opts.label || '').startsWith('verify-fix')), 'a structured gate failure reaches the verify-fixer');
+});
+
 test('a verify-fix that commits after a clean review round is not ready-for-PR', async () => {
     // Review certifies clean, then a gate fails and VERIFY-FIX commits new code.
     // Those commits never went through adversarial review, so the stale cleanRound

--- a/scripts/canopy-loop.workflow.test.js
+++ b/scripts/canopy-loop.workflow.test.js
@@ -434,10 +434,14 @@ test('codex-cli: an unavailable codex run falls back to Claude instead of a sile
     const harness = calls.find((c) => (c.opts.label || '').startsWith('sol-cli-r'));
     assert.ok(harness, 'codex harness invoked');
     assert.match(harness.prompt, /solUnavailable/, 'harness signals unavailability rather than empty findings');
-    assert.match(harness.prompt, /trap 'rm -f/, 'harness cleans up its temp files');
-    // Randomised, unguessable heredoc delimiter (not the fixed, collidable SOL_PROMPT).
-    assert.match(harness.prompt, /<<'SOL_PROMPT_[a-z0-9]{8,}'/, 'per-run nonce heredoc delimiter');
-    assert.doesNotMatch(harness.prompt, /<<'SOL_PROMPT'\n/, 'no fixed collidable delimiter');
+    assert.match(harness.prompt, /rm -f/, 'harness cleans up its temp files');
+    // Injection-hardened: the prompt is written to a temp file with the Write tool
+    // between <<<PROMPT>>> markers — NO shell heredoc, so no delimiter for an
+    // untrusted brief line to close (mirrors the codexAgent read-only harness).
+    assert.match(harness.prompt, /Write tool/, 'prompt written via the Write tool, not a shell heredoc');
+    assert.match(harness.prompt, /<<<PROMPT>>>/, 'prompt fenced by non-shell markers');
+    assert.doesNotMatch(harness.prompt, /cat > "\$P" <</, 'no shell heredoc in the review harness');
+    assert.doesNotMatch(harness.prompt, /SOL_PROMPT_/, 'the collidable/computable heredoc nonce is gone');
 });
 
 test('codex-cli: a THROWING codex harness falls back to Claude, not a lost scope', async () => {

--- a/scripts/canopy-loop.workflow.test.js
+++ b/scripts/canopy-loop.workflow.test.js
@@ -265,18 +265,20 @@ test('a singleton non-terminal agent failure does NOT trip systemic-failure mode
 });
 
 test('an unroutable Sol lens slot is reviewed by the Claude fallback, not lost', async () => {
-    // Every Sol agent throws (router down); the Claude fallback for one Sol lens
-    // reports a real defect. If the fallback did NOT run, no finding would exist.
+    // ONE Sol lens slot throws (its lens scope must not be dropped); the whole-diff
+    // Sol reviewer still runs, so the round keeps real cross-family coverage. The
+    // Claude fallback for the downed lens reports a real defect — proof the scope
+    // was covered rather than lost.
     const { agent } = makeAgent((_p, opts) => {
         const l = opts.label || '';
-        if (l.startsWith('sol-r')) return { __throw: 'sol unroutable' };
-        if (l === 'review-r1:2') return finding('defect on a Sol-owned lens');
+        if (l === 'sol-r1:2') return { __throw: 'sol lens slot unroutable' }; // one lens slot down
+        if (l === 'review-r1:2') return finding('defect on a Sol-owned lens'); // its Claude fallback catches it
         if (l.startsWith('verify-r1')) return { real: true, reason: 'confirmed' };
         return undefined;
     });
     const r = await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
     assert.ok(r.confirmedFindingsResolved >= 1, 'Sol lens defect surfaced via Claude fallback');
-    assert.equal(r.readyForPR, true);
+    assert.equal(r.readyForPR, true, 'the whole-diff Sol reviewer kept real cross-family coverage');
 });
 
 test('a fully-failed reviewer slot does not certify a clean round (fail closed)', async () => {
@@ -869,6 +871,22 @@ test('three consecutive Sol failures trip the breaker: later rounds spawn no Sol
         r.residualRisks.some((s) => /WITHOUT real cross-family/i.test(s)),
         'the lost cross-family coverage is a named residual risk',
     );
+});
+
+test('a clean review round with NO real Sol coverage cannot certify (mixed-model contract)', async () => {
+    // Every Sol slot is unroutable, so the certifying round ran entirely on Claude
+    // fallbacks — not the documented cross-family review. readyForPR previously
+    // ignored roundsWithoutSol and certified anyway; it must now fail closed.
+    const { agent } = makeAgent((_p, opts) => {
+        if (opts.model === 'gpt-5.6-sol') return { __throw: 'router down' }; // all Sol → Claude fallback
+        return undefined; // Claude reviewers return empty → clean round
+    });
+    const r = await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
+    assert.equal(r.loopClean, true, 'the round itself found nothing');
+    assert.equal(r.modelCoverage.solDead, true, 'the Sol route is dead');
+    assert.equal(r.reviewIncomplete, true, 'a Sol-less certifying round is not a certified review');
+    assert.equal(r.readyForPR, false, 'the mixed-model contract blocks certification without real Sol coverage');
+    assert.ok(r.residualRisks.some((s) => /cross-family/i.test(s)));
 });
 
 test('modelCoverage reports requested vs actual per slot class on a healthy run', async () => {

--- a/scripts/canopy-loop.workflow.test.js
+++ b/scripts/canopy-loop.workflow.test.js
@@ -354,11 +354,13 @@ test('readyForPR is false when the implementer leaves open acceptance-criteria T
     assert.ok(r.residualRisks.some((s) => /open acceptance-criteria TODOs/i.test(s)));
 });
 
-test('a throwing review fixer exhausts the round cap and is never ready-for-PR', async () => {
+test('a throwing review fixer stalls the loop (no progress) and is never ready-for-PR', async () => {
     // EVERY round surfaces the same real, confirmed finding whose fixer throws
-    // (StructuredOutput retry cap). The loop must run to roundCap WITHOUT a clean
-    // round and report the branch as NOT ready — the sole guard of that safety
-    // property. (Also proves a throwing fixer resolves the workflow, never aborts.)
+    // (StructuredOutput retry cap). The fixer applies nothing and the confirmed
+    // count never falls, so the progress-stall detector must stop the loop after
+    // STALL_PATIENCE (default 2) no-progress rounds WITHOUT a clean round and
+    // report the branch as NOT ready — the sole guard of that safety property.
+    // (Also proves a throwing fixer resolves the workflow, never aborts.)
     const { agent } = makeAgent((_p, opts) => {
         const l = opts.label || '';
         // Mixed rounds surface the finding on the Claude lens-0 reviewer; gpt-only
@@ -372,13 +374,15 @@ test('a throwing review fixer exhausts the round cap and is never ready-for-PR',
     const r = await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
     // Workflow resolves with a structured result rather than throwing out.
     assert.equal(typeof r, 'object');
+    assert.equal(r.reviewRounds, 2, 'the loop stalls after STALL_PATIENCE (2) no-progress rounds, not the old fixed cap');
+    assert.equal(r.reviewStalled, true, 'the stop is a progress stall, not a clean round');
     assert.equal(r.confirmedFindingsResolved, 0, 'a throwing fixer applies nothing → nothing counts resolved');
     assert.equal(r.loopClean, false, 'a round with an unfixed confirmed finding is not clean');
     assert.equal(r.reviewIncomplete, false, 'coverage was complete — the finding was confirmed, not lost');
     assert.equal(r.readyForPR, false, 'unresolved confirmed findings must block ready-for-PR');
     assert.ok(
-        r.residualRisks.some((s) => /round cap with unresolved confirmed findings/i.test(s)),
-        'the round-cap residual risk is reported',
+        r.residualRisks.some((s) => /did NOT converge/i.test(s)),
+        'the non-convergence residual risk is reported',
     );
 });
 
@@ -539,6 +543,165 @@ test('review escalates to gpt-5.6-sol-only after the mixed round cap', async () 
     assert.ok(solReviewRounds.has(3) && solReviewRounds.has(5), 'gpt-5.6-sol reviewers run the gpt-only rounds');
     assert.equal(r.readyForPR, false, 'unresolved confirmed findings across the escalation block PR');
     assert.equal(r.reviewRounds, 5, 'the loop ran to the hard round cap');
+});
+
+test('explicit hardRoundCap disables the stall detector (old fixed-count behavior)', async () => {
+    // A caller who passes hardRoundCap wants the OLD fixed behavior: the loop runs
+    // up to exactly that many rounds and the progress-stall early stop is OFF, even
+    // though the same finding re-confirms every round with no progress (which would
+    // otherwise stall at 2). Proves args.hardRoundCap pins the backstop AND turns
+    // off the stall detector.
+    const { agent } = makeAgent((_p, opts) => {
+        const l = opts.label || '';
+        if (/^review-r\d+:1$/.test(l)) return finding('never fixed'); // mixed rounds
+        if (/^sol-r\d+:1$/.test(l)) return finding('never fixed'); // gpt-only rounds
+        if (/^verify-r\d+:1$/.test(l)) return { real: true, reason: 'c' };
+        if (l.startsWith('fix-r')) return { __throw: 'cap' };
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs({ hardRoundCap: 4 }), agent, parallel, phase, () => {});
+    assert.equal(r.reviewRounds, 4, 'runs to the fixed hardRoundCap, not the 2-round stall');
+    assert.equal(r.reviewStalled, false, 'the stall detector is disabled under an explicit hardRoundCap');
+    assert.equal(r.backstopRounds, 4, 'hardRoundCap pins the absolute ceiling');
+    assert.equal(r.readyForPR, false);
+});
+
+test('a steady-progress run runs PAST the old 10-round cap to a clean round', async () => {
+    // The core regression the stall detector fixes: a legitimately-converging change
+    // is never cut off by an arbitrary count. Each round surfaces a DISTINCT
+    // confirmed finding that the fixer APPLIES (progress every round), so the loop
+    // never stalls; the change goes clean at round 12 — past the old fixed cap of 10
+    // — and certifies. (Fixer/verify use the happy defaults: applied ids honored,
+    // gates green.)
+    const { agent } = makeAgent((_p, opts) => {
+        const l = opts.label || '';
+        const m = /^(?:review|sol)-r(\d+):1$/.exec(l);
+        if (m) {
+            const rnd = Number(m[1]);
+            return rnd <= 11 ? finding(`distinct converging defect round ${rnd}`) : { findings: [] };
+        }
+        if (/^verify-r\d+:1$/.test(l)) return { real: true, reason: 'confirmed' };
+        return undefined; // fixer (happy) applies every id → progress each round
+    });
+    const r = await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
+    assert.ok(r.reviewRounds > 10, `steady-progress run is not cut at the old 10-cap (ran ${r.reviewRounds} rounds)`);
+    assert.equal(r.reviewRounds, 12, 'goes clean the round after the last distinct finding');
+    assert.equal(r.reviewStalled, false, 'a converging run never trips the stall detector');
+    assert.equal(r.loopClean, true);
+    assert.equal(r.readyForPR, true, 'a converged + green run certifies');
+    assert.equal(r.confirmedFindingsResolved, 11, 'all 11 progressively-fixed findings counted');
+});
+
+test('a stalled run (2 no-progress rounds) stops early with the non-convergence residual', async () => {
+    // The #167 config-page.js shape: the same confirmed finding recurs and the fixer
+    // never resolves it, so no round makes progress. The stall detector stops after
+    // STALL_PATIENCE (default 2) no-progress rounds and reports non-convergence with
+    // readyForPR:false — instead of grinding to the old 10-round cap.
+    const { agent } = makeAgent((_p, opts) => {
+        const l = opts.label || '';
+        if (/^(?:review|sol)-r\d+:1$/.test(l)) return finding('entangled unfixable defect');
+        if (/^verify-r\d+:1$/.test(l)) return { real: true, reason: 'reproduces' };
+        if (l.startsWith('fix-r')) return { applied: [], unresolved: ['r' + 'x'], commits: [] }; // never resolves
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
+    assert.equal(r.reviewRounds, 2, 'stops after STALL_PATIENCE (2) no-progress rounds');
+    assert.equal(r.reviewStalled, true);
+    assert.equal(r.loopClean, false);
+    assert.equal(r.readyForPR, false, 'a non-converged review must not certify readyForPR');
+    assert.ok(r.residualRisks.some((s) => /did NOT converge/i.test(s)), 'non-convergence residual present');
+    assert.ok(r.residualRisks.some((s) => /splitting the change/i.test(s)), 'residual advises splitting the change');
+});
+
+test('a lower stallPatience stops a no-progress run even sooner', async () => {
+    // args.stallPatience is caller-overridable; patience 1 stalls after a single
+    // no-progress round.
+    const { agent } = makeAgent((_p, opts) => {
+        const l = opts.label || '';
+        if (/^(?:review|sol)-r\d+:1$/.test(l)) return finding('unfixable');
+        if (/^verify-r\d+:1$/.test(l)) return { real: true, reason: 'x' };
+        if (l.startsWith('fix-r')) return { __throw: 'cap' };
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs({ stallPatience: 1 }), agent, parallel, phase, () => {});
+    assert.equal(r.reviewRounds, 1, 'stallPatience 1 stalls after the first no-progress round');
+    assert.equal(r.reviewStalled, true);
+});
+
+test('the runaway backstop halts a forever-progressing (never-converging) run', async () => {
+    // The pathological entangled-file case: every round confirms a NEW distinct
+    // finding that the fixer APPLIES (so it always "makes progress" and never
+    // stalls), yet a new one always appears so it never goes clean. Only the
+    // absolute backstop can stop it. args.backstopRounds pins a low ceiling for the
+    // test; the run halts there, not-clean and not-ready.
+    const { agent } = makeAgent((_p, opts) => {
+        const l = opts.label || '';
+        const m = /^(?:review|sol)-r(\d+):1$/.exec(l);
+        if (m) return finding(`endless distinct defect ${m[1]}`); // a NEW finding every round, forever
+        if (/^verify-r\d+:1$/.test(l)) return { real: true, reason: 'confirmed' };
+        return undefined; // fixer (happy) applies each → progress, never a stall
+    });
+    const r = await runWorkflow(baseArgs({ backstopRounds: 4 }), agent, parallel, phase, () => {});
+    assert.equal(r.backstopRounds, 4, 'the explicit backstop ceiling is honored');
+    assert.equal(r.reviewRounds, 4, 'the backstop halts the forever-progressing run at the ceiling');
+    assert.equal(r.reviewStalled, false, 'it never stalled — it always progressed; the backstop stopped it');
+    assert.equal(r.loopClean, false);
+    assert.equal(r.readyForPR, false);
+    assert.ok(r.residualRisks.some((s) => /runaway backstop/i.test(s)), 'the backstop residual is reported');
+});
+
+test('a pure-oscillation round (re-report of a ledger-refuted finding) stalls immediately', async () => {
+    // Round 1: finding A is REFUTED (ledgered) while an unrelated finding B is
+    // confirmed+fixed (so the round is not clean and the loop continues). Round 2: a
+    // reviewer re-reports A and a verifier confirms it — the confirmed set is WHOLLY
+    // a re-report of a ledger-disposed item, i.e. the loop is re-litigating a
+    // settled finding. That is pure oscillation and must stall at once
+    // (stallOscillation) even though it is only the first no-progress round.
+    const { agent } = makeAgent((_p, opts) => {
+        const l = opts.label || '';
+        if (l === 'review-r1:1')
+            return {
+                findings: [
+                    { file: 'a.js', line: 1, severity: 'major', summary: 'oscillating defect A', failureScenario: 'x' },
+                    { file: 'b.js', line: 2, severity: 'major', summary: 'unrelated defect B', failureScenario: 'y' },
+                ],
+            };
+        if (l === 'verify-r1:1') return { real: false, reason: 'A does not reproduce' }; // refuted → ledgered
+        if (l === 'verify-r1:2') return { real: true, reason: 'B reproduces' }; // confirmed+fixed → progress
+        if (l === 'review-r2:1')
+            return { findings: [{ file: 'a.js', line: 1, severity: 'major', summary: 'oscillating defect A', failureScenario: 'x' }] }; // same fingerprint re-reported
+        if (l === 'verify-r2:1') return { real: true, reason: 'A now claimed real (re-litigated)' };
+        if (l === 'fix-r2') return { __throw: 'cannot fix' };
+        return undefined; // fix-r1 (happy) applies B
+    });
+    const r = await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
+    assert.equal(r.reviewRounds, 2, 'oscillation is detected on the round the settled finding returns');
+    assert.equal(r.reviewStalled, true);
+    assert.equal(r.stallOscillation, true, 'the stall is flagged as pure oscillation');
+    assert.equal(r.readyForPR, false);
+    assert.ok(r.residualRisks.some((s) => /pure oscillation/i.test(s)));
+});
+
+test('severity-gated minors-only round exits clean without triggering stall logic', async () => {
+    // Requirement #4: on a docs/spec surface, a confirmed MINOR becomes an advisory
+    // note and the round counts CLEAN and exits BEFORE any stall/backstop logic. The
+    // run must certify (loopClean, readyForPR) and never be flagged as stalled — the
+    // stall detector only matters when confirmed blocker/major findings keep coming.
+    const { agent, calls } = makeAgent((_p, opts) => {
+        const l = opts.label || '';
+        if (l === 'review-r1:1')
+            return { findings: [{ file: 'docs/a.md', line: 3, severity: 'minor', summary: 'stale phrasing', failureScenario: 'x' }] };
+        if (l.startsWith('verify-r1')) return { real: true, severity: 'minor', reason: 'true but cosmetic' };
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs({ surface: 'docs', runtime: false }), agent, parallel, phase, () => {});
+    assert.equal(r.reviewRounds, 1, 'a minors-only round exits clean at round 1');
+    assert.equal(r.loopClean, true);
+    assert.equal(r.reviewStalled, false, 'a minors-only clean exit never trips the stall detector');
+    assert.ok(r.advisoryNotes.some((s) => /stale phrasing/.test(s)));
+    assert.ok(!calls.some((c) => (c.opts.label || '').startsWith('fix-r')), 'no fixer for minors only');
+    assert.equal(r.readyForPR, true);
+    assert.ok(!r.residualRisks.some((s) => /did NOT converge|runaway backstop/i.test(s)), 'no stall/backstop residual on a clean minors-only run');
 });
 
 test('verify enforces a committed, clean handoff as a blocking gate', async () => {
@@ -1053,9 +1216,12 @@ test('docs/spec reviews carry a severity rubric and verifiers are required to re
     assert.match(verify.prompt, /Return severity \(blocker\/major\/minor\) REQUIRED/, 'verifier is required to return severity');
 });
 
-test('docs surface: the hard round cap defaults to roundCap+1, not 10', async () => {
-    // quick depth → mixed roundCap 2 → docs hard cap 3. A blocker every round
-    // with a throwing fixer must stop after 3 rounds instead of churning to 10.
+test('docs surface: a re-confirmed blocker with no progress stalls fast (well under the backstop)', async () => {
+    // quick depth → mixed roundCap 2 → docs backstop roundCap+1 = 3. A blocker
+    // re-confirmed every round with a throwing fixer makes no progress, so the
+    // stall detector stops it at STALL_PATIENCE (2) rounds — before the docs
+    // backstop — instead of the old fixed 10-round churn. (The minors→advisory
+    // clean exit is unaffected; only blocker/major churn reaches the stall path.)
     const { agent } = makeAgent((_p, opts) => {
         const l = opts.label || '';
         if (/^review-r\d+:1$/.test(l)) return finding('real blocker'); // mixed rounds
@@ -1065,7 +1231,9 @@ test('docs surface: the hard round cap defaults to roundCap+1, not 10', async ()
         return undefined;
     });
     const r = await runWorkflow(baseArgs({ surface: 'docs', runtime: false }), agent, parallel, phase, () => {});
-    assert.equal(r.reviewRounds, 3, 'docs hard cap is roundCap+1 (2+1)');
+    assert.equal(r.backstopRounds, 3, 'docs backstop stays low (roundCap+1 = 2+1)');
+    assert.equal(r.reviewRounds, 2, 'the stall detector stops docs churn at STALL_PATIENCE (2), under the backstop');
+    assert.equal(r.reviewStalled, true);
     assert.equal(r.readyForPR, false);
 });
 

--- a/scripts/canopy-loop.workflow.test.js
+++ b/scripts/canopy-loop.workflow.test.js
@@ -136,6 +136,38 @@ test('an all-null explore batch is treated as a provider outage and pauses befor
     assert.ok(!calls.some((c) => c.opts.phase === 'Verify'), 'no verify spawned during an outage');
 });
 
+test('startPhase:"review" skips explore/plan/implement and can still certify readyForPR', async () => {
+    const { agent, calls } = makeAgent(null);
+    const r = await runWorkflow(baseArgs({ startPhase: 'review' }), agent, parallel, phase, () => {});
+    assert.ok(!calls.some((c) => (c.opts.label || '').startsWith('explore')), 'no explorers on resume');
+    assert.ok(!calls.some((c) => (c.opts.label || '').startsWith('plan')), 'no planners on resume');
+    assert.ok(!calls.some((c) => (c.opts.label || '').startsWith('implement')), 'no implementer on resume');
+    assert.ok(calls.some((c) => c.opts.phase === 'Review'), 'review loop runs');
+    assert.ok(calls.some((c) => c.opts.phase === 'Verify'), 'verify runs');
+    assert.equal(r.implement.resumed, true, 'implementation is a synthesized resume placeholder');
+    assert.equal(r.loopClean, true);
+    assert.equal(r.readyForPR, true, 'a full review + green gates on resume can certify the branch');
+});
+
+test('startPhase:"verify" runs gates only and can NEVER certify readyForPR (fail closed)', async () => {
+    const { agent, calls } = makeAgent(null);
+    const r = await runWorkflow(baseArgs({ startPhase: 'verify' }), agent, parallel, phase, () => {});
+    assert.ok(!calls.some((c) => c.opts.phase === 'Review'), 'no review agents on a verify-only resume');
+    assert.ok(calls.some((c) => c.opts.phase === 'Verify'), 'verify runs');
+    assert.equal(r.loopClean, false);
+    assert.equal(r.reviewIncomplete, true);
+    assert.equal(r.readyForPR, false, 'green gates without review must not certify');
+    assert.ok(r.residualRisks.some((s) => /review loop was SKIPPED/i.test(s)));
+});
+
+test('an unknown startPhase falls back to a full run', async () => {
+    const { agent, calls } = makeAgent(null);
+    const r = await runWorkflow(baseArgs({ startPhase: 'implment' }), agent, parallel, phase, () => {});
+    assert.ok(calls.some((c) => (c.opts.label || '').startsWith('explore')), 'explorers run');
+    assert.equal(r.startPhase, 'explore');
+    assert.equal(r.readyForPR, true);
+});
+
 test('a singleton non-terminal agent failure does NOT trip systemic-failure mode', async () => {
     // One explorer dying for its own reasons is the existing, expected fallback
     // path — the run must complete normally (fail-closed semantics unchanged).

--- a/scripts/canopy-loop.workflow.test.js
+++ b/scripts/canopy-loop.workflow.test.js
@@ -453,6 +453,57 @@ test('a verify-fix that commits after a clean review round is not ready-for-PR',
     assert.ok(r.residualRisks.some((s) => /never adversarially reviewed/i.test(s)));
 });
 
+test('a verify-fixer that commits but returns null is still caught by the HEAD-sha check', async () => {
+    // The fixer commits real code, then dies before reporting (null / throw /
+    // omitted commits array). The old commits-array-only detection would leave
+    // verifyFixCommitted false and certify unreviewed code. HEAD moving between
+    // the failing verify and the green re-verify must mark the branch unreviewed
+    // regardless of what the fixer reported.
+    const { agent } = makeAgent((_p, opts) => {
+        const l = opts.label || '';
+        if (l === 'verify') return { gates: [{ name: 'g', pass: false }], allBlockingPassed: false, failures: ['boom'], headSha: 'aaa111' };
+        if (l.startsWith('verify-retry')) return { gates: [{ name: 'g', pass: true }], allBlockingPassed: true, e2e: { run: false, pass: true }, headSha: 'bbb222' };
+        if (l.startsWith('verify-fix')) return null; // committed, then failed to report
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
+    assert.equal(r.loopClean, true, 'the review round itself was clean');
+    assert.equal(r.verifyFixCommitted, true, 'HEAD moved after a verify-fix → unreviewed commits');
+    assert.equal(r.readyForPR, false);
+    assert.ok(r.residualRisks.some((s) => /never adversarially reviewed/i.test(s)));
+});
+
+test('an unverifiable HEAD after a verify-fix fails closed', async () => {
+    // If the re-verify cannot report HEAD at all, the loop cannot prove the
+    // fixer did NOT commit — treat the branch as unreviewed (fail closed).
+    const { agent } = makeAgent((_p, opts) => {
+        const l = opts.label || '';
+        if (l === 'verify') return { gates: [{ name: 'g', pass: false }], allBlockingPassed: false, failures: ['boom'], headSha: 'aaa111' };
+        if (l.startsWith('verify-retry')) return { gates: [{ name: 'g', pass: true }], allBlockingPassed: true, e2e: { run: false, pass: true } }; // no headSha
+        if (l.startsWith('verify-fix')) return { applied: [], commits: [] }; // claims nothing committed
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
+    assert.equal(r.verifyFixCommitted, true, 'unreadable HEAD after a fix attempt fails closed');
+    assert.equal(r.readyForPR, false);
+});
+
+test('an unchanged HEAD across a no-op verify-fix attempt stays ready-for-PR', async () => {
+    // The fixer ran but proved it committed nothing, and HEAD is identical
+    // across verify runs — the reviewed range is unchanged, so a green re-verify
+    // may certify.
+    const { agent } = makeAgent((_p, opts) => {
+        const l = opts.label || '';
+        if (l === 'verify') return { gates: [{ name: 'g', pass: false }], allBlockingPassed: false, failures: ['flake'], headSha: 'aaa111' };
+        if (l.startsWith('verify-retry')) return { gates: [{ name: 'g', pass: true }], allBlockingPassed: true, e2e: { run: false, pass: true }, headSha: 'aaa111' };
+        if (l.startsWith('verify-fix')) return { applied: [], commits: [] };
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
+    assert.equal(r.verifyFixCommitted, false, 'identical HEAD + empty commits report → nothing unreviewed');
+    assert.equal(r.readyForPR, true);
+});
+
 test('an unknown surface coerces to cross and runs every surface gate', async () => {
     const { agent, calls } = makeAgent(null);
     await runWorkflow(baseArgs({ surface: 'clinet', runtime: false }), agent, parallel, phase, () => {});

--- a/scripts/canopy-loop.workflow.test.js
+++ b/scripts/canopy-loop.workflow.test.js
@@ -453,6 +453,60 @@ test('a verify-fix that commits after a clean review round is not ready-for-PR',
     assert.ok(r.residualRisks.some((s) => /never adversarially reviewed/i.test(s)));
 });
 
+test('a below-quorum explore spawns one consolidated recovery explorer and continues', async () => {
+    // quick depth = 2 explorers, quorum 2. One fails → recovery explorer covers
+    // the gap → the run proceeds normally.
+    const { agent, calls } = makeAgent((_p, opts) => {
+        if ((opts.label || '') === 'explore:1') return null;
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
+    assert.ok(calls.some((c) => (c.opts.label || '') === 'explore:recovery'), 'recovery explorer spawned');
+    assert.equal(r.status, 'complete');
+    assert.equal(r.readyForPR, true);
+    assert.equal(r.agentStats.explore.attempted, 3, '2 parallel + 1 recovery attempts accounted');
+    assert.equal(r.agentStats.explore.nulls, 1);
+});
+
+test('an explore still below quorum after recovery pauses before the writer', async () => {
+    const { agent, calls } = makeAgent((_p, opts) => {
+        const l = opts.label || '';
+        if (l === 'explore:1' || l === 'explore:recovery') return null;
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs(), agent, parallel, phase, () => {});
+    assert.equal(r.status, 'paused');
+    assert.match(r.pauseReason, /quorum|maps/i);
+    assert.equal(r.resumeFrom.phase, 'explore');
+    assert.ok(!calls.some((c) => (c.opts.label || '').startsWith('plan')), 'no planners after quorum failure');
+    assert.ok(!calls.some((c) => (c.opts.label || '').startsWith('implement')), 'no writer after quorum failure');
+    assert.ok(!calls.some((c) => c.opts.phase === 'Verify'), 'no verify after quorum failure');
+    assert.equal(r.readyForPR, false);
+});
+
+test('a below-quorum plan phase spawns one recovery planner and continues', async () => {
+    // standard depth = 3 planners, quorum 2. Two fail → recovery planner
+    // restores the quorum.
+    const { agent, calls } = makeAgent((_p, opts) => {
+        const l = opts.label || '';
+        if (l.startsWith('plan:2') || l.startsWith('plan:3')) return null; // (plan:2 is a ':sol' slot)
+        return undefined;
+    });
+    const r = await runWorkflow(baseArgs({ depth: 'standard' }), agent, parallel, phase, () => {});
+    assert.ok(calls.some((c) => (c.opts.label || '') === 'plan:recovery'), 'recovery planner spawned');
+    assert.equal(r.status, 'complete');
+    assert.equal(r.readyForPR, true);
+});
+
+test('agentStats accounts every phase on a happy run', async () => {
+    const { agent } = makeAgent(null);
+    const r = await runWorkflow(baseArgs({ depth: 'standard' }), agent, parallel, phase, () => {});
+    assert.equal(r.agentStats.explore.attempted, 8);
+    assert.equal(r.agentStats.explore.succeeded, 8);
+    assert.equal(r.agentStats.plan.attempted, 3);
+    assert.ok(r.agentStats.review.attempted >= 1, 'review batches accounted');
+});
+
 test('three consecutive Sol failures trip the breaker: later rounds spawn no Sol attempts', async () => {
     // Every Sol-routed agent throws (dead router). Round 1 burns its attempts
     // (that is where the 3 consecutive failures accrue); a confirmed finding


### PR DESCRIPTION
## What this is

A self-audit-and-improve pass over the Canopy AI development workflow itself — the `.agents/` agentic-loop skill + engine (`canopy-loop.js`), its docs, and the engineering skill. A Fable-high + gpt-5.6-sol-high auditor pair reviewed the workflow, a single writer applied accepted findings, and the pair re-audited the *improved* code — three rounds, converging. Every change is grounded in a concrete failure from the last week's production loop runs (SR-15, SR-06, #454) or a defect found reading `canopy-loop.js` against its own SKILL.md/README promises.

**Design goal (maintainer):** serve two envelopes well — a light path for **fixes** (contained changes, minimal fan-out, fast convergence) and a resilient path for **features** (multi-day, survives session-limit exhaustion, resumes).

**31 commits · tests 432 → 487 (all green, every new test failing-first) · `.agents/` skill files + `scripts/canopy-loop.workflow.test.js` only · no product code, no CI changes.**

Left as **draft** deliberately — this rewrites the machinery that builds Canopy, so it wants a human read before merge.

## The three rounds

- **Round 1 (12 commits)** — the foundational gaps: quota-pause, resume, verify-fix integrity, docs convergence, Sol waste.
- **Round 2 (14 commits)** — bugs found *in* round 1's fixes: a 1-finding late round misclassified as an outage; a resume path that could never re-certify; a Sol review harness still injectable via hydrated issue bodies.
- **Round 3 (5 commits)** — refinements of round 2's fixes: per-finding (not boolean) unresolved tracking, ledger persistence across resume, real-route Sol preflight. Both auditors opened with "the code is in strong shape, most criteria already implemented" — the convergence signal.

## What changed, by theme

**Resilience / multi-day (the FEATURES envelope)**
- **Terminal-failure pause** — a classifier recognizes session/usage-limit/quota/credit exhaustion; the loop stops scheduling agents, skips Localize and verify-fix retries, and returns `status:'paused'` with `pauseReason`, `resumeFrom {phase,round}`, the finding ledger, and HEAD sha. This is the #454 failure (round 6 + verify + localize all died burning retries into a hard limit) turned into a clean stop. Route-aware (Sol vs implementer quota handled distinctly). Singleton per-agent failures keep byte-identical fail-closed semantics.
- **`startPhase` resume** (`explore`|`review`|`verify`) with a **`reviewedHead` escape hatch**: a run paused after a clean review re-certifies on resume iff the verify agent's independently-reported HEAD sha matches the recorded reviewed sha — otherwise fail closed. No more re-spending ~100 agents / 3h to reproduce committed state.
- **Ledger persistence across resume** — a resumed review keeps its refutation/fix suppression instead of re-churning refuted findings.

**Correctness**
- **Verify-fix SHA integrity** — a verify-time fixer that commits then returns null/throws no longer slips unreviewed code past certification; HEAD movement is detected independently of the fixer's report; unreadable HEAD fails closed.
- **Per-finding unresolved tracking** — replaced a single `unfixedConfirmed` boolean (which any later unrelated fix could clear) with a fingerprint map; `readyForPR` blocks while any confirmed finding is neither applied nor refuted.
- **Empty Verify ≠ code failure** — a Verify result with no structured gate evidence re-verifies read-only (infrastructure retry) instead of inviting a code-writing fixer to guess.

**Convergence / cost (the FIXES envelope)**
- **Docs/spec review** — factual-defect-only bar (wording/style aren't findings), severity-gated fixing (confirmed minors → `advisoryNotes`, minors-only round counts clean), lower docs hard-cap, opt-in `reviewMode:'spec'`. Directly targets the SR-15 (10 rounds, 26 review commits) vs SR-06 (2 rounds) delta on the same machinery.
- **Finding ledger** carried into later rounds (compact equal-share rendering, no head-slice drop) with a no-re-report-without-new-evidence rule.
- **Sol circuit breaker + real-route preflight** (both codex-cli and agent routes) — a dead Sol route is detected up front or after 3 strikes, ending the dozens-of-doomed-spawns waste (22–23 empty-result agents/run historically). `modelCoverage` + `agentStats` surface requested-vs-actual model per slot so "mixed-model review" is verifiable, and a certifying round must have real cross-family coverage or it fails closed.
- **Explore/plan quorum**, **docs-surface run trimming** (docs-specific angles, Localize skipped for docs), **equal-share digests** for phase handoffs.

**Ergonomics & accuracy**
- **Issue self-hydration** (`issue: <N>` → `gh`-fetched brief; explicit `briefText` overrides; failed fetch falls back or pauses if the issue was the only task source), **`envSetup` prelude** for the DOTNET_ROOT-shadowing class, a **doc-accuracy sweep** (sizing/routing tables, lenses, all new args, an "operating envelopes" note), and a **bounded post-publication watch** step in the engineering skill (required-up-to-date + auto-merge does not update branches — which needed manual babysitting this week).

## Deferred (genuine feature-scale, not defects)

Named by the auditors, out of scope for a contained audit pass, with mitigations already in place: independent review of the Localize commit; a Phase-0 git preflight to distrust a resumed branch; a central physical-call accounting wrapper; canary Sol staging. These are the next multi-day-feature iteration's work, not blockers here.

## Test coverage

55 new regression tests (432 → 487), each verified failing-first against the pre-change source: terminal-pause paths, startPhase + reviewedHead resume (match certifies / mismatch fails closed), the verify-fix SHA hole, per-finding unresolved tracking (unrelated-fix-can't-clear), docs severity gating, the 40-entry ledger, the breaker, quorum, preflight (both routes), env/hydration, and empty-Verify infrastructure retry.
