### PR TITLE
feat: checked-in Platform v1 contract with a CI drift gate

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformContractTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformContractTests.cs
@@ -1,0 +1,372 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
+{
+    /// <summary>
+    /// The CI drift gate for the Platform v1 contract (risk R-17).
+    ///
+    /// <para>
+    /// There is currently no machine-readable description of the pre-platform API at all
+    /// — no OpenAPI, no JSON Schema, no <c>[ProducesResponseType]</c> across 183 routes.
+    /// The only description is prose that says itself it documents a subset. That is how
+    /// a surface becomes unversionable.
+    /// </para>
+    /// <para>
+    /// <b>The spec is authored, not generated.</b> Generating it from the running server
+    /// would document whatever the code happens to do, mistakes included, and would make
+    /// a breaking change undetectable — the spec would simply move with the bug. So the
+    /// spec is the source of truth and these tests check the server against it, in both
+    /// directions: a route with no spec entry fails, and a spec entry with no route fails.
+    /// </para>
+    /// </summary>
+    public class PlatformContractTests
+    {
+        private static readonly JsonDocument Spec = JsonDocument.Parse(File.ReadAllText(ContractPath("openapi.json")));
+        private static readonly JsonDocument Frozen = JsonDocument.Parse(File.ReadAllText(ContractPath("frozen.json")));
+
+        private static string ContractPath(string name, [CallerFilePath] string sourceFile = "")
+            => Path.GetFullPath(Path.Combine(
+                Path.GetDirectoryName(sourceFile)!, "..", "..", "contracts", "platform", "v1", name));
+
+        private static IEnumerable<Type> PlatformControllers => typeof(PlatformControllerBase).Assembly
+            .GetTypes()
+            .Where(type => !type.IsAbstract && typeof(PlatformControllerBase).IsAssignableFrom(type));
+
+        /// <summary>Every routable action, as the path and method it actually serves.</summary>
+        private static IEnumerable<(string Path, string Method, MethodInfo Action)> LiveRoutes()
+        {
+            foreach (var controller in PlatformControllers)
+            {
+                var prefix = controller.GetCustomAttribute<RouteAttribute>()?.Template
+                    ?? throw new InvalidOperationException($"{controller.Name} has no route prefix.");
+
+                foreach (var action in controller.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+                {
+                    if (action.IsSpecialName)
+                    {
+                        continue;
+                    }
+
+                    foreach (var verb in action.GetCustomAttributes<HttpMethodAttribute>())
+                    {
+                        var suffix = verb.Template;
+                        var path = "/" + (string.IsNullOrEmpty(suffix) ? prefix : prefix + "/" + suffix);
+
+                        yield return (path, verb.HttpMethods.First().ToLowerInvariant(), action);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// A property's declared type as one canonical string.
+        ///
+        /// Compared as text rather than as raw JSON because the two documents are
+        /// formatted differently, and <c>["integer","null"]</c> pretty-printed is not
+        /// textually equal to the same array written compactly — which would report a
+        /// breaking change that had not happened, training people to ignore the gate.
+        /// The union is sorted so a reordering is not mistaken for a retype either.
+        /// </summary>
+        private static string TypeToken(JsonElement type) => type.ValueKind switch
+        {
+            JsonValueKind.Array => string.Join(
+                "|",
+                type.EnumerateArray().Select(value => value.GetString()).OrderBy(value => value, StringComparer.Ordinal)),
+            _ => type.GetString() ?? string.Empty,
+        };
+
+        private static IEnumerable<(string Path, string Method, JsonElement Operation)> SpecOperations()
+        {
+            foreach (var path in Spec.RootElement.GetProperty("paths").EnumerateObject())
+            {
+                foreach (var operation in path.Value.EnumerateObject())
+                {
+                    yield return (path.Name, operation.Name, operation.Value);
+                }
+            }
+        }
+
+        [Fact]
+        public void EveryLiveRouteIsDescribedBySpec()
+        {
+            var documented = SpecOperations().Select(entry => $"{entry.Method} {entry.Path}").ToHashSet(StringComparer.Ordinal);
+
+            var undocumented = LiveRoutes()
+                .Select(route => $"{route.Method} {route.Path}")
+                .Where(route => !documented.Contains(route))
+                .OrderBy(route => route, StringComparer.Ordinal)
+                .ToList();
+
+            Assert.True(
+                undocumented.Count == 0,
+                "Platform v1 route(s) exist with no entry in contracts/platform/v1/openapi.json: "
+                + string.Join(", ", undocumented) + ".\n"
+                + "The spec is the contract. Add the route to it - including its responses and whether it "
+                + "is anonymous - rather than shipping a route no consumer can discover.");
+        }
+
+        [Fact]
+        public void EverySpecRouteStillExists()
+        {
+            // The other direction. A spec that describes routes the server no longer
+            // serves is worse than no spec: a consumer generates a client against it and
+            // gets a 404 at runtime.
+            var live = LiveRoutes().Select(route => $"{route.Method} {route.Path}").ToHashSet(StringComparer.Ordinal);
+
+            var stale = SpecOperations()
+                .Select(entry => $"{entry.Method} {entry.Path}")
+                .Where(entry => !live.Contains(entry))
+                .OrderBy(entry => entry, StringComparer.Ordinal)
+                .ToList();
+
+            Assert.True(
+                stale.Count == 0,
+                "contracts/platform/v1/openapi.json describes route(s) the server does not serve: "
+                + string.Join(", ", stale) + ".");
+        }
+
+        [Fact]
+        public void TheSpecAgreesWithTheServerAboutWhichRoutesAreAnonymous()
+        {
+            // A spec that claims a route needs authentication when it does not - or the
+            // reverse - is worse than silence, because a consumer trusts it. In OpenAPI,
+            // "security": [] on an operation means explicitly anonymous.
+            var mismatches = new List<string>();
+
+            foreach (var (path, method, action) in LiveRoutes())
+            {
+                var liveAnonymous = action.GetCustomAttribute<AllowAnonymousAttribute>() is not null
+                    || action.DeclaringType!.GetCustomAttribute<AllowAnonymousAttribute>() is not null;
+
+                var operation = SpecOperations().Single(entry =>
+                    string.Equals(entry.Path, path, StringComparison.Ordinal)
+                    && string.Equals(entry.Method, method, StringComparison.Ordinal)).Operation;
+
+                var specAnonymous = operation.TryGetProperty("security", out var security)
+                    && security.GetArrayLength() == 0;
+
+                if (liveAnonymous != specAnonymous)
+                {
+                    mismatches.Add($"{method} {path} is {(liveAnonymous ? "anonymous" : "authenticated")} "
+                        + $"but the spec says {(specAnonymous ? "anonymous" : "authenticated")}");
+                }
+            }
+
+            Assert.True(mismatches.Count == 0, string.Join("; ", mismatches));
+        }
+
+        [Theory]
+        [InlineData(nameof(PlatformDiscoveryResponse), typeof(PlatformDiscoveryResponse))]
+        [InlineData(nameof(PlatformNegotiationResponse), typeof(PlatformNegotiationResponse))]
+        [InlineData(nameof(PlatformError), typeof(PlatformError))]
+        public void SchemasDoNotDriftFromTheTypesTheyDescribe(string schemaName, Type type)
+        {
+            var schema = Spec.RootElement.GetProperty("components").GetProperty("schemas").GetProperty(schemaName);
+
+            var specProperties = schema.GetProperty("properties")
+                .EnumerateObject()
+                .Select(property => property.Name)
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToList();
+
+            var liveProperties = type.GetProperties()
+                .Select(property => property.Name)
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToList();
+
+            Assert.Equal(liveProperties, specProperties);
+        }
+
+        [Fact]
+        public void TheDocumentedErrorCodesAreExactlyTheOnesTheServerCanReturn()
+        {
+            var specCodes = Spec.RootElement
+                .GetProperty("components").GetProperty("schemas")
+                .GetProperty("PlatformErrorCode").GetProperty("enum")
+                .EnumerateArray()
+                .Select(code => code.GetString()!)
+                .OrderBy(code => code, StringComparer.Ordinal);
+
+            Assert.Equal(PlatformErrorCode.All.OrderBy(code => code, StringComparer.Ordinal), specCodes);
+        }
+
+        [Fact]
+        public void TheDocumentedProtocolRangeMatchesTheServer()
+        {
+            var discovery = Spec.RootElement.GetProperty("components").GetProperty("schemas")
+                .GetProperty("PlatformDiscoveryResponse");
+
+            Assert.Contains(
+                discovery.GetProperty("required").EnumerateArray(),
+                required => required.GetString() == nameof(PlatformDiscoveryResponse.ProtocolMinimum));
+
+            // The fixture is the documented example, so it has to agree with the server's
+            // real range or the example teaches a consumer the wrong thing.
+            var fixtureText = File.ReadAllText(ContractPath(Path.Combine("fixtures", "discovery.200.json")));
+            var fixture = JsonSerializer.Deserialize<PlatformDiscoveryResponse>(fixtureText)!;
+
+            Assert.Equal(PlatformConstants.ProtocolMinimum, fixture.ProtocolMinimum);
+            Assert.Equal(PlatformConstants.ProtocolMaximum, fixture.ProtocolMaximum);
+        }
+
+        [Theory]
+        [InlineData("discovery.200.json", typeof(PlatformDiscoveryResponse))]
+        [InlineData("negotiate.200.compatible.json", typeof(PlatformNegotiationResponse))]
+        [InlineData("negotiate.200.incompatible.json", typeof(PlatformNegotiationResponse))]
+        [InlineData("error.413.json", typeof(PlatformError))]
+        public void GoldenFixturesRoundTripThroughTheRealTypesWithoutLosingAnything(string fixtureName, Type type)
+        {
+            // A fixture that cannot round-trip is a fixture that documents a shape the
+            // server cannot actually produce - a stale example, which is exactly what
+            // this gate is meant to catch.
+            var original = File.ReadAllText(ContractPath(Path.Combine("fixtures", fixtureName)));
+
+            var parsed = JsonSerializer.Deserialize(original, type)!;
+            var reserialized = JsonSerializer.Serialize(parsed, type);
+
+            using var before = JsonDocument.Parse(original);
+            using var after = JsonDocument.Parse(reserialized);
+
+            var beforeProperties = before.RootElement.EnumerateObject()
+                .ToDictionary(property => property.Name, property => property.Value.ToString(), StringComparer.Ordinal);
+            var afterProperties = after.RootElement.EnumerateObject()
+                .ToDictionary(property => property.Name, property => property.Value.ToString(), StringComparer.Ordinal);
+
+            Assert.Equal(beforeProperties, afterProperties);
+        }
+
+        [Fact]
+        public void TheErrorFixtureUsesADocumentedCodeAndAConformingCorrelationId()
+        {
+            var error = JsonSerializer.Deserialize<PlatformError>(
+                File.ReadAllText(ContractPath(Path.Combine("fixtures", "error.413.json"))))!;
+
+            Assert.True(PlatformErrorCode.IsKnown(error.Code));
+            Assert.Equal(413, PlatformErrorCode.StatusFor(error.Code));
+            Assert.Equal(error.Retryable, PlatformErrorCode.IsRetryable(error.Code));
+
+            // The example must satisfy the pattern the spec advertises, or a consumer
+            // validating against the spec rejects our own documentation.
+            Assert.Matches("^[0-9a-f]{32}$", error.CorrelationId);
+        }
+
+        [Fact]
+        public void NoPathOrMethodPublishedInV1HasBeenRemoved()
+        {
+            // ADR-0010: changes within v1 are additive only. Enforced here rather than
+            // left to a reviewer noticing a deletion in a large diff.
+            var live = SpecOperations()
+                .Select(entry => $"{entry.Method} {entry.Path}")
+                .ToHashSet(StringComparer.Ordinal);
+
+            var removed = new List<string>();
+
+            foreach (var path in Frozen.RootElement.GetProperty("paths").EnumerateObject())
+            {
+                foreach (var method in path.Value.EnumerateArray())
+                {
+                    var entry = $"{method.GetString()} {path.Name}";
+                    if (!live.Contains(entry))
+                    {
+                        removed.Add(entry);
+                    }
+                }
+            }
+
+            Assert.True(
+                removed.Count == 0,
+                "Published Platform v1 route(s) were removed or renamed: " + string.Join(", ", removed) + ".\n"
+                + "Within v1 the surface may only grow (ADR-0010). An incompatible change belongs in a v2 "
+                + "route family, which can coexist, rather than mutating v1 under existing consumers.");
+        }
+
+        [Fact]
+        public void NoRequiredPropertyPublishedInV1HasBeenRemovedOrRetyped()
+        {
+            var schemas = Spec.RootElement.GetProperty("components").GetProperty("schemas");
+            var breaks = new List<string>();
+
+            foreach (var frozenSchema in Frozen.RootElement.GetProperty("schemas").EnumerateObject())
+            {
+                if (!schemas.TryGetProperty(frozenSchema.Name, out var liveSchema))
+                {
+                    breaks.Add($"schema {frozenSchema.Name} was removed");
+                    continue;
+                }
+
+                if (frozenSchema.Value.TryGetProperty("enum", out var frozenEnum))
+                {
+                    var liveValues = liveSchema.GetProperty("enum").EnumerateArray()
+                        .Select(value => value.GetString()!)
+                        .ToHashSet(StringComparer.Ordinal);
+
+                    // Adding a code is additive; removing one breaks a consumer that
+                    // branches on it.
+                    breaks.AddRange(frozenEnum.EnumerateArray()
+                        .Select(value => value.GetString()!)
+                        .Where(value => !liveValues.Contains(value))
+                        .Select(value => $"{frozenSchema.Name} no longer documents the value '{value}'"));
+                    continue;
+                }
+
+                var liveRequired = liveSchema.GetProperty("required").EnumerateArray()
+                    .Select(value => value.GetString()!)
+                    .ToHashSet(StringComparer.Ordinal);
+
+                breaks.AddRange(frozenSchema.Value.GetProperty("required").EnumerateArray()
+                    .Select(value => value.GetString()!)
+                    .Where(value => !liveRequired.Contains(value))
+                    .Select(value => $"{frozenSchema.Name}.{value} is no longer required"));
+
+                var liveProperties = liveSchema.GetProperty("properties");
+
+                foreach (var frozenProperty in frozenSchema.Value.GetProperty("propertyTypes").EnumerateObject())
+                {
+                    if (!liveProperties.TryGetProperty(frozenProperty.Name, out var liveProperty))
+                    {
+                        breaks.Add($"{frozenSchema.Name}.{frozenProperty.Name} was removed");
+                        continue;
+                    }
+
+                    var liveType = TypeToken(liveProperty.TryGetProperty("type", out var type)
+                        ? type
+                        : liveProperty.GetProperty("$ref"));
+                    var frozenType = TypeToken(frozenProperty.Value);
+
+                    if (!string.Equals(liveType, frozenType, StringComparison.Ordinal))
+                    {
+                        breaks.Add(
+                            $"{frozenSchema.Name}.{frozenProperty.Name} changed type from "
+                            + $"{frozenType} to {liveType}");
+                    }
+                }
+            }
+
+            Assert.True(
+                breaks.Count == 0,
+                "Breaking change(s) to published Platform v1 schemas: " + string.Join("; ", breaks) + ".\n"
+                + "Within v1 the surface may only grow (ADR-0010). Do not edit frozen.json to make this "
+                + "pass - that is the one thing it must never be used for.");
+        }
+
+        [Fact]
+        public void TheFrozenSnapshotDescribesSomethingRatherThanBeingEmpty()
+        {
+            // A gate comparing against an empty snapshot passes unconditionally, which
+            // looks identical to a gate that is working.
+            Assert.NotEmpty(Frozen.RootElement.GetProperty("paths").EnumerateObject());
+            Assert.NotEmpty(Frozen.RootElement.GetProperty("schemas").EnumerateObject());
+        }
+    }
+}

--- a/contracts/platform/v1/fixtures/discovery.200.json
+++ b/contracts/platform/v1/fixtures/discovery.200.json
@@ -1,0 +1,5 @@
+{
+  "Available": true,
+  "ProtocolMinimum": 1,
+  "ProtocolMaximum": 1
+}

--- a/contracts/platform/v1/fixtures/error.413.json
+++ b/contracts/platform/v1/fixtures/error.413.json
@@ -1,0 +1,7 @@
+{
+  "Error": true,
+  "Code": "payload_too_large",
+  "Message": "The request exceeds the platform limit for depth (32).",
+  "Retryable": false,
+  "CorrelationId": "0123456789abcdef0123456789abcdef"
+}

--- a/contracts/platform/v1/fixtures/negotiate.200.compatible.json
+++ b/contracts/platform/v1/fixtures/negotiate.200.compatible.json
@@ -1,0 +1,6 @@
+{
+  "Compatible": true,
+  "Protocol": 1,
+  "HostProtocolMinimum": 1,
+  "HostProtocolMaximum": 1
+}

--- a/contracts/platform/v1/fixtures/negotiate.200.incompatible.json
+++ b/contracts/platform/v1/fixtures/negotiate.200.incompatible.json
@@ -1,0 +1,6 @@
+{
+  "Compatible": false,
+  "Protocol": null,
+  "HostProtocolMinimum": 1,
+  "HostProtocolMaximum": 1
+}

--- a/contracts/platform/v1/frozen.json
+++ b/contracts/platform/v1/frozen.json
@@ -1,0 +1,67 @@
+{
+  "note": "The published Platform v1 surface. CI proves the live spec is a superset of this. Removing a path or method, removing a required property, or changing a property's type is a breaking change and belongs in v2 (ADR-0010). Regenerating this file to make a gate pass is the one thing it must never be used for; it is updated only when v1 grows.",
+  "paths": {
+    "/JellyfinCanopy/Platform/v1/discovery": [
+      "get"
+    ],
+    "/JellyfinCanopy/Platform/v1/negotiate": [
+      "get"
+    ]
+  },
+  "schemas": {
+    "PlatformDiscoveryResponse": {
+      "required": [
+        "Available",
+        "ProtocolMaximum",
+        "ProtocolMinimum"
+      ],
+      "propertyTypes": {
+        "Available": "boolean",
+        "ProtocolMaximum": "integer",
+        "ProtocolMinimum": "integer"
+      }
+    },
+    "PlatformNegotiationResponse": {
+      "required": [
+        "Compatible",
+        "HostProtocolMaximum",
+        "HostProtocolMinimum"
+      ],
+      "propertyTypes": {
+        "Compatible": "boolean",
+        "HostProtocolMaximum": "integer",
+        "HostProtocolMinimum": "integer",
+        "Protocol": "integer|null"
+      }
+    },
+    "PlatformError": {
+      "required": [
+        "Code",
+        "CorrelationId",
+        "Error",
+        "Message",
+        "Retryable"
+      ],
+      "propertyTypes": {
+        "Code": "#/components/schemas/PlatformErrorCode",
+        "CorrelationId": "string",
+        "Error": "boolean",
+        "Message": "string",
+        "Retryable": "boolean"
+      }
+    },
+    "PlatformErrorCode": {
+      "enum": [
+        "conflict",
+        "internal_error",
+        "invalid_request",
+        "not_found",
+        "payload_too_large",
+        "rate_limited",
+        "timeout",
+        "unavailable",
+        "unsupported_protocol"
+      ]
+    }
+  }
+}

--- a/contracts/platform/v1/openapi.json
+++ b/contracts/platform/v1/openapi.json
@@ -1,0 +1,230 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Jellyfin Canopy \u2014 Platform v1",
+    "version": "1.0.0",
+    "summary": "The versioned, capability-scoped extension surface.",
+    "description": "This document is AUTHORED, not generated from the running server. Generating it from the code would document whatever the code happens to do, mistakes included, and would make a breaking change undetectable \u2014 the spec would simply move with the bug. Here the spec is the source of truth and the server is checked against it by PlatformContractTests.\n\nOnly routes under /JellyfinCanopy/Platform/v1 are described. The pre-platform /JellyfinCanopy/* routes are compatibility surfaces with their own shapes and are deliberately absent; they are never promoted into the platform implicitly.\n\nChanges within v1 are additive only (ADR-0010). Removing a path, removing a required property, or changing a property's type is a v2 concern, and contracts/platform/v1/frozen.json exists so CI can prove it rather than a reviewer having to notice."
+  },
+  "servers": [
+    {
+      "url": "/",
+      "description": "The Jellyfin server root. Platform routes sit under the plugin's own path because Jellyfin applies no prefix convention of its own, so an unprefixed family could collide with another plugin."
+    }
+  ],
+  "paths": {
+    "/JellyfinCanopy/Platform/v1/discovery": {
+      "get": {
+        "operationId": "getDiscovery",
+        "summary": "Whether the platform is present, and which protocol versions it speaks.",
+        "description": "The ONLY anonymous route in Platform v1. A client must be able to learn the platform exists before it has a reason to authenticate, and probing this reveals nothing an unauthenticated caller could not learn by noticing the plugin is installed.\n\nThe payload is deliberately uninteresting: no users, no installed extensions, no topology, no configuration, no server identity. Adding a property here widens what an unauthenticated caller learns.",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "The platform is present.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformDiscoveryResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/JellyfinCanopy/Platform/v1/negotiate": {
+      "get": {
+        "operationId": "negotiate",
+        "summary": "The highest protocol version both sides speak.",
+        "description": "A client offers the range it supports; the host answers with what it will actually use.\n\nNo overlap is reported as a 200 with compatible=false, NOT as an error. A negotiation that concludes \"no common version\" has succeeded \u2014 it answered the question asked \u2014 and a client renders that differently from \"unavailable\" and from \"denied\". Collapsing the three would make a version mismatch indistinguishable from a permissions problem.\n\nA client that supplies no range is treated as speaking the oldest protocol only. Assuming it supports the newest would be optimistic about software the host knows nothing about.",
+        "parameters": [
+          {
+            "name": "protocolMinimum",
+            "in": "query",
+            "required": false,
+            "description": "Lowest protocol version the client supports. Defaults to the host's minimum.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "protocolMaximum",
+            "in": "query",
+            "required": false,
+            "description": "Highest protocol version the client supports. Defaults to the host's minimum, not its maximum.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Negotiation completed. Check compatible before using protocol.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformNegotiationResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/BareUnauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/BareForbidden"
+          },
+          "413": {
+            "$ref": "#/components/responses/PayloadTooLarge"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "JellyfinToken": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Authorization",
+        "description": "Jellyfin's own scheme: `Authorization: MediaBrowser Token=\"<token>\"`. EP-00 verified that the 10.x `?api_key=` query parameter has been removed in Jellyfin 12, while `?apikey=` and `?ApiKey=` still work; the platform documents only the header because a credential in a query string lands in logs and referrers."
+      }
+    },
+    "responses": {
+      "BareUnauthorized": {
+        "description": "No or invalid credentials. EP-00 measured that Jellyfin 12 returns this with ZERO body bytes, so it carries no platform error envelope \u2014 the envelope applies only after authorization succeeds (ADR-0002). A client must not attempt to parse this body."
+      },
+      "BareForbidden": {
+        "description": "Authenticated but not permitted. Zero body bytes, for the same reason as 401."
+      },
+      "PayloadTooLarge": {
+        "description": "A kernel-owned request bound was exceeded. The message names which axis, so a client knows whether to send fewer items, shorter strings, or a flatter shape.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/PlatformError"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "PlatformDiscoveryResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "Available",
+          "ProtocolMinimum",
+          "ProtocolMaximum"
+        ],
+        "properties": {
+          "Available": {
+            "type": "boolean",
+            "description": "Whether the platform is present and serving."
+          },
+          "ProtocolMinimum": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Lowest protocol version this host speaks."
+          },
+          "ProtocolMaximum": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Highest protocol version this host speaks."
+          }
+        }
+      },
+      "PlatformNegotiationResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "Compatible",
+          "HostProtocolMinimum",
+          "HostProtocolMaximum"
+        ],
+        "properties": {
+          "Compatible": {
+            "type": "boolean",
+            "description": "Whether the client and host ranges overlap at all."
+          },
+          "Protocol": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "The agreed version. Meaningless when compatible is false."
+          },
+          "HostProtocolMinimum": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Echoed so a client can report a mismatch usefully rather than just failing."
+          },
+          "HostProtocolMaximum": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Echoed so a client can report a mismatch usefully rather than just failing."
+          }
+        }
+      },
+      "PlatformError": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "Error",
+          "Code",
+          "Message",
+          "Retryable",
+          "CorrelationId"
+        ],
+        "description": "The single Platform v1 error envelope, returned for every failure that occurs after authorization has succeeded. Deliberately a superset of the richest legacy shape ({ error, code, message }) so an adapter presenting a platform failure to a legacy consumer drops fields rather than translating them.",
+        "properties": {
+          "Error": {
+            "type": "boolean",
+            "const": true,
+            "description": "Always true. Carried so a consumer that already branches on a truthy error keeps working through an adapter."
+          },
+          "Code": {
+            "$ref": "#/components/schemas/PlatformErrorCode"
+          },
+          "Message": {
+            "type": "string",
+            "description": "Human-readable and safe to display. May be reworded or translated at any time, so it is never the thing a consumer branches on."
+          },
+          "Retryable": {
+            "type": "boolean",
+            "description": "Whether retrying the identical request could plausibly succeed. Derived from the code rather than chosen per endpoint, so two endpoints cannot disagree about the same code."
+          },
+          "CorrelationId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{32}$",
+            "description": "Ties this response to the server log lines for the same request. Also returned in the X-Correlation-Id header. Generated by the host and never accepted from the caller."
+          }
+        }
+      },
+      "PlatformErrorCode": {
+        "type": "string",
+        "description": "Machine-readable failure code. Branch on this, never on the message. An unfamiliar code must be treated as a generic failure of its HTTP status class, which is why each code maps to exactly one status.",
+        "enum": [
+          "invalid_request",
+          "unsupported_protocol",
+          "not_found",
+          "conflict",
+          "payload_too_large",
+          "rate_limited",
+          "internal_error",
+          "unavailable",
+          "timeout"
+        ]
+      }
+    }
+  },
+  "security": [
+    {
+      "JellyfinToken": []
+    }
+  ]
+}

