### PR TITLE
fix(bookmarks): adopt modal accessibility contract

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/bookmarks.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/bookmarks.identity.test.ts
@@ -154,6 +154,83 @@ describe('bookmark player identity ownership', () => {
     expect(modal.textContent).toContain('551-600 / 1000');
   });
 
+  it('publishes named native OSD controls and a keyboard-owned player dialog', async () => {
+    const api = await loadModule();
+    const opener = document.createElement('button');
+    opener.textContent = 'Open bookmark editor';
+    document.body.appendChild(opener);
+    opener.focus();
+
+    await api.updateMarkers();
+    const marker = document.querySelector<HTMLButtonElement>('.jc-bookmark-marker')!;
+    expect(marker.tagName).toBe('BUTTON');
+    expect(marker.type).toBe('button');
+    expect(marker.getAttribute('aria-label')).toContain('A');
+    marker.click();
+    expect(video.currentTime).toBe(40);
+
+    await api.showModal('view');
+    const modal = document.querySelector<HTMLElement>('.jc-bm-player-modal-overlay')!;
+    expect(modal.getAttribute('role')).toBe('dialog');
+    expect(modal.getAttribute('aria-modal')).toBe('true');
+    const titleId = modal.getAttribute('aria-labelledby')!;
+    const descriptionId = modal.getAttribute('aria-describedby')!;
+    expect(document.getElementById(titleId)?.textContent).toContain('Your Bookmarks');
+    expect(document.getElementById(descriptionId)?.textContent).toContain('Movie A');
+    expect(document.activeElement).toBe(modal.querySelector('.jc-bookmark-input:not([readonly])'));
+    expect(document.body.classList.contains('jc-modal-open')).toBe(true);
+
+    for (const button of modal.querySelectorAll<HTMLButtonElement>('button')) {
+      const name = button.getAttribute('aria-label') || button.textContent?.trim() || button.title;
+      expect(name, `button ${button.className} needs an accessible name`).toBeTruthy();
+    }
+
+    const cancel = modal.querySelector<HTMLButtonElement>('.jc-bookmark-btn-cancel')!;
+    const close = modal.querySelector<HTMLButtonElement>('.jc-bookmark-modal-close')!;
+    cancel.focus();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+    expect(document.activeElement).toBe(close);
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(document.body.classList.contains('jc-modal-open')).toBe(false);
+    expect(document.activeElement).toBe(opener);
+  });
+
+  it('keeps player input labels unique across repeated same-type dialogs', async () => {
+    const api = await loadModule();
+    const opener = document.createElement('button');
+    opener.textContent = 'Open repeated bookmark editors';
+    document.body.appendChild(opener);
+    opener.focus();
+
+    await api.showModal('view');
+    await api.showModal('view');
+
+    const dialogs = [...document.querySelectorAll<HTMLElement>('.jc-bm-player-modal-overlay')];
+    expect(dialogs).toHaveLength(2);
+    const editableInputs = dialogs.map(dialog =>
+      dialog.querySelector<HTMLInputElement>('.jc-bookmark-input:not([readonly])')!
+    );
+    const timeInputs = dialogs.map(dialog =>
+      dialog.querySelector<HTMLInputElement>('.jc-bookmark-input[readonly]')!
+    );
+    expect(new Set([...editableInputs, ...timeInputs].map(input => input.id)).size).toBe(4);
+    dialogs.forEach((dialog, index) => {
+      const labels = [...dialog.querySelectorAll<HTMLLabelElement>('.jc-bookmark-input-group label')];
+      expect(labels).toHaveLength(2);
+      expect(labels[0].control).toBe(timeInputs[index]);
+      expect(labels[1].control).toBe(editableInputs[index]);
+      expect(timeInputs[index].labels).toHaveLength(1);
+      expect(editableInputs[index].labels).toHaveLength(1);
+    });
+    expect(document.activeElement).toBe(editableInputs[1]);
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(document.activeElement).toBe(editableInputs[0]);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(document.activeElement).toBe(opener);
+  });
+
   it('makes retained A markers, OSD buttons, and every modal control inert after a server switch', async () => {
     const api = await loadModule();
     await api.updateMarkers();

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/bookmarks.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/bookmarks.ts
@@ -15,6 +15,11 @@ import {
   persistedBookmarkIdentity,
   type BookmarkIdentityRecord
 } from './bookmark-identity';
+import {
+  createBookmarkModalControlId,
+  installBookmarkModalA11y,
+  releaseBookmarkModalA11y
+} from './modal-a11y';
 
 interface CancelableDebounced<T extends (...args: any[]) => void> {
   (...args: Parameters<T>): void;
@@ -1360,7 +1365,8 @@ import {
       const percent = (bookmark.timestamp / duration) * 100;
       const markerColor = bookmark.exactMatch ? '#00d4ff' : '#ffa500';
 
-      const marker = document.createElement('div');
+      const marker = document.createElement('button');
+      marker.type = 'button';
       marker.className = 'jc-bookmark-marker';
       marker.dataset.jcIdentityOwned = 'true';
       marker.dataset.jcIdentityEpoch = String(captured.context!.epoch);
@@ -1375,6 +1381,9 @@ import {
         z-index: 1000;
         pointer-events: all;
         cursor: pointer;
+        border: 0;
+        padding: 0;
+        background: transparent;
         display: flex;
         align-items: center;
         justify-content: center;
@@ -1382,6 +1391,7 @@ import {
 
       const icon = document.createElement('span');
       icon.className = 'material-icons';
+      icon.setAttribute('aria-hidden', 'true');
       icon.textContent = 'location_pin';
       icon.style.cssText = `
         font-size: 24px;
@@ -1395,6 +1405,7 @@ import {
       const labelText = bookmark.label || JC.t!('bookmark_no_label');
       const versionNote = !bookmark.exactMatch ? ` ${JC.t!('bookmark_file_changed')}` : '';
       marker.title = `${labelText} - ${formatTimestamp(bookmark.timestamp)}${versionNote}`;
+      marker.setAttribute('aria-label', marker.title);
 
       // Click to jump to bookmark
       marker.addEventListener('click', (e) => {
@@ -1519,6 +1530,8 @@ import {
       : Math.max(0, orderedExistingBookmarks.findIndex(bookmark => Number(bookmark.timestamp) >= currentTime));
     let existingBookmarkPage = Math.floor(selectedExistingIndex / bookmarkModalPageSize);
     const existingBookmarkPageCount = Math.max(1, Math.ceil(orderedExistingBookmarks.length / bookmarkModalPageSize));
+    const timeInputId = createBookmarkModalControlId('time');
+    const labelInputId = createBookmarkModalControlId('label');
     const existingBookmarkRows = (): string => orderedExistingBookmarks
       .slice(
         existingBookmarkPage * bookmarkModalPageSize,
@@ -1533,8 +1546,8 @@ import {
             ${!bm.exactMatch ? `<div class="jc-bookmark-item-warning">${JC.t!('bookmark_file_changed')}</div>` : ''}
           </div>
           <div class="jc-bookmark-item-actions">
-            <button class="jc-bookmark-btn jc-bookmark-btn-jump" data-bookmark-id="${escapeHtml(bm.id)}" title="${JC.t!('bookmark_jump')}"><span class="material-icons">forward</span></button>
-            <button class="jc-bookmark-btn jc-bookmark-btn-delete" data-bookmark-id="${escapeHtml(bm.id)}" title="${JC.t!('bookmark_delete_confirm')}"><span class="material-icons">delete</span></button>
+            <button type="button" class="jc-bookmark-btn jc-bookmark-btn-jump" data-bookmark-id="${escapeHtml(bm.id)}" title="${escapeHtml(JC.t!('bookmark_jump'))}" aria-label="${escapeHtml(`${JC.t!('bookmark_jump')}: ${formatTimestamp(bm.timestamp)}`)}"><span class="material-icons" aria-hidden="true">forward</span></button>
+            <button type="button" class="jc-bookmark-btn jc-bookmark-btn-delete" data-bookmark-id="${escapeHtml(bm.id)}" title="${escapeHtml(JC.t!('bookmark_delete_confirm'))}" aria-label="${escapeHtml(JC.t!('bookmark_delete_confirm'))}"><span class="material-icons" aria-hidden="true">delete</span></button>
           </div>
         </div>`).join('');
 
@@ -1593,6 +1606,11 @@ import {
         }
         .jc-bookmark-modal-close:hover {
           background: rgba(255,255,255,0.1);
+        }
+        .jc-bm-player-modal-overlay button:focus-visible,
+        .jc-bm-player-modal-overlay input:focus-visible {
+          outline: 3px solid #64b5f6;
+          outline-offset: 3px;
         }
         .jc-bookmark-modal-actions {
           display: flex;
@@ -1818,26 +1836,26 @@ import {
       </style>
       <div class="jc-bookmark-modal">
         <div class="jc-bookmark-hero">
-          <div class="jc-bookmark-hero-title">
+          <h2 class="jc-bookmark-hero-title">
             <span>${title}</span>
-          </div>
+          </h2>
           <div class="jc-bookmark-hero-subtitle">${escapeHtml(details.name)}</div>
         </div>
         <div class="jc-bookmark-form-grid">
           <div class="jc-bookmark-input-group">
-            <label for="bookmark-time">${JC.t!('bookmark_time_label')}</label>
+            <label for="${timeInputId}">${JC.t!('bookmark_time_label')}</label>
             <input
               type="text"
-              id="bookmark-time"
+              id="${timeInputId}"
               class="jc-bookmark-input"
               value="${formatTimestamp(timestamp)}"
               readonly>
           </div>
           <div class="jc-bookmark-input-group">
-            <label for="bookmark-label">${JC.t!('bookmark_label_label')}</label>
+            <label for="${labelInputId}">${JC.t!('bookmark_label_label')}</label>
             <input
               type="text"
-              id="bookmark-label"
+              id="${labelInputId}"
               class="jc-bookmark-input"
               placeholder="${JC.t!('bookmark_label_placeholder')}"
               value="${escapeHtml(label)}"
@@ -1852,9 +1870,9 @@ import {
             </div>
             <div class="jc-bookmark-items-page">${existingBookmarkRows()}</div>
             <div class="jc-bookmark-items-pagination" style="display:flex;align-items:center;justify-content:center;gap:12px;">
-              <button class="jc-bookmark-btn jc-bookmark-items-prev" ${existingBookmarkPage === 0 ? 'disabled' : ''}><span class="material-icons">chevron_left</span></button>
-              <span class="jc-bookmark-items-status"></span>
-              <button class="jc-bookmark-btn jc-bookmark-items-next" ${existingBookmarkPage >= existingBookmarkPageCount - 1 ? 'disabled' : ''}><span class="material-icons">chevron_right</span></button>
+              <button type="button" class="jc-bookmark-btn jc-bookmark-items-prev" aria-label="${escapeHtml(JC.t!('calendar_prev'))}" ${existingBookmarkPage === 0 ? 'disabled' : ''}><span class="material-icons" aria-hidden="true">chevron_left</span></button>
+              <span class="jc-bookmark-items-status" aria-live="polite"></span>
+              <button type="button" class="jc-bookmark-btn jc-bookmark-items-next" aria-label="${escapeHtml(JC.t!('calendar_next'))}" ${existingBookmarkPage >= existingBookmarkPageCount - 1 ? 'disabled' : ''}><span class="material-icons" aria-hidden="true">chevron_right</span></button>
             </div>
           </div>
         ` : `
@@ -1872,11 +1890,11 @@ import {
     modal.dataset.jcIdentityEpoch = String(captured.context.epoch);
     modal.innerHTML = `
       <div class="jc-bm-player-modal-container">
-        <button class="jc-bookmark-modal-close">×</button>
+        <button type="button" class="jc-bookmark-modal-close" aria-label="Close bookmark dialog">×</button>
         ${formHtml}
         <div class="jc-bookmark-modal-actions">
-          <button class="jc-bookmark-btn-submit">${isEdit ? JC.t!('bookmark_save') : JC.t!('bookmark_add')}</button>
-          <button class="jc-bookmark-btn-cancel">
+          <button type="button" class="jc-bookmark-btn-submit">${isEdit ? JC.t!('bookmark_save') : JC.t!('bookmark_add')}</button>
+          <button type="button" class="jc-bookmark-btn-cancel">
             <span class="material-icons" aria-hidden="true" style="font-size: 18px;">close</span>
             <span>Cancel</span>
           </button>
@@ -1886,7 +1904,6 @@ import {
 
     if (!isIdentityCurrent(captured)) return;
     document.body.appendChild(modal);
-    JC.core.refreshSafety!.holdElement(modal, 'modal');
 
     const modalTimers = new Set<number>();
     let removalTimer: number | null = null;
@@ -1910,7 +1927,7 @@ import {
       removalTimer = null;
       document.removeEventListener('viewshow', requestClose);
       activeModalDisposers.delete(modal);
-      JC.core.refreshSafety!.releaseElement(modal);
+      releaseBookmarkModalA11y(modal);
       modal.remove();
     };
 
@@ -1922,6 +1939,7 @@ import {
       }
       if (closing) return;
       closing = true;
+      releaseBookmarkModalA11y(modal);
       modal.style.opacity = '0';
       removalTimer = window.setTimeout(removeModalNow, 200);
     };
@@ -1951,6 +1969,12 @@ import {
     modal.addEventListener('click', (e) => {
       if (isIdentityCurrent(captured) && e.target === modal) requestClose();
     });
+    installBookmarkModalA11y(modal, {
+      title: modal.querySelector<HTMLElement>('.jc-bookmark-hero-title')!,
+      description: modal.querySelector<HTMLElement>('.jc-bookmark-hero-subtitle'),
+      initialFocus: modal.querySelector<HTMLInputElement>(`#${labelInputId}`),
+      onEscape: requestClose
+    });
 
     // Focus label input after modal opens
     scheduleModalTask(() => {
@@ -1958,15 +1982,13 @@ import {
         disposeModal(true);
         return;
       }
-      const labelInput = modal.querySelector<HTMLInputElement>('#bookmark-label');
-      if (labelInput) labelInput.focus();
       modal.style.opacity = '1';
     }, 10);
 
     // Submit
     modal.querySelector('.jc-bookmark-btn-submit')?.addEventListener('click', () => { void (async () => {
       if (!isModalOwnerCurrent()) return;
-      const labelInput = modal.querySelector<HTMLInputElement>('#bookmark-label')!.value.trim();
+      const labelInput = modal.querySelector<HTMLInputElement>(`#${labelInputId}`)!.value.trim();
 
       try {
         let saved: boolean | Record<string, unknown> | null;
@@ -2096,6 +2118,7 @@ import {
     bookmarkBtn.dataset.jcIdentityOwned = 'true';
     bookmarkBtn.dataset.jcIdentityEpoch = String(captured.context.epoch);
     bookmarkBtn.title = JC.t!('shortcut_BookmarkCurrentTime');
+    bookmarkBtn.setAttribute('aria-label', JC.t!('shortcut_BookmarkCurrentTime'));
     bookmarkBtn.innerHTML = '<span class="largePaperIconButton material-icons" aria-hidden="true">bookmark_add</span>';
 
     bookmarkBtn.onclick = (e) => {
@@ -2265,7 +2288,7 @@ import {
         invalidateBookmarkMarkerOutput();
         removeOwnedBookmarkButtons();
         document.querySelectorAll('.jc-bm-player-modal-overlay').forEach((node) => {
-          JC.core.refreshSafety!.releaseElement(node);
+          releaseBookmarkModalA11y(node as HTMLElement);
           node.remove();
         });
         initialized = false;
@@ -2295,7 +2318,7 @@ import {
     cleanupBookmarks = (): void => undefined;
     removeOwnedBookmarkButtons();
     document.querySelectorAll('.jc-bm-player-modal-overlay').forEach((node) => {
-      JC.core.refreshSafety!.releaseElement(node);
+      releaseBookmarkModalA11y(node as HTMLElement);
       node.remove();
     });
   }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-items.navigation.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-items.navigation.test.ts
@@ -46,7 +46,7 @@ describe('bookmark details navigation', () => {
             group: {
                 type: 'movie',
                 details: { itemId, name: 'Base URL fixture' },
-                bookmarks: [],
+                bookmarks: [{ id: 'bookmark-one', itemId, timestamp: 42, label: 'Scene' }],
             },
         }, 'movie');
 
@@ -56,6 +56,21 @@ describe('bookmark details navigation', () => {
         expect(title?.href).toBe(
             'http://localhost:3000/jellyfin/web/index.html#/details?id=item%2Fwith%20%3F%23%26%20delimiters'
         );
+
+        const posterLink = container.querySelector<HTMLAnchorElement>('.jc-bookmark-item-poster-link');
+        expect(posterLink?.tagName).toBe('A');
+        expect(posterLink?.getAttribute('href')).toBe(title?.getAttribute('href'));
+        expect(posterLink?.getAttribute('aria-label')).toBe('Base URL fixture');
+
+        const timestamp = container.querySelector<HTMLButtonElement>('.jc-bm-time');
+        expect(timestamp?.tagName).toBe('BUTTON');
+        expect(timestamp?.type).toBe('button');
+        expect(timestamp?.getAttribute('aria-label')).toContain('bookmark_jump');
+
+        for (const button of container.querySelectorAll<HTMLButtonElement>('button')) {
+            const name = button.getAttribute('aria-label') || button.textContent?.trim() || button.title;
+            expect(name, `button ${button.className} needs an accessible name`).toBeTruthy();
+        }
 
         container.querySelector<HTMLElement>('.jc-bookmark-item-poster')?.click();
         expect(show).toHaveBeenCalledWith(

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-items.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-items.ts
@@ -145,12 +145,18 @@ export async function renderBookmarkItems(
 
     // Create the card header HTML
     const detailsHref = routeHref('details', { id: group.details.itemId || '' });
+    const detailsLabel = escapeHtml(group.details.name || 'Unknown Item');
     const headerHtml = `
       <div class="jc-bookmark-item-header">
         ${posterUrl ? `
-          <img src="${escapeHtml(posterUrl)}"
-               class="jc-bookmark-item-poster"
-               data-item-id="${escapeHtml(group.details.itemId)}">
+          <a href="${escapeHtml(detailsHref)}"
+             class="jc-bookmark-item-poster-link"
+             data-item-id="${escapeHtml(group.details.itemId)}"
+             aria-label="${detailsLabel}">
+            <img src="${escapeHtml(posterUrl)}"
+                 alt=""
+                 class="jc-bookmark-item-poster">
+          </a>
         ` : `
           <div class="jc-bookmark-item-placeholder"><span class="material-icons" style="font-size: 48px; opacity: 0.3;">image_not_supported</span></div>
         `}
@@ -162,12 +168,12 @@ export async function renderBookmarkItems(
           </div>
         </div>
         ${orphaned && group.details.tmdbId ? `
-          <button class="btnFindReplacement jc-btn-find-replacement" data-group-key="${escapeHtml(key)}" title="${JC.t!('bookmark_find_replacement')}">
+          <button type="button" class="btnFindReplacement jc-btn-find-replacement" data-group-key="${escapeHtml(key)}" title="${escapeHtml(JC.t!('bookmark_find_replacement'))}" aria-label="${escapeHtml(JC.t!('bookmark_find_replacement'))}">
             <span class="material-icons" aria-hidden="true">find_replace</span>
           </button>
         ` : ''}
         ${!orphaned && group.bookmarks.some((bm: any) => bm.syncedFrom) ? `
-          <button class="btnAdjustOffset jc-offset-icon" data-group-key="${escapeHtml(key)}" title="${JC.t!('bookmark_adjust_offset')}">
+          <button type="button" class="btnAdjustOffset jc-offset-icon" data-group-key="${escapeHtml(key)}" title="${escapeHtml(JC.t!('bookmark_adjust_offset'))}" aria-label="${escapeHtml(JC.t!('bookmark_adjust_offset'))}">
             <span class="material-icons" aria-hidden="true">schedule</span>
           </button>
         ` : ''}
@@ -197,10 +203,11 @@ export async function renderBookmarkItems(
     }
 
     // Add poster click handler
-    const poster = itemCard.querySelector<HTMLElement>('.jc-bookmark-item-poster');
+    const poster = itemCard.querySelector<HTMLAnchorElement>('.jc-bookmark-item-poster-link');
     if (poster) {
-      poster.addEventListener('click', () => {
+      poster.addEventListener('click', (event) => {
         if (!JC.identity.isCurrent(context)) return;
+        event.preventDefault();
         const itemId = poster.dataset.itemId;
         if (itemId) {
           (window.Emby?.Page as { show?: (path: string) => void } | undefined)
@@ -226,30 +233,36 @@ export async function renderBookmarkItems(
         info.className = 'jc-bookmark-info';
         info.innerHTML = `
           ${bm.label ? `<div class="jc-bookmark-label">${escapeHtml(bm.label)}</div>` : ''}
-          <div class="jc-bm-time" data-item-id="${escapeHtml(bm.itemId)}" data-time="${Number(bm.timestamp) || 0}">
+          <button type="button" class="jc-bm-time" data-item-id="${escapeHtml(bm.itemId)}" data-time="${Number(bm.timestamp) || 0}" aria-label="${escapeHtml(`${JC.t!('bookmark_jump')}: ${formatTimestamp(bm.timestamp)}`)}">
             <span>${bm.progress ? `${Number(bm.progress) || 0}% • ` : ''}${formatTimestamp(bm.timestamp)}</span>
-          </div>
+          </button>
         `;
 
         const actions = document.createElement('div');
         actions.className = 'jc-bookmark-actions';
 
         const deleteBtn = document.createElement('button');
+        deleteBtn.type = 'button';
         deleteBtn.className = 'btnDeleteBookmark jc-btn jc-btn-delete';
         deleteBtn.innerHTML = '<span class="material-icons" aria-hidden="true">delete</span>';
         deleteBtn.dataset.bookmarkId = bm.id;
+        deleteBtn.setAttribute('aria-label', JC.t!('bookmark_delete_confirm'));
 
         // Only add play and edit buttons if not orphaned
         if (!orphaned) {
           const playBtn = document.createElement('button');
+          playBtn.type = 'button';
           playBtn.className = 'btnPlayBookmark jc-btn';
           playBtn.innerHTML = '<span class="material-icons" aria-hidden="true">play_arrow</span>';
           playBtn.dataset.itemId = bm.itemId;
           playBtn.dataset.time = bm.timestamp;
+          playBtn.setAttribute('aria-label', `${JC.t!('bookmark_jump')}: ${formatTimestamp(bm.timestamp)}`);
 
           const editBtn = document.createElement('button');
+          editBtn.type = 'button';
           editBtn.className = 'btnEditBookmark jc-btn';
           editBtn.innerHTML = '<span class="material-icons" aria-hidden="true">edit</span>';
+          editBtn.setAttribute('aria-label', JC.t!('bookmark_edit_title'));
 
           actions.appendChild(playBtn);
           actions.appendChild(editBtn);
@@ -269,6 +282,7 @@ export async function renderBookmarkItems(
         timeInput.className = 'jc-input';
         timeInput.value = formatTimestamp(bm.timestamp);
         timeInput.placeholder = JC.t!('bookmark_time_placeholder');
+        timeInput.setAttribute('aria-label', JC.t!('bookmark_time_label'));
 
         const labelInput = document.createElement('input');
         labelInput.type = 'text';
@@ -276,14 +290,19 @@ export async function renderBookmarkItems(
         labelInput.value = bm.label || '';
         labelInput.placeholder = JC.t!('bookmark_label_placeholder');
         labelInput.maxLength = 100;
+        labelInput.setAttribute('aria-label', JC.t!('bookmark_label_label'));
 
         const saveBtn = document.createElement('button');
+        saveBtn.type = 'button';
         saveBtn.className = 'jc-btn-action';
         saveBtn.innerHTML = '<span class="material-icons" aria-hidden="true">save</span>';
+        saveBtn.setAttribute('aria-label', JC.t!('bookmark_save'));
 
         const cancelBtn = document.createElement('button');
+        cancelBtn.type = 'button';
         cancelBtn.className = 'jc-btn-action jc-btn-cancel';
         cancelBtn.innerHTML = '<span class="material-icons" aria-hidden="true">close</span>';
+        cancelBtn.setAttribute('aria-label', 'Cancel bookmark edit');
 
         editRow.appendChild(timeInput);
         editRow.appendChild(labelInput);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-modals.merge.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-modals.merge.test.ts
@@ -66,6 +66,21 @@ function selectTarget(modal: HTMLElement, itemId: string): void {
   radio.dispatchEvent(new Event('change', { bubbles: true }));
 }
 
+function expectNamedDialog(modal: HTMLElement): void {
+  expect(modal.getAttribute('role')).toBe('dialog');
+  expect(modal.getAttribute('aria-modal')).toBe('true');
+  const titleId = modal.getAttribute('aria-labelledby');
+  const descriptionId = modal.getAttribute('aria-describedby');
+  expect(titleId).toBeTruthy();
+  expect(descriptionId).toBeTruthy();
+  expect(document.getElementById(titleId!)?.textContent?.trim()).not.toBe('');
+  expect(document.getElementById(descriptionId!)?.textContent?.trim()).not.toBe('');
+  for (const button of modal.querySelectorAll<HTMLButtonElement>('button')) {
+    const name = button.getAttribute('aria-label') || button.textContent?.trim() || button.title;
+    expect(name, `button ${button.className} needs an accessible name`).toBeTruthy();
+  }
+}
+
 describe('bookmarks duplicate merge modal', () => {
   const coverageRun = (import.meta as unknown as { env?: Record<string, string> }).env?.VITE_JC_V8_COVERAGE === '1';
   const renderBudgetMs = coverageRun ? 10_000 : 500;
@@ -113,6 +128,88 @@ describe('bookmarks duplicate merge modal', () => {
 
     modal.querySelector<HTMLButtonElement>('.jc-bookmark-btn-cancel')!.click();
     expect(getRefreshSafetyHoldCount('modal')).toBe(0);
+  });
+
+  it('exposes a named offset dialog, traps focus, closes on Escape, and restores its opener', () => {
+    const opener = document.createElement('button');
+    opener.textContent = 'Open offset';
+    document.body.appendChild(opener);
+    opener.focus();
+
+    showOffsetAdjustmentModal({
+      details: { name: 'Movie' },
+      bookmarks: [{ ...versionA, syncedFrom: 'source' }]
+    }, context);
+    const modal = modalElement();
+    expectNamedDialog(modal);
+    expect(document.activeElement).toBe(modal.querySelector('.jc-modal-input'));
+    expect(document.body.classList.contains('jc-modal-open')).toBe(true);
+
+    const apply = modal.querySelector<HTMLButtonElement>('.btnApplyOffset')!;
+    const close = modal.querySelector<HTMLButtonElement>('.jc-bm-library-modal-close')!;
+    apply.focus();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+    expect(document.activeElement).toBe(close);
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(document.body.classList.contains('jc-modal-open')).toBe(false);
+    expect(document.activeElement).toBe(opener);
+  });
+
+  it('keeps control labels owned by the top dialog across repeated offset opens', () => {
+    const opener = document.createElement('button');
+    opener.textContent = 'Open repeated offsets';
+    document.body.appendChild(opener);
+    opener.focus();
+    const group = {
+      details: { name: 'Movie' },
+      bookmarks: [{ ...versionA, syncedFrom: 'source' }]
+    };
+
+    showOffsetAdjustmentModal(group, context);
+    showOffsetAdjustmentModal(group, context);
+
+    const dialogs = [...document.querySelectorAll<HTMLElement>('.jc-bm-library-modal-overlay')];
+    expect(dialogs).toHaveLength(2);
+    dialogs.forEach(expectNamedDialog);
+    const inputs = dialogs.map(dialog => dialog.querySelector<HTMLInputElement>('.jc-modal-input')!);
+    expect(inputs[0].id).not.toBe(inputs[1].id);
+    dialogs.forEach((dialog, index) => {
+      const label = dialog.querySelector<HTMLLabelElement>('.jc-modal-label')!;
+      expect(label.control).toBe(inputs[index]);
+      expect(inputs[index].labels).toHaveLength(1);
+    });
+    expect(document.activeElement).toBe(inputs[1]);
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(document.activeElement).toBe(inputs[0]);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(document.activeElement).toBe(opener);
+  });
+
+  it('keeps one topmost bookmark modal owner across nested rapid opens and closes', () => {
+    const opener = document.createElement('button');
+    opener.textContent = 'Open dialogs';
+    document.body.appendChild(opener);
+    opener.focus();
+    showOffsetAdjustmentModal({
+      details: { name: 'Movie' },
+      bookmarks: [{ ...versionA, syncedFrom: 'source' }]
+    }, context);
+    const offsetInput = document.querySelector<HTMLInputElement>('.jc-modal-input')!;
+
+    showDuplicatesSyncModal(duplicateStore(), context);
+    const dialogs = [...document.querySelectorAll<HTMLElement>('[role="dialog"]')];
+    expect(dialogs).toHaveLength(2);
+    dialogs.forEach(expectNamedDialog);
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(document.body.classList.contains('jc-modal-open')).toBe(true);
+    expect(document.activeElement).toBe(offsetInput);
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(document.body.classList.contains('jc-modal-open')).toBe(false);
+    expect(document.activeElement).toBe(opener);
   });
 
   it('labels versions neutrally before selection and target/source only after it', () => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-modals.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-modals.ts
@@ -11,6 +11,11 @@ import { formatTimestamp, renderActiveBookmarks } from './library-render';
 import type { IdentityContext } from '../../types/jc';
 import { normalizeBookmarkMediaType } from './media-types';
 import { bookmarkIdentityLabel } from './bookmark-identity';
+import {
+  createBookmarkModalControlId,
+  installBookmarkModalA11y,
+  releaseBookmarkModalA11y
+} from './modal-a11y';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -35,8 +40,9 @@ function ownModal(modal: HTMLElement): void {
 }
 
 function closeModal(modal: HTMLElement): void {
-  JC.core.refreshSafety!.releaseElement(modal);
-  if (!modal.isConnected) return;
+  releaseBookmarkModalA11y(modal);
+  if (!modal.isConnected || modal.dataset.jcClosing === 'true') return;
+  modal.dataset.jcClosing = 'true';
   modal.style.opacity = '0';
   const timer = window.setTimeout(() => {
     modalTimers.delete(timer);
@@ -49,7 +55,7 @@ export function resetBookmarksLibraryModals(): void {
   for (const timer of modalTimers) window.clearTimeout(timer);
   modalTimers.clear();
   document.querySelectorAll('[data-jc-bookmark-library-modal="true"]').forEach((modal) => {
-    JC.core.refreshSafety!.releaseElement(modal);
+    releaseBookmarkModalA11y(modal as HTMLElement);
     modal.remove();
   });
 }
@@ -69,13 +75,14 @@ export function showOffsetAdjustmentModal(
   }
   const previewBookmarks = syncedBookmarks.slice(0, BOOKMARK_OFFSET_PREVIEW_SIZE);
   const previewRemainder = syncedBookmarks.length - previewBookmarks.length;
+  const offsetInputId = createBookmarkModalControlId('offset');
 
   const modal = document.createElement('div');
   modal.className = 'jc-bm-library-modal-overlay';
   ownModal(modal);
   modal.innerHTML = `
     <div class="jc-bm-library-modal-container" style="max-width: 550px;">
-      <button class="jc-bm-library-modal-close">×</button>
+      <button type="button" class="jc-bm-library-modal-close" aria-label="Close bookmark offset dialog">×</button>
       <div class="jc-bm-library-modal-content">
         <div class="jc-bookmarks-modal-header">
           <span class="material-icons" aria-hidden="true" style="font-size: 48px; color: #2196f3; flex-shrink: 0;">schedule</span>
@@ -91,8 +98,8 @@ export function showOffsetAdjustmentModal(
         </div>
 
         <div style="margin-bottom: 24px;">
-          <label for="offset-adjustment-input" class="jc-modal-label"><span class="material-icons" style="font-size: 14px; vertical-align: middle;">schedule</span> ${JC.t!('bookmark_offset_label')}</label>
-          <input type="number" id="offset-adjustment-input" value="0" step="0.1" placeholder="0" class="jc-modal-input">
+          <label for="${offsetInputId}" class="jc-modal-label"><span class="material-icons" style="font-size: 14px; vertical-align: middle;">schedule</span> ${JC.t!('bookmark_offset_label')}</label>
+          <input type="number" id="${offsetInputId}" value="0" step="0.1" placeholder="0" class="jc-modal-input">
           <div class="jc-modal-help-text">${JC.t!('bookmark_offset_help')}</div>
         </div>
 
@@ -109,11 +116,11 @@ export function showOffsetAdjustmentModal(
       </div>
 
       <div class="jc-bookmark-modal-actions">
-        <button class="jc-bookmark-btn-cancel">
+        <button type="button" class="jc-bookmark-btn-cancel">
           <span class="material-icons" aria-hidden="true" style="font-size: 18px;">close</span>
           <span>Cancel</span>
         </button>
-        <button class="btnApplyOffset jc-modal-btn-primary">
+        <button type="button" class="btnApplyOffset jc-modal-btn-primary">
           <span class="material-icons" aria-hidden="true" style="font-size: 18px;">check</span>
           <span>${JC.t!('bookmark_apply_offset')}</span>
         </button>
@@ -122,7 +129,6 @@ export function showOffsetAdjustmentModal(
   `;
 
   document.body.appendChild(modal);
-  JC.core.refreshSafety!.holdElement(modal, 'modal');
 
   const closeDialog = () => closeModal(modal);
   // Body-level modal: the page's dispose bag closes it on drain.
@@ -133,11 +139,17 @@ export function showOffsetAdjustmentModal(
   modal.addEventListener('click', (e) => {
     if (e.target === modal) closeDialog();
   });
+  installBookmarkModalA11y(modal, {
+    title: modal.querySelector<HTMLElement>('.jc-modal-title')!,
+    description: modal.querySelector<HTMLElement>('.jc-modal-subtitle'),
+    initialFocus: modal.querySelector<HTMLInputElement>(`#${offsetInputId}`),
+    onEscape: closeDialog
+  });
 
   // Apply offset button handler
   modal.querySelector('.btnApplyOffset')?.addEventListener('click', () => { void (async () => {
     if (!JC.identity.isCurrent(context)) return;
-    const offset = parseFloat(modal.querySelector<HTMLInputElement>('#offset-adjustment-input')!.value) || 0;
+    const offset = parseFloat(modal.querySelector<HTMLInputElement>(`#${offsetInputId}`)!.value) || 0;
 
     const btn = modal.querySelector<HTMLButtonElement>('.btnApplyOffset')!;
     btn.disabled = true;
@@ -467,24 +479,24 @@ export function showDuplicatesSyncModal(
   modal.style.cssText = 'position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.85); z-index: 10000; display: flex; align-items: center; justify-content: center; opacity: 0; transition: opacity 0.2s;';
   modal.innerHTML = `
     <div class="jc-bm-library-modal-container" style="max-width: 700px; background: #181818; border-radius: 12px; padding: 24px; position: relative; box-shadow: 0 8px 32px rgba(0,0,0,0.8); max-height: 85vh; overflow-y: auto;">
-      <button class="jc-bm-library-modal-close" style="position: absolute; top: 16px; right: 16px; background: transparent; border: none; color: #fff; font-size: 32px; cursor: pointer; width: 40px; height: 40px; display: flex; align-items: center; justify-content: center; border-radius: 50%; transition: background 0.2s;">×</button>
+      <button type="button" class="jc-bm-library-modal-close" aria-label="Close duplicate bookmarks dialog" style="position: absolute; top: 16px; right: 16px; background: transparent; border: none; color: #fff; font-size: 32px; cursor: pointer; width: 40px; height: 40px; display: flex; align-items: center; justify-content: center; border-radius: 50%; transition: background 0.2s;">×</button>
       <div class="jc-bm-library-modal-content">
         <div class="jc-bookmarks-modal-header" style="display: flex; gap: 16px; align-items: flex-start; margin-bottom: 24px;">
           <span class="material-icons" aria-hidden="true" style="font-size: 48px; color: #ff9800; flex-shrink: 0;">merge</span>
           <div style="flex: 1;">
-            <h2 style="margin: 0 0 8px 0; font-size: 24px; font-weight: 700; color: #fff;">${JC.t!('bookmark_duplicate_title')}</h2>
-            <p style="margin: 0; font-size: 13px; color: #aaa;">${JC.t!('bookmark_duplicate_subtitle').replace('{count}', String(duplicates.length))}</p>
+            <h2 class="jc-modal-title" style="margin: 0 0 8px 0; font-size: 24px; font-weight: 700; color: #fff;">${JC.t!('bookmark_duplicate_title')}</h2>
+            <p class="jc-modal-subtitle" style="margin: 0; font-size: 13px; color: #aaa;">${JC.t!('bookmark_duplicate_subtitle').replace('{count}', String(duplicates.length))}</p>
           </div>
         </div>
         <div class="jc-duplicate-groups-page" style="margin-top: 20px;"></div>
         <div class="jc-duplicate-group-pagination" style="display:flex;align-items:center;justify-content:center;gap:12px;">
-          <button class="jc-btn jc-duplicate-groups-prev" aria-label="${escapeHtml(JC.t!('calendar_prev'))}"><span class="material-icons">chevron_left</span></button>
-          <span class="jc-duplicate-groups-status"></span>
-          <button class="jc-btn jc-duplicate-groups-next" aria-label="${escapeHtml(JC.t!('calendar_next'))}"><span class="material-icons">chevron_right</span></button>
+          <button type="button" class="jc-btn jc-duplicate-groups-prev" aria-label="${escapeHtml(JC.t!('calendar_prev'))}"><span class="material-icons" aria-hidden="true">chevron_left</span></button>
+          <span class="jc-duplicate-groups-status" aria-live="polite"></span>
+          <button type="button" class="jc-btn jc-duplicate-groups-next" aria-label="${escapeHtml(JC.t!('calendar_next'))}"><span class="material-icons" aria-hidden="true">chevron_right</span></button>
         </div>
       </div>
       <div class="jc-bookmark-modal-actions">
-        <button class="jc-bookmark-btn-cancel">
+        <button type="button" class="jc-bookmark-btn-cancel">
           <span class="material-icons" aria-hidden="true" style="font-size: 18px;">close</span>
           <span>Close</span>
         </button>
@@ -493,7 +505,6 @@ export function showDuplicatesSyncModal(
   `;
 
   document.body.appendChild(modal);
-  JC.core.refreshSafety!.holdElement(modal, 'modal');
 
   const closeDialog = () => closeModal(modal);
   // Body-level modal: the page's dispose bag closes it on drain.
@@ -504,7 +515,6 @@ export function showDuplicatesSyncModal(
   modal.addEventListener('click', (e) => {
     if (e.target === modal) closeDialog();
   });
-
   let groupPage = 0;
   const versionPages = new Map<number, number>();
   const selectedTargets = new Map<number, string>();
@@ -546,7 +556,7 @@ export function showDuplicatesSyncModal(
                 <input type="radio" class="jc-merge-target-choice" name="jc-merge-target-${dupIndex}" value="${escapeHtml(itemId)}" data-dup-index="${dupIndex}" ${isTarget ? 'checked' : ''}>
                 <span>${JC.t!('bookmark_select_target')}</span>
               </label>
-              <button class="jc-btn" data-offset-item-id="${escapeHtml(itemId)}" data-dup-index="${dupIndex}"><span class="material-icons">schedule</span><span>${JC.t!('bookmark_adjust_offset')}</span></button>
+              <button type="button" class="jc-btn" data-offset-item-id="${escapeHtml(itemId)}" data-dup-index="${dupIndex}"><span class="material-icons" aria-hidden="true">schedule</span><span>${JC.t!('bookmark_adjust_offset')}</span></button>
             </div>`;
         }).join('');
       return `
@@ -555,11 +565,11 @@ export function showDuplicatesSyncModal(
           <div style="font-size:12px;color:#888;margin-bottom:12px;">${JC.t!('bookmark_split_versions').replace('{count}', String(Number(dup.totalBookmarks) || 0)).replace('{versions}', String(itemIds.length))}</div>
           ${versions}
           <div class="jc-duplicate-version-pagination" style="display:flex;align-items:center;gap:8px;">
-            <button class="jc-btn jc-duplicate-versions-prev" data-dup-index="${dupIndex}" ${versionPage === 0 ? 'disabled' : ''}><span class="material-icons">chevron_left</span></button>
-            <span class="jc-duplicate-versions-status">${versionStart + 1}-${Math.min(versionStart + BOOKMARK_DUPLICATE_VERSION_PAGE_SIZE, itemIds.length)} / ${itemIds.length}</span>
-            <button class="jc-btn jc-duplicate-versions-next" data-dup-index="${dupIndex}" ${versionPage >= versionPageCount - 1 ? 'disabled' : ''}><span class="material-icons">chevron_right</span></button>
+            <button type="button" class="jc-btn jc-duplicate-versions-prev" aria-label="${escapeHtml(JC.t!('calendar_prev'))}" data-dup-index="${dupIndex}" ${versionPage === 0 ? 'disabled' : ''}><span class="material-icons" aria-hidden="true">chevron_left</span></button>
+            <span class="jc-duplicate-versions-status" aria-live="polite">${versionStart + 1}-${Math.min(versionStart + BOOKMARK_DUPLICATE_VERSION_PAGE_SIZE, itemIds.length)} / ${itemIds.length}</span>
+            <button type="button" class="jc-btn jc-duplicate-versions-next" aria-label="${escapeHtml(JC.t!('calendar_next'))}" data-dup-index="${dupIndex}" ${versionPage >= versionPageCount - 1 ? 'disabled' : ''}><span class="material-icons" aria-hidden="true">chevron_right</span></button>
           </div>
-          <button class="jc-btn jc-merge-execute" data-dup-index="${dupIndex}" ${selected ? '' : 'disabled'}><span class="material-icons">merge</span><span>${JC.t!('bookmark_merge_primary')}</span></button>
+          <button type="button" class="jc-btn jc-merge-execute" data-dup-index="${dupIndex}" ${selected ? '' : 'disabled'}><span class="material-icons" aria-hidden="true">merge</span><span>${JC.t!('bookmark_merge_primary')}</span></button>
         </div>`;
     }).join('');
 
@@ -572,14 +582,20 @@ export function showDuplicatesSyncModal(
         if (!JC.identity.isCurrent(context)) return;
         selectedTargets.set(Number(radio.dataset.dupIndex), radio.value);
         renderDuplicateModalPage();
+        [...groupsContainer.querySelectorAll<HTMLInputElement>('.jc-merge-target-choice')]
+          .find(candidate => candidate.value === radio.value)?.focus();
       });
     });
     groupsContainer.querySelectorAll<HTMLButtonElement>('.jc-duplicate-versions-prev, .jc-duplicate-versions-next').forEach(button => {
       button.addEventListener('click', () => {
         const index = Number(button.dataset.dupIndex);
         const delta = button.classList.contains('jc-duplicate-versions-next') ? 1 : -1;
+        const focusClass = delta > 0 ? 'jc-duplicate-versions-next' : 'jc-duplicate-versions-prev';
         versionPages.set(index, Math.max(0, (versionPages.get(index) || 0) + delta));
         renderDuplicateModalPage();
+        groupsContainer.querySelector<HTMLButtonElement>(
+          `.jc-duplicate-group[data-dup-index="${index}"] .${focusClass}`
+        )?.focus();
       });
     });
     groupsContainer.querySelectorAll<HTMLButtonElement>('[data-offset-item-id]').forEach(button => {
@@ -637,6 +653,13 @@ export function showDuplicatesSyncModal(
     renderDuplicateModalPage();
   });
   renderDuplicateModalPage();
+  installBookmarkModalA11y(modal, {
+    title: modal.querySelector<HTMLElement>('.jc-modal-title')!,
+    description: modal.querySelector<HTMLElement>('.jc-modal-subtitle'),
+    initialFocus: modal.querySelector<HTMLInputElement>('.jc-merge-target-choice')
+      ?? modal.querySelector<HTMLButtonElement>('.jc-bookmark-btn-cancel'),
+    onEscape: closeDialog
+  });
 
   scheduleModalTask(context, () => { if (modal.isConnected) modal.style.opacity = '1'; }, 10);
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-replacements.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-replacements.test.ts
@@ -513,7 +513,20 @@ describe('bookmark replacement library search', () => {
 
     await findAndOfferReplacement(group(), button, context);
 
-    expect(document.querySelector('[data-jc-bookmark-library-modal="true"]')).not.toBeNull();
+    const modal = document.querySelector<HTMLElement>('[data-jc-bookmark-library-modal="true"]')!;
+    expect(modal.getAttribute('role')).toBe('dialog');
+    expect(modal.getAttribute('aria-modal')).toBe('true');
+    expect(document.getElementById(modal.getAttribute('aria-labelledby')!)?.textContent)
+      .toContain('Replacement Found');
+    expect(document.getElementById(modal.getAttribute('aria-describedby')!)?.textContent)
+      .toContain('Migrate 1 bookmark');
+    const replacement = modal.querySelector<HTMLButtonElement>('.replacement-option')!;
+    expect(replacement.tagName).toBe('BUTTON');
+    expect(replacement.getAttribute('aria-pressed')).toBe('false');
+    expect(document.activeElement).toBe(replacement);
+    replacement.click();
+    expect(replacement.getAttribute('aria-pressed')).toBe('true');
+    expect(modal.querySelector('.jc-bm-library-modal-close')?.getAttribute('aria-label')).toBeTruthy();
     expect(mocks.toast).not.toHaveBeenCalled();
     expect(button.disabled).toBe(false);
   });
@@ -621,6 +634,14 @@ describe('bookmark replacement library search', () => {
     await findAllOrphanedAndOfferMigration({ orphan }, context);
     expect(getRefreshSafetyHoldCount()).toBe(1);
 
+    const summary = document.querySelector<HTMLElement>('[data-jc-bookmark-library-modal="true"]')!;
+    expect(summary.getAttribute('role')).toBe('dialog');
+    expect(document.getElementById(summary.getAttribute('aria-labelledby')!)?.textContent)
+      .toContain('Orphaned Bookmarks');
+    expect(document.getElementById(summary.getAttribute('aria-describedby')!)?.textContent)
+      .toContain('replacements available');
+    expect(document.activeElement).toBe(summary.querySelector('.btnMigrateOrphaned'));
+
     document.querySelector<HTMLButtonElement>('.btnMigrateOrphaned')!.click();
     expect(getRefreshSafetyHoldCount()).toBe(1);
     expect(getRefreshSafetyHoldCount('interaction')).toBe(1);
@@ -632,5 +653,9 @@ describe('bookmark replacement library search', () => {
     expect(getRefreshSafetyHoldCount()).toBe(1);
     expect(getRefreshSafetyHoldCount('interaction')).toBe(0);
     expect(getRefreshSafetyHoldCount('modal')).toBe(1);
+    const selection = [...document.querySelectorAll<HTMLElement>('[data-jc-bookmark-library-modal="true"]')]
+      .find(element => element.querySelector('.replacement-option'))!;
+    expect(selection.getAttribute('role')).toBe('dialog');
+    expect(document.activeElement).toBe(selection.querySelector('.replacement-option'));
   });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-replacements.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-replacements.ts
@@ -17,6 +17,10 @@ import {
   compareBookmarkIdentity,
   type BookmarkIdentityRecord
 } from './bookmark-identity';
+import {
+  installBookmarkModalA11y,
+  releaseBookmarkModalA11y
+} from './modal-a11y';
 
 const replacementModalTimers = new Set<number>();
 const replacementModalTimerCleanups = new Map<number, () => void>();
@@ -231,8 +235,9 @@ function ownReplacementModal(modal: HTMLElement): void {
 }
 
 function closeReplacementModal(modal: HTMLElement): void {
-  JC.core.refreshSafety!.releaseElement(modal);
-  if (!modal.isConnected) return;
+  releaseBookmarkModalA11y(modal);
+  if (!modal.isConnected || modal.dataset.jcClosing === 'true') return;
+  modal.dataset.jcClosing = 'true';
   modal.style.opacity = '0';
   const timer = window.setTimeout(() => {
     replacementModalTimers.delete(timer);
@@ -247,7 +252,7 @@ export function resetBookmarksLibraryReplacementModals(): void {
   for (const cleanup of replacementModalTimerCleanups.values()) cleanup();
   replacementModalTimerCleanups.clear();
   document.querySelectorAll('[data-jc-bookmark-library-modal="true"]').forEach((modal) => {
-    JC.core.refreshSafety!.releaseElement(modal);
+    releaseBookmarkModalA11y(modal as HTMLElement);
     modal.remove();
   });
 }
@@ -474,7 +479,7 @@ function showReplacementSelectionModal(
   modal.style.cssText = 'position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.9); z-index: 10000; display: flex; align-items: center; justify-content: center; opacity: 0; transition: opacity 0.2s;';
   modal.innerHTML = `
     <div class="jc-bm-library-modal-container jc-replacement-modal-container">
-      <button class="jc-bm-library-modal-close">×</button>
+      <button type="button" class="jc-bm-library-modal-close" aria-label="Close replacement selection dialog">×</button>
       <div class="jc-bm-library-modal-content" style="padding: 28px;">
         <div class="jc-bookmarks-modal-header">
           <span class="material-icons" aria-hidden="true" style="font-size: 48px; color: #4caf50; flex-shrink: 0;">find_replace</span>
@@ -499,25 +504,25 @@ function showReplacementSelectionModal(
               tag: item.ImageTags?.Primary
             });
             return `
-              <div class="replacement-option" data-item-index="${idx}" style="display: flex; gap: 12px; background: rgba(76,175,80,0.05); border: 2px solid rgba(76,175,80,0.2); border-radius: 8px; padding: 12px; cursor: pointer; transition: all 0.2s; align-items: center;">
-                ${posterUrl ? `<img src="${escapeHtml(posterUrl)}" style="width: 60px; height: 90px; object-fit: cover; border-radius: 6px; flex-shrink: 0;">` : '<div style="width: 60px; height: 90px; background: rgba(255,255,255,0.05); border-radius: 6px; flex-shrink: 0;"></div>'}
+              <button type="button" class="replacement-option" data-item-index="${idx}" aria-pressed="false" style="display: flex; width: 100%; gap: 12px; background: rgba(76,175,80,0.05); border: 2px solid rgba(76,175,80,0.2); border-radius: 8px; padding: 12px; cursor: pointer; transition: all 0.2s; align-items: center; text-align: left; color: inherit; font: inherit;">
+                ${posterUrl ? `<img src="${escapeHtml(posterUrl)}" alt="" style="width: 60px; height: 90px; object-fit: cover; border-radius: 6px; flex-shrink: 0;">` : '<div aria-hidden="true" style="width: 60px; height: 90px; background: rgba(255,255,255,0.05); border-radius: 6px; flex-shrink: 0;"></div>'}
                 <div style="flex: 1;">
                   <div style="font-weight: 600; margin-bottom: 4px; color: #fff; font-size: 15px;">${escapeHtml(item.Name)}</div>
                   <div style="font-size: 12px; color: #aaa; margin-bottom: 4px;">${escapeHtml(item.ProductionYear || '')}</div>
                   <div style="font-size: 11px; color: #888;">Item ID: ${escapeHtml(item.Id.substring(0,16))}...</div>
                 </div>
                 <span class="material-icons" aria-hidden="true" style="color: #4caf50; font-size: 28px; display: none; flex-shrink: 0;">check_circle</span>
-              </div>
+              </button>
             `;
           }).join('')}
         </div>
       </div>
       <div class="jc-modal-actions-padded">
-        <button class="jc-modal-btn-cancel-alt jc-bookmark-btn-cancel">
+        <button type="button" class="jc-modal-btn-cancel-alt jc-bookmark-btn-cancel">
           <span class="material-icons" aria-hidden="true" style="font-size: 18px;">close</span>
           <span>Cancel</span>
         </button>
-        <button class="jc-modal-btn-submit jc-bookmark-btn-submit" disabled>
+        <button type="button" class="jc-modal-btn-submit jc-bookmark-btn-submit" disabled>
           <span class="material-icons" aria-hidden="true" style="font-size: 18px;">swap_horiz</span>
           <span>Migrate Bookmarks</span>
         </button>
@@ -529,7 +534,6 @@ function showReplacementSelectionModal(
   // list in case it synchronously re-entered navigation.
   if (!isReplacementFlowCurrent(context, pageOwner)) return;
   document.body.appendChild(modal);
-  JC.core.refreshSafety!.holdElement(modal, 'modal');
 
   let selectedItem: JellyfinReplacementItem | null = null;
 
@@ -542,6 +546,12 @@ function showReplacementSelectionModal(
   modal.addEventListener('click', (e) => {
     if (e.target === modal) closeDialog();
   });
+  installBookmarkModalA11y(modal, {
+    title: modal.querySelector<HTMLElement>('.jc-modal-title')!,
+    description: modal.querySelector<HTMLElement>('.jc-modal-subtitle'),
+    initialFocus: modal.querySelector<HTMLButtonElement>('.replacement-option'),
+    onEscape: closeDialog
+  });
 
   // Selection handlers
   modal.querySelectorAll<HTMLElement>('.replacement-option').forEach(option => {
@@ -553,11 +563,13 @@ function showReplacementSelectionModal(
       modal.querySelectorAll<HTMLElement>('.replacement-option').forEach(opt => {
         opt.style.borderColor = 'rgba(76,175,80,0.2)';
         opt.style.background = 'rgba(76,175,80,0.05)';
+        opt.setAttribute('aria-pressed', 'false');
         opt.querySelector<HTMLElement>('.material-icons')!.style.display = 'none';
       });
 
       option.style.borderColor = '#4caf50';
       option.style.background = 'rgba(76,175,80,0.15)';
+      option.setAttribute('aria-pressed', 'true');
       option.querySelector<HTMLElement>('.material-icons')!.style.display = 'block';
 
       const submitBtn = modal.querySelector<HTMLButtonElement>('.jc-bookmark-btn-submit')!;
@@ -730,13 +742,13 @@ function showOrphanedSummaryModal(
   modal.style.cssText = 'position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.85); z-index: 10000; display: flex; align-items: center; justify-content: center; opacity: 0; transition: opacity 0.2s;';
   modal.innerHTML = `
     <div class="jc-bm-library-modal-container" style="max-width: 700px; background: #181818; border-radius: 12px; padding: 24px; position: relative; box-shadow: 0 8px 32px rgba(0,0,0,0.8);">
-      <button class="jc-bm-library-modal-close" style="position: absolute; top: 16px; right: 16px; background: transparent; border: none; color: #fff; font-size: 32px; cursor: pointer; width: 40px; height: 40px; display: flex; align-items: center; justify-content: center; border-radius: 50%; transition: background 0.2s;">×</button>
+      <button type="button" class="jc-bm-library-modal-close" aria-label="Close orphaned bookmarks dialog" style="position: absolute; top: 16px; right: 16px; background: transparent; border: none; color: #fff; font-size: 32px; cursor: pointer; width: 40px; height: 40px; display: flex; align-items: center; justify-content: center; border-radius: 50%; transition: background 0.2s;">×</button>
       <div class="jc-bm-library-modal-content">
         <div class="jc-bookmarks-modal-header">
           <span class="material-icons" aria-hidden="true" style="font-size: 32px; color: #4caf50;">search</span>
           <div>
-            <h2 style="margin: 0 0 4px 0; font-size: 20px;">Orphaned Bookmarks</h2>
-            <p style="margin: 0; font-size: 13px; color: #999;">Found ${replacementResults.length} item(s) with replacements available</p>
+            <h2 class="jc-modal-title" style="margin: 0 0 4px 0; font-size: 20px;">Orphaned Bookmarks</h2>
+            <p class="jc-modal-subtitle" style="margin: 0; font-size: 13px; color: #999;">Found ${replacementResults.length} item(s) with replacements available</p>
           </div>
         </div>
         <div style="margin-top: 20px; max-height: 400px; overflow-y: auto;">
@@ -747,7 +759,7 @@ function showOrphanedSummaryModal(
                   <div class="jc-orphaned-result-name">${escapeHtml(result.group.details.name)}</div>
                   <div class="jc-orphaned-result-count">${result.group.bookmarks.length} bookmark(s) • ${result.matches.length} replacement(s) found</div>
                 </div>
-                <button class="btnMigrateOrphaned jc-btn" data-result-index="${idx}">
+                <button type="button" class="btnMigrateOrphaned jc-btn" data-result-index="${idx}">
                   <span class="material-icons" aria-hidden="true" style="font-size: 16px;">find_replace</span>
                   <span>Migrate</span>
                 </button>
@@ -760,7 +772,7 @@ function showOrphanedSummaryModal(
         </div>
       </div>
       <div class="jc-bookmark-modal-actions">
-        <button class="jc-bookmark-btn-cancel">
+        <button type="button" class="jc-bookmark-btn-cancel">
           <span class="material-icons" aria-hidden="true" style="font-size: 18px;">close</span>
           <span>Close</span>
         </button>
@@ -770,7 +782,6 @@ function showOrphanedSummaryModal(
 
   if (!isReplacementFlowCurrent(context, pageOwner)) return;
   document.body.appendChild(modal);
-  JC.core.refreshSafety!.holdElement(modal, 'modal');
 
   const closeDialog = () => closeReplacementModal(modal);
   // Body-level modal: the page's dispose bag closes it on drain.
@@ -780,6 +791,12 @@ function showOrphanedSummaryModal(
   modal.querySelector('.jc-bookmark-btn-cancel')?.addEventListener('click', closeDialog);
   modal.addEventListener('click', (e) => {
     if (e.target === modal) closeDialog();
+  });
+  installBookmarkModalA11y(modal, {
+    title: modal.querySelector<HTMLElement>('.jc-modal-title')!,
+    description: modal.querySelector<HTMLElement>('.jc-modal-subtitle'),
+    initialFocus: modal.querySelector<HTMLButtonElement>('.btnMigrateOrphaned'),
+    onEscape: closeDialog
   });
 
   // Migrate button handlers

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-styles.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/library-styles.ts
@@ -209,6 +209,13 @@ export function injectBookmarksLibraryStyles(): void {
       background: rgba(255,255,255,0.1);
     }
 
+    .jc-bm-library-modal-overlay button:focus-visible,
+    .jc-bm-library-modal-overlay input:focus-visible,
+    .jc-bm-library-modal-overlay a:focus-visible {
+      outline: 3px solid #64b5f6;
+      outline-offset: 3px;
+    }
+
     .jc-bookmarks-modal-header {
       display: flex;
       gap: 16px;
@@ -419,13 +426,26 @@ export function injectBookmarksLibraryStyles(): void {
       transform: scale(1.1);
     }
 
+    .jc-bookmark-item-poster-link {
+      width: 86px;
+      height: 129px;
+      border-radius: 6px;
+      display: block;
+      flex-shrink: 0;
+    }
+
+    .jc-bookmark-item-poster-link:focus-visible {
+      outline: 3px solid #64b5f6;
+      outline-offset: 3px;
+    }
+
     .jc-bookmark-item-poster {
       width: 86px;
       height: 129px;
       object-fit: cover;
       border-radius: 6px;
       cursor: pointer;
-      flex-shrink: 0;
+      display: block;
     }
 
     .jc-bookmark-item-placeholder {
@@ -524,6 +544,25 @@ export function injectBookmarksLibraryStyles(): void {
 
     .jc-bookmark-time:hover {
       color: #ccc;
+    }
+
+    /* #90: keep the legacy class until #570 resolves its separate styling
+       mismatch, but make the now-native timestamp button visually neutral and
+       give keyboard focus a durable affordance. */
+    .jc-bm-time {
+      appearance: none;
+      border: 0;
+      padding: 0;
+      background: transparent;
+      color: inherit;
+      font: inherit;
+      text-align: left;
+      cursor: pointer;
+    }
+
+    .jc-bm-time:focus-visible {
+      outline: 3px solid #64b5f6;
+      outline-offset: 3px;
     }
 
     .jc-bookmark-actions {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/modal-a11y.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/bookmarks/modal-a11y.ts
@@ -1,0 +1,65 @@
+// Shared accessibility ownership for every Bookmarks overlay. Keeping the
+// handle registry here lets either bookmark surface drain an overlay without
+// leaking the repository-wide modal stack or restoring focus twice.
+
+import {
+  installModalA11y,
+  type ModalA11yHandle,
+  type ModalA11yOptions
+} from '../../core/modal-a11y';
+
+const handles = new WeakMap<HTMLElement, ModalA11yHandle>();
+let nextAccessibleId = 0;
+
+type BookmarkModalControl = 'label' | 'offset' | 'time';
+
+export interface BookmarkModalA11yOptions {
+  title: HTMLElement;
+  description?: HTMLElement | null;
+  initialFocus?: ModalA11yOptions['initialFocus'];
+  onEscape: () => void;
+}
+
+function ownedId(element: HTMLElement, part: 'title' | 'description'): string {
+  if (element.id) return element.id;
+  nextAccessibleId += 1;
+  element.id = `jc-bookmark-dialog-${part}-${nextAccessibleId}`;
+  return element.id;
+}
+
+/** Allocate a document-unique label/control relationship for one modal instance. */
+export function createBookmarkModalControlId(part: BookmarkModalControl): string {
+  nextAccessibleId += 1;
+  return `jc-bookmark-dialog-${part}-${nextAccessibleId}`;
+}
+
+/** Acquire the one shared modal/keyboard owner for a Bookmarks overlay. */
+export function installBookmarkModalA11y(
+  modal: HTMLElement,
+  options: BookmarkModalA11yOptions
+): void {
+  releaseBookmarkModalA11y(modal, false);
+  const descriptionId = options.description
+    ? ownedId(options.description, 'description')
+    : '';
+  if (descriptionId) modal.setAttribute('aria-describedby', descriptionId);
+  else modal.removeAttribute('aria-describedby');
+
+  const handle = installModalA11y(modal, {
+    labelledBy: ownedId(options.title, 'title'),
+    initialFocus: options.initialFocus,
+    onEscape: options.onEscape
+  });
+  handles.set(modal, handle);
+}
+
+/** Release modal-stack, shortcut-gate, refresh-safety, and focus ownership. */
+export function releaseBookmarkModalA11y(
+  modal: HTMLElement,
+  restoreFocus = true
+): void {
+  const handle = handles.get(modal);
+  if (!handle) return;
+  handles.delete(modal);
+  handle.release(restoreFocus);
+}

--- a/e2e/bookmarks-responsive.spec.ts
+++ b/e2e/bookmarks-responsive.spec.ts
@@ -61,6 +61,7 @@ interface JellyfinItem {
     Id: string;
     Name?: string;
     Type?: string;
+    ProviderIds?: { Tmdb?: string; Tvdb?: string };
 }
 
 interface ItemsResponse {
@@ -108,6 +109,24 @@ async function bookmarkBatch(
             body: JSON.stringify({ Revision: revision, Operations: operations }),
         }
     );
+}
+
+async function addRawBookmarkFixture(
+    baseURL: string,
+    session: Session,
+    records: Array<{ id: string; bookmark: BookmarkItem & Record<string, unknown> }>
+): Promise<void> {
+    for (let attempt = 0; attempt < 6; attempt++) {
+        const current = await readBookmarkState(baseURL, session);
+        const response = await bookmarkBatch(baseURL, session, current.Revision, records.map((record) => ({
+            Type: 'add',
+            BookmarkId: record.id,
+            Bookmark: record.bookmark,
+        })));
+        if (response.status === 200) return;
+        if (response.status !== 409) throw new Error(`bookmark raw fixture add -> ${response.status}`);
+    }
+    throw new Error('bookmark raw fixture add could not acquire a stable revision');
 }
 
 async function addBookmarkFixture(
@@ -163,6 +182,24 @@ async function removeBookmarkFixture(
         }
     }
     throw new Error('bookmark fixture cleanup could not acquire a stable revision');
+}
+
+async function removeBookmarksByLabelPrefix(
+    baseURL: string,
+    session: Session,
+    prefix: string
+): Promise<void> {
+    for (let attempt = 0; attempt < 6; attempt++) {
+        const current = await readBookmarkState(baseURL, session);
+        const operations = Object.entries(current.Bookmarks)
+            .filter(([, bookmark]) => String(bookmark.Label || '').startsWith(prefix))
+            .map(([id]) => ({ Type: 'delete', BookmarkId: id }));
+        if (operations.length === 0) return;
+        const response = await bookmarkBatch(baseURL, session, current.Revision, operations);
+        if (response.status === 200) return;
+        if (response.status !== 409) throw new Error(`bookmark prefix cleanup -> ${response.status}`);
+    }
+    throw new Error('bookmark prefix cleanup could not acquire a stable revision');
 }
 
 async function seedLayout(page: Page, seed: string): Promise<void> {
@@ -411,6 +448,24 @@ test.describe.serial('Bookmarks responsive containment (#466 findings 1–2)', (
                 const apply = modal.locator('.btnApplyOffset');
                 await expect(modal).toBeVisible();
                 await expect(close).toBeVisible();
+                await expect(overlay).toHaveAttribute('role', 'dialog');
+                await expect(overlay).toHaveAttribute('aria-modal', 'true');
+                const titleId = await overlay.getAttribute('aria-labelledby');
+                const descriptionId = await overlay.getAttribute('aria-describedby');
+                expect(titleId).toBeTruthy();
+                expect(descriptionId).toBeTruthy();
+                await expect(page.locator(`#${titleId}`)).toHaveText(/Adjust Offset/i);
+                await expect(page.locator(`#${descriptionId}`)).not.toHaveText('');
+                await expect(page.locator('body')).toHaveClass(/jc-modal-open/);
+                const offsetInput = modal.locator('.jc-modal-input');
+                await expect(offsetInput).toBeFocused();
+
+                await offsetInput.press('Shift+Tab');
+                await expect(close).toBeFocused();
+                await close.press('Shift+Tab');
+                await expect(apply).toBeFocused();
+                await apply.press('Tab');
+                await expect(close).toBeFocused();
 
                 const initial = await modal.evaluate((element) => {
                     const rect = element.getBoundingClientRect();
@@ -474,12 +529,229 @@ test.describe.serial('Bookmarks responsive containment (#466 findings 1–2)', (
                     `fixed-bookmark-offset-${testCase.layout}-320x568-actions.png`
                 );
 
-                await modal.locator('.jc-bookmark-btn-cancel').click();
+                await page.keyboard.press('Escape');
                 await expect(overlay).toBeHidden();
+                await expect(page.locator('body')).not.toHaveClass(/jc-modal-open/);
+                await expect(card.locator('.btnAdjustOffset')).toBeFocused();
                 assertNoRuntimeErrors(consoleErrors);
             } finally {
                 await removeBookmarkFixture(baseURL!, admin, fixture.ids);
             }
         });
     }
+
+    test('keyboard users can add, activate, edit, and delete a bookmark through native controls', async ({
+        page,
+        consoleErrors,
+        baseURL,
+    }) => {
+        const labelPrefix = `JC keyboard ${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+        try {
+            await seedLayout(page, 'modern');
+            await loginAs(page, 'admin', consoleErrors);
+            await expectExactLayout(page, 'modern');
+
+            await page.evaluate(() => {
+                (window as any).JellyfinCanopy.bookmarksPage.showPage();
+            });
+            await page.waitForFunction(
+                () => typeof (window as any).JellyfinCanopy.initializeBookmarks === 'function',
+                undefined,
+                { timeout: 20_000 }
+            );
+
+            await page.evaluate(({ itemId }) => {
+                document.getElementById('jc-e2e-bookmark-player')?.remove();
+                const canopy = (window as any).JellyfinCanopy;
+                (window as any).__jcE2eOriginalIsVideoPage = canopy.isVideoPage;
+                canopy.isVideoPage = () => true;
+                const host = document.createElement('div');
+                host.id = 'jc-e2e-bookmark-player';
+                host.innerHTML = `
+                    <div class="videoPlayerContainer"><video></video></div>
+                    <div class="videoOsdBottom">
+                        <button type="button" class="btnUserRating" data-id="${itemId}"></button>
+                        <div class="osdPositionSliderContainer"><input class="osdPositionSlider" type="range"></div>
+                        <div class="buttons focuscontainer-x"><button type="button" class="btnVideoOsdSettings">Settings</button></div>
+                    </div>`;
+                const video = host.querySelector('video')!;
+                Object.defineProperty(video, 'duration', { configurable: true, value: 600 });
+                Object.defineProperty(video, 'currentTime', { configurable: true, writable: true, value: 123 });
+                document.body.appendChild(host);
+                canopy.initializeBookmarks();
+            }, { itemId: movie.Id });
+
+            const osdAdd = page.locator('#jcBookmarkBtn');
+            await expect(osdAdd).toBeVisible({ timeout: 20_000 });
+            await expect(osdAdd).toHaveAttribute('aria-label', /bookmark|current time/i);
+            await osdAdd.focus();
+            await osdAdd.press('Enter');
+
+            const editor = page.getByRole('dialog', { name: /Add Bookmark/i });
+            await expect(editor).toBeVisible();
+            const editorLabelInput = editor.locator('.jc-bookmark-input:not([readonly])');
+            await expect(editorLabelInput).toBeFocused();
+            await editorLabelInput.fill(labelPrefix);
+            await editor.getByRole('button', { name: /^Add Bookmark$/i }).press('Enter');
+            await expect(editor).toBeHidden();
+
+            const marker = page.locator('.jc-bookmark-marker').filter({ has: page.locator('.material-icons') }).first();
+            await expect(marker).toBeVisible({ timeout: 20_000 });
+            await expect(marker).toHaveAttribute('aria-label', new RegExp(labelPrefix));
+            await page.locator('#jc-e2e-bookmark-player video').evaluate((video) => {
+                (video as HTMLVideoElement).currentTime = 1;
+            });
+            await marker.focus();
+            await marker.press('Enter');
+            expect(await page.locator('#jc-e2e-bookmark-player video').evaluate(
+                (video) => (video as HTMLVideoElement).currentTime
+            )).toBe(123);
+
+            await page.evaluate(() => {
+                const canopy = (window as any).JellyfinCanopy;
+                canopy.cleanupBookmarks();
+                canopy.isVideoPage = (window as any).__jcE2eOriginalIsVideoPage;
+                delete (window as any).__jcE2eOriginalIsVideoPage;
+                document.getElementById('jc-e2e-bookmark-player')?.remove();
+            });
+
+            await openBookmarks(page, labelPrefix);
+            let row = page.locator('.jc-bookmark-row').filter({ hasText: labelPrefix }).first();
+            await row.getByRole('button', { name: /Edit Bookmark/i }).press('Enter');
+            await expect(row.locator('.jc-input:not(.jc-input-label)')).toBeFocused();
+            const labelInput = row.locator('.jc-input-label');
+            await labelInput.fill(`${labelPrefix} edited`);
+            await row.getByRole('button', { name: /^Save$/i }).press('Enter');
+            row = page.locator('.jc-bookmark-row').filter({ hasText: `${labelPrefix} edited` }).first();
+            await expect(row).toBeVisible({ timeout: 20_000 });
+            await row.getByRole('button', { name: /delete/i }).press('Enter');
+            await expect(row).toBeHidden({ timeout: 20_000 });
+            assertNoRuntimeErrors(consoleErrors);
+        } finally {
+            await removeBookmarksByLabelPrefix(baseURL!, admin, labelPrefix);
+        }
+    });
+
+    test('keyboard duplicate, replacement, and migration flows expose named modal controls', async ({
+        page,
+        consoleErrors,
+        baseURL,
+    }) => {
+        const tmdbId = String(movie.ProviderIds?.Tmdb || '');
+        expect(tmdbId, 'seeded Movie exposes its deterministic TMDB identity').not.toBe('');
+        const nonce = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+        const duplicatePrefix = `JC duplicate ${nonce}`;
+        const replacementPrefix = `JC replacement ${nonce}`;
+        const duplicateSourceItemId = crypto.randomUUID().replaceAll('-', '');
+        const replacementSourceItemId = crypto.randomUUID().replaceAll('-', '');
+        const duplicateIds = [`bm_keyboard_${nonce}_target`, `bm_keyboard_${nonce}_source`];
+        const replacementId = `bm_keyboard_${nonce}_replacement`;
+
+        try {
+            await addRawBookmarkFixture(baseURL!, admin, [
+                {
+                    id: duplicateIds[0],
+                    bookmark: {
+                        ItemId: movie.Id,
+                        ItemType: 'movie',
+                        MediaType: 'movie',
+                        IdentityVersion: 1,
+                        TmdbId: tmdbId,
+                        Timestamp: 40,
+                        Label: `${duplicatePrefix} target`,
+                        Name: movie.Name || 'Movie',
+                    },
+                },
+                {
+                    id: duplicateIds[1],
+                    bookmark: {
+                        ItemId: duplicateSourceItemId,
+                        ItemType: 'movie',
+                        MediaType: 'movie',
+                        IdentityVersion: 1,
+                        TmdbId: tmdbId,
+                        Timestamp: 80,
+                        Label: `${duplicatePrefix} source`,
+                        Name: movie.Name || 'Movie',
+                    },
+                },
+            ]);
+
+            await seedLayout(page, 'modern');
+            await loginAs(page, 'admin', consoleErrors);
+            await expectExactLayout(page, 'modern');
+            await openBookmarks(page, duplicatePrefix);
+
+            const duplicateTrigger = page.getByRole('button', { name: /Find Duplicates/i });
+            await duplicateTrigger.focus();
+            await duplicateTrigger.press('Enter');
+            const duplicateDialog = page.getByRole('dialog', { name: /Duplicate Detected/i });
+            await expect(duplicateDialog).toBeVisible();
+            await expect(page.locator('body')).toHaveClass(/jc-modal-open/);
+            const targetChoice = duplicateDialog.locator(
+                `.jc-merge-target-choice[value="${movie.Id}"]`
+            );
+            await targetChoice.focus();
+            await targetChoice.press('Space');
+            const merge = duplicateDialog.locator('.jc-merge-execute:not([disabled])');
+            await expect(merge).toBeEnabled();
+            page.once('dialog', (dialog) => dialog.accept());
+            await merge.press('Enter');
+            await expect(duplicateDialog).toBeHidden({ timeout: 20_000 });
+
+            await expect.poll(async () => {
+                const state = await readBookmarkState(baseURL!, admin);
+                return Object.values(state.Bookmarks)
+                    .filter((bookmark) => String(bookmark.Label || '').startsWith(duplicatePrefix))
+                    .map((bookmark) => bookmark.ItemId);
+            }).toEqual([movie.Id, movie.Id]);
+
+            await addRawBookmarkFixture(baseURL!, admin, [{
+                id: replacementId,
+                bookmark: {
+                    ItemId: replacementSourceItemId,
+                    ItemType: 'movie',
+                    MediaType: 'movie',
+                    IdentityVersion: 1,
+                    TmdbId: tmdbId,
+                    Timestamp: 120,
+                    Label: replacementPrefix,
+                    Name: movie.Name || 'Movie',
+                },
+            }]);
+            await page.reload();
+            await expectExactLayout(page, 'modern');
+            await openBookmarks(page, replacementPrefix);
+            const replacementCard = page.locator('.jc-bookmark-item')
+                .filter({ hasText: replacementPrefix })
+                .first();
+            const replacementTrigger = replacementCard.getByRole('button', { name: /Find Replacement/i });
+            await replacementTrigger.focus();
+            await replacementTrigger.press('Enter');
+
+            const replacementDialog = page.getByRole('dialog', { name: /Replacement Found/i });
+            await expect(replacementDialog).toBeVisible({ timeout: 30_000 });
+            const option = replacementDialog.locator('.replacement-option').first();
+            await expect(option).toBeFocused();
+            await option.press('Space');
+            await expect(option).toHaveAttribute('aria-pressed', 'true');
+            await replacementDialog.getByRole('button', { name: /Migrate Bookmarks/i }).press('Enter');
+            await expect(replacementDialog).toBeHidden({ timeout: 20_000 });
+
+            await expect.poll(async () => {
+                const state = await readBookmarkState(baseURL!, admin);
+                return {
+                    oldPresent: Object.hasOwn(state.Bookmarks, replacementId),
+                    itemIds: Object.entries(state.Bookmarks)
+                    .filter(([, bookmark]) => String(bookmark.Label || '').startsWith(replacementPrefix))
+                    .map(([, bookmark]) => bookmark.ItemId),
+                };
+            }).toEqual({ oldPresent: false, itemIds: [movie.Id] });
+            assertNoRuntimeErrors(consoleErrors);
+        } finally {
+            await removeBookmarksByLabelPrefix(baseURL!, admin, duplicatePrefix);
+            await removeBookmarksByLabelPrefix(baseURL!, admin, replacementPrefix);
+            await removeBookmarkFixture(baseURL!, admin, [...duplicateIds, replacementId]);
+        }
+    });
 });

--- a/e2e/required-test-inventory.json
+++ b/e2e/required-test-inventory.json
@@ -30,6 +30,8 @@
     "e2e/bookmarks-responsive.spec.ts › Bookmarks responsive containment (#466 findings 1–2) › modern: Bookmark offset modal keeps close and actions reachable at 320x568",
     "e2e/bookmarks-responsive.spec.ts › Bookmarks responsive containment (#466 findings 1–2) › legacy: populated Bookmarks grid and footer fit 320px and 360px",
     "e2e/bookmarks-responsive.spec.ts › Bookmarks responsive containment (#466 findings 1–2) › legacy: Bookmark offset modal keeps close and actions reachable at 320x568",
+    "e2e/bookmarks-responsive.spec.ts › Bookmarks responsive containment (#466 findings 1–2) › keyboard users can add, activate, edit, and delete a bookmark through native controls",
+    "e2e/bookmarks-responsive.spec.ts › Bookmarks responsive containment (#466 findings 1–2) › keyboard duplicate, replacement, and migration flows expose named modal controls",
     "e2e/boot.spec.ts › boot › initializes with all core namespaces and no real console errors",
     "e2e/boot.spec.ts › boot › shared notifications are accessible, stacked, exact-once, and route-owned",
     "e2e/console-net.spec.ts › console and HTTP error safety net › late responses retain exact Request ownership across a sink reset",

--- a/scripts/bundle-budgets.json
+++ b/scripts/bundle-budgets.json
@@ -18,8 +18,8 @@
     "maxFeatureExpandedRawBytes": 786432,
     "maxFeatureExpandedGzipBytes": 262144,
     "maxSourceMapRawBytes": 6000000,
-    "maxTotalRawBytes": 7214923,
+    "maxTotalRawBytes": 7232098,
     "maxClientManifestRawBytes": 262144,
-    "maxPublishedRawBytes": 7299671
+    "maxPublishedRawBytes": 7316960
   }
 }


### PR DESCRIPTION
## Summary

- route every bookmark player, offset, duplicate, replacement, and migration overlay through the shared modal accessibility owner
- give each dialog a named accessibility tree, trapped focus, topmost Escape handling, opener restoration, and shortcut suppression
- replace OSD markers and library icon actions with native, screen-reader-named controls while preserving pointer behavior
- allocate unique per-instance control IDs so repeated same-type dialogs cannot bind labels to buried controls
- add unit and live-browser keyboard regressions, and register the new required E2E inventory

## User impact

Keyboard and screen-reader users can operate the complete bookmark workflow: add, activate, edit, delete, merge duplicates, choose replacements, migrate bookmarks, adjust offsets, and close nested or repeated dialogs without focus or shortcut leakage.

## Validation

- independent exact-head review: APPROVE for db0cb0974c1320ba7cb78adab2425de350c2077e
- focused bookmark tests: 85/85 with single-worker performance isolation
- full client coverage: 2,040/2,040 tests across 244 files; exact 2,808/3,201 line ratchet
- repository script tests: 621/621; Playwright discovery: 176 tests
- disposable Jellyfin 12 browser proof: bookmark-responsive 6/6 with runtime-error gate clean
- deterministic bundle: 173 files, build 1788c55b5f8993ca1c69acbafde8c469ed97527dd27614c9e91191fc82de3506
- exact bundle totals: 7,232,098 raw and 7,316,960 published raw
- source and legacy typechecks, syntax, performance rules, translations, bundle contracts, lint policy, and diff checks passed
- Release build: 0 warnings, 0 errors

## AI assistance

Implemented and reviewed with AI assistance under the repository engineering workflow. All changes were independently reviewed and validated with the commands above.

Fixes #90