### PR TITLE
fix(qa): clear remaining repository lint errors

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/helpers.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/helpers.ts
@@ -122,42 +122,39 @@ export async function getItemCached(itemId: string, options: GetItemCachedOption
         throw new Error(`Shared item lookup capacity exceeded (${ITEM_CACHE_MAX_IN_FLIGHT} active requests)`);
     }
 
-    let token: ItemCacheEntry;
-    const promise = ApiClient.getItem(userId, itemId)
-        .then((item) => {
-            if (!JC.identity.isCurrent(context)) return null;
-            // A privacy reset or newer forced fetch may retire this request while
-            // it is in flight. Only the promise that still owns the key may publish.
-            if (inFlightItems.get(key) === token) {
-                setItemCache(key, {
-                    item,
-                    ts: Date.now(),
-                    promise: null,
-                    owner: context,
-                    userId: normalizedUserId,
-                    itemId: normalizedItemId
-                });
-                inFlightItems.delete(key);
-            }
-            return item;
-        })
-        .catch((err: unknown) => {
-            // Likewise, an older rejection must not delete a newer request/value.
-            if (inFlightItems.get(key) === token) inFlightItems.delete(key);
-            if (!JC.identity.isCurrent(context)) return null;
-            throw err;
-        });
-
-    token = {
+    const token: ItemCacheEntry = {
         item: null,
         ts: now,
-        promise,
+        promise: ApiClient.getItem(userId, itemId)
+            .then((item) => {
+                if (!JC.identity.isCurrent(context)) return null;
+                // A privacy reset or newer forced fetch may retire this request while
+                // it is in flight. Only the promise that still owns the key may publish.
+                if (inFlightItems.get(key) === token) {
+                    setItemCache(key, {
+                        item,
+                        ts: Date.now(),
+                        promise: null,
+                        owner: context,
+                        userId: normalizedUserId,
+                        itemId: normalizedItemId
+                    });
+                    inFlightItems.delete(key);
+                }
+                return item;
+            })
+            .catch((err: unknown) => {
+                // Likewise, an older rejection must not delete a newer request/value.
+                if (inFlightItems.get(key) === token) inFlightItems.delete(key);
+                if (!JC.identity.isCurrent(context)) return null;
+                throw err;
+            }),
         owner: context,
         userId: normalizedUserId,
         itemId: normalizedItemId
     };
     inFlightItems.set(key, token);
-    return promise;
+    return token.promise;
 }
 
 JC.identity.registerReset('enhanced-item-cache', () => {

--- a/scripts/release/repository-policy.test.js
+++ b/scripts/release/repository-policy.test.js
@@ -100,7 +100,7 @@ test('release reuses exact-SHA Build/Test and Security gates after ancestry proo
     assert.match(release, /security-gates:[\s\S]*?with:\n\s+verify_repository_policy: true/);
     assert.match(security, /workflow_call:[\s\S]*?secrets:\n\s+REPOSITORY_POLICY_TOKEN:[\s\S]*?required: true/);
     const repositoryPolicyCondition = security.match(
-        /  repository-policy:\n[\s\S]*?\n    if: ([^\n]+)\n/
+        / {2}repository-policy:\n[\s\S]*?\n {4}if: ([^\n]+)\n/
     )?.[1];
     assert.equal(
         repositoryPolicyCondition,


### PR DESCRIPTION
Fixes #541
Fixes #542

## Summary

- make the shared item-request ownership token a `const` binding while preserving its promise-identity fence
- express repository-policy indentation with explicit regex quantifiers
- clear the two pre-existing ESLint errors found during #176 validation without widening any lint or bundle budget

## Root cause and impact

The item-cache request token used delayed one-time assignment, which made the binding look mutable even though only the referenced entry's state participates in the in-flight ownership contract. The repository-policy regression used visually repeated literal spaces, which is hard to audit and violates `no-regex-spaces`.

The cache promise is now initialized directly inside its immutable token. The policy assertion retains the same exact two- and four-space YAML indentation through explicit quantifiers.

## Validation

- full repository lint: 0 errors (5,485 existing warnings, below the advisory cap)
- full client suite: 1,841/1,841
- full script suite: 618/618
- focused enhanced-helper suite: 21/21
- focused repository-policy suite: 4/4
- bundle budget/reproducibility suite: 9/9
- source typecheck, deterministic bundle build, and diff check: green

## Safety

- no lint rule or warning/error budget was weakened
- no repository-policy assertion was broadened
- stale cache promises still cannot publish or delete a newer request owner
- no deployment is included