### PR TITLE
Enforce edition-aware watchlist access (#154)

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/ScheduledTasks/SeerrScheduledTaskPaginationTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/ScheduledTasks/SeerrScheduledTaskPaginationTests.cs
@@ -5,6 +5,7 @@ using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
 using Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr;
 using Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks;
+using Jellyfin.Plugin.JellyfinCanopy.Services;
 using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
@@ -133,6 +134,7 @@ public sealed class SeerrScheduledTaskPaginationTests
         var secondUser = new User("second-user", "provider", "password-provider");
         var movie = new Movie
         {
+            Id = Guid.NewGuid(),
             Name = "Staged movie",
             ProviderIds = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
@@ -198,7 +200,8 @@ public sealed class SeerrScheduledTaskPaginationTests
             new RecordingHttpClientFactory(handler),
             userConfigurationManager: null!,
             NullLogger<JellyfinToSeerrWatchlistSyncTask>.Instance,
-            configProvider);
+            configProvider,
+            new StubItemLookupService());
 
         await task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
 
@@ -302,7 +305,8 @@ public sealed class SeerrScheduledTaskPaginationTests
             new RecordingHttpClientFactory(handler),
             userConfigurationManager: null!,
             NullLogger<SeerrWatchlistSyncTask>.Instance,
-            provider);
+            provider,
+            new StubItemLookupService());
 
         var executeTask = task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
         await watchlistStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
@@ -384,11 +388,835 @@ public sealed class SeerrScheduledTaskPaginationTests
             new RecordingHttpClientFactory(handler),
             userConfigurationManager: null!,
             NullLogger<SeerrWatchlistSyncTask>.Instance,
-            provider);
+            provider,
+            StubItemLookupService.FromItems(new BaseItem[] { firstMovie, secondMovie }));
 
         await task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
 
         Assert.Equal(1, Volatile.Read(ref saveCalls));
+    }
+
+    [Fact]
+    public async Task SeerrToJellyfinTask_InaccessibleFirstUsesAccessibleAlternate()
+    {
+        var user = new User("alternate-sync-user", "provider", "password-provider");
+        var inaccessible = MovieWithTmdbId("Restricted cut", "701");
+        inaccessible.Id = Guid.Parse("00000000-0000-0000-0000-000000000021");
+        var accessible = MovieWithTmdbId("Accessible cut", "701");
+        accessible.Id = Guid.Parse("00000000-0000-0000-0000-000000000022");
+        var items = new BaseItem[] { inaccessible, accessible };
+        var handler = new RequestRoutingHandler(request => request.RequestUri!.AbsolutePath switch
+        {
+            "/api/v1/user" => UserMap(user, 7),
+            "/api/v1/user/7/watchlist" => Json(new
+            {
+                page = 1,
+                totalPages = 1,
+                totalResults = 1,
+                results = new[]
+                {
+                    new { tmdbId = 701, mediaType = "movie", title = "Alternate cut" },
+                },
+            }),
+            var path => throw new Xunit.Sdk.XunitException($"Unexpected path {path}."),
+        });
+        BaseItem? savedItem = null;
+        var userData = new StubUserDataManager
+        {
+            GetUserDataHook = (_, item) => new UserItemData
+            {
+                Key = item.Id.ToString("N"),
+                Likes = false,
+            },
+            SaveUserDataHook = (_, item, _, _, _) => savedItem = item,
+        };
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = _ => items,
+        };
+        var lookup = StubItemLookupService.FromItems(
+            items,
+            (ids, _) => ids.Where(id => id == accessible.Id).ToHashSet());
+        var task = new SeerrWatchlistSyncTask(
+            library,
+            new StubUserManager(user),
+            userData,
+            new RecordingHttpClientFactory(handler),
+            userConfigurationManager: null!,
+            NullLogger<SeerrWatchlistSyncTask>.Instance,
+            new FakePluginConfigProvider(new PluginConfiguration
+            {
+                SeerrEnabled = true,
+                SyncSeerrWatchlist = true,
+                AddRequestedMediaToWatchlist = false,
+                PreventWatchlistReAddition = false,
+                SeerrUrls = "http://only",
+                SeerrApiKey = "key",
+            }),
+            lookup);
+
+        await task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
+
+        Assert.Equal(2, lookup.ProviderQueryCount);
+        Assert.Equal(3, lookup.AccessQueryCount);
+        Assert.Equal(1, userData.GetUserDataBatchCallCount);
+        Assert.Equal(0, userData.GetUserDataCallCount);
+        Assert.Same(accessible, savedItem);
+    }
+
+    [Fact]
+    public async Task SeerrToJellyfinTask_AccessRevokedDuringOwnershipProofDoesNotSave()
+    {
+        var user = new User("revoked-sync-user", "provider", "password-provider");
+        var movie = MovieWithTmdbId("Revoked movie", "702");
+        var handler = new RequestRoutingHandler(request => request.RequestUri!.AbsolutePath switch
+        {
+            "/api/v1/user" => UserMap(user, 7),
+            "/api/v1/user/7/watchlist" => Json(new
+            {
+                page = 1,
+                totalPages = 1,
+                totalResults = 1,
+                results = new[]
+                {
+                    new { tmdbId = 702, mediaType = "movie", title = "Revoked movie" },
+                },
+            }),
+            var path => throw new Xunit.Sdk.XunitException($"Unexpected path {path}."),
+        });
+        var accessReads = 0;
+        var lookup = StubItemLookupService.FromItems(
+            new BaseItem[] { movie },
+            (ids, _) => Interlocked.Increment(ref accessReads) == 1
+                ? ids.ToHashSet()
+                : new HashSet<Guid>());
+        var saveCalls = 0;
+        var task = new SeerrWatchlistSyncTask(
+            new CountingLibraryManager
+            {
+                GetItemListHook = _ => new BaseItem[] { movie },
+            },
+            new StubUserManager(user),
+            new StubUserDataManager
+            {
+                GetUserDataHook = (_, item) => new UserItemData
+                {
+                    Key = item.Id.ToString("N"),
+                    Likes = false,
+                },
+                SaveUserDataHook = (_, _, _, _, _) => Interlocked.Increment(ref saveCalls),
+            },
+            new RecordingHttpClientFactory(handler),
+            userConfigurationManager: null!,
+            NullLogger<SeerrWatchlistSyncTask>.Instance,
+            new FakePluginConfigProvider(new PluginConfiguration
+            {
+                SeerrEnabled = true,
+                SyncSeerrWatchlist = true,
+                AddRequestedMediaToWatchlist = false,
+                PreventWatchlistReAddition = false,
+                SeerrUrls = "http://only",
+                SeerrApiKey = "key",
+            }),
+            lookup);
+
+        await task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
+
+        Assert.Equal(2, accessReads);
+        Assert.Equal(0, saveCalls);
+    }
+
+    [Fact]
+    public async Task SeerrToJellyfinTask_FirstUsersSaveRevokesSecondUsersAccess()
+    {
+        var firstUser = new User("first-revocation-user", "provider", "password-provider");
+        var secondUser = new User("second-revocation-user", "provider", "password-provider");
+        var movie = MovieWithTmdbId("Shared movie", "703");
+        var handler = new RequestRoutingHandler(request => request.RequestUri!.AbsolutePath switch
+        {
+            "/api/v1/user" => Json(new
+            {
+                results = new[]
+                {
+                    new { id = 7, jellyfinUserId = firstUser.Id },
+                    new { id = 8, jellyfinUserId = secondUser.Id },
+                },
+                pageInfo = new { page = 1, pages = 1, results = 2 },
+            }),
+            "/api/v1/user/7/watchlist" or "/api/v1/user/8/watchlist" => Json(new
+            {
+                page = 1,
+                totalPages = 1,
+                totalResults = 1,
+                results = new[]
+                {
+                    new { tmdbId = 703, mediaType = "movie", title = "Shared movie" },
+                },
+            }),
+            var path => throw new Xunit.Sdk.XunitException($"Unexpected path {path}."),
+        });
+        var secondUserRevoked = false;
+        var lookup = StubItemLookupService.FromItems(
+            new BaseItem[] { movie },
+            (ids, user) => user.Id == secondUser.Id && secondUserRevoked
+                ? new HashSet<Guid>()
+                : ids.ToHashSet());
+        var savedUsers = new List<Guid>();
+        var userData = new StubUserDataManager
+        {
+            GetUserDataHook = (_, item) => new UserItemData
+            {
+                Key = item.Id.ToString("N"),
+                Likes = false,
+            },
+            SaveUserDataHook = (user, _, _, _, _) =>
+            {
+                savedUsers.Add(user.Id);
+                secondUserRevoked = true;
+            },
+        };
+        var task = new SeerrWatchlistSyncTask(
+            new CountingLibraryManager
+            {
+                GetItemListHook = _ => new BaseItem[] { movie },
+            },
+            new StubUserManager(firstUser, secondUser),
+            userData,
+            new RecordingHttpClientFactory(handler),
+            userConfigurationManager: null!,
+            NullLogger<SeerrWatchlistSyncTask>.Instance,
+            new FakePluginConfigProvider(new PluginConfiguration
+            {
+                SeerrEnabled = true,
+                SyncSeerrWatchlist = true,
+                AddRequestedMediaToWatchlist = false,
+                PreventWatchlistReAddition = false,
+                SeerrUrls = "http://only",
+                SeerrApiKey = "key",
+            }),
+            lookup);
+
+        await task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
+
+        Assert.Equal(new[] { firstUser.Id }, savedUsers);
+        Assert.Equal(2, lookup.ProviderQueryCount);
+        Assert.Equal(6, lookup.AccessQueryCount);
+    }
+
+    [Fact]
+    public async Task SeerrToJellyfinTask_AlreadyLikedEditionDoesNotLikeAnotherCut()
+    {
+        var user = new User("existing-cut-user", "provider", "password-provider");
+        var unlikedEdition = MovieWithTmdbId("Unliked cut", "704");
+        unlikedEdition.Id = Guid.Parse("00000000-0000-0000-0000-000000000023");
+        var likedEdition = MovieWithTmdbId("Liked cut", "704");
+        likedEdition.Id = Guid.Parse("00000000-0000-0000-0000-000000000024");
+        var items = new BaseItem[] { unlikedEdition, likedEdition };
+        var handler = new RequestRoutingHandler(request => request.RequestUri!.AbsolutePath switch
+        {
+            "/api/v1/user" => UserMap(user, 7),
+            "/api/v1/user/7/watchlist" => Json(new
+            {
+                page = 1,
+                totalPages = 1,
+                totalResults = 1,
+                results = new[]
+                {
+                    new { tmdbId = 704, mediaType = "movie", title = "Existing cut" },
+                },
+            }),
+            var path => throw new Xunit.Sdk.XunitException($"Unexpected path {path}."),
+        });
+        var saveCount = 0;
+        var userData = new StubUserDataManager
+        {
+            GetUserDataBatchHook = (accessibleItems, _) => accessibleItems.ToDictionary(
+                static item => item.Id,
+                item => new UserItemData
+                {
+                    Key = item.Id.ToString("N"),
+                    Likes = item.Id == likedEdition.Id,
+                }),
+            SaveUserDataHook = (_, _, _, _, _) => saveCount++,
+        };
+        var lookup = StubItemLookupService.FromItems(items);
+        var task = new SeerrWatchlistSyncTask(
+            new CountingLibraryManager
+            {
+                GetItemListHook = _ => items,
+            },
+            new StubUserManager(user),
+            userData,
+            new RecordingHttpClientFactory(handler),
+            userConfigurationManager: null!,
+            NullLogger<SeerrWatchlistSyncTask>.Instance,
+            new FakePluginConfigProvider(new PluginConfiguration
+            {
+                SeerrEnabled = true,
+                SyncSeerrWatchlist = true,
+                AddRequestedMediaToWatchlist = false,
+                PreventWatchlistReAddition = false,
+                SeerrUrls = "http://only",
+                SeerrApiKey = "key",
+            }),
+            lookup);
+
+        await task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
+
+        Assert.Equal(0, saveCount);
+        Assert.Equal(1, userData.GetUserDataBatchCallCount);
+        Assert.Equal(3, lookup.AccessQueryCount);
+    }
+
+    [Fact]
+    public async Task SeerrToJellyfinTask_UnlikeAtFinalAccessBarrierSavesBeforeMarker()
+    {
+        var baseDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "jc-watchlist-scheduled-live-data-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(baseDirectory);
+        try
+        {
+            var user = new User("scheduled-unlike-user", "provider", "password-provider");
+            var movie = MovieWithTmdbId("Scheduled unlike", "705");
+            var handler = new RequestRoutingHandler(request => request.RequestUri!.AbsolutePath switch
+            {
+                "/api/v1/user" => UserMap(user, 7),
+                "/api/v1/user/7/watchlist" => Json(new
+                {
+                    page = 1,
+                    totalPages = 1,
+                    totalResults = 1,
+                    results = new[]
+                    {
+                        new { tmdbId = 705, mediaType = "movie", title = "Scheduled unlike" },
+                    },
+                }),
+                var path => throw new Xunit.Sdk.XunitException($"Unexpected path {path}."),
+            });
+            var unliked = false;
+            var lookup = StubItemLookupService.FromItems(new BaseItem[] { movie });
+            lookup.BeforeAccessQuery = count =>
+            {
+                if (count == 3)
+                {
+                    unliked = true;
+                }
+            };
+            var saveCount = 0;
+            var userData = new StubUserDataManager
+            {
+                GetUserDataBatchHook = (items, _) => items.ToDictionary(
+                    static item => item.Id,
+                    item => new UserItemData
+                    {
+                        Key = item.Id.ToString("N"),
+                        Likes = !unliked,
+                    }),
+                SaveUserDataHook = (_, _, data, _, _) =>
+                {
+                    Assert.True(data.Likes);
+                    saveCount++;
+                },
+            };
+            var userConfiguration = new UserConfigurationManager(
+                new StubAppPaths(baseDirectory),
+                NullLogger<UserConfigurationManager>.Instance);
+            var task = new SeerrWatchlistSyncTask(
+                new CountingLibraryManager
+                {
+                    GetItemListHook = _ => new BaseItem[] { movie },
+                },
+                new StubUserManager(user),
+                userData,
+                new RecordingHttpClientFactory(handler),
+                userConfiguration,
+                NullLogger<SeerrWatchlistSyncTask>.Instance,
+                new FakePluginConfigProvider(new PluginConfiguration
+                {
+                    SeerrEnabled = true,
+                    SyncSeerrWatchlist = true,
+                    AddRequestedMediaToWatchlist = false,
+                    PreventWatchlistReAddition = true,
+                    SeerrUrls = "http://only",
+                    SeerrApiKey = "key",
+                }),
+                lookup);
+
+            await task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
+
+            Assert.True(unliked);
+            Assert.Equal(1, saveCount);
+            var marker = Assert.Single(
+                userConfiguration.GetProcessedWatchlistItems(user.Id).Items);
+            Assert.Equal("sync", marker.Source);
+            Assert.Equal(705, marker.TmdbId);
+        }
+        finally
+        {
+            Directory.Delete(baseDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task JellyfinToSeerrTask_ExportsOnlyEachUsersAccessibleLikes()
+    {
+        var firstUser = new User("first-scope", "provider", "password-provider");
+        var secondUser = new User("second-scope", "provider", "password-provider");
+        var firstMovie = MovieWithTmdbId("First scope movie", "801");
+        firstMovie.Id = Guid.Parse("00000000-0000-0000-0000-000000000031");
+        var firstUsersSecondMovie = MovieWithTmdbId("First scope sequel", "803");
+        firstUsersSecondMovie.Id = Guid.Parse("00000000-0000-0000-0000-000000000033");
+        var secondMovie = MovieWithTmdbId("Second scope movie", "802");
+        secondMovie.Id = Guid.Parse("00000000-0000-0000-0000-000000000032");
+        var secondUsersSecondMovie = MovieWithTmdbId("Second scope sequel", "804");
+        secondUsersSecondMovie.Id = Guid.Parse("00000000-0000-0000-0000-000000000034");
+        var movies = new[]
+        {
+            firstMovie,
+            firstUsersSecondMovie,
+            secondMovie,
+            secondUsersSecondMovie,
+        };
+        var posts = new List<(string UserId, int TmdbId)>();
+        var handler = new RequestRoutingHandler(request =>
+        {
+            var path = request.RequestUri!.AbsolutePath;
+            if (path == "/api/v1/user")
+            {
+                return Json(new
+                {
+                    results = new[]
+                    {
+                        new { id = 7, jellyfinUserId = firstUser.Id },
+                        new { id = 8, jellyfinUserId = secondUser.Id },
+                    },
+                    pageInfo = new { page = 1, pages = 1, results = 2 },
+                });
+            }
+
+            if (path is "/api/v1/user/7/watchlist" or "/api/v1/user/8/watchlist")
+            {
+                return EmptyWatchlist();
+            }
+
+            if (path == "/api/v1/user/7")
+            {
+                return Json(new { id = 7, jellyfinUserId = firstUser.Id });
+            }
+
+            if (path == "/api/v1/user/8")
+            {
+                return Json(new { id = 8, jellyfinUserId = secondUser.Id });
+            }
+
+            if (request.Method == HttpMethod.Post && path == "/api/v1/watchlist")
+            {
+                var apiUser = Assert.Single(request.Headers.GetValues("X-Api-User"));
+                using var body = JsonDocument.Parse(
+                    request.Content!.ReadAsStringAsync().GetAwaiter().GetResult());
+                posts.Add((apiUser, body.RootElement.GetProperty("tmdbId").GetInt32()));
+                return Json(new { id = 1 });
+            }
+
+            throw new Xunit.Sdk.XunitException($"Unexpected request {request.Method} {request.RequestUri}.");
+        });
+        var lookup = StubItemLookupService.FromItems(
+            movies,
+            (ids, user) => ids.Where(id => user.Id == firstUser.Id
+                    ? id == firstMovie.Id || id == firstUsersSecondMovie.Id
+                    : id == secondMovie.Id || id == secondUsersSecondMovie.Id)
+                .ToHashSet());
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = query => query.IncludeItemTypes.Contains(Jellyfin.Data.Enums.BaseItemKind.Movie)
+                ? movies.Cast<BaseItem>().ToArray()
+                : Array.Empty<BaseItem>(),
+        };
+        var userData = new StubUserDataManager
+        {
+            GetUserDataHook = (_, item) => new UserItemData
+            {
+                Key = item.Id.ToString("N"),
+                Likes = true,
+            },
+        };
+        var task = new JellyfinToSeerrWatchlistSyncTask(
+            library,
+            new StubUserManager(firstUser, secondUser),
+            userData,
+            new RecordingHttpClientFactory(handler),
+            userConfigurationManager: null!,
+            NullLogger<JellyfinToSeerrWatchlistSyncTask>.Instance,
+            new FakePluginConfigProvider(OutboundConfig()),
+            lookup);
+
+        await task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
+
+        Assert.Equal(
+            new[] { ("7", 801), ("7", 803), ("8", 802), ("8", 804) },
+            posts);
+        Assert.Equal(1, lookup.ProviderQueryCount);
+        Assert.Equal(8, lookup.AccessQueryCount);
+        Assert.Equal(8, userData.GetUserDataBatchCallCount);
+        Assert.Equal(0, userData.GetUserDataCallCount);
+    }
+
+    [Theory]
+    [InlineData("access")]
+    [InlineData("like")]
+    public async Task JellyfinToSeerrTask_FirstPostRevocationSuppressesSecondPost(
+        string revocation)
+    {
+        var user = new User("late-revocation-user", "provider", "password-provider");
+        var firstMovie = MovieWithTmdbId("First late movie", "805");
+        firstMovie.Id = Guid.Parse("00000000-0000-0000-0000-000000000035");
+        var secondMovie = MovieWithTmdbId("Second late movie", "806");
+        secondMovie.Id = Guid.Parse("00000000-0000-0000-0000-000000000036");
+        var movies = new[] { firstMovie, secondMovie };
+        var revoked = false;
+        var posts = new List<int>();
+        var handler = new RequestRoutingHandler(request =>
+        {
+            var path = request.RequestUri!.AbsolutePath;
+            if (path == "/api/v1/user") return UserMap(user, 7);
+            if (path == "/api/v1/user/7/watchlist") return EmptyWatchlist();
+            if (path == "/api/v1/user/7")
+            {
+                return Json(new { id = 7, jellyfinUserId = user.Id });
+            }
+
+            if (request.Method == HttpMethod.Post && path == "/api/v1/watchlist")
+            {
+                using var body = JsonDocument.Parse(
+                    request.Content!.ReadAsStringAsync().GetAwaiter().GetResult());
+                posts.Add(body.RootElement.GetProperty("tmdbId").GetInt32());
+                revoked = true;
+                return Json(new { id = 1 });
+            }
+
+            throw new Xunit.Sdk.XunitException($"Unexpected request {request.Method} {request.RequestUri}.");
+        });
+        var lookup = StubItemLookupService.FromItems(
+            movies,
+            (ids, _) => ids.Where(id => !(revoked
+                    && revocation == "access"
+                    && id == secondMovie.Id))
+                .ToHashSet());
+        var userData = new StubUserDataManager
+        {
+            GetUserDataHook = (_, item) => new UserItemData
+            {
+                Key = item.Id.ToString("N"),
+                Likes = !(revoked
+                    && revocation == "like"
+                    && item.Id == secondMovie.Id),
+            },
+        };
+        var task = new JellyfinToSeerrWatchlistSyncTask(
+            new CountingLibraryManager
+            {
+                GetItemListHook = query => query.IncludeItemTypes.Contains(
+                        Jellyfin.Data.Enums.BaseItemKind.Movie)
+                    ? movies.Cast<BaseItem>().ToArray()
+                    : Array.Empty<BaseItem>(),
+            },
+            new StubUserManager(user),
+            userData,
+            new RecordingHttpClientFactory(handler),
+            userConfigurationManager: null!,
+            NullLogger<JellyfinToSeerrWatchlistSyncTask>.Instance,
+            new FakePluginConfigProvider(OutboundConfig()),
+            lookup);
+
+        await task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
+
+        Assert.Equal(new[] { 805 }, posts);
+        Assert.Equal(1, lookup.ProviderQueryCount);
+        Assert.Equal(4, lookup.AccessQueryCount);
+        Assert.Equal(
+            revocation == "access" ? 3 : 4,
+            userData.GetUserDataBatchCallCount);
+    }
+
+    [Fact]
+    public async Task JellyfinToSeerrTask_FirstPostRebindSuppressesSecondPost()
+    {
+        var user = new User("late-rebind-user", "provider", "password-provider");
+        var reboundUserId = Guid.NewGuid();
+        var firstMovie = MovieWithTmdbId("First rebind movie", "807");
+        firstMovie.Id = Guid.Parse("00000000-0000-0000-0000-000000000037");
+        var secondMovie = MovieWithTmdbId("Second rebind movie", "808");
+        secondMovie.Id = Guid.Parse("00000000-0000-0000-0000-000000000038");
+        var movies = new[] { firstMovie, secondMovie };
+        var bindingReads = 0;
+        var rebound = false;
+        var posts = new List<int>();
+        var handler = new RequestRoutingHandler(request =>
+        {
+            var path = request.RequestUri!.AbsolutePath;
+            if (path == "/api/v1/user") return UserMap(user, 7);
+            if (path == "/api/v1/user/7/watchlist") return EmptyWatchlist();
+            if (path == "/api/v1/user/7")
+            {
+                bindingReads++;
+                return Json(new
+                {
+                    id = 7,
+                    jellyfinUserId = rebound ? reboundUserId : user.Id,
+                });
+            }
+
+            if (request.Method == HttpMethod.Post && path == "/api/v1/watchlist")
+            {
+                using var body = JsonDocument.Parse(
+                    request.Content!.ReadAsStringAsync().GetAwaiter().GetResult());
+                posts.Add(body.RootElement.GetProperty("tmdbId").GetInt32());
+                rebound = true;
+                return Json(new { id = 1 });
+            }
+
+            throw new Xunit.Sdk.XunitException($"Unexpected request {request.Method} {request.RequestUri}.");
+        });
+        var lookup = StubItemLookupService.FromItems(movies);
+        var userData = new StubUserDataManager
+        {
+            GetUserDataHook = (_, item) => new UserItemData
+            {
+                Key = item.Id.ToString("N"),
+                Likes = true,
+            },
+        };
+        var task = new JellyfinToSeerrWatchlistSyncTask(
+            new CountingLibraryManager
+            {
+                GetItemListHook = query => query.IncludeItemTypes.Contains(
+                        Jellyfin.Data.Enums.BaseItemKind.Movie)
+                    ? movies.Cast<BaseItem>().ToArray()
+                    : Array.Empty<BaseItem>(),
+            },
+            new StubUserManager(user),
+            userData,
+            new RecordingHttpClientFactory(handler),
+            userConfigurationManager: null!,
+            NullLogger<JellyfinToSeerrWatchlistSyncTask>.Instance,
+            new FakePluginConfigProvider(OutboundConfig()),
+            lookup);
+
+        await task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
+
+        Assert.Equal(new[] { 807 }, posts);
+        Assert.Equal(3, bindingReads);
+        Assert.Equal(1, lookup.ProviderQueryCount);
+        Assert.Equal(3, lookup.AccessQueryCount);
+        Assert.Equal(3, userData.GetUserDataBatchCallCount);
+        Assert.Equal(0, userData.GetUserDataCallCount);
+    }
+
+    [Fact]
+    public void JellyfinToSeerrTask_LateAuthorizationBudgetCountsPreflightAndMutationReads()
+    {
+        Assert.Equal(
+            3,
+            JellyfinToSeerrWatchlistSyncTask.LateAuthorizationQueriesPerMutation);
+
+        const int exactPreflightBindings = 2;
+        var exactMutations = JellyfinToSeerrWatchlistSyncTask.MaximumLateMutationAuthorizations;
+        Assert.Equal(
+            JellyfinToSeerrWatchlistSyncTask.MaximumLateAuthorizationQueries,
+            (exactMutations
+                * JellyfinToSeerrWatchlistSyncTask.LateAuthorizationQueriesPerMutation)
+                + exactPreflightBindings);
+        Assert.True(
+            JellyfinToSeerrWatchlistSyncTask.LateAuthorizationBudget.CanFit(
+                exactMutations,
+                exactPreflightBindings));
+        Assert.False(
+            JellyfinToSeerrWatchlistSyncTask.LateAuthorizationBudget.CanFit(
+                exactMutations,
+                exactPreflightBindings + 1));
+
+        var budget = new JellyfinToSeerrWatchlistSyncTask.LateAuthorizationBudget();
+        Assert.True(budget.TryReservePreflightBinding());
+        Assert.True(budget.TryReservePreflightBinding());
+        for (var index = 0; index < exactMutations; index++)
+        {
+            Assert.True(budget.TryReserveMutation());
+        }
+
+        Assert.Equal(
+            JellyfinToSeerrWatchlistSyncTask.MaximumLateAuthorizationQueries,
+            budget.ReservedQueries);
+        Assert.False(budget.TryReservePreflightBinding());
+        Assert.False(budget.TryReserveMutation());
+    }
+
+    [Theory]
+    [InlineData(WatchlistLibraryResolver.MaximumCandidates, true)]
+    [InlineData(WatchlistLibraryResolver.MaximumCandidates + 1, false)]
+    public async Task JellyfinToSeerrTask_LibrarySnapshotUsesBoundedPagesAtExactLimit(
+        int itemCount,
+        bool expectedComplete)
+    {
+        var movie = MovieWithTmdbId("Paged movie", "900");
+        var queries = new List<(int Start, int Limit)>();
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = query =>
+            {
+                Assert.InRange(
+                    query.Limit ?? 0,
+                    1,
+                    JellyfinToSeerrWatchlistSyncTask.LibraryEnumerationPageSize);
+                var start = query.StartIndex ?? 0;
+                queries.Add((start, query.Limit!.Value));
+                if (!query.IncludeItemTypes.Contains(Jellyfin.Data.Enums.BaseItemKind.Movie)
+                    || start >= itemCount)
+                {
+                    return Array.Empty<BaseItem>();
+                }
+
+                var count = Math.Min(query.Limit.Value, itemCount - start);
+                return Enumerable.Repeat<BaseItem>(movie, count).ToArray();
+            },
+        };
+        var destination = new List<(BaseItem item, string mediaType)>();
+
+        var complete = await JellyfinToSeerrWatchlistSyncTask.TryCollectLibraryItemsBoundedAsync(
+            library,
+            destination,
+            CancellationToken.None);
+
+        Assert.Equal(expectedComplete, complete);
+        Assert.Equal(itemCount, destination.Count);
+        Assert.All(
+            queries,
+            query => Assert.InRange(
+                query.Limit,
+                1,
+                JellyfinToSeerrWatchlistSyncTask.LibraryEnumerationPageSize));
+    }
+
+    [Fact]
+    public async Task JellyfinToSeerrTask_LibrarySnapshotObservesCancellationBetweenPages()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var movie = MovieWithTmdbId("Cancellation page", "901");
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = query =>
+            {
+                cancellation.Cancel();
+                return Enumerable.Repeat<BaseItem>(movie, query.Limit!.Value).ToArray();
+            },
+        };
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            JellyfinToSeerrWatchlistSyncTask.TryCollectLibraryItemsBoundedAsync(
+                library,
+                new List<(BaseItem item, string mediaType)>(),
+                cancellation.Token));
+        Assert.Equal(1, library.GetItemListCallCount);
+    }
+
+    [Fact]
+    public async Task JellyfinToSeerrTask_AccessRevokedDuringFreshBindingDoesNotExport()
+    {
+        var user = new User("revoked-export-user", "provider", "password-provider");
+        var movie = MovieWithTmdbId("Revoked export", "803");
+        var accessReads = 0;
+        var lookup = StubItemLookupService.FromItems(
+            new[] { movie },
+            (ids, _) => Interlocked.Increment(ref accessReads) == 1
+                ? ids.ToHashSet()
+                : new HashSet<Guid>());
+        var handler = new RequestRoutingHandler(request =>
+        {
+            var path = request.RequestUri!.AbsolutePath;
+            if (path == "/api/v1/user") return UserMap(user, 7);
+            if (path == "/api/v1/user/7/watchlist") return EmptyWatchlist();
+            if (path == "/api/v1/user/7")
+            {
+                return Json(new { id = 7, jellyfinUserId = user.Id });
+            }
+
+            if (request.Method == HttpMethod.Post) return Json(new { id = 1 });
+            throw new Xunit.Sdk.XunitException($"Unexpected request {request.Method} {request.RequestUri}.");
+        });
+        var task = CreateOutboundTask(user, new[] { movie }, handler, new FakePluginConfigProvider(OutboundConfig()), lookup);
+
+        await task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
+
+        Assert.Equal(2, accessReads);
+        Assert.DoesNotContain(handler.Requests, request => request.Method == HttpMethod.Post);
+    }
+
+    [Theory]
+    [InlineData("access")]
+    [InlineData("like")]
+    public async Task JellyfinToSeerrTask_FinalBindingReadRevocationSuppressesPost(
+        string revokedAuthority)
+    {
+        var user = new User("binding-window-user", "provider", "password-provider");
+        var movie = MovieWithTmdbId("Binding window movie", "809");
+        var revoked = false;
+        var bindingReads = 0;
+        var handler = new RequestRoutingHandler(request =>
+        {
+            var path = request.RequestUri!.AbsolutePath;
+            if (path == "/api/v1/user") return UserMap(user, 7);
+            if (path == "/api/v1/user/7/watchlist") return EmptyWatchlist();
+            if (path == "/api/v1/user/7")
+            {
+                if (Interlocked.Increment(ref bindingReads) == 2)
+                {
+                    revoked = true;
+                }
+
+                return Json(new { id = 7, jellyfinUserId = user.Id });
+            }
+
+            if (request.Method == HttpMethod.Post) return Json(new { id = 1 });
+            throw new Xunit.Sdk.XunitException(
+                $"Unexpected request {request.Method} {request.RequestUri}.");
+        });
+        var lookup = StubItemLookupService.FromItems(
+            new BaseItem[] { movie },
+            (ids, _) => revoked && revokedAuthority == "access"
+                ? new HashSet<Guid>()
+                : ids.ToHashSet());
+        var userData = new StubUserDataManager
+        {
+            GetUserDataHook = (_, item) => new UserItemData
+            {
+                Key = item.Id.ToString("N"),
+                Likes = !(revoked && revokedAuthority == "like"),
+            },
+        };
+        var task = new JellyfinToSeerrWatchlistSyncTask(
+            new CountingLibraryManager
+            {
+                GetItemListHook = query => query.IncludeItemTypes.Contains(
+                        Jellyfin.Data.Enums.BaseItemKind.Movie)
+                    ? new BaseItem[] { movie }
+                    : Array.Empty<BaseItem>(),
+            },
+            new StubUserManager(user),
+            userData,
+            new RecordingHttpClientFactory(handler),
+            userConfigurationManager: null!,
+            NullLogger<JellyfinToSeerrWatchlistSyncTask>.Instance,
+            new FakePluginConfigProvider(OutboundConfig()),
+            lookup);
+
+        await task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
+
+        Assert.Equal(2, bindingReads);
+        Assert.DoesNotContain(handler.Requests, request => request.Method == HttpMethod.Post);
+        Assert.Equal(3, lookup.AccessQueryCount);
+        Assert.Equal(
+            revokedAuthority == "access" ? 2 : 3,
+            userData.GetUserDataBatchCallCount);
     }
 
     [Theory]
