### PR TITLE
test: stop deadline assertions measuring CI scheduler latency

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/JikanAnimeFillerProviderTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/JikanAnimeFillerProviderTests.cs
@@ -130,19 +130,40 @@ public sealed class JikanAnimeFillerProviderTests
     [Fact]
     public async Task PerRequestDeadline_CoversAResponseBodyThatStallsAfterHeaders()
     {
+        // Deliberately far apart, so "which deadline fired" is not a close call.
+        var requestTimeout = TimeSpan.FromMilliseconds(50);
+        var operationTimeout = TimeSpan.FromSeconds(30);
+        var discriminator = TimeSpan.FromSeconds(5);
+
         var handler = new FixedOriginHandler { StallEpisodeBody = true };
         var provider = new JikanAnimeFillerProvider(
             new FixedOriginFactory(handler),
             NullLogger<JikanAnimeFillerProvider>.Instance,
             new ProviderRateGate(TimeSpan.Zero),
             new ProviderRateGate(TimeSpan.Zero),
-            requestTimeout: TimeSpan.FromMilliseconds(50),
-            operationTimeout: TimeSpan.FromSeconds(1));
+            requestTimeout: requestTimeout,
+            operationTimeout: operationTimeout);
         var started = DateTimeOffset.UtcNow;
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => provider.GetEpisodesAsync(20, CancellationToken.None));
 
-        Assert.True(DateTimeOffset.UtcNow - started < TimeSpan.FromSeconds(1));
+        // Both deadlines are internal linked CancellationTokenSources, so elapsed time
+        // is the only signal a caller has for WHICH one fired. That makes the bound
+        // unavoidable - but it must be derived from the gap between the two deadlines,
+        // not from a magic constant.
+        //
+        // It previously used a 1s operation deadline and asserted elapsed < 1s, i.e. it
+        // asserted the runner was not busy. On a two-core CI runner shared with five
+        // other jobs that failed intermittently on PRs that could not have caused it.
+        // The deadlines are now three orders of magnitude apart and the assertion sits
+        // ~100x above the expected value and ~6x below the failure value, so it
+        // discriminates the same thing without measuring scheduler latency.
+        var elapsed = DateTimeOffset.UtcNow - started;
+        Assert.True(
+            elapsed < discriminator,
+            $"Expected the {requestTimeout.TotalMilliseconds}ms REQUEST deadline to fire, but the call took "
+            + $"{elapsed.TotalSeconds:F1}s, which suggests it ran to the "
+            + $"{operationTimeout.TotalSeconds:F0}s OPERATION deadline instead.");
     }
 
     private sealed class FixedOriginFactory(HttpMessageHandler handler) : IHttpClientFactory

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/MaintainerrClientContractTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/MaintainerrClientContractTests.cs
@@ -346,8 +346,14 @@ public sealed class MaintainerrClientContractTests
     [Fact]
     public async Task DashboardAndItemStatus_UseOneDeadlineAcrossSequentialPhases()
     {
+        // The per-request deadline is deliberately far above the per-operation ones.
+        // The point of this test is that ONE operation deadline spans the sequential
+        // phases rather than each phase restarting it; if it restarted, each call would
+        // instead run to the request deadline. Keeping those two an order of magnitude
+        // apart makes that distinction robust rather than a race with the CI scheduler.
+        var requestDeadline = TimeSpan.FromSeconds(30);
         var timings = new MaintainerrClient.MaintainerrClientTimings(
-            RequestDeadline: TimeSpan.FromSeconds(2),
+            RequestDeadline: requestDeadline,
             TestOperationDeadline: TimeSpan.FromMilliseconds(300),
             ItemStatusOperationDeadline: TimeSpan.FromMilliseconds(180),
             DashboardOperationDeadline: TimeSpan.FromMilliseconds(220),
@@ -384,9 +390,22 @@ public sealed class MaintainerrClientContractTests
             CancellationToken.None);
 
         stopwatch.Stop();
+
+        // These two are the contract, and they are deterministic: if the deadline
+        // restarted per phase, the second call would not have timed out at all.
         Assert.Equal(MaintainerrErrorCode.Timeout, dashboard.Error);
         Assert.Equal(MaintainerrErrorCode.Timeout, item.Error);
-        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(1));
+
+        // This one distinguishes the ~400ms operation deadlines from the request
+        // deadline. It was previously a bare `< 1s`, which on a shared two-core runner
+        // measured scheduler availability rather than plugin behaviour and failed
+        // intermittently on unrelated PRs. Deriving it from the configured request
+        // deadline keeps the same discrimination with a large margin either side.
+        Assert.True(
+            stopwatch.Elapsed < requestDeadline,
+            $"Both phases timed out, but the pair took {stopwatch.Elapsed.TotalSeconds:F1}s, "
+            + $"which suggests they ran to the {requestDeadline.TotalSeconds:F0}s request "
+            + "deadline rather than sharing one operation deadline.");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Two tests failed three times in one session on PRs whose diffs touched **only**
`research/` markdown. Both assert a real contract deterministically and then add a
wall-clock upper bound that, on a shared two-core runner, measures runner
availability rather than plugin behaviour.

