### PR TITLE
fix: cancel initial tag cache reconciliation

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/StartupCancellationContractTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/StartupCancellationContractTests.cs
@@ -1,0 +1,42 @@
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services;
+
+/// <summary>
+/// Pins the scheduled-task cancellation chain for the potentially large first-install
+/// tag-cache reconcile.
+/// </summary>
+public sealed class StartupCancellationContractTests
+{
+    [Fact]
+    public void StartupTask_ThreadsItsCancellationTokenIntoTheInitialTagCacheBuild()
+    {
+        var startupSource = File.ReadAllText(Path.Combine(
+            SourceRoot(), "Services", "StartupService.cs"));
+        var executeStart = startupSource.IndexOf(
+            "public async Task ExecuteAsync", StringComparison.Ordinal);
+        Assert.True(executeStart >= 0);
+        var executeEnd = startupSource.IndexOf(
+            "private void EnsureScriptInjected", executeStart, StringComparison.Ordinal);
+        Assert.True(executeEnd > executeStart);
+        var executeBody = startupSource[executeStart..executeEnd];
+
+        Assert.Contains("await Task.Run(() =>", executeBody);
+        Assert.Contains("}, cancellationToken);", executeBody);
+        Assert.Contains(
+            "_tagCacheService.BuildFullCache(null, cancellationToken);",
+            executeBody);
+        Assert.DoesNotContain("CancellationToken.None", executeBody);
+
+        var tagCacheSource = File.ReadAllText(Path.Combine(
+            SourceRoot(), "Services", "TagCacheService.cs"));
+        Assert.Contains(
+            "cancellationToken.ThrowIfCancellationRequested();",
+            tagCacheSource);
+    }
+
+    private static string SourceRoot([CallerFilePath] string sourceFile = "")
+        => Path.GetFullPath(Path.Combine(
+            Path.GetDirectoryName(sourceFile)!, "..", "..", "Jellyfin.Plugin.JellyfinCanopy"));
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/StartupService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/StartupService.cs
@@ -90,7 +90,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     if (_tagCacheService.Count == 0)
                     {
                         _logger.LogInformation("[TagCache] No cache on disk, building initial cache...");
-                        _tagCacheService.BuildFullCache(null, CancellationToken.None);
+                        _tagCacheService.BuildFullCache(null, cancellationToken);
                     }
                 }
                 catch (System.Exception ex)


### PR DESCRIPTION
## Summary

- pass the scheduled startup task's cancellation token into the initial tag-cache reconciliation
- retain the existing cancellation-aware `Task.Run` scheduling path on current `main`
- add a source-contract regression guard covering the complete startup-to-cache cancellation chain and forbidding `CancellationToken.None` in `ExecuteAsync`

Closes #364

## Validation

- regression test failed before the production fix and passed afterward (1/1)
- full server coverage suite: 2,275/2,275 tests passed; exact covered/total line evidence remained 26,967/35,660
- Release plugin build: succeeded with 0 warnings and 0 errors
- independent read-only review: `APPROVE`

## AI assistance

Implementation, regression coverage, validation, and review were completed with Codex assistance.