@@ -402,6 +1230,7 @@ public sealed class SeerrScheduledTaskPaginationTests
         var user = new User("linked-user", "provider", "password-provider");
         var validMovie = new Movie
         {
+            Id = Guid.NewGuid(),
             Name = "Valid first movie",
             ProviderIds = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
@@ -410,6 +1239,7 @@ public sealed class SeerrScheduledTaskPaginationTests
         };
         var invalidMovie = new Movie
         {
+            Id = Guid.NewGuid(),
             Name = "Invalid later movie",
             ProviderIds = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
@@ -471,7 +1301,8 @@ public sealed class SeerrScheduledTaskPaginationTests
             new RecordingHttpClientFactory(handler),
             userConfigurationManager: null!,
             NullLogger<JellyfinToSeerrWatchlistSyncTask>.Instance,
-            configProvider);
+            configProvider,
+            new StubItemLookupService());
 
         await task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
 
@@ -609,7 +1440,9 @@ public sealed class SeerrScheduledTaskPaginationTests
         await task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
 
         Assert.Single(handler.Requests, request => request.Method == HttpMethod.Post);
-        Assert.Single(handler.Requests, request => request.Uri.AbsolutePath == "/api/v1/user/7");
+        Assert.Equal(
+            2,
+            handler.Requests.Count(request => request.Uri.AbsolutePath == "/api/v1/user/7"));
     }
 
     [Fact]
@@ -672,7 +1505,8 @@ public sealed class SeerrScheduledTaskPaginationTests
             new RecordingHttpClientFactory(handler),
             userConfigurationManager: null!,
             NullLogger<SeerrWatchlistSyncTask>.Instance,
-            configProvider);
+            configProvider,
+            new StubItemLookupService());
 
         await task.ExecuteAsync(new Progress<double>(), CancellationToken.None);
 
@@ -904,6 +1738,7 @@ public sealed class SeerrScheduledTaskPaginationTests
     private static Movie MovieWithTmdbId(string name, string tmdbId)
         => new()
         {
+            Id = Guid.NewGuid(),
             Name = name,
             ProviderIds = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
@@ -931,7 +1766,8 @@ public sealed class SeerrScheduledTaskPaginationTests
         User user,
         IReadOnlyList<Movie> movies,
         HttpMessageHandler handler,
-        FakePluginConfigProvider configProvider)
+        FakePluginConfigProvider configProvider,
+        StubItemLookupService? itemLookup = null)
     {
         var libraryManager = new CountingLibraryManager
         {
@@ -955,7 +1791,8 @@ public sealed class SeerrScheduledTaskPaginationTests
             new RecordingHttpClientFactory(handler),
             userConfigurationManager: null!,
             NullLogger<JellyfinToSeerrWatchlistSyncTask>.Instance,
-            configProvider);
+            configProvider,
+            itemLookup ?? new StubItemLookupService());
     }
 
     private static HttpResponseMessage Json(object body, HttpStatusCode status = HttpStatusCode.OK)

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/MonitorIdempotencyTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/MonitorIdempotencyTests.cs
@@ -30,7 +30,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
                 null!,
                 null!,
                 NullLogger<WatchlistMonitor>.Instance,
-                new FakePluginConfigProvider(WatchlistEnabled()));
+                new FakePluginConfigProvider(WatchlistEnabled()),
+                new StubItemLookupService());
 
             monitor.Initialize();
             monitor.Initialize();

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/MonitorSubscriptionLifecycleTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/MonitorSubscriptionLifecycleTests.cs
@@ -39,7 +39,8 @@ public sealed class MonitorSubscriptionLifecycleTests
                 null!,
                 null!,
                 NullLogger<WatchlistMonitor>.Instance,