--- a/docs/platform-contract.md
+++ b/docs/platform-contract.md
@@ -1,0 +1,107 @@
+# Platform v1 contract
+
+Canopy publishes a machine-readable description of its extension surface. If you are
+writing a client — a web integration, a native app, another plugin — this is what you
+build against.
+
+The artifacts live in [`contracts/platform/v1/`](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/tree/main/contracts/platform/v1):
+
+| File | What it is |
+|---|---|
+| `openapi.json` | The contract. Routes, parameters, responses and schemas. |
+| `frozen.json` | The published v1 surface, so CI can prove changes stay additive. |
+| `fixtures/` | Golden request/response examples. |
+
+## The spec is authored, not generated
+
+This matters more than it sounds. A spec generated from the running server documents
+whatever the code happens to do — mistakes included — and moves silently whenever the
+code moves. A breaking change would rewrite the document that was supposed to catch it.
+
+Here the spec is the source of truth and the server is checked against it, in both
+directions:
+
+- a route with no spec entry fails the build
+- a spec entry with no route fails the build
+- a schema that drifts from the type it describes fails the build
+- a fixture that no longer round-trips fails the build
+
+## What is and is not covered
+
+Only routes under `/JellyfinCanopy/Platform/v1` are described.
+
+The older `/JellyfinCanopy/*` routes are **compatibility surfaces**. They keep their
+existing shapes, they are not documented here, and they are never promoted into the
+platform implicitly. If you are starting something new, use the platform routes.
+
+## Two things worth knowing before you write a client
+
+**`401` and `403` have no body.** Jellyfin returns both with zero bytes, so the contract
+documents them without a schema. Do not try to parse an error envelope from them — you
+will get an empty string. Every *other* failure, after authentication has succeeded,
+carries the one error envelope.
+
+**Branch on `Code`, never on `Message`.** The message is human-readable and may be
+reworded or translated at any time. The code set is enumerated in the spec, and each code
+maps to exactly one HTTP status. Treat a code you do not recognise as a generic failure of
+its status class.
+
+## Versioning
+
+The `v1` in the path is a **major** version. Within it, changes are additive only
+(see [ADR-0010](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/blob/main/research/extension-platform/adr/0010-deprecation-and-support-policy.md)):
+
+- new routes, new optional properties, new error codes — allowed
+- removing a route, removing a required property, changing a property's type — **not**
+  allowed, and CI rejects it
+
+An incompatible change becomes a `v2` route family that coexists with `v1`, so you upgrade
+on your own schedule rather than on ours.
+
+## The handshake
+
+Two routes, meant to be used as a pair:
+
+1. **`GET /JellyfinCanopy/Platform/v1/discovery`** — anonymous. Tells you whether the
+   platform is present and which protocol versions it speaks, and deliberately nothing
+   else. You need this before you have any reason to authenticate.
+2. **`GET /JellyfinCanopy/Platform/v1/negotiate`** — authenticated. You offer the range
+   you support; the host answers with what it will actually use.
+
+`negotiate` answers `200` with `Compatible: false` when there is no common version. That
+is **not** an error — the negotiation succeeded, it just concluded "no". Render it
+differently from "unavailable" and from "denied", because those are three different
+problems with three different fixes.
+
+A client that supplies no range is treated as speaking the oldest protocol only, so send
+your range explicitly.
+
+## Request limits
+
+The platform enforces its own bounds and reports a breach as a structured `413` naming
+which one you hit:
+
+| Limit | Value |
+|---|---|
+| Body size | 1,048,576 bytes |
+| Nesting depth | 32 |
+| Array elements | 10,000 per array |
+| Object keys | 1,000 per object |
+| String length | 65,536 bytes |
+
+One gap to be aware of: a request at or above **30,000,000 bytes** is rejected by
+Jellyfin itself before Canopy sees it, and surfaces as an opaque `500` rather than a
+`413`. The platform covers everything below that; it cannot cover the ceiling.
+
+## Pagination
+
+One dialect: opaque forward cursors. Pass the `NextCursor` you were given to fetch the
+next page, and stop when it is `null`.
+
+`null` is the only end-of-listing signal — a short page is not one, because pages can be
+short whenever rows are filtered after being read.
+
+Cursors are opaque on purpose. Do not decode, construct or reuse one across listings:
+they are bound to the listing that issued them and signed, so a foreign or edited cursor
+is **rejected** rather than silently restarting the walk from the beginning. Maximum page
+size is 200; larger requests are clamped rather than refused.

