### PR TITLE
fix: contain playback event handler failures

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/AutoRequestHandlerSafetyTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/AutoRequestHandlerSafetyTests.cs
@@ -1,62 +1,101 @@
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Services.AutoRequest;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
 {
     /// <summary>
-    /// Guards the async-void safety contract (CSSVC-7). The auto-request playback handlers are
-    /// <c>async void</c>, so an exception that escapes their catch (e.g. a logging failure inside the
-    /// catch itself) becomes an unobserved exception that crashes the host. Every such handler's
-    /// <c>catch (Exception)</c> must therefore be double-guarded: the logging call inside it is itself
-    /// wrapped in a swallowing try/catch. This source-scan trips any handler that regresses.
+    /// Guards the playback-event handoff contract (CSSVC-7 / PERF(S7)). Jellyfin raises these
+    /// callbacks synchronously, so subscribed handlers must remain synchronous O(1) dispatchers:
+    /// <c>async void</c> cannot be observed by the host event pump and any exception escaping after
+    /// an await can crash the process.
     /// </summary>
     public class AutoRequestHandlerSafetyTests
     {
-        private static readonly string[] MonitorFiles =
+        private static readonly (string FileName, int HandlerCount)[] MonitorFiles =
         {
-            "AutoMovieRequestMonitor.cs",
-            "AutoSeasonRequestMonitor.cs",
+            ("AutoMovieRequestMonitor.cs", 1),
+            ("AutoSeasonRequestMonitor.cs", 2),
         };
 
         private static readonly Regex AsyncVoidHandler = new(
-            @"private\s+async\s+void\s+(On\w+)\s*\(", RegexOptions.Compiled);
+            @"private\s+async\s+void\s+OnPlayback\w+\s*\(", RegexOptions.Compiled);
 
-        private static readonly Regex OuterExceptionCatch = new(
-            @"catch\s*\(\s*Exception\b", RegexOptions.Compiled);
+        private static readonly Regex SynchronousVoidHandler = new(
+            @"private\s+void\s+(OnPlayback\w+)\s*\(", RegexOptions.Compiled);
 
-        // A nested try followed by a catch inside the outer catch body — the double-guard.
-        private static readonly Regex NestedTryCatch = new(
-            @"\btry\b[\s\S]*?\bcatch\b", RegexOptions.Compiled);
+        [Theory]
+        [MemberData(nameof(MonitorSources))]
+        public void PlaybackEventHandlers_AreSynchronousDispatchers(string name, int expectedHandlerCount)
+        {
+            var text = File.ReadAllText(FindSource(name));
+
+            Assert.DoesNotMatch(AsyncVoidHandler, text);
+
+            var handlers = SynchronousVoidHandler.Matches(text);
+            Assert.Equal(expectedHandlerCount, handlers.Count);
+            foreach (Match handler in handlers)
+            {
+                var handlerName = handler.Groups[1].Value;
+                var body = ExtractBracedBlock(text, text.IndexOf('{', handler.Index + handler.Length));
+                Assert.False(string.IsNullOrEmpty(body), $"{name}.{handlerName}: could not extract the method body");
+                Assert.Contains("DispatchPlaybackEvent(", body, StringComparison.Ordinal);
+                Assert.DoesNotContain("await ", body, StringComparison.Ordinal);
+                Assert.DoesNotContain("GetEnabledIntegration(", body, StringComparison.Ordinal);
+            }
+        }
+
+        public static TheoryData<string, int> MonitorSources()
+        {
+            var data = new TheoryData<string, int>();
+            foreach (var (fileName, handlerCount) in MonitorFiles)
+            {
+                data.Add(fileName, handlerCount);
+            }
+
+            return data;
+        }
 
         [Fact]
-        public void AsyncVoidPlaybackHandlers_HaveDoubleGuardedCatch()
+        public async Task DispatchPlaybackEvent_ContainsPostAwaitFailure()
         {
-            foreach (var name in MonitorFiles)
-            {
-                var text = File.ReadAllText(FindSource(name));
-                var handlers = AsyncVoidHandler.Matches(text);
-                Assert.True(handlers.Count > 0, $"{name} has no 'private async void On*' handler — did the file move or change shape?");
+            var logger = new RecordingLogger();
+            using var watcher = new TestPlaybackWatcher(logger);
 
-                foreach (Match handler in handlers)
+            var dispatch = watcher.Dispatch(
+                "OnPlaybackProgress",
+                async () =>
                 {
-                    var handlerName = handler.Groups[1].Value;
-                    var body = ExtractBracedBlock(text, text.IndexOf('{', handler.Index + handler.Length));
-                    Assert.False(string.IsNullOrEmpty(body), $"{name}.{handlerName}: could not extract the method body");
+                    await Task.Yield();
+                    throw new InvalidOperationException("after-await");
+                });
 
-                    var outerCatch = OuterExceptionCatch.Match(body!);
-                    Assert.True(outerCatch.Success, $"{name}.{handlerName} has no catch(Exception) block");
+            await dispatch.WaitAsync(TimeSpan.FromSeconds(5));
 
-                    var catchBody = ExtractBracedBlock(body!, body!.IndexOf('{', outerCatch.Index + outerCatch.Length));
-                    Assert.False(string.IsNullOrEmpty(catchBody), $"{name}.{handlerName}: could not extract the catch(Exception) body");
+            var logged = await logger.Entry.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.IsType<InvalidOperationException>(logged.Exception);
+            Assert.Contains("OnPlaybackProgress", logged.Message, StringComparison.Ordinal);
+        }
 
-                    Assert.True(
-                        NestedTryCatch.IsMatch(catchBody!),
-                        $"{name}.{handlerName}'s catch(Exception) is not double-guarded. An exception escaping an "
-                        + "async void handler's catch (e.g. a logging failure) crashes the host — wrap the catch "
-                        + "body in try { ... } catch { }.");
-                }
-            }
+        [Fact]
+        public async Task DispatchPlaybackEvent_ContainsLoggerFailure()
+        {
+            var logger = new ThrowingLogger();
+            using var watcher = new TestPlaybackWatcher(logger);
+
+            var dispatch = watcher.Dispatch(
+                "OnPlaybackStopped",
+                async () =>
+                {
+                    await Task.Yield();
+                    throw new InvalidOperationException("after-await");
+                });
+
+            await dispatch.WaitAsync(TimeSpan.FromSeconds(5));
+            await logger.Called.Task.WaitAsync(TimeSpan.FromSeconds(5));
         }
 
         // The brace-matched block starting at openBraceIndex (inclusive), or null.
