### PR TITLE
feat: Platform v1 route family with a deny-by-default authorization base

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformAnonymousSurfaceTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformAnonymousSurfaceTests.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using MediaBrowser.Common.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
+{
+    /// <summary>
+    /// Pins the public surface of Platform v1.
+    ///
+    /// The pre-platform <c>/JellyfinCanopy/*</c> routes fail OPEN — an endpoint with no
+    /// authorization attribute is anonymous, and nothing catches it. Platform v1 fails
+    /// closed via <see cref="PlatformControllerBase"/>, and these tests make that a
+    /// build-enforced property rather than a convention someone has to remember.
+    ///
+    /// Same technique as <c>AtomicFileWriteGuardTests</c>: an explicit allowlist, plus
+    /// an anti-rot test so the allowlist cannot quietly outlive what it describes.
+    /// </summary>
+    public class PlatformAnonymousSurfaceTests
+    {
+        /// <summary>
+        /// Every anonymous Platform v1 action, with the reason it is allowed to be one.
+        ///
+        /// Adding an entry here widens what an unauthenticated caller can reach. That
+        /// should be a deliberate, reviewable change — which is the entire point of
+        /// listing them.
+        /// </summary>
+        private static readonly Dictionary<string, string> AllowedAnonymousActions = new(StringComparer.Ordinal)
+        {
+            [$"{nameof(PlatformDiscoveryController)}.{nameof(PlatformDiscoveryController.GetDiscovery)}"] =
+                "A client must be able to learn whether the platform exists before it has a reason to "
+                + "authenticate. The payload is availability plus the protocol range and nothing else.",
+        };
+
+        private static IEnumerable<Type> PlatformControllers => typeof(PlatformControllerBase).Assembly
+            .GetTypes()
+            .Where(type => !type.IsAbstract && typeof(PlatformControllerBase).IsAssignableFrom(type));
+
+        private static IEnumerable<MethodInfo> ActionsOf(Type controller) => controller
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(method => !method.IsSpecialName);
+
+        [Fact]
+        public void EveryPlatformControllerInheritsTheDenyByDefaultBase()
+        {
+            // A controller that sits under the platform route prefix but does NOT derive
+            // from the base would silently escape the [Authorize] this all depends on.
+            var strays = typeof(PlatformControllerBase).Assembly
+                .GetTypes()
+                .Where(type => !type.IsAbstract && typeof(ControllerBase).IsAssignableFrom(type))
+                .Where(type => type.GetCustomAttributes<RouteAttribute>()
+                    .Any(route => route.Template?.StartsWith(PlatformConstants.RoutePrefix, StringComparison.Ordinal) == true))
+                .Where(type => !typeof(PlatformControllerBase).IsAssignableFrom(type))
+                .Select(type => type.Name)
+                .ToList();
+
+            Assert.True(
+                strays.Count == 0,
+                "These controllers serve Platform v1 routes without deriving from PlatformControllerBase, "
+                + "so they do not inherit its deny-by-default authorization: " + string.Join(", ", strays));
+        }
+
+        [Fact]
+        public void NoUndeclaredAnonymousActionExists()
+        {
+            var anonymous = new List<string>();
+
+            foreach (var controller in PlatformControllers)
+            {
+                foreach (var action in ActionsOf(controller))
+                {
+                    var isAnonymous = action.GetCustomAttribute<AllowAnonymousAttribute>() is not null
+                        || controller.GetCustomAttribute<AllowAnonymousAttribute>() is not null;
+                    if (isAnonymous)
+                    {
+                        anonymous.Add($"{controller.Name}.{action.Name}");
+                    }
+                }
+            }
+
+            var undeclared = anonymous.Where(name => !AllowedAnonymousActions.ContainsKey(name)).ToList();
+
+            Assert.True(
+                undeclared.Count == 0,
+                "New anonymous Platform v1 action(s) appeared. If that is intended, add each to "
+                + "AllowedAnonymousActions with the reason it may be reached without authentication: "
+                + string.Join(", ", undeclared));
+        }
+
+        [Fact]
+        public void AllowlistedAnonymousActionsStillExist()
+        {
+            // Anti-rot: an allowlist entry naming an action that has been renamed or
+            // deleted stops describing anything, and quietly stops protecting anything.
+            var missing = AllowedAnonymousActions.Keys
+                .Where(entry =>
+                {
+                    var parts = entry.Split('.');
+                    var controller = PlatformControllers.FirstOrDefault(type => type.Name == parts[0]);
+                    return controller is null || ActionsOf(controller).All(action => action.Name != parts[1]);
+                })
+                .ToList();
+
+            Assert.True(
+                missing.Count == 0,
+                "AllowedAnonymousActions names action(s) that no longer exist; remove the stale entries: "
+                + string.Join(", ", missing));
+        }
+
+        [Fact]
+        public void ActionsWithoutAnExplicitPolicyInheritAuthentication()
+        {
+            // The property that makes forgetting safe: an action that declares nothing
+            // is authenticated, because the base says so.
+            var baseAuthorize = typeof(PlatformControllerBase).GetCustomAttribute<AuthorizeAttribute>();
+            Assert.NotNull(baseAuthorize);
+
+            // A bare [Authorize] means "any signed-in user". Jellyfin 12 has no
+            // Policies.DefaultAuthorization constant to name here — verified in EP-00,
+            // where referencing it failed the build.
+            Assert.Null(baseAuthorize!.Policy);
+        }
+
+        [Fact]
+        public void ElevatedActionsUseTheOnlyPolicyJellyfin12Defines()
+        {
+            // If a platform action ever declares a policy, it must be the one the host
+            // actually has. Anything else is a runtime 500 waiting to happen.
+            var policies = PlatformControllers
+                .SelectMany(ActionsOf)
+                .Select(action => action.GetCustomAttribute<AuthorizeAttribute>()?.Policy)
+                .Where(policy => !string.IsNullOrEmpty(policy))
+                .Distinct()
+                .ToList();
+
+            Assert.All(policies, policy => Assert.Equal(Policies.RequiresElevation, policy));
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformControllerBaseTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformControllerBaseTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
+{
+    /// <summary>
+    /// Identity resolution is the hinge every later authorization decision hangs on,
+    /// so it is tested against claims directly rather than trusted to inspection.
+    ///
+    /// EP-00 established the fact these tests encode: with a non-admin token, injected
+    /// <c>Jellyfin-UserId</c> / <c>X-Jellyfin-User-Id</c> / <c>X-Emby-Authorization</c>
+    /// headers and a <c>jellyfin-userid</c> cookie all still resolved to the caller's
+    /// own id (spike-evidence S14). The base therefore reads the CLAIM and nothing
+    /// else, and these tests fail if it ever starts reading anything else.
+    /// </summary>
+    public class PlatformControllerBaseTests
+    {
+        /// <summary>Minimal concrete controller; the base is abstract and has no behaviour of its own to host.</summary>
+        private sealed class TestController : PlatformControllerBase
+        {
+            public Guid? ExposedUserId => ActingUserId;
+
+            public string? ExposedDeviceId => ActingDeviceId;
+        }
+
+        private static TestController WithClaims(params Claim[] claims) => new()
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = new ClaimsPrincipal(new ClaimsIdentity(claims, "Test")),
+                },
+
+                // Not populated by default, and the forgery tests below write route values.
+                RouteData = new RouteData(),
+            },
+        };
+
+        [Fact]
+        public void ActingUserId_ComesFromTheJellyfinUserIdClaim()
+        {
+            var id = Guid.NewGuid();
+
+            Assert.Equal(id, WithClaims(new Claim("Jellyfin-UserId", id.ToString())).ExposedUserId);
+        }
+
+        [Fact]
+        public void ActingUserId_MatchesTheClaimNameCaseInsensitively()
+        {
+            // Claim type casing is not something a plugin controls, and a casing change
+            // in the host must not silently turn every caller anonymous.
+            var id = Guid.NewGuid();
+
+            Assert.Equal(id, WithClaims(new Claim("jellyfin-userid", id.ToString())).ExposedUserId);
+        }
+
+        [Theory]
+        // Nothing to read.
+        [InlineData(null)]
+        // Present but unusable. Treated as "no identity" rather than throwing: an
+        // unparseable claim is the host's problem, not a 500 for the caller.
+        [InlineData("not-a-guid")]
+        [InlineData("")]
+        // The empty GUID is a real value that means "nobody". Accepting it would let a
+        // caller with no identity look like a user whose id happens to be all zeroes.
+        [InlineData("00000000-0000-0000-0000-000000000000")]
+        public void ActingUserId_IsNullWhenTheClaimIsAbsentOrUnusable(string? raw)
+        {
+            var controller = raw is null
+                ? WithClaims()
+                : WithClaims(new Claim("Jellyfin-UserId", raw));
+
+            Assert.Null(controller.ExposedUserId);
+        }
+
+        [Fact]
+        public void ActingDeviceId_IsReadForAttributionAndIsAllowedToBeAbsent()
+        {
+            Assert.Equal("living-room-tv", WithClaims(new Claim("Jellyfin-DeviceId", "living-room-tv")).ExposedDeviceId);
+
+            // Absent is normal, not an error: a device id is attribution only and never
+            // authority, so nothing may refuse to serve a caller that has none (ADR-0011).
+            Assert.Null(WithClaims().ExposedDeviceId);
+        }
+
+        [Fact]
+        public void ActingUserId_IgnoresHeadersCookiesAndRouteValuesEntirely()
+        {
+            // The forgery attempt EP-00 actually ran, reproduced as a unit test so a
+            // future refactor toward "just read the header, it is simpler" fails loudly.
+            var real = Guid.NewGuid();
+            var forged = Guid.NewGuid();
+
+            var controller = WithClaims(new Claim("Jellyfin-UserId", real.ToString()));
+            var context = controller.ControllerContext.HttpContext;
+
+            context.Request.Headers["Jellyfin-UserId"] = forged.ToString();
+            context.Request.Headers["X-Jellyfin-User-Id"] = forged.ToString();
+            context.Request.Headers["X-Emby-Authorization"] = $"MediaBrowser UserId=\"{forged}\"";
+            context.Request.Headers["Cookie"] = $"jellyfin-userid={forged}";
+            controller.ControllerContext.RouteData.Values["userId"] = forged.ToString();
+
+            Assert.Equal(real, controller.ExposedUserId);
+        }
+
+        [Fact]
+        public void ActingUserId_PrefersNothingWhenOnlyAForgedSourceIsPresent()
+        {
+            // The dangerous half of the previous test: with NO claim, every caller-supplied
+            // source saying "I am this user" must still resolve to no identity at all.
+            var forged = Guid.NewGuid();
+
+            var controller = WithClaims();
+            controller.ControllerContext.HttpContext.Request.Headers["Jellyfin-UserId"] = forged.ToString();
+            controller.ControllerContext.RouteData.Values["userId"] = forged.ToString();
+
+            Assert.Null(controller.ExposedUserId);
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformDiscoveryControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformDiscoveryControllerTests.cs
@@ -1,0 +1,84 @@
+using System.Linq;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
+{
+    public class PlatformDiscoveryControllerTests
+    {
+        private static PlatformDiscoveryController Controller() => new();
+
+        [Fact]
+        public void Discovery_ExposesAvailabilityAndProtocolRangeAndNothingElse()
+        {
+            var response = Assert.IsType<OkObjectResult>(Controller().GetDiscovery().Result);
+            var payload = Assert.IsType<PlatformDiscoveryResponse>(response.Value);
+
+            Assert.True(payload.Available);
+            Assert.Equal(PlatformConstants.ProtocolMinimum, payload.ProtocolMinimum);
+            Assert.Equal(PlatformConstants.ProtocolMaximum, payload.ProtocolMaximum);
+
+            // The shape is the contract. This is an ANONYMOUS payload, so a new property
+            // is a new thing an unauthenticated caller learns about this server - it
+            // should have to be added here deliberately, not arrive by accident.
+            var properties = typeof(PlatformDiscoveryResponse).GetProperties().Select(p => p.Name).OrderBy(n => n);
+            Assert.Equal(
+                new[] { nameof(PlatformDiscoveryResponse.Available), nameof(PlatformDiscoveryResponse.ProtocolMaximum), nameof(PlatformDiscoveryResponse.ProtocolMinimum) },
+                properties);
+        }
+
+        [Theory]
+        // A client offering exactly what the host speaks.
+        [InlineData(1, 1, true, 1)]
+        // A forward-looking client: negotiate down to what the host actually has,
+        // rather than refusing a client that is willing to speak our version.
+        [InlineData(1, 5, true, 1)]
+        // A client that has dropped support for everything this host speaks. Its own
+        // outcome, distinct from "unavailable" and from "denied".
+        [InlineData(4, 9, false, null)]
+        public void Negotiate_PicksTheHighestCommonVersion(int clientMin, int clientMax, bool compatible, int? expected)
+        {
+            var response = Assert.IsType<OkObjectResult>(Controller().Negotiate(clientMin, clientMax).Result);
+            var payload = Assert.IsType<PlatformNegotiationResponse>(response.Value);
+
+            Assert.Equal(compatible, payload.Compatible);
+            Assert.Equal(expected, payload.Protocol);
+        }
+
+        [Fact]
+        public void Negotiate_AlwaysEchoesTheHostRange()
+        {
+            // Including on the incompatible path: a client that cannot talk to us should
+            // be able to say WHY in its logs rather than just failing.
+            var response = Assert.IsType<OkObjectResult>(Controller().Negotiate(9, 9).Result);
+            var payload = Assert.IsType<PlatformNegotiationResponse>(response.Value);
+
+            Assert.False(payload.Compatible);
+            Assert.Equal(PlatformConstants.ProtocolMinimum, payload.HostProtocolMinimum);
+            Assert.Equal(PlatformConstants.ProtocolMaximum, payload.HostProtocolMaximum);
+        }
+
+        [Fact]
+        public void Negotiate_WithNoRangeSuppliedAssumesTheOldestProtocol()
+        {
+            // A client that says nothing is treated as speaking v1 only. Assuming it
+            // supports our newest would be optimistic about software we know nothing about.
+            var response = Assert.IsType<OkObjectResult>(Controller().Negotiate(null, null).Result);
+            var payload = Assert.IsType<PlatformNegotiationResponse>(response.Value);
+
+            Assert.True(payload.Compatible);
+            Assert.Equal(PlatformConstants.ProtocolMinimum, payload.Protocol);
+        }
+
+        [Fact]
+        public void RoutePrefixIsVersionedAndNamespacedUnderTheExistingPluginPath()
+        {
+            // Two properties matter here. It carries a MAJOR version, so an incompatible
+            // v2 can coexist rather than mutating v1 under consumers. And it sits under
+            // the plugin's own path, so it cannot collide with another plugin's routes -
+            // Jellyfin applies no prefix convention of its own.
+            Assert.Equal("JellyfinCanopy/Platform/v1", PlatformConstants.RoutePrefix);
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformConstants.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformConstants.cs
@@ -1,0 +1,28 @@
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>
+    /// Constants shared by every Platform v1 surface.
+    ///
+    /// Platform v1 is the versioned, capability-scoped boundary described in
+    /// <c>research/extension-platform/</c>. It is deliberately separate from the
+    /// existing <c>/JellyfinCanopy/*</c> routes, which remain compatibility surfaces
+    /// and are never promoted into the platform implicitly.
+    /// </summary>
+    public static class PlatformConstants
+    {
+        /// <summary>
+        /// The Platform v1 route family.
+        ///
+        /// The <c>v1</c> segment is a MAJOR version. Incompatible majors coexist as
+        /// separate route families rather than mutating in place, so a consumer can
+        /// upgrade on its own schedule (ADR-0001, ADR-0010).
+        /// </summary>
+        public const string RoutePrefix = "JellyfinCanopy/Platform/v1";
+
+        /// <summary>Lowest protocol version this host speaks.</summary>
+        public const int ProtocolMinimum = 1;
+
+        /// <summary>Highest protocol version this host speaks.</summary>
+        public const int ProtocolMaximum = 1;
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformControllerBase.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformControllerBase.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Linq;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>
+    /// Base for every Platform v1 controller. Authorization is asserted HERE, once,
+    /// rather than remembered per action.
+    ///
+    /// This exists because the pre-platform surface fails <em>open</em>: nine routes
+    /// under <c>/JellyfinCanopy/*</c> are anonymous purely by carrying no attribute,
+    /// and only two of those carry a comment saying why. A new endpoint that forgets
+    /// <c>[Authorize]</c> is silently public and nothing catches it.
+    ///
+    /// Platform v1 inverts that. <see cref="AuthorizeAttribute"/> on the base applies
+    /// to every derived action, so an endpoint that declares nothing is authenticated,
+    /// not public. Making one anonymous requires writing <c>[AllowAnonymous]</c>
+    /// explicitly, and <c>PlatformAnonymousSurfaceTests</c> pins the resulting set —
+    /// so widening the public surface is a deliberate, reviewable act.
+    ///
+    /// Two Jellyfin 12 facts this relies on, both measured in EP-00 rather than
+    /// assumed (see <c>research/extension-platform/spike-evidence.md</c> S9):
+    ///
+    /// <list type="bullet">
+    /// <item><description><c>Policies.DefaultAuthorization</c> does NOT exist. The
+    /// only policy constant a plugin needs is <c>Policies.RequiresElevation</c>, with
+    /// a bare <c>[Authorize]</c> meaning "any signed-in user".</description></item>
+    /// <item><description><c>401</c> and <c>403</c> are returned by the host with
+    /// zero body bytes. Platform error envelopes apply only AFTER authorization
+    /// succeeds; these are never wrapped (ADR-0002).</description></item>
+    /// </list>
+    /// </summary>
+    [ApiController]
+    [Authorize]
+    [Produces("application/json")]
+    public abstract class PlatformControllerBase : ControllerBase
+    {
+        /// <summary>
+        /// The acting user, derived from Jellyfin's authentication claims and nothing
+        /// else.
+        ///
+        /// EP-00 verified that this cannot be forged: with a non-admin token, injected
+        /// <c>Jellyfin-UserId</c>, <c>X-Jellyfin-User-Id</c>, <c>X-Emby-Authorization</c>
+        /// header values and a <c>jellyfin-userid</c> cookie all still resolved to the
+        /// caller's own id (spike-evidence S14). No route value, header, cookie or
+        /// payload field may ever be consulted instead of this.
+        /// </summary>
+        protected Guid? ActingUserId
+        {
+            get
+            {
+                var raw = User.Claims.FirstOrDefault(claim =>
+                    string.Equals(claim.Type, "Jellyfin-UserId", StringComparison.OrdinalIgnoreCase))?.Value;
+
+                return Guid.TryParse(raw, out var parsed) && parsed != Guid.Empty ? parsed : null;
+            }
+        }
+
+        /// <summary>
+        /// The device the caller is using, for attribution only.
+        ///
+        /// Attribution is never authority: a device identifier is caller-supplied and
+        /// may not influence any access decision (ADR-0011).
+        /// </summary>
+        protected string? ActingDeviceId => User.Claims.FirstOrDefault(claim =>
+            string.Equals(claim.Type, "Jellyfin-DeviceId", StringComparison.OrdinalIgnoreCase))?.Value;
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformDiscoveryController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformDiscoveryController.cs
@@ -1,0 +1,105 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>
+    /// Entry point for Platform v1: what the platform is, and what it will speak to
+    /// this particular caller.
+    /// </summary>
+    [Route(PlatformConstants.RoutePrefix)]
+    public class PlatformDiscoveryController : PlatformControllerBase
+    {
+        /// <summary>
+        /// Anonymous availability probe.
+        ///
+        /// This is the ONLY anonymous route in Platform v1, and its payload is
+        /// deliberately uninteresting: whether the platform is present, and which
+        /// protocol versions it speaks. Nothing else — no users, no installed
+        /// extensions, no topology, no configuration, no server identity.
+        ///
+        /// It is anonymous because a client has to be able to discover whether the
+        /// platform exists at all before it has a reason to authenticate, and because
+        /// probing it tells an unauthenticated caller nothing they could not learn by
+        /// noticing the plugin is installed.
+        /// </summary>
+        [HttpGet("discovery")]
+        [AllowAnonymous]
+        public ActionResult<PlatformDiscoveryResponse> GetDiscovery() => Ok(new PlatformDiscoveryResponse
+        {
+            Available = true,
+            ProtocolMinimum = PlatformConstants.ProtocolMinimum,
+            ProtocolMaximum = PlatformConstants.ProtocolMaximum,
+        });
+
+        /// <summary>
+        /// Authenticated negotiation: the highest protocol version both sides speak.
+        ///
+        /// A client offers the range it supports; the host answers with what it will
+        /// actually use. No overlap is its own outcome, distinct from "unavailable"
+        /// and from "denied", because a client renders those three differently.
+        /// </summary>
+        [HttpGet("negotiate")]
+        public ActionResult<PlatformNegotiationResponse> Negotiate(
+            [FromQuery] int? protocolMinimum,
+            [FromQuery] int? protocolMaximum)
+        {
+            var clientMinimum = protocolMinimum ?? PlatformConstants.ProtocolMinimum;
+            var clientMaximum = protocolMaximum ?? PlatformConstants.ProtocolMinimum;
+
+            var negotiated = clientMaximum < PlatformConstants.ProtocolMaximum
+                ? clientMaximum
+                : PlatformConstants.ProtocolMaximum;
+            var floor = clientMinimum > PlatformConstants.ProtocolMinimum
+                ? clientMinimum
+                : PlatformConstants.ProtocolMinimum;
+
+            if (negotiated < floor)
+            {
+                return Ok(new PlatformNegotiationResponse
+                {
+                    Compatible = false,
+                    HostProtocolMinimum = PlatformConstants.ProtocolMinimum,
+                    HostProtocolMaximum = PlatformConstants.ProtocolMaximum,
+                });
+            }
+
+            return Ok(new PlatformNegotiationResponse
+            {
+                Compatible = true,
+                Protocol = negotiated,
+                HostProtocolMinimum = PlatformConstants.ProtocolMinimum,
+                HostProtocolMaximum = PlatformConstants.ProtocolMaximum,
+            });
+        }
+    }
+
+    /// <summary>Anonymous discovery payload. Adding a field here widens what an unauthenticated caller learns.</summary>
+    public class PlatformDiscoveryResponse
+    {
+        /// <summary>Whether the platform is present and serving.</summary>
+        public bool Available { get; set; }
+
+        /// <summary>Lowest protocol version this host speaks.</summary>
+        public int ProtocolMinimum { get; set; }
+
+        /// <summary>Highest protocol version this host speaks.</summary>
+        public int ProtocolMaximum { get; set; }
+    }
+
+    /// <summary>Result of negotiating a protocol version with an authenticated caller.</summary>
+    public class PlatformNegotiationResponse
+    {
+        /// <summary>Whether the client and host ranges overlap at all.</summary>
+        public bool Compatible { get; set; }
+
+        /// <summary>The agreed version. Meaningless when <see cref="Compatible"/> is false.</summary>
+        public int? Protocol { get; set; }
+
+        /// <summary>Echoed so a client can report the mismatch usefully rather than just failing.</summary>
+        public int HostProtocolMinimum { get; set; }
+
+        /// <summary>Echoed so a client can report the mismatch usefully rather than just failing.</summary>
+        public int HostProtocolMaximum { get; set; }
+    }
+}

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -19,9 +19,9 @@ const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the clean measurement envelopes', () => {
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2327, totalLines: 2667 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 27505, totalLines: 36211 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 27545, totalLines: 36251 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 5);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 6);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -21,12 +21,12 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 27505,
-        "totalLines": 36211
+        "coveredLines": 27545,
+        "totalLines": 36251
       },
       "tolerance": {
-        "missingCoveredLines": 5,
-        "rationale": "The final #453 host-semantics review pass ignores source Range/If-Range for the rewritten shell so every byte-range shape receives the complete injected representation and conditional requests are evaluated against its transformed ETag. Real Static Files regressions cover short, unsatisfiable, open-ended, oversized, and multi-range requests; related cache-capacity, non-cacheable-source, unknown-encoding, non-success, cold-HEAD, and bypass cases preserve the existing coverage ratchet while exercising the bounded fallback paths. Six clean .NET 10.0.9/Coverlet runs on 2026-07-27 each passed all 2,319 tests at the same 36,211-line scope: two measured 27,500 covered lines, three measured 27,503, and one measured the reviewed high-water at 27,505 (75.958%). Retaining the existing evidence-bounded five-line Coverlet tolerance makes the minimum 27,500/36,211 (75.944%), stricter than the prior 27,481/36,205 tolerated floor (75.904%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 6,
+        "rationale": "EP-01.1 (#504) adds the Platform v1 route family: PlatformConstants, the deny-by-default PlatformControllerBase, and PlatformDiscoveryController, which move the instrumented scope from 36,211 to 36,251 lines. Every added line is exercised. PlatformDiscoveryControllerTests pins the anonymous discovery payload shape and the negotiation outcomes including the no-overlap and no-range-supplied paths; PlatformControllerBaseTests drives ActingUserId and ActingDeviceId directly from claims, including the absent, unparseable and empty-GUID cases and the EP-00 forgery attempt (spike-evidence S14) replayed as headers, cookie and route values that must not be consulted; PlatformAnonymousSurfaceTests pins the anonymous action allowlist, its anti-rot counterpart, and the fact that a Platform action declaring no policy inherits authentication. Eight clean .NET 10.0.9/Coverlet runs on 2026-07-28 each passed all 2,340 tests at the same 36,251-line scope and measured 27,543 covered lines five times, 27,545 twice, and 27,539 once, so the reviewed high-water is 27,545 (75.984%) over an observed Coverlet spread of six lines. The tolerance moves from five lines to six to match that measured spread exactly, because a five-line tolerance would put the floor at 27,540 and reject the 27,539 run that was observed on unchanged code; it is widened by measurement, not to absorb a failure. The resulting minimum of 27,539/36,251 (75.954%) is still stricter than the prior 27,500/36,211 tolerated floor (75.944%), so the ratchet tightens in percentage terms. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
Establishes the route family every other EP-01 piece hangs off, and fixes the authorization default while the surface is still empty enough to fix cheaply.

## Why a new base rather than more `[Authorize]` attributes

The pre-platform `/JellyfinCanopy/*` surface **fails open**. Nine routes there are anonymous purely by carrying no attribute, and only two carry a comment saying why. An endpoint that forgets `[Authorize]` is silently public and nothing catches it.

Platform v1 inverts the default. `PlatformControllerBase` asserts `[Authorize]` once, so a derived action that declares nothing is authenticated. Making one anonymous means writing `[AllowAnonymous]` explicitly — and then `PlatformAnonymousSurfaceTests` makes you say why.

The allowlist records the *reason* each entry may be reached unauthenticated, and an anti-rot test fails if an entry names an action that has been renamed or deleted, so the list cannot quietly stop describing what it protects.

**The guard was negative-tested, not just written.** Temporarily adding an undeclared `[AllowAnonymous]` action produced:

> New anonymous Platform v1 action(s) appeared. If that is intended, add each to AllowedAnonymousActions with the reason it may be reached without authentication: SneakyController.Leak

## The one anonymous route

`GET /JellyfinCanopy/Platform/v1/discovery` returns availability plus the protocol range and **nothing else** — no users, no installed extensions, no topology, no configuration, no server identity. It is anonymous because a client must be able to learn the platform exists before it has a reason to authenticate, and probing it reveals nothing beyond "the plugin is installed".

Its shape is pinned by test. A new property on that DTO is a new thing an unauthenticated caller learns, so it should have to be added deliberately rather than arrive by accident.

`GET .../negotiate` is authenticated and treats **no overlap** as its own outcome, distinct from "unavailable" and from "denied" — a client renders those three differently, and collapsing them would make a version mismatch indistinguishable from a permissions problem.

## Identity cannot be asserted by the caller

`ActingUserId` reads the `Jellyfin-UserId` claim and nothing else. The EP-00 forgery attempt (`spike-evidence.md` S14) is replayed as a unit test: `Jellyfin-UserId` / `X-Jellyfin-User-Id` / `X-Emby-Authorization` headers, a `jellyfin-userid` cookie and a route value all naming a different user must not move the answer — and with no claim at all, those sources must still resolve to *no identity*. A later refactor toward "just read the header, it's simpler" now fails loudly.

`ActingDeviceId` is attribution only and is allowed to be absent; a device id is caller-supplied and never authority (ADR-0011).

## Two host facts encoded here were measured, not assumed

Both from EP-00:

- `Policies.DefaultAuthorization` **does not exist** in Jellyfin 12 — referencing it fails the build. A bare `[Authorize]` is how "any signed-in user" is spelled, and `Policies.RequiresElevation` is the only policy constant. A test pins that any policy a platform action declares must be that one, since anything else is a runtime 500 waiting to happen.
- `401`/`403` are returned by the host with **zero body bytes**, so platform error envelopes (#505) apply only *after* authorization succeeds and never wrap these.

The `v1` segment is a MAJOR version so an incompatible v2 can coexist rather than mutating v1 under consumers, and the family sits under the plugin's own path because Jellyfin applies no prefix convention of its own — an unprefixed route family could collide with another plugin (ADR-0001, ADR-0010).

## Coverage baseline

Scope moves 36,211 → 36,251 lines; every added line is exercised. The reviewed high-water goes to **27,545/36,251**.

Eight clean runs (2,340 tests passing each time) measured 27,543 five times, 27,545 twice, and 27,539 once. The tolerance widens 5 → 6 lines to match that **measured** Coverlet spread, because a 5-line tolerance would put the floor at 27,540 and reject the 27,539 run observed on unchanged code. The resulting floor of 27,539/36,251 = **75.954%** is stricter than the previous 75.944%, so the ratchet tightens in percentage terms rather than loosening.

## Verification

- 2,340/2,340 server tests pass; 21/21 in the new Platform suites
- `coverage-baseline.test.js` 13/13, with its scope-drift, regression, stale-baseline and broad-tolerance negative boundaries intact
- `syntax`, `check:performance-rules`, `typecheck`, `typecheck:src`, `check:toolchain`, `test:client:coverage`, `test:scripts` (503/503), `check:markdown-links`, `validate-translations` all green
- ESLint reports 2 errors, both pre-existing on `main` in `src/enhanced/helpers.ts` and `src/seerr/modal.ts`, neither touched here; lint is advisory in CI

Closes #504