-                Provider);
+                Provider,
+                new StubItemLookupService());
             AutoMovie = new AutoMovieRequestMonitor(
                 Sessions,
                 null!,

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrCacheTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrCacheTests.cs
@@ -111,7 +111,8 @@ public class SeerrCacheTests
             null!,
             null!,
             NullLogger<WatchlistMonitor>.Instance,
-            provider);
+            provider,
+            new StubItemLookupService());
         // Disabled auto monitors with null event sources: reconciliation must not
         // dereference session-manager events when no subscription exists or is desired.
         var autoMovie = new AutoMovieRequestMonitor(

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/WatchlistLibraryResolverTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/WatchlistLibraryResolverTests.cs
@@ -1,0 +1,564 @@
+using System.Collections;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.JellyfinCanopy.Data;
+using Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks;
+using Jellyfin.Plugin.JellyfinCanopy.Services;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Model.Entities;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services;
+
+public sealed class WatchlistLibraryResolverTests
+{
+    [Fact]
+    public void Resolve_InaccessibleLowestId_SelectsAccessibleAlternate()
+    {
+        var user = User("alternate-user");
+        var inaccessible = Movie(
+            "00000000-0000-0000-0000-000000000001",
+            101,
+            "Restricted cut");
+        var accessible = Movie(
+            "00000000-0000-0000-0000-000000000002",
+            101,
+            "Accessible cut");
+        var lookup = StubItemLookupService.FromItems(
+            new BaseItem[] { inaccessible, accessible },
+            (ids, _) => ids.Where(id => id == accessible.Id).ToHashSet());
+        var resolver = new WatchlistLibraryResolver(
+            new CountingLibraryManager
+            {
+                GetItemListHook = _ => new BaseItem[] { inaccessible, accessible },
+            },
+            lookup);
+
+        var batch = resolver.Resolve(
+            new[] { new WatchlistMediaKey("movie", 101) },
+            new[] { user });
+
+        Assert.True(batch.IsComplete);
+        Assert.Same(
+            accessible,
+            batch.Get(user, new WatchlistMediaKey("movie", 101)).SelectedItem);
+        Assert.Equal(1, lookup.ProviderQueryCount);
+        Assert.Equal(1, lookup.AccessQueryCount);
+    }
+
+    [Fact]
+    public void Resolve_NoAccessibleEdition_FailsClosed()
+    {
+        var user = User("no-access-user");
+        var movie = Movie(
+            "00000000-0000-0000-0000-000000000003",
+            102,
+            "Restricted movie");
+        var lookup = StubItemLookupService.FromItems(
+            new BaseItem[] { movie },
+            (_, _) => new HashSet<Guid>());
+        var resolver = new WatchlistLibraryResolver(new CountingLibraryManager(), lookup);
+
+        var match = resolver.Resolve(
+                new[] { new WatchlistMediaKey("movie", 102) },
+                new[] { user },
+                new BaseItem[] { movie })
+            .Get(user, new WatchlistMediaKey("movie", 102));
+
+        Assert.Equal(WatchlistLibraryMatchState.Inaccessible, match.State);
+        Assert.Null(match.SelectedItem);
+    }
+
+    [Fact]
+    public void Resolve_MovieAndTvNamespacesRemainTypeCorrect()
+    {
+        var user = User("namespace-user");
+        var movie = Movie(
+            "00000000-0000-0000-0000-000000000004",
+            103,
+            "Movie namespace");
+        var series = new Series
+        {
+            Id = Guid.Parse("00000000-0000-0000-0000-000000000005"),
+            Name = "TV namespace",
+        };
+        series.ProviderIds["Tmdb"] = "103";
+        var items = new BaseItem[] { movie, series };
+        var lookup = StubItemLookupService.FromItems(items);
+        var resolver = new WatchlistLibraryResolver(new CountingLibraryManager(), lookup);
+
+        var batch = resolver.Resolve(
+            new[]
+            {
+                new WatchlistMediaKey("movie", 103),
+                new WatchlistMediaKey("tv", 103),
+            },
+            new[] { user },
+            items);
+
+        Assert.Same(movie, batch.Get(user, new WatchlistMediaKey("movie", 103)).SelectedItem);
+        Assert.Same(series, batch.Get(user, new WatchlistMediaKey("tv", 103)).SelectedItem);
+    }
+
+    [Fact]
+    public void Resolve_ProviderPairLimitFailsClosedBeforeAccessProjection()
+    {
+        var user = User("bounded-user");
+        var lookup = new StubItemLookupService();
+        var resolver = new WatchlistLibraryResolver(new CountingLibraryManager(), lookup);
+        var keys = Enumerable.Range(
+                1,
+                WatchlistLibraryResolver.MaximumProviderPairs + 1)
+            .Select(static tmdbId => new WatchlistMediaKey("movie", tmdbId))
+            .ToList();
+
+        var batch = resolver.Resolve(keys, new[] { user });
+
+        Assert.False(batch.IsComplete);
+        Assert.Equal(1, lookup.ProviderQueryCount);
+        Assert.Equal(0, lookup.AccessQueryCount);
+    }
+
+    [Fact]
+    public void Resolve_UserKeyCrossProductLimitFailsBeforeConstructingOrQuerying()
+    {
+        var users = Enumerable.Range(1, 501)
+            .Select(index => User($"bounded-user-{index}"))
+            .ToList();
+        var keys = Enumerable.Range(1, 200)
+            .Select(static tmdbId => new WatchlistMediaKey("movie", tmdbId))
+            .ToList();
+        var lookup = new StubItemLookupService();
+        var resolver = new WatchlistLibraryResolver(new CountingLibraryManager(), lookup);
+
+        var batch = resolver.Resolve(keys, users);
+
+        Assert.False(batch.IsComplete);
+        Assert.Equal(0, lookup.ProviderQueryCount);
+        Assert.Equal(0, lookup.AccessQueryCount);
+    }
+
+    [Fact]
+    public void Resolve_AggregateCandidateProjectionLimitFailsBeforeAccessQueries()
+    {
+        var users = new[] { User("first"), User("second"), User("third") };
+        var candidates = Enumerable.Range(1, 83_334)
+            .Select(_ => new ItemLookupCandidate(
+                Guid.NewGuid(),
+                ItemLookupKind.Movie,
+                null,
+                false))
+            .ToList();
+        var lookup = new StubItemLookupService(
+            candidateProjection: providers => providers.ToDictionary(
+                static pair => pair,
+                _ => (IReadOnlyList<ItemLookupCandidate>)candidates));
+        var resolver = new WatchlistLibraryResolver(new CountingLibraryManager(), lookup);
+
+        var batch = resolver.Resolve(
+            new[] { new WatchlistMediaKey("movie", 301) },
+            users);
+
+        Assert.False(batch.IsComplete);
+        Assert.Equal(1, lookup.ProviderQueryCount);
+        Assert.Equal(0, lookup.AccessQueryCount);
+    }
+
+    [Fact]
+    public void Resolve_RepeatedRequestsEnumerateKnownEditionsOncePerDistinctMediaKey()
+    {
+        var user = User("repeated-binding-user");
+        var key = new WatchlistMediaKey("movie", 302);
+        var movie = Movie(
+            "00000000-0000-0000-0000-000000000008",
+            302,
+            "Repeated binding movie");
+        var knownEditions = new CountingReadOnlyCollection(new BaseItem[] { movie });
+        var lookup = StubItemLookupService.FromItems(new BaseItem[] { movie });
+        var resolver = new WatchlistLibraryResolver(new CountingLibraryManager(), lookup);
+        var requests = Enumerable.Repeat(
+                new WatchlistLibraryRequest(user, key),
+                20)
+            .ToList();
+
+        var batch = resolver.Resolve(
+            requests,
+            new Dictionary<WatchlistMediaKey, CountingReadOnlyCollection>
+            {
+                [key] = knownEditions,
+            });
+
+        Assert.True(batch.IsComplete);
+        Assert.Same(movie, batch.Get(user, key).SelectedItem);
+        Assert.Equal(1, knownEditions.EnumerationCount);
+        Assert.Equal(1, lookup.ProviderQueryCount);
+        Assert.Equal(1, lookup.AccessQueryCount);
+    }
+
+    [Fact]
+    public void Resolve_OversizedKnownEditionProjectionFailsBeforeEnumerationOrProviderQuery()
+    {
+        var user = User("oversized-known-user");
+        var key = new WatchlistMediaKey("movie", 303);
+        var knownEditions = new CountingReadOnlyCollection(
+            Array.Empty<BaseItem>(),
+            WatchlistLibraryResolver.MaximumCandidates + 1,
+            throwOnEnumeration: true);
+        var lookup = new StubItemLookupService();
+        var resolver = new WatchlistLibraryResolver(new CountingLibraryManager(), lookup);
+
+        var batch = resolver.Resolve(
+            new[] { new WatchlistLibraryRequest(user, key) },
+            new Dictionary<WatchlistMediaKey, CountingReadOnlyCollection>
+            {
+                [key] = knownEditions,
+            });
+
+        Assert.False(batch.IsComplete);
+        Assert.Equal(0, knownEditions.EnumerationCount);
+        Assert.Equal(0, lookup.ProviderQueryCount);
+        Assert.Equal(0, lookup.AccessQueryCount);
+    }
+
+    [Fact]
+    public void PrepareDispatchSelections_RepeatedBindingsEnumerateDistinctEditionSetLinearly()
+    {
+        var user = User("linear-selection-user");
+        var key = new WatchlistMediaKey("movie", 304);
+        var movie = Movie(
+            "00000000-0000-0000-0000-000000000009",
+            304,
+            "Linear selection movie");
+        var editions = new CountingReadOnlyList(new BaseItem[] { movie });
+        var library = new WatchlistLibraryBatch(
+            new Dictionary<Guid, IReadOnlyDictionary<WatchlistMediaKey, WatchlistLibraryMatch>>
+            {
+                [user.Id] = new Dictionary<WatchlistMediaKey, WatchlistLibraryMatch>
+                {
+                    [key] = new WatchlistLibraryMatch(
+                        WatchlistLibraryMatchState.Accessible,
+                        editions),
+                },
+            },
+            true);
+        var userData = new StubUserDataManager
+        {
+            GetUserDataBatchHook = (items, _) => items.ToDictionary(
+                static item => item.Id,
+                item => new UserItemData
+                {
+                    Key = item.Id.ToString("N"),
+                    Likes = true,
+                }),
+        };
+        var repeatedBindings = Enumerable.Repeat(
+                new WatchlistLibraryRequest(user, key),
+                20_000)
+            .ToList();
+
+        var selections = JellyfinToSeerrWatchlistSyncTask.PrepareDispatchSelections(
+            repeatedBindings,
+            library,
+            userData,
+            CancellationToken.None);
+
+        Assert.Same(movie, Assert.Single(selections).Value);
+        Assert.Equal(2, editions.EnumerationCount);
+        Assert.Equal(1, userData.GetUserDataBatchCallCount);
+        Assert.Equal(1, userData.GetUserDataBatchItemCount);
+    }
+
+    [Fact]
+    public void Resolve_MaterializesCandidateItemsInOneThousandItemBatches()
+    {
+        var user = User("materialization-user");
+        var key = new WatchlistMediaKey("movie", 305);
+        var items = Enumerable.Range(1, WatchlistLibraryResolver.MaterializationBatchSize + 1)
+            .Select(index => Movie(
+                $"00000000-0000-0000-0001-{index.ToString("D12", System.Globalization.CultureInfo.InvariantCulture)}",
+                305,
+                $"Materialized {index}"))
+            .Cast<BaseItem>()
+            .ToList();
+        var byId = items.ToDictionary(static item => item.Id);
+        var lookup = StubItemLookupService.FromItems(items);
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = query =>
+            {
+                Assert.InRange(
+                    query.ItemIds.Length,
+                    1,
+                    WatchlistLibraryResolver.MaterializationBatchSize);
+                Assert.Equal(query.ItemIds.Length + 1, query.Limit);
+                return query.ItemIds.Select(id => byId[id]).ToList();
+            },
+        };
+        var resolver = new WatchlistLibraryResolver(library, lookup);
+
+        var batch = resolver.Resolve(new[] { key }, new[] { user });
+
+        Assert.True(batch.IsComplete);
+        Assert.Equal(items.Count, batch.Get(user, key).AccessibleItems.Count);
+        Assert.Equal(2, library.GetItemListCallCount);
+    }
+
+    [Fact]
+    public void Resolve_CancellationAfterAccessQueryStopsBeforeNextUser()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var first = User("cancel-first");
+        var second = User("cancel-second");
+        var movie = Movie(
+            "00000000-0000-0000-0000-000000000010",
+            306,
+            "Cancellation movie");
+        var lookup = StubItemLookupService.FromItems(new BaseItem[] { movie });
+        lookup.BeforeAccessQuery = count =>
+        {
+            if (count == 1)
+            {
+                cancellation.Cancel();
+            }
+        };
+        var resolver = new WatchlistLibraryResolver(new CountingLibraryManager(), lookup);
+
+        Assert.Throws<OperationCanceledException>(() => resolver.Resolve(
+            new[] { new WatchlistMediaKey("movie", 306) },
+            new[] { first, second },
+            new BaseItem[] { movie },
+            cancellation.Token));
+        Assert.Equal(1, lookup.AccessQueryCount);
+    }
+
+    [Theory]
+    [InlineData(WatchlistLibraryResolver.AccessProjectionBatchSize, 1)]
+    [InlineData(WatchlistLibraryResolver.AccessProjectionBatchSize + 1, 2)]
+    public void GetAccessibleItemIdsBounded_ExactAndMaxPlusOneStayWithinBatchSize(
+        int itemCount,
+        int expectedQueries)
+    {
+        var user = User("bounded-access-user");
+        var itemIds = Enumerable.Range(1, itemCount)
+            .Select(DeterministicGuid)
+            .Reverse()
+            .ToList();
+        var lookup = new StubItemLookupService();
+        var resolver = new WatchlistLibraryResolver(new CountingLibraryManager(), lookup);
+
+        var accessibleIds = resolver.GetAccessibleItemIdsBounded(
+            itemIds,
+            user,
+            CancellationToken.None);
+
+        Assert.Equal(expectedQueries, lookup.AccessQueryCount);
+        Assert.All(
+            lookup.AccessQueryItemIds,
+            query => Assert.InRange(
+                query.Count,
+                1,
+                WatchlistLibraryResolver.AccessProjectionBatchSize));
+        Assert.Equal(
+            itemIds.OrderBy(static id => id),
+            lookup.AccessQueryItemIds.SelectMany(static query => query));
+        Assert.True(accessibleIds.SetEquals(itemIds));
+    }
+
+    [Fact]
+    public void Resolve_MaxPlusOneAccessProjectionUsesTwoBoundedQueries()
+    {
+        var user = User("resolve-bounded-access-user");
+        var key = new WatchlistMediaKey("movie", 307);
+        var items = Enumerable.Range(
+                1,
+                WatchlistLibraryResolver.AccessProjectionBatchSize + 1)
+            .Select(index => Movie(
+                DeterministicGuid(index).ToString(),
+                key.TmdbId,
+                $"Bounded resolve {index}"))
+            .Cast<BaseItem>()
+            .ToList();
+        var lookup = StubItemLookupService.FromItems(items);
+        var resolver = new WatchlistLibraryResolver(new CountingLibraryManager(), lookup);
+
+        var batch = resolver.Resolve(new[] { key }, new[] { user }, items);
+
+        Assert.True(batch.IsComplete);
+        Assert.Equal(items.Count, batch.Get(user, key).AccessibleItems.Count);
+        Assert.Equal(2, lookup.AccessQueryCount);
+        Assert.All(
+            lookup.AccessQueryItemIds,
+            query => Assert.InRange(
+                query.Count,
+                1,
+                WatchlistLibraryResolver.AccessProjectionBatchSize));
+    }
+
+    [Fact]
+    public void RevalidateAccessibleItems_MaxPlusOneUsesTwoBoundedQueries()
+    {
+        var user = User("revalidate-bounded-access-user");
+        var key = new WatchlistMediaKey("movie", 308);
+        var items = Enumerable.Range(
+                1,
+                WatchlistLibraryResolver.AccessProjectionBatchSize + 1)
+            .Select(index => Movie(
+                DeterministicGuid(index).ToString(),
+                key.TmdbId,
+                $"Bounded revalidation {index}"))
+            .Cast<BaseItem>()
+            .ToList();
+        var lookup = new StubItemLookupService();
+        var resolver = new WatchlistLibraryResolver(new CountingLibraryManager(), lookup);
+
+        var accessibleItems = resolver.RevalidateAccessibleItems(
+            user,
+            key,
+            items,
+            CancellationToken.None);
+
+        Assert.Equal(items.Count, accessibleItems.Count);
+        Assert.Equal(2, lookup.AccessQueryCount);
+        Assert.All(
+            lookup.AccessQueryItemIds,
+            query => Assert.InRange(
+                query.Count,
+                1,
+                WatchlistLibraryResolver.AccessProjectionBatchSize));
+    }
+
+    [Fact]
+    public void GetAccessibleItemIdsBounded_CancellationStopsSingleUserBetweenBatches()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var user = User("cancel-bounded-access-user");
+        var itemIds = Enumerable.Range(
+                1,
+                WatchlistLibraryResolver.AccessProjectionBatchSize + 1)
+            .Select(DeterministicGuid)
+            .ToList();
+        var lookup = new StubItemLookupService();
+        lookup.BeforeAccessQuery = count =>
+        {
+            if (count == 1)
+            {
+                cancellation.Cancel();
+            }
+        };
+        var resolver = new WatchlistLibraryResolver(new CountingLibraryManager(), lookup);
+
+        Assert.Throws<OperationCanceledException>(() => resolver.GetAccessibleItemIdsBounded(
+            itemIds,
+            user,
+            cancellation.Token));
+        Assert.Equal(1, lookup.AccessQueryCount);
+        Assert.Equal(
+            WatchlistLibraryResolver.AccessProjectionBatchSize,
+            Assert.Single(lookup.AccessQueryItemIds).Count);
+    }
+
+    [Fact]
+    public void SelectPreferred_ChoosesAlreadyLikedAccessibleEdition()
+    {
+        var lowerId = Movie(
+            "00000000-0000-0000-0000-000000000006",
+            104,
+            "Unliked cut");
+        var higherId = Movie(
+            "00000000-0000-0000-0000-000000000007",
+            104,
+            "Liked cut");
+        var match = new WatchlistLibraryMatch(
+            WatchlistLibraryMatchState.Accessible,
+            new BaseItem[] { lowerId, higherId });
+        var lowerData = new UserItemData { Key = lowerId.Id.ToString("N"), Likes = false };
+        var higherData = new UserItemData { Key = higherId.Id.ToString("N"), Likes = true };
+
+        var selection = match.SelectPreferred(new Dictionary<Guid, UserItemData>
+        {
+            [lowerId.Id] = lowerData,
+            [higherId.Id] = higherData,
+        });
+
+        Assert.NotNull(selection);
+        Assert.Same(higherId, selection.Item);
+        Assert.Same(higherData, selection.UserData);
+    }
+
+    private static User User(string name)
+        => new(name, "provider", "password-provider");
+
+    private static Guid DeterministicGuid(int index)
+        => Guid.Parse($"00000000-0000-0000-0002-{index.ToString("D12", System.Globalization.CultureInfo.InvariantCulture)}");
+
+    private static Movie Movie(string id, int tmdbId, string name)
+    {
+        var movie = new Movie
+        {
+            Id = Guid.Parse(id),
+            Name = name,
+        };
+        movie.ProviderIds["Tmdb"] = tmdbId.ToString(
+            System.Globalization.CultureInfo.InvariantCulture);
+        return movie;
+    }
+
+    private sealed class CountingReadOnlyCollection : IReadOnlyCollection<BaseItem>
+    {
+        private readonly IReadOnlyList<BaseItem> _items;
+        private readonly bool _throwOnEnumeration;
+
+        public CountingReadOnlyCollection(
+            IReadOnlyList<BaseItem> items,
+            int? reportedCount = null,
+            bool throwOnEnumeration = false)
+        {
+            _items = items;
+            Count = reportedCount ?? items.Count;
+            _throwOnEnumeration = throwOnEnumeration;
+        }
+
+        public int Count { get; }
+
+        public int EnumerationCount { get; private set; }
+
+        public IEnumerator<BaseItem> GetEnumerator()
+        {
+            EnumerationCount++;
+            if (_throwOnEnumeration)
+            {
+                throw new Xunit.Sdk.XunitException("The oversized collection must not be enumerated.");
+            }
+
+            return _items.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    private sealed class CountingReadOnlyList : IReadOnlyList<BaseItem>
+    {
+        private readonly IReadOnlyList<BaseItem> _items;
+
+        public CountingReadOnlyList(IReadOnlyList<BaseItem> items)
+        {
+            _items = items;
+        }
+
+        public int Count => _items.Count;
+
+        public BaseItem this[int index] => _items[index];
+
+        public int EnumerationCount { get; private set; }
+
+        public IEnumerator<BaseItem> GetEnumerator()
+        {
+            EnumerationCount++;
+            return _items.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/WatchlistMonitorAuthorizationTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/WatchlistMonitorAuthorizationTests.cs
@@ -40,6 +40,339 @@ public sealed class WatchlistMonitorAuthorizationTests
     }
 
     [Fact]
+    public async Task InaccessibleEventEdition_UsesAccessibleAlternate()
+    {
+        var user = new User("alternate-user", "provider", "password-provider");
+        var eventEdition = Movie(101);
+        eventEdition.Id = Guid.Parse("00000000-0000-0000-0000-000000000011");
+        var accessibleEdition = Movie(101);
+        accessibleEdition.Id = Guid.Parse("00000000-0000-0000-0000-000000000012");
+        var items = new BaseItem[] { eventEdition, accessibleEdition };
+        var lookup = StubItemLookupService.FromItems(
+            items,
+            (ids, _) => ids.Where(id => id == accessibleEdition.Id).ToHashSet());
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = _ => items,
+        };
+        var handler = new MonitorHandler((request, _) => request.RequestUri!.AbsolutePath switch
+        {
+            "/api/v1/request" => Page(RequestRow(1, 7, user.Id, 101)),
+            "/api/v1/user" => Page(UserRow(7, user.Id)),
+            var path => throw new Xunit.Sdk.XunitException($"Unexpected path {path}."),
+        });
+        var data = new RecordingUserDataManager();
+        var monitor = CreateMonitor(
+            user,
+            data,
+            handler,
+            new FakePluginConfigProvider(Config()),
+            library,
+            lookup);
+
+        await monitor.ProcessItemForWatchlistForTestAsync(eventEdition);
+
+        Assert.Equal(1, data.SaveCount);
+        Assert.Same(accessibleEdition, data.SavedItem);
+        Assert.Equal(2, lookup.ProviderQueryCount);
+        Assert.Equal(3, lookup.AccessQueryCount);
+    }
+
+    [Fact]
+    public async Task AccessRevokedDuringOwnershipBarrier_WritesNothing()
+    {
+        var user = new User("revoked-user", "provider", "password-provider");
+        var movie = Movie(101);
+        var accessReads = 0;
+        var lookup = StubItemLookupService.FromItems(
+            new BaseItem[] { movie },
+            (ids, _) => Interlocked.Increment(ref accessReads) == 1
+                ? ids.ToHashSet()
+                : new HashSet<Guid>());
+        var handler = new MonitorHandler((request, _) => request.RequestUri!.AbsolutePath switch
+        {
+            "/api/v1/request" => Page(RequestRow(1, 7, user.Id, 101)),
+            "/api/v1/user" => Page(UserRow(7, user.Id)),
+            var path => throw new Xunit.Sdk.XunitException($"Unexpected path {path}."),
+        });
+        var data = new RecordingUserDataManager();
+        var monitor = CreateMonitor(
+            user,
+            data,
+            handler,
+            new FakePluginConfigProvider(Config()),
+            new CountingLibraryManager(),
+            lookup);
+
+        await monitor.ProcessItemForWatchlistForTestAsync(movie);
+
+        Assert.Equal(2, accessReads);
+        Assert.Equal(0, data.SaveCount);
+        Assert.NotEqual(true, data.Data.Likes);
+    }
+
+    [Fact]
+    public async Task FirstUsersSaveRevokesSecondUsersAccess_SecondUserIsNotMutated()
+    {
+        var firstUser = new User("first-requester", "provider", "password-provider");
+        var secondUser = new User("second-requester", "provider", "password-provider");
+        var movie = Movie(103);
+        var secondUserRevoked = false;
+        var lookup = StubItemLookupService.FromItems(
+            new BaseItem[] { movie },
+            (ids, user) => user.Id == secondUser.Id && secondUserRevoked
+                ? new HashSet<Guid>()
+                : ids.ToHashSet());
+        var handler = new MonitorHandler((request, _) => request.RequestUri!.AbsolutePath switch
+        {
+            "/api/v1/request" => Page(
+                RequestRow(1, 7, firstUser.Id, 103),
+                RequestRow(2, 8, secondUser.Id, 103)),
+            "/api/v1/user" => Page(
+                UserRow(7, firstUser.Id),
+                UserRow(8, secondUser.Id)),
+            var path => throw new Xunit.Sdk.XunitException($"Unexpected path {path}."),
+        });
+        var savedUsers = new List<Guid>();
+        var userData = new StubUserDataManager
+        {
+            GetUserDataHook = (_, item) => new UserItemData
+            {
+                Key = item.Id.ToString("N"),
+                Likes = false,
+            },
+            SaveUserDataHook = (user, _, _, _, _) =>
+            {
+                savedUsers.Add(user.Id);
+                secondUserRevoked = true;
+            },
+        };
+        var monitor = new WatchlistMonitor(
+            new CountingLibraryManager(),
+            new StubUserManager(firstUser, secondUser),
+            userData,
+            new RecordingHttpClientFactory(handler),
+            userConfigurationManager: null!,
+            NullLogger<WatchlistMonitor>.Instance,
+            new FakePluginConfigProvider(Config()),
+            lookup);
+
+        await monitor.ProcessItemForWatchlistForTestAsync(movie);
+
+        Assert.Equal(new[] { firstUser.Id }, savedUsers);
+        Assert.Equal(6, lookup.AccessQueryCount);
+    }
+
+    [Fact]
+    public async Task AlreadyLikedAccessibleEdition_DoesNotLikeAnotherEdition()
+    {
+        var user = new User("liked-edition-user", "provider", "password-provider");
+        var unlikedEdition = Movie(104);
+        unlikedEdition.Id = Guid.Parse("00000000-0000-0000-0000-000000000013");
+        var likedEdition = Movie(104);
+        likedEdition.Id = Guid.Parse("00000000-0000-0000-0000-000000000014");
+        var items = new BaseItem[] { unlikedEdition, likedEdition };
+        var lookup = StubItemLookupService.FromItems(items);
+        var handler = new MonitorHandler((request, _) => request.RequestUri!.AbsolutePath switch
+        {
+            "/api/v1/request" => Page(RequestRow(1, 7, user.Id, 104)),
+            "/api/v1/user" => Page(UserRow(7, user.Id)),
+            var path => throw new Xunit.Sdk.XunitException($"Unexpected path {path}."),
+        });
+        var saveCount = 0;
+        var userData = new StubUserDataManager
+        {
+            GetUserDataBatchHook = (accessibleItems, _) => accessibleItems.ToDictionary(
+                static item => item.Id,
+                item => new UserItemData
+                {
+                    Key = item.Id.ToString("N"),
+                    Likes = item.Id == likedEdition.Id,
+                }),
+            SaveUserDataHook = (_, _, _, _, _) => saveCount++,
+        };
+        var monitor = new WatchlistMonitor(
+            new CountingLibraryManager
+            {
+                GetItemListHook = _ => items,
+            },
+            new StubUserManager(user),
+            userData,
+            new RecordingHttpClientFactory(handler),
+            userConfigurationManager: null!,
+            NullLogger<WatchlistMonitor>.Instance,
+            new FakePluginConfigProvider(Config()),
+            lookup);
+
+        await monitor.ProcessItemForWatchlistForTestAsync(unlikedEdition);
+
+        Assert.Equal(0, saveCount);
+        Assert.Equal(1, userData.GetUserDataBatchCallCount);
+    }
+
+    [Fact]
+    public async Task UnlikeAtFinalAccessBarrier_SavesLikeBeforeProcessedMarker()
+    {
+        var baseDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "jc-watchlist-monitor-live-data-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(baseDirectory);
+        try
+        {
+            var user = new User("monitor-unlike-user", "provider", "password-provider");
+            var movie = Movie(105);
+            var handler = new MonitorHandler((request, _) => request.RequestUri!.AbsolutePath switch
+            {
+                "/api/v1/request" => Page(RequestRow(1, 7, user.Id, 105)),
+                "/api/v1/user" => Page(UserRow(7, user.Id)),
+                var path => throw new Xunit.Sdk.XunitException($"Unexpected path {path}."),
+            });
+            var unliked = false;
+            var lookup = StubItemLookupService.FromItems(new BaseItem[] { movie });
+            lookup.BeforeAccessQuery = count =>
+            {
+                if (count == 3)
+                {
+                    unliked = true;
+                }
+            };
+            var saveCount = 0;
+            var userData = new StubUserDataManager
+            {
+                GetUserDataBatchHook = (items, _) => items.ToDictionary(
+                    static item => item.Id,
+                    item => new UserItemData
+                    {
+                        Key = item.Id.ToString("N"),
+                        Likes = !unliked,
+                    }),
+                SaveUserDataHook = (_, _, data, _, _) =>
+                {
+                    Assert.True(data.Likes);
+                    saveCount++;
+                },
+            };
+            var userConfiguration = new UserConfigurationManager(
+                new StubAppPaths(baseDirectory),
+                NullLogger<UserConfigurationManager>.Instance);
+            var config = Config();
+            config.PreventWatchlistReAddition = true;
+            var monitor = CreateMonitor(
+                user,
+                userData,
+                handler,
+                new FakePluginConfigProvider(config),
+                new CountingLibraryManager(),
+                lookup,
+                userConfiguration);
+
+            await monitor.ProcessItemForWatchlistForTestAsync(movie);
+
+            Assert.True(unliked);
+            Assert.Equal(1, saveCount);
+            var marker = Assert.Single(
+                userConfiguration.GetProcessedWatchlistItems(user.Id).Items);
+            Assert.Equal("monitor", marker.Source);
+            Assert.Equal(105, marker.TmdbId);
+        }
+        finally
+        {
+            Directory.Delete(baseDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ConfigurationChangeDuringFinalAccessQuery_SuppressesSave()
+    {
+        var user = new User("post-access-config-user", "provider", "password-provider");
+        var movie = Movie(106);
+        var handler = new MonitorHandler((request, _) => request.RequestUri!.AbsolutePath switch
+        {
+            "/api/v1/request" => Page(RequestRow(1, 7, user.Id, 106)),
+            "/api/v1/user" => Page(UserRow(7, user.Id)),
+            var path => throw new Xunit.Sdk.XunitException($"Unexpected path {path}."),
+        });
+        var provider = new FakePluginConfigProvider(Config());
+        var lookup = StubItemLookupService.FromItems(new BaseItem[] { movie });
+        lookup.BeforeAccessQuery = count =>
+        {
+            if (count == 3)
+            {
+                provider.Current = new PluginConfiguration();
+            }
+        };
+        var saveCount = 0;
+        var userData = new StubUserDataManager
+        {
+            GetUserDataHook = (_, item) => new UserItemData
+            {
+                Key = item.Id.ToString("N"),
+                Likes = false,
+            },
+            SaveUserDataHook = (_, _, _, _, _) => saveCount++,
+        };
+        var monitor = CreateMonitor(
+            user,
+            userData,
+            handler,
+            provider,
+            new CountingLibraryManager(),
+            lookup);
+
+        await monitor.ProcessItemForWatchlistForTestAsync(movie);
+
+        Assert.Equal(3, lookup.AccessQueryCount);
+        Assert.Equal(0, saveCount);
+        Assert.Equal(0, userData.GetUserDataBatchCallCount);
+    }
+
+    [Fact]
+    public async Task NoAccessibleEdition_DoesNotSaveOrCommitProcessedMarker()
+    {
+        var baseDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "jc-watchlist-access-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(baseDirectory);
+        try
+        {
+            var user = new User("no-access-user", "provider", "password-provider");
+            var movie = Movie(101);
+            var lookup = StubItemLookupService.FromItems(
+                new BaseItem[] { movie },
+                (_, _) => new HashSet<Guid>());
+            var handler = new MonitorHandler((request, _) => request.RequestUri!.AbsolutePath switch
+            {
+                "/api/v1/request" => Page(RequestRow(1, 7, user.Id, 101)),
+                "/api/v1/user" => Page(UserRow(7, user.Id)),
+                var path => throw new Xunit.Sdk.XunitException($"Unexpected path {path}."),
+            });
+            var config = Config();
+            config.PreventWatchlistReAddition = true;
+            var userConfiguration = new UserConfigurationManager(
+                new StubAppPaths(baseDirectory),
+                NullLogger<UserConfigurationManager>.Instance);
+            var data = new RecordingUserDataManager();
+            var monitor = CreateMonitor(
+                user,
+                data,
+                handler,
+                new FakePluginConfigProvider(config),
+                new CountingLibraryManager(),
+                lookup,
+                userConfiguration);
+
+            await monitor.ProcessItemForWatchlistForTestAsync(movie);
+
+            Assert.Equal(0, data.SaveCount);
+            Assert.Empty(userConfiguration.GetProcessedWatchlistItems(user.Id).Items);
+        }
+        finally
+        {
+            Directory.Delete(baseDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task RequestOwnerIdMustMatchSameSourceUserMap()
     {
         var user = new User("source-bound-user", "provider", "password-provider");
@@ -238,17 +571,21 @@ public sealed class WatchlistMonitorAuthorizationTests
 
     private static WatchlistMonitor CreateMonitor(
         User user,
-        RecordingUserDataManager data,
+        IUserDataManager data,
         HttpMessageHandler handler,
-        FakePluginConfigProvider provider)
+        FakePluginConfigProvider provider,
+        CountingLibraryManager? library = null,
+        StubItemLookupService? itemLookup = null,
+        UserConfigurationManager? userConfigurationManager = null)
         => new(
-            new CountingLibraryManager(),
+            library ?? new CountingLibraryManager(),
             new StubUserManager(user),
             data,
             new RecordingHttpClientFactory(handler),
-            null!,
+            userConfigurationManager!,
             NullLogger<WatchlistMonitor>.Instance,
-            provider);
+            provider,
+            itemLookup ?? new StubItemLookupService());
 
     private static PluginConfiguration Config(string urls = "http://seerr:5055")
         => new()
@@ -262,7 +599,11 @@ public sealed class WatchlistMonitorAuthorizationTests
 
     private static Movie Movie(int tmdbId)
     {
-        var movie = new Movie { Name = $"Movie {tmdbId}" };
+        var movie = new Movie
+        {
+            Id = Guid.NewGuid(),
+            Name = $"Movie {tmdbId}",
+        };
         movie.ProviderIds["Tmdb"] = tmdbId.ToString(System.Globalization.CultureInfo.InvariantCulture);
         return movie;
     }
@@ -338,6 +679,8 @@ public sealed class WatchlistMonitorAuthorizationTests
 
         public int SaveCount { get; private set; }
 
+        public BaseItem? SavedItem { get; private set; }
+
         public event EventHandler<UserDataSaveEventArgs>? UserDataSaved
         {
             add { }
@@ -352,7 +695,10 @@ public sealed class WatchlistMonitorAuthorizationTests
             UserItemData userData,
             UserDataSaveReason reason,
             CancellationToken cancellationToken)
-            => SaveCount++;
+        {
+            SavedItem = item;
+            SaveCount++;
+        }
 
         public void SaveUserData(
             User user,
@@ -367,7 +713,7 @@ public sealed class WatchlistMonitorAuthorizationTests
         public Dictionary<Guid, UserItemData> GetUserDataBatch(
             IReadOnlyList<BaseItem> items,
             User user)
-            => throw new NotImplementedException();
+            => items.ToDictionary(static item => item.Id, _ => Data);
 
         public UserItemDataDto? GetUserDataDto(
             BaseItem item,

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/WatchlistMonitorLifecycleTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/WatchlistMonitorLifecycleTests.cs
@@ -46,7 +46,8 @@ public sealed class WatchlistMonitorLifecycleTests
             new RecordingHttpClientFactory(handler),
             null!,
             NullLogger<WatchlistMonitor>.Instance,
-            new FakePluginConfigProvider(EnabledConfiguration()));
+            new FakePluginConfigProvider(EnabledConfiguration()),
+            new StubItemLookupService());
 
         monitor.Initialize();
         library.RaiseItemAdded(Movie(123));
@@ -308,7 +309,8 @@ public sealed class WatchlistMonitorLifecycleTests
                 SeerrEnabled = true,
                 SeerrUrls = "http://seerr:5055",
                 SeerrApiKey = "key",
-            }));
+            }),
+            new StubItemLookupService());
 
         monitor.Initialize();
         var movie = new Movie { Name = "Cancellation sentinel" };
@@ -352,7 +354,8 @@ public sealed class WatchlistMonitorLifecycleTests
             new RecordingHttpClientFactory(handler),
             null!,
             NullLogger<WatchlistMonitor>.Instance,
-            provider);
+            provider,
+            new StubItemLookupService());
     }
 
     private static PluginConfiguration EnabledConfiguration()

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/TestDoubles/StubItemLookupService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/TestDoubles/StubItemLookupService.cs
@@ -1,5 +1,6 @@
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.JellyfinCanopy.Data;
+using MediaBrowser.Controller.Entities;
 
 namespace Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
 