@@ -86,6 +125,83 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             var root = Path.GetFullPath(Path.Combine(
                 Path.GetDirectoryName(sourceFile)!, "..", "..", "Jellyfin.Plugin.JellyfinCanopy"));
             return Directory.EnumerateFiles(root, fileName, SearchOption.AllDirectories).First();
+        }
+
+        private sealed class TestPlaybackWatcher : PlaybackWatcherBase
+        {
+            public TestPlaybackWatcher(ILogger logger)
+                : base(
+                    sessionManager: null!,
+                    userManager: null!,
+                    libraryManager: null!,
+                    logger,
+                    configProvider: null!)
+            {
+            }
+
+            protected override string LogPrefix => "[Test]";
+
+            protected override string FeatureNoun => "test";
+
+            protected override string DisabledMonitoringName => "Test";
+
+            protected override bool IsFeatureEnabled(PluginConfiguration config) => true;
+
+            protected override void SubscribeEvents()
+            {
+            }
+
+            protected override void UnsubscribeEvents()
+            {
+            }
+
+            public Task Dispatch(string handlerName, Func<Task> work)
+                => DispatchPlaybackEvent(handlerName, work);
+        }
+
+        private sealed class RecordingLogger : ILogger
+        {
+            public TaskCompletionSource<(Exception? Exception, string Message)> Entry { get; }
+                = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public IDisposable? BeginScope<TState>(TState state)
+                where TState : notnull
+                => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                Entry.TrySetResult((exception, formatter(state, exception)));
+            }
+        }
+
+        private sealed class ThrowingLogger : ILogger
+        {
+            public TaskCompletionSource Called { get; }
+                = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public IDisposable? BeginScope<TState>(TState state)
+                where TState : notnull
+                => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                Called.TrySetResult();
+                throw new InvalidOperationException("logger-failed");
+            }
         }
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/AutoMovieRequestMonitor.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/AutoMovieRequestMonitor.cs
@@ -45,85 +45,82 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             _sessionManager.PlaybackProgress -= OnPlaybackProgress;
         }
 