## What was wrong

**`JikanAnimeFillerProviderTests.PerRequestDeadline_...`** configured a 50 ms
request deadline inside a **1 s** operation deadline, then asserted the whole call
finished within **1 s**. It was distinguishing the two by a margin the scheduler
could erase.

**`MaintainerrClientContractTests.DashboardAndItemStatus_...`** asserted a bare
`< 1s` against ~400 ms of operation deadlines and a 2 s request deadline.

In both cases the deterministic assertions — `OperationCanceledException`, and two
`MaintainerrErrorCode.Timeout` results — already prove the contract. The timing
bound only distinguished *which* deadline fired.

## The fix

Make the two deadlines far apart, and derive the bound from the configuration
instead of a magic constant.

| Test | before | after |
|---|---|---|
| Jikan | request 50 ms, operation **1 s**, assert `< 1s` | request 50 ms, operation **30 s**, assert `< 5s` |
| Maintainerr | request **2 s**, assert `< 1s` | request **30 s**, assert `< requestDeadline` |

The Jikan bound now sits ~100× above the expected value and ~6× below the failure
value. The Maintainerr assertion now literally says what it means: *these calls
shared one operation deadline instead of each running to the request deadline.*

Both bounds carry a failure message naming which deadline the test thinks fired,
so the next person seeing this red does not have to reverse-engineer it.

## Why not the stronger fix

This is deliberately **not** the strongest option, and I want to be straight about
that. I looked for a way to remove the timing assertion entirely.

Both deadlines are internal linked `CancellationTokenSource`s
(`JikanAnimeFillerProvider.cs:174-186`), so elapsed time is the **only** signal a
caller has for which one fired. Deleting the bound would drop the discrimination
these tests exist for. Widening the gap keeps it while removing the race.

If the timeouts are ever made observable — a distinct error code, or an injected
`TimeProvider` — these should become exact assertions and the timing bound should
go. Worth doing; out of scope here.

## Verification

Both tests pass **5/5 with six CPU-saturating background processes running**,
where the previous bounds were failing on an idle-ish CI runner.

```
run 1: Passed! - Failed: 0, Passed: 2 ... Duration: 557 ms
run 2: Passed! - Failed: 0, Passed: 2 ... Duration: 581 ms
run 3: Passed! - Failed: 0, Passed: 2 ... Duration: 613 ms
run 4: Passed! - Failed: 0, Passed: 2 ... Duration: 572 ms
run 5: Passed! - Failed: 0, Passed: 2 ... Duration: 581 ms
failures under load: 0
```

## Not changed

The three other wall-clock bounds in the suite — two in `ReviewsStoreTests`
(2 s budgets with diagnostic messages) and one in `ContinueWatchingEventWritersTests`
(a named `timeBudget`) — were not observed failing and are less tightly wound.
Left alone rather than churned speculatively.

## AI assistance

AI-assisted implementation and verification were used. The failures were diagnosed
from CI logs and the fix stress-tested locally under load.

Closes #501
