### PR TITLE
fix(server): persist Seerr spoiler intent durably

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/AdminTargetPreferenceControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/AdminTargetPreferenceControllerTests.cs
@@ -33,6 +33,8 @@ public sealed class AdminTargetPreferenceControllerTests : IDisposable
     private readonly StubUserManager _userManager;
     private readonly FakePluginConfigProvider _provider;
     private readonly CountingLibraryManager _library;
+    private readonly SpoilerPendingService _pending;
+    private readonly SpoilerSeerrPendingPromoter _promoter;
 
     public AdminTargetPreferenceControllerTests()
     {
@@ -53,15 +55,44 @@ public sealed class AdminTargetPreferenceControllerTests : IDisposable
             SpoilerBlurEnabled = true
         });
         _library = new CountingLibraryManager();
+        _pending = new SpoilerPendingService(
+            _manager,
+            _library,
+            _userManager,
+            NullLogger<SpoilerPendingService>.Instance);
+        _promoter = new SpoilerSeerrPendingPromoter(
+            _library,
+            _userManager,
+            _manager,
+            _provider,
+            _pending,
+            NullLogger<SpoilerSeerrPendingPromoter>.Instance);
+        _promoter.StartAsync(CancellationToken.None).GetAwaiter().GetResult();
+        _promoter.ReplayCompletionForTest.GetAwaiter().GetResult();
+        _pending.PendingRegistrationChanged += ApplyPendingRegistration;
     }
 
     public void Dispose()
     {
+        _pending.PendingRegistrationChanged -= ApplyPendingRegistration;
+        _promoter.StopAsync(CancellationToken.None).GetAwaiter().GetResult();
         HiddenContentResponseFilter.InvalidateUser(ActorId);
         HiddenContentResponseFilter.InvalidateUser(TargetId);
         SpoilerUserResolver.InvalidateUser(ActorId);
         SpoilerUserResolver.InvalidateUser(TargetId);
         try { Directory.Delete(_baseDir, recursive: true); } catch { /* best effort */ }
+    }
+
+    private void ApplyPendingRegistration(string pendingKey, Guid userId, bool registered)
+    {
+        if (registered)
+        {
+            _promoter.RegisterPending(pendingKey, userId);
+        }
+        else
+        {
+            _promoter.UnregisterPending(pendingKey, userId);
+        }
     }
 
     [Fact]
@@ -979,7 +1010,7 @@ public sealed class AdminTargetPreferenceControllerTests : IDisposable
                 ["FutureOverrideResource"] = resourceExtension.RootElement.Clone()
             }
         };
-        SpoilerSeerrPendingPromoter.RegisterPending(stalePendingKey, _target.Id);
+        _promoter.RegisterPending(stalePendingKey, _target.Id);
         SpoilerUserResolver.SeedUserStateCacheForTest(ActorId);
         SpoilerUserResolver.SeedUserStateCacheForTest(TargetId);
 
@@ -1054,8 +1085,8 @@ public sealed class AdminTargetPreferenceControllerTests : IDisposable
             Assert.Equal("Actor series", Assert.Single(actor.Series).Value.SeriesName);
             Assert.True(actor.Prefs.HideTags);
 
-            Assert.False(SpoilerSeerrPendingPromoter.IsKeyRegisteredForTest(stalePendingKey));
-            Assert.True(SpoilerSeerrPendingPromoter.IsKeyRegisteredForTest(pendingKey));
+            Assert.False(_promoter.IsKeyRegisteredForTest(stalePendingKey));
+            Assert.True(_promoter.IsKeyRegisteredForTest(pendingKey));
 
             var readController = SpoilerController();
             var readEnvelope = AssertOkEnvelope(
@@ -1073,8 +1104,8 @@ public sealed class AdminTargetPreferenceControllerTests : IDisposable
         }
         finally
         {
-            SpoilerSeerrPendingPromoter.UnregisterPending(stalePendingKey, _target.Id);
-            SpoilerSeerrPendingPromoter.UnregisterPending(pendingKey, _target.Id);
+            _promoter.UnregisterPending(stalePendingKey, _target.Id);
+            _promoter.UnregisterPending(pendingKey, _target.Id);
         }
     }
 
@@ -1319,7 +1350,7 @@ public sealed class AdminTargetPreferenceControllerTests : IDisposable
                 .ExtensionData["zOpaque"]
                 .GetRawText());
         Assert.Equal(0, _library.GetItemByIdUserCallCount);
-        SpoilerSeerrPendingPromoter.UnregisterPending(pendingKey, _target.Id);
+        _promoter.UnregisterPending(pendingKey, _target.Id);
     }
 
     [Fact]
@@ -1354,7 +1385,7 @@ public sealed class AdminTargetPreferenceControllerTests : IDisposable
         };
         var before = File.ReadAllBytes(UserFile(_target.Id, SpoilerFile));
         SpoilerUserResolver.SeedUserStateCacheForTest(TargetId);
-        SpoilerSeerrPendingPromoter.RegisterPending(pendingKey, _target.Id);
+        _promoter.RegisterPending(pendingKey, _target.Id);
 
         try
         {
@@ -1403,11 +1434,11 @@ public sealed class AdminTargetPreferenceControllerTests : IDisposable
                     TargetId,
                     SpoilerFile).OverridesRevision);
             Assert.True(SpoilerUserResolver.IsUserStateCachedForTest(TargetId));
-            Assert.True(SpoilerSeerrPendingPromoter.IsKeyRegisteredForTest(pendingKey));
+            Assert.True(_promoter.IsKeyRegisteredForTest(pendingKey));
         }
         finally
         {
-            SpoilerSeerrPendingPromoter.UnregisterPending(pendingKey, _target.Id);
+            _promoter.UnregisterPending(pendingKey, _target.Id);
         }
     }
 
@@ -1644,7 +1675,7 @@ public sealed class AdminTargetPreferenceControllerTests : IDisposable
         {
             foreach (var key in allKeys)
             {
-                SpoilerSeerrPendingPromoter.UnregisterPending(key, _target.Id);
+                _promoter.UnregisterPending(key, _target.Id);
             }
         }
     }
@@ -2513,7 +2544,7 @@ public sealed class AdminTargetPreferenceControllerTests : IDisposable
         });
         const string pendingKey = "movie:9090";
         SpoilerUserResolver.SeedUserStateCacheForTest(TargetId);
-        SpoilerSeerrPendingPromoter.BeforeAuthoritativeGateReconcileForTests =
+        _pending.BeforeAuthoritativeGateReconcileForTests =
             (userKey, _) =>
             {
                 if (userKey == TargetId)
@@ -2554,8 +2585,8 @@ public sealed class AdminTargetPreferenceControllerTests : IDisposable
         }
         finally
         {
-            SpoilerSeerrPendingPromoter.BeforeAuthoritativeGateReconcileForTests = null;
-            SpoilerSeerrPendingPromoter.UnregisterPending(pendingKey, _target.Id);
+            _pending.BeforeAuthoritativeGateReconcileForTests = null;
+            _promoter.UnregisterPending(pendingKey, _target.Id);
         }
     }
 
@@ -2593,11 +2624,6 @@ public sealed class AdminTargetPreferenceControllerTests : IDisposable
         long? ifMatch = null,
         string? rawIfMatch = null)
     {
-        var pending = new SpoilerPendingService(
-            _manager,
-            _library,
-            _userManager,
-            NullLogger<SpoilerPendingService>.Instance);
         var sessions = new CountingSessionManager();
         var requestIdentity = new RequestIdentityService(
             sessions,
@@ -2619,7 +2645,7 @@ public sealed class AdminTargetPreferenceControllerTests : IDisposable
             _provider,
             _manager,
             _library,
-            pending,
+            _pending,
             resolver,
             new StubUserDataManager());
         ConfigureController(controller, ifMatch, rawIfMatch);

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/ArrRequestsQueueFilterTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/ArrRequestsQueueFilterTests.cs
@@ -94,7 +94,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 userManager: null!,
                 new SeerrCache(provider),
                 provider,
-                parentalFilter: null!);
+                parentalFilter: null!,
+                spoilerPendingService: null!);
 
             var items = await client.GetRequestsForUser("7");
 

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SeerrQuotaSourceAffinityTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SeerrQuotaSourceAffinityTests.cs
@@ -622,7 +622,8 @@ public class SeerrQuotaSourceAffinityTests
             userManager: null!,
             new SeerrCache(provider),
             provider,
-            new PassthroughParentalFilter());
+            new PassthroughParentalFilter(),
+            null!);
         var resolvedUser = new SeerrUser { Id = 7, SourceUrl = SourceA };
 
         var result = await client.ProxyRequestAsync(
@@ -677,7 +678,8 @@ public class SeerrQuotaSourceAffinityTests
             userManager: null!,
             cache,
             provider,
-            new PassthroughParentalFilter());
+            new PassthroughParentalFilter(),
+            null!);
 
         var result = await client.ProxyRequestAsync(
             "/api/v1/user/7/quota",
@@ -705,7 +707,8 @@ public class SeerrQuotaSourceAffinityTests
             userManager: null!,
             new SeerrCache(provider),
             provider,
-            new PassthroughParentalFilter());
+            new PassthroughParentalFilter(),
+            null!);
 
         var result = await client.ProxyRequestAsync(
             "/api/v1/user/7/quota",
@@ -734,7 +737,8 @@ public class SeerrQuotaSourceAffinityTests
             userManager: null!,
             new SeerrCache(provider),
             provider,
-            new PassthroughParentalFilter());
+            new PassthroughParentalFilter(),
+            null!);
 
         var result = await client.ProxyRequestAsync(
             "/api/v1/user/7/quota",

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SeerrUserManualWatchlistSyncTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SeerrUserManualWatchlistSyncTests.cs
@@ -343,7 +343,8 @@ public sealed class SeerrUserManualWatchlistSyncTests
             users,
             cache,
             provider,
-            parentalFilter: null!);
+            parentalFilter: null!,
+            spoilerPendingService: null!);
         var controller = new SeerrUserController(
             factory,
             NullLogger<SeerrUserController>.Instance,

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SpoilerGuardControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SpoilerGuardControllerTests.cs
@@ -42,12 +42,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             public required UserConfigurationManager Mgr { get; init; }
             public required CountingLibraryManager Lib { get; init; }
             public required SpoilerPendingService Pending { get; init; }
+            public required SpoilerSeerrPendingPromoter Promoter { get; init; }
             public required SpoilerGuardController Controller { get; init; }
             public required StubUserDataManager UserData { get; init; }
             public required User User { get; init; }
 
             public void Dispose()
             {
+                Promoter.StopAsync(CancellationToken.None).GetAwaiter().GetResult();
                 try { Directory.Delete(Dir, recursive: true); } catch { /* best-effort */ }
             }
         }
@@ -63,6 +65,15 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             var userManager = includeUserInManager ? new StubUserManager(user) : new StubUserManager();
             var provider = new FakePluginConfigProvider(cfg);
             var pending = new SpoilerPendingService(mgr, lib, userManager, NullLogger<SpoilerPendingService>.Instance);
+            var promoter = new SpoilerSeerrPendingPromoter(
+                lib,
+                userManager,
+                mgr,
+                provider,
+                pending,
+                NullLogger<SpoilerSeerrPendingPromoter>.Instance);
+            promoter.StartAsync(CancellationToken.None).GetAwaiter().GetResult();
+            promoter.ReplayCompletionForTest.GetAwaiter().GetResult();
             var sessions = new CountingSessionManager();
             var requestIdentity = new RequestIdentityService(
                 sessions,
@@ -90,7 +101,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) },
             };
 
-            return new Harness { Dir = dir, Mgr = mgr, Lib = lib, Pending = pending, Controller = controller, UserData = userData, User = user };
+            return new Harness { Dir = dir, Mgr = mgr, Lib = lib, Pending = pending, Promoter = promoter, Controller = controller, UserData = userData, User = user };
         }
 
         // ─── Display-name sanitizer ───────────────────────────────────────────────
@@ -156,14 +167,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             const string keyA = "tv:101";
             const string keyB = "movie:202";
 
-            // First save registers both pending keys in the promoter's static gate.
+            // First save registers both pending keys in the promoter's instance gate.
             var first = new UserSpoilerBlur();
             first.PendingTmdb[keyA] = new SpoilerBlurPendingEntry { MediaType = "tv", TmdbId = "101" };
             first.PendingTmdb[keyB] = new SpoilerBlurPendingEntry { MediaType = "movie", TmdbId = "202" };
             var r1 = h.Controller.SaveUserSpoilerBlur(userId.ToString(), first);
             Assert.IsType<OkObjectResult>(r1);
-            Assert.True(SpoilerSeerrPendingPromoter.IsKeyRegisteredForTest(keyA));
-            Assert.True(SpoilerSeerrPendingPromoter.IsKeyRegisteredForTest(keyB));
+            Assert.True(h.Promoter.IsKeyRegisteredForTest(keyA));
+            Assert.True(h.Promoter.IsKeyRegisteredForTest(keyB));
             Assert.Equal(
                 1,
                 h.Mgr.GetUserConfigurationStrict<UserSpoilerBlur>(
@@ -175,8 +186,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             second.PendingTmdb[keyA] = new SpoilerBlurPendingEntry { MediaType = "tv", TmdbId = "101" };
             var r2 = h.Controller.SaveUserSpoilerBlur(userId.ToString(), second);
             Assert.IsType<OkObjectResult>(r2);
-            Assert.True(SpoilerSeerrPendingPromoter.IsKeyRegisteredForTest(keyA));
-            Assert.False(SpoilerSeerrPendingPromoter.IsKeyRegisteredForTest(keyB));
+            Assert.True(h.Promoter.IsKeyRegisteredForTest(keyA));
+            Assert.False(h.Promoter.IsKeyRegisteredForTest(keyB));
             Assert.Equal(
                 2,
                 h.Mgr.GetUserConfigurationStrict<UserSpoilerBlur>(
@@ -192,8 +203,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             Assert.IsType<ConflictObjectResult>(
                 h.Controller.SaveUserSpoilerBlur(userId.ToString(), stale));
 
-            // Cleanup so the static gate doesn't leak into other tests.
-            SpoilerSeerrPendingPromoter.UnregisterPending(keyA, userId);
+            // Cleanup keeps the harness state explicit before disposal.
+            h.Promoter.UnregisterPending(keyA, userId);
         }
 
         [Fact]
@@ -387,7 +398,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                     userKey,
                     SpoilerFile).OverridesRevision;
 
-            SpoilerSeerrPendingPromoter.UnregisterPending("tv:9876", h.User.Id);
+            h.Promoter.UnregisterPending("tv:9876", h.User.Id);
         }
 
         [Fact]
@@ -726,12 +737,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                     }
                 }
             });
-            SpoilerSeerrPendingPromoter.RegisterPending(pendingKey, h.User.Id);
+            h.Promoter.RegisterPending(pendingKey, h.User.Id);
             h.Controller.Request.Headers.IfMatch = "\"1\"";
             using var removalCommitted = new ManualResetEventSlim();
             using var allowDelayedReconcile = new ManualResetEventSlim();
             var firstReconcile = 0;
-            SpoilerSeerrPendingPromoter.BeforeAuthoritativeGateReconcileForTests =
+            h.Pending.BeforeAuthoritativeGateReconcileForTests =
                 (observedUser, keys) =>
                 {
                     if (observedUser == userKey
@@ -769,11 +780,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                         SpoilerGuardOverridesRevision.Advance(state);
                         return 1;
                     });
-                SpoilerSeerrPendingPromoter.ReconcilePendingKeys(
-                    h.Mgr,
+                h.Pending.ReconcilePendingKeys(
                     userKey,
                     new[] { pendingKey });
-                Assert.True(SpoilerSeerrPendingPromoter.IsKeyRegisteredForTest(pendingKey));
+                Assert.True(h.Promoter.IsKeyRegisteredForTest(pendingKey));
 
                 allowDelayedReconcile.Set();
                 Assert.IsType<OkObjectResult>(await removal);
@@ -785,7 +795,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 Assert.Equal(
                     "Newer re-add",
                     stored.PendingTmdb[pendingKey].DisplayName);
-                Assert.True(SpoilerSeerrPendingPromoter.IsKeyRegisteredForTest(pendingKey));
+                Assert.True(h.Promoter.IsKeyRegisteredForTest(pendingKey));
             }
             finally
             {
@@ -794,8 +804,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 {
                     try { await removal; } catch { /* asserted on the primary path */ }
                 }
-                SpoilerSeerrPendingPromoter.BeforeAuthoritativeGateReconcileForTests = null;
-                SpoilerSeerrPendingPromoter.UnregisterPending(pendingKey, h.User.Id);
+                h.Pending.BeforeAuthoritativeGateReconcileForTests = null;
+                h.Promoter.UnregisterPending(pendingKey, h.User.Id);
             }
         }
 
@@ -961,7 +971,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 }
             });
             var before = File.ReadAllBytes(SpoilerPath(h));
-            SpoilerSeerrPendingPromoter.RegisterPending(pendingKey, h.User.Id);
+            h.Promoter.RegisterPending(pendingKey, h.User.Id);
 
             try
             {
@@ -982,11 +992,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 Assert.True(stored.PendingTmdb.ContainsKey(pendingKey));
                 Assert.Equal(12, stored.OverridesRevision);
                 Assert.True(
-                    SpoilerSeerrPendingPromoter.IsKeyRegisteredForTest(pendingKey));
+                    h.Promoter.IsKeyRegisteredForTest(pendingKey));
             }
             finally
             {
-                SpoilerSeerrPendingPromoter.UnregisterPending(pendingKey, h.User.Id);
+                h.Promoter.UnregisterPending(pendingKey, h.User.Id);
             }
         }
 
@@ -1148,7 +1158,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             var userKey = h.User.Id.ToString("N");
             h.Mgr.SaveUserConfiguration(userKey, SpoilerFile, state);
             var before = File.ReadAllBytes(SpoilerPath(h));
-            SpoilerSeerrPendingPromoter.RegisterPending(pendingKey, h.User.Id);
+            h.Promoter.RegisterPending(pendingKey, h.User.Id);
 
             try
             {
@@ -1177,7 +1187,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             }
             finally
             {
-                SpoilerSeerrPendingPromoter.UnregisterPending(pendingKey, h.User.Id);
+                h.Promoter.UnregisterPending(pendingKey, h.User.Id);
             }
         }
 
@@ -1198,7 +1208,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             Assert.Equal(1, stored.OverridesRevision);
 
             // The recorded pending key primes the promoter gate; clean it up.
-            SpoilerSeerrPendingPromoter.UnregisterPending("tv:888", h.User.Id);
+            h.Promoter.UnregisterPending("tv:888", h.User.Id);
         }
 
         [Fact]
@@ -1220,7 +1230,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
 
             Assert.False(SpoilerUserResolver.IsUserStateCachedForTest(userKey));
 
-            SpoilerSeerrPendingPromoter.UnregisterPending("tv:999", h.User.Id);
+            h.Promoter.UnregisterPending("tv:999", h.User.Id);
         }
 
         // ─── Health endpoint: non-admin sees only own corruption events ───────────