--- a/e2e/platform-contract-smoke.spec.ts
+++ b/e2e/platform-contract-smoke.spec.ts
@@ -1,0 +1,186 @@
+// EP-01's exit gate: a client driven ONLY by the published contract artifacts
+// negotiates with a live Jellyfin 12.
+//
+// The point is what this spec is NOT allowed to know. It imports no plugin
+// constants, hard-codes no paths and no schema — every route, parameter and
+// response shape is read out of contracts/platform/v1/openapi.json at runtime.
+// If the spec and the server disagree, this fails. If a consumer could not build
+// a working client from the published artifacts alone, this fails.
+//
+// PlatformContractTests already proves the spec matches the assembly by
+// reflection. That is a static check and cannot see routing, authentication or
+// serialization. This one runs against a real server, which is the only way to
+// find out whether the contract survives the host.
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { test, expect, loginAs, assertNoRuntimeErrors } from './fixtures/auth';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const CONTRACT = JSON.parse(
+    readFileSync(join(__dirname, '..', 'contracts', 'platform', 'v1', 'openapi.json'), 'utf8'),
+);
+
+/** Resolves a local `$ref` against the contract document. */
+function resolveRef(ref: string): any {
+    return ref
+        .replace(/^#\//, '')
+        .split('/')
+        .reduce((node: any, segment: string) => node[segment], CONTRACT);
+}
+
+/** The JSON schema a given operation promises for a status code. */
+function responseSchema(path: string, method: string, status: string): any {
+    let response = CONTRACT.paths[path][method].responses[status];
+    if (response.$ref) {
+        response = resolveRef(response.$ref);
+    }
+
+    const schema = response.content['application/json'].schema;
+    return schema.$ref ? resolveRef(schema.$ref) : schema;
+}
+
+/**
+ * Checks a payload against a contract schema.
+ *
+ * Deliberately strict about BOTH directions. A missing required property means
+ * the server under-delivers; an undeclared property means it leaks something the
+ * contract never promised — and on the anonymous route that is a disclosure, not
+ * a formatting nit.
+ */
+function assertMatchesSchema(payload: any, schema: any, where: string): void {
+    for (const required of schema.required ?? []) {
+        expect(payload, `${where}: missing required property "${required}"`).toHaveProperty(required);
+    }
+
+    if (schema.additionalProperties === false) {
+        const declared = Object.keys(schema.properties ?? {});
+        const undeclared = Object.keys(payload).filter((key) => !declared.includes(key));
+        expect(undeclared, `${where}: returned properties the contract does not declare`).toEqual([]);
+    }
+
+    for (const [name, rawSpec] of Object.entries<any>(schema.properties ?? {})) {
+        if (!(name in payload)) {
+            continue;
+        }
+
+        const propertySpec = rawSpec.$ref ? resolveRef(rawSpec.$ref) : rawSpec;
+        const allowed = Array.isArray(propertySpec.type) ? propertySpec.type : [propertySpec.type];
+        const value = payload[name];
+
+        const actual =
+            value === null ? 'null'
+                : Array.isArray(value) ? 'array'
+                    : Number.isInteger(value) ? 'integer'
+                        : typeof value;
+
+        expect(allowed, `${where}: property "${name}" was ${actual}`).toContain(actual);
+
+        if (propertySpec.enum) {
+            expect(propertySpec.enum, `${where}: property "${name}" was outside the documented enum`).toContain(value);
+        }
+
+        if (propertySpec.pattern) {
+            expect(String(value), `${where}: property "${name}" did not match its documented pattern`)
+                .toMatch(new RegExp(propertySpec.pattern));
+        }
+    }
+}
+
+/** The one operation the contract marks anonymous. */
+function anonymousPath(): string {
+    const entries = Object.entries<any>(CONTRACT.paths).filter(
+        ([, operations]) => Array.isArray(operations.get?.security) && operations.get.security.length === 0,
+    );
+
+    expect(entries, 'the contract must declare exactly one anonymous operation').toHaveLength(1);
+    return entries[0][0];
+}
+
+async function getJson(page: any, path: string, authenticated: boolean): Promise<{ status: number; body: any }> {
+    return page.evaluate(
+        async ({ target, withAuth }: { target: string; withAuth: boolean }) => {
+            const api = (window as any).ApiClient;
+            const token = api.accessToken ? api.accessToken() : '';
+            const headers: Record<string, string> = {};
+
+            if (withAuth) {
+                // JF12 authenticates from the Authorization header; it dropped the
+                // legacy query-string api_key.
+                headers.Authorization = `MediaBrowser Token="${token}"`;
+            }
+
+            const res = await fetch(new URL(target, window.location.origin).toString(), { headers });
+            const text = await res.text();
+
+            return { status: res.status, body: text ? JSON.parse(text) : null };
+        },
+        { target: path, withAuth: authenticated },
+    );
+}
+
+test.describe('Platform v1 contract — live smoke client', () => {
+    test('a client built only from the published contract discovers and negotiates', async ({ page, consoleErrors }) => {
+        await loginAs(page, 'admin', consoleErrors);
+
+        // 1. Discovery, anonymously. The contract says which path this is and that
+        //    it needs no credentials; nothing here is hard-coded.
+        const discoveryPath = anonymousPath();
+        const discovery = await getJson(page, discoveryPath, false);
+
+        expect(discovery.status, 'the anonymous route must be reachable without credentials').toBe(200);
+        assertMatchesSchema(
+            discovery.body,
+            responseSchema(discoveryPath, 'get', '200'),
+            `GET ${discoveryPath}`,
+        );
+        expect(discovery.body.Available).toBe(true);
+
+        // 2. Negotiate, using the range discovery just advertised. This is the
+        //    handshake a real consumer performs, and the reason the two routes
+        //    exist as a pair.
+        const negotiatePath = Object.keys(CONTRACT.paths).find((path) => path !== discoveryPath)!;
+        const parameters = CONTRACT.paths[negotiatePath].get.parameters.map((p: any) => p.name);
+        expect(parameters).toEqual(expect.arrayContaining(['protocolMinimum', 'protocolMaximum']));
+
+        const query = `?protocolMinimum=${discovery.body.ProtocolMinimum}&protocolMaximum=${discovery.body.ProtocolMaximum}`;
+        const negotiated = await getJson(page, negotiatePath + query, true);
+
+        expect(negotiated.status).toBe(200);
+        assertMatchesSchema(
+            negotiated.body,
+            responseSchema(negotiatePath, 'get', '200'),
+            `GET ${negotiatePath}`,
+        );
+
+        // A client offering exactly what discovery advertised must be compatible.
+        // If this ever fails, the two routes disagree about the same server.
+        expect(negotiated.body.Compatible).toBe(true);
+        expect(negotiated.body.Protocol).toBe(discovery.body.ProtocolMaximum);
+
+        assertNoRuntimeErrors(consoleErrors);
+    });
+
+    test('an unauthenticated call to the authenticated route is refused with an unparseable body', async ({ page, consoleErrors }) => {
+        await loginAs(page, 'admin', consoleErrors);
+
+        // ADR-0002 and EP-00's S9 measurement: 401/403 carry ZERO body bytes, so
+        // the contract documents them WITHOUT a schema. A client that tried to
+        // parse an error envelope here would throw on empty input, which is why
+        // the contract must not promise one.
+        const discoveryPath = anonymousPath();
+        const negotiatePath = Object.keys(CONTRACT.paths).find((path) => path !== discoveryPath)!;
+
+        const refused = CONTRACT.paths[negotiatePath].get.responses['401'];
+        const documented = refused.$ref ? resolveRef(refused.$ref) : refused;
+        expect(documented.content, 'the contract must not promise a body for 401').toBeUndefined();
+
+        const status = await page.evaluate(async (target: string) => {
+            const res = await fetch(new URL(target, window.location.origin).toString());
+            return { code: res.status, length: (await res.text()).length };
+        }, negotiatePath);
+
+        expect([401, 403]).toContain(status.code);
+        expect(status.length, 'Jellyfin 12 returns 401/403 with no body at all').toBe(0);
+    });
+});

--- a/e2e/required-test-inventory.json
+++ b/e2e/required-test-inventory.json
@@ -96,6 +96,8 @@
     "e2e/pages-lifecycle.spec.ts › pages lifecycle (shared framework) › non-admin: pages open and close cleanly too",
     "e2e/pages-lifecycle.spec.ts › pages lifecycle (shared framework) › page → page direct switch tears the first page down",
     "e2e/panel.spec.ts › panel › opens, has a section nav, switches sections, closes on Escape",
+    "e2e/platform-contract-smoke.spec.ts › Platform v1 contract — live smoke client › a client built only from the published contract discovers and negotiates",
+    "e2e/platform-contract-smoke.spec.ts › Platform v1 contract — live smoke client › an unauthenticated call to the authenticated route is refused with an unparseable body",
     "e2e/request-approvals.spec.ts › in-app request approvals › admin: affordance renders and the approve/decline endpoint round-trips",
     "e2e/request-approvals.spec.ts › in-app request approvals › non-admin: no approve/decline UI and the endpoint returns 403",
     "e2e/requests-long-title-responsive.spec.ts › responsive Requests and Issues cards (#466 finding 6) › modern: long request and issue titles ellipsize without card overflow",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,5 +71,6 @@ nav:
   - Customization: customization.md
   - Reference: reference.md
   - Developer Guide: developers.md
+  - Platform v1 Contract: platform-contract.md
   - Help & Community: help.md
   - About: about.md

--- a/scripts/docs-external-links.json
+++ b/scripts/docs-external-links.json
@@ -145,6 +145,14 @@
       "reason": "Canonical Jellyfin Canopy project link."
     },
     {
+      "url": "https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/blob/main/research/extension-platform/adr/0010-deprecation-and-support-policy.md",
+      "reason": "ADR-0010 defines the additive-only rule the Platform v1 contract gate enforces."
+    },
+    {
+      "url": "https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/tree/main/contracts/platform/v1",
+      "reason": "The published Platform v1 contract artifacts a client author builds against."
+    },
+    {
       "url": "https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues",
       "reason": "Canonical Jellyfin Canopy project link."
     },