-        // Handle playback progress events to detect when user starts watching a movie.
-        // async void handler: the catch below is double-guarded so an exception escaping it
-        // (e.g. a logging failure) can't crash the host. See PlaybackWatcherBase.
-        private async void OnPlaybackProgress(object? sender, PlaybackProgressEventArgs e)
+        // PERF(S7): Jellyfin raises this synchronously on its session-event pump. Keep
+        // the subscribed callback O(1); all config and integration work starts on the
+        // observed worker boundary owned by PlaybackWatcherBase.
+        private void OnPlaybackProgress(object? sender, PlaybackProgressEventArgs e)
         {
-            try
+            _ = DispatchPlaybackEvent(
+                nameof(OnPlaybackProgress),
+                () => HandlePlaybackProgressAsync(e));
+        }
+
+        private async Task HandlePlaybackProgressAsync(PlaybackProgressEventArgs e)
+        {
+            // Check if auto-movie-request is enabled
+            var integration = GetEnabledIntegration();
+            if (integration?.Configuration is not PluginConfiguration config)
             {
-                // Check if auto-movie-request is enabled
-                var integration = GetEnabledIntegration();
-                if (integration?.Configuration is not PluginConfiguration config)
-                {
-                    return;
-                }
-
-                // Only process movies
-                if (e.Item?.GetBaseItemKind() != BaseItemKind.Movie)
-                {
-                    return;
-                }
-
-                // Check if conditions for triggering are met based on configuration
-                if (e.PlaybackPositionTicks.HasValue && e.Item.RunTimeTicks.HasValue && e.Item.RunTimeTicks.Value > 0)
-                {
-                    var progressPercentage = (double)e.PlaybackPositionTicks.Value / e.Item.RunTimeTicks.Value;
-                    var progressMinutes = TimeSpan.FromTicks(e.PlaybackPositionTicks.Value).TotalMinutes;
-
-                    var triggerType = config.AutoMovieRequestTriggerType ?? "Both";
-                    var minutesWatched = config.AutoMovieRequestMinutesWatched;
-
-                    bool shouldTrigger = false;
-
-                    if (triggerType == "OnStart")
-                    {
-                        // Trigger only on movie start (less than 5 minutes in and less than 5% progress)
-                        shouldTrigger = (progressMinutes <= 5 && progressPercentage < 0.05);
-                    }
-                    else if (triggerType == "OnMinutesWatched")
-                    {
-                        // Trigger only when user has watched for configured minutes
-                        shouldTrigger = (progressMinutes >= minutesWatched);
-                    }
-                    else if (triggerType == "Both")
-                    {
-                        // Trigger on either condition
-                        shouldTrigger = (progressMinutes <= 5 && progressPercentage < 0.05) || (progressMinutes >= minutesWatched);
-                    }
-
-                    if (shouldTrigger)
-                    {
-                        // Create a unique key using userId and item ID
-                        var session = e.Session;
-                        var item = e.Item;
-                        if (session == null || item == null)
-                        {
-                            return;
-                        }
-
-                        var userId = session.UserId;
-                        var sessionItemKey = $"{userId}_{item.Id}";
-
-                        await ExecuteDeduplicatedAsync(
-                            integration,
-                            sessionItemKey,
-                            async () =>
-                            {
-                                _logger.LogInformation($"[Auto-Movie-Request] Movie '{item.Name}' started by {session.UserName ?? "Unknown"}, checking for collection");
-                                return await _autoMovieRequestService
-                                    .CheckMovieForCollectionRequestAsync(item, userId, integration)
-                                    .ConfigureAwait(false);
-                            }).ConfigureAwait(false);
-                    }
-                }
+                return;
             }
-            catch (Exception ex)
+
+            // Only process movies
+            if (e.Item?.GetBaseItemKind() != BaseItemKind.Movie)
             {
-                // async void: an exception escaping this catch would become an unobserved exception
-                // that crashes the host, so guard the logging call itself.
-                try { _logger.LogError($"[Auto-Movie-Request] Error in OnPlaybackProgress: {ex.Message}"); }
-                catch { /* never let a logging failure crash the host from an async void handler */ }
+                return;
+            }
+
+            // Check if conditions for triggering are met based on configuration
+            if (e.PlaybackPositionTicks.HasValue && e.Item.RunTimeTicks.HasValue && e.Item.RunTimeTicks.Value > 0)
+            {
+                var progressPercentage = (double)e.PlaybackPositionTicks.Value / e.Item.RunTimeTicks.Value;
+                var progressMinutes = TimeSpan.FromTicks(e.PlaybackPositionTicks.Value).TotalMinutes;
+
+                var triggerType = config.AutoMovieRequestTriggerType ?? "Both";
+                var minutesWatched = config.AutoMovieRequestMinutesWatched;
+
+                bool shouldTrigger = false;
+
+                if (triggerType == "OnStart")
+                {
+                    // Trigger only on movie start (less than 5 minutes in and less than 5% progress)
+                    shouldTrigger = (progressMinutes <= 5 && progressPercentage < 0.05);
+                }
+                else if (triggerType == "OnMinutesWatched")
+                {
+                    // Trigger only when user has watched for configured minutes
+                    shouldTrigger = (progressMinutes >= minutesWatched);
+                }
+                else if (triggerType == "Both")
+                {
+                    // Trigger on either condition
+                    shouldTrigger = (progressMinutes <= 5 && progressPercentage < 0.05) || (progressMinutes >= minutesWatched);
+                }
+
+                if (shouldTrigger)
+                {
+                    // Create a unique key using userId and item ID
+                    var session = e.Session;
+                    var item = e.Item;
+                    if (session == null || item == null)
+                    {
+                        return;
+                    }
+
+                    var userId = session.UserId;
+                    var sessionItemKey = $"{userId}_{item.Id}";
+
+                    await ExecuteDeduplicatedAsync(
+                        integration,
+                        sessionItemKey,
+                        async () =>
+                        {
+                            _logger.LogInformation($"[Auto-Movie-Request] Movie '{item.Name}' started by {session.UserName ?? "Unknown"}, checking for collection");
+                            return await _autoMovieRequestService
+                                .CheckMovieForCollectionRequestAsync(item, userId, integration)
+                                .ConfigureAwait(false);
+                        }).ConfigureAwait(false);
+                }
             }
         }
     }

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/AutoRequest/PlaybackWatcherBase.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/AutoRequest/PlaybackWatcherBase.cs
@@ -15,14 +15,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.AutoRequest
     /// duplicates share one reservation; successful and definitive checks retain
     /// a one-hour cooldown, while retryable and cancelled checks release it.
     ///
