### PR TITLE
fix(bookmarks): own superseded library renders

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-render.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-render.ts
@@ -103,6 +103,10 @@ let activeContainer: HTMLElement | null = null;
 let activeContainerIdentity: IdentityContext | null = null;
 let activeRenderController: AbortController | null = null;
 
+function isAbortError(error: unknown): boolean {
+  return (error as { name?: string } | null)?.name === 'AbortError';
+}
+
 /** Set (or clear) the render target for the current page adoption. */
 export function setActiveContainer(container: HTMLElement | null): void {
   activeContainer = container;
@@ -143,8 +147,20 @@ export function renderActiveBookmarks(context: IdentityContext | null = JC.ident
     if (!JC.identity.isCurrent(context)) return;
     const container = activeContainer;
     if (container && container.isConnected && activeContainerIdentity?.epoch === context.epoch) {
-      void renderBookmarksLibrary(container, context);
+      startBookmarksLibraryRender(container, context);
     }
+  });
+}
+
+/** Own a lifecycle-triggered render promise without hiding genuine failures. */
+export function startBookmarksLibraryRender(
+  container: HTMLElement,
+  context: IdentityContext | null = JC.identity.capture()
+): void {
+  if (!context || !JC.identity.isCurrent(context)) return;
+  void renderBookmarksLibrary(container, context).catch((error: unknown) => {
+    if (isAbortError(error) || !JC.identity.isCurrent(context)) return;
+    console.error(`${logPrefix} Render failed:`, error);
   });
 }
 
@@ -306,7 +322,7 @@ export async function renderBookmarksLibrary(
   const selectPage = (page: number): void => {
     if (signal.aborted || !JC.identity.isCurrent(context)) return;
     container.dataset[pageDatasetKey] = String(page);
-    void renderBookmarksLibrary(container, context);
+    startBookmarksLibraryRender(container, context);
   };
   previousPageBtn?.addEventListener('click', () => selectPage(currentPage - 1));
   nextPageBtn?.addEventListener('click', () => selectPage(currentPage + 1));
@@ -410,7 +426,7 @@ export async function renderBookmarksLibrary(
           container.dataset.currentTab = tab;
           const nextPageDatasetKey = `bookmarkPage${tab[0].toUpperCase()}${tab.slice(1)}`;
           container.dataset[nextPageDatasetKey] = '0';
-          void renderBookmarksLibrary(container, context);
+          startBookmarksLibraryRender(container, context);
         });
       });
     }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-scale.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-scale.test.ts
@@ -8,7 +8,11 @@ vi.mock('./library-modals', () => ({
 }));
 
 import { renderBookmarkItems } from './library-items';
