### PR TITLE
fix: open phone settings sections without the slide-in animation

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/template.pane-motion.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/template.pane-motion.test.ts
@@ -1,0 +1,81 @@
+// Guard: opening a settings section on a phone must not animate.
+//
+// Below 760px the panel is two stacked layers — the section list and the detail
+// pane — and `.jc-panel-main` is parked off-screen with `translateX(102%)` until
+// `.jc-pane-open` pulls it back to `translateX(0)`. That transform used to carry
+// `transition: transform 200ms ease`, so every section tap slid the pane in and
+// every back tap slid it out. The motion is removed: the layer swap is instant.
+//
+// The rule is CSS inside a template literal with no JS reader, and jsdom does
+// not evaluate media queries, so this reads template.ts from disk and asserts on
+// the shipped phone block directly.
+
+import * as ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+const TEST_FILE_PATH = decodeURIComponent(new URL(import.meta.url).pathname);
+const TEMPLATE_PATH = TEST_FILE_PATH.replace(/[^/]+$/, 'template.ts');
+const SOURCE = ts.sys.readFile(TEMPLATE_PATH) ?? '';
+
+/** Strip `/* … *\/` comments so the guards see only live CSS declarations. */
+function stripComments(css: string): string {
+    return css.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+/**
+ * Returns the body of the `@media (max-width: 760px)` block, brace-balanced so
+ * the nested rule sets come along and the surrounding desktop CSS does not.
+ */
+function phoneMediaBlock(source: string): string {
+    const header = '@media (max-width: 760px) {';
+    const start = source.indexOf(header);
+    if (start < 0) return '';
+    let depth = 0;
+    for (let i = start + header.length - 1; i < source.length; i++) {
+        if (source[i] === '{') depth++;
+        else if (source[i] === '}' && --depth === 0) {
+            return source.slice(start + header.length, i);
+        }
+    }
+    return '';
+}
+
+/** Returns the declarations of every rule in `block` whose selector matches. */
+function declarationsFor(block: string, selector: string): string[] {
+    return [...block.matchAll(/([^{}]+)\{([^{}]*)\}/g)]
+        .filter((rule) => rule[1].includes(selector))
+        .map((rule) => rule[2]);
+}
+
+describe('phone-mode settings pane motion', () => {
+    const block = phoneMediaBlock(stripComments(SOURCE));
+
+    it('found the phone media block', () => {
+        expect(SOURCE.length).toBeGreaterThan(0);
+        expect(block).toContain('.jc-panel-main');
+    });
+
+    // The transform is load-bearing: it is the only thing keeping the closed
+    // detail pane off-screen over the section list.
+    it('still parks the closed detail pane off-screen with a transform', () => {
+        const closed = declarationsFor(block, '.jc-panel-main')
+            .filter((declarations) => declarations.includes('translateX(102%)'));
+        expect(closed).toHaveLength(1);
+        expect(block).toContain('.jc-pane-open .jc-panel-main { transform: translateX(0); }');
+    });
+
+    // The regression this guard exists for.
+    it('does not transition or animate the detail-pane layer', () => {
+        for (const declarations of declarationsFor(block, '.jc-panel-main')) {
+            expect(declarations).not.toMatch(/\btransition\b/);
+            expect(declarations).not.toMatch(/\banimation\b/);
+        }
+    });
+
+    // A transition on the nav layer or the body would slide the same swap from
+    // the other side, so the whole phone block stays motion-free.
+    it('keeps the whole phone block free of transitions and animations', () => {
+        expect(block).not.toMatch(/\btransition\s*:/);
+        expect(block).not.toMatch(/\banimation\s*:/);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/template.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/template.ts
@@ -92,7 +92,7 @@ export function buildPanelHtml(ctx: PanelContext): string {
             <style>
                 /* Adaptive settings view: section nav on the left, one pane at a
                    time on the right; below 760px the nav is the first screen and
-                   panes slide in with a back button. */
+                   the pane covers it instantly with a back button. */
                 #jellyfin-canopy-panel .jc-panel-body { display: grid; grid-template-columns: 230px minmax(0, 1fr); flex: 1; min-height: 0; background: ${panelBgColor}; }
                 #jellyfin-canopy-panel .jc-panel-nav { display: flex; flex-direction: column; gap: 10px; padding: 14px 12px; border-right: 1px solid rgba(255,255,255,0.08); background: rgba(0,0,0,0.18); overflow-y: auto; }
                 #jellyfin-canopy-panel .jc-panel-nav-items { display: flex; flex-direction: column; gap: 3px; }
@@ -114,7 +114,10 @@ export function buildPanelHtml(ctx: PanelContext): string {
                     #jellyfin-canopy-panel { top: 0 !important; left: 0 !important; transform: none !important; width: 100vw !important; max-width: 100vw !important; height: 100dvh !important; max-height: 100dvh !important; border-radius: 0 !important; border: none !important; box-sizing: border-box !important; }
                     #jellyfin-canopy-panel .jc-panel-body { display: block; position: relative; overflow: hidden; }
                     #jellyfin-canopy-panel .jc-panel-nav { position: absolute; inset: 0; border-right: none; z-index: 1; }
-                    #jellyfin-canopy-panel .jc-panel-main { position: absolute; inset: 0; z-index: 2; background: rgb(24, 24, 24); transform: translateX(102%); transition: transform 200ms ease; }
+                    /* The closed pane is parked off-screen by the transform alone —
+                       deliberately untransitioned so opening a section swaps the
+                       layer instantly instead of sliding it in. */
+                    #jellyfin-canopy-panel .jc-panel-main { position: absolute; inset: 0; z-index: 2; background: rgb(24, 24, 24); transform: translateX(102%); }
                     #jellyfin-canopy-panel .jc-panel-body.jc-pane-open .jc-panel-main { transform: translateX(0); }
                     #jellyfin-canopy-panel .jc-panel-body.jc-pane-open .jc-pane-back { display: inline-flex; }
                     #jellyfin-canopy-panel .jc-spoiler-overrides-form { grid-template-columns:1fr; }


### PR DESCRIPTION
## What and why

On a phone, opening a section in **Canopy User Settings** animated. Below 760px the panel is two stacked layers — the section list and the detail pane — and `.jc-panel-main` carried `transition: transform 200ms ease` alongside the `translateX(102%)` that parks it off-screen. Every section tap slid the pane in and every back tap slid it out.

Frame-by-frame measurement showed the motion also **overshoots past its resting position**, which is what made it read as a bounce rather than a slide. Sampling `.jc-panel-main`'s viewport x on each animation frame after a tap at 390×844:

```
before:  397.8, 397.8, 397.8, 126.8, 126.8, 38.86, -0.29, 0.47, -0.03, -0.25, -0.45, 0, 0, ...
after:   397.8, 397.8, 397.8, 397.8, 397.8, 397.8, 397.8,     0,    0,     0,     0, 0, 0, ...
```

The pane crosses zero into negative x and springs back before settling.

## Implementation

Drop the `transition` declaration and keep the `transform`. The transform is load-bearing — it is the only thing keeping the closed detail pane off-screen over the section list — so both end states are unchanged and the layer swap is simply instant. No state, timers, listeners, or classes were added or removed; `jc-pane-open` toggling, `syncLayerFocus`/`inert` focus ownership, `lastOpenedTab` persistence, and the back button are untouched, as is the desktop two-column layout (the transform only ever existed inside the phone media query).

`template.pane-motion.test.ts` reads the shipped template from disk and pins the phone media block free of transitions and animations while asserting the off-screen transform is still present, so the motion cannot creep back. The rule is CSS in a template literal with no JS reader and jsdom does not evaluate media queries, hence the source-level guard — the same approach `src/test/ratings-css.test.ts` already uses.

## Limitations

The `<details>` `scrollIntoView({ behavior: 'smooth' })` autoscroll in `panel.ts` is deliberately untouched — it is a separate animation on a separate interaction (expanding a collapsible block inside a section) and was explicitly out of scope for this change.

## Tests

New guard verified fails-before/passes-after by stashing the fix:

- pre-fix template: 2 of 4 assertions fail (`does not transition or animate the detail-pane layer`, `keeps the whole phone block free of transitions and animations`)
- post-fix: 4/4 pass

Full CI-equivalent gate, clean:

- 617 script tests, `typecheck`, `typecheck:src` — pass
- 2387 .NET tests — pass
- .NET coverage 27687/36405 = 76.053% (required 76.044%) — holds
- Release build — 0 warnings, 0 errors
- `manifest.json` — valid, 3 version entries, 0 warnings

ESLint is advisory here and is reported, not repaired: the two changed files produce 61 warnings / 0 errors both before and after, so this branch adds no lint findings.

## Live results

Verified on a throwaway seeded Jellyfin 12 raised by `e2e/docker/seed.sh` on 127.0.0.1:8100, then torn down with `docker compose ... down -v`. No shared service was touched.

- `e2e/settings-panel-responsive.spec.ts` — 2/2 pass, modern and legacy layouts
- Frame-sampling probe (temporary, not committed) at 390×844 for both `je_arradmin` and `je_arruser`: `transitionDuration` `0.2s` → `0s`, and no intermediate pane position in any sampled frame after the fix
- Back-button return is likewise instantaneous; the closed pane still parks fully off-screen (left ≥ 390 at a 390px viewport)
- Screenshot 50ms after a tap shows the pane already fully rendered and in place, matching native Jellyfin panel chrome
- Zero runtime console errors for both users

Performance is strictly reduced — one fewer compositor animation per section tap — so the jank benchmark cannot regress.

## Review ledger

| ID | Profile / model | Disposition | Evidence |
| --- | --- | --- | --- |
| D1 | discovery / general, medium | clean | Whole-diff discovery over `origin/main..HEAD` returned `verdict: clean`, zero findings. Confirmed the change removes only the phone-scoped transform transition while preserving both end-state transforms, desktop rules, navigation state, focus ownership, persistence, and back-button behavior, and found no transition-dependent consumer. |

No confirmation round was required — nothing was fixed, so there is no fix delta to confirm.

The marker-gated final release review was **skipped by explicit decision**. That gate requires a live-proof marker only a deploy to the shared `jellyfin-12` (:8099) container can write, and that container is currently off-limits; the live proof above was taken on the disposable isolated instance instead.

## AI assistance

Implemented and verified with Claude Code (Opus 5). Independent review pass by gpt-5.6-sol via the repository's Codex review wrapper.
