### PR TITLE
docs: clarify watchlist auto-add scope

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinCanopy/Configuration/configPage.html
@@ -1529,7 +1529,7 @@
                             <div class="checkboxContainer"><label><input id="addRequestedMediaToWatchlist" data-config-key="AddRequestedMediaToWatchlist" is="emby-checkbox" type="checkbox"/><span>Add requested media to Watchlist</span></label></div>
                             <div class="jc-setting-description" data-desc-for="addRequestedMediaToWatchlist">
                                 <div class="fieldDescription jc-field-desc-xl">
-                                    When enabled, any media requested through Seerr Search via Jellyfin Canopy will automatically be added to the requesting user's Watchlist.<br/><br/>
+                                    When enabled, media requested in any configured Seerr instance will automatically be added to the requesting user's Watchlist when it becomes available in Jellyfin. This includes requests created outside Jellyfin Canopy.<br/><br/>
                                     <strong>Note:</strong> Requires <a class="jc-bold-link" href="https://github.com/ranaldsgift/KefinTweaks" target="_blank">KefinTweaks</a> to be installed to actually view the watchlisted items.
                                     <span class="jc-installed-badge" data-plugin="kefintweaks"><i class="material-icons" aria-hidden="true">check_circle</i>KefinTweaks detected</span>
                                 </div>

--- a/docs/discover.md
+++ b/docs/discover.md
@@ -522,7 +522,7 @@ Keep watchlists in step between Seerr and Jellyfin, in either direction. Configu
 
 **Seerr → Jellyfin** *(requires the [KefinTweaks plugin](https://github.com/ranaldsgift/KefinTweaks) to provide watchlist functionality)*
 
-- Adds requested items to the Jellyfin watchlist when they become available in the library.
+- Adds items requested in any configured Seerr instance to the requesting user's Jellyfin watchlist when they become available in the library, including requests created outside Canopy.
 - Syncs Seerr watchlist items to Jellyfin.
 - Remembers previously removed items so they aren't re-added.
 - Runs via the **Sync Watchlist from Seerr to Jellyfin** scheduled task.
@@ -536,7 +536,7 @@ Keep watchlists in step between Seerr and Jellyfin, in either direction. Configu
 
 | Setting | Default | What it does |
 | --- | --- | --- |
-| **Add requested media to Watchlist** | — | Auto-adds requested items when they become available (needs KefinTweaks). |
+| **Add requested media to Watchlist** | — | Auto-adds items from any configured Seerr instance when they become available, including requests created outside Canopy (needs KefinTweaks). |
 | **Sync Seerr Watchlist → Jellyfin** | — | Syncs Seerr watchlist items to Jellyfin. |
 | **Sync Jellyfin Watchlist → Seerr** | — | Syncs each user's Jellyfin watchlist to their linked Seerr account. |
 | **Prevent re-adding removed items** | — | Remembers removed items so they aren't re-added. |

--- a/scripts/watchlist-admin-description.test.js
+++ b/scripts/watchlist-admin-description.test.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const ROOT = path.resolve(__dirname, '..');
+const CONFIG_PAGE = path.join(
+    ROOT,
+    'Jellyfin.Plugin.JellyfinCanopy',
+    'Configuration',
+    'configPage.html'
+);
+const DISCOVER_DOCS = path.join(ROOT, 'docs', 'discover.md');
+
+test('watchlist auto-add copy covers requests created outside Canopy', () => {
+    const configPage = fs.readFileSync(CONFIG_PAGE, 'utf8');
+    const docs = fs.readFileSync(DISCOVER_DOCS, 'utf8');
+
+    assert.match(configPage, /media requested in any configured Seerr instance/);
+    assert.match(configPage, /This includes requests created outside Jellyfin Canopy\./);
+    assert.doesNotMatch(configPage, /requested through Seerr Search via Jellyfin Canopy/);
+    assert.match(docs, /including requests created outside Canopy/);
+});


### PR DESCRIPTION
## Summary

- correct the Watchlist admin description to reflect that auto-add considers requests from every configured Seerr instance, including requests created outside Canopy
- align the public discovery/watchlist documentation with the same scope
- add a source-contract regression that rejects the stale Canopy-only wording

## Root cause

The UI copy described a Canopy-origin restriction that the implementation does not track or enforce. `WatchlistMonitor` fetches each configured Seerr identity domain's complete `filter=all` request collection without a user header, then matches media and the source-bound requesting user.

## Validation

- `node --test scripts/watchlist-admin-description.test.js` — 1 passed
- `npm run test:scripts` — 503 passed
- `npm run test:server:coverage` — 2,274 passed; 26,967/35,660 lines (75.623%), exact reviewed baseline
- `npm run check:docs` — content, permissions, assets, and strict MkDocs build passed
- `npm run syntax`
- `npm run typecheck:src`
- `npm run typecheck`
- `npx eslint scripts/watchlist-admin-description.test.js`
- `git diff --check origin/main...HEAD`
- independent GPT-5.6 Sol Ultra whole-commit review — `APPROVE`

## Scope and risk

Documentation/admin-copy and its regression only; runtime watchlist behavior is unchanged.

## AI assistance

AI-assisted implementation and review were used. The final diff and validation evidence were independently inspected.

Closes #367