-import { renderBookmarksLibrary, resetBookmarksLibraryRender } from './library-render';
+import {
+  renderBookmarksLibrary,
+  resetBookmarksLibraryRender,
+  startBookmarksLibraryRender,
+} from './library-render';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -134,6 +138,57 @@ describe('bookmark library scale bounds', () => {
     await rendering;
 
     expect(container.querySelectorAll('.jc-bookmark-row')).toHaveLength(0);
+  });
+
+  it('quietly retires interaction-owned pagination and tab renders', async () => {
+    store = bookmarkStore(1000);
+    const normal = plugin.getMockImplementation() as (
+      path: string,
+      options?: { body?: any; signal?: AbortSignal }
+    ) => Promise<any>;
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    for (const selector of ['.jc-bookmark-page-next', '.jc-tab[data-tab="tv"]']) {
+      resetBookmarksLibraryRender();
+      plugin.mockImplementation(normal);
+      const container = document.createElement('div');
+      document.body.replaceChildren(container);
+      await renderBookmarksLibrary(container);
+
+      let heldSignal: AbortSignal | undefined;
+      plugin.mockImplementation((path: string, options?: { body?: any; signal?: AbortSignal }) => {
+        if (!path.includes('/page?')) return normal(path, options);
+        heldSignal = options?.signal;
+        return new Promise((_resolve, reject) => {
+          heldSignal?.addEventListener('abort', () => {
+            reject(Object.assign(new Error('Request was aborted'), { name: 'AbortError' }));
+          }, { once: true });
+        });
+      });
+
+      container.querySelector<HTMLButtonElement>(selector)!.click();
+      await vi.waitFor(() => expect(heldSignal).toBeDefined());
+      resetBookmarksLibraryRender();
+      await vi.waitFor(() => expect(heldSignal?.aborted).toBe(true));
+      await Promise.resolve();
+    }
+
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it('reports a genuine fire-and-forget render failure', async () => {
+    const failure = new Error('bookmark page transport failed');
+    plugin.mockRejectedValueOnce(failure);
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    startBookmarksLibraryRender(container);
+
+    await vi.waitFor(() => expect(consoleError).toHaveBeenCalledWith(
+      '🪼 Jellyfin Canopy: Bookmarks Library: Render failed:',
+      failure
+    ));
   });
 
   it('renders fifty rows with three requests and stays responsive at the supported maximum', async () => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/page.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/page.ts
@@ -13,10 +13,10 @@
 
 import { JC } from '../../globals';
 import {
-    renderBookmarksLibrary,
     renderActiveBookmarks,
     resetBookmarksLibraryRender,
     setActiveContainer,
+    startBookmarksLibraryRender,
 } from './library-render';
 import { resetBookmarksLibraryPlayback } from './library-items';
 import { resetBookmarksLibraryModals } from './library-modals';
@@ -53,7 +53,7 @@ function render({ host, handle }: PageContext): void {
     // down to the host.)
     handle.addListener(document, 'jc-bookmarks-updated', () => renderActiveBookmarks());
 
-    void renderBookmarksLibrary(container);
+    startBookmarksLibraryRender(container);
 }
 
 export const bookmarksPageDescriptor: PageDescriptor & { id: 'bookmarks' } = {

--- a/scripts/bundle-budgets.json
+++ b/scripts/bundle-budgets.json
@@ -18,8 +18,8 @@
     "maxFeatureExpandedRawBytes": 786432,
     "maxFeatureExpandedGzipBytes": 262144,
     "maxSourceMapRawBytes": 6000000,
-    "maxTotalRawBytes": 7213738,
+    "maxTotalRawBytes": 7214923,
     "maxClientManifestRawBytes": 262144,
-    "maxPublishedRawBytes": 7298486
+    "maxPublishedRawBytes": 7299671
   }
 }


### PR DESCRIPTION
## Summary

- route every lifecycle, refresh, pagination, and tab-triggered bookmark-library render through one owned fire-and-forget launcher
- consume only expected abort/stale-identity cancellation while reporting genuine render failures to the existing runtime error gate
- add regression coverage through real pagination and tab controls, plus a genuine-failure assertion
- ratchet total and published bundle bytes to the exact measured output; all feature/request/gzip/source-map ceilings remain unchanged

## User impact

Rapid bookmark updates, tab switches, pagination, or route teardown no longer produce an unhandled `Request was aborted` browser error when a newer render supersedes an in-flight one.

## Validation

- independent exact-head review: APPROVE for `06d050de690ac1791553655ac2ef24ab5c5664d4`
- focused bookmark library scale tests: 5/5
- full client coverage: 2,035/2,035 tests across 244 files; exact 2,808/3,201 line ratchet
- repository script tests: 621/621
- deterministic bundle: 173 files, build `02eb36b0c1eb57b0c4fbd03037850021de3079fd0d29435b5f57d363edc3b4cb`
- bundle totals: 7,214,923 raw and 7,299,671 published raw
- source and legacy typechecks, syntax, performance rules, translations, lint policy, and `git diff --check` passed
- Release build: 0 warnings, 0 errors
- disposable Jellyfin 12 browser proof forced an in-flight bookmark page abort and passed the shared runtime-error gate

## AI assistance

Implemented and reviewed with AI assistance under the repository engineering workflow. All changes were independently reviewed and validated with the commands above.

Fixes #571