### PR TITLE
Batch anime filler warning lookups (#457)

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/AnimeFillerControllerContractTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/AnimeFillerControllerContractTests.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Security.Claims;
 using System.Text.Json;
+using Jellyfin.Data.Enums;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
 using Jellyfin.Plugin.JellyfinCanopy.Controllers;
@@ -44,9 +45,10 @@ public sealed class AnimeFillerControllerContractTests
         Assert.Contains("uniqueIds.Length > 100", source, StringComparison.Ordinal);
         Assert.NotNull(classify.GetCustomAttribute<RequestSizeLimitAttribute>());
         Assert.Contains("[RequestSizeLimit(64 * 1024)]", source, StringComparison.Ordinal);
-        Assert.Contains("GetItemById<BaseItem>(itemId, user)", source, StringComparison.Ordinal);
-        Assert.Contains("GetItemById<BaseItem>(episode.SeriesId, user)", source, StringComparison.Ordinal);
-        Assert.DoesNotContain("GetItemById<BaseItem>(itemId)", source, StringComparison.Ordinal);
+        Assert.Contains("UserAccessQuery.BuildItemIds(_libraryManager, user, itemIds)", source, StringComparison.Ordinal);
+        Assert.Contains("SeriesEpisodePageSize = 256", source, StringComparison.Ordinal);
+        Assert.Contains("StartIndex = startIndex", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("GetItemById<BaseItem>", source, StringComparison.Ordinal);
         Assert.DoesNotContain("episode.Series ??", source, StringComparison.Ordinal);
     }
 
@@ -73,16 +75,23 @@ public sealed class AnimeFillerControllerContractTests
         };
         var library = new CountingLibraryManager
         {
-            GetItemByIdUserHook = (id, resolvedUser) =>
+            GetItemListHook = query =>
             {
-                Assert.Equal(user.Id, resolvedUser?.Id);
-                return id == episodeId ? episode : id == seriesId ? series : null;
+                Assert.Equal(user.Id, query.User?.Id);
+                if (query.ItemIds.Length > 0)
+                {
+                    return query.IncludeItemTypes.Contains(BaseItemKind.Episode)
+                        ? [episode]
+                        : [series];
+                }
+
+                Assert.Equal(seriesId, query.ParentId);
+                return
+                [
+                    new Episode { SeriesId = seriesId, ParentIndexNumber = 1, IndexNumber = 12 },
+                    episode,
+                ];
             },
-            GetItemListHook = _ =>
-            [
-                new Episode { SeriesId = seriesId, ParentIndexNumber = 1, IndexNumber = 12 },
-                episode,
-            ],
         };
         var provider = new FakeProvider
         {
@@ -102,9 +111,262 @@ public sealed class AnimeFillerControllerContractTests
         Assert.Equal("manual-series-mapping", payload.Items[0].Reason);
         Assert.Equal("Unknown", payload.Items[1].Classification);
         Assert.Equal("unavailable", payload.Items[1].Reason);
-        Assert.Equal(2, library.GetItemByIdUserCallCount);
-        Assert.Equal(1, library.GetItemListCallCount);
+        Assert.Equal(0, library.GetItemByIdUserCallCount);
+        Assert.Equal(3, library.GetItemListCallCount);
         Assert.Equal(1, provider.EpisodeCalls);
+    }
+
+    [Fact]
+    public async Task Classification_BatchesMixedItems_ByDistinctCallerVisibleSeries()
+    {
+        var user = new User("anime-user", "provider", "password-provider");
+        var topParentId = Guid.NewGuid();
+        var seriesA = AnimeSeries("Series A", 20);
+        var seriesB = AnimeSeries("Series B", 30);
+        var inaccessibleSeries = AnimeSeries("Private series", 40);
+        var episodeA1 = NumberedEpisode(seriesA.Id, 1, 1);
+        var episodeA2 = NumberedEpisode(seriesA.Id, 2, 1);
+        var episodeB1 = NumberedEpisode(seriesB.Id, 1, 1);
+        var inaccessibleParent = NumberedEpisode(inaccessibleSeries.Id, 1, 1);
+        var standalone = NumberedEpisode(Guid.Empty, 1, 1);
+        var nonEpisode = new Series { Id = Guid.NewGuid(), Name = "Not an episode" };
+        var missingId = Guid.NewGuid();
+        var bulkQueries = 0;
+        var recursiveQueries = new Dictionary<Guid, int>();
+        var library = new CountingLibraryManager
+        {
+            ConfigureUserAccessHook = (query, resolvedUser) =>
+            {
+                Assert.Same(user, resolvedUser);
+                Assert.Empty(query.ItemIds);
+                query.TopParentIds = [topParentId];
+            },
+            GetItemListHook = query =>
+            {
+                Assert.Same(user, query.User);
+                if (query.ItemIds.Length > 0)
+                {
+                    bulkQueries++;
+                    Assert.Equal([topParentId], query.TopParentIds);
+                    Assert.Equal(query.ItemIds.Length, query.Limit);
+                    if (query.IncludeItemTypes.Contains(BaseItemKind.Episode))
+                    {
+                        Assert.Equal(7, query.ItemIds.Length);
+                        return [episodeA1, episodeA2, episodeB1, inaccessibleParent, standalone, nonEpisode];
+                    }
+
+                    Assert.Equal(3, query.ItemIds.Length);
+                    Assert.Contains(seriesA.Id, query.ItemIds);
+                    Assert.Contains(seriesB.Id, query.ItemIds);
+                    Assert.Contains(inaccessibleSeries.Id, query.ItemIds);
+                    // The inaccessible parent is deliberately omitted by the caller-scoped seam.
+                    return [seriesA, seriesB];
+                }
+
+                recursiveQueries[query.ParentId] = recursiveQueries.GetValueOrDefault(query.ParentId) + 1;
+                Assert.Equal(0, query.StartIndex);
+                Assert.Equal(256, query.Limit);
+                return query.ParentId == seriesA.Id
+                    ? [
+                        new Episode { SeriesId = seriesA.Id, ParentIndexNumber = 1, IndexNumber = 1 },
+                        new Episode { SeriesId = seriesA.Id, ParentIndexNumber = 1, IndexNumber = 2 },
+                        episodeA2,
+                    ]
+                    : [episodeB1];
+            },
+        };
+        var provider = new FakeProvider
+        {
+            EpisodesByMalId = new Dictionary<int, AnimeProviderEpisodes>
+            {
+                [20] = AnimeProviderEpisodes.Create(20, new Dictionary<int, bool> { [1] = false, [3] = true }),
+                [30] = AnimeProviderEpisodes.Create(30, new Dictionary<int, bool> { [1] = true }),
+            },
+        };
+        var controller = BuildController(EnabledConfig(), provider, library, user);
+        var invalid = "not-a-guid";
+        var alternateEpisodeA2 = "{" + episodeA2.Id.ToString().ToUpperInvariant() + "}";
+        string[] requested =
+        [
+            episodeA2.Id.ToString(),
+            invalid,
+            episodeA1.Id.ToString(),
+            episodeB1.Id.ToString(),
+            alternateEpisodeA2,
+            episodeA2.Id.ToString(),
+            inaccessibleParent.Id.ToString(),
+            standalone.Id.ToString(),
+            nonEpisode.Id.ToString(),
+            missingId.ToString(),
+        ];
+
+        var result = await controller.Classify(new AnimeFillerBatchRequest(requested));
+
+        var payload = Assert.IsType<AnimeFillerBatchResponse>(Assert.IsType<OkObjectResult>(result).Value);
+        Assert.Equal(requested, payload.Items.Select(item => item.ItemId));
+        Assert.Equal(
+            ["Filler", "Unknown", "Canon", "Filler", "Filler", "Filler", "Unknown", "Unknown", "Unknown", "Unknown"],
+            payload.Items.Select(item => item.Classification));
+        Assert.Equal("not-recognized-as-anime", payload.Items[6].Reason);
+        Assert.Equal("not-recognized-as-anime", payload.Items[7].Reason);
+        Assert.Equal("unavailable", payload.Items[8].Reason);
+        Assert.Equal("unavailable", payload.Items[9].Reason);
+        Assert.Equal(2, bulkQueries);
+        Assert.Equal(1, recursiveQueries[seriesA.Id]);
+        Assert.Equal(1, recursiveQueries[seriesB.Id]);
+        Assert.Equal(2, recursiveQueries.Count);
+        Assert.Equal(4, library.GetItemListCallCount);
+        Assert.Equal(0, library.GetItemByIdUserCallCount);
+        Assert.Equal(2, provider.EpisodeCalls);
+    }
+
+    [Fact]
+    public async Task Classification_HundredEpisodeBatch_HasConstantBulkAndPerSeriesQueryCount()
+    {
+        var user = new User("anime-user", "provider", "password-provider");
+        var series = AnimeSeries("Hundred episode series", 99);
+        var episodes = Enumerable.Range(1, 100)
+            .Select(index => NumberedEpisode(series.Id, 1, index))
+            .ToArray();
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = query =>
+            {
+                if (query.ItemIds.Length > 0)
+                {
+                    return query.IncludeItemTypes.Contains(BaseItemKind.Episode)
+                        ? episodes
+                        : [series];
+                }
+
+                Assert.Equal(series.Id, query.ParentId);
+                Assert.Equal(256, query.Limit);
+                return episodes;
+            },
+        };
+        var provider = new FakeProvider
+        {
+            Episodes = AnimeProviderEpisodes.Create(
+                99,
+                Enumerable.Range(1, 100).ToDictionary(index => index, index => index % 2 == 0)),
+        };
+        var controller = BuildController(EnabledConfig(), provider, library, user);
+
+        var result = await controller.Classify(new AnimeFillerBatchRequest(
+            episodes.Select(episode => episode.Id.ToString()).ToArray()));
+
+        var items = Assert.IsType<AnimeFillerBatchResponse>(Assert.IsType<OkObjectResult>(result).Value).Items;
+        Assert.Equal(100, items.Count);
+        Assert.Equal(50, items.Count(item => item.Classification == "Filler"));
+        Assert.Equal(50, items.Count(item => item.Classification == "Canon"));
+        Assert.Equal(3, library.GetItemListCallCount);
+        Assert.Equal(0, library.GetItemByIdUserCallCount);
+        Assert.Equal(1, provider.EpisodeCalls);
+    }
+
+    [Fact]
+    public async Task Classification_PagesOneSeriesScan_AndReusesItsNumberingIndex()
+    {
+        var user = new User("anime-user", "provider", "password-provider");
+        var series = AnimeSeries("Long series", 42);
+        var requestedEpisode = NumberedEpisode(series.Id, 3, 1);
+        var libraryEpisodes = Enumerable.Range(1, 255)
+            .Select(index => NumberedEpisode(series.Id, 1, index))
+            .Concat(Enumerable.Range(1, 2).Select(index => NumberedEpisode(series.Id, 2, index)))
+            .Cast<BaseItem>()
+            .ToArray();
+        var pageStarts = new List<int>();
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = query =>
+            {
+                if (query.ItemIds.Length > 0)
+                {
+                    return query.IncludeItemTypes.Contains(BaseItemKind.Episode)
+                        ? [requestedEpisode]
+                        : [series];
+                }
+
+                var startIndex = query.StartIndex ?? 0;
+                var limit = query.Limit ?? int.MaxValue;
+                pageStarts.Add(startIndex);
+                Assert.Equal(256, limit);
+                return libraryEpisodes.Skip(startIndex).Take(limit).ToArray();
+            },
+        };
+        var provider = new FakeProvider
+        {
+            Episodes = AnimeProviderEpisodes.Create(42, new Dictionary<int, bool> { [258] = true }),
+        };
+        var controller = BuildController(EnabledConfig(), provider, library, user);
+
+        var result = await controller.Classify(new AnimeFillerBatchRequest(
+            [requestedEpisode.Id.ToString(), requestedEpisode.Id.ToString()]));
+
+        var items = Assert.IsType<AnimeFillerBatchResponse>(Assert.IsType<OkObjectResult>(result).Value).Items;
+        Assert.Equal(["Filler", "Filler"], items.Select(item => item.Classification));
+        Assert.Equal([0, 256], pageStarts);
+        Assert.Equal(4, library.GetItemListCallCount);
+        Assert.Equal(1, provider.EpisodeCalls);
+    }
+
+    [Fact]
+    public async Task Classification_CancellationStopsPagedSeriesWork_WithoutProviderDispatch()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var user = new User("anime-user", "provider", "password-provider");
+        var series = AnimeSeries("Cancelled series", 52);
+        var requestedEpisode = NumberedEpisode(series.Id, 2, 1);
+        var recursiveCalls = 0;
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = query =>
+            {
+                if (query.ItemIds.Length > 0)
+                {
+                    return query.IncludeItemTypes.Contains(BaseItemKind.Episode)
+                        ? [requestedEpisode]
+                        : [series];
+                }
+
+                recursiveCalls++;
+                cancellation.Cancel();
+                return Enumerable.Range(1, 256)
+                    .Select(index => (BaseItem)NumberedEpisode(series.Id, 1, index))
+                    .ToArray();
+            },
+        };
+        var provider = new FakeProvider
+        {
+            Episodes = AnimeProviderEpisodes.Create(52, new Dictionary<int, bool> { [257] = true }),
+        };
+        var controller = BuildController(EnabledConfig(), provider, library, user, cancellation.Token);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => controller.Classify(
+            new AnimeFillerBatchRequest([requestedEpisode.Id.ToString()])));
+
+        Assert.Equal(1, recursiveCalls);
+        Assert.Equal(0, provider.EpisodeCalls);
+    }
+
+    [Fact]
+    public async Task Classification_BulkLookupFaultsKeepTheExistingUnknownResponseContract()
+    {
+        var user = new User("anime-user", "provider", "password-provider");
+        var requestedId = Guid.NewGuid();
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = _ => throw new IOException("library unavailable"),
+        };
+        var provider = new FakeProvider();
+        var controller = BuildController(EnabledConfig(), provider, library, user);
+
+        var result = await controller.Classify(new AnimeFillerBatchRequest([requestedId.ToString(), "invalid"]));
+
+        var items = Assert.IsType<AnimeFillerBatchResponse>(Assert.IsType<OkObjectResult>(result).Value).Items;
+        Assert.All(items, item => Assert.Equal("Unknown", item.Classification));
+        Assert.All(items, item => Assert.Equal("unavailable", item.Reason));
+        Assert.Equal(0, provider.EpisodeCalls);
     }
 
     [Fact]
