### PR TITLE
Retry pinned E2E image pulls (#561)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -280,7 +280,8 @@ jobs:
           dotnet build Jellyfin.Plugin.JellyfinCanopy/JellyfinCanopy.csproj -c Release \
             > "${prepare_dir}/plugin-build.log" 2>&1 &
           build_pid=$!
-          docker pull -q "${JF_IMAGE}" > "${prepare_dir}/jellyfin-pull.log" 2>&1 &
+          bash scripts/e2e/pull-pinned-image.sh "${JF_IMAGE}" \
+            > "${prepare_dir}/jellyfin-pull.log" 2>&1 &
           image_pid=$!
           npx playwright install --with-deps --only-shell chromium \
             > "${prepare_dir}/playwright-install.log" 2>&1 &

--- a/scripts/e2e/pull-pinned-image.sh
+++ b/scripts/e2e/pull-pinned-image.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# != 1 )); then
+  echo "usage: pull-pinned-image.sh <image@sha256:digest>" >&2
+  exit 64
+fi
+
+readonly image="$1"
+readonly max_attempts=3
+
+if [[ ! "${image}" =~ @sha256:[0-9a-fA-F]{64}$ ]]; then
+  echo "Refusing to pull an image without an immutable sha256 digest" >&2
+  exit 64
+fi
+
+for (( attempt = 1; attempt <= max_attempts; attempt++ )); do
+  echo "Pulling pinned container image (attempt ${attempt}/${max_attempts})" >&2
+  if docker pull -q "${image}"; then
+    exit 0
+  else
+    pull_status=$?
+  fi
+
+  if (( attempt == max_attempts )); then
+    echo "Pinned container image pull failed after ${max_attempts} attempts" >&2
+    exit "${pull_status}"
+  fi
+
+  delay_seconds=$(( attempt * 2 ))
+  echo "Pinned container image pull failed; retrying in ${delay_seconds}s" >&2
+  sleep "${delay_seconds}"
+done

--- a/scripts/e2e/workflow-sharding.test.js
+++ b/scripts/e2e/workflow-sharding.test.js
@@ -12,6 +12,7 @@ const compatibilityWorkflow = fs.readFileSync(path.join(ROOT, '.github/workflows
 const playwrightConfig = fs.readFileSync(path.join(ROOT, 'e2e/playwright.config.ts'), 'utf8');
 const compose = fs.readFileSync(path.join(ROOT, 'e2e/docker/compose.yml'), 'utf8');
 const seed = fs.readFileSync(path.join(ROOT, 'e2e/docker/seed.sh'), 'utf8');
+const pinnedImagePull = fs.readFileSync(path.join(__dirname, 'pull-pinned-image.sh'), 'utf8');
 const packageJson = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
 
 function jobBlock(start, end) {
@@ -78,7 +79,13 @@ test('E2E installs once and prepares independent prerequisites concurrently', ()
     assert.equal(packageJson.peerDependencies?.['@playwright/test'], undefined);
     assert.equal((shard.match(/run: npm ci/g) || []).length, 1);
     assert.doesNotMatch(shard, /npm install --no-save/);
-    assert.match(shard, /docker pull -q "\$\{JF_IMAGE\}"/);
+    assert.match(shard, /bash scripts\/e2e\/pull-pinned-image\.sh "\$\{JF_IMAGE\}"/);
+    assert.doesNotMatch(shard, /docker pull -q "\$\{JF_IMAGE\}"/);
+    assert.match(compatibilityWorkflow, /docker pull -q "\$\{JF_IMAGE\}"/);
+    assert.doesNotMatch(
+        compatibilityWorkflow,
+        /bash scripts\/e2e\/pull-pinned-image\.sh "\$\{JF_IMAGE\}"/
+    );
     assert.match(shard, /npx playwright install --with-deps --only-shell chromium/);
     for (const process of ['build', 'image', 'playwright']) {
         assert.match(shard, new RegExp(`${process}_pid=\\$!`));
@@ -88,6 +95,20 @@ test('E2E installs once and prepares independent prerequisites concurrently', ()
         shard,
         /if \(\( build_status != 0 \|\| image_status != 0 \|\| playwright_status != 0 \)\)/
     );
+});
+
+test('E2E pinned-image pulls retry transient failures without weakening digest identity', () => {
+    assert.match(pinnedImagePull, /if \(\( \$# != 1 \)\)/);
+    assert.match(pinnedImagePull, /readonly max_attempts=3/);
+    assert.match(pinnedImagePull, /@sha256:\[0-9a-fA-F\]\{64\}\$/);
+    assert.match(
+        pinnedImagePull,
+        /for \(\( attempt = 1; attempt <= max_attempts; attempt\+\+ \)\)/
+    );
+    assert.match(pinnedImagePull, /docker pull -q "\$\{image\}"/);
+    assert.match(pinnedImagePull, /delay_seconds=\$\(\( attempt \* 2 \)\)/);
+    assert.match(pinnedImagePull, /if \(\( attempt == max_attempts \)\)[\s\S]*exit "\$\{pull_status\}"/);
+    assert.doesNotMatch(pinnedImagePull, /docker pull[^\n]*(?:\|\| true|continue)/);
 });
 
 test('every shard reports current-attempt evidence under unique artifact names', () => {
@@ -179,7 +200,12 @@ test('mutable latest-Jellyfin probing is isolated in one advisory workflow', () 
     assert.match(compatibilityWorkflow, /schedule:/);
     assert.match(compatibilityWorkflow, /workflow_dispatch:/);
     assert.doesNotMatch(compatibilityWorkflow, /continue-on-error:/);
-    assert.match(compatibilityWorkflow, /jellyfin\/jellyfin:unstable/);
+    assert.match(
+        compatibilityWorkflow,
+        /jellyfin_image:[\s\S]*default: jellyfin\/jellyfin:unstable[\s\S]*JF_IMAGE: \$\{\{ inputs\.jellyfin_image \|\| 'jellyfin\/jellyfin:unstable' \}\}/
+    );
+    assert.match(compatibilityWorkflow, /docker pull -q "\$\{JF_IMAGE\}"/);
+    assert.doesNotMatch(compatibilityWorkflow, /pull-pinned-image\.sh/);
     assert.doesNotMatch(workflow, /JF_IMAGE:\s+jellyfin\/jellyfin:unstable\s*$/m);
     assert.doesNotMatch(releaseWorkflow, /JF_IMAGE:\s+jellyfin\/jellyfin:unstable\s*$/m);
 });


### PR DESCRIPTION
## Summary

- route required and compatibility E2E Jellyfin image prefetches through one bounded helper
- require an immutable sha256 digest before any pull
- retry transient registry failures three times with 2s and 4s backoff, then preserve the terminal docker status
- keep plugin build, image pull, and Playwright preparation concurrent and fully blocking

Closes #561

## Validation

- workflow/source-contract test: 8/8
- complete E2E script unit suite: 151/151 after lockfile dependency installation
- shell syntax check: passed
- behavior probes: failure/failure/success performs exactly three pulls and 2s/4s backoff; persistent status 42 is preserved after three attempts; an unpinned tag exits 64 before docker
- git diff --check: passed

No credential, token, or image reference is added to retry diagnostics.