### PR TITLE
Honor live Anime Filler cache hours

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/AnimeFillerServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/AnimeFillerServiceTests.cs
@@ -379,6 +379,95 @@ public sealed class AnimeFillerServiceTests
     }
 
     [Fact]
+    public async Task ClassifyAsync_ReducedCacheHours_ExpiresExistingEntryAtTheNewBoundary()
+    {
+        var time = new ManualTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var initialConfig = EnabledConfig();
+        initialConfig.AnimeFillerCacheHours = 24;
+        var configProvider = new FakePluginConfigProvider(initialConfig);
+        var provider = new FakeProvider
+        {
+            Episodes = AnimeProviderEpisodes.Create(20, new Dictionary<int, bool> { [1] = true }),
+        };
+        var service = CreateService(provider, configProvider, time);
+        var identity = Identity(new Dictionary<string, string> { ["MAL"] = "20" });
+
+        var initial = await service.ClassifyAsync(identity, 1, CancellationToken.None);
+        time.Advance(TimeSpan.FromHours(1));
+        var reducedConfig = EnabledConfig();
+        reducedConfig.AnimeFillerCacheHours = 1;
+        configProvider.Current = reducedConfig;
+        provider.Episodes = AnimeProviderEpisodes.Create(20, new Dictionary<int, bool> { [1] = false });
+
+        var refreshed = await service.ClassifyAsync(identity, 1, CancellationToken.None);
+
+        Assert.Equal(AnimeEpisodeClassification.Filler, initial.Classification);
+        Assert.Equal(AnimeEpisodeClassification.Canon, refreshed.Classification);
+        Assert.Equal(2, provider.EpisodeCalls);
+    }
+
+    [Fact]
+    public async Task ClassifyAsync_IncreasedCacheHours_ExtendsExistingEntryFromItsFetchTime()
+    {
+        var time = new ManualTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var initialConfig = EnabledConfig();
+        initialConfig.AnimeFillerCacheHours = 1;
+        var configProvider = new FakePluginConfigProvider(initialConfig);
+        var provider = new FakeProvider
+        {
+            Episodes = AnimeProviderEpisodes.Create(20, new Dictionary<int, bool> { [1] = true }),
+        };
+        var service = CreateService(provider, configProvider, time);
+        var identity = Identity(new Dictionary<string, string> { ["MAL"] = "20" });
+
+        var initial = await service.ClassifyAsync(identity, 1, CancellationToken.None);
+        time.Advance(TimeSpan.FromHours(1));
+        var increasedConfig = EnabledConfig();
+        increasedConfig.AnimeFillerCacheHours = 24;
+        configProvider.Current = increasedConfig;
+        provider.Episodes = AnimeProviderEpisodes.Create(20, new Dictionary<int, bool> { [1] = false });
+
+        var cached = await service.ClassifyAsync(identity, 1, CancellationToken.None);
+
+        Assert.Equal(AnimeEpisodeClassification.Filler, initial.Classification);
+        Assert.Equal(AnimeEpisodeClassification.Filler, cached.Classification);
+        Assert.Equal(1, provider.EpisodeCalls);
+    }
+
+    [Theory]
+    [InlineData(-1, 1)]
+    [InlineData(0, 1)]
+    [InlineData(1, 1)]
+    [InlineData(168, 168)]
+    [InlineData(169, 168)]
+    public async Task ClassifyAsync_CacheHours_AreClampedAndExpireAtTheExactBoundary(
+        int configuredHours,
+        int expectedHours)
+    {
+        var time = new ManualTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var config = EnabledConfig();
+        config.AnimeFillerCacheHours = configuredHours;
+        var provider = new FakeProvider
+        {
+            Episodes = AnimeProviderEpisodes.Create(20, new Dictionary<int, bool> { [1] = true }),
+        };
+        var service = CreateService(provider, config, time);
+        var identity = Identity(new Dictionary<string, string> { ["MAL"] = "20" });
+
+        await service.ClassifyAsync(identity, 1, CancellationToken.None);
+        time.Advance(TimeSpan.FromHours(expectedHours) - TimeSpan.FromTicks(1));
+        await service.ClassifyAsync(identity, 1, CancellationToken.None);
+        Assert.Equal(1, provider.EpisodeCalls);
+
+        time.Advance(TimeSpan.FromTicks(1));
+        provider.Episodes = AnimeProviderEpisodes.Create(20, new Dictionary<int, bool> { [1] = false });
+        var refreshed = await service.ClassifyAsync(identity, 1, CancellationToken.None);
+
+        Assert.Equal(AnimeEpisodeClassification.Canon, refreshed.Classification);
+        Assert.Equal(2, provider.EpisodeCalls);
+    }
+
+    [Fact]
     public async Task ClassifyAsync_UsesExpiredLastGoodDataWhenRefreshFails()
     {
         var time = new ManualTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
@@ -403,9 +492,20 @@ public sealed class AnimeFillerServiceTests
         PluginConfiguration? config = null,
         TimeProvider? timeProvider = null,
         int maximumActiveProviderKeys = 128)