@@ -1319,11 +1329,6 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
         public void PromoteForUser_EventItemInaccessible_PromotesAccessibleTmdbDuplicate()
         {
             using var h = Build();
-            var userManager = new StubUserManager(h.User);
-            var promoter = new SpoilerSeerrPendingPromoter(
-                h.Lib, userManager, h.Mgr, new FakePluginConfigProvider(null), h.Pending,
-                NullLogger<SpoilerSeerrPendingPromoter>.Instance);
-
             const string pendingKey = "tv:555";
             var state = new UserSpoilerBlur();
             state.PendingTmdb[pendingKey] = new SpoilerBlurPendingEntry { MediaType = "tv", TmdbId = "555" };
@@ -1336,7 +1341,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             h.Lib.GetItemListHook = _ =>
                 new List<BaseItem> { new Series { Id = dupId, Name = longName } };
 
-            var outcome = promoter.PromoteForUser(h.User.Id, eventItemId, pendingKey, "Orig", isSeries: true);
+            var outcome = h.Promoter.PromoteForUser(h.User.Id, eventItemId, pendingKey, "Orig", isSeries: true);
 
             Assert.Equal(SpoilerSeerrPendingPromoter.PromotionOutcome.Promoted, outcome);
             var stored = h.Mgr.GetUserConfiguration<UserSpoilerBlur>(h.User.Id.ToString("N"), SpoilerFile);
@@ -1356,13 +1361,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             bool isSeries)
         {
             using var h = Build();
-            var promoter = new SpoilerSeerrPendingPromoter(
-                h.Lib,
-                new StubUserManager(h.User),
-                h.Mgr,
-                new FakePluginConfigProvider(null),
-                h.Pending,
-                NullLogger<SpoilerSeerrPendingPromoter>.Instance);
+            var promoter = h.Promoter;
             var itemId = CapacityGuid(isSeries ? 4_301 : 4_302);
             var pendingKey = isSeries ? "tv:717171" : "movie:818181";
             h.Lib.GetItemByIdUserHook = (id, scopedUser) =>
@@ -1400,7 +1399,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             h.Mgr.SaveUserConfiguration(userKey, SpoilerFile, state);
             var before = File.ReadAllBytes(SpoilerPath(h));
             SpoilerUserResolver.SeedUserStateCacheForTest(userKey);
-            SpoilerSeerrPendingPromoter.RegisterPending(pendingKey, h.User.Id);
+            promoter.RegisterPending(pendingKey, h.User.Id);
 
             try
             {
@@ -1428,11 +1427,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                     isSeries ? stored.Series.Keys : stored.Movies.Keys);
                 Assert.True(SpoilerUserResolver.IsUserStateCachedForTest(userKey));
                 Assert.True(
-                    SpoilerSeerrPendingPromoter.IsKeyRegisteredForTest(pendingKey));
+                    promoter.IsKeyRegisteredForTest(pendingKey));
             }
             finally
             {
-                SpoilerSeerrPendingPromoter.UnregisterPending(pendingKey, h.User.Id);
+                promoter.UnregisterPending(pendingKey, h.User.Id);
             }
         }
 

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/TagCacheSpoilerStripProjectionTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/TagCacheSpoilerStripProjectionTests.cs
@@ -24,6 +24,12 @@ using Season = MediaBrowser.Controller.Entities.TV.Season;
 
 namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
 {
+    [CollectionDefinition(Name, DisableParallelization = true)]
+    public sealed class BaseItemStaticHostCollection
+    {
+        public const string Name = "BaseItem static host";
+    }
+
     /// <summary>
     /// BI-PERF-037 (#98): the Spoiler Guard tag-cache projection must acquire its
     /// runtime facts (item resolution, played state, season index/any-watched) in
@@ -33,6 +39,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
     /// season's watched aggregate per relevant revision, and failing CLOSED on
     /// cancellation (never a partially-unstripped 200).
     /// </summary>
+    [Collection(BaseItemStaticHostCollection.Name)]
     public sealed class TagCacheSpoilerStripProjectionTests
     {
         // ── AC1: bounded batch calls, never one manager call per entry ─────────

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/LibraryScanEventGuardTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/LibraryScanEventGuardTests.cs
@@ -55,7 +55,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             "SeerrScanTriggerService.cs",     // cheap config/kind check -> counter + debounce timer
             "WatchlistMonitor.cs",            // constant-time gates -> bounded coalescing channel worker
             "ContinueWatchingPlaybackEvents.cs", // bounded id intake -> lifecycle-owned drain worker (GetUsers + per-user prune off-thread)
-            "SpoilerSeerrPendingPromoter.cs", // cheap gate ContainsKey -> coalesced Task.Run sweep (GetItemById + RMW off-thread)
+            "SpoilerSeerrPendingPromoter.cs", // cheap gate ContainsKey -> coalesced channel-worker sweep (GetItemById + RMW off-thread)
         };
 
         // Off-thread worker methods on the reviewed subscribers: invoked via a debounce Timer or

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/MaintainerrClientContractTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/MaintainerrClientContractTests.cs
@@ -810,6 +810,19 @@ public sealed class MaintainerrClientContractTests
         Assert.Equal(MaintainerrErrorCode.Timeout, timedOut.Error);
     }
 
+    [Fact]
+    public async Task Test_PreCanceledCallerStopsBeforeAnyHttpRequest()
+    {
+        var handler = new RoutingHandler(SuccessResponse);
+
+        var result = await Client(handler, Provider()).TestAsync(
+            BaseUrl,
+            new CancellationToken(canceled: true));
+
+        Assert.Equal(MaintainerrErrorCode.Canceled, result.Error);
+        Assert.Empty(handler.Requests);
+    }
+
     [Theory]
     [InlineData(MachineId, true, null)]
     [InlineData("fedcba9876543210fedcba9876543210", false, "identity_mismatch")]

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/Seerr4kCapabilityTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/Seerr4kCapabilityTests.cs
@@ -39,7 +39,8 @@ public class Seerr4kCapabilityTests
             null!,
             new SeerrCache(provider),
             provider,
-            new PassthroughParentalFilter());
+            new PassthroughParentalFilter(),
+            null!);
         return (client, handler);
     }
 

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/Seerr4kMasterSwitchTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/Seerr4kMasterSwitchTests.cs
@@ -39,7 +39,8 @@ public class Seerr4kMasterSwitchTests
             null!,
             new SeerrCache(provider),
             provider,
-            new PassthroughParentalFilter());
+            new PassthroughParentalFilter(),
+            null!);
         // A resolvable user so the gate is reached; permissions are irrelevant here.
         handler.AddResponse("/api/v1/user", $"{{\"results\":[{{\"id\":42,\"jellyfinUserId\":\"{UserId}\",\"permissions\":2048}}],\"pageInfo\":{{\"page\":1,\"pages\":1,\"results\":1}}}}");
         return (client, handler);

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/Seerr4kRequestGateTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/Seerr4kRequestGateTests.cs
@@ -42,7 +42,8 @@ public class Seerr4kRequestGateTests
             null!,
             new SeerrCache(provider),
             provider,
-            new PassthroughParentalFilter());
+            new PassthroughParentalFilter(),
+            null!);
         return (client, handler);
     }
 

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrClientTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrClientTests.cs
@@ -79,7 +79,7 @@ public class SeerrClientTests
     // ─── IPluginConfigProvider seam ──────────────────────────────────────────
 
     private static SeerrClient NewClient(FakePluginConfigProvider provider)
-        => new(new ThrowingHttpClientFactory(), NullLogger<SeerrClient>.Instance, null!, new SeerrCache(provider), provider, null!);
+        => new(new ThrowingHttpClientFactory(), NullLogger<SeerrClient>.Instance, null!, new SeerrCache(provider), provider, null!, null!);
 
     [Fact]
     public async Task GetSeerrUserId_ReadsConfigThroughInjectedProvider_AndSkipsWorkWhenUnconfigured()
@@ -115,6 +115,7 @@ public class SeerrClientTests
             null!,
             new SeerrCache(provider),
             provider,
+            null!,
             null!);
 
         var resolution = await client.ResolveSeerrUser(
@@ -143,6 +144,7 @@ public class SeerrClientTests
             null!,
             new SeerrCache(provider),
             provider,
+            null!,
             null!);
 
         Assert.Null(await client.GetWatchlistForUser("42"));
@@ -166,6 +168,7 @@ public class SeerrClientTests
             null!,
             new SeerrCache(provider),
             provider,
+            null!,
             null!);
 
         Assert.False(await client.GetStatusActiveAsync());
@@ -188,6 +191,7 @@ public class SeerrClientTests
             null!,
             new SeerrCache(provider),
             provider,
+            null!,
             null!);
 
         var statusTask = client.GetStatusActiveAsync();

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrDownloadStatusPrivacyTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrDownloadStatusPrivacyTests.cs
@@ -72,7 +72,8 @@ public sealed class SeerrDownloadStatusPrivacyTests
             null!,
             cache,
             provider,
-            new PassthroughParentalFilter());
+            new PassthroughParentalFilter(),
+            spoilerPendingService: null!);
         var caller = new SeerrCaller(UserId, IsAdmin: true);
 
         var first = Assert.IsType<ContentResult>(await client.ProxyRequestAsync(
@@ -136,7 +137,8 @@ public sealed class SeerrDownloadStatusPrivacyTests
             null!,
             cache,
             provider,
-            new PassthroughParentalFilter());
+            new PassthroughParentalFilter(),
+            spoilerPendingService: null!);
         var caller = new SeerrCaller(UserId, IsAdmin: false);
 
         var first = Assert.IsType<ContentResult>(await client.ProxyRequestAsync(

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrIntentDurabilityTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrIntentDurabilityTests.cs
@@ -1,0 +1,509 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Text.Json;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Controllers;
+using Jellyfin.Plugin.JellyfinCanopy.Services;
+using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.TV;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services;
+
+public sealed class SeerrIntentDurabilityTests : IDisposable
+{
+    private const string Source = "http://seerr:5055";
+    private readonly string _directory = Path.Combine(
+        Path.GetTempPath(),
+        "jc-seerr-intent-" + Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+        catch
+        {
+            // Best-effort test cleanup.
+        }
+    }
+
+    [Fact]
+    public async Task SuccessfulRequest_ReturnsOnlyAfterSpoilerIntentIsDurable()
+    {
+        var user = new User("intent-user", "provider", "password-provider");
+        var userId = user.Id.ToString("N");
+        var handler = new RecordingHttpMessageHandler();
+        handler.AddResponse(
+            "/api/v1/user",
+            $"{{\"results\":[{{\"id\":42,\"jellyfinUserId\":\"{userId}\",\"permissions\":2}}],\"pageInfo\":{{\"page\":1,\"pages\":1,\"results\":1}}}}");
+        handler.AddResponse("/api/v1/request", "{\"id\":1}", HttpStatusCode.Created);
+
+        var config = new PluginConfiguration
+        {
+            SeerrEnabled = true,
+            SeerrUrls = Source,
+            SeerrApiKey = "test-key",
+            SpoilerBlurEnabled = true,
+            SpoilerAutoEnableOnSeerrRequest = true,
+        };
+        var provider = new FakePluginConfigProvider(config);
+        var manager = new UserConfigurationManager(
+            new StubAppPaths(_directory),
+            NullLogger<UserConfigurationManager>.Instance);
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = _ => Array.Empty<BaseItem>(),
+        };
+        var users = new StubUserManager(user);
+        var pending = new SpoilerPendingService(
+            manager,
+            library,
+            users,
+            NullLogger<SpoilerPendingService>.Instance);
+        var client = new SeerrClient(
+            new RecordingHttpClientFactory(handler),
+            NullLogger<SeerrClient>.Instance,
+            users,
+            new SeerrCache(provider),
+            provider,
+            new PassthroughParentalFilter(),
+            pending);
+
+        var result = await client.ProxyRequestAsync(
+            "/api/v1/request",
+            HttpMethod.Post,
+            "{\"mediaType\":\"tv\",\"mediaId\":123,\"seasons\":[2]}",
+            new SeerrCaller(userId, IsAdmin: true));
+
+        Assert.IsType<ContentResult>(result);
+        var state = manager.GetUserConfiguration<UserSpoilerBlur>(
+            userId,
+            "spoilerblur.json");
+        Assert.True(state.PendingTmdb.ContainsKey("tv:123"));
+        Assert.Equal(1, state.OverridesRevision);
+    }
+
+    [Fact]
+    public async Task PostCommitReconcileFailure_StillAcknowledgesDurableIntent()
+    {
+        var setup = CreateClientHarness();
+        setup.Pending.BeforeAuthoritativeGateReconcileForTests = (_, _) =>
+            throw new IOException("deterministic acceleration failure");
+
+        var result = await setup.Client.ProxyRequestAsync(
+            "/api/v1/request",
+            HttpMethod.Post,
+            "{\"mediaType\":\"movie\",\"mediaId\":124}",
+            new SeerrCaller(setup.User.Id.ToString("N"), IsAdmin: true));
+
+        Assert.IsType<ContentResult>(result);
+        var state = ReadState(setup);
+        Assert.True(state.PendingTmdb.ContainsKey("movie:124"));
+        Assert.Equal(1, state.OverridesRevision);
+    }
+
+    [Fact]
+    public async Task TvSeasonsRoute_CannotBypassSharedDurableSuccessBoundary()
+    {
+        var setup = CreateClientHarness();
+        var controller = new SeerrUserController(
+            new RecordingHttpClientFactory(setup.Handler),
+            NullLogger<SeerrUserController>.Instance,
+            setup.Users,
+            new SeerrCache(setup.Provider),
+            setup.Provider,
+            null!,
+            setup.Library,
+            setup.Client)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = new ClaimsPrincipal(new ClaimsIdentity(
+                        new[] { new Claim("Jellyfin-UserId", setup.User.Id.ToString()) },
+                        "TestAuth")),
+                },
+            },
+        };
+        using var document = JsonDocument.Parse(
+            "{\"mediaType\":\"tv\",\"mediaId\":321,\"seasons\":[3]}");
+
+        var result = await controller.RequestTvSeasons(321, document.RootElement);
+
+        Assert.IsType<ContentResult>(result);
+        Assert.True(ReadState(setup).PendingTmdb.ContainsKey("tv:321"));
+    }
+
+    [Fact]
+    public async Task UpstreamSuccess_WithUnresolvedFullPendingStore_ReturnsExplicitPartialSuccess()
+    {
+        var setup = CreateClientHarness();
+        SeedPendingCap(setup);
+
+        var result = Assert.IsType<ObjectResult>(await setup.Client.ProxyRequestAsync(
+            "/api/v1/request",
+            HttpMethod.Post,
+            "{\"mediaType\":\"movie\",\"mediaId\":999}",
+            new SeerrCaller(setup.User.Id.ToString("N"), IsAdmin: true)));
+
+        Assert.Equal(500, result.StatusCode);
+        Assert.Equal("seerr_accepted_spoiler_intent_failed", ReadProperty<string>(result.Value, "code"));
+        Assert.True(ReadProperty<bool>(result.Value, "seerrAccepted"));
+        Assert.False(ReadProperty<bool>(result.Value, "spoilerIntentRecorded"));
+        Assert.Equal("pending_cap_exceeded", ReadProperty<string>(result.Value, "reason"));
+        Assert.Equal(SpoilerPendingService.MaxPendingTmdbPerUser, ReadState(setup).PendingTmdb.Count);
+    }
+
+    [Fact]
+    public async Task UpstreamAcceptedUnsupportedMediaType_ReturnsTruthfulPartialSuccess()
+    {
+        var setup = CreateClientHarness();
+
+        var result = Assert.IsType<ObjectResult>(await setup.Client.ProxyRequestAsync(
+            "/api/v1/request",
+            HttpMethod.Post,
+            "{\"mediaType\":\"music\",\"mediaId\":999}",
+            new SeerrCaller(setup.User.Id.ToString("N"), IsAdmin: true)));
+
+        Assert.Equal(500, result.StatusCode);
+        Assert.Equal("seerr_accepted_spoiler_intent_failed", ReadProperty<string>(result.Value, "code"));
+        Assert.Equal("unsupported_request_target", ReadProperty<string>(result.Value, "reason"));
+        Assert.True(ReadProperty<bool>(result.Value, "seerrAccepted"));
+        Assert.False(ReadProperty<bool>(result.Value, "spoilerIntentRecorded"));
+        Assert.Contains("Do not retry", ReadProperty<string>(result.Value, "message"));
+        Assert.Contains("movie/tv", ReadProperty<string>(result.Value, "message"));
+        Assert.Contains("verify", ReadProperty<string>(result.Value, "message"));
+        Assert.Empty(ReadState(setup).PendingTmdb);
+    }
+
+    [Fact]
+    public async Task CapacityOpeningBeforeFallback_ReportsNewPendingRowAsDurable()
+    {
+        var setup = CreateClientHarness();
+        SeedPendingCap(setup);
+        const string removedKey = "movie:100000";
+        setup.Pending.BeforeCapFallbackForTest = () =>
+        {
+            setup.Manager.RmwUserConfiguration<UserSpoilerBlur>(
+                setup.User.Id.ToString("N"),
+                "spoilerblur.json",
+                state => state.PendingTmdb.Remove(removedKey) ? 1 : 0);
+        };
+
+        var result = await setup.Client.ProxyRequestAsync(
+            "/api/v1/request",
+            HttpMethod.Post,
+            "{\"mediaType\":\"movie\",\"mediaId\":999}",
+            new SeerrCaller(setup.User.Id.ToString("N"), IsAdmin: true));
+
+        Assert.IsType<ContentResult>(result);
+        var state = ReadState(setup);
+        Assert.False(state.PendingTmdb.ContainsKey(removedKey));
+        Assert.True(state.PendingTmdb.ContainsKey("movie:999"));
+        Assert.Equal(SpoilerPendingService.MaxPendingTmdbPerUser, state.PendingTmdb.Count);
+    }
+
+    [Fact]
+    public async Task UpstreamSuccess_AtPendingCapWithAccessibleSeries_DurablyPromotes()
+    {
+        var setup = CreateClientHarness();
+        SeedPendingCap(setup);
+        var series = new Series { Id = Guid.NewGuid(), Name = "Already Here" };
+        series.ProviderIds["Tmdb"] = "999";
+        setup.Library.GetItemListHook = _ => new BaseItem[] { series };
+
+        var result = await setup.Client.ProxyRequestAsync(
+            "/api/v1/request",
+            HttpMethod.Post,
+            "{\"mediaType\":\"tv\",\"mediaId\":999}",
+            new SeerrCaller(setup.User.Id.ToString("N"), IsAdmin: true));
+
+        Assert.IsType<ContentResult>(result);
+        var state = ReadState(setup);
+        Assert.Equal(SpoilerPendingService.MaxPendingTmdbPerUser, state.PendingTmdb.Count);
+        Assert.True(state.Series.ContainsKey(series.Id.ToString("N")));
+    }
+
+    [Fact]
+    public async Task RequestSubresourceMutation_IsNotMisclassifiedAsNewMediaIntent()
+    {
+        var setup = CreateClientHarness();
+        setup.Handler.AddResponse("/api/v1/request/7/approve", "{\"id\":7}");
+
+        var result = await setup.Client.ProxyRequestAsync(
+            "/api/v1/request/7/approve",
+            HttpMethod.Post,
+            "{\"mediaType\":\"tv\",\"mediaId\":777}",
+            new SeerrCaller(setup.User.Id.ToString("N"), IsAdmin: true));
+
+        Assert.IsType<ContentResult>(result);
+        Assert.Empty(ReadState(setup).PendingTmdb);
+    }
+
+    [Fact]
+    public async Task UpstreamSuccess_WithCorruptIntentStore_ReturnsExplicitPartialSuccess()
+    {
+        var setup = CreateClientHarness();
+        setup.Manager.SaveUserConfiguration(
+            setup.User.Id.ToString("N"),
+            "spoilerblur.json",
+            new UserSpoilerBlur());
+        var path = Path.Combine(
+            _directory,
+            "configurations",
+            "Jellyfin.Plugin.JellyfinCanopy",
+            setup.User.Id.ToString("N"),
+            "spoilerblur.json");
+        File.WriteAllText(path, "{{{ corrupt intent store");
+
+        var result = Assert.IsType<ObjectResult>(await setup.Client.ProxyRequestAsync(
+            "/api/v1/request",
+            HttpMethod.Post,
+            "{\"mediaType\":\"movie\",\"mediaId\":654}",
+            new SeerrCaller(setup.User.Id.ToString("N"), IsAdmin: true)));
+
+        Assert.Equal(500, result.StatusCode);
+        Assert.Equal("seerr_accepted_spoiler_intent_failed", ReadProperty<string>(result.Value, "code"));
+        Assert.Equal("intent_store_unavailable", ReadProperty<string>(result.Value, "reason"));
+        Assert.True(ReadProperty<bool>(result.Value, "seerrAccepted"));
+    }
+
+    [Fact]
+    public async Task RequestCancellationAfterUpstreamSuccess_CannotAbandonDurableIntent()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var setup = CreateClientHarness(new CancelDuringResponseFilter(cancellation));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => setup.Client.ProxyRequestAsync(
+            "/api/v1/request",
+            HttpMethod.Post,
+            "{\"mediaType\":\"tv\",\"mediaId\":876}",
+            new SeerrCaller(setup.User.Id.ToString("N"), IsAdmin: true),
+            cancellation.Token));
+
+        Assert.True(ReadState(setup).PendingTmdb.ContainsKey("tv:876"));
+    }
+
+    [Fact]
+    public async Task RequestCancellationAfterSuccessHeadersBeforeJsonCompletion_CannotAbandonIntent()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var setup = CreateClientHarness();
+        var body = new BlockingResponseStream();
+        setup.Handler.ResponseFactory = request =>
+        {
+            if (request.RequestUri!.AbsolutePath != "/api/v1/request")
+            {
+                return null;
+            }
+
+            var content = new StreamContent(body);
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+            return new HttpResponseMessage(HttpStatusCode.Created) { Content = content };
+        };
+
+        var requestTask = setup.Client.ProxyRequestAsync(
+            "/api/v1/request",
+            HttpMethod.Post,
+            "{\"mediaType\":\"tv\",\"mediaId\":877}",
+            new SeerrCaller(setup.User.Id.ToString("N"), IsAdmin: true),
+            cancellation.Token);
+        await body.ReadStarted.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.True(ReadState(setup).PendingTmdb.ContainsKey("tv:877"));
+        cancellation.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => requestTask);
+        Assert.True(body.CancellationObserved);
+    }
+
+    [Fact]
+    public async Task AutoEnableDecision_IsFrozenBeforeDispatchDespiteInPlaceDisableAfterAcceptance()
+    {
+        var setup = CreateClientHarness();
+        setup.Handler.BeforeResponse = request =>
+        {
+            if (request.RequestUri!.AbsolutePath == "/api/v1/request")
+            {
+                setup.Provider.Current!.SpoilerAutoEnableOnSeerrRequest = false;
+            }
+        };
+
+        var result = await setup.Client.ProxyRequestAsync(
+            "/api/v1/request",
+            HttpMethod.Post,
+            "{\"mediaType\":\"movie\",\"mediaId\":878}",
+            new SeerrCaller(setup.User.Id.ToString("N"), IsAdmin: true));
+
+        Assert.IsType<ContentResult>(result);
+        Assert.False(setup.Provider.Current!.SpoilerAutoEnableOnSeerrRequest);
+        Assert.True(ReadState(setup).PendingTmdb.ContainsKey("movie:878"));
+    }
+
+    private ClientHarness CreateClientHarness(ISeerrParentalFilter? parentalFilter = null)
+    {
+        var user = new User("intent-harness", "provider", "password-provider");
+        var handler = new RecordingHttpMessageHandler();
+        handler.AddResponse(
+            "/api/v1/user",
+            $"{{\"results\":[{{\"id\":42,\"jellyfinUserId\":\"{user.Id:N}\",\"permissions\":2}}],\"pageInfo\":{{\"page\":1,\"pages\":1,\"results\":1}}}}");
+        handler.AddResponse("/api/v1/request", "{\"id\":1}", HttpStatusCode.Created);
+        var provider = new FakePluginConfigProvider(new PluginConfiguration
+        {
+            SeerrEnabled = true,
+            SeerrUrls = Source,
+            SeerrApiKey = "test-key",
+            SpoilerBlurEnabled = true,
+            SpoilerAutoEnableOnSeerrRequest = true,
+        });
+        var manager = new UserConfigurationManager(
+            new StubAppPaths(_directory),
+            NullLogger<UserConfigurationManager>.Instance);
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = _ => Array.Empty<BaseItem>(),
+        };
+        var users = new StubUserManager(user);
+        var pending = new SpoilerPendingService(
+            manager,
+            library,
+            users,
+            NullLogger<SpoilerPendingService>.Instance);
+        var client = new SeerrClient(
+            new RecordingHttpClientFactory(handler),
+            NullLogger<SeerrClient>.Instance,
+            users,
+            new SeerrCache(provider),
+            provider,
+            parentalFilter ?? new PassthroughParentalFilter(),
+            pending);
+        return new ClientHarness(user, users, handler, provider, manager, library, pending, client);
+    }
+
+    private static void SeedPendingCap(ClientHarness setup)
+    {
+        var state = new UserSpoilerBlur();
+        for (var i = 0; i < SpoilerPendingService.MaxPendingTmdbPerUser; i++)
+        {
+            var key = $"movie:{100_000 + i}";
+            state.PendingTmdb[key] = new SpoilerBlurPendingEntry
+            {
+                MediaType = "movie",
+                TmdbId = (100_000 + i).ToString(System.Globalization.CultureInfo.InvariantCulture),
+            };
+        }
+
+        setup.Manager.SaveUserConfiguration(setup.User.Id.ToString("N"), "spoilerblur.json", state);
+    }
+
+    private static UserSpoilerBlur ReadState(ClientHarness setup)
+        => setup.Manager.GetUserConfiguration<UserSpoilerBlur>(
+            setup.User.Id.ToString("N"),
+            "spoilerblur.json");
+
+    private static T ReadProperty<T>(object? value, string name)
+        => Assert.IsType<T>(value?.GetType().GetProperty(name)?.GetValue(value));
+
+    private sealed record ClientHarness(
+        User User,
+        StubUserManager Users,
+        RecordingHttpMessageHandler Handler,
+        FakePluginConfigProvider Provider,
+        UserConfigurationManager Manager,
+        CountingLibraryManager Library,
+        SpoilerPendingService Pending,
+        SeerrClient Client);
+
+    private sealed class PassthroughParentalFilter : ISeerrParentalFilter
+    {
+        public Task<SeerrParentalResult> ApplyAsync(string json, string apiPath, SeerrCaller caller)
+            => Task.FromResult(new SeerrParentalResult(false, json));
+
+        public Task<bool> IsBlockedAsync(string mediaType, int tmdbId, SeerrCaller caller)
+            => Task.FromResult(false);
+
+        public Task<bool> IsTmdbProxyPathBlockedAsync(string tmdbApiPath, SeerrCaller caller)
+            => Task.FromResult(false);
+    }
+
+    private sealed class CancelDuringResponseFilter : ISeerrParentalFilter
+    {
+        private readonly CancellationTokenSource _cancellation;
+
+        public CancelDuringResponseFilter(CancellationTokenSource cancellation)
+            => _cancellation = cancellation;
+
+        public Task<SeerrParentalResult> ApplyAsync(string json, string apiPath, SeerrCaller caller)
+        {
+            _cancellation.Cancel();
+            return Task.FromResult(new SeerrParentalResult(false, json));
+        }
+
+        public Task<bool> IsBlockedAsync(string mediaType, int tmdbId, SeerrCaller caller)
+            => Task.FromResult(false);
+
+        public Task<bool> IsTmdbProxyPathBlockedAsync(string tmdbApiPath, SeerrCaller caller)
+            => Task.FromResult(false);
+    }
+
+    private sealed class BlockingResponseStream : Stream
+    {
+        private readonly TaskCompletionSource _readStarted = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task ReadStarted => _readStarted.Task;
+
+        public bool CancellationObserved { get; private set; }
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+            => throw new NotSupportedException();
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            _readStarted.TrySetResult();
+            try
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                throw new InvalidOperationException("The blocked response unexpectedly resumed.");
+            }
+            catch (OperationCanceledException)
+            {
+                CancellationObserved = true;
+                throw;
+            }
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        public override void Flush() => throw new NotSupportedException();
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrIssueViewPolicyTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrIssueViewPolicyTests.cs
@@ -46,7 +46,8 @@ public class SeerrIssueViewPolicyTests
             null!,
             new SeerrCache(provider),
             provider,
