### PR TITLE
fix: unblock release manifest checks

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main", "master" ]
   pull_request:
     branches: [ "main", "master" ]
+  workflow_dispatch:
   workflow_call:
     inputs:
       verify_repository_policy:

--- a/scripts/release/repository-policy.test.js
+++ b/scripts/release/repository-policy.test.js
@@ -99,11 +99,19 @@ test('release reuses exact-SHA Build/Test and Security gates after ancestry proo
     assert.match(security, /pull_request:[\s\S]*?workflow_dispatch:\s*\n\s+workflow_call:/);
     assert.match(release, /security-gates:[\s\S]*?with:\n\s+verify_repository_policy: true/);
     assert.match(security, /workflow_call:[\s\S]*?secrets:\n\s+REPOSITORY_POLICY_TOKEN:[\s\S]*?required: true/);
+    const repositoryPolicyCondition = security.match(
+        /  repository-policy:\n[\s\S]*?\n    if: ([^\n]+)\n/
+    )?.[1];
+    assert.equal(
+        repositoryPolicyCondition,
+        "github.event_name == 'schedule' || inputs.verify_repository_policy"
+    );
     assert.match(security, /repository-policy:\n\s+name: Repository Policy[\s\S]*?if: github\.event_name == 'schedule' \|\| inputs\.verify_repository_policy[\s\S]*?actions: read\n\s+contents: read[\s\S]*?verify-repository-policy\.js/);
     assert.match(security, /Checkout reviewed source[\s\S]*?persist-credentials: false/);
     assert.match(security, /Verify live release policy matches the committed contract\n\s+env:\n\s+GH_TOKEN: \$\{\{ github\.token \}\}\n\s+RULESET_TOKEN: \$\{\{ secrets\.REPOSITORY_POLICY_TOKEN \}\}/);
     assert.match(release, /security-gates:[\s\S]*?secrets:\n\s+REPOSITORY_POLICY_TOKEN: \$\{\{ secrets\.REPOSITORY_POLICY_TOKEN \}\}[\s\S]*?actions: read\n\s+contents: read/);
     assert.match(release, /actions: write # dispatch required checks for the generated manifest PR/);
+    assert.match(release, /for workflow in build\.yml security-scan\.yml; do/);
     assert.match(release, /gh workflow run "\$workflow" --ref "\$BRANCH"/);
     assert.match(release, /node scripts\/release\/check-dispatch\.js/);
     assert.match(release, /did not start for exact proposal \$head_sha/);

--- a/scripts/release/repository-policy.test.js
+++ b/scripts/release/repository-policy.test.js
@@ -96,9 +96,9 @@ test('release reuses exact-SHA Build/Test and Security gates after ancestry proo
     assert.match(release, /security-gates:[\s\S]*?needs: provenance[\s\S]*?uses: \.\/\.github\/workflows\/security-scan\.yml/);
     assert.match(release, /needs: \[provenance, quality-gates, security-gates\]/);
     assert.match(security, /pull_request:[\s\S]*?workflow_call:[\s\S]*?verify_repository_policy:/);
+    assert.match(security, /pull_request:[\s\S]*?workflow_dispatch:\s*\n\s+workflow_call:/);
     assert.match(release, /security-gates:[\s\S]*?with:\n\s+verify_repository_policy: true/);
     assert.match(security, /workflow_call:[\s\S]*?secrets:\n\s+REPOSITORY_POLICY_TOKEN:[\s\S]*?required: true/);
-    assert.doesNotMatch(security, /workflow_dispatch/);
     assert.match(security, /repository-policy:\n\s+name: Repository Policy[\s\S]*?if: github\.event_name == 'schedule' \|\| inputs\.verify_repository_policy[\s\S]*?actions: read\n\s+contents: read[\s\S]*?verify-repository-policy\.js/);
     assert.match(security, /Checkout reviewed source[\s\S]*?persist-credentials: false/);
     assert.match(security, /Verify live release policy matches the committed contract\n\s+env:\n\s+GH_TOKEN: \$\{\{ github\.token \}\}\n\s+RULESET_TOKEN: \$\{\{ secrets\.REPOSITORY_POLICY_TOKEN \}\}/);

--- a/scripts/release/version-policy.test.js
+++ b/scripts/release/version-policy.test.js
@@ -15,12 +15,21 @@ const {
     requirePluginReleaseLine,
     validateReleaseVersion,
 } = require('./version-policy.js');
+const { compareVersions } = require('./validate-manifest.js');
 const { writeZipFixture } = require('../lib/zip-test-fixture.js');
 
 const ROOT = path.resolve(__dirname, '../..');
 const MANIFEST = path.join(ROOT, 'manifest.json');
 const PROJECT = path.join(ROOT, 'Jellyfin.Plugin.JellyfinCanopy', 'JellyfinCanopy.csproj');
 const SCRIPT = path.join(__dirname, 'version-policy.js');
+
+function readCatalogBefore(version) {
+    const manifest = JSON.parse(fs.readFileSync(MANIFEST, 'utf8'));
+    return manifest.map(plugin => ({
+        ...plugin,
+        versions: plugin.versions.filter(entry => compareVersions(entry.version, version) < 0),
+    }));
+}
 
 test('plugin tags normalize independently from the Jellyfin target ABI', () => {
     const policy = readVersionPolicy();
@@ -34,7 +43,7 @@ test('plugin tags normalize independently from the Jellyfin target ABI', () => {
     );
 });
 
-test('the documented next tag is monotonic and remains in the configured release line', () => {
+test('the documented tag example is monotonic against an older catalog fixture', () => {
     const releasing = fs.readFileSync(path.join(ROOT, 'RELEASING.md'), 'utf8');
     const example = releasing.match(/git tag (\d+\.\d+\.\d+\.\d+)/)?.[1];
     assert.ok(example, 'RELEASING.md must contain a four-part git tag example');
@@ -47,7 +56,8 @@ test('the documented next tag is monotonic and remains in the configured release
         version: '2.0.1.0',
         targetAbi: '12.0.0.0',
     });
-    const manifest = JSON.parse(fs.readFileSync(MANIFEST, 'utf8'));
+    const manifest = readCatalogBefore(result.version);
+    assert.ok(manifest.some(plugin => plugin.versions.length > 0));
     assert.doesNotThrow(() => requireNewPluginVersion(result.version, manifest));
 });
 
@@ -128,7 +138,7 @@ test('manifest generation writes plugin version 2.0.1.0 with ABI 12 independentl
         const zipName = 'Jellyfin.Plugin.JellyfinCanopy_12.0.0.zip';
         const zipPath = path.join(temporary, zipName);
         const wrongZipPath = path.join(temporary, 'Jellyfin.Plugin.JellyfinCanopy_13.0.0.zip');
-        const manifest = JSON.parse(fs.readFileSync(MANIFEST, 'utf8'));
+        const manifest = readCatalogBefore('2.0.1.0');
         fs.writeFileSync(manifestPath, JSON.stringify(manifest));
         fs.writeFileSync(changelogPath, 'Version-policy fixture');
         writeZipFixture(zipPath, [

--- a/scripts/release/version-policy.test.js
+++ b/scripts/release/version-policy.test.js
@@ -15,7 +15,6 @@ const {
     requirePluginReleaseLine,
     validateReleaseVersion,
 } = require('./version-policy.js');
-const { compareVersions } = require('./validate-manifest.js');
 const { writeZipFixture } = require('../lib/zip-test-fixture.js');
 
 const ROOT = path.resolve(__dirname, '../..');
@@ -23,12 +22,12 @@ const MANIFEST = path.join(ROOT, 'manifest.json');
 const PROJECT = path.join(ROOT, 'Jellyfin.Plugin.JellyfinCanopy', 'JellyfinCanopy.csproj');
 const SCRIPT = path.join(__dirname, 'version-policy.js');
 
-function readCatalogBefore(version) {
+function readHistoricalCatalogFixture() {
     const manifest = JSON.parse(fs.readFileSync(MANIFEST, 'utf8'));
-    return manifest.map(plugin => ({
-        ...plugin,
-        versions: plugin.versions.filter(entry => compareVersions(entry.version, version) < 0),
-    }));
+    assert.equal(manifest.length, 1, 'version-policy fixture expects Canopy as the sole catalog plugin');
+    const historical = manifest[0].versions.find(entry => entry.version === '2.0.0.0');
+    assert.ok(historical, 'version-policy fixture requires the retained 2.0.0.0 catalog entry');
+    return [{ ...manifest[0], versions: [historical] }];
 }
 
 test('plugin tags normalize independently from the Jellyfin target ABI', () => {
@@ -43,7 +42,7 @@ test('plugin tags normalize independently from the Jellyfin target ABI', () => {
     );
 });
 
-test('the documented tag example is monotonic against an older catalog fixture', () => {
+test('the documented tag example is monotonic against the explicit 2.0.0.0 fixture', () => {
     const releasing = fs.readFileSync(path.join(ROOT, 'RELEASING.md'), 'utf8');
     const example = releasing.match(/git tag (\d+\.\d+\.\d+\.\d+)/)?.[1];
     assert.ok(example, 'RELEASING.md must contain a four-part git tag example');
@@ -56,8 +55,8 @@ test('the documented tag example is monotonic against an older catalog fixture',
         version: '2.0.1.0',
         targetAbi: '12.0.0.0',
     });
-    const manifest = readCatalogBefore(result.version);
-    assert.ok(manifest.some(plugin => plugin.versions.length > 0));
+    const manifest = readHistoricalCatalogFixture();
+    assert.deepEqual(manifest[0].versions.map(entry => entry.version), ['2.0.0.0']);
     assert.doesNotThrow(() => requireNewPluginVersion(result.version, manifest));
 });
 
@@ -138,7 +137,7 @@ test('manifest generation writes plugin version 2.0.1.0 with ABI 12 independentl
         const zipName = 'Jellyfin.Plugin.JellyfinCanopy_12.0.0.zip';
         const zipPath = path.join(temporary, zipName);
         const wrongZipPath = path.join(temporary, 'Jellyfin.Plugin.JellyfinCanopy_13.0.0.zip');
-        const manifest = readCatalogBefore('2.0.1.0');
+        const manifest = readHistoricalCatalogFixture();
         fs.writeFileSync(manifestPath, JSON.stringify(manifest));
         fs.writeFileSync(changelogPath, 'Version-policy fixture');
         writeZipFixture(zipPath, [


### PR DESCRIPTION
## Summary

- allow the unprivileged Security Scan workflow to be dispatched against an exact release-manifest commit
- keep the privileged repository-policy job restricted to scheduled runs or explicit reusable-workflow calls
- make version-policy tests use an explicit historical catalog fixture instead of the live release manifest
- lock both release dispatch targets and the privileged-job condition with regression tests

## Why

The 2.0.1.1 release published correctly, but its generated manifest proposal could not complete exact-head verification: `security-scan.yml` had no `workflow_dispatch` trigger, and two version-policy fixtures treated the live manifest as pre-release state after 2.0.1.1 was added.

## Validation

- release test suite: 83/83 passed
- full script suite on this branch: 494/494 passed
- full script suite with the generated 2.0.1.1 manifest integrated: 494/494 passed
- independent mutation review confirmed unsafe privileged dispatches and missing security dispatches are rejected
- workflow YAML parsing and `git diff --check` passed

After this lands, the generated 2.0.1.1 manifest branch will be updated from `main` and the release workflow will resume without replacing the already-published ZIP.