### PR TITLE
[BI-QA] Make Maintainerr route-exit cancellation deterministic

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/maintainerr/page.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/maintainerr/page.test.ts
@@ -131,6 +131,37 @@ describe('Maintainerr native page', () => {
         expect(plugin).not.toHaveBeenCalled();
     });
 
+    it('accepts cancellation before upstream work starts and publishes no stale dashboard', async () => {
+        let upstreamStarted = false;
+        let requestSignal: AbortSignal | undefined;
+        const plugin = vi.fn((
+            _path: string,
+            options?: { signal?: AbortSignal },
+        ) => new Promise<unknown>((resolve, reject) => {
+            requestSignal = options?.signal;
+            requestSignal?.addEventListener('abort', () => {
+                reject(new DOMException('canceled before upstream start', 'AbortError'));
+            }, { once: true });
+            queueMicrotask(() => {
+                if (requestSignal?.aborted) return;
+                upstreamStarted = true;
+                resolve(dashboard());
+            });
+        }));
+        JC.core.api = { plugin } as unknown as ApiApi;
+
+        void maintainerrPageDescriptor.render({ host, handle, signal: adoption.signal });
+        adoption.abort();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(requestSignal?.aborted).toBe(true);
+        expect(upstreamStarted).toBe(false);
+        expect(host.querySelectorAll('.jc-maintainerr-collection')).toHaveLength(0);
+        expect(host.textContent).not.toContain('Weekend cleanup');
+        expect(host.querySelector('[role="alert"]')).toBeNull();
+    });
+
     it('renders safe views, local controls, binary units, and modal focus lifecycle', async () => {
         const plugin = vi.fn((path: string) => {
             if (path === '/maintainerr/dashboard') return Promise.resolve(dashboard());

--- a/e2e/fixtures/maintainerr.ts
+++ b/e2e/fixtures/maintainerr.ts
@@ -16,21 +16,25 @@ export type MaintainerrMode =
     | 'redirect'
     | 'oversized';
 
-export interface MaintainerrAuditRow {
+export interface MaintainerrInFlightRow {
     schemaVersion: 1;
     sequence: number;
     method: string;
     path: string;
     query: Record<string, string>;
-    status: number;
     mode: MaintainerrMode;
-    aborted: boolean;
     credentialHeadersPresent: boolean;
+}
+
+export interface MaintainerrAuditRow extends MaintainerrInFlightRow {
+    status: number;
+    aborted: boolean;
 }
 
 interface MaintainerrAuditFile {
     schemaVersion: 1;
     requests: MaintainerrAuditRow[];
+    inFlight: MaintainerrInFlightRow[];
 }
 
 interface FixtureState {
@@ -108,7 +112,7 @@ export async function setMaintainerrMode(mode: MaintainerrMode): Promise<Maintai
 
 /** Clear only the bounded, sanitized request ledger owned by the current shard. */
 export async function clearMaintainerrAudit(): Promise<void> {
-    await writeAtomically(auditPath(), { schemaVersion: 1, requests: [] });
+    await writeAtomically(auditPath(), { schemaVersion: 1, requests: [], inFlight: [] });
 }
 
 /** Read the current shard's bounded, sanitized Maintainerr request ledger. */
@@ -119,6 +123,20 @@ export async function readMaintainerrAudit(): Promise<MaintainerrAuditRow[]> {
             throw new Error('invalid hermetic Maintainerr request ledger');
         }
         return parsed.requests;
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+        throw error;
+    }
+}
+
+/** Read sanitized requests accepted by the fixture but not yet completed. */
+export async function readMaintainerrInFlight(): Promise<MaintainerrInFlightRow[]> {
+    try {
+        const parsed = JSON.parse(await fs.readFile(auditPath(), 'utf8')) as Partial<MaintainerrAuditFile>;
+        if (parsed.schemaVersion !== 1 || !Array.isArray(parsed.inFlight)) {
+            throw new Error('invalid hermetic Maintainerr in-flight ledger');
+        }
+        return parsed.inFlight;
     } catch (error) {
         if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
         throw error;

--- a/e2e/maintainerr.spec.ts
+++ b/e2e/maintainerr.spec.ts
@@ -26,9 +26,11 @@ import {
 import {
     clearMaintainerrAudit,
     readMaintainerrAudit,
+    readMaintainerrInFlight,
     seededMaintainerrItemId,
     setMaintainerrMode,
     type MaintainerrAuditRow,
+    type MaintainerrInFlightRow,
 } from './fixtures/maintainerr';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -125,7 +127,7 @@ function assertSanitizedProjection(value: unknown): void {
     );
 }
 
-function assertSafeAudit(rows: readonly MaintainerrAuditRow[]): void {
+function assertSafeAuditRows(rows: readonly MaintainerrInFlightRow[]): void {
     expect(rows.length, 'Maintainerr audit remains bounded').toBeLessThanOrEqual(256);
     for (const row of rows) {
         expect(row.schemaVersion).toBe(1);
@@ -137,6 +139,10 @@ function assertSafeAudit(rows: readonly MaintainerrAuditRow[]): void {
             (key) => key === 'size' || key === 'sort' || key === 'sortOrder',
         )).toBe(true);
     }
+}
+
+function assertSafeAudit(rows: readonly MaintainerrAuditRow[]): void {
+    assertSafeAuditRows(rows);
 }
 
 async function assertSafeExternalLink(
@@ -798,18 +804,36 @@ test.describe.serial('Maintainerr integration', () => {
             (window as any).JellyfinCanopy.maintainerrPage.showPage();
         });
         await dashboardRequest;
+
+        let upstreamSequence = 0;
+        await expect.poll(
+            async () => {
+                const inFlight = await readMaintainerrInFlight();
+                assertSafeAuditRows(inFlight);
+                upstreamSequence = inFlight.find((row) => row.mode === 'slow')?.sequence || 0;
+                return upstreamSequence;
+            },
+            {
+                message: 'a sanitized slow upstream request is accepted before route exit',
+                timeout: 15_000,
+                intervals: [100, 250, 500],
+            },
+        ).toBeGreaterThan(0);
+
         await showRoute(page, '/home');
         await waitForHash(page, '/home');
         await expect(page.locator('#jc-maintainerr-container')).toHaveCount(0);
 
         await expect.poll(
-            async () => (await readMaintainerrAudit()).filter((row) => row.aborted).length,
+            async () => (await readMaintainerrAudit()).some(
+                (row) => row.sequence === upstreamSequence && row.aborted,
+            ),
             {
-                message: 'the last downstream waiter cancels slow upstream probes',
+                message: 'the observed upstream request aborts after its last waiter leaves',
                 timeout: 15_000,
                 intervals: [100, 250, 500],
             },
-        ).toBeGreaterThan(0);
+        ).toBe(true);
         const audit = await readMaintainerrAudit();
         assertSafeAudit(audit);
         expect(audit.every((row) => row.aborted), 'no slow response completes after route exit')

--- a/e2e/mock-integrations/server.js
+++ b/e2e/mock-integrations/server.js
@@ -15,6 +15,7 @@ const MAX_BODY_BYTES = 1024 * 1024;
 const MAX_MAINTAINERR_AUDIT_ROWS = 256;
 const MAINTAINERR_SLOW_MS = 20_000;
 const MAINTAINERR_SECRET_SENTINEL = 'UPSTREAM_SECRET_MUST_NOT_ESCAPE';
+let nextMaintainerrAuditSequence = 1;
 // Maintainerr 3.18 only SQL-pages the default/deleteSoonest shape. Every
 // media-metadata sort hydrates the full collection before slicing.
 const MAINTAINERR_SORT_FIELDS = new Set(['deleteSoonest']);
@@ -434,44 +435,85 @@ function maintainerrAuditQuery(url) {
     return safe;
 }
 
-function appendMaintainerrAudit(row) {
-    let current = { schemaVersion: 1, requests: [] };
+function readMaintainerrAuditState() {
+    let current = { schemaVersion: 1, requests: [], inFlight: [] };
     try {
         const parsed = JSON.parse(fs.readFileSync(MAINTAINERR_AUDIT_FILE, 'utf8'));
-        if (parsed?.schemaVersion === 1 && Array.isArray(parsed.requests)) current = parsed;
+        if (parsed?.schemaVersion === 1 && Array.isArray(parsed.requests)) {
+            current = {
+                schemaVersion: 1,
+                requests: parsed.requests,
+                inFlight: Array.isArray(parsed.inFlight) ? parsed.inFlight : [],
+            };
+        }
     } catch {
         // A missing audit file is the normal initial state for every shard.
     }
-    const lastSequence = current.requests.reduce(
-        (maximum, entry) => Math.max(maximum, Number(entry?.sequence) || 0),
-        0
-    );
-    const requestsForAudit = [...current.requests, {
+    return current;
+}
+
+function writeMaintainerrAuditState(current) {
+    const next = `${JSON.stringify({
         schemaVersion: 1,
-        sequence: lastSequence + 1,
-        ...row,
-    }].slice(-MAX_MAINTAINERR_AUDIT_ROWS);
-    const next = `${JSON.stringify({ schemaVersion: 1, requests: requestsForAudit }, null, 2)}\n`;
+        requests: current.requests.slice(-MAX_MAINTAINERR_AUDIT_ROWS),
+        inFlight: current.inFlight.slice(-MAX_MAINTAINERR_AUDIT_ROWS),
+    }, null, 2)}\n`;
     const temporary = `${MAINTAINERR_AUDIT_FILE}.${process.pid}.tmp`;
     fs.writeFileSync(temporary, next, { mode: 0o600 });
     fs.renameSync(temporary, MAINTAINERR_AUDIT_FILE);
 }
 
+function beginMaintainerrAudit(row) {
+    const current = readMaintainerrAuditState();
+    const lastSequence = [...current.requests, ...current.inFlight].reduce(
+        (maximum, entry) => Math.max(maximum, Number(entry?.sequence) || 0),
+        0
+    );
+    const sequence = Math.max(nextMaintainerrAuditSequence, lastSequence + 1);
+    nextMaintainerrAuditSequence = sequence + 1;
+    const inFlightRow = {
+        schemaVersion: 1,
+        sequence,
+        ...row,
+    };
+    writeMaintainerrAuditState({
+        ...current,
+        inFlight: [...current.inFlight, inFlightRow],
+    });
+    return inFlightRow;
+}
+
+function completeMaintainerrAudit(inFlightRow, status, aborted) {
+    const current = readMaintainerrAuditState();
+    writeMaintainerrAuditState({
+        ...current,
+        requests: [...current.requests, {
+            ...inFlightRow,
+            status,
+            aborted,
+        }],
+        inFlight: current.inFlight.filter(entry => entry?.sequence !== inFlightRow.sequence),
+    });
+}
+
 function trackMaintainerrRequest(request, response, url, mode) {
+    const inFlightRow = beginMaintainerrAudit({
+        method: request.method || '',
+        path: maintainerrAuditPath(url.pathname),
+        query: maintainerrAuditQuery(url),
+        mode,
+        credentialHeadersPresent: Object.keys(request.headers)
+            .some(name => /authorization|api[-_]?key|token|cookie|credential/i.test(name)),
+    });
     let recorded = false;
     const record = aborted => {
         if (recorded) return;
         recorded = true;
-        appendMaintainerrAudit({
-            method: request.method || '',
-            path: maintainerrAuditPath(url.pathname),
-            query: maintainerrAuditQuery(url),
-            status: response.headersSent ? response.statusCode : 0,
-            mode,
-            aborted,
-            credentialHeadersPresent: Object.keys(request.headers)
-                .some(name => /authorization|api[-_]?key|token|cookie|credential/i.test(name)),
-        });
+        completeMaintainerrAudit(
+            inFlightRow,
+            response.headersSent ? response.statusCode : 0,
+            aborted
+        );
     };
     response.once('finish', () => record(false));
     response.once('close', () => record(!response.writableEnded));

--- a/scripts/e2e/docker-isolation.test.js
+++ b/scripts/e2e/docker-isolation.test.js
@@ -110,6 +110,10 @@ test('Maintainerr is a private strict read-only fixture with bounded sanitized e
     assert.match(mockServer, /hermetic Maintainerr fixture is read-only/);
     assert.match(mockServer, /MAX_MAINTAINERR_AUDIT_ROWS = 256/);
     assert.match(mockServer, /maintainerr-requests\.json/);
+    assert.match(mockServer, /inFlight: current\.inFlight\.slice\(-MAX_MAINTAINERR_AUDIT_ROWS\)/);
+    assert.match(mockServer, /beginMaintainerrAudit/);
+    assert.match(mockServer, /completeMaintainerrAudit/);
+    assert.match(mockServer, /current\.inFlight\.filter/);
     assert.match(mockServer, /writeFileSync\(temporary, next, \{ mode: 0o600 \}\)/);
     assert.match(mockServer, /renameSync\(temporary, MAINTAINERR_AUDIT_FILE\)/);
     assert.match(mockServer, /credentialHeadersPresent/);


### PR DESCRIPTION
Closes #566

## Root cause

The route-exit E2E waited only for the browser-to-Jellyfin dashboard request. Route teardown could cancel that request before Jellyfin opened a Maintainerr connection, leaving the completion-only fixture ledger empty even though cancel-before-send was valid. The test then incorrectly required an aborted upstream row and timed out.

## Change

- add a bounded, sanitized `inFlight` ledger to the hermetic Maintainerr fixture;
- record a process-monotonic sequence synchronously when the fixture accepts a request, then atomically move that exact sequence to the completed ledger on finish or abort;
- wait for a specific slow upstream sequence before route exit and require that same sequence to complete aborted;
- add a deterministic unit proof for cancellation before queued upstream work starts and verify no stale dashboard/error publication;
- preserve schema-v1 compatibility, shard isolation, atomic mode-0600 writes, parameterized paths, allowlisted queries, and the existing 15-second assertions.

## Validation

Exact head: `1db28deba173e84f93869429b274cd417f8cb8dc`

- independent exact-SHA review: APPROVE, no findings;
- focused Maintainerr page tests: 26/26;
- Docker fixture-isolation tests: 16/16;
- complete client suite: 2,013/2,013;
- complete script suite: 621/621;
- client coverage: 2,808/3,201 lines (87.723%), exact reviewed high-water;
- TypeScript source and JS typechecks, lint, syntax, deterministic bundle, and translations: passed;
- Release plugin build: zero warnings/errors;
- official two-CPU live Maintainerr file: 10/10;
- official two-CPU route-exit test: 10/10 consecutive repetitions, approximately 3.0–3.5 seconds each;
- `git diff --check`: passed.

The repeat-only validation intentionally trips the required-inventory duplicate guard after the browser executions; all 10 target tests passed. A separate order-sensitive item-status exact-call-count flake found during full-order validation is tracked as #567.

## AI assistance

This PR was developed with AI assistance. The implementation, tests, live browser evidence, and exact diff were independently reviewed and validated before publication.