-            new PassthroughParentalFilter());
+            new PassthroughParentalFilter(),
+            spoilerPendingService: null!);
         return (client, handler);
     }
 

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrPaginationIntegrationTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrPaginationIntegrationTests.cs
@@ -1164,7 +1164,8 @@ public class SeerrPaginationIntegrationTests
             userManager: null!,
             cache,
             provider,
-            parentalFilter: null!);
+            parentalFilter: null!,
+            spoilerPendingService: null!);
         return (client, cache);
     }
 
@@ -1178,7 +1179,8 @@ public class SeerrPaginationIntegrationTests
             userManager: null!,
             cache,
             provider,
-            parentalFilter: null!);
+            parentalFilter: null!,
+            spoilerPendingService: null!);
 
     private static object UserRow(int id, string jellyfinUserId) => new
     {

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrPublicScopeHeaderTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrPublicScopeHeaderTests.cs
@@ -42,7 +42,8 @@ public class SeerrPublicScopeHeaderTests
             null!,
             new SeerrCache(provider),
             provider,
-            new PassthroughParentalFilter());
+            new PassthroughParentalFilter(),
+            null!);
         return (client, handler);
     }
 
@@ -238,7 +239,8 @@ public class SeerrPublicScopeHeaderTests
             null!,
             new SeerrCache(provider),
             provider,
-            new PassthroughParentalFilter());
+            new PassthroughParentalFilter(),
+            null!);
         var caller = new SeerrCaller(UserId, IsAdmin: true);
 
         await client.ProxyRequestAsync(
@@ -281,7 +283,8 @@ public class SeerrPublicScopeHeaderTests
             null!,
             new SeerrCache(provider),
             provider,
-            new PassthroughParentalFilter());
+            new PassthroughParentalFilter(),
+            null!);
         var caller = new SeerrCaller(UserId, IsAdmin: true);
 
         await client.ProxyRequestAsync(
@@ -335,7 +338,8 @@ public class SeerrPublicScopeHeaderTests
             null!,
             cache,
             provider,
-            new PassthroughParentalFilter());
+            new PassthroughParentalFilter(),
+            null!);
 
         var result = Assert.IsType<ObjectResult>(await client.ProxyRequestAsync(
             "/api/v1/issue",

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrReadGenerationFenceTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrReadGenerationFenceTests.cs
@@ -313,7 +313,8 @@ public sealed class SeerrReadGenerationFenceTests
             userManager: null!,
             cache,
             provider,
-            parentalFilter);
+            parentalFilter,
+            spoilerPendingService: null!);
 
     private static PluginConfiguration Configuration(string source, string apiKey) => new()
     {

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SpoilerGuardTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SpoilerGuardTests.cs
@@ -19,7 +19,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
     /// Unit coverage for the pure/testable pieces of the Spoiler Guard port:
     /// the admin-cap-vs-user-override strip gate, the placeholder sanitizer, the
     /// cache-bust tag mutation, the per-user state dictionary comparer round-trip
-    /// through the real store serializer, the Seerr-promoter static gate, and the
+    /// through the real store serializer, the Seerr-promoter instance gate, and the
     /// SkiaSharp blur service's structural fallback + cache bounding.
     /// </summary>
     public class SpoilerGuardTests
@@ -331,40 +331,69 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             }
         }
 
-        // ─── SpoilerSeerrPendingPromoter static gate atomicity ───────────────────
+        // ─── SpoilerSeerrPendingPromoter instance gate atomicity ─────────────────
 
         [Fact]