@@ -131,8 +393,9 @@ public sealed class AnimeFillerControllerContractTests
         };
         var library = new CountingLibraryManager
         {
-            GetItemByIdUserHook = (id, _) => id == episodeId ? episode : id == seriesId ? series : null,
-            GetItemListHook = _ => [episode],
+            GetItemListHook = query => query.ItemIds.Length > 0
+                ? query.IncludeItemTypes.Contains(BaseItemKind.Episode) ? [episode] : [series]
+                : [episode],
         };
         var provider = new FakeProvider
         {
@@ -188,7 +451,7 @@ public sealed class AnimeFillerControllerContractTests
         };
         var library = new CountingLibraryManager
         {
-            GetItemByIdUserHook = (id, _) => id == episode.Id ? episode : id == series.Id ? series : null,
+            GetItemListHook = query => query.IncludeItemTypes.Contains(BaseItemKind.Episode) ? [episode] : [series],
         };
         var provider = new FakeProvider
         {
@@ -251,10 +514,16 @@ public sealed class AnimeFillerControllerContractTests
         PluginConfiguration? config,
         FakeProvider provider,
         CountingLibraryManager library,
-        User? user)
+        User? user,
+        CancellationToken cancellationToken = default)
     {
         var configProvider = new FakePluginConfigProvider(config);
         var userManager = user is null ? new StubUserManager() : new StubUserManager(user);
+        if (user is not null && library.ConfigureUserAccessHook is null)
+        {
+            library.ConfigureUserAccessHook = (_, resolvedUser) => Assert.Same(user, resolvedUser);
+        }
+
         var service = new AnimeFillerService(provider, configProvider, NullLogger<AnimeFillerService>.Instance);
         var controller = new AnimeFillerWarningsController(
             new RecordingHttpClientFactory(new HttpClientHandler()),
@@ -273,6 +542,7 @@ public sealed class AnimeFillerControllerContractTests
             HttpContext = new DefaultHttpContext
             {
                 User = new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth")),
+                RequestAborted = cancellationToken,
             },
         };
         return controller;
@@ -284,9 +554,31 @@ public sealed class AnimeFillerControllerContractTests
         AnimeFillerCacheHours = 24,
     };
 
