### PR TITLE
Fix detached notification timer teardown

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/ui-kit.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/ui-kit.test.ts
@@ -312,6 +312,51 @@ describe('toast scheduling', () => {
         expect(document.querySelectorAll('.jc-notification')).toHaveLength(3);
     });
 
+    it('retires the announcement queue if its browser realm disappears between dwell and gap', () => {
+        vi.useFakeTimers();
+        queueNotificationAnnouncementForTesting('Active before teardown', 'info', 'active-before-teardown');
+        queueNotificationAnnouncementForTesting('Pending before teardown', 'info', 'pending-before-teardown');
+        const runtime = Reflect.get(
+            window,
+            Symbol.for('JellyfinCanopy.notificationRuntime.v1')
+        ) as {
+            announcements: unknown[];
+            announcementTimer: number | null;
+            announcementActive: boolean;
+            announcementInGap: boolean;
+            activeAnnouncementKey: string | null;
+            activeAnnouncementAdmission: string | null;
+        };
+        expect(runtime.announcementActive).toBe(true);
+        expect(runtime.announcements).toHaveLength(1);
+
+        let callbackError: unknown;
+        vi.stubGlobal('window', undefined);
+        vi.stubGlobal('document', undefined);
+        try {
+            vi.advanceTimersByTime(500);
+        } catch (error) {
+            callbackError = error;
+        } finally {
+            vi.unstubAllGlobals();
+        }
+
+        expect(callbackError).toBeUndefined();
+        expect(runtime.announcements).toHaveLength(0);
+        expect(runtime.announcementTimer).toBeNull();
+        expect(runtime.announcementActive).toBe(false);
+        expect(runtime.announcementInGap).toBe(false);
+        expect(runtime.activeAnnouncementKey).toBeNull();
+        expect(runtime.activeAnnouncementAdmission).toBeNull();
+
+        expect(queueNotificationAnnouncementForTesting(
+            'Recovered after teardown',
+            'info',
+            'recovered-after-teardown'
+        )).toBe('queued');
+        expect(runtime.announcementActive).toBe(true);
+    });
+
     it('coalesces an explicit duplicate key in first-seen order', () => {
         vi.useFakeTimers();
         notify({ message: 'First copy', duration: 2_000, dedupeKey: 'same-event' });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/ui-kit.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/ui-kit.ts
@@ -351,6 +351,15 @@ function presentationCallbacksFor(announcement: Announcement): Array<() => void>
     return announcement.presentedCallbacks;
 }
 
+function resetAnnouncementQueueState(): void {
+    notificationRuntime.announcements.length = 0;
+    notificationRuntime.announcementTimer = null;
+    notificationRuntime.announcementActive = false;
+    notificationRuntime.announcementInGap = false;
+    notificationRuntime.activeAnnouncementKey = null;
+    notificationRuntime.activeAnnouncementAdmission = null;
+}
+
 function clearCentralAnnouncementLanes(): void {
     if (typeof document === 'undefined') return;
     document.getElementById(NOTIFICATION_OWNER_ID)
@@ -359,6 +368,10 @@ function clearCentralAnnouncementLanes(): void {
 }
 
 function scheduleAnnouncementGap(): void {
+    if (typeof document === 'undefined' || typeof window === 'undefined') {
+        resetAnnouncementQueueState();
+        return;
+    }
     notificationRuntime.announcementTimer = window.setTimeout(() => {
         notificationRuntime.announcementTimer = null;
         notificationRuntime.announcementInGap = false;
@@ -384,12 +397,7 @@ function drainAnnouncements(): void {
     // A real timer may outlive a jsdom document or a host WebView teardown.
     // Retire the detached queue without touching missing globals.
     if (typeof document === 'undefined' || typeof window === 'undefined') {
-        notificationRuntime.announcements.length = 0;
-        notificationRuntime.announcementTimer = null;
-        notificationRuntime.announcementActive = false;
-        notificationRuntime.announcementInGap = false;
-        notificationRuntime.activeAnnouncementKey = null;
-        notificationRuntime.activeAnnouncementAdmission = null;
+        resetAnnouncementQueueState();
         return;
     }
     // Queue admission enforces this invariant. Keep the bounded compare here
@@ -542,15 +550,10 @@ export function queueTerminalNotificationAnnouncementForTesting(
 }
 
 function clearAnnouncements(): void {
-    notificationRuntime.announcements.length = 0;
     if (notificationRuntime.announcementTimer != null) {
         clearTimeout(notificationRuntime.announcementTimer);
     }
-    notificationRuntime.announcementTimer = null;
-    notificationRuntime.announcementActive = false;
-    notificationRuntime.announcementInGap = false;
-    notificationRuntime.activeAnnouncementKey = null;
-    notificationRuntime.activeAnnouncementAdmission = null;
+    resetAnnouncementQueueState();
     if (typeof document !== 'undefined') {
         const owner = document.getElementById(NOTIFICATION_OWNER_ID);
         owner?.querySelectorAll<HTMLElement>('[data-jc-announcer]')

--- a/scripts/bundle-budgets.json
+++ b/scripts/bundle-budgets.json
@@ -9,8 +9,8 @@
     "maxBootRawBytes": 524288,
     "maxBootGzipBytes": 196608,
     "maxColdHomeRequests": 24,
-    "maxColdHomeRawBytes": 198920,
-    "maxColdHomeGzipBytes": 66652,
+    "maxColdHomeRawBytes": 198837,
+    "maxColdHomeGzipBytes": 66650,
     "maxFeatureRequests": 16,
     "maxFeatureRawBytes": 524288,
     "maxFeatureGzipBytes": 196608,
@@ -20,6 +20,6 @@
     "maxSourceMapRawBytes": 6000000,
     "maxTotalRawBytes": 7000000,
     "maxClientManifestRawBytes": 262144,
-    "maxPublishedRawBytes": 7068652
+    "maxPublishedRawBytes": 7068544
   }
 }

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -25,12 +25,12 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         baselines.policy.description,
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
-    assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2701, totalLines: 3095 });
+    assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2705, totalLines: 3094 });
     assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 28559, totalLines: 37106 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 2,
-        minimumCoveredLines: 2701,
-        maximumCoveredLines: 2701,
+        minimumCoveredLines: 2705,
+        maximumCoveredLines: 2705,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
         cleanRuns: 7,

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -10,17 +10,17 @@
       "scope": "Jellyfin.Plugin.JellyfinCanopy/src/core/**",
       "report": "coverage/coverage-summary.json",
       "measured": {
-        "coveredLines": 2701,
-        "totalLines": 3095
+        "coveredLines": 2705,
+        "totalLines": 3094
       },
       "observations": {
         "cleanRuns": 2,
-        "minimumCoveredLines": 2701,
-        "maximumCoveredLines": 2701
+        "minimumCoveredLines": 2705,
+        "maximumCoveredLines": 2705
       },
       "tolerance": {
         "missingCoveredLines": 1,
-        "rationale": "Repairing #170's final accessibility audit findings adds 112 instrumented client/core lines beyond the initial candidate for presentation-callback tickets that link expiry, retry, and completion timing to spoken admission, a bounded terminal-saturation fallback, reason-aware focus teardown, and a newest-drain delegate that re-arms active or gap timers inherited from the pre-callback v1 document owner; 91 net added lines are covered. Two clean Node 22.20/V8 runs on 2026-08-01 each passed all 1,879 tests across 238 files and reproduced exactly 2,701/3,095, advancing the absolute reviewed high-water from 2,610 covered lines while moving the expanded-scope percentage from 87.496% to 87.270%. Retaining the one-line instrumentation tolerance makes the new floor 2,700/3,095 (87.237%) versus the former 2,609/2,983 (87.462%); this explicit 0.225-point change is reviewed lifecycle/backpressure scope growth, not a fixed-scope regression. coverage-baseline.test.js retains the exact below-floor, above-baseline, scope-change, observed-high-water, and broad-tolerance negative boundaries."
+        "rationale": "Fixing #549 centralizes duplicate notification queue resets and adds an explicit detached-realm guard before the active-to-gap timer transition. The refactor contracts the instrumented client/core scope by one line while the deterministic teardown regression advances covered lines by four. Two clean Node 22.20/V8 runs on 2026-08-01 each passed all 1,880 tests across 238 files with zero unhandled errors and reproduced exactly 2,705/3,094 (87.427%), advancing the reviewed high-water from 2,701 covered lines. Retaining the one-line instrumentation tolerance makes the new floor 2,704/3,094 (87.395%), stricter than the prior 2,700/3,095 floor (87.237%). coverage-baseline.test.js retains the exact below-floor, above-baseline, scope-change, observed-high-water, and broad-tolerance negative boundaries."
       }
     },
     "server": {


### PR DESCRIPTION
## Summary

- fail closed when an accessible-notification dwell timer fires after its browser realm has been torn down
- centralize announcement queue state reset so detached drains, navigation/identity teardown, and the active-to-gap transition share one invariant
- add a deterministic fake-timer regression that removes `window` and `document` during the 500 ms dwell, verifies complete reset, and proves later recovery
- tighten the reviewed client coverage and bundle ratchets to the exact new measurements

## Validation

- focused notification/runtime tests: 53 passed
- source type-check: passed
- full client coverage twice: 238 files, 1,880 tests, zero unhandled errors, exactly 2,705/3,094 lines both runs
- coverage policy tests: passed
- script suite: 618 passed
- deterministic bundle twice:
  - build ID `937e3d464bfa190a532834634233d7b1278080bae1e8ae36dd6f76217815b6af`
  - cold Home: 198,837 raw / 66,650 gzip bytes
  - published: 7,068,544 bytes
- syntax, performance, toolchain, translations (26 × 958), npm audit, and advisory lint: passed
- two independent reviews approved the exact commit

No deployment was performed.

Fixes #549