### PR TITLE
Add an accessible notification contract

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/ar.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/ar.json
@@ -639,6 +639,8 @@
   "hidden_content_hide_button": "إخفاء",
   "hidden_content_already_hidden": "مخفي",
   "hidden_content_item_hidden": "تم إخفاء \"{name}\"",
+  "hidden_content_undo_available": "تم إخفاء \"{name}\". يتوفر إجراء التراجع.",
+  "hidden_content_item_restored": "تمت استعادة \"{name}\"",
   "hidden_content_undo": "تراجع",
   "hidden_content_unhide": "إظهار",
   "hidden_content_manage_button": "إدارة المحتوى المخفي",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/bg.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/bg.json
@@ -639,6 +639,8 @@
   "hidden_content_hide_button": "Скрий",
   "hidden_content_already_hidden": "Скрито",
   "hidden_content_item_hidden": "„{name}“ е скрито",
+  "hidden_content_undo_available": "„{name}“ е скрито. Налично е действие „Отмяна“.",
+  "hidden_content_item_restored": "„{name}“ е възстановено",
   "hidden_content_undo": "Отмяна",
   "hidden_content_unhide": "Покажи",
   "hidden_content_manage_button": "Управление на скритото съдържание",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/ca.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/ca.json
@@ -639,6 +639,8 @@
   "hidden_content_hide_button": "Ocultar",
   "hidden_content_already_hidden": "Ocult",
   "hidden_content_item_hidden": "\"{name}\" ocult",
+  "hidden_content_undo_available": "S'ha ocultat \"{name}\". L'acció Desfer està disponible.",
+  "hidden_content_item_restored": "\"{name}\" restaurat",
   "hidden_content_undo": "Desfer",
   "hidden_content_unhide": "Mostrar",
   "hidden_content_manage_button": "Gestionar el contingut ocult",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/cs.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/cs.json
@@ -639,6 +639,8 @@
   "hidden_content_hide_button": "Skrýt",
   "hidden_content_already_hidden": "Skryto",
   "hidden_content_item_hidden": "\"{name}\" skryto",
+  "hidden_content_undo_available": "Položka „{name}“ byla skryta. Akce Vrátit zpět je k dispozici.",
+  "hidden_content_item_restored": "\"{name}\" obnoveno",
   "hidden_content_undo": "Vrátit zpět",
   "hidden_content_unhide": "Odkrýt",
   "hidden_content_manage_button": "Spravovat skrytý obsah",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/da.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/da.json
@@ -639,6 +639,8 @@
   "hidden_content_hide_button": "Skjul",
   "hidden_content_already_hidden": "Skjult",
   "hidden_content_item_hidden": "\"{name}\" skjult",
+  "hidden_content_undo_available": "\"{name}\" er skjult. Handlingen Fortryd er tilgængelig.",
+  "hidden_content_item_restored": "\"{name}\" gendannet",
   "hidden_content_undo": "Fortryd",
   "hidden_content_unhide": "Vis",
   "hidden_content_manage_button": "Administrer skjult indhold",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/de.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/de.json
@@ -639,6 +639,8 @@
   "hidden_content_hide_button": "Verbergen",
   "hidden_content_already_hidden": "Versteckt",
   "hidden_content_item_hidden": "\"{name}\" versteckt",
+  "hidden_content_undo_available": "„{name}“ wurde ausgeblendet. Die Aktion „Rückgängig“ ist verfügbar.",
+  "hidden_content_item_restored": "\"{name}\" wiederhergestellt",
   "hidden_content_undo": "Rückgängig",
   "hidden_content_unhide": "Anzeigen",
   "hidden_content_manage_button": "Versteckte Inhalte verwalten",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/en-GB.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/en-GB.json
@@ -640,6 +640,8 @@
   "hidden_content_hide_button": "Hide",
   "hidden_content_already_hidden": "Hidden",
   "hidden_content_item_hidden": "\"{name}\" hidden",
+  "hidden_content_undo_available": "\"{name}\" hidden. Undo is available.",
+  "hidden_content_item_restored": "\"{name}\" restored",
   "hidden_content_undo": "Undo",
   "hidden_content_unhide": "Unhide",
   "hidden_content_manage_button": "Manage Hidden Content",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/en-US.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/en-US.json
@@ -640,6 +640,8 @@
   "hidden_content_hide_button": "Hide",
   "hidden_content_already_hidden": "Hidden",
   "hidden_content_item_hidden": "\"{name}\" hidden",
+  "hidden_content_undo_available": "\"{name}\" hidden. Undo is available.",
+  "hidden_content_item_restored": "\"{name}\" restored",
   "hidden_content_undo": "Undo",
   "hidden_content_unhide": "Unhide",
   "hidden_content_manage_button": "Manage Hidden Content",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/en.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/en.json
@@ -642,6 +642,8 @@
   "hidden_content_hide_button": "Hide",
   "hidden_content_already_hidden": "Hidden",
   "hidden_content_item_hidden": "\"{name}\" hidden",
+  "hidden_content_undo_available": "\"{name}\" hidden. Undo is available.",
+  "hidden_content_item_restored": "\"{name}\" restored",
   "hidden_content_undo": "Undo",
   "hidden_content_unhide": "Unhide",
   "hidden_content_manage_button": "Manage Hidden Content",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/es.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/es.json
@@ -639,6 +639,8 @@
   "hidden_content_hide_button": "Ocultar",
   "hidden_content_already_hidden": "Oculto",
   "hidden_content_item_hidden": "\"{name}\" oculto",
+  "hidden_content_undo_available": "\"{name}\" oculto. La acción Deshacer está disponible.",
+  "hidden_content_item_restored": "\"{name}\" restaurado",
   "hidden_content_undo": "Deshacer",
   "hidden_content_unhide": "Mostrar",
   "hidden_content_manage_button": "Gestionar contenido oculto",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/fr.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/fr.json
@@ -639,6 +639,8 @@
   "hidden_content_hide_button": "Masquer",
   "hidden_content_already_hidden": "Masqué",
   "hidden_content_item_hidden": "\"{name}\" masqué",
+  "hidden_content_undo_available": "« {name} » masqué. L’action Annuler est disponible.",
+  "hidden_content_item_restored": "\"{name}\" restauré",
   "hidden_content_undo": "Annuler",
   "hidden_content_unhide": "Afficher",
   "hidden_content_manage_button": "Gérer le contenu masqué",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/he.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/he.json
@@ -172,6 +172,8 @@
   "requests_hours_ago": "{hours}h ago",
   "hidden_content_filter_calendar": "Filter Calendar",
   "hidden_content_item_hidden": "\"{name}\" hidden",
+  "hidden_content_undo_available": "\"{name}\" הוסתר. פעולת ביטול זמינה.",
+  "hidden_content_item_restored": "\"{name}\" שוחזר",
   "reviews_edit": "Edit",
   "hidden_content_entire_show": "Entire show",
   "seerr_btn_deleted": "Deleted",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/hu.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/hu.json
@@ -639,6 +639,8 @@
   "hidden_content_hide_button": "Elrejtés",
   "hidden_content_already_hidden": "Elrejtve",
   "hidden_content_item_hidden": "\"{name}\" elrejtve",
+  "hidden_content_undo_available": "„{name}” elrejtve. A Visszavonás művelet elérhető.",
+  "hidden_content_item_restored": "\"{name}\" visszaállítva",
   "hidden_content_undo": "Visszavonás",
   "hidden_content_unhide": "Megjelenítés",
   "hidden_content_manage_button": "Rejtett tartalom kezelése",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/it.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/it.json
@@ -639,6 +639,8 @@
   "hidden_content_hide_button": "Nascondi",
   "hidden_content_already_hidden": "Nascosto",
   "hidden_content_item_hidden": "\"{name}\" nascosto",
+  "hidden_content_undo_available": "\"{name}\" nascosto. L'azione Annulla è disponibile.",
+  "hidden_content_item_restored": "\"{name}\" ripristinato",
   "hidden_content_undo": "Annulla",
   "hidden_content_unhide": "Mostra",
   "hidden_content_manage_button": "Gestisci contenuti nascosti",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/nl.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/nl.json
@@ -639,6 +639,8 @@
   "hidden_content_hide_button": "Verbergen",
   "hidden_content_already_hidden": "Hidden",
   "hidden_content_item_hidden": "\"{name}\" verborgen",
+  "hidden_content_undo_available": "\"{name}\" verborgen. De actie Ongedaan maken is beschikbaar.",
+  "hidden_content_item_restored": "\"{name}\" hersteld",
   "hidden_content_undo": "Ongedaan maken",
   "hidden_content_unhide": "Unhide",
   "hidden_content_manage_button": "Verborgen inhoud beheren",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/no.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/no.json
@@ -639,6 +639,8 @@
   "hidden_content_hide_button": "Skjul",
   "hidden_content_already_hidden": "Skjult",
   "hidden_content_item_hidden": "\"{name}\" skjult",
+  "hidden_content_undo_available": "\"{name}\" skjult. Handlingen Angre er tilgjengelig.",
+  "hidden_content_item_restored": "\"{name}\" gjenopprettet",
   "hidden_content_undo": "Angre",
   "hidden_content_unhide": "Vis",
   "hidden_content_manage_button": "Administrer skjult innhold",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/pl.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/pl.json
@@ -638,6 +638,8 @@
   "hidden_content_hide_button": "Ukryj",
   "hidden_content_already_hidden": "Ukryte",
   "hidden_content_item_hidden": "\"{name}\" ukryte",
+  "hidden_content_undo_available": "„{name}” ukryte. Dostępna jest akcja Cofnij.",
+  "hidden_content_item_restored": "\"{name}\" przywrócone",
   "hidden_content_undo": "Cofnij",
   "hidden_content_unhide": "Pokaż",
   "hidden_content_manage_button": "Zarządzaj ukrytą zawartością",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/pr.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/pr.json
@@ -639,6 +639,8 @@
   "hidden_content_hide_button": "Hide",
   "hidden_content_already_hidden": "Hidden, arrr",
   "hidden_content_item_hidden": "\"{name}\" be hidden now",
+  "hidden_content_undo_available": "\"{name}\" be hidden now. Undo be ready.",
+  "hidden_content_item_restored": "\"{name}\" be restored now",
   "hidden_content_undo": "Undo",
   "hidden_content_unhide": "Show",
   "hidden_content_manage_button": "Manage Hidden Booty",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/pt-BR.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/pt-BR.json
@@ -639,6 +639,8 @@
   "hidden_content_hide_button": "Ocultar",
   "hidden_content_already_hidden": "Oculto",
   "hidden_content_item_hidden": "\"{name}\" oculto",
+  "hidden_content_undo_available": "\"{name}\" oculto. A ação Desfazer está disponível.",
+  "hidden_content_item_restored": "\"{name}\" restaurado",
   "hidden_content_undo": "Desfazer",
   "hidden_content_unhide": "Mostrar",
   "hidden_content_manage_button": "Gerir conteúdo oculto",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/pt.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/pt.json
@@ -639,6 +639,8 @@
   "hidden_content_hide_button": "Ocultar",
   "hidden_content_already_hidden": "Oculto",
   "hidden_content_item_hidden": "\"{name}\" oculto",
+  "hidden_content_undo_available": "\"{name}\" oculto. A ação Desfazer está disponível.",
+  "hidden_content_item_restored": "\"{name}\" restaurado",
   "hidden_content_undo": "Desfazer",
   "hidden_content_unhide": "Mostrar",
   "hidden_content_manage_button": "Gerir conteúdo oculto",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/ru.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/ru.json
@@ -638,6 +638,8 @@
   "hidden_content_hide_button": "Скрыть",
   "hidden_content_already_hidden": "Скрыто",
   "hidden_content_item_hidden": "\"{name}\" скрыто",
+  "hidden_content_undo_available": "«{name}» скрыто. Доступно действие «Отменить».",
+  "hidden_content_item_restored": "\"{name}\" восстановлено",
   "hidden_content_undo": "Отменить",
   "hidden_content_unhide": "Показать",
   "hidden_content_manage_button": "Управление скрытым содержимым",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/sk.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/sk.json
@@ -639,6 +639,8 @@
   "hidden_content_hide_button": "Skryť",
   "hidden_content_already_hidden": "Skryté",
   "hidden_content_item_hidden": "\"{name}\" skryté",
+  "hidden_content_undo_available": "„{name}“ skryté. Akcia Vrátiť späť je k dispozícii.",
+  "hidden_content_item_restored": "\"{name}\" obnovené",
   "hidden_content_undo": "Vrátiť späť",
   "hidden_content_unhide": "Odkryť",
   "hidden_content_manage_button": "Spravovať skrytý obsah",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/sv.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/sv.json
@@ -639,6 +639,8 @@
   "hidden_content_hide_button": "Dölj",
   "hidden_content_already_hidden": "Dold",
   "hidden_content_item_hidden": "\"{name}\" dold",
+  "hidden_content_undo_available": "\"{name}\" dold. Åtgärden Ångra är tillgänglig.",
+  "hidden_content_item_restored": "\"{name}\" återställt",
   "hidden_content_undo": "Ångra",
   "hidden_content_unhide": "Visa",
   "hidden_content_manage_button": "Hantera dolt innehåll",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/tr.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/tr.json
@@ -639,6 +639,8 @@
   "hidden_content_hide_button": "Gizle",
   "hidden_content_already_hidden": "Gizli",
   "hidden_content_item_hidden": "\"{name}\" gizlendi",
+  "hidden_content_undo_available": "\"{name}\" gizlendi. Geri al işlemi kullanılabilir.",
+  "hidden_content_item_restored": "\"{name}\" geri yüklendi",
   "hidden_content_undo": "Geri al",
   "hidden_content_unhide": "Göster",
   "hidden_content_manage_button": "Gizli içeriği yönet",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/zh-CN.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/zh-CN.json
@@ -639,6 +639,8 @@
   "hidden_content_hide_button": "隐藏",
   "hidden_content_already_hidden": "已隐藏",
   "hidden_content_item_hidden": "已隐藏「{name}」",
+  "hidden_content_undo_available": "已隐藏「{name}」。可使用“复原”操作。",
+  "hidden_content_item_restored": "已恢复「{name}」",
   "hidden_content_undo": "复原",
   "hidden_content_unhide": "取消隐藏",
   "hidden_content_manage_button": "管理隐藏内容",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/zh-HK.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/zh-HK.json
@@ -639,6 +639,8 @@
   "hidden_content_hide_button": "隱藏",
   "hidden_content_already_hidden": "已隱藏",
   "hidden_content_item_hidden": "已隱藏「{name}」",
