### PR TITLE
perf(spoiler): scope watched-cache series eviction

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SpoilerGuardTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SpoilerGuardTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
 using Jellyfin.Plugin.JellyfinCanopy.Services;
@@ -57,6 +58,111 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             Assert.False(SpoilerBlurImageFilter.ShouldBlur(new[] { true }));
             Assert.False(SpoilerBlurImageFilter.ShouldBlur(Array.Empty<bool>()));
         }
+
+        [Fact]
+        public void SeriesUserDataSaved_EvictsOnlyAffectedUserSeries()
+        {
+            SpoilerBlurImageFilter.ClearWatchedCacheForTest();
+            var userData = new StubUserDataManager();
+            var filter = CreateInvalidationFilter(userData);
+            var affectedUser = Guid.NewGuid();
+            var otherUser = Guid.NewGuid();
+            var affectedSeries = Guid.NewGuid();
+            var unrelatedSeries = Guid.NewGuid();
+            var affectedSeasonOne = Guid.NewGuid();
+            var affectedSeasonTwo = Guid.NewGuid();
+            var sameUserUnrelatedSeason = Guid.NewGuid();
+            var otherUserAffectedSeriesSeason = Guid.NewGuid();
+            var otherUserUnrelatedSeason = Guid.NewGuid();
+
+            try
+            {
+                Assert.Equal(1, userData.UserDataSavedSubscriberCount);
+                SpoilerBlurImageFilter.SeedWatchedCacheForTest(
+                    affectedUser, affectedSeries, affectedSeasonOne, anyWatched: true);
+                SpoilerBlurImageFilter.SeedWatchedCacheForTest(
+                    affectedUser, affectedSeries, affectedSeasonTwo, anyWatched: false);
+                SpoilerBlurImageFilter.SeedWatchedCacheForTest(
+                    affectedUser, unrelatedSeries, sameUserUnrelatedSeason, anyWatched: true);
+                SpoilerBlurImageFilter.SeedWatchedCacheForTest(
+                    otherUser, affectedSeries, otherUserAffectedSeriesSeason, anyWatched: true);
+                SpoilerBlurImageFilter.SeedWatchedCacheForTest(
+                    otherUser, unrelatedSeries, otherUserUnrelatedSeason, anyWatched: false);
+
+                userData.RaiseUserDataSaved(
+                    affectedUser,
+                    new StubSeries { Id = affectedSeries },
+                    UserDataSaveReason.TogglePlayed);
+
+                Assert.True(SpinWait.SpinUntil(
+                    () => !SpoilerBlurImageFilter.IsSeriesInvalidationPendingForTest(affectedUser, affectedSeries),
+                    TimeSpan.FromSeconds(5)));
+                Assert.False(SpoilerBlurImageFilter.IsSeasonWatchedCachedForTest(affectedUser, affectedSeasonOne));
+                Assert.False(SpoilerBlurImageFilter.IsSeasonWatchedCachedForTest(affectedUser, affectedSeasonTwo));
+                Assert.True(SpoilerBlurImageFilter.IsSeasonWatchedCachedForTest(affectedUser, sameUserUnrelatedSeason));
+                Assert.True(SpoilerBlurImageFilter.IsSeasonWatchedCachedForTest(otherUser, otherUserAffectedSeriesSeason));
+                Assert.True(SpoilerBlurImageFilter.IsSeasonWatchedCachedForTest(otherUser, otherUserUnrelatedSeason));
+            }
+            finally
+            {
+                filter.Dispose();
+                Assert.Equal(0, userData.UserDataSavedSubscriberCount);
+                SpoilerBlurImageFilter.ClearWatchedCacheForTest();
+            }
+        }
+
+        [Fact]
+        public void SeasonUserDataSaved_EvictsOnlyAffectedUserSeasonSynchronously()
+        {
+            SpoilerBlurImageFilter.ClearWatchedCacheForTest();
+            var userData = new StubUserDataManager();
+            var filter = CreateInvalidationFilter(userData);
+            var affectedUser = Guid.NewGuid();
+            var otherUser = Guid.NewGuid();
+            var seriesId = Guid.NewGuid();
+            var affectedSeason = Guid.NewGuid();
+            var siblingSeason = Guid.NewGuid();
+
+            try
+            {
+                SpoilerBlurImageFilter.SeedWatchedCacheForTest(
+                    affectedUser, seriesId, affectedSeason, anyWatched: true);
+                SpoilerBlurImageFilter.SeedWatchedCacheForTest(
+                    affectedUser, seriesId, siblingSeason, anyWatched: false);
+                SpoilerBlurImageFilter.SeedWatchedCacheForTest(
+                    otherUser, seriesId, affectedSeason, anyWatched: true);
+
+                userData.RaiseUserDataSaved(
+                    affectedUser,
+                    new StubEpisode
+                    {
+                        Id = Guid.NewGuid(),
+                        SeriesId = seriesId,
+                        SeasonId = affectedSeason,
+                    },
+                    UserDataSaveReason.TogglePlayed);
+
+                Assert.False(SpoilerBlurImageFilter.IsSeasonWatchedCachedForTest(affectedUser, affectedSeason));
+                Assert.True(SpoilerBlurImageFilter.IsSeasonWatchedCachedForTest(affectedUser, siblingSeason));
+                Assert.True(SpoilerBlurImageFilter.IsSeasonWatchedCachedForTest(otherUser, affectedSeason));
+            }
+            finally
+            {
+                filter.Dispose();
+                SpoilerBlurImageFilter.ClearWatchedCacheForTest();
+            }
+        }
+
+        private static SpoilerBlurImageFilter CreateInvalidationFilter(StubUserDataManager userData)
+            => new(
+                libraryManager: null!,
+                userManager: null!,
+                userDataManager: userData,
+                chapterManager: null!,
+                resolver: null!,
+                blurService: null!,
+                configProvider: null!,
+                logger: NullLogger<SpoilerBlurImageFilter>.Instance);
 
         // ─── F2: fail-closed on an unrecognized (content-bearing) result shape ────
 

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/SpoilerBlurImageFilter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/SpoilerBlurImageFilter.cs
@@ -206,8 +206,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             if (!seasonId.HasValue && !seriesId.HasValue) return;
 
             // Season-scoped events: evict the single affected key SYNCHRONOUSLY.