-    /// Subclasses keep only their trigger predicate and handling logic. The playback
-    /// event handlers themselves stay in the subclasses as async void with their own
-    /// try/catch.
-    ///
-    /// Because those handlers are async void, an exception escaping their catch (e.g. from
-    /// the catch block itself) would become an unobserved exception that crashes the host.
-    /// Each subclass handler therefore double-guards its catch — the logging call inside the
-    /// outer catch is itself wrapped in a swallowing try/catch.
+    /// Subclasses keep only their trigger predicate and handling logic. Jellyfin's
+    /// synchronous playback-event delegates hand work to <see cref="DispatchPlaybackEvent"/>
+    /// so no async continuation or expensive configuration/integration work runs on the
+    /// host event pump.
     /// </summary>
     public abstract class PlaybackWatcherBase : IDisposable
     {
@@ -161,6 +157,59 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.AutoRequest
                     sessionItemKey,
                     operation)
                 : Task.FromResult(false);
+        }
+
+        /// <summary>
+        /// Defers a Jellyfin playback-event callback to the thread pool and contains every
+        /// non-fatal failure inside an observed <see cref="Task"/> boundary.
+        /// </summary>
+        /// <remarks>
+        /// PERF(S7): subscribed event handlers call only this O(1) dispatcher. Configuration
+        /// resolution and Seerr work start on the worker, while
+        /// <see cref="ExecuteDeduplicatedAsync"/> coalesces concurrent user/item operations.
+        /// </remarks>
+        protected Task DispatchPlaybackEvent(string handlerName, Func<Task> work)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(handlerName);
+            ArgumentNullException.ThrowIfNull(work);
+
+            try
+            {
+                return Task.Run(() => RunPlaybackEventSafelyAsync(handlerName, work));
+            }
+            catch (Exception ex)
+            {
+                TryLogPlaybackEventFailure(handlerName, ex);
+                return Task.CompletedTask;
+            }
+        }
+
+        private async Task RunPlaybackEventSafelyAsync(string handlerName, Func<Task> work)
+        {
+            try
+            {
+                await work().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                TryLogPlaybackEventFailure(handlerName, ex);
+            }
+        }
+
+        private void TryLogPlaybackEventFailure(string handlerName, Exception exception)
+        {
+            try
+            {
+                _logger.LogError(
+                    exception,
+                    "{LogPrefix} Error in {HandlerName}",
+                    LogPrefix,
+                    handlerName);
+            }
+            catch
+            {
+                // A logger failure must not fault detached playback-event work.
+            }
         }
 
         // Cleanup when the plugin is disposed. Terminal: marks the watcher disposed

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/AutoSeasonRequestMonitor.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/AutoSeasonRequestMonitor.cs
@@ -47,42 +47,111 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             _sessionManager.PlaybackProgress -= OnPlaybackProgress;
         }
 