@@ -14,15 +15,40 @@ public sealed class StubItemLookupService : IItemLookupService
         IReadOnlyCollection<Guid>,
         User,
         IReadOnlySet<Guid>> _accessProjection;
+    private readonly Func<
+        IReadOnlyCollection<(string Provider, string Value)>,
+        Dictionary<(string Provider, string Value), IReadOnlyList<ItemLookupCandidate>>> _candidateProjection;
 
     public StubItemLookupService(
-        Func<IReadOnlyCollection<Guid>, User, IReadOnlySet<Guid>>? accessProjection = null)
+        Func<IReadOnlyCollection<Guid>, User, IReadOnlySet<Guid>>? accessProjection = null,
+        Func<
+            IReadOnlyCollection<(string Provider, string Value)>,
+            Dictionary<(string Provider, string Value), IReadOnlyList<ItemLookupCandidate>>>? candidateProjection = null)
     {
         _accessProjection = accessProjection
             ?? ((itemIds, _) => itemIds.ToHashSet());
+        _candidateProjection = candidateProjection ?? (_ => new());
     }
 
     public int AccessQueryCount { get; private set; }
+
+    public List<IReadOnlyList<Guid>> AccessQueryItemIds { get; } = new();
+
+    public int ProviderQueryCount { get; private set; }
+
+    public Action<int>? BeforeAccessQuery { get; set; }
+
+    public static StubItemLookupService FromItems(
+        IEnumerable<BaseItem> items,
+        Func<IReadOnlyCollection<Guid>, User, IReadOnlySet<Guid>>? accessProjection = null)
+    {
+        var itemSnapshot = items.ToList();
+        return new StubItemLookupService(
+            accessProjection,
+            providers => ItemLookupService.MapProviderPairs(
+                itemSnapshot,
+                ItemLookupService.NormalizePairs(providers)));
+    }
 
     public IReadOnlyList<Guid> GetItemIdsByProviders(
         IDictionary<string, string>? providers,
@@ -32,19 +58,35 @@ public sealed class StubItemLookupService : IItemLookupService
     public Dictionary<(string Provider, string Value), IReadOnlyList<ItemLookupCandidate>>
         GetItemCandidatesByProvidersBatch(
             IReadOnlyCollection<(string Provider, string Value)> providers)
-        => new();
+    {
+        ProviderQueryCount++;
+        return _candidateProjection(providers);
+    }
 
     public ItemLookupBatchResult GetItemCandidatesByProvidersBatchBounded(
         IReadOnlyCollection<(string Provider, string Value)> providers,
         int maxProviderPairs,
         int maxCandidates)
-        => new(new(), true);
+    {
+        ProviderQueryCount++;
+        if (providers.Count > maxProviderPairs)
+        {
+            return new(new(), false);
+        }
+
+        var candidates = _candidateProjection(providers);
+        return candidates.Values.Sum(static matches => matches.Count) > maxCandidates
+            ? new(new(), false)
+            : new(candidates, true);
+    }
 
     public IReadOnlySet<Guid> GetAccessibleItemIdsBatch(
         IReadOnlyCollection<Guid> itemIds,
         User user)
     {
         AccessQueryCount++;
+        AccessQueryItemIds.Add(itemIds.ToArray());
+        BeforeAccessQuery?.Invoke(AccessQueryCount);
         return _accessProjection(itemIds, user);
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/TestDoubles/StubUserDataManager.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/TestDoubles/StubUserDataManager.cs
@@ -85,8 +85,23 @@ public sealed class StubUserDataManager : IUserDataManager
     {
         GetUserDataBatchCallCount++;
         GetUserDataBatchItemCount += items.Count;
-        if (GetUserDataBatchHook == null) throw new NotImplementedException();
-        return GetUserDataBatchHook(items, user);
+        if (GetUserDataBatchHook != null)
+        {
+            return GetUserDataBatchHook(items, user);
+        }
+
+        if (GetUserDataHook == null) throw new NotImplementedException();
+        var result = new Dictionary<Guid, UserItemData>();
+        foreach (var item in items)
+        {
+            var data = GetUserDataHook(user, item);
+            if (data != null)
+            {
+                result[item.Id] = data;
+            }
+        }
+
+        return result;
     }
 
     public UserItemDataDto? GetUserDataDto(BaseItem item, BaseItemDto? itemDto, User user, DtoOptions options) => throw new NotImplementedException();

--- a/Jellyfin.Plugin.JellyfinCanopy/ScheduledTasks/JellyfinToSeerrWatchlistSyncTask.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/ScheduledTasks/JellyfinToSeerrWatchlistSyncTask.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Data;
 using Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
@@ -22,6 +23,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
     // Scheduled task that syncs Jellyfin watchlist items to Seerr watchlist.
     public class JellyfinToSeerrWatchlistSyncTask : IScheduledTask
     {
+        internal const int MaximumLateAuthorizationQueries = 200_000;
+        internal const int LibraryEnumerationPageSize = 1_000;
+        // One access projection, one Likes read, and one exact Seerr binding
+        // lookup are reserved for every candidate mutation.
+        internal const int LateAuthorizationQueriesPerMutation = 3;
+        internal const int MaximumLateMutationAuthorizations =
+            MaximumLateAuthorizationQueries / LateAuthorizationQueriesPerMutation;
+
         private readonly ILibraryManager _libraryManager;
         private readonly IUserManager _userManager;
         private readonly IUserDataManager _userDataManager;
@@ -29,6 +38,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
         private readonly Configuration.UserConfigurationManager _userConfigurationManager;
         private readonly ILogger<JellyfinToSeerrWatchlistSyncTask> _logger;
         private readonly IPluginConfigProvider _configProvider;
+        private readonly WatchlistLibraryResolver _watchlistLibraryResolver;
 
         public JellyfinToSeerrWatchlistSyncTask(
             ILibraryManager libraryManager,
@@ -37,7 +47,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
             IHttpClientFactory httpClientFactory,
             Configuration.UserConfigurationManager userConfigurationManager,
             ILogger<JellyfinToSeerrWatchlistSyncTask> logger,
-            IPluginConfigProvider configProvider)
+            IPluginConfigProvider configProvider,
+            IItemLookupService itemLookup)
         {
             _libraryManager = libraryManager;
             _userManager = userManager;
@@ -46,6 +57,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
             _userConfigurationManager = userConfigurationManager;
             _configProvider = configProvider;
             _logger = logger;
+            _watchlistLibraryResolver = new WatchlistLibraryResolver(
+                libraryManager,
+                itemLookup);
         }
 
         public string Name => "Sync Watchlist from Jellyfin to Seerr";
@@ -149,22 +163,62 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
 
             _logger.LogInformation($"[Jellyfin→Seerr Watchlist Sync] Found {jellyfinUsers.Count} Jellyfin users");
 
-            // Pre-fetch all movies and series with TMDB IDs once — shared across users
-            var allMovies = _libraryManager.GetItemList(new InternalItemsQuery
+            // PERF(S2): visit the one shared movie/series snapshot in cancellable
+            // 1,000-item pages. A sentinel item makes the aggregate 100,000-item
+            // ceiling complete-or-nothing without ever materializing a giant query.
+            var allLibraryItems = new List<(BaseItem item, string mediaType)>();
+            if (!await TryCollectLibraryItemsBoundedAsync(
+                    _libraryManager,
+                    allLibraryItems,
+                    cancellationToken).ConfigureAwait(false))
             {
-                IncludeItemTypes = new[] { BaseItemKind.Movie },
-                HasTmdbId = true,
-                Recursive = true
-            }).Select(i => (item: i, mediaType: "movie"));
+                _logger.LogWarning(
+                    "[Jellyfin→Seerr Watchlist Sync] The bounded Jellyfin movie/series snapshot exceeded its item limit. No Seerr mutations will be attempted.");
+                progress?.Report(100);
+                return;
+            }
 
-            var allSeries = _libraryManager.GetItemList(new InternalItemsQuery
+            var allLibraryItemIds = allLibraryItems
+                .Select(static entry => entry.item.Id)
+                .Distinct()
+                .ToList();
+            var linkedUserCount = jellyfinUsers.Count(user =>
+                SeerrUserIdentityDomains.FindBindings(
+                    seerrUserDomains,
+                    user.Id.ToString()).Count > 0);
+            if (linkedUserCount > 0
+                && allLibraryItemIds.Count
+                    > WatchlistLibraryResolver.MaximumCandidateProjections / linkedUserCount)
             {
-                IncludeItemTypes = new[] { BaseItemKind.Series },
-                HasTmdbId = true,
-                Recursive = true
-            }).Select(i => (item: i, mediaType: "tv"));
+                _logger.LogWarning(
+                    "[Jellyfin→Seerr Watchlist Sync] The aggregate linked-user/library access projection budget was exceeded. No Seerr mutations will be attempted.");
+                progress?.Report(100);
+                return;
+            }
 
