### PR TITLE
fix: preserve replacement body observers

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/dom-observer.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/dom-observer.test.ts
@@ -5,7 +5,74 @@
 // re-injection checks instead of one MutationObserver per feature).
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { JC } from '../globals';
-import { ensureInjected, onSidebarRebuild, waitForElement } from './dom-observer';
+import {
+    createObserver,
+    disconnectObserver,
+    ensureInjected,
+    onBodyMutation,
+    onSidebarRebuild,
+    waitForElement
+} from './dom-observer';
+
+describe('body subscriber replacement ownership', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+    });
+    afterEach(() => {
+        document.body.innerHTML = '';
+        vi.restoreAllMocks();
+    });
+
+    const flushMutation = async (): Promise<void> => {
+        document.body.appendChild(document.createElement('div'));
+        await new Promise((resolve) => setTimeout(resolve, 0));
+    };
+
+    it('does not let a stale direct handle remove its replacement', async () => {
+        const first = vi.fn();
+        const replacement = vi.fn();
+        const staleHandle = onBodyMutation('test-direct-replacement', first);
+        const liveHandle = onBodyMutation('test-direct-replacement', replacement);
+
+        try {
+            staleHandle.disconnect();
+            await flushMutation();
+
+            expect(first).not.toHaveBeenCalled();
+            expect(replacement).toHaveBeenCalled();
+        } finally {
+            liveHandle.disconnect();
+        }
+    });
+
+    it('does not let a stale body-observer proxy remove its replacement', async () => {
+        const first = vi.fn();
+        const replacement = vi.fn();
+        const config = { childList: true, subtree: true };
+        const staleObserver = createObserver(
+            'test-proxy-replacement',
+            first,
+            document.body,
+            config
+        );
+        createObserver(
+            'test-proxy-replacement',
+            replacement,
+            document.body,
+            config
+        );
+
+        try {
+            staleObserver.disconnect();
+            await flushMutation();
+
+            expect(first).not.toHaveBeenCalled();
+            expect(replacement).toHaveBeenCalled();
+        } finally {
+            disconnectObserver('test-proxy-replacement');
+        }
+    });
+});
 
 describe('ensureInjected', () => {
     beforeEach(() => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/dom-observer.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/dom-observer.ts
@@ -108,14 +108,15 @@ export function onBodyMutation(
     if (bodySubscribers.has(id)) {
         console.warn(`🪼 Jellyfin Canopy: Replacing body observer subscriber: ${id}`);
     }
-    bodySubscribers.set(id, { callback, priority });
+    const subscriber = { callback, priority };
+    bodySubscribers.set(id, subscriber);
     if (priority !== 0) {
         resortBodySubscribers();
     }
     ensureBodyObserver();
     console.log(`🪼 Jellyfin Canopy: Body subscriber registered: ${id} (priority: ${priority}, total: ${bodySubscribers.size})`);
     const cleanup = (): void => {
-        if (!bodySubscribers.has(id)) return;
+        if (bodySubscribers.get(id) !== subscriber) return;
         bodySubscribers.delete(id);
         console.log(`🪼 Jellyfin Canopy: Body subscriber removed: ${id} (remaining: ${bodySubscribers.size})`);
         stopBodyObserverIfEmpty();

--- a/scripts/bundle-budgets.json
+++ b/scripts/bundle-budgets.json
@@ -9,7 +9,7 @@
     "maxBootRawBytes": 524288,
     "maxBootGzipBytes": 196608,
     "maxColdHomeRequests": 24,
-    "maxColdHomeRawBytes": 183692,
+    "maxColdHomeRawBytes": 183702,
     "maxColdHomeGzipBytes": 62311,
     "maxFeatureRequests": 16,
     "maxFeatureRawBytes": 524288,

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -18,7 +18,7 @@ const ROOT = path.join(__dirname, '..');
 const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the clean measurement envelopes', () => {
-    assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2326, totalLines: 2666 });
+    assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2327, totalLines: 2667 });
     assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 26967, totalLines: 35660 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 5);

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -9,12 +9,12 @@
       "scope": "Jellyfin.Plugin.JellyfinCanopy/src/core/**",
       "report": "coverage/coverage-summary.json",
       "measured": {
-        "coveredLines": 2326,
-        "totalLines": 2666
+        "coveredLines": 2327,
+        "totalLines": 2667
       },
       "tolerance": {
         "missingCoveredLines": 1,
-        "rationale": "The rebased branch combines the server-owned ARR download lifecycle regressions with the actor-isolated admin-target Canopy User Settings editor. The admin-target tests exercise one additional existing core line without changing the 2666-line client/core scope, advancing the reviewed high-water from 2325/2666 (87.209%) to 2326/2666 (87.247%). Two clean combined Node 22.20/V8 runs on 2026-07-26 each passed all 1603 tests across 227 files and reproduced exactly 2326/2666. Retaining the one-line tolerance makes the minimum 2325/2666 (87.209%), equal to the prior reviewed high-water and stricter than its 2324/2666 tolerated floor (87.172%). coverage-baseline.test.js retains the exact below-floor, above-baseline, scope-change, and broad-tolerance negative boundaries."
+        "rationale": "The #369 body-observer ownership fix adds one instrumented and covered client/core line so stale handles compare their exact subscriber identity before cleanup, advancing the reviewed high-water from 2326/2666 (87.247%) to 2327/2667 (87.252%). Two clean Node 22.20/V8 runs on 2026-07-27 each passed all 1788 tests across 233 files and reproduced exactly 2327/2667. Retaining the existing one-line tolerance makes the minimum 2326/2667 (87.214%), stricter than the prior 2325/2666 tolerated floor (87.209%). coverage-baseline.test.js retains the exact below-floor, above-baseline, scope-change, and broad-tolerance negative boundaries."
       }
     },
     "server": {


### PR DESCRIPTION
## Summary

- bind each body-subscriber cleanup handle to the exact subscriber object it created
- prevent stale direct and managed body-observer handles from deleting a newer subscriber with the same ID
- add regressions for both `onBodyMutation` and `createObserver(document.body)` replacement paths
- advance the reviewed client-coverage baseline to the repeated exact 2,327/2,667 measurement
- raise the cold-Home raw ceiling only to the exact measured 183,702 bytes

Closes #369

## Validation

- focused `dom-observer` tests: 16/16
- full client coverage: 233 files, 1,788/1,788 tests, 2,327/2,667 lines
- script tests: 503/503
- `typecheck:src`, legacy `typecheck`, syntax, performance policy, changed-file ESLint, and diff check
- deterministic bundle: 173 files; build `19a203e291c32cef6b0402c443917211440b8dcc7038339a2ca94ec432488155`; cold Home 183,702 raw bytes
- independent read-only review of commit `2530e4d0b8c6cddbbcbd2df43efc62750de845b3`: APPROVE

## AI assistance

This change was developed and reviewed with AI assistance. I reviewed and validated the implementation and understand the ownership behavior.