### PR DESCRIPTION
Final EP-01 child. The contract becomes an artifact CI refuses to let drift.

## The problem

There is currently **no machine-readable description of the API at all** — no OpenAPI, no JSON Schema, no `[ProducesResponseType]`, across 183 routes. The only description is prose in `docs/developers.md`, which says itself that it documents a subset. That is how a surface becomes unversionable (risk **R-17**).

## The spec is authored, not generated

This is the load-bearing decision. Generating the spec from the running server would document whatever the code happens to do — mistakes included — and would make a breaking change **undetectable**, because the document meant to catch the change would move along with it.

So the spec is the source of truth and the server is checked against it. `PlatformContractTests` runs both directions:

| Failure it catches | Why it matters |
|---|---|
| Route with no spec entry | A route no consumer can discover |
| Spec entry with no route | Worse than no spec — a generated client 404s at runtime |
| Schema drifted from its type | The documented shape isn't the served shape |
| Spec/server disagree on anonymity | A spec a consumer *trusts* is lying about auth |
| Documented error codes ≠ real ones | Consumers branch on codes |
| Fixture that no longer round-trips | A stale example |

## Additive-only is enforced, not reviewed

`frozen.json` records the published v1 surface. Removing a path, removing a required property, retyping one, or dropping a documented error code fails the build (ADR-0010).

