### PR TITLE
Fix stale translations after same-version deployments

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/bootstrap/translations-loading.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/bootstrap/translations-loading.test.ts
@@ -20,6 +20,7 @@ describe('translation loader deployment ownership', () => {
     beforeEach(() => {
         localStorage.clear();
         document.documentElement.lang = '';
+        document.querySelectorAll('script[plugin="Jellyfin Canopy"]').forEach((node) => node.remove());
         window.JellyfinCanopy.pluginVersion = '2.0.0.0';
         window.JellyfinCanopy.pluginConfig = {};
         vi.spyOn(console, 'log').mockImplementation(() => undefined);
@@ -44,7 +45,7 @@ describe('translation loader deployment ownership', () => {
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock.mock.calls.map(([input]) => requestUrl(input))).toEqual([
-            'http://jellyfin.test/JellyfinCanopy/locales/en.json',
+            'http://jellyfin.test/JellyfinCanopy/locales/en.json?v=2.0.0.0',
         ]);
     });
 
@@ -65,12 +66,12 @@ describe('translation loader deployment ownership', () => {
 
         await expect(loadTranslations()).resolves.toEqual({ greeting: 'remote fallback' });
         expect(fallbackFetch.mock.calls.map(([input]) => requestUrl(input))).toEqual([
-            'http://jellyfin.test/JellyfinCanopy/locales/en.json',
+            'http://jellyfin.test/JellyfinCanopy/locales/en.json?v=2.0.0.0',
             expect.stringContaining('4eh5xitv6787h645ebv/Jellyfin-Canopy/main/'),
         ]);
     });
 
-    it('uses a 24-hour plugin-version cache and retires entries from older builds', async () => {
+    it('uses a 24-hour deployment-revision cache and retires entries from older builds', async () => {
         localStorage.setItem('JC_translation_en_1.9.0.0', JSON.stringify({ greeting: 'old build' }));
         localStorage.setItem('JC_translation_ts_en_1.9.0.0', String(Date.now()));
         const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(response(true, { greeting: 'current build' }));
@@ -90,5 +91,43 @@ describe('translation loader deployment ownership', () => {
         fetchMock.mockResolvedValue(response(true, { greeting: 'refreshed' }));
         await expect(loadTranslations()).resolves.toEqual({ greeting: 'refreshed' });
         expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('bypasses a same-version locale cache after a hot deployment', async () => {
+        const script = document.createElement('script');
+        script.setAttribute('plugin', 'Jellyfin Canopy');
+        script.setAttribute('version', '2.0.0.0-639206738759190300');
+        document.head.appendChild(script);
+
+        localStorage.setItem('JC_translation_en_2.0.0.0', JSON.stringify({ greeting: 'stale' }));
+        localStorage.setItem('JC_translation_ts_en_2.0.0.0', String(Date.now()));
+        const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(response(true, { greeting: 'fresh' }));
+        globalThis.fetch = fetchMock;
+
+        await expect(loadTranslations()).resolves.toEqual({ greeting: 'fresh' });
+
+        expect(fetchMock.mock.calls.map(([input]) => requestUrl(input))).toEqual([
+            'http://jellyfin.test/JellyfinCanopy/locales/en.json?v=2.0.0.0-639206738759190300',
+        ]);
+        expect(localStorage.getItem('JC_translation_en_2.0.0.0')).toBeNull();
+        expect(localStorage.getItem('JC_translation_ts_en_2.0.0.0')).toBeNull();
+        expect(JSON.parse(
+            localStorage.getItem('JC_translation_en_2.0.0.0-639206738759190300')!,
+        )).toEqual({ greeting: 'fresh' });
+    });
+
+    it('preserves the acknowledged server cache-clear watermark', async () => {
+        localStorage.setItem('JC_translation_clear_ts', '639206738759190300');
+        localStorage.setItem('JC_translation_en_1.9.0.0', JSON.stringify({ greeting: 'old build' }));
+        localStorage.setItem('JC_translation_ts_en_1.9.0.0', String(Date.now()));
+        globalThis.fetch = vi.fn<typeof fetch>().mockResolvedValue(
+            response(true, { greeting: 'current build' }),
+        );
+
+        await expect(loadTranslations()).resolves.toEqual({ greeting: 'current build' });
+
+        expect(localStorage.getItem('JC_translation_clear_ts')).toBe('639206738759190300');
+        expect(localStorage.getItem('JC_translation_en_1.9.0.0')).toBeNull();
+        expect(localStorage.getItem('JC_translation_ts_en_1.9.0.0')).toBeNull();
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/bootstrap/translations.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/bootstrap/translations.ts
@@ -19,6 +19,7 @@ import localeManifest from '../../locale-manifest.json';
     // strings. Only used as the last-resort fallback when AssetCacheEnabled === false.
     const GITHUB_RAW_BASE = 'https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/main/Jellyfin.Plugin.JellyfinCanopy/js/locales';
     const CACHE_DURATION = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
+    const CLEAR_TIMESTAMP_KEY = 'JC_translation_clear_ts';
     const SUPPORTED_LOCALES = new Set(localeManifest.locales);
 
     type LangResult = { translations: Record<string, string>; usedLang: string };
@@ -78,11 +79,41 @@ import localeManifest from '../../locale-manifest.json';
         return 'unknown';
     }
 
-    function cleanOldTranslationCache(pluginVersion: string): void {
+    async function getTranslationRevision(): Promise<string> {
+        const scriptElement = document.querySelector<HTMLScriptElement>(
+            'script[plugin="Jellyfin Canopy"]',
+        );
+        if (scriptElement?.getAttribute('dev') === 'true') {
+            return `dev-${Date.now()}`;
+        }
+
+        // The injected script revision contains the plugin version plus the
+        // deployed DLL timestamp. Unlike the bare assembly version, it changes
+        // for every hot deployment and is already the canonical cache-buster
+        // for the loader scripts.
+        const revisionCandidate = scriptElement?.getAttribute('version')?.trim() || '';
+        const deployedRevision = revisionCandidate.length <= 128
+            && /^[A-Za-z0-9._-]+$/.test(revisionCandidate)
+            ? revisionCandidate
+            : '';
+        return deployedRevision || await getPluginVersion();
+    }
+
+    function bundledLocaleUrl(code: string, revision: string): string {
+        return ApiClient.getUrl(
+            `/JellyfinCanopy/locales/${code}.json?v=${encodeURIComponent(revision)}`,
+        );
+    }
+
+    function cleanOldTranslationCache(revision: string): void {
         const storedKeys = JC.storage.local.keys('translations', 'translation-cache-prefix');
         for (const key of storedKeys.value || []) {
+            // This is the durable acknowledgement of the server-side
+            // Refresh Translation Cache task, not a locale payload. Removing it
+            // here would replay the same clear signal on every later boot.
+            if (key === CLEAR_TIMESTAMP_KEY) continue;
             if (key.startsWith('JC_translation_') || key.startsWith('JC_translation_ts_')) {
-                if (!key.includes(`_${pluginVersion}`)) {
+                if (!key.endsWith(`_${revision}`)) {
                     JC.storage.local.remove('translations', key, 'translation-cache-entry');
                     console.log(`🪼 Jellyfin Canopy: Removed old translation cache: ${key}`);
                 }
@@ -90,9 +121,9 @@ import localeManifest from '../../locale-manifest.json';
         }
     }
 
-    async function tryLoadSingleLanguage(code: string, pluginVersion: string): Promise<LangResult> {
-        const cacheKey = `JC_translation_${code}_${pluginVersion}`;
-        const timestampKey = `JC_translation_ts_${code}_${pluginVersion}`;
+    async function tryLoadSingleLanguage(code: string, revision: string): Promise<LangResult> {
+        const cacheKey = `JC_translation_${code}_${revision}`;
+        const timestampKey = `JC_translation_ts_${code}_${revision}`;
         const cachedTranslations = JC.storage.local.readJson(
             'translations', cacheKey, isTranslationRecord, 'translation-cache-payload',
         );
@@ -103,19 +134,19 @@ import localeManifest from '../../locale-manifest.json';
         if (cachedTranslations.state === 'Valid' && cachedTimestamp.state === 'Valid') {
             const age = Date.now() - cachedTimestamp.value;
             if (age < CACHE_DURATION) {
-                console.log(`🪼 Jellyfin Canopy: Using cached translations for ${code} (age: ${Math.round(age / 1000 / 60)} minutes, version: ${pluginVersion})`);
+                console.log(`🪼 Jellyfin Canopy: Using cached translations for ${code} (age: ${Math.round(age / 1000 / 60)} minutes, revision: ${revision})`);
                 return { translations: cachedTranslations.value, usedLang: code };
             }
         }
 
         console.log(`🪼 Jellyfin Canopy: Loading bundled translations for ${code}...`);
         try {
-            const bundledResponse = await fetch(ApiClient.getUrl(`/JellyfinCanopy/locales/${code}.json`));
+            const bundledResponse = await fetch(bundledLocaleUrl(code, revision));
             if (bundledResponse.ok) {
                 const translations = await bundledResponse.json() as Record<string, string>;
                 JC.storage.local.write('translations', cacheKey, JSON.stringify(translations), 'translation-cache-payload');
                 JC.storage.local.write('translations', timestampKey, Date.now().toString(), 'translation-cache-timestamp');
-                console.log(`🪼 Jellyfin Canopy: Successfully loaded and cached bundled translations for ${code} (version: ${pluginVersion})`);
+                console.log(`🪼 Jellyfin Canopy: Successfully loaded and cached bundled translations for ${code} (revision: ${revision})`);
                 return { translations, usedLang: code };
             }
         } catch (bundledError) {
@@ -146,7 +177,7 @@ import localeManifest from '../../locale-manifest.json';
                 const payloadWrite = JC.storage.local.write('translations', cacheKey, JSON.stringify(translations), 'translation-cache-payload');
                 const timestampWrite = JC.storage.local.write('translations', timestampKey, Date.now().toString(), 'translation-cache-timestamp');
                 if (payloadWrite.state === 'Valid' && timestampWrite.state === 'Valid') {
-                    console.log(`🪼 Jellyfin Canopy: Successfully fetched and cached translations for ${code} from GitHub (version: ${pluginVersion})`);
+                    console.log(`🪼 Jellyfin Canopy: Successfully fetched and cached translations for ${code} from GitHub (revision: ${revision})`);
                 }
                 return { translations, usedLang: code };
             }
@@ -161,8 +192,8 @@ import localeManifest from '../../locale-manifest.json';
 
                 if (englishResponse.ok) {
                     const translations = await englishResponse.json() as Record<string, string>;
-                    const enCacheKey = `JC_translation_en_${pluginVersion}`;
-                    const enTimestampKey = `JC_translation_ts_en_${pluginVersion}`;
+                    const enCacheKey = `JC_translation_en_${revision}`;
+                    const enTimestampKey = `JC_translation_ts_en_${revision}`;
                     JC.storage.local.write('translations', enCacheKey, JSON.stringify(translations), 'translation-cache-payload');
                     JC.storage.local.write('translations', enTimestampKey, Date.now().toString(), 'translation-cache-timestamp');
                     return { translations, usedLang: 'en' };
@@ -181,7 +212,7 @@ import localeManifest from '../../locale-manifest.json';
         }
 
         console.log(`🪼 Jellyfin Canopy: Loading bundled translations for ${code}...`);
-        let response = await fetch(ApiClient.getUrl(`/JellyfinCanopy/locales/${code}.json`));
+        let response = await fetch(bundledLocaleUrl(code, revision));
 
         if (response.ok) {
             const translations = await response.json() as Record<string, string>;
@@ -191,7 +222,7 @@ import localeManifest from '../../locale-manifest.json';
         }
 
         console.warn(`🪼 Jellyfin Canopy: Bundled ${code} not found, falling back to bundled English`);
-        response = await fetch(ApiClient.getUrl('/JellyfinCanopy/locales/en.json'));
+        response = await fetch(bundledLocaleUrl('en', revision));
         if (response.ok) {
             return { translations: await response.json() as Record<string, string>, usedLang: 'en' };
         }
@@ -201,7 +232,7 @@ import localeManifest from '../../locale-manifest.json';
 
     JC.loadTranslations = async function (): Promise<Record<string, string>> {
         try {
-            const pluginVersion = await getPluginVersion();
+            const revision = await getTranslationRevision();
 
             let user: unknown = ApiClient.getCurrentUser ? ApiClient.getCurrentUser() : null;
             if (user instanceof Promise) {
@@ -227,12 +258,12 @@ import localeManifest from '../../locale-manifest.json';
                 }
             }
 
-            cleanOldTranslationCache(pluginVersion);
+            cleanOldTranslationCache(revision);
 
             const langCodes = buildLanguageChain(lang);
             for (const code of langCodes) {
                 try {
-                    const result = await tryLoadSingleLanguage(code, pluginVersion);
+                    const result = await tryLoadSingleLanguage(code, revision);
                     if (result && result.translations) {
                         return result.translations;
                     }

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -208,7 +208,7 @@ Both values are **advisory only** — the input enforces no minimum or maximum, 
 
 ## Internationalization
 
-Jellyfin Canopy speaks 26 bundled languages and picks the right one automatically, so most users never touch a language setting. It detects each user's Jellyfin profile language, loads the matching translation from the plugin's bundled locale files on first load, and caches it for 24 hours. Only when the [third-party asset cache](#third-party-assets) is disabled does it fall back to fetching translations from GitHub. Outdated caches are cleared automatically when the plugin updates.
+Jellyfin Canopy speaks 26 bundled languages and picks the right one automatically, so most users never touch a language setting. It detects each user's Jellyfin profile language, loads the matching translation from the plugin's bundled locale files on first load, and caches it for 24 hours. Each deployed plugin build uses its own locale URL and browser-cache namespace, including same-version hot deployments, so an older catalog is never reused for a newer DLL. Only when the [third-party asset cache](#third-party-assets) is disabled does it fall back to fetching translations from GitHub. Outdated caches are cleared automatically when the plugin updates.
 
 **Default UI Language** (on the **Display** tab) overrides the automatic detection for everyone:
 

--- a/scripts/validate-translations.test.js
+++ b/scripts/validate-translations.test.js
@@ -266,9 +266,10 @@ test('translation deployment docs stay aligned with the bundled-first runtime co
     assert.ok(bundledFetch >= 0, 'runtime must request the installed bundled locale');
     assert.ok(fallbackGate > bundledFetch, 'remote fallback gate must follow bundled loading');
     assert.ok(remoteFetch > fallbackGate, 'GitHub must remain a gated last-resort fallback');
-    assert.match(loader, /JC_translation_\$\{code\}_\$\{pluginVersion\}/);
+    assert.match(loader, /JC_translation_\$\{code\}_\$\{revision\}/);
+    assert.match(loader, /locales\/\$\{code\}\.json\?v=\$\{encodeURIComponent\(revision\)\}/);
     assert.match(loader, /const CACHE_DURATION = 24 \* 60 \* 60 \* 1000/);
-    assert.match(loader, /cleanOldTranslationCache\(pluginVersion\)/);
+    assert.match(loader, /cleanOldTranslationCache\(revision\)/);
     assert.match(loader, /Jellyfin-Canopy\/main\/Jellyfin\.Plugin\.JellyfinCanopy\/js\/locales/);
     assert.doesNotMatch(loader, /n00bcodr\/Jellyfin-Enhanced/);
 


### PR DESCRIPTION
## What changed

- Scope the 24-hour translation cache to Canopy's deployment-specific script revision instead of the unchanged assembly version.
- Append that revision to every bundled locale request, including retries and the bundled English fallback, so immutable browser caching remains safe.
- Preserve the scheduled translation-cache clear watermark while retiring obsolete locale payloads.
- Add regressions for same-version hot deployments and watermark preservation, and document the cache contract.

## Root cause

The new Spoiler Guard persistent-override translations were present in all 26 bundled locales and on the live server, but an existing browser could retain the pre-change catalog. Both localStorage and the immutable locale URL were keyed only by the unchanged `2.0.0.0` assembly version, so `JC.t` returned the raw key names for newly added strings.

## Impact

After this change, each deployed DLL receives a distinct translation cache namespace and locale URL. Existing users automatically load the current catalog after a hot deployment without manually clearing browser storage or waiting 24 hours.

## Validation

- Focused translation loader/fallback tests: 8 passed
- Full client suite: 1,785 passed
- Repository script suite: 502 passed
- Server suite: 2,274 passed, 0 skipped
- All 26 locale catalogs: 956/956 keys
- TypeScript type checks, syntax inventory, performance rules, deterministic bundle build, targeted zero-warning lint, and strict docs build passed
- Two independent reviews approved with no remaining blocker/high/medium findings