### PR TITLE
fix(bookmarks): bind modals to page adoption owner

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-modals.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-modals.ts
@@ -5,7 +5,7 @@
 // (Converted from js/enhanced/bookmarks-library-modals.js — bodies semantically identical.)
 
 import { JC } from '../../globals';
-import { currentPageHandle } from '../pages/fallback-host';
+import { currentPageOwner } from '../pages/fallback-host';
 import { escapeHtml, toast } from '../../core/ui-kit';
 import { formatTimestamp, renderActiveBookmarks } from './library-render';
 import type { IdentityContext } from '../../types/jc';
@@ -118,7 +118,7 @@ export function showOffsetAdjustmentModal(
 
   const closeDialog = () => closeModal(modal);
   // Body-level modal: the page's dispose bag closes it on drain.
-  currentPageHandle()?.track(closeDialog);
+  currentPageOwner('bookmarks')?.handle.track(closeDialog);
 
   modal.querySelector('.jc-bm-library-modal-close')?.addEventListener('click', closeDialog);
   modal.querySelector('.jc-bookmark-btn-cancel')?.addEventListener('click', closeDialog);
@@ -384,7 +384,7 @@ export function showDuplicatesSyncModal(
 
   const closeDialog = () => closeModal(modal);
   // Body-level modal: the page's dispose bag closes it on drain.
-  currentPageHandle()?.track(closeDialog);
+  currentPageOwner('bookmarks')?.handle.track(closeDialog);
 
   modal.querySelector('.jc-bm-library-modal-close')?.addEventListener('click', closeDialog);
   modal.querySelector('.jc-bookmark-btn-cancel')?.addEventListener('click', closeDialog);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-replacements.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-replacements.test.ts
@@ -4,12 +4,14 @@ import { getRefreshSafetyHoldCount } from '../../core/lifecycle';
 import type { ApiApi, IdentityContext } from '../../types/jc';
 
 const mocks = vi.hoisted(() => ({
+  currentPageOwner: vi.fn(),
   currentPageHandle: vi.fn(),
   getItemCached: vi.fn(),
   toast: vi.fn()
 }));
 
 vi.mock('../pages/fallback-host', () => ({
+  currentPageOwner: mocks.currentPageOwner,
   currentPageHandle: mocks.currentPageHandle
 }));
 vi.mock('../helpers', () => ({
@@ -44,6 +46,20 @@ interface TestBookmark {
   episodeNumber: number | null;
   episodeEndNumber: number | null;
   name: string;
+}
+
+interface TestPageAdoption {
+  pageId: string;
+  handle: { track: ReturnType<typeof vi.fn> };
+}
+
+let livePageAdoption: TestPageAdoption | null;
+
+function pageAdoption(
+  pageId = 'bookmarks',
+  handle: TestPageAdoption['handle'] = { track: vi.fn() }
+): TestPageAdoption {
+  return { pageId, handle };
 }
 
 function bookmark(overrides: Partial<TestBookmark> = {}): TestBookmark {
@@ -133,7 +149,13 @@ function expectMainRequest(
 describe('bookmark replacement library search', () => {
   beforeEach(() => {
     document.body.innerHTML = '';
-    mocks.currentPageHandle.mockReset().mockReturnValue({ track: vi.fn() });
+    livePageAdoption = pageAdoption();
+    mocks.currentPageOwner.mockReset().mockImplementation((expectedPageId?: string) => (
+      livePageAdoption && (!expectedPageId || livePageAdoption.pageId === expectedPageId)
+        ? livePageAdoption
+        : null
+    ));
+    mocks.currentPageHandle.mockReset().mockImplementation(() => livePageAdoption?.handle ?? null);
     mocks.getItemCached.mockReset();
     mocks.toast.mockReset();
     JC.t = (key: string) => key.startsWith('bookmark_orphaned_') ? `${key}:{count}` : key;
@@ -496,6 +518,46 @@ describe('bookmark replacement library search', () => {
     expect(button.disabled).toBe(false);
   });
 
+  it('does not start replacement work from a non-Bookmarks Canopy page', async () => {
+    livePageAdoption = pageAdoption('calendar');
+    const jf = vi.fn().mockResolvedValue(page([item('replacement', 'target-tmdb')], 1, 0));
+    installApi(jf);
+    const context = captureIdentity('foreign-page-user');
+    const button = document.createElement('button');
+
+    await findAndOfferReplacement(group(), button, context);
+
+    expect(jf).not.toHaveBeenCalled();
+    expect(document.querySelector('[data-jc-bookmark-library-modal="true"]')).toBeNull();
+    expect(mocks.toast).not.toHaveBeenCalled();
+    expect(button.disabled).toBe(false);
+  });
+
+  it('drops a replacement result after the originating Bookmarks adoption is replaced', async () => {
+    const sharedHandle = { track: vi.fn() };
+    const origin = pageAdoption('bookmarks', sharedHandle);
+    livePageAdoption = origin;
+    const held = deferred<unknown>();
+    const jf = vi.fn().mockReturnValueOnce(held.promise);
+    installApi(jf);
+    const context = captureIdentity('replaced-bookmarks-user');
+    const button = document.createElement('button');
+
+    const pending = findAndOfferReplacement(group(), button, context);
+    await vi.waitFor(() => expect(jf).toHaveBeenCalledTimes(1));
+
+    // The framework deliberately reuses one lifecycle dispose bag. Only the
+    // adoption token distinguishes this fresh Bookmarks instance from origin.
+    livePageAdoption = pageAdoption('bookmarks', sharedHandle);
+    held.resolve(page([item('replacement', 'target-tmdb')], 1, 0));
+    await pending;
+
+    expect(document.querySelector('[data-jc-bookmark-library-modal="true"]')).toBeNull();
+    expect(sharedHandle.track).not.toHaveBeenCalled();
+    expect(mocks.toast).not.toHaveBeenCalled();
+    expect(button.disabled).toBe(false);
+  });
+
   // AC6: a single failed search gates the whole batch — no migration modal, a
   // distinct failure toast rather than a false 'no replacement found'.
   it('never offers an orphan migration from failed partial search results', async () => {
@@ -527,6 +589,26 @@ describe('bookmark replacement library search', () => {
 
     expect(mocks.toast.mock.calls).toEqual([['bookmark_orphaned_no_replacement:1', 4000]]);
     expect(document.querySelector('[data-jc-bookmark-library-modal="true"]')).toBeNull();
+  });
+
+  it('drops an orphan summary when its Bookmarks owner is no longer current', async () => {
+    const orphan = bookmark({ itemId: 'missing-orphan' });
+    mocks.getItemCached.mockRejectedValue(Object.assign(new Error('not found'), { status: 404 }));
+    const held = deferred<unknown>();
+    const jf = vi.fn().mockReturnValueOnce(held.promise);
+    installApi(jf);
+    const context = captureIdentity('orphan-page-owner-user');
+
+    const pending = findAllOrphanedAndOfferMigration({ orphan }, context);
+    await vi.waitFor(() => expect(jf).toHaveBeenCalledTimes(1));
+
+    livePageAdoption = pageAdoption('calendar');
+    held.resolve(page([item('replacement', 'target-tmdb')], 1, 0));
+    await pending;
+
+    expect(document.querySelector('[data-jc-bookmark-library-modal="true"]')).toBeNull();
+    expect(livePageAdoption.handle.track).not.toHaveBeenCalled();
+    expect(mocks.toast).not.toHaveBeenCalled();
   });
 
   it('keeps one refresh-safety owner across the summary-to-selection modal handoff', async () => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-replacements.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-replacements.ts
@@ -5,11 +5,12 @@
 // (Converted from js/enhanced/bookmarks-library-replacements.js — bodies semantically identical.)
 
 import { JC } from '../../globals';
-import { currentPageHandle } from '../pages/fallback-host';
+import { currentPageOwner } from '../pages/fallback-host';
 import { escapeHtml, toast } from '../../core/ui-kit';
 import { getItemCached } from '../helpers';
 import { renderActiveBookmarks } from './library-render';
 import type { IdentityContext } from '../../types/jc';
+import type { PageAdoptionOwner } from '../pages/types';
 import { normalizeBookmarkMediaType, replacementItemTypes } from './media-types';
 import {
   BOOKMARK_IDENTITY_VERSION,
@@ -24,6 +25,7 @@ export const SERIES_ENRICHMENT_MAX_URL_LENGTH = 2048;
 const REPLACEMENT_PAGE_SIZE = 500;
 const REPLACEMENT_MAX_PAGES = 1000;
 const REPLACEMENT_MAX_ITEMS = REPLACEMENT_PAGE_SIZE * REPLACEMENT_MAX_PAGES;
+const BOOKMARKS_PAGE_ID = 'bookmarks';
 
 /**
  * How many source bookmarks a MOVE-style migration durably relocated: every
@@ -201,6 +203,7 @@ function currentImageApiClient(): ImageApiClient | null {
 
 function scheduleReplacementTask(
   context: IdentityContext,
+  pageOwner: PageAdoptionOwner,
   callback: () => void,
   delay: number,
   cleanup?: () => void
@@ -209,13 +212,17 @@ function scheduleReplacementTask(
     replacementModalTimers.delete(timer);
     replacementModalTimerCleanups.delete(timer);
     try {
-      if (JC.identity.isCurrent(context)) callback();
+      if (isReplacementFlowCurrent(context, pageOwner)) callback();
     } finally {
       cleanup?.();
     }
   }, delay);
   replacementModalTimers.add(timer);
   if (cleanup) replacementModalTimerCleanups.set(timer, cleanup);
+}
+
+function isReplacementFlowCurrent(context: IdentityContext, pageOwner: PageAdoptionOwner): boolean {
+  return JC.identity.isCurrent(context) && currentPageOwner(BOOKMARKS_PAGE_ID) === pageOwner;
 }
 
 function ownReplacementModal(modal: HTMLElement): void {
@@ -419,17 +426,18 @@ export async function findAndOfferReplacement(
   triggerBtn: HTMLButtonElement,
   context: IdentityContext | null = JC.identity.capture()
 ): Promise<void> {
-  if (!context || !JC.identity.isCurrent(context)) return;
+  const pageOwner = currentPageOwner(BOOKMARKS_PAGE_ID);
+  if (!context || !pageOwner || !JC.identity.isCurrent(context)) return;
   triggerBtn.disabled = true;
 
   try {
     const result = await searchForReplacementItem(group.details, context);
     // The await can straddle an account transition; a stale continuation must
     // not paint this user's toast (or modal) over the next account's UI.
-    if (!JC.identity.isCurrent(context)) return;
+    if (!isReplacementFlowCurrent(context, pageOwner)) return;
     switch (result.status) {
       case 'match':
-        showReplacementSelectionModal(group, result.items, context);
+        showReplacementSelectionModal(group, result.items, context, pageOwner);
         return;
       case 'no-match':
         toast(JC.t!('bookmark_no_replacement'), 3000);
@@ -451,12 +459,12 @@ export async function findAndOfferReplacement(
 function showReplacementSelectionModal(
   oldGroup: BookmarkGroup,
   replacementItems: JellyfinReplacementItem[],
-  context: IdentityContext
+  context: IdentityContext,
+  pageOwner: PageAdoptionOwner
 ): void {
-  // These modals are reached from awaited flows (library search, orphan
-  // scan): the page can drain mid-await. A modal with no live adoption to
-  // own its teardown must not appear over the destination view.
-  if (!JC.identity.isCurrent(context) || !currentPageHandle()) return;
+  // Delayed callers fence the exact originating Bookmarks adoption before
+  // publishing or registering teardown in its dispose bag.
+  if (!isReplacementFlowCurrent(context, pageOwner)) return;
   const apiClient = currentImageApiClient();
   if (!apiClient) return;
 
@@ -517,6 +525,9 @@ function showReplacementSelectionModal(
     </div>
   `;
 
+  // getImageUrl is host-owned code; re-check after rendering the candidate
+  // list in case it synchronously re-entered navigation.
+  if (!isReplacementFlowCurrent(context, pageOwner)) return;
   document.body.appendChild(modal);
   JC.core.refreshSafety!.holdElement(modal, 'modal');
 
@@ -524,7 +535,7 @@ function showReplacementSelectionModal(
 
   const closeDialog = () => closeReplacementModal(modal);
   // Body-level modal: the page's dispose bag closes it on drain.
-  currentPageHandle()?.track(closeDialog);
+  pageOwner.handle.track(closeDialog);
 
   modal.querySelector('.jc-bm-library-modal-close')?.addEventListener('click', closeDialog);
   modal.querySelector('.jc-bookmark-btn-cancel')?.addEventListener('click', closeDialog);
@@ -535,7 +546,7 @@ function showReplacementSelectionModal(
   // Selection handlers
   modal.querySelectorAll<HTMLElement>('.replacement-option').forEach(option => {
     option.addEventListener('click', () => {
-      if (!JC.identity.isCurrent(context)) return;
+      if (!isReplacementFlowCurrent(context, pageOwner)) return;
       const idx = parseInt(option.dataset.itemIndex!);
       selectedItem = replacementItems[idx];
 
@@ -557,7 +568,7 @@ function showReplacementSelectionModal(
 
   // Migrate handler
   modal.querySelector('.jc-bookmark-btn-submit')?.addEventListener('click', () => { void (async () => {
-    if (!JC.identity.isCurrent(context)) return;
+    if (!isReplacementFlowCurrent(context, pageOwner)) return;
     if (!selectedItem) return;
 
     const btn = modal.querySelector<HTMLButtonElement>('.jc-bookmark-btn-submit')!;
@@ -567,7 +578,7 @@ function showReplacementSelectionModal(
     try {
       // Fetch full details for new item
       const fullItem = await getItemCached(selectedItem.Id, { userId: context.userId });
-      if (!JC.identity.isCurrent(context) || !isJellyfinReplacementItem(fullItem)) return;
+      if (!isReplacementFlowCurrent(context, pageOwner) || !isJellyfinReplacementItem(fullItem)) return;
 
       const newDetails = {
         ...replacementIdentity(selectedItem),
@@ -580,7 +591,7 @@ function showReplacementSelectionModal(
       // originals intact (the old pre-delete lost data if syncing failed).
       const oldIds = oldGroup.bookmarks.map((bookmark) => bookmark.id);
       await JC.bookmarks!.syncBookmarks(oldGroup.bookmarks, newDetails, 0, oldIds);
-      if (!JC.identity.isCurrent(context)) return;
+      if (!isReplacementFlowCurrent(context, pageOwner)) return;
 
       // syncBookmarks returns only the newly created target rows, but a MOVE
       // migrates every source — including any that deduplicated into an existing
@@ -596,7 +607,7 @@ function showReplacementSelectionModal(
       // setTimeout needed).
       renderActiveBookmarks(context);
     } catch (e) {
-      if (!JC.identity.isCurrent(context)) return;
+      if (!isReplacementFlowCurrent(context, pageOwner)) return;
       console.error('Migration failed:', e);
       toast(JC.t!('bookmark_migration_failed'), 3000);
       btn.disabled = false;
@@ -604,7 +615,7 @@ function showReplacementSelectionModal(
     }
   })(); });
 
-  scheduleReplacementTask(context, () => { if (modal.isConnected) modal.style.opacity = '1'; }, 10);
+  scheduleReplacementTask(context, pageOwner, () => { if (modal.isConnected) modal.style.opacity = '1'; }, 10);
 }
 
 /**
@@ -614,7 +625,8 @@ export async function findAllOrphanedAndOfferMigration(
   bookmarks: Record<string, StoredBookmark>,
   context: IdentityContext | null = JC.identity.capture()
 ): Promise<void> {
-  if (!context || !JC.identity.isCurrent(context)) return;
+  const pageOwner = currentPageOwner(BOOKMARKS_PAGE_ID);
+  if (!context || !pageOwner || !JC.identity.isCurrent(context)) return;
   const apiClient = currentImageApiClient();
   if (!apiClient) {
     toast(JC.t!('toast_api_client_unavailable'), 3000);
@@ -639,14 +651,13 @@ export async function findAllOrphanedAndOfferMigration(
 
   // Check each item
   for (const group of Object.values(byItem)) {
-    if (!JC.identity.isCurrent(context)) return;
     const itemId = group.details.itemId;
     try {
       await getItemCached(itemId, { userId });
-      if (!JC.identity.isCurrent(context)) return;
+      if (!isReplacementFlowCurrent(context, pageOwner)) return;
       // Item exists, not orphaned
     } catch (e) {
-      if (!JC.identity.isCurrent(context)) return;
+      if (!isReplacementFlowCurrent(context, pageOwner)) return;
       // DATA-SAFETY: only an explicit 404 means the item is truly gone. A
       // transient failure must not be treated as orphaned (which would offer a
       // destructive migration); keep it and warn.
@@ -672,8 +683,8 @@ export async function findAllOrphanedAndOfferMigration(
   const replacementResults: ReplacementResult[] = [];
   let failedSearchCount = 0;
   for (const group of orphanedGroups) {
-    if (!JC.identity.isCurrent(context)) return;
     const result = await searchForReplacementItem(group.details, context);
+    if (!isReplacementFlowCurrent(context, pageOwner)) return;
     switch (result.status) {
       case 'match':
         replacementResults.push({ group, matches: result.items });
@@ -688,10 +699,6 @@ export async function findAllOrphanedAndOfferMigration(
     }
   }
 
-  // The final search's await can resolve after an account transition; re-fence
-  // before publishing any batch outcome toast or the summary modal.
-  if (!JC.identity.isCurrent(context)) return;
-
   if (failedSearchCount > 0) {
     toast(JC.t!('bookmark_orphaned_search_failed').replace('{count}', String(failedSearchCount)), 4000);
     return;
@@ -703,15 +710,20 @@ export async function findAllOrphanedAndOfferMigration(
   }
 
   // Show summary modal
-  showOrphanedSummaryModal(replacementResults, context);
+  showOrphanedSummaryModal(replacementResults, context, pageOwner);
 }
 
 /**
  * Show summary of all orphaned items with replacements
  */
-function showOrphanedSummaryModal(replacementResults: ReplacementResult[], context: IdentityContext): void {
-  // Same delayed-flow guard as showReplacementSelectionModal.
-  if (!JC.identity.isCurrent(context) || !currentPageHandle()) return;
+function showOrphanedSummaryModal(
+  replacementResults: ReplacementResult[],
+  context: IdentityContext,
+  pageOwner: PageAdoptionOwner
+): void {
+  // The caller fenced after the final awaited search; retain the invariant at
+  // this publisher boundary so future call sites cannot omit exact ownership.
+  if (!isReplacementFlowCurrent(context, pageOwner)) return;
   const modal = document.createElement('div');
   modal.className = 'jc-bm-library-modal-overlay';
   ownReplacementModal(modal);
@@ -756,12 +768,13 @@ function showOrphanedSummaryModal(replacementResults: ReplacementResult[], conte
     </div>
   `;
 
+  if (!isReplacementFlowCurrent(context, pageOwner)) return;
   document.body.appendChild(modal);
   JC.core.refreshSafety!.holdElement(modal, 'modal');
 
   const closeDialog = () => closeReplacementModal(modal);
   // Body-level modal: the page's dispose bag closes it on drain.
-  currentPageHandle()?.track(closeDialog);
+  pageOwner.handle.track(closeDialog);
 
   modal.querySelector('.jc-bm-library-modal-close')?.addEventListener('click', closeDialog);
   modal.querySelector('.jc-bookmark-btn-cancel')?.addEventListener('click', closeDialog);
@@ -772,7 +785,7 @@ function showOrphanedSummaryModal(replacementResults: ReplacementResult[], conte
   // Migrate button handlers
   modal.querySelectorAll<HTMLElement>('.btnMigrateOrphaned').forEach(btn => {
     btn.addEventListener('click', () => {
-      if (!JC.identity.isCurrent(context)) return;
+      if (!isReplacementFlowCurrent(context, pageOwner)) return;
       const idx = parseInt(btn.dataset.resultIndex!);
       const result = replacementResults[idx];
       // This is one uninterrupted user flow: transfer a temporary safety hold
@@ -780,11 +793,11 @@ function showOrphanedSummaryModal(replacementResults: ReplacementResult[], conte
       // selection overlay has synchronously acquired its own modal hold.
       const releaseHandoff = JC.core.refreshSafety!.acquireHold('interaction');
       closeDialog();
-      scheduleReplacementTask(context, () => {
-        showReplacementSelectionModal(result.group, result.matches, context);
+      scheduleReplacementTask(context, pageOwner, () => {
+        showReplacementSelectionModal(result.group, result.matches, context, pageOwner);
       }, 300, releaseHandoff);
     });
   });
 
-  scheduleReplacementTask(context, () => { if (modal.isConnected) modal.style.opacity = '1'; }, 10);
+  scheduleReplacementTask(context, pageOwner, () => { if (modal.isConnected) modal.style.opacity = '1'; }, 10);
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content-page/admin.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content-page/admin.ts
@@ -6,7 +6,7 @@
 // identical; the JC.internals.hiddenContentPage bag is now real module exports.)
 
 import { JC } from '../../globals';
-import { currentPageHandle } from '../pages/fallback-host';
+import { currentPageOwner } from '../pages/fallback-host';
 import {
     cancelPageTimeout,
     capturePageFence,
@@ -697,7 +697,7 @@ export function openAdminAddModal(): void {
     // can never re-save and re-apply a 'hidden' that permanently locks the page.
     const prevBodyOverflow = hadStaleOverlay ? '' : document.body.style.overflow;
     const prevHtmlOverflow = hadStaleOverlay ? '' : document.documentElement.style.overflow;
-    const pageHandle = currentPageHandle();
+    const pageHandle = currentPageOwner('hidden-content')?.handle;
     let searchTimer: number | null = null;
     let searchToken = 0;
     let closed = false;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content-page/state.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content-page/state.ts
@@ -8,7 +8,7 @@
 // detection that every other hidden-content-page-* module reads.
 
 import { JC } from '../../globals';
-import { currentPageHandle } from '../pages/fallback-host';
+import { currentPageOwner } from '../pages/fallback-host';
 import type { IdentityContext } from '../../types/jc';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -190,7 +190,7 @@ export function showUnhideConfirmation(message: string, onConfirm: () => void, i
     const overlay = document.createElement('div');
     overlay.className = 'jc-hide-confirm-overlay';
     overlay.dataset.jcIdentityOwned = 'true';
-    const pageHandle = currentPageHandle();
+    const pageHandle = currentPageOwner('hidden-content')?.handle;
 
     const dialog = document.createElement('div');
     dialog.className = 'jc-hide-confirm-dialog';

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/pages/fallback-host.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/pages/fallback-host.ts
@@ -19,7 +19,7 @@
 //    handler applies — rewrite it during adoption, then verify on a frame.
 
 import { JC } from '../../globals';
-import type { PageDescriptor } from './types';
+import type { PageAdoptionOwner, PageDescriptor } from './types';
 import { resolvePage, pageAvailable } from './registry';
 import { PAGE_NAV_ATTR } from './router-bridge';
 import { clearEarlyMask } from './early-mask';
@@ -166,12 +166,15 @@ function adopt(descriptor: PageDescriptor, host: HTMLElement): void {
 }
 
 /**
- * The live adoption's dispose bag, DOM-validated — page-owned overlays that
- * must append to document.body (dialogs, pickers) register their close
- * function here so navigating away can never strand them over another view.
+ * The unique owner token for the live adoption constrained to one page id.
+ * Object identity changes on every fresh adoption even though its lifecycle
+ * dispose bag is reused. Body-level overlays register teardown through handle.
  */
-export function currentPageHandle(): import('../../types/jc').LifecycleHandle | null {
-    return adoptedPageId() !== null ? adoption!.handle : null;
+export function currentPageOwner(expectedPageId: string): PageAdoptionOwner | null {
+    if (adoptedPageId() !== expectedPageId) return null;
+    // The internal Adoption object is already unique per open; expose only its
+    // lifecycle-owner surface instead of allocating a second identity object.
+    return adoption!;
 }
 
 /** Re-render the currently adopted page in place (entry-point re-click). */

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/pages/framework.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/pages/framework.test.ts
@@ -8,7 +8,13 @@ import '../../core/lifecycle';
 import '../../core/navigation';
 import '../../core/dom-observer';
 import { registerPage, resolvePage, orderedPages, pageAvailable } from './registry';
-import { initFallbackHost, adoptedPageId, drain, lateAdoptIfOnPage } from './fallback-host';
+import {
+    initFallbackHost,
+    adoptedPageId,
+    currentPageOwner,
+    drain,
+    lateAdoptIfOnPage,
+} from './fallback-host';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -217,6 +223,30 @@ describe('pages framework', () => {
         expect(renders).toEqual(['alpha', 'beta']);
         expect(fallback.querySelector('.jc-test-alpha')).toBeNull();
         expect(fallback.querySelector('.jc-test-beta')).not.toBeNull();
+    });
+
+    it('gives every page open a unique owner while reusing the lifecycle dispose bag', () => {
+        setHash('#/alpha');
+        const fallback = mountFallback();
+        fireViewBeforeShow(fallback);
+        const alphaOwner = currentPageOwner('alpha');
+
+        expect(alphaOwner).not.toBeNull();
+        expect(currentPageOwner('beta')).toBeNull();
+        expect(alphaOwner?.handle).toBe(currentPageOwner('alpha')?.handle);
+
+        setHash('#/beta');
+        const betaOwner = currentPageOwner('beta');
+
+        expect(betaOwner).not.toBeNull();
+        expect(betaOwner).not.toBe(alphaOwner);
+        expect(betaOwner?.handle).toBe(alphaOwner?.handle);
+        expect(currentPageOwner('alpha')).toBeNull();
+
+        setHash('#/alpha');
+        const nextAlphaOwner = currentPageOwner('alpha');
+        expect(nextAlphaOwner).not.toBe(alphaOwner);
+        expect(nextAlphaOwner?.handle).toBe(alphaOwner?.handle);
     });
 
     it('disconnect backstop: a wholesale element detach drains without any event', async () => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/pages/types.d.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/pages/types.d.ts
@@ -26,6 +26,16 @@ export interface PageContext {
     signal: AbortSignal;
 }
 
+/**
+ * Unique owner for one routed-page adoption. The lifecycle handle is shared
+ * across adoptions, so consumers must compare the owner object itself when an
+ * async continuation needs to prove that its originating page is still live.
+ */
+export interface PageAdoptionOwner {
+    /** Shared dispose bag drained when this adoption leaves. */
+    readonly handle: LifecycleHandle;
+}
+
 /** A registered page. Descriptors carry NO lifecycle code — only content. */
 export interface PageDescriptor {
     /** Stable id, also the PagesOrder token (e.g. 'calendar'). */


### PR DESCRIPTION
Fixes #358

## Summary

- Replace the generic live-page handle lookup with a page-id-constrained adoption owner whose object identity changes on every page opening while retaining the shared lifecycle dispose bag.
- Capture the exact Bookmarks owner before replacement/orphan work begins and revalidate both page-owner identity and user identity after every await, delayed callback, publication boundary, and interaction.
- Bind replacement and orphan modal teardown to the captured originating owner, so navigation to Calendar or a fresh Bookmarks adoption cannot receive stale UI.
- Make the existing Bookmarks and Hidden Content modal consumers declare their required page explicitly.

## Regression proof

- Frozen old behavior failed all three new cases: work launched from Calendar, a result rendered after same-handle Bookmarks re-adoption, and an orphan summary rendered over Calendar.
- Direct post-rebase scope: 48/48.
- Implementer focused scope: 6 files / 96 tests.
- Full client coverage: 234 files / 1,804 tests, 2,327/2,667 lines.
- Script suite: 618/618.
- Both typechecks, deterministic bundle, syntax, performance guard, toolchain, targeted changed-file lint, build, and diff checks passed.
- Independent root review: APPROVE.

## Safety

- No replacement-search or migration semantics changed.
- No deployment requested or performed.
