### PR TITLE
Reject mixed logout cancellation stacks (#557)

### DIFF
--- a/e2e/account-switch.spec.ts
+++ b/e2e/account-switch.spec.ts
@@ -23,6 +23,7 @@ import type {
 } from 'playwright/test';
 import {
     hasValidConcurrentLogoutResponses,
+    isExpectedJellyfinWebTanStackCancellation,
     isExpectedSignedOutHomeAxios401,
     isExpectedSignedOutHostLogout4xx,
 } from '../scripts/e2e/jellyfin-host-noise';
@@ -40,11 +41,6 @@ const USER_FILES = [
 const ACCOUNT_SWITCH_PATH = /\/JellyfinCanopy\/user-settings\/([^/?]+)\/([^/?]+)(?:\?|$)/i;
 const EXPECTED_IDENTITY_ABORT =
     /Failed to save settings\.json.*(?:IdentityStaleError|AbortError|Request was aborted)/i;
-// Jellyfin Web's TanStack query layer logs its own cancellation stack when
-// Dashboard.logout() revokes the active query client. Scope this to the exact
-// host bundle; a CancelledError with any Canopy frame remains a failure.
-const HOST_LOGOUT_NOISE =
-    /CancelledError[\s\S]*node_modules\.%40tanstack\.query-core\.bundle\.js/i;
 const LATE_LOGOUT_PROBE_HEADER = 'x-jc-e2e-late-logout-probe';
 const LOGOUT_EXACT_PROBE = 'logout-exact';
 const LOGOUT_WRONG_PATH_PROBE = 'logout-wrong-path';
@@ -836,7 +832,7 @@ function assertOnlyHostLogoutNoise(
         response.status === 401
         && isExpectedSignedOutHostLogout4xx(response, evidence));
     const unexpectedDetails = consoleErrors.realDetails().filter((detail) =>
-        !HOST_LOGOUT_NOISE.test(detail.text)
+        !isExpectedJellyfinWebTanStackCancellation(detail, evidence)
         && !(allowExpectedIdentityAbort && EXPECTED_IDENTITY_ABORT.test(detail.text))
         && !isExpectedSignedOutHomeAxios401(detail, evidence, hasAllowedHost401)
         && !(syncPlay400 && /Failed to load resource:.*status of 400 \(Bad Request\)/i.test(detail.text)));

--- a/scripts/e2e/jellyfin-host-noise.js
+++ b/scripts/e2e/jellyfin-host-noise.js
@@ -14,6 +14,7 @@ const JELLYFIN_WEB_CHUNK_FRAME = /(?:^|\n)[^\n]*(?:(?:https?:\/\/[^/\s)]+)|(?<![
 const CANOPY_STACK_FRAME = /(?:^|\n)[^\n]*(?:\bJellyfinCanopy\b|\/JellyfinCanopy(?:\/|[?#]))/i;
 const HOME_TAB_SOURCE = /^\/web\/hometab\.[A-Za-z0-9]{12,}\.chunk\.js$/;
 const AXIOS_BUNDLE_PATH = '/web/node_modules.axios.bundle.js';
+const TANSTACK_QUERY_BUNDLE_PATH = '/web/node_modules.%40tanstack.query-core.bundle.js';
 
 /**
  * @typedef {object} SignedOutEvidence
@@ -328,6 +329,84 @@ function isExpectedSignedOutHomeAxios401(detail, evidence, hasAllowedHost401) {
     });
 }
 
+/**
+ * Classifies the stock TanStack cancellation stack emitted by Jellyfin Web
+ * while logout revokes its active query client. Require a console error whose
+ * first line and source chunk match the observed host event, followed by the
+ * exact observed TanStack-only frame sequence. Any missing, reordered,
+ * substituted, malformed, credential-bearing, Canopy, or additional frame
+ * fails closed.
+ *
+ * @param {{text: string, url?: string, source?: string}} detail
+ * @param {LogoutEvidence} evidence
+ */
+function isExpectedJellyfinWebTanStackCancellation(detail, evidence) {
+    if (detail?.source !== 'console' || !hasCompleteSignedOutEvidence(evidence)) return false;
+
+    let origin;
+    try {
+        origin = new URL(evidence.origin);
+    } catch {
+        return false;
+    }
+    if (origin.username !== '' || origin.password !== ''
+        || origin.pathname !== '/' || origin.search !== '' || origin.hash !== '') return false;
+
+    try {
+        const source = new URL(String(detail.url || ''));
+        if (source.origin !== origin.origin
+            || source.username !== ''
+            || source.password !== ''
+            || !HOME_TAB_SOURCE.test(source.pathname)
+            || source.search !== ''
+            || source.hash !== '') return false;
+    } catch {
+        return false;
+    }
+
+    const text = String(detail.text || '');
+    if (CANOPY_STACK_FRAME.test(text)) return false;
+    const lines = text.split('\n');
+    if (lines[0] !== 'e: CancelledError' || lines.length !== 11) return false;
+
+    const expectedFrames = [
+        { frame: /^\s+at Object\.cancel \((https?:\/\/[^)\s]+)\)$/, coordinates: '2:90321' },
+        { frame: /^\s+at e\.value \((https?:\/\/[^)\s]+)\)$/, coordinates: '2:42018' },
+        { frame: /^\s+at e\.value \((https?:\/\/[^)\s]+)\)$/, coordinates: '2:42232' },
+        { frame: /^\s+at e\.value \((https?:\/\/[^)\s]+)\)$/, coordinates: '2:53013' },
+        { frame: /^\s+at (https?:\/\/\S+)$/, coordinates: '2:53199' },
+        { frame: /^\s+at Array\.forEach \(<anonymous>\)$/ },
+        { frame: /^\s+at (https?:\/\/\S+)$/, coordinates: '2:53176' },
+        { frame: /^\s+at Object\.batch \((https?:\/\/[^)\s]+)\)$/, coordinates: '2:26154' },
+        { frame: /^\s+at e\.value \((https?:\/\/[^)\s]+)\)$/, coordinates: '2:53147' },
+        { frame: /^\s+at t\.value \((https?:\/\/[^)\s]+)\)$/, coordinates: '2:72222' },
+    ];
+    let bundleVersion = '';
+    for (let index = 0; index < expectedFrames.length; index += 1) {
+        const line = lines[index + 1];
+        const expected = expectedFrames[index];
+        const match = line.match(expected.frame);
+        if (!match) return false;
+        if (!match[1]) continue;
+        const coordinates = match[1].match(/:(\d+):(\d+)$/);
+        if (!coordinates || `${coordinates[1]}:${coordinates[2]}` !== expected.coordinates) return false;
+        try {
+            const frame = new URL(match[1].slice(0, -coordinates[0].length));
+            if (frame.origin !== origin.origin
+                || frame.username !== ''
+                || frame.password !== ''
+                || frame.hash !== ''
+                || !/^\?[A-Za-z0-9]{12,}$/.test(frame.search)
+                || frame.pathname !== TANSTACK_QUERY_BUNDLE_PATH) return false;
+            if (bundleVersion === '') bundleVersion = frame.search;
+            else if (frame.search !== bundleVersion) return false;
+        } catch {
+            return false;
+        }
+    }
+    return true;
+}
+
 module.exports = {
     HOME_LOGOUT_AXIOS_401,
     HOME_SELECTED_INDEX_ERROR,
@@ -338,6 +417,7 @@ module.exports = {
     isKnownHiddenContentHostNoise,
     isKnownJellyfinWebScrollHandlerError,
     isKnownJellyfinWebHostNoise,
+    isExpectedJellyfinWebTanStackCancellation,
     isExpectedSignedOutHostLogout4xx,
     isExpectedSignedOutHomeAxios401,
 };

--- a/scripts/e2e/jellyfin-host-noise.test.js
+++ b/scripts/e2e/jellyfin-host-noise.test.js
@@ -12,6 +12,7 @@ const {
     SCROLL_HANDLER_ERROR,
     hasValidConcurrentLogoutResponses,
     isExpectedCanopyPauseScreenImageProbe404,
+    isExpectedJellyfinWebTanStackCancellation,
     isKnownHiddenContentHostNoise,
     isKnownJellyfinWebScrollHandlerError,
     isKnownJellyfinWebHostNoise,
@@ -61,6 +62,125 @@ const COMPLETE_SIGNED_OUT = {
         oldTokenStatus: 401,
     },
 };
+const OBSERVED_TANSTACK_CANCELLATION = {
+    source: 'console',
+    url: `${LOGOUT_ORIGIN}/web/hometab.123456789abc.chunk.js`,
+    text: 'e: CancelledError\n'
+        + `    at Object.cancel (${LOGOUT_ORIGIN}/web/node_modules.%40tanstack.query-core.bundle.js?123456789abc:2:90321)\n`
+        + `    at e.value (${LOGOUT_ORIGIN}/web/node_modules.%40tanstack.query-core.bundle.js?123456789abc:2:42018)\n`
+        + `    at e.value (${LOGOUT_ORIGIN}/web/node_modules.%40tanstack.query-core.bundle.js?123456789abc:2:42232)\n`
+        + `    at e.value (${LOGOUT_ORIGIN}/web/node_modules.%40tanstack.query-core.bundle.js?123456789abc:2:53013)\n`
+        + `    at ${LOGOUT_ORIGIN}/web/node_modules.%40tanstack.query-core.bundle.js?123456789abc:2:53199\n`
+        + '    at Array.forEach (<anonymous>)\n'
+        + `    at ${LOGOUT_ORIGIN}/web/node_modules.%40tanstack.query-core.bundle.js?123456789abc:2:53176\n`
+        + `    at Object.batch (${LOGOUT_ORIGIN}/web/node_modules.%40tanstack.query-core.bundle.js?123456789abc:2:26154)\n`
+        + `    at e.value (${LOGOUT_ORIGIN}/web/node_modules.%40tanstack.query-core.bundle.js?123456789abc:2:53147)\n`
+        + `    at t.value (${LOGOUT_ORIGIN}/web/node_modules.%40tanstack.query-core.bundle.js?123456789abc:2:72222)`,
+};
+
+test('logout TanStack classifier accepts the exact stock-only cancellation stack', () => {
+    assert.equal(
+        isExpectedJellyfinWebTanStackCancellation(
+            OBSERVED_TANSTACK_CANCELLATION,
+            COMPLETE_SIGNED_OUT
+        ),
+        true
+    );
+});
+
+test('logout TanStack classifier rejects mixed Canopy stacks and contract drift', () => {
+    const stock = OBSERVED_TANSTACK_CANCELLATION.text;
+    const lines = stock.split('\n');
+    const rejected = [
+        { ...OBSERVED_TANSTACK_CANCELLATION, source: 'pageerror' },
+        { ...OBSERVED_TANSTACK_CANCELLATION, url: `${LOGOUT_ORIGIN}/web/dashboard.123456789abc.chunk.js` },
+        {
+            ...OBSERVED_TANSTACK_CANCELLATION,
+            url: OBSERVED_TANSTACK_CANCELLATION.url.replace('://', '://user:password@'),
+        },
+        { ...OBSERVED_TANSTACK_CANCELLATION, text: stock.replace('CancelledError', 'CanceledError') },
+        { ...OBSERVED_TANSTACK_CANCELLATION, text: `${stock}\nCancelledError` },
+        {
+            ...OBSERVED_TANSTACK_CANCELLATION,
+            text: [lines[0], lines[2], lines[1], ...lines.slice(3)].join('\n'),
+        },
+        {
+            ...OBSERVED_TANSTACK_CANCELLATION,
+            text: [...lines.slice(0, 2), lines[3], lines[2], ...lines.slice(4)].join('\n'),
+        },
+        {
+            ...OBSERVED_TANSTACK_CANCELLATION,
+            text: [...lines.slice(0, 5), lines[7], lines[6], lines[5], ...lines.slice(8)].join('\n'),
+        },
+        {
+            ...OBSERVED_TANSTACK_CANCELLATION,
+            text: lines.slice(0, -1).join('\n'),
+        },
+        {
+            ...OBSERVED_TANSTACK_CANCELLATION,
+            text: stock.replace('Array.forEach (<anonymous>)', 'Array.map (<anonymous>)'),
+        },
+        {
+            ...OBSERVED_TANSTACK_CANCELLATION,
+            text: `${stock}\n    at render (${LOGOUT_ORIGIN}/web/node_modules.%40tanstack.query-core.bundle.js?123456789abc:3:29)`,
+        },
+        {
+            ...OBSERVED_TANSTACK_CANCELLATION,
+            text: stock.replace('Object.cancel (http', 'Object.cancel (unexpected-token http'),
+        },
+        {
+            ...OBSERVED_TANSTACK_CANCELLATION,
+            text: stock.replace('Object.batch (http', 'Object.batch (unexpected-token http'),
+        },
+        {
+            ...OBSERVED_TANSTACK_CANCELLATION,
+            text: stock.replace(`${LOGOUT_ORIGIN}/web/`, `${LOGOUT_ORIGIN.replace('://', '://user:password@')}/web/`),
+        },
+        {
+            ...OBSERVED_TANSTACK_CANCELLATION,
+            text: stock.replace(
+                `${LOGOUT_ORIGIN}/web/node_modules.%40tanstack.query-core.bundle.js?123456789abc:2:72222`,
+                `${LOGOUT_ORIGIN.replace('://', '://user:password@')}/web/node_modules.%40tanstack.query-core.bundle.js?123456789abc:2:72222`
+            ),
+        },
+        { ...OBSERVED_TANSTACK_CANCELLATION, text: stock.replace('/web/node_modules.', '/web/other.') },
+        { ...OBSERVED_TANSTACK_CANCELLATION, text: stock.replace(LOGOUT_ORIGIN, 'http://example.test') },
+        { ...OBSERVED_TANSTACK_CANCELLATION, text: stock.replace('?123456789abc', '') },
+        {
+            ...OBSERVED_TANSTACK_CANCELLATION,
+            text: stock.replace('?123456789abc:2:72222', '?fedcba9876543210abcd:2:72222'),
+        },
+        {
+            ...OBSERVED_TANSTACK_CANCELLATION,
+            text: stock.replace(':2:72222)', ':999:888)'),
+        },
+        {
+            ...OBSERVED_TANSTACK_CANCELLATION,
+            text: stock.replace(
+                'e: CancelledError\n',
+                `e: CancelledError\n    at Canopy (${LOGOUT_ORIGIN}/JellyfinCanopy/dist/jc.bundle.js?123456789abc:1:9)\n`
+            ),
+        },
+        {
+            ...OBSERVED_TANSTACK_CANCELLATION,
+            text: `${stock}\n    at Canopy (${LOGOUT_ORIGIN}/JellyfinCanopy/dist/jc.bundle.js?123456789abc:1:9)`,
+        },
+    ];
+    for (const [index, detail] of rejected.entries()) {
+        assert.equal(
+            isExpectedJellyfinWebTanStackCancellation(detail, COMPLETE_SIGNED_OUT),
+            false,
+            `unexpectedly accepted TanStack cancellation drift case ${index}`
+        );
+    }
+    assert.equal(
+        isExpectedJellyfinWebTanStackCancellation(
+            OBSERVED_TANSTACK_CANCELLATION,
+            { ...COMPLETE_SIGNED_OUT, signedOut: { ...COMPLETE_SIGNED_OUT.signedOut, initialized: true } }
+        ),
+        false
+    );
+});
 
 test('concurrent logout accepts either request as the session-revocation owner', () => {
     const requestZeroWins = [
@@ -513,6 +633,8 @@ test('account switching scopes logout Axios noise to the phase-local response cl
     const fixture = fs.readFileSync(path.join(ROOT, 'e2e/fixtures/auth.ts'), 'utf8');
     assert.match(source, /hasValidConcurrentLogoutResponses\(orderedResponses\)/);
     assert.doesNotMatch(source, /orderedResponses\[0\][\s\S]{0,200}status: 204/);
+    assert.match(source, /isExpectedJellyfinWebTanStackCancellation\(detail, evidence\)/);
+    assert.doesNotMatch(source, /HOST_LOGOUT_NOISE/);
     assert.match(source, /isExpectedSignedOutHomeAxios401\(detail, evidence, hasAllowedHost401\)/);
     assert.match(source, /response\.status === 401\s*&& isExpectedSignedOutHostLogout4xx\(response, evidence\)/);
     assert.match(source, /failed\.filter\(\(response\) => !isExpectedSignedOutHostLogout4xx\(response, evidence\)\)/);


### PR DESCRIPTION
## Summary

- replace the account-switch test broad logout-cancellation regex with a shared evidence-bound classifier
- accept only the exact same-origin versioned Jellyfin Web plus TanStack cancellation stack after complete signed-out evidence
- reject Canopy frames, non-stock bundles, wrong source/order/origin, malformed text, and incomplete logout evidence
- preserve #405 socket-drain, final page-close, and phase-scoped identity-abort behavior during the rebase

Closes #557

## Validation

- host-noise source-contract suite: 24/24
- JavaScript/config TypeScript check: passed
- strict source TypeScript check: passed
- focused ESLint: 0 errors (the E2E TypeScript file remains outside the configured ESLint file set)
- git diff --check: passed
- rebased onto the merged #176 fix with an equal range-diff and unchanged stable patch ID
- independent review: APPROVE on exact head `15584d1a51653e21dbd85b45f30450fe2888e515`

The classifier remains fail-closed: any mixed Canopy/TanStack stack or contract drift stays in the fatal runtime-error set.

Developed with AI assistance; the implementation and exact rebased patch were independently reviewed before publication.