-        public void PromoterGate_RegisterUnregister_TracksUsersAndRemovesEmptyKey()
+        public async Task PromoterGate_RegisterUnregister_TracksUsersAndRemovesEmptyKey()
         {
+            var directory = Path.Combine(Path.GetTempPath(), "jc-promoter-gate-" + Guid.NewGuid().ToString("N"));
+            var manager = new UserConfigurationManager(
+                new StubAppPaths(directory),
+                NullLogger<UserConfigurationManager>.Instance);
+            var library = new CountingLibraryManager();
+            var users = new StubUserManager();
+            var pending = new SpoilerPendingService(
+                manager,
+                library,
+                users,
+                NullLogger<SpoilerPendingService>.Instance);
+            var promoter = new SpoilerSeerrPendingPromoter(
+                library,
+                users,
+                manager,
+                new FakePluginConfigProvider(null),
+                pending,
+                NullLogger<SpoilerSeerrPendingPromoter>.Instance);
             var key = "tv:" + Guid.NewGuid().ToString("N");
             var userA = Guid.NewGuid();
             var userB = Guid.NewGuid();
+            await promoter.StartAsync(CancellationToken.None);
+            await promoter.ReplayCompletionForTest;
 
-            Assert.False(SpoilerSeerrPendingPromoter.IsKeyRegisteredForTest(key));
+            try
+            {
+                Assert.False(promoter.IsKeyRegisteredForTest(key));
 
-            SpoilerSeerrPendingPromoter.RegisterPending(key, userA);
-            SpoilerSeerrPendingPromoter.RegisterPending(key, userB);
-            Assert.True(SpoilerSeerrPendingPromoter.IsKeyRegisteredForTest(key));
-            Assert.Equal(2, SpoilerSeerrPendingPromoter.RegisteredUserCountForTest(key));
+                promoter.RegisterPending(key, userA);
+                promoter.RegisterPending(key, userB);
+                Assert.True(promoter.IsKeyRegisteredForTest(key));
+                Assert.Equal(2, promoter.RegisteredUserCountForTest(key));
 
-            // Re-register is idempotent (set semantics).
-            SpoilerSeerrPendingPromoter.RegisterPending(key, userA);
-            Assert.Equal(2, SpoilerSeerrPendingPromoter.RegisteredUserCountForTest(key));
+                // Re-register is idempotent (set semantics).
+                promoter.RegisterPending(key, userA);
+                Assert.Equal(2, promoter.RegisteredUserCountForTest(key));
 
-            SpoilerSeerrPendingPromoter.UnregisterPending(key, userA);
-            Assert.Equal(1, SpoilerSeerrPendingPromoter.RegisteredUserCountForTest(key));
-            Assert.True(SpoilerSeerrPendingPromoter.IsKeyRegisteredForTest(key));
+                promoter.UnregisterPending(key, userA);
+                Assert.Equal(1, promoter.RegisteredUserCountForTest(key));
+                Assert.True(promoter.IsKeyRegisteredForTest(key));
 
-            // Removing the last user drops the key entirely.
-            SpoilerSeerrPendingPromoter.UnregisterPending(key, userB);
-            Assert.False(SpoilerSeerrPendingPromoter.IsKeyRegisteredForTest(key));
+                // Removing the last user drops the key entirely.
+                promoter.UnregisterPending(key, userB);
+                Assert.False(promoter.IsKeyRegisteredForTest(key));
 
-            // Unregistering a gone key + empty inputs are no-ops (no throw).
-            SpoilerSeerrPendingPromoter.UnregisterPending(key, userB);
-            SpoilerSeerrPendingPromoter.RegisterPending(string.Empty, userA);
-            SpoilerSeerrPendingPromoter.RegisterPending(key, Guid.Empty);
-            Assert.False(SpoilerSeerrPendingPromoter.IsKeyRegisteredForTest(key));
-            Assert.False(SpoilerSeerrPendingPromoter.IsKeyRegisteredForTest(string.Empty));
+                // Unregistering a gone key + empty inputs are no-ops (no throw).
+                promoter.UnregisterPending(key, userB);
+                promoter.RegisterPending(string.Empty, userA);
+                promoter.RegisterPending(key, Guid.Empty);
+                Assert.False(promoter.IsKeyRegisteredForTest(key));
+                Assert.False(promoter.IsKeyRegisteredForTest(string.Empty));
+            }
+            finally
+            {
+                await promoter.StopAsync(CancellationToken.None);
+            }
+
+            try { Directory.Delete(directory, recursive: true); } catch { /* best-effort cleanup */ }
         }
 
         // ─── ImageBlurService ─────────────────────────────────────────────────────

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SpoilerPendingPromoterLifecycleTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SpoilerPendingPromoterLifecycleTests.cs
@@ -1,0 +1,712 @@
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Services;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.TV;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services;
+
+public sealed class SpoilerPendingPromoterLifecycleTests : IDisposable
+{
+    private const string SpoilerFile = "spoilerblur.json";
+    private readonly string _directory = Path.Combine(
+        Path.GetTempPath(),
+        "jc-promoter-lifecycle-" + Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+        catch
+        {
+            // Best-effort test cleanup.
+        }
+    }
+
+    [Fact]
+    public async Task StopAsync_DrainsAcceptedPromotion_AndNoWorkerWriteSurvivesStop()
+    {
+        var harness = CreateHarness();
+        const string pendingKey = "tv:123";
+        var series = VisibleSeries("123");
+        SavePending(harness.Manager, harness.User.Id, pendingKey);
+        harness.Library.GetItemListHook = _ => new BaseItem[] { series };
+        harness.Library.GetItemByIdUserHook = (_, _) => series;
+
+        var entered = NewSignal();
+        var release = NewSignal();
+        harness.Promoter.BeforePromotionForTest = _ =>
+        {
+            entered.TrySetResult();
+            return release.Task;
+        };
+
+        await harness.Promoter.StartAsync(CancellationToken.None);
+        await entered.Task;
+
+        var stop = harness.Promoter.StopAsync(CancellationToken.None);
+        Assert.False(stop.IsCompleted);
+
+        release.TrySetResult();
+        await stop;
+
+        var state = ReadState(harness.Manager, harness.User.Id);
+        Assert.Empty(state.PendingTmdb);
+        Assert.True(state.Series.ContainsKey(series.Id.ToString("N")));
+
+        // The completed owner has unsubscribed. A later matching event cannot
+        // launch detached work or mutate the already-drained generation.
+        harness.Library.RaiseItemAdded(series);
+        Assert.Empty(ReadState(harness.Manager, harness.User.Id).PendingTmdb);
+    }
+
+    [Fact]
+    public async Task StartupReplayBeyondQueueCapacity_ReturnsBeforeAdmissionBlocks_AndCanceledStopAbortsOwnership()
+    {
+        var harness = CreateHarness(queueCapacity: SpoilerSeerrPendingPromoter.DefaultQueueCapacity);
+        var pendingKeys = Enumerable.Range(600, SpoilerSeerrPendingPromoter.DefaultQueueCapacity + 2)
+            .Select(value => $"tv:{value}")
+            .ToArray();
+        SavePending(harness.Manager, harness.User.Id, pendingKeys);
+
+        var firstEntered = NewSignal();
+        var releaseFirst = NewSignal();
+        var replayReachedBlockedAdmission = NewSignal();
+        var firstSweep = 0;
+        string? blockedKey = null;
+        Series? blockedSeries = null;
+        harness.Promoter.BeforePromotionForTest = key =>
+        {
+            if (Interlocked.Exchange(ref firstSweep, 1) != 0)
+            {
+                return Task.CompletedTask;
+            }
+
+            blockedKey = key;
+            blockedSeries = VisibleSeries(key.Substring(key.IndexOf(':') + 1));
+            firstEntered.TrySetResult();
+            return releaseFirst.Task;
+        };
+        harness.Promoter.BeforeReplayWriteForTest = (_, scheduledCount) =>
+        {
+            if (scheduledCount >= SpoilerSeerrPendingPromoter.DefaultQueueCapacity + 2)
+            {
+                replayReachedBlockedAdmission.TrySetResult();
+            }
+        };
+        harness.Library.GetItemListHook = query =>
+        {
+            if (blockedSeries != null
+                && query.HasAnyProviderId != null
+                && query.HasAnyProviderId.TryGetValue("Tmdb", out var requestedTmdb)
+                && blockedSeries.ProviderIds.TryGetValue("Tmdb", out var blockedTmdb)
+                && string.Equals(requestedTmdb, blockedTmdb, StringComparison.Ordinal))
+            {
+                return new BaseItem[] { blockedSeries };
+            }
+
+            return Array.Empty<BaseItem>();
+        };
+        harness.Library.GetItemByIdUserHook = (itemId, user) =>
+            blockedSeries != null
+            && itemId == blockedSeries.Id
+            && user?.Id == harness.User.Id
+                ? blockedSeries
+                : null;
+
+        var start = harness.Promoter.StartAsync(CancellationToken.None);
+        await firstEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await replayReachedBlockedAdmission.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var startReturnedBeforeReplayFilledTheBoundedQueue = start.IsCompletedSuccessfully;
+
+        using var hostDeadline = new CancellationTokenSource();
+        var stop = harness.Promoter.StopAsync(hostDeadline.Token);
+        hostDeadline.Cancel();
+        var stopCompletedBeforeBlockedPromotionWasReleased = false;
+        try
+        {
+            await stop.WaitAsync(TimeSpan.FromSeconds(5));
+            stopCompletedBeforeBlockedPromotionWasReleased = true;
+        }
+        catch (TimeoutException)
+        {
+            // Bound cleanup of the pre-fix lifecycle deadlock so the regression
+            // can report both violated contracts without stranding the test host.
+        }
+        finally
+        {
+            releaseFirst.TrySetResult();
+            await start.WaitAsync(TimeSpan.FromSeconds(5));
+            await stop.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+
+        Assert.True(
+            startReturnedBeforeReplayFilledTheBoundedQueue
+            && stopCompletedBeforeBlockedPromotionWasReleased,
+            "Durable replay must leave the startup path and a canceled host deadline "
+            + "must abort queued/in-flight ownership. "
+            + $"Startup returned: {startReturnedBeforeReplayFilledTheBoundedQueue}; "
+            + $"stop completed before release: {stopCompletedBeforeBlockedPromotionWasReleased}.");
+
+        Assert.NotNull(blockedKey);
+        Assert.NotNull(blockedSeries);
+        harness.Library.RaiseItemAdded(blockedSeries);
+        var stoppedState = ReadState(harness.Manager, harness.User.Id);
+        Assert.Equal(pendingKeys.Length, stoppedState.PendingTmdb.Count);
+        Assert.Empty(stoppedState.Series);
+
+        // Cancellation abandons only ephemeral ownership. The durable row is
+        // replayed and promoted by a fresh generation without another event.
+        var restarted = NewPromoter(
+            harness,
+            SpoilerSeerrPendingPromoter.DefaultQueueCapacity);
+        var replayed = NewSignal();
+        restarted.AfterPromotionForTest = key =>
+        {
+            if (string.Equals(key, blockedKey, StringComparison.OrdinalIgnoreCase))
+            {
+                replayed.TrySetResult();
+            }
+        };
+        await restarted.StartAsync(CancellationToken.None);
+        await replayed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await restarted.StopAsync(CancellationToken.None);
+
+        var replayedState = ReadState(harness.Manager, harness.User.Id);
+        Assert.False(replayedState.PendingTmdb.ContainsKey(blockedKey));
+        Assert.True(replayedState.Series.ContainsKey(blockedSeries.Id.ToString("N")));
+    }
+
+    [Fact]
+    public async Task ConcurrentStart_WaitsForBlockedStopBeforeCreatingNextGeneration()
+    {
+        var harness = CreateHarness();
+        const string pendingKey = "tv:234";
+        SavePending(harness.Manager, harness.User.Id, pendingKey);
+        harness.Library.GetItemListHook = _ => Array.Empty<BaseItem>();
+        var firstEntered = NewSignal();
+        var releaseFirst = NewSignal();
+        var secondEntered = NewSignal();
+        var sweepCount = 0;
+        harness.Promoter.BeforePromotionForTest = _ =>
+        {
+            if (Interlocked.Increment(ref sweepCount) == 1)
+            {
+                firstEntered.TrySetResult();
+                return releaseFirst.Task;
+            }
+
+            secondEntered.TrySetResult();
+            return Task.CompletedTask;
+        };
+
+        await harness.Promoter.StartAsync(CancellationToken.None);
+        await firstEntered.Task;
+        var stop = harness.Promoter.StopAsync(CancellationToken.None);
+        var restart = harness.Promoter.StartAsync(CancellationToken.None);
+
+        Assert.False(stop.IsCompleted);
+        Assert.False(restart.IsCompleted);
+        Assert.True(harness.Promoter.IsUserRegisteredForTest(pendingKey, harness.User.Id));
+
+        releaseFirst.TrySetResult();
+        await stop;
+        await restart;
+        await secondEntered.Task;
+
+        Assert.True(harness.Promoter.IsUserRegisteredForTest(pendingKey, harness.User.Id));
+        Assert.Equal(2, Volatile.Read(ref sweepCount));
+        await harness.Promoter.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task Startup_DeletedUserRowsCannotFillQueueOrHoldLifecycleGate()
+    {
+        var harness = CreateHarness(queueCapacity: 1);
+        var deletedUserId = Guid.NewGuid();
+        var orphanKeys = new[] { "tv:301", "tv:302", "tv:303" };
+        SavePending(harness.Manager, deletedUserId, orphanKeys);
+        var orphanSweepEntered = NewSignal();
+        var releaseOrphanSweep = NewSignal();
+        harness.Promoter.BeforePromotionForTest = _ =>
+        {
+            orphanSweepEntered.TrySetResult();
+            return releaseOrphanSweep.Task;
+        };
+
+        await harness.Promoter.StartAsync(CancellationToken.None);
+        var replay = harness.Promoter.ReplayCompletionForTest;
+        var winner = await Task.WhenAny(replay, orphanSweepEntered.Task)
+            .WaitAsync(TimeSpan.FromSeconds(5));
+        var replayCompletedWithoutOrphanSweep = ReferenceEquals(winner, replay);
+
+        // Keep the old failure mode bounded: if startup admitted the three
+        // orphan keys, one is running, one fills the channel, and the third
+        // holds StartAsync inside the lifecycle gate. Removing the in-memory
+        // registrations lets that broken generation drain before assertion.
+        foreach (var key in orphanKeys)
+        {
+            harness.Promoter.UnregisterPending(key, deletedUserId);
+        }
+
+        releaseOrphanSweep.TrySetResult();
+        await replay.WaitAsync(TimeSpan.FromSeconds(5));
+        await harness.Promoter.StopAsync(CancellationToken.None);
+
+        Assert.True(
+            replayCompletedWithoutOrphanSweep,
+            "Background replay must skip durable directories whose Jellyfin user no longer exists.");
+        Assert.All(
+            orphanKeys,
+            key => Assert.False(harness.Promoter.IsKeyRegisteredForTest(key)));
+        var orphanState = ReadState(harness.Manager, deletedUserId);
+        Assert.Equal(3, orphanState.PendingTmdb.Count);
+        Assert.All(orphanKeys, key => Assert.True(orphanState.PendingTmdb.ContainsKey(key)));
+    }
+
+    [Fact]
+    public async Task DeletedUserDuringSweep_DoesNotStarveLiveKey_AndGracefulStopDrainsIt()
+    {
+        var deletedUser = new User("deleted-during-sweep", "provider", "password-provider");
+        var liveUser = new User("live-behind-orphan", "provider", "password-provider");
+        var harness = CreateHarness(new[] { deletedUser, liveUser }, queueCapacity: 1);
+        const string orphanKey = "tv:401";
+        const string liveKey = "tv:402";
+        var liveSeries = VisibleSeries("402");
+        harness.Library.GetItemListHook = query =>
+        {
+            if (query.HasAnyProviderId != null
+                && query.HasAnyProviderId.TryGetValue("Tmdb", out var requestedTmdb)
+                && string.Equals(requestedTmdb, "402", StringComparison.Ordinal))
+            {
+                return new BaseItem[] { liveSeries };
+            }
+
+            return Array.Empty<BaseItem>();
+        };
+        harness.Library.GetItemByIdUserHook = (itemId, user) =>
+            itemId == liveSeries.Id && user?.Id == liveUser.Id ? liveSeries : null;
+
+        var firstOrphanSweepEntered = NewSignal();
+        var releaseFirstOrphanSweep = NewSignal();
+        var repeatedOrphanSweepEntered = NewSignal();
+        var releaseRepeatedOrphanSweep = NewSignal();
+        var liveSweepEntered = NewSignal();
+        var releaseLiveSweep = NewSignal();
+        var orphanSweepCount = 0;
+        harness.Promoter.BeforePromotionForTest = key =>
+        {
+            if (string.Equals(key, orphanKey, StringComparison.OrdinalIgnoreCase))
+            {
+                if (Interlocked.Increment(ref orphanSweepCount) == 1)
+                {
+                    firstOrphanSweepEntered.TrySetResult();
+                    return releaseFirstOrphanSweep.Task;
+                }
+
+                repeatedOrphanSweepEntered.TrySetResult();
+                return releaseRepeatedOrphanSweep.Task;
+            }
+
+            if (string.Equals(key, liveKey, StringComparison.OrdinalIgnoreCase))
+            {
+                liveSweepEntered.TrySetResult();
+                return releaseLiveSweep.Task;
+            }
+
+            return Task.CompletedTask;
+        };
+
+        await harness.Promoter.StartAsync(CancellationToken.None);
+        await harness.Promoter.ReplayCompletionForTest;
+        SavePending(harness.Manager, deletedUser.Id, orphanKey);
+        SavePending(harness.Manager, liveUser.Id, liveKey);
+        harness.Pending.NotifyPendingRegistered(orphanKey, deletedUser.Id);
+        await firstOrphanSweepEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // The durable directory remains, but Jellyfin deletes the user while
+        // the already-accepted sweep is paused. Queue the live key behind it.
+        harness.Users.GetUserByIdHook = userId =>
+            userId == deletedUser.Id
+                ? null
+                : userId == liveUser.Id
+                    ? liveUser
+                    : null;
+        harness.Pending.NotifyPendingRegistered(liveKey, liveUser.Id);
+        releaseFirstOrphanSweep.TrySetResult();
+
+        var winner = await Task.WhenAny(liveSweepEntered.Task, repeatedOrphanSweepEntered.Task)
+            .WaitAsync(TimeSpan.FromSeconds(5));
+        var liveKeyWasNotStarved = ReferenceEquals(winner, liveSweepEntered.Task);
+
+        var stop = harness.Promoter.StopAsync(CancellationToken.None);
+        Assert.False(stop.IsCompleted);
+
+        // Whichever old/new path won is deliberately blocked above. Release
+        // both barriers so the stop can prove that all accepted work drains.
+        releaseRepeatedOrphanSweep.TrySetResult();
+        releaseLiveSweep.TrySetResult();
+        await stop.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.True(
+            liveKeyWasNotStarved,
+            "A deleted user's durable row must not self-rerun ahead of a later accepted key.");
+        Assert.Equal(1, Volatile.Read(ref orphanSweepCount));
+        Assert.True(ReadState(harness.Manager, deletedUser.Id).PendingTmdb.ContainsKey(orphanKey));
+        var liveState = ReadState(harness.Manager, liveUser.Id);
+        Assert.Empty(liveState.PendingTmdb);
+        Assert.True(liveState.Series.ContainsKey(liveSeries.Id.ToString("N")));
+    }
+
+    [Fact]
+    public async Task AbsentPendingRow_StillReconcilesAndUnregistersEphemeralGate()
+    {
+        var harness = CreateHarness();
+        const string pendingKey = "tv:501";
+        var series = VisibleSeries("501");
+        harness.Library.GetItemListHook = _ => new BaseItem[] { series };
+        harness.Library.GetItemByIdUserHook = (_, _) => series;
+        var swept = NewSignal();
+        harness.Promoter.AfterPromotionForTest = key =>
+        {
+            if (string.Equals(key, pendingKey, StringComparison.OrdinalIgnoreCase))
+            {
+                swept.TrySetResult();
+            }
+        };
+
+        await harness.Promoter.StartAsync(CancellationToken.None);
+        await harness.Promoter.ReplayCompletionForTest;
+        harness.Pending.NotifyPendingRegistered(pendingKey, harness.User.Id);
+        await swept.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.False(harness.Promoter.IsKeyRegisteredForTest(pendingKey));
+        Assert.Empty(ReadState(harness.Manager, harness.User.Id).PendingTmdb);
+        await harness.Promoter.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task UnregisteredQueuedKey_IsSkippedWithoutRecreatingEphemeralOwnership()
+    {
+        var harness = CreateHarness();
+        const string pendingKey = "tv:502";
+        SavePending(harness.Manager, harness.User.Id, pendingKey);
+        harness.Library.GetItemListHook = _ => Array.Empty<BaseItem>();
+        var entered = NewSignal();
+        var release = NewSignal();
+        var swept = NewSignal();
+        harness.Promoter.BeforePromotionForTest = key =>
+        {
+            if (string.Equals(key, pendingKey, StringComparison.OrdinalIgnoreCase))
+            {
+                entered.TrySetResult();
+                return release.Task;
+            }
+
+            return Task.CompletedTask;
+        };
+        harness.Promoter.AfterPromotionForTest = key =>
+        {
+            if (string.Equals(key, pendingKey, StringComparison.OrdinalIgnoreCase))
+            {
+                swept.TrySetResult();
+            }
+        };
+
+        await harness.Promoter.StartAsync(CancellationToken.None);
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        harness.Promoter.UnregisterPending(pendingKey, harness.User.Id);
+        release.TrySetResult();
+        await swept.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await harness.Promoter.StopAsync(CancellationToken.None);
+
+        Assert.False(harness.Promoter.IsKeyRegisteredForTest(pendingKey));
+        Assert.True(ReadState(harness.Manager, harness.User.Id).PendingTmdb.ContainsKey(pendingKey));
+    }
+
+    [Fact]
+    public async Task RegisterPending_RetriesWhenLastUserRemovalDetachesObtainedDictionary()
+    {
+        var harness = CreateHarness();
+        await harness.Promoter.StartAsync(CancellationToken.None);
+        await harness.Promoter.ReplayCompletionForTest;
+        const string pendingKey = "tv:345";
+        var existingUser = harness.User.Id;
+        var registeringUser = Guid.NewGuid();
+        harness.Promoter.RegisterPending(pendingKey, existingUser);
+        var dictionaryObtained = NewSignal();
+        var allowAdd = NewSignal();
+        harness.Promoter.PendingDictionaryAcquiredForTest = (key, userId) =>
+        {
+            if (key == pendingKey && userId == registeringUser)
+            {
+                dictionaryObtained.TrySetResult();
+                allowAdd.Task.GetAwaiter().GetResult();
+            }
+        };
+
+        var register = Task.Run(() => harness.Promoter.RegisterPending(pendingKey, registeringUser));
+        await dictionaryObtained.Task;
+        harness.Promoter.UnregisterPending(pendingKey, existingUser);
+        Assert.False(harness.Promoter.IsKeyRegisteredForTest(pendingKey));
+
+        allowAdd.TrySetResult();
+        await register;
+
+        Assert.True(harness.Promoter.IsUserRegisteredForTest(pendingKey, registeringUser));
+        Assert.Equal(1, harness.Promoter.RegisteredUserCountForTest(pendingKey));
+        await harness.Promoter.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task FreshInstance_ReplaysDurableRowWithoutAnotherLibraryEvent()
+    {
+        var harness = CreateHarness();
+        const string pendingKey = "tv:456";
+        SavePending(harness.Manager, harness.User.Id, pendingKey);
+        harness.Library.GetItemListHook = _ => Array.Empty<BaseItem>();
+
+        var firstSweep = NewSignal();
+        harness.Promoter.AfterPromotionForTest = _ => firstSweep.TrySetResult();
+        await harness.Promoter.StartAsync(CancellationToken.None);
+        await firstSweep.Task;
+        await harness.Promoter.StopAsync(CancellationToken.None);
+        Assert.True(ReadState(harness.Manager, harness.User.Id).PendingTmdb.ContainsKey(pendingKey));
+
+        var series = VisibleSeries("456");
+        harness.Library.GetItemListHook = _ => new BaseItem[] { series };
+        harness.Library.GetItemByIdUserHook = (_, _) => series;
+        var restarted = NewPromoter(harness, queueCapacity: 2);
+        var replayed = NewSignal();
+        restarted.AfterPromotionForTest = _ => replayed.TrySetResult();
+
+        await restarted.StartAsync(CancellationToken.None);
+        await replayed.Task;
+        await restarted.StopAsync(CancellationToken.None);
+
+        var state = ReadState(harness.Manager, harness.User.Id);
+        Assert.Empty(state.PendingTmdb);
+        Assert.True(state.Series.ContainsKey(series.Id.ToString("N")));
+    }
+
+    [Fact]
+    public async Task DuplicateBurst_Coalesces_AndSaturationLeavesEveryIntentDurable()
+    {
+        var harness = CreateHarness(queueCapacity: 1);
+        harness.Library.GetItemListHook = _ => Array.Empty<BaseItem>();
+        var entered = NewSignal();
+        var release = NewSignal();
+        harness.Promoter.BeforePromotionForTest = key =>
+        {
+            if (string.Equals(key, "tv:100", StringComparison.OrdinalIgnoreCase))
+            {
+                entered.TrySetResult();
+            }
+
+            return release.Task;
+        };
+        await harness.Promoter.StartAsync(CancellationToken.None);
+        await harness.Promoter.ReplayCompletionForTest;
+
+        Assert.True(harness.Pending.RegisterSeerrIntent(
+            harness.User.Id,
+            "{\"mediaType\":\"tv\",\"mediaId\":100}").IsDurable);
+        await entered.Task;
+        for (var i = 0; i < 64; i++)
+        {
+            Assert.True(harness.Pending.RegisterSeerrIntent(
+                harness.User.Id,
+                "{\"mediaType\":\"tv\",\"mediaId\":100}").IsDurable);
+        }
+
+        Assert.True(harness.Pending.RegisterSeerrIntent(
+            harness.User.Id,
+            "{\"mediaType\":\"tv\",\"mediaId\":101}").IsDurable);
+        Assert.True(harness.Pending.RegisterSeerrIntent(
+            harness.User.Id,
+            "{\"mediaType\":\"tv\",\"mediaId\":102}").IsDurable);
+
+        var durable = ReadState(harness.Manager, harness.User.Id);
+        Assert.Equal(3, durable.PendingTmdb.Count);
+        Assert.Equal(1, harness.Promoter.RegisteredUserCountForTest("tv:100"));
+        Assert.InRange(harness.Promoter.ScheduledKeyCountForTest, 1, 2);
+
+        release.TrySetResult();
+        await harness.Promoter.StopAsync(CancellationToken.None);
+        Assert.Equal(3, ReadState(harness.Manager, harness.User.Id).PendingTmdb.Count);
+    }
+
+    [Fact]
+    public async Task HotKeyRerun_RequeuesAtTailSoInterleavedColdKeyRunsNext()
+    {
+        var harness = CreateHarness(queueCapacity: 2);
+        const string hotKey = "tv:700";
+        const string coldKey = "tv:701";
+        harness.Library.GetItemListHook = _ => Array.Empty<BaseItem>();
+        var firstHotEntered = NewSignal();
+        var releaseFirstHot = NewSignal();
+        var secondHotEntered = NewSignal();
+        var coldEntered = NewSignal();
+        var hotSweepCount = 0;
+        var sweepOrdinal = 0;
+        var secondHotOrdinal = 0;
+        var coldOrdinal = 0;
+        harness.Promoter.BeforePromotionForTest = key =>
+        {
+            var ordinal = Interlocked.Increment(ref sweepOrdinal);
+            if (string.Equals(key, hotKey, StringComparison.OrdinalIgnoreCase))
+            {
+                if (Interlocked.Increment(ref hotSweepCount) == 1)
+                {
+                    firstHotEntered.TrySetResult();
+                    return releaseFirstHot.Task;
+                }
+
+                Volatile.Write(ref secondHotOrdinal, ordinal);
+                secondHotEntered.TrySetResult();
+            }
+            else if (string.Equals(key, coldKey, StringComparison.OrdinalIgnoreCase))
+            {
+                Volatile.Write(ref coldOrdinal, ordinal);
+                coldEntered.TrySetResult();
+            }
+
+            return Task.CompletedTask;
+        };
+
+        await harness.Promoter.StartAsync(CancellationToken.None);
+        await harness.Promoter.ReplayCompletionForTest;
+        SavePending(harness.Manager, harness.User.Id, hotKey, coldKey);
+        harness.Pending.NotifyPendingRegistered(hotKey, harness.User.Id);
+        await firstHotEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        harness.Pending.NotifyPendingRegistered(coldKey, harness.User.Id);
+        harness.Pending.NotifyPendingRegistered(hotKey, harness.User.Id);
+        releaseFirstHot.TrySetResult();
+
+        await coldEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await secondHotEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await harness.Promoter.StopAsync(CancellationToken.None);
+
+        Assert.True(
+            Volatile.Read(ref coldOrdinal) < Volatile.Read(ref secondHotOrdinal),
+            "An active key's rerun must requeue at the tail instead of monopolizing the worker. "
+            + $"Cold ordinal: {Volatile.Read(ref coldOrdinal)}; "
+            + $"second hot ordinal: {Volatile.Read(ref secondHotOrdinal)}.");
+        Assert.True(ReadState(harness.Manager, harness.User.Id).PendingTmdb.ContainsKey(hotKey));
+        Assert.True(ReadState(harness.Manager, harness.User.Id).PendingTmdb.ContainsKey(coldKey));
+    }
+
+    [Fact]
+    public async Task SharedTmdbKey_PromotesEveryUserInOneCoalescedSweep()
+    {
+        var userA = new User("shared-a", "provider", "password-provider");
+        var userB = new User("shared-b", "provider", "password-provider");
+        var harness = CreateHarness(new[] { userA, userB });
+        const string pendingKey = "tv:789";
+        SavePending(harness.Manager, userA.Id, pendingKey);
+        SavePending(harness.Manager, userB.Id, pendingKey);
+        var series = VisibleSeries("789");
+        harness.Library.GetItemListHook = _ => new BaseItem[] { series };
+        harness.Library.GetItemByIdUserHook = (_, _) => series;
+        var swept = NewSignal();
+        var releaseSweep = NewSignal();
+        harness.Promoter.BeforePromotionForTest = _ => releaseSweep.Task;
+        harness.Promoter.AfterPromotionForTest = _ => swept.TrySetResult();
+
+        await harness.Promoter.StartAsync(CancellationToken.None);
+        await harness.Promoter.ReplayCompletionForTest;
+        releaseSweep.TrySetResult();
+        await swept.Task;
+        await harness.Promoter.StopAsync(CancellationToken.None);
+
+        Assert.True(ReadState(harness.Manager, userA.Id).Series.ContainsKey(series.Id.ToString("N")));
+        Assert.True(ReadState(harness.Manager, userB.Id).Series.ContainsKey(series.Id.ToString("N")));
+    }
+
+    private Harness CreateHarness(int queueCapacity = 4)
+        => CreateHarness(new[] { new User("lifecycle-user", "provider", "password-provider") }, queueCapacity);
+
+    private Harness CreateHarness(IReadOnlyList<User> users, int queueCapacity = 4)
+    {
+        var manager = new UserConfigurationManager(
+            new StubAppPaths(_directory),
+            NullLogger<UserConfigurationManager>.Instance);
+        var library = new CountingLibraryManager();
+        var userManager = new StubUserManager(users.ToArray());
+        var provider = new FakePluginConfigProvider(new PluginConfiguration
+        {
+            SpoilerBlurEnabled = true,
+        });
+        var pending = new SpoilerPendingService(
+            manager,
+            library,
+            userManager,
+            NullLogger<SpoilerPendingService>.Instance);
+        var harness = new Harness(
+            manager,
+            library,
+            userManager,
+            provider,
+            pending,
+            null!,
+            users[0]);
+        return harness with { Promoter = NewPromoter(harness, queueCapacity) };
+    }
+
+    private static SpoilerSeerrPendingPromoter NewPromoter(Harness harness, int queueCapacity)
+        => new(
+            harness.Library,
+            harness.Users,
+            harness.Manager,
+            harness.Provider,
+            harness.Pending,
+            NullLogger<SpoilerSeerrPendingPromoter>.Instance,
+            queueCapacity);
+
+    private static void SavePending(
+        UserConfigurationManager manager,
+        Guid userId,
+        params string[] pendingKeys)
+    {
+        var state = new UserSpoilerBlur();
+        foreach (var pendingKey in pendingKeys)
+        {
+            var separator = pendingKey.IndexOf(':');
+            state.PendingTmdb[pendingKey] = new SpoilerBlurPendingEntry
+            {
+                MediaType = pendingKey.Substring(0, separator),
+                TmdbId = pendingKey.Substring(separator + 1),
+            };
+        }
+
+        manager.SaveUserConfiguration(userId.ToString("N"), SpoilerFile, state);
+    }
+
+    private static UserSpoilerBlur ReadState(UserConfigurationManager manager, Guid userId)
+        => manager.GetUserConfiguration<UserSpoilerBlur>(userId.ToString("N"), SpoilerFile);
+
+    private static Series VisibleSeries(string tmdbId)
+    {
+        var series = new Series { Id = Guid.NewGuid(), Name = "Series " + tmdbId };
+        series.ProviderIds["Tmdb"] = tmdbId;
+        return series;
+    }
+
+    private static TaskCompletionSource NewSignal()
+        => new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private sealed record Harness(
+        UserConfigurationManager Manager,
+        CountingLibraryManager Library,
+        StubUserManager Users,
+        FakePluginConfigProvider Provider,
+        SpoilerPendingService Pending,
+        SpoilerSeerrPendingPromoter Promoter,
+        User User);
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/TestDoubles/RecordingHttpClientFactory.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/TestDoubles/RecordingHttpClientFactory.cs
@@ -46,6 +46,10 @@ public sealed class RecordingHttpMessageHandler : HttpMessageHandler
     /// disposed by the caller's <c>using</c> once SendAsync returns, so the body must be read here).</summary>
     public List<CapturedRequest> Sent { get; } = new();
 
+    public Action<HttpRequestMessage>? BeforeResponse { get; set; }
+
+    public Func<HttpRequestMessage, HttpResponseMessage?>? ResponseFactory { get; set; }
+
     public sealed record CapturedRequest(HttpMethod Method, string Path, string Body);
 
     public void AddResponse(string pathSuffix, string body, HttpStatusCode status = HttpStatusCode.OK)
@@ -66,6 +70,13 @@ public sealed class RecordingHttpMessageHandler : HttpMessageHandler
         Sent.Add(new CapturedRequest(request.Method, request.RequestUri!.AbsolutePath, body));
 
         var path = request.RequestUri!.AbsolutePath;
+        BeforeResponse?.Invoke(request);
+        var customResponse = ResponseFactory?.Invoke(request);
+        if (customResponse != null)
+        {
+            return Task.FromResult(customResponse);
+        }
+
         foreach (var (suffix, response) in _responses)
         {
             if (path.EndsWith(suffix, StringComparison.Ordinal))

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/SeerrProxyController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/SeerrProxyController.cs
@@ -56,7 +56,6 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
 
         private readonly ISeerrClient _seerr;
         private readonly ISeerrParentalFilter _parentalFilter;
-        private readonly SpoilerPendingService _spoilerPending;
         private readonly TimeProvider _timeProvider;
 
         internal Action? BeforeIssueProjectionPublishForTest { get; set; }
@@ -98,7 +97,6 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             ArgumentNullException.ThrowIfNull(timeProvider);
             _seerr = seerr;
             _parentalFilter = parentalFilter;
-            _spoilerPending = spoilerPending;
             _timeProvider = timeProvider;
         }
 
@@ -268,77 +266,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
         [Authorize]
         public async Task<IActionResult> SeerrRequest([FromBody] JsonElement requestBody)
         {
-            var result = await ProxySeerrRequest("/api/v1/request", HttpMethod.Post, requestBody.ToString());
-
-            // Auto-on-request Spoiler Guard pending — best-effort, never blocks the
-            // request. Gated by SpoilerBlurEnabled + SpoilerAutoEnableOnSeerrRequest.
-            // Only a 2xx counts as user intent; anything else fails closed.
-            try
-            {
-                var cfg = _configProvider.ConfigurationOrNull;
-                if (cfg?.SpoilerBlurEnabled == true
-                    && cfg?.SpoilerAutoEnableOnSeerrRequest == true
-                    && IsSeerrRequestResultSuccessful(result))
-                {
-                    // Snapshot identity + body BEFORE Task.Run — HttpContext/User are
-                    // invalid after we return; clone the request-scoped JsonElement.
-                    var userId = UserHelper.GetCurrentUserId(User);
-                    if (userId != null && userId != Guid.Empty)
-                    {
-                        var capturedUserId = userId.Value;
-                        JsonElement bodyClone;
-                        try { bodyClone = requestBody.Clone(); }
-                        catch { bodyClone = default; }
-
-                        if (bodyClone.ValueKind == JsonValueKind.Object)
-                        {
-                            _ = Task.Run(() => _spoilerPending.TryAutoEnableFromSeerrRequest(capturedUserId, bodyClone));
-                        }
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning($"Spoiler Guard auto-on-request hook threw {ex.GetType().Name}: {ex.Message}");
-            }
-
-            return result;
-        }
-
-        // True only for a 2xx proxy result. 409 fails closed: it's an ambiguous Seerr
-        // conflict (MEDIA_EXISTS vs quota/permission denial) whose body SeerrHttpHelper
-        // has already replaced, so we can't distinguish. Null StatusCode counts as OK
-        // only for ContentResult (the success path defaults to 200); a null on
-        // ObjectResult/StatusCodeResult is failure.
-        private static bool IsSeerrRequestResultSuccessful(IActionResult result)
-        {
-            int? status;
-            bool allowNullAsOk = false;
-            if (result is ContentResult cr)
-            {
-                status = cr.StatusCode;
-                allowNullAsOk = true;
-            }
-            else if (result is ObjectResult or)
-            {
-                status = or.StatusCode;
-            }
-            else if (result is StatusCodeResult sr)
-            {
-                status = sr.StatusCode;
-            }
-            else
-            {
-                return false;
-            }
-
-            if (status is null)
-            {
-                if (!allowNullAsOk) return false;
-                status = 200;
-            }
-            int sc = status.Value;
-            return sc >= 200 && sc < 300;
+            // The shared SeerrClient owns the success boundary.  It durably
+            // records any configured Spoiler Guard intent before returning the
+            // upstream 2xx, which also covers the TV-seasons controller route.
+            return await ProxySeerrRequest("/api/v1/request", HttpMethod.Post, requestBody.ToString());
         }
 
         [HttpGet("seerr/request")]

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/SpoilerGuardController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/SpoilerGuardController.cs
@@ -26,9 +26,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
     /// accessor pair, the corruption-health surface, the per-series / per-movie /
     /// per-collection opt-in toggles, the per-user strip-override prefs and the
     /// pre-acquisition (Seerr / not-yet-downloaded) pending flow. All per-user state
-    /// lives in spoilerblur.json; the promoter's static gate is reconciled on every
-    /// pending-affecting write. Split out of the monolithic controller; routes are
-    /// identical to the reference so the client is unchanged.
+    /// lives in spoilerblur.json; the hosted promoter's instance gate is reconciled
+    /// from that authoritative file after every pending-affecting write. Split out
+    /// of the monolithic controller; routes are identical to the reference so the
+    /// client is unchanged.
     /// </summary>
     [Route("JellyfinCanopy")]
     [ApiController]
@@ -1860,8 +1861,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 SpoilerUserResolver.InvalidateUser(userKey);
                 // Either way the key is no longer pending for this user — keep the
                 // promoter's gate consistent so it stops sweeping this user.
-                SpoilerSeerrPendingPromoter.ReconcilePendingKeys(
-                    _userConfigurationManager,
+                _pendingService.ReconcilePendingKeys(
                     userKey,
                     new[] { pendingKey });
                 var (removedAnything, removedFrom, removedJellyfinId) = resultBox[0];
@@ -2155,8 +2155,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             string userKey,
             IEnumerable<string> priorPending,
             IEnumerable<string> currentPending)
-            => SpoilerSeerrPendingPromoter.ReconcilePendingKeys(
-                _userConfigurationManager,
+            => _pendingService.ReconcilePendingKeys(
                 userKey,
                 priorPending.Concat(currentPending));
 

--- a/Jellyfin.Plugin.JellyfinCanopy/Helpers/Seerr/SeerrHttpHelper.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Helpers/Seerr/SeerrHttpHelper.cs
@@ -154,21 +154,70 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
             string url,
             SeerrDispatchFence dispatchFence,
             CancellationToken ct = default)
-            => SendAndReadJsonAsync(httpClient, request, url, MaxBodyBytes, dispatchFence, ct);
+            => SendAndReadJsonCoreAsync(
+                httpClient,
+                request,
+                url,
+                MaxBodyBytes,
+                dispatchFence,
+                responseHeadersObserved: null,
+                ct);
 
-        internal static async Task<(string? Json, SeerrError? Error, int HttpStatus)> SendAndReadJsonAsync(
+        internal static Task<(string? Json, SeerrError? Error, int HttpStatus)> SendAndReadJsonAsync(
+            HttpClient httpClient,
+            HttpRequestMessage request,
+            string url,
+            SeerrDispatchFence dispatchFence,
+            Func<HttpResponseMessage, bool> responseHeadersObserved,
+            CancellationToken ct = default)
+            => SendAndReadJsonCoreAsync(
+                httpClient,
+                request,
+                url,
+                MaxBodyBytes,
+                dispatchFence,
+                responseHeadersObserved,
+                ct);
+
+        internal static Task<(string? Json, SeerrError? Error, int HttpStatus)> SendAndReadJsonAsync(
             HttpClient httpClient,
             HttpRequestMessage request,
             string url,
             int maxBodyBytes,
             SeerrDispatchFence dispatchFence,
             CancellationToken ct = default)
+            => SendAndReadJsonCoreAsync(
+                httpClient,
+                request,
+                url,
+                maxBodyBytes,
+                dispatchFence,
+                responseHeadersObserved: null,
+                ct);
+
+        private static async Task<(string? Json, SeerrError? Error, int HttpStatus)> SendAndReadJsonCoreAsync(
+            HttpClient httpClient,
+            HttpRequestMessage request,
+            string url,
+            int maxBodyBytes,
+            SeerrDispatchFence dispatchFence,
+            Func<HttpResponseMessage, bool>? responseHeadersObserved,
+            CancellationToken ct)
         {
             using var response = await SendResponseHeadersReadAsync(
                 httpClient,
                 request,
                 dispatchFence,
                 ct).ConfigureAwait(false);
+            // This synchronous boundary runs immediately after the upstream
+            // response headers arrive and before RequestAborted is observed by
+            // the bounded body reader. Mutation owners can durably record a
+            // confirmed 2xx side effect here without bypassing the shared
+            // timeout, cancellation, content-type, and body-size protections.
+            if (responseHeadersObserved?.Invoke(response) == false)
+            {
+                return (null, null, (int)response.StatusCode);
+            }
             var (json, error) = await ReadResponseAsync(response, url, maxBodyBytes, ct).ConfigureAwait(false);
             return (json, error, (int)response.StatusCode);
         }

--- a/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
@@ -190,8 +190,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy
             serviceCollection.AddSingleton<SpoilerBlurImageFilter>();
             serviceCollection.AddSingleton<SpoilerFieldStripFilter>();
             // Shared pre-acquisition ("pending") pending-add core used by BOTH the
-            // SpoilerGuardController HTTP endpoints and the Seerr auto-request hook on
-            // SeerrProxyController. Depends only on the config store + library +
+            // SpoilerGuardController HTTP endpoints and SeerrClient's durable
+            // auto-request success boundary. Depends only on the config store + library +
             // user managers (never ISeerrClient), so it stays cycle-free.
             serviceCollection.AddSingleton<SpoilerPendingService>();
             serviceCollection.AddHostedService<SpoilerSeerrPendingPromoter>();

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrClient.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrClient.cs
@@ -11,6 +11,7 @@ using Jellyfin.Plugin.JellyfinCanopy.Configuration;
 using Jellyfin.Plugin.JellyfinCanopy.Helpers;
 using Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr;
 using Jellyfin.Plugin.JellyfinCanopy.Model.Seerr;
+using Jellyfin.Plugin.JellyfinCanopy.Services;
 using MediaBrowser.Controller.Library;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -39,6 +40,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
         private readonly ISeerrCache _seerrCache;
         private readonly IPluginConfigProvider _configProvider;
         private readonly ISeerrParentalFilter _parentalFilter;
+        private readonly SpoilerPendingService _spoilerPendingService;
         private readonly ConcurrentDictionary<string, SemaphoreSlim> _userResolutionGates = new(
             StringComparer.OrdinalIgnoreCase);
 
@@ -48,7 +50,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             IUserManager userManager,
             ISeerrCache seerrCache,
             IPluginConfigProvider configProvider,
-            ISeerrParentalFilter parentalFilter)
+            ISeerrParentalFilter parentalFilter,
+            SpoilerPendingService spoilerPendingService)
         {
             _httpClientFactory = httpClientFactory;
             _logger = logger;
@@ -56,6 +59,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             _seerrCache = seerrCache;
             _configProvider = configProvider;
             _parentalFilter = parentalFilter;
+            _spoilerPendingService = spoilerPendingService;
         }
 
         // ── URL / id helpers (hoisted from SeerrUserResolver) ───────────
@@ -2173,6 +2177,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                 urls = new[] { boundSourceUrl! };
             }
 
+            // Freeze this mutation's local durability obligation after the final
+            // pre-dispatch configuration/identity proof. PluginConfiguration is
+            // mutable, so reading the live object again after a Seerr 2xx could
+            // let an in-place true→false change silently abandon an obligation
+            // that was enabled when the request was sent.
+            var persistSpoilerIntentOnSuccess = config.SpoilerBlurEnabled
+                && config.SpoilerAutoEnableOnSeerrRequest
+                && IsCreateMediaRequest(apiPath, method);
             var httpClient = SeerrHttpHelper.CreateClient(_httpClientFactory);
             httpClient.Timeout = TimeSpan.FromSeconds(15);
 
@@ -2242,12 +2254,37 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                     using var request = SeerrHttpHelper.BuildRequest(method, requestUri, config.SeerrApiKey, requestUserId, content);
                     if (content != null) _logger.LogDebug($"Request body: {content}");
 
+                    IActionResult? spoilerIntentFailure = null;
                     var (json, error, _) = await SeerrHttpHelper.SendAndReadJsonAsync(
                         httpClient,
                         request,
                         requestUri,
                         requestDispatchFence,
+                        response =>
+                        {
+                            if (persistSpoilerIntentOnSuccess
+                                && response.IsSuccessStatusCode
+                                && SeerrHttpHelper.IsJsonContentType(response))
+                            {
+                                // ResponseHeadersRead has confirmed the upstream
+                                // mutation before the caller cancellation token is
+                                // next observed by the bounded JSON body reader.
+                                spoilerIntentFailure = RecordSpoilerIntent(
+                                    jellyfinUserId,
+                                    content);
+                            }
+
+                            // A combined-failure result is already complete at
+                            // this boundary; do not let a slow/cancelled response
+                            // body hide the explicit remediation from the caller.
+                            return spoilerIntentFailure == null;
+                        },
                         cancellationToken).ConfigureAwait(false);
+
+                    if (spoilerIntentFailure != null)
+                    {
+                        return spoilerIntentFailure;
+                    }
 
                     if (error == null && json != null)
                     {
@@ -2367,6 +2404,71 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             }
 
             return new ObjectResult(lastErrorBody) { StatusCode = lastStatusCode };
+        }
+
+        private static bool IsCreateMediaRequest(string apiPath, HttpMethod method)
+        {
+            if (method != HttpMethod.Post)
+            {
+                return false;
+            }
+
+            var queryIndex = apiPath.IndexOf('?', StringComparison.Ordinal);
+            var pathOnly = queryIndex >= 0 ? apiPath.Substring(0, queryIndex) : apiPath;
+            pathOnly = pathOnly.TrimEnd('/');
+            return string.Equals(pathOnly, "/api/v1/request", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private IActionResult? RecordSpoilerIntent(string jellyfinUserId, string? content)
+        {
+            string failureCode;
+            try
+            {
+                if (_spoilerPendingService == null)
+                {
+                    failureCode = "intent_service_unavailable";
+                }
+                else if (!Guid.TryParse(jellyfinUserId, out var userId) || userId == Guid.Empty)
+                {
+                    failureCode = "jellyfin_user_unavailable";
+                }
+                else
+                {
+                    var registration = _spoilerPendingService.RegisterSeerrIntent(userId, content);
+                    if (registration.IsDurable)
+                    {
+                        return null;
+                    }
+
+                    failureCode = registration.Code;
+                }
+            }
+            catch (Exception ex)
+            {
+                failureCode = "intent_store_unavailable";
+                _logger.LogError(
+                    ex,
+                    "Seerr accepted a media request for {User}, but its Spoiler Guard intent could not be persisted.",
+                    ResolveUserDisplay(jellyfinUserId));
+            }
+
+            _logger.LogWarning(
+                "Seerr accepted a media request for {User}, but Spoiler Guard intent registration failed: {FailureCode}",
+                ResolveUserDisplay(jellyfinUserId),
+                failureCode);
+            var message = failureCode == "unsupported_request_target"
+                ? "Seerr accepted a request target outside its supported movie/tv contract, so Spoiler Guard cannot auto-protect it. Do not retry the request; verify the accepted request in Seerr and manually protect a supported movie or series if needed."
+                : "Seerr accepted the request, but Spoiler Guard could not record its pending intent. Do not retry the Seerr request; add the title to Spoiler Guard manually.";
+            return new ObjectResult(new
+            {
+                error = true,
+                code = "seerr_accepted_spoiler_intent_failed",
+                message,
+                seerrAccepted = true,
+                spoilerIntentRecorded = false,
+                reason = failureCode,
+            })
+            { StatusCode = 500 };
         }
 
         public void InvalidateUserIdentityCache(string jellyfinUserId)

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/SpoilerPendingService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/SpoilerPendingService.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
+using System.Linq;
 using System.Text;
 using System.Text.Json;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
@@ -16,8 +18,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
     /// Shared core for the pre-acquisition ("pending") Spoiler Guard flow. Owns the
     /// TMDB→library lookup, the pending-entry cap, the display-name sanitizer and the
     /// RMW promote/record logic so BOTH the HTTP endpoint (SpoilerGuardController's
-    /// POST/DELETE spoiler-blur/pending) AND the fire-and-forget Seerr auto-request
-    /// hook (SeerrProxyController) reuse one implementation.
+    /// POST/DELETE spoiler-blur/pending) and the synchronous SeerrClient success
+    /// boundary reuse one implementation.
     ///
     /// Registered as a singleton. Deliberately depends only on the config store,
     /// ILibraryManager and IUserManager — never on ISeerrClient — so it can be
@@ -36,6 +38,19 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         private readonly IUserManager _userManager;
         private readonly ILogger<SpoilerPendingService> _logger;
 
+        /// <summary>
+        /// Raised after the durable store has changed (or an existing durable row
+        /// has been re-observed).  The hosted promoter treats this only as a
+        /// bounded acceleration signal; <c>spoilerblur.json</c> remains the replay
+        /// authority when no worker is running or its queue is saturated.
+        /// </summary>
+        internal event Action<string, Guid, bool>? PendingRegistrationChanged;
+
+        internal Action? BeforeCapFallbackForTest { get; set; }
+
+        internal Action<string, IReadOnlyCollection<string>>?
+            BeforeAuthoritativeGateReconcileForTests { get; set; }
+
         public SpoilerPendingService(
             UserConfigurationManager userConfigurationManager,
             ILibraryManager libraryManager,
@@ -49,7 +64,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         }
 
         /// <summary>
-        /// Structured outcome shared by the HTTP layer and the fire-and-forget log layer.
+        /// Structured outcome shared by the HTTP layer and Seerr intent registration.
         /// <c>Promoted</c> is one of "series", "movie", "pending" or "cap-exceeded".
         /// <c>CapacityCategory</c> identifies which dictionary refused a new entry.
         /// </summary>
@@ -60,10 +75,267 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             bool WroteSomething,
             string? CapacityCategory = null);
 
-        // ─── Shared core (manual POST + auto-on-Seerr-request) ───────────────────
+        /// <summary>
+        /// Result of synchronously recording the local half of a successful Seerr
+        /// media request.  A successful result means either PendingTmdb or the
+        /// final Series/Movies collection was atomically persisted before the
+        /// caller received the Seerr acknowledgment.
+        /// </summary>
+        internal sealed record SeerrIntentRegistration(bool IsDurable, string Code, string? PendingKey = null);
+
+        /// <summary>
+        /// Persists the smallest replayable Spoiler Guard intent without doing a
+        /// library query first.  Promotion is signalled only after the strict RMW
+        /// returns, so an accepted worker item can never outrun its durable row.
+        /// </summary>
+        internal SeerrIntentRegistration RegisterSeerrIntent(Guid userId, string? requestBody)
+        {
+            if (!TryParseSeerrRequestTarget(
+                    requestBody,
+                    out var mediaType,
+                    out var canonicalTmdb,
+                    out var parseFailureCode))
+            {
+                return new SeerrIntentRegistration(false, parseFailureCode);
+            }
+
+            var jUser = _userManager.GetUserById(userId);
+            if (jUser == null)
+            {
+                return new SeerrIntentRegistration(false, "jellyfin_user_unavailable");
+            }
+
+            var pendingKey = $"{mediaType}:{canonicalTmdb}";
+            var userKey = userId.ToString("N");
+            var capExceeded = false;
+            _userConfigurationManager.RmwUserConfiguration<UserSpoilerBlur>(
+                userKey,
+                SpoilerBlurImageFilter.SpoilerBlurFileName,
+                state =>
+                {
+                    if (state.PendingTmdb.ContainsKey(pendingKey))
+                    {
+                        return 0;
+                    }
+
+                    if (state.PendingTmdb.Count >= MaxPendingTmdbPerUser
+                        || !SpoilerGuardOverrideCapacity.CanInsert(
+                            state.PendingTmdb,
+                            pendingKey))
+                    {
+                        capExceeded = true;
+                        return 0;
+                    }
+
+                    state.PendingTmdb[pendingKey] = new SpoilerBlurPendingEntry
+                    {
+                        MediaType = mediaType,
+                        TmdbId = canonicalTmdb,
+                        DisplayName = string.Empty,
+                        RequestedAt = DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture),
+                    };
+                    SpoilerGuardOverridesRevision.Advance(state);
+                    return 1;
+                });
+
+            SpoilerUserResolver.InvalidateUser(userKey);
+            if (!capExceeded)
+            {
+                ReconcilePendingKeysAfterCommit(userKey, new[] { pendingKey });
+                return new SeerrIntentRegistration(true, "recorded", pendingKey);
+            }
+
+            // Preserve the pre-existing cap contract: an already-present,
+            // accessible title can still be protected directly even when all 500
+            // pre-acquisition slots are occupied.  This synchronous fallback is
+            // also durable before acknowledgment; only unresolved titles fail with
+            // the explicit partial-success contract at the Seerr boundary.
+            BeforeCapFallbackForTest?.Invoke();
+            var promoted = AddPending(userId, jUser, mediaType, canonicalTmdb, displayName: null);
+            return promoted.Promoted switch
+            {
+                "series" or "movie" => new SeerrIntentRegistration(true, "promoted", pendingKey),
+                // Capacity may open between the first strict cap check and the
+                // compatibility fallback. AddPending's `pending` result proves
+                // the target row is now durable, whether this invocation wrote it
+                // or re-observed a concurrent writer.
+                "pending" => new SeerrIntentRegistration(true, "recorded", pendingKey),
+                _ => new SeerrIntentRegistration(false, "pending_cap_exceeded", pendingKey),
+            };
+        }
+
+        private static bool TryParseSeerrRequestTarget(
+            string? requestBody,
+            out string mediaType,
+            out string canonicalTmdb,
+            out string failureCode)
+        {
+            mediaType = string.Empty;
+            canonicalTmdb = string.Empty;
+            failureCode = "invalid_request_target";
+            if (string.IsNullOrWhiteSpace(requestBody))
+            {
+                return false;
+            }
+
+            try
+            {
+                using var document = JsonDocument.Parse(requestBody);
+                var root = document.RootElement;
+                if (root.ValueKind != JsonValueKind.Object
+                    || !root.TryGetProperty("mediaType", out var mediaTypeElement)
+                    || mediaTypeElement.ValueKind != JsonValueKind.String
+                    || !root.TryGetProperty("mediaId", out var mediaIdElement))
+                {
+                    return false;
+                }
+
+                mediaType = mediaTypeElement.GetString()?.Trim().ToLowerInvariant() ?? string.Empty;
+                if (mediaType is not ("tv" or "movie"))
+                {
+                    failureCode = "unsupported_request_target";
+                    return false;
+                }
+
+                int tmdbId;
+                if (mediaIdElement.ValueKind == JsonValueKind.Number)
+                {
+                    if (!mediaIdElement.TryGetInt32(out tmdbId))
+                    {
+                        return false;
+                    }
+                }
+                else if (mediaIdElement.ValueKind == JsonValueKind.String)
+                {
+                    if (!int.TryParse(
+                            mediaIdElement.GetString(),
+                            NumberStyles.Integer,
+                            CultureInfo.InvariantCulture,
+                            out tmdbId))
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    return false;
+                }
+
+                if (tmdbId <= 0)
+                {
+                    return false;
+                }
+
+                canonicalTmdb = tmdbId.ToString(CultureInfo.InvariantCulture);
+                return true;
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+        }
+
+        internal void NotifyPendingRegistered(string pendingKey, Guid userId)
+        {
+            if (string.IsNullOrEmpty(pendingKey) || userId == Guid.Empty)
+            {
+                return;
+            }
+
+            PendingRegistrationChanged?.Invoke(pendingKey, userId, true);
+        }
+
+        internal void NotifyPendingRemoved(string pendingKey, Guid userId)
+        {
+            if (string.IsNullOrEmpty(pendingKey) || userId == Guid.Empty)
+            {
+                return;
+            }
+
+            PendingRegistrationChanged?.Invoke(pendingKey, userId, false);
+        }
+
+        /// <summary>
+        /// Publishes acceleration signals from the authoritative durable state while
+        /// holding the same user-file lock as every writer. A delayed reconciliation
+        /// can therefore never unregister a key restored by a newer write. The event
+        /// is intentionally ephemeral: a stopped or saturated hosted worker rebuilds
+        /// the complete gate from <c>spoilerblur.json</c> on its next start.
+        /// </summary>
+        internal void ReconcilePendingKeys(
+            string userKey,
+            IEnumerable<string> affectedKeys)
+        {
+            if (!Guid.TryParseExact(userKey, "N", out var userId)
+                || userId == Guid.Empty)
+            {
+                return;
+            }
+
+            var keys = affectedKeys
+                .Where(static key => !string.IsNullOrEmpty(key))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            if (keys.Length == 0)
+            {
+                return;
+            }
+
+            BeforeAuthoritativeGateReconcileForTests?.Invoke(userKey, keys);
+            lock (_userConfigurationManager.GetUserFileLock(
+                userKey,
+                SpoilerBlurImageFilter.SpoilerBlurFileName))
+            {
+                var read = _userConfigurationManager
+                    .ReadExistingUserConfiguration<UserSpoilerBlur>(
+                        userKey,
+                        SpoilerBlurImageFilter.SpoilerBlurFileName);
+                if (read.IsFault || !read.HasUsableValue || read.Value == null)
+                {
+                    throw new IOException(
+                        $"Unable to reconcile pending gate from store status {read.Status}.");
+                }
+
+                foreach (var key in keys)
+                {
+                    if (read.Value.PendingTmdb.ContainsKey(key))
+                    {
+                        NotifyPendingRegistered(key, userId);
+                    }
+                    else
+                    {
+                        NotifyPendingRemoved(key, userId);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Best-effort acceleration after a durable commit. A signalling or reread
+        /// failure must not turn an already-persisted Seerr intent into a false
+        /// failure response; restart replay remains the correctness fallback.
+        /// </summary>
+        internal void ReconcilePendingKeysAfterCommit(
+            string userKey,
+            IEnumerable<string> affectedKeys)
+        {
+            try
+            {
+                ReconcilePendingKeys(userKey, affectedKeys);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    "Committed Spoiler Guard state for {User}, but pending-gate reconciliation failed ({ExceptionType}). Durable rows will replay on restart.",
+                    ResolveUserDisplay(userKey),
+                    ex.GetType().Name);
+            }
+        }
+
+        // ─── Shared core (manual POST + cap-full Seerr fallback) ─────────────────
         // Library lookup + RMW. Strict-read corruption (InvalidDataException /
         // JsonException) propagates to the caller so the HTTP endpoint can 503; the
-        // Seerr hook wraps this in a log-and-swallow.
+        // SeerrClient converts this into an explicit partial-success response.
         public SpoilerBlurPendingResult AddPending(
             Guid userId,
             JUser jUser,
@@ -117,10 +389,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                         false,
                         "series");
                 }
-                SpoilerSeerrPendingPromoter.ReconcilePendingKeys(
-                    _userConfigurationManager,
-                    userKey,
-                    new[] { pendingKey });
+                ReconcilePendingKeysAfterCommit(userKey, new[] { pendingKey });
                 SpoilerUserResolver.InvalidateUser(userKey); // F7: state changed (Series/Movies)
                 _logger.LogInformation($"Spoiler Guard pending resolved to existing series '{existingSeries.Name}' ({seriesKey}) for {ResolveUserDisplay(userKey)}");
                 return new SpoilerBlurPendingResult("series", seriesKey, existingSeries.Name, changed > 0);
@@ -166,10 +435,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                         false,
                         "movies");
                 }
-                SpoilerSeerrPendingPromoter.ReconcilePendingKeys(
-                    _userConfigurationManager,
-                    userKey,
-                    new[] { pendingKey });
+                ReconcilePendingKeysAfterCommit(userKey, new[] { pendingKey });
                 SpoilerUserResolver.InvalidateUser(userKey); // F7: state changed (Series/Movies)
                 _logger.LogInformation($"Spoiler Guard pending resolved to existing movie '{existingMovie.Name}' ({movieKey}) for {ResolveUserDisplay(userKey)}");
                 return new SpoilerBlurPendingResult("movie", movieKey, existingMovie.Name, changed > 0);
@@ -225,10 +491,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             }
             // Prime the promoter's fast-path gate so the next ItemAdded matching this
             // TMDB id sweeps THIS user instead of bailing.
-            SpoilerSeerrPendingPromoter.ReconcilePendingKeys(
-                _userConfigurationManager,
-                userKey,
-                new[] { pendingKey });
+            ReconcilePendingKeysAfterCommit(userKey, new[] { pendingKey });
             _logger.LogInformation($"Spoiler Guard pending recorded {pendingKey} for {ResolveUserDisplay(userKey)} (not yet in library)");
 
             // TOCTOU recovery: the scanner may have added the item between the
@@ -320,10 +583,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     false,
                     "series");
             }
-            SpoilerSeerrPendingPromoter.ReconcilePendingKeys(
-                _userConfigurationManager,
-                userKey,
-                new[] { pendingKey });
+            ReconcilePendingKeysAfterCommit(userKey, new[] { pendingKey });
             SpoilerUserResolver.InvalidateUser(userKey); // F7: state changed (Series)
             _logger.LogInformation($"Spoiler Guard pending TOCTOU-promoted to series '{series.Name}' ({seriesKey}) for {ResolveUserDisplay(userKey)}");
             return new SpoilerBlurPendingResult(
@@ -375,10 +635,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     false,
                     "movies");
             }
-            SpoilerSeerrPendingPromoter.ReconcilePendingKeys(
-                _userConfigurationManager,
-                userKey,
-                new[] { pendingKey });
+            ReconcilePendingKeysAfterCommit(userKey, new[] { pendingKey });
             SpoilerUserResolver.InvalidateUser(userKey); // F7: state changed (Movies)
             _logger.LogInformation($"Spoiler Guard pending TOCTOU-promoted to movie '{movie.Name}' ({movieKey}) for {ResolveUserDisplay(userKey)}");
             return new SpoilerBlurPendingResult(
@@ -422,54 +679,6 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 _logger.LogWarning($"FindLibraryItemByTmdb({mediaType}, {tmdbId}) threw {ex.GetType().Name}: {ex.Message}");
             }
             return null;
-        }
-
-        // Off-thread continuation for the Seerr auto-request hook — must NOT touch
-        // HttpContext / User (userId is captured by the caller before Task.Run). Parses
-        // the cloned request body, resolves the user, and delegates to AddPending.
-        // Log-and-swallow: a Spoiler Guard failure must never surface on the request.
-        public void TryAutoEnableFromSeerrRequest(Guid userId, JsonElement requestBody)
-        {
-            try
-            {
-                if (requestBody.ValueKind != JsonValueKind.Object) return;
-                if (!requestBody.TryGetProperty("mediaType", out var mtProp) || mtProp.ValueKind != JsonValueKind.String) return;
-                if (!requestBody.TryGetProperty("mediaId", out var miProp)) return;
-
-                var rawType = mtProp.GetString();
-                if (string.IsNullOrEmpty(rawType)) return;
-                var mediaType = rawType.ToLowerInvariant();
-                if (mediaType != "tv" && mediaType != "movie") return;
-
-                int tmdbInt;
-                if (miProp.ValueKind == JsonValueKind.Number)
-                {
-                    if (!miProp.TryGetInt32(out tmdbInt) || tmdbInt <= 0) return;
-                }
-                else if (miProp.ValueKind == JsonValueKind.String)
-                {
-                    if (!int.TryParse(miProp.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out tmdbInt)
-                        || tmdbInt <= 0) return;
-                }
-                else
-                {
-                    return;
-                }
-
-                var jUser = _userManager.GetUserById(userId);
-                if (jUser == null) return;
-
-                var canonicalTmdb = tmdbInt.ToString(CultureInfo.InvariantCulture);
-                var summary = AddPending(userId, jUser, mediaType, canonicalTmdb, displayName: null);
-                if (summary.WroteSomething)
-                {
-                    _logger.LogInformation($"Spoiler Guard auto-on-request {summary.Promoted} for {mediaType}:{canonicalTmdb} by {ResolveUserDisplay(userId.ToString("N"))}");
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning($"Spoiler Guard auto-on-request task threw {ex.GetType().Name}: {ex.Message}");
-            }
         }
 
         // Clamp + strip control / format chars so a poisoned modal payload can't grow

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/SpoilerSeerrPendingPromoter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/SpoilerSeerrPendingPromoter.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
 using MediaBrowser.Controller.Entities;
@@ -15,173 +16,29 @@ using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.JellyfinCanopy.Services
 {
-    // Promotes pending Spoiler Guard entries (UserSpoilerBlur.PendingTmdb) into
-    // real Series/Movies entries when matching library items land via Seerr or
-    // any other source. Hooks ILibraryManager.ItemAdded + ItemUpdated.
-    //
-    // Load discipline: library events fire in rapid bursts while a season is
-    // importing (each episode add refreshes the parent Series, so one download
-    // batch can raise dozens of Series ItemUpdated events in under a minute).
-    // Everything here is therefore designed to stay OFF the scanner's hot path
-    // and OFF the library database during those bursts:
-    //
-    //   1. _pendingUsersByKey maps "tv:{tmdb}"/"movie:{tmdb}" -> the set of
-    //      users who actually have that key pending. A sweep only ever touches
-    //      those users (usually exactly one) — never the whole user table.
-    //   2. Sweeps are coalesced per key: one in-flight sweep at a time, a
-    //      rerun flag for events that arrive mid-sweep, and a short settle
-    //      delay so an import burst collapses into a single sweep instead of
-    //      one library read + file RMW per event.
-    //   3. Keys are UNREGISTERED once no user holds them anymore (promotion,
-    //      user delete, or pending-DELETE endpoint), so a promoted show stops
-    //      costing anything on subsequent library events. The gate is a pure
-    //      performance optimization — per-user spoilerblur.json files remain
-    //      the source of truth, and sweeps re-verify against them.
-    //
-    // Per-user library access is checked via GetItemById(id, user) — a user
-    // who can't see the new item won't get the Spoiler Guard entry promoted
-    // for them (they stay registered and are retried on later events), which
-    // would otherwise be a UX bug (entry shows up in their management UI for
-    // a title they can't access).
+    /// <summary>
+    /// Promotes durable <see cref="UserSpoilerBlur.PendingTmdb"/> rows when the
+    /// corresponding media becomes visible in a user's library.  One bounded,
+    /// instance-owned worker serializes all file writes; library events only
+    /// record a coalesced key and never perform database or file I/O.
+    /// </summary>
     public sealed class SpoilerSeerrPendingPromoter : IHostedService
     {
-        // Populated on StartAsync from the per-user spoilerblur.json files and
-        // kept in sync by the controller endpoints + the sweeps below.
-        private static readonly ConcurrentDictionary<string, ConcurrentDictionary<Guid, byte>> _pendingUsersByKey
-            = new(StringComparer.OrdinalIgnoreCase);
+        internal const int DefaultQueueCapacity = 256;
+        private const int ReplayYieldInterval = 64;
 
-        // Per-key sweep coalescing. _sweepRunning holds keys with an active
-        // background sweep; _sweepRerun holds keys that saw another library
-        // event while their sweep was running (or scheduled) and need one more
-        // pass afterwards.
-        private static readonly ConcurrentDictionary<string, byte> _sweepRunning
-            = new(StringComparer.OrdinalIgnoreCase);
-        private static readonly ConcurrentDictionary<string, byte> _sweepRerun
-            = new(StringComparer.OrdinalIgnoreCase);
-
-        // How long a scheduled sweep waits before running. Two purposes:
-        // lets the burst of ItemAdded/ItemUpdated events a season import
-        // fires coalesce into one sweep, and keeps our library reads away
-        // from the exact moment the scanner is writing the item that raised
-        // the event. Promotion is not latency-sensitive — the entry only
-        // needs to flip before the user next browses the title.
-        private const int SweepSettleDelayMs = 2000;
-
-        // Exposed so the controller's POST/DELETE endpoints can keep the gate
-        // accurate without coupling to the hosted-service instance.
-        public static void RegisterPending(string pendingKey, Guid userId)
-        {
-            if (string.IsNullOrEmpty(pendingKey) || userId == Guid.Empty) return;
-            var users = _pendingUsersByKey.GetOrAdd(
-                pendingKey, _ => new ConcurrentDictionary<Guid, byte>());
-            users.TryAdd(userId, 0);
-        }
-
-        public static void UnregisterPending(string pendingKey, Guid userId)
-        {
-            if (string.IsNullOrEmpty(pendingKey) || userId == Guid.Empty) return;
-            if (!_pendingUsersByKey.TryGetValue(pendingKey, out var users)) return;
-            users.TryRemove(userId, out _);
-            if (users.IsEmpty)
-            {
-                // Remove the key, but atomically: a concurrent RegisterPending
-                // could add a user to `users` between our IsEmpty check and the
-                // removal, which would strand that user's pending row (no sweep
-                // until restart). TryRemove(KeyValuePair) only deletes if the
-                // mapped set is STILL the same (now-empty) instance; if a racer
-                // swapped in a fresh set via GetOrAdd, or repopulated this one,
-                // the delete is refused. Re-check the recovered set and merge
-                // any late arrivals back so nothing is lost.
-                if (((ICollection<KeyValuePair<string, ConcurrentDictionary<Guid, byte>>>)_pendingUsersByKey)
-                        .Remove(new KeyValuePair<string, ConcurrentDictionary<Guid, byte>>(pendingKey, users))
-                    && !users.IsEmpty)
-                {
-                    foreach (var lateUser in users.Keys)
-                    {
-                        RegisterPending(pendingKey, lateUser);
-                    }
-                }
-            }
-        }
-
-        // Test seams (Tests has InternalsVisibleTo) over the static gate.
-        internal static bool IsKeyRegisteredForTest(string pendingKey)
-            => _pendingUsersByKey.ContainsKey(pendingKey);
-
-        internal static int RegisteredUserCountForTest(string pendingKey)
-            => _pendingUsersByKey.TryGetValue(pendingKey, out var users) ? users.Count : 0;
-
-        // AsyncLocal keeps deterministic race/fault hooks isolated when xUnit
-        // runs controller classes in parallel. Task.Run carries the originating
-        // test's execution context, while an unrelated test can install its own
-        // hook without overwriting this one.
-        private static readonly AsyncLocal<Action<string, IReadOnlyCollection<string>>?>
-            _beforeAuthoritativeGateReconcileForTests = new();
-
-        internal static Action<string, IReadOnlyCollection<string>>?
-            BeforeAuthoritativeGateReconcileForTests
-        {
-            get => _beforeAuthoritativeGateReconcileForTests.Value;
-            set => _beforeAuthoritativeGateReconcileForTests.Value = value;
-        }
-
-        /// <summary>
-        /// Reconciles only the affected pending keys from the authoritative
-        /// store state while owning the same user/file lock as all writers.
-        /// A delayed remove can therefore never unregister a key that a newer
-        /// writer has already restored.
-        /// </summary>
-        internal static void ReconcilePendingKeys(
-            UserConfigurationManager configManager,
-            string userKey,
-            IEnumerable<string> affectedKeys)
-        {
-            if (!Guid.TryParseExact(userKey, "N", out var userId)
-                || userId == Guid.Empty)
-            {
-                return;
-            }
-
-            var keys = affectedKeys
-                .Where(static key => !string.IsNullOrEmpty(key))
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray();
-            if (keys.Length == 0) return;
-
-            BeforeAuthoritativeGateReconcileForTests?.Invoke(userKey, keys);
-            lock (configManager.GetUserFileLock(
-                userKey,
-                SpoilerBlurImageFilter.SpoilerBlurFileName))
-            {
-                var read = configManager.ReadExistingUserConfiguration<UserSpoilerBlur>(
-                    userKey,
-                    SpoilerBlurImageFilter.SpoilerBlurFileName);
-                if (read.IsFault || !read.HasUsableValue || read.Value == null)
-                {
-                    throw new IOException(
-                        $"Unable to reconcile pending gate from store status {read.Status}.");
-                }
-
-                foreach (var key in keys)
-                {
-                    if (read.Value.PendingTmdb.ContainsKey(key))
-                    {
-                        RegisterPending(key, userId);
-                    }
-                    else
-                    {
-                        UnregisterPending(key, userId);
-                    }
-                }
-            }
-        }
-
+        private readonly object _lifecycleSync = new();
         private readonly ILibraryManager _libraryManager;
         private readonly IUserManager _userManager;
         private readonly UserConfigurationManager _configManager;
         private readonly IPluginConfigProvider _configProvider;
         private readonly SpoilerPendingService _pendingService;
         private readonly ILogger<SpoilerSeerrPendingPromoter> _logger;
+        private readonly int _queueCapacity;
+
+        private WorkerGeneration? _generation;
+        private WorkerGeneration? _stoppingGeneration;
+        private Task _stoppingTask = Task.CompletedTask;
 
         public SpoilerSeerrPendingPromoter(
             ILibraryManager libraryManager,
@@ -189,88 +46,464 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             UserConfigurationManager configManager,
             IPluginConfigProvider configProvider,
             SpoilerPendingService pendingService,
-            ILogger<SpoilerSeerrPendingPromoter> logger)
+            ILogger<SpoilerSeerrPendingPromoter> logger,
+            int queueCapacity = DefaultQueueCapacity)
         {
+            if (queueCapacity <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(queueCapacity));
+            }
+
             _libraryManager = libraryManager;
             _userManager = userManager;
             _configManager = configManager;
             _configProvider = configProvider;
-            // Reused for the F5 user-scoped TMDB duplicate lookup. Depends only
-            // on the config/library/user managers (never ISeerrClient nor
-            // this promoter), so injecting it here introduces no DI cycle.
             _pendingService = pendingService;
             _logger = logger;
+            _queueCapacity = queueCapacity;
         }
 
-        public Task StartAsync(CancellationToken cancellationToken)
+        /// <summary>
+        /// Deterministic barrier used only by concurrency tests.  It runs on the
+        /// single worker immediately before a promotion attempt.
+        /// </summary>
+        internal Func<string, Task>? BeforePromotionForTest { get; set; }
+
+        internal Action<string>? AfterPromotionForTest { get; set; }
+
+        internal Action<string, int>? BeforeReplayWriteForTest { get; set; }
+
+        internal Action<string, Guid>? PendingDictionaryAcquiredForTest { get; set; }
+
+        internal bool IsKeyRegisteredForTest(string pendingKey)
         {
-            // Repopulate the in-memory gate from disk so a restart doesn't
-            // silently break promotion for users with already-pending entries.
-            try
+            var generation = GetGenerationForTest();
+            return generation != null && generation.PendingUsersByKey.ContainsKey(pendingKey);
+        }
+
+        internal int RegisteredUserCountForTest(string pendingKey)
+        {
+            var generation = GetGenerationForTest();
+            return generation != null
+                && generation.PendingUsersByKey.TryGetValue(pendingKey, out var users)
+                    ? users.Count
+                    : 0;
+        }
+
+        internal bool IsUserRegisteredForTest(string pendingKey, Guid userId)
+        {
+            var generation = GetGenerationForTest();
+            return generation != null
+                && generation.PendingUsersByKey.TryGetValue(pendingKey, out var users)
+                && users.ContainsKey(userId);
+        }
+
+        internal int ScheduledKeyCountForTest
+            => GetGenerationForTest()?.QueuedOrRunning.Count ?? 0;
+
+        internal Task ReplayCompletionForTest
+            => Volatile.Read(ref _generation)?.ReplayTask ?? Task.CompletedTask;
+
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            while (true)
             {
-                ScanExistingPendingKeys();
+                Task stoppingTask;
+                lock (_lifecycleSync)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (_generation != null)
+                    {
+                        return;
+                    }
+
+                    stoppingTask = _stoppingTask;
+                    if (stoppingTask.IsCompleted)
+                    {
+                        StartGenerationLocked();
+                        return;
+                    }
+                }
+
+                // The old worker owns its maps until it is fully joined. Waiting
+                // outside the short lifecycle lock prevents a concurrent restart
+                // from clearing state that an old generation can still touch.
+                await stoppingTask.WaitAsync(cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception ex)
-            {
-                _logger.LogWarning($"SpoilerSeerrPromoter: startup scan failed (gate may miss already-pending entries until next write): {ex.Message}");
-            }
-            _libraryManager.ItemAdded += OnItemAdded;
-            // ItemAdded fires before Jellyfin's TMDB provider has fetched
-            // metadata — ProviderIds.Tmdb is typically empty at that moment.
-            // ItemUpdated fires after metadata refresh, at which point
-            // ProviderIds.Tmdb is populated, so we re-run the same logic.
-            // The sweep is idempotent (gate + ContainsKey checks) so the
-            // double-fire on items that arrive with metadata already in
-            // place is harmless.
-            _libraryManager.ItemUpdated += OnItemAdded;
-            return Task.CompletedTask;
         }
 
         public Task StopAsync(CancellationToken cancellationToken)
         {
-            _libraryManager.ItemAdded -= OnItemAdded;
-            _libraryManager.ItemUpdated -= OnItemAdded;
-            return Task.CompletedTask;
+            lock (_lifecycleSync)
+            {
+                var generation = _generation;
+                if (generation != null)
+                {
+                    generation.Accepting = false;
+                    Volatile.Write(ref _generation, null);
+                    Volatile.Write(ref _stoppingGeneration, generation);
+                    _pendingService.PendingRegistrationChanged -= OnPendingRegistrationChanged;
+                    _libraryManager.ItemAdded -= OnItemAdded;
+                    _libraryManager.ItemUpdated -= OnItemAdded;
+
+                    // Replay owns only ephemeral admission state. Cancel it for
+                    // every stop, then close admission; durable rows remain on disk
+                    // for the next generation. A host deadline additionally aborts
+                    // the worker's queued/in-flight ownership.
+                    generation.ReplayCancellation.Cancel();
+                    generation.Channel.Writer.TryComplete();
+                    RegisterStopDeadlineLocked(generation, cancellationToken);
+                    _stoppingTask = JoinGenerationAsync(generation);
+                }
+                else if (_stoppingGeneration != null)
+                {
+                    // Concurrent stop callers share the same join, but any caller's
+                    // deadline may still tighten that generation's shutdown.
+                    RegisterStopDeadlineLocked(_stoppingGeneration, cancellationToken);
+                }
+
+                return _stoppingTask;
+            }
         }
 
