### PR TITLE
fix: keep Active Streams header readiness recoverable

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/active-streams.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/active-streams.test.ts
@@ -1,10 +1,8 @@
-// Teardown test for src/extras/active-streams.ts (MISC-6).
+// Header-readiness and teardown tests for src/extras/active-streams.ts.
 //
-// When the header tray isn't mounted, tryInjectHeader schedules a 500ms retry.
-// Pre-fix that timer id was never stored, so destroy() couldn't cancel it — a
-// disable racing the retry window let a pending retry re-run the full injection
-// after teardown. The fix stores the id and clears it on both teardown paths
-// (stopObserver + destroy).
+// The shared body observer is the durable readiness owner: a slow Jellyfin
+// header must remain eligible until it mounts, without a capped polling ladder,
+// and teardown must invalidate the observer callback before it can inject.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 interface StreamsApi {
@@ -15,17 +13,26 @@ function api(): StreamsApi {
     return window.JellyfinCanopy as unknown as StreamsApi;
 }
 
+let headerContainer: HTMLElement | null;
+let bodyMutationCallback: (() => void) | null;
+let unsubscribe = vi.fn();
+
 function stubEnvironment(): void {
+    headerContainer = null;
+    bodyMutationCallback = null;
+    unsubscribe = vi.fn();
     const JC = window.JellyfinCanopy as unknown as Record<string, unknown>;
     JC.pluginConfig = { ActiveStreamsEnabled: true };
     JC.currentUser = { Policy: { IsAdministrator: true } };
-    // Header tray never mounts → tryInjectHeader always takes the retry branch.
     JC.helpers = {
-        getHeaderRightContainer: () => null,
-        onBodyMutation: () => ({ unsubscribe() { /* no-op */ } }),
+        getHeaderRightContainer: () => headerContainer,
+        onBodyMutation: (_id: string, callback: () => void) => {
+            bodyMutationCallback = callback;
+            return { unsubscribe };
+        },
     };
     JC.core = {
-        api: {},
+        api: { plugin: vi.fn().mockResolvedValue([]) },
         lifecycle: { register: () => ({ track: <T>(r: T): T => r, teardown() { /* no-op */ } }) },
         navigation: { onNavigate: () => () => { /* unsubscribe */ } },
     };
@@ -38,33 +45,49 @@ async function loadFresh(): Promise<void> {
     installActiveStreams();
 }
 
-describe('active-streams header-retry teardown', () => {
+describe('active-streams header readiness ownership', () => {
     beforeEach(() => {
         vi.useFakeTimers();
         document.body.innerHTML = '';
     });
 
     afterEach(() => {
+        try { api().activeStreams.destroy(); } catch { /* not initialized */ }
         vi.clearAllTimers();
         vi.useRealTimers();
     });
 
-    it('cancels the pending header-injection retry on destroy so it cannot fire post-teardown', async () => {
+    it('waits on the body observer until a delayed header mounts without a give-up timer', async () => {
         await loadFresh();
 
         api().activeStreams.initialize();
-        // The tray container is null, so a 500ms retry is pending.
-        expect(vi.getTimerCount()).toBe(1);
-
-        api().activeStreams.destroy();
-        // Pre-fix the retry timer was untracked, so destroy() left it pending (1).
+        expect(document.getElementById('jc-active-streams')).toBeNull();
+        expect(bodyMutationCallback).not.toBeNull();
         expect(vi.getTimerCount()).toBe(0);
 
-        // And nothing re-schedules or re-injects after teardown.
-        const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
-        vi.advanceTimersByTime(600);
-        expect(setTimeoutSpy).not.toHaveBeenCalled();
+        for (let probe = 0; probe < 25; probe++) bodyMutationCallback!();
         expect(document.getElementById('jc-active-streams')).toBeNull();
-        setTimeoutSpy.mockRestore();
+        expect(vi.getTimerCount()).toBe(0);
+
+        headerContainer = document.createElement('div');
+        document.body.appendChild(headerContainer);
+        bodyMutationCallback!();
+
+        expect(headerContainer.querySelector('#jc-active-streams')).not.toBeNull();
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('invalidates the body-observer readiness callback on destroy', async () => {
+        await loadFresh();
+        api().activeStreams.initialize();
+
+        api().activeStreams.destroy();
+        expect(unsubscribe).toHaveBeenCalledTimes(1);
+
+        headerContainer = document.createElement('div');
+        document.body.appendChild(headerContainer);
+        bodyMutationCallback!();
+
+        expect(document.getElementById('jc-active-streams')).toBeNull();
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/active-streams.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/active-streams.ts
@@ -99,11 +99,6 @@ let _lastUpdated: Date | null = null;
 // the first injection (boot / toggle-on, post-paint by architecture) gets the
 // one-time width-expand entrance; re-mount re-injections attach instantly.
 let _headerInjectedOnce = false;
-// The 500ms header-injection retry (fired when the header tray isn't mounted
-// yet). Stored so both teardown paths (stopObserver + destroy) can cancel a
-// pending retry — otherwise a disable racing the retry window re-injects the
-// full button + panel + poll after teardown (zombie UI).
-let _headerRetryTimer: ReturnType<typeof setTimeout> | null = null;
 // ── Live-update resources (only alive while the panel is open) ──────────────
 let _liveTimer: ReturnType<typeof setInterval> | null = null;
 let _liveUnsub: (() => void) | null = null;
@@ -1823,16 +1818,14 @@ const injectPanel = (context: IdentityContext): void => {
 };
 
 // ── Header button ────────────────────────────────────────────────────────
-const tryInjectHeader = (attempts: number, context: IdentityContext): void => {
+const tryInjectHeader = (context: IdentityContext): void => {
     if (!isCurrentContext(context)) return;
     if (document.getElementById('jc-active-streams')) return;
-    if (attempts > 20) return;
 
     const headerRight = JC.helpers.getHeaderRightContainer();
-    if (!headerRight) {
-        _headerRetryTimer = setTimeout(() => tryInjectHeader(attempts + 1, context), 500);
-        return;
-    }
+    // PERF(R9): readiness belongs to the durable body observer below. A slow
+    // host mount remains eligible without a capped give-up or polling timer.
+    if (!headerRight) return;
 
     const btn = stampOwner(document.createElement('button'), context);
     btn.id = 'jc-active-streams';
@@ -1879,7 +1872,7 @@ const startObserver = (context: IdentityContext): void => {
     if (_observer) return;
     const callback = (): void => {
         if (!isCurrentContext(context)) return;
-        if (!document.getElementById('jc-active-streams')) tryInjectHeader(0, context);
+        if (!document.getElementById('jc-active-streams')) tryInjectHeader(context);
     };
     if (JC?.helpers?.onBodyMutation) {
         _observer = JC.helpers.onBodyMutation('active-streams', callback);
@@ -1892,9 +1885,6 @@ const startObserver = (context: IdentityContext): void => {
 
 const stopObserver = (): void => {
     if (_observer) { _observer.unsubscribe(); _observer = null; }
-    // The observer callback re-invokes tryInjectHeader; cancel any pending
-    // header-injection retry so it can't re-inject after teardown.
-    if (_headerRetryTimer) { clearTimeout(_headerRetryTimer); _headerRetryTimer = null; }
 };
 
 // ── Public API ───────────────────────────────────────────────────────────
@@ -1918,7 +1908,7 @@ const activeStreamsApi = {
         console.log(`${LOG} Active Streams: initializing.`);
         injectStyles();
         startObserver(context);
-        tryInjectHeader(0, context);
+        tryInjectHeader(context);
         // Re-apply theme vars on every navigation (hashchange, popstate
         // and pushState — the old raw hashchange listener missed the
         // latter). Tracked via a lifecycle handle so destroy() removes it.
@@ -1934,7 +1924,6 @@ const activeStreamsApi = {
         if (_lifecycle) { _lifecycle.teardown(); _lifecycle = null; }
         if (_outsideClickListener) { document.removeEventListener('click', _outsideClickListener); _outsideClickListener = null; }
         if (_broadcastCollapseTimer) { clearTimeout(_broadcastCollapseTimer); _broadcastCollapseTimer = null; }
-        if (_headerRetryTimer) { clearTimeout(_headerRetryTimer); _headerRetryTimer = null; }
         document.getElementById('jc-active-streams')?.remove();
         document.getElementById('jc-active-streams-panel')?.remove();
         document.getElementById('jc-active-streams-styles')?.remove();


### PR DESCRIPTION
## Summary

- replace the capped 500 ms Active Streams header retry ladder with the shared body-mutation observer's durable readiness ownership
- keep delayed legacy and modern toolbar mounts eligible for injection without a standing polling timer
- invalidate the observer callback during teardown so stale callbacks cannot inject after destruction

Closes #451

## Verification

- regression-first: the new observer-readiness test failed against the previous implementation because it scheduled a retry timer
- targeted Active Streams tests: 2/2 passed
- full client suite with coverage: 1,789/1,789 passed; exact client/core coverage 2,327/2,667
- `npm run typecheck:src`
- `npm run check:syntax`
- `npm run check:performance-rules`
- deterministic bundle build ID: `11056537192d91f67e25731d2b24a4067f1e96384cd60708aa6d25cf5e3c3d47`
- independent read-only Codex review: APPROVE

AI assistance was used for implementation and review.