### PR TITLE
test(seerr): prove bounded quota reset projection

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SeerrQuotaPaginationTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SeerrQuotaPaginationTests.cs
@@ -1,15 +1,39 @@
+using System.Diagnostics;
 using System.Globalization;
 using System.Net;
 using System.Text;
 using System.Text.Json;
 using Jellyfin.Plugin.JellyfinCanopy.Controllers;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers;
 
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class SeerrQuotaPaginationCollection
+{
+    public const string Name = "Seerr quota pagination";
+}
+
+[Collection(SeerrQuotaPaginationCollection.Name)]
 public class SeerrQuotaPaginationTests
 {
-    private static readonly DateTime StableNow = DateTime.UtcNow;
+    private const int HeavyUserRequestRows = 10_000;
+    private const int HeavyUserPageSize = 100;
+    private const int HeavyUserPageCount = HeavyUserRequestRows / HeavyUserPageSize;
+    private const int HeavyUserExpectedHttpRequests = HeavyUserPageCount * 2;
+
+    // This is a regression guard, not a throughput target. The exact HTTP count
+    // pins the two complete scans. The process-wide ceilings leave roughly
+    // 25 KiB of allocation per source row and five seconds of CI headroom while
+    // still catching an unbounded page loop or a material per-row blow-up.
+    private const long HeavyUserMaximumAllocatedBytes = 256L * 1024 * 1024;
+    private const long HeavyUserMaximumElapsedMilliseconds = 5_000;
+
+    private static readonly DateTime StableNow = new(2026, 1, 15, 12, 0, 0, DateTimeKind.Utc);
+    private readonly ITestOutputHelper _output;
+
+    public SeerrQuotaPaginationTests(ITestOutputHelper output) => _output = output;
 
     [Fact]
     public async Task RequestHistory_ReadsOldestSentinelBeyondFirstHundredRows()
@@ -63,6 +87,141 @@ public class SeerrQuotaPaginationTests
         Assert.Equal(2, handler.Requests.Count);
     }
 
