### PR TITLE
Upgrade vulnerable PyMdown Extensions docs dependency

### DIFF
--- a/requirements-docs.in
+++ b/requirements-docs.in
@@ -1,5 +1,6 @@
 # Direct documentation dependencies. Regenerate requirements-docs.txt with
 # pip-tools 7.5.2 and pip 25.3 under the version in .python-version-docs:
 # pip-compile --generate-hashes --strip-extras --output-file=requirements-docs.txt requirements-docs.in
-mkdocs-material==9.6.12
+mkdocs-material==9.7.7
 mdx-truly-sane-lists==1.3
+pymdown-extensions==11.0.1

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -257,9 +257,9 @@ mkdocs-get-deps==0.2.2 \
     --hash=sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1 \
     --hash=sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650
     # via mkdocs
-mkdocs-material==9.6.12 \
-    --hash=sha256:92b4fbdc329e4febc267ca6e2c51e8501fa97b2225c5f4deb4d4e43550f8e61e \
-    --hash=sha256:add6a6337b29f9ea7912cb1efc661de2c369060b040eb5119855d794ea85b473
+mkdocs-material==9.7.7 \
+    --hash=sha256:8ea9bb1737a5b524a5f9dcf2e1b4ebda8274ae3008aa7845720a97083bef708f \
+    --hash=sha256:c0649c065b1b0512d60aad8c10f947f8e455284475239b364b610f2deb4d0855
     # via -r requirements-docs.in
 mkdocs-material-extensions==1.3.1 \
     --hash=sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443 \
@@ -285,10 +285,12 @@ pygments==2.20.0 \
     --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \
     --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
     # via mkdocs-material
-pymdown-extensions==10.21.3 \
-    --hash=sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354 \
-    --hash=sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6
-    # via mkdocs-material
+pymdown-extensions==11.0.1 \
+    --hash=sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2 \
+    --hash=sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0
+    # via
+    #   -r requirements-docs.in
+    #   mkdocs-material
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
     --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427


### PR DESCRIPTION
## Summary

- upgrade the documentation toolchain to `mkdocs-material==9.7.7`
- pin `pymdown-extensions==11.0.1`, which contains the fix for GHSA-9xwg-3r6f-jcx2
- preserve the existing hash-locked requirements workflow

## Security context

The affected `pymdown-extensions` version was reported through Dependabot. The vulnerable `b64` extension is not enabled by this repository, so this is a dependency-hardening fix rather than evidence of a runtime exploit.

## Validation

- Python 3.13.14 hash-locked install and `pip check`
- strict MkDocs build
- `npm run check:docs`
- focused documentation tests (34)
- repository script tests (618)
- toolchain validation
- `npm audit` (0 vulnerabilities)
- `pip-audit` against PyPI and OSV (no known vulnerabilities)
- baseline-versus-candidate generated docs comparison: 75 files, zero byte differences
- verified `b64` remains absent from `mkdocs.yml`

No deployment was performed.

Fixes #544