### PR TITLE
research(extension-platform): adopt native-first scope for Platform v1

### DIFF
--- a/research/extension-platform/README.md
+++ b/research/extension-platform/README.md
@@ -3,6 +3,10 @@
 Tracking issue: [#39 — EP-00](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/39)
 Roadmap board: [Jellyfin Elevate Extension Platform](https://github.com/users/4eh5xitv6787h645ebv/projects/3)
 
+> **Scope decided 2026-07-28:** v1 is **native-first** — EP-01, EP-02, EP-06 and
+> EP-08 only. See [ADR-0012](adr/0012-native-first-scope.md). Everything else is
+> deferred, not cancelled.
+
 **Nothing described here is implemented.** This directory is the decision record
 for EP-00, the research milestone that has to be finished before any platform
 code is written. Every document is *proposed* until its milestone's exit gate.
@@ -36,6 +40,7 @@ code is written. Every document is *proposed* until its milestone's exit gate.
 | [0009](adr/0009-packaging-and-kernel-placement.md) | packaging and kernel placement | proposed |
 | [0010](adr/0010-deprecation-and-support-policy.md) | deprecation and support policy | proposed |
 | [0011](adr/0011-identity-and-authority.md) | identity and authority | proposed |
+| [0012](adr/0012-native-first-scope.md) | **native-first scope for v1** | **accepted** |
 
 ## The five results that shaped everything
 

--- a/research/extension-platform/adr/0012-native-first-scope.md
+++ b/research/extension-platform/adr/0012-native-first-scope.md
@@ -1,0 +1,104 @@
+# ADR-0012 — Native-first scope for v1
+
+Status: **accepted** (2026-07-28) · Owner: programme · Supersedes the implicit
+assumption in [`v1-capability-freeze.md`](../v1-capability-freeze.md) that all
+twelve milestones would run
+
+## Context
+
+EP-00 finished with the programme scoped as written: EP-01 through EP-12, with
+GA-grade acceptance criteria — schema fuzzing, multi-hour soak, a private beta
+with external provider and client authors, SDKs in C#, TypeScript and Kotlin, a
+conformance kit, and a native TV reference adapter.
+
+Two facts made that scope worth re-examining before EP-01 fixed anything
+expensive.
+
+**There are no external consumers.** Not "few" — none. Every acceptance criterion
+that assumes an ecosystem (private beta, three-language SDKs, conformance kit,
+independent pilots) is work whose value is contingent on developers who have not
+asked for it. That is risk **R-01**, scored High/High, and it does not improve by
+building more platform.
+
+**There is exactly one committed consumer, and it is native.** A first-party
+Kotlin fork of `jellyfin-androidtv` is in development by the same owner. That
+changed **R-02** from High to Medium — but it also concentrated the entire
+adoption case on one client class.
+
+Four options were considered: the full programme (A), an internal platform v0
+covering EP-01→EP-06 (B), native-first covering EP-01/02/06/08 (C), and
+extracting the reusable primitives with no kernel at all (D).
+
+## Decision
+
+**Option C.** Build **EP-01, EP-02, EP-06 and EP-08**. Defer EP-03's full
+registry, EP-04's provider SDK, EP-05's state and event platform, EP-07's web
+contributions, and all of EP-09 through EP-12.
+
+## Rationale
+
+**The platform's marginal value is highest where Canopy cannot reach at all.**
+For the web, Canopy already injects directly and owns the whole surface; a
+platform there mostly buys the ability for *third parties* to contribute UI, and
+there are none. For native, the value is different in kind — it is the only way
+any Canopy capability reaches Android TV.
+
+**It defers the most expensive and least proven work.** EP-07 is the bulk of the
+remaining cost, and the browser spike verified the mechanism on the **modern
+layout only**; legacy, mobile, Web-TV, accessibility, localisation and jank
+budgets are all untested. EP-08's protocol, by contrast, is already exercised end
+to end by the headless fixture
+([S18](../spike-evidence.md#s18--a-headless-native-client-can-drive-the-protocol-and-every-refusal-is-distinct)):
+negotiation, graceful omission, paginated rows, confirmed actions and six distinct
+refusal codes.
+
+**The server-side-effect class already works on native, today.** A Spoiler Guard
+toggle added to the Android TV fork flips server state and the client sees blurred
+thumbnails and replaced episode titles with **no rendering code at all**
+([jellyfin-androidtv#1](https://github.com/4eh5xitv6787h645ebv/jellyfin-androidtv/pull/1)).
+That is a hardcoded route rather than a platform capability, which is precisely
+what EP-06 turns it into — so the first capability family has a working precedent
+and a real consumer on day one.
+
+**Nothing is foreclosed.** Contracts stay versioned either way, and ADR-0010's
+additive-only rule means option A or B remains reachable by continuing rather than
+by rewriting. C is a subset of B, which is a prefix of A.
+
+## What this gives up, stated plainly
+
+Third-party extensibility, a public SDK, and the conformance kit. An external
+developer cannot build against this scope — that is the point, not an oversight.
+The contracts are **internal-facing but versioned**, so going public later is
+additive work rather than a redesign.
+
+## Consequences
+
+- The `v1` in `/JellyfinCanopy/Platform/v1` is a real version with a real
+  compatibility policy, but its only consumers are first-party. A `v2` therefore
+  costs nothing externally, which materially lowers **R-09**.
+- EP-06 must extract capability families to owning services anyway, so the
+  no-duplication rule (**R-08**) still applies in full.
+- **A new risk: single-consumer bias.** With one adopter the protocol may end up
+  shaped around one client's needs and prove awkward for the next. Mitigation: the
+  headless fixture from EP-00.3 stays green alongside the real client, so every
+  contract has at least one consumer that cannot quietly depend on Android TV
+  behaviour.
+- Deferred milestones stay open on the board but are marked deferred, so the
+  roadmap does not read as eleven items in progress.
+
+## Rejected alternatives
+
+- **Option A, the full programme.** Nothing in EP-00 showed it cannot be built.
+  Rejected because its acceptance criteria assume an ecosystem that no evidence
+  says wants to exist, and because 12–24 months part-time competes directly with
+  the bug inventory (**R-05**).
+- **Option B, internal platform v0 (EP-01→EP-06).** A reasonable answer and a
+  superset of C. Rejected as the *starting* scope because it still builds the
+  provider runtime and state/event platform before anything consumes them; C
+  reaches a working native consumer sooner and B remains reachable by continuing.
+- **Option D, extract the primitives and skip the kernel.** Taken more seriously
+  than its size suggests — `ArrUrlGuard`, `BoundedTtlCache`, `UserAccessQuery` and
+  `AtomicFile` are nearly reuse-ready, so a fortnight would deliver most of the
+  practical reuse. Rejected because it cannot deliver anything a *client*
+  consumes — no descriptors, no actions, no events — and so is not a path to the
+  Android TV work at all.

--- a/research/extension-platform/v1-capability-freeze.md
+++ b/research/extension-platform/v1-capability-freeze.md
@@ -1,8 +1,13 @@
 # Frozen v1 capability list
 
 Tracking issue: [#39 — EP-00](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/39)
-Status: **proposed** (EP-00). "Frozen" means *the list does not grow without a new
+Status: **re-scoped 2026-07-28** by [ADR-0012](adr/0012-native-first-scope.md) —
+v1 is **native-first**. "Frozen" means *the list does not grow without a new
 EP-00-level decision* — not that it is implemented. Nothing here exists yet.
+
+**In v1 scope:** C1, C2 (minimal), C3 (deferred), C6, C8, C9, C10.
+**Deferred:** C4, C5, C7 and the full C2/C3 registry and provider runtime — see
+the table at the end.
 
 Adding to this list requires named consumers, a security and authority analysis,
 failure and lifecycle behaviour, a compatibility policy and a bounded tracking
@@ -114,12 +119,12 @@ owning Canopy service. Exposed through that owner — never reimplemented.
 
 | Family | Axis | Candidate |
 |---|---|---|
+| Per-title user state | opaque action + per-user isolation | **Spoiler Guard** — already driven from Android TV as a hardcoded route ([androidtv#1](https://github.com/4eh5xitv6787h645ebv/jellyfin-androidtv/pull/1)); EP-06 turns it into a platform capability |
 | Per-user data workflow | state + per-user isolation | bookmarks / selected user state |
 | Integration action workflow | opaque action + upstream | a Seerr request action on item detail |
-| Admin live workflow | events + elevated authorization | Active Streams status and actions |
 
-A fourth candidate, the Discovery home row, is a stretch goal for EP-10 rather
-than a v1 commitment.
+The admin live workflow (Active Streams) moves out of v1 with EP-05's events. The
+Discovery home row remains a stretch goal, not a commitment.
 
 ## C10 — Diagnostics and audit
 
@@ -140,23 +145,42 @@ proxy · provider-to-provider calls · cross-extension state · blob or media
 storage · webhooks · custom Jellyfin WebSocket message types · modifying official
 Jellyfin clients · Jellyfin 13 support · telemetry.
 
-## Dependency order
+## Dependency order — native-first
 
 ```
-EP-00 ─▶ EP-01 ─▶ EP-02 ─▶ EP-03 ─┬─▶ EP-04 ─┐
-                                  └─▶ EP-05 ─┴─▶ EP-06 ─┬─▶ EP-07 ─┐
-                                                        └─▶ EP-08 ─┴─▶ EP-09 ─▶ EP-10 ─▶ EP-11 ─▶ EP-12
+EP-00 ─▶ EP-01 ─▶ EP-02 ─▶ EP-06 ─▶ EP-08          ← in scope
+                     ╎
+                     ╎ deferred: EP-03, EP-04, EP-05, EP-07,
+                     ╌╌╌╌╌╌╌╌╌╌  EP-09, EP-10, EP-11, EP-12
 ```
 
-| Capability | Delivered by |
+EP-06 no longer waits on EP-03/04/05. With no third-party extensions there is
+nothing to register and no provider to invoke, so the gateway calls Canopy's own
+owning services directly through the host adapter. Reinstating those milestones
+later is additive: the gateway gains a provider source, it does not change shape.
+
+### What each deferred milestone was going to give us, and why it can wait
+
+| Deferred | Why it can wait |
 |---|---|
-| C1 | EP-01, EP-06 |
-| C2 | EP-03 |
-| C3 | EP-04 |
-| C4 | EP-05 |
-| C5 | EP-05 |
-| C6 | EP-02, EP-06 |
-| C7 | EP-07 |
-| C8 | EP-08 |
-| C9 | EP-06, EP-10 |
-| C10 | EP-03, EP-11 |
+| EP-03 registry, admin approval, manifest lifecycle | nothing third-party to register; the kernel is the only provider |
+| EP-04 provider SDK + JSON ABI runtime | the ABI is proven ([S2](spike-evidence.md#s2--no-shared-type-identity-and-the-failure-is-silent), [S3](spike-evidence.md#s3--cross-plugin-di-works-but-only-by-foreign-concrete-type)) but has no consumer |
+| EP-05 namespaced state + events | EP-06 uses Canopy's existing stores; revisit when an extension needs its own |
+| EP-07 declarative web contributions | Canopy already owns the web surface; highest cost, lowest marginal value, layout breadth untested |
+| EP-09 SDKs, scaffolding, conformance kit | for external developers who do not exist yet |
+| EP-10 independent pilots | requires EP-09 |
+| EP-11 certification, beta, GA | requires a public contract, which this scope deliberately avoids |
+| EP-12 je12-dev adoption policy | applies to a finished platform |
+
+| Capability | Delivered by | v1 scope |
+|---|---|---|
+| C1 discovery/negotiation | EP-01, EP-06 | **in** |
+| C2 registry + lifecycle | EP-03 | **deferred** — no third-party extensions |
+| C3 provider invocation | EP-04 | **deferred** — no providers |
+| C4 namespaced state | EP-05 | **deferred** |
+| C5 events | EP-05 | **deferred** |
+| C6 opaque actions | EP-02, EP-06 | **in** |
+| C7 declarative web slots | EP-07 | **deferred** |
+| C8 native descriptor schema | EP-08 | **in** |
+| C9 reference capability families | EP-06 | **in** — Spoiler Guard first |
+| C10 diagnostics + audit | EP-02, EP-06 | **in**, minus registry diagnostics |


### PR DESCRIPTION
## Summary

Records the scope decision taken after EP-00: **Platform v1 is native-first**.
Build EP-01, EP-02, EP-06 and EP-08. Defer the registry, provider SDK, state and
event platform, web contributions, SDKs, pilots, certification and the je12-dev
policy.

Adds `adr/0012-native-first-scope.md`, re-scopes `v1-capability-freeze.md`, and
updates the README.

## Why

**The platform's marginal value is highest where Canopy cannot reach at all.** For
the web, Canopy already injects directly and owns the whole surface, so a platform
there mostly buys *third-party* UI contribution — and there are no third parties.
For native it is the only way any Canopy capability reaches Android TV, and there
is now one committed consumer.

**It defers the most expensive and least proven milestone.** The browser spike
verified EP-07's mechanism on the **modern layout only**; legacy, mobile, Web-TV,
accessibility, localisation and jank budgets are untested. EP-08's protocol is
already exercised end to end by the headless fixture, and the server-side-effect
class is **already working on a real Android TV client with no rendering code**
([androidtv#1](https://github.com/4eh5xitv6787h645ebv/jellyfin-androidtv/pull/1)).

**Nothing is foreclosed.** Contracts stay versioned, and ADR-0010's additive-only
rule means the fuller scopes remain reachable by continuing rather than rewriting.
C is a subset of B, which is a prefix of A.

## What it gives up

Third-party extensibility, a public SDK, and the conformance kit. An external
developer cannot build against this scope — that is the point, not an oversight.
The ADR says so plainly rather than glossing it.

## Two things that change shape

**The dependency order.** EP-06 no longer waits on EP-03/04/05: with no
third-party extensions there is nothing to register and no provider to invoke, so
the gateway calls Canopy's own owning services through the host adapter.
Reinstating them later is additive — the gateway gains a provider source, it does
not change shape.

**A new risk.** Single-consumer bias: with one adopter the protocol may end up
shaped around one client's needs and prove awkward for the next. Mitigation is
that the EP-00.3 headless fixture stays green alongside the real client, so every
contract has a consumer that cannot quietly depend on Android TV behaviour.

## Also recorded

The capability freeze now marks each of C1–C10 in or out of v1, and lists what
each deferred milestone was going to give us and why it can wait — so the deferral
is auditable rather than implicit. Spoiler Guard becomes the **first** reference
capability family, since it already has a working precedent and a live consumer.

## Validation

- `npm run check:docs` — pass, including `mkdocs build --strict`.
- Internal link and anchor check across `research/extension-platform/` — 0 broken.
- Research-only; no production code, no ratchet touched.

## AI assistance

AI-assisted research and drafting were used. The four options were presented with
costs and risks, and the decision was the maintainer's.