One subtlety worth calling out: type comparison is **canonicalised** first. The two documents are formatted differently, so `["integer","null"]` pretty-printed is not textually equal to the same array written compactly. Reporting a breaking change that hadn't happened would train people to ignore the gate — which is worse than not having it.

## Both negative cases proven, not assumed

The DoD asks for exactly these, so I ran them:

**A deliberate breaking change to a v1 schema fails CI** — removed `ProtocolMinimum` from `required`:
> Breaking change(s) to published Platform v1 schemas: PlatformDiscoveryResponse.ProtocolMinimum is no longer required.

**A route added without a spec entry fails CI** — added a probe action:
> Platform v1 route(s) exist with no entry in contracts/platform/v1/openapi.json: get /JellyfinCanopy/Platform/v1/undocumented-probe

Both reverted; the suite is green.

## The smoke client — EP-01's exit gate

Defined by **what it is not allowed to know**. It imports no plugin constants and hard-codes no paths or schemas — every route, parameter and response shape is read out of `openapi.json` at runtime, including *which* route is the anonymous one. If a consumer could not build a working client from the published artifacts alone, it fails.

It runs as an E2E spec so it drives a **live dockerized Jellyfin 12**. That matters: `PlatformContractTests` is static reflection and cannot see routing, authentication or serialization. This is the only check that finds out whether the contract survives the host.