+    [Fact]
+    public async Task RequestHistory_ReportedPagesBeyondMaximum_TerminatesAfterFirstRequest()
+    {
+        var handler = new RoutingHandler(_ => Page(1, 3, 3, 1));
+        using var client = new HttpClient(handler);
+
+        var result = await SeerrProxyController.FetchQuotaRequestHistoryAsync(
+            client,
+            "http://seerr",
+            "key",
+            "7",
+            SeerrDispatchFenceTestFactory.Create(),
+            CancellationToken.None,
+            pageSize: 1,
+            maximumPages: 2,
+            maximumItems: 10);
+
+        Assert.False(result.IsComplete);
+        Assert.Empty(result.Items);
+        Assert.Equal("Pagination exceeded the 2 page safety bound.", result.FailureReason);
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
+    public async Task RequestHistory_ReportedItemsBeyondMaximum_TerminatesAfterFirstRequest()
+    {
+        var handler = new RoutingHandler(_ => Page(1, 1, 3, 1));
+        using var client = new HttpClient(handler);
+
+        var result = await SeerrProxyController.FetchQuotaRequestHistoryAsync(
+            client,
+            "http://seerr",
+            "key",
+            "7",
+            SeerrDispatchFenceTestFactory.Create(),
+            CancellationToken.None,
+            pageSize: 1,
+            maximumPages: 10,
+            maximumItems: 2);
+
+        Assert.False(result.IsComplete);
+        Assert.Empty(result.Items);
+        Assert.Equal("Pagination exceeded the 2 item safety bound.", result.FailureReason);
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
+    public async Task RequestHistory_TenThousandRequestProfile_StaysWithinRequestAllocationAndTimeBudgets()
+    {
+        // Warm JIT, HttpClient and JSON parsing outside the measured interval.
+        var warmHandler = new RoutingHandler(_ => Page(1, 1, 1, 1));
+        using (var warmClient = new HttpClient(warmHandler))
+        {
+            var warmResult = await SeerrProxyController.FetchQuotaRequestHistoryAsync(
+                warmClient,
+                "http://seerr",
+                "key",
+                "7",
+                SeerrDispatchFenceTestFactory.Create(),
+                CancellationToken.None);
+            Assert.True(warmResult.IsComplete, warmResult.FailureReason);
+        }
+
+        // Serialize deterministic source pages before measuring. The measured
+        // interval includes every HTTP response object/body, parse, clone,
+        // identity/fingerprint check and the second stable-snapshot scan.
+        var pagePayloads = Enumerable.Range(0, HeavyUserPageCount)
+            .Select(pageIndex => JsonSerializer.Serialize(new
+            {
+                results = Enumerable.Range((pageIndex * HeavyUserPageSize) + 1, HeavyUserPageSize)
+                    .Select(id => new
+                    {
+                        id,
+                        type = "movie",
+                        status = 2,
+                        createdAt = StableNow.AddMinutes(id).ToString("O", CultureInfo.InvariantCulture),
+                        requestedBy = new { id = 7 },
+                        media = new { mediaType = "movie" },
+                    })
+                    .ToArray(),
+                pageInfo = new
+                {
+                    page = pageIndex + 1,
+                    pages = HeavyUserPageCount,
+                    results = HeavyUserRequestRows,
+                },
+            }))
+            .ToArray();
+        var handler = new RoutingHandler(uri =>
+        {
+            var skip = QueryInt(uri, "skip");
+            if (skip < 0 || skip % HeavyUserPageSize != 0 || skip >= HeavyUserRequestRows)
+            {
+                throw new InvalidOperationException($"Unexpected skip {skip}.");
+            }
+
+            return JsonText(pagePayloads[skip / HeavyUserPageSize]);
+        });
+        using var client = new HttpClient(handler);
+
+        var allocatedBefore = GC.GetTotalAllocatedBytes(precise: true);
+        var stopwatch = Stopwatch.StartNew();
+        var result = await SeerrProxyController.FetchQuotaRequestHistoryAsync(
+            client,
+            "http://seerr",
+            "key",
+            "7",
+            SeerrDispatchFenceTestFactory.Create(),
+            CancellationToken.None,
+            pageSize: HeavyUserPageSize);
+        stopwatch.Stop();
+        var allocatedBytes = GC.GetTotalAllocatedBytes(precise: true) - allocatedBefore;
+
+        _output.WriteLine(
+            "rows={0} pageSize={1} pagesPerScan={2} httpRequests={3} allocatedBytes={4} elapsedMs={5:F3}",
+            HeavyUserRequestRows,
+            HeavyUserPageSize,
+            HeavyUserPageCount,
+            handler.Requests.Count,
+            allocatedBytes,
+            stopwatch.Elapsed.TotalMilliseconds);
+
+        Assert.True(result.IsComplete, result.FailureReason);
+        Assert.Equal(HeavyUserRequestRows, result.Items.Count);
+        Assert.Equal(1, result.Items[0].GetProperty("id").GetInt32());
+        Assert.Equal(HeavyUserRequestRows, result.Items[^1].GetProperty("id").GetInt32());
+        Assert.Equal(HeavyUserExpectedHttpRequests, handler.Requests.Count);
+        Assert.True(
+            allocatedBytes <= HeavyUserMaximumAllocatedBytes,
+            $"{HeavyUserRequestRows} request rows allocated {allocatedBytes} bytes; budget is {HeavyUserMaximumAllocatedBytes} bytes.");
+        Assert.True(
+            stopwatch.ElapsedMilliseconds <= HeavyUserMaximumElapsedMilliseconds,
+            $"{HeavyUserRequestRows} request rows took {stopwatch.Elapsed}; budget is {HeavyUserMaximumElapsedMilliseconds} ms.");
+    }
+
     private static HttpResponseMessage Page(int page, int pages, int totalResults, params int[] ids)
         => Json(new
         {
@@ -79,6 +238,12 @@ public class SeerrQuotaPaginationTests
         => new(status)
         {
             Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json"),
+        };
+
+    private static HttpResponseMessage JsonText(string body)
+        => new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json"),
         };
 
     private static int QueryInt(Uri uri, string name)

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SeerrQuotaSourceAffinityTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SeerrQuotaSourceAffinityTests.cs
@@ -411,6 +411,44 @@ public class SeerrQuotaSourceAffinityTests
     }
 
     [Fact]
+    public async Task GetQuota_OldAndDeclinedPrefixBeyondFirstPageDoesNotHideActiveReset()
+    {
+        var now = new DateTime(2026, 1, 15, 12, 0, 0, DateTimeKind.Utc);
+        var activeCreatedAt = now.AddDays(-1);
+        var rows = Enumerable.Range(1, 60)
+            .Select(id => RequestRow(id, now.AddDays(-8).AddMinutes(id), ignoreQuota: false))
+            .Concat(Enumerable.Range(61, 60)
+                .Select(id => RequestRow(id, now.AddDays(-6).AddMinutes(id), ignoreQuota: false, status: 3)))
+            .Append(RequestRow(121, activeCreatedAt, ignoreQuota: false))
+            .ToArray();
+        var handler = new RecordingHandler(request =>
+        {
+            var skip = QueryInt(request.RequestUri!, "skip");
+            return Json(new
+            {
+                results = rows.Skip(skip).Take(100).ToArray(),
+                pageInfo = new { page = (skip / 100) + 1, pages = 2, results = rows.Length },
+            });
+        });
+        var seerr = new PinnedQuotaClient(
+            new SeerrUser { Id = 7, SourceUrl = SourceA },
+            QuotaBody());
+        var controller = BuildController(
+            handler,
+            seerr,
+            timeProvider: new ManualTimeProvider(new DateTimeOffset(now)));
+
+        var result = Assert.IsType<ContentResult>(await controller.GetSeerrQuota());
+        var body = JsonNode.Parse(result.Content!)!.AsObject();
+
+        Assert.True((bool?)body["resetProjectionComplete"]);
+        Assert.Equal(
+            activeCreatedAt.AddDays(7),
+            DateTime.Parse((string)body["movie"]!["nextResetAt"]!, null, System.Globalization.DateTimeStyles.RoundtripKind));
+        Assert.Equal(new[] { 0, 100, 0, 100 }, handler.Requests.Select(request => QueryInt(request.Uri, "skip")));
+    }
+
+    [Fact]
     public async Task GetQuota_TvSeasonCountMismatch_OmitsProjection()
     {
         var handler = new RecordingHandler(_ => Json(new
@@ -442,23 +480,17 @@ public class SeerrQuotaSourceAffinityTests
     }
 
     [Fact]
-    public async Task GetQuota_DeclinedAndExpiredBoundaryRowsDoNotContribute()
+    public async Task GetQuota_ExactRollingBoundaryAndDeclinedRowsDoNotContribute()
     {
-        var now = DateTime.UtcNow;
-        var activeCreatedAt = now.AddDays(-1);
+        var now = new DateTime(2026, 1, 15, 12, 0, 0, DateTimeKind.Utc);
+        var windowBoundary = now.AddDays(-7);
+        var activeCreatedAt = windowBoundary.AddTicks(1);
         var handler = new RecordingHandler(_ => Json(new
         {
             results = new object[]
             {
-                RequestRow(1, now.AddDays(-8), ignoreQuota: false),
-                new
-                {
-                    id = 2,
-                    type = "movie",
-                    status = 3,
-                    createdAt = now.ToString("O", System.Globalization.CultureInfo.InvariantCulture),
-                    requestedBy = new { id = 7 },
-                },
+                RequestRow(1, windowBoundary, ignoreQuota: false),
+                RequestRow(2, now, ignoreQuota: false, status: 3),
                 RequestRow(3, activeCreatedAt, ignoreQuota: false),
             },
             pageInfo = new { page = 1, pages = 1, results = 3 },
@@ -466,7 +498,10 @@ public class SeerrQuotaSourceAffinityTests
         var seerr = new PinnedQuotaClient(
             new SeerrUser { Id = 7, SourceUrl = SourceA },
             QuotaBody());
-        var controller = BuildController(handler, seerr);
+        var controller = BuildController(
+            handler,
+            seerr,
+            timeProvider: new ManualTimeProvider(new DateTimeOffset(now)));
 
         var result = Assert.IsType<ContentResult>(await controller.GetSeerrQuota());
         var body = JsonNode.Parse(result.Content!)!.AsObject();
@@ -718,7 +753,8 @@ public class SeerrQuotaSourceAffinityTests
     private static SeerrProxyController BuildController(
         RecordingHandler handler,
         PinnedQuotaClient seerr,
-        FakePluginConfigProvider? provider = null)
+        FakePluginConfigProvider? provider = null,
+        TimeProvider? timeProvider = null)
     {
         provider ??= new FakePluginConfigProvider(Configuration());
         var controller = new SeerrProxyController(
@@ -729,7 +765,8 @@ public class SeerrQuotaSourceAffinityTests
             provider,
             seerr,
             parentalFilter: null!,
-            spoilerPending: null!);
+            spoilerPending: null!,
+            timeProvider: timeProvider ?? TimeProvider.System);
         var identity = new ClaimsIdentity(
             new[] { new Claim("Jellyfin-UserId", JellyfinUserId) },
             "TestAuth");
@@ -807,12 +844,12 @@ public class SeerrQuotaSourceAffinityTests
             },
         });
 
-    private static object RequestRow(int id, DateTime createdAt, bool ignoreQuota)
+    private static object RequestRow(int id, DateTime createdAt, bool ignoreQuota, int status = 2)
         => new
         {
             id,
             type = "movie",
-            status = 2,
+            status,
             ignoreQuota,
             createdAt = createdAt.ToString("O", System.Globalization.CultureInfo.InvariantCulture),
             requestedBy = new { id = 7 },
@@ -870,6 +907,12 @@ public class SeerrQuotaSourceAffinityTests
         return null;
     }
 
+    private static int QueryInt(Uri uri, string name)
+        => int.Parse(
+            QueryValue(uri, name)
+                ?? throw new InvalidOperationException($"Missing query parameter '{name}' from {uri}."),
+            System.Globalization.CultureInfo.InvariantCulture);
+
     private sealed record CapturedRequest(Uri Uri, string? ApiUser);
 
     private sealed class RecordingHandler : HttpMessageHandler
@@ -891,6 +934,11 @@ public class SeerrQuotaSourceAffinityTests
             Requests.Add(new CapturedRequest(request.RequestUri!, apiUser));
             return Task.FromResult(_route(request));
         }
+    }
+
+    private sealed class ManualTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
     }
 
     private sealed class PinnedQuotaClient : ISeerrClient

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/SeerrProxyController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/SeerrProxyController.cs
@@ -57,6 +57,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
         private readonly ISeerrClient _seerr;
         private readonly ISeerrParentalFilter _parentalFilter;
         private readonly SpoilerPendingService _spoilerPending;
+        private readonly TimeProvider _timeProvider;
 
         internal Action? BeforeIssueProjectionPublishForTest { get; set; }
 
@@ -69,11 +70,36 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             ISeerrClient seerr,
             ISeerrParentalFilter parentalFilter,
             SpoilerPendingService spoilerPending)