+    private static Series AnimeSeries(string name, int myAnimeListId)
+    {
+        var series = new Series
+        {
+            Id = Guid.NewGuid(),
+            Name = name,
+            Genres = ["Anime"],
+        };
+        series.ProviderIds["MyAnimeList"] = myAnimeListId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        return series;
+    }
+
+    private static Episode NumberedEpisode(Guid seriesId, int season, int episode) => new()
+    {
+        Id = Guid.NewGuid(),
+        SeriesId = seriesId,
+        ParentIndexNumber = season,
+        IndexNumber = episode,
+    };
+
     private sealed class FakeProvider : IAnimeFillerProvider
     {
         public AnimeProviderEpisodes? Episodes { get; init; }
+
+        public IReadOnlyDictionary<int, AnimeProviderEpisodes>? EpisodesByMalId { get; init; }
 
         public IReadOnlyList<AnimeProviderCandidate> Candidates { get; init; } = [];
 
@@ -310,7 +602,9 @@ public sealed class AnimeFillerControllerContractTests
         public Task<AnimeProviderEpisodes?> GetEpisodesAsync(int myAnimeListId, CancellationToken cancellationToken)
         {
             EpisodeCalls++;
-            return Task.FromResult(Episodes);
+            return Task.FromResult(
+                EpisodesByMalId?.GetValueOrDefault(myAnimeListId)
+                ?? Episodes);
         }
     }
 

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/AnimeFillerWarningsController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/AnimeFillerWarningsController.cs
@@ -1,4 +1,5 @@
 using Jellyfin.Data.Enums;