-        // Handle playback stopped events to check if we should request next season.
-        // async void handler: the catch below is double-guarded so an exception escaping it
-        // (e.g. a logging failure) can't crash the host. See PlaybackWatcherBase.
-        private async void OnPlaybackStopped(object? sender, PlaybackStopEventArgs e)
+        // PERF(S7): Jellyfin raises this synchronously on its session-event pump. Keep
+        // the subscribed callback O(1); all config and integration work starts on the
+        // observed worker boundary owned by PlaybackWatcherBase.
+        private void OnPlaybackStopped(object? sender, PlaybackStopEventArgs e)
         {
-            try
+            _ = DispatchPlaybackEvent(
+                nameof(OnPlaybackStopped),
+                () => HandlePlaybackStoppedAsync(e));
+        }
+
+        private async Task HandlePlaybackStoppedAsync(PlaybackStopEventArgs e)
+        {
+            // Check if auto-season-request is enabled
+            var integration = GetEnabledIntegration();
+            if (integration?.Configuration is not PluginConfiguration config)
             {
-                // Check if auto-season-request is enabled
-                var integration = GetEnabledIntegration();
-                if (integration?.Configuration is not PluginConfiguration config)
+                return;
+            }
+
+            // Only process TV episodes
+            if (e.Item?.GetBaseItemKind() != BaseItemKind.Episode)
+            {
+                return;
+            }
+
+            _logger.LogDebug($"[Auto-Season-Request] PlaybackStopped event fired for episode: {e.Item?.Name}");
+
+            // Check if the episode was watched (at least 90% completion)
+            var playedToCompletion = e.PlayedToCompletion;
+            var completionPercentage = 0.0;
+            if (e.Item != null && e.PlaybackPositionTicks.HasValue && e.Item.RunTimeTicks.HasValue && e.Item.RunTimeTicks.Value > 0)
+            {
+                completionPercentage = (double)e.PlaybackPositionTicks.Value / e.Item.RunTimeTicks.Value;
+            }
+            //This probably can be removed but leaving it for now as a debug log
+
+            _logger.LogInformation($"[Auto-Season-Request] Episode '{e.Item?.Name ?? "Unknown"}' - PlayedToCompletion: {playedToCompletion}, Completion: {completionPercentage:P1}");
+
+            if (playedToCompletion || completionPercentage >= 0.9)
+            {
+                // Deduplicate stop events for the same user+item (same pattern as OnPlaybackProgress)
+                var session = e.Session;
+                var item = e.Item;
+                if (session == null || item == null)
                 {
                     return;
                 }
 
-                // Only process TV episodes
-                if (e.Item?.GetBaseItemKind() != BaseItemKind.Episode)
+                var userId = session.UserId;
+                var sessionItemKey = $"stopped_{userId}_{item.Id}";
+                var executed = await ExecuteDeduplicatedAsync(
+                    integration,
+                    sessionItemKey,
+                    async () =>
+                    {
+                        _logger.LogInformation($"[Auto-Season-Request] Episode '{item.Name}' completed by {session.UserName ?? "Unknown"}, checking threshold");
+                        return await _autoSeasonRequestService
+                            .CheckEpisodeCompletionAsync(item, userId, integration)
+                            .ConfigureAwait(false);
+                    }).ConfigureAwait(false);
+                if (!executed)
                 {
-                    return;
+                    _logger.LogDebug($"[Auto-Season-Request] PlaybackStopped already processed for '{item.Name}', skipping duplicate");
                 }
+            }
+            //This probably can be removed but leaving it for now as a debug log
+            else
+            {
+                _logger.LogDebug($"[Auto-Season-Request] Episode not completed enough ({completionPercentage:P1}), skipping");
+            }
+        }
 
