### PR TITLE
docs: mark required E2E as blocking

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -307,9 +307,10 @@ JF_BASE_URL=http://127.0.0.1:8100 npm run e2e
 docker compose -f e2e/docker/compose.yml down -v
 ```
 
-CI runs the same stack on every PR across six isolated native Playwright shards
-(advisory while the infrastructure earns trust). Each CI server is explicitly
-capped at two CPUs and verifies Docker applied that quota before seeding.
+CI runs the same stack across six isolated native Playwright shards. The shards
+and their aggregate are blocking checks for pull requests, `main` pushes, and
+reusable release calls. Each CI server is explicitly capped at two CPUs and
+verifies Docker applied that quota before seeding.
 
 For a faster whole-suite run on a Linux development machine, use the opt-in
 local sharding runner:


### PR DESCRIPTION
## Summary

Corrects the stale contributor guidance that still described the six-shard Jellyfin 12 E2E lane as advisory.

The updated wording now matches the authoritative workflow contract: all six shards and their aggregate are blocking for pull requests, `main` pushes, and reusable release calls.

Closes #440.

## Root cause and impact

The E2E workflow was ratcheted to a blocking gate, but the nearby `CONTRIBUTING.md` prose retained its earlier advisory description. Contributors could therefore misunderstand which failures prevent delivery and release.

## Validation

- `npm run check:toolchain` — Node v22.20.0 / npm 10.9.3
- `npm ci` — 198 packages installed, 0 vulnerabilities
- `node --test scripts/e2e/workflow-sharding.test.js` — 7 passed, 0 failed
- `npm run check:docs` — offline content, permission, asset, and strict MkDocs gates passed under locked Python 3.13.14 dependencies
- `git diff --check`
- Independent Sol Ultra review: no material findings

## Scope

Documentation-only. No source, workflow, test, generated artifact, or runtime behavior changed.

## AI assistance

This PR was developed and independently reviewed with AI assistance. The resulting diff and validation evidence were inspected before publication.