+using Jellyfin.Plugin.JellyfinCanopy.Data;
 using Jellyfin.Plugin.JellyfinCanopy.Helpers;
 using Jellyfin.Plugin.JellyfinCanopy.Services;
 using Jellyfin.Plugin.JellyfinCanopy.Services.AnimeFiller;
@@ -19,6 +20,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers;
 [ApiController]
 public sealed class AnimeFillerWarningsController : JellyfinCanopyControllerBase
 {
+    // PERF(S2): recursive per-series enumeration is page-bounded. Only one page is
+    // resident while the compact season-maximum numbering index is constructed.
+    private const int SeriesEpisodePageSize = 256;
+
     private readonly ILibraryManager _libraryManager;
     private readonly AnimeFillerService _animeFillerService;
     private readonly IAnimeFillerProvider _provider;
@@ -55,56 +60,74 @@ public sealed class AnimeFillerWarningsController : JellyfinCanopyControllerBase
         var user = userId.HasValue ? _userManager.GetUserById(userId.Value) : null;
         if (user is null) return Forbid();
 
-        var byId = new Dictionary<string, AnimeFillerItemResponse>(StringComparer.OrdinalIgnoreCase);
+        var cancellationToken = HttpContext.RequestAborted;
+        cancellationToken.ThrowIfCancellationRequested();
+        var validItemIds = uniqueIds
+            .Select(value => Guid.TryParse(value, out var itemId) ? itemId : Guid.Empty)
+            .Where(itemId => itemId != Guid.Empty)
+            .Distinct()
+            .ToArray();
+        var episodesById = GetCallerVisibleItems<Episode>(
+            validItemIds,
+            user,
+            BaseItemKind.Episode,
+            "episode",
+            cancellationToken);
+        var numberedEpisodes = episodesById.Values
+            .Where(IsNumberedEpisode)
+            .ToDictionary(episode => episode.Id);
+        var seriesIds = numberedEpisodes.Values
+            .Select(episode => episode.SeriesId)
+            .Where(seriesId => seriesId != Guid.Empty)
+            .Distinct()
+            .ToArray();
+        var seriesById = GetCallerVisibleItems<Series>(
+            seriesIds,
+            user,
+            BaseItemKind.Series,
+            "series",
+            cancellationToken);
+
+        var byId = new Dictionary<Guid, AnimeFillerItemResponse>();
         var mappings = _animeFillerService.GetMappings();
-        foreach (var requestedId in uniqueIds)
+        var numberingBySeries = new Dictionary<Guid, AnimeFillerEpisodeNumbering?>();
+        foreach (var itemId in validItemIds)
         {
-            if (!Guid.TryParse(requestedId, out var itemId))
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!numberedEpisodes.TryGetValue(itemId, out var episode))
             {
-                byId[requestedId] = Unknown(requestedId, "unavailable");
+                byId[itemId] = Unknown(itemId.ToString(), "unavailable");
                 continue;
             }
 
-            Episode? episode = null;
-            try
+            // Do not trust the relationship object cached on the episode: it can be
+            // incomplete, and it is not itself evidence that the caller can access the
+            // parent. The distinct parent batch above resolves it through the same
+            // caller-scoped library seam.
+            if (!seriesById.TryGetValue(episode.SeriesId, out var series) || !IsAnime(series))
             {
-                episode = _libraryManager.GetItemById<BaseItem>(itemId, user) as Episode;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogDebug(ex, "Caller-scoped anime episode lookup failed.");
-            }
-
-            if (episode is null || episode.ParentIndexNumber is null || episode.ParentIndexNumber <= 0 || episode.IndexNumber is null || episode.IndexNumber <= 0)
-            {
-                byId[requestedId] = Unknown(requestedId, "unavailable");
+                byId[itemId] = Unknown(itemId.ToString(), "not-recognized-as-anime");
                 continue;
             }
 
-            Series? series = null;
-            try
-            {
-                // Do not trust the relationship object cached on the episode: it can be
-                // incomplete, and it is not itself evidence that the caller can access the
-                // parent. Resolve the series through the same caller-scoped library seam.
-                series = _libraryManager.GetItemById<BaseItem>(episode.SeriesId, user) as Series;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogDebug(ex, "Caller-scoped anime series lookup failed.");
-            }
-
-            if (series is null || !IsAnime(series))
-            {
-                byId[requestedId] = Unknown(requestedId, "not-recognized-as-anime");
-                continue;
-            }
-
-            var seasonNumber = episode.ParentIndexNumber.Value;
+            var seasonNumber = episode.ParentIndexNumber.GetValueOrDefault();
             var usesSeasonMapping = mappings.Seasons.ContainsKey((series.Id, seasonNumber));
-            var providerEpisode = usesSeasonMapping
-                ? episode.IndexNumber.Value
-                : CalculateAbsoluteEpisodeNumber(series, episode, user);
+            int? providerEpisode;
+            if (usesSeasonMapping)
+            {
+                providerEpisode = episode.IndexNumber.GetValueOrDefault();
+            }
+            else
+            {
+                if (!numberingBySeries.TryGetValue(series.Id, out var numbering))
+                {
+                    numbering = LoadEpisodeNumbering(series, user, cancellationToken);
+                    numberingBySeries[series.Id] = numbering;
+                }
+
+                providerEpisode = numbering?.Calculate(seasonNumber, episode.IndexNumber.GetValueOrDefault());
+            }
+
             var identity = new AnimeSeriesIdentity(
                 series.Id,
                 seasonNumber,
@@ -115,16 +138,25 @@ public sealed class AnimeFillerWarningsController : JellyfinCanopyControllerBase
                 identity,
                 providerEpisode,
                 episode.Name,
-                HttpContext.RequestAborted).ConfigureAwait(false);
-            byId[requestedId] = new AnimeFillerItemResponse(
-                requestedId,
+                cancellationToken).ConfigureAwait(false);
+            byId[itemId] = new AnimeFillerItemResponse(
+                itemId.ToString(),
                 classification.Classification.ToString(),
                 classification.Reason,
                 classification.MyAnimeListId,
                 classification.SourceUrl);
         }
 