-                _logger.LogDebug($"[Auto-Season-Request] PlaybackStopped event fired for episode: {e.Item?.Name}");
+        // PERF(S7): this delegate only dispatches; see OnPlaybackStopped.
+        private void OnPlaybackProgress(object? sender, PlaybackProgressEventArgs e)
+        {
+            _ = DispatchPlaybackEvent(
+                nameof(OnPlaybackProgress),
+                () => HandlePlaybackProgressAsync(e));
+        }
 
-                // Check if the episode was watched (at least 90% completion)
-                var playedToCompletion = e.PlayedToCompletion;
-                var completionPercentage = 0.0;
-                if (e.Item != null && e.PlaybackPositionTicks.HasValue && e.Item.RunTimeTicks.HasValue && e.Item.RunTimeTicks.Value > 0)
+        private async Task HandlePlaybackProgressAsync(PlaybackProgressEventArgs e)
+        {
+            // Check if auto-season-request is enabled
+            var integration = GetEnabledIntegration();
+            if (integration?.Configuration is not PluginConfiguration config)
+            {
+                return;
+            }
+
+            // Only process TV episodes
+            if (e.Item?.GetBaseItemKind() != BaseItemKind.Episode)
+            {
+                return;
+            }
+
+            // Only check when episode just started (within first 2 minutes)
+            if (e.PlaybackPositionTicks.HasValue && e.Item.RunTimeTicks.HasValue && e.Item.RunTimeTicks.Value > 0)
+            {
+                var progressPercentage = (double)e.PlaybackPositionTicks.Value / e.Item.RunTimeTicks.Value;
+                var progressMinutes = TimeSpan.FromTicks(e.PlaybackPositionTicks.Value).TotalMinutes;
+
+                // Only trigger on episode start (less than 2 minutes in)
+                if (progressMinutes <= 2 && progressPercentage < 0.05)
                 {
-                    completionPercentage = (double)e.PlaybackPositionTicks.Value / e.Item.RunTimeTicks.Value;
-                }
-                //This probably can be removed but leaving it for now as a debug log
-
-                _logger.LogInformation($"[Auto-Season-Request] Episode '{e.Item?.Name ?? "Unknown"}' - PlayedToCompletion: {playedToCompletion}, Completion: {completionPercentage:P1}");
-
-                if (playedToCompletion || completionPercentage >= 0.9)
-                {
-                    // Deduplicate stop events for the same user+item (same pattern as OnPlaybackProgress)
+                    // Create a unique key using userId and item ID
                     var session = e.Session;
                     var item = e.Item;
                     if (session == null || item == null)
@@ -91,96 +160,19 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     }
 
                     var userId = session.UserId;
-                    var sessionItemKey = $"stopped_{userId}_{item.Id}";
-                    var executed = await ExecuteDeduplicatedAsync(
+                    var sessionItemKey = $"{userId}_{item.Id}";
+
+                    await ExecuteDeduplicatedAsync(
                         integration,
                         sessionItemKey,
                         async () =>
                         {
-                            _logger.LogInformation($"[Auto-Season-Request] Episode '{item.Name}' completed by {session.UserName ?? "Unknown"}, checking threshold");
+                            _logger.LogInformation($"[Auto-Season-Request] Episode '{item.Name}' started by {session.UserName ?? "Unknown"}, checking threshold");
                             return await _autoSeasonRequestService
                                 .CheckEpisodeCompletionAsync(item, userId, integration)
                                 .ConfigureAwait(false);
                         }).ConfigureAwait(false);
-                    if (!executed)
-                    {
-                        _logger.LogDebug($"[Auto-Season-Request] PlaybackStopped already processed for '{item.Name}', skipping duplicate");
-                    }
                 }
-                //This probably can be removed but leaving it for now as a debug log
-                else
-                {
-                    _logger.LogDebug($"[Auto-Season-Request] Episode not completed enough ({completionPercentage:P1}), skipping");
-                }
-            }
-            catch (Exception ex)
-            {
-                // async void: an exception escaping this catch would become an unobserved exception
-                // that crashes the host, so guard the logging call itself.
-                try { _logger.LogError($"[Auto-Season-Request] Error in OnPlaybackStopped: {ex.Message}"); }
-                catch { /* never let a logging failure crash the host from an async void handler */ }
-            }
-        }
-
-        // Handle playback progress events to detect when user starts watching a new episode.
-        // async void handler: the catch below is double-guarded so an exception escaping it
-        // (e.g. a logging failure) can't crash the host. See PlaybackWatcherBase.
-        private async void OnPlaybackProgress(object? sender, PlaybackProgressEventArgs e)
-        {
-            try
-            {
-                // Check if auto-season-request is enabled
-                var integration = GetEnabledIntegration();
-                if (integration?.Configuration is not PluginConfiguration config)
-                {
-                    return;
-                }
-
-                // Only process TV episodes
-                if (e.Item?.GetBaseItemKind() != BaseItemKind.Episode)
-                {
-                    return;
-                }
-
-                // Only check when episode just started (within first 2 minutes)
-                if (e.PlaybackPositionTicks.HasValue && e.Item.RunTimeTicks.HasValue && e.Item.RunTimeTicks.Value > 0)
-                {
-                    var progressPercentage = (double)e.PlaybackPositionTicks.Value / e.Item.RunTimeTicks.Value;
-                    var progressMinutes = TimeSpan.FromTicks(e.PlaybackPositionTicks.Value).TotalMinutes;
-
-                    // Only trigger on episode start (less than 2 minutes in)
-                    if (progressMinutes <= 2 && progressPercentage < 0.05)
-                    {
-                        // Create a unique key using userId and item ID
-                        var session = e.Session;
-                        var item = e.Item;
-                        if (session == null || item == null)
-                        {
-                            return;
-                        }
-
-                        var userId = session.UserId;
-                        var sessionItemKey = $"{userId}_{item.Id}";
-
-                        await ExecuteDeduplicatedAsync(
-                            integration,
-                            sessionItemKey,
-                            async () =>
-                            {
-                                _logger.LogInformation($"[Auto-Season-Request] Episode '{item.Name}' started by {session.UserName ?? "Unknown"}, checking threshold");
-                                return await _autoSeasonRequestService
-                                    .CheckEpisodeCompletionAsync(item, userId, integration)
-                                    .ConfigureAwait(false);
-                            }).ConfigureAwait(false);
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                // async void: an exception escaping this catch would become an unobserved exception
-                // that crashes the host, so guard the logging call itself.
-                try { _logger.LogError($"[Auto-Season-Request] Error in OnPlaybackProgress: {ex.Message}"); }
-                catch { /* never let a logging failure crash the host from an async void handler */ }
             }
         }
     }

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -1081,7 +1081,7 @@ grep -rn "PERF(S7" Jellyfin.Plugin.JellyfinCanopy/
 
 **Enforced.** Review-enforced today. SR-09 extends the S1 guard (`LibraryScanEventGuardTests`) to cover `ISessionManager` and user-lifecycle subscriptions with the same allowlist + synchronous-body denylist.
 
-**In the tree (documented DEBT):** `Services/AutoMovieRequestMonitor.cs` and `Services/AutoSeasonRequestMonitor.cs` — `OnPlaybackProgress` runs config resolution plus (deduplicated) Seerr calls on **every** progress tick of every stream; the dedup bounds the remote calls but the per-tick resolution work still scales with concurrent streams.
+**In the tree (documented DEBT):** `Services/AutoMovieRequestMonitor.cs` and `Services/AutoSeasonRequestMonitor.cs` keep the synchronous Jellyfin callbacks O(1) by dispatching to an exception-contained worker. The worker still resolves configuration once per progress tick before the existing user+item Seerr deduplication, so that deferred per-tick work remains to be coalesced.
 
 #### S8 — Startup cost bound
 

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -19,7 +19,7 @@ const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the clean measurement envelopes', () => {
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2327, totalLines: 2667 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 26975, totalLines: 35661 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 26991, totalLines: 35680 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 5);
 });

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -21,12 +21,12 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 26975,
-        "totalLines": 35661
+        "coveredLines": 26991,
+        "totalLines": 35680
       },
       "tolerance": {
         "missingCoveredLines": 5,
-        "rationale": "The #370 controller identity fix adds the Jellyfin 12 Jellyfin-UserId claim to the shared session-control resolver while retaining all legacy fallbacks, with direct behavioral coverage for claim precedence and compatibility. Two clean .NET 10.0.9/Coverlet runs on 2026-07-27 each passed all 2,279 tests and reproduced 35,661 instrumented lines; Coverlet reported 26,973 and 26,975 covered lines, so the reviewed high-water advances from 26,967/35,660 (75.623%) to 26,975/35,661 (75.643%). Retaining the existing evidence-bounded five-line Coverlet tolerance covers that two-line instrumentation variance and makes the minimum 26,970/35,661 (75.629%), stricter than the prior 26,962/35,660 floor (75.609%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, and broad-tolerance negative boundaries."
+        "rationale": "The #452 playback-event safety fix replaces three async-void host callbacks with synchronous O(1) dispatchers and an exception-contained observed Task boundary, with behavioral coverage for post-await failures and a failing logger. Two clean .NET 10.0.9/Coverlet runs on 2026-07-27 each passed all 2,282 tests and reproduced exactly 26,991/35,680 instrumented lines (75.647%), so the reviewed high-water advances from 26,975/35,661 (75.643%). Retaining the existing evidence-bounded five-line Coverlet tolerance makes the minimum 26,986/35,680 (75.633%), stricter than the prior 26,970/35,661 floor (75.629%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
## Summary

- replace the movie progress, season progress, and season stopped `async void` subscribers with synchronous O(1) dispatchers
- run configuration and integration work behind a shared observed `Task` boundary so post-await failures cannot escape into Jellyfin's session event pump
- double-contain error logging so a logger failure cannot fault the detached worker
- preserve the existing generation-aware user/item deduplication and request behavior
- replace the old guard that required `async void` with regression and behavioral exception-containment coverage
- keep the remaining deferred per-tick S7 coalescing debt documented accurately

Closes #452

## Verification

- regression-first: 2/2 source-contract cases failed against the previous `async void` production shape
- focused final regression suite: 4/4 passed
- full server coverage: 2,282/2,282 passed; exact 26,991/35,680 lines (75.647%), required floor 26,986/35,680
- repeated pre-baseline measurements reproduced exactly 26,991/35,680 twice
- release build: 0 warnings, 0 errors
- script tests: 503/503 passed
- strict documentation gate passed with Python 3.13.14
- Node 22.20.0 / npm 10.9.3 toolchain check passed
- deterministic final bundle build ID: `e69e4e45472dee82c28433416fdfe6ac55f043df4cfffc7fd764d571d268fbd2`
- repository ESLint remains advisory with pre-existing findings; the modified script test is clean under targeted ESLint
- independent read-only Codex review: APPROVE

AI assistance was used for implementation and review.