-            var allLibraryItems = allMovies.Concat(allSeries).ToList();
+            var libraryItemsByKey = new Dictionary<WatchlistMediaKey, List<BaseItem>>();
+            foreach (var (item, mediaType) in allLibraryItems)
+            {
+                if (!item.ProviderIds.TryGetValue("Tmdb", out var tmdbIdText)
+                    || !int.TryParse(
+                        tmdbIdText,
+                        NumberStyles.None,
+                        CultureInfo.InvariantCulture,
+                        out var tmdbId)
+                    || tmdbId <= 0)
+                {
+                    continue;
+                }
+
+                var mediaKey = new WatchlistMediaKey(mediaType, tmdbId);
+                if (!libraryItemsByKey.TryGetValue(mediaKey, out var editions))
+                {
+                    editions = new List<BaseItem>();
+                    libraryItemsByKey.Add(mediaKey, editions);
+                }
+
+                editions.Add(item);
+            }
 
             // Stage every local watchlist and every source-local absence proof for
             // the whole run before the first Seerr mutation. A failure on a later
@@ -186,8 +240,30 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                         continue;
                     }
 
-                    var rawJellyfinWatchlist = allLibraryItems
-                        .Where(t => _userDataManager.GetUserData(jellyfinUser, t.item)?.Likes == true)
+                    // Project the one shared library snapshot through this user's
+                    // current access policy before reading any per-item state. The
+                    // fixed ids are queried in cancellable 1,000-item batches,
+                    // never as a library scan or one giant policy query.
+                    var accessibleItemIds = _watchlistLibraryResolver.GetAccessibleItemIdsBounded(
+                        allLibraryItemIds,
+                        jellyfinUser,
+                        cancellationToken);
+                    var accessibleLibraryItems = allLibraryItems
+                        .Where(t => accessibleItemIds.Contains(t.item.Id))
+                        .ToList();
+                    var accessibleBaseItems = accessibleLibraryItems
+                        .Select(static entry => entry.item)
+                        .DistinctBy(static item => item.Id)
+                        .ToList();
+                    var userDataById = accessibleBaseItems.Count == 0
+                        ? new Dictionary<Guid, UserItemData>()
+                        : _userDataManager.GetUserDataBatch(
+                            accessibleBaseItems,
+                            jellyfinUser);
+                    var rawJellyfinWatchlist = accessibleLibraryItems
+                        .Where(t => userDataById.TryGetValue(t.item.Id, out var userData)
+                            && userData.Likes == true)
+                        .OrderBy(static entry => entry.item.Id)
                         .ToList();
                     var jellyfinWatchlist = new List<(
                         BaseItem Item,
@@ -274,6 +350,185 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
             }
 
             cancellationToken.ThrowIfCancellationRequested();
+            var pendingExports = new List<PendingWatchlistExport>();
+            var pendingExportIdentities = new HashSet<(
+                string SourceUrl,
+                string SeerrUserId,
+                string ItemKey)>();
+            var resolutionRequests = new HashSet<(Guid UserId, WatchlistMediaKey Key)>();
+            foreach (var jellyfinUser in jellyfinUsers)
+            {
+                if (!stagedInputs.TryGetValue(jellyfinUser.Id, out var stagedInput))
+                {
+                    continue;
+                }
+
+                foreach (var (binding, seerrWatchlistKeys) in stagedInput.SeerrWatchlists)
+                {
+                    foreach (var (_, mediaType, tmdbId, key) in stagedInput.JellyfinWatchlist)
+                    {
+                        if (seerrWatchlistKeys.Contains(key))
+                        {
+                            continue;
+                        }
+
+                        var identity = (binding.SourceUrl, binding.SeerrUserId, key);
+                        if (!pendingExportIdentities.Add(identity))
+                        {
+                            continue;
+                        }
+
+                        if (pendingExports.Count >= MaximumLateMutationAuthorizations)
+                        {
+                            _logger.LogWarning(
+                                "[Jellyfin→Seerr Watchlist Sync] The aggregate late-authorization query budget was exceeded. No Seerr mutations will be attempted.");
+                            progress?.Report(100);
+                            return;
+                        }
+
+                        var mediaKey = new WatchlistMediaKey(mediaType, tmdbId);
+                        if (resolutionRequests.Add((jellyfinUser.Id, mediaKey))
+                            && resolutionRequests.Count > WatchlistLibraryResolver.MaximumResolutionRequests)
+                        {
+                            _logger.LogWarning(
+                                "[Jellyfin→Seerr Watchlist Sync] The aggregate user/media export-resolution budget was exceeded. No Seerr mutations will be attempted.");
+                            progress?.Report(100);
+                            return;
+                        }
+
+                        pendingExports.Add(new PendingWatchlistExport(
+                            jellyfinUser,
+                            binding,
+                            mediaKey,
+                            key));
+                    }
+                }
+            }
+
+            var pendingBindings = pendingExports
+                .GroupBy(static pending => (
+                    pending.User.Id,
+                    pending.Binding.SourceUrl,
+                    pending.Binding.SeerrUserId))
+                .Select(static group => group.First())
+                .ToList();
+            if (!LateAuthorizationBudget.CanFit(
+                    pendingExports.Count,
+                    pendingBindings.Count))
+            {
+                _logger.LogWarning(
+                    "[Jellyfin→Seerr Watchlist Sync] The aggregate preflight and mutation authorization budget was exceeded. No Seerr mutations will be attempted.");
+                progress?.Report(100);
+                return;
+            }
+
+            var lateAuthorizationBudget = new LateAuthorizationBudget();
+
+            // A linked account authorizes every item for the same source-local
+            // user. Validate each distinct binding once before the final batched
+            // provider resolution. Exact binding ownership, fixed-id access and
+            // Likes are deliberately rechecked later at each individual POST
+            // boundary.
+            foreach (var pendingBinding in pendingBindings)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!TryAuthorizeMutationConfiguration(
+                        mutationConfigStamp,
+                        initialApiKey,
+                        pendingBinding.Binding.SourceUrl))
+                {
+                    _logger.LogWarning(
+                        "[Jellyfin→Seerr Watchlist Sync] Plugin configuration changed while preparing linked-user validation. No Seerr mutations will be attempted.");
+                    progress?.Report(100);
+                    return;
+                }
+
+                if (!lateAuthorizationBudget.TryReservePreflightBinding())
+                {
+                    _logger.LogWarning(
+                        "[Jellyfin→Seerr Watchlist Sync] The aggregate late-authorization query budget was exhausted before linked-user validation.");
+                    progress?.Report(100);
+                    return;
+                }
+
+                var freshBindingIsValid = await HasFreshExactBindingAsync(
+                    httpClient,
+                    pendingBinding.Binding.SourceUrl,
+                    pendingBinding.Binding.SeerrUserId,
+                    pendingBinding.User.Id,
+                    initialApiKey,
+                    dispatchFence,
+                    cancellationToken).ConfigureAwait(false);
+                if (!TryAuthorizeMutationConfiguration(
+                        mutationConfigStamp,
+                        initialApiKey,
+                        pendingBinding.Binding.SourceUrl)
+                    || !freshBindingIsValid)
+                {
+                    _logger.LogWarning(
+                        $"[Jellyfin→Seerr Watchlist Sync] Fresh linked-user validation failed for {pendingBinding.User.Username} on {pendingBinding.Binding.SourceUrl}. No Seerr mutations will be attempted.");
+                    progress?.Report(100);
+                    return;
+                }
+            }
+
+            var libraryRequests = pendingExports
+                .GroupBy(static pending => (pending.User.Id, pending.MediaKey))
+                .Select(static group => new WatchlistLibraryRequest(
+                    group.First().User,
+                    group.Key.MediaKey))
+                .ToList();
+            WatchlistLibraryBatch dispatchLibrary;
+            try
+            {
+                dispatchLibrary = _watchlistLibraryResolver.Resolve(
+                    libraryRequests,
+                    libraryItemsByKey,
+                    cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    $"[Jellyfin→Seerr Watchlist Sync] Failed to prepare the final batched Jellyfin access projection: {ex.Message}. No Seerr mutations will be attempted.");
+                progress?.Report(100);
+                return;
+            }
+
+            if (!dispatchLibrary.IsComplete)
+            {
+                _logger.LogWarning(
+                    "[Jellyfin→Seerr Watchlist Sync] The final bounded Jellyfin access lookup was incomplete. No Seerr mutations will be attempted.");
+                progress?.Report(100);
+                return;
+            }
+
+            Dictionary<(Guid UserId, WatchlistMediaKey MediaKey), BaseItem> dispatchSelections;
+            try
+            {
+                dispatchSelections = PrepareDispatchSelections(
+                    pendingExports.Select(static pending => new WatchlistLibraryRequest(
+                        pending.User,
+                        pending.MediaKey)).ToList(),
+                    dispatchLibrary,
+                    _userDataManager,
+                    cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    $"[Jellyfin→Seerr Watchlist Sync] Failed to prepare the bounded current-Likes projection: {ex.Message}. No Seerr mutations will be attempted.");
+                progress?.Report(100);
+                return;
+            }
+
             var totalUsers = jellyfinUsers.Count;
             var processedUsers = 0;
             var totalItemsAdded = 0;
@@ -281,7 +536,6 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                 string SourceUrl,
                 string SeerrUserId,
                 string ItemKey)>();
-
             foreach (var jellyfinUser in jellyfinUsers)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -318,7 +572,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
 
                     foreach (var (binding, seerrWatchlistKeys) in stagedWatchlists)
                     {
-                        foreach (var (item, mediaType, tmdbId, key) in jellyfinWatchlist)
+                        foreach (var (_, mediaType, tmdbId, key) in jellyfinWatchlist)
                         {
                             cancellationToken.ThrowIfCancellationRequested();
 
@@ -338,21 +592,40 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                                 continue;
                             }
 
-                            // Re-authorize immediately before the awaited fresh
-                            // account lookup, then again after it. The exact user
-                            // endpoint proves the source-local numeric id still
-                            // belongs to this Jellyfin GUID at commit time.
+                            var mediaKey = new WatchlistMediaKey(mediaType, tmdbId);
+                            if (!dispatchSelections.TryGetValue(
+                                    (jellyfinUser.Id, mediaKey),
+                                    out var dispatchItem))
+                            {
+                                _logger.LogDebug(
+                                    $"[Jellyfin→Seerr Watchlist Sync] Suppressed {key} because no currently accessible edition remains liked for {jellyfinUser.Username}.");
+                                itemsSkipped++;
+                                continue;
+                            }
+
                             if (!TryAuthorizeMutationConfiguration(
                                     mutationConfigStamp,
                                     initialApiKey,
                                     binding.SourceUrl))
                             {
                                 _logger.LogWarning(
-                                    "[Jellyfin→Seerr Watchlist Sync] Plugin configuration changed while preparing a watchlist mutation. The run was stopped before dispatch.");
+                                    "[Jellyfin→Seerr Watchlist Sync] Plugin configuration changed before late item authorization. The run was stopped before dispatch.");
                                 progress?.Report(100);
                                 return;
                             }
 
