### PR TITLE
fix(tags): process duplicate cast entries reliably (#361)

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.identity.test.ts
@@ -66,7 +66,7 @@ describe('people tags identity lifecycle', () => {
         const disconnects: ReturnType<typeof vi.fn>[] = [];
         JC.helpers = {
             ...originalHelpers,
-            createObserver: vi.fn((_id, callback) => {
+            createObserver: vi.fn((_id: string, callback: MutationCallback) => {
                 callbacks.push(callback);
                 const disconnect = vi.fn();
                 disconnects.push(disconnect);
@@ -74,7 +74,7 @@ describe('people tags identity lifecycle', () => {
             }),
         };
 
-        const responseA = deferred<any>();
+        const responseA = deferred<unknown>();
         const plugin = vi.fn()
             .mockReturnValueOnce(responseA.promise)
             .mockResolvedValueOnce({ currentAge: 44, birthPlace: 'Perth, Australia' });
@@ -86,7 +86,7 @@ describe('people tags identity lifecycle', () => {
         surface.initializePeopleTags!();
         expect(callbacks).toHaveLength(1);
 
-        callbacks[0]([{ addedNodes: [document.createElement('div')] }] as unknown as MutationRecord[], {} as MutationObserver);
+        callbacks[0]([{ addedNodes: [cardA] }] as unknown as MutationRecord[], {} as MutationObserver);
         await vi.advanceTimersByTimeAsync(100);
         expect(plugin).toHaveBeenCalledTimes(1);
 
@@ -102,7 +102,7 @@ describe('people tags identity lifecycle', () => {
 
         // Even if a queued copy of A's observer callback is delivered, its
         // captured epoch keeps it dormant.
-        callbacks[0]([{ addedNodes: [document.createElement('div')] }] as unknown as MutationRecord[], {} as MutationObserver);
+        callbacks[0]([{ addedNodes: [cardA] }] as unknown as MutationRecord[], {} as MutationObserver);
         await vi.advanceTimersByTimeAsync(100);
         expect(plugin).toHaveBeenCalledTimes(1);
 
@@ -110,7 +110,7 @@ describe('people tags identity lifecycle', () => {
         const cardB = mountPersonCard('person-b');
         surface.initializePeopleTags!();
         expect(callbacks).toHaveLength(2);
-        callbacks[1]([{ addedNodes: [document.createElement('div')] }] as unknown as MutationRecord[], {} as MutationObserver);
+        callbacks[1]([{ addedNodes: [cardB] }] as unknown as MutationRecord[], {} as MutationObserver);
         await vi.advanceTimersByTimeAsync(100);
         await Promise.resolve();
         await Promise.resolve();

--- a/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.perf.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.perf.test.ts
@@ -6,7 +6,8 @@
 // persist the localStorage cache ONCE per settled batch (not once per person,
 // which re-serialized the entire map every time = O(N^2) main-thread work).
 // Correctness contracts must be preserved exactly: identity/navigation
-// cancellation, per-person dedup, cache TTL/ownership semantics, and
+// cancellation, per-person lookup dedup, per-card render completion,
+// cache TTL/ownership semantics, and
 // identical rendered output (age chips / place banner / deceased poster).
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { JC } from '../globals';
@@ -28,6 +29,7 @@ afterAll(() => {
  * TAG_FALLBACK_CONCURRENCY).
  */
 const CONCURRENCY_CAP = 6;
+const RETRY_DELAYS_MS = [250, 500, 1000, 2000] as const;
 
 const CACHE_KEY = 'JellyfinCanopy-peopleTagsCache';
 const CACHE_TIMESTAMP_KEY = 'JellyfinCanopy-peopleTagsCacheTimestamp';
@@ -98,9 +100,11 @@ function cardFor(personId: string): HTMLElement {
     return document.querySelector<HTMLElement>(`.personCard[data-id="${personId}"]`)!;
 }
 
-function fireObserver(callback: MutationCallback): void {
+function fireObserver(callback: MutationCallback, addedNode?: Node): void {
+    const fallbackNode = Array.from(document.querySelectorAll('.personCard')).at(-1)
+        ?? document.createElement('div');
     callback(
-        [{ addedNodes: [document.createElement('div')] }] as unknown as MutationRecord[],
+        [{ addedNodes: [addedNode ?? fallbackNode] }] as unknown as MutationRecord[],
         {} as MutationObserver,
     );
 }
@@ -179,6 +183,66 @@ describe('people tags bounded-concurrency batch (BI-PERF-137)', () => {
         localStorage.clear();
         resetDetailsViewTrackingForTests();
         vi.useRealTimers();
+    });
+
+    it('R9: discovers already-mounted duplicate cast and guest cards without a synthetic mutation', async () => {
+        const { plugin } = instrumentedPlugin(() => ({
+            currentAge: 38,
+            birthPlace: 'Perth, Australia',
+        }));
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        mountCastPage(
+            'item-initial-discovery',
+            ['person-already-mounted', 'person-already-mounted'],
+            ['person-already-mounted'],
+        );
+
+        // The cast predates initialization and no observer callback is fired.
+        // Observation is installed first, then one normal debounced pass owns
+        // the mounted page so all concrete occurrences share one lookup.
+        surface.initializePeopleTags!();
+        expect(observerCallbacks).toHaveLength(1);
+        await vi.advanceTimersByTimeAsync(99);
+        expect(plugin).toHaveBeenCalledTimes(0);
+        await vi.advanceTimersByTimeAsync(1);
+        await vi.advanceTimersByTimeAsync(5);
+
+        expect(plugin).toHaveBeenCalledTimes(1);
+        expect(document.querySelectorAll('.personCard')).toHaveLength(3);
+        expect(document.querySelectorAll('.jc-people-age-container')).toHaveLength(3);
+        expect(document.querySelectorAll('.jc-people-place-banner')).toHaveLength(3);
+    });
+
+    it('R9: same-identity reinitialization rediscovers a mounted cast without a synthetic mutation', async () => {
+        const { plugin } = instrumentedPlugin(() => ({
+            currentAge: 39,
+            birthPlace: 'Perth, Australia',
+        }));
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        mountCastPage(
+            'item-reinit-discovery',
+            ['person-reinit-mounted', 'person-reinit-mounted'],
+        );
+
+        surface.initializePeopleTags!();
+        await vi.advanceTimersByTimeAsync(105);
+        expect(plugin).toHaveBeenCalledTimes(1);
+        expect(document.querySelectorAll('.jc-people-age-container')).toHaveLength(2);
+
+        // Teardown removes the old projection, but the page and identity stay
+        // put. The replacement initializer must restore both occurrences from
+        // its persistent cache without depending on a future body mutation.
+        surface.initializePeopleTags!();
+        expect(observerCallbacks).toHaveLength(2);
+        expect(document.querySelectorAll('.jc-people-age-container')).toHaveLength(0);
+        await vi.advanceTimersByTimeAsync(99);
+        expect(document.querySelectorAll('.jc-people-age-container')).toHaveLength(0);
+        await vi.advanceTimersByTimeAsync(1);
+        await vi.advanceTimersByTimeAsync(5);
+
+        expect(plugin).toHaveBeenCalledTimes(1);
+        expect(document.querySelectorAll('.jc-people-age-container')).toHaveLength(2);
+        expect(document.querySelectorAll('.jc-people-place-banner')).toHaveLength(2);
     });
 
     it('AC1/AC5: drains a 20-person cast with >1 but <=cap requests in flight', async () => {
@@ -299,12 +363,13 @@ describe('people tags bounded-concurrency batch (BI-PERF-137)', () => {
         expect(plugin).toHaveBeenCalledTimes(inFlightBeforeNavigation);
     });
 
-    it('AC3: an identity transition mid-render applies no tags and persists nothing', async () => {
+    it('AC3: an identity transition mid-render applies no duplicate tags and persists nothing', async () => {
         const { plugin, pending } = instrumentedPlugin();
         JC.core.api = { plugin } as unknown as typeof JC.core.api;
-        mountCastPage('item-ident-a', ['person-ident-a', 'person-ident-b']);
+        mountCastPage('item-ident-a', ['person-ident-a', 'person-ident-a'], ['person-ident-a']);
+        const oldCards = Array.from(document.querySelectorAll<HTMLElement>('.personCard'));
         await startProcessing();
-        expect(plugin).toHaveBeenCalledTimes(2);
+        expect(plugin).toHaveBeenCalledTimes(1);
         const writeSpy = vi.spyOn(JC.storage.local, 'write');
 
         JC.identity.transition('people-perf-server-b', 'people-perf-user-b', 'people-perf-switch');
@@ -317,13 +382,22 @@ describe('people tags bounded-concurrency batch (BI-PERF-137)', () => {
         expect(document.querySelectorAll('.jc-people-age-container')).toHaveLength(0);
         expect(document.querySelectorAll('.jc-people-place-banner')).toHaveLength(0);
         expect(document.querySelectorAll('.jc-deceased-poster')).toHaveLength(0);
+        for (const card of oldCards) {
+            expect(card.querySelector('.jc-people-age-container')).toBeNull();
+            expect(card.querySelector('.jc-people-place-banner')).toBeNull();
+            expect(card.classList.contains('jc-deceased-poster')).toBe(false);
+        }
         const labels = writeSpy.mock.calls.map((call) => call[3]);
         expect(labels.filter((label) => label === 'cache-payload')).toHaveLength(0);
         expect(labels.filter((label) => label === 'cache-timestamps')).toHaveLength(0);
     });
 
-    it('AC3: duplicate person ids fetch once and only the cast-first card renders', async () => {
-        const { plugin } = instrumentedPlugin(() => ({ currentAge: 44, birthPlace: 'Perth, Australia' }));
+    it('AC3: duplicate person ids fetch once and render every card without changing cast order or identity', async () => {
+        const { plugin } = instrumentedPlugin(() => ({
+            isDeceased: true,
+            ageAtDeath: 44,
+            birthPlace: 'Perth, Australia',
+        }));
         JC.core.api = { plugin } as unknown as typeof JC.core.api;
         window.location.hash = '#/details?id=item-dup';
         document.body.innerHTML = `
@@ -332,18 +406,165 @@ describe('people tags bounded-concurrency batch (BI-PERF-137)', () => {
                 <div id="guestCastCollapsible">${personCardHtml('person-dup')}</div>
             </div>`;
         recordDetailsViewShown(document.querySelector('#itemDetailPage'));
+        const cardsBefore = Array.from(document.querySelectorAll<HTMLElement>('.personCard'));
 
         await startProcessing();
+        await vi.advanceTimersByTimeAsync(5);
+        const ageTagsBefore = cardsBefore.map((card) => card.querySelector('.jc-people-age-container'));
+        const placeTagsBefore = cardsBefore.map((card) => card.querySelector('.jc-people-place-banner'));
         // A second observer pass must not re-process anything.
         fireObserver(observerCallbacks[observerCallbacks.length - 1]);
         await vi.advanceTimersByTimeAsync(100);
         await vi.advanceTimersByTimeAsync(5);
 
         expect(plugin).toHaveBeenCalledTimes(1);
-        const cards = document.querySelectorAll<HTMLElement>('.personCard');
-        expect(cards[0].querySelector('.jc-people-age-container')).not.toBeNull();
-        expect(cards[1].querySelector('.jc-people-age-container')).toBeNull();
-        expect(cards[2].querySelector('.jc-people-age-container')).toBeNull();
+        const cardsAfter = Array.from(document.querySelectorAll<HTMLElement>('.personCard'));
+        expect(cardsAfter.map((card) => card.parentElement?.id)).toEqual([
+            'castCollapsible',
+            'castCollapsible',
+            'guestCastCollapsible',
+        ]);
+        cardsAfter.forEach((card, index) => {
+            // The projection decorates the existing Jellyfin card in place;
+            // it must not reorder or replace duplicate cast occurrences.
+            expect(card).toBe(cardsBefore[index]);
+            expect(card.classList.contains('jc-deceased-poster')).toBe(true);
+            expect(card.querySelectorAll('.jc-people-age-container')).toHaveLength(1);
+            expect(card.querySelectorAll('.jc-people-place-banner')).toHaveLength(1);
+            expect(card.querySelector('.jc-people-age-container')).toBe(ageTagsBefore[index]);
+            expect(card.querySelector('.jc-people-place-banner')).toBe(placeTagsBefore[index]);
+            expect(card.querySelector('.jc-people-age-text')?.textContent).toBe('44y');
+            expect(card.querySelector('.jc-people-place-text')?.textContent).toBe('Perth, Australia');
+            expect(card.querySelector('.jc-people-age-container')?.getAttribute('data-jc-identity-owned'))
+                .toBe('true');
+            expect(card.querySelector('.jc-people-place-banner')?.getAttribute('data-jc-identity-owned'))
+                .toBe('true');
+        });
+    });
+
+    it('AC3: one disconnected duplicate does not prevent other live occurrences from rendering', async () => {
+        const { plugin, pending } = instrumentedPlugin();
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        mountCastPage(
+            'item-partial-dup',
+            ['person-partial-dup', 'person-partial-dup'],
+            ['person-partial-dup'],
+        );
+
+        const cards = Array.from(document.querySelectorAll<HTMLElement>('.personCard'));
+        await startProcessing();
+        expect(plugin).toHaveBeenCalledTimes(1);
+        expect(pending).toHaveLength(1);
+
+        // Connectivity is an occurrence-level guard: dropping the first card
+        // must not abort projection onto the other cards sharing its lookup.
+        cards[0].remove();
+        pending[0].resolve({
+            isDeceased: true,
+            ageAtDeath: 44,
+            birthPlace: 'Perth, Australia',
+        });
+        await vi.advanceTimersByTimeAsync(5);
+
+        expect(cards[0].isConnected).toBe(false);
+        expect(cards[0].classList.contains('jc-deceased-poster')).toBe(false);
+        expect(cards[0].querySelector('.jc-people-age-container')).toBeNull();
+        expect(cards[0].querySelector('.jc-people-place-banner')).toBeNull();
+        for (const card of cards.slice(1)) {
+            expect(card.isConnected).toBe(true);
+            expect(card.classList.contains('jc-deceased-poster')).toBe(true);
+            expect(card.querySelector('.jc-people-age-container')).not.toBeNull();
+            expect(card.querySelector('.jc-people-place-banner')).not.toBeNull();
+        }
+    });
+
+    it('AC3: a post-quiet duplicate reopens processing, reuses hot data, and ignores unrelated churn', async () => {
+        const { plugin } = instrumentedPlugin(() => ({ currentAge: 44, birthPlace: 'Perth, Australia' }));
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        mountCastPage('item-late-dup', ['person-late-dup']);
+
+        await startProcessing();
+        await vi.advanceTimersByTimeAsync(5);
+        const castCard = cardFor('person-late-dup');
+        expect(castCard.querySelectorAll('.jc-people-age-container')).toHaveLength(1);
+
+        // Let the existing two-second quiet gate close before the duplicate
+        // occurrence mounts. Relevant cast mutations must reopen that gate.
+        await vi.advanceTimersByTimeAsync(2100);
+
+        document.querySelector('#guestCastCollapsible')!.insertAdjacentHTML(
+            'beforeend',
+            personCardHtml('person-late-dup'),
+        );
+        const guestCard = document.querySelector<HTMLElement>(
+            '#guestCastCollapsible .personCard[data-id="person-late-dup"]',
+        )!;
+        fireObserver(observerCallbacks[observerCallbacks.length - 1], guestCard);
+        await vi.advanceTimersByTimeAsync(100);
+        await vi.advanceTimersByTimeAsync(5);
+
+        // The first result is reused instead of issuing another /person call,
+        // but render completion remains owned by each concrete card.
+        expect(plugin).toHaveBeenCalledTimes(1);
+        expect(castCard.querySelectorAll('.jc-people-age-container')).toHaveLength(1);
+        expect(guestCard.querySelectorAll('.jc-people-age-container')).toHaveLength(1);
+        expect(guestCard.querySelectorAll('.jc-people-place-banner')).toHaveLength(1);
+
+        const guestAgeTag = guestCard.querySelector('.jc-people-age-container');
+        await vi.advanceTimersByTimeAsync(2100);
+
+        // Unrelated same-page additions after the next quiet period must not
+        // reopen processing or even arm the debounce timer.
+        const unrelated = document.createElement('div');
+        document.querySelector('#itemDetailPage')!.appendChild(unrelated);
+        const timerCountBefore = vi.getTimerCount();
+        fireObserver(observerCallbacks[observerCallbacks.length - 1], unrelated);
+        expect(vi.getTimerCount()).toBe(timerCountBefore);
+        await vi.advanceTimersByTimeAsync(500);
+        expect(plugin).toHaveBeenCalledTimes(1);
+        expect(castCard.querySelectorAll('.jc-people-age-container')).toHaveLength(1);
+        expect(guestCard.querySelectorAll('.jc-people-age-container')).toHaveLength(1);
+        expect(guestCard.querySelector('.jc-people-age-container')).toBe(guestAgeTag);
+    });
+
+    it('AC3/R8: structurally rejects large unrelated subtrees and outside-owned person cards', async () => {
+        const { plugin } = instrumentedPlugin(() => ({ currentAge: 39 }));
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        mountCastPage('item-owned-scan', ['person-owned-scan']);
+
+        await startProcessing();
+        await vi.advanceTimersByTimeAsync(5);
+        await vi.advanceTimersByTimeAsync(2100);
+        expect(plugin).toHaveBeenCalledTimes(1);
+
+        // An arbitrary body subtree may be enormous and may even contain
+        // selectors that LOOK like People Tags work. Ownership must be
+        // established against the concrete cast/guest sections before any
+        // descendant traversal or selector query is attempted.
+        const unrelated = document.createElement('section');
+        unrelated.innerHTML = Array.from(
+            { length: 1000 },
+            (_, index) => personCardHtml(`outside-nested-${index}`),
+        ).join('');
+        document.body.appendChild(unrelated);
+        const unrelatedQuery = vi.spyOn(unrelated, 'querySelectorAll');
+        const treeWalker = vi.spyOn(document, 'createTreeWalker');
+        const timersBefore = vi.getTimerCount();
+        fireObserver(observerCallbacks[observerCallbacks.length - 1], unrelated);
+
+        const outsideCard = document.createElement('div');
+        outsideCard.className = 'personCard';
+        outsideCard.dataset.id = 'outside-direct';
+        outsideCard.innerHTML = '<div class="cardScalable"></div>';
+        document.body.appendChild(outsideCard);
+        fireObserver(observerCallbacks[observerCallbacks.length - 1], outsideCard);
+
+        expect(unrelatedQuery).not.toHaveBeenCalled();
+        expect(treeWalker).not.toHaveBeenCalled();
+        expect(vi.getTimerCount()).toBe(timersBefore);
+        await vi.advanceTimersByTimeAsync(500);
+        expect(plugin).toHaveBeenCalledTimes(1);
+        expect(outsideCard.querySelector('.jc-people-age-container')).toBeNull();
     });
 
     it.each([true, false])(
@@ -536,12 +757,12 @@ describe('people tags bounded-concurrency batch (BI-PERF-137)', () => {
 
     it('AC3: cards replaced mid-batch on the SAME item are re-tagged, not permanently dropped', async () => {
         // Adversarial lifecycle case: React re-renders the cast cards for the
-        // SAME item while the bounded batch is in flight. Person ids were
-        // eagerly finalized at collection time, so the results for the old
-        // (now disconnected) cards were correctly dropped BUT the remembered
-        // rerun skipped every replacement card as "already processed",
-        // finishing with zero overlays. Ids must only finalize once an overlay
-        // lands on a LIVE card.
+        // SAME item while the bounded batch is in flight. The old id-level
+        // completion model eagerly finalized actors at collection time, so the
+        // results for the old (now disconnected) cards were correctly dropped
+        // BUT the remembered rerun skipped every replacement card as "already
+        // processed", finishing with zero overlays. Completion must belong to
+        // each concrete card and only land after a definitive live result.
         const { plugin, pending } = instrumentedPlugin();
         JC.core.api = { plugin } as unknown as typeof JC.core.api;
         const castIds = Array.from({ length: 8 }, (_, index) => `person-repl-${index}`);
@@ -577,10 +798,10 @@ describe('people tags bounded-concurrency batch (BI-PERF-137)', () => {
     it('AC3/AC4: a details→details transition never processes the outgoing view under the incoming item id', async () => {
         // During Jellyfin's details→details push the URL flips to item B while
         // item A's view is still the visible one and B is not mounted yet. A
-        // shared actor must NOT be fetched/marked-processed under itemId=B off
-        // the outgoing A view, or B's real card is skipped by processedPersonIds
-        // and never tagged. getVisibleDetailsPage() reports the transition
-        // (null) so the batch/rerun defers.
+        // shared actor must NOT be fetched/rendered under itemId=B off the
+        // outgoing A view, or the result can seed B-scoped hot-cache data from
+        // the wrong page and be reused by B's real card. getVisibleDetailsPage()
+        // reports the transition (null) so the batch/rerun defers.
         const { plugin, pending } = instrumentedPlugin();
         JC.core.api = { plugin } as unknown as typeof JC.core.api;
         mountCastPage('item-trans-a', ['person-shared', 'person-a-only']);
@@ -593,8 +814,8 @@ describe('people tags bounded-concurrency batch (BI-PERF-137)', () => {
         window.location.hash = '#/details?id=item-trans-b';
         fireObserver(observerCallbacks[observerCallbacks.length - 1]);
         await vi.advanceTimersByTimeAsync(100);
-        // Settle A's in-flight requests — they must apply nothing and, crucially,
-        // must not finalize the shared actor's id under item B.
+        // Settle A's in-flight requests — they must apply nothing and must not
+        // seed or reuse item-B cache data from the outgoing page.
         for (const request of pending.splice(0, pending.length)) {
             request.resolve({ currentAge: 30 });
         }
@@ -737,45 +958,484 @@ describe('people tags bounded-concurrency batch (BI-PERF-137)', () => {
         expect(document.querySelectorAll('.jc-people-age-container')).toHaveLength(7);
     });
 
-    it('AC3: a transient fetch failure does not finalize the id — a later pass re-fetches and tags', async () => {
-        // Fail-open contract: when /person rejects (backend/TMDB blip) the id
-        // must NOT be finalized in processedPersonIds. If it were, a later pass
-        // after the backend recovers — or a card re-render — would skip it and
-        // its overlays would be absent until a full item-state reset. The first
-        // attempt is deferred (rejected); a later attempt resolves with data.
+    it('AC3/R9: duplicate cards recover automatically on one grouped backoff retry', async () => {
         vi.spyOn(console, 'warn').mockImplementation(() => {});
         seedOwnedCache({});
-        const attempts = new Map<string, number>();
-        const { plugin, pending } = instrumentedPlugin((path) => {
-            const n = (attempts.get(path) ?? 0) + 1;
-            attempts.set(path, n);
-            return n === 1 ? undefined : { currentAge: 40, birthPlace: 'Perth, Australia' };
+        let attempt = 0;
+        const plugin = vi.fn(() => {
+            attempt += 1;
+            if (attempt === 1) return Promise.reject(new Error('backend down'));
+            return Promise.resolve({ currentAge: 40, birthPlace: 'Perth, Australia' });
         });
         JC.core.api = { plugin } as unknown as typeof JC.core.api;
-        const castIds = ['person-retry-a', 'person-retry-b'];
-        mountCastPage('item-retry', castIds);
+        mountCastPage(
+            'item-retry',
+            ['person-retry', 'person-retry'],
+            ['person-retry'],
+        );
 
         await startProcessing();
-        // Fail every in-flight first attempt (a transient backend outage).
-        for (const request of pending.splice(0, pending.length)) {
-            request.reject(new Error('backend down'));
-        }
-        await vi.advanceTimersByTimeAsync(5);
+        expect(plugin).toHaveBeenCalledTimes(1);
         expect(document.querySelectorAll('.jc-people-age-container')).toHaveLength(0);
 
-        // The backend recovers and the cast re-renders (fresh elements, same
-        // ids) on the SAME item. Because the ids were released, not finalized,
-        // the replacement cards re-fetch and tag.
-        document.querySelector('#castCollapsible')!.innerHTML = castIds.map(personCardHtml).join('');
-        fireObserver(observerCallbacks[observerCallbacks.length - 1]);
+        // A relevant duplicate mounting during backoff joins the pending
+        // attempt instead of creating a parallel observer-owned retry chain.
+        document.querySelector('#guestCastCollapsible')!.insertAdjacentHTML(
+            'beforeend',
+            personCardHtml('person-retry'),
+        );
+        const addedCard = Array.from(document.querySelectorAll<HTMLElement>('.personCard')).at(-1)!;
+        fireObserver(observerCallbacks[observerCallbacks.length - 1], addedCard);
+        await vi.advanceTimersByTimeAsync(100);
+        expect(plugin).toHaveBeenCalledTimes(1);
+
+        // Recovery is automatic, and every duplicate shares the single
+        // request made by the backoff attempt.
+        await vi.advanceTimersByTimeAsync(RETRY_DELAYS_MS[0] - 100 - 1);
+        expect(plugin).toHaveBeenCalledTimes(1);
+        await vi.advanceTimersByTimeAsync(1);
+        await vi.advanceTimersByTimeAsync(5);
+
+        expect(plugin).toHaveBeenCalledTimes(2);
+        for (const card of document.querySelectorAll<HTMLElement>('.personCard')) {
+            expect(card.querySelector('.jc-people-age-container')).not.toBeNull();
+            expect(card.querySelector('.jc-people-place-banner')).not.toBeNull();
+        }
+    });
+
+    it('R9: disabling while a retry waits prevents every later call and render', async () => {
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        let attempt = 0;
+        const plugin = vi.fn(() => {
+            attempt += 1;
+            if (attempt === 1) return Promise.reject(new Error('backend down'));
+            return Promise.resolve({
+                currentAge: 40,
+                birthPlace: 'Perth, Australia',
+            });
+        });
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        mountCastPage(
+            'item-disable-retry-wait',
+            ['person-disable-retry', 'person-disable-retry'],
+            ['person-disable-retry'],
+        );
+
+        surface.initializePeopleTags!();
+        await vi.advanceTimersByTimeAsync(100);
+        expect(plugin).toHaveBeenCalledTimes(1);
+        expect(document.querySelectorAll('.jc-people-age-container')).toHaveLength(0);
+
+        // The first failure has armed a retry whose backend result would now
+        // succeed. Disable before its boundary and let every ladder delay pass:
+        // the stale timer must retire its owner without issuing or projecting.
+        JC.currentSettings = { peopleTagsEnabled: false };
+        await vi.advanceTimersByTimeAsync(
+            RETRY_DELAYS_MS.reduce((total, delay) => total + delay, 0) + 10_000,
+        );
+
+        expect(plugin).toHaveBeenCalledTimes(1);
+        expect(document.querySelectorAll('.jc-people-age-container')).toHaveLength(0);
+        expect(document.querySelectorAll('.jc-people-place-banner')).toHaveLength(0);
+    });
+
+    it('R9: disabling during an in-flight lookup rejects its later render and retry work', async () => {
+        const { plugin, pending } = instrumentedPlugin();
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        mountCastPage(
+            'item-disable-inflight',
+            ['person-disable-inflight', 'person-disable-inflight'],
+            ['person-disable-inflight'],
+        );
+
+        surface.initializePeopleTags!();
+        await vi.advanceTimersByTimeAsync(100);
+        expect(plugin).toHaveBeenCalledTimes(1);
+        expect(pending).toHaveLength(1);
+
+        JC.currentSettings = { peopleTagsEnabled: false };
+        pending.shift()!.resolve({
+            currentAge: 40,
+            birthPlace: 'Perth, Australia',
+            isDeceased: true,
+        });
+        await vi.advanceTimersByTimeAsync(5);
+        await vi.advanceTimersByTimeAsync(
+            RETRY_DELAYS_MS.reduce((total, delay) => total + delay, 0) + 10_000,
+        );
+
+        expect(plugin).toHaveBeenCalledTimes(1);
+        expect(document.querySelectorAll('.jc-people-age-container')).toHaveLength(0);
+        expect(document.querySelectorAll('.jc-people-place-banner')).toHaveLength(0);
+        expect(document.querySelectorAll('.jc-deceased-poster')).toHaveLength(0);
+        expect(localStorage.getItem(CACHE_KEY)).toBeNull();
+    });
+
+    it('AC3/R9: in-flight additions coalesce into each counted retry at exact ladder boundaries', async () => {
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        seedOwnedCache({});
+        const { plugin, pending } = instrumentedPlugin();
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        mountCastPage(
+            'item-retry-inflight',
+            ['person-retry-inflight', 'person-retry-inflight'],
+            ['person-retry-inflight'],
+        );
+
+        await startProcessing();
+        expect(plugin).toHaveBeenCalledTimes(1);
+
+        // Hold and fail the initial request plus the first three retries. A
+        // new owned duplicate mounts while EACH failing request is in flight.
+        // It must join the next scheduled fanout; it must never drain the
+        // remembered rerun immediately or create an uncounted parallel call.
+        for (let index = 0; index < RETRY_DELAYS_MS.length; index += 1) {
+            document.querySelector('#guestCastCollapsible')!.insertAdjacentHTML(
+                'beforeend',
+                personCardHtml('person-retry-inflight'),
+            );
+            const addedCard = Array.from(document.querySelectorAll<HTMLElement>('.personCard')).at(-1)!;
+            fireObserver(observerCallbacks[observerCallbacks.length - 1], addedCard);
+            await vi.advanceTimersByTimeAsync(100);
+
+            expect(plugin).toHaveBeenCalledTimes(index + 1);
+            const failingRequest = pending.shift();
+            expect(failingRequest).toBeDefined();
+            failingRequest!.reject(new Error(`backend down ${index}`));
+            await vi.advanceTimersByTimeAsync(0);
+
+            // No immediate rerun: the next request starts on, and only on,
+            // this ladder entry's exact boundary.
+            expect(plugin).toHaveBeenCalledTimes(index + 1);
+            await vi.advanceTimersByTimeAsync(RETRY_DELAYS_MS[index] - 1);
+            expect(plugin).toHaveBeenCalledTimes(index + 1);
+            await vi.advanceTimersByTimeAsync(1);
+            expect(plugin).toHaveBeenCalledTimes(index + 2);
+        }
+
+        // The fourth counted retry recovers. Every duplicate collected across
+        // the failed in-flight waves receives the one grouped result.
+        expect(plugin).toHaveBeenCalledTimes(1 + RETRY_DELAYS_MS.length);
+        const recovery = pending.shift();
+        expect(recovery).toBeDefined();
+        recovery!.resolve({ currentAge: 40, birthPlace: 'Perth, Australia' });
+        await vi.advanceTimersByTimeAsync(5);
+
+        expect(pending).toHaveLength(0);
+        expect(document.querySelectorAll('.personCard')).toHaveLength(7);
+        expect(document.querySelectorAll('.jc-people-age-container')).toHaveLength(7);
+        expect(document.querySelectorAll('.jc-people-place-banner')).toHaveLength(7);
+    });
+
+    it('AC3/R9: hidden time consumes neither retry calls nor retry-attempt budget', async () => {
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        let hidden = false;
+        vi.spyOn(document, 'visibilityState', 'get').mockImplementation(
+            () => (hidden ? 'hidden' : 'visible'),
+        );
+        const plugin = vi.fn(() => Promise.reject(new Error('backend down')));
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        mountCastPage('item-retry-hidden', ['person-retry-hidden', 'person-retry-hidden']);
+
+        await startProcessing();
+        expect(plugin).toHaveBeenCalledTimes(1);
+
+        for (let index = 0; index < RETRY_DELAYS_MS.length; index += 1) {
+            hidden = true;
+            document.dispatchEvent(new Event('visibilitychange'));
+            await vi.advanceTimersByTimeAsync(50_000);
+            expect(plugin).toHaveBeenCalledTimes(index + 1);
+
+            hidden = false;
+            document.dispatchEvent(new Event('visibilitychange'));
+            await vi.advanceTimersByTimeAsync(RETRY_DELAYS_MS[index] - 1);
+            expect(plugin).toHaveBeenCalledTimes(index + 1);
+            await vi.advanceTimersByTimeAsync(1);
+            expect(plugin).toHaveBeenCalledTimes(index + 2);
+        }
+
+        // The same four-entry ladder is exhausted after visibility-resumed
+        // attempts; hidden intervals did not burn entries or spawn requests.
+        await vi.advanceTimersByTimeAsync(10_000);
+        expect(plugin).toHaveBeenCalledTimes(1 + RETRY_DELAYS_MS.length);
+    });
+
+    it('AC3/R9: persistent failure exhausts one bounded ladder and a future relevant mutation recovers', async () => {
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        seedOwnedCache({});
+        let backendHealthy = false;
+        const plugin = vi.fn(() => {
+            if (!backendHealthy) return Promise.reject(new Error('backend down'));
+            return Promise.resolve({ currentAge: 41, birthPlace: 'Perth, Australia' });
+        });
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        mountCastPage(
+            'item-retry-cap',
+            ['person-retry-cap', 'person-retry-cap'],
+            ['person-retry-cap'],
+        );
+
+        await startProcessing();
+        await vi.advanceTimersByTimeAsync(
+            RETRY_DELAYS_MS.reduce((total, delay) => total + delay, 0) + 5,
+        );
+
+        // One initial lookup plus four retries, with duplicates still grouped.
+        expect(plugin).toHaveBeenCalledTimes(1 + RETRY_DELAYS_MS.length);
+        expect(document.querySelectorAll('.jc-people-age-container')).toHaveLength(0);
+        await vi.advanceTimersByTimeAsync(10_000);
+        expect(plugin).toHaveBeenCalledTimes(1 + RETRY_DELAYS_MS.length);
+
+        // Exhaustion is not permanent poison. A later relevant occurrence
+        // starts fresh and fans one recovered lookup out to every live card.
+        backendHealthy = true;
+        document.querySelector('#guestCastCollapsible')!.insertAdjacentHTML(
+            'beforeend',
+            personCardHtml('person-retry-cap'),
+        );
+        const addedCard = Array.from(document.querySelectorAll<HTMLElement>('.personCard')).at(-1)!;
+        fireObserver(observerCallbacks[observerCallbacks.length - 1], addedCard);
         await vi.advanceTimersByTimeAsync(100);
         await vi.advanceTimersByTimeAsync(5);
 
-        for (const id of castIds) {
-            expect(cardFor(id).querySelector('.jc-people-age-container')).not.toBeNull();
+        expect(plugin).toHaveBeenCalledTimes(2 + RETRY_DELAYS_MS.length);
+        expect(document.querySelectorAll('.jc-people-age-container')).toHaveLength(4);
+        expect(document.querySelectorAll('.jc-people-place-banner')).toHaveLength(4);
+    });
+
+    it('AC3/R9: same-identity navigation cancels the outgoing page retry ladder', async () => {
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const plugin = vi.fn((path: string) => {
+            if (path.includes('person-retry-nav-a')) return Promise.reject(new Error('backend down'));
+            return Promise.resolve({ currentAge: 42 });
+        });
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        mountCastPage('item-retry-nav-a', ['person-retry-nav-a', 'person-retry-nav-a']);
+
+        await startProcessing();
+        expect(plugin).toHaveBeenCalledTimes(1);
+
+        mountCastPage('item-retry-nav-b', ['person-retry-nav-b']);
+        const currentCard = cardFor('person-retry-nav-b');
+        fireObserver(observerCallbacks[observerCallbacks.length - 1], currentCard);
+        await vi.advanceTimersByTimeAsync(100);
+        await vi.advanceTimersByTimeAsync(5);
+        await vi.advanceTimersByTimeAsync(10_000);
+
+        const paths = plugin.mock.calls.map((call) => String(call[0]));
+        expect(paths.filter((path) => path.includes('person-retry-nav-a'))).toHaveLength(1);
+        expect(paths.filter((path) => path.includes('person-retry-nav-b'))).toHaveLength(1);
+        expect(currentCard.querySelector('.jc-people-age-container')).not.toBeNull();
+    });
+
+    it('AC3/R9: details-to-non-details navigation releases a hidden retry owner before a fresh ladder', async () => {
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        let hidden = false;
+        vi.spyOn(document, 'visibilityState', 'get').mockImplementation(
+            () => (hidden ? 'hidden' : 'visible'),
+        );
+        const addListener = vi.spyOn(document, 'addEventListener');
+        const removeListener = vi.spyOn(document, 'removeEventListener');
+        const plugin = vi.fn((path: string) => {
+            if (path.includes('person-retry-null-a')) return Promise.reject(new Error('backend down'));
+            return Promise.resolve({ currentAge: 42 });
+        });
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        mountCastPage('item-retry-null-a', ['person-retry-null-a']);
+
+        await startProcessing();
+        expect(plugin).toHaveBeenCalledTimes(1);
+        const visibilityHandler = addListener.mock.calls.find(
+            ([name]) => name === 'visibilitychange',
+        )?.[1];
+        expect(visibilityHandler).toBeDefined();
+
+        hidden = true;
+        document.dispatchEvent(new Event('visibilitychange'));
+        window.location.hash = '#/home';
+        document.body.innerHTML = '<main id="home-page"></main>';
+        fireObserver(observerCallbacks[observerCallbacks.length - 1], document.querySelector('#home-page')!);
+
+        expect(removeListener).toHaveBeenCalledWith('visibilitychange', visibilityHandler);
+        hidden = false;
+        document.dispatchEvent(new Event('visibilitychange'));
+        await vi.advanceTimersByTimeAsync(10_000);
+        expect(plugin).toHaveBeenCalledTimes(1);
+
+        // A later details item owns a fresh ladder. No callback retained from
+        // the null-route page may wake the exhausted/outgoing scope.
+        mountCastPage('item-retry-null-b', ['person-retry-null-b']);
+        const freshCard = cardFor('person-retry-null-b');
+        fireObserver(observerCallbacks[observerCallbacks.length - 1], freshCard);
+        await vi.advanceTimersByTimeAsync(100);
+        await vi.advanceTimersByTimeAsync(5);
+
+        const paths = plugin.mock.calls.map((call) => String(call[0]));
+        expect(paths.filter((path) => path.includes('person-retry-null-a'))).toHaveLength(1);
+        expect(paths.filter((path) => path.includes('person-retry-null-b'))).toHaveLength(1);
+        expect(freshCard.querySelector('.jc-people-age-container')).not.toBeNull();
+    });
+
+    it('AC3/R9: identity teardown cancels every pending retry attempt', async () => {
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        let hidden = false;
+        vi.spyOn(document, 'visibilityState', 'get').mockImplementation(
+            () => (hidden ? 'hidden' : 'visible'),
+        );
+        const addListener = vi.spyOn(document, 'addEventListener');
+        const removeListener = vi.spyOn(document, 'removeEventListener');
+        const plugin = vi.fn(() => Promise.reject(new Error('backend down')));
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        mountCastPage('item-retry-identity', ['person-retry-identity']);
+
+        await startProcessing();
+        expect(plugin).toHaveBeenCalledTimes(1);
+        const visibilityHandler = addListener.mock.calls.find(
+            ([name]) => name === 'visibilitychange',
+        )?.[1];
+        expect(visibilityHandler).toBeDefined();
+
+        hidden = true;
+        document.dispatchEvent(new Event('visibilitychange'));
+
+        JC.identity.transition('people-retry-server-b', 'people-retry-user-b', 'people-retry-switch');
+        await vi.advanceTimersByTimeAsync(10_000);
+
+        expect(plugin).toHaveBeenCalledTimes(1);
+        expect(removeListener).toHaveBeenCalledWith('visibilitychange', visibilityHandler);
+        expect(document.querySelectorAll('.jc-people-age-container')).toHaveLength(0);
+    });
+
+    it('AC3: a partial person-card shell renders from hot data when its scalable anchor mounts', async () => {
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const { plugin } = instrumentedPlugin(() => ({
+            currentAge: 43,
+            birthPlace: 'Perth, Australia',
+        }));
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        window.location.hash = '#/details?id=item-partial-shell';
+        document.body.innerHTML = `
+            <div id="itemDetailPage">
+                <div id="castCollapsible">
+                    <div class="personCard" data-id="person-partial-shell"></div>
+                </div>
+                <div id="guestCastCollapsible"></div>
+            </div>`;
+        recordDetailsViewShown(document.querySelector('#itemDetailPage'));
+        const card = cardFor('person-partial-shell');
+
+        await startProcessing();
+        await vi.advanceTimersByTimeAsync(5);
+        expect(plugin).toHaveBeenCalledTimes(1);
+        expect(card.querySelector('.jc-people-age-container')).toBeNull();
+        await vi.advanceTimersByTimeAsync(2100);
+
+        const shell = document.createElement('div');
+        shell.innerHTML = '<div class="cardScalable"></div>';
+        card.appendChild(shell);
+        fireObserver(observerCallbacks[observerCallbacks.length - 1], shell);
+        await vi.advanceTimersByTimeAsync(100);
+        await vi.advanceTimersByTimeAsync(5);
+
+        expect(plugin).toHaveBeenCalledTimes(1);
+        expect(card.querySelectorAll('.jc-people-age-container')).toHaveLength(1);
+        expect(card.querySelectorAll('.jc-people-place-banner')).toHaveLength(1);
+        const ageTag = card.querySelector('.jc-people-age-container');
+        const placeTag = card.querySelector('.jc-people-place-banner');
+
+        // Observer records caused by People Tags' own overlay appends are not
+        // structural shell additions and must not re-project the hot result.
+        fireObserver(observerCallbacks[observerCallbacks.length - 1], ageTag!);
+        fireObserver(observerCallbacks[observerCallbacks.length - 1], placeTag!);
+        await vi.advanceTimersByTimeAsync(500);
+        expect(plugin).toHaveBeenCalledTimes(1);
+        expect(card.querySelector('.jc-people-age-container')).toBe(ageTag);
+        expect(card.querySelector('.jc-people-place-banner')).toBe(placeTag);
+    });
+
+    it('AC3/R8: a direct scalable-anchor addition is detected inside the owned card', async () => {
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const { plugin } = instrumentedPlugin(() => ({
+            currentAge: 43,
+            birthPlace: 'Perth, Australia',
+        }));
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        window.location.hash = '#/details?id=item-direct-anchor';
+        document.body.innerHTML = `
+            <div id="itemDetailPage">
+                <div id="castCollapsible">
+                    <div class="personCard" data-id="person-direct-anchor"></div>
+                </div>
+                <div id="guestCastCollapsible"></div>
+            </div>`;
+        recordDetailsViewShown(document.querySelector('#itemDetailPage'));
+        const card = cardFor('person-direct-anchor');
+
+        await startProcessing();
+        await vi.advanceTimersByTimeAsync(5);
+        await vi.advanceTimersByTimeAsync(2100);
+        expect(plugin).toHaveBeenCalledTimes(1);
+        expect(card.querySelector('.jc-people-age-container')).toBeNull();
+
+        const anchor = document.createElement('div');
+        anchor.className = 'cardScalable';
+        card.appendChild(anchor);
+        fireObserver(observerCallbacks[observerCallbacks.length - 1], anchor);
+        await vi.advanceTimersByTimeAsync(100);
+        await vi.advanceTimersByTimeAsync(5);
+
+        expect(plugin).toHaveBeenCalledTimes(1);
+        expect(card.querySelectorAll('.jc-people-age-container')).toHaveLength(1);
+        expect(card.querySelectorAll('.jc-people-place-banner')).toHaveLength(1);
+    });
+
+    it('AC3/R8: owned descendant traversal yields after the two-millisecond batch budget', async () => {
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const { plugin } = instrumentedPlugin(() => ({ currentAge: 43 }));
+        JC.core.api = { plugin } as unknown as typeof JC.core.api;
+        window.location.hash = '#/details?id=item-budget-anchor';
+        document.body.innerHTML = `
+            <div id="itemDetailPage">
+                <div id="castCollapsible">
+                    <div class="personCard" data-id="person-budget-anchor"></div>
+                </div>
+                <div id="guestCastCollapsible"></div>
+            </div>`;
+        recordDetailsViewShown(document.querySelector('#itemDetailPage'));
+        const card = cardFor('person-budget-anchor');
+
+        await startProcessing();
+        await vi.advanceTimersByTimeAsync(5);
+        await vi.advanceTimersByTimeAsync(2100);
+        expect(card.querySelector('.jc-people-age-container')).toBeNull();
+
+        const shell = document.createElement('div');
+        let parent = shell;
+        for (let index = 0; index < 20; index += 1) {
+            const child = document.createElement('div');
+            parent.appendChild(child);
+            parent = child;
         }
-        // Two failed first attempts + two successful re-fetches.
-        expect(plugin).toHaveBeenCalledTimes(4);
+        parent.className = 'cardScalable';
+        card.appendChild(shell);
+
+        let clock = 0;
+        const performanceNow = vi.spyOn(performance, 'now').mockImplementation(() => {
+            clock += 1;
+            return clock;
+        });
+        fireObserver(observerCallbacks[observerCallbacks.length - 1], shell);
+
+        // The deep anchor is not reached in the observer callback. A zero-delay
+        // continuation owns the remaining traversal instead of letting one
+        // body mutation monopolise the main thread.
+        expect(performanceNow).toHaveBeenCalled();
+        expect(card.querySelector('.jc-people-age-container')).toBeNull();
+        expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+        await vi.advanceTimersByTimeAsync(250);
+        expect(plugin).toHaveBeenCalledTimes(1);
+        expect(card.querySelectorAll('.jc-people-age-container')).toHaveLength(1);
     });
 
     it('AC4: a completion timer does not preempt a guest section still queued in the debounce', async () => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/tags/peopletags.ts
@@ -70,6 +70,21 @@ const JC = JEBase as typeof JEBase & {
 export const PEOPLE_TAGS_CONCURRENCY = 6;
 
 /**
+ * PERF(R9/#361): one bounded, item/page-owned retry ladder for transient
+ * person lookups. Four retries after the initial attempt cover short backend
+ * stalls without turning a persistent outage into an unbounded request loop.
+ */
+const PEOPLE_TAGS_RETRY_DELAYS_MS = [250, 500, 1000, 2000] as const;
+
+/**
+ * PERF(R8/#361): body-observer work may inspect descendants only after an
+ * added node is structurally proven to intersect the owned cast surfaces.
+ * Traversal then yields after this small synchronous budget and resumes from
+ * the same cursor asynchronously, keeping large React mounts off one frame.
+ */
+const PEOPLE_TAGS_OBSERVER_SCAN_BUDGET_MS = 2;
+
+/**
  * PERF(#359) GLOBAL request budget. The per-batch worker pool caps concurrency
  * WITHIN one generation, but a same-identity reinitialization (a supported
  * settings restart) starts a fresh pool while the retired generation's requests
@@ -172,12 +187,19 @@ function initializePeopleTags(): void {
     const context = JC.identity.capture();
     if (!context || !JC.identity.isCurrent(context)) return;
     // Capture THIS initializer's generation (teardown above already bumped the
-    // counter). isCurrent() now means "this closure is still the live one AND
-    // the identity is unchanged" — a later initialize/teardown makes the first
-    // conjunct false, retiring every guard downstream without a per-call edit.
+    // counter). generationIsCurrent() means "this closure is still the live
+    // one AND the identity is unchanged" — a later initialize/teardown makes
+    // the first conjunct false, retiring every guard downstream without a
+    // per-call edit.
     const myGeneration = peopleTagsGeneration;
-    const isCurrent = (): boolean =>
+    const generationIsCurrent = (): boolean =>
         peopleTagsGeneration === myGeneration && JC.identity.isCurrent(context);
+    // User settings can disable this feature without changing identity or
+    // generation. Treat that as an immediate work fence so waiting retries,
+    // semaphore waiters, in-flight results and render commits cannot outlive
+    // the visible toggle state.
+    const isCurrent = (): boolean =>
+        generationIsCurrent() && JC.currentSettings?.peopleTagsEnabled === true;
     const timers = new Set<number>();
     let observerHandle: { disconnect?: () => void; unsubscribe?: () => void } | null = null;
 
@@ -190,7 +212,11 @@ function initializePeopleTags(): void {
     const schedule = (fn: () => void, delay: number): number => {
         const timer = window.setTimeout(() => {
             timers.delete(timer);
-            if (isCurrent()) fn();
+            // Generation ownership, rather than feature eligibility, decides
+            // whether the callback may run: a timer whose feature was disabled
+            // still needs to clear its retry/debounce bookkeeping, but every
+            // work path below rechecks isCurrent() before fetching or rendering.
+            if (generationIsCurrent()) fn();
         }, delay);
         timers.add(timer);
         return timer;
@@ -275,7 +301,6 @@ function initializePeopleTags(): void {
     Hot.peopleTags = hotPeopleTags;
 
     let processedCastMembers = new WeakSet<Element>();
-    let processedPersonIds = new Set<string>();
     let lastProcessedItemId: string | null = null;
     let peopleTagsComplete = false; // Set true after all cast members tagged for current item
     let isProcessing = false;
@@ -286,7 +311,57 @@ function initializePeopleTags(): void {
     // stays untagged after a stale batch exits.
     let rerunRequested = false;
 
+    // PERF(R9/#361): a SINGLE retry ladder belongs to one concrete visible
+    // page + item under this initializer's captured identity/generation.
+    // `retryAttempts` counts automatic retries that actually STARTED while
+    // visible (the initial observer-driven request is not part of the four-
+    // entry delay table). A hidden tab owns no timer and consumes no entry.
+    let retryTimer: number | null = null;
+    let retryPage: HTMLElement | null = null;
+    let retryItemId: string | null = null;
+    let retryAttempts = 0;
+    let retryWaiting = false;
+    let retryVisibilityListener: (() => void) | null = null;
+    // Installed by initialize() once its observer scan cursor exists. Cleanup
+    // invokes the hook so no deferred traversal retains an old page/generation.
+    let cancelPendingObserverScan: (() => void) | null = null;
+
+    const retryScopeMatches = (page: HTMLElement, itemId: string): boolean =>
+        retryPage === page && retryItemId === itemId;
+
+    const pageScopeIsCurrent = (page: HTMLElement, itemId: string): boolean => {
+        if (!isCurrent()) return false;
+        const visible = getVisibleDetailsPage();
+        return visible !== null && visible.page === page && visible.itemId === itemId;
+    };
+
+    const clearRetryTimer = (): void => {
+        if (retryTimer !== null) {
+            clearTimeout(retryTimer);
+            timers.delete(retryTimer);
+        }
+        retryTimer = null;
+    };
+
+    const removeRetryVisibilityListener = (): void => {
+        if (retryVisibilityListener === null) return;
+        document.removeEventListener('visibilitychange', retryVisibilityListener);
+        retryVisibilityListener = null;
+    };
+
+    const resetRetryLadder = (): void => {
+        clearRetryTimer();
+        removeRetryVisibilityListener();
+        retryPage = null;
+        retryItemId = null;
+        retryAttempts = 0;
+        retryWaiting = false;
+    };
+
     activePeopleTagsCleanup = (clearPersistent) => {
+        cancelPendingObserverScan?.();
+        cancelPendingObserverScan = null;
+        resetRetryLadder();
         for (const timer of timers) clearTimeout(timer);
         timers.clear();
         if (observerHandle?.unsubscribe) observerHandle.unsubscribe();
@@ -388,9 +463,10 @@ function initializePeopleTags(): void {
      * map per person (that was O(N^2) main-thread JSON work across a cast).
      * `cacheChanged` tells the batch owner (processCastMembers) that one
      * settled-batch flush is required. `failed` distinguishes a TRANSIENT
-     * backend/network error (retryable — the id must NOT be finalized) from a
-     * genuine empty response (definitive — safe to finalize); only the fetch
-     * itself is gated by the global request budget so cache hits stay free.
+     * backend/network error (retryable — concrete cards remain unprocessed)
+     * from a genuine empty response (definitive — cards may be completed);
+     * only the fetch itself is gated by the global request budget so cache
+     * hits stay free.
      * @param personId
      * @param itemId (optional, for calculating age at release)
      */
@@ -428,6 +504,9 @@ function initializePeopleTags(): void {
         // batch has been retired mid-flight.
         await peopleTagsRequestGate.acquire();
         try {
+            // The setting or identity may have changed while this worker was
+            // queued behind another generation's global request permits.
+            if (!isCurrent()) return { data: null, cacheChanged: false, failed: false };
             const queryString = itemId ? `?itemId=${encodeURIComponent(itemId)}` : '';
             const data = await JC.core.api.plugin(`/person/${encodeURIComponent(personId)}${queryString}`, {
                 cacheKey: `people-tags:${cacheKey}`,
@@ -447,8 +526,8 @@ function initializePeopleTags(): void {
             return { data: null, cacheChanged: false, failed: false };
         } catch (error) {
             if (isCurrent()) console.warn(`${logPrefix} Failed to fetch person info for ${personId}:`, error);
-            // Transient failure — leave the id un-finalized so a later pass can
-            // recover it once the backend is healthy.
+            // Transient failure — let the projection owner leave every card
+            // unprocessed so a later pass can recover once the backend is healthy.
             return { data: null, cacheChanged: false, failed: true };
         } finally {
             peopleTagsRequestGate.release();
@@ -591,7 +670,7 @@ function initializePeopleTags(): void {
     }
 
     interface PersonCardTask {
-        card: HTMLElement;
+        cards: HTMLElement[];
         personId: string;
     }
 
@@ -599,23 +678,22 @@ function initializePeopleTags(): void {
      * Synchronously collect the unprocessed person-card tasks of one
      * cast/guest cast collapsible section within the OWNED visible page.
      *
-     * PERF(#359) dedup is two-tier so a card REPLACED mid-batch is never lost:
-     *  - `processedPersonIds` holds ids whose overlay already landed on a live
-     *    card in a PRIOR pass — never re-fetch those.
-     *  - `claimedIds` (batch-local) holds ids claimed by THIS collection so the
-     *    same person is fetched once even when it appears in both sections.
-     * An id is promoted into `processedPersonIds` ONLY once its overlay lands
-     * on a connected card (see the worker in processCastMembers). Eagerly
-     * marking ids processed here — as the first pass did — permanently starved
-     * every replacement card when React re-rendered the cast mid-batch.
+     * PERF(#359/#361) fetch dedup and render completion have different owners:
+     *  - `claimedTasks` groups every unprocessed card occurrence by person id,
+     *    so the batch performs one lookup even when the same person appears
+     *    repeatedly within cast or across cast/guest sections.
+     *  - `processedCastMembers` records completion per concrete card only after
+     *    a definitive result is applied. A later duplicate or React replacement
+     *    therefore reuses the hot/persistent person result and still receives
+     *    its own overlay instead of being skipped by a person-id render gate.
      * @param page - The owned visible details page to search within.
      * @param collapsibleSelector - CSS selector for the collapsible (e.g., '#castCollapsible' or '#guestCastCollapsible')
-     * @param claimedIds - Ids already claimed by this batch's collection.
+     * @param claimedTasks - Unique lookup tasks already claimed by this batch.
      */
     function collectSectionTasks(
         page: HTMLElement,
         collapsibleSelector: string,
-        claimedIds: Set<string>,
+        claimedTasks: Map<string, PersonCardTask>,
     ): PersonCardTask[] {
         const tasks: PersonCardTask[] = [];
         const collapsible = page.querySelector(collapsibleSelector);
@@ -628,18 +706,19 @@ function initializePeopleTags(): void {
 
         for (const card of castCards) {
             if (processedCastMembers.has(card)) continue;
-            processedCastMembers.add(card);
 
             const personId = card.getAttribute('data-id');
             if (!personId) continue;
 
-            // Already applied to a live card in a prior pass, or already
-            // claimed by this batch — either way, do not enqueue it again.
-            if (processedPersonIds.has(personId)) continue;
-            if (claimedIds.has(personId)) continue;
+            const claimed = claimedTasks.get(personId);
+            if (claimed) {
+                claimed.cards.push(card);
+                continue;
+            }
 
-            claimedIds.add(personId);
-            tasks.push({ card, personId });
+            const task = { cards: [card], personId };
+            claimedTasks.set(personId, task);
+            tasks.push(task);
         }
         return tasks;
     }
@@ -662,76 +741,85 @@ function initializePeopleTags(): void {
     interface PersonCardOutcome {
         /** Whether the lookup changed the persistent cache state. */
         cacheChanged: boolean;
-        /**
-         * Whether the person id may be finalized in `processedPersonIds`. True
-         * once a definitive attempt reached a LIVE card under the current batch
-         * (rendered, or the person genuinely had no data). False when the
-         * result was DROPPED because the target card disconnected, the page
-         * moved on, OR the fetch failed transiently — releasing the id so a
-         * remembered rerun (or a replacement card) re-attempts it instead of
-         * skipping it forever.
-         */
-        committed: boolean;
+        /** Whether every still-unprocessed occurrence needs a bounded retry. */
+        transientFailure: boolean;
     }
 
     /**
-     * Fetch and render one person card's overlays. Result application is
-     * guarded by the batch currency (identity + owned page/item) and card
-     * connectivity — a stale navigation mid-flight applies NO tags to the new
-     * page and does NOT commit the person id.
+     * Fetch one person's data and project it onto every matching card collected
+     * for this batch. Each application independently preserves the identity,
+     * owned-page, item, and connectivity guards; only a concrete card that
+     * receives a definitive current result is marked complete.
      */
-    async function processPersonCard(
+    async function processPersonCards(
         task: PersonCardTask,
         currentItemId: string,
         batchIsCurrent: () => boolean,
     ): Promise<PersonCardOutcome> {
-        const { card, personId } = task;
+        const { cards, personId } = task;
         try {
             const { data: personData, cacheChanged, failed } = await getPersonInfo(personId, currentItemId);
-            if (!batchIsCurrent() || !card.isConnected) return { cacheChanged, committed: false };
+            if (!batchIsCurrent()) return { cacheChanged, transientFailure: false };
             // A transient fetch failure is NOT a definitive no-data result:
-            // release the id (committed:false) so a remembered rerun or a
-            // replacement card re-attempts it once the backend recovers.
-            if (failed) return { cacheChanged, committed: false };
-            if (!personData) return { cacheChanged, committed: true };
+            // keep every concrete card unprocessed so a remembered observer
+            // pass can retry the same live elements after recovery.
+            if (failed) return { cacheChanged, transientFailure: true };
 
-            // Apply deceased styling to poster if applicable
-            if (personData.isDeceased) {
-                card.classList.add('jc-deceased-poster');
-                console.debug(`${logPrefix} Marked ${personId} as deceased`);
-            }
+            for (const card of cards) {
+                if (!batchIsCurrent()) break;
+                if (!card.isConnected) continue;
 
-            // Find the cardScalable element (image container with position: relative)
-            const cardScalable = card.querySelector('.cardScalable');
-            if (!cardScalable) {
-                console.warn(`${logPrefix} No cardScalable found for ${personId}`);
-                return { cacheChanged, committed: true };
-            }
+                // A genuine no-data result is definitive for this occurrence.
+                if (!personData) {
+                    processedCastMembers.add(card);
+                    continue;
+                }
 
-            // Remove existing tags if any
-            const existingAgeContainer = cardScalable.querySelector('.jc-people-age-container');
-            if (existingAgeContainer) {
-                existingAgeContainer.remove();
-            }
-            const existingPlaceBanner = cardScalable.querySelector('.jc-people-place-banner');
-            if (existingPlaceBanner) {
-                existingPlaceBanner.remove();
-            }
+                try {
+                    // Apply deceased styling to poster if applicable.
+                    if (personData.isDeceased) {
+                        card.classList.add('jc-deceased-poster');
+                        console.debug(`${logPrefix} Marked ${personId} as deceased`);
+                    }
 
-            // Create and append age chips (top-left) and place banner (bottom)
-            const tags = createPeopleTag(personData);
-            if (!batchIsCurrent() || !cardScalable.isConnected) return { cacheChanged, committed: false };
-            if (tags.ageContainer.children.length > 0) {
-                cardScalable.appendChild(tags.ageContainer);
+                    // Find the image container with position: relative.
+                    const cardScalable = card.querySelector('.cardScalable');
+                    if (!cardScalable) {
+                        console.warn(`${logPrefix} No cardScalable found for ${personId}`);
+                        // React may have mounted the person-card shell before
+                        // its scalable image anchor. This data-bearing card is
+                        // NOT complete; a relevant descendant mutation will
+                        // re-project the hot result once the anchor exists.
+                        continue;
+                    }
+
+                    // Remove existing tags if any.
+                    cardScalable.querySelector('.jc-people-age-container')?.remove();
+                    cardScalable.querySelector('.jc-people-place-banner')?.remove();
+
+                    // Create and append age chips (top-left) and place banner (bottom).
+                    const tags = createPeopleTag(personData);
+                    if (!batchIsCurrent() || !cardScalable.isConnected) continue;
+                    if (tags.ageContainer.children.length > 0) {
+                        cardScalable.appendChild(tags.ageContainer);
+                    }
+                    if (tags.placeContainer.children.length > 0) {
+                        cardScalable.appendChild(tags.placeContainer);
+                    }
+                    processedCastMembers.add(card);
+                } catch (error) {
+                    console.warn(`${logPrefix} Error projecting cast member ${personId}:`, error);
+                }
             }
-            if (tags.placeContainer.children.length > 0) {
-                cardScalable.appendChild(tags.placeContainer);
-            }
-            return { cacheChanged, committed: true };
+            return { cacheChanged, transientFailure: false };
         } catch (error) {
             console.warn(`${logPrefix} Error processing cast member ${personId}:`, error);
-            return { cacheChanged: false, committed: false };
+            return { cacheChanged: false, transientFailure: true };
         }
+    }
+
+    interface CastMembersOutcome {
+        transientFailure: boolean;
     }
 
     /**
@@ -744,33 +832,33 @@ function initializePeopleTags(): void {
      * renders individually as its result lands; the persistent cache is
      * flushed once after the whole batch settles.
      */
-    async function processCastMembers(page: HTMLElement, currentItemId: string): Promise<void> {
-        if (!isCurrent() || isProcessing) return;
+    async function processCastMembers(
+        page: HTMLElement,
+        currentItemId: string,
+    ): Promise<CastMembersOutcome> {
+        if (!isCurrent() || isProcessing) return { transientFailure: false };
         isProcessing = true;
+        let transientFailure = false;
 
         try {
-            // Collect both sections synchronously (cast first so duplicate
-            // person ids keep preferring the normal-cast card) from the OWNED
-            // page, then interleave so neither section starves behind the
-            // other. `claimedIds` dedups within the batch without prematurely
-            // finalizing dedup across passes.
-            const claimedIds = new Set<string>();
+            // Collect both sections synchronously from the OWNED page. Cast is
+            // collected first so the first normal-cast occurrence owns a
+            // shared person's task position; every later occurrence joins its
+            // card list. Unique cast/guest tasks are then interleaved so neither
+            // section starves behind the other.
+            const claimedTasks = new Map<string, PersonCardTask>();
             const tasks = interleaveTasks(
-                collectSectionTasks(page, '#castCollapsible', claimedIds),
-                collectSectionTasks(page, '#guestCastCollapsible', claimedIds),
+                collectSectionTasks(page, '#castCollapsible', claimedTasks),
+                collectSectionTasks(page, '#guestCastCollapsible', claimedTasks),
             );
-            if (tasks.length === 0) return;
+            if (tasks.length === 0) return { transientFailure: false };
 
             // The batch is current only while the SAME owned page is still the
             // visible details view for the SAME item. getVisibleDetailsPage()
             // returns null mid-transition (details→details push), so the batch
             // aborts rather than tagging the outgoing view under the incoming
             // item's id.
-            const batchIsCurrent = (): boolean => {
-                if (!isCurrent()) return false;
-                const visible = getVisibleDetailsPage();
-                return visible !== null && visible.page === page && visible.itemId === currentItemId;
-            };
+            const batchIsCurrent = (): boolean => pageScopeIsCurrent(page, currentItemId);
 
             let cacheChanged = false;
             let nextIndex = 0;
@@ -780,15 +868,12 @@ function initializePeopleTags(): void {
                     nextIndex += 1;
                     if (index >= tasks.length) return;
                     const task = tasks[index];
-                    const outcome = await processPersonCard(task, currentItemId, batchIsCurrent);
+                    const outcome = await processPersonCards(task, currentItemId, batchIsCurrent);
                     // Persist if ANY task changed the cache (aggregate-any, not
                     // last-write-wins — a later cache HIT must not erase an
                     // earlier fetch's need to flush).
                     if (outcome.cacheChanged) cacheChanged = true;
-                    // Finalize dedup ONLY after the overlay landed on a live
-                    // card; a dropped (disconnected) card releases its id so a
-                    // remembered rerun requeues the replacement.
-                    if (outcome.committed) processedPersonIds.add(task.personId);
+                    if (outcome.transientFailure) transientFailure = true;
                 }
             };
             const workerCount = Math.min(PEOPLE_TAGS_CONCURRENCY, tasks.length);
@@ -798,10 +883,13 @@ function initializePeopleTags(): void {
             // per person = O(N^2) across a cast).
             if (cacheChanged && isCurrent()) persistPeopleCache();
 
+            return { transientFailure };
+
         } catch (error) {
             if (isCurrent()) console.error(`${logPrefix} Error in processCastMembers:`, error);
+            return { transientFailure: true };
         } finally {
-            if (isCurrent()) isProcessing = false;
+            if (generationIsCurrent()) isProcessing = false;
         }
     }
 
@@ -814,8 +902,103 @@ function initializePeopleTags(): void {
         // Handle item details page display with an identity-owned debounce.
         // A helper-owned timeout cannot be cancelled synchronously on logout.
         let debounceTimer: number | null = null;
-        const runPeopleTags = () => {
-            if (!isCurrent()) return;
+
+        const clearDebounceTimer = (): void => {
+            if (debounceTimer === null) return;
+            clearTimeout(debounceTimer);
+            timers.delete(debounceTimer);
+            debounceTimer = null;
+        };
+
+        const documentIsVisible = (): boolean => document.visibilityState !== 'hidden';
+
+        /** Keep one listener only while a retry ladder owns a page/item. */
+        function ensureRetryVisibilityListener(): void {
+            if (retryVisibilityListener !== null) return;
+            retryVisibilityListener = () => {
+                const page = retryPage;
+                const itemId = retryItemId;
+                if (!page || !itemId || !pageScopeIsCurrent(page, itemId)) {
+                    resetRetryLadder();
+                    return;
+                }
+                if (!documentIsVisible()) {
+                    // Hidden time does not count down a partially elapsed
+                    // backoff. Visibility resumes this SAME entry in full.
+                    clearRetryTimer();
+                    return;
+                }
+                if (retryWaiting && retryTimer === null) armRetryTimer(page, itemId);
+            };
+            document.addEventListener('visibilitychange', retryVisibilityListener);
+        }
+
+        /** Arm the current unconsumed ladder entry, but only while visible. */
+        function armRetryTimer(page: HTMLElement, itemId: string): void {
+            if (!retryWaiting || retryTimer !== null) return;
+            if (!retryScopeMatches(page, itemId) || !pageScopeIsCurrent(page, itemId)) {
+                resetRetryLadder();
+                return;
+            }
+            ensureRetryVisibilityListener();
+            if (!documentIsVisible()) return;
+
+            const delay = PEOPLE_TAGS_RETRY_DELAYS_MS[retryAttempts];
+            retryTimer = schedule(() => {
+                retryTimer = null;
+                if (!retryWaiting || !retryScopeMatches(page, itemId)
+                    || !pageScopeIsCurrent(page, itemId)) {
+                    resetRetryLadder();
+                    return;
+                }
+                // A visibilitychange normally cancels this timer immediately.
+                // Recheck at the boundary for hosts that update visibilityState
+                // before delivering the event; the entry remains unconsumed.
+                if (!documentIsVisible()) return;
+
+                retryWaiting = false;
+                retryAttempts += 1;
+                peopleTagsComplete = false;
+                runPeopleTags();
+            }, delay);
+        }
+
+        /** Arm at most one automatic retry for the current page/item scope. */
+        const scheduleTransientRetry = (page: HTMLElement, itemId: string): void => {
+            if (!pageScopeIsCurrent(page, itemId)) {
+                if (retryScopeMatches(page, itemId)) resetRetryLadder();
+                return;
+            }
+            if (!retryScopeMatches(page, itemId)) {
+                resetRetryLadder();
+                retryPage = page;
+                retryItemId = itemId;
+            }
+            if (retryWaiting) return;
+            if (retryAttempts >= PEOPLE_TAGS_RETRY_DELAYS_MS.length) {
+                clearRetryTimer();
+                retryWaiting = false;
+                removeRetryVisibilityListener();
+                console.warn(`${logPrefix} Transient retry ladder exhausted for item ${itemId}`);
+                // Preserve the exhausted count as the automatic-attempt cap.
+                // Cards remain unprocessed; a future relevant mutation resets
+                // the ladder and can recover after the backend is healthy.
+                return;
+            }
+
+            retryWaiting = true;
+            ensureRetryVisibilityListener();
+            armRetryTimer(page, itemId);
+        };
+
+        function runPeopleTags(): void {
+            if (!isCurrent()) {
+                // A disabled feature may reach here from a timer already queued
+                // by the formerly enabled generation. Retire its strong page
+                // reference and visibility listener without issuing work.
+                if (generationIsCurrent()) resetRetryLadder();
+                return;
+            }
 
             // Resolve the visible details page and its item id as ONE owned
             // pair. getVisibleDetailsPage() returns null mid-transition
@@ -829,20 +1012,27 @@ function initializePeopleTags(): void {
 
             const castSection = page.querySelector('#castCollapsible');
             const guestCastSection = page.querySelector('#guestCastCollapsible');
-            if (!castSection && !guestCastSection) return;
+            if (!castSection && !guestCastSection) {
+                if (retryScopeMatches(page, itemId)) resetRetryLadder();
+                return;
+            }
 
             try {
                 // Reset cache when navigating to a new item
                 if (lastProcessedItemId !== itemId) {
+                    resetRetryLadder();
                     lastProcessedItemId = itemId;
                     processedCastMembers = new WeakSet();
-                    processedPersonIds = new Set();
                     peopleTagsComplete = false;
                     console.debug(`${logPrefix} New item detected: ${itemId}`);
                 }
 
                 // Skip if already fully processed for this item.
                 if (peopleTagsComplete) return;
+                // A queued observer debounce can outlive the failed batch that
+                // created the retry owner. It joins that counted attempt; it
+                // must not start an immediate, uncounted request in parallel.
+                if (retryScopeMatches(page, itemId) && retryWaiting) return;
                 // A batch is already draining: remember that another pass is
                 // owed (a late guest-cast mount, or a navigation to a new item)
                 // and let the settling batch pick it up. Dropping it here is
@@ -858,12 +1048,43 @@ function initializePeopleTags(): void {
                 // completions from previous navigations don't mark the wrong
                 // item as done.
                 const processingItemId = itemId;
-                void processCastMembers(page, itemId).then(() => {
-                    if (!isCurrent()) return;
-                    // A rerun was requested while this batch ran (guest cards
-                    // mounted, or the URL moved to a new item). Drain it now
-                    // instead of scheduling completion, so both sections and
-                    // the current page are always tagged.
+                void processCastMembers(page, itemId).then((outcome) => {
+                    if (!isCurrent()) {
+                        // In-flight requests cannot be forcibly aborted through
+                        // this API seam, but their result and retry owner are
+                        // synchronously fenced once they settle.
+                        if (generationIsCurrent()) resetRetryLadder();
+                        return;
+                    }
+                    // Scope retirement owns ordering first. A remembered rerun
+                    // on a DIFFERENT current page is still drained immediately;
+                    // an old page can never install a ladder for the new one.
+                    if (!pageScopeIsCurrent(page, processingItemId)) {
+                        if (retryScopeMatches(page, processingItemId)) resetRetryLadder();
+                        if (rerunRequested) {
+                            rerunRequested = false;
+                            runPeopleTags();
+                        }
+                        return;
+                    }
+                    if (outcome.transientFailure) {
+                        // Failure accounting owns same-scope reruns. Every card
+                        // added while this request was in flight is still live
+                        // and will be collected by the next COUNTED snapshot.
+                        // Cancel a not-yet-fired observer debounce for the same
+                        // reason: it coalesces into this one retry owner.
+                        rerunRequested = false;
+                        clearDebounceTimer();
+                        peopleTagsComplete = false;
+                        scheduleTransientRetry(page, processingItemId);
+                        return;
+                    }
+
+                    // A definitive settled pass ends any prior failure ladder.
+                    resetRetryLadder();
+                    // Definitive data may have landed while a new card mounted.
+                    // Its concrete occurrence was not in the settled snapshot,
+                    // so drain that owed projection now (the hot result is free).
                     if (rerunRequested) {
                         rerunRequested = false;
                         runPeopleTags();
@@ -881,6 +1102,8 @@ function initializePeopleTags(): void {
                         // newly mounted section untagged.
                         if (isCurrent() && !isProcessing && !rerunRequested
                             && debounceTimer === null
+                            && retryTimer === null
+                            && !retryWaiting
                             && lastProcessedItemId === processingItemId) {
                             peopleTagsComplete = true;
                         }
@@ -889,17 +1112,193 @@ function initializePeopleTags(): void {
             } catch (e) {
                 // Ignore errors (likely not on an item page)
             }
-        };
+        }
         const handlePeopleTags = () => {
             if (!isCurrent()) return;
-            if (debounceTimer !== null) {
-                clearTimeout(debounceTimer);
-                timers.delete(debounceTimer);
-            }
+            clearDebounceTimer();
             debounceTimer = schedule(() => {
                 debounceTimer = null;
                 runPeopleTags();
             }, 100);
+        };
+
+        /**
+         * One resumable ownership-first scan. `mutations` and TreeWalker keep
+         * their exact cursor positions across zero-delay slices; no selector
+         * query ever runs against an arbitrary added body subtree.
+         */
+        interface ObserverScanCursor {
+            page: HTMLElement;
+            itemId: string;
+            sections: Element[];
+            mutations: MutationRecord[];
+            mutationIndex: number;
+            addedNodeIndex: number;
+            pendingRoots: Element[];
+            seenRoots: WeakSet<Element>;
+            walker: TreeWalker | null;
+        }
+
+        type ObserverScanResult = 'complete' | 'overflow' | 'relevant';
+        const pendingObserverScans: ObserverScanCursor[] = [];
+        let observerScanTimer: number | null = null;
+
+        const clearPendingObserverScans = (): void => {
+            if (observerScanTimer !== null) {
+                clearTimeout(observerScanTimer);
+                timers.delete(observerScanTimer);
+            }
+            observerScanTimer = null;
+            pendingObserverScans.length = 0;
+        };
+        cancelPendingObserverScan = clearPendingObserverScans;
+
+        const cardBelongsToScan = (cursor: ObserverScanCursor, card: HTMLElement): boolean =>
+            cursor.page.contains(card) && cursor.sections.some((section) => section.contains(card));
+
+        const classifyObserverElement = (cursor: ObserverScanCursor, element: Element): boolean => {
+            if (element.matches('.personCard')
+                && cardBelongsToScan(cursor, element as HTMLElement)) {
+                return true;
+            }
+            if (!element.matches('.cardScalable')) return false;
+            const card = element.closest<HTMLElement>('.personCard');
+            if (!card || !cardBelongsToScan(cursor, card)) return false;
+            // A replacement/late anchor makes completion concrete again. This
+            // is harmless for a whole new card (it is absent from the WeakSet)
+            // and necessary for a previously completed shell.
+            processedCastMembers.delete(card);
+            return true;
+        };
+
+        /** Consume one added node (or mutation boundary) and queue owned roots. */
+        const queueNextOwnedRoots = (cursor: ObserverScanCursor): 'advanced' | 'done' => {
+            if (cursor.mutationIndex >= cursor.mutations.length) return 'done';
+            const mutation = cursor.mutations[cursor.mutationIndex];
+            if (cursor.addedNodeIndex >= mutation.addedNodes.length) {
+                cursor.mutationIndex += 1;
+                cursor.addedNodeIndex = 0;
+                return 'advanced';
+            }
+
+            const node = mutation.addedNodes[cursor.addedNodeIndex];
+            cursor.addedNodeIndex += 1;
+            if (!(node instanceof Element)) return 'advanced';
+
+            // Structural narrowing happens BEFORE descendant traversal. An
+            // added descendant scans itself; an added page/wrapper scans only
+            // the concrete cast section(s) it contains. An unrelated subtree
+            // is rejected here in O(number of owned sections).
+            for (const section of cursor.sections) {
+                let root: Element | null = null;
+                if (node === section || section.contains(node)) root = node;
+                else if (node.contains(section)) root = section;
+                if (root !== null && !cursor.seenRoots.has(root)) cursor.pendingRoots.push(root);
+            }
+            return 'advanced';
+        };
+
+        const drainObserverScan = (cursor: ObserverScanCursor): ObserverScanResult => {
+            if (!pageScopeIsCurrent(cursor.page, cursor.itemId)) return 'complete';
+            const startedAt = performance.now();
+            let didWork = false;
+
+            while (true) {
+                if (didWork && performance.now() - startedAt >= PEOPLE_TAGS_OBSERVER_SCAN_BUDGET_MS) {
+                    return 'overflow';
+                }
+
+                if (cursor.walker !== null) {
+                    const element = cursor.walker.nextNode() as Element | null;
+                    didWork = true;
+                    if (element === null) {
+                        cursor.walker = null;
+                        continue;
+                    }
+                    if (classifyObserverElement(cursor, element)) return 'relevant';
+                    continue;
+                }
+
+                const root = cursor.pendingRoots.pop();
+                if (root) {
+                    didWork = true;
+                    if (cursor.seenRoots.has(root) || !cursor.page.contains(root)) continue;
+                    cursor.seenRoots.add(root);
+                    cursor.walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT);
+                    if (classifyObserverElement(cursor, root)) return 'relevant';
+                    continue;
+                }
+
+                const progress = queueNextOwnedRoots(cursor);
+                if (progress === 'done') return 'complete';
+                didWork = true;
+            }
+        };
+
+        const handleRelevantAddition = (page: HTMLElement, itemId: string): void => {
+            if (!pageScopeIsCurrent(page, itemId)) return;
+            clearPendingObserverScans();
+            peopleTagsComplete = false;
+            const matchesRetryScope = retryScopeMatches(page, itemId);
+            const retryExhausted = matchesRetryScope
+                && !retryWaiting
+                && retryAttempts >= PEOPLE_TAGS_RETRY_DELAYS_MS.length;
+            if ((retryPage !== null && !matchesRetryScope) || retryExhausted) {
+                resetRetryLadder();
+            } else if (matchesRetryScope && retryWaiting) {
+                // Timer-backed and hidden visibility-backed waits are the same
+                // owner: the new card joins its next counted snapshot.
+                return;
+            }
+            handlePeopleTags();
+        };
+
+        const scheduleObserverScanContinuation = (): void => {
+            if (observerScanTimer !== null || pendingObserverScans.length === 0) return;
+            observerScanTimer = schedule(() => {
+                observerScanTimer = null;
+                if (!isCurrent()) {
+                    clearPendingObserverScans();
+                    return;
+                }
+                const cursor = pendingObserverScans[0];
+                if (!cursor) return;
+                const result = drainObserverScan(cursor);
+                if (result === 'relevant') {
+                    handleRelevantAddition(cursor.page, cursor.itemId);
+                    return;
+                }
+                if (result === 'complete') pendingObserverScans.shift();
+                scheduleObserverScanContinuation();
+            }, 0);
+        };
+
+        const inspectRelevantAdditions = (
+            mutations: MutationRecord[],
+            page: HTMLElement,
+            itemId: string,
+            castSection: Element | null,
+            guestCastSection: Element | null,
+        ): void => {
+            const sections = [castSection, guestCastSection].filter((section): section is Element => section !== null);
+            const cursor: ObserverScanCursor = {
+                page,
+                itemId,
+                sections,
+                mutations,
+                mutationIndex: 0,
+                addedNodeIndex: 0,
+                pendingRoots: [],
+                seenRoots: new WeakSet<Element>(),
+                walker: null,
+            };
+            const result = drainObserverScan(cursor);
+            if (result === 'relevant') {
+                handleRelevantAddition(page, itemId);
+            } else if (result === 'overflow') {
+                pendingObserverScans.push(cursor);
+                scheduleObserverScanContinuation();
+            }
         };
 
         // Create managed observer for people tags.
@@ -908,28 +1307,35 @@ function initializePeopleTags(): void {
         observerHandle = JC.helpers.createObserver(
             'people-tags',
             (mutations) => {
-                if (!isCurrent() || !JC.currentSettings?.peopleTagsEnabled) return;
+                if (!generationIsCurrent()) return;
+                if (!isCurrent()) {
+                    clearDebounceTimer();
+                    clearPendingObserverScans();
+                    resetRetryLadder();
+                    rerunRequested = false;
+                    peopleTagsComplete = false;
+                    return;
+                }
 
-                // Reset completion flag when navigating to a different item
-                // (must happen BEFORE the peopleTagsComplete check)
+                // Navigation owns every queued callback, including the NULL id
+                // of details→non-details. Release the old page strongly held by
+                // an active OR exhausted retry and discard traversal/debounce
+                // cursors before probing whether the new route has cast work.
                 try {
                     const currentId = getItemIdFromUrl();
-                    if (currentId && currentId !== lastProcessedItemId) {
+                    if (currentId !== lastProcessedItemId) {
+                        clearDebounceTimer();
+                        clearPendingObserverScans();
+                        resetRetryLadder();
+                        rerunRequested = false;
                         peopleTagsComplete = false;
+                        if (currentId === null) {
+                            lastProcessedItemId = null;
+                            processedCastMembers = new WeakSet();
+                            return;
+                        }
                     }
                 } catch {}
-
-                if (peopleTagsComplete) return;
-
-                // Only react to actual node additions, not attribute changes
-                let hasNewNodes = false;
-                for (const mutation of mutations) {
-                    if (mutation.addedNodes.length > 0) {
-                        hasNewNodes = true;
-                        break;
-                    }
-                }
-                if (!hasNewNodes) return;
 
                 // Resolve the owned visible page (duplicate-id safe; null
                 // mid-transition). runPeopleTags re-resolves the same pair, so
@@ -941,7 +1347,13 @@ function initializePeopleTags(): void {
                 const guestCastSection = visible.page.querySelector('#guestCastCollapsible');
                 if (!castSection && !guestCastSection) return;
 
-                handlePeopleTags();
+                inspectRelevantAdditions(
+                    mutations,
+                    visible.page,
+                    visible.itemId,
+                    castSection,
+                    guestCastSection,
+                );
             },
             document.body,
             {
@@ -949,6 +1361,13 @@ function initializePeopleTags(): void {
                 subtree: true
             }
         );
+
+        // R9/#361: activation or a same-identity/config restart can occur after
+        // Jellyfin has already mounted the cast. Schedule one owned-page pass
+        // after observation begins so those cards cannot depend on an unrelated
+        // future body mutation; the normal debounce coalesces any simultaneous
+        // cast mount into this same bounded snapshot.
+        handlePeopleTags();
 
         console.debug(`${logPrefix} Initialization complete`);
     }


### PR DESCRIPTION
Closes #361.

Summary
- Render every duplicate cast occurrence after People Tags eligibility resolves, including duplicates inserted during quiet-period processing.
- Bound counted retry/backoff work globally while preserving coalescing and visibility-aware pause/resume behavior.
- Fence async work across live disable, navigation, identity, and lifecycle changes, and discover already-mounted casts on install/reinstall.
- Keep observer work resumable within the owned 2 ms scan budget.

Validation
- Focused People Tags unit/performance tests: 40/40 passed.
- Source and legacy TypeScript checks passed.
- Syntax and performance-rule guards passed (262 files; 904 ms CPU).
- Deterministic bundle and full client coverage gates passed on the frozen reviewed tree (236 files / 1,841 tests; exact coverage baseline).
- Independent whole-diff review: APPROVED at SHA-256 `46508500c9b3642e732b34a521335d716075fb934ec6d4ad2fdd86716396f1d5`.
- Rebase onto current `main` preserved that exact binary diff and stable patch identity.

No deployment was performed.