### PR TITLE
Fix capped modal history retry race

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/modal.history.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/modal.history.test.ts
@@ -633,6 +633,10 @@ describe('Seerr request modal history ownership', () => {
                 const markerAfterIssue: unknown = history.state;
                 expect(historyOwnerForTest()?.pendingOwnedTraversal?.phase).toBe('issued');
                 vi.advanceTimersByTime(0);
+                // The router PUSH runs in the first timer and queues the
+                // classic fallback from inside that callback. Advance the
+                // clock so the newly queued retry gets its own task.
+                vi.advanceTimersByTime(1);
 
                 expect(history.state).toEqual(routeGState);
                 if (direction === 'forward') {
@@ -1412,6 +1416,7 @@ describe('Seerr request modal history ownership', () => {
         observeCurrentHistoryMutation('pushState');
         const routeBState: unknown = history.state;
         const routeBHref = location.href;
+        vi.advanceTimersByTime(0);
 
         expect(onClose).toHaveBeenCalledTimes(1);
         expect(isAnyModalOpen()).toBe(false);
@@ -1432,6 +1437,38 @@ describe('Seerr request modal history ownership', () => {
         expect(historyOwnerForTest()?.records.size).toBe(0);
     });
 
+    it('cancels the deferred classic retry when the original Back pop wins first', () => {
+        const routeAState: unknown = history.state;
+        const routeAHref = location.href;
+        vi.spyOn(history, 'back').mockImplementation(() => undefined);
+        const go = vi.spyOn(history, 'go').mockImplementation(() => undefined);
+        const forward = vi.spyOn(history, 'forward').mockImplementation(() => undefined);
+        const shown = showModal();
+
+        shown.handle.close();
+        vi.advanceTimersByTime(0);
+        history.pushState({ host: 'capped-route-b' }, '', '/web/index.html#/capped-route-b');
+        observeCurrentHistoryMutation('pushState');
+        const routeBState: unknown = history.state;
+        const routeBHref = location.href;
+
+        expect(historyOwnerForTest()?.pendingOwnedTraversal?.phase).toBe('superseded-issued');
+        // Model the browser delivering the already-issued Back before the
+        // separately queued classic retry task. dispatchPop() normally drains
+        // close timers first, which would invert this exact race.
+        History.prototype.replaceState.call(history, routeAState, '', routeAHref);
+        window.dispatchEvent(new PopStateEvent('popstate', { state: routeAState }));
+        expect(historyOwnerForTest()?.pendingOwnedTraversal?.phase).toBe('recovering-forward');
+        vi.advanceTimersByTime(0);
+        expect(go).not.toHaveBeenCalled();
+
+        dispatchPop(shown.modalState, routeAHref);
+        expect(forward).toHaveBeenCalledTimes(2);
+        dispatchPop(routeBState, routeBHref);
+        expect(historyOwnerForTest()?.pendingOwnedTraversal).toBeNull();
+        expect(history.state).toEqual(routeBState);
+    });
+
     it('keeps an older live modal open while recovering through a retired nested marker', () => {
         const routeAHref = location.href;
         const outerClose = vi.fn();
@@ -1449,6 +1486,7 @@ describe('Seerr request modal history ownership', () => {
         observeCurrentHistoryMutation('pushState');
         const routeBState: unknown = history.state;
         const routeBHref = location.href;
+        vi.advanceTimersByTime(0);
 
         expect(go).toHaveBeenCalledWith(-2);
         expect(innerClose).toHaveBeenCalledTimes(1);
@@ -1473,7 +1511,7 @@ describe('Seerr request modal history ownership', () => {
         expect(innerClose).toHaveBeenCalledTimes(1);
     });
 
-    it('reissues the exact classic base delta once for every distinct late push', () => {
+    it('coalesces same-task late pushes into one retry at the latest classic base delta', () => {
         const routeAState: unknown = history.state;
         const routeAHref = location.href;
         vi.spyOn(history, 'back').mockImplementation(() => undefined);
@@ -1491,8 +1529,9 @@ describe('Seerr request modal history ownership', () => {
         observeCurrentHistoryMutation('pushState');
         const routeCState: unknown = history.state;
         const routeCHref = location.href;
+        vi.advanceTimersByTime(0);
 
-        expect(go.mock.calls).toEqual([[-2], [-3]]);
+        expect(go.mock.calls).toEqual([[-3]]);
         dispatchPop(routeAState, routeAHref);
         dispatchPop(shown.modalState, routeAHref);
         dispatchPop(routeBState, routeBHref);
@@ -1518,6 +1557,7 @@ describe('Seerr request modal history ownership', () => {
         observeCurrentHistoryMutation('pushState', 'PUSH', 'raw-push-entry-b');
         observeCurrentHistoryMutation('HISTORY_UPDATE', 'PUSH', 'raw-push-entry-b');
         observeCurrentHistoryMutation('HISTORY_UPDATE', 'POP', 'raw-push-entry-b');
+        vi.advanceTimersByTime(0);
 
         expect(go.mock.calls).toEqual([[-2]]);
         expect(historyOwnerForTest()?.pendingOwnedTraversal?.phase).toBe('superseded-issued');
@@ -1555,6 +1595,7 @@ describe('Seerr request modal history ownership', () => {
             vi.advanceTimersByTime(0);
             history.pushState({ host: 'superseded-route-b' }, '', '/web/index.html#/superseded-route-b');
             observeCurrentHistoryMutation('pushState');
+            vi.advanceTimersByTime(0);
             expect(go.mock.calls).toEqual([[-2]]);
 
             dispatchPop(routeAState, routeAHref);
@@ -1586,6 +1627,7 @@ describe('Seerr request modal history ownership', () => {
         observeCurrentHistoryMutation('pushState');
         const routeBState: unknown = history.state;
         const routeBHref = location.href;
+        vi.advanceTimersByTime(0);
 
         expect(go).toHaveBeenCalledWith(-2);
         expect(historyOwnerForTest()?.pendingOwnedTraversal?.phase).toBe('superseded-issued');
@@ -1734,6 +1776,7 @@ describe('Seerr request modal history ownership', () => {
                 observeCurrentHistoryMutation('pushState');
                 const routeBState: unknown = history.state;
                 const routeBHref = location.href;
+                vi.advanceTimersByTime(0);
 
                 expect(go).toHaveBeenCalledWith(-2);
                 dispatchPop(routeAState, routeAHref);
@@ -1896,6 +1939,7 @@ describe('Seerr request modal history ownership', () => {
         vi.advanceTimersByTime(0);
         history.pushState(structuredClone(sameState), '', sameHref);
         observeCurrentHistoryMutation('pushState');
+        vi.advanceTimersByTime(0);
         expect(go).toHaveBeenCalledWith(-2);
 
         dispatchPop(structuredClone(sameState), sameHref);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/modal.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/modal.ts
@@ -104,6 +104,8 @@ interface PendingOwnedTraversal {
     markerNavigationKey: string | null;
     hostNavigationKey: string | null;
     classicEntriesAboveBase: number;
+    /** One deferred classic retry; canceled logically when the original Back wins. */
+    classicRetryQueued: boolean;
     lastHostEntryKey: string | null;
     /** Recovery has crossed this transaction's private marker toward its target. */
     recoveringMarkerCrossed: boolean;
@@ -431,6 +433,9 @@ function getHistoryOwner(): ModalHistoryOwnerState {
             if (!Number.isSafeInteger(ownedTraversal.classicEntriesAboveBase)
                 || ownedTraversal.classicEntriesAboveBase < 1) {
                 ownedTraversal.classicEntriesAboveBase = 1;
+            }
+            if (typeof ownedTraversal.classicRetryQueued !== 'boolean') {
+                ownedTraversal.classicRetryQueued = false;
             }
             if (typeof ownedTraversal.lastHostEntryKey !== 'string') {
                 ownedTraversal.lastHostEntryKey = null;
@@ -988,13 +993,24 @@ function handleModalHistoryMutation(mutation: HistoryMutation): void {
                 && !reactivePush
                 && pending.hostNavigationKey === null) {
                 pending.classicEntriesAboveBase += 1;
-                try {
-                    // A late push can cancel Firefox's already-issued Back.
-                    // Reissuing the exact base delta coalesces with Chromium's
-                    // pending target and forces one deterministic owned pop.
-                    history.go(-pending.classicEntriesAboveBase);
-                } catch (error) {
-                    console.warn(`${logPrefix} could not settle a pushed route over modal Back:`, error);
+                if (!pending.classicRetryQueued) {
+                    pending.classicRetryQueued = true;
+                    setTimeout(() => {
+                        pending.classicRetryQueued = false;
+                        if (owner.pendingOwnedTraversal !== pending
+                            || pending.phase !== 'superseded-issued'
+                            || pending.hostNavigationKey !== null) return;
+                        try {
+                            // A late push can cancel Firefox's already-issued
+                            // Back. Retry only if that Back did not produce a
+                            // pop first; issuing both traversals synchronously
+                            // can leave a queued Forward at Chromium's capped
+                            // history boundary and undo the user's next Back.
+                            history.go(-pending.classicEntriesAboveBase);
+                        } catch (error) {
+                            console.warn(`${logPrefix} could not settle a pushed route over modal Back:`, error);
+                        }
+                    }, 0);
                 }
             }
         }
@@ -1256,6 +1272,7 @@ function armRetiredMarkerTraversal(
             ? retiredBase?.hostNavigationKey ?? marker.hostNavigationKey ?? null
             : null,
         classicEntriesAboveBase: 1,
+        classicRetryQueued: false,
         lastHostEntryKey: null,
         recoveringMarkerCrossed: false,
         markerSnapshot: marker,
@@ -1914,6 +1931,7 @@ modal.create = function({ title, subtitle, bodyHtml, backdropPath, backdropUrl, 
             markerNavigationKey: currentNavigationEntryKey(),
             hostNavigationKey: null,
             classicEntriesAboveBase: 1,
+            classicRetryQueued: false,
             lastHostEntryKey: null,
             recoveringMarkerCrossed: false,
             markerSnapshot: null,

--- a/scripts/bundle-budgets.json
+++ b/scripts/bundle-budgets.json
@@ -18,8 +18,8 @@
     "maxFeatureExpandedRawBytes": 786432,
     "maxFeatureExpandedGzipBytes": 262144,
     "maxSourceMapRawBytes": 6000000,
-    "maxTotalRawBytes": 7148662,
+    "maxTotalRawBytes": 7150179,
     "maxClientManifestRawBytes": 262144,
-    "maxPublishedRawBytes": 7233410
+    "maxPublishedRawBytes": 7234927
   }
 }


### PR DESCRIPTION
## Summary

Fixes the capped-history recurrence in the shared Seerr modal history owner.

When a host PUSH arrived after modal `Back` had already been issued, the classic-history fallback immediately issued `history.go(-N)`. At Chromium's 50-entry cap, both the original Back and the fallback could apply: recovery returned to route B, then the leftover traversal undid the user's next Back and stranded them on B.

The fallback is now one deferred, coalesced retry. If the original Back pop wins first, the transaction phase changes and the queued retry becomes a no-op. If Firefox cancels the original Back, the deferred retry still settles the latest exact base delta. Existing history-owner state is migrated safely across a hot generation.

## Changes

- defer and logically cancel the classic late-PUSH retry when the original pop wins
- coalesce multiple same-task PUSH entries into one exact retry
- add deterministic coverage for the capped-history ordering and update affected timing assertions
- ratchet the generated distribution high-water by the exact measured 1,517-byte increase

## Validation

- modal-history Vitest: 90/90
- full client coverage: 2,012/2,012; coverage ratchet matched 2,808/3,201 lines
- digest-pinned Jellyfin 12, 2-CPU exact capped-boundary E2E: 10/10 repeated
- complete modal-history Jellyfin 12 E2E: 26/26
- both TypeScript checks, focused ESLint, full lint verifier, bundle build, syntax inventory, performance-rules guard, and 619/619 script tests
- Release server build: 0 warnings / 0 errors
- independent review: APPROVE on exact SHA `415bdf9d34eeecb459ae6d0b192194f9f6f61556`

Developed with AI assistance; the implementation and evidence were reviewed before publication.

Closes #176