+  "hidden_content_undo_available": "已隱藏「{name}」。可使用「復原」操作。",
+  "hidden_content_item_restored": "已還原「{name}」",
   "hidden_content_undo": "復原",
   "hidden_content_unhide": "取消隱藏",
   "hidden_content_manage_button": "管理隱藏內容",

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/arr-links.notification.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/arr-links.notification.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from './arr-globals';
+import { notifyArrLinkError } from './arr-links';
+
+describe('arr-links urgent notifications', () => {
+    const notify = vi.fn();
+
+    beforeEach(() => {
+        notify.mockReset();
+        JC.core.ui = {
+            ...(JC.core.ui || {}),
+            notify,
+        } as typeof JC.core.ui;
+        JC.toast = vi.fn();
+    });
+
+    it('uses safe typed assertive copy for dynamic integration failures', () => {
+        notifyArrLinkError('<img src=x onerror=alert(1)> failed', 'arr-links:test');
+
+        expect(notify).toHaveBeenCalledWith({
+            message: '<img src=x onerror=alert(1)> failed',
+            severity: 'error',
+            duration: 8000,
+            dedupeKey: 'arr-links:test',
+        });
+        expect(JC.toast).not.toHaveBeenCalled();
+    });
+
+    it('does not turn notification backpressure into an integration failure', () => {
+        notify.mockImplementation(() => { throw new Error('notification capacity full'); });
+        const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        expect(() => notifyArrLinkError('Arr unavailable', 'arr-links:full')).not.toThrow();
+        expect(error).toHaveBeenCalledWith(
+            expect.stringContaining('notification rejected'),
+            expect.any(Error)
+        );
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/arr-links.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/arr-links.ts
@@ -103,6 +103,19 @@ function isActive(context: IdentityContext, expectedGeneration: number): boolean
     return arrLinksGeneration === expectedGeneration && JC.identity.isCurrent(context);
 }
 
+/** Route urgent integration failures through the typed assertive owner. */
+export function notifyArrLinkError(message: string, dedupeKey: string): void {
+    if (JC.core.ui?.notify) {
+        try {
+            JC.core.ui.notify({ message, severity: 'error', duration: 8000, dedupeKey });
+        } catch (error) {
+            console.error('🪼 Jellyfin Canopy: Arr link error notification rejected:', error);
+        }
+        return;
+    }
+    JC.toast?.(JC.escapeHtml(message), 8000, 'error');
+}
+
 function waitForRetry(context: IdentityContext, expectedGeneration: number, delay: number): Promise<void> {
     return new Promise((resolve) => {
         const finish = (): void => {
@@ -185,12 +198,18 @@ async function initializeArrLinks(): Promise<void> {
     // Surface stored-config corruption to the admin on first init rather than waiting for
     // an action endpoint. The backend ships boolean flags in /private-config so the frontend
     // can toast without round-tripping an action call.
-    if (JC?.pluginConfig?.SonarrInstancesCorrupt && typeof JC.toast === 'function') {
-        JC.toast('⚠ Sonarr instance configuration is corrupt. Open the Jellyfin Canopy config page to reset it.');
+    if (JC?.pluginConfig?.SonarrInstancesCorrupt) {
+        notifyArrLinkError(
+            'Sonarr instance configuration is corrupt. Open the Jellyfin Canopy config page to reset it.',
+            'arr-links:sonarr-config-corrupt'
+        );
         console.error(`${logPrefix} SonarrInstances stored JSON is corrupt.`);
     }
-    if (JC?.pluginConfig?.RadarrInstancesCorrupt && typeof JC.toast === 'function') {
-        JC.toast('⚠ Radarr instance configuration is corrupt. Open the Jellyfin Canopy config page to reset it.');
+    if (JC?.pluginConfig?.RadarrInstancesCorrupt) {
+        notifyArrLinkError(
+            'Radarr instance configuration is corrupt. Open the Jellyfin Canopy config page to reset it.',
+            'arr-links:radarr-config-corrupt'
+        );
         console.error(`${logPrefix} RadarrInstances stored JSON is corrupt.`);
     }
 
@@ -397,19 +416,6 @@ async function initializeArrLinks(): Promise<void> {
         const _toastedGlobalFailure: Record<string, boolean> = { sonarr: false, radarr: false };
         const _toastedInstanceErrors = new Set<string>();
 
-        // Alias the shared helper so the toast concatenations read short. JC.toast renders
-        // via innerHTML, so any caller-controlled field (admin-set instance name, upstream
-        // error reason) must pass through escape() to prevent stored XSS.
-        // The inline fallback is a real escaper so XSS is blocked even if helpers.js
-        // hasn't loaded yet (e.g. a load-order race on first init).
-        const esc = (s: unknown): string => {
-            if (JC.helpers?.escHtml) return JC.helpers.escHtml(s);
-            // eslint-disable-next-line @typescript-eslint/no-base-to-string -- frozen behavior: non-strings coerce via String()
-            return String(s == null ? '' : s)
-                .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-                .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
-        };
-
         function surfaceInstanceErrors(kind: string, errors: InstanceError[] | undefined): void {
             if (!Array.isArray(errors) || errors.length === 0) {
                 // Empty-errors fetch means everything that was failing has recovered. Drop any
@@ -425,9 +431,10 @@ async function initializeArrLinks(): Promise<void> {
                 seenThisTick.add(key);
                 if (_toastedInstanceErrors.has(key)) return;
                 _toastedInstanceErrors.add(key);
-                if (typeof JC.toast === 'function') {
-                    JC.toast('⚠ ' + esc(kind) + ' instance "' + esc(err.instanceName || 'unknown') + '" failed: ' + esc(err.reason));
-                }
+                notifyArrLinkError(
+                    `${kind} instance "${err.instanceName || 'unknown'}" failed: ${err.reason || 'Unknown error'}`,
+                    `arr-links:${key}`
+                );
                 console.warn(`${logPrefix} ${kind} instance "${err.instanceName}" error: ${err.reason}`);
             });
             // Self-heal: drop memo entries for errors that didn't reappear this tick.
@@ -439,9 +446,10 @@ async function initializeArrLinks(): Promise<void> {
         function surfaceGlobalFailure(kind: string, detail: unknown): void {
             if (_toastedGlobalFailure[kind.toLowerCase()]) return;
             _toastedGlobalFailure[kind.toLowerCase()] = true;
-            if (typeof JC.toast === 'function') {
-                JC.toast('⚠ ' + esc(kind) + ' lookup failed; links unavailable. See console for details.');
-            }
+            notifyArrLinkError(
+                `${kind} lookup failed; links unavailable. See console for details.`,
+                `arr-links:${kind.toLowerCase()}:lookup-failed`
+            );
             console.warn(`${logPrefix} ${kind} lookup backend failed:`, detail);
         }
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/calendar/calendar-error-state.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/calendar/calendar-error-state.test.ts
@@ -6,10 +6,12 @@
 // and remain retryable rather than silently under-populating the filter.
 import { describe, expect, it, beforeEach, vi } from 'vitest';
 import '../../core/ui-kit';
+import type { NotificationOptions } from '../../types/jc';
 
 describe('calendar page error state', () => {
     let plugin: ReturnType<typeof vi.fn>;
     let toast: ReturnType<typeof vi.fn>;
+    let notify: ReturnType<typeof vi.fn<(options: NotificationOptions) => void>>;
     let data: typeof import('./data');
     let views: typeof import('./render-views');
 
@@ -17,8 +19,9 @@ describe('calendar page error state', () => {
         vi.resetModules();
         plugin = vi.fn();
         toast = vi.fn();
+        notify = vi.fn<(options: NotificationOptions) => void>();
         const JC = window.JellyfinCanopy as unknown as Record<string, unknown>;
-        JC.core = { api: { plugin } };
+        JC.core = { api: { plugin }, ui: { notify } };
         JC.pluginConfig = { SeerrEnabled: true, CalendarFilterByLibraryAccess: true };
         JC.t = (k: string) => k;
         JC.toast = toast;
@@ -33,8 +36,10 @@ describe('calendar page error state', () => {
 
         expect(data.state.eventsError).toBe(true);
         expect(data.state.events.length).toBe(0);
-        expect(toast).toHaveBeenCalledTimes(1);
-        expect(String(toast.mock.calls[0][0])).toContain('calendar_load_error');
+        const notification = notify.mock.calls.at(-1)?.[0];
+        expect(notification?.message).toContain('calendar_load_error');
+        expect(notification?.severity).toBe('error');
+        expect(toast).not.toHaveBeenCalled();
 
         data.state.isLoading = false;
         const container = document.createElement('div');
@@ -67,6 +72,7 @@ describe('calendar page error state', () => {
         expect(data.state.requestedLoaded).toBe(true);
         expect(data.state.requestedError).toBe(false);
         expect(toast).not.toHaveBeenCalled();
+        expect(notify).not.toHaveBeenCalled();
     });
 
     it('flags a snapshot failure, publishes no partial keys, and allows a retry', async () => {
@@ -78,8 +84,10 @@ describe('calendar page error state', () => {
         expect(data.state.requestedError).toBe(true);
         expect(data.state.requestedLoaded).toBe(false);
         expect(data.state.requestedItems.size).toBe(0);
-        expect(toast).toHaveBeenCalledTimes(1);
-        expect(String(toast.mock.calls[0][0])).toContain('calendar_load_error');
+        const notification = notify.mock.calls.at(-1)?.[0];
+        expect(notification?.message).toContain('calendar_load_error');
+        expect(notification?.severity).toBe('error');
+        expect(toast).not.toHaveBeenCalled();
 
         plugin.mockResolvedValue({
             complete: true,

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/calendar/data.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/calendar/data.ts
@@ -275,9 +275,10 @@ export async function fetchCalendarEvents(startDate: Date, endDate: Date, signal
         // flag it + toast once — otherwise the calendar would render "No
         // upcoming releases" as though the range were genuinely empty (W4-ERR-3).
         state.eventsError = true;
-        if (typeof JC.toast === 'function') {
-            JC.toast('⚠ ' + esc(describeFetchError(error, JC.t?.('calendar_load_error') || 'Unable to load calendar')));
-        }
+        notifyCalendarError(
+            describeFetchError(error, JC.t?.('calendar_load_error') || 'Unable to load calendar'),
+            'calendar:events-total-failure'
+        );
         return null;
     }
 }
@@ -286,17 +287,17 @@ export async function fetchCalendarEvents(startDate: Date, endDate: Date, signal
 // calendar refresh. Self-heals: when an error stops appearing the memo entry is dropped
 // so a future reoccurrence re-toasts.
 const _toastedCalendarErrors = new Set<string>();
-// Alias the shared HTML-escape helper to keep toast concatenations short. JC.toast uses
-// innerHTML so admin-set instance names + upstream error reasons must be escaped.
-// The inline fallback is a real escaper so XSS is blocked even if helpers.js
-// hasn't loaded yet (e.g. a load-order race on first init).
-const esc = (s: unknown): string => {
-    if (JC.helpers?.escHtml) return JC.helpers.escHtml(s);
-    // eslint-disable-next-line @typescript-eslint/no-base-to-string -- frozen behavior: non-strings coerce via String()
-    return String(s == null ? '' : s)
-        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
-};
+function notifyCalendarError(message: string, dedupeKey: string): void {
+    if (JC.core.ui?.notify) {
+        try {
+            JC.core.ui.notify({ message, severity: 'error', duration: 8000, dedupeKey });
+        } catch (error) {
+            console.error(`${logPrefix} Error notification rejected:`, error);
+        }
+        return;
+    }
+    JC.toast?.(JC.escapeHtml(message), 8000, 'error');
+}
 function surfaceCalendarErrors(errors: CalendarErrorEntry[] | undefined): void {
     if (!Array.isArray(errors) || errors.length === 0) {
         // All previously-failing instances have recovered — drop the memo so future errors re-toast.
@@ -309,12 +310,10 @@ function surfaceCalendarErrors(errors: CalendarErrorEntry[] | undefined): void {
         seenThisTick.add(key);
         if (_toastedCalendarErrors.has(key)) return;
         _toastedCalendarErrors.add(key);
-        if (typeof JC.toast === 'function') {
-            JC.toast(
-                '⚠ ' + esc(err.source || 'Arr') + ' calendar instance "' +
-                esc(err.instanceName || 'unknown') + '" failed: ' + esc(err.reason)
-            );
-        }
+        notifyCalendarError(
+            `${err.source || 'Arr'} calendar instance "${err.instanceName || 'unknown'}" failed: ${err.reason || 'Unknown error'}`,
+            `calendar:instance:${key}`
+        );
         console.warn(`${logPrefix} ${err.source || 'Arr'} instance "${err.instanceName}" error: ${err.reason}`);
     });
     // Drop memo entries for errors that didn't reappear — lets future occurrences re-toast.
@@ -445,9 +444,10 @@ async function fetchUserRequests(signal?: AbortSignal): Promise<void> {
         state.requestedItems = new Set();
         state.requestedLoaded = false;
         state.requestedError = true;
-        if (typeof JC.toast === 'function') {
-            JC.toast('⚠ ' + esc(describeFetchError(error, JC.t?.('calendar_load_error') || 'Unable to load calendar')));
-        }
+        notifyCalendarError(
+            describeFetchError(error, JC.t?.('calendar_load_error') || 'Unable to load calendar'),
+            'calendar:requests-total-failure'
+        );
     } finally {
         if (!JC.identity.isCurrent(context)) return;
         // Releasing the latch is required on same-identity page teardown so a

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/requests/data.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/requests/data.ts
@@ -1153,9 +1153,12 @@ export async function fetchDownloads(signal?: AbortSignal): Promise<unknown> {
                     : Math.min(downloadsWholeSnapshotExpiresAt, transportDeadline);
         }
         scheduleDownloadsSnapshotExpiry();
-        if (!downloadsFailureToasted && typeof JC.toast === 'function') {
+        if (!downloadsFailureToasted) {
             downloadsFailureToasted = true;
-            JC.toast(JC.t?.('downloads_load_error') || 'Unable to load download activity');
+            notifyRequestError(
+                JC.t?.('downloads_load_error') || 'Unable to load download activity',
+                'requests:downloads-total-failure'
+            );
         }
         return null;
     } finally {
@@ -1171,6 +1174,30 @@ export async function fetchDownloads(signal?: AbortSignal): Promise<unknown> {
 /** Refresh only lifecycle/history data (search and History paging use this). */
 export function refreshDownloads(signal?: AbortSignal): Promise<unknown> {
     return fetchDownloads(signal ?? activeSignal ?? undefined);
+}
+
+function notifyRequestError(message: string, dedupeKey: string, duration = 8000): void {
+    if (JC.core.ui?.notify) {
+        try {
+            JC.core.ui.notify({ message, severity: 'error', duration, dedupeKey });
+        } catch (error) {
+            console.error(`${logPrefix} Error notification rejected:`, error);
+        }
+        return;
+    }
+    JC.toast?.(JC.escapeHtml(message), duration, 'error');
+}
+
+function notifyRequestSuccess(message: string, dedupeKey: string): void {
+    if (JC.core.ui?.notify) {
+        try {
+            JC.core.ui.notify({ message, severity: 'success', dedupeKey });
+        } catch (error) {
+            console.error(`${logPrefix} Success notification rejected:`, error);
+        }
+        return;
+    }
+    JC.toast?.(JC.escapeHtml(message));
 }
 
 /**
@@ -1388,9 +1415,11 @@ export async function fetchIssues(signal?: AbortSignal): Promise<unknown> {
         // 403 = no issue-read permission — surface once, then stop polling issues.
         if ((error as { status?: number } | null)?.status === 403) {
             state.issuesPermissionDenied = true;
-            if (typeof JC?.toast === 'function') {
-                JC.toast(JC.t?.('seerr_err_no_issue_view_permission') || 'No permission to view issues', 4000);
-            }
+            notifyRequestError(
+                JC.t?.('seerr_err_no_issue_view_permission') || 'No permission to view issues',
+                'requests:issues-permission',
+                4000
+            );
         }
         return null;
     } finally {
@@ -1476,13 +1505,10 @@ export async function handleRequestAction(btn: HTMLButtonElement, action: 'appro
             ...(requestSignal ? { signal: requestSignal } : {}),
         });
         if (requestSignal?.aborted || !JC.identity.isCurrent(context)) return;
-        // Static, param-free localized strings (class (a)) — no interpolation
-        // reaches toast()'s innerHTML, so no escaping is required here.
-        if (typeof JC.toast === 'function') {
-            JC.toast(action === 'approve'
-                ? (JC.t?.('requests_approved_toast') || 'Request approved')
-                : (JC.t?.('requests_declined_toast') || 'Request declined'));
-        }
+        const successMessage = action === 'approve'
+            ? (JC.t?.('requests_approved_toast') || 'Request approved')
+            : (JC.t?.('requests_declined_toast') || 'Request declined');
+        notifyRequestSuccess(successMessage, `requests:action-success:${action}:${requestId}`);
         await fetchRequests(requestSignal);
         if (requestSignal?.aborted || !JC.identity.isCurrent(context)) return;
         renderPage();
@@ -1491,9 +1517,10 @@ export async function handleRequestAction(btn: HTMLButtonElement, action: 'appro
         console.error(`${logPrefix} Failed to ${action} request ${requestId}:`, err);
         siblingButtons.forEach((b) => { b.disabled = false; });
         if (icon) icon.textContent = action === 'approve' ? 'check' : 'close';
-        if (typeof JC.toast === 'function') {
-            JC.toast(JC.t?.('requests_action_error') || 'Couldn’t update the request. Please try again.');
-        }
+        notifyRequestError(
+            JC.t?.('requests_action_error') || 'Couldn’t update the request. Please try again.',
+            `requests:action:${action}:${requestId}`
+        );
     }
 }
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/requests/requests-error-state.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/requests/requests-error-state.test.ts
@@ -5,6 +5,7 @@
 // and a total downloads-fetch failure must toast once instead of silently
 // showing "No active downloads".
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NotificationOptions } from '../../types/jc';
 // ui-kit installs the real JC.escapeHtml (the setup stub is a no-op) which the
 // render modules capture at import.
 import '../../core/ui-kit';
@@ -136,6 +137,7 @@ function mixedSourceEnvelope(): Record<string, unknown> {
 describe('requests page error state', () => {
     let plugin: ReturnType<typeof vi.fn>;
     let toast: ReturnType<typeof vi.fn>;
+    let notify: ReturnType<typeof vi.fn<(options: NotificationOptions) => void>>;
     let data: typeof import('./data');
     let render: typeof import('./render');
 
@@ -144,8 +146,9 @@ describe('requests page error state', () => {
         document.body.innerHTML = '';
         plugin = vi.fn();
         toast = vi.fn();
+        notify = vi.fn<(options: NotificationOptions) => void>();
         const JC = window.JellyfinCanopy as unknown as Record<string, unknown>;
-        JC.core = { api: { plugin } };
+        JC.core = { api: { plugin }, ui: { notify } };
         JC.pluginConfig = { SeerrEnabled: true, ShowDownloadsInRequests: true };
         JC.t = (k: string) => k;
         JC.toast = toast;
@@ -214,8 +217,13 @@ describe('requests page error state', () => {
         expect(data.state.downloadsError).toBe(true);
         expect(data.state.downloadsStale).toBe(true);
         expect(data.state.downloadsHasSnapshot).toBe(false);
-        expect(toast).toHaveBeenCalledTimes(1);
-        expect(String(toast.mock.calls[0][0])).toContain('downloads_load_error');
+        expect(notify).toHaveBeenCalledTimes(1);
+        expect(notify.mock.calls[0][0]).toMatchObject({
+            message: 'downloads_load_error',
+            severity: 'error',
+            dedupeKey: 'requests:downloads-total-failure',
+        });
+        expect(toast).not.toHaveBeenCalled();
 
         const container = document.createElement('div');
         document.body.appendChild(container);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/arr/search/actions.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/arr/search/actions.ts
@@ -124,7 +124,22 @@ export function toast(iconKey: string, message: string, duration = 4000): void {
 // Icon keys must exist in the JC.t icon registry (js/locales use these): search, success, error.
 export function toastInfo(message: string): void { toast('search', message); }
 export function toastSuccess(message: string): void { toast('success', message, 5000); }
-export function toastError(message: string): void { toast('error', message, 6000); }
+export function toastError(message: string): void {
+    if (JC.core.ui?.notify) {
+        try {
+            JC.core.ui.notify({ message, severity: 'error', duration: 6000 });
+        } catch (error) {
+            console.error(`${logPrefix} Error notification rejected:`, error);
+        }
+        return;
+    }
+    try {
+        const iconHtml = JC.t ? JC.t('{{icon:error}}') : '';
+        JC.toast!(`${iconHtml} ${JC.escapeHtml(message)}`, 6000, 'error');
+    } catch (error) {
+        console.error(`${logPrefix} Error notification rejected:`, error);
+    }
+}
 
 // ── Downloads-page deep-link (reuses the existing page; never a second one) ──
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/ui-kit.reinstall.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/ui-kit.reinstall.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../globals';
+
+describe('notification document owner reinstall', () => {
+    const originalEvents = window.Events;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        document.body.innerHTML = '';
+        window.Events = {
+            on: vi.fn(),
+            off: vi.fn(),
+            trigger: vi.fn(),
+        };
+    });
+
+    afterEach(() => {
+        window.Events = originalEvents;
+        vi.runOnlyPendingTimers();
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+        document.body.innerHTML = '';
+    });
+
+    it('reuses one queue, lifecycle registration, owner, and teardown across module reevaluation', async () => {
+        const registerReset = vi.spyOn(JC.identity, 'registerReset');
+        const action = vi.fn();
+        const dismissed = vi.fn();
+        const firstGraph = await import('./ui-kit');
+        const first = firstGraph.notifyAction({
+            message: 'First graph action',
+            persistent: true,
+            actionLabel: 'Run first',
+            onAction: action,
+            onDismiss: dismissed,
+        });
+        const retainedFirstButton = first.element.querySelector<HTMLButtonElement>('button')!;
+        firstGraph.queueNotificationAnnouncementForTesting(
+            'Retained pre-callback announcement',
+            'info',
+            'retained-pre-callback'
+        );
+        type RetainedAnnouncement = {
+            message: string;
+            urgency: 'polite' | 'assertive';
+            dedupeKey: string | null;
+            admission: 'primary' | 'terminal';
+            presentedCallbacks?: Array<() => void>;
+        };
+        const runtime = Reflect.get(
+            window,
+            Symbol.for('JellyfinCanopy.notificationRuntime.v1')
+        ) as {
+            announcements: RetainedAnnouncement[];
+            announcementTimer: number | null;
+            announcementActive: boolean;
+            announcementInGap: boolean;
+            activeAnnouncementKey: string | null;
+            activeAnnouncementAdmission: 'primary' | 'terminal' | null;
+        };
+        const retainedPreCallback = runtime.announcements
+            .find((announcement) => announcement.dedupeKey === 'retained-pre-callback')!;
+        delete retainedPreCallback.presentedCallbacks;
+
+        // Emulate the pre-callback v1 graph retaining timer ownership. Its
+        // closed-over drain can present later events but cannot run their new
+        // presentedCallbacks, so a repaired graph must cancel and re-arm it.
+        const retireThroughLegacyClosure = (lane: HTMLElement): void => {
+            runtime.announcementTimer = window.setTimeout(() => {
+                lane.textContent = '';
+                runtime.announcementActive = false;
+                runtime.announcementInGap = true;
+                runtime.activeAnnouncementKey = null;
+                runtime.activeAnnouncementAdmission = null;
+                runtime.announcementTimer = window.setTimeout(() => {
+                    runtime.announcementTimer = null;
+                    runtime.announcementInGap = false;
+                    legacyDrainWithoutCallbacks();
+                }, 50);
+            }, 500);
+        };
+        const legacyDrainWithoutCallbacks = (): void => {
+            if (runtime.announcementActive || runtime.announcementInGap) return;
+            const next = runtime.announcements.shift();
+            if (!next) return;
+            const lane = document.querySelector<HTMLElement>(`[data-jc-announcer="${next.urgency}"]`)!;
+            lane.textContent = next.message;
+            runtime.announcementActive = true;
+            runtime.activeAnnouncementKey = next.dedupeKey;
+            runtime.activeAnnouncementAdmission = next.admission;
+            retireThroughLegacyClosure(lane);
+        };
+        clearTimeout(runtime.announcementTimer!);
+        retireThroughLegacyClosure(
+            document.querySelector<HTMLElement>('[data-jc-announcer="polite"]')!
+        );
+
+        vi.resetModules();
+        const secondGraph = await import('./ui-kit');
+        const second = secondGraph.notifyAction({
+            message: 'Second graph action',
+            duration: 8_000,
+            actionLabel: 'Run second',
+            actionAvailableAnnouncement: 'Second graph action available',
+            onAction: action,
+            onDismiss: dismissed,
+        });
+        const retainedSecondButton = second.element.querySelector<HTMLButtonElement>('button')!;
+
+        expect(registerReset).toHaveBeenCalledTimes(1);
+        expect(document.querySelectorAll('#jc-notification-owner')).toHaveLength(1);
+        expect(document.querySelectorAll('.jc-notification')).toHaveLength(2);
+        expect(document.querySelectorAll('[aria-live="polite"]')).toHaveLength(1);
+        expect(document.querySelectorAll('[aria-live="assertive"]')).toHaveLength(1);
+
+        vi.advanceTimersByTime(550);
+        expect(document.querySelector('[data-jc-announcer="polite"]')?.textContent)
+            .toBe('Retained pre-callback announcement');
+        vi.advanceTimersByTime(550);
+        expect(document.querySelector('[data-jc-announcer="polite"]')?.textContent)
+            .toBe('Second graph action available');
+        vi.advanceTimersByTime(7_999);
+        expect(second.element.style.transform).toBe('translateX(0)');
+        vi.advanceTimersByTime(1);
+        expect(second.element.style.transform).toBe('translateX(100%)');
+
+        history.pushState({}, '', `#notification-reinstall-${Date.now()}`);
+
+        expect(document.querySelectorAll('.jc-notification')).toHaveLength(0);
+        expect(dismissed).toHaveBeenCalledTimes(2);
+        expect(dismissed).toHaveBeenNthCalledWith(1, 'timeout');
+        expect(dismissed).toHaveBeenNthCalledWith(2, 'navigation');
+        retainedFirstButton.click();
+        retainedSecondButton.click();
+        expect(action).not.toHaveBeenCalled();
+        expect(vi.getTimerCount()).toBe(0);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/ui-kit.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/ui-kit.test.ts
@@ -1,11 +1,15 @@
 // Unit tests for src/core/ui-kit.ts (escapeHtml + CSS injection).
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
     escapeHtml,
     expandIn,
     injectCss,
     muiIconButton,
     muiMenuItem,
+    notify,
+    notifyAction,
+    queueNotificationAnnouncementForTesting,
+    queueTerminalNotificationAnnouncementForTesting,
     removeCss,
     sectionContainer,
     toast
@@ -201,35 +205,710 @@ describe('expandIn', () => {
 });
 
 describe('toast scheduling', () => {
+    afterEach(() => {
+        history.pushState({}, '', `#notification-test-cleanup-${Date.now()}-${Math.random()}`);
+        vi.runOnlyPendingTimers();
+        vi.useRealTimers();
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+        document.querySelectorAll('.jellyfin-canopy-toast, #jc-notification-owner').forEach((node) => node.remove());
+    });
+
+    it('announces legacy toast text once through one document-life polite live region', () => {
+        vi.useFakeTimers();
+        toast('<strong>Saved</strong>', 1_000);
+
+        expect(document.querySelectorAll('#jc-notification-owner')).toHaveLength(1);
+        const visual = document.querySelector('.jellyfin-canopy-toast');
+        expect(visual?.getAttribute('aria-live')).toBe('off');
+        expect(visual?.getAttribute('role')).toBeNull();
+        expect(document.querySelector('[data-jc-announcer="polite"]')?.textContent).toBe('Saved');
+        expect(document.querySelectorAll('[aria-live="polite"]')).toHaveLength(1);
+    });
+
+    it('coalesces byte-equivalent pending legacy announcements without dropping either visual event', () => {
+        vi.useFakeTimers();
+        toast('<strong>Saved</strong>', 1_000);
+        toast('<strong>Saved</strong>', 1_000);
+
+        expect(document.querySelectorAll('.jellyfin-canopy-toast')).toHaveLength(2);
+        expect(document.querySelector('[data-jc-announcer="polite"]')?.textContent).toBe('Saved');
+        vi.advanceTimersByTime(550);
+        expect(document.querySelector('[data-jc-announcer="polite"]')?.textContent).toBe('');
+    });
+
+    it('adopts cards from duplicate owners and stacks into one stable document owner', () => {
+        vi.useFakeTimers();
+        notify({ message: 'Owned card', persistent: true });
+        const owner = document.getElementById('jc-notification-owner')!;
+        const duplicateStack = document.createElement('div');
+        duplicateStack.className = 'jc-notification-stack';
+        const stackCard = document.createElement('div');
+        stackCard.className = 'jc-notification';
+        stackCard.dataset.testCard = 'stack';
+        duplicateStack.appendChild(stackCard);
+        owner.appendChild(duplicateStack);
+        const duplicateOwner = document.createElement('div');
+        duplicateOwner.id = 'jc-notification-owner';
+        const ownerCard = document.createElement('div');
+        ownerCard.className = 'jc-notification';
+        ownerCard.dataset.testCard = 'owner';
+        duplicateOwner.appendChild(ownerCard);
+        document.body.appendChild(duplicateOwner);
+
+        notify({ message: 'Triggers adoption', persistent: true });
+
+        expect(document.querySelectorAll('#jc-notification-owner')).toHaveLength(1);
+        expect(owner.querySelectorAll(':scope > .jc-notification-stack')).toHaveLength(1);
+        expect(owner.querySelector('[data-test-card="stack"]')).toBe(stackCard);
+        expect(owner.querySelector('[data-test-card="owner"]')).toBe(ownerCard);
+    });
+
     it('shows, hides, and removes the toast on deterministic timers', () => {
         vi.useFakeTimers();
-        try {
-            toast('<strong>Saved</strong>', 1_000);
+        toast('<strong>Saved</strong>', 1_000);
 
-            const node = document.querySelector<HTMLElement>('.jellyfin-canopy-toast');
-            expect(node).not.toBeNull();
-            expect(node?.innerHTML).toBe('<strong>Saved</strong>');
-            expect(node?.style.transform).toBe('translateX(100%)');
+        const node = document.querySelector<HTMLElement>('.jellyfin-canopy-toast');
+        expect(node).not.toBeNull();
+        expect(node?.innerHTML).toBe('<strong>Saved</strong>');
+        expect(node?.style.transform).toBe('translateX(100%)');
 
-            vi.advanceTimersByTime(9);
-            expect(node?.style.transform).toBe('translateX(100%)');
+        vi.advanceTimersByTime(9);
+        expect(node?.style.transform).toBe('translateX(100%)');
 
-            vi.advanceTimersByTime(1);
-            expect(node?.style.transform).toBe('translateX(0)');
+        vi.advanceTimersByTime(1);
+        expect(node?.style.transform).toBe('translateX(0)');
 
-            vi.advanceTimersByTime(990);
-            expect(node?.style.transform).toBe('translateX(100%)');
-            expect(node?.isConnected).toBe(true);
+        vi.advanceTimersByTime(990);
+        expect(node?.style.transform).toBe('translateX(100%)');
+        expect(node?.isConnected).toBe(true);
 
-            vi.advanceTimersByTime(299);
-            expect(node?.isConnected).toBe(true);
+        vi.advanceTimersByTime(299);
+        expect(node?.isConnected).toBe(true);
 
-            vi.advanceTimersByTime(1);
-            expect(node?.isConnected).toBe(false);
-        } finally {
-            vi.runOnlyPendingTimers();
-            vi.useRealTimers();
-            document.querySelectorAll('.jellyfin-canopy-toast').forEach((node) => node.remove());
+        vi.advanceTimersByTime(1);
+        expect(node?.isConnected).toBe(false);
+    });
+
+    it('serializes rapid announcements without losing or duplicating text', () => {
+        vi.useFakeTimers();
+        notify({ message: 'First', duration: 2_000 });
+        notify({ message: 'Second', duration: 2_000 });
+        notify({ message: 'Third', duration: 2_000 });
+
+        const polite = document.querySelector<HTMLElement>('[data-jc-announcer="polite"]')!;
+        expect(polite.textContent).toBe('First');
+        vi.advanceTimersByTime(500);
+        expect(polite.textContent).toBe('');
+        vi.advanceTimersByTime(50);
+        expect(polite.textContent).toBe('Second');
+        vi.advanceTimersByTime(500);
+        expect(polite.textContent).toBe('');
+        vi.advanceTimersByTime(50);
+        expect(polite.textContent).toBe('Third');
+        vi.advanceTimersByTime(500);
+        expect(polite.textContent).toBe('');
+        expect(document.querySelectorAll('#jc-notification-owner')).toHaveLength(1);
+        expect(document.querySelectorAll('.jc-notification')).toHaveLength(3);
+    });
+
+    it('coalesces an explicit duplicate key in first-seen order', () => {
+        vi.useFakeTimers();
+        notify({ message: 'First copy', duration: 2_000, dedupeKey: 'same-event' });
+        notify({ message: 'Duplicate copy', duration: 2_000, dedupeKey: 'same-event' });
+        notify({ message: 'Distinct', duration: 2_000, dedupeKey: 'other-event' });
+
+        const polite = document.querySelector<HTMLElement>('[data-jc-announcer="polite"]')!;
+        expect(polite.textContent).toBe('First copy');
+        vi.advanceTimersByTime(500);
+        expect(polite.textContent).toBe('');
+        vi.advanceTimersByTime(50);
+        expect(polite.textContent).toBe('Distinct');
+        vi.advanceTimersByTime(500);
+        expect(polite.textContent).toBe('');
+    });
+
+    it('reserves bounded outcome capacity and rejects the 33rd pending primary message explicitly', () => {
+        vi.useFakeTimers();
+        for (let index = 0; index < 32; index += 1) {
+            queueNotificationAnnouncementForTesting(`Message ${index}`, 'info', `message-${index}`);
         }
+
+        expect(() => notify({
+            message: 'Overflow',
+            persistent: true,
+            dedupeKey: 'overflow',
+        })).toThrow(/backpressure/i);
+
+        const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        expect(() => toast('Legacy overflow')).not.toThrow();
+        expect(error).toHaveBeenCalledWith(
+            expect.stringContaining('Legacy toast rejected'),
+            expect.objectContaining({ name: 'NotificationBackpressureError' })
+        );
+
+        history.pushState({}, '', `#notification-overflow-cleanup-${Date.now()}`);
+    });
+
+    it('bounds visible cards even when explicit announcement keys coalesce', () => {
+        vi.useFakeTimers();
+        for (let index = 0; index < 32; index += 1) {
+            notify({
+                message: `Visible ${index}`,
+                persistent: true,
+                dedupeKey: 'one-spoken-event',
+            });
+        }
+
+        expect(document.querySelectorAll('.jc-notification')).toHaveLength(32);
+        expect(() => notify({
+            message: 'Visible overflow',
+            persistent: true,
+            dedupeKey: 'one-spoken-event',
+        })).toThrow(/notifications backpressure/i);
+        expect(document.querySelectorAll('.jc-notification')).toHaveLength(32);
+
+        history.pushState({}, '', `#notification-card-overflow-cleanup-${Date.now()}`);
+    });
+
+    it('keeps reserved terminal capacity available when the primary queue is saturated', async () => {
+        vi.useFakeTimers();
+        const handle = notifyAction({
+            message: 'Needs Undo',
+            persistent: true,
+            actionLabel: 'Undo',
+            onAction: () => { throw new Error('write failed'); },
+            actionErrorAnnouncement: 'Undo was not saved. Try again.',
+        });
+        for (let index = 0; index < 31; index += 1) {
+            queueNotificationAnnouncementForTesting(`Primary ${index}`, 'info', `primary-${index}`);
+        }
+
+        handle.element.querySelector<HTMLButtonElement>('button')!.click();
+        await Promise.resolve();
+        expect(handle.element.querySelector<HTMLButtonElement>('button')!.disabled).toBe(false);
+        vi.advanceTimersByTime(550);
+        expect(document.querySelector('[data-jc-announcer="assertive"]')?.textContent)
+            .toBe('Undo was not saved. Try again.');
+
+        history.pushState({}, '', `#notification-terminal-reserve-cleanup-${Date.now()}`);
+    });
+
+    it('starts an action expiry only after its queued availability event is presented', () => {
+        vi.useFakeTimers();
+        for (let index = 0; index < 31; index += 1) {
+            queueNotificationAnnouncementForTesting(`Ahead ${index}`, 'info', `ahead-${index}`);
+        }
+        const action = vi.fn();
+        const handle = notifyAction({
+            message: 'Queued item hidden',
+            actionAvailableAnnouncement: 'Queued item hidden. Undo is available.',
+            duration: 8_000,
+            actionLabel: 'Undo',
+            onAction: action,
+        });
+
+        vi.advanceTimersByTime(17_049);
+        expect(handle.element.isConnected).toBe(true);
+        expect(handle.element.style.transform).toBe('translateX(0)');
+        expect(document.querySelector('[data-jc-announcer="polite"]')?.textContent).toBe('');
+
+        vi.advanceTimersByTime(1);
+        expect(document.querySelector('[data-jc-announcer="polite"]')?.textContent)
+            .toBe('Queued item hidden. Undo is available.');
+        vi.advanceTimersByTime(7_999);
+        expect(handle.element.isConnected).toBe(true);
+        expect(handle.element.style.transform).toBe('translateX(0)');
+        vi.advanceTimersByTime(1);
+        expect(handle.element.style.transform).toBe('translateX(100%)');
+        expect(action).not.toHaveBeenCalled();
+    });
+
+    it('keeps a terminal-saturation completion polite and readable for a full dwell', async () => {
+        vi.useFakeTimers();
+        vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: true }));
+        const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        const dismissed = vi.fn();
+        const handle = notifyAction({
+            message: 'Action ready',
+            actionAvailableAnnouncement: 'Action ready. Resolve is available.',
+            persistent: true,
+            actionLabel: 'Resolve',
+            onAction: vi.fn(),
+            actionAnnouncement: 'Action completed',
+            onDismiss: dismissed,
+        });
+        for (let index = 0; index < 95; index += 1) {
+            queueTerminalNotificationAnnouncementForTesting(
+                `Terminal ${index}`,
+                'success',
+                `terminal-${index}`
+            );
+        }
+
+        handle.element.querySelector<HTMLButtonElement>('button')!.click();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const status = handle.element.querySelector<HTMLElement>('.jc-notification-action-status')!;
+        expect(status.textContent).toBe('Action completed');
+        expect(status.getAttribute('aria-live')).toBe('polite');
+        expect(status.getAttribute('aria-atomic')).toBe('true');
+        expect(handle.element.isConnected).toBe(true);
+        expect(error).toHaveBeenCalledWith(
+            expect.stringContaining('Could not queue action completion'),
+            expect.objectContaining({ name: 'NotificationBackpressureError' })
+        );
+
+        vi.advanceTimersByTime(2_999);
+        expect(handle.element.isConnected).toBe(true);
+        expect(dismissed).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(1);
+        expect(handle.element.isConnected).toBe(false);
+        expect(dismissed).toHaveBeenCalledOnce();
+        expect(dismissed).toHaveBeenCalledWith('action');
+    });
+
+    it('maps urgent severity to the assertive lane and renders typed text safely', () => {
+        vi.useFakeTimers();
+        const handle = notify({ message: '<img src=x onerror=alert(1)> Failed', severity: 'error' });
+
+        expect(handle.element.textContent).toBe('<img src=x onerror=alert(1)> Failed');
+        expect(handle.element.querySelector('img')).toBeNull();
+        expect(handle.element.getAttribute('aria-live')).toBe('off');
+        expect(document.querySelector('[data-jc-announcer="assertive"]')?.textContent)
+            .toBe('<img src=x onerror=alert(1)> Failed');
+        expect(document.querySelector('[data-jc-announcer="polite"]')?.textContent).toBe('');
+    });
+
+    it('rejects typed notices without accessible message or action text before admission', () => {
+        vi.useFakeTimers();
+        expect(() => notify({ message: '   ' })).toThrow(/accessible text/i);
+        expect(() => notifyAction({
+            message: 'Action available',
+            actionLabel: ' ',
+            onAction: vi.fn(),
+        })).toThrow(/accessible label/i);
+        expect(document.querySelectorAll('.jc-notification')).toHaveLength(0);
+        expect(document.querySelector('[data-jc-announcer="polite"]')?.textContent ?? '').toBe('');
+    });
+
+    it('lets audited legacy producers opt into assertive urgency without changing their HTML card', () => {
+        vi.useFakeTimers();
+        toast('<span aria-hidden="true">!</span><strong>Save failed</strong>', 2_000, 'error');
+
+        const visual = document.querySelector<HTMLElement>('.jellyfin-canopy-toast')!;
+        expect(visual.innerHTML).toBe('<span aria-hidden="true">!</span><strong>Save failed</strong>');
+        expect(visual.dataset.jcNotificationSeverity).toBe('error');
+        expect(document.querySelector('[data-jc-announcer="assertive"]')?.textContent)
+            .toBe('Save failed');
+        expect(document.querySelector('[data-jc-announcer="polite"]')?.textContent).toBe('');
+    });
+
+    it('moves urgent work ahead of queued polite announcements without dropping either', () => {
+        vi.useFakeTimers();
+        notify({ message: 'First', duration: 2_000 });
+        notify({ message: 'Second', duration: 2_000 });
+        notify({ message: 'Urgent', severity: 'error', duration: 2_000 });
+        const polite = document.querySelector<HTMLElement>('[data-jc-announcer="polite"]')!;
+        const assertive = document.querySelector<HTMLElement>('[data-jc-announcer="assertive"]')!;
+
+        expect(polite.textContent).toBe('First');
+        vi.advanceTimersByTime(500);
+        expect(assertive.textContent).toBe('');
+        vi.advanceTimersByTime(50);
+        expect(assertive.textContent).toBe('Urgent');
+        vi.advanceTimersByTime(500);
+        expect(polite.textContent).toBe('');
+        vi.advanceTimersByTime(50);
+        expect(polite.textContent).toBe('Second');
+    });
+
+    it('runs an action and terminal callback exactly once under repeated input', async () => {
+        vi.useFakeTimers();
+        const action = vi.fn();
+        const dismissed = vi.fn();
+        const handle = notifyAction({
+            message: 'Hidden A',
+            duration: 1_000,
+            actionLabel: 'Undo',
+            onAction: action,
+            actionAnnouncement: 'A restored',
+            onDismiss: dismissed,
+        });
+        const button = handle.element.querySelector<HTMLButtonElement>('button')!;
+
+        button.click();
+        button.click();
+        await Promise.resolve();
+        vi.advanceTimersByTime(550);
+        vi.advanceTimersByTime(3_000);
+        handle.dismiss();
+        vi.advanceTimersByTime(300);
+
+        expect(action).toHaveBeenCalledTimes(1);
+        expect(dismissed).toHaveBeenCalledTimes(1);
+        expect(dismissed).toHaveBeenCalledWith('action');
+    });
+
+    it('keeps an async action pending and announces completion only after it resolves', async () => {
+        vi.useFakeTimers();
+        let resolveAction!: () => void;
+        const action = vi.fn(() => new Promise<void>((resolve) => {
+            resolveAction = resolve;
+        }));
+        const handle = notifyAction({
+            message: 'Saving Undo',
+            duration: 1_000,
+            actionLabel: 'Undo',
+            onAction: action,
+            actionAnnouncement: 'Undo saved',
+        });
+        const button = handle.element.querySelector<HTMLButtonElement>('button')!;
+
+        button.click();
+        vi.advanceTimersByTime(5_000);
+        expect(button.disabled).toBe(true);
+        expect(button.getAttribute('aria-busy')).toBe('true');
+        expect(handle.element.isConnected).toBe(true);
+        expect(document.querySelector('[data-jc-announcer="polite"]')?.textContent).toBe('');
+
+        resolveAction();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(document.querySelector('[data-jc-announcer="polite"]')?.textContent).toBe('Undo saved');
+        expect(button.hasAttribute('aria-busy')).toBe(false);
+        expect(handle.element.style.transform).toBe('translateX(0)');
+        vi.advanceTimersByTime(2_999);
+        expect(handle.element.style.transform).toBe('translateX(0)');
+        vi.advanceTimersByTime(1);
+        expect(handle.element.style.transform).toBe('translateX(100%)');
+        expect(action).toHaveBeenCalledOnce();
+    });
+
+    it('announces a synchronous action failure and restores the same action for retry', async () => {
+        vi.useFakeTimers();
+        const action = vi.fn()
+            .mockImplementationOnce(() => { throw new Error('first attempt failed'); })
+            .mockImplementationOnce(() => undefined);
+        const handle = notifyAction({
+            message: 'Hidden A',
+            persistent: true,
+            actionLabel: 'Undo',
+            onAction: action,
+            actionErrorAnnouncement: 'Undo failed. Try again.',
+        });
+        const button = handle.element.querySelector<HTMLButtonElement>('button')!;
+
+        button.click();
+        await Promise.resolve();
+        expect(handle.element.isConnected).toBe(true);
+        expect(button.disabled).toBe(false);
+        vi.advanceTimersByTime(500);
+        vi.advanceTimersByTime(50);
+        expect(document.querySelector('[data-jc-announcer="assertive"]')?.textContent)
+            .toBe('Undo failed. Try again.');
+        expect(handle.element.querySelector('.jc-notification-action-status')?.textContent)
+            .toBe('Undo failed. Try again.');
+
+        button.click();
+        button.click();
+        await Promise.resolve();
+        expect(action).toHaveBeenCalledTimes(2);
+    });
+
+    it('announces a rejected async action and restores retry without an unhandled rejection', async () => {
+        vi.useFakeTimers();
+        const action = vi.fn().mockRejectedValue(new Error('network failed'));
+        const handle = notifyAction({
+            message: 'Needs retry',
+            persistent: true,
+            actionLabel: 'Retry',
+            onAction: action,
+            actionErrorAnnouncement: 'Retry failed. Try again.',
+        });
+        const button = handle.element.querySelector<HTMLButtonElement>('button')!;
+
+        button.click();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(handle.element.isConnected).toBe(true);
+        expect(button.disabled).toBe(false);
+        button.click();
+        await Promise.resolve();
+        expect(action).toHaveBeenCalledTimes(2);
+    });
+
+    it('gives a restored action a complete fresh retry window after a slow rejection', async () => {
+        vi.useFakeTimers();
+        vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        let rejectFirst!: (error: Error) => void;
+        const action = vi.fn(() => new Promise<void>((_resolve, reject) => {
+            rejectFirst = reject;
+        }));
+        const dismissed = vi.fn();
+        const handle = notifyAction({
+            message: 'Hidden A',
+            duration: 1_000,
+            actionLabel: 'Undo',
+            onAction: action,
+            actionErrorAnnouncement: 'Undo failed. Try again.',
+            onDismiss: dismissed,
+        });
+        const button = handle.element.querySelector<HTMLButtonElement>('button')!;
+
+        vi.advanceTimersByTime(600);
+        button.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+        button.click();
+        button.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget: document.body }));
+        handle.element.dispatchEvent(new Event('pointerleave'));
+        vi.advanceTimersByTime(2_000);
+
+        expect(handle.element.isConnected).toBe(true);
+        expect(button.disabled).toBe(true);
+
+        rejectFirst(new Error('slow failure'));
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(handle.element.isConnected).toBe(true);
+        expect(button.disabled).toBe(false);
+        expect(document.querySelector('[data-jc-announcer="assertive"]')?.textContent)
+            .toBe('Undo failed. Try again.');
+
+        vi.advanceTimersByTime(999);
+        expect(handle.element.isConnected).toBe(true);
+        expect(handle.element.style.transform).toBe('translateX(0)');
+        expect(button.disabled).toBe(false);
+        expect(dismissed).not.toHaveBeenCalled();
+
+        vi.advanceTimersByTime(1);
+        expect(handle.element.style.transform).toBe('translateX(100%)');
+        expect(dismissed).toHaveBeenCalledOnce();
+        expect(dismissed).toHaveBeenCalledWith('timeout');
+        vi.advanceTimersByTime(300);
+        expect(handle.element.isConnected).toBe(false);
+        expect(action).toHaveBeenCalledTimes(1);
+    });
+
+    it('pauses expiry while pointer or keyboard focus remains within the notice', () => {
+        vi.useFakeTimers();
+        const handle = notifyAction({
+            message: 'Hidden A',
+            duration: 1_000,
+            actionLabel: 'Undo',
+            onAction: vi.fn(),
+        });
+        const button = handle.element.querySelector<HTMLButtonElement>('button')!;
+        vi.advanceTimersByTime(400);
+        handle.element.dispatchEvent(new Event('pointerenter'));
+        button.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+        vi.advanceTimersByTime(2_000);
+        expect(handle.element.isConnected).toBe(true);
+
+        handle.element.dispatchEvent(new Event('pointerleave'));
+        vi.advanceTimersByTime(2_000);
+        expect(handle.element.isConnected).toBe(true);
+
+        button.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget: document.body }));
+        vi.advanceTimersByTime(599);
+        expect(handle.element.style.transform).toBe('translateX(0)');
+        vi.advanceTimersByTime(1);
+        expect(handle.element.style.transform).toBe('translateX(100%)');
+    });
+
+    it('does not steal focus when an actionable notification is presented', () => {
+        vi.useFakeTimers();
+        const prior = document.createElement('button');
+        document.body.appendChild(prior);
+        prior.focus();
+
+        notifyAction({ message: 'Hidden A', actionLabel: 'Undo', onAction: vi.fn() });
+
+        expect(document.activeElement).toBe(prior);
+        prior.remove();
+    });
+
+    it('returns focus to the prior connected control when a focused notice is removed', () => {
+        vi.useFakeTimers();
+        const prior = document.createElement('button');
+        document.body.appendChild(prior);
+        prior.focus();
+        const handle = notifyAction({ message: 'Hidden A', actionLabel: 'Undo', onAction: vi.fn() });
+        const button = handle.element.querySelector<HTMLButtonElement>('button')!;
+        button.focus();
+        expect(document.activeElement).toBe(button);
+
+        handle.dismiss();
+        vi.advanceTimersByTime(300);
+
+        expect(document.activeElement).toBe(prior);
+        expect(handle.element.isConnected).toBe(false);
+        prior.remove();
+    });
+
+    it('blurs a focused action safely when its prior focus target is gone', () => {
+        vi.useFakeTimers();
+        const handle = notifyAction({ message: 'Hidden A', actionLabel: 'Undo', onAction: vi.fn() });
+        const button = handle.element.querySelector<HTMLButtonElement>('button')!;
+        button.focus();
+        handle.dismiss();
+        vi.advanceTimersByTime(300);
+
+        expect(document.activeElement).not.toBe(button);
+        expect(handle.element.isConnected).toBe(false);
+    });
+
+    it('isolates a throwing terminal callback while still removing the notice', () => {
+        vi.useFakeTimers();
+        const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        const handle = notify({
+            message: 'Callback isolation',
+            onDismiss: () => { throw new Error('consumer callback failed'); },
+        });
+
+        expect(() => handle.dismiss()).not.toThrow();
+        vi.advanceTimersByTime(300);
+
+        expect(handle.element.isConnected).toBe(false);
+        expect(warning).toHaveBeenCalledWith(
+            expect.stringContaining('dismiss callback failed'),
+            expect.any(Error)
+        );
+    });
+
+    it('supports an explicitly persistent actionable notification', () => {
+        vi.useFakeTimers();
+        const handle = notifyAction({
+            message: 'Needs a decision',
+            persistent: true,
+            actionLabel: 'Resolve',
+            onAction: vi.fn(),
+        });
+
+        vi.advanceTimersByTime(60_000);
+        expect(handle.element.isConnected).toBe(true);
+        handle.dismiss();
+        vi.advanceTimersByTime(300);
+        expect(handle.element.isConnected).toBe(false);
+    });
+
+    it('skips enter and removal animation when reduced motion is requested', () => {
+        vi.useFakeTimers();
+        vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: true }));
+        const handle = notify({ message: 'Saved', duration: 1_000 });
+
+        expect(handle.element.style.transition).toBe('none');
+        expect(handle.element.style.transform).toBe('translateX(0)');
+        handle.dismiss();
+        expect(handle.element.isConnected).toBe(false);
+    });
+
+    it('tears down route-owned notices and leaves retained actions inert', () => {
+        vi.useFakeTimers();
+        const prior = document.createElement('button');
+        document.body.appendChild(prior);
+        prior.focus();
+        const action = vi.fn();
+        const dismissed = vi.fn();
+        const handle = notifyAction({
+            message: 'Hidden A',
+            duration: 8_000,
+            actionLabel: 'Undo',
+            onAction: action,
+            onDismiss: dismissed,
+        });
+        const retainedButton = handle.element.querySelector<HTMLButtonElement>('button')!;
+        retainedButton.focus();
+        const priorFocus = vi.spyOn(prior, 'focus');
+
+        history.pushState({}, '', `#notification-test-${Date.now()}`);
+
+        expect(handle.element.isConnected).toBe(false);
+        expect(priorFocus).not.toHaveBeenCalled();
+        expect(document.activeElement).not.toBe(prior);
+        expect(document.activeElement).not.toBe(retainedButton);
+        retainedButton.click();
+        vi.runOnlyPendingTimers();
+        expect(action).not.toHaveBeenCalled();
+        expect(dismissed).toHaveBeenCalledTimes(1);
+        expect(dismissed).toHaveBeenCalledWith('navigation');
+        expect(document.querySelector('[data-jc-announcer="polite"]')?.textContent).toBe('');
+        prior.remove();
+    });
+
+    it('tears down identity-owned notices synchronously and leaves retained actions inert', () => {
+        vi.useFakeTimers();
+        const prior = document.createElement('button');
+        document.body.appendChild(prior);
+        prior.focus();
+        const setTimeoutSpy = vi.spyOn(window, 'setTimeout');
+        const clearTimeoutSpy = vi.spyOn(window, 'clearTimeout');
+        const action = vi.fn();
+        const dismissed = vi.fn();
+        const handle = notifyAction({
+            message: 'Old account action',
+            persistent: true,
+            actionLabel: 'Undo',
+            onAction: action,
+            onDismiss: dismissed,
+        });
+        expect(setTimeoutSpy).toHaveBeenCalledTimes(2);
+        const notificationTimerIds: number[] = [];
+        for (const result of setTimeoutSpy.mock.results) {
+            notificationTimerIds.push(result.value as number);
+        }
+        const retainedButton = handle.element.querySelector<HTMLButtonElement>('button')!;
+        retainedButton.focus();
+        const priorFocus = vi.spyOn(prior, 'focus');
+
+        const nextEpoch = window.JellyfinCanopy.identity.getEpoch() + 1;
+        window.JellyfinCanopy.identity.transition(
+            `notification-server-${nextEpoch}`,
+            `notification-user-${nextEpoch}`,
+            'notification-test-switch'
+        );
+
+        expect(handle.element.isConnected).toBe(false);
+        expect(priorFocus).not.toHaveBeenCalled();
+        expect(document.activeElement).not.toBe(prior);
+        expect(document.activeElement).not.toBe(retainedButton);
+        expect(dismissed).toHaveBeenCalledWith('identity');
+        retainedButton.click();
+        expect(action).not.toHaveBeenCalled();
+        for (const timerId of notificationTimerIds) {
+            expect(clearTimeoutSpy.mock.calls.some(([cleared]) => cleared === timerId)).toBe(true);
+        }
+        prior.remove();
+    });
+
+    it('suppresses a late async completion after route teardown', async () => {
+        vi.useFakeTimers();
+        let resolveAction!: () => void;
+        const action = vi.fn(() => new Promise<void>((resolve) => {
+            resolveAction = resolve;
+        }));
+        const dismissed = vi.fn();
+        const handle = notifyAction({
+            message: 'Pending route action',
+            persistent: true,
+            actionLabel: 'Run',
+            onAction: action,
+            actionAnnouncement: 'Should not be announced',
+            onDismiss: dismissed,
+        });
+        handle.element.querySelector<HTMLButtonElement>('button')!.click();
+
+        history.pushState({}, '', `#notification-pending-route-${Date.now()}`);
+        resolveAction();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(handle.element.isConnected).toBe(false);
+        expect(dismissed).toHaveBeenCalledOnce();
+        expect(dismissed).toHaveBeenCalledWith('navigation');
+        expect(document.querySelector('[data-jc-announcer="polite"]')?.textContent).toBe('');
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/ui-kit.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/ui-kit.ts
@@ -9,25 +9,143 @@
 
 import { JC } from '../globals';
 import { assetUrl } from './asset-urls';
+import { onNavigate } from './navigation';
 import type {
+    ActionableNotificationOptions,
     ExpandInOptions,
     MuiIconButtonOptions,
     MuiMenuItemOptions,
+    NotificationDismissReason,
+    NotificationHandle,
+    NotificationOptions,
+    NotificationSeverity,
     SectionContainerOptions,
     UiApi
 } from '../types/jc';
 
 JC.core = JC.core || {};
 
-const toastTimers = new Set<number>();
+const NOTIFICATION_OWNER_ID = 'jc-notification-owner';
+const NOTIFICATION_CSS_ID = 'jc-notification-css';
+const NOTIFICATION_RUNTIME_OWNER = Symbol.for('JellyfinCanopy.notificationRuntime.v1');
+const ANNOUNCEMENT_DWELL_MS = 500;
+const ANNOUNCEMENT_GAP_MS = 50;
+/** Completed actions remain readable for this full interval before dismissal. */
+const ACTION_COMPLETION_DWELL_MS = 3000;
+/** Visible cards are bounded independently from the assistive announcement queue. */
+const MAX_ACTIVE_NOTIFICATIONS = 32;
+/** Primary producers cannot consume the space reserved for action outcomes. */
+const MAX_PRIMARY_ANNOUNCEMENTS = 32;
+const MAX_PENDING_ANNOUNCEMENTS = 96;
 
-function scheduleToastTask(callback: () => void, delay: number): void {
-    const context = JC.identity.capture();
-    const timer = window.setTimeout(() => {
-        toastTimers.delete(timer);
-        if (!context || JC.identity.isCurrent(context)) callback();
-    }, delay);
-    toastTimers.add(timer);
+interface Announcement {
+    readonly message: string;
+    readonly urgency: 'polite' | 'assertive';
+    readonly dedupeKey: string | null;
+    readonly admission: 'primary' | 'terminal';
+    // Optional for compatibility with events retained by the v1 document owner
+    // across a content-hashed module upgrade from the pre-callback shape.
+    presentedCallbacks?: Array<() => void>;
+}
+
+interface AnnouncementTicket {
+    readonly state: 'queued' | 'coalesced';
+    /** Cancel only while the owned event is still pending. */
+    cancel(): boolean;
+}
+
+interface NotificationRecord {
+    readonly id: string;
+    readonly element: HTMLElement;
+    readonly identity: ReturnType<typeof JC.identity.capture>;
+    readonly generation: number;
+    readonly onDismiss?: (reason: NotificationDismissReason) => void;
+    returnFocus: HTMLElement | null;
+    remaining: number;
+    startedAt: number;
+    showTimer: number | null;
+    expiryTimer: number | null;
+    completionTimer: number | null;
+    removalTimer: number | null;
+    cancelPendingActionAnnouncement: (() => void) | null;
+    pointerInside: boolean;
+    focusInside: boolean;
+    persistent: boolean;
+    disposed: boolean;
+    actionInvoked: boolean;
+}
+
+interface NotificationRuntime {
+    readonly version: 1;
+    readonly announcements: Announcement[];
+    readonly notifications: Set<NotificationRecord>;
+    sequence: number;
+    generation: number;
+    announcementTimer: number | null;
+    announcementActive: boolean;
+    announcementInGap: boolean;
+    activeAnnouncementKey: string | null;
+    activeAnnouncementAdmission: Announcement['admission'] | null;
+    lifecycleInstalled: boolean;
+    ownerInstallPending: boolean;
+    drainDelegate: () => void;
+    resetDelegate: (reason: 'navigation' | 'identity') => void;
+}
+
+function isNotificationRuntime(value: unknown): value is NotificationRuntime {
+    if (!value || typeof value !== 'object') return false;
+    const candidate = value as Partial<NotificationRuntime>;
+    return candidate.version === 1
+        && Array.isArray(candidate.announcements)
+        && candidate.notifications instanceof Set
+        && typeof candidate.sequence === 'number'
+        && typeof candidate.generation === 'number'
+        && typeof candidate.resetDelegate === 'function';
+}
+
+const publishedNotificationRuntime = Reflect.get(window, NOTIFICATION_RUNTIME_OWNER) as unknown;
+if (publishedNotificationRuntime !== undefined && !isNotificationRuntime(publishedNotificationRuntime)) {
+    throw new TypeError('Jellyfin Canopy notification runtime has conflicting document ownership');
+}
+
+/**
+ * One document-owned state machine survives content-hashed module retries.
+ * Each evaluated graph delegates through this same state instead of retaining
+ * duplicate queues, route callbacks, timers, or focus-owning cards.
+ */
+const notificationRuntime: NotificationRuntime = isNotificationRuntime(publishedNotificationRuntime)
+    ? publishedNotificationRuntime
+    : {
+        version: 1,
+        announcements: [],
+        notifications: new Set<NotificationRecord>(),
+        sequence: 0,
+        generation: 0,
+        announcementTimer: null,
+        announcementActive: false,
+        announcementInGap: false,
+        activeAnnouncementKey: null,
+        activeAnnouncementAdmission: null,
+        lifecycleInstalled: false,
+        ownerInstallPending: false,
+        drainDelegate: () => undefined,
+        resetDelegate: () => undefined,
+    };
+
+if (publishedNotificationRuntime === undefined
+    && !Reflect.set(window, NOTIFICATION_RUNTIME_OWNER, notificationRuntime)) {
+    throw new TypeError('Jellyfin Canopy could not publish the document notification runtime');
+}
+
+/** Explicit synchronous backpressure when either bounded notification resource is full. */
+export class NotificationBackpressureError extends Error {
+    constructor(resource: 'notifications' | 'announcements' = 'announcements') {
+        const capacity = resource === 'notifications'
+            ? String(MAX_ACTIVE_NOTIFICATIONS)
+            : `${MAX_PRIMARY_ANNOUNCEMENTS} primary / ${MAX_PENDING_ANNOUNCEMENTS} total`;
+        super(`Notification ${resource} backpressure: capacity ${capacity} is full`);
+        this.name = 'NotificationBackpressureError';
+    }
 }
 
 /**
@@ -110,60 +228,856 @@ export function removeCss(id: string): boolean {
     return false;
 }
 
-/**
- * Displays a short-lived toast notification (moved from enhanced/ui.js).
- * NOTE: renders via innerHTML — escape user-controlled content with
- * JC.core.ui.escapeHtml before passing it in.
- * @param html The (already localized/escaped) content to display.
- * @param duration How long to show the toast, in ms.
- */
-export function toast(html: string, duration?: number): void {
+function prefersReducedMotion(): boolean {
+    return typeof window !== 'undefined'
+        && typeof window.matchMedia === 'function'
+        && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+function ensureNotificationCss(): void {
+    if (document.getElementById(NOTIFICATION_CSS_ID)) return;
+    injectCss(NOTIFICATION_CSS_ID, `
+        #${NOTIFICATION_OWNER_ID} .jc-notification-stack {
+            position: fixed;
+            right: 20px;
+            bottom: 20px;
+            z-index: 99999;
+            display: flex;
+            flex-direction: column;
+            align-items: flex-end;
+            gap: 10px;
+            max-height: calc(100vh - 40px);
+            overflow-y: auto;
+            pointer-events: none;
+        }
+        #${NOTIFICATION_OWNER_ID} .jc-notification {
+            overflow-wrap: anywhere;
+            pointer-events: auto;
+        }
+        #${NOTIFICATION_OWNER_ID} .jc-notification-action-status[hidden] { display: none !important; }
+        #${NOTIFICATION_OWNER_ID} .jc-notification-action:hover { filter: brightness(1.3); }
+        #${NOTIFICATION_OWNER_ID} .jc-notification-live {
+            position: absolute !important;
+            width: 1px !important;
+            height: 1px !important;
+            padding: 0 !important;
+            margin: -1px !important;
+            overflow: hidden !important;
+            clip: rect(0, 0, 0, 0) !important;
+            white-space: nowrap !important;
+            border: 0 !important;
+        }
+        @media (prefers-reduced-motion: reduce) {
+            #${NOTIFICATION_OWNER_ID} .jc-notification,
+            #${NOTIFICATION_OWNER_ID} .jc-notification * {
+                transition: none !important;
+                animation: none !important;
+            }
+        }
+    `);
+}
+
+function ensureNotificationOwner(): HTMLElement {
+    ensureNotificationCss();
+    const duplicates = Array.from(document.querySelectorAll<HTMLElement>(`#${NOTIFICATION_OWNER_ID}`));
+    let owner = duplicates.find((candidate) => Array.from(notificationRuntime.notifications)
+        .some((record) => candidate.contains(record.element)))
+        || duplicates.shift()
+        || null;
+    if (!owner) {
+        owner = document.createElement('div');
+        owner.id = NOTIFICATION_OWNER_ID;
+    }
+    owner.dataset.jcNotificationOwner = 'v1';
+    if (!owner.isConnected) {
+        const parent = document.body || document.documentElement;
+        parent.appendChild(owner);
+    }
+
+    const politeDuplicates = Array.from(owner.querySelectorAll<HTMLElement>('[data-jc-announcer="polite"]'));
+    const polite = politeDuplicates.shift() || null;
+    politeDuplicates.forEach((node) => node.remove());
+    if (!polite) {
+        const polite = document.createElement('div');
+        polite.className = 'jc-notification-live';
+        polite.dataset.jcAnnouncer = 'polite';
+        polite.setAttribute('aria-live', 'polite');
+        polite.setAttribute('aria-atomic', 'true');
+        polite.setAttribute('aria-relevant', 'additions text');
+        owner.appendChild(polite);
+    }
+
+    const assertiveDuplicates = Array.from(owner.querySelectorAll<HTMLElement>('[data-jc-announcer="assertive"]'));
+    const assertive = assertiveDuplicates.shift() || null;
+    assertiveDuplicates.forEach((node) => node.remove());
+    if (!assertive) {
+        const assertive = document.createElement('div');
+        assertive.className = 'jc-notification-live';
+        assertive.dataset.jcAnnouncer = 'assertive';
+        assertive.setAttribute('aria-live', 'assertive');
+        assertive.setAttribute('aria-atomic', 'true');
+        assertive.setAttribute('aria-relevant', 'additions text');
+        owner.appendChild(assertive);
+    }
+
+    const stackDuplicates = Array.from(owner.querySelectorAll<HTMLElement>(':scope > .jc-notification-stack'));
+    let stack = stackDuplicates.shift() || null;
+    if (!stack) {
+        const stack = document.createElement('div');
+        stack.className = 'jc-notification-stack';
+        stack.setAttribute('aria-live', 'off');
+        owner.appendChild(stack);
+    }
+    stack = owner.querySelector<HTMLElement>(':scope > .jc-notification-stack')!;
+    for (const duplicateStack of stackDuplicates) {
+        duplicateStack.querySelectorAll<HTMLElement>(':scope > .jc-notification')
+            .forEach((card) => stack.appendChild(card));
+        duplicateStack.remove();
+    }
+
+    for (const duplicateOwner of duplicates) {
+        if (duplicateOwner === owner) continue;
+        duplicateOwner.querySelectorAll<HTMLElement>('.jc-notification')
+            .forEach((card) => stack.appendChild(card));
+        duplicateOwner.remove();
+    }
+    return owner;
+}
+
+function presentationCallbacksFor(announcement: Announcement): Array<() => void> {
+    if (!Array.isArray(announcement.presentedCallbacks)) {
+        announcement.presentedCallbacks = [];
+    }
+    return announcement.presentedCallbacks;
+}
+
+function clearCentralAnnouncementLanes(): void {
+    if (typeof document === 'undefined') return;
+    document.getElementById(NOTIFICATION_OWNER_ID)
+        ?.querySelectorAll<HTMLElement>('[data-jc-announcer]')
+        .forEach((lane) => { lane.textContent = ''; });
+}
+
+function scheduleAnnouncementGap(): void {
+    notificationRuntime.announcementTimer = window.setTimeout(() => {
+        notificationRuntime.announcementTimer = null;
+        notificationRuntime.announcementInGap = false;
+        notificationRuntime.drainDelegate();
+    }, ANNOUNCEMENT_GAP_MS);
+}
+
+function scheduleActiveAnnouncementRetirement(): void {
+    notificationRuntime.announcementTimer = window.setTimeout(() => {
+        clearCentralAnnouncementLanes();
+        notificationRuntime.announcementActive = false;
+        notificationRuntime.announcementInGap = true;
+        notificationRuntime.activeAnnouncementKey = null;
+        notificationRuntime.activeAnnouncementAdmission = null;
+        // Give assistive technology an observable empty state before the same
+        // live lane receives another message. Replacing text in one task can
+        // otherwise collapse two rapid events into one spoken update.
+        scheduleAnnouncementGap();
+    }, ANNOUNCEMENT_DWELL_MS);
+}
+
+function drainAnnouncements(): void {
+    // A real timer may outlive a jsdom document or a host WebView teardown.
+    // Retire the detached queue without touching missing globals.
+    if (typeof document === 'undefined' || typeof window === 'undefined') {
+        notificationRuntime.announcements.length = 0;
+        notificationRuntime.announcementTimer = null;
+        notificationRuntime.announcementActive = false;
+        notificationRuntime.announcementInGap = false;
+        notificationRuntime.activeAnnouncementKey = null;
+        notificationRuntime.activeAnnouncementAdmission = null;
+        return;
+    }
+    // Queue admission enforces this invariant. Keep the bounded compare here
+    // too so the self-rescheduling drain fails closed if internal code drifts.
+    if (notificationRuntime.announcements.length > MAX_PENDING_ANNOUNCEMENTS) {
+        throw new NotificationBackpressureError('announcements');
+    }
+    if (notificationRuntime.announcementActive || notificationRuntime.announcementInGap) return;
+    const next = notificationRuntime.announcements.shift();
+    if (!next) return;
+    const owner = ensureNotificationOwner();
+    const lane = owner.querySelector<HTMLElement>(`[data-jc-announcer="${next.urgency}"]`);
+    if (!lane) return;
+    notificationRuntime.announcementActive = true;
+    notificationRuntime.activeAnnouncementKey = next.dedupeKey;
+    notificationRuntime.activeAnnouncementAdmission = next.admission;
+    lane.textContent = next.message;
+    const callbacks = presentationCallbacksFor(next).splice(0);
+    for (const callback of callbacks) {
+        try {
+            callback();
+        } catch (error) {
+            console.warn('🪼 Jellyfin Canopy: Notification presentation callback failed', error);
+        }
+    }
+    scheduleActiveAnnouncementRetirement();
+}
+
+function adoptAnnouncementTimerOwnership(): void {
+    // A content-hashed predecessor may still own a v1 timer whose closure calls
+    // its old drain implementation. Cancel and re-arm that phase so every later
+    // event is drained by this graph and presentation callbacks cannot be lost.
+    if (notificationRuntime.announcementTimer != null) {
+        clearTimeout(notificationRuntime.announcementTimer);
+        notificationRuntime.announcementTimer = null;
+    }
+    notificationRuntime.drainDelegate = drainAnnouncements;
+    if (notificationRuntime.announcementActive) {
+        scheduleActiveAnnouncementRetirement();
+    } else if (notificationRuntime.announcementInGap) {
+        scheduleAnnouncementGap();
+    } else {
+        drainAnnouncements();
+    }
+}
+
+function queueAnnouncement(
+    message: string,
+    severity: NotificationSeverity = 'info',
+    dedupeKey?: string,
+    admission: Announcement['admission'] = 'primary',
+    onPresented?: () => void
+): AnnouncementTicket {
+    const normalized = message.replace(/\s+/g, ' ').trim();
+    if (!normalized) {
+        onPresented?.();
+        return { state: 'coalesced', cancel: () => false };
+    }
+    const normalizedKey = dedupeKey?.trim() || null;
+    if (normalizedKey && notificationRuntime.activeAnnouncementKey === normalizedKey) {
+        onPresented?.();
+        return { state: 'coalesced', cancel: () => false };
+    }
+    const pendingDuplicate = normalizedKey
+        ? notificationRuntime.announcements.find((item) => item.dedupeKey === normalizedKey)
+        : null;
+    if (pendingDuplicate) {
+        if (!onPresented) return { state: 'coalesced', cancel: () => false };
+        const presentedCallbacks = presentationCallbacksFor(pendingDuplicate);
+        presentedCallbacks.push(onPresented);
+        let callbackPending = true;
+        return {
+            state: 'coalesced',
+            cancel: () => {
+                if (!callbackPending) return false;
+                const index = presentedCallbacks.indexOf(onPresented);
+                if (index < 0) {
+                    callbackPending = false;
+                    return false;
+                }
+                presentedCallbacks.splice(index, 1);
+                callbackPending = false;
+                return true;
+            }
+        };
+    }
+    const activeCount = notificationRuntime.announcementActive ? 1 : 0;
+    const pendingCount = notificationRuntime.announcements.length + activeCount;
+    const primaryCount = notificationRuntime.announcements
+        .filter((item) => item.admission === 'primary').length
+        + (notificationRuntime.activeAnnouncementAdmission === 'primary' ? 1 : 0);
+    if (pendingCount >= MAX_PENDING_ANNOUNCEMENTS
+        || (admission === 'primary' && primaryCount >= MAX_PRIMARY_ANNOUNCEMENTS)) {
+        throw new NotificationBackpressureError('announcements');
+    }
+    const announcement: Announcement = {
+        message: normalized,
+        urgency: severity === 'warning' || severity === 'error' ? 'assertive' : 'polite',
+        dedupeKey: normalizedKey,
+        admission,
+        presentedCallbacks: onPresented ? [onPresented] : [],
+    };
+    if (announcement.urgency === 'assertive') {
+        // Preserve the currently spoken message, then put urgent work ahead of
+        // queued polite work without reordering other urgent announcements.
+        const firstPolite = notificationRuntime.announcements
+            .findIndex((item) => item.urgency === 'polite');
+        if (firstPolite < 0) notificationRuntime.announcements.push(announcement);
+        else notificationRuntime.announcements.splice(firstPolite, 0, announcement);
+    } else {
+        notificationRuntime.announcements.push(announcement);
+    }
+    let pending = true;
+    const ticket: AnnouncementTicket = {
+        state: 'queued',
+        cancel: () => {
+            if (!pending) return false;
+            const index = notificationRuntime.announcements.indexOf(announcement);
+            if (index < 0) {
+                pending = false;
+                return false;
+            }
+            notificationRuntime.announcements.splice(index, 1);
+            presentationCallbacksFor(announcement).length = 0;
+            pending = false;
+            return true;
+        }
+    };
+    drainAnnouncements();
+    if (!notificationRuntime.announcements.includes(announcement)) pending = false;
+    return ticket;
+}
+
+/** @internal Narrow production-queue seam for bounded admission tests. */
+export function queueNotificationAnnouncementForTesting(
+    message: string,
+    severity: NotificationSeverity = 'info',
+    dedupeKey?: string
+): 'queued' | 'coalesced' {
+    return queueAnnouncement(message, severity, dedupeKey).state;
+}
+
+/** @internal Terminal-capacity seam for deterministic completion fallback tests. */
+export function queueTerminalNotificationAnnouncementForTesting(
+    message: string,
+    severity: NotificationSeverity = 'success',
+    dedupeKey?: string
+): 'queued' | 'coalesced' {
+    return queueAnnouncement(message, severity, dedupeKey, 'terminal').state;
+}
+
+function clearAnnouncements(): void {
+    notificationRuntime.announcements.length = 0;
+    if (notificationRuntime.announcementTimer != null) {
+        clearTimeout(notificationRuntime.announcementTimer);
+    }
+    notificationRuntime.announcementTimer = null;
+    notificationRuntime.announcementActive = false;
+    notificationRuntime.announcementInGap = false;
+    notificationRuntime.activeAnnouncementKey = null;
+    notificationRuntime.activeAnnouncementAdmission = null;
+    if (typeof document !== 'undefined') {
+        const owner = document.getElementById(NOTIFICATION_OWNER_ID);
+        owner?.querySelectorAll<HTMLElement>('[data-jc-announcer]')
+            .forEach((lane) => { lane.textContent = ''; });
+    }
+}
+
+function deriveAnnouncement(html: string): string {
+    const template = document.createElement('template');
+    template.innerHTML = html;
+    template.content.querySelectorAll('svg, .material-icons, [aria-hidden="true"]').forEach((node) => node.remove());
+    return (template.content.textContent || '').replace(/\s+/g, ' ').trim();
+}
+
+function clearRecordTimer(
+    record: NotificationRecord,
+    key: 'showTimer' | 'expiryTimer' | 'completionTimer' | 'removalTimer'
+): void {
+    const timer = record[key];
+    if (timer != null) clearTimeout(timer);
+    record[key] = null;
+}
+
+function shouldRestoreNotificationFocus(reason: NotificationDismissReason): boolean {
+    return reason !== 'navigation' && reason !== 'identity';
+}
+
+function removeRecord(record: NotificationRecord, restoreFocus: boolean): void {
+    clearRecordTimer(record, 'removalTimer');
+    clearRecordTimer(record, 'completionTimer');
+    const active = typeof document === 'undefined' ? null : document.activeElement;
+    if (typeof HTMLElement !== 'undefined'
+        && active instanceof HTMLElement
+        && record.element.contains(active)) {
+        const returnTarget = record.returnFocus;
+        if (restoreFocus && returnTarget?.isConnected && !record.element.contains(returnTarget)) {
+            returnTarget.focus({ preventScroll: true });
+        } else {
+            active.blur();
+        }
+    }
+    record.element.remove();
+    notificationRuntime.notifications.delete(record);
+}
+
+function dismissRecord(
+    record: NotificationRecord,
+    reason: NotificationDismissReason,
+    immediate = false
+): void {
+    if (record.disposed) {
+        if (immediate) removeRecord(record, shouldRestoreNotificationFocus(reason));
+        return;
+    }
+    record.disposed = true;
+    record.cancelPendingActionAnnouncement?.();
+    record.cancelPendingActionAnnouncement = null;
+    clearRecordTimer(record, 'showTimer');
+    clearRecordTimer(record, 'expiryTimer');
+    clearRecordTimer(record, 'completionTimer');
+    const action = record.element.querySelector<HTMLButtonElement>('.jc-notification-action');
+    if (action) {
+        action.removeAttribute('aria-busy');
+    }
+    record.element.classList.remove('jc-visible');
+    record.element.style.transform = 'translateX(100%)';
+    try {
+        record.onDismiss?.(reason);
+    } catch (error) {
+        console.warn('🪼 Jellyfin Canopy: Notification dismiss callback failed', error);
+    }
+    const restoreFocus = shouldRestoreNotificationFocus(reason);
+    if (immediate || prefersReducedMotion() || typeof window === 'undefined') {
+        removeRecord(record, restoreFocus);
+    } else {
+        record.removalTimer = window.setTimeout(() => removeRecord(record, restoreFocus), 300);
+    }
+}
+
+function scheduleActionCompletionDismiss(record: NotificationRecord): void {
+    if (record.disposed || record.completionTimer != null) return;
+    if (typeof window === 'undefined') {
+        dismissRecord(record, 'action', true);
+        return;
+    }
+    record.completionTimer = window.setTimeout(() => {
+        record.completionTimer = null;
+        dismissRecord(record, 'action');
+    }, ACTION_COMPLETION_DWELL_MS);
+}
+
+function startExpiry(record: NotificationRecord): void {
+    if (record.disposed || record.persistent || record.pointerInside
+        || record.focusInside || record.actionInvoked) return;
+    if (typeof window === 'undefined') {
+        dismissRecord(record, 'programmatic', true);
+        return;
+    }
+    record.startedAt = Date.now();
+    record.expiryTimer = window.setTimeout(() => {
+        record.expiryTimer = null;
+        dismissRecord(record, 'timeout');
+    }, record.remaining);
+}
+
+function pauseExpiry(record: NotificationRecord): void {
+    if (record.disposed || record.expiryTimer == null) return;
+    record.remaining = Math.max(0, record.remaining - (Date.now() - record.startedAt));
+    clearRecordTimer(record, 'expiryTimer');
+}
+
+function resumeExpiry(record: NotificationRecord): void {
+    if (record.disposed || record.pointerInside || record.focusInside
+        || record.actionInvoked || record.expiryTimer != null) return;
+    startExpiry(record);
+}
+
+interface InternalNotificationOptions extends NotificationOptions {
+    readonly legacyClass?: string;
+    readonly action?: {
+        readonly label: string;
+        readonly invoke: () => void | Promise<void>;
+        readonly availableAnnouncement?: string;
+        readonly announcement?: string;
+        readonly errorAnnouncement?: string;
+    };
+}
+
+function createNotification(options: InternalNotificationOptions): NotificationHandle {
+    if (typeof options.message !== 'string' || options.message.trim() === '') {
+        throw new TypeError('Notification message must contain accessible text');
+    }
+    if (options.action
+        && (typeof options.action.label !== 'string' || options.action.label.trim() === '')) {
+        throw new TypeError('Notification action must have an accessible label');
+    }
+    if (options.action && typeof options.action.invoke !== 'function') {
+        throw new TypeError('Notification action callback must be callable');
+    }
+    if (options.action?.availableAnnouncement !== undefined
+        && (typeof options.action.availableAnnouncement !== 'string'
+            || options.action.availableAnnouncement.trim() === '')) {
+        throw new TypeError('Notification action availability must contain accessible text');
+    }
+    if (notificationRuntime.notifications.size >= MAX_ACTIVE_NOTIFICATIONS) {
+        throw new NotificationBackpressureError('notifications');
+    }
+    // Admission happens before the owner, card, or timers become observable.
+    // A rejected producer therefore cannot leave an inaccessible visual orphan.
+    let initialAnnouncementPresented = false;
+    let notificationRecord: NotificationRecord | null = null;
+    const initialAnnouncement = options.action
+        ? (options.action.availableAnnouncement || `${options.message} — ${options.action.label}`)
+        : options.message;
+    const initialAnnouncementTicket = queueAnnouncement(
+        initialAnnouncement,
+        options.severity || 'info',
+        // Every actionable card represents a distinct reachable control, so its
+        // availability event must never be coalesced with another action.
+        options.action ? undefined : options.dedupeKey,
+        'primary',
+        options.action
+            ? () => {
+                initialAnnouncementPresented = true;
+                if (notificationRecord) {
+                    notificationRecord.cancelPendingActionAnnouncement = null;
+                    startExpiry(notificationRecord);
+                }
+            }
+            : undefined
+    );
+
+    const owner = ensureNotificationOwner();
+    const stack = owner.querySelector<HTMLElement>('.jc-notification-stack')!;
     const identity = JC.identity.capture();
-    const ms = duration ?? (JC.CONFIG?.TOAST_DURATION || 1500);
-
-    // Use the theme system to get appropriate colors
+    const severity = options.severity || 'info';
+    const configuredDuration = options.duration
+        ?? (options.action ? 8000 : (JC.CONFIG?.TOAST_DURATION || 1500));
+    const duration = Number.isFinite(configuredDuration) ? Math.max(0, configuredDuration) : 1500;
     const themeVars = JC.themer?.getThemeVariables?.() || {};
-    const toastBg = themeVars.secondaryBg || 'linear-gradient(135deg, rgba(0,0,0,0.9), rgba(40,40,40,0.9))';
-    const toastBorder = `1px solid ${themeVars.primaryAccent || 'rgba(255,255,255,0.1)'}`;
-    const blurValue = themeVars.blur || '30px';
-
-    const t = document.createElement('div');
-    t.className = 'jellyfin-canopy-toast';
-    if (identity) t.dataset.jcIdentityOwned = 'true';
-    Object.assign(t.style, {
-        position: 'fixed',
-        bottom: '20px',
-        right: '20px',
-        transform: 'translateX(100%)',
-        background: toastBg,
+    const reducedMotion = prefersReducedMotion();
+    const element = document.createElement('div');
+    const id = `jc-notification-${++notificationRuntime.sequence}`;
+    element.id = id;
+    element.className = `jc-notification${options.legacyClass ? ` ${options.legacyClass}` : ''}`;
+    element.dataset.jcNotificationSeverity = severity;
+    element.setAttribute('aria-live', 'off');
+    if (identity) element.dataset.jcIdentityOwned = 'true';
+    Object.assign(element.style, {
+        position: 'relative',
+        transform: reducedMotion ? 'translateX(0)' : 'translateX(100%)',
+        background: themeVars.secondaryBg || 'linear-gradient(135deg, rgba(0,0,0,0.9), rgba(40,40,40,0.9))',
         color: '#fff',
-        padding: '10px 14px',
+        padding: options.action ? '12px 16px' : '10px 14px',
         borderRadius: '8px',
-        zIndex: 99999,
         fontSize: 'clamp(13px, 2vw, 16px)',
         textShadow: '-1px -1px 10px black',
         fontWeight: '500',
         boxShadow: '0 4px 20px rgba(0,0,0,0.3)',
-        backdropFilter: `blur(${blurValue})`,
-        border: toastBorder,
-        transition: 'transform 0.3s ease-out',
-        maxWidth: 'clamp(280px, 80vw, 350px)'
+        backdropFilter: `blur(${themeVars.blur || '30px'})`,
+        border: `1px solid ${themeVars.primaryAccent || 'rgba(255,255,255,0.1)'}`,
+        transition: reducedMotion ? 'none' : 'transform 0.3s ease-out',
+        maxWidth: options.action ? '380px' : 'clamp(280px, 80vw, 350px)'
     });
-    t.innerHTML = html; // Note: the calling function should pass the localized string
-    document.body.appendChild(t);
-    scheduleToastTask(() => { if (t.isConnected) t.style.transform = 'translateX(0)'; }, 10);
-    scheduleToastTask(() => {
-        if (!t.isConnected) return;
-        t.style.transform = 'translateX(100%)';
-        scheduleToastTask(() => t.remove(), 300);
-    }, ms);
+    const message = document.createElement('span');
+    message.className = 'jc-notification-message';
+    message.textContent = options.message;
+    element.appendChild(message);
+
+    const record: NotificationRecord = {
+        id,
+        element,
+        identity,
+        generation: notificationRuntime.generation,
+        onDismiss: options.onDismiss,
+        returnFocus: null,
+        remaining: duration,
+        startedAt: Date.now(),
+        showTimer: null,
+        expiryTimer: null,
+        completionTimer: null,
+        removalTimer: null,
+        cancelPendingActionAnnouncement: options.action && !initialAnnouncementPresented
+            ? () => { initialAnnouncementTicket.cancel(); }
+            : null,
+        pointerInside: false,
+        focusInside: false,
+        persistent: options.persistent === true,
+        disposed: false,
+        actionInvoked: false
+    };
+    notificationRecord = record;
+    notificationRuntime.notifications.add(record);
+
+    if (options.action) {
+        Object.assign(element.style, { display: 'flex', alignItems: 'center', gap: '12px' });
+        const content = document.createElement('span');
+        content.className = 'jc-notification-content';
+        content.style.flex = '1';
+        element.replaceChildren(content);
+        content.appendChild(message);
+        const actionStatus = document.createElement('span');
+        actionStatus.id = `${id}-action-status`;
+        actionStatus.className = 'jc-notification-action-status';
+        actionStatus.hidden = true;
+        Object.assign(actionStatus.style, {
+            display: 'block',
+            marginTop: '4px',
+            fontSize: '12px',
+            fontWeight: '400',
+        });
+        content.appendChild(actionStatus);
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'jc-notification-action';
+        button.textContent = options.action.label;
+        button.setAttribute('aria-describedby', `${id}-message ${id}-action-status`);
+        message.id = `${id}-message`;
+        Object.assign(button.style, {
+            background: 'rgba(255,255,255,0.15)',
+            border: '1px solid rgba(255,255,255,0.25)',
+            color: '#fff',
+            padding: '4px 12px',
+            borderRadius: '4px',
+            cursor: 'pointer',
+            fontSize: '13px',
+            fontWeight: '600',
+            whiteSpace: 'nowrap'
+        });
+        const clearActionStatus = (): void => {
+            actionStatus.hidden = true;
+            actionStatus.textContent = '';
+            actionStatus.removeAttribute('aria-live');
+            actionStatus.removeAttribute('aria-atomic');
+        };
+        const showActionStatus = (statusMessage: string): void => {
+            actionStatus.removeAttribute('aria-live');
+            actionStatus.removeAttribute('aria-atomic');
+            actionStatus.textContent = statusMessage;
+            actionStatus.hidden = false;
+        };
+        const showFallbackLiveStatus = (
+            statusMessage: string,
+            urgency: 'polite' | 'assertive'
+        ): void => {
+            actionStatus.hidden = true;
+            actionStatus.textContent = '';
+            actionStatus.setAttribute('aria-live', urgency);
+            actionStatus.setAttribute('aria-atomic', 'true');
+            actionStatus.hidden = false;
+            actionStatus.textContent = statusMessage;
+        };
+        const restoreFailedAction = (error: unknown): void => {
+            console.warn('🪼 Jellyfin Canopy: Notification action failed', error);
+            if (record.disposed || record.generation !== notificationRuntime.generation
+                || (record.identity && !JC.identity.isCurrent(record.identity))) return;
+            record.actionInvoked = false;
+            button.disabled = false;
+            button.removeAttribute('aria-busy');
+            // A failed action is a new actionable state. Do not consume its
+            // retry window with time that elapsed before or during the failed
+            // attempt; the full configured duration starts after restoration.
+            record.remaining = duration;
+            const failureMessage = options.action?.errorAnnouncement
+                || `${options.action?.label || 'Action'} failed. Try again.`;
+            showActionStatus(failureMessage);
+            let failurePresented = false;
+            try {
+                const failureTicket = queueAnnouncement(
+                    failureMessage,
+                    'error',
+                    `${record.id}:action-error`,
+                    'terminal',
+                    () => {
+                        failurePresented = true;
+                        record.cancelPendingActionAnnouncement = null;
+                        resumeExpiry(record);
+                    }
+                );
+                if (!failurePresented) {
+                    record.cancelPendingActionAnnouncement = () => { failureTicket.cancel(); };
+                }
+            } catch (backpressureError) {
+                // Keep the retry contract visible even in pathological queue
+                // saturation. This bounded per-card live fallback is used only
+                // when the central terminal queue explicitly rejects admission.
+                console.error('🪼 Jellyfin Canopy: Could not queue action failure announcement', backpressureError);
+                showFallbackLiveStatus(failureMessage, 'assertive');
+                resumeExpiry(record);
+            }
+        };
+        button.addEventListener('click', () => {
+            if (record.disposed || record.actionInvoked) return;
+            if (record.identity && !JC.identity.isCurrent(record.identity)) {
+                dismissRecord(record, 'identity', true);
+                return;
+            }
+            record.cancelPendingActionAnnouncement?.();
+            record.cancelPendingActionAnnouncement = null;
+            record.actionInvoked = true;
+            button.disabled = true;
+            button.setAttribute('aria-busy', 'true');
+            clearActionStatus();
+            pauseExpiry(record);
+            try {
+                const result = options.action!.invoke();
+                void Promise.resolve(result).then(() => {
+                    if (record.disposed || record.generation !== notificationRuntime.generation
+                        || (record.identity && !JC.identity.isCurrent(record.identity))) return;
+                    button.removeAttribute('aria-busy');
+                    if (options.action?.announcement) {
+                        let completionPresented = false;
+                        try {
+                            const completionTicket = queueAnnouncement(
+                                options.action.announcement,
+                                'success',
+                                `${record.id}:action-success`,
+                                'terminal',
+                                () => {
+                                    completionPresented = true;
+                                    record.cancelPendingActionAnnouncement = null;
+                                    scheduleActionCompletionDismiss(record);
+                                }
+                            );
+                            if (!completionPresented) {
+                                record.cancelPendingActionAnnouncement = () => { completionTicket.cancel(); };
+                            }
+                        } catch (backpressureError) {
+                            console.error('🪼 Jellyfin Canopy: Could not queue action completion announcement', backpressureError);
+                            // The operation did complete. Keep a bounded, polite,
+                            // per-card live fallback visible for the full dwell;
+                            // reduced motion changes animation, never readability.
+                            showFallbackLiveStatus(options.action.announcement, 'polite');
+                            scheduleActionCompletionDismiss(record);
+                        }
+                    } else {
+                        dismissRecord(record, 'action');
+                    }
+                }).catch(restoreFailedAction);
+            } catch (error) {
+                restoreFailedAction(error);
+            }
+        });
+        element.appendChild(button);
+    }
+
+    element.addEventListener('pointerenter', () => {
+        record.pointerInside = true;
+        pauseExpiry(record);
+    });
+    element.addEventListener('pointerleave', () => {
+        record.pointerInside = false;
+        resumeExpiry(record);
+    });
+    element.addEventListener('focusin', (event) => {
+        const previous = event.relatedTarget;
+        if (previous instanceof HTMLElement
+            && previous.isConnected && !element.contains(previous)) {
+            record.returnFocus = previous;
+        }
+        record.focusInside = true;
+        pauseExpiry(record);
+    });
+    element.addEventListener('focusout', (event) => {
+        const next = event.relatedTarget;
+        record.focusInside = next instanceof Node && element.contains(next);
+        resumeExpiry(record);
+    });
+
+    stack.appendChild(element);
+    if (!reducedMotion) {
+        record.showTimer = window.setTimeout(() => {
+            record.showTimer = null;
+            if (!record.disposed && element.isConnected) {
+                element.classList.add('jc-visible');
+                element.style.transform = 'translateX(0)';
+            }
+        }, 10);
+    } else {
+        element.classList.add('jc-visible');
+    }
+    if (!options.action || initialAnnouncementPresented) startExpiry(record);
+
+    return {
+        id,
+        element,
+        dismiss: () => dismissRecord(record, 'programmatic')
+    };
 }
 
-JC.identity.registerReset('ui-toasts', () => {
-    for (const timer of toastTimers) clearTimeout(timer);
-    toastTimers.clear();
-    document.querySelectorAll('.jellyfin-canopy-toast').forEach((node) => node.remove());
-});
+/** Show a safe text notification through the shared document-life owner. */
+export function notify(options: NotificationOptions): NotificationHandle {
+    return createNotification(options);
+}
+
+/** Show a safe text notification with one keyboard-reachable action. */
+export function notifyAction(options: ActionableNotificationOptions): NotificationHandle {
+    return createNotification({
+        ...options,
+        action: {
+            label: options.actionLabel,
+            invoke: options.onAction,
+            availableAnnouncement: options.actionAvailableAnnouncement,
+            announcement: options.actionAnnouncement,
+            errorAnnouncement: options.actionErrorAnnouncement
+        }
+    });
+}
+
+/**
+ * Displays a short-lived toast notification (moved from enhanced/ui.js).
+ * NOTE: preserves the frozen innerHTML contract — escape user-controlled
+ * content with JC.core.ui.escapeHtml before passing it in.
+ * @param html The (already localized/escaped) content to display.
+ * @param duration How long to show the toast, in ms.
+ * @param severity Optional explicit urgency for migrated legacy producers.
+ */
+export function toast(
+    html: string,
+    duration?: number,
+    severity: NotificationSeverity = 'info'
+): void {
+    let handle: NotificationHandle;
+    const announcement = deriveAnnouncement(html);
+    try {
+        handle = createNotification({
+            message: announcement,
+            duration,
+            severity,
+            // The compatibility API cannot accept an event identity. Coalesce
+            // only equivalent normalized pending spoken copy; each visual card and
+            // every later occurrence after the queue drains remain intact.
+            dedupeKey: `legacy:${severity}:${announcement}`,
+            legacyClass: 'jellyfin-canopy-toast'
+        });
+    } catch (error) {
+        if (!(error instanceof NotificationBackpressureError)) throw error;
+        // The frozen legacy adapter has historically been fire-and-forget.
+        // Typed notify/notifyAction remain the producer-visible backpressure API.
+        console.error('🪼 Jellyfin Canopy: Legacy toast rejected by notification backpressure', error);
+        return;
+    }
+    // Frozen compatibility/XSS contract: callers still own escaping and the
+    // supplied markup remains the card's exact innerHTML.
+    handle.element.innerHTML = html;
+}
+
+function resetNotifications(reason: 'navigation' | 'identity'): void {
+    notificationRuntime.generation += 1;
+    for (const record of Array.from(notificationRuntime.notifications)) {
+        dismissRecord(record, reason, true);
+    }
+    clearAnnouncements();
+}
+
+// An older content-hashed graph may own the one lifecycle callback. Always
+// replace its delegate so teardown executes the newest compatible code while
+// retaining exactly one navigation and identity registration per document.
+notificationRuntime.resetDelegate = resetNotifications;
+
+function installNotificationRuntime(): void {
+    if (document.body) {
+        ensureNotificationOwner();
+    } else if (!notificationRuntime.ownerInstallPending) {
+        notificationRuntime.ownerInstallPending = true;
+        document.addEventListener('DOMContentLoaded', () => {
+            notificationRuntime.ownerInstallPending = false;
+            ensureNotificationOwner();
+        }, { once: true });
+    }
+
+    if (notificationRuntime.lifecycleInstalled) return;
+    const offNavigate = onNavigate(() => notificationRuntime.resetDelegate('navigation'));
+    try {
+        JC.identity.registerReset(
+            'ui-toasts',
+            () => notificationRuntime.resetDelegate('identity')
+        );
+        notificationRuntime.lifecycleInstalled = true;
+    } catch (error) {
+        offNavigate();
+        throw error;
+    }
+}
+
+adoptAnnouncementTimerOwnership();
+installNotificationRuntime();
 
 // ── MUI component kit (v12 React/MUI markup match) ──────────────────────────
 //
@@ -349,6 +1263,8 @@ export function expandIn(el: HTMLElement, options: ExpandInOptions = {}): void {
 const ui: UiApi = {
     escapeHtml,
     toast,
+    notify,
+    notifyAction,
     injectCss,
     removeCss,
     muiIconButton,

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-items.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-items.ts
@@ -315,12 +315,12 @@ export async function renderBookmarkItems(
               toast(JC.t!('toast_bookmark_updated'), 2000);
               renderActiveBookmarks(context);
             } else {
-              toast(JC.t!('toast_bookmark_save_failed'), 3000);
+              toast(JC.t!('toast_bookmark_save_failed'), 3000, 'error');
             }
           } catch (err) {
             if (!JC.identity.isCurrent(context)) return;
             console.error('Bookmark update failed', err);
-            toast(JC.t!('toast_bookmark_save_failed'), 3000);
+            toast(JC.t!('toast_bookmark_save_failed'), 3000, 'error');
           } finally {
             if (JC.identity.isCurrent(context)) {
               saveBtn.disabled = false;
@@ -344,7 +344,7 @@ export async function renderBookmarkItems(
           } catch (error) {
             if (!JC.identity.isCurrent(context)) return;
             console.error('Bookmark delete failed', error);
-            toast(JC.t!('bookmark_delete_failed'), 3000);
+            toast(JC.t!('bookmark_delete_failed'), 3000, 'error');
           }
         })(); });
 
@@ -376,7 +376,7 @@ async function playItemAtTime(
     const apiClient: any = window.ApiClient || (window as any).ConnectionManager?.currentApiClient();
     if (!apiClient) {
       console.warn(`${logPrefix} API client not available`);
-      toast(JC.t!('toast_api_client_unavailable'), 3000);
+      toast(JC.t!('toast_api_client_unavailable'), 3000, 'error');
       return;
     }
 
@@ -399,7 +399,7 @@ async function playItemAtTime(
 
     if (!currentSession) {
       console.warn(`${logPrefix} Could not find current session`);
-      toast(JC.t!('toast_session_not_found'), 3000);
+      toast(JC.t!('toast_session_not_found'), 3000, 'error');
       return;
     }
 
@@ -436,6 +436,6 @@ async function playItemAtTime(
   } catch (e) {
     if (!JC.identity.isCurrent(context)) return;
     console.error(`${logPrefix} Failed to play item:`, e);
-    toast(JC.t!('toast_playback_failed').replace('{error}', JC.escapeHtml((e as any).message || 'Unknown error')), 3000);
+    toast(JC.t!('toast_playback_failed').replace('{error}', JC.escapeHtml((e as any).message || 'Unknown error')), 3000, 'error');
   }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-modals.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-modals.ts
@@ -161,14 +161,14 @@ export function showOffsetAdjustmentModal(
         // blind setTimeout needed).
         renderActiveBookmarks(context);
       } else {
-        toast(JC.t!('bookmark_update_failed'), 3000);
+        toast(JC.t!('bookmark_update_failed'), 3000, 'error');
         btn.disabled = false;
         btn.querySelector('span:last-child')!.textContent = JC.t!('bookmark_apply_offset');
       }
     } catch (e) {
       if (!JC.identity.isCurrent(context)) return;
       console.error('Failed to apply offset:', e);
-      toast(JC.t!('bookmark_offset_failed'), 3000);
+      toast(JC.t!('bookmark_offset_failed'), 3000, 'error');
       btn.disabled = false;
       btn.querySelector('span:last-child')!.textContent = JC.t!('bookmark_apply_offset');
     }
@@ -482,7 +482,7 @@ export function showDuplicatesSyncModal(
       } catch (e) {
         if (!JC.identity.isCurrent(context)) return;
         console.error('Merge failed:', e);
-        toast(JC.t!('bookmark_merge_failed'), 3000);
+        toast(JC.t!('bookmark_merge_failed'), 3000, 'error');
         btn.disabled = false;
         btn.querySelector('span:last-child')!.textContent = JC.t!('bookmark_merge_primary');
       }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-render.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-render.ts
@@ -243,7 +243,7 @@ export async function renderBookmarksLibrary(
     } catch (error) {
       if (!JC.identity.isCurrent(context)) return;
       console.error('Cleanup failed:', error);
-      toast(JC.t!('bookmark_cleanup_failed'), 3000);
+      toast(JC.t!('bookmark_cleanup_failed'), 3000, 'error');
     } finally {
       if (JC.identity.isCurrent(context)) {
         cleanupBtn.disabled = false;
@@ -273,7 +273,7 @@ export async function renderBookmarksLibrary(
     } catch (error) {
       if (!JC.identity.isCurrent(context)) return;
       console.error('Delete failed:', error);
-      toast(JC.t!('bookmark_delete_failed'), 3000);
+      toast(JC.t!('bookmark_delete_failed'), 3000, 'error');
     } finally {
       if (JC.identity.isCurrent(context)) {
         deleteAllBtn.disabled = false;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-replacements.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-replacements.test.ts
@@ -472,7 +472,7 @@ describe('bookmark replacement library search', () => {
 
     await findAndOfferReplacement(group(), failedButton, failedContext);
 
-    expect(mocks.toast).toHaveBeenCalledWith('bookmark_search_failed', 3000);
+    expect(mocks.toast).toHaveBeenCalledWith('bookmark_search_failed', 3000, 'error');
     expect(mocks.toast).not.toHaveBeenCalledWith('bookmark_no_replacement', expect.anything());
     expect(failedButton.disabled).toBe(false);
     expect(document.querySelector('[data-jc-bookmark-library-modal="true"]')).toBeNull();
@@ -575,7 +575,7 @@ describe('bookmark replacement library search', () => {
 
     await findAllOrphanedAndOfferMigration({ first, second }, context);
 
-    expect(mocks.toast.mock.calls).toEqual([['bookmark_orphaned_search_failed:1', 4000]]);
+    expect(mocks.toast.mock.calls).toEqual([['bookmark_orphaned_search_failed:1', 4000, 'error']]);
     expect(document.querySelector('[data-jc-bookmark-library-modal="true"]')).toBeNull();
   });
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-replacements.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-replacements.ts
@@ -443,7 +443,7 @@ export async function findAndOfferReplacement(
         toast(JC.t!('bookmark_no_replacement'), 3000);
         return;
       case 'failed':
-        toast(JC.t!('bookmark_search_failed'), 3000);
+        toast(JC.t!('bookmark_search_failed'), 3000, 'error');
         return;
       case 'cancelled':
         return;
@@ -609,7 +609,7 @@ function showReplacementSelectionModal(
     } catch (e) {
       if (!isReplacementFlowCurrent(context, pageOwner)) return;
       console.error('Migration failed:', e);
-      toast(JC.t!('bookmark_migration_failed'), 3000);
+      toast(JC.t!('bookmark_migration_failed'), 3000, 'error');
       btn.disabled = false;
       btn.querySelector('span:last-child')!.textContent = JC.t!('bookmark_migrate');
     }
@@ -629,7 +629,7 @@ export async function findAllOrphanedAndOfferMigration(
   if (!context || !pageOwner || !JC.identity.isCurrent(context)) return;
   const apiClient = currentImageApiClient();
   if (!apiClient) {
-    toast(JC.t!('toast_api_client_unavailable'), 3000);
+    toast(JC.t!('toast_api_client_unavailable'), 3000, 'error');
     return;
   }
 
@@ -700,7 +700,7 @@ export async function findAllOrphanedAndOfferMigration(
   }
 
   if (failedSearchCount > 0) {
-    toast(JC.t!('bookmark_orphaned_search_failed').replace('{count}', String(failedSearchCount)), 4000);
+    toast(JC.t!('bookmark_orphaned_search_failed').replace('{count}', String(failedSearchCount)), 4000, 'error');
     return;
   }
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/config.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/config.ts
@@ -529,7 +529,7 @@ function emitPersistenceFailure(
     const now = Date.now();
     if (now - (_lastErrorToastAt.get(cacheKey) || 0) < 2000) return;
     _lastErrorToastAt.set(cacheKey, now);
-    toast(`{{icon:error}} ${escapeHtml(persistenceFailureMessage(error, rollbackApplied))}`, 5000);
+    toast(`{{icon:error}} ${escapeHtml(persistenceFailureMessage(error, rollbackApplied))}`, 5000, 'error');
 }
 
 function notifyPersistenceFailure(

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/random-button.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/random-button.ts
@@ -70,7 +70,7 @@ async function getRandomItem(context: IdentityContext): Promise<any> {
     } catch (error) {
         if (!JC.identity.isCurrent(context)) return null;
         console.error('🪼 Jellyfin Canopy: Error fetching random item:', error);
-        toast(`${JC.icon!(JC.IconName!.ERROR)} ${JC.escapeHtml((error as any)?.message || 'Unknown error')}`, 2000);
+        toast(`${JC.icon!(JC.IconName!.ERROR)} ${JC.escapeHtml((error as any)?.message || 'Unknown error')}`, 2000, 'error');
         return null;
     }
 }
@@ -97,7 +97,7 @@ function navigateToItem(context: IdentityContext, item: any): void {
         toast(JC.t!('toast_random_item_loaded'), 2000);
     } else {
         console.error('🪼 Jellyfin Canopy: Invalid item object or ID:', item);
-        toast(JC.t!('toast_generic_error'), 2000);
+        toast(JC.t!('toast_generic_error'), 2000, 'error');
     }
 }
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/dialogs.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/dialogs.ts
@@ -5,9 +5,11 @@
 // (Converted from js/enhanced/hidden-content-dialogs.js — bodies semantically identical.)
 
 import { JC } from '../../globals';
+import { NotificationBackpressureError, notifyAction } from '../../core/ui-kit';
 import { getSettings, hideItem, unhideItem } from './data';
+import { debouncedSave, flushPendingSave } from './save';
 import type { HideItemParams } from './data';
-import type { IdentityContext } from '../../types/jc';
+import type { IdentityContext, NotificationHandle } from '../../types/jc';
 
 /** Options customising the hide-confirmation dialog variants. */
 export interface HideDialogOptions {
@@ -34,10 +36,8 @@ interface DialogFence {
 }
 
 let dialogGeneration = 0;
-let activeUndoClose: (() => void) | null = null;
 let activeConfirmClose: (() => void) | null = null;
-const dialogTimeouts = new Set<number>();
-const dialogFrames = new Set<number>();
+const activeUndoNotifications = new Set<NotificationHandle>();
 
 function captureDialogFence(): DialogFence {
     return {
@@ -51,47 +51,15 @@ function isDialogFenceCurrent(fence: DialogFence): boolean {
         && (!fence.context || JC.identity.isCurrent(fence.context));
 }
 
-function scheduleDialogTimeout(callback: () => void, delay: number): number {
-    const handle = window.setTimeout(() => {
-        dialogTimeouts.delete(handle);
-        callback();
-    }, delay);
-    dialogTimeouts.add(handle);
-    return handle;
-}
-
-function cancelDialogTimeout(handle: number | null): void {
-    if (handle == null) return;
-    clearTimeout(handle);
-    dialogTimeouts.delete(handle);
-}
-
-function scheduleDialogFrame(callback: () => void): number {
-    const handle = requestAnimationFrame(() => {
-        dialogFrames.delete(handle);
-        callback();
-    });
-    dialogFrames.add(handle);
-    return handle;
-}
-
-function cancelDialogFrame(handle: number | null): void {
-    if (handle == null) return;
-    cancelAnimationFrame(handle);
-    dialogFrames.delete(handle);
-}
-
 export function resetDialogUi(): void {
     dialogGeneration += 1;
-    activeUndoClose?.();
+    for (const notification of activeUndoNotifications) notification.dismiss();
+    activeUndoNotifications.clear();
     activeConfirmClose?.();
-    activeUndoClose = null;
     activeConfirmClose = null;
-    for (const handle of dialogTimeouts) clearTimeout(handle);
-    for (const handle of dialogFrames) cancelAnimationFrame(handle);
-    dialogTimeouts.clear();
-    dialogFrames.clear();
-    document.querySelectorAll('.jc-undo-toast, .jc-hide-confirm-overlay').forEach((node) => {
+    // Shared notification handles own their exit timer and focus restoration.
+    // Remove only confirmation UI and pre-contract legacy Undo nodes here.
+    document.querySelectorAll('.jc-hide-confirm-overlay, .jc-undo-toast:not(.jc-notification)').forEach((node) => {
         JC.core.refreshSafety!.releaseElement(node);
         node.remove();
     });
@@ -115,76 +83,63 @@ function suppressionStorageKey(context: IdentityContext | null): string {
 export function showUndoToast(itemName: string, itemId: string): void {
     const fence = captureDialogFence();
     if (!isDialogFenceCurrent(fence)) return;
-    activeUndoClose?.();
-
-    const themeVars = JC.themer?.getThemeVariables?.() || {};
-    const toastBg = themeVars.secondaryBg || 'linear-gradient(135deg, rgba(0,0,0,0.9), rgba(40,40,40,0.9))';
-    const toastBorder = `1px solid ${themeVars.primaryAccent || 'rgba(255,255,255,0.1)'}`;
-    const blurValue = themeVars.blur || '30px';
-
-    const toast = document.createElement('div');
-    toast.className = 'jc-undo-toast';
-    toast.dataset.jcIdentityOwned = 'true';
-    Object.assign(toast.style, {
-        background: toastBg,
-        border: toastBorder,
-        backdropFilter: `blur(${blurValue})`
-    });
-
-    const textSpan = document.createElement('span');
-    textSpan.className = 'jc-undo-toast-text';
-    textSpan.textContent = JC.t!('hidden_content_item_hidden', { name: itemName });
-    toast.appendChild(textSpan);
-
-    const accentColor = themeVars.primaryAccent || 'rgba(255,255,255,0.15)';
-
-    const undoBtn = document.createElement('button');
-    undoBtn.className = 'jc-undo-btn';
-    Object.assign(undoBtn.style, {
-        background: `color-mix(in srgb, ${accentColor} 25%, transparent)`,
-        borderColor: accentColor
-    });
-    undoBtn.textContent = JC.t!('hidden_content_undo');
-    let frameHandle: number | null = null;
-    let dismissHandle: number | null = null;
-    let removalHandle: number | null = null;
-    const dispose = (): void => {
-        cancelDialogFrame(frameHandle);
-        cancelDialogTimeout(dismissHandle);
-        cancelDialogTimeout(removalHandle);
-        frameHandle = null;
-        dismissHandle = null;
-        removalHandle = null;
-        toast.remove();
-        if (activeUndoClose === dispose) activeUndoClose = null;
-    };
-    const dismiss = (): void => {
-        if (!isDialogFenceCurrent(fence)) {
-            dispose();
-            return;
-        }
-        toast.classList.remove('jc-visible');
-        cancelDialogTimeout(removalHandle);
-        removalHandle = scheduleDialogTimeout(dispose, 300);
-    };
-    activeUndoClose = dispose;
-
-    undoBtn.addEventListener('click', () => {
-        if (!isDialogFenceCurrent(fence)) return;
+    const message = JC.t!('hidden_content_item_hidden', { name: itemName });
+    const actionLabel = JC.t!('hidden_content_undo');
+    let undoApplied = false;
+    let notification: NotificationHandle | null = null;
+    try {
+        notification = notifyAction({
+            message,
+            severity: 'success',
+            duration: UNDO_TOAST_DURATION,
+            actionLabel,
+            actionAvailableAnnouncement: JC.t!('hidden_content_undo_available', { name: itemName }),
+            onAction: async () => {
+                if (!isDialogFenceCurrent(fence)) return;
+                if (!undoApplied) {
+                    // The visible action is immediate, but completion is not true
+                    // until the same identity's write has reached the server.
+                    unhideItem(itemId);
+                    undoApplied = true;
+                } else {
+                    // A rejected first flush already applied the local Undo. A
+                    // user retry must launch a fresh persistence attempt instead
+                    // of reporting success merely because no debounce remains.
+                    debouncedSave();
+                }
+                await flushPendingSave();
+            },
+            actionAnnouncement: JC.t!('hidden_content_item_restored', { name: itemName }),
+            actionErrorAnnouncement: JC.t!('hidden_content_save_failed_persistent'),
+            onDismiss: () => {
+                if (notification) activeUndoNotifications.delete(notification);
+            }
+        });
+    } catch (error) {
+        if (!(error instanceof NotificationBackpressureError)) throw error;
+        // Never commit a hide whose distinct Undo control could not be
+        // admitted. Restore it immediately and persist that rollback; the
+        // explicit diagnostic tells operators why the requested hide did not stick.
+        console.error('🪼 Jellyfin Canopy: Undo notification saturated; reverting hidden item', error);
         unhideItem(itemId);
-        dismiss();
-    });
-    toast.appendChild(undoBtn);
+        void flushPendingSave().catch((persistenceError) => {
+            console.error('🪼 Jellyfin Canopy: Saturation rollback could not be persisted', persistenceError);
+        });
+        return;
+    }
+    activeUndoNotifications.add(notification);
 
-    document.body.appendChild(toast);
-    frameHandle = scheduleDialogFrame(() => {
-        frameHandle = null;
-        if (isDialogFenceCurrent(fence)) toast.classList.add('jc-visible');
-    });
-    dismissHandle = scheduleDialogTimeout(() => {
-        dismissHandle = null;
-        if (toast.parentNode) dismiss();
-    }, UNDO_TOAST_DURATION);
+    // Preserve the feature's existing styling/test hooks while the lifecycle,
+    // action, timing, and announcements are owned by the shared notification kit.
+    notification.element.classList.add('jc-undo-toast');
+    notification.element.querySelector('.jc-notification-message')?.classList.add('jc-undo-toast-text');
+    const undoButton = notification.element.querySelector<HTMLElement>('.jc-notification-action');
+    undoButton?.classList.add('jc-undo-btn');
+    const accentColor = JC.themer?.getThemeVariables?.().primaryAccent || 'rgba(255,255,255,0.15)';
+    if (undoButton) {
+        undoButton.style.background = `color-mix(in srgb, ${accentColor} 25%, transparent)`;
+        undoButton.style.borderColor = accentColor;
+    }
 }
 
 // ============================================================

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/save.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/save.ts
@@ -118,7 +118,7 @@ async function recoverRevisionConflict(
     const conflictedRoot = sentRoot || getHiddenData();
     if (getHiddenData() !== conflictedRoot) {
         try {
-            toast(JC.t!('panel_admin_target_conflict_error'), 5000);
+            toast(JC.t!('panel_admin_target_conflict_error'), 5000, 'error');
         } catch { /* the in-memory intent remains fenced without a toast surface */ }
         return;
     }
@@ -129,7 +129,7 @@ async function recoverRevisionConflict(
         return;
     }
     try {
-        toast(JC.t!('panel_admin_target_conflict_error'), 5000);
+        toast(JC.t!('panel_admin_target_conflict_error'), 5000, 'error');
     } catch { /* the data recovery remains authoritative without a toast surface */ }
     if (recovered) {
         if (conflictFencedContext === context) conflictFencedContext = null;
@@ -913,7 +913,7 @@ function scheduleFlushRetry(attempt: number, context: IdentityContext): void {
         console.error('🪼 Jellyfin Canopy: hidden-content save retries exhausted; local change may be lost on reload');
         // User-visible toast — the bulk-save endpoint is genuinely down at this point.
         try {
-            toast(JC.t!('hidden_content_save_failed_persistent'), 5000);
+            toast(JC.t!('hidden_content_save_failed_persistent'), 5000, 'error');
         } catch (_) { /* toast helper unavailable, console.error above is best-effort */ }
         pendingRetryHandle = null;
         pendingRetryContext = null;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/styles.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/styles.ts
@@ -99,47 +99,6 @@ export function injectCSS(): void {
             background: rgba(255,255,255,0.08);
         }
 
-        .jc-undo-toast {
-            position: fixed;
-            bottom: 20px;
-            right: 20px;
-            color: #fff;
-            padding: 12px 16px;
-            border-radius: 8px;
-            z-index: 99999;
-            font-size: clamp(13px, 2vw, 16px);
-            font-weight: 500;
-            text-shadow: -1px -1px 10px black;
-            box-shadow: 0 4px 20px rgba(0,0,0,0.3);
-            display: flex;
-            align-items: center;
-            gap: 12px;
-            transform: translateX(100%);
-            transition: transform 0.3s ease-out;
-            max-width: 380px;
-        }
-        .jc-undo-toast.jc-visible {
-            transform: translateX(0);
-        }
-        .jc-undo-toast-text {
-            flex: 1;
-        }
-        .jc-undo-btn {
-            background: rgba(255,255,255,0.15);
-            border: 1px solid rgba(255,255,255,0.25);
-            color: #fff;
-            padding: 4px 12px;
-            border-radius: 4px;
-            cursor: pointer;
-            font-size: 13px;
-            font-weight: 600;
-            white-space: nowrap;
-            transition: background 0.2s ease, border-color 0.2s ease;
-        }
-        .jc-undo-btn:hover {
-            filter: brightness(1.3);
-        }
-
         .jc-hidden-management-overlay {
             position: fixed;
             inset: 0;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/ui-identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/ui-identity.test.ts
@@ -11,6 +11,10 @@ import { createTestFeatureScope, type TestFeatureScope } from '../../test/featur
 
 let featureScope: TestFeatureScope | null = null;
 
+async function drainMicrotasks(turns = 12): Promise<void> {
+    for (let index = 0; index < turns; index += 1) await Promise.resolve();
+}
+
 function activateFeature(): void {
     featureScope = createTestFeatureScope();
     void hiddenContentRuntimeFeature.activate(featureScope.scope);
@@ -141,5 +145,178 @@ describe('hidden-content identity-owned UI', () => {
         expect(document.querySelector('.jc-hidden-management-overlay')?.textContent).toContain('B');
         expect(cardBox.querySelector('.jc-hide-btn')).toBeTruthy();
         expect(cardBox.querySelector('.jc-hide-btn')).not.toBe(retainedCardButton);
+    });
+
+    it('keeps two rapid Undo actions distinct and independently actionable', () => {
+        const owner = startSession();
+        installHiddenData(owner, {
+            a: { itemId: 'item-a', name: 'A', type: 'Movie' },
+            b: { itemId: 'item-b', name: 'B', type: 'Movie' },
+        });
+        activateFeature();
+        JC.t = (key: string, values?: Record<string, unknown>) => key === 'hidden_content_item_hidden'
+            ? `"${String(values?.name)}" hidden`
+            : key;
+
+        showUndoToast('A', 'a');
+        showUndoToast('B', 'b');
+
+        const undoButtons = Array.from(document.querySelectorAll<HTMLButtonElement>('.jc-undo-btn'));
+        expect(undoButtons).toHaveLength(2);
+        expect(undoButtons.map((button) => button.parentElement?.textContent)).toEqual([
+            '"A" hiddenhidden_content_undo',
+            '"B" hiddenhidden_content_undo',
+        ]);
+
+        undoButtons[1].click();
+        undoButtons[1].click();
+        expect(Object.keys(getHiddenData().items)).toEqual(['a']);
+        undoButtons[0].click();
+        expect(getHiddenData().items).toEqual({});
+    });
+
+    it('restores same-page focus after config-restart teardown owns the Undo exit', async () => {
+        const owner = startSession();
+        installHiddenData(owner, { a: { itemId: 'item-a', name: 'A', type: 'Movie' } });
+        activateFeature();
+        const prior = document.createElement('button');
+        document.body.appendChild(prior);
+        prior.focus();
+
+        showUndoToast('A', 'a');
+        const notification = document.querySelector<HTMLElement>('.jc-undo-toast')!;
+        const undo = notification.querySelector<HTMLButtonElement>('.jc-undo-btn')!;
+        undo.focus();
+        expect(document.activeElement).toBe(undo);
+
+        await featureScope!.dispose();
+        featureScope = null;
+
+        // The shared owner, not Hidden Content's cleanup query, owns the exit.
+        expect(notification.isConnected).toBe(true);
+        vi.advanceTimersByTime(299);
+        expect(notification.isConnected).toBe(true);
+        vi.advanceTimersByTime(1);
+        expect(notification.isConnected).toBe(false);
+        expect(document.activeElement).toBe(prior);
+        prior.remove();
+    });
+
+    it('rolls a hide back instead of losing its Undo when notification capacity is saturated', async () => {
+        const owner = startSession();
+        installHiddenData(owner, { a: { itemId: 'item-a', name: 'A', type: 'Movie' } });
+        activateFeature();
+        vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        for (let index = 0; index < 32; index += 1) {
+            JC.core.ui!.notify({
+                message: `Retained ${index}`,
+                persistent: true,
+                dedupeKey: 'saturation-seed',
+            });
+        }
+
+        showUndoToast('A', 'a');
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(document.querySelector('.jc-undo-toast')).toBeNull();
+        expect(getHiddenData().items).toEqual({});
+        expect(console.error).toHaveBeenCalledWith(
+            expect.stringContaining('reverting hidden item'),
+            expect.objectContaining({ name: 'NotificationBackpressureError' })
+        );
+    });
+
+    it('uses localized completed-state copy after Undo succeeds', async () => {
+        const owner = startSession();
+        installHiddenData(owner, { a: { itemId: 'item-a', name: 'A', type: 'Movie' } });
+        activateFeature();
+        const keys: string[] = [];
+        JC.t = (key: string, values?: Record<string, unknown>) => {
+            keys.push(key);
+            return key === 'hidden_content_item_restored'
+                ? `"${String(values?.name)}" restored`
+                : key;
+        };
+
+        showUndoToast('A', 'a');
+        document.querySelector<HTMLButtonElement>('.jc-undo-btn')!.click();
+        await Promise.resolve();
+
+        expect(keys).toContain('hidden_content_item_restored');
+        expect(keys).not.toContain('hidden_content_unhide');
+    });
+
+    it('does not announce or dismiss Undo completion before persistence acknowledges it', async () => {
+        const owner = startSession();
+        installHiddenData(owner, { a: { itemId: 'item-a', name: 'A', type: 'Movie' } });
+        activateFeature();
+        JC.t = (key: string, values?: Record<string, unknown>) => key === 'hidden_content_item_hidden'
+            ? `"${String(values?.name)}" hidden`
+            : key === 'hidden_content_item_restored'
+                ? `"${String(values?.name)}" restored`
+                : key;
+        let acknowledge!: (value: unknown) => void;
+        const ajax = vi.spyOn(ApiClient, 'ajax').mockImplementation(() => new Promise((resolve) => {
+            acknowledge = resolve;
+        }));
+
+        showUndoToast('A', 'a');
+        const notification = document.querySelector<HTMLElement>('.jc-undo-toast')!;
+        const button = notification.querySelector<HTMLButtonElement>('.jc-undo-btn')!;
+        button.click();
+        await Promise.resolve();
+
+        expect(ajax).toHaveBeenCalledOnce();
+        expect(getHiddenData().items).toEqual({});
+        expect(button.disabled).toBe(true);
+        expect(notification.isConnected).toBe(true);
+        vi.advanceTimersByTime(550);
+        expect(document.querySelector('[data-jc-announcer="polite"]')?.textContent).toBe('');
+
+        acknowledge({});
+        await drainMicrotasks();
+
+        expect(document.querySelector('[data-jc-announcer="polite"]')?.textContent).toBe('"A" restored');
+        expect(notification.style.transform).toBe('translateX(0)');
+        vi.advanceTimersByTime(2_999);
+        expect(notification.style.transform).toBe('translateX(0)');
+        vi.advanceTimersByTime(1);
+        expect(notification.style.transform).toBe('translateX(100%)');
+    });
+
+    it('keeps a failed persisted Undo visibly retryable and sends a fresh write on retry', async () => {
+        const owner = startSession();
+        installHiddenData(owner, { a: { itemId: 'item-a', name: 'A', type: 'Movie' } });
+        activateFeature();
+        JC.t = (key: string) => key;
+        vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        const ajax = vi.spyOn(ApiClient, 'ajax')
+            .mockRejectedValueOnce(new Error('offline'))
+            .mockResolvedValueOnce({});
+
+        showUndoToast('A', 'a');
+        const notification = document.querySelector<HTMLElement>('.jc-undo-toast')!;
+        const button = notification.querySelector<HTMLButtonElement>('.jc-undo-btn')!;
+        button.click();
+        await drainMicrotasks();
+
+        expect(ajax).toHaveBeenCalledOnce();
+        expect(notification.isConnected).toBe(true);
+        expect(button.disabled).toBe(false);
+        expect(notification.querySelector('.jc-notification-action-status')?.textContent)
+            .toBe('hidden_content_save_failed_persistent');
+
+        button.click();
+        await drainMicrotasks();
+
+        expect(ajax).toHaveBeenCalledTimes(2);
+        expect(notification.isConnected).toBe(true);
+        vi.advanceTimersByTime(550);
+        expect(notification.style.transform).toBe('translateX(0)');
+        vi.advanceTimersByTime(2_999);
+        expect(notification.style.transform).toBe('translateX(0)');
+        vi.advanceTimersByTime(1);
+        expect(notification.style.transform).toBe('translateX(100%)');
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/playback.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/playback.ts
@@ -93,7 +93,7 @@ const openSettings = (cb: () => void): void => {
 const adjustPlaybackSpeed = (direction: 'increase' | 'decrease'): void => {
     const video = getVideo();
     if (!video) {
-        toast(JC.t!('toast_no_video_found'));
+        toast(JC.t!('toast_no_video_found'), undefined, 'warning');
         return;
     }
     const speeds = [0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0];
@@ -117,7 +117,7 @@ const adjustPlaybackSpeed = (direction: 'increase' | 'decrease'): void => {
 const resetPlaybackSpeed = (): void => {
     const video = getVideo();
     if (!video) {
-        toast(JC.t!('toast_no_video_found'));
+        toast(JC.t!('toast_no_video_found'), undefined, 'warning');
         return;
     }
     video.playbackRate = 1.0;
@@ -131,7 +131,7 @@ const resetPlaybackSpeed = (): void => {
 const jumpToPercentage = (percentage: number): void => {
     const video = getVideo();
     if (!video || !video.duration) {
-        toast(JC.t!('toast_no_video_found'));
+        toast(JC.t!('toast_no_video_found'), undefined, 'warning');
         return;
     }
     video.currentTime = video.duration * (percentage / 100);
@@ -347,7 +347,7 @@ const frameStep = async (direction: 'forward' | 'back'): Promise<void> => {
     const expectedGeneration = playbackGeneration;
     const video = getVideo();
     if (!video) {
-        toast(JC.t!('toast_no_video_found'));
+        toast(JC.t!('toast_no_video_found'), undefined, 'warning');
         return;
     }
     const playbackKey = getFpsCacheKey(context, getCurrentVideoItemId(), video);
@@ -461,11 +461,11 @@ const jumpToLastPosition = (): void => {
     if (!context) return;
     const video = getVideo();
     if (!video) {
-        toast(JC.t!('toast_no_video_found'));
+        toast(JC.t!('toast_no_video_found'), undefined, 'warning');
         return;
     }
     if (_lastPositionBeforeSeek === null) {
-        toast(tWithFallback('toast_no_last_position', '{{icon:rewind}} No previous position saved'));
+        toast(tWithFallback('toast_no_last_position', '{{icon:rewind}} No previous position saved'), undefined, 'warning');
         return;
     }
     const targetTime = _lastPositionBeforeSeek;
@@ -502,7 +502,7 @@ const skipIntroOutro = (): void => {
             toast('⏭️ Skipped');
         }
     } else {
-        toast(JC.t!('toast_no_skip_button'));
+        toast(JC.t!('toast_no_skip_button'), undefined, 'warning');
     }
 };
 
@@ -516,7 +516,7 @@ const cycleSubtitleTrack = (): void => {
         if (!JC.identity.isCurrent(context)) return;
         const allItems = document.querySelectorAll('.actionSheetContent .listItem');
         if (allItems.length === 0) {
-            toast(JC.t!('toast_no_subtitles_found'));
+            toast(JC.t!('toast_no_subtitles_found'), undefined, 'warning');
             document.body.click();
             return;
         }
@@ -527,7 +527,7 @@ const cycleSubtitleTrack = (): void => {
         });
 
         if (subtitleOptions.length === 0) {
-            toast(JC.t!('toast_no_subtitles_found'));
+            toast(JC.t!('toast_no_subtitles_found'), undefined, 'warning');
             document.body.click();
             return;
         }
@@ -570,7 +570,7 @@ const cycleAudioTrack = (): void => {
         const audioOptions = Array.from(document.querySelectorAll('.actionSheetContent .listItem')).filter(item => item.querySelector('.listItemBodyText.actionSheetItemText'));
 
         if (audioOptions.length === 0) {
-            toast(JC.t!('toast_no_audio_tracks_found'));
+            toast(JC.t!('toast_no_audio_tracks_found'), undefined, 'warning');
             document.body.click();
             return;
         }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/hidden-content-tab.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/hidden-content-tab.ts
@@ -272,7 +272,7 @@ export function wireHiddenContentListeners(ctx: PanelContext): void {
                         setStatus(`${message} ${translatedStatus(
                             'panel_admin_target_refresh_status',
                         )}`, true);
-                        toast(escapeHtml(message));
+                        toast(escapeHtml(message), undefined, 'error');
                         setDisabled(false);
                         await ctx.reconcileAfterSaveFailure();
                     },
@@ -310,7 +310,7 @@ export function wireHiddenContentListeners(ctx: PanelContext): void {
                     ),
                 );
                 setStatus(message, true);
-                toast(escapeHtml(message));
+                toast(escapeHtml(message), undefined, 'error');
             }
         });
         ctx.registerCleanup(() => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/language.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/language.ts
@@ -180,7 +180,7 @@ export function wireLanguageControls(ctx: PanelContext): void {
                         && error.kind === 'cancelled')) return;
                 (e.target as HTMLSelectElement).value = previousLang;
                 if (editor.mode === 'admin-target') {
-                    toast(JC.t!('panel_admin_target_save_error'));
+                    toast(JC.t!('panel_admin_target_save_error'), undefined, 'error');
                 }
                 await ctx.reconcileAfterSaveFailure?.();
                 return;
@@ -201,7 +201,7 @@ export function wireLanguageControls(ctx: PanelContext): void {
             if (editor.mode === 'admin-target') {
                 toast(escapeHtml(JC.t!('panel_admin_target_refresh_notice')));
             } else if (newLang && !translationExists) {
-                toast(`${JC.icon!(JC.IconName!.WARNING)} Translation file not available for selected language. Falling back to English.`);
+                toast(`${JC.icon!(JC.IconName!.WARNING)} Translation file not available for selected language. Falling back to English.`, undefined, 'warning');
             } else {
                 toast(JC.t!('toast_language_changed'));
             }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/panel.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/panel.ts
@@ -201,7 +201,7 @@ export function showEnhancedPanel(launch: SettingsPanelLaunchContext | null = nu
             ? 'panel_admin_target_unauthorized'
             : 'panel_admin_target_load_error';
         console.warn('🪼 Jellyfin Canopy: Could not open Canopy User Settings:', error);
-        toast(JC.t!(key));
+        toast(JC.t!(key), undefined, 'error');
     }).finally(() => {
         if (openingPromise === opening) openingPromise = null;
         // Every early/stale return leaves the reservation in opening state.

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/release-notes.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/release-notes.ts
@@ -33,7 +33,7 @@ export async function showReleaseNotesNotification(): Promise<void> {
     } catch (error) {
         if (controller.signal.aborted || !JC.identity.isCurrent(context)) return;
         console.error('🪼 Jellyfin Canopy: Failed to fetch release notes:', error);
-        toast(JC.icon!(JC.IconName!.ERROR) + ' Could not load release notes.');
+        toast(JC.icon!(JC.IconName!.ERROR) + ' Could not load release notes.', undefined, 'error');
         return;
     } finally {
         releaseControllers.delete(controller);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/settings.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/settings.ts
@@ -77,7 +77,7 @@ function persistEditorSettings(ctx: PanelContext, editor: PanelEditorContext): P
                     : classified?.kind === 'conflict'
                         ? 'panel_admin_target_conflict_error'
                         : 'panel_admin_target_save_error';
-                toast(JC.t!(key));
+                toast(JC.t!(key), undefined, 'error');
             }
             await reconcileAfterFailure(ctx, editor);
             if (editor.appliesToActor && JC.identity.isCurrent(editor.actor)) {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/shortcut-editor.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/shortcut-editor.ts
@@ -41,7 +41,7 @@ export function wireShortcutEditor(ctx: PanelContext): void {
                 : classified?.kind === 'authorization'
                     ? 'panel_admin_target_unauthorized'
                     : 'panel_admin_target_save_error';
-            toast(JC.t!(key));
+            toast(JC.t!(key), undefined, 'error');
         }
         keyElement.blur();
         await ctx.reconcileAfterSaveFailure?.();

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/detail-button.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/detail-button.ts
@@ -281,7 +281,7 @@ function performToggle(
     }).catch((err) => {
         if (!isLiveButton(button, context, visiblePage)) return;
         console.error(`${logPrefix} Toggle failed:`, err);
-        JC.toast?.(JC.t!('spoiler_blur_error_toast'));
+        JC.toast?.(JC.t!('spoiler_blur_error_toast'), undefined, 'error');
     }).finally(() => {
         if (isLiveButton(button, context, visiblePage)) button.disabled = false;
     });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/seerr-toggle.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/seerr-toggle.ts
@@ -93,7 +93,7 @@ export function buildSeerrPendingToggle(data: any, mediaType: string): HTMLButto
             } catch (err) {
                 if (!isOwnedButton(true)) return;
                 console.warn(`${logPrefix} pending toggle failed:`, err);
-                JC.toast?.(JC.t!('spoiler_blur_pending_error_toast'));
+                JC.toast?.(JC.t!('spoiler_blur_pending_error_toast'), undefined, 'error');
             } finally {
                 if (isOwnedButton(true)) {
                     refreshLabel();

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/settings-tab.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/spoiler-guard/settings-tab.ts
@@ -501,7 +501,7 @@ export function wireSpoilerGuardListeners(
                         setStatus(`${message} ${translatedStatus(
                             'panel_admin_target_refresh_status',
                         )}`, true);
-                        toast(escapeHtml(message));
+                        toast(escapeHtml(message), undefined, 'error');
                         setDisabled(false);
                         await panel.reconcileAfterSaveFailure();
                     },
@@ -582,7 +582,7 @@ export function wireSpoilerGuardListeners(
             console.error(`${logPrefix} saveSbPrefs failed:`, err);
             // Revert the box the user clicked so they see the change didn't stick.
             changedBox.checked = previousChecked;
-            JC.toast?.(JC.t!('spoiler_blur_error_toast'));
+            JC.toast?.(JC.t!('spoiler_blur_error_toast'), undefined, 'error');
         } finally {
             // A's stale finally must not re-enable a retained control after B
             // has synchronously torn the panel down.

--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/active-streams.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/active-streams.ts
@@ -5,7 +5,7 @@ import { JC as JEBase } from '../globals';
 import { describeFetchError } from '../core/fetch-error';
 import { insertHeaderTrayButton, HeaderTrayOrder } from '../enhanced/header-tray';
 import { createStableMethodFacade } from '../core/feature-loader';
-import type { ApiApi, IdentityContext, LifecycleApi, LifecycleHandle, NavigationApi, PluginConfig, UiApi } from '../types/jc';
+import type { ApiApi, IdentityContext, LifecycleApi, LifecycleHandle, NavigationApi, NotificationSeverity, PluginConfig, UiApi } from '../types/jc';
 
 /**
  * Local view of the shared namespace adding the public member this module
@@ -14,7 +14,7 @@ import type { ApiApi, IdentityContext, LifecycleApi, LifecycleHandle, Navigation
 const JC = JEBase as typeof JEBase & {
     activeStreams?: { initialize(): void; destroy(): void };
     t?: (key: string, params?: Record<string, unknown>) => string;
-    toast?: (html: string, duration?: number) => void;
+    toast?: (html: string, duration?: number, severity?: NotificationSeverity) => void;
     currentUser?: { Policy?: { IsAdministrator?: boolean } };
     pluginConfig: PluginConfig & { ActiveStreamsEnabled?: boolean; ActiveStreamsAllUsers?: boolean };
     core: { api: ApiApi; navigation: NavigationApi; lifecycle: LifecycleApi; ui?: UiApi };
@@ -73,8 +73,16 @@ const isAdmin = (): boolean => JC?.currentUser?.Policy?.IsAdministrator === true
 // Fire a transient toast if the host exposes one (no-op under jsdom tests).
 // Callers only ever pass trusted localized strings (no session-derived data),
 // so no escaping is needed at these sites (X1).
-const notify = (message: string): void => {
-    try { (JC.toast || JC.core?.ui?.toast)?.(message); } catch (_) { /* non-fatal */ }
+const notify = (message: string, severity: NotificationSeverity = 'info'): void => {
+    try {
+        if (JC.core?.ui?.notify) {
+            JC.core.ui.notify({ message, severity });
+            return;
+        }
+        (JC.toast || JC.core?.ui?.toast)?.(message, undefined, severity);
+    } catch (error) {
+        console.error(`${LOG} notification rejected`, error);
+    }
 };
 
 // ── Live-update cadence ────────────────────────────────────────────────────
@@ -991,11 +999,11 @@ const sendSessionStop = async (sessionId: string, context: IdentityContext): Pro
             skipRetry: true,
         });
         if (!isCurrentContext(context)) return;
-        notify(JC.t?.('session_control_stopped') || 'Stream stopped');
+        notify(JC.t?.('session_control_stopped') || 'Stream stopped', 'success');
         void updateCounter({ live: true }, context);
     } catch (err) {
         if (!isCurrentContext(context)) return;
-        notify(JC.t?.('session_control_stop_failed') || 'Failed to stop the stream');
+        notify(JC.t?.('session_control_stop_failed') || 'Failed to stop the stream', 'error');
         console.warn(`${LOG} stop session failed:`, err);
     }
 };

--- a/Jellyfin.Plugin.JellyfinCanopy/src/facade.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/facade.ts
@@ -18,7 +18,7 @@
 // (internal, still-typed-incrementally) members on top. Removing or renaming
 // any member here is a breaking change to the public contract.
 
-import type { JECore, PluginConfig, UserSettings } from './types/jc';
+import type { JECore, NotificationSeverity, PluginConfig, UserSettings } from './types/jc';
 
 /**
  * The frozen public API of window.JellyfinCanopy. Signatures here MUST match
@@ -42,7 +42,7 @@ export interface JellyfinCanopyPublicApi {
     /** Translation lookup — returns the key itself when no translation exists. */
     t?: (key: string, params?: Record<string, unknown>) => string;
     /** Shows a transient toast notification. */
-    toast?: (html: string, duration?: number) => void;
+    toast?: (html: string, duration?: number, severity?: NotificationSeverity) => void;
     /** Custom sidebar plugin links (config-page.js calls .refresh() to preview). */
     customPlugins?: { refresh: () => void };
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/api.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/api.ts
@@ -402,7 +402,7 @@ api.surfaceUserStatusBanner = function(status) {
             ? JC.escapeHtml(rawMsg)
             : String(rawMsg).replace(/[&<>"']/g, function(c){return ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#039;'} as Record<string, string>)[c];});
         if (typeof JC !== 'undefined' && typeof JC.toast === 'function') {
-            JC.toast(`Seerr: ${msg}`, 6000);
+            JC.toast(`Seerr: ${msg}`, 6000, 'warning');
         } else {
             console.warn(`${logPrefix} ${rawMsg}`);
         }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/issue-reporter.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/issue-reporter.ts
@@ -288,7 +288,7 @@ issueReporter.showReportModal = function (tmdbId, itemName, mediaType, backdropU
             }
 
             if (!issueType) {
-                JC.toast!('Issue Type is required', 3000);
+                JC.toast!('Issue Type is required', 3000, 'warning');
                 return;
             }
 
@@ -321,11 +321,11 @@ issueReporter.showReportModal = function (tmdbId, itemName, mediaType, backdropU
                 console.error(`${logPrefix} Error reporting issue:`, error);
                 const errorMsg = error?.message || error?.toString() || '';
                 if (error?.status === 403) {
-                    JC.toast!(JC.t!('seerr_err_no_issue_permission'), 4000);
+                    JC.toast!(JC.t!('seerr_err_no_issue_permission'), 4000, 'error');
                 } else if (errorMsg.toLowerCase().includes('seerr') || errorMsg.toLowerCase().includes('unavailable') || error?.status === 503 || error?.status === 0) {
-                    JC.toast!('Seerr is not available', 4000);
+                    JC.toast!('Seerr is not available', 4000, 'error');
                 } else {
-                    JC.toast!(JC.t!('seerr_report_issue_error'), 4000);
+                    JC.toast!(JC.t!('seerr_report_issue_error'), 4000, 'error');
                 }
                 button.disabled = false;
                 button.textContent = JC.t!('seerr_report_issue_submit');
@@ -814,15 +814,15 @@ issueReporter.createUnavailableButton = function (container, itemName, mediaType
         e.stopPropagation();
         if (!isReporterIdentityCurrent(context)) return;
         if (reason === 'no-tmdb') {
-            JC.toast!('TMDB ID not found for this item', 4000);
+            JC.toast!('TMDB ID not found for this item', 4000, 'warning');
         } else if (reason === 'no-seerr') {
-            JC.toast!('Seerr is not available', 4000);
+            JC.toast!('Seerr is not available', 4000, 'error');
         } else if (reason === 'no-both') {
-            JC.toast!('TMDB ID not found and Seerr is not available', 4000);
+            JC.toast!('TMDB ID not found and Seerr is not available', 4000, 'error');
         } else if (reason === 'no-permissions') {
-            JC.toast!('You do not have permissions to report issues', 4000);
+            JC.toast!('You do not have permissions to report issues', 4000, 'error');
         } else {
-            JC.toast!(JC.t!('seerr_report_unavailable_toast'), 4000);
+            JC.toast!(JC.t!('seerr_report_unavailable_toast'), 4000, 'error');
         }
     });
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/request-settings-fail-closed.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/request-settings-fail-closed.test.ts
@@ -51,7 +51,7 @@ describe('Seerr request settings fail closed', () => {
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(createModal).not.toHaveBeenCalled();
         expect(postMock).not.toHaveBeenCalled();
-        expect(toast).toHaveBeenCalledWith('seerr_toast_no_season_info', 4000);
+        expect(toast).toHaveBeenCalledWith('seerr_toast_no_season_info', 4000, 'warning');
     });
 
     it.each([
@@ -66,7 +66,7 @@ describe('Seerr request settings fail closed', () => {
 
         expect(createModal).not.toHaveBeenCalled();
         expect(postMock).not.toHaveBeenCalled();
-        expect(toast).toHaveBeenCalledWith('seerr_toast_no_season_info', 4000);
+        expect(toast).toHaveBeenCalledWith('seerr_toast_no_season_info', 4000, 'warning');
     });
 
     it('keeps a later outage unavailable instead of reusing unscoped last-good settings', async () => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/seerr.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/seerr.ts
@@ -244,7 +244,7 @@ function initializeSeerrScript(): void {
         } else if (data.error) {
             // Empty results WITH an error means the search backend failed —
             // surface it once instead of silently rendering no section (W4-ERR-4).
-            JC.toast?.(JC.escapeHtml(data.error));
+            JC.toast?.(JC.escapeHtml(data.error), undefined, 'error');
         }
     }
 
@@ -700,7 +700,7 @@ function initializeSeerrScript(): void {
                             errorMessage = error.responseJSON.message;
                         }
                         // Escape API error before display to prevent reflected XSS
-                        JC.toast!(escapeHtml(errorMessage), 4000);
+                        JC.toast!(escapeHtml(errorMessage), 4000, 'error');
                     }
                     item.disabled = false;
                     item.innerHTML = `<span>Request in 4K</span>`;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/quota.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/quota.ts
@@ -166,7 +166,7 @@ async function showQuotaErrorDialog(error: any, mediaType: any) {
             console.warn(`${logPrefix} Dashboard.alert threw, falling back to toast:`, err);
         }
     }
-    JC.toast!(escapeHtml(`${title}: ${lines.join(' — ')}`), 8000);
+    JC.toast!(escapeHtml(`${title}: ${lines.join(' — ')}`), 8000, 'warning');
 }
 
 async function handleRequestError(error: any, mediaType: any, requestBtn: any, resetLabel: any) {
@@ -177,7 +177,7 @@ async function handleRequestError(error: any, mediaType: any, requestBtn: any, r
         // Seerr 500 stack no longer leaks to the toast; a clean short message
         // still passes through. escapeHtml keeps the innerHTML toast sink safe
         // (and leaves the fallback's {{icon:error}} token intact) (W4-ERR-8).
-        JC.toast!(escapeHtml(describeFetchError(error, JC.t!('seerr_modal_toast_request_fail'))), 4000);
+        JC.toast!(escapeHtml(describeFetchError(error, JC.t!('seerr_modal_toast_request_fail'))), 4000, 'error');
     }
     if (requestBtn) {
         requestBtn.disabled = false;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/request-modals.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/request-modals.ts
@@ -41,7 +41,7 @@ ui.showMovieRequestModal = async function (tmdbId: any, title: any, searchResult
             const folderSelect = modalEl.querySelector<HTMLSelectElement>('#movie-folder');
 
             if (!serverSelect?.value || !qualitySelect?.value || !folderSelect?.value) {
-                JC.toast!(JC.t!('seerr_modal_toast_options_missing'), 3000);
+                JC.toast!(JC.t!('seerr_modal_toast_options_missing'), 3000, 'warning');
                 return;
             }
 
@@ -89,7 +89,7 @@ ui.showMovieRequestModal = async function (tmdbId: any, title: any, searchResult
     } catch (error: any) {
         if (!JC.identity.isCurrent(identity) || !modalElement.isConnected) return;
         console.error(`${logPrefix} Failed to load advanced options:`, error);
-        JC.toast!(JC.t!('seerr_err_load_server_options'), 3000);
+        JC.toast!(JC.t!('seerr_err_load_server_options'), 3000, 'error');
     }
 
 
@@ -153,12 +153,12 @@ ui.showCollectionRequestModal = async function (collectionId: any, collectionNam
         if (!JC.identity.isCurrent(identity)) return;
     } catch (error: any) {
         if (!JC.identity.isCurrent(identity)) return;
-        JC.toast!(JC.t!('seerr_toast_collection_fetch_failed'), 4000);
+        JC.toast!(JC.t!('seerr_toast_collection_fetch_failed'), 4000, 'error');
         return;
     }
 
     if (!collectionDetails?.parts || collectionDetails.parts.length === 0) {
-        JC.toast!(JC.t!('seerr_toast_no_movies_in_collection'), 4000);
+        JC.toast!(JC.t!('seerr_toast_no_movies_in_collection'), 4000, 'warning');
         return;
     }
 
@@ -286,7 +286,7 @@ ui.showCollectionRequestModal = async function (collectionId: any, collectionNam
                 const quality = modalEl.querySelector<HTMLSelectElement>('#movie-quality')?.value;
                 const folder = modalEl.querySelector<HTMLSelectElement>('#movie-folder')?.value;
                 if (!server || !quality || !folder) {
-                    JC.toast!(JC.t!('seerr_modal_toast_options_missing') || 'Please select all options', 3000);
+                    JC.toast!(JC.t!('seerr_modal_toast_options_missing') || 'Please select all options', 3000, 'warning');
                     requestBtn.disabled = false;
                     requestBtn.textContent = JC.t!('seerr_modal_request_selected_movies') || 'Request Selected Movies';
                     return;
@@ -300,7 +300,7 @@ ui.showCollectionRequestModal = async function (collectionId: any, collectionNam
                 )).map((checkbox) => Number.parseInt(checkbox.dataset.tmdbId || '', 10));
 
                 if (selectedMovies.length === 0) {
-                    JC.toast!(JC.t!('seerr_modal_toast_select_movie') || 'Please select at least one movie', 3000);
+                    JC.toast!(JC.t!('seerr_modal_toast_select_movie') || 'Please select at least one movie', 3000, 'warning');
                     requestBtn.disabled = false;
                     requestBtn.textContent = JC.t!('seerr_modal_request_selected_movies') || 'Request Selected Movies';
                     return;
@@ -333,7 +333,7 @@ ui.showCollectionRequestModal = async function (collectionId: any, collectionNam
                 if (otherFailures > 0) {
                     toastText += ' ' + JC.t!('seerr_toast_collection_failed_count', { count: otherFailures });
                 }
-                JC.toast!(toastText, 4000);
+                JC.toast!(toastText, 4000, otherFailures > 0 ? 'warning' : 'success');
                 if (quotaHitError) {
                     await ui.showQuotaErrorDialog(quotaHitError, 'movie');
                     if (!isCurrent()) return;
@@ -354,7 +354,7 @@ ui.showCollectionRequestModal = async function (collectionId: any, collectionNam
                 modalEl._jcIdentityCleanups?.add(() => clearTimeout(refreshTimer));
             } catch (error: any) {
                 if (!isCurrent()) return;
-                JC.toast!(JC.t!('seerr_modal_toast_request_fail') || 'Request failed', 4000);
+                JC.toast!(JC.t!('seerr_modal_toast_request_fail') || 'Request failed', 4000, 'error');
                 requestBtn.disabled = false;
                 requestBtn.textContent = JC.t!('seerr_modal_request_selected_movies') || 'Request Selected Movies';
             }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/season-modal.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/season-modal.ts
@@ -60,7 +60,7 @@ ui.showSeasonSelectionModal = async function (tmdbId: any, mediaType: any, showT
     }
     if (!isCurrentGeneration()) return;
     if (!requestSettings?.available) {
-        JC.toast!(JC.t!('seerr_toast_no_season_info'), 4000);
+        JC.toast!(JC.t!('seerr_toast_no_season_info'), 4000, 'warning');
         return;
     }
     const { partialRequestsEnabled, enableSpecialEpisodes } = requestSettings;
@@ -83,7 +83,7 @@ ui.showSeasonSelectionModal = async function (tmdbId: any, mediaType: any, showT
     }
     if (!isCurrentGeneration() || initialRequestController.signal.aborted) return;
     if (!tvDetails?.seasons) {
-        JC.toast!(JC.t!('seerr_toast_no_season_info'), 4000);
+        JC.toast!(JC.t!('seerr_toast_no_season_info'), 4000, 'warning');
         return;
     }
 
@@ -125,7 +125,7 @@ ui.showSeasonSelectionModal = async function (tmdbId: any, mediaType: any, showT
             // barrier: the non-partial path does not read checkboxes at all.
             // Require the latest validated snapshot before either request path.
             if (seasonList?._requestStateValid !== true) {
-                JC.toast!(JC.t!('seerr_toast_no_season_info'), 4000);
+                JC.toast!(JC.t!('seerr_toast_no_season_info'), 4000, 'warning');
                 requestBtn.disabled = false;
                 requestBtn.textContent = is4k
                     ? (JC.t!('seerr_btn_request_4k') || 'Request in 4K')
@@ -139,7 +139,7 @@ ui.showSeasonSelectionModal = async function (tmdbId: any, mediaType: any, showT
                 const quality = modalEl.querySelector('#tv-quality').value;
                 const folder = modalEl.querySelector('#tv-folder').value;
                 if (!server || !quality || !folder) {
-                    JC.toast!(JC.t!('seerr_modal_toast_options_missing'), 3000);
+                    JC.toast!(JC.t!('seerr_modal_toast_options_missing'), 3000, 'warning');
                     requestBtn.disabled = false;
                     requestBtn.textContent = is4k ? (JC.t!('seerr_btn_request_4k') || 'Request in 4K') : (partialRequestsEnabled ? JC.t!('seerr_modal_request_selected') : JC.t!('seerr_modal_request'));
                     return;
@@ -152,7 +152,7 @@ ui.showSeasonSelectionModal = async function (tmdbId: any, mediaType: any, showT
                     // Partial requests enabled: request selected seasons (exclude the Select All checkbox)
                     const selectedSeasons = Array.from(modalEl.querySelectorAll('.seerr-season-item .seerr-season-checkbox:checked:not(:disabled)')).map((cb: any) => parseInt(cb.dataset.seasonNumber));
                     if (selectedSeasons.length === 0) {
-                        JC.toast!(JC.t!('seerr_modal_toast_select_season'), 3000);
+                        JC.toast!(JC.t!('seerr_modal_toast_select_season'), 3000, 'warning');
                         requestBtn.disabled = false;
                         requestBtn.textContent = is4k ? (JC.t!('seerr_btn_request_4k') || 'Request in 4K') : JC.t!('seerr_modal_request_selected');
                         return;
@@ -379,7 +379,7 @@ ui.showSeasonSelectionModal = async function (tmdbId: any, mediaType: any, showT
         } catch (error: any) {
             if (!isLiveModal()) return;
             console.error(`${logPrefix} Failed to load TV advanced options:`, error);
-            JC.toast!(JC.t!('seerr_err_load_server_options'), 3000);
+            JC.toast!(JC.t!('seerr_err_load_server_options'), 3000, 'error');
         }
     }
 };

--- a/Jellyfin.Plugin.JellyfinCanopy/src/test/setup.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/test/setup.ts
@@ -260,6 +260,16 @@ window.JellyfinCanopy = bootstrapJE;
 // itself forever (100ms retry loop) waiting for the host router.
 window.Emby = { Page: {} };
 
+// Jellyfin 12 publishes the router event bus before the client bundle runs.
+// Supplying it here keeps navigation on its production subscription path and
+// prevents its bounded legacy-host retry timer from contaminating unrelated
+// fake-timer assertions after modules import the notification owner.
+window.Events = {
+    on: () => undefined,
+    off: () => undefined,
+    trigger: () => undefined,
+};
+
 // Minimal ApiClient: only what the core modules call at import/test time.
 const apiClientStub = {
     serverId: () => 'test-server-id',

--- a/Jellyfin.Plugin.JellyfinCanopy/src/types/jc.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/types/jc.ts
@@ -427,9 +427,72 @@ export interface SectionContainerOptions {
     className?: string;
 }
 
+/** How urgently assistive technology should announce a notification. */
+export type NotificationSeverity = 'info' | 'success' | 'warning' | 'error';
+
+/** Why a notification reached its single terminal state. */
+export type NotificationDismissReason = 'action' | 'timeout' | 'programmatic' | 'navigation' | 'identity';
+
+/** Idempotent controller returned by the shared notification owner. */
+export interface NotificationHandle {
+    readonly id: string;
+    readonly element: HTMLElement;
+    dismiss(): void;
+}
+
+/** A text-only, screen-reader-announced notification. */
+export interface NotificationOptions {
+    /** User-facing text. It is rendered with `textContent`, never as HTML. */
+    message: string;
+    /** Info/success are polite; warning/error are assertive. Defaults to info. */
+    severity?: NotificationSeverity;
+    /**
+     * Visible lifetime in ms. Defaults to 8s for actions, otherwise the configured toast duration.
+     * A failed action receives a fresh full lifetime after its retry control is restored.
+     */
+    duration?: number;
+    /** Keep visible until action or programmatic teardown instead of starting an expiry timer. */
+    persistent?: boolean;
+    /**
+     * Explicit AT-announcement coalescing key; the first pending announcement
+     * for a key wins its position and text. Action cards remain independently actionable.
+     */
+    dedupeKey?: string;
+    /** Called once after the notification reaches a terminal state. */
+    onDismiss?: (reason: NotificationDismissReason) => void;
+}
+
+/** A notification carrying one keyboard-reachable action. */
+export interface ActionableNotificationOptions extends NotificationOptions {
+    actionLabel: string;
+    onAction: () => void | Promise<void>;
+    /**
+     * Localized live-region copy that announces both the state change and that
+     * the action is available. Defaults to `message — actionLabel`.
+     */
+    actionAvailableAnnouncement?: string;
+    /** Optional one-time announcement after a successful action. */
+    actionAnnouncement?: string;
+    /** Assertive copy announced when the action fails before the same action is restored. */
+    actionErrorAnnouncement?: string;
+}
+
 export interface UiApi {
     escapeHtml(value: unknown): string;
-    toast(html: string, duration?: number): void;
+    /** Frozen HTML compatibility adapter. Callers must escape untrusted input. */
+    toast(html: string, duration?: number, severity?: NotificationSeverity): void;
+    /**
+     * Show a safe text notification through the shared document-life owner.
+     * @throws NotificationBackpressureError when the bounded card or announcement queue is full.
+     */
+    notify(options: NotificationOptions): NotificationHandle;
+    /**
+     * Show a safe text notification with one keyboard-reachable action.
+     * The returned action stays disabled while its promise is pending and is
+     * restored with visible + assertive failure state if that promise rejects.
+     * @throws NotificationBackpressureError when the bounded card or announcement queue is full.
+     */
+    notifyAction(options: ActionableNotificationOptions): NotificationHandle;
     injectCss(id: string, css: string): void;
     removeCss(id: string): boolean;
     /** Theme-token-aware MUI IconButton (clones the AppBar action-button markup). */
@@ -734,7 +797,7 @@ export interface JEGlobal extends JellyfinCanopyPublicApi {
     clientRefreshBootstrapUnavailableServerId?: string;
     initialized?: boolean;
     escapeHtml: (value: unknown) => string;
-    toast?: (html: string, duration?: number) => void;
+    toast?: (html: string, duration?: number, severity?: NotificationSeverity) => void;
     requestManager?: RequestManagerApi;
     /** Fail-open browser-storage owner installed before any feature code runs. */
     storage: BrowserStorageApi;

--- a/e2e/admin-target-user-settings.spec.ts
+++ b/e2e/admin-target-user-settings.spec.ts
@@ -3008,7 +3008,7 @@ test.describe('admin target user settings', () => {
                         }
                     }
                 });
-                observer.observe(document.body, { childList: true });
+                observer.observe(document.body, { childList: true, subtree: true });
                 scope.__jcAdminTargetIdentityFailureObserver = observer;
             }, loadError);
 
@@ -3295,7 +3295,7 @@ test.describe('admin target user settings', () => {
                         for (const node of Array.from(mutation.addedNodes)) observe(node);
                     }
                 });
-                observer.observe(document.body, { childList: true });
+                observer.observe(document.body, { childList: true, subtree: true });
                 scope.__jcAdminTargetUnauthorizedObserver = observer;
             }, unauthorizedText);
 

--- a/e2e/boot.spec.ts
+++ b/e2e/boot.spec.ts
@@ -67,4 +67,96 @@ test.describe('boot', () => {
         }
         assertNoRuntimeErrors(consoleErrors);
     });
+
+    test('shared notifications are accessible, stacked, exact-once, and route-owned', async ({ page, consoleErrors }) => {
+        await loginAs(page, 'admin', consoleErrors);
+
+        const initial = await page.evaluate(() => {
+            const ui = (window as any).JellyfinCanopy.core.ui;
+            const ownerBefore = document.getElementById('jc-notification-owner');
+            (window as any).__jcNotificationActions = [];
+            (window as any).__jcNotificationAnnouncements = [];
+            const announcementObserver = new MutationObserver((mutations) => {
+                for (const mutation of mutations) {
+                    const target = mutation.target instanceof Element
+                        ? mutation.target
+                        : mutation.target.parentElement;
+                    const lane = target?.closest<HTMLElement>('[data-jc-announcer]');
+                    if (lane?.textContent) {
+                        (window as any).__jcNotificationAnnouncements.push(lane.textContent);
+                    }
+                }
+            });
+            if (ownerBefore) {
+                announcementObserver.observe(ownerBefore, { subtree: true, childList: true, characterData: true });
+            }
+            const first = ui.notifyAction({
+                message: 'First item hidden',
+                actionAvailableAnnouncement: 'First item hidden. Undo first is available.',
+                severity: 'success',
+                duration: 8_000,
+                actionLabel: 'Undo first',
+                onAction: () => (window as any).__jcNotificationActions.push('first'),
+            });
+            ui.notifyAction({
+                message: 'Second item hidden',
+                actionAvailableAnnouncement: 'Second item hidden. Undo second is available.',
+                severity: 'success',
+                duration: 8_000,
+                actionLabel: 'Undo second',
+                onAction: () => (window as any).__jcNotificationActions.push('second'),
+            });
+            (window as any).__jcRetainedNotificationButton = first.element.querySelector('button');
+            const owner = document.getElementById('jc-notification-owner');
+            const buttons = Array.from(owner?.querySelectorAll<HTMLButtonElement>('.jc-notification-action') || []);
+            return {
+                ownerPreinstalled: !!ownerBefore,
+                owners: document.querySelectorAll('#jc-notification-owner').length,
+                cards: owner?.querySelectorAll('.jc-notification').length,
+                politeRegions: owner?.querySelectorAll('[aria-live="polite"]').length,
+                assertiveRegions: owner?.querySelectorAll('[aria-live="assertive"]').length,
+                visualLiveValues: Array.from(owner?.querySelectorAll('.jc-notification') || [])
+                    .map((node) => node.getAttribute('aria-live')),
+                buttonTypes: buttons.map((button) => button.type),
+            };
+        });
+
+        expect(initial).toEqual({
+            ownerPreinstalled: true,
+            owners: 1,
+            cards: 2,
+            politeRegions: 1,
+            assertiveRegions: 1,
+            visualLiveValues: ['off', 'off'],
+            buttonTypes: ['button', 'button'],
+        });
+        await expect.poll(() => page.evaluate(() => (window as any).__jcNotificationAnnouncements))
+            .toEqual([
+                'First item hidden. Undo first is available.',
+                'Second item hidden. Undo second is available.',
+            ]);
+        await page.evaluate(() => {
+            const buttons = document.querySelectorAll<HTMLButtonElement>('.jc-notification-action');
+            buttons[1]?.click();
+            buttons[1]?.click();
+        });
+        await expect.poll(() => page.evaluate(() => (window as any).__jcNotificationActions))
+            .toEqual(['second']);
+
+        await page.evaluate(() => (window as any).JellyfinCanopy.core.ui.notify({
+            message: 'Urgent save failure',
+            severity: 'error',
+            duration: 8_000,
+            dedupeKey: 'e2e:urgent-save-failure',
+        }));
+        await expect.poll(() => page.locator('[data-jc-announcer="assertive"]').textContent())
+            .toBe('Urgent save failure');
+
+        await page.evaluate(() => history.pushState({}, '', '#/home?jc-notification-proof=1'));
+        await expect(page.locator('.jc-notification')).toHaveCount(0);
+        await page.evaluate(() => (window as any).__jcRetainedNotificationButton.click());
+        expect(await page.evaluate(() => (window as any).__jcNotificationActions)).toEqual(['second']);
+        await expect(page.locator('#jc-notification-owner')).toHaveCount(1);
+        assertNoRuntimeErrors(consoleErrors);
+    });
 });

--- a/e2e/required-test-inventory.json
+++ b/e2e/required-test-inventory.json
@@ -31,6 +31,7 @@
     "e2e/bookmarks-responsive.spec.ts › Bookmarks responsive containment (#466 findings 1–2) › legacy: populated Bookmarks grid and footer fit 320px and 360px",
     "e2e/bookmarks-responsive.spec.ts › Bookmarks responsive containment (#466 findings 1–2) › legacy: Bookmark offset modal keeps close and actions reachable at 320x568",
     "e2e/boot.spec.ts › boot › initializes with all core namespaces and no real console errors",
+    "e2e/boot.spec.ts › boot › shared notifications are accessible, stacked, exact-once, and route-owned",
     "e2e/console-net.spec.ts › console and HTTP error safety net › late responses retain exact Request ownership across a sink reset",
     "e2e/console-net.spec.ts › console and HTTP error safety net › structured console errors retain their source script URL",
     "e2e/console-net.spec.ts › console and HTTP error safety net › unexpected4xx() catches a broken plugin endpoint but not an allowlisted url",

--- a/e2e/spoiler-guard.spec.ts
+++ b/e2e/spoiler-guard.spec.ts
@@ -192,13 +192,15 @@ async function armToastWatcher(page: Page): Promise<void> {
         const obs = new MutationObserver((muts) => {
             for (const m of muts) {
                 for (const n of Array.from(m.addedNodes)) {
-                    if (n instanceof HTMLElement && n.classList.contains('jellyfin-canopy-toast')) {
+                    if (n instanceof HTMLElement
+                        && (n.classList.contains('jellyfin-canopy-toast')
+                            || n.querySelector('.jellyfin-canopy-toast'))) {
                         (window as any).__jeToastSeen = true;
                     }
                 }
             }
         });
-        obs.observe(document.body, { childList: true });
+        obs.observe(document.body, { childList: true, subtree: true });
         (window as any).__jeToastObs = obs;
     });
 }

--- a/scripts/bundle-budgets.json
+++ b/scripts/bundle-budgets.json
@@ -9,8 +9,8 @@
     "maxBootRawBytes": 524288,
     "maxBootGzipBytes": 196608,
     "maxColdHomeRequests": 24,
-    "maxColdHomeRawBytes": 183961,
-    "maxColdHomeGzipBytes": 62422,
+    "maxColdHomeRawBytes": 198920,
+    "maxColdHomeGzipBytes": 66652,
     "maxFeatureRequests": 16,
     "maxFeatureRawBytes": 524288,
     "maxFeatureGzipBytes": 196608,
@@ -20,6 +20,6 @@
     "maxSourceMapRawBytes": 6000000,
     "maxTotalRawBytes": 7000000,
     "maxClientManifestRawBytes": 262144,
-    "maxPublishedRawBytes": 7000000
+    "maxPublishedRawBytes": 7068652
   }
 }

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -25,12 +25,12 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         baselines.policy.description,
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
-    assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2337, totalLines: 2677 });
+    assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2701, totalLines: 3095 });
     assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 28559, totalLines: 37106 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 2,
-        minimumCoveredLines: 2337,
-        maximumCoveredLines: 2337,
+        minimumCoveredLines: 2701,
+        maximumCoveredLines: 2701,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
         cleanRuns: 7,

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -10,17 +10,17 @@
       "scope": "Jellyfin.Plugin.JellyfinCanopy/src/core/**",
       "report": "coverage/coverage-summary.json",
       "measured": {
-        "coveredLines": 2337,
-        "totalLines": 2677
+        "coveredLines": 2701,
+        "totalLines": 3095
       },
       "observations": {
         "cleanRuns": 2,
-        "minimumCoveredLines": 2337,
-        "maximumCoveredLines": 2337
+        "minimumCoveredLines": 2701,
+        "maximumCoveredLines": 2701
       },
       "tolerance": {
         "missingCoveredLines": 1,
-        "rationale": "Completing #171's cache-invalidation ownership adds ten instrumented and covered client/core lines so active or queued cacheable GETs are retired before invalidation and a stale response cannot publish after clearCache or clearCacheMatching. Two clean Node 22.20/V8 runs on 2026-08-01 each passed all 1,825 tests across 236 files and reproduced exactly 2,337/2,677, advancing the reviewed high-water from 2,327/2,667 (87.252%) to 2,337/2,677 (87.299%). Retaining the existing one-line tolerance makes the minimum 2,336/2,677 (87.262%), stricter than the prior 2,326/2,667 tolerated floor (87.214%). coverage-baseline.test.js retains the exact below-floor, above-baseline, scope-change, observed-high-water, and broad-tolerance negative boundaries."
+        "rationale": "Repairing #170's final accessibility audit findings adds 112 instrumented client/core lines beyond the initial candidate for presentation-callback tickets that link expiry, retry, and completion timing to spoken admission, a bounded terminal-saturation fallback, reason-aware focus teardown, and a newest-drain delegate that re-arms active or gap timers inherited from the pre-callback v1 document owner; 91 net added lines are covered. Two clean Node 22.20/V8 runs on 2026-08-01 each passed all 1,879 tests across 238 files and reproduced exactly 2,701/3,095, advancing the absolute reviewed high-water from 2,610 covered lines while moving the expanded-scope percentage from 87.496% to 87.270%. Retaining the one-line instrumentation tolerance makes the new floor 2,700/3,095 (87.237%) versus the former 2,609/2,983 (87.462%); this explicit 0.225-point change is reviewed lifecycle/backpressure scope growth, not a fixed-scope regression. coverage-baseline.test.js retains the exact below-floor, above-baseline, scope-change, observed-high-water, and broad-tolerance negative boundaries."
       }
     },
     "server": {


### PR DESCRIPTION
## Summary

- replace transient, visually owned toast announcements with one document-global notification owner
- provide typed polite/assertive announcements, ordered admission, deduplication, bounded terminal fallback, and generation-safe reinstall/teardown
- migrate actionable Hidden Content undo feedback so rapid actions are preserved, keyboard/focus timing is explicit, and reduced-motion behavior remains equivalent
- migrate notification consumers and localize the shared accessible status text across all 26 shipped locales
- add focused lifecycle, queue, saturation, reinstall, consumer, DOM, and E2E regressions

Fixes #170.

## Accessibility/runtime evidence

A clean production archive was exercised against a disposable Jellyfin 12 server. The shipped DOM exposed one owner with the expected polite/assertive/atomic/relevant semantics, and the notification phrase traversed Chromium → AT-SPI → Orca → Speech Dispatcher → espeak-ng → captured PulseAudio PCM. The disposable environment was fully torn down afterward; no deployment was performed.

## Validation

- `npm run typecheck:src` — pass
- `npm run validate-translations` — all 26 locales, 958/958 keys each
- `npm run test:client` — 1,879/1,879 across 238 files
- `npm run test:client:coverage` — exact reviewed high-water 2,701/3,095
- focused bundle/manifest/coverage tests — 28/28
- `npm run test:scripts` — 618/618
- two independent bundle builds — identical build ID `0ddc6f3ce7822849470d360fb91e43d953fec5b728f56456087026e5b52b044c`
- independent exact-head review — APPROVE
- `git diff --check` — clean

## Integration bookkeeping

The branch preserves #349's monotonic coverage policy and seven-run server envelope (28,557–28,559/37,106), while recording #170's exact 2,701/3,095 client profile. Current-main #340 blobs are unchanged.

No deployment is included.