### PR TITLE
research(extension-platform): headless native-client fixture drives the protocol

### DIFF
--- a/research/extension-platform/capability-inventory.md
+++ b/research/extension-platform/capability-inventory.md
@@ -137,5 +137,6 @@ Carried forward as EP-00 child issues rather than assumed either way.
 6. Whether two plugins shipping a **byte-identical, same-version** contract
    assembly behave as S2 showed for two *different* versions. Documented .NET
    behaviour says yes; this spike did not show it.
-7. Version negotiation of any kind — `/Ep00Spike/Discovery` returns a static
-   range and nothing negotiates against it.
+7. ~~Version negotiation of any kind.~~ **Done ([S18](spike-evidence.md#s18--a-headless-native-client-can-drive-the-protocol-and-every-refusal-is-distinct)):**
+   highest-common-version negotiation, an older client still negotiating, no-overlap
+   as its own error code, and component-level graceful omission reported by name.

--- a/research/extension-platform/spike-evidence.md
+++ b/research/extension-platform/spike-evidence.md
@@ -673,6 +673,80 @@ every opaque frame, so **origin is useless for attribution** — a broker must k
 
 Recorded against [#491](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/491).
 
+## S18 — A headless native client can drive the protocol, and every refusal is distinct
+
+Replay: probe L in [`spikes/ep-00/run-spike.sh`](spikes/ep-00/run-spike.sh), which
+runs [`spikes/ep-00/native/fixture.py`](spikes/ep-00/native/fixture.py) against a
+minimal server surface (negotiate / catalog / invoke). The fixture speaks only
+HTTP and JSON and renders nothing — which is the only thing a fixture can honestly
+prove about a protocol. **20 checks, 20 passed.**
+
+### Negotiation and graceful omission
+
+| Behaviour | Result |
+|---|---|
+| client `1–2`, host `1–2` | negotiates **2** |
+| client `1–1` | negotiates **1** — an older client is not refused |
+| client `9–9` | `protocol_incompatible`, with both ranges echoed |
+| client declares only `row` | receives **only** rows |
+| components it cannot render | reported in `componentsOmitted` **by name** |
+| contributions it cannot render | reported in `omitted` with `component_not_supported_by_client` |
+
+Omission is explicit in both directions. A client author can see *what* was
+withheld and *why*, instead of wondering why a surface never appears — which is
+the failure mode that makes optional protocol features undebuggable.
+
+### The descriptor is sufficient to render
+
+A paginated row carries **item references only** (`itemId` + label), never rendered
+content, so the client fetches and draws with its own SDK. Paging reports
+`page`, `pageSize`, `totalItems` and `hasMore`, and the final page correctly says
+`hasMore: false`. A detail action carries a native-renderable confirmation
+(`title`, `confirmLabel`, `cancelLabel`) and an **opaque capability** — the string
+`method` appears nowhere in it.
+
+### Every refusal is its own machine code
+
+| Situation | Code |
+|---|---|
+| valid capability, first use | accepted |
+| same capability again | `action_replayed` |
+| no capability supplied | `action_missing` |
+| tampered signature | `action_signature_invalid` |
+| another user's capability | `action_wrong_user` |
+| the extension behind it is down | `provider_unavailable` |
+| unauthenticated | bare **401** — not a malformed catalog |
+
+`action_wrong_user` and `action_expired` are deliberately separate: a client
+retries one and re-authenticates for the other.
+
+### Two design defects the fixture caught
+
+Both would have shipped unnoticed without a client actually driving the protocol.
+
+1. **A delimiter-sensitive capability format.** The first version joined
+   `operationId`, `userId` and `expiry` with `.` and split on it. The operation id
+   was `ep00.action.request` — which contains dots — so **every valid capability
+   decoded as malformed**. The payload is now base64url-encoded with a unit
+   separator between fields. A capability format must not be delimiter-sensitive to
+   values its issuer does not control.
+2. **Single-use protection rejecting a legitimate second action.** Two capabilities
+   minted in the same second for the same `(operation, user)` were byte-identical,
+   so the replay check refused the second one. Each capability now carries a nonce.
+   This is the kind of defect that appears only under a real client's usage
+   pattern — fetch catalog, act, fetch catalog, act.
+
+### What this does not prove
+
+Nothing about any real client. No Android TV, Roku, Kodi or Swift code was
+involved. The fixture proves the protocol is *implementable* by a client that
+executes no downloaded content; the [client
+matrix](supported-client-matrix.md#the-first-native-adopter) records the
+first-party Android TV fork as the adopter that will test whether it is
+*pleasant* to implement.
+
+Recorded against [#492](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/492).
+
 ## What this spike did not establish
 
 Carried into later milestones rather than assumed.
@@ -685,9 +759,9 @@ Carried into later milestones rather than assumed.
    the context is never unloaded, disable and enable both need a restart, and a
    runtime drop-in install is not discovered.
 3. **No concurrency or sustained load.** Every probe was sequential.
-4. **No native or TV client was involved.** Nothing here supports any claim about
-   Android TV, Roku, Kodi or Swift.
-   → [#492](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/492)
+4. **No native or TV client was involved**, and that is still true —
+   [S18](#s18--a-headless-native-client-can-drive-the-protocol-and-every-refusal-is-distinct)
+   proves the protocol is implementable, not that any client implements it.
 5. ~~No declarative web contribution, sandboxed frame or `postMessage` broker.~~
    **Done — see [S17](#s17--browser-slots-render-idempotently-the-frame-is-genuinely-isolated-and-there-is-no-csp).**
    The "Playwright is not provisioned" reason was simply wrong; it needed `npm ci`.

--- a/research/extension-platform/spikes/ep-00/Jellyfin.Plugin.Ep00Host/Ep00SpikeController.cs
+++ b/research/extension-platform/spikes/ep-00/Jellyfin.Plugin.Ep00Host/Ep00SpikeController.cs
@@ -21,14 +21,25 @@ public class Ep00SpikeController : ControllerBase
     private readonly ManifestProbe _manifests;
     private readonly LoadContextWatcher _watcher;
     private readonly ToctouProbe _toctou;
+    private readonly NativeSurface _native;
 
-    public Ep00SpikeController(ProviderBinder binder, ManifestProbe manifests, LoadContextWatcher watcher, ToctouProbe toctou)
+    public Ep00SpikeController(
+        ProviderBinder binder,
+        ManifestProbe manifests,
+        LoadContextWatcher watcher,
+        ToctouProbe toctou,
+        NativeSurface native)
     {
         _binder = binder;
         _manifests = manifests;
         _watcher = watcher;
         _toctou = toctou;
+        _native = native;
     }
+
+    private string CallerId => User.Claims
+        .FirstOrDefault(c => string.Equals(c.Type, "Jellyfin-UserId", StringComparison.OrdinalIgnoreCase))?.Value
+        ?? string.Empty;
 
     /// <summary>Anonymous discovery: availability and protocol range only. No topology.</summary>
     [HttpGet("Discovery")]
@@ -75,6 +86,24 @@ public class Ep00SpikeController : ControllerBase
     [HttpGet("Toctou")]
     [Authorize(Policy = Policies.RequiresElevation)]
     public ActionResult<object> Toctou([FromQuery] int iterations) => Ok(_toctou.Run(iterations));
+
+    /// <summary>EP-00.3: highest-common-version negotiation for a native client.</summary>
+    [HttpPost("Native/Negotiate")]
+    [Authorize]
+    [Consumes(MediaTypeNames.Application.Json)]
+    public ActionResult<object> Negotiate([FromBody] JsonElement request) => Ok(_native.Negotiate(request));
+
+    /// <summary>EP-00.3: a catalog filtered to what the client said it can render.</summary>
+    [HttpPost("Native/Catalog")]
+    [Authorize]
+    [Consumes(MediaTypeNames.Application.Json)]
+    public ActionResult<object> Catalog([FromBody] JsonElement request) => Ok(_native.Catalog(request, CallerId));
+
+    /// <summary>EP-00.3: invoke an opaque action capability.</summary>
+    [HttpPost("Native/Invoke")]
+    [Authorize]
+    public ActionResult<object> NativeInvoke([FromQuery] string? capability, [FromQuery] bool providerDown) =>
+        Ok(_native.Invoke(capability, CallerId, providerDown));
 
     [HttpGet("Manifests")]
     [Authorize(Policy = Policies.RequiresElevation)]

--- a/research/extension-platform/spikes/ep-00/Jellyfin.Plugin.Ep00Host/NativeSurface.cs
+++ b/research/extension-platform/spikes/ep-00/Jellyfin.Plugin.Ep00Host/NativeSurface.cs
@@ -1,0 +1,277 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace Jellyfin.Plugin.Ep00Host;
+
+/// <summary>
+/// EP-00.3 — the smallest server side of the native/TV protocol that a client can be
+/// written against: negotiate, fetch a filtered catalog, invoke an opaque action.
+///
+/// Throwaway. It exists to prove the *protocol* is implementable by a client that
+/// executes no downloaded content, and to make the failure states distinguishable.
+/// It is not Platform v1.
+/// </summary>
+public sealed class NativeSurface
+{
+    /// <summary>The protocol range this host speaks.</summary>
+    public const int ProtocolMin = 1;
+
+    /// <summary>The protocol range this host speaks.</summary>
+    public const int ProtocolMax = 2;
+
+    /// <summary>How long a minted action capability stays usable.</summary>
+    private static readonly TimeSpan ActionLifetime = TimeSpan.FromSeconds(30);
+
+    private readonly byte[] _signingKey = RandomNumberGenerator.GetBytes(32);
+    private readonly HashSet<string> _spentActions = new(StringComparer.Ordinal);
+    private readonly object _gate = new();
+
+    /// <summary>Component kinds a client may declare. A client that omits one never receives it.</summary>
+    private static readonly string[] AllComponents = ["row", "detail-action", "badge", "form"];
+
+    /// <summary>
+    /// Highest-common-version negotiation. A client declares what it can render; the
+    /// host answers with what it will actually send.
+    /// </summary>
+    public Dictionary<string, object?> Negotiate(JsonElement request)
+    {
+        var clientMin = ReadInt(request, "protocolMin", 1);
+        var clientMax = ReadInt(request, "protocolMax", 1);
+        var components = ReadStrings(request, "components");
+        var inputModes = ReadStrings(request, "inputModes");
+        var locale = ReadString(request, "locale") ?? "en-US";
+
+        var negotiated = Math.Min(clientMax, ProtocolMax);
+        if (negotiated < Math.Max(clientMin, ProtocolMin))
+        {
+            return new Dictionary<string, object?>
+            {
+                ["ok"] = false,
+                ["error"] = "protocol_incompatible",
+                ["hostRange"] = new { min = ProtocolMin, max = ProtocolMax },
+                ["clientRange"] = new { min = clientMin, max = clientMax },
+                // A distinct, actionable state: not "unavailable", not "denied".
+                ["detail"] = "No overlap between the client and host protocol ranges.",
+            };
+        }
+
+        var supported = AllComponents.Where(components.Contains).ToArray();
+        var omitted = AllComponents.Except(supported).ToArray();
+
+        return new Dictionary<string, object?>
+        {
+            ["ok"] = true,
+            ["protocol"] = negotiated,
+            ["components"] = supported,
+            // Told plainly, so a client author can see what it is missing rather than
+            // wondering why a surface never appears.
+            ["componentsOmitted"] = omitted,
+            ["inputModes"] = inputModes.Length == 0 ? new[] { "pointer" } : inputModes,
+            ["locale"] = locale,
+            ["catalogRevision"] = "rev-1",
+        };
+    }
+
+    /// <summary>
+    /// A catalog filtered to what the client said it can render. Anything else is
+    /// omitted entirely — never approximated, never half-sent.
+    /// </summary>
+    public Dictionary<string, object?> Catalog(JsonElement request, string userId)
+    {
+        var components = ReadStrings(request, "components");
+        var page = Math.Max(1, ReadInt(request, "page", 1));
+        var pageSize = Math.Clamp(ReadInt(request, "pageSize", 2), 1, 10);
+
+        var all = new List<Dictionary<string, object?>>
+        {
+            new()
+            {
+                ["kind"] = "row",
+                ["id"] = "ep00.row.continue",
+                ["title"] = "Spike row",
+                // Item references only. The client fetches and renders with its own SDK.
+                ["items"] = Enumerable.Range(1, 7)
+                    .Select(i => new Dictionary<string, object?>
+                    {
+                        ["itemId"] = "00000000000000000000000000000" + i.ToString("000", CultureInfo.InvariantCulture),
+                        ["label"] = "Item " + i.ToString(CultureInfo.InvariantCulture),
+                    })
+                    .Skip((page - 1) * pageSize)
+                    .Take(pageSize)
+                    .ToArray(),
+                ["page"] = page,
+                ["pageSize"] = pageSize,
+                ["totalItems"] = 7,
+                ["hasMore"] = page * pageSize < 7,
+            },
+            new()
+            {
+                ["kind"] = "detail-action",
+                ["id"] = "ep00.action.request",
+                ["label"] = "Request",
+                ["icon"] = "download",
+                ["confirm"] = new Dictionary<string, object?>
+                {
+                    ["title"] = "Request this?",
+                    ["confirmLabel"] = "Request",
+                    ["cancelLabel"] = "Cancel",
+                },
+                // The client never names a provider method. It gets an opaque capability.
+                ["action"] = MintAction("ep00.action.request", userId),
+            },
+            new()
+            {
+                ["kind"] = "badge",
+                ["id"] = "ep00.badge.filler",
+                ["label"] = "Filler",
+            },
+        };
+
+        var sent = all.Where(d => components.Contains((string)d["kind"]!)).ToList();
+        var omitted = all.Where(d => !components.Contains((string)d["kind"]!))
+            .Select(d => new { id = d["id"], kind = d["kind"], reason = "component_not_supported_by_client" })
+            .ToArray();
+
+        return new Dictionary<string, object?>
+        {
+            ["catalogRevision"] = "rev-1",
+            ["contributions"] = sent,
+            ["omitted"] = omitted,
+        };
+    }
+
+    /// <summary>
+    /// Invokes an opaque action capability. Every reason for refusal is a distinct
+    /// machine code, because a client has to render them differently.
+    /// </summary>
+    public Dictionary<string, object?> Invoke(string? token, string userId, bool simulateProviderDown)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return Fail("action_missing", "No action capability supplied.");
+        }
+
+        // The payload is base64url-encoded before signing. An earlier version joined
+        // the fields with '.' and split on it — which broke the moment an operation id
+        // contained a dot ("ep00.action.request"), turning every valid capability into
+        // action_malformed. A capability format must not be delimiter-sensitive to
+        // values its issuer does not control.
+        var parts = token.Split('.');
+        if (parts.Length != 2)
+        {
+            return Fail("action_malformed", "Capability is not in the expected form.");
+        }
+
+        var expected = Sign(parts[0]);
+        if (!CryptographicOperations.FixedTimeEquals(
+                Encoding.UTF8.GetBytes(expected), Encoding.UTF8.GetBytes(parts[1])))
+        {
+            return Fail("action_signature_invalid", "Capability was not issued by this host.");
+        }
+
+        string[] fields;
+        try
+        {
+            fields = Encoding.UTF8.GetString(Base64UrlDecode(parts[0])).Split('\u001f');
+        }
+        catch (FormatException)
+        {
+            return Fail("action_malformed", "Capability payload is not decodable.");
+        }
+
+        if (fields.Length != 4)
+        {
+            return Fail("action_malformed", "Capability payload has the wrong shape.");
+        }
+
+        if (!string.Equals(fields[1], userId, StringComparison.Ordinal))
+        {
+            // Bound to the user it was minted for. Replaying another user's capability
+            // is a different failure from an expired one and must look different.
+            return Fail("action_wrong_user", "Capability was issued to a different user.");
+        }
+
+        if (!long.TryParse(fields[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out var expiresUnix)
+            || DateTimeOffset.FromUnixTimeSeconds(expiresUnix) < DateTimeOffset.UtcNow)
+        {
+            return Fail("action_expired", "Capability has expired; fetch the catalog again.");
+        }
+
+        lock (_gate)
+        {
+            if (!_spentActions.Add(token))
+            {
+                return Fail("action_replayed", "Capability has already been used.");
+            }
+        }
+
+        if (simulateProviderDown)
+        {
+            return Fail("provider_unavailable", "The extension behind this action is not responding.");
+        }
+
+        return new Dictionary<string, object?>
+        {
+            ["ok"] = true,
+            ["operationId"] = fields[0],
+            ["result"] = "accepted",
+        };
+    }
+
+    private Dictionary<string, object?> MintAction(string operationId, string userId)
+    {
+        var expires = DateTimeOffset.UtcNow.Add(ActionLifetime).ToUnixTimeSeconds();
+        // A per-capability nonce. Without it, two capabilities minted in the same
+        // second for the same (operation, user) are byte-identical — so single-use
+        // replay protection rejects the SECOND legitimate action as a replay. The
+        // fixture caught exactly that.
+        var nonce = Convert.ToHexStringLower(RandomNumberGenerator.GetBytes(8));
+
+        // Unit separator: not legal in an operation id, a GUID or a number, so the
+        // fields cannot be confused with each other however they are named.
+        var raw = string.Create(CultureInfo.InvariantCulture, $"{operationId}\u001f{userId}\u001f{expires}\u001f{nonce}");
+        var payload = Base64UrlEncode(Encoding.UTF8.GetBytes(raw));
+        return new Dictionary<string, object?>
+        {
+            ["kind"] = "opaque",
+            ["capability"] = payload + "." + Sign(payload),
+            ["expiresInSeconds"] = (int)ActionLifetime.TotalSeconds,
+        };
+    }
+
+    private static string Base64UrlEncode(byte[] bytes) =>
+        Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+    private static byte[] Base64UrlDecode(string value)
+    {
+        var padded = value.Replace('-', '+').Replace('_', '/');
+        return Convert.FromBase64String(padded.PadRight(padded.Length + ((4 - (padded.Length % 4)) % 4), '='));
+    }
+
+    private string Sign(string payload) =>
+        Convert.ToHexStringLower(HMACSHA256.HashData(_signingKey, Encoding.UTF8.GetBytes(payload)));
+
+    private static Dictionary<string, object?> Fail(string code, string detail) => new()
+    {
+        ["ok"] = false,
+        ["error"] = code,
+        ["detail"] = detail,
+    };
+
+    private static int ReadInt(JsonElement e, string name, int fallback) =>
+        e.ValueKind == JsonValueKind.Object && e.TryGetProperty(name, out var v) && v.TryGetInt32(out var i)
+            ? i
+            : fallback;
+
+    private static string? ReadString(JsonElement e, string name) =>
+        e.ValueKind == JsonValueKind.Object && e.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String
+            ? v.GetString()
+            : null;
+
+    private static string[] ReadStrings(JsonElement e, string name) =>
+        e.ValueKind == JsonValueKind.Object && e.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.Array
+            ? v.EnumerateArray().Where(x => x.ValueKind == JsonValueKind.String).Select(x => x.GetString()!).ToArray()
+            : [];
+}

--- a/research/extension-platform/spikes/ep-00/Jellyfin.Plugin.Ep00Host/PluginServiceRegistrator.cs
+++ b/research/extension-platform/spikes/ep-00/Jellyfin.Plugin.Ep00Host/PluginServiceRegistrator.cs
@@ -12,5 +12,6 @@ public class PluginServiceRegistrator : IPluginServiceRegistrator
         serviceCollection.AddSingleton<ManifestProbe>();
         serviceCollection.AddSingleton<LoadContextWatcher>();
         serviceCollection.AddSingleton<ToctouProbe>();
+        serviceCollection.AddSingleton<NativeSurface>();
     }
 }

--- a/research/extension-platform/spikes/ep-00/native/fixture.py
+++ b/research/extension-platform/spikes/ep-00/native/fixture.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""EP-00.3 — a headless native-client fixture.
+
+Stands in for a TV client that executes no downloaded content. It speaks only
+HTTP + JSON, renders nothing, and asserts that a descriptor is *sufficient* to
+render — which is the only thing a fixture can honestly prove about a protocol.
+
+What it is not: evidence about any real client. See supported-client-matrix.md.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+BASE = sys.argv[1] if len(sys.argv) > 1 else "http://localhost:8199"
+TOKEN = sys.argv[2]
+TOKEN2 = sys.argv[3] if len(sys.argv) > 3 else None
+
+results: list[tuple[str, bool, str]] = []
+
+
+def call(path: str, payload=None, token: str | None = None, method: str | None = None):
+    url = f"{BASE}{path}"
+    data = json.dumps(payload).encode() if payload is not None else None
+    request = urllib.request.Request(url, data=data, method=method or ("POST" if data else "GET"))
+    request.add_header("Authorization", f"MediaBrowser Token={token or TOKEN}")
+    if data:
+        request.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return response.status, json.loads(response.read() or b"null")
+    except urllib.error.HTTPError as error:
+        body = error.read()
+        try:
+            return error.code, json.loads(body or b"null")
+        except json.JSONDecodeError:
+            return error.code, {"raw": body[:200].decode("utf-8", "replace")}
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    results.append((name, condition, detail))
+    print(f"  {'PASS' if condition else 'FAIL'}  {name}" + (f"  — {detail}" if detail else ""))
+
+
+# 1. Negotiation, and the incompatible case as a DISTINCT state -----------------
+_, modern = call("/Ep00Spike/Native/Negotiate", {
+    "protocolMin": 1, "protocolMax": 2,
+    "components": ["row", "detail-action", "badge", "form"],
+    "inputModes": ["dpad"], "locale": "en-GB",
+})
+check("negotiates the highest common protocol", modern.get("protocol") == 2, f"got {modern.get('protocol')}")
+check("echoes the client's input mode", modern.get("inputModes") == ["dpad"])
+
+_, limited = call("/Ep00Spike/Native/Negotiate", {
+    "protocolMin": 1, "protocolMax": 1, "components": ["row"], "inputModes": ["dpad"],
+})
+check("an older client still negotiates", limited.get("protocol") == 1)
+check("unsupported components are named, not silently dropped",
+      sorted(limited.get("componentsOmitted", [])) == ["badge", "detail-action", "form"])
+
+_, future = call("/Ep00Spike/Native/Negotiate", {"protocolMin": 9, "protocolMax": 9, "components": ["row"]})
+check("no protocol overlap is its own error code",
+      future.get("error") == "protocol_incompatible", str(future.get("error")))
+
+# 2. A descriptor is sufficient to render a paginated row ----------------------
+_, page1 = call("/Ep00Spike/Native/Catalog", {"components": ["row"], "page": 1, "pageSize": 3})
+row = next((c for c in page1["contributions"] if c["kind"] == "row"), None)
+check("row descriptor present", row is not None)
+check("row carries item REFERENCES only, never rendered content",
+      all(set(i) == {"itemId", "label"} for i in row["items"]))
+check("row is paginated and says whether more exists",
+      row["page"] == 1 and len(row["items"]) == 3 and row["hasMore"] is True)
+
+_, page3 = call("/Ep00Spike/Native/Catalog", {"components": ["row"], "page": 3, "pageSize": 3})
+last = next(c for c in page3["contributions"] if c["kind"] == "row")
+check("the final page reports no more", last["hasMore"] is False and len(last["items"]) == 1)
+
+# 3. Graceful omission ---------------------------------------------------------
+check("a client that cannot render an action never receives one",
+      all(c["kind"] == "row" for c in page1["contributions"]))
+check("omissions are reported with a reason",
+      {o["kind"] for o in page1["omitted"]} == {"detail-action", "badge"}
+      and all(o["reason"] == "component_not_supported_by_client" for o in page1["omitted"]))
+
+# 4. A detail action carries confirmation and an opaque capability -------------
+_, full = call("/Ep00Spike/Native/Catalog", {"components": ["row", "detail-action"], "pageSize": 3})
+action = next(c for c in full["contributions"] if c["kind"] == "detail-action")
+check("action declares a confirmation step the client renders natively",
+      set(action["confirm"]) == {"title", "confirmLabel", "cancelLabel"})
+check("action exposes an OPAQUE capability, never a provider method name",
+      action["action"]["kind"] == "opaque" and "capability" in action["action"]
+      and "method" not in json.dumps(action["action"]))
+
+capability = action["action"]["capability"]
+
+# 5. Every refusal is a distinct, actionable state -----------------------------
+_, ok = call(f"/Ep00Spike/Native/Invoke?capability={urllib.parse.quote(capability)}", method="POST")
+check("a valid capability is accepted once", ok.get("ok") is True, str(ok.get("error")))
+
+_, replay = call(f"/Ep00Spike/Native/Invoke?capability={urllib.parse.quote(capability)}", method="POST")
+check("replaying it is refused with its own code", replay.get("error") == "action_replayed", str(replay.get("error")))
+
+_, missing = call("/Ep00Spike/Native/Invoke", method="POST")
+check("a missing capability is its own code", missing.get("error") == "action_missing")
+
+_, forged = call(f"/Ep00Spike/Native/Invoke?capability={urllib.parse.quote(capability[:-4] + 'dead')}", method="POST")
+check("a forged signature is refused", forged.get("error") == "action_signature_invalid", str(forged.get("error")))
+
+if TOKEN2:
+    _, other = call("/Ep00Spike/Native/Catalog", {"components": ["detail-action"]}, token=TOKEN2)
+    other_capability = next(c for c in other["contributions"] if c["kind"] == "detail-action")["action"]["capability"]
+    _, crossed = call(f"/Ep00Spike/Native/Invoke?capability={urllib.parse.quote(other_capability)}", method="POST")
+    check("another user's capability is refused, distinctly from expiry",
+          crossed.get("error") == "action_wrong_user", str(crossed.get("error")))
+
+_, fresh = call("/Ep00Spike/Native/Catalog", {"components": ["detail-action"]})
+down_capability = next(c for c in fresh["contributions"] if c["kind"] == "detail-action")["action"]["capability"]
+_, down = call(f"/Ep00Spike/Native/Invoke?capability={urllib.parse.quote(down_capability)}&providerDown=true", method="POST")
+check("a provider outage is distinguishable from a permission problem",
+      down.get("error") == "provider_unavailable", str(down.get("error")))
+
+# 6. Platform absent -----------------------------------------------------------
+status, _ = call("/Ep00Spike/Native/Catalog", {"components": ["row"]}, token="not-a-real-token")
+check("an unauthenticated client gets 401, not a malformed catalog", status == 401, f"HTTP {status}")
+
+print()
+failed = [name for name, ok_, _ in results if not ok_]
+print(json.dumps({
+    "checks": len(results),
+    "passed": len(results) - len(failed),
+    "failed": failed,
+}, indent=2))
+sys.exit(1 if failed else 0)

--- a/research/extension-platform/spikes/ep-00/run-spike.sh
+++ b/research/extension-platform/spikes/ep-00/run-spike.sh
@@ -269,6 +269,9 @@ curl -s -X POST "$B/Ep00Spike/Echo" -H "$AUTH" -H 'Content-Type: application/jso
   --data-binary "@$WORK/deep.json"
 echo
 
+log "Probe L — headless native-client fixture (EP-00.3)"
+python3 "$HERE/native/fixture.py" "$B" "$TOKEN" "$TOKEN2"
+
 log "Probe K — TOCTOU race: validate-then-open vs open-then-validate"
 curl -s -G "$B/Ep00Spike/Toctou" -H "$AUTH" --data-urlencode 'iterations=4000' | python3 -m json.tool
 

--- a/research/extension-platform/supported-client-matrix.md
+++ b/research/extension-platform/supported-client-matrix.md
@@ -79,7 +79,11 @@ not closed.
 
 ## Adoption path for a native client
 
-Deliberately small, so that adopting it is a weekend rather than a quarter:
+Deliberately small, so that adopting it is a weekend rather than a quarter. Each
+step below is now exercised by a headless fixture
+([S18](spike-evidence.md#s18--a-headless-native-client-can-drive-the-protocol-and-every-refusal-is-distinct)), so a client
+author is implementing against something that has been driven end to end rather
+than against prose:
 
 1. call the authenticated negotiation endpoint, declaring supported protocol
    range, surface schemas, component set, input modes, layout constraints,


### PR DESCRIPTION
## Summary

A headless native-client fixture that drives the protocol end to end: negotiate,
fetch a filtered catalog, invoke an opaque action. It speaks only HTTP and JSON and
renders nothing — which is the only thing a fixture can honestly prove about a
protocol. **20 checks, 20 pass.**

Stacked on #499.

## Negotiation and graceful omission

| Behaviour | Result |
|---|---|
| client `1–2`, host `1–2` | negotiates **2** |
| client `1–1` | negotiates **1** — an older client is not refused |
| client `9–9` | `protocol_incompatible`, both ranges echoed |
| client declares only `row` | receives **only** rows |
| components it cannot render | named in `componentsOmitted` |
| contributions it cannot render | listed in `omitted` with a reason |

Omission is explicit in both directions. A client author can see *what* was
withheld and *why* — instead of wondering why a surface never appears, which is the
failure mode that makes optional protocol features undebuggable.

## The descriptor is sufficient to render

A paginated row carries **item references only** (`itemId` + label), never rendered
content, so the client draws with its own SDK. Paging reports `page`, `pageSize`,
`totalItems`, `hasMore`, and the final page correctly says `hasMore: false`. A
detail action carries a native-renderable confirmation and an **opaque capability**
— the string `method` appears nowhere in it.

## Every refusal is its own machine code

`action_replayed` · `action_missing` · `action_signature_invalid` ·
`action_wrong_user` · `provider_unavailable` · bare **401** when unauthenticated.

`action_wrong_user` and `action_expired` are deliberately separate: a client retries
one and re-authenticates for the other.

## Two design defects the fixture caught

Both would have shipped unnoticed without a client actually driving the protocol.

1. **The capability format was delimiter-sensitive.** It joined `operationId`,
   `userId` and expiry with `.` and split on it. The operation id was
   `ep00.action.request` — which contains dots — so **every valid capability decoded
   as malformed**. A capability format must not be delimiter-sensitive to values its
   issuer does not control. Now base64url with a unit separator.
2. **Single-use protection rejected a legitimate second action.** Two capabilities
   minted in the same second for the same `(operation, user)` were byte-identical,
   so the second was refused as a replay. Each capability now carries a nonce. That
   defect only appears under a real client's fetch → act → fetch → act pattern.

## What this does not prove

Nothing about any real client. No Android TV, Roku, Kodi or Swift code was
involved. The fixture proves the protocol is *implementable* by a client that
executes no downloaded content; the client matrix records the first-party
[Android TV fork](https://github.com/4eh5xitv6787h645ebv/jellyfin-androidtv) as the
adopter that will test whether it is *pleasant* to implement.

## Validation

- Probe L in `run-spike.sh`, end to end against a disposable
  `jellyfin/jellyfin:12.0-rc3.20260722-020441` container — 20/20.
- `npm run check:docs` — pass, including `mkdocs build --strict`.
- `dotnet build … -c Release` — 0 warnings, 0 errors.
- Internal link and anchor check — 0 broken.

## Scope and risk

Additive and inert. Everything under `research/`. No production code, no change to
the E2E suite, no ratchet touched.

## AI assistance

AI-assisted research, implementation and review were used. Both design defects
above were caught by the fixture rather than by reading, which is the argument for
having built it.

Closes #492