-            // A ConcurrentDictionary.TryRemove is O(1) and allocation-free, so it
-            // is safe on the publish thread — and it closes the race where a user
+            // The bounded cache's TryRemove is O(1) and allocation-free, so it is
+            // safe on the publish thread — and it closes the race where a user
             // marks the season's only watched episode unplayed and immediately
             // re-requests the season art before a queued eviction has run (the
             // stale "AnyWatched=true" entry would pass CLEAR bytes through).
@@ -215,7 +215,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             // sweep iterates the whole cache and does not belong on this thread.
             if (seasonId.HasValue && seasonId.Value != Guid.Empty)
             {
-                _watchedCache.TryRemove(userId.ToString("N") + ":" + seasonId.Value.ToString("N"), out _);
+                _watchedCache.TryRemove(new SeasonWatchedCacheKey(userId, seasonId.Value), out _);
                 return;
             }
 
@@ -243,16 +243,19 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                         // Instance-field _disposed read at execution time
                         // so post-Dispose lambdas no-op fast.
                         if (_disposed) return;
-                        // Series-level event — invalidate every cached season
-                        // for this user (keys are "{userN}:{seasonN}", so we
-                        // iterate). Cheap: cache is small (≤512) and this is
-                        // rare. ToArray so the snapshot survives a concurrent
-                        // insert and future framework changes to Keys.
-                        var prefix = userId.ToString("N") + ":";
-                        foreach (var k in _watchedCache.Keys.ToArray())
+                        // Series-level event — invalidate only cached seasons
+                        // owned by this (user, series). The cache remains bounded
+                        // at 512 entries, and this rare sweep stays off the event
+                        // publisher thread. Enumerating takes a stable snapshot;
+                        // expected-value removal avoids deleting a concurrently
+                        // replaced entry whose season moved to another series.
+                        foreach (var entry in _watchedCache)
                         {
-                            if (k.StartsWith(prefix, StringComparison.Ordinal))
-                                _watchedCache.TryRemove(k, out _);
+                            if (entry.Key.UserId == userId
+                                && entry.Value.SeriesId == seriesId.Value)
+                            {
+                                _watchedCache.Remove(entry.Key, entry.Value);
+                            }
                         }
                     }
                     catch (Exception ex)