-        // Best-effort startup scan — corrupt or missing files are skipped on
-        // purpose: the gate is a performance optimization, not a correctness
-        // invariant. Reuses UserConfigurationManager's path + serializer
-        // discipline (GetAllUserIds enumerates the canonical per-user config
-        // dirs under {PluginsPath}/configurations/Jellyfin.Plugin.JellyfinCanopy;
-        // GetUserConfiguration is the lenient System.Text.Json read the store
-        // writes with) instead of a raw file read + separate deserializer.
-        private void ScanExistingPendingKeys()
+        private void StartGenerationLocked()
         {
-            int users = 0, keys = 0;
-            foreach (var userIdN in _configManager.GetAllUserIds())
+            var generation = new WorkerGeneration(_queueCapacity)
             {
-                if (!Guid.TryParseExact(userIdN, "N", out var userId)) continue;
+                Accepting = true,
+            };
+            Volatile.Write(ref _generation, generation);
+            _pendingService.PendingRegistrationChanged += OnPendingRegistrationChanged;
+            _libraryManager.ItemAdded += OnItemAdded;
+            _libraryManager.ItemUpdated += OnItemAdded;
+            generation.WorkerTask = RunWorkerAsync(generation);
+            generation.ReplayTask = ReplayExistingPendingKeysAsync(generation);
+        }
 