-        return Ok(new AnimeFillerBatchResponse(requestedIds.Select(id => byId[id]).ToArray()));
+        return Ok(new AnimeFillerBatchResponse(requestedIds.Select(requestedId =>
+        {
+            if (!Guid.TryParse(requestedId, out var itemId)
+                || !byId.TryGetValue(itemId, out var response))
+            {
+                return Unknown(requestedId, "unavailable");
+            }
+
+            return response with { ItemId = requestedId };
+        }).ToArray()));
     }
 
     /// <summary>Returns non-secret configuration and mapping validation for administrators.</summary>
@@ -192,25 +224,54 @@ public sealed class AnimeFillerWarningsController : JellyfinCanopyControllerBase
             && int.TryParse(value, System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out var id)
             && id > 0;
 
-    private int? CalculateAbsoluteEpisodeNumber(Series series, Episode current, Jellyfin.Database.Implementations.Entities.User user)
+    private IReadOnlyDictionary<Guid, T> GetCallerVisibleItems<T>(
+        IReadOnlyCollection<Guid> itemIds,
+        Jellyfin.Database.Implementations.Entities.User user,
+        BaseItemKind itemKind,
+        string itemDescription,
+        CancellationToken cancellationToken)
+        where T : BaseItem
+    {
+        if (itemIds.Count == 0) return new Dictionary<Guid, T>();
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var query = UserAccessQuery.BuildItemIds(_libraryManager, user, itemIds);
+            query.IncludeItemTypes = [itemKind];
+            query.Limit = itemIds.Count;
+            var requested = itemIds.ToHashSet();
+            var items = _libraryManager.GetItemList(query)
+                .OfType<T>()
+                .Where(item => requested.Contains(item.Id))
+                .GroupBy(item => item.Id)
+                .ToDictionary(group => group.Key, group => group.First());
+            cancellationToken.ThrowIfCancellationRequested();
+            return items;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Caller-scoped anime {ItemDescription} batch lookup failed.", itemDescription);
+            return new Dictionary<Guid, T>();
+        }
+    }
+
+    private AnimeFillerEpisodeNumbering? LoadEpisodeNumbering(
+        Series series,
+        Jellyfin.Database.Implementations.Entities.User user,
+        CancellationToken cancellationToken)
     {
         try
         {
-            var query = new InternalItemsQuery(user)
-            {
-                ParentId = series.Id,
-                IncludeItemTypes = [BaseItemKind.Episode],
-                Recursive = true,
-            };
-            var libraryEpisodes = _libraryManager.GetItemList(query)
-                .OfType<Episode>()
-                .Select(episode => (episode.ParentIndexNumber, episode.IndexNumber));
-            // A completely absent prior season makes absolute numbering unprovable.
-            // Virtual episodes are included by the recursive query and close normal file gaps.
-            return AnimeFillerMappingParser.CalculateAbsoluteEpisodeNumber(
-                current.ParentIndexNumber!.Value,
-                current.IndexNumber!.Value,
-                libraryEpisodes);
+            return AnimeFillerMappingParser.IndexAbsoluteEpisodeNumbers(
+                EnumerateSeriesEpisodeNumbers(series.Id, user, cancellationToken));
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -218,6 +279,43 @@ public sealed class AnimeFillerWarningsController : JellyfinCanopyControllerBase
             return null;
         }
     }