+            : this(
+                httpClientFactory,
+                logger,
+                userManager,
+                seerrCache,
+                configProvider,
+                seerr,
+                parentalFilter,
+                spoilerPending,
+                TimeProvider.System)
+        {
+        }
+
+        internal SeerrProxyController(
+            IHttpClientFactory httpClientFactory,
+            ILogger<SeerrProxyController> logger,
+            IUserManager userManager,
+            ISeerrCache seerrCache,
+            IPluginConfigProvider configProvider,
+            ISeerrClient seerr,
+            ISeerrParentalFilter parentalFilter,
+            SpoilerPendingService spoilerPending,
+            TimeProvider timeProvider)
             : base(httpClientFactory, logger, userManager, seerrCache, configProvider)
         {
+            ArgumentNullException.ThrowIfNull(timeProvider);
             _seerr = seerr;
             _parentalFilter = parentalFilter;
             _spoilerPending = spoilerPending;
+            _timeProvider = timeProvider;
         }
 
         // Thin delegation kept so the ~35 proxy endpoints below read unchanged;
@@ -515,7 +541,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                     dispatchFence,
                     HttpContext.RequestAborted);
             });
-            var projectionNow = DateTime.UtcNow;
+            var projectionNow = _timeProvider.GetUtcNow().UtcDateTime;
 
             var movieTask = ComputeNextResetAsync(
                 quota,

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -21,16 +21,16 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
     assert.equal(baselines.schemaVersion, 2);
     assert.equal(baselines.policy.baselineSelection, 'observed-high-water');
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2327, totalLines: 2667 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 27855, totalLines: 36572 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 27868, totalLines: 36585 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 2,
         minimumCoveredLines: 2327,
         maximumCoveredLines: 2327,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
-        cleanRuns: 3,
-        minimumCoveredLines: 27854,
-        maximumCoveredLines: 27855,
+        cleanRuns: 5,
+        minimumCoveredLines: 27867,
+        maximumCoveredLines: 27868,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 6);

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 27855,
-        "totalLines": 36572
+        "coveredLines": 27868,
+        "totalLines": 36585
       },
       "observations": {
-        "cleanRuns": 3,
-        "minimumCoveredLines": 27854,
-        "maximumCoveredLines": 27855
+        "cleanRuns": 5,
+        "minimumCoveredLines": 27867,
+        "maximumCoveredLines": 27868
       },
       "tolerance": {
         "missingCoveredLines": 6,
-        "rationale": "Fixing #456 adds three instrumented AnimeFillerService lines so cached episode freshness is recomputed from the fetch timestamp and the current clamped AnimeFillerCacheHours on every read. Three .NET 10.0.9/Coverlet measurements on 2026-08-01 had the same 36,572-line scope and measured 27,854, 27,854, and 27,855 covered lines; the high-water run passed all 2,465 server tests. The deterministic time-provider regressions exercise configuration reductions, increases, invalid values, clamp boundaries, and exact expiry without scheduler timing. The existing six-line tolerance is retained because the one-line spread here does not prove that the earlier observed five- and six-line Coverlet variation has disappeared; keeping it avoids turning instrumentation noise into failures while the floor still rises to 27,849/36,572 (76.148%) from 27,845/36,569 (76.144%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, and broad-tolerance negative boundaries."
+        "rationale": "Completing #160's quota-reset acceptance evidence adds 13 instrumented controller lines for a production-defaulted TimeProvider seam, allowing the integrated endpoint regressions to pin the exact rolling-window boundary while preserving runtime behavior. Five .NET 10.0.9/Coverlet measurements on 2026-08-01 had the same 36,585-line scope and measured 27,867, 27,867, 27,867, 27,868, and 27,867 covered lines; the high-water run passed all 2,469 server tests, including the >100-row old/declined-prefix case, explicit pagination safety bounds, and the 10,000-request performance profile. The existing six-line tolerance is retained because the one-line spread does not prove that the previously observed five- and six-line Coverlet variation has disappeared; keeping it avoids turning instrumentation noise into failures while the floor still rises to 27,862/36,585 (76.157%) from 27,849/36,572 (76.148%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
Resolves #160

## Summary
- add an internal, production-defaulted `TimeProvider` seam so quota reset boundaries are deterministic without changing the public controller contract
- prove an old/declined prefix beyond the first 100-row page cannot hide the active rolling-window reset
- pin the exact exclusive rolling-window boundary and explicit page/item safety-budget failures
- add a 10,000-request profile that requires exactly two complete 100-page scans and bounds allocation/time
- advance the reviewed server coverage high-water for the fixed expanded scope

## Validation
- focused Release quota suites: 44/44
- full server coverage suite: 2,469/2,469
- five fixed-scope measurements: 27,867, 27,867, 27,867, 27,868, 27,867 / 36,585; reviewed high-water 27,868
- Release plugin build: 0 warnings, 0 errors
- coverage baseline contract: 14/14
- 10,000-row profile: exactly 200 HTTP requests, 56,302,632 allocated bytes, 370.787 ms (budgets 256 MiB / 5 s)
- independent review: APPROVE, no findings
- `git diff --check`: clean

## Safety
- no timeout increase, failure suppression, or partial reset timestamp
- production behavior retains `TimeProvider.System`
- no deployment performed