-                UserSpoilerBlur state;
+        private void RegisterStopDeadlineLocked(
+            WorkerGeneration generation,
+            CancellationToken cancellationToken)
+        {
+            if (!cancellationToken.CanBeCanceled)
+            {
+                return;
+            }
+
+            generation.StopRegistrations.Add(cancellationToken.Register(
+                static state => ((CancellationTokenSource)state!).Cancel(),
+                generation.WorkerCancellation));
+        }
+
+        private async Task JoinGenerationAsync(WorkerGeneration generation)
+        {
+            // Always yield so StopAsync can publish the shared join task while it
+            // still owns the lifecycle lock, even when both background tasks have
+            // already completed.
+            await Task.Yield();
+            try
+            {
                 try
                 {
-                    state = _configManager.GetUserConfiguration<UserSpoilerBlur>(
-                        userIdN, SpoilerBlurImageFilter.SpoilerBlurFileName);
+                    await generation.ReplayTask.ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                    when (generation.ReplayCancellation.IsCancellationRequested)
+                {
+                    // Expected generation shutdown.
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogWarning($"SpoilerSeerrPromoter: skipping unreadable state for {userIdN}: {ex.GetType().Name}");
-                    continue;
+                    _logger.LogWarning(
+                        "SpoilerSeerrPromoter: replay worker stopped unexpectedly: {Message}",
+                        ex.Message);
                 }
 
-                if (state?.PendingTmdb == null || state.PendingTmdb.Count == 0) continue;
-                users++;
-                foreach (var key in state.PendingTmdb.Keys)
+                try
                 {
-                    if (string.IsNullOrEmpty(key)) continue;
-                    RegisterPending(key, userId);
-                    keys++;
+                    await generation.WorkerTask.ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                    when (generation.WorkerCancellation.IsCancellationRequested)
+                {
+                    // Expected host-deadline cancellation.
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(
+                        "SpoilerSeerrPromoter: promotion worker stopped unexpectedly: {Message}",
+                        ex.Message);
                 }
             }
-            if (keys > 0)
+            finally
             {
-                _logger.LogInformation($"SpoilerSeerrPromoter: gate primed with {keys} pending key(s) across {users} user file(s)");
+                CancellationTokenRegistration[] stopRegistrations;
+                lock (_lifecycleSync)
+                {
+                    if (ReferenceEquals(_stoppingGeneration, generation))
+                    {
+                        Volatile.Write(ref _stoppingGeneration, null);
+                    }
+
+                    stopRegistrations = generation.StopRegistrations.ToArray();
+                    generation.StopRegistrations.Clear();
+                }
+
+                foreach (var registration in stopRegistrations)
+                {
+                    registration.Dispose();
+                }
+
+                generation.PendingUsersByKey.Clear();
+                generation.QueuedOrRunning.Clear();
+                generation.Rerun.Clear();
+                generation.ReplayCancellation.Dispose();
+                generation.WorkerCancellation.Dispose();
+            }
+        }
+
+        private async Task ReplayExistingPendingKeysAsync(WorkerGeneration generation)
+        {
+            // Force all filesystem enumeration and durable admission off the
+            // hosted-service startup call, even when the first writes fit in the
+            // channel synchronously.
+            await Task.Yield();
+            var cancellationToken = generation.ReplayCancellation.Token;
+            var userCount = 0;
+            var rowCount = 0;
+            try
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var userIds = _configManager.GetAllUserIds();
+                cancellationToken.ThrowIfCancellationRequested();
+                foreach (var userIdN in userIds)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (!Guid.TryParseExact(userIdN, "N", out var userId))
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        if (_userManager.GetUserById(userId) == null)
+                        {
+                            // User configuration directories can outlive a deleted
+                            // Jellyfin user. Keep the durable file untouched for
+                            // explicit recovery, but never admit its rows to this
+                            // generation's bounded queue.
+                            _logger.LogInformation(
+                                "SpoilerSeerrPromoter: skipping durable pending state for deleted user {User}",
+                                userIdN);
+                            continue;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        // A transient user-store lookup failure is not proof that
+                        // the durable owner was deleted. Leave its rows on disk for
+                        // a later restart rather than failing plugin startup.
+                        _logger.LogWarning(
+                            "SpoilerSeerrPromoter: skipping user lookup failure for {User}: {ExceptionType}",
+                            userIdN,
+                            ex.GetType().Name);
+                        continue;
+                    }
+
+                    UserSpoilerBlur state;
+                    try
+                    {
+                        state = _configManager.GetUserConfiguration<UserSpoilerBlur>(
+                            userIdN,
+                            SpoilerBlurImageFilter.SpoilerBlurFileName);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(
+                            "SpoilerSeerrPromoter: skipping unreadable state for {User}: {ExceptionType}",
+                            userIdN,
+                            ex.GetType().Name);
+                        continue;
+                    }
+
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (state.PendingTmdb.Count == 0)
+                    {
+                        continue;
+                    }
+
+                    userCount++;
+                    foreach (var key in state.PendingTmdb.Keys)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        if (string.IsNullOrEmpty(key))
+                        {
+                            continue;
+                        }
+
+                        RegisterPending(generation, key, userId);
+                        rowCount++;
+                        await ScheduleReplayAsync(
+                            generation,
+                            key,
+                            cancellationToken).ConfigureAwait(false);
+
+                        if (rowCount % ReplayYieldInterval == 0)
+                        {
+                            await Task.Yield();
+                        }
+                    }
+                }
+
+                if (rowCount > 0)
+                {
+                    _logger.LogInformation(
+                        "SpoilerSeerrPromoter: replayed {Rows} durable pending row(s) across {Users} user file(s)",
+                        rowCount,
+                        userCount);
+                }
+            }
+            catch (OperationCanceledException)
+                when (cancellationToken.IsCancellationRequested)
+            {
+                // Stop owns cancellation; all unprocessed rows remain durable.
+            }
+            catch (ChannelClosedException) when (!generation.Accepting)
+            {
+                // Stop closed admission after canceling replay.
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    "SpoilerSeerrPromoter: durable replay stopped after {Rows} row(s): {Message}",
+                    rowCount,
+                    ex.Message);
+            }
+        }
+
+        private async Task ScheduleReplayAsync(
+            WorkerGeneration generation,
+            string pendingKey,
+            CancellationToken cancellationToken)
+        {
+            generation.Rerun[pendingKey] = 0;
+            if (!generation.QueuedOrRunning.TryAdd(pendingKey, 0))
+            {
+                return;
+            }
+
+            try
+            {
+                BeforeReplayWriteForTest?.Invoke(
+                    pendingKey,
+                    generation.QueuedOrRunning.Count);
+                await generation.Channel.Writer.WriteAsync(
+                    pendingKey,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                generation.QueuedOrRunning.TryRemove(pendingKey, out _);
+                generation.Rerun.TryRemove(pendingKey, out _);
+                throw;
+            }
+        }
+
+        private void OnPendingRegistrationChanged(string pendingKey, Guid userId, bool registered)
+        {
+            var generation = Volatile.Read(ref _generation);
+            if (generation == null || !generation.Accepting)
+            {
+                return;
+            }
+
+            if (registered)
+            {
+                RegisterPending(generation, pendingKey, userId);
+                TrySchedule(generation, pendingKey);
+            }
+            else
+            {
+                UnregisterPending(generation, pendingKey, userId);
+            }
+        }
+
+        internal void RegisterPending(string pendingKey, Guid userId)
+        {
+            var generation = Volatile.Read(ref _generation);
+            if (generation != null && generation.Accepting)
+            {
+                RegisterPending(generation, pendingKey, userId);
+            }
+        }
+
+        private void RegisterPending(
+            WorkerGeneration generation,
+            string pendingKey,
+            Guid userId)
+        {
+            if (string.IsNullOrEmpty(pendingKey) || userId == Guid.Empty)
+            {
+                return;
+            }
+
+            while (true)
+            {
+                var users = generation.PendingUsersByKey.GetOrAdd(
+                    pendingKey,
+                    static _ => new ConcurrentDictionary<Guid, byte>());
+                PendingDictionaryAcquiredForTest?.Invoke(pendingKey, userId);
+                users.TryAdd(userId, 0);
+
+                // An unregister can remove the last old user and detach this
+                // per-key dictionary between GetOrAdd and TryAdd. Publishing to
+                // that detached instance would lose the durable registration.
+                // Accept the add only while the outer map still owns exactly it;
+                // otherwise remove our stale copy and merge into the live map.
+                if (generation.PendingUsersByKey.TryGetValue(pendingKey, out var current)
+                    && ReferenceEquals(users, current))
+                {
+                    return;
+                }
+
+                users.TryRemove(userId, out _);
+            }
+        }
+
+        internal void UnregisterPending(string pendingKey, Guid userId)
+        {
+            var generation = Volatile.Read(ref _generation);
+            if (generation != null)
+            {
+                UnregisterPending(generation, pendingKey, userId);
+            }
+        }
+
+        private void UnregisterPending(
+            WorkerGeneration generation,
+            string pendingKey,
+            Guid userId)
+        {
+            if (string.IsNullOrEmpty(pendingKey)
+                || userId == Guid.Empty
+                || !generation.PendingUsersByKey.TryGetValue(pendingKey, out var users))
+            {
+                return;
+            }
+
+            users.TryRemove(userId, out _);
+            if (!users.IsEmpty)
+            {
+                return;
+            }
+
+            if (((ICollection<KeyValuePair<string, ConcurrentDictionary<Guid, byte>>>)generation.PendingUsersByKey)
+                    .Remove(new KeyValuePair<string, ConcurrentDictionary<Guid, byte>>(pendingKey, users))
+                && !users.IsEmpty)
+            {
+                foreach (var lateUser in users.Keys)
+                {
+                    RegisterPending(generation, pendingKey, lateUser);
+                }
             }
         }
 
@@ -278,160 +511,313 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         {
             try
             {
-                var cfg = _configProvider.ConfigurationOrNull;
-                if (cfg?.SpoilerBlurEnabled != true) return;
+                var generation = Volatile.Read(ref _generation);
+                if (generation == null
+                    || !generation.Accepting
+                    || _configProvider.ConfigurationOrNull?.SpoilerBlurEnabled != true)
+                {
+                    return;
+                }
 
-                var item = e?.Item;
-                if (item is not Series && item is not Movie) return;
+                var item = e.Item;
+                if (item is not Series && item is not Movie)
+                {
+                    return;
+                }
 
-                if (item.ProviderIds == null
-                    || !item.ProviderIds.TryGetValue("Tmdb", out var tmdbId)
+                if (!item.ProviderIds.TryGetValue("Tmdb", out var tmdbId)
                     || string.IsNullOrEmpty(tmdbId))
                 {
                     return;
                 }
-                var mediaType = item is Series ? "tv" : "movie";
-                var pendingKey = $"{mediaType}:{tmdbId}";
 
-                // Fast-path gate: if NO user has this key pending, we're done —
-                // this is the path every library event for non-pending items
-                // takes, so it must stay allocation- and I/O-free.
-                if (!_pendingUsersByKey.ContainsKey(pendingKey)) return;
+                var pendingKey = $"{(item is Series ? "tv" : "movie")}:{tmdbId}";
+                if (!generation.PendingUsersByKey.ContainsKey(pendingKey))
+                {
+                    return;
+                }
 
-                // PERF(S1): the scan-thread handler ends here — record the id +
-                // schedule a coalesced off-thread sweep; no DB query or file I/O
-                // runs synchronously. See docs/developers.md#performance-rules (S1).
-                ScheduleSweep(pendingKey, item.Id, item.Name ?? string.Empty, item is Series);
+                // PERF(S1): a constant-time coalescing signal is the end of the
+                // synchronous scan-thread path.  All lookups and RMWs are owned by
+                // the single hosted worker.
+                TrySchedule(generation, pendingKey);
             }
             catch (Exception ex)
             {
-                _logger.LogWarning($"SpoilerSeerrPromoter: handler failed before scheduling: {ex.Message}");
+                _logger.LogWarning(
+                    "SpoilerSeerrPromoter: handler failed before scheduling: {Message}",
+                    ex.Message);
             }
         }
 
-        // Coalesced background sweep scheduler. At most one sweep per key runs
-        // at a time; events that arrive while one is running (or settling) set
-        // the rerun flag and are folded into a single follow-up pass. This is
-        // what keeps a rapid-fire episode import (Series ItemUpdated storms)
-        // from turning into dozens of concurrent library reads + file RMWs
-        // racing the scanner.
-        private void ScheduleSweep(string pendingKey, Guid itemId, string itemName, bool isSeries)
+        private bool TrySchedule(WorkerGeneration generation, string pendingKey)
         {
-            _sweepRerun[pendingKey] = 0;
-            if (!_sweepRunning.TryAdd(pendingKey, 0)) return; // active sweep picks up the rerun flag
-
-            _ = Task.Run(async () =>
+            if (!generation.Accepting
+                || !generation.PendingUsersByKey.ContainsKey(pendingKey))
             {
-                try
-                {
-                    await Task.Delay(SweepSettleDelayMs).ConfigureAwait(false);
-                    while (_sweepRerun.TryRemove(pendingKey, out _))
-                    {
-                        SweepPendingUsers(pendingKey, itemId, itemName, isSeries);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning($"SpoilerSeerrPromoter: sweep for {pendingKey} failed: {ex.Message}");
-                }
-                finally
-                {
-                    _sweepRunning.TryRemove(pendingKey, out _);
-                    // Late-arrival race: an event may have set the rerun flag
-                    // after the loop's last check but before the running flag
-                    // cleared. Reschedule so it isn't lost.
-                    if (_sweepRerun.ContainsKey(pendingKey) && _pendingUsersByKey.ContainsKey(pendingKey))
-                    {
-                        ScheduleSweep(pendingKey, itemId, itemName, isSeries);
-                    }
-                }
-            });
+                return false;
+            }
+
+            generation.Rerun[pendingKey] = 0;
+            if (!generation.QueuedOrRunning.TryAdd(pendingKey, 0))
+            {
+                return true;
+            }
+
+            if (generation.Channel.Writer.TryWrite(pendingKey))
+            {
+                return true;
+            }
+
+            generation.QueuedOrRunning.TryRemove(pendingKey, out _);
+            generation.Rerun.TryRemove(pendingKey, out _);
+            _logger.LogWarning(
+                "SpoilerSeerrPromoter: bounded queue is full; {PendingKey} remains durable and will replay on restart or a later library event",
+                pendingKey);
+            return false;
         }
 
-        private void SweepPendingUsers(string pendingKey, Guid itemId, string itemName, bool isSeries)
+        private async Task RunWorkerAsync(WorkerGeneration generation)
         {
-            if (!_pendingUsersByKey.TryGetValue(pendingKey, out var users)) return;
+            var cancellationToken = generation.WorkerCancellation.Token;
+            try
+            {
+                await foreach (var pendingKey in generation.Channel.Reader
+                    .ReadAllAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    var canceled = false;
+                    try
+                    {
+                        // One dequeue owns exactly one sweep. A signal arriving
+                        // during that sweep leaves Rerun set, and the finally path
+                        // admits it at the channel tail so later keys get a turn.
+                        generation.Rerun.TryRemove(pendingKey, out _);
+                        cancellationToken.ThrowIfCancellationRequested();
+                        if (BeforePromotionForTest != null)
+                        {
+                            await BeforePromotionForTest(pendingKey)
+                                .WaitAsync(cancellationToken).ConfigureAwait(false);
+                        }
 
-            // Snapshot: the set can be mutated concurrently by the controller.
+                        cancellationToken.ThrowIfCancellationRequested();
+                        SweepPendingUsers(generation, pendingKey, cancellationToken);
+                        cancellationToken.ThrowIfCancellationRequested();
+                        AfterPromotionForTest?.Invoke(pendingKey);
+                    }
+                    catch (OperationCanceledException)
+                        when (cancellationToken.IsCancellationRequested)
+                    {
+                        canceled = true;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(
+                            "SpoilerSeerrPromoter: sweep for {PendingKey} failed: {Message}",
+                            pendingKey,
+                            ex.Message);
+                    }
+                    finally
+                    {
+                        generation.QueuedOrRunning.TryRemove(pendingKey, out _);
+                        if (!canceled
+                            && !cancellationToken.IsCancellationRequested
+                            && generation.Rerun.ContainsKey(pendingKey)
+                            && generation.PendingUsersByKey.ContainsKey(pendingKey))
+                        {
+                            TrySchedule(generation, pendingKey);
+                        }
+                    }
+
+                    if (canceled)
+                    {
+                        break;
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+                when (cancellationToken.IsCancellationRequested)
+            {
+                // The host deadline abandoned this generation's ownership.
+            }
+        }
+
+        private void SweepPendingUsers(
+            WorkerGeneration generation,
+            string pendingKey,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!generation.PendingUsersByKey.TryGetValue(pendingKey, out var users))
+            {
+                return;
+            }
+
             foreach (var userId in users.Keys.ToArray())
             {
                 try
                 {
-                    var outcome = PromoteForUser(userId, itemId, pendingKey, itemName, isSeries);
-                    if (outcome != PromotionOutcome.StillPending)
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var outcome = PromoteDurableIntent(
+                        userId,
+                        pendingKey,
+                        cancellationToken);
+                    if (outcome == PromotionOutcome.UserMissing)
                     {
-                        // Promoted, already gone, or user deleted — either way
-                        // this user no longer holds the pending key, so stop
-                        // sweeping them for it.
-                        ReconcilePendingKeys(
-                            _configManager,
+                        // A durable directory may survive user deletion. Do not
+                        // reconcile that orphan row: authoritative disk replay
+                        // would immediately re-register it, set the rerun marker while
+                        // this key is running, and starve every later queue item.
+                        UnregisterPending(generation, pendingKey, userId);
+                    }
+                    else if (outcome != PromotionOutcome.StillPending)
+                    {
+                        // Promoted or already absent: reconcile from disk. A
+                        // concurrent writer may have restored the key after
+                        // this promotion's RMW completed.
+                        _pendingService.ReconcilePendingKeysAfterCommit(
                             userId.ToString("N"),
                             new[] { pendingKey });
                     }
                 }
+                catch (OperationCanceledException)
+                    when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
                 catch (Exception ex)
                 {
-                    // Keep the user registered so a later event retries them.
-                    _logger.LogWarning($"SpoilerSeerrPromoter: per-user promotion failed for user {userId} on {pendingKey}: {ex.Message}");
+                    _logger.LogWarning(
+                        "SpoilerSeerrPromoter: per-user promotion failed for user {UserId} on {PendingKey}: {Message}",
+                        userId,
+                        pendingKey,
+                        ex.Message);
                 }
             }
         }
 
-        // Internal (Tests has InternalsVisibleTo) so the F5 duplicate-fallback
-        // path can be driven directly without racing the async sweep.
-        internal enum PromotionOutcome
+        private PromotionOutcome PromoteDurableIntent(
+            Guid userId,
+            string pendingKey,
+            CancellationToken cancellationToken)
         {
-            Promoted,      // pending row consumed (or already promoted earlier)
-            NotPending,    // user deleted / file no longer has the key
-            StillPending,  // user can't see the item yet — retry on later events
+            cancellationToken.ThrowIfCancellationRequested();
+            var jUser = _userManager.GetUserById(userId);
+            if (jUser == null)
+            {
+                return PromotionOutcome.UserMissing;
+            }
+
+            var separator = pendingKey.IndexOf(':', StringComparison.Ordinal);
+            if (separator <= 0 || separator >= pendingKey.Length - 1)
+            {
+                return PromotionOutcome.StillPending;
+            }
+
+            var mediaType = pendingKey.Substring(0, separator);
+            var tmdbId = pendingKey.Substring(separator + 1);
+            cancellationToken.ThrowIfCancellationRequested();
+            var item = _pendingService.FindLibraryItemByTmdb(jUser, mediaType, tmdbId);
+            if (item == null)
+            {
+                return PromotionOutcome.StillPending;
+            }
+
+            return PromoteForUser(
+                userId,
+                item.Id,
+                pendingKey,
+                item.Name ?? string.Empty,
+                item is Series,
+                cancellationToken);
         }
 
-        internal PromotionOutcome PromoteForUser(Guid userId, Guid itemId, string pendingKey, string itemName, bool isSeries)
+        internal enum PromotionOutcome
         {
-            var jUser = _userManager.GetUserById(userId);
-            if (jUser == null) return PromotionOutcome.NotPending;
+            Promoted,
+            NotPending,
+            StillPending,
+            UserMissing,
+        }
 
-            // Library-access gate: if the user can't see the item (filtered
-            // by library access), don't promote — they'd never see a card
-            // for it but would see a stranded entry in management UI.
+        internal PromotionOutcome PromoteForUser(
+            Guid userId,
+            Guid itemId,
+            string pendingKey,
+            string itemName,
+            bool isSeries,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var jUser = _userManager.GetUserById(userId);
+            if (jUser == null)
+            {
+                return PromotionOutcome.UserMissing;
+            }
+
             BaseItem? visibleItem;
             try
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 visibleItem = _libraryManager.GetItemById<BaseItem>(itemId, jUser);
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+            catch (OperationCanceledException)
+                when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception ex)
             {
-                _logger.LogWarning($"SpoilerSeerrPromoter: GetItemById({itemId},{userId}) threw {ex.GetType().Name}: {ex.Message}");
+                _logger.LogWarning(
+                    "SpoilerSeerrPromoter: GetItemById({ItemId},{UserId}) threw {ExceptionType}: {Message}",
+                    itemId,
+                    userId,
+                    ex.GetType().Name,
+                    ex.Message);
                 return PromotionOutcome.StillPending;
             }
+
             if (visibleItem == null)
             {
-                // F5: the event's itemId may be a library DUPLICATE this user
-                // cannot access (the same TMDB id also exists in a library they
-                // do have access to). Stranding the pending entry in that case
-                // is a bug — try a user-scoped TMDB lookup for an accessible
-                // duplicate of the right type and promote THAT id instead.
-                var dup = TryFindAccessibleDuplicate(jUser, pendingKey, isSeries);
-                if (dup == null) return PromotionOutcome.StillPending;
-                itemId = dup.Id;
-                if (!string.IsNullOrEmpty(dup.Name)) itemName = dup.Name;
+                var duplicate = TryFindAccessibleDuplicate(
+                    jUser,
+                    pendingKey,
+                    isSeries,
+                    cancellationToken);
+                if (duplicate == null)
+                {
+                    return PromotionOutcome.StillPending;
+                }
+
+                itemId = duplicate.Id;
+                if (!string.IsNullOrEmpty(duplicate.Name))
+                {
+                    itemName = duplicate.Name;
+                }
             }
 
             var userKey = userId.ToString("N");
-            var fileName = SpoilerBlurImageFilter.SpoilerBlurFileName;
             var itemKey = itemId.ToString("N");
             var persistedItemName = PersistedPayloadPolicy
                 .ClampPersistedDisplayName(itemName);
 
             try
             {
-                var stillHadPending = new[] { false };
-                var capacityExceeded = new[] { false };
+                cancellationToken.ThrowIfCancellationRequested();
+                var stillHadPending = false;
+                var capacityExceeded = false;
                 _configManager.RmwUserConfiguration<UserSpoilerBlur>(
-                    userKey, fileName, state =>
+                    userKey,
+                    SpoilerBlurImageFilter.SpoilerBlurFileName,
+                    state =>
                     {
-                        if (!state.PendingTmdb.ContainsKey(pendingKey)) return 0;
-                        stillHadPending[0] = true;
+                        cancellationToken.ThrowIfCancellationRequested();
+                        if (!state.PendingTmdb.ContainsKey(pendingKey))
+                        {
+                            return 0;
+                        }
+
+                        stillHadPending = true;
                         if (isSeries)
                         {
                             if (!state.Series.ContainsKey(itemKey)
@@ -439,18 +825,23 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                                     state.Series,
                                     itemKey))
                             {
-                                capacityExceeded[0] = true;
+                                capacityExceeded = true;
                                 return 0;
                             }
+
                             state.PendingTmdb.Remove(pendingKey);
                             SpoilerGuardOverridesRevision.Advance(state);
-                            if (state.Series.ContainsKey(itemKey)) return 1;
-                            state.Series[itemKey] = new SpoilerBlurSeriesEntry
+                            if (!state.Series.ContainsKey(itemKey))
                             {
-                                SeriesId = itemKey,
-                                SeriesName = persistedItemName,
-                                EnabledAt = DateTime.UtcNow.ToString("o", System.Globalization.CultureInfo.InvariantCulture),
-                            };
+                                state.Series[itemKey] = new SpoilerBlurSeriesEntry
+                                {
+                                    SeriesId = itemKey,
+                                    SeriesName = persistedItemName,
+                                    EnabledAt = DateTime.UtcNow.ToString(
+                                        "o",
+                                        System.Globalization.CultureInfo.InvariantCulture),
+                                };
+                            }
                         }
                         else
                         {
@@ -459,77 +850,156 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                                     state.Movies,
                                     itemKey))
                             {
-                                capacityExceeded[0] = true;
+                                capacityExceeded = true;
                                 return 0;
                             }
+
                             state.PendingTmdb.Remove(pendingKey);
                             SpoilerGuardOverridesRevision.Advance(state);
-                            if (state.Movies.ContainsKey(itemKey)) return 1;
-                            state.Movies[itemKey] = new SpoilerBlurMovieEntry
+                            if (!state.Movies.ContainsKey(itemKey))
                             {
-                                MovieId = itemKey,
-                                MovieName = persistedItemName,
-                                EnabledAt = DateTime.UtcNow.ToString("o", System.Globalization.CultureInfo.InvariantCulture),
-                            };
+                                state.Movies[itemKey] = new SpoilerBlurMovieEntry
+                                {
+                                    MovieId = itemKey,
+                                    MovieName = persistedItemName,
+                                    EnabledAt = DateTime.UtcNow.ToString(
+                                        "o",
+                                        System.Globalization.CultureInfo.InvariantCulture),
+                                };
+                            }
                         }
+
                         return 1;
                     });
-                if (capacityExceeded[0])
+
+                if (capacityExceeded)
                 {
                     _logger.LogWarning(
                         $"SpoilerSeerrPromoter: retained {pendingKey} for user {userId}; " +
                         $"{(isSeries ? "series" : "movie")} list is at capacity.");
                     return PromotionOutcome.StillPending;
                 }
-                if (stillHadPending[0])
+
+                if (!stillHadPending)
                 {
-                    // F7: Series/Movies changed — drop the user's cached state so
-                    // the image/strip filters blur the promoted title immediately.
-                    SpoilerUserResolver.InvalidateUser(userKey);
-                    _logger.LogInformation($"SpoilerSeerrPromoter: promoted {pendingKey} -> {(isSeries ? "series" : "movie")} {itemKey} for user {userId}");
-                    return PromotionOutcome.Promoted;
+                    return PromotionOutcome.NotPending;
                 }
-                // File no longer holds the key (promoted via the controller's
-                // TOCTOU path, or removed by the user) — nothing to do.
-                return PromotionOutcome.NotPending;
+
+                SpoilerUserResolver.InvalidateUser(userKey);
+                _logger.LogInformation(
+                    "SpoilerSeerrPromoter: promoted {PendingKey} -> {MediaType} {ItemKey} for user {UserId}",
+                    pendingKey,
+                    isSeries ? "series" : "movie",
+                    itemKey,
+                    userId);
+                return PromotionOutcome.Promoted;
+            }
+            catch (OperationCanceledException)
+                when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (UserStoreUnhealthyException)
             {
-                // Keep the registration for a post-repair event, but do not log
-                // every library notification for the same durable generation.
                 return PromotionOutcome.StillPending;
             }
             catch (InvalidDataException ex)
             {
-                _logger.LogWarning($"SpoilerSeerrPromoter: skipping {userId}/{pendingKey} due to corrupt spoilerblur.json: {ex.Message}");
-                // Strict read will keep failing until the file is repaired;
-                // keep the user registered so repair + a later event recovers.
+                _logger.LogWarning(
+                    "SpoilerSeerrPromoter: skipping {UserId}/{PendingKey} due to corrupt spoilerblur.json: {Message}",
+                    userId,
+                    pendingKey,
+                    ex.Message);
                 return PromotionOutcome.StillPending;
             }
         }
 
