### PR TITLE
docs: codify responsive UI contract

### DIFF
--- a/.agents/skills/jellyfin-canopy-engineering/SKILL.md
+++ b/.agents/skills/jellyfin-canopy-engineering/SKILL.md
@@ -97,6 +97,12 @@ Preserve these repository contracts:
 
 - Jellyfin 12 and .NET 10 are the supported server/runtime boundary.
 - Modern MUI and legacy web layouts must both remain valid when UI is touched.
+- Every visible UI change must satisfy the repository's
+  [responsive UI contract](../../../CONTRIBUTING.md#responsive-ui-contract):
+  prove containment and reachability in every affected layout and across the
+  relevant phone, landscape, tablet, desktop, breakpoint-neighbor,
+  long-content, and resize boundaries. A single screenshot or one emulated
+  phone is not acceptance evidence.
 - Authentication, authorization, per-user isolation, escaping, cancellation,
   disposal, bounded memory/work, and live-configuration generation ownership
   must fail closed.
@@ -142,6 +148,14 @@ Select proportionately:
 - Client behavior: focused Vitest while iterating, then `typecheck:src`, legacy
   `typecheck`, full client coverage, bundle, syntax, and relevant
   layout/navigation E2E.
+- Visible client UI: follow the
+  [responsive UI contract](../../../CONTRIBUTING.md#responsive-ui-contract),
+  add direct geometry/reachability assertions for every affected surface,
+  register production acceptance cases in `e2e/required-test-inventory.json`,
+  and capture representative evidence for every affected layout and form
+  factor when layout behavior changes. For shared layout primitives or
+  width-generic responsive fixes, run the permanent 50-device popularity proxy
+  after deduplicating it to its distinct CSS viewports.
 - Server behavior: focused xUnit while iterating, then release build and full
   server coverage.
 - Cross-surface or generated resources: run both client and server owners plus

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -25,6 +25,13 @@ If applicable, add screenshots to help explain your problem.
  - Theme being used: [e.g. Jellyfish, Zesty, etc.,]
  - [ ] [FileTransformation](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation) Installed
 
+**Visual/layout details (complete when the bug affects rendered UI):**
+ - Client and Version: [e.g. Firefox 142, Jellyfin Android 2.x]
+ - Jellyfin Layout: [modern MUI or legacy; does it reproduce in both?]
+ - CSS Viewport: [open the browser console and report `innerWidth × innerHeight`, e.g. 390 × 844]
+ - Orientation: [portrait or landscape]
+ - Browser Zoom / OS Display Scaling: [e.g. 100% / 125%]
+ - Content State: [e.g. long title, unbroken name, item count, every action visible, empty/populated]
 
 **Logs**
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Summary
+
+<!-- What changed, why, and which user/developer outcome it owns. -->
+
+## Validation
+
+<!-- List exact commands, test counts, layouts, viewports, and manual evidence. -->
+
+- [ ] I ran the risk-appropriate repository checks and listed the exact results.
+- [ ] I added or updated regression/acceptance evidence for externally visible behavior.
+- [ ] I did not weaken a test, inventory, coverage, lint, performance, or security ratchet merely to make the branch green.
+
+## Visible UI changes
+
+<!-- Select the applicable impact boundary. -->
+
+- [ ] This PR cannot affect rendered UI or layout.
+- [ ] This PR affects rendered UI/layout; the evidence below is supplied.
+- [ ] Every affected modern/legacy layout satisfies the [responsive UI contract](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/blob/main/CONTRIBUTING.md#responsive-ui-contract); any layout-specific exclusion is explained.
+- [ ] The affected phone, landscape, tablet, desktop, breakpoint-neighbor, long-content/count, and dynamic-resize boundaries were exercised and listed.
+- [ ] Browser tests directly assert containment, overflow, intersection, and action/close-control reachability.
+- [ ] Production acceptance cases are registered in `e2e/required-test-inventory.json`.
+- [ ] Representative before/after screenshots are included for every affected form factor when layout behavior changes.
+
+## Assistance and risk
+
+<!-- Note AI assistance, breaking changes, residual risks, and follow-up work. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,66 @@ reviewed budget adjustment, and completed E2E proof for the contributor.
 5. **Proof = an `e2e/` spec.**
    Extend the stub: log in with the `loginAs` fixture, drive the feature, assert what the user sees, and assert `consoleErrors.real()` is empty. Specs must be idempotent and restore any server state they touch.
 
+### Responsive UI contract
+
+Every change that creates or modifies visible UI — including CSS-only changes,
+injected controls, cards, dialogs, banners, drawers, and admin surfaces — must
+prove responsive containment. One screenshot from one emulated phone is not
+acceptance evidence.
+
+1. **Exercise every affected Jellyfin layout.** Run shared surfaces in the
+   modern MUI layout and the user-selectable legacy layout. For an intentionally
+   layout-specific surface, prove the other layout is absent or unaffected and
+   state that boundary in the PR. Do not infer the layout from viewport width
+   or the generic `layout-desktop` class; use the repository's layout helpers
+   and fixtures.
+2. **Cover the affected boundaries.** Reproduce a responsive bug at its
+   original CSS viewport, and exercise the pixel immediately below, at, and
+   above every changed media-query breakpoint. Select every form-factor family
+   the same owner or CSS rule can reach from the baseline matrix:
+   `320×568` narrow-phone stress, `360×800` and `390×844` phones, a `430×739`
+   large phone, `568×320` narrow and `844×390` common phone landscapes,
+   `800×1280` and `1024×1366` tablets, and a `1440×900` desktop.
+   Phone-affecting work always includes the independent `320px` stress case.
+   Shared containers/layout primitives and width-generic responsive fixes must
+   additionally sweep the 50-device popularity proxy in
+   `e2e/fixtures/popular-mobile-device-viewports.ts`, deduplicated to its
+   distinct portrait CSS viewports. A local change need not run unrelated form
+   factors, but its PR must list the selected matrix and why it bounds the
+   affected owner.
+3. **Stress real content, not placeholders.** Include long spaced and
+   unbroken titles/names, translated or deliberately expanded labels, the
+   largest meaningful count/badge, every action, and populated plus empty
+   states. Page/collection titles and collection/item counts that identify the
+   active surface must remain fully visible. Other intentional truncation
+   needs an accessible way to obtain the full value without requiring hover,
+   must not resize or hide adjacent controls, and must be stated in the owning
+   acceptance contract.
+4. **Assert geometry and reachability directly.** Browser tests must prove the
+   document and owned root do not gain unintended horizontal overflow; owned
+   children stay inside their intended container and viewport; text and
+   controls do not intersect fixed, sticky, or native UI; actions and close
+   controls remain reachable by touch/keyboard; and a scrollable region can
+   actually reach every clipped edge. Screenshots supplement these assertions;
+   they do not replace them.
+5. **Exercise dynamic layout.** Fixed/sticky UI, drawers, banners, dialogs,
+   and code that reads geometry must survive a
+   `wide → narrow → landscape → wide-back` sequence in one page session. This
+   catches stale offsets that a fresh page at each size cannot expose.
+6. **Make the proof durable.** Put externally meaningful responsive cases in
+   `e2e/required-test-inventory.json`, run them with retries disabled for
+   acceptance evidence, and include representative screenshots for every
+   affected layout and form factor when layout behavior changes. Screenshots
+   are review artifacts, not pixel baselines unless a committed snapshot
+   explicitly owns that contract. Removing or weakening an owning case
+   requires an explicit replacement rationale; merely updating the inventory
+   is not proof that coverage remains equivalent.
+
+The implementation patterns and geometry checks are documented in
+[Responsive containment](docs/developers.md#responsive-containment).
+Required CI is Chromium-based; when a change relies on browser-sensitive CSS
+or input behavior, also perform the existing Firefox and Edge manual checks.
+
 ### Performance rules
 
 Injected UI must never jank the host client — and must never silently fail to appear on a slow server or connection. The full doctrine — each rule with its reasoning and the pattern to copy — is in the [performance rules](docs/developers.md#performance-rules); the implementation sites are marked `// PERF(Rn):` in the source. Check your PR against all nine:
@@ -307,9 +367,11 @@ JF_BASE_URL=http://127.0.0.1:8100 npm run e2e
 docker compose -f e2e/docker/compose.yml down -v
 ```
 
-CI runs the same stack on every PR across six isolated native Playwright shards
-(advisory while the infrastructure earns trust). Each CI server is explicitly
-capped at two CPUs and verifies Docker applied that quota before seeding.
+CI runs the same stack on every PR across six isolated native Playwright
+shards. The shard aggregate and exact required-test inventory are blocking on
+pull requests, `main` pushes, and reusable release calls. Each CI server is
+explicitly capped at two CPUs and verifies Docker applied that quota before
+seeding.
 
 For a faster whole-suite run on a Linux development machine, use the opt-in
 local sharding runner:
@@ -1097,7 +1159,7 @@ Before submitting a PR, ensure you've tested:
 - [ ] Compatible with Jellyfin 12.x — **both** the modern (MUI) layout and the legacy layout (`localStorage.layout`)
 - [ ] Works on different browsers (Chrome, Firefox, Edge)
 - [ ] Doesn't break existing functionality
-- [ ] Mobile compatibility (if applicable)
+- [ ] Any visible UI change satisfies the [responsive UI contract](#responsive-ui-contract), including long-content and dynamic-resize proof
 - [ ] Injected UI survives navigation and the `/video` round trip (see the [React re-render survival guide](docs/developers.md#react-re-render-survival))
 
 ## 📋 Feature Request Guidelines
@@ -1130,8 +1192,9 @@ If you have questions or need help:
 For UI changes:
 
 - Use the ui-kit (`JC.core.ui`) so injected UI matches native markup and follows the active theme
-- Test with different Jellyfin themes and both layouts
-- Provide before/after screenshots
+- Follow the [responsive UI contract](#responsive-ui-contract)
+- Test with different Jellyfin themes and every affected layout
+- Provide representative before/after screenshots for every affected form factor
 
 ---
 

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -26,6 +26,116 @@ The route tree is chosen **once at module init** (`WEB src/RootAppRouter.tsx`), 
 
 **Present ≠ visible.** On the modern layout the entire legacy header block stays in the DOM inside a `display:none` wrapper (`WEB src/components/AppHeader.tsx`). Existence checks silently produce invisible UI. `.skinHeader`/`.MuiAppBar-root` are `position:fixed`, so `offsetParent === null` even when they are visible — check children instead.
 
+### Responsive containment
+
+Responsive correctness is a geometry and reachability contract, not a
+device-name screenshot exercise. Jellyfin's modern and legacy layouts can
+share a route while providing different native containers, fixed headers,
+drawers, and flex constraints. A rule that happens to fit one layout or one
+freshly loaded viewport can still overflow the other layout, hide content
+behind native UI, or retain stale offsets after a resize.
+
+The contributor-facing requirements live under **Responsive UI contract** in
+the repository's `CONTRIBUTING.md`. The baseline CSS-pixel matrix is:
+
+| Boundary | Viewport | Purpose |
+| --- | --- | --- |
+| Narrow-phone stress | `320×568` | Smallest supported width; deliberately outside the popularity roster |
+| Common phones | `360×800`, `390×844`, `430×739` | Budget Android, standard phone, and large-phone widths |
+| Phone landscape | `568×320`, `844×390` | Narrow stress plus common short dynamic viewport pressure |
+| Tablets | `800×1280`, `1024×1366` | Android/iPad-class layouts and intermediate breakpoint islands |
+| Desktop | `1440×900` | Full navigation, rail, toolbar, and multi-column state |
+
+These are browser-content dimensions in CSS pixels, not panel hardware pixels.
+Physical resolution without device-pixel ratio, browser chrome, display zoom,
+and orientation does not identify the available layout width.
+
+Select every family the same owner or CSS rule can affect; a local change does
+not need unrelated form factors. For shared containers, layout primitives, and
+width-generic responsive fixes, also import `POPULAR_MOBILE_DEVICES` from
+`e2e/fixtures/popular-mobile-device-viewports.ts`, deduplicate identical
+`width×height` pairs, and execute every distinct portrait viewport. The roster
+contains 50 researched phone/tablet representatives but intentionally collapses
+to fewer CSS viewport executions: model popularity and layout coverage are
+different facts. Keep the independent `320px` stress case and add
+`breakpoint−1`, `breakpoint`, and `breakpoint+1` whenever a changed media query
+creates a layout transition.
+
+#### What browser tests must measure
+
+Check the document, each non-scrolling owned root, and the descendants that can
+create their intrinsic width. Compare each box with its own containing box;
+`window.innerWidth` can include the vertical scrollbar gutter. Choose the
+strict-child locator deliberately so it excludes content owned by an
+intentional scrollport. Allow a one-pixel rounding tolerance, but do not hide a
+failure with `overflow-x:hidden` on the document:
+
+```ts
+const geometry = await root.evaluate((element) => {
+    const documentRoot =
+        document.scrollingElement || document.documentElement;
+    const owner = element.getBoundingClientRect();
+    const documentOverflow =
+        documentRoot.scrollWidth - documentRoot.clientWidth;
+    const rootOverflow = element.scrollWidth - element.clientWidth;
+    const escaped = [
+        ...element.querySelectorAll<HTMLElement>('[data-containment="strict"]'),
+    ]
+        .map((node) => ({ node, rect: node.getBoundingClientRect() }))
+        .filter(
+            ({ rect }) =>
+                rect.left < owner.left - 1 || rect.right > owner.right + 1,
+        )
+        .map(({ node }) => node.id || node.className);
+    return { documentOverflow, rootOverflow, escaped };
+});
+
+expect(geometry.documentOverflow).toBeLessThanOrEqual(1);
+expect(geometry.rootOverflow).toBeLessThanOrEqual(1);
+expect(geometry.escaped).toEqual([]);
+```
+
+Intentional scrollports need a separate reachability assertion instead of the
+`rootOverflow` assertion above. Scroll to both extremes on each relevant axis
+and assert that the visually leading/trailing owned descendants enter the
+scrollport's visible bounds. This catches unreachable negative overflow and
+works when horizontal offsets have RTL-specific semantics. Offset comparisons
+with the reported scroll range are useful supplementary evidence, but do not
+prove reachability by themselves. Restore the initial position afterward.
+
+Those are only the base checks. The owning spec must also assert the actual
+contract: children remain within their grid/card/toolbar/dialog; page/collection
+titles and collection/item counts that identify the active surface remain fully
+visible; other intentional truncation exposes its full value accessibly without
+requiring hover; buttons have measurable hit boxes and unclipped labels/icons;
+fixed or sticky elements do not intersect native controls; and every dialog
+action and close control is reachable. A scrollable container passes only when
+its complete content can be reached, not merely because `overflow:auto`
+appears in computed CSS.
+
+Use content that can defeat optimistic layouts: a long spaced title, an
+unbroken token, expanded/localized labels, the largest meaningful count or
+badge, every action present, and both populated and empty states. Flex/grid
+children that carry text normally need `min-width:0`; wrapping action rows need
+an explicit wrap or scroll policy; fixed heights are suspect when content can
+wrap.
+
+Resize-sensitive code must be tested in one live page with
+`wide → narrow → landscape → wide-back`. Recreating the page at each size
+cannot detect a stale cached measurement. Use `ResizeObserver` or an owning
+layout signal where geometry genuinely changes, tear it down with the feature
+lifecycle, and assert final geometry after every transition.
+
+Responsive acceptance cases belong in `e2e/required-test-inventory.json`.
+Required Playwright runs disable retries. The six-shard aggregate rejects
+failed/flaky/skipped outcomes, missing/unexpected/duplicate tests, stale
+evidence, and inventory drift. Representative screenshots for every affected
+layout and form factor make review easier, but geometry assertions own the
+pass/fail decision; a screenshot becomes a pixel baseline only when a
+committed snapshot explicitly owns it. Existing examples include
+`e2e/bookmarks-responsive.spec.ts`, `e2e/admin-responsive.spec.ts`, and
+`e2e/maintenance-banner-responsive.spec.ts`.
+
 #### Stable anchors — modern layout
 
 | Surface | Selector (live-verified) |

--- a/scripts/responsive-ui-policy.test.js
+++ b/scripts/responsive-ui-policy.test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const ROOT = path.join(__dirname, '..');
+const read = file => fs.readFileSync(path.join(ROOT, file), 'utf8');
+
+const agents = read('AGENTS.md');
+const engineering = read('.agents/skills/jellyfin-canopy-engineering/SKILL.md');
+const contributing = read('CONTRIBUTING.md');
+const developers = read('docs/developers.md');
+const pullRequestTemplate = read('.github/pull_request_template.md');
+const bugTemplate = read('.github/ISSUE_TEMPLATE/bug.md');
+const buildWorkflow = read('.github/workflows/build.yml');
+const workflowCode = buildWorkflow
+    .split('\n')
+    .filter(line => !line.trimStart().startsWith('#'))
+    .join('\n');
+
+test('responsive UI policy stays connected across agent, contributor, developer and PR surfaces', () => {
+    assert.match(agents, /\.agents\/skills\/jellyfin-canopy-engineering\/SKILL\.md/);
+    assert.match(engineering, /CONTRIBUTING\.md#responsive-ui-contract/);
+    assert.match(contributing, /^### Responsive UI contract$/m);
+    assert.match(contributing, /docs\/developers\.md#responsive-containment/);
+    assert.match(developers, /^### Responsive containment$/m);
+    assert.match(developers, /Responsive UI contract[\s\S]*`CONTRIBUTING\.md`/);
+    assert.match(pullRequestTemplate, /CONTRIBUTING\.md#responsive-ui-contract/);
+    assert.match(bugTemplate, /^\*\*Visual\/layout details \(complete when the bug affects rendered UI\):\*\*$/m);
+});
+
+test('responsive UI policy retains its required acceptance boundaries', () => {
+    assert.match(contributing, /modern MUI layout[\s\S]*user-selectable legacy layout/);
+    assert.match(contributing, /below, at, and[\s\S]*above every changed media-query breakpoint/);
+    assert.match(contributing, /`320×568`[\s\S]*`568×320`[\s\S]*`800×1280`[\s\S]*`1440×900`/);
+    assert.match(contributing, /Select every form-factor family[\s\S]*same owner or CSS rule can reach/);
+    assert.match(contributing, /50-device popularity proxy[\s\S]*e2e\/fixtures\/popular-mobile-device-viewports\.ts[\s\S]*distinct portrait CSS viewports/);
+    assert.match(contributing, /local change need not run unrelated form[\s\S]*why it bounds the[\s\S]*affected owner/);
+    assert.match(contributing, /long spaced and[\s\S]*unbroken titles\/names[\s\S]*largest meaningful count\/badge/);
+    assert.match(contributing, /Page\/collection titles and collection\/item counts[\s\S]*must remain fully visible/);
+    assert.match(contributing, /document and owned root[\s\S]*horizontal overflow[\s\S]*scrollable region[\s\S]*every clipped edge/);
+    assert.match(contributing, /wide → narrow → landscape → wide-back/);
+    assert.match(contributing, /e2e\/required-test-inventory\.json/);
+    assert.match(contributing, /screenshots for every[\s\S]*affected layout and form factor/);
+    assert.match(pullRequestTemplate, /^## Visible UI changes$/m);
+    assert.match(pullRequestTemplate, /affected phone, landscape, tablet, desktop, breakpoint-neighbor, long-content\/count, and dynamic-resize boundaries/);
+    assert.match(pullRequestTemplate, /containment, overflow, intersection, and action\/close-control reachability/);
+    assert.match(bugTemplate, /Client and Version[\s\S]*Jellyfin Layout[\s\S]*CSS Viewport[\s\S]*Orientation[\s\S]*Browser Zoom \/ OS Display Scaling[\s\S]*Content State/);
+});
+
+test('responsive UI policy records the actual blocking E2E wiring', () => {
+    assert.doesNotMatch(contributing, /advisory while the infrastructure earns trust/);
+    assert.match(workflowCode, /^[ ]{2}pull_request:\n[ ]{4}branches: \[main, master\]$/m);
+    assert.match(workflowCode, /^[ ]{2}workflow_call:$/m);
+    assert.match(workflowCode, /^[ ]{2}e2e:\n[\s\S]*?^[ ]{4}needs: \[e2e_shard, bundle-equivalence\]$/m);
+    assert.match(workflowCode, /node scripts\/e2e\/shard-result\.js aggregate[\s\S]*node scripts\/e2e\/required-inventory\.js aggregate/);
+    assert.match(workflowCode, /\(\( marker_status == 0 && inventory_status == 0 \)\)/);
+});


### PR DESCRIPTION
## Summary

Follow-up policy work for #463's responsive collection UI fix:

- define a risk-based responsive UI contract covering every affected Jellyfin layout, breakpoint neighbors, long content, identifying titles/counts, direct geometry and reachability assertions, dynamic resize, and the deduplicated 50-device viewport proxy
- add implementation guidance for containment and intentional-scroll reachability
- add PR and bug-report prompts that capture UI impact, CSS viewport, orientation, layout, scaling, content state, tests, and visual evidence
- add a blocking script-policy test that prevents the contract and existing E2E workflow wiring from silently drifting
- correct the contributor guide's stale description of required E2E as advisory

## Validation

- [x] I ran the risk-appropriate repository checks and listed the exact results.
- [x] I added or updated regression/acceptance evidence for externally visible behavior.
- [x] I did not weaken a test, inventory, coverage, lint, performance, or security ratchet merely to make the branch green.

Exact results:

- `npm run test:scripts` — 497/497 passed
- `PATH=/home/jake/jc-docs-python-3.13.14/bin:$PATH PYTHONNOUSERSITE=1 npm run check:docs` — content, permissions, assets, and strict MkDocs build passed under Python 3.13.14 / pip 25.3
- `npx eslint scripts/responsive-ui-policy.test.js` — passed
- `git diff --check` — passed
- two independent read-only final reviews — approved

No browser E2E run is required for this patch because it changes only documentation, contribution templates, the canonical agent policy, and its script-level anti-drift test; it cannot affect the rendered plugin.

## Visible UI changes

- [x] This PR cannot affect rendered UI or layout.
- [ ] This PR affects rendered UI/layout; the evidence below is supplied.
- [ ] Every affected modern/legacy layout satisfies the [responsive UI contract](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/blob/main/CONTRIBUTING.md#responsive-ui-contract); any layout-specific exclusion is explained.
- [ ] The affected phone, landscape, tablet, desktop, breakpoint-neighbor, long-content/count, and dynamic-resize boundaries were exercised and listed.
- [ ] Browser tests directly assert containment, overflow, intersection, and action/close-control reachability.
- [ ] Production acceptance cases are registered in `e2e/required-test-inventory.json`.
- [ ] Representative before/after screenshots are included for every affected form factor when layout behavior changes.

## Assistance and risk

AI assistance was used for repository research, implementation, validation, and two independent final reviews. The patch has no runtime or deployment effect. Its main maintenance risk is policy drift; `scripts/responsive-ui-policy.test.js` now pins the acceptance boundaries and the actual required E2E workflow wiring.