-        => new(
+        => CreateService(
             provider,
             new FakePluginConfigProvider(config ?? EnabledConfig()),
+            timeProvider,
+            maximumActiveProviderKeys);
+
+    private static AnimeFillerService CreateService(
+        FakeProvider provider,
+        FakePluginConfigProvider configProvider,
+        TimeProvider? timeProvider = null,
+        int maximumActiveProviderKeys = 128)
+        => new(
+            provider,
+            configProvider,
             NullLogger<AnimeFillerService>.Instance,
             timeProvider ?? TimeProvider.System,
             maximumActiveProviderKeys);

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/AnimeFiller/AnimeFillerService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/AnimeFiller/AnimeFillerService.cs
@@ -178,10 +178,13 @@ public sealed class AnimeFillerService
     private async Task<AnimeProviderEpisodes?> GetEpisodesAsync(int malId, int configuredHours, CancellationToken cancellationToken)
     {
         var now = _timeProvider.GetUtcNow();
+        var freshnessLifetime = TimeSpan.FromHours(Math.Clamp(configuredHours, 1, 168));
         CachedEpisodes? lastGood = null;
         if (_episodeCache.TryGet(malId, out var cached))
         {
-            if (cached.FreshUntil > now) return cached.Value;
+            // Freshness is evaluated from the fetch time on every read so a live
+            // cache-hours change also governs entries created before that save.
+            if (now - cached.CachedAt < freshnessLifetime) return cached.Value;
             lastGood = cached;
         }
 
@@ -200,8 +203,10 @@ public sealed class AnimeFillerService
                     _errorBackoff.Set("episodes:" + malId.ToString(CultureInfo.InvariantCulture), true, TimeSpan.FromSeconds(30));
                     return null;
                 }
-                var hours = Math.Clamp(configuredHours, 1, 168);
-                _episodeCache.Set(malId, new CachedEpisodes(fetched, _timeProvider.GetUtcNow().AddHours(hours)), TimeSpan.FromDays(7));
+                _episodeCache.Set(
+                    malId,
+                    new CachedEpisodes(fetched, _timeProvider.GetUtcNow()),
+                    TimeSpan.FromDays(7));
                 return (object?)fetched;
             }, cancellationToken).ConfigureAwait(false);
             if (!flight.Accepted)
@@ -251,5 +256,5 @@ public sealed class AnimeFillerService
 
     private sealed record SeriesResolution(int? MyAnimeListId, bool TransientFailure);
 
-    private sealed record CachedEpisodes(AnimeProviderEpisodes Value, DateTimeOffset FreshUntil);
+    private sealed record CachedEpisodes(AnimeProviderEpisodes Value, DateTimeOffset CachedAt);
 }

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -19,7 +19,7 @@ const baselines = loadBaselines();
 
 test('reviewed coverage baselines match the clean measurement envelopes', () => {
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2327, totalLines: 2667 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 27851, totalLines: 36569 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 27855, totalLines: 36572 });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 6);
 });

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -21,12 +21,12 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 27851,
-        "totalLines": 36569
+        "coveredLines": 27855,
+        "totalLines": 36572
       },
       "tolerance": {
         "missingCoveredLines": 6,
-        "rationale": "Fixing #515 (PR #526) raised covered lines from 27,847 to 27,851 at an unchanged 36,569-line scope. The gain is real rather than measurement drift: the logger shutdown test previously started its 100ms shutdown budget before waiting for the gated write to begin, so on a busy machine shutdown abandoned the write before it started and the in-flight-abandon path went unexercised. Waiting for the write first makes that path run every time, which is both the point of the test and the source of the four extra covered lines. Ten clean .NET 10.0.9/Coverlet runs on 2026-07-29 each passed all tests at the same 36,569-line scope and every one measured exactly 27,851 covered lines (76.160%) - zero observed spread, which is itself evidence the path is now deterministic rather than sometimes-taken. The six-line tolerance is retained rather than narrowed to the observed zero, because earlier scopes in this repository showed spreads of five and six lines and CI hardware differs from the machine sampled here; narrowing to the luckiest window would convert ordinary Coverlet jitter into red builds. The floor rises to 27,845/36,569 (76.144%) from the prior 27,841/36,569 (76.133%). An eleventh run was discarded rather than counted: it failed TagCacheSpoilerStripProjectionTests.Benchmark15kBroadScope_StaysWithinCallAllocationAndTimeBudgets, a pre-existing 1500ms wall-clock benchmark budget unrelated to this change, filed as #527. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, and broad-tolerance negative boundaries."
+        "rationale": "Fixing #456 adds three instrumented AnimeFillerService lines so cached episode freshness is recomputed from the fetch timestamp and the current clamped AnimeFillerCacheHours on every read. Three .NET 10.0.9/Coverlet measurements on 2026-08-01 had the same 36,572-line scope and measured 27,854, 27,854, and 27,855 covered lines; the high-water run passed all 2,465 server tests. The deterministic time-provider regressions exercise configuration reductions, increases, invalid values, clamp boundaries, and exact expiry without scheduler timing. The existing six-line tolerance is retained because the one-line spread here does not prove that the earlier observed five- and six-line Coverlet variation has disappeared; keeping it avoids turning instrumentation noise into failures while the floor still rises to 27,849/36,572 (76.148%) from 27,845/36,569 (76.144%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
## Summary

- store the immutable Anime Filler episode fetch timestamp instead of a freshness deadline captured from old settings
- evaluate freshness on every read using the current 1–168 hour clamped setting
- preserve the seven-day last-good retention, cache bounds, shared flights, cancellation, and backoff behavior
- add deterministic reduction, increase, clamp, and exact-boundary regressions
- advance the reviewed server coverage high-water with three clean fixed-scope measurements

Resolves #456

## Validation

- pre-fix reduction and increase regressions failed against the old deadline behavior
- Anime Filler focused suite: 25/25 passed
- full server coverage: 2,465/2,465 passed; 27,854/36,572 within the reviewed 27,855 high-water and six-line tolerance
- full script suite: 617/617 passed
- release build: 0 warnings, 0 errors
- coverage-baseline tests: 13/13 passed
- `git diff --check` passed
- independent review: approved with no remaining findings

No browser E2E was run locally because this is an isolated server cache-policy change with deterministic `TimeProvider` coverage; the required CI E2E matrix remains blocking.