-        // F5 helper: resolve an accessible library duplicate for the pending key
-        // (parsed as "{tv|movie}:{tmdbId}") scoped to the user, when the event's
-        // own itemId wasn't visible to them. Returns the item only when its type
-        // matches the pending media type. Reuses SpoilerPendingService's indexed
-        // TMDB lookup so the matching happens in the DB, not a client-side scan.
-        private BaseItem? TryFindAccessibleDuplicate(JUser jUser, string pendingKey, bool isSeries)
+        private BaseItem? TryFindAccessibleDuplicate(
+            JUser jUser,
+            string pendingKey,
+            bool isSeries,
+            CancellationToken cancellationToken)
         {
-            var sep = pendingKey.IndexOf(':');
-            if (sep <= 0 || sep >= pendingKey.Length - 1) return null;
-            var mediaType = pendingKey.Substring(0, sep);
-            var tmdb = pendingKey.Substring(sep + 1);
+            cancellationToken.ThrowIfCancellationRequested();
+            var separator = pendingKey.IndexOf(':', StringComparison.Ordinal);
+            if (separator <= 0 || separator >= pendingKey.Length - 1)
+            {
+                return null;
+            }
+
+            var mediaType = pendingKey.Substring(0, separator);
+            var tmdb = pendingKey.Substring(separator + 1);
             try
             {
-                var dup = _pendingService.FindLibraryItemByTmdb(jUser, mediaType, tmdb);
-                if (isSeries && dup is Series) return dup;
-                if (!isSeries && dup is Movie) return dup;
+                cancellationToken.ThrowIfCancellationRequested();
+                var duplicate = _pendingService.FindLibraryItemByTmdb(jUser, mediaType, tmdb);
+                cancellationToken.ThrowIfCancellationRequested();
+                if (isSeries && duplicate is Series)
+                {
+                    return duplicate;
+                }
+
+                if (!isSeries && duplicate is Movie)
+                {
+                    return duplicate;
+                }
+            }
+            catch (OperationCanceledException)
+                when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception ex)
             {
-                _logger.LogWarning($"SpoilerSeerrPromoter: duplicate TMDB lookup for {pendingKey} threw {ex.GetType().Name}: {ex.Message}");
+                _logger.LogWarning(
+                    "SpoilerSeerrPromoter: duplicate TMDB lookup for {PendingKey} threw {ExceptionType}: {Message}",
+                    pendingKey,
+                    ex.GetType().Name,
+                    ex.Message);
             }