@@ -809,11 +812,42 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         // mark-watched → next-navigation roundtrips see fresh data.
         private static readonly TimeSpan SeasonWatchedCacheTtl = TimeSpan.FromSeconds(30);
 
-        private static readonly BoundedTtlCache<string, bool> _watchedCache = new(
+        private readonly record struct SeasonWatchedCacheKey(Guid UserId, Guid SeasonId);
+
+        private readonly record struct SeasonWatchedCacheEntry(Guid SeriesId, bool AnyWatched);
+
+        // The value retains the owning series so a rare Series-level event can
+        // target its aggregate seasons without discarding unrelated series for
+        // the same user. The key remains (user, season), preserving the O(1)
+        // synchronous eviction needed for Episode/Season watched-state changes.
+        private static readonly BoundedTtlCache<SeasonWatchedCacheKey, SeasonWatchedCacheEntry> _watchedCache = new(
             maximumEntries: 512,
             maximumWeight: 512,
-            comparer: StringComparer.Ordinal,
             defaultTtl: () => SeasonWatchedCacheTtl);
+
+        internal static void ClearWatchedCacheForTest()
+        {
+            _watchedCache.Clear();
+            _pendingInvalidations.Clear();
+        }
+
+        internal static void SeedWatchedCacheForTest(
+            Guid userId,
+            Guid seriesId,
+            Guid seasonId,
+            bool anyWatched)
+        {
+            _watchedCache.Set(
+                new SeasonWatchedCacheKey(userId, seasonId),
+                new SeasonWatchedCacheEntry(seriesId, anyWatched),
+                SeasonWatchedCacheTtl);
+        }
+
+        internal static bool IsSeasonWatchedCachedForTest(Guid userId, Guid seasonId)
+            => _watchedCache.ContainsKey(new SeasonWatchedCacheKey(userId, seasonId));
+
+        internal static bool IsSeriesInvalidationPendingForTest(Guid userId, Guid seriesId)
+            => _pendingInvalidations.ContainsKey((userId, seriesId));
 
         // Does this candidate's spoiler state cover the item at all? Used to
         // pick the effective user when a shared-IP request yields several
@@ -999,10 +1033,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         // uncertainty, not exposure.
         private bool HasWatchedAnyEpisodeInSeason(JUser user, Season season)
         {
-            var key = user.Id.ToString("N") + ":" + season.Id.ToString("N");
+            var key = new SeasonWatchedCacheKey(user.Id, season.Id);
             if (_watchedCache.TryGetValue(key, out var hit))
             {
-                return hit;
+                return hit.AnyWatched;
             }
 
             bool anyWatched = false;
@@ -1050,7 +1084,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             // succeeds.
             if (!determinationFailed)
             {
-                _watchedCache.Set(key, anyWatched, SeasonWatchedCacheTtl);
+                _watchedCache.Set(
+                    key,
+                    new SeasonWatchedCacheEntry(season.SeriesId, anyWatched),
+                    SeasonWatchedCacheTtl);
             }
 
             return anyWatched;

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -21,7 +21,7 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
     assert.equal(baselines.schemaVersion, 2);
     assert.equal(baselines.policy.baselineSelection, 'observed-high-water');
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2327, totalLines: 2667 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 27868, totalLines: 36585 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 27995, totalLines: 36602 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 2,
         minimumCoveredLines: 2327,
@@ -29,11 +29,11 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
     });
     assert.deepEqual(baselines.profiles.server.observations, {
         cleanRuns: 5,
-        minimumCoveredLines: 27867,
-        maximumCoveredLines: 27868,
+        minimumCoveredLines: 27988,
+        maximumCoveredLines: 27995,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 6);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 7);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 27868,
-        "totalLines": 36585
+        "coveredLines": 27995,
+        "totalLines": 36602
       },
       "observations": {
         "cleanRuns": 5,
-        "minimumCoveredLines": 27867,
-        "maximumCoveredLines": 27868
+        "minimumCoveredLines": 27988,
+        "maximumCoveredLines": 27995
       },
       "tolerance": {
-        "missingCoveredLines": 6,
-        "rationale": "Completing #160's quota-reset acceptance evidence adds 13 instrumented controller lines for a production-defaulted TimeProvider seam, allowing the integrated endpoint regressions to pin the exact rolling-window boundary while preserving runtime behavior. Five .NET 10.0.9/Coverlet measurements on 2026-08-01 had the same 36,585-line scope and measured 27,867, 27,867, 27,867, 27,868, and 27,867 covered lines; the high-water run passed all 2,469 server tests, including the >100-row old/declined-prefix case, explicit pagination safety bounds, and the 10,000-request performance profile. The existing six-line tolerance is retained because the one-line spread does not prove that the previously observed five- and six-line Coverlet variation has disappeared; keeping it avoids turning instrumentation noise into failures while the floor still rises to 27,862/36,585 (76.157%) from 27,849/36,572 (76.148%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 7,
+        "rationale": "Fixing #365 adds explicit series ownership to the Spoiler Guard season-watched cache and event-path regressions for the affected (user, series), same-user unrelated-series, cross-user, synchronous season-eviction, and subscription-lifecycle boundaries. After rebasing on merged #160 and the schema-v2 observed-high-water policy from #349, five clean .NET 10.0.9/Coverlet runs on 2026-08-01 each passed all 2,471 server tests at the identical 36,602-line scope and measured 27,992, 27,988, 27,995, 27,993, and 27,993 covered lines. The reviewed high-water is therefore 27,995/36,602 (76.485%). The fixed-scope seven-line spread is direct evidence that the former six-line allowance is one line too narrow, so the tolerance advances only to seven; that remains 0.019 percentage points, far below the policy cap, and raises the enforced floor to 27,988/36,602 (76.466%) from 27,862/36,585 (76.157%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
Resolves #365

## Summary
- retain series ownership in each bounded `(user, season)` watched-cache value
- keep exact season eviction synchronous and O(1)
- scope deferred series sweeps to the exact `(user, series)` pair
- use expected-value removal so a concurrently replaced season belonging to another series is preserved
- prove same-user unrelated series and cross-user entries survive the real `UserDataSaved` event path
- advance the server coverage high-water from five clean fixed-scope runs

## Validation
- old-behavior regression reproduced: a series event removed the same user's unrelated-series entry
- focused event regressions: 2/2
- full Spoiler Guard suite: 22/22
- five post-rebase server runs: 2,471/2,471 each
- fixed 36,602-line measurements: 27,992, 27,988, 27,995, 27,993, 27,993; reviewed high-water 27,995
- coverage contract: 14/14; script suite: 618/618
- Release plugin build: 0 warnings, 0 errors
- independent review: APPROVE, no findings
- `git diff --check`: clean

## Safety
- cache remains bounded to 512 entries with the existing 30-second TTL
- existing `(user, series)` dispatch coalescing and disposal/unsubscription lifecycle are unchanged
- no deployment performed