### PR TITLE
fix: resolve controlling sessions from Jellyfin 12 identity

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/ControllerUserIdentityTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/ControllerUserIdentityTests.cs
@@ -1,0 +1,60 @@
+using System.Security.Claims;
+using Jellyfin.Plugin.JellyfinCanopy.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers;
+
+public sealed class ControllerUserIdentityTests
+{
+    [Fact]
+    public void CurrentUserId_PrefersTheJellyfin12Claim()
+    {
+        var jellyfinUserId = Guid.NewGuid();
+        var legacyUserId = Guid.NewGuid();
+        var controller = CreateController(
+            new Claim("Jellyfin-UserId", jellyfinUserId.ToString()),
+            new Claim(ClaimTypes.NameIdentifier, legacyUserId.ToString()));
+
+        Assert.Equal(jellyfinUserId, controller.ResolveCurrentUserId());
+    }
+
+    [Theory]
+    [InlineData(ClaimTypes.NameIdentifier)]
+    [InlineData("sub")]
+    [InlineData("Sid")]
+    public void CurrentUserId_KeepsLegacyClaimFallbacks(string claimType)
+    {
+        var expected = Guid.NewGuid();
+        var controller = CreateController(new Claim(claimType, expected.ToString()));
+
+        Assert.Equal(expected, controller.ResolveCurrentUserId());
+    }
+
+    private static IdentityProbeController CreateController(params Claim[] claims)
+    {
+        var controller = new IdentityProbeController
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"))
+                }
+            }
+        };
+        return controller;
+    }
+
+    private sealed class IdentityProbeController : JellyfinCanopyControllerBase
+    {
+        public IdentityProbeController()
+            : base(null!, NullLogger.Instance, null!, null!, null!)
+        {
+        }
+
+        public Guid ResolveCurrentUserId() => GetCurrentUserId();
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/ConfigController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/ConfigController.cs
@@ -222,9 +222,6 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             var deviceId = User.FindFirst("Jellyfin-DeviceId")?.Value;
             if (!string.IsNullOrWhiteSpace(deviceId))
             {
-                // NOTE: UserHelper reads the JF12 claim ("Jellyfin-UserId");
-                // the base controller's GetCurrentUserId() probes legacy claim
-                // types (NameIdentifier/sub/Sid) that JF12 does not set.
                 _liveSessionRegistry.Touch(deviceId, UserHelper.GetCurrentUserId(User) ?? Guid.Empty);
             }
         }

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/JellyfinCanopyControllerBase.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/JellyfinCanopyControllerBase.cs
@@ -165,7 +165,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
 
         protected Guid GetCurrentUserId()
         {
-            var claim = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)
+            var claim = User.FindFirst("Jellyfin-UserId")
+                     ?? User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)
                      ?? User.FindFirst("sub")
                      ?? User.FindFirst("Sid");
             if (claim != null && Guid.TryParse(claim.Value, out var id))

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -19,7 +19,7 @@ const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the clean measurement envelopes', () => {
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2327, totalLines: 2667 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 26967, totalLines: 35660 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 26975, totalLines: 35661 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 5);
 });

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -21,12 +21,12 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 26967,
-        "totalLines": 35660
+        "coveredLines": 26975,
+        "totalLines": 35661
       },
       "tolerance": {
         "missingCoveredLines": 5,
-        "rationale": "The combined tree includes both the Maintainerr v3.18 read-only integration and the complete elevated, actor-isolated Canopy User Settings resources for Hidden Content preferences, Spoiler Guard preferences, persistent Spoiler Guard overrides, and bounded Hidden Content inventory/item administration. Relative to their shared 22,637/31,176 baseline, the two changes add 4,484 instrumented lines and 4,330 covered lines across closed transport authorization, caller-scoped projection, bounded cache/admission, target-isolated persistence, concurrency, compatibility, opaque-data preservation, and negative-boundary regressions, raising coverage to 26,967/35,660 (75.623%). Three clean combined .NET 10.0.9/Coverlet runs on 2026-07-26 each passed all 2,274 tests and reproduced exactly 26,967/35,660. Retaining the existing evidence-bounded five-line Coverlet tolerance makes the minimum 26,962/35,660 (75.609%), stricter than both the pre-rebase admin-target floor of 25,462/33,961 (74.974%) and the Maintainerr-only floor of 24,134/32,875 (73.412%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, and broad-tolerance negative boundaries."
+        "rationale": "The #370 controller identity fix adds the Jellyfin 12 Jellyfin-UserId claim to the shared session-control resolver while retaining all legacy fallbacks, with direct behavioral coverage for claim precedence and compatibility. Two clean .NET 10.0.9/Coverlet runs on 2026-07-27 each passed all 2,279 tests and reproduced 35,661 instrumented lines; Coverlet reported 26,973 and 26,975 covered lines, so the reviewed high-water advances from 26,967/35,660 (75.623%) to 26,975/35,661 (75.643%). Retaining the existing evidence-bounded five-line Coverlet tolerance covers that two-line instrumentation variance and makes the minimum 26,970/35,661 (75.629%), stricter than the prior 26,962/35,660 floor (75.609%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
## Summary

- prefer Jellyfin 12's authoritative `Jellyfin-UserId` claim in the shared controller user resolver
- preserve `NameIdentifier`, `sub`, and `Sid` as legacy fallbacks
- add behavioral coverage for Jellyfin 12 precedence and every legacy fallback
- remove the now-stale legacy-only resolver comment
- advance the exact server coverage ratchet from 26,967/35,660 to a reviewed 26,975/35,661 high-water, retaining the existing five-line instrumentation envelope and a stricter minimum floor

This restores controlling-session attribution for both Active Streams and Maintenance Mode.

Closes #370

## Validation

- regression test: failed 1/4 before the production fix; passed 4/4 afterward
- full server coverage: 2,279/2,279 tests passed; gate passed at 26,973/35,661 within the reviewed 26,975/35,661 envelope
- build-script tests: 503/503 passed
- modified script test: ESLint passed
- repository-wide lint remains advisory and reports pre-existing findings outside this change
- independent read-only review: `APPROVE`

## AI assistance

Implementation, regression coverage, validation, ratchet evidence, and review were completed with Codex assistance.