+
             return null;
+        }
+
+        private WorkerGeneration? GetGenerationForTest()
+            => Volatile.Read(ref _generation) ?? Volatile.Read(ref _stoppingGeneration);
+
+        private sealed class WorkerGeneration
+        {
+            public WorkerGeneration(int queueCapacity)
+            {
+                Channel = System.Threading.Channels.Channel.CreateBounded<string>(
+                    new BoundedChannelOptions(queueCapacity)
+                    {
+                        SingleReader = true,
+                        SingleWriter = false,
+                        FullMode = BoundedChannelFullMode.Wait,
+                        AllowSynchronousContinuations = false,
+                    });
+            }
+
+            public Channel<string> Channel { get; }
+
+            public ConcurrentDictionary<string, ConcurrentDictionary<Guid, byte>> PendingUsersByKey { get; }
+                = new(StringComparer.OrdinalIgnoreCase);
+
+            public ConcurrentDictionary<string, byte> QueuedOrRunning { get; }
+                = new(StringComparer.OrdinalIgnoreCase);
+
+            public ConcurrentDictionary<string, byte> Rerun { get; }
+                = new(StringComparer.OrdinalIgnoreCase);
+
+            public CancellationTokenSource ReplayCancellation { get; } = new();
+
+            public CancellationTokenSource WorkerCancellation { get; } = new();
+
+            public List<CancellationTokenRegistration> StopRegistrations { get; } = new();
+
+            public Task ReplayTask { get; set; } = Task.CompletedTask;
+
+            public Task WorkerTask { get; set; } = Task.CompletedTask;
+
+            public volatile bool Accepting;
         }
     }
 }

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -21,7 +21,7 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
     assert.equal(baselines.schemaVersion, 2);
     assert.equal(baselines.policy.baselineSelection, 'observed-high-water');
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2337, totalLines: 2677 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 28067, totalLines: 36668 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 28559, totalLines: 37106 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 2,
         minimumCoveredLines: 2337,
@@ -29,8 +29,8 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
     });
     assert.deepEqual(baselines.profiles.server.observations, {
         cleanRuns: 5,
-        minimumCoveredLines: 28066,
-        maximumCoveredLines: 28067,
+        minimumCoveredLines: 28558,
+        maximumCoveredLines: 28559,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 1);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 1);

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 28067,
-        "totalLines": 36668
+        "coveredLines": 28559,
+        "totalLines": 37106
       },
       "observations": {
         "cleanRuns": 5,
-        "minimumCoveredLines": 28066,
-        "maximumCoveredLines": 28067
+        "minimumCoveredLines": 28558,
+        "maximumCoveredLines": 28559
       },
       "tolerance": {
         "missingCoveredLines": 1,
-        "rationale": "Fixing #457 replaces up to 200 per-episode scalar lookups and 100 repeated full-series queries with two caller-scoped ID batches plus one page-bounded numbering scan per distinct series, backed by mixed-access, duplicate, fault, cancellation, pagination, and exact 100-ID regressions. Five clean .NET 10.0.9/Coverlet runs on 2026-08-01 each passed all 2,482 server tests at the identical 36,668-line scope and measured 28,066, 28,067, 28,066, 28,066, and 28,067 covered lines. The reviewed high-water is therefore 28,067/36,668 (76.544%). The fixed-scope one-line spread permits tightening the instrumentation tolerance from seven lines to one (0.003 percentage points), raising the enforced floor to 28,066/36,668 (76.541%) from 27,988/36,602 (76.466%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "rationale": "Completing the independent review of #165 keeps durable Seerr acknowledgement behind the atomic per-user Spoiler Guard intent write, while moving the O(users x rows) startup replay out of the lifecycle gate into generation-owned incremental, cancellable background work. A host stop deadline now cancels replay plus queued and in-flight ownership, joins the whole generation before completing, leaves durable rows replayable, and prevents writes after completion. Each dequeue performs one bounded key sweep and tail-requeues any rerun so a hot key cannot monopolize the worker. The regressions prove startup returns while 258 distinct live keys reach an actually blocked bounded admission, a concurrent canceled stop aborts that blocked generation without a hook release, a fresh generation replays the durable row, and an interleaved cold key runs before a hot-key rerun. They also retain orphan-user, mid-sweep deletion, restart serialization, no-post-stop-write, and durable reconciliation controls. Test-only isolation serializes the process-wide BaseItem host mutation and covers pre-canceled Maintainerr URL preflight, removing unrelated nondeterministic coverage branches without widening the budget. Five clean .NET 10.0.9/Coverlet runs on 2026-08-01 each passed all 2,507 server tests at the identical 37,106-line scope and measured 28,559, 28,558, 28,558, 28,558, and 28,558 covered lines. The reviewed high-water is therefore 28,559/37,106 (76.966%). The fixed-scope one-line spread retains the existing one-line instrumentation tolerance and makes the enforced floor 28,558/37,106 (76.963%), above the prior 28,444/36,969 floor (76.940%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
Fixes #165

Replaces the obsolete, conflicting implementation in #342.

## Summary

- persist each accepted Seerr/Spoiler Guard intent before returning the successful Canopy-side contract
- route promotion through a bounded, lifecycle-owned worker with durable replay and per-user/TMDB coalescing
- make startup replay, saturation fallback, cancellation, and StopAsync behavior explicit and testable
- report partial success honestly when accepted targets cannot be scheduled or persisted
- preserve existing authorization, timeout, content-type, body-size, duplicate-edition, and library-event behavior

## Root cause and impact

The previous path acknowledged successful Seerr responses before its detached work had durably recorded the corresponding Spoiler Guard intent. Shutdown, cancellation, queue pressure, or a later background failure could therefore lose promised work; the static/detached promoter could also continue writing after service stop.

This change makes accepted intent replayable before acknowledgment and gives one generation-owned worker responsibility for replay and promotion. Stop joins both active work and replay, while burst requests remain bounded and idempotently coalesced.

## Validation

- independent exact-tree review: APPROVE
- lifecycle regressions: 12/12, repeated 20 times (240/240)
- issue-focused server scope: 129/129
- full server suite: 2507/2507
- full client suite: 1841/1841
- script suite: 618/618
- server line coverage: 28,558/37,106, within the reviewed one-line ratchet tolerance
- coverage baseline tests: 14/14
- source and legacy typechecks, syntax, performance guard, diff check, and Release build: green

## Safety

- accepted work is durable before the success contract is exposed
- immediate shutdown drains work or leaves a replayable durable record
- no configuration write occurs after StopAsync completes
- startup replay does not depend on process-static state
- orphaned users are skipped and unregistered
- queue saturation has an explicit durable fallback
- no deployment is included