### PR TITLE
Drain account-switch host sockets before teardown (#405)

### DIFF
--- a/e2e/account-switch.spec.ts
+++ b/e2e/account-switch.spec.ts
@@ -15,7 +15,12 @@ import {
     type ConsoleErrors,
     type FailedResponse,
 } from './fixtures/auth';
-import type { Page, Request, Route } from 'playwright/test';
+import type {
+    Page,
+    Request,
+    Route,
+    WebSocket as PlaywrightWebSocket,
+} from 'playwright/test';
 import {
     hasValidConcurrentLogoutResponses,
     isExpectedSignedOutHomeAxios401,
@@ -62,6 +67,11 @@ type LogoutSegment = Extract<Segment, 'logout-a1' | 'logout-b1' | 'logout-a2'>;
 interface DocumentIdentity {
     marker: string;
     timeOrigin: number;
+}
+
+interface HostSocketTracker {
+    openCount(): number;
+    dispose(): void;
 }
 
 interface LoginResult {
@@ -178,6 +188,51 @@ function normalizeIdentityPart(value: unknown): string {
     return String(value ?? '').trim().replace(/-/g, '').toLowerCase();
 }
 
+/**
+ * Track only the stock Jellyfin notification socket, never its credential-bearing
+ * query string. Waiting for every observed socket to close prevents a new login
+ * from overlapping the previous same-device session in the upstream server.
+ */
+function trackHostSockets(page: Page): HostSocketTracker {
+    const open = new Set<PlaywrightWebSocket>();
+    const onWebSocket = (socket: PlaywrightWebSocket): void => {
+        let isHostSocket = false;
+        try {
+            isHostSocket = new URL(socket.url()).pathname === '/socket';
+        } catch {
+            // A malformed URL cannot be the exact stock Jellyfin socket.
+        }
+        if (!isHostSocket) return;
+        open.add(socket);
+        socket.once('close', () => open.delete(socket));
+    };
+    page.on('websocket', onWebSocket);
+
+    let disposed = false;
+    return {
+        openCount: () => open.size,
+        dispose: () => {
+            if (disposed) return;
+            disposed = true;
+            page.off('websocket', onWebSocket);
+            open.clear();
+        },
+    };
+}
+
+async function waitForHostSocketDrain(
+    sockets: HostSocketTracker,
+    label: string
+): Promise<void> {
+    await expect.poll(
+        () => sockets.openCount(),
+        {
+            message: `${label}: every page-owned Jellyfin socket closes before the next identity`,
+            timeout: 15_000,
+        }
+    ).toBe(0);
+}
+
 function parseUserFileRequest(request: Request, segment: Segment): UserFileRequest | null {
     const match = new URL(request.url()).pathname.match(ACCOUNT_SWITCH_PATH);
     if (!match) return null;
@@ -289,7 +344,8 @@ async function readDiagnostics(page: Page): Promise<Diagnostics> {
 async function spaLogout(
     page: Page,
     documentIdentity: DocumentIdentity,
-    oldToken: string
+    oldToken: string,
+    sockets: HostSocketTracker
 ): Promise<LogoutEvidence> {
     const origin = new URL(page.url()).origin;
     const clientDeviceId = await page.evaluate(
@@ -493,6 +549,11 @@ async function spaLogout(
             signedOut.oldTokenStatus,
             'the pre-logout access token is independently revoked'
         ).toBe(401);
+        // Jellyfin server #16457 can terminate when two callbacks dispose the
+        // same session controller concurrently. Dashboard.logout() initiates
+        // the socket close asynchronously, so HTTP/logout completion alone is
+        // not a safe boundary before the same device authenticates again.
+        await waitForHostSocketDrain(sockets, 'logout');
         await expectSameDocument(page, documentIdentity);
         return {
             epoch: state.epoch,
@@ -760,7 +821,8 @@ function collectProvenDelayedLogoutFailures(
 function assertOnlyHostLogoutNoise(
     consoleErrors: ConsoleErrors,
     label: string,
-    evidence: LogoutEvidence
+    evidence: LogoutEvidence,
+    allowExpectedIdentityAbort = false
 ): void {
     expect(
         consoleErrors.unexpected5xx(),
@@ -775,7 +837,7 @@ function assertOnlyHostLogoutNoise(
         && isExpectedSignedOutHostLogout4xx(response, evidence));
     const unexpectedDetails = consoleErrors.realDetails().filter((detail) =>
         !HOST_LOGOUT_NOISE.test(detail.text)
-        && !EXPECTED_IDENTITY_ABORT.test(detail.text)
+        && !(allowExpectedIdentityAbort && EXPECTED_IDENTITY_ABORT.test(detail.text))
         && !isExpectedSignedOutHomeAxios401(detail, evidence, hasAllowedHost401)
         && !(syncPlay400 && /Failed to load resource:.*status of 400 \(Bad Request\)/i.test(detail.text)));
     expect(
@@ -794,6 +856,8 @@ test.describe('no-reload account identity switching', () => {
         consoleErrors,
     }) => {
         test.slow();
+        const hostSockets = trackHostSockets(page);
+        page.once('close', hostSockets.dispose);
         await loginAs(page, 'admin', consoleErrors);
         const documentIdentity = await installDocumentIdentity(page);
         const a1 = await currentIdentity(page);
@@ -1017,7 +1081,7 @@ test.describe('no-reload account identity switching', () => {
         }
 
         segment = 'logout-a1';
-        const logoutA1 = await spaLogout(page, documentIdentity, a1Token);
+        const logoutA1 = await spaLogout(page, documentIdentity, a1Token, hostSockets);
         const logoutA1Epoch = logoutA1.epoch;
         const logoutA1Phase: CompletedLogoutPhase = {
             evidence: logoutA1,
@@ -1055,7 +1119,12 @@ test.describe('no-reload account identity switching', () => {
             ),
             'the induced save race reports only the expected identity abort'
         ).toEqual([]);
-        assertOnlyHostLogoutNoise(consoleErrors, 'A1 logout / held-save abort', logoutA1);
+        assertOnlyHostLogoutNoise(
+            consoleErrors,
+            'A1 logout / held-save abort',
+            logoutA1,
+            true
+        );
 
         // Hold one exact stock signed-out request past both the completed A1
         // logout evidence and the B1 authentication boundary. This reproduces
@@ -1150,7 +1219,7 @@ test.describe('no-reload account identity switching', () => {
         assertNoRuntimeErrors(consoleErrors);
         consoleErrors.reset();
         segment = 'logout-b1';
-        const logoutB1 = await spaLogout(page, documentIdentity, b1Login.token);
+        const logoutB1 = await spaLogout(page, documentIdentity, b1Login.token, hostSockets);
         const logoutB1Epoch = logoutB1.epoch;
         const logoutB1Phase: CompletedLogoutPhase = {
             evidence: logoutB1,
@@ -1197,7 +1266,7 @@ test.describe('no-reload account identity switching', () => {
         assertNoRuntimeErrors(consoleErrors);
         consoleErrors.reset();
         segment = 'logout-a2';
-        const logoutA2 = await spaLogout(page, documentIdentity, a2Login.token);
+        const logoutA2 = await spaLogout(page, documentIdentity, a2Login.token, hostSockets);
         const logoutA2Epoch = logoutA2.epoch;
         const logoutA2Phase: CompletedLogoutPhase = {
             evidence: logoutA2,
@@ -1207,7 +1276,12 @@ test.describe('no-reload account identity switching', () => {
         };
         completedLogoutPhases.push(logoutA2Phase);
         expect(logoutA2Epoch).toBeGreaterThan(a2.epoch);
-        assertOnlyHostLogoutNoise(consoleErrors, 'A2 logout / held-loader abort', logoutA2);
+        assertOnlyHostLogoutNoise(
+            consoleErrors,
+            'A2 logout / held-loader abort',
+            logoutA2,
+            true
+        );
 
         // Reproduce #340 without a timer: hold the real B2 authentication
         // request, start three host requests while beginSpaLogin is awaiting
@@ -1544,6 +1618,23 @@ test.describe('no-reload account identity switching', () => {
         // These failures exist only as negative controls. Remove their exact
         // fixture objects after proving the production gate kept all three fatal.
         consoleErrors.acknowledgeExpected4xx(remainingB2Failures);
+        // Playwright otherwise closes the authenticated B2 page immediately.
+        // Perform the same evidence-backed native logout used by every earlier
+        // phase, drain its socket, then close the page so no request or console
+        // event can arrive after the final strict diagnostic gate (#405).
+        const finalB2Logout = await spaLogout(
+            page,
+            documentIdentity,
+            b2Login.token,
+            hostSockets
+        );
+        await page.close();
+        assertOnlyHostLogoutNoise(consoleErrors, 'final B2 logout', finalB2Logout);
+        const expectedFinalB2Failures = consoleErrors.unexpected4xx().filter((response) =>
+            isExpectedSignedOutHostLogout4xx(response, finalB2Logout));
+        consoleErrors.acknowledgeExpected4xx(expectedFinalB2Failures);
+        consoleErrors.reset();
         assertNoRuntimeErrors(consoleErrors);
+        hostSockets.dispose();
     });
 });

--- a/scripts/e2e/jellyfin-host-noise.test.js
+++ b/scripts/e2e/jellyfin-host-noise.test.js
@@ -549,6 +549,18 @@ test('account switching scopes logout Axios noise to the phase-local response cl
     assert.match(source, /const b1Login = await beginAuthenticationTransition\(logoutA1Phase, 'user'\)/);
     assert.match(source, /const a2Login = await beginAuthenticationTransition\(logoutB1Phase, 'admin'\)/);
 
+    // Upstream Jellyfin #16457 can crash when overlapping same-device socket
+    // closures race session disposal. The account-switch test must observe all
+    // stock /socket instances, drain them after every logout, and explicitly
+    // close/drain final B2 before Playwright tears the page down.
+    assert.match(source, /new URL\(socket\.url\(\)\)\.pathname === '\/socket'/);
+    assert.match(source, /const hostSockets = trackHostSockets\(page\);[\s\S]{0,120}await loginAs\(page, 'admin'/);
+    assert.equal((source.match(/spaLogout\(page, documentIdentity, [^,]+, hostSockets\)/g) ?? []).length, 3);
+    assert.match(source, /await waitForHostSocketDrain\(sockets, 'logout'\)/);
+    assert.match(source, /const finalB2Logout = await spaLogout\([\s\S]{0,160}b2Login\.token,[\s\S]{0,80}hostSockets[\s\S]{0,80}\);\s*await page\.close\(\);/);
+    assert.match(source, /assertOnlyHostLogoutNoise\(consoleErrors, 'final B2 logout', finalB2Logout\);[\s\S]{0,300}acknowledgeExpected4xx\(expectedFinalB2Failures\);\s*consoleErrors\.reset\(\);\s*assertNoRuntimeErrors\(consoleErrors\);\s*hostSockets\.dispose\(\);/);
+    assert.doesNotMatch(source, /logoutCurrentHostSessionAndDrain/);
+
     // Selection remains the intersection of exact Request ownership, complete
     // phase evidence, exact host shape, and an absent/revoked credential.
     assert.match(source, /const phase = phases\.find\(\(\{ requests, authenticationTransitionRequests \}\) =>\s*requests\.has\(request\) \|\| authenticationTransitionRequests\.has\(request\)\)/);


### PR DESCRIPTION
## Summary

- track stock Jellyfin `/socket` connections during account-switch E2E coverage without exposing access-token query data
- drain those sockets after every host logout and close the final page before classifying shutdown noise
- keep the final runtime gate fail-closed by acknowledging only exact observed host 4xx noise and retaining every 5xx or unexpected error
- extend the static contract tests over the teardown ordering and classifier boundaries

Closes #405

## Validation

- `node --test scripts/e2e/jellyfin-host-noise.test.js` — 22/22
- `npm run typecheck`
- `npm run typecheck:src`
- `npm run lint -- --quiet`
- `git diff --check origin/main...HEAD`
- live account-switch E2E — 1/1
- repeated live account-switch E2E — 20/20, with no fatal/unhandled/concurrency/disposal/invalid-operation/synchronization-lock/WebSocket exception signature

A distinct pre-existing mixed Canopy/TanStack classifier defect found during review is tracked separately as #557.