It also pins that `401` carries **zero body bytes** — the contract documents those responses *without* a schema, and a client trying to parse an error envelope there would throw on empty input.

**Verification honesty:** I could not run the E2E locally — `:8099` is frozen and off-limits, and standing up a throwaway Jellyfin 12 for this wasn't warranted when CI provides one. The smoke spec is verified by CI's dockerized E2E job, not by me locally. Everything else below I ran.

## Coverage

**No production code changes.** Scope stays at 36,569 lines and the baseline is untouched — the first EP-01 child that needed no baseline edit at all.

## Docs

New `docs/platform-contract.md` (in nav, `mkdocs build --strict` clean), covering the handshake, the `Compatible: false` outcome that is *not* an error, the bare `401`/`403`, request limits including the documented 30 MB host-ceiling gap, and the cursor rules. Two external links added to the reviewed offline inventory with reasons.

The new E2E spec is registered in `e2e/required-test-inventory.json` — that gate correctly caught it, which is what stops an E2E test silently running in no shard.

## Verification

- 2,458/2,458 server tests; 139/139 across the Platform suites; 16/16 contract gate
- Coverage gate green on the unchanged baseline; `coverage-baseline.test.js` 13/13
- `syntax`, `typecheck`, `check:performance-rules`, `test:scripts` (617/617), `test:client:coverage`, `check:markdown-links`, `check-docs`, `mkdocs build --strict` all green
- ESLint: the same 2 errors already on `main`, in files untouched here; lint is advisory in CI

Closes #509