+                            if (!lateAuthorizationBudget.TryReserveMutation())
+                            {
+                                _logger.LogWarning(
+                                    "[Jellyfin→Seerr Watchlist Sync] The aggregate late-authorization query budget was exhausted. The run was stopped before dispatch.");
+                                progress?.Report(100);
+                                return;
+                            }
+
+                            // The remote binding lookup is the only awaited late
+                            // check. Complete it first, then read access and Likes
+                            // synchronously so neither local authority can go stale
+                            // across network latency before the POST.
                             var freshBindingIsValid = await HasFreshExactBindingAsync(
                                 httpClient,
                                 binding.SourceUrl,
@@ -361,6 +634,43 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                                 initialApiKey,
                                 dispatchFence,
                                 cancellationToken).ConfigureAwait(false);
+                            if (!TryAuthorizeMutationConfiguration(
+                                    mutationConfigStamp,
+                                    initialApiKey,
+                                    binding.SourceUrl)
+                                || !freshBindingIsValid)
+                            {
+                                _logger.LogWarning(
+                                    $"[Jellyfin→Seerr Watchlist Sync] Fresh linked-user validation failed for {jellyfinUser.Username} on {binding.SourceUrl}. The run was stopped before dispatch.");
+                                progress?.Report(100);
+                                return;
+                            }
+
+                            var currentItem = _watchlistLibraryResolver.RevalidateSelection(
+                                jellyfinUser,
+                                mediaKey,
+                                dispatchItem,
+                                cancellationToken);
+                            if (currentItem == null)
+                            {
+                                _logger.LogDebug(
+                                    $"[Jellyfin→Seerr Watchlist Sync] Suppressed {key} because the selected edition is no longer accessible to {jellyfinUser.Username}.");
+                                itemsSkipped++;
+                                continue;
+                            }
+
+                            var currentUserData = _userDataManager.GetUserDataBatch(
+                                new[] { currentItem },
+                                jellyfinUser);
+                            cancellationToken.ThrowIfCancellationRequested();
+                            if (!currentUserData.TryGetValue(currentItem.Id, out var liveUserData)
+                                || liveUserData.Likes != true)
+                            {
+                                _logger.LogDebug(
+                                    $"[Jellyfin→Seerr Watchlist Sync] Suppressed {key} because the selected edition is no longer liked by {jellyfinUser.Username}.");
+                                itemsSkipped++;
+                                continue;
+                            }
 
                             if (!TryAuthorizeMutationConfiguration(
                                     mutationConfigStamp,
@@ -368,15 +678,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                                     binding.SourceUrl))
                             {
                                 _logger.LogWarning(
-                                    "[Jellyfin→Seerr Watchlist Sync] Plugin configuration changed during the final linked-user validation. The run was stopped before dispatch.");
-                                progress?.Report(100);
-                                return;
-                            }
-
-                            if (!freshBindingIsValid)
-                            {
-                                _logger.LogWarning(
-                                    $"[Jellyfin→Seerr Watchlist Sync] Fresh linked-user validation failed for {jellyfinUser.Username} on {binding.SourceUrl}. The run was stopped before dispatch.");
+                                    "[Jellyfin→Seerr Watchlist Sync] Plugin configuration changed during the late item authorization. The run was stopped before dispatch.");
                                 progress?.Report(100);
                                 return;
                             }
@@ -397,7 +699,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                                 initialApiKey,
                                 tmdbId,
                                 mediaType,
-                                item.Name ?? string.Empty,
+                                currentItem.Name ?? string.Empty,
                                 dispatchFence,
                                 cancellationToken).ConfigureAwait(false);
 
@@ -406,7 +708,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                                 itemsAdded++;
                                 totalItemsAdded++;
                                 seerrWatchlistKeys.Add(key);
-                                _logger.LogInformation($"[Jellyfin→Seerr Watchlist Sync] ✓ Added to Seerr watchlist: {item.Name} for user {jellyfinUser.Username} on {binding.SourceUrl}");
+                                _logger.LogInformation($"[Jellyfin→Seerr Watchlist Sync] ✓ Added to Seerr watchlist: {currentItem.Name} for user {jellyfinUser.Username} on {binding.SourceUrl}");
                             }
                             else if (result == 0)
                             {
@@ -438,6 +740,130 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
             _logger.LogInformation($"=================================================================================================================================");
             _logger.LogInformation($"[Jellyfin→Seerr Watchlist Sync] Completed. Added {totalItemsAdded} total items across {processedUsers} users");
             progress?.Report(100);
+        }
+
+        /// <summary>
+        /// Collects the complete movie/series provider snapshot in bounded pages.
+        /// The shared destination limit includes both media kinds and one sentinel.
+        /// </summary>
+        internal static async Task<bool> TryCollectLibraryItemsBoundedAsync(
+            ILibraryManager libraryManager,
+            List<(BaseItem item, string mediaType)> destination,
+            CancellationToken cancellationToken)
+        {
+            foreach (var (kind, mediaType) in new[]
+            {
+                (BaseItemKind.Movie, "movie"),
+                (BaseItemKind.Series, "tv"),
+            })
+            {
+                var startIndex = 0;
+                while (true)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var remainingWithSentinel =
+                        (WatchlistLibraryResolver.MaximumCandidates + 1)
+                        - destination.Count;
+                    if (remainingWithSentinel <= 0)
+                    {
+                        return false;
+                    }
+
+                    var pageLimit = Math.Min(
+                        LibraryEnumerationPageSize,
+                        remainingWithSentinel);
+                    var page = libraryManager.GetItemList(new InternalItemsQuery
+                    {
+                        IncludeItemTypes = new[] { kind },
+                        HasTmdbId = true,
+                        Recursive = true,
+                        StartIndex = startIndex,
+                        Limit = pageLimit
+                    });
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (page.Count > pageLimit)
+                    {
+                        return false;
+                    }
+
+                    foreach (var item in page)
+                    {
+                        destination.Add((item, mediaType));
+                    }
+
+                    if (destination.Count > WatchlistLibraryResolver.MaximumCandidates)
+                    {
+                        return false;
+                    }
+
+                    if (page.Count < pageLimit)
+                    {
+                        break;
+                    }
+
+                    startIndex = checked(startIndex + page.Count);
+                    await Task.Yield();
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Reads each distinct user/media edition set and selects it once, regardless
+        /// of how many source-local Seerr bindings will consume that selection.
+        /// Candidate enumeration therefore remains linear in the resolver's bounded
+        /// user/key projection rather than multiplying by binding count.
+        /// </summary>
+        internal static Dictionary<(Guid UserId, WatchlistMediaKey MediaKey), BaseItem>
+            PrepareDispatchSelections(
+                IReadOnlyCollection<WatchlistLibraryRequest> requests,
+                WatchlistLibraryBatch library,
+                IUserDataManager userDataManager,
+                CancellationToken cancellationToken)
+        {
+            var distinctRequests = requests
+                .GroupBy(static request => (request.User.Id, request.Key))
+                .Select(static group => group.First())
+                .ToList();
+            var selections = new Dictionary<(
+                Guid UserId,
+                WatchlistMediaKey MediaKey), BaseItem>();
+            foreach (var userGroup in distinctRequests.GroupBy(static request => request.User.Id))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var user = userGroup.First().User;
+                var userItems = new List<BaseItem>();
+                var userItemIds = new HashSet<Guid>();
+                foreach (var request in userGroup)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    foreach (var item in library.Get(user, request.Key).AccessibleItems)
+                    {
+                        if (userItemIds.Add(item.Id))
+                        {
+                            userItems.Add(item);
+                        }
+                    }
+                }
+
+                var userData = userItems.Count == 0
+                    ? new Dictionary<Guid, UserItemData>()
+                    : userDataManager.GetUserDataBatch(userItems, user);
+                cancellationToken.ThrowIfCancellationRequested();
+                foreach (var request in userGroup)
+                {
+                    var selection = library
+                        .Get(user, request.Key)
+                        .SelectPreferred(userData);
+                    if (selection?.UserData.Likes == true)
+                    {
+                        selections[(user.Id, request.Key)] = selection.Item;
+                    }
+                }
+            }
+
+            return selections;
         }
 
         private bool TryAuthorizeMutationConfiguration(
@@ -756,6 +1182,48 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
             {
                 _logger.LogError($"[Jellyfin→Seerr Watchlist Sync] Error adding {title} to Seerr watchlist: {ex.Message}");
                 return -1;
+            }
+        }
+
+        private readonly record struct PendingWatchlistExport(
+            JUser User,
+            SeerrUserBinding Binding,
+            WatchlistMediaKey MediaKey,
+            string ItemKey);
+
+        internal sealed class LateAuthorizationBudget
+        {
+            public int ReservedQueries { get; private set; }
+
+            public static bool CanFit(int mutationCount, int preflightBindingCount)
+            {
+                if (mutationCount < 0 || preflightBindingCount < 0)
+                {
+                    return false;
+                }
+
+                return ((long)mutationCount * LateAuthorizationQueriesPerMutation)
+                    + preflightBindingCount
+                    <= MaximumLateAuthorizationQueries;
+            }
+
+            public bool TryReservePreflightBinding()
+                => TryReserve(1);
+
+            public bool TryReserveMutation()
+                => TryReserve(LateAuthorizationQueriesPerMutation);
+
+            private bool TryReserve(int queryCount)
+            {
+                if (ReservedQueries < 0
+                    || queryCount < 1
+                    || ReservedQueries > MaximumLateAuthorizationQueries - queryCount)
+                {
+                    return false;
+                }
+
+                ReservedQueries += queryCount;
+                return true;
             }
         }
 

--- a/Jellyfin.Plugin.JellyfinCanopy/ScheduledTasks/SeerrWatchlistSyncTask.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/ScheduledTasks/SeerrWatchlistSyncTask.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Data;
 using Jellyfin.Plugin.JellyfinCanopy.Helpers;
 using Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr;
 using MediaBrowser.Controller;
@@ -23,13 +24,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
     // Scheduled task that syncs Seerr watchlist items to Jellyfin watchlist.
     public partial class SeerrWatchlistSyncTask : IScheduledTask
     {
-        private readonly ILibraryManager _libraryManager;
         private readonly IUserManager _userManager;
         private readonly IUserDataManager _userDataManager;
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly Configuration.UserConfigurationManager _userConfigurationManager;
         private readonly ILogger<SeerrWatchlistSyncTask> _logger;
         private readonly IPluginConfigProvider _configProvider;
+        private readonly WatchlistLibraryResolver _watchlistLibraryResolver;
 
         public SeerrWatchlistSyncTask(
             ILibraryManager libraryManager,
@@ -38,15 +39,18 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
             IHttpClientFactory httpClientFactory,
             Configuration.UserConfigurationManager userConfigurationManager,
             ILogger<SeerrWatchlistSyncTask> logger,
-            IPluginConfigProvider configProvider)
+            IPluginConfigProvider configProvider,
+            IItemLookupService itemLookup)
         {
-            _libraryManager = libraryManager;
             _userManager = userManager;
             _userDataManager = userDataManager;
             _httpClientFactory = httpClientFactory;
             _userConfigurationManager = userConfigurationManager;
             _configProvider = configProvider;
             _logger = logger;
+            _watchlistLibraryResolver = new WatchlistLibraryResolver(
+                libraryManager,
+                itemLookup);
         }
 
         public string Name => "Sync Watchlist from Seerr to Jellyfin";
@@ -283,6 +287,58 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
             }
 
             cancellationToken.ThrowIfCancellationRequested();
+            var stagedLibraryRequests = new List<WatchlistLibraryRequest>();
+            foreach (var user in jellyfinUsers)
+            {
+                if (!stagedInputs.TryGetValue(user.Id, out var stagedInput))
+                {
+                    continue;
+                }
+
+                var userKeys = stagedInput.WatchlistItems
+                    .Concat(stagedInput.RequestItems)
+                    .Select(static item => new WatchlistMediaKey(item.MediaType, item.TmdbId))
+                    .Where(static key => key.IsValid)
+                    .Distinct();
+                foreach (var key in userKeys)
+                {
+                    if (stagedLibraryRequests.Count >= WatchlistLibraryResolver.MaximumResolutionRequests)
+                    {
+                        _logger.LogWarning(
+                            "[Seerr→Jellyfin Watchlist Sync] The aggregate user/media resolution budget was exceeded. No local changes will be applied.");
+                        progress?.Report(100);
+                        return;
+                    }
+
+                    stagedLibraryRequests.Add(new WatchlistLibraryRequest(user, key));
+                }
+            }
+
+            try
+            {
+                var preparedLibrary = _watchlistLibraryResolver.Resolve(
+                    stagedLibraryRequests,
+                    cancellationToken: cancellationToken);
+                if (!preparedLibrary.IsComplete)
+                {
+                    _logger.LogWarning(
+                        "[Seerr→Jellyfin Watchlist Sync] The bounded Jellyfin candidate lookup was incomplete. No local changes will be applied.");
+                    progress?.Report(100);
+                    return;
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    $"[Seerr→Jellyfin Watchlist Sync] Failed while preparing the Jellyfin access snapshot: {ex.Message}. No local changes will be applied.");
+                progress?.Report(100);
+                return;
+            }
+
             // Remote rows and their owner bindings form one authorization
             // snapshot. Re-prove the complete all-domain identity map after all
             // watchlist/request reads and require exact equality immediately
@@ -329,6 +385,36 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
             }
 
             config = commitConfig;
+            WatchlistLibraryBatch commitLibrary;
+            try
+            {
+                // Re-run both provider resolution and the sparse per-user access
+                // projection after the awaited ownership proof. Each selected
+                // edition is projected once more immediately before its synchronous
+                // save/marker below.
+                commitLibrary = _watchlistLibraryResolver.Resolve(
+                    stagedLibraryRequests,
+                    cancellationToken: cancellationToken);
+                if (!commitLibrary.IsComplete)
+                {
+                    _logger.LogWarning(
+                        "[Seerr→Jellyfin Watchlist Sync] The final bounded Jellyfin access lookup was incomplete. No local changes will be applied.");
+                    progress?.Report(100);
+                    return;
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    $"[Seerr→Jellyfin Watchlist Sync] Failed while revalidating Jellyfin access: {ex.Message}. No local changes will be applied.");
+                progress?.Report(100);
+                return;
+            }
+
             var totalUsers = jellyfinUsers.Count;
             var processedUsers = 0;
             var totalItemsAdded = 0;
@@ -390,9 +476,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                     var alreadyProcessedItems = new List<string>();
                     var alreadyInWatchlistItems = new List<string>();
                     var notInLibraryItems = new List<string>();
+                    var inaccessibleItems = new List<string>();
                     var processedKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                     foreach (var item in combinedItems)
                     {
+                        cancellationToken.ThrowIfCancellationRequested();
                         var key = $"{item.MediaType}:{item.TmdbId}";
                         if (!processedKeys.Add(key))
                         {
@@ -410,9 +498,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                         var result = await ProcessWatchlistItem(
                             jellyfinUser,
                             item,
+                            commitLibrary.Get(
+                                jellyfinUser,
+                                new WatchlistMediaKey(item.MediaType, item.TmdbId)),
                             config,
                             dispatchFence,
-                            CancellationToken.None).ConfigureAwait(false);
+                            cancellationToken).ConfigureAwait(false);
                         if (result == WatchlistItemResult.ConfigurationChanged
                             || !CanCommit())
                         {
@@ -442,6 +533,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                             case WatchlistItemResult.NotInLibrary:
                                 notInLibraryItems.Add(itemInfo);
                                 break;
+                            case WatchlistItemResult.Inaccessible:
+                                inaccessibleItems.Add(itemInfo);
+                                break;
                         }
                     }
 
@@ -459,7 +553,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                         _logger.LogDebug($"[Seerr→Jellyfin Watchlist Sync] Items not in library for user {jellyfinUser.Username} (will be auto-added by WatchlistMonitor): {string.Join(", ", notInLibraryItems)}");
                     }
 
-                    _logger.LogInformation($"[Seerr→Jellyfin Watchlist Sync] User {jellyfinUser.Username}: Added {itemsAdded} items to watchlist, {itemsPending} items added to pending watchlist, {alreadyProcessedItems.Count} already processed, {alreadyInWatchlistItems.Count} already in watchlist, {notInLibraryItems.Count} not in library");
+                    if (inaccessibleItems.Count > 0)
+                    {
+                        _logger.LogDebug($"[Seerr→Jellyfin Watchlist Sync] Items outside the current library access scope for user {jellyfinUser.Username}: {string.Join(", ", inaccessibleItems)}");
+                    }
+
+                    _logger.LogInformation($"[Seerr→Jellyfin Watchlist Sync] User {jellyfinUser.Username}: Added {itemsAdded} items to watchlist, {itemsPending} items added to pending watchlist, {alreadyProcessedItems.Count} already processed, {alreadyInWatchlistItems.Count} already in watchlist, {notInLibraryItems.Count} not in library, {inaccessibleItems.Count} inaccessible");
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
@@ -808,6 +907,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
             AlreadyInWatchlist,
             AlreadyProcessed,
             NotInLibrary,
+            Inaccessible,
             ConfigurationChanged,
             Skipped
         }
@@ -832,6 +932,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
         private Task<WatchlistItemResult> ProcessWatchlistItem(
             JUser user,
             WatchlistItem watchlistItem,
+            WatchlistLibraryMatch libraryMatch,
             PluginConfiguration config,
             SeerrDispatchFence dispatchFence,
             CancellationToken cancellationToken)
@@ -858,35 +959,53 @@ namespace Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks
                     }
                 }
 
-                // Determine Jellyfin item type based on Seerr media type
-                var itemType = watchlistItem.MediaType == "movie" ? BaseItemKind.Movie : BaseItemKind.Series;
-
-                // Find the item in Jellyfin library by TMDB ID
-                var items = _libraryManager.GetItemList(new InternalItemsQuery
-                {
-                    IncludeItemTypes = new[] { itemType },
-                    HasTmdbId = true,
-                    Recursive = true
-                });
-
-                var item = items.FirstOrDefault(i =>
-                    i.ProviderIds != null
-                    && i.ProviderIds.TryGetValue("Tmdb", out var tmdbId)
-                    && MatchesTmdb(tmdbId, watchlistItem.TmdbId));
-
-                if (item == null)
+                if (libraryMatch.State == WatchlistLibraryMatchState.NotInLibrary)
                 {
                     // Item not in library yet - WatchlistMonitor will automatically add it when it arrives
                     return Task.FromResult(WatchlistItemResult.NotInLibrary);
                 }
 