+
+    private IEnumerable<(int? Season, int? Episode)> EnumerateSeriesEpisodeNumbers(
+        Guid seriesId,
+        Jellyfin.Database.Implementations.Entities.User user,
+        CancellationToken cancellationToken)
+    {
+        var startIndex = 0;
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var query = new InternalItemsQuery(user)
+            {
+                ParentId = seriesId,
+                IncludeItemTypes = [BaseItemKind.Episode],
+                Recursive = true,
+                StartIndex = startIndex,
+                Limit = SeriesEpisodePageSize,
+                OrderBy =
+                [
+                    (ItemSortBy.ParentIndexNumber, JSortOrder.Ascending),
+                    (ItemSortBy.IndexNumber, JSortOrder.Ascending),
+                ],
+            };
+            var page = _libraryManager.GetItemList(query);
+            cancellationToken.ThrowIfCancellationRequested();
+            foreach (var episode in page.OfType<Episode>())
+            {
+                yield return (episode.ParentIndexNumber, episode.IndexNumber);
+            }
+
+            if (page.Count < SeriesEpisodePageSize) yield break;
+            startIndex = checked(startIndex + page.Count);
+        }
+    }
+
+    private static bool IsNumberedEpisode(Episode episode)
+        => episode.ParentIndexNumber is > 0 && episode.IndexNumber is > 0;
 
     private static AnimeFillerItemResponse Unknown(string itemId, string reason) => new(itemId, nameof(AnimeEpisodeClassification.Unknown), reason, null, null);
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/AnimeFiller/AnimeFillerMappingParser.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/AnimeFiller/AnimeFillerMappingParser.cs
@@ -143,18 +143,50 @@ internal static class AnimeFillerMappingParser
         int currentSeason,
         int currentEpisode,
         IEnumerable<(int? Season, int? Episode)> libraryEpisodes)
