### PR TITLE
Decouple modal history probes from frame polling (#176)

### DIFF
--- a/e2e/seerr-modal-history.spec.ts
+++ b/e2e/seerr-modal-history.spec.ts
@@ -322,7 +322,10 @@ test.describe('Seerr modal history ownership', () => {
         await page.waitForFunction(
             () => (history.state as { jcHistoryProof?: string } | null)?.jcHistoryProof === 'late-cap-route-a',
             undefined,
-            { timeout: 30_000 }
+            // Do not couple the assertion loop to requestAnimationFrame. CI can
+            // temporarily throttle rendering after a same-URL history pop even
+            // though the popstate transaction has already settled.
+            { polling: 50, timeout: 30_000 }
         );
         await page.evaluate(() => history.forward());
         await page.waitForFunction(
@@ -443,7 +446,7 @@ test.describe('Seerr modal history ownership', () => {
                     && !owner?.pendingOwnedTraversal
                     && !document.querySelector('.seerr-season-modal')
                     && !document.body.classList.contains('jc-modal-open');
-            }, undefined, { timeout: 30_000 });
+            }, undefined, { polling: 50, timeout: 30_000 });
             expect(await page.evaluate(() => (window as any).__jcAsyncCanonicalProof)).toEqual({
                 laterStates: ['async-canonical-route-b'],
                 rewriteRuns: 1,
@@ -547,7 +550,7 @@ test.describe('Seerr modal history ownership', () => {
                 && state.canonicalized === true
                 && !owner?.pendingOwnedTraversal
                 && !document.querySelector('.seerr-season-modal');
-        }, undefined, { timeout: 30_000 });
+        }, undefined, { polling: 50, timeout: 30_000 });
         expect(await page.evaluate(() => (window as any).__jcSyncCanonicalProof)).toEqual({
             laterStates: ['sync-canonical-route-b'],
             rewriteRuns: 1,
@@ -948,7 +951,7 @@ test.describe('Seerr modal history ownership', () => {
                 && !document.querySelector('.seerr-season-modal')
                 && !document.body.classList.contains('jc-modal-open')
                 && !owner.pendingOwnedTraversal;
-        }, undefined, { timeout: 30_000 });
+        }, undefined, { polling: 50, timeout: 30_000 });
         expect(await page.evaluate(() => (window as any).__jcReactivePushProof)).toEqual({
             laterStates: [],
             reactiveRuns: 1,
@@ -1031,7 +1034,7 @@ test.describe('Seerr modal history ownership', () => {
             return (window as any).__jcLateReplaceProof.arrivals.at(-1) === 'late-replace-route-b'
                 && !document.querySelector('.seerr-season-modal')
                 && !owner.pendingOwnedTraversal;
-        }, undefined, { timeout: 30_000 });
+        }, undefined, { polling: 50, timeout: 30_000 });
         expect(await page.evaluate(() => (window as any).__jcLateReplaceProof.writeState)).toEqual({
             jcHistoryProof: 'late-replace-route-b',
             preservedA: { exact: 23 },
@@ -1250,7 +1253,7 @@ test.describe('Seerr modal history ownership', () => {
             const owner = (window as any).__jellyfinCanopySeerrModalHistoryOwnerV2;
             return (window as any).__jcNestedLateProof.arrivals.at(-1) === 'nested-late-route-b'
                 && !owner.pendingOwnedTraversal;
-        }, undefined, { timeout: 30_000 });
+        }, undefined, { polling: 50, timeout: 30_000 });
         await expect(modals).toHaveCount(1);
         await expect(modals).toHaveAccessibleName('Nested late outer M1');
         expect(await page.evaluate(


### PR DESCRIPTION
## Summary

- make the six modal-history state probes that failed across three independent two-CPU CI runs poll on a 50 ms timer instead of the Playwright default requestAnimationFrame loop
- preserve every exact state, DOM, owner-settlement, and 30-second fail-closed predicate
- avoid treating render-frame throttling as a failed browser-history transaction

Closes #176

## Evidence

- PR #558 attempt 1 timed out the sync recovered-B and nested late-push probes; attempt 2 timed out the capped-boundary Back and requestAnimationFrame-canonicalization probes
- PR #559 timed out the reactive stale-pop and late copied-marker replacement probes while the first four timer-polled probes passed
- the failures moved between otherwise unchanged modal-history tests while 30 neighboring tests passed in each failed shard
- retained traces from PR #558 showed completed popstate/DOM progress rather than a runtime error
- isolated original probes passed 20/20 and the full original modal-history file passed 26/26 on a fresh two-CPU Jellyfin 12 stack
- the original four updated probes passed 20/20 after their polling change
- after adding the two PR #559 probes, both TypeScript typechecks, Playwright discovery of all 26 tests, and git diff --check pass
- the full CI run on the six-probe head is the final two-CPU acceptance gate

The polling change does not widen allowed state: each probe still requires its exact history state, cleared owner transaction, and expected modal DOM before succeeding.