-                // Get user data
-                var userData = _userDataManager.GetUserData(user, item);
-                if (userData == null)
+                if (libraryMatch.AccessibleItems.Count == 0)
                 {
-                    _logger.LogWarning($"[Seerr→Jellyfin Watchlist Sync] User data is null for item {item.Name}; skipping.");
+                    // A type-correct edition exists, but none is visible to this user
+                    // (or it disappeared while the final snapshot was materialized).
+                    return Task.FromResult(WatchlistItemResult.Inaccessible);
+                }
+
+                var mediaKey = new WatchlistMediaKey(
+                    watchlistItem.MediaType,
+                    watchlistItem.TmdbId);
+                var currentAccessibleItems = _watchlistLibraryResolver.RevalidateAccessibleItems(
+                    user,
+                    mediaKey,
+                    libraryMatch.AccessibleItems,
+                    cancellationToken);
+                if (currentAccessibleItems.Count == 0)
+                {
+                    return Task.FromResult(WatchlistItemResult.Inaccessible);
+                }
+
+                // Access is fixed immediately before this current user-data read.
+                // Re-select across every still-accessible edition so a concurrent
+                // unlike cannot create a processed marker with no Like, and a
+                // newly liked alternate cannot cause a duplicate cut to be liked.
+                var userDataByItemId = _userDataManager.GetUserDataBatch(
+                    currentAccessibleItems,
+                    user);
+                cancellationToken.ThrowIfCancellationRequested();
+                var currentMatch = new WatchlistLibraryMatch(
+                    WatchlistLibraryMatchState.Accessible,
+                    currentAccessibleItems);
+                var selection = currentMatch.SelectPreferred(userDataByItemId);
+                if (selection == null)
+                {
+                    _logger.LogWarning(
+                        $"[Seerr→Jellyfin Watchlist Sync] User data is unavailable for every accessible edition of TMDB {watchlistItem.TmdbId}; skipping.");
                     return Task.FromResult(WatchlistItemResult.Skipped);
                 }
+
+                var item = selection.Item;
+                var userData = selection.UserData;
 
                 // Check if already in watchlist
                 if (userData.Likes == true)

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/WatchlistLibraryResolver.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/WatchlistLibraryResolver.cs
@@ -1,0 +1,595 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using Jellyfin.Plugin.JellyfinCanopy.Data;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Entities;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Services
+{
+    /// <summary>
+    /// Resolves Seerr movie/TV identities to every type-correct Jellyfin edition a
+    /// user may currently access. Provider resolution, access projection and item
+    /// materialization are each batched; callers can take a second snapshot at their
+    /// mutation boundary to close over revocation during asynchronous preparation.
+    /// </summary>
+    internal sealed class WatchlistLibraryResolver
+    {
+        internal const int MaximumProviderPairs = 25_000;
+        internal const int MaximumCandidates = 100_000;
+        internal const int MaximumResolutionRequests = 100_000;
+        internal const int MaximumCandidateProjections = 250_000;
+        internal const int AccessProjectionBatchSize = 1_000;
+        internal const int MaterializationBatchSize = 1_000;
+
+        private readonly ILibraryManager _libraryManager;
+        private readonly IItemLookupService _itemLookup;
+
+        public WatchlistLibraryResolver(
+            ILibraryManager libraryManager,
+            IItemLookupService itemLookup)
+        {
+            _libraryManager = libraryManager;
+            _itemLookup = itemLookup;
+        }
+
+        public WatchlistLibraryBatch Resolve(
+            IReadOnlyCollection<WatchlistMediaKey> keys,
+            IReadOnlyCollection<JUser> users,
+            IReadOnlyCollection<BaseItem>? knownItems = null,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (keys.Count > MaximumResolutionRequests
+                || users.Count > MaximumResolutionRequests)
+            {
+                return WatchlistLibraryBatch.Incomplete;
+            }
+
+            var uniqueKeys = keys
+                .Where(static key => key.IsValid)
+                .Distinct()
+                .ToList();
+            var uniqueUsers = users
+                .GroupBy(static user => user.Id)
+                .Select(static group => group.First())
+                .ToList();
+
+            // This overload intentionally means every user needs every key. Prove
+            // that the cross-product fits the aggregate work budget before
+            // constructing it; the sparse overload below is preferred for bulk
+            // callers whose users own different key sets.
+            if (uniqueUsers.Count > 0
+                && uniqueKeys.Count > MaximumResolutionRequests / uniqueUsers.Count)
+            {
+                return WatchlistLibraryBatch.Incomplete;
+            }
+
+            var requests = new List<WatchlistLibraryRequest>(uniqueKeys.Count * uniqueUsers.Count);
+            foreach (var user in uniqueUsers)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                foreach (var key in uniqueKeys)
+                {
+                    requests.Add(new WatchlistLibraryRequest(user, key));
+                }
+            }
+
+            return Resolve(requests, knownItems, cancellationToken);
+        }
+
+        public WatchlistLibraryBatch Resolve(
+            IReadOnlyCollection<WatchlistLibraryRequest> requests,
+            IReadOnlyCollection<BaseItem>? knownItems = null,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (requests.Count > MaximumResolutionRequests
+                || knownItems?.Count > MaximumCandidates)
+            {
+                return WatchlistLibraryBatch.Incomplete;
+            }
+
+            var usersById = new Dictionary<Guid, JUser>();
+            var keysByUserId = new Dictionary<Guid, HashSet<WatchlistMediaKey>>();
+            var resolutionCount = 0;
+            foreach (var request in requests)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!request.Key.IsValid)
+                {
+                    continue;
+                }
+
+                usersById.TryAdd(request.User.Id, request.User);
+                if (!keysByUserId.TryGetValue(request.User.Id, out var userKeys))
+                {
+                    userKeys = new HashSet<WatchlistMediaKey>();
+                    keysByUserId.Add(request.User.Id, userKeys);
+                }
+
+                if (userKeys.Add(request.Key))
+                {
+                    if (resolutionCount >= MaximumResolutionRequests)
+                    {
+                        return WatchlistLibraryBatch.Incomplete;
+                    }
+
+                    resolutionCount++;
+                }
+            }
+
+            if (resolutionCount == 0)
+            {
+                return new WatchlistLibraryBatch(
+                    new Dictionary<
+                        Guid,
+                        IReadOnlyDictionary<WatchlistMediaKey, WatchlistLibraryMatch>>(),
+                    true);
+            }
+
+            var uniqueKeys = keysByUserId.Values
+                .SelectMany(static keys => keys)
+                .Distinct()
+                .ToList();
+            var providerPairs = uniqueKeys
+                .Select(static key => key.ProviderPair)
+                .Distinct()
+                .ToList();
+
+            var candidateBatch = _itemLookup.GetItemCandidatesByProvidersBatchBounded(
+                providerPairs,
+                MaximumProviderPairs,
+                MaximumCandidates);
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!candidateBatch.IsComplete)
+            {
+                return WatchlistLibraryBatch.Incomplete;
+            }
+
+            var candidates = candidateBatch.Candidates.ToDictionary(
+                static pair => pair.Key,
+                static pair => (IReadOnlyList<ItemLookupCandidate>)pair.Value.ToList());
+            if (knownItems != null)
+            {
+                // An ItemAdded event may arrive before the provider index query can
+                // observe that exact item. Merge only the explicitly supplied,
+                // identity-checked items; the batch lookup still supplies every
+                // alternate edition already present in the library index.
+                var knownCandidates = ItemLookupService.MapProviderPairs(
+                    knownItems,
+                    providerPairs);
+                foreach (var (pair, matches) in knownCandidates)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var merged = candidates.GetValueOrDefault(pair)
+                        ?.Concat(matches)
+                        ?? matches;
+                    candidates[pair] = merged
+                        .DistinctBy(static candidate => candidate.ItemId)
+                        .OrderBy(static candidate => candidate.ItemId)
+                        .ToList();
+                }
+            }
+
+            if (candidates.Values.Sum(static matches => (long)matches.Count) > MaximumCandidates)
+            {
+                return WatchlistLibraryBatch.Incomplete;
+            }
+
+            var candidatesByKey = uniqueKeys.ToDictionary(
+                static key => key,
+                key => (IReadOnlyList<ItemLookupCandidate>)GetTypeCorrectCandidates(candidates, key)
+                    .ToList());
+            long candidateProjectionCount = 0;
+            foreach (var userKeys in keysByUserId.Values)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                foreach (var key in userKeys)
+                {
+                    candidateProjectionCount += candidatesByKey.GetValueOrDefault(key)?.Count ?? 0;
+                    if (candidateProjectionCount > MaximumCandidateProjections)
+                    {
+                        return WatchlistLibraryBatch.Incomplete;
+                    }
+                }
+            }
+
+            var accessibleIdsByUser = new Dictionary<Guid, IReadOnlySet<Guid>>();
+            var candidateIdSet = new HashSet<Guid>();
+            foreach (var (userId, userKeys) in keysByUserId)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var userCandidateIds = userKeys
+                    .SelectMany(key => candidatesByKey.GetValueOrDefault(key)
+                        ?? Array.Empty<ItemLookupCandidate>())
+                    .Select(static candidate => candidate.ItemId)
+                    .Distinct()
+                    .ToList();
+                candidateIdSet.UnionWith(userCandidateIds);
+                accessibleIdsByUser[userId] = GetAccessibleItemIdsBounded(
+                    userCandidateIds,
+                    usersById[userId],
+                    cancellationToken);
+            }
+
+            var accessibleCandidateIds = accessibleIdsByUser.Values
+                .SelectMany(static ids => ids)
+                .Where(candidateIdSet.Contains)
+                .Distinct()
+                .ToHashSet();
+            var itemsById = (knownItems ?? Array.Empty<BaseItem>())
+                .Where(item => accessibleCandidateIds.Contains(item.Id))
+                .GroupBy(static item => item.Id)
+                .ToDictionary(static group => group.Key, static group => group.First());
+            var missingIds = accessibleCandidateIds
+                .Where(id => !itemsById.ContainsKey(id))
+                .ToArray();
+            if (missingIds.Length > 0)
+            {
+                for (var offset = 0; offset < missingIds.Length; offset += MaterializationBatchSize)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var itemIds = missingIds
+                        .Skip(offset)
+                        .Take(MaterializationBatchSize)
+                        .ToArray();
+                    var materialized = _libraryManager.GetItemList(new InternalItemsQuery
+                    {
+                        ItemIds = itemIds,
+                        Recursive = true,
+                        Limit = itemIds.Length + 1
+                    });
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    foreach (var item in materialized)
+                    {
+                        if (accessibleCandidateIds.Contains(item.Id))
+                        {
+                            itemsById.TryAdd(item.Id, item);
+                        }
+                    }
+                }
+            }
+
+            var resolutions = new Dictionary<
+                Guid,
+                IReadOnlyDictionary<WatchlistMediaKey, WatchlistLibraryMatch>>();
+            foreach (var (userId, userKeys) in keysByUserId)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var allowedIds = accessibleIdsByUser[userId];
+                var userResolutions = new Dictionary<WatchlistMediaKey, WatchlistLibraryMatch>();
+                foreach (var key in userKeys)
+                {
+                    var typeCorrectCandidates = candidatesByKey.GetValueOrDefault(key)
+                        ?? Array.Empty<ItemLookupCandidate>();
+                    if (typeCorrectCandidates.Count == 0)
+                    {
+                        userResolutions[key] = WatchlistLibraryMatch.NotInLibrary;
+                        continue;
+                    }
+
+                    var accessibleItems = typeCorrectCandidates
+                        .Where(candidate => allowedIds.Contains(candidate.ItemId))
+                        .Select(candidate => itemsById.GetValueOrDefault(candidate.ItemId))
+                        .Where(item => item != null && MatchesIdentity(item, key))
+                        .Cast<BaseItem>()
+                        .DistinctBy(static item => item.Id)
+                        .OrderBy(static item => item.Id)
+                        .ToList();
+                    userResolutions[key] = accessibleItems.Count == 0
+                        ? WatchlistLibraryMatch.Inaccessible
+                        : new WatchlistLibraryMatch(
+                            WatchlistLibraryMatchState.Accessible,
+                            accessibleItems);
+                }
+
+                resolutions[userId] = userResolutions;
+            }
+
+            return new WatchlistLibraryBatch(resolutions, true);
+        }
+
+        /// <summary>
+        /// Resolves a sparse request set while flattening the caller's bounded
+        /// library snapshot once per distinct requested media key. The count pass
+        /// rejects an oversized projection before any edition list is enumerated
+        /// and, because the provider lookup occurs in the delegated overload, before
+        /// any provider or access query is issued.
+        /// </summary>
+        public WatchlistLibraryBatch Resolve<TCollection>(
+            IReadOnlyCollection<WatchlistLibraryRequest> requests,
+            IReadOnlyDictionary<WatchlistMediaKey, TCollection> knownItemsByKey,
+            CancellationToken cancellationToken = default)
+            where TCollection : IReadOnlyCollection<BaseItem>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (requests.Count > MaximumResolutionRequests)
+            {
+                return WatchlistLibraryBatch.Incomplete;
+            }
+
+            var requestedKeys = requests
+                .Select(static request => request.Key)
+                .Where(static key => key.IsValid)
+                .Distinct()
+                .ToList();
+            long projectedItemCount = 0;
+            foreach (var key in requestedKeys)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!knownItemsByKey.TryGetValue(key, out var editions))
+                {
+                    continue;
+                }
+
+                projectedItemCount += editions.Count;
+                if (projectedItemCount > MaximumCandidates)
+                {
+                    return WatchlistLibraryBatch.Incomplete;
+                }
+            }
+
+            var knownItems = new List<BaseItem>((int)projectedItemCount);
+            var knownItemIds = new HashSet<Guid>();
+            var enumeratedItemCount = 0;
+            foreach (var key in requestedKeys)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!knownItemsByKey.TryGetValue(key, out var editions))
+                {
+                    continue;
+                }
+
+                foreach (var item in editions)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (enumeratedItemCount >= MaximumCandidates)
+                    {
+                        return WatchlistLibraryBatch.Incomplete;
+                    }
+
+                    enumeratedItemCount++;
+                    if (knownItemIds.Add(item.Id))
+                    {
+                        knownItems.Add(item);
+                    }
+                }
+            }
+
+            return Resolve(requests, knownItems, cancellationToken);
+        }
+
+        /// <summary>
+        /// Revalidates one already-selected edition at the narrow local-mutation
+        /// boundary. This intentionally avoids another provider search: the item id
+        /// is fixed, identity-checked, and projected through the live user policy
+        /// before its user data is saved or marked processed.
+        /// </summary>
+        public BaseItem? RevalidateSelection(
+            JUser user,
+            WatchlistMediaKey key,
+            BaseItem item,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!key.IsValid
+                || item.Id == Guid.Empty
+                || !MatchesIdentity(item, key))
+            {
+                return null;
+            }
+
+            var accessibleIds = GetAccessibleItemIdsBounded(
+                new[] { item.Id },
+                user,
+                cancellationToken);
+            return accessibleIds.Contains(item.Id)
+                ? item
+                : null;
+        }
+
+        /// <summary>
+        /// Reprojects a previously bounded, type-correct edition set through the
+        /// target user's live access policy. The provider lookup remains batched at
+        /// the caller; this boundary performs one fixed-id access query and returns
+        /// only identities that still match the requested typed media key.
+        /// </summary>
+        public IReadOnlyList<BaseItem> RevalidateAccessibleItems(
+            JUser user,
+            WatchlistMediaKey key,
+            IReadOnlyList<BaseItem> items,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!key.IsValid || items.Count == 0)
+            {
+                return Array.Empty<BaseItem>();
+            }
+
+            var candidates = items
+                .Where(item => item.Id != Guid.Empty && MatchesIdentity(item, key))
+                .DistinctBy(static item => item.Id)
+                .OrderBy(static item => item.Id)
+                .ToList();
+            if (candidates.Count == 0)
+            {
+                return Array.Empty<BaseItem>();
+            }
+
+            var accessibleIds = GetAccessibleItemIdsBounded(
+                candidates.Select(static item => item.Id).ToArray(),
+                user,
+                cancellationToken);
+            return candidates
+                .Where(item => accessibleIds.Contains(item.Id))
+                .ToList();
+        }
+
+        /// <summary>
+        /// Projects a deterministic fixed-id set through Jellyfin's live user
+        /// policy in bounded queries. Only ids requested in the corresponding
+        /// chunk may enter the union, so an unexpected host result fails closed.
+        /// The synchronous host API cannot be awaited, but yielding between chunks
+        /// prevents one large user projection from monopolizing the worker thread.
+        /// </summary>
+        internal IReadOnlySet<Guid> GetAccessibleItemIdsBounded(
+            IEnumerable<Guid> itemIds,
+            JUser user,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var orderedIds = itemIds
+                .Where(static id => id != Guid.Empty)
+                .Distinct()
+                .OrderBy(static id => id)
+                .ToList();
+            var accessibleIds = new HashSet<Guid>();
+            for (var offset = 0; offset < orderedIds.Count; offset += AccessProjectionBatchSize)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var batch = orderedIds
+                    .Skip(offset)
+                    .Take(AccessProjectionBatchSize)
+                    .ToArray();
+                var batchSet = batch.ToHashSet();
+                var batchAccessibleIds = _itemLookup.GetAccessibleItemIdsBatch(batch, user);
+                cancellationToken.ThrowIfCancellationRequested();
+                foreach (var accessibleId in batchAccessibleIds)
+                {
+                    if (batchSet.Contains(accessibleId))
+                    {
+                        accessibleIds.Add(accessibleId);
+                    }
+                }
+
+                if (offset + batch.Length < orderedIds.Count)
+                {
+                    Thread.Yield();
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+            }
+
+            return accessibleIds;
+        }
+
+        private static IEnumerable<ItemLookupCandidate> GetTypeCorrectCandidates(
+            Dictionary<(string Provider, string Value), IReadOnlyList<ItemLookupCandidate>> candidates,
+            WatchlistMediaKey key)
+            => candidates.TryGetValue(key.ProviderPair, out var matches)
+                ? matches.Where(candidate => candidate.Kind == key.ExpectedKind)
+                : Enumerable.Empty<ItemLookupCandidate>();
+
+        private static bool MatchesIdentity(BaseItem item, WatchlistMediaKey key)
+            => ItemLookupService.GetItemKind(item) == key.ExpectedKind
+                && item.ProviderIds.TryGetValue("Tmdb", out var tmdbId)
+                && string.Equals(tmdbId, key.ProviderPair.Value, StringComparison.Ordinal);
+    }
+
+    internal readonly record struct WatchlistLibraryRequest(
+        JUser User,
+        WatchlistMediaKey Key);
+
+    internal readonly record struct WatchlistMediaKey(string MediaType, int TmdbId)
+    {
+        public bool IsValid
+            => TmdbId > 0
+                && (string.Equals(MediaType, "movie", StringComparison.Ordinal)
+                    || string.Equals(MediaType, "tv", StringComparison.Ordinal));
+
+        public ItemLookupKind ExpectedKind
+            => string.Equals(MediaType, "movie", StringComparison.Ordinal)
+                ? ItemLookupKind.Movie
+                : string.Equals(MediaType, "tv", StringComparison.Ordinal)
+                    ? ItemLookupKind.Series
+                    : ItemLookupKind.Other;
+
+        public (string Provider, string Value) ProviderPair
+            => ("Tmdb", TmdbId.ToString(CultureInfo.InvariantCulture));
+    }
+
+    internal enum WatchlistLibraryMatchState
+    {
+        NotInLibrary,
+        Inaccessible,
+        Accessible
+    }
+
+    internal sealed record WatchlistLibraryMatch(
+        WatchlistLibraryMatchState State,
+        IReadOnlyList<BaseItem> AccessibleItems)
+    {
+        public static WatchlistLibraryMatch NotInLibrary { get; } = new(
+            WatchlistLibraryMatchState.NotInLibrary,
+            Array.Empty<BaseItem>());
+
+        public static WatchlistLibraryMatch Inaccessible { get; } = new(
+            WatchlistLibraryMatchState.Inaccessible,
+            Array.Empty<BaseItem>());
+
+        public BaseItem? SelectedItem => AccessibleItems.FirstOrDefault();
+
+        /// <summary>
+        /// Chooses an already-liked accessible edition first. If none is liked,
+        /// chooses the lowest-id accessible edition for which Jellyfin returned
+        /// user data. Both passes preserve the resolver's deterministic id order.
+        /// </summary>
+        public WatchlistLibrarySelection? SelectPreferred(
+            IReadOnlyDictionary<Guid, UserItemData> userDataByItemId)
+        {
+            foreach (var item in AccessibleItems)
+            {
+                if (userDataByItemId.TryGetValue(item.Id, out var userData)
+                    && userData.Likes == true)
+                {
+                    return new WatchlistLibrarySelection(item, userData);
+                }
+            }
+
+            foreach (var item in AccessibleItems)
+            {
+                if (userDataByItemId.TryGetValue(item.Id, out var userData))
+                {
+                    return new WatchlistLibrarySelection(item, userData);
+                }
+            }
+
+            return null;
+        }
+    }
+
+    internal sealed record WatchlistLibrarySelection(
+        BaseItem Item,
+        UserItemData UserData);
+
+    internal sealed class WatchlistLibraryBatch
+    {
+        private readonly IReadOnlyDictionary<
+            Guid,
+            IReadOnlyDictionary<WatchlistMediaKey, WatchlistLibraryMatch>> _resolutions;
+
+        public WatchlistLibraryBatch(
+            IReadOnlyDictionary<Guid, IReadOnlyDictionary<WatchlistMediaKey, WatchlistLibraryMatch>> resolutions,
+            bool isComplete)
+        {
+            _resolutions = resolutions;
+            IsComplete = isComplete;
+        }
+
+        public static WatchlistLibraryBatch Incomplete { get; } = new(
+            new Dictionary<Guid, IReadOnlyDictionary<WatchlistMediaKey, WatchlistLibraryMatch>>(),
+            false);
+
+        public bool IsComplete { get; }
+
+        public WatchlistLibraryMatch Get(JUser user, WatchlistMediaKey key)
+            => _resolutions.TryGetValue(user.Id, out var userResolutions)
+                && userResolutions.TryGetValue(key, out var resolution)
+                    ? resolution
+                    : WatchlistLibraryMatch.NotInLibrary;
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/WatchlistMonitor.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/WatchlistMonitor.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Data;
 using Jellyfin.Plugin.JellyfinCanopy.Helpers;
 using Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr;
 using Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks;
@@ -35,6 +36,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         private readonly UserConfigurationManager _userConfigurationManager;
         private readonly ILogger<WatchlistMonitor> _logger;
         private readonly IPluginConfigProvider _configProvider;
+        private readonly WatchlistLibraryResolver _watchlistLibraryResolver;
         private const int WorkQueueCapacity = 1024;
         // A local mutation batch can be partially committed before an unexpected exception.
         // Do not replay it automatically; the next Jellyfin update event is the safe re-drive.
@@ -62,7 +64,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             IHttpClientFactory httpClientFactory,
             UserConfigurationManager userConfigurationManager,
             ILogger<WatchlistMonitor> logger,
-            IPluginConfigProvider configProvider)
+            IPluginConfigProvider configProvider,
+            IItemLookupService itemLookup)
         {
             _libraryManager = libraryManager;
             _userManager = userManager;
@@ -71,6 +74,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             _userConfigurationManager = userConfigurationManager;
             _configProvider = configProvider;
             _logger = logger;
+            _watchlistLibraryResolver = new WatchlistLibraryResolver(
+                libraryManager,
+                itemLookup);
             _workQueue = new BoundedCoalescingWorker<Guid, WatchlistWorkItem>(
                 WorkQueueCapacity,
                 WorkMaximumAttempts,
@@ -461,41 +467,33 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     .Where(id => !blockedIds.Contains(id))
                     .Distinct(StringComparer.OrdinalIgnoreCase)
                     .ToList();
+                var requesterUsers = requesterIds
+                    .Select(id => usersByNormalizedId.GetValueOrDefault(id))
+                    .Where(static user => user != null)
+                    .Cast<User>()
+                    .ToList();
+                var mediaKey = new WatchlistMediaKey(mediaType, tmdbId);
 
                 // Stage every local decision without changing UserItemData or processed-marker
                 // files. A later ownership/configuration failure therefore produces zero partial
                 // local writes across a multi-requester event.
-                var pendingMutations = new List<PendingWatchlistMutation>();
-                foreach (var jellyfinUserId in requesterIds)
+                var preparedLibrary = _watchlistLibraryResolver.Resolve(
+                    new[] { mediaKey },
+                    requesterUsers,
+                    new[] { item },
+                    cancellationToken);
+                if (!preparedLibrary.IsComplete)
                 {
-                    cancellationToken.ThrowIfCancellationRequested();
-
-                    if (!usersByNormalizedId.TryGetValue(jellyfinUserId, out var user))
-                    {
-                        continue;
-                    }
-
-                    // Check if prevention is enabled and item was already processed
-                    if (config.PreventWatchlistReAddition)
-                    {
-                        var processedItems = _userConfigurationManager.GetProcessedWatchlistItems(user.Id);
-                        if (processedItems.Items.Any(p => p.TmdbId == tmdbId && p.MediaType == mediaType))
-                        {
-                            continue; // Skip this user, item was already processed
-                        }
-                    }
-
-                    var userData = _userDataManager.GetUserData(user, item);
-                    if (userData != null && userData.Likes != true)
-                    {
-                        pendingMutations.Add(new PendingWatchlistMutation(user, userData, addLike: true));
-                    }
-                    else if (userData != null && userData.Likes == true && config.PreventWatchlistReAddition)
-                    {
-                        pendingMutations.Add(new PendingWatchlistMutation(user, userData, addLike: false));
-                    }
+                    _logger.LogWarning(
+                        "[Watchlist] The bounded Jellyfin candidate lookup was incomplete; no local watchlists were changed.");
+                    return;
                 }
 
+                var pendingMutations = BuildPendingMutations(
+                    requesterUsers,
+                    preparedLibrary,
+                    mediaKey,
+                    config);
                 if (pendingMutations.Count == 0) return;
 
                 // Ownership can be rebound while request rows and local user data are being
@@ -527,6 +525,28 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     return;
                 }
 
+                // Access may be revoked (or an edition replaced) during the
+                // awaited ownership proof. Resolve the complete candidate set and
+                // every requester projection again at the final local-write barrier.
+                var dispatchLibrary = _watchlistLibraryResolver.Resolve(
+                    new[] { mediaKey },
+                    requesterUsers,
+                    new[] { item },
+                    cancellationToken);
+                if (!dispatchLibrary.IsComplete)
+                {
+                    _logger.LogWarning(
+                        "[Watchlist] The final bounded Jellyfin access lookup was incomplete; no local watchlists were changed.");
+                    return;
+                }
+
+                pendingMutations = BuildPendingMutations(
+                    requesterUsers,
+                    dispatchLibrary,
+                    mediaKey,
+                    config);
+                if (pendingMutations.Count == 0) return;
+
                 var addedCount = 0;
                 var addedUsers = new List<string>();
                 foreach (var pending in pendingMutations)
@@ -539,13 +559,61 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                         return;
                     }
 