+        => IndexAbsoluteEpisodeNumbers(libraryEpisodes).Calculate(currentSeason, currentEpisode);
+
+    /// <summary>
+    /// Builds the per-series numbering index once so a classification batch can reuse it for
+    /// every requested episode in that series.
+    /// </summary>
+    internal static AnimeFillerEpisodeNumbering IndexAbsoluteEpisodeNumbers(
+        IEnumerable<(int? Season, int? Episode)> libraryEpisodes)
+    {
+        var seasonMaxima = new Dictionary<int, int>();
+        foreach (var value in libraryEpisodes)
+        {
+            if (value.Season is not > 0 || value.Episode is not > 0) continue;
+            if (!seasonMaxima.TryGetValue(value.Season.Value, out var maximum)
+                || value.Episode.Value > maximum)
+            {
+                seasonMaxima[value.Season.Value] = value.Episode.Value;
+            }
+        }
+
+        return new AnimeFillerEpisodeNumbering(seasonMaxima);
+    }
+}
+
+/// <summary>Compact per-series maximum-episode index used to prove absolute numbering.</summary>
+internal sealed class AnimeFillerEpisodeNumbering
+{
+    private readonly IReadOnlyDictionary<int, int> _seasonMaxima;
+
+    internal AnimeFillerEpisodeNumbering(IReadOnlyDictionary<int, int> seasonMaxima)
+    {
+        _seasonMaxima = seasonMaxima;
+    }
+
+    /// <summary>Returns the absolute episode number only when every prior season is present.</summary>
+    internal int? Calculate(int currentSeason, int currentEpisode)
     {
         if (currentSeason <= 0 || currentEpisode <= 0) return null;
         try
         {
-            var priorSeasons = libraryEpisodes
-                .Where(value => value.Season is > 0 && value.Season < currentSeason && value.Episode is > 0)
-                .GroupBy(value => value.Season!.Value)
-                .ToDictionary(group => group.Key, group => group.Max(value => value.Episode!.Value));
             var before = 0;
             for (var season = 1; season < currentSeason; season++)
             {
-                if (!priorSeasons.TryGetValue(season, out var maximumEpisode)) return null;
+                if (!_seasonMaxima.TryGetValue(season, out var maximumEpisode)) return null;
                 before = checked(before + maximumEpisode);
             }
 

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -21,7 +21,7 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
     assert.equal(baselines.schemaVersion, 2);
     assert.equal(baselines.policy.baselineSelection, 'observed-high-water');
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2337, totalLines: 2677 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 27995, totalLines: 36602 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 28067, totalLines: 36668 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 2,
         minimumCoveredLines: 2337,
@@ -29,11 +29,11 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
     });
     assert.deepEqual(baselines.profiles.server.observations, {
         cleanRuns: 5,
-        minimumCoveredLines: 27988,
-        maximumCoveredLines: 27995,
+        minimumCoveredLines: 28066,
+        maximumCoveredLines: 28067,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 7);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 1);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 27995,
-        "totalLines": 36602
+        "coveredLines": 28067,
+        "totalLines": 36668
       },
       "observations": {
         "cleanRuns": 5,
-        "minimumCoveredLines": 27988,
-        "maximumCoveredLines": 27995
+        "minimumCoveredLines": 28066,
+        "maximumCoveredLines": 28067
       },
       "tolerance": {
-        "missingCoveredLines": 7,
-        "rationale": "Fixing #365 adds explicit series ownership to the Spoiler Guard season-watched cache and event-path regressions for the affected (user, series), same-user unrelated-series, cross-user, synchronous season-eviction, and subscription-lifecycle boundaries. After rebasing on merged #160 and the schema-v2 observed-high-water policy from #349, five clean .NET 10.0.9/Coverlet runs on 2026-08-01 each passed all 2,471 server tests at the identical 36,602-line scope and measured 27,992, 27,988, 27,995, 27,993, and 27,993 covered lines. The reviewed high-water is therefore 27,995/36,602 (76.485%). The fixed-scope seven-line spread is direct evidence that the former six-line allowance is one line too narrow, so the tolerance advances only to seven; that remains 0.019 percentage points, far below the policy cap, and raises the enforced floor to 27,988/36,602 (76.466%) from 27,862/36,585 (76.157%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 1,
+        "rationale": "Fixing #457 replaces up to 200 per-episode scalar lookups and 100 repeated full-series queries with two caller-scoped ID batches plus one page-bounded numbering scan per distinct series, backed by mixed-access, duplicate, fault, cancellation, pagination, and exact 100-ID regressions. Five clean .NET 10.0.9/Coverlet runs on 2026-08-01 each passed all 2,482 server tests at the identical 36,668-line scope and measured 28,066, 28,067, 28,066, 28,066, and 28,067 covered lines. The reviewed high-water is therefore 28,067/36,668 (76.544%). The fixed-scope one-line spread permits tightening the instrumentation tolerance from seven lines to one (0.003 percentage points), raising the enforced floor to 28,066/36,668 (76.541%) from 27,988/36,602 (76.466%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
Closes #457

## Summary

- replace per-episode scalar library reads with two caller-scoped bulk queries
- reuse one compact absolute-numbering index per distinct visible series with deterministic 256-item paging
- preserve request order, duplicates, Unknown responses, fault handling, and cancellation
- add batch, access, paging, cancellation, ordering, and source-seam regressions

## Verification

- focused controller contract tests: 14/14
- full server coverage: 2,482/2,482 across five clean implementation runs; fixed scope 36,668 with measured high water 28,067 and floor 28,066
- script tests: 618/618
- release build, performance guard, coverage policy, and diff checks passed
- independent whole-diff review approved the frozen patch

No deployment was performed.