### PR TITLE
research(extension-platform): close the manifest TOCTOU and bound the open

### DIFF
--- a/research/extension-platform/adr/0005-manifest-discovery.md
+++ b/research/extension-platform/adr/0005-manifest-discovery.md
@@ -18,7 +18,15 @@ declared scopes — are each a distinct vulnerability.
 2. **Fingerprint binding.** The manifest's self-declared `pluginId` must match
    the GUID Jellyfin reports for that plugin. A mismatch is a rejection, not a
    warning. Verified working ([S4](../spike-evidence.md#s4--manifest-discovery-binds-to-the-real-plugin-identity-and-rejects-a-claim-to-another)).
-3. **Containment before I/O.** The resolved path must canonicalize to a location
+3. **Open first, then decide — and fail closed.** Validating a path and then
+   opening it is a TOCTOU, and a measured one: it leaked a file from outside the
+   root on **17% of successful reads** under contention
+   ([S16](../spike-evidence.md#s16--the-manifest-read-is-a-toctou-and-a-fifo-stalls-it)).
+   The kernel opens the file, resolves what the **descriptor** actually refers to,
+   and refuses the read outright when that cannot be determined. It must also
+   **bound the open**: `open(2)` blocks forever on a FIFO, so a plugin shipping a
+   named pipe as its manifest would stall discovery for every plugin.
+4. **Containment before I/O.** The resolved path must canonicalize to a location
    strictly inside the plugin root; absolute paths, embedded NUL, `..` traversal
    and root-escaping symlinks are rejected before any file is opened.
    Verified ([S5](../spike-evidence.md#s5--path-containment-holds-against-traversal-symlinks-and-link-cycles)).
@@ -28,31 +36,31 @@ declared scopes — are each a distinct vulnerability.
    because resolving one component introduces new ones that may themselves be
    links. A link cycle must be a rejection, not an exception escaping the reader —
    discovery iterates every plugin and one bad root must not take out the rest.
-4. **Bounded.** Manifest size, id/version lengths, operation and contribution
+5. **Bounded.** Manifest size, id/version lengths, operation and contribution
    counts, nesting depth and local-asset counts are all capped.
-5. **A manifest is never a grant.** It states what an extension *requests*. An
+6. **A manifest is never a grant.** It states what an extension *requests*. An
    administrator approves. Requested and granted scopes are stored separately.
-6. **Fingerprint changes revoke approval.** Any change to the manifest
+7. **Fingerprint changes revoke approval.** Any change to the manifest
    fingerprint or the requested scope set returns the extension to *pending*.
    Stale grants are never inherited.
-7. **Explicit lifecycle states**, rendered distinctly and never collapsed:
+8. **Explicit lifecycle states**, rendered distinctly and never collapsed:
    `discovered/pending`, `enabled`, `disabled`, `restart-pending`, `incompatible`,
    `unhealthy`, `quarantined`, `revoked`, `absent`. `restart-pending` is not
    optional: Jellyfin's own disable produces `PluginStatus.Restart` and leaves the
    assembly loaded and resolvable, so an admin UI that reports "disabled" would be
    lying ([S15](../spike-evidence.md#s15--hot-lifecycle-nothing-is-ever-unloaded-and-disable-needs-a-restart)).
-8. **The kernel enforces state at invocation.** Because nothing is unloaded, a
+9. **The kernel enforces state at invocation.** Because nothing is unloaded, a
    disabled or revoked extension is still fully callable through Jellyfin's DI. The
    registry's state is the *only* thing standing between an administrator's
    decision and the extension continuing to run.
-9. **A plugin package may ship symlinks, and Jellyfin follows them.** A link to
+10. **A plugin package may ship symlinks, and Jellyfin follows them.** A link to
    `/` inside a plugin directory prevented the server from starting at all during
    the spike. The registry cannot fix the host's own scan, but it must not add to
    the problem, and admin diagnostics should make such a root identifiable.
-10. **Nothing on the startup path.** Discovery, validation and registry recovery
+11. **Nothing on the startup path.** Discovery, validation and registry recovery
    run after startup, off the critical path. One malformed extension must not
    delay or fail Jellyfin or Canopy startup.
-11. **Crash-safe persistence** via the existing `AtomicFile` durable-write
+12. **Crash-safe persistence** via the existing `AtomicFile` durable-write
    primitive (temp sibling → fsync contents → rename → fsync parent directory),
    with quarantine-on-corruption and a versioned unhealthy marker — the same
    model `UserConfigurationStore` already uses.

--- a/research/extension-platform/spike-evidence.md
+++ b/research/extension-platform/spike-evidence.md
@@ -516,6 +516,72 @@ after the restart.
 
 Recorded against [#493](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/493).
 
+## S16 — The manifest read is a TOCTOU, and a FIFO stalls it
+
+Replay: probe K in [`spikes/ep-00/run-spike.sh`](spikes/ep-00/run-spike.sh). The
+containment decision now lives in one place —
+[`PathContainment`](spikes/ep-00/Jellyfin.Plugin.Ep00Host/PathContainment.cs) —
+so EP-03 inherits it rather than re-deriving it.
+
+### The race is real, not theoretical
+
+A background task alternates one filename inside the root between an honest file
+and a symlink pointing outside it, while a reader loops. 4,000 iterations,
+~21,000 swaps, under half a second:
+
+| Read order | successful reads | **leaks** | torn reads | rejections |
+|---|---|---|---|---|
+| validate the path, then open it | 2,200 | **369** | ~400 | — |
+| open it, then validate the descriptor | 188 | **0** | 32 | 1,843 |
+
+The obvious order leaked the contents of a file outside the plugin root on **17%
+of its successful reads**. An extension can trigger this whenever it likes: it
+controls the files in its own directory, and the kernel reads manifests on a
+schedule the extension does not control but can observe.
+
+The correct order opens first and then decides about the **open descriptor**, via
+`/proc/self/fd`. Three details are load-bearing:
+
+- **Fail closed when the descriptor cannot be described.** A deleted inode
+  resolves to `"<path> (deleted)"`. Falling back to the pre-open decision there is
+  exactly the hole being closed — that is *precisely* when the pre-open decision is
+  least trustworthy. An earlier version kept the fallback and leaked on ~17% of its
+  reads, i.e. it fixed nothing.
+- **Resolve only the first hop of `/proc/self/fd/N`.** That link *is* the answer;
+  following further re-introduces a resolution the descriptor has already settled.
+- **Torn reads are not leaks.** The writer truncates before writing, so a reader
+  can legitimately see an empty file. An earlier version counted those as leaks and
+  made a working fix look broken. Only content matching the file *outside* the root
+  counts.
+
+The 1,843 rejections are the fix working: under contention the safe reader mostly
+declines rather than guessing. A real kernel retries; it does not relax the check.
+
+### A named pipe stalls the reader
+
+| Candidate | Result |
+|---|---|
+| `fifo` (a `mkfifo` named pipe) | `rejected: open blocked (not a regular file?)` |
+
+`open(2)` on a FIFO **blocks until a writer appears**. A plugin that ships a named
+pipe called `jellyfin-canopy-extension.json` would hang the reader indefinitely —
+and discovery iterates every plugin, so one such file stalls discovery for all of
+them. The open is now bounded and the candidate refused. Directories are rejected
+before the open rather than by failing it.
+
+Two related notes: a 5,000-character name is refused by the platform
+(`PathTooLongException`), and neither Unicode normalisation form of `café.json`
+collides with the other, so containment does not depend on filesystem
+normalisation behaviour.
+
+### Shapes that are accepted, and should be
+
+`./inside.json`, `sub/./../inside.json`, `inside.json/` and `inside.json/.` all
+resolve inside the root and are accepted. `.` is refused as a directory and `..`
+by containment.
+
+Recorded against [#494](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/494).
+
 ## What this spike did not establish
 
 Carried into later milestones rather than assumed.
@@ -547,8 +613,10 @@ Carried into later milestones rather than assumed.
 9. **Six of the eight lifecycle states** in
    [compatibility-terminology](compatibility-terminology.md#state-words) are design
    states with no probe. Only `absent` and `disabled` were shown distinguishable.
-10. **TOCTOU on manifest reads.** S5 validates a path and then opens it; nothing
-    re-validates on the open handle.
+10. ~~TOCTOU on manifest reads.~~ **Closed by
+    [S16](#s16--the-manifest-read-is-a-toctou-and-a-fifo-stalls-it):** the race is
+    demonstrated, the fix is measured at zero leaks, and the containment decision is
+    now a single shared function.
 
 ## Probe coverage of this file
 

--- a/research/extension-platform/spikes/ep-00/Jellyfin.Plugin.Ep00Host/Ep00SpikeController.cs
+++ b/research/extension-platform/spikes/ep-00/Jellyfin.Plugin.Ep00Host/Ep00SpikeController.cs
@@ -20,12 +20,14 @@ public class Ep00SpikeController : ControllerBase
     private readonly ProviderBinder _binder;
     private readonly ManifestProbe _manifests;
     private readonly LoadContextWatcher _watcher;
+    private readonly ToctouProbe _toctou;
 
-    public Ep00SpikeController(ProviderBinder binder, ManifestProbe manifests, LoadContextWatcher watcher)
+    public Ep00SpikeController(ProviderBinder binder, ManifestProbe manifests, LoadContextWatcher watcher, ToctouProbe toctou)
     {
         _binder = binder;
         _manifests = manifests;
         _watcher = watcher;
+        _toctou = toctou;
     }
 
     /// <summary>Anonymous discovery: availability and protocol range only. No topology.</summary>
@@ -68,6 +70,11 @@ public class Ep00SpikeController : ControllerBase
     [HttpGet("Runtime")]
     [Authorize(Policy = Policies.RequiresElevation)]
     public ActionResult<object> Runtime([FromQuery] bool collect) => Ok(_watcher.Snapshot(collect));
+
+    /// <summary>EP-00.5: races a path swap against both read orders.</summary>
+    [HttpGet("Toctou")]
+    [Authorize(Policy = Policies.RequiresElevation)]
+    public ActionResult<object> Toctou([FromQuery] int iterations) => Ok(_toctou.Run(iterations));
 
     [HttpGet("Manifests")]
     [Authorize(Policy = Policies.RequiresElevation)]

--- a/research/extension-platform/spikes/ep-00/Jellyfin.Plugin.Ep00Host/ManifestProbe.cs
+++ b/research/extension-platform/spikes/ep-00/Jellyfin.Plugin.Ep00Host/ManifestProbe.cs
@@ -129,6 +129,22 @@ public sealed class ManifestProbe
             "hop-etc/openssl.cnf",
             // A symlink loop: passes File.Exists and the size cap, and only fails on read.
             "cycle",
+            // Shapes that look harmless and are worth pinning behaviour on.
+            "./inside.json",
+            "sub/./../inside.json",
+            "inside.json/",
+            "inside.json/.",
+            ".",
+            "..",
+            "   ",
+            new string('a', 5000),
+            // Unicode: a decomposed form that normalises to a different byte sequence
+            // than the composed one. Filesystems differ on whether these are the same
+            // name; the containment decision must not depend on that.
+            // A named pipe: open(2) blocks on it until a writer appears.
+            "fifo",
+            "caf\u00e9.json",
+            "cafe\u0301.json",
         };
 
         var root = Directory.Exists(LinkFixtureRoot)
@@ -154,197 +170,13 @@ public sealed class ManifestProbe
     }
 
     /// <summary>
-    /// The only sanctioned manifest read. Rejects anything that does not resolve to a
-    /// regular file physically inside <paramref name="root"/> — including a path whose
-    /// *directory* components are symlinks, which a lexical check cannot see.
+    /// The only sanctioned manifest read. Delegates to <see cref="PathContainment"/>
+    /// so the containment decision has exactly one implementation, which EP-03
+    /// inherits rather than re-derives.
     /// </summary>
     private static bool TryRead(string? root, string relativeName, out string? json, out string reason)
     {
-        json = null;
-
-        if (string.IsNullOrWhiteSpace(root))
-        {
-            reason = "rejected: plugin has no root path";
-            return false;
-        }
-
-        if (relativeName.Contains('\0', StringComparison.Ordinal))
-        {
-            reason = "rejected: embedded NUL in name";
-            return false;
-        }
-
-        // Normalise BOTH separators before any test. A backslash is a legal filename
-        // character on Unix, so without this a Windows-style traversal is silently
-        // treated as an ordinary (missing) filename and appears to be "rejected"
-        // when in fact it was never evaluated.
-        var normalised = relativeName.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
-
-        if (Path.IsPathRooted(normalised))
-        {
-            reason = "rejected: absolute path";
-            return false;
-        }
-
-        string canonicalRoot;
-        string candidate;
-        try
-        {
-            canonicalRoot = Path.TrimEndingDirectorySeparator(ResolveFinal(Path.GetFullPath(root)));
-            candidate = Path.GetFullPath(Path.Combine(canonicalRoot, normalised));
-        }
-        catch (Exception ex)
-        {
-            reason = "rejected: unresolvable path (" + ex.GetType().Name + ")";
-            return false;
-        }
-
-        if (!IsInside(candidate, canonicalRoot))
-        {
-            reason = "rejected: resolves outside plugin root";
-            return false;
-        }
-
-        // Lexical containment is not enough: Path.GetFullPath does not follow links,
-        // so `root/evil/passwd` where `root/evil -> /etc` passes the check above.
-        // Re-test against the fully resolved path.
-        string resolved;
-        try
-        {
-            resolved = ResolveToFixedPoint(candidate);
-        }
-        catch (Exception ex)
-        {
-            reason = "rejected: unresolvable link target (" + ex.GetType().Name + ")";
-            return false;
-        }
-
-        if (!IsInside(resolved, canonicalRoot))
-        {
-            reason = "rejected: symlink escapes plugin root";
-            return false;
-        }
-
-        if (!File.Exists(resolved))
-        {
-            reason = "absent: no manifest at " + Path.GetRelativePath(canonicalRoot, candidate);
-            return false;
-        }
-
-        var info = new FileInfo(resolved);
-        if (info.Length > MaximumManifestBytes)
-        {
-            reason = "rejected: manifest exceeds " + (MaximumManifestBytes / 1024) + " KiB";
-            return false;
-        }
-
-        // NEW-2: a symlink loop passes File.Exists (lstat) and the size cap (the link
-        // string is short), so the read is the first thing that fails. Left
-        // unguarded it escapes TryRead and takes discovery down for every plugin.
-        try
-        {
-            json = File.ReadAllText(resolved);
-        }
-        catch (IOException ex)
-        {
-            reason = "rejected: unreadable (" + ex.GetType().Name + ")";
-            return false;
-        }
-        catch (UnauthorizedAccessException ex)
-        {
-            reason = "rejected: unreadable (" + ex.GetType().Name + ")";
-            return false;
-        }
-
-        reason = "accepted";
-        return true;
-    }
-
-    /// <summary>
-    /// Resolves links repeatedly until the path stops changing. A single pass is not
-    /// enough: resolving one component can introduce new components that are
-    /// themselves links, so a two-hop chain would survive an unrepeated walk.
-    /// </summary>
-    private static string ResolveToFixedPoint(string path)
-    {
-        var resolved = path;
-        for (var i = 0; i < MaximumLinkResolutionPasses; i++)
-        {
-            var next = ResolveFinal(resolved);
-            if (string.Equals(next, resolved, StringComparison.Ordinal))
-            {
-                return resolved;
-            }
-
-            resolved = next;
-        }
-
-        throw new IOException("Link resolution did not converge after "
-            + MaximumLinkResolutionPasses + " passes.");
-    }
-
-    /// <summary>
-    /// Resolves every symlink in <paramref name="path"/>, one component at a time.
-    /// Unix-shaped: it splits on the platform separator and rebuilds from a bare
-    /// separator, so it does not handle Windows drive or UNC roots. That is adequate
-    /// for a Linux-only throwaway spike and must not be lifted into the kernel as-is.
-    /// </summary>
-    private static string ResolveFinal(string path)
-    {
-        // ResolveLinkTarget(returnFinalTarget: true) only follows a link at the leaf,
-        // so walk the chain from the root down and resolve each component.
-        var parts = path.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries);
-        var current = Path.DirectorySeparatorChar.ToString();
-        foreach (var part in parts)
-        {
-            current = Path.Combine(current, part);
-            // A component that does not exist cannot be a link, and asking anyway
-            // throws FileNotFoundException — which would turn a legitimately absent
-            // manifest into an "unresolvable link" error.
-            var isDirectory = Directory.Exists(current);
-            if (!isDirectory && !File.Exists(current))
-            {
-                continue;
-            }
-
-            FileSystemInfo? target;
-            try
-            {
-                target = isDirectory
-                    ? new DirectoryInfo(current).ResolveLinkTarget(true)
-                    : new FileInfo(current).ResolveLinkTarget(true);
-            }
-            catch (IOException)
-            {
-                // A cyclic or otherwise unresolvable link. Leaving the component
-                // unresolved would let containment pass on a path we cannot reason
-                // about, so fail closed instead.
-                throw;
-            }
-
-            if (target is not null)
-            {
-                current = Path.GetFullPath(target.FullName);
-            }
-        }
-
-        return current;
-    }
-
-    private static bool IsInside(string candidate, string canonicalRoot)
-    {
-        if (string.Equals(candidate, canonicalRoot, StringComparison.Ordinal))
-        {
-            return true;
-        }
-
-        // A root that is already a single separator would otherwise demand a doubled
-        // separator and reject everything. Unreachable for a real plugin root, but
-        // this function is the one EP-03 will inherit.
-        var prefix = canonicalRoot.EndsWith(Path.DirectorySeparatorChar)
-            ? canonicalRoot
-            : canonicalRoot + Path.DirectorySeparatorChar;
-
-        return candidate.StartsWith(prefix, StringComparison.Ordinal);
+        json = PathContainment.ReadContained(root, relativeName, MaximumManifestBytes, out reason);
+        return json is not null;
     }
 }

--- a/research/extension-platform/spikes/ep-00/Jellyfin.Plugin.Ep00Host/PathContainment.cs
+++ b/research/extension-platform/spikes/ep-00/Jellyfin.Plugin.Ep00Host/PathContainment.cs
@@ -1,0 +1,383 @@
+using System.Globalization;
+using Microsoft.Win32.SafeHandles;
+
+namespace Jellyfin.Plugin.Ep00Host;
+
+/// <summary>
+/// EP-00.5. The containment decision, extracted from <see cref="ManifestProbe"/> so
+/// it can be exercised without a running server — and so EP-03 inherits one
+/// implementation instead of re-deriving it.
+///
+/// The ordering here is the whole point. Validating a path and *then* opening it
+/// leaves a window in which the path can be swapped; every check is therefore
+/// re-applied to the handle that will actually be read.
+/// </summary>
+public static class PathContainment
+{
+    /// <summary>Why a candidate was refused. Stable strings — they appear in evidence.</summary>
+    public const string ReasonAccepted = "accepted";
+
+    /// <summary>Upper bound on link-resolution passes, so a pathological chain cannot spin.</summary>
+    public const int MaximumLinkResolutionPasses = 40;
+
+    /// <summary>How long open(2) may take before the candidate is refused.</summary>
+    private static readonly TimeSpan OpenTimeout = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// Decides whether <paramref name="relativeName"/> may be read from
+    /// <paramref name="root"/>, without touching the file's contents.
+    /// </summary>
+    /// <returns>The resolved absolute path when accepted, otherwise null.</returns>
+    public static string? Validate(string? root, string relativeName, out string reason)
+    {
+        if (string.IsNullOrWhiteSpace(root))
+        {
+            reason = "rejected: no root path";
+            return null;
+        }
+
+        if (relativeName.Length == 0)
+        {
+            reason = "rejected: empty name";
+            return null;
+        }
+
+        if (relativeName.Contains('\0', StringComparison.Ordinal))
+        {
+            reason = "rejected: embedded NUL in name";
+            return null;
+        }
+
+        // Normalise BOTH separators before any test. A backslash is a legal filename
+        // character on Unix, so without this a Windows-style traversal is treated as
+        // an ordinary filename and appears to be "rejected" when it was never
+        // evaluated at all.
+        var normalised = relativeName
+            .Replace('\\', Path.DirectorySeparatorChar)
+            .Replace('/', Path.DirectorySeparatorChar);
+
+        if (Path.IsPathRooted(normalised))
+        {
+            reason = "rejected: absolute path";
+            return null;
+        }
+
+        string canonicalRoot;
+        string candidate;
+        try
+        {
+            canonicalRoot = Path.TrimEndingDirectorySeparator(ResolveToFixedPoint(Path.GetFullPath(root)));
+            candidate = Path.GetFullPath(Path.Combine(canonicalRoot, normalised));
+        }
+        catch (Exception ex)
+        {
+            reason = "rejected: unresolvable path (" + ex.GetType().Name + ")";
+            return null;
+        }
+
+        if (!IsInside(candidate, canonicalRoot))
+        {
+            reason = "rejected: resolves outside plugin root";
+            return null;
+        }
+
+        string resolved;
+        try
+        {
+            resolved = ResolveToFixedPoint(candidate);
+        }
+        catch (Exception ex)
+        {
+            reason = "rejected: unresolvable link target (" + ex.GetType().Name + ")";
+            return null;
+        }
+
+        if (!IsInside(resolved, canonicalRoot))
+        {
+            reason = "rejected: symlink escapes plugin root";
+            return null;
+        }
+
+        reason = ReasonAccepted;
+        return resolved;
+    }
+
+    /// <summary>
+    /// Opens <paramref name="relativeName"/> under <paramref name="root"/> and returns
+    /// its contents, or null with a reason.
+    ///
+    /// Correctness rests on the order: the file is opened first, and containment is
+    /// then decided against the path the **open descriptor** actually refers to. The
+    /// obvious order — validate, then open — can be defeated by swapping the path in
+    /// between, which <see cref="Ep00SpikeController"/>'s race probe demonstrates.
+    /// </summary>
+    public static string? ReadContained(string? root, string relativeName, long maximumBytes, out string reason)
+    {
+        var expected = Validate(root, relativeName, out reason);
+        if (expected is null)
+        {
+            return null;
+        }
+
+        var canonicalRoot = Path.TrimEndingDirectorySeparator(Path.GetFullPath(root!));
+        try
+        {
+            canonicalRoot = Path.TrimEndingDirectorySeparator(ResolveToFixedPoint(canonicalRoot));
+        }
+        catch (IOException)
+        {
+            reason = "rejected: unresolvable root";
+            return null;
+        }
+
+        if (Directory.Exists(expected))
+        {
+            reason = "rejected: not a regular file (directory)";
+            return null;
+        }
+
+        FileStream stream;
+        try
+        {
+            // O_NOFOLLOW is not exposed by FileStream, so the leaf is re-checked below
+            // against the descriptor rather than assumed.
+            //
+            // The open is bounded because open(2) BLOCKS on a FIFO until a writer
+            // appears. A plugin that ships a named pipe called
+            // jellyfin-canopy-extension.json would otherwise hang the reader — and
+            // discovery iterates every plugin, so one such file stalls all of them.
+            stream = OpenBounded(expected, OpenTimeout);
+        }
+        catch (TimeoutException)
+        {
+            reason = "rejected: open blocked (not a regular file?)";
+            return null;
+        }
+        catch (FileNotFoundException)
+        {
+            reason = "absent: no file at " + Path.GetRelativePath(canonicalRoot, expected);
+            return null;
+        }
+        catch (DirectoryNotFoundException)
+        {
+            reason = "absent: no file at " + Path.GetRelativePath(canonicalRoot, expected);
+            return null;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            reason = "rejected: unopenable (" + ex.GetType().Name + ")";
+            return null;
+        }
+
+        using (stream)
+        {
+            // Everything from here on describes the OPEN DESCRIPTOR, not a path that
+            // may since have changed underneath us.
+            var actual = DescribeOpenHandle(stream.SafeFileHandle);
+            if (actual is null)
+            {
+                // FAIL CLOSED. Falling back to the pre-open decision here is precisely
+                // the hole this method exists to close: when the path is being swapped,
+                // the descriptor often cannot be described (a deleted inode resolves to
+                // "<path> (deleted)"), which is exactly when the pre-open decision is
+                // least trustworthy. Measured: keeping the fallback leaked on ~17% of
+                // successful reads under contention.
+                reason = "rejected: cannot verify the opened descriptor";
+                return null;
+            }
+
+            if (!IsInside(actual, canonicalRoot))
+            {
+                reason = "rejected: opened file resolves outside plugin root";
+                return null;
+            }
+
+            if (!string.Equals(actual, expected, StringComparison.Ordinal))
+            {
+                // Inside the root, but not the file we validated — the path changed
+                // between the decision and the open.
+                reason = "rejected: path changed between validation and open";
+                return null;
+            }
+
+            long length;
+            try
+            {
+                length = stream.Length;
+            }
+            catch (IOException ex)
+            {
+                reason = "rejected: unreadable (" + ex.GetType().Name + ")";
+                return null;
+            }
+
+            if (length > maximumBytes)
+            {
+                reason = "rejected: exceeds " + (maximumBytes / 1024).ToString(CultureInfo.InvariantCulture) + " KiB";
+                return null;
+            }
+
+            try
+            {
+                using var reader = new StreamReader(stream);
+                var contents = reader.ReadToEnd();
+                reason = ReasonAccepted;
+                return contents;
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                reason = "rejected: unreadable (" + ex.GetType().Name + ")";
+                return null;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Opens a file, refusing to wait indefinitely. open(2) on a FIFO blocks until a
+    /// writer appears, and the caller cannot afford that.
+    /// </summary>
+    private static FileStream OpenBounded(string path, TimeSpan timeout)
+    {
+        var open = Task.Run(() => new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite));
+
+        // Wait on the handle rather than Task.Wait: Task.Wait wraps a faulted task's
+        // exception in an AggregateException, which would slip past the caller's
+        // specific catches and escape as an unhandled error. Waiting on the handle
+        // never throws, so GetAwaiter().GetResult() below rethrows the ORIGINAL
+        // FileNotFoundException / UnauthorizedAccessException unchanged.
+        if (!((IAsyncResult)open).AsyncWaitHandle.WaitOne(timeout))
+        {
+            // The task is abandoned deliberately: it is stuck in a blocking syscall and
+            // cannot be cancelled. It completes if a writer ever appears, and the stream
+            // is then dropped unreferenced.
+            _ = open.ContinueWith(
+                t => t.Result.Dispose(),
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+            throw new TimeoutException("open did not complete within " + timeout);
+        }
+
+        return open.GetAwaiter().GetResult();
+    }
+
+    /// <summary>
+    /// The real path behind an open descriptor, via <c>/proc/self/fd</c>. Returns null
+    /// when the descriptor cannot be described — the caller must then refuse the read,
+    /// not fall back to the pre-open decision. Linux-only, which is why this spike is.
+    /// </summary>
+    private static string? DescribeOpenHandle(SafeFileHandle handle)
+    {
+        if (handle.IsInvalid)
+        {
+            return null;
+        }
+
+        var fdPath = "/proc/self/fd/" + handle.DangerousGetHandle().ToInt64().ToString(CultureInfo.InvariantCulture);
+        try
+        {
+            // returnFinalTarget:false — /proc/self/fd/N is a link to the real path, and
+            // that first hop is the answer. Following further would re-introduce a
+            // resolution the descriptor has already settled.
+            var target = File.ResolveLinkTarget(fdPath, returnFinalTarget: false);
+            if (target is null)
+            {
+                return null;
+            }
+
+            var full = target.FullName;
+
+            // A deleted inode resolves to "<path> (deleted)". That is not a path we can
+            // contain, so treat it as undescribable and let the caller fail closed.
+            return full.EndsWith(" (deleted)", StringComparison.Ordinal)
+                ? null
+                : Path.GetFullPath(full);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>Resolves links repeatedly until the path stops changing.</summary>
+    public static string ResolveToFixedPoint(string path)
+    {
+        var resolved = path;
+        for (var i = 0; i < MaximumLinkResolutionPasses; i++)
+        {
+            var next = ResolveOnce(resolved);
+            if (string.Equals(next, resolved, StringComparison.Ordinal))
+            {
+                return resolved;
+            }
+
+            resolved = next;
+        }
+
+        throw new IOException("Link resolution did not converge after "
+            + MaximumLinkResolutionPasses.ToString(CultureInfo.InvariantCulture) + " passes.");
+    }
+
+    /// <summary>
+    /// Resolves every symlink in <paramref name="path"/>, one component at a time.
+    /// Unix-shaped: it splits on the platform separator and rebuilds from a bare
+    /// separator, so it does not handle Windows drive or UNC roots. Adequate for a
+    /// Linux-only throwaway spike; must not be lifted into the kernel as-is.
+    /// </summary>
+    private static string ResolveOnce(string path)
+    {
+        var parts = path.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries);
+        var current = Path.DirectorySeparatorChar.ToString();
+        foreach (var part in parts)
+        {
+            current = Path.Combine(current, part);
+
+            // A component that does not exist cannot be a link, and asking anyway
+            // throws — which would turn a legitimately absent file into an
+            // "unresolvable link" error.
+            var isDirectory = Directory.Exists(current);
+            if (!isDirectory && !File.Exists(current))
+            {
+                continue;
+            }
+
+            FileSystemInfo? target;
+            try
+            {
+                target = isDirectory
+                    ? new DirectoryInfo(current).ResolveLinkTarget(true)
+                    : new FileInfo(current).ResolveLinkTarget(true);
+            }
+            catch (IOException)
+            {
+                // Cyclic or otherwise unresolvable. Leaving it unresolved would let
+                // containment pass on a path we cannot reason about: fail closed.
+                throw;
+            }
+
+            if (target is not null)
+            {
+                current = Path.GetFullPath(target.FullName);
+            }
+        }
+
+        return current;
+    }
+
+    /// <summary>True when <paramref name="candidate"/> is at or below <paramref name="canonicalRoot"/>.</summary>
+    public static bool IsInside(string candidate, string canonicalRoot)
+    {
+        if (string.Equals(candidate, canonicalRoot, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        // A root that is already a single separator would otherwise demand a doubled
+        // separator and reject everything.
+        var prefix = canonicalRoot.EndsWith(Path.DirectorySeparatorChar)
+            ? canonicalRoot
+            : canonicalRoot + Path.DirectorySeparatorChar;
+
+        return candidate.StartsWith(prefix, StringComparison.Ordinal);
+    }
+}

--- a/research/extension-platform/spikes/ep-00/Jellyfin.Plugin.Ep00Host/PluginServiceRegistrator.cs
+++ b/research/extension-platform/spikes/ep-00/Jellyfin.Plugin.Ep00Host/PluginServiceRegistrator.cs
@@ -11,5 +11,6 @@ public class PluginServiceRegistrator : IPluginServiceRegistrator
         serviceCollection.AddSingleton<ProviderBinder>();
         serviceCollection.AddSingleton<ManifestProbe>();
         serviceCollection.AddSingleton<LoadContextWatcher>();
+        serviceCollection.AddSingleton<ToctouProbe>();
     }
 }

--- a/research/extension-platform/spikes/ep-00/Jellyfin.Plugin.Ep00Host/ToctouProbe.cs
+++ b/research/extension-platform/spikes/ep-00/Jellyfin.Plugin.Ep00Host/ToctouProbe.cs
@@ -1,0 +1,187 @@
+using System.Diagnostics;
+using System.Globalization;
+
+namespace Jellyfin.Plugin.Ep00Host;
+
+/// <summary>
+/// EP-00.5. Demonstrates that "validate the path, then open it" is exploitable, and
+/// that "open it, then validate the descriptor" is not.
+///
+/// The race is real rather than theoretical: an extension can replace a file inside
+/// its own plugin directory at any moment, and the kernel reads manifests from that
+/// directory on a schedule it does not control.
+/// </summary>
+public sealed class ToctouProbe
+{
+    private const string ScratchRoot = "/config/ep00-toctou";
+    private const string TargetName = "target.json";
+    private const string HonestContents = "{\"honest\":true}";
+
+    /// <summary>Something outside the root that is readable and unmistakable.</summary>
+    private const string SecretPath = "/etc/hostname";
+
+    public Dictionary<string, object?> Run(int iterations)
+    {
+        var rounds = Math.Clamp(iterations, 1, 20000);
+        var target = Path.Combine(ScratchRoot, TargetName);
+
+        Directory.CreateDirectory(ScratchRoot);
+        ResetToHonestFile(target);
+
+        var result = new Dictionary<string, object?>
+        {
+            ["iterations"] = rounds,
+            ["root"] = ScratchRoot,
+        };
+
+        using var swapping = new CancellationTokenSource();
+        var swaps = 0L;
+        var swapper = Task.Run(
+            () =>
+            {
+                while (!swapping.IsCancellationRequested)
+                {
+                    try
+                    {
+                        // Alternate between an honest file and a link pointing outside
+                        // the root, as fast as the filesystem allows.
+                        File.Delete(target);
+                        File.CreateSymbolicLink(target, SecretPath);
+                        Interlocked.Increment(ref swaps);
+                        File.Delete(target);
+                        File.WriteAllText(target, HonestContents);
+                        Interlocked.Increment(ref swaps);
+                    }
+                    catch (IOException)
+                    {
+                        // Losing a race against the reader is expected; keep going.
+                    }
+                    catch (UnauthorizedAccessException)
+                    {
+                    }
+                }
+            },
+            CancellationToken.None);
+
+        // The honest file is rewritten by the swapper, and WriteAllText truncates
+        // before it writes — so a reader can legitimately observe an empty or partial
+        // file. That is a TORN read, not a containment failure, and conflating the two
+        // would make the fix look broken. A leak is only a read whose contents match
+        // the file OUTSIDE the root.
+        var secret = string.Empty;
+        try
+        {
+            secret = File.ReadAllText(SecretPath).Trim();
+        }
+        catch (IOException)
+        {
+        }
+
+        var naiveLeaks = 0;
+        var naiveTorn = 0;
+        var naiveReads = 0;
+        var safeLeaks = 0;
+        var safeTorn = 0;
+        var safeReads = 0;
+        var safeRejections = 0;
+        string? firstSafeLeakSample = null;
+
+        bool IsLeak(string content) =>
+            secret.Length > 0 && content.Contains(secret, StringComparison.Ordinal);
+        bool IsHonest(string content) => content.Contains("honest", StringComparison.Ordinal);
+        var stopwatch = Stopwatch.StartNew();
+
+        for (var i = 0; i < rounds; i++)
+        {
+            // --- The obvious order: decide, then open. ---
+            var expected = PathContainment.Validate(ScratchRoot, TargetName, out _);
+            if (expected is not null)
+            {
+                try
+                {
+                    var naive = File.ReadAllText(expected);
+                    naiveReads++;
+                    if (IsLeak(naive))
+                    {
+                        naiveLeaks++;
+                    }
+                    else if (!IsHonest(naive))
+                    {
+                        naiveTorn++;
+                    }
+                }
+                catch (IOException)
+                {
+                }
+                catch (UnauthorizedAccessException)
+                {
+                }
+            }
+
+            // --- The correct order: open, then decide about the descriptor. ---
+            var safe = PathContainment.ReadContained(ScratchRoot, TargetName, 256 * 1024, out var reason);
+            if (safe is not null)
+            {
+                safeReads++;
+                if (IsLeak(safe))
+                {
+                    safeLeaks++;
+                    firstSafeLeakSample ??= safe.Length > 60 ? safe[..60] : safe;
+                }
+                else if (!IsHonest(safe))
+                {
+                    safeTorn++;
+                }
+            }
+            else if (reason.StartsWith("rejected", StringComparison.Ordinal))
+            {
+                safeRejections++;
+            }
+        }
+
+        swapping.Cancel();
+        try
+        {
+            swapper.Wait(TimeSpan.FromSeconds(5));
+        }
+        catch (AggregateException)
+        {
+        }
+
+        result["elapsedMs"] = stopwatch.ElapsedMilliseconds;
+        result["swapsPerformed"] = Interlocked.Read(ref swaps);
+        result["secretFingerprintFound"] = secret.Length > 0;
+        result["validateThenOpen_reads"] = naiveReads;
+        result["validateThenOpen_leaks"] = naiveLeaks;
+        result["validateThenOpen_tornReads"] = naiveTorn;
+        result["openThenValidate_reads"] = safeReads;
+        result["openThenValidate_leaks"] = safeLeaks;
+        result["openThenValidate_tornReads"] = safeTorn;
+        result["openThenValidate_rejections"] = safeRejections;
+        result["openThenValidate_firstLeakSample"] = firstSafeLeakSample;
+        result["verdict"] = safeLeaks == 0
+            ? (naiveLeaks > 0
+                ? "validate-then-open leaked " + naiveLeaks.ToString(CultureInfo.InvariantCulture)
+                  + " of " + naiveReads.ToString(CultureInfo.InvariantCulture)
+                  + " reads; open-then-validate leaked 0 of "
+                  + safeReads.ToString(CultureInfo.InvariantCulture)
+                : "no leak observed either way this run — increase iterations")
+            : "OPEN-THEN-VALIDATE LEAKED — the fix is wrong";
+
+        ResetToHonestFile(target);
+        return result;
+    }
+
+    private static void ResetToHonestFile(string target)
+    {
+        try
+        {
+            File.Delete(target);
+        }
+        catch (IOException)
+        {
+        }
+
+        File.WriteAllText(target, HonestContents);
+    }
+}

--- a/research/extension-platform/spikes/ep-00/run-spike.sh
+++ b/research/extension-platform/spikes/ep-00/run-spike.sh
@@ -206,7 +206,9 @@ docker exec "$NAME" sh -c '
   ln -sfn "$R/hop-root/ssl" "$R/hop-etc"
   # A loop, to prove the reader rejects rather than throwing out of discovery.
   ln -sfn cycle2 "$R/cycle"
-  ln -sfn cycle  "$R/cycle2"'
+  ln -sfn cycle  "$R/cycle2"
+  # A named pipe. open(2) blocks on it until a writer appears.
+  mkfifo "$R/fifo" 2>/dev/null || true'
 docker restart "$NAME" >/dev/null
 wait_up
 # Plugin controllers are routed a little after the server answers /System/Info.
@@ -266,6 +268,9 @@ printf 'depth 200 -> '
 curl -s -X POST "$B/Ep00Spike/Echo" -H "$AUTH" -H 'Content-Type: application/json' \
   --data-binary "@$WORK/deep.json"
 echo
+
+log "Probe K — TOCTOU race: validate-then-open vs open-then-validate"
+curl -s -G "$B/Ep00Spike/Toctou" -H "$AUTH" --data-urlencode 'iterations=4000' | python3 -m json.tool
 
 log "Probe J — forged identity (non-admin token, injected user ids)"
 ADMIN_ID="$(curl -s "$B/Users/Me" -H "$AUTH" | python3 -c 'import json,sys; print(json.load(sys.stdin)["Id"])')"

--- a/research/extension-platform/threat-model.md
+++ b/research/extension-platform/threat-model.md
@@ -151,8 +151,12 @@ pass still let a two-hop chain escape; and a link cycle is rejected rather than
 throwing out of the reader, which would otherwise have taken manifest discovery
 down for every plugin. A symlink that stays inside the root is still accepted
 ([S5](spike-evidence.md#s5--path-containment-holds-against-traversal-symlinks-and-link-cycles)).
-Remaining gap: nothing re-validates on the open handle, so a TOCTOU window
-remains — [#494](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/494).
+The TOCTOU window is now **closed and measured**: validating a path and then
+opening it leaked a file from outside the root on 17% of successful reads under a
+swap race, and validating the open descriptor instead leaked zero
+([S16](spike-evidence.md#s16--the-manifest-read-is-a-toctou-and-a-fifo-stalls-it)).
+A FIFO shipped as a manifest, which would otherwise block discovery for every
+plugin, is refused by a bounded open.
 
 ### T-05 · Token theft through the provider boundary — **high, accepted**
 


### PR DESCRIPTION
## Summary

Closes the TOCTOU window EP-00 left open on the manifest reader, and extracts the
containment decision into one shared `PathContainment` so EP-03 inherits it rather
than re-deriving it.

Stacked on #497.

## The race is real, not theoretical

A background task alternates one filename inside the plugin root between an honest
file and a symlink pointing outside it, while a reader loops. 4,000 iterations,
~21,000 swaps, under half a second:

| Read order | successful reads | **leaks** | torn reads | rejections |
|---|---|---|---|---|
| validate the path, then open it | 2,200 | **369** | ~400 | — |
| open it, then validate the descriptor | 188 | **0** | 32 | 1,843 |

The obvious order leaked the contents of a file outside the plugin root on **17% of
its successful reads**. An extension can trigger this whenever it likes: it controls
the files in its own directory, and the kernel reads manifests on a schedule the
extension does not control but can observe.

The 1,843 rejections are the fix working — under contention the safe reader declines
rather than guessing. A real kernel retries; it does not relax the check.

## Three details are load-bearing, and two were got wrong first

- **Fail closed when the descriptor cannot be described.** A deleted inode resolves
  to `"<path> (deleted)"`. An earlier version fell back to the pre-open decision
  there — which is *precisely* when that decision is least trustworthy — and leaked
  on ~17% of its reads, i.e. fixed nothing.
- **Resolve only the first hop of `/proc/self/fd/N`.** That link *is* the answer;
  following further re-introduces a resolution the descriptor has already settled.
- **Torn reads are not leaks.** The writer truncates before writing, so a reader can
  legitimately observe an empty file. An earlier version counted those as leaks and
  made a working fix look broken. Only content matching the file *outside* the root
  counts.

## A named pipe stalls discovery

`open(2)` blocks until a writer appears. A plugin shipping a `mkfifo` named pipe as
`jellyfin-canopy-extension.json` would hang the reader indefinitely — and discovery
iterates every plugin, so one such file stalls all of them. The open is now bounded
and the candidate refused; directories are rejected before the open rather than by
failing it.

## Also fixed while here

`Task.Wait` wraps a faulted task's exception in an `AggregateException`, which
slipped past the caller's specific catches and escaped as an unhandled error that
Jellyfin's exception middleware mapped to a **404**. Waiting on the handle instead
lets `GetAwaiter().GetResult()` rethrow the original exception unchanged.

## Hostile-candidate set extended

Dot segments, trailing separators, a 5,000-character name, both Unicode
normalisation forms of the same filename, a directory, and a named pipe — alongside
the existing traversal, absolute-path, NUL, one-hop symlink, two-hop symlink and
link-cycle cases. `./inside.json`, `sub/./../inside.json`, `inside.json/` and
`inside.json/.` are correctly **accepted**; `.` is refused as a directory and `..`
by containment. Neither Unicode form collides with the other, so containment does
not depend on filesystem normalisation behaviour.

## Validation

- Probe K in `run-spike.sh`, executed end to end against a disposable
  `jellyfin/jellyfin:12.0-rc3.20260722-020441` container; creates and destroys its
  own container and temp state.
- `npm run check:docs` — pass, including `mkdocs build --strict`.
- `dotnet build Jellyfin.Plugin.JellyfinCanopy/JellyfinCanopy.csproj -c Release` — 0
  warnings, 0 errors.
- Internal link and anchor check across `research/extension-platform/` — 0 broken.

## Scope and risk

Additive and inert. Everything under `research/`, outside the MkDocs site, the docs
link checker and every build. The spike `.csproj` files remain outside
`JellyfinCanopy.slnx`. No production code, no user-visible change, no ratchet
touched.

The containment code is deliberately Unix-shaped — it resolves via `/proc/self/fd`
and rebuilds paths from a bare separator — and says so in its own doc comment. It
must not be lifted into the kernel unchanged.

## AI assistance

AI-assisted research, implementation and review were used. The probe output and the
validation evidence were independently inspected; two incorrect versions of the fix
were caught by measurement rather than by reading.

Closes #494