-                    if (pending.AddLike)
+                    // The final bulk snapshot precedes this loop. Re-project every
+                    // bounded edition immediately before each save/marker, then
+                    // re-read current user data and select again. This closes both
+                    // access revocation and stale liked-edition decisions.
+                    var currentAccessibleItems = _watchlistLibraryResolver.RevalidateAccessibleItems(
+                        pending.User,
+                        mediaKey,
+                        dispatchLibrary.Get(pending.User, mediaKey).AccessibleItems,
+                        cancellationToken);
+                    if (currentAccessibleItems.Count == 0)
                     {
-                        pending.UserData.Likes = true;
+                        _logger.LogDebug(
+                            "[Watchlist] Suppressed TMDB {TmdbId} for {User} because no edition is still accessible.",
+                            tmdbId,
+                            pending.User.Username);
+                        continue;
+                    }
+
+                    // The access query is synchronous but can overlap an admin
+                    // save. Fence its completion, then fence the current user-data
+                    // read as well, before any local write.
+                    if (!IsCurrentMutationAuthorized(configStamp))
+                    {
+                        _logger.LogWarning(
+                            "[Watchlist] Configuration changed during final access validation; remaining writes were suppressed.");
+                        return;
+                    }
+
+                    var currentUserData = _userDataManager.GetUserDataBatch(
+                        currentAccessibleItems,
+                        pending.User);
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (!IsCurrentMutationAuthorized(configStamp))
+                    {
+                        _logger.LogWarning(
+                            "[Watchlist] Configuration changed during final user-data validation; remaining writes were suppressed.");
+                        return;
+                    }
+
+                    var currentMatch = new WatchlistLibraryMatch(
+                        WatchlistLibraryMatchState.Accessible,
+                        currentAccessibleItems);
+                    var currentSelection = currentMatch.SelectPreferred(currentUserData);
+                    if (currentSelection == null)
+                    {
+                        continue;
+                    }
+
+                    if (currentSelection.UserData.Likes != true)
+                    {
+                        currentSelection.UserData.Likes = true;
                         _userDataManager.SaveUserData(
                             pending.User,
-                            item,
-                            pending.UserData,
+                            currentSelection.Item,
+                            currentSelection.UserData,
                             UserDataSaveReason.UpdateUserRating,
                             cancellationToken);
                         addedCount++;
@@ -557,7 +625,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                             TryMarkProcessed(pending.User.Id, tmdbId, mediaType, "monitor");
                         }
                     }
-                    else if (IsCurrentMutationAuthorized(configStamp))
+                    else if (config.PreventWatchlistReAddition
+                        && IsCurrentMutationAuthorized(configStamp))
                     {
                         TryMarkProcessed(pending.User.Id, tmdbId, mediaType, "existing");
                     }
@@ -566,7 +635,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 // Only log if we actually added the item to at least one watchlist
                 if (addedCount > 0)
                 {
-                    _logger.LogInformation($"[Watchlist] ✓ Added '{item.Name}' to watchlist for {string.Join(", ", addedUsers)}");
+                    _logger.LogInformation($"[Watchlist] ✓ Added TMDB {tmdbId} to watchlist for {string.Join(", ", addedUsers)}");
                 }
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -578,6 +647,37 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 _logger.LogError($"[Watchlist] Error in ProcessItemForWatchlist: {ex.Message}\nStack trace: {ex.StackTrace}");
                 throw;
             }
+        }
+
+        private List<PendingWatchlistMutation> BuildPendingMutations(
+            IReadOnlyCollection<User> users,
+            WatchlistLibraryBatch library,
+            WatchlistMediaKey mediaKey,
+            PluginConfiguration config)
+        {
+            var pendingMutations = new List<PendingWatchlistMutation>();
+            foreach (var user in users)
+            {
+                if (config.PreventWatchlistReAddition)
+                {
+                    var processedItems = _userConfigurationManager.GetProcessedWatchlistItems(user.Id);
+                    if (processedItems.Items.Any(p => p.TmdbId == mediaKey.TmdbId
+                        && p.MediaType == mediaKey.MediaType))
+                    {
+                        continue;
+                    }
+                }
+
+                var libraryMatch = library.Get(user, mediaKey);
+                if (libraryMatch.AccessibleItems.Count == 0)
+                {
+                    continue;
+                }
+
+                pendingMutations.Add(new PendingWatchlistMutation(user));
+            }
+
+            return pendingMutations;
         }
 
         // Serialize the processed-watchlist marker append through the locked RMW primitive so a
@@ -1047,18 +1147,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
 
         private sealed class PendingWatchlistMutation
         {
-            public PendingWatchlistMutation(User user, UserItemData userData, bool addLike)
+            public PendingWatchlistMutation(User user)
             {
                 User = user;
-                UserData = userData;
-                AddLike = addLike;
             }
 
             public User User { get; }
-
-            public UserItemData UserData { get; }
-
-            public bool AddLike { get; }
         }
 
         // Model for Seerr request items with requesting user

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,16 +26,16 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2808, totalLines: 3201 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 28559, totalLines: 37106 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 29245, totalLines: 37825 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 3,
         minimumCoveredLines: 2808,
         maximumCoveredLines: 2808,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
-        cleanRuns: 7,
-        minimumCoveredLines: 28557,
-        maximumCoveredLines: 28559,
+        cleanRuns: 4,
+        minimumCoveredLines: 29243,
+        maximumCoveredLines: 29245,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);
@@ -50,11 +50,17 @@ for (const name of ['client', 'server']) {
             totalLines: profile.measured.totalLines,
         };
         const result = evaluateCoverage(tolerated, profile);
-        assert.equal(result.ok, true);
-        assert.equal(
-            result.reason,
-            profile.tolerance.missingCoveredLines === 0 ? 'exact' : 'within-tolerance'
-        );
+        assert.deepEqual(result, profile.tolerance.missingCoveredLines === 0
+            ? {
+                ok: true,
+                reason: 'exact',
+                message: 'measurement matches the reviewed observed high-water',
+            }
+            : {
+                ok: true,
+                reason: 'within-tolerance',
+                message: `measurement is within the ${profile.tolerance.missingCoveredLines}-line instrumentation tolerance`,
+            });
     });
 
     test(`${name} negative fixture fails after representative covered lines are removed`, () => {

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 28559,
-        "totalLines": 37106
+        "coveredLines": 29245,
+        "totalLines": 37825
       },
       "observations": {
-        "cleanRuns": 7,
-        "minimumCoveredLines": 28557,
-        "maximumCoveredLines": 28559
+        "cleanRuns": 4,
+        "minimumCoveredLines": 29243,
+        "maximumCoveredLines": 29245
       },
       "tolerance": {
         "missingCoveredLines": 2,
-        "rationale": "Completing #165 established a reviewed high-water of 28,559/37,106 after five clean .NET 10.0.9/Coverlet runs passed all 2,507 server tests at the identical scope and measured 28,559, 28,558, 28,558, 28,558, and 28,558 covered lines. A GitHub Actions run for PR #545 on 2026-08-01 used the unchanged server source/test tree, passed the same 2,507 tests at the same 37,106-line scope, and measured 28,557, proving the bounded Coverlet instrumentation envelope extends one line lower than the original five-run sample. A seventh clean local validation run on the same server source/test tree and scope measured 28,558 and confirmed the adjusted gate. The seven-run reviewed envelope is therefore 28,557–28,559, while the monotonic high-water remains 28,559/37,106 (76.966%). Under the fixed-scope direct-observation policy, a two-line tolerance (0.005 percentage points) admits only the exact newly observed low side and sets the floor at 28,557/37,106 (76.961%), still above the prior 28,444/36,969 floor (76.940%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "rationale": "Fixing #154 adds a bounded, access-aware multi-edition resolver and mutation-boundary revalidation for all three watchlist consumers. The final hardening deduplicates outbound edition selection across bindings; orders each final exact binding GET before current access and Likes reads; re-reads current UserItemData at scheduled and monitor write barriers; fences monitor configuration after access and user-data queries; counts preflight binding GETs in the 200,000-query authorization budget; pages the 100,000-item library snapshot in cancellable 1,000-item batches; and routes resolver preparation, final edition revalidation, and outbound staging through deterministic cancellable 1,000-id access-policy queries. Focused regressions cover inaccessible-first, no-access, markers, per-user exports, typed namespaces, duplicate editions, linear repeated-binding enumeration, current access and unlike races, configuration changes during access, exact aggregate and access-batch boundaries, and cancellation between library pages and single-user access chunks. Three clean .NET 10.0.9/Coverlet runs on 2026-08-02 each passed all 2,547 server tests at the identical 37,825-line scope and measured 29,244, 29,245, and 29,244 covered lines. PR #559 run 30725667910 then passed the same 2,547 tests on .NET 10.0.10 at the identical scope and directly observed 29,243 covered lines. The reviewed high-water therefore advances from 29,221/37,802 (77.300%) to 29,245/37,825 (77.317%), while the four-run instrumentation envelope sets the exact floor at 29,243/37,825 (77.311%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
## Summary

- resolve watchlist matches across every local edition while enforcing each Jellyfin user current access policy
- fence scheduled and monitor writes against binding, configuration, access, and UserItemData races
- bound aggregate authorization work and page every item and access projection in deterministic cancellable 1,000-ID chunks
- preserve typed provider namespaces, deterministic selection, per-user markers, and fail-closed behavior
- add exact-boundary, race, cancellation, duplicate-edition, and linear-work regressions

Closes #154

## Validation

- focused watchlist regressions: 75/75
- full server suite: 2,547/2,547 on repeated clean local runs and on the .NET 10.0.10 CI observation
- server coverage gate: four directly observed clean measurements span 29,243–29,245/37,825; reviewed high-water remains 29,245 and the exact floor is 29,243 with a two-line instrumentation tolerance
- coverage policy tests: 14/14, including below-floor, above-high-water, scope-drift, insufficient-observation, and broad-tolerance rejection
- Release build: 0 warnings, 0 errors
- changed-file formatting and git diff --check: passed
- independent final review: APPROVED after both the bounded access-projection follow-up and the final CI-observed coverage envelope

The separate provider-pair candidate mapping performance defect discovered during review is tracked as #555.