### PR TITLE
Make provider-pair candidate mapping linear

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Data/ItemLookupServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Data/ItemLookupServiceTests.cs
@@ -158,6 +158,30 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Data
         }
 
         [Fact]
+        public void MapProviderPairs_MembershipWorkIsLinearForUniqueAndRepeatedEditions()
+        {
+            const int uniqueEditionCount = 4_096;
+            var uniqueItems = Enumerable.Range(1, uniqueEditionCount)
+                .Select(index => MovieWith(new Guid(index, 0, 0, new byte[8]), ("Tmdb", "603")))
+                .ToArray();
+            var repeatedItems = uniqueItems
+                .Select(item => MovieWith(item.Id, ("Tmdb", "603")));
+            var items = uniqueItems.Cast<BaseItem>().Concat(repeatedItems).ToArray();
+            var membershipChecks = 0;
+
+            var map = ItemLookupService.MapProviderPairs(
+                items,
+                new List<(string, string)> { ("Tmdb", "603") },
+                () => membershipChecks++);
+
+            Assert.Equal(items.Length, membershipChecks);
+            Assert.Equal(uniqueEditionCount, map[("Tmdb", "603")].Count);
+            Assert.Equal(
+                uniqueItems.Select(item => item.Id).OrderBy(id => id),
+                map[("Tmdb", "603")].Select(candidate => candidate.ItemId));
+        }
+
+        [Fact]
         public void MapProviderPairs_PreservesCandidateMediaType()
         {
             var movie = MovieWith(Guid.NewGuid(), ("Tmdb", "42"));

--- a/Jellyfin.Plugin.JellyfinCanopy/Data/ItemLookupService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Data/ItemLookupService.cs
@@ -190,17 +190,20 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Data
         /// </summary>
         internal static Dictionary<(string Provider, string Value), IReadOnlyList<ItemLookupCandidate>> MapProviderPairs(
             IEnumerable<BaseItem> items,
-            IReadOnlyCollection<(string Provider, string Value)> pairs)
-            => MapProviderPairsCore(items, pairs, int.MaxValue, out _);
+            IReadOnlyCollection<(string Provider, string Value)> pairs,
+            Action? membershipProbe = null)
+            => MapProviderPairsCore(items, pairs, int.MaxValue, out _, membershipProbe);
 
         private static Dictionary<(string Provider, string Value), IReadOnlyList<ItemLookupCandidate>> MapProviderPairsCore(
             IEnumerable<BaseItem> items,
             IReadOnlyCollection<(string Provider, string Value)> pairs,
             int maxCandidates,
-            out bool complete)
+            out bool complete,
+            Action? membershipProbe = null)
         {
             var requested = new HashSet<(string, string)>(pairs);
             var map = new Dictionary<(string Provider, string Value), List<ItemLookupCandidate>>();
+            var seenCandidates = new HashSet<(string Provider, string Value, Guid ItemId)>();
             var candidateCount = 0;
 
             foreach (var item in items)
@@ -223,20 +226,21 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Data
                         map[key] = candidates;
                     }
 
-                    if (candidates.All(candidate => candidate.ItemId != item.Id))
-                    {
-                        if (candidateCount >= maxCandidates)
-                        {
-                            complete = false;
-                            return new Dictionary<(string, string), IReadOnlyList<ItemLookupCandidate>>();
-                        }
+                    membershipProbe?.Invoke();
+                    if (!seenCandidates.Add((kv.Key, kv.Value, item.Id)))
+                        continue;
 
-                        var kind = GetItemKind(item);
-                        var hasMediaFile = kind is ItemLookupKind.Movie or ItemLookupKind.Episode
-                            && !string.IsNullOrWhiteSpace(item.Path);
-                        candidates.Add(new ItemLookupCandidate(item.Id, kind, item.Path, hasMediaFile));
-                        candidateCount++;
+                    if (candidateCount >= maxCandidates)
+                    {
+                        complete = false;
+                        return new Dictionary<(string, string), IReadOnlyList<ItemLookupCandidate>>();
                     }
+
+                    var kind = GetItemKind(item);
+                    var hasMediaFile = kind is ItemLookupKind.Movie or ItemLookupKind.Episode
+                        && !string.IsNullOrWhiteSpace(item.Path);
+                    candidates.Add(new ItemLookupCandidate(item.Id, kind, item.Path, hasMediaFile));
+                    candidateCount++;
                 }
             }
 

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,7 +26,7 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2808, totalLines: 3201 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 29245, totalLines: 37825 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 29247, totalLines: 37827 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 3,
         minimumCoveredLines: 2808,
@@ -34,8 +34,8 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
     });
     assert.deepEqual(baselines.profiles.server.observations, {
         cleanRuns: 4,
-        minimumCoveredLines: 29243,
-        maximumCoveredLines: 29245,
+        minimumCoveredLines: 29245,
+        maximumCoveredLines: 29247,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 29245,
-        "totalLines": 37825
+        "coveredLines": 29247,
+        "totalLines": 37827
       },
       "observations": {
         "cleanRuns": 4,
-        "minimumCoveredLines": 29243,
-        "maximumCoveredLines": 29245
+        "minimumCoveredLines": 29245,
+        "maximumCoveredLines": 29247
       },
       "tolerance": {
         "missingCoveredLines": 2,
-        "rationale": "Fixing #154 adds a bounded, access-aware multi-edition resolver and mutation-boundary revalidation for all three watchlist consumers. The final hardening deduplicates outbound edition selection across bindings; orders each final exact binding GET before current access and Likes reads; re-reads current UserItemData at scheduled and monitor write barriers; fences monitor configuration after access and user-data queries; counts preflight binding GETs in the 200,000-query authorization budget; pages the 100,000-item library snapshot in cancellable 1,000-item batches; and routes resolver preparation, final edition revalidation, and outbound staging through deterministic cancellable 1,000-id access-policy queries. Focused regressions cover inaccessible-first, no-access, markers, per-user exports, typed namespaces, duplicate editions, linear repeated-binding enumeration, current access and unlike races, configuration changes during access, exact aggregate and access-batch boundaries, and cancellation between library pages and single-user access chunks. Three clean .NET 10.0.9/Coverlet runs on 2026-08-02 each passed all 2,547 server tests at the identical 37,825-line scope and measured 29,244, 29,245, and 29,244 covered lines. PR #559 run 30725667910 then passed the same 2,547 tests on .NET 10.0.10 at the identical scope and directly observed 29,243 covered lines. The reviewed high-water therefore advances from 29,221/37,802 (77.300%) to 29,245/37,825 (77.317%), while the four-run instrumentation envelope sets the exact floor at 29,243/37,825 (77.311%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "rationale": "Fixing #555 replaces the per-candidate linear duplicate scan in provider-pair mapping with bounded hash membership and adds an instrumented 4,096-edition regression proving one membership operation per matching item/provider incidence while preserving deterministic ordering, repeated-ID deduplication, media typing, and the fail-closed candidate ceiling. Four clean .NET 10.0.9/Coverlet runs on 2026-08-02 each passed all 2,548 server tests at the identical 37,827-line scope and measured 29,246, 29,247, 29,245, and 29,246 covered lines. Relative to the #154 main baseline of 29,245/37,825, the implementation adds two instrumented lines, advances the reviewed high-water to 29,247/37,827 (77.318%), and sets the exact observed floor at 29,245/37,827 (77.313%), still above the prior 29,243/37,825 (77.311%) floor. The two-line tolerance admits only the directly observed identical-scope spread. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
Closes #555

## Root cause

`ItemLookupService.MapProviderPairsCore` checked every accumulated candidate with `candidates.All(...)` for each matching item/provider incidence. Large duplicate-edition groups therefore performed quadratic duplicate membership work before reaching the existing candidate ceiling.

## Change

- track seen `(provider, value, itemId)` tuples in a `HashSet`, making membership amortized O(1) per matching incidence;
- preserve ordinal provider/value semantics, first-seen candidate details, deterministic final GUID ordering, media typing, and the existing fail-closed candidate ceiling;
- add an internal instrumentation seam and a 4,096-unique-edition regression with repeated IDs that proves exactly one membership operation per incidence;
- advance the fixed-scope server coverage high-water from 29,245 to 29,247 covered lines while retaining the evidence-backed two-line downward tolerance.

## Validation

Exact rebased head: `4bb6b11d822c6fd9e7ae03a398d2a854d8b01f96`

- focused `ItemLookupServiceTests`: 15/15 passed;
- coverage-baseline contract and negative tests: 14/14 passed;
- patch-identical pre-rebase full server suite: 2,548/2,548 passed in each of four clean runs;
- clean-run server coverage observations: 29,245–29,247 / 37,827 lines, high-water 29,247, tolerance 2;
- repository script tests: 619/619 passed;
- Release builds: zero warnings/errors;
- `git diff --check`: passed;
- mechanical rebase confirmed by identical range-diff and stable patch ID `260142d32facdef602ea7acd5c1d0696c5d43db0`.

Independent review: APPROVE on exact rebased head with no correctness, bounds, regression-test, API-seam, coverage-baseline, or rebase findings.

## AI assistance

This PR was developed with AI assistance. The implementation, tests, coverage evidence, and exact rebased diff were reviewed and validated before publication.