### PR TITLE
Fix derived tag-cache dependency invalidation (#93)

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/TagCacheDependencyInvalidationTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/TagCacheDependencyInvalidationTests.cs
@@ -1,0 +1,2825 @@
+using System.Diagnostics;
+using Jellyfin.Data.Enums;
+using Jellyfin.Plugin.JellyfinCanopy.Model;
+using Jellyfin.Plugin.JellyfinCanopy.Services;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services;
+
+public sealed class TagCacheDependencyInvalidationTests
+{
+    private static readonly DateTime SavedAt = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void FieldDependencyInventory_CoversEveryTagCacheEntryField()
+    {
+        var properties = typeof(TagCacheEntry)
+            .GetProperties()
+            .Select(property => property.Name)
+            .OrderBy(name => name, StringComparer.Ordinal);
+
+        Assert.Equal(
+            properties,
+            TagCacheDependencyGraph.FieldDependencies.Keys.OrderBy(name => name, StringComparer.Ordinal));
+        Assert.Equal(
+            TagCacheFieldDependency.OwnItem | TagCacheFieldDependency.ParentSeries,
+            TagCacheDependencyGraph.FieldDependencies[nameof(TagCacheEntry.SeriesTmdbId)]);
+        Assert.Equal(
+            TagCacheFieldDependency.OwnItem | TagCacheFieldDependency.FirstEpisode,
+            TagCacheDependencyGraph.FieldDependencies[nameof(TagCacheEntry.StreamData)]);
+        Assert.Equal(
+            TagCacheFieldDependency.OwnItem
+                | TagCacheFieldDependency.FirstEpisode
+                | TagCacheFieldDependency.ParentSeries,
+            TagCacheDependencyGraph.FieldDependencies[nameof(TagCacheEntry.Genres)]);
+        Assert.Equal(
+            TagCacheDependencyGraph.FieldDependencies
+                .Where(pair => pair.Value.HasFlag(TagCacheFieldDependency.ParentSeries))
+                .Select(pair => pair.Key)
+                .OrderBy(name => name, StringComparer.Ordinal),
+            TagCacheDependencyGraph.ParentSeriesConsumers.Keys.OrderBy(name => name, StringComparer.Ordinal));
+        Assert.Equal(
+            new[] { BaseItemKind.Season },
+            TagCacheDependencyGraph.ParentSeriesConsumers[nameof(TagCacheEntry.Genres)]);
+        Assert.Equal(
+            new[] { BaseItemKind.Episode, BaseItemKind.Season },
+            TagCacheDependencyGraph.ParentSeriesConsumers[nameof(TagCacheEntry.SeriesTmdbId)]);
+        Assert.Equal(
+            new[] { BaseItemKind.Episode, BaseItemKind.Season },
+            TagCacheDependencyGraph.DescendantKinds());
+    }
+
+    [Fact]
+    public void ParentSeriesGraph_UpdatesEveryAndOnlyDeclaredEpisodeField()
+    {
+        var series = new StubSeries
+        {
+            Id = Guid.NewGuid(),
+            CommunityRating = 9,
+            CriticRating = 90,
+            ProviderIds = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["Tmdb"] = "new-parent" },
+        };
+        var episode = new StubEpisode { Id = Guid.NewGuid(), SeriesId = series.Id };
+        var streamData = new TagStreamData { ItemName = "unchanged" };
+        var existing = new TagCacheEntry
+        {
+            Type = "Episode",
+            TmdbId = "own-tmdb",
+            SeriesTmdbId = "old-parent",
+            SeasonNumber = 2,
+            EpisodeNumber = 3,
+            Genres = new[] { "Own" },
+            CommunityRating = 1,
+            CriticRating = 10,
+            AudioLanguages = new[] { "eng" },
+            StreamData = streamData,
+            LastUpdated = 5,
+            SeriesId = Key(series.Id),
+            SeasonId = Key(Guid.NewGuid()),
+            StreamSourceId = Key(episode.Id),
+            SourceRevision = 123,
+        };
+
+        var refreshed = TagCacheDependencyGraph.ApplyParentSeriesRefresh(
+            series,
+            episode,
+            existing,
+            _ => throw new InvalidOperationException("Episode refresh must not inspect first Episode"),
+            lastUpdated: 6);
+
+        Assert.Equal("new-parent", refreshed.SeriesTmdbId);
+        Assert.Equal(9, refreshed.CommunityRating);
+        Assert.Equal(90, refreshed.CriticRating);
+        Assert.Equal(6, refreshed.LastUpdated);
+        Assert.Equal(existing.Type, refreshed.Type);
+        Assert.Equal(existing.TmdbId, refreshed.TmdbId);
+        Assert.Equal(existing.SeasonNumber, refreshed.SeasonNumber);
+        Assert.Equal(existing.EpisodeNumber, refreshed.EpisodeNumber);
+        Assert.Same(existing.Genres, refreshed.Genres);
+        Assert.Same(existing.AudioLanguages, refreshed.AudioLanguages);
+        Assert.Same(streamData, refreshed.StreamData);
+        Assert.Equal(existing.SeriesId, refreshed.SeriesId);
+        Assert.Equal(existing.SeasonId, refreshed.SeasonId);
+        Assert.Equal(existing.StreamSourceId, refreshed.StreamSourceId);
+        Assert.Equal(existing.SourceRevision, refreshed.SourceRevision);
+    }
+
+    [Fact]
+    public void EpisodeChange_CapturesExactlySelfSeasonAndSeriesWithoutDiscovery()
+    {
+        var episode = new StubEpisode
+        {
+            Id = Guid.NewGuid(),
+            SeriesId = Guid.NewGuid(),
+            SeasonId = Guid.NewGuid(),
+        };
+
+        var oldSeriesId = Guid.NewGuid();
+        var oldSeasonId = Guid.NewGuid();
+        var change = TagCacheDependencyGraph.Capture(
+            episode,
+            removed: false,
+            new TagCacheEntry
+            {
+                SeriesId = Key(oldSeriesId),
+                SeasonId = Key(oldSeasonId),
+            });
+        var targets = new[] { change.Id }
+            .Concat(TagCacheDependencyGraph.DirectDerivedTargets(change).Select(static target => target.Id))
+            .ToHashSet();
+
+        Assert.Equal(
+            new[]
+            {
+                episode.Id,
+                episode.SeasonId,
+                episode.SeriesId,
+                oldSeriesId,
+                oldSeasonId,
+            }.ToHashSet(),
+            targets);
+        Assert.False(TagCacheDependencyGraph.NeedsSeriesDescendantDiscovery(change));
+    }
+
+    [Fact]
+    public void SeriesEvent_RecordsOnScanThreadWithoutLibraryQuery()
+    {
+        var queryCount = 0;
+        var series = new StubSeries { Id = Guid.NewGuid(), DateLastSaved = SavedAt };
+        var library = new CountingLibraryManager
+        {
+            GetItemListHook = _ =>
+            {
+                queryCount++;
+                throw new InvalidOperationException("library discovery must not run on the event thread");
+            },
+        };
+        using var service = NewService(library);
+        using var monitor = new TagCacheMonitor(library, service, NullLogger<TagCacheMonitor>.Instance);
+        monitor.Initialize();
+
+        library.RaiseItemUpdated(series);
+
+        Assert.Equal(0, queryCount);
+        Assert.Equal(1, service.PendingChangeCountForTest);
+    }
+
+    [Fact]
+    public void LargeSeriesEventBurst_StaysOnConstantTimeRecordPath()
+    {
+        const int EventCount = 10_000;
+        var series = new StubSeries { Id = Guid.NewGuid(), DateLastSaved = SavedAt };
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = _ => throw new InvalidOperationException("event intake must not resolve items"),
+            GetItemListHook = _ => throw new InvalidOperationException("event intake must not scan the library"),
+        };
+        using var service = NewService(library);
+        using var monitor = new TagCacheMonitor(library, service, NullLogger<TagCacheMonitor>.Instance);
+        monitor.Initialize();
+
+        var elapsed = Stopwatch.StartNew();
+        for (var i = 0; i < EventCount; i++)
+        {
+            library.RaiseItemUpdated(series);
+        }
+
+        elapsed.Stop();
+
+        Assert.Equal(1, service.PendingChangeCountForTest);
+        Assert.Equal(0, library.GetItemByIdCallCount);
+        Assert.Equal(0, library.GetItemListCallCount);
+        Assert.True(
+            elapsed.Elapsed < TimeSpan.FromSeconds(5),
+            $"Recording {EventCount} synchronous Series events took {elapsed.Elapsed}; expected under 5 seconds.");
+    }
+
+    [Fact]
+    public void LargeSeriesDistinctEpisodeBurst_HasBoundedQueryFreeEventIntake()
+    {
+        const int EventCount = 10_000;
+        var seriesId = Guid.NewGuid();
+        var seasonId = Guid.NewGuid();
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = _ => throw new InvalidOperationException("event intake must not resolve items"),
+            GetItemListHook = _ => throw new InvalidOperationException("event intake must not scan the library"),
+        };
+        using var service = NewService(library);
+        using var monitor = new TagCacheMonitor(library, service, NullLogger<TagCacheMonitor>.Instance);
+        monitor.Initialize();
+
+        var elapsed = Stopwatch.StartNew();
+        for (var i = 0; i < EventCount; i++)
+        {
+            library.RaiseItemUpdated(new StubEpisode
+            {
+                Id = Guid.NewGuid(),
+                SeriesId = seriesId,
+                SeasonId = seasonId,
+            });
+        }
+
+        elapsed.Stop();
+
+        Assert.Equal(EventCount, service.PendingChangeCountForTest);
+        Assert.Equal(0, library.GetItemByIdCallCount);
+        Assert.Equal(0, library.GetItemListCallCount);
+        Assert.True(
+            elapsed.Elapsed < TimeSpan.FromSeconds(5),
+            $"Recording {EventCount} distinct synchronous Episode events took {elapsed.Elapsed}; expected under 5 seconds.");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void EpisodeAddOrUpdate_RebuildsExactlyEpisodeSeasonAndSeries(bool added)
+    {
+        var seriesId = Guid.NewGuid();
+        var seasonId = Guid.NewGuid();
+        var episodeId = Guid.NewGuid();
+        var unrelatedId = Guid.NewGuid();
+        var series = new StubSeries
+        {
+            Id = seriesId,
+            DateLastSaved = SavedAt,
+            Genres = Array.Empty<string>(),
+        };
+        var season = new StubSeason
+        {
+            Id = seasonId,
+            SeriesId = seriesId,
+            DateLastSaved = SavedAt,
+            CommunityRating = 7,
+        };
+        var episode = new StubEpisode
+        {
+            Id = episodeId,
+            SeriesId = seriesId,
+            SeasonId = seasonId,
+            DateLastSaved = SavedAt,
+            Genres = new[] { "Episode" },
+        };
+        var resolvedIds = new List<Guid>();
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id =>
+            {
+                resolvedIds.Add(id);
+                return id == seriesId ? series : id == seasonId ? season : id == episodeId ? episode : null;
+            },
+            GetItemListHook = query => query.ParentId == seriesId || query.ParentId == seasonId
+                ? new BaseItem[] { episode }
+                : Array.Empty<BaseItem>(),
+        };
+        using var service = NewService(library);
+        var unrelated = new TagCacheEntry { Type = "Movie" };
+        service.SeedEntryForTest(Key(unrelatedId), unrelated);
+        using var monitor = new TagCacheMonitor(library, service, NullLogger<TagCacheMonitor>.Instance);
+        monitor.Initialize();
+
+        if (added) library.RaiseItemAdded(episode);
+        else library.RaiseItemUpdated(episode);
+        service.FlushPendingForTest();
+
+        Assert.True(service.ContainsKeyForTest(Key(episodeId)));
+        Assert.True(service.ContainsKeyForTest(Key(seasonId)));
+        Assert.True(service.ContainsKeyForTest(Key(seriesId)));
+        Assert.Equal(new[] { episodeId, seasonId, seriesId }.ToHashSet(), resolvedIds.ToHashSet());
+        Assert.Same(unrelated, service.GetEntryForTest(Key(unrelatedId)));
+    }
+
+    [Fact]
+    public void EpisodeReparenting_RebuildsOldAndNewSeriesAndSeasons()
+    {
+        var oldSeriesId = Guid.NewGuid();
+        var oldSeasonId = Guid.NewGuid();
+        var newSeriesId = Guid.NewGuid();
+        var newSeasonId = Guid.NewGuid();
+        var episodeId = Guid.NewGuid();
+        var oldReplacement = new StubEpisode
+        {
+            Id = Guid.NewGuid(),
+            SeriesId = oldSeriesId,
+            SeasonId = oldSeasonId,
+            Genres = new[] { "Old replacement" },
+            Name = "Old replacement",
+            Path = "/library/old-replacement.mkv",
+            DateLastSaved = SavedAt,
+        };
+        var movedEpisode = new StubEpisode
+        {
+            Id = episodeId,
+            SeriesId = newSeriesId,
+            SeasonId = newSeasonId,
+            Genres = new[] { "Moved" },
+            Name = "Moved",
+            Path = "/library/moved.mkv",
+            DateLastSaved = SavedAt,
+        };
+        var items = new Dictionary<Guid, BaseItem>
+        {
+            [oldSeriesId] = new StubSeries { Id = oldSeriesId, Genres = new[] { "Stable" }, DateLastSaved = SavedAt },
+            [oldSeasonId] = new StubSeason { Id = oldSeasonId, SeriesId = oldSeriesId, CommunityRating = 1, Genres = new[] { "Stable" }, DateLastSaved = SavedAt },
+            [newSeriesId] = new StubSeries { Id = newSeriesId, Genres = new[] { "Stable" }, DateLastSaved = SavedAt },
+            [newSeasonId] = new StubSeason { Id = newSeasonId, SeriesId = newSeriesId, CommunityRating = 1, Genres = new[] { "Stable" }, DateLastSaved = SavedAt },
+            [episodeId] = movedEpisode,
+        };
+        var resolved = new List<Guid>();
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id =>
+            {
+                resolved.Add(id);
+                return items.GetValueOrDefault(id);
+            },
+            GetItemListHook = query => query.ParentId == oldSeriesId || query.ParentId == oldSeasonId
+                ? new BaseItem[] { oldReplacement }
+                : query.ParentId == newSeriesId || query.ParentId == newSeasonId
+                    ? new BaseItem[] { movedEpisode }
+                    : Array.Empty<BaseItem>(),
+        };
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(episodeId), new TagCacheEntry
+        {
+            Type = "Episode",
+            SeriesId = Key(oldSeriesId),
+            SeasonId = Key(oldSeasonId),
+            StreamSourceId = Key(episodeId),
+        });
+        foreach (var parentId in new[] { oldSeriesId, oldSeasonId, newSeriesId, newSeasonId })
+        {
+            service.SeedEntryForTest(Key(parentId), new TagCacheEntry
+            {
+                Type = parentId == oldSeriesId || parentId == newSeriesId ? "Series" : "Season",
+                Genres = new[] { "Stable" },
+                StreamData = new TagStreamData { ItemPath = "stale.mkv" },
+            });
+        }
+        using var monitor = new TagCacheMonitor(library, service, NullLogger<TagCacheMonitor>.Instance);
+        monitor.Initialize();
+
+        library.RaiseItemUpdated(movedEpisode);
+        service.FlushPendingForTest();
+
+        Assert.Contains(oldSeriesId, resolved);
+        Assert.Contains(oldSeasonId, resolved);
+        Assert.Contains(newSeriesId, resolved);
+        Assert.Contains(newSeasonId, resolved);
+        Assert.Equal("old-replacement.mkv", service.GetEntryForTest(Key(oldSeriesId))!.StreamData!.ItemPath);
+        Assert.Equal("old-replacement.mkv", service.GetEntryForTest(Key(oldSeasonId))!.StreamData!.ItemPath);
+        Assert.Equal("moved.mkv", service.GetEntryForTest(Key(newSeriesId))!.StreamData!.ItemPath);
+        Assert.Equal("moved.mkv", service.GetEntryForTest(Key(newSeasonId))!.StreamData!.ItemPath);
+        Assert.Equal(Key(newSeriesId), service.GetEntryForTest(Key(episodeId))!.SeriesId);
+        Assert.Equal(Key(newSeasonId), service.GetEntryForTest(Key(episodeId))!.SeasonId);
+    }
+
+    [Fact]
+    public void RemovingSeason_TombstonesRecursiveEpisodesAndRepairsSeries()
+    {
+        var seriesId = Guid.NewGuid();
+        var seasonId = Guid.NewGuid();
+        var episodeIds = new[] { Guid.NewGuid(), Guid.NewGuid() };
+        var replacement = new StubEpisode
+        {
+            Id = Guid.NewGuid(),
+            SeriesId = seriesId,
+            Name = "Remaining",
+            Path = "/library/remaining.mkv",
+            DateLastSaved = SavedAt,
+        };
+        var series = new StubSeries { Id = seriesId, DateLastSaved = SavedAt };
+        var removedSeason = new StubSeason { Id = seasonId, SeriesId = seriesId };
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => id == seriesId ? series : null,
+            GetItemListHook = query => query.ParentId == seriesId
+                ? new BaseItem[] { replacement }
+                : Array.Empty<BaseItem>(),
+        };
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(seriesId), new TagCacheEntry { Type = "Series", StreamData = new TagStreamData { ItemPath = "removed-season.mkv" } });
+        service.SeedEntryForTest(Key(seasonId), new TagCacheEntry { Type = "Season", SeriesId = Key(seriesId) });
+        foreach (var episodeId in episodeIds)
+        {
+            service.SeedEntryForTest(Key(episodeId), new TagCacheEntry
+            {
+                Type = "Episode",
+                SeriesId = Key(seriesId),
+                SeasonId = Key(seasonId),
+            });
+        }
+        using var monitor = new TagCacheMonitor(library, service, NullLogger<TagCacheMonitor>.Instance);
+        monitor.Initialize();
+
+        library.RaiseItemRemoved(removedSeason);
+        service.FlushPendingForTest();
+
+        Assert.False(service.ContainsKeyForTest(Key(seasonId)));
+        Assert.All(episodeIds, id => Assert.False(service.ContainsKeyForTest(Key(id))));
+        Assert.Equal("remaining.mkv", service.GetEntryForTest(Key(seriesId))!.StreamData!.ItemPath);
+        Assert.Equal(1, service.Version);
+    }
+
+    [Fact]
+    public void RemovingSeries_TombstonesEveryCachedSeasonAndEpisodeButNotUnrelatedItems()
+    {
+        var seriesId = Guid.NewGuid();
+        var seasonId = Guid.NewGuid();
+        var episodeId = Guid.NewGuid();
+        var unrelatedId = Guid.NewGuid();
+        var removedSeries = new StubSeries { Id = seriesId };
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = _ => throw new InvalidOperationException("removal must use the local relationship index"),
+            GetItemListHook = _ => throw new InvalidOperationException("removal must use the local relationship index"),
+        };
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(seriesId), new TagCacheEntry { Type = "Series" });
+        service.SeedEntryForTest(Key(seasonId), new TagCacheEntry { Type = "Season", SeriesId = Key(seriesId) });
+        service.SeedEntryForTest(Key(episodeId), new TagCacheEntry { Type = "Episode", SeriesId = Key(seriesId), SeasonId = Key(seasonId) });
+        var unrelated = new TagCacheEntry { Type = "Movie" };
+        service.SeedEntryForTest(Key(unrelatedId), unrelated);
+        using var monitor = new TagCacheMonitor(library, service, NullLogger<TagCacheMonitor>.Instance);
+        monitor.Initialize();
+
+        library.RaiseItemRemoved(removedSeries);
+        service.FlushPendingForTest();
+
+        Assert.False(service.ContainsKeyForTest(Key(seriesId)));
+        Assert.False(service.ContainsKeyForTest(Key(seasonId)));
+        Assert.False(service.ContainsKeyForTest(Key(episodeId)));
+        Assert.Same(unrelated, service.GetEntryForTest(Key(unrelatedId)));
+        Assert.Equal(0, library.GetItemByIdCallCount);
+        Assert.Equal(0, library.GetItemListCallCount);
+        Assert.Equal(1, service.Version);
+    }
+
+    [Fact]
+    public void RecursiveSeriesRemoval_OverridesSameBatchUpdateStillInsideRemovedSeries()
+    {
+        var seriesId = Guid.NewGuid();
+        var episode = new StubEpisode { Id = Guid.NewGuid(), SeriesId = seriesId };
+        var removedSeries = new StubSeries { Id = seriesId };
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = _ => null,
+            GetItemListHook = _ => Array.Empty<BaseItem>(),
+        };
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(seriesId), new TagCacheEntry { Type = "Series" });
+        service.SeedEntryForTest(Key(episode.Id), new TagCacheEntry { Type = "Episode", SeriesId = Key(seriesId) });
+
+        service.EnqueueItemChange(episode, removed: false);
+        service.EnqueueItemChange(removedSeries, removed: true);
+        service.FlushPendingForTest();
+
+        Assert.False(service.ContainsKeyForTest(Key(episode.Id)));
+        Assert.Equal(0, service.PendingChangeCountForTest);
+    }
+
+    [Fact]
+    public void RecursiveSeriesRemoval_PreservesSameBatchEpisodeMovedOutsideSeries()
+    {
+        var removedSeriesId = Guid.NewGuid();
+        var newSeriesId = Guid.NewGuid();
+        var episode = new StubEpisode
+        {
+            Id = Guid.NewGuid(),
+            SeriesId = newSeriesId,
+            DateLastSaved = SavedAt,
+        };
+        var removedSeries = new StubSeries { Id = removedSeriesId };
+        var newSeries = new StubSeries { Id = newSeriesId, DateLastSaved = SavedAt };
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => id == episode.Id ? episode : id == newSeriesId ? newSeries : null,
+            GetItemListHook = query => query.ParentId == newSeriesId
+                ? new BaseItem[] { episode }
+                : Array.Empty<BaseItem>(),
+        };
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(removedSeriesId), new TagCacheEntry { Type = "Series" });
+        service.SeedEntryForTest(Key(episode.Id), new TagCacheEntry
+        {
+            Type = "Episode",
+            SeriesId = Key(removedSeriesId),
+        });
+
+        service.EnqueueItemChange(episode, removed: false);
+        service.EnqueueItemChange(removedSeries, removed: true);
+        service.FlushPendingForTest();
+
+        Assert.False(service.ContainsKeyForTest(Key(removedSeriesId)));
+        Assert.Equal(Key(newSeriesId), service.GetEntryForTest(Key(episode.Id))!.SeriesId);
+    }
+
+    [Fact]
+    public void RecursiveSeriesRemoval_PreservesSameBatchEpisodeDetachedFromAnySeries()
+    {
+        var removedSeriesId = Guid.NewGuid();
+        var episode = new StubEpisode
+        {
+            Id = Guid.NewGuid(),
+            SeriesId = Guid.Empty,
+            DateLastSaved = SavedAt,
+        };
+        var removedSeries = new StubSeries { Id = removedSeriesId };
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => id == episode.Id ? episode : null,
+            GetItemListHook = _ => Array.Empty<BaseItem>(),
+        };
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(removedSeriesId), new TagCacheEntry { Type = "Series" });
+        service.SeedEntryForTest(Key(episode.Id), new TagCacheEntry
+        {
+            Type = "Episode",
+            SeriesId = Key(removedSeriesId),
+        });
+
+        service.EnqueueItemChange(episode, removed: false);
+        service.EnqueueItemChange(removedSeries, removed: true);
+        service.FlushPendingForTest();
+
+        Assert.False(service.ContainsKeyForTest(Key(removedSeriesId)));
+        Assert.True(service.ContainsKeyForTest(Key(episode.Id)));
+        Assert.Null(service.GetEntryForTest(Key(episode.Id))!.SeriesId);
+    }
+
+    [Fact]
+    public void RecursiveSeasonRemoval_PreservesSameBatchEpisodeDetachedFromAnySeason()
+    {
+        var seriesId = Guid.NewGuid();
+        var removedSeasonId = Guid.NewGuid();
+        var series = new StubSeries { Id = seriesId, DateLastSaved = SavedAt };
+        var episode = new StubEpisode
+        {
+            Id = Guid.NewGuid(),
+            SeriesId = seriesId,
+            SeasonId = Guid.Empty,
+            DateLastSaved = SavedAt,
+        };
+        var removedSeason = new StubSeason { Id = removedSeasonId, SeriesId = seriesId };
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => id == episode.Id ? episode : id == seriesId ? series : null,
+            GetItemListHook = query => query.ParentId == seriesId
+                ? new BaseItem[] { episode }
+                : Array.Empty<BaseItem>(),
+        };
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(seriesId), new TagCacheEntry { Type = "Series" });
+        service.SeedEntryForTest(Key(removedSeasonId), new TagCacheEntry
+        {
+            Type = "Season",
+            SeriesId = Key(seriesId),
+        });
+        service.SeedEntryForTest(Key(episode.Id), new TagCacheEntry
+        {
+            Type = "Episode",
+            SeriesId = Key(seriesId),
+            SeasonId = Key(removedSeasonId),
+        });
+
+        service.EnqueueItemChange(episode, removed: false);
+        service.EnqueueItemChange(removedSeason, removed: true);
+        service.FlushPendingForTest();
+
+        Assert.False(service.ContainsKeyForTest(Key(removedSeasonId)));
+        Assert.True(service.ContainsKeyForTest(Key(episode.Id)));
+        Assert.Null(service.GetEntryForTest(Key(episode.Id))!.SeasonId);
+    }
+
+    [Fact]
+    public void InFlightSecondReparent_CannotStrandTheIntermediateSeriesAfterChildFirstApply()
+    {
+        var oldSeriesId = Guid.Parse("10000000-0000-0000-0000-000000000000");
+        var intermediateSeriesId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+        var finalSeriesId = Guid.Parse("20000000-0000-0000-0000-000000000000");
+        var episodeId = Guid.Parse("ffffffff-ffff-ffff-ffff-ffffffffffff");
+        var oldSeries = new StubSeries { Id = oldSeriesId, DateLastSaved = SavedAt };
+        var intermediateSeries = new StubSeries { Id = intermediateSeriesId, DateLastSaved = SavedAt };
+        var finalSeries = new StubSeries { Id = finalSeriesId, DateLastSaved = SavedAt };
+        StubEpisode liveEpisode = new()
+        {
+            Id = episodeId,
+            SeriesId = intermediateSeriesId,
+            Name = "Intermediate",
+            Path = "/library/intermediate.mkv",
+            DateLastSaved = SavedAt,
+        };
+        var movedAgain = false;
+        var library = new CountingLibraryManager();
+        using var service = NewService(library);
+        library.GetItemByIdHook = id =>
+        {
+            if (id == episodeId)
+            {
+                if (!movedAgain)
+                {
+                    movedAgain = true;
+                    liveEpisode = new StubEpisode
+                    {
+                        Id = episodeId,
+                        SeriesId = finalSeriesId,
+                        Name = "Final",
+                        Path = "/library/final.mkv",
+                        DateLastSaved = SavedAt,
+                    };
+                    service.EnqueueItemChange(liveEpisode, removed: false);
+                }
+
+                return liveEpisode;
+            }
+
+            return id == oldSeriesId
+                ? oldSeries
+                : id == intermediateSeriesId
+                    ? intermediateSeries
+                    : id == finalSeriesId
+                        ? finalSeries
+                        : null;
+        };
+        library.GetItemListHook = query =>
+            query.ParentId == liveEpisode.SeriesId
+                ? new BaseItem[] { liveEpisode }
+                : Array.Empty<BaseItem>();
+        service.SeedEntryForTest(Key(episodeId), new TagCacheEntry
+        {
+            Type = "Episode",
+            SeriesId = Key(oldSeriesId),
+        });
+        service.SeedEntryForTest(Key(oldSeriesId), StaleContainer());
+        service.SeedEntryForTest(Key(intermediateSeriesId), StaleContainer());
+        service.SeedEntryForTest(Key(finalSeriesId), StaleContainer());
+
+        service.EnqueueItemChange(new StubEpisode
+        {
+            Id = episodeId,
+            SeriesId = intermediateSeriesId,
+            DateLastSaved = SavedAt,
+        }, removed: false);
+        service.FlushPendingForTest();
+        service.FlushPendingForTest();
+
+        Assert.Null(service.GetEntryForTest(Key(intermediateSeriesId))!.StreamData);
+        Assert.Equal("final.mkv", service.GetEntryForTest(Key(finalSeriesId))!.StreamData!.ItemPath);
+        Assert.Equal(Key(finalSeriesId), service.GetEntryForTest(Key(episodeId))!.SeriesId);
+    }
+
+    [Fact]
+    public void BatchedRecursiveSeriesRemoval_ScansCacheOnceAndJournalsEveryTombstone()
+    {
+        const int SeriesCount = 50;
+        const int EpisodesPerSeries = 10;
+        var removedSeries = Enumerable.Range(0, SeriesCount)
+            .Select(_ => new StubSeries { Id = Guid.NewGuid() })
+            .ToArray();
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = _ => throw new InvalidOperationException("recursive removal must be cache-indexed"),
+            GetItemListHook = _ => throw new InvalidOperationException("recursive removal must be cache-indexed"),
+        };
+        using var service = NewService(library);
+        foreach (var series in removedSeries)
+        {
+            service.SeedEntryForTest(Key(series.Id), new TagCacheEntry { Type = "Series" });
+            for (var index = 0; index < EpisodesPerSeries; index++)
+            {
+                var episodeId = Guid.NewGuid();
+                service.SeedEntryForTest(Key(episodeId), new TagCacheEntry
+                {
+                    Type = "Episode",
+                    SeriesId = Key(series.Id),
+                });
+            }
+        }
+        var cachedCount = SeriesCount * (EpisodesPerSeries + 1);
+
+        foreach (var series in removedSeries)
+        {
+            service.EnqueueItemChange(series, removed: true);
+        }
+        service.FlushPendingForTest();
+
+        Assert.Equal(0, service.Count);
+        Assert.Equal(cachedCount, service.RemovedDependencyEntriesVisitedForTest);
+        Assert.Equal(cachedCount, service.ContentRevision);
+        Assert.Equal(1, service.Version);
+    }
+
+    [Fact]
+    public void SeasonReparenting_RebuildsOldAndNewSeries()
+    {
+        var oldSeriesId = Guid.NewGuid();
+        var newSeriesId = Guid.NewGuid();
+        var seasonId = Guid.NewGuid();
+        var oldFirst = new StubEpisode { Id = Guid.NewGuid(), SeriesId = oldSeriesId, Name = "Old remaining", Path = "/library/old-remaining.mkv" };
+        var newFirst = new StubEpisode { Id = Guid.NewGuid(), SeriesId = newSeriesId, SeasonId = seasonId, Name = "Moved season", Path = "/library/moved-season.mkv" };
+        var movedEpisode = new StubEpisode
+        {
+            Id = Guid.NewGuid(),
+            SeriesId = newSeriesId,
+            SeasonId = seasonId,
+            DateLastSaved = SavedAt,
+        };
+        var oldSeries = new StubSeries { Id = oldSeriesId, DateLastSaved = SavedAt };
+        var newSeries = new StubSeries { Id = newSeriesId, DateLastSaved = SavedAt };
+        var movedSeason = new StubSeason { Id = seasonId, SeriesId = newSeriesId, CommunityRating = 1, DateLastSaved = SavedAt };
+        var items = new Dictionary<Guid, BaseItem>
+        {
+            [oldSeriesId] = oldSeries,
+            [newSeriesId] = newSeries,
+            [seasonId] = movedSeason,
+            [movedEpisode.Id] = movedEpisode,
+        };
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => items.GetValueOrDefault(id),
+            GetItemListHook = query => query.AncestorIds?.Contains(seasonId) == true
+                ? new BaseItem[] { movedEpisode }
+                : query.ParentId == oldSeriesId
+                ? new BaseItem[] { oldFirst }
+                : query.ParentId == newSeriesId || query.ParentId == seasonId
+                    ? new BaseItem[] { newFirst }
+                    : Array.Empty<BaseItem>(),
+        };
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(seasonId), new TagCacheEntry { Type = "Season", SeriesId = Key(oldSeriesId) });
+        service.SeedEntryForTest(Key(movedEpisode.Id), new TagCacheEntry
+        {
+            Type = "Episode",
+            SeriesId = Key(oldSeriesId),
+            SeasonId = Key(seasonId),
+            CommunityRating = 1,
+        });
+        service.SeedEntryForTest(Key(oldSeriesId), new TagCacheEntry { Type = "Series" });
+        service.SeedEntryForTest(Key(newSeriesId), new TagCacheEntry { Type = "Series" });
+        using var monitor = new TagCacheMonitor(library, service, NullLogger<TagCacheMonitor>.Instance);
+        monitor.Initialize();
+
+        library.RaiseItemUpdated(movedSeason);
+        service.FlushPendingForTest();
+
+        Assert.Equal("old-remaining.mkv", service.GetEntryForTest(Key(oldSeriesId))!.StreamData!.ItemPath);
+        Assert.Equal("moved-season.mkv", service.GetEntryForTest(Key(newSeriesId))!.StreamData!.ItemPath);
+        Assert.Equal(Key(newSeriesId), service.GetEntryForTest(Key(seasonId))!.SeriesId);
+        Assert.Equal(Key(newSeriesId), service.GetEntryForTest(Key(movedEpisode.Id))!.SeriesId);
+    }
+
+    [Fact]
+    public void SeasonReparenting_OutOfRemovedSeriesPreservesAndRepairsItsCachedEpisodes()
+    {
+        var oldSeriesId = Guid.NewGuid();
+        var newSeriesId = Guid.NewGuid();
+        var seasonId = Guid.NewGuid();
+        var newSeries = new StubSeries
+        {
+            Id = newSeriesId,
+            CommunityRating = 9,
+            ProviderIds = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["Tmdb"] = "new" },
+            DateLastSaved = SavedAt,
+        };
+        var movedSeason = new StubSeason
+        {
+            Id = seasonId,
+            SeriesId = newSeriesId,
+            CommunityRating = 1,
+            DateLastSaved = SavedAt,
+        };
+        var episodes = Enumerable.Range(0, 3)
+            .Select(_ => new StubEpisode
+            {
+                Id = Guid.NewGuid(),
+                SeriesId = newSeriesId,
+                SeasonId = seasonId,
+                DateLastSaved = SavedAt,
+            })
+            .ToArray();
+        var removedSeries = new StubSeries { Id = oldSeriesId };
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => id == newSeriesId
+                ? newSeries
+                : id == seasonId
+                    ? movedSeason
+                    : null,
+            GetItemListHook = query => query.AncestorIds?.Contains(seasonId) == true
+                || query.ParentId == seasonId
+                || query.ParentId == newSeriesId
+                    ? episodes
+                    : Array.Empty<BaseItem>(),
+        };
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(oldSeriesId), new TagCacheEntry { Type = "Series" });
+        service.SeedEntryForTest(Key(newSeriesId), new TagCacheEntry { Type = "Series" });
+        service.SeedEntryForTest(Key(seasonId), new TagCacheEntry
+        {
+            Type = "Season",
+            SeriesId = Key(oldSeriesId),
+        });
+        foreach (var episode in episodes)
+        {
+            service.SeedEntryForTest(Key(episode.Id), new TagCacheEntry
+            {
+                Type = "Episode",
+                SeriesId = Key(oldSeriesId),
+                SeasonId = Key(seasonId),
+                SeriesTmdbId = "old",
+                SourceRevision = SavedAt.Ticks,
+            });
+        }
+
+        service.EnqueueItemChange(movedSeason, removed: false);
+        service.EnqueueItemChange(removedSeries, removed: true);
+        service.FlushPendingForTest();
+
+        Assert.False(service.ContainsKeyForTest(Key(oldSeriesId)));
+        Assert.Equal(Key(newSeriesId), service.GetEntryForTest(Key(seasonId))!.SeriesId);
+        Assert.All(episodes, episode =>
+        {
+            var entry = service.GetEntryForTest(Key(episode.Id));
+            Assert.NotNull(entry);
+            Assert.Equal(Key(newSeriesId), entry!.SeriesId);
+            Assert.Equal("new", entry.SeriesTmdbId);
+        });
+    }
+
+    [Fact]
+    public void SeasonMoveOutOfRemovedSeries_IncompleteDiscoveryKeepsCachedEpisodesAndRetries()
+    {
+        var oldSeriesId = Guid.NewGuid();
+        var newSeriesId = Guid.NewGuid();
+        var seasonId = Guid.NewGuid();
+        var episodeId = Guid.NewGuid();
+        var newSeries = new StubSeries { Id = newSeriesId, DateLastSaved = SavedAt };
+        var movedSeason = new StubSeason
+        {
+            Id = seasonId,
+            SeriesId = newSeriesId,
+            CommunityRating = 1,
+            DateLastSaved = SavedAt,
+        };
+        var movedEpisode = new StubEpisode
+        {
+            Id = episodeId,
+            SeriesId = newSeriesId,
+            SeasonId = seasonId,
+            DateLastSaved = SavedAt,
+        };
+        var removedSeries = new StubSeries { Id = oldSeriesId };
+        var descendantQueries = 0;
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => id == newSeriesId ? newSeries : id == seasonId ? movedSeason : null,
+            GetItemListHook = query => query.AncestorIds?.Contains(seasonId) == true
+                && ++descendantQueries >= 3
+                    ? new BaseItem[] { movedEpisode }
+                    : Array.Empty<BaseItem>(), // first two snapshots are transiently incomplete
+        };
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(oldSeriesId), new TagCacheEntry { Type = "Series" });
+        service.SeedEntryForTest(Key(newSeriesId), new TagCacheEntry { Type = "Series" });
+        service.SeedEntryForTest(Key(seasonId), new TagCacheEntry
+        {
+            Type = "Season",
+            SeriesId = Key(oldSeriesId),
+        });
+        var cachedEpisode = new TagCacheEntry
+        {
+            Type = "Episode",
+            SeriesId = Key(oldSeriesId),
+            SeasonId = Key(seasonId),
+            SourceRevision = SavedAt.Ticks,
+        };
+        service.SeedEntryForTest(Key(episodeId), cachedEpisode);
+
+        service.EnqueueItemChange(movedSeason, removed: false);
+        service.EnqueueItemChange(removedSeries, removed: true);
+        service.FlushPendingForTest();
+
+        Assert.False(service.ContainsKeyForTest(Key(oldSeriesId)));
+        Assert.Same(cachedEpisode, service.GetEntryForTest(Key(episodeId)));
+        Assert.Equal(1, service.PendingChangeCountForTest);
+
+        service.FlushPendingForTest();
+
+        Assert.Same(cachedEpisode, service.GetEntryForTest(Key(episodeId)));
+        Assert.Equal(1, service.PendingChangeCountForTest);
+
+        service.FlushPendingForTest();
+
+        Assert.Equal(Key(newSeriesId), service.GetEntryForTest(Key(episodeId))!.SeriesId);
+        Assert.Equal(0, service.PendingChangeCountForTest);
+        Assert.Equal(3, descendantQueries);
+    }
+
+    [Fact]
+    public void VerifiedSeriesSnapshot_OverridesSyntheticRemovalForConcurrentReparent()
+    {
+        var oldSeriesId = Guid.NewGuid();
+        var newSeriesId = Guid.NewGuid();
+        var episodeId = Guid.NewGuid();
+        var oldSeries = new StubSeries { Id = oldSeriesId };
+        var newSeries = new StubSeries { Id = newSeriesId, DateLastSaved = SavedAt };
+        var episode = new StubEpisode
+        {
+            Id = episodeId,
+            SeriesId = newSeriesId,
+            DateLastSaved = SavedAt,
+        };
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => id == newSeriesId ? newSeries : null,
+            GetItemListHook = query => query.AncestorIds?.Contains(newSeriesId) == true
+                || query.ParentId == newSeriesId
+                    ? new BaseItem[] { episode }
+                    : Array.Empty<BaseItem>(),
+        };
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(oldSeriesId), new TagCacheEntry { Type = "Series" });
+        service.SeedEntryForTest(Key(newSeriesId), new TagCacheEntry { Type = "Series" });
+        service.SeedEntryForTest(Key(episodeId), new TagCacheEntry
+        {
+            Type = "Episode",
+            SeriesId = Key(oldSeriesId),
+            SourceRevision = SavedAt.Ticks,
+        });
+
+        service.EnqueueItemChange(oldSeries, removed: true);
+        service.EnqueueItemChange(newSeries, removed: false);
+        service.FlushPendingForTest();
+
+        Assert.False(service.ContainsKeyForTest(Key(oldSeriesId)));
+        Assert.Equal(Key(newSeriesId), service.GetEntryForTest(Key(episodeId))!.SeriesId);
+        Assert.Equal(0, service.PendingChangeCountForTest);
+    }
+
+    [Fact]
+    public void SeriesSnapshot_RepairsEpisodeMoveBetweenSeasonsInTheSameSeries()
+    {
+        var seriesId = Guid.NewGuid();
+        var oldSeasonId = Guid.NewGuid();
+        var newSeasonId = Guid.NewGuid();
+        var episodeId = Guid.NewGuid();
+        var series = new StubSeries { Id = seriesId, DateLastSaved = SavedAt };
+        var oldSeason = new StubSeason { Id = oldSeasonId, SeriesId = seriesId, DateLastSaved = SavedAt };
+        var newSeason = new StubSeason { Id = newSeasonId, SeriesId = seriesId, DateLastSaved = SavedAt };
+        var episode = new StubEpisode
+        {
+            Id = episodeId,
+            SeriesId = seriesId,
+            SeasonId = newSeasonId,
+            DateLastSaved = SavedAt,
+        };
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => id == seriesId
+                ? series
+                : id == oldSeasonId
+                    ? oldSeason
+                    : id == newSeasonId
+                        ? newSeason
+                        : null,
+            GetItemListHook = query => query.AncestorIds?.Contains(seriesId) == true
+                ? new BaseItem[] { oldSeason, newSeason, episode }
+                : query.ItemIds?.Contains(oldSeasonId) == true
+                    ? new BaseItem[] { oldSeason }
+                    : query.ParentId == seriesId || query.ParentId == newSeasonId
+                        ? new BaseItem[] { episode }
+                        : query.ParentId == oldSeasonId
+                            ? Array.Empty<BaseItem>()
+                            : throw new InvalidOperationException("unexpected same-Series Season-move query"),
+        };
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(seriesId), new TagCacheEntry { Type = "Series" });
+        service.SeedEntryForTest(Key(oldSeasonId), new TagCacheEntry { Type = "Season", SeriesId = Key(seriesId) });
+        service.SeedEntryForTest(Key(newSeasonId), new TagCacheEntry { Type = "Season", SeriesId = Key(seriesId) });
+        service.SeedEntryForTest(Key(episodeId), new TagCacheEntry
+        {
+            Type = "Episode",
+            SeriesId = Key(seriesId),
+            SeasonId = Key(oldSeasonId),
+            SourceRevision = SavedAt.Ticks,
+        });
+
+        service.EnqueueItemChange(series, removed: false);
+        service.FlushPendingForTest();
+
+        Assert.Equal(Key(newSeasonId), service.GetEntryForTest(Key(episodeId))!.SeasonId);
+        Assert.Equal(0, service.PendingChangeCountForTest);
+    }
+
+    [Fact]
+    public void UnchangedEpisodeParents_AreRebuiltWhenTheirCacheRowsAreMissing()
+    {
+        var seriesId = Guid.NewGuid();
+        var seasonId = Guid.NewGuid();
+        var episode = new StubEpisode
+        {
+            Id = Guid.NewGuid(),
+            SeriesId = seriesId,
+            SeasonId = seasonId,
+            DateLastSaved = SavedAt,
+        };
+        var series = new StubSeries { Id = seriesId, DateLastSaved = SavedAt };
+        var season = new StubSeason { Id = seasonId, SeriesId = seriesId, DateLastSaved = SavedAt };
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => id == episode.Id ? episode : id == seriesId ? series : id == seasonId ? season : null,
+            GetItemListHook = query => query.ParentId == seriesId || query.ParentId == seasonId
+                ? new BaseItem[] { episode }
+                : Array.Empty<BaseItem>(),
+        };
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(episode.Id), new TagCacheEntry
+        {
+            Type = "Episode",
+            SeriesId = Key(seriesId),
+            SeasonId = Key(seasonId),
+            SourceRevision = SavedAt.Ticks,
+        });
+
+        service.EnqueueItemChange(episode, removed: false);
+        service.FlushPendingForTest();
+
+        Assert.Equal("Series", service.GetEntryForTest(Key(seriesId))!.Type);
+        Assert.Equal("Season", service.GetEntryForTest(Key(seasonId))!.Type);
+    }
+
+    [Fact]
+    public void RemovingFirstEpisode_RebuildsSeriesAndSeasonFromReplacement()
+    {
+        var seriesId = Guid.NewGuid();
+        var seasonId = Guid.NewGuid();
+        var removedId = Guid.NewGuid();
+        var replacementId = Guid.NewGuid();
+        var series = new StubSeries { Id = seriesId, Genres = Array.Empty<string>(), DateLastSaved = SavedAt };
+        var season = new StubSeason
+        {
+            Id = seasonId,
+            SeriesId = seriesId,
+            Genres = Array.Empty<string>(),
+            CommunityRating = 7.5f,
+            DateLastSaved = SavedAt,
+        };
+        var replacement = new ControlledEpisode
+        {
+            Id = replacementId,
+            SeriesId = seriesId,
+            SeasonId = seasonId,
+            Name = "Replacement",
+            Path = "/library/replacement.mkv",
+            Genres = new[] { "Fresh" },
+            DateLastSaved = SavedAt,
+            MediaSources = new[]
+            {
+                new MediaSourceInfo
+                {
+                    Name = "Replacement source",
+                    Path = "/library/replacement-source.mkv",
+                    MediaStreams = new[]
+                    {
+                        new MediaStream
+                        {
+                            Type = MediaStreamType.Audio,
+                            Language = "eng",
+                            Codec = "aac",
+                            Channels = 2,
+                        },
+                    },
+                },
+            },
+        };
+        var removed = new StubEpisode
+        {
+            Id = removedId,
+            SeriesId = seriesId,
+            SeasonId = seasonId,
+        };
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => id == seriesId
+                ? series
+                : id == seasonId
+                    ? season
+                    : id == replacementId
+                        ? replacement
+                        : null,
+            GetItemListHook = query => query.ParentId == seriesId || query.ParentId == seasonId
+                ? new BaseItem[] { replacement }
+                : Array.Empty<BaseItem>(),
+        };
+
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(removedId), new TagCacheEntry { Type = "Episode" });
+        service.SeedEntryForTest(Key(seriesId), StaleContainer());
+        service.SeedEntryForTest(Key(seasonId), StaleContainer());
+        using var monitor = new TagCacheMonitor(library, service, NullLogger<TagCacheMonitor>.Instance);
+        monitor.Initialize();
+
+        library.RaiseItemRemoved(removed);
+        service.FlushPendingForTest();
+
+        Assert.False(service.ContainsKeyForTest(Key(removedId)));
+        AssertReplacement(service.GetEntryForTest(Key(seriesId)));
+        AssertReplacement(service.GetEntryForTest(Key(seasonId)));
+    }
+
+    [Fact]
+    public void FirstEpisodeReplacementProbeFailure_ClearsRemovedEpisodeMedia()
+    {
+        var seriesId = Guid.NewGuid();
+        var removedId = Guid.NewGuid();
+        var replacement = new ControlledEpisode
+        {
+            Id = Guid.NewGuid(),
+            SeriesId = seriesId,
+            Name = "Replacement",
+            Path = "/library/replacement.mkv",
+            Genres = new[] { "Fresh" },
+            DateLastSaved = SavedAt,
+            ThrowOnProbe = true,
+        };
+        var series = new StubSeries { Id = seriesId, Genres = Array.Empty<string>(), DateLastSaved = SavedAt };
+        var removed = new StubEpisode { Id = removedId, SeriesId = seriesId };
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => id == seriesId ? series : null,
+            GetItemListHook = query => query.ParentId == seriesId
+                ? new BaseItem[] { replacement }
+                : Array.Empty<BaseItem>(),
+        };
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(removedId), new TagCacheEntry { Type = "Episode" });
+        service.SeedEntryForTest(Key(seriesId), new TagCacheEntry
+        {
+            Type = "Series",
+            StreamSourceId = Key(removedId),
+            StreamData = new TagStreamData
+            {
+                ItemName = "Removed",
+                ItemPath = "removed.mkv",
+                Streams = new List<TagMediaStream> { new() { Codec = "old-codec" } },
+                Sources = new List<TagMediaSource> { new() { Path = "removed-source.mkv" } },
+            },
+            AudioLanguages = new[] { "old" },
+        });
+        using var monitor = new TagCacheMonitor(library, service, NullLogger<TagCacheMonitor>.Instance);
+        monitor.Initialize();
+
+        library.RaiseItemRemoved(removed);
+        service.FlushPendingForTest();
+
+        var entry = service.GetEntryForTest(Key(seriesId));
+        Assert.NotNull(entry);
+        Assert.Equal(Key(replacement.Id), entry!.StreamSourceId);
+        Assert.Equal("Replacement", entry.StreamData!.ItemName);
+        Assert.Equal("replacement.mkv", entry.StreamData.ItemPath);
+        Assert.Null(entry.StreamData.Streams);
+        Assert.Null(entry.StreamData.Sources);
+        Assert.Null(entry.AudioLanguages);
+        Assert.Equal(new[] { "Fresh" }, entry.Genres);
+        Assert.Equal(0, entry.SourceRevision);
+    }
+
+    [Fact]
+    public void RemovingOnlyEpisode_ClearsAllFirstEpisodeDerivedFields()
+    {
+        var seriesId = Guid.NewGuid();
+        var removed = new StubEpisode { Id = Guid.NewGuid(), SeriesId = seriesId };
+        var series = new StubSeries { Id = seriesId, Genres = Array.Empty<string>(), DateLastSaved = SavedAt };
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => id == seriesId ? series : null,
+            GetItemListHook = _ => Array.Empty<BaseItem>(),
+        };
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(removed.Id), new TagCacheEntry { Type = "Episode" });
+        service.SeedEntryForTest(Key(seriesId), new TagCacheEntry
+        {
+            Type = "Series",
+            Genres = new[] { "Removed" },
+            StreamSourceId = Key(removed.Id),
+            StreamData = new TagStreamData
+            {
+                ItemName = "Removed",
+                ItemPath = "removed.mkv",
+                Streams = new List<TagMediaStream> { new() },
+                Sources = new List<TagMediaSource> { new() },
+            },
+            AudioLanguages = new[] { "eng" },
+        });
+        using var monitor = new TagCacheMonitor(library, service, NullLogger<TagCacheMonitor>.Instance);
+        monitor.Initialize();
+
+        library.RaiseItemRemoved(removed);
+        service.FlushPendingForTest();
+
+        var entry = service.GetEntryForTest(Key(seriesId));
+        Assert.NotNull(entry);
+        Assert.Empty(entry!.Genres!);
+        Assert.Null(entry.StreamSourceId);
+        Assert.Null(entry.StreamData);
+        Assert.Null(entry.AudioLanguages);
+    }
+
+    [Fact]
+    public void FirstEpisodeLookupFailure_PreservesParentAndRetries()
+    {
+        var seriesId = Guid.NewGuid();
+        var removed = new StubEpisode { Id = Guid.NewGuid(), SeriesId = seriesId };
+        var replacement = new StubEpisode
+        {
+            Id = Guid.NewGuid(),
+            SeriesId = seriesId,
+            Name = "Recovered",
+            Path = "/library/recovered.mkv",
+            DateLastSaved = SavedAt,
+        };
+        var series = new StubSeries { Id = seriesId, DateLastSaved = SavedAt };
+        var queryFails = true;
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => id == seriesId ? series : null,
+            GetItemListHook = query => query.ParentId == seriesId
+                ? queryFails
+                    ? throw new InvalidOperationException("transient first-Episode query failure")
+                    : new BaseItem[] { replacement }
+                : Array.Empty<BaseItem>(),
+        };
+        using var service = NewService(library);
+        var old = StaleContainer();
+        old.Genres = Array.Empty<string>();
+        old.StreamSourceId = Key(removed.Id);
+        service.SeedEntryForTest(Key(removed.Id), new TagCacheEntry { Type = "Episode" });
+        service.SeedEntryForTest(Key(seriesId), old);
+        using var monitor = new TagCacheMonitor(library, service, NullLogger<TagCacheMonitor>.Instance);
+        monitor.Initialize();
+
+        library.RaiseItemRemoved(removed);
+        service.FlushPendingForTest();
+
+        Assert.Same(old, service.GetEntryForTest(Key(seriesId)));
+        Assert.Equal(1, service.PendingChangeCountForTest);
+
+        queryFails = false;
+        service.FlushPendingForTest();
+
+        Assert.Equal(0, service.PendingChangeCountForTest);
+        Assert.Equal("recovered.mkv", service.GetEntryForTest(Key(seriesId))!.StreamData!.ItemPath);
+    }
+
+    [Fact]
+    public void SameSourceProbeFailure_KeepsStreamsButPublishesFreshNameAndPath()
+    {
+        var seriesId = Guid.NewGuid();
+        var firstEpisode = new ControlledEpisode
+        {
+            Id = Guid.NewGuid(),
+            SeriesId = seriesId,
+            Name = "Renamed",
+            Path = "/moved/renamed.mkv",
+            ThrowOnProbe = true,
+            DateLastSaved = SavedAt,
+        };
+        var series = new StubSeries { Id = seriesId, DateLastSaved = SavedAt };
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => id == seriesId ? series : null,
+            GetItemListHook = query => query.ParentId == seriesId
+                ? new BaseItem[] { firstEpisode }
+                : Array.Empty<BaseItem>(),
+        };
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(seriesId), new TagCacheEntry
+        {
+            Type = "Series",
+            StreamSourceId = Key(firstEpisode.Id),
+            StreamData = new TagStreamData
+            {
+                ItemName = "Old name",
+                ItemPath = "old-path.mkv",
+                Streams = new List<TagMediaStream> { new() { Codec = "h264" } },
+                Sources = new List<TagMediaSource> { new() { Path = "old-source.mkv" } },
+            },
+            AudioLanguages = new[] { "eng" },
+        });
+        using var monitor = new TagCacheMonitor(library, service, NullLogger<TagCacheMonitor>.Instance);
+        monitor.Initialize();
+
+        library.RaiseItemUpdated(series);
+        service.FlushPendingForTest();
+
+        var entry = service.GetEntryForTest(Key(seriesId));
+        Assert.Equal("Renamed", entry!.StreamData!.ItemName);
+        Assert.Equal("renamed.mkv", entry.StreamData.ItemPath);
+        Assert.Equal("h264", Assert.Single(entry.StreamData.Streams!).Codec);
+        Assert.Equal("old-source.mkv", Assert.Single(entry.StreamData.Sources!).Path);
+        Assert.Equal(new[] { "eng" }, entry.AudioLanguages);
+    }
+
+    [Fact]
+    public void UpdatingSeries_RebuildsOnlyDescendantsThatCaptureSeriesFields()
+    {
+        var seriesId = Guid.NewGuid();
+        var seasonId = Guid.NewGuid();
+        var episodeId = Guid.NewGuid();
+        var unrelatedId = Guid.NewGuid();
+        var series = new StubSeries
+        {
+            Id = seriesId,
+            CommunityRating = 9.1f,
+            CriticRating = 91,
+            Genres = new[] { "Updated" },
+            DateLastSaved = SavedAt,
+            ProviderIds = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Tmdb"] = "new-series-tmdb",
+            },
+        };
+        var season = new StubSeason
+        {
+            Id = seasonId,
+            SeriesId = seriesId,
+            IndexNumber = 1,
+            Genres = Array.Empty<string>(),
+            DateLastSaved = SavedAt,
+        };
+        var episode = new StubEpisode
+        {
+            Id = episodeId,
+            SeriesId = seriesId,
+            SeasonId = seasonId,
+            ParentIndexNumber = 1,
+            IndexNumber = 2,
+            Genres = Array.Empty<string>(),
+            DateLastSaved = SavedAt,
+        };
+        var resolvedIds = new List<Guid>();
+        var queries = new List<InternalItemsQuery>();
+        var unrelatedEpisode = new StubEpisode
+        {
+            Id = unrelatedId,
+            SeriesId = Guid.NewGuid(),
+            SeasonId = seasonId,
+            Genres = new[] { "Foreign" },
+            DateLastSaved = SavedAt,
+        };
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id =>
+            {
+                resolvedIds.Add(id);
+                return id == seriesId ? series : id == seasonId ? season : id == episodeId ? episode : null;
+            },
+            GetItemListHook = query =>
+            {
+                queries.Add(query);
+                if (query.AncestorIds?.Contains(seriesId) == true)
+                {
+                    return new BaseItem[] { season, unrelatedEpisode, episode };
+                }
+
+                if (query.ParentId == seriesId || query.ParentId == seasonId)
+                {
+                    return new BaseItem[] { episode };
+                }
+
+                return Array.Empty<BaseItem>();
+            },
+        };
+
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(seriesId), new TagCacheEntry { Type = "Series" });
+        var staleSeasonInherited = StaleInherited();
+        staleSeasonInherited.SeriesId = Key(seriesId);
+        service.SeedEntryForTest(Key(seasonId), staleSeasonInherited);
+        var staleEpisodeInherited = StaleInherited();
+        staleEpisodeInherited.SeriesId = Key(seriesId);
+        staleEpisodeInherited.SeasonId = Key(seasonId);
+        staleEpisodeInherited.Genres = Array.Empty<string>();
+        service.SeedEntryForTest(Key(episodeId), staleEpisodeInherited);
+        var unrelated = new TagCacheEntry { Type = "Movie", Genres = new[] { "Untouched" } };
+        service.SeedEntryForTest(Key(unrelatedId), unrelated);
+        using var monitor = new TagCacheMonitor(library, service, NullLogger<TagCacheMonitor>.Instance);
+        monitor.Initialize();
+
+        library.RaiseItemUpdated(series);
+        service.FlushPendingForTest();
+
+        AssertInheritedSeriesFields(service.GetEntryForTest(Key(seasonId)));
+        AssertInheritedSeriesFields(service.GetEntryForTest(Key(episodeId)));
+        Assert.Same(unrelated, service.GetEntryForTest(Key(unrelatedId)));
+        Assert.DoesNotContain(unrelatedId, resolvedIds);
+        Assert.Contains(queries, query => query.AncestorIds?.SequenceEqual(new[] { seriesId }) == true);
+        Assert.DoesNotContain(
+            queries,
+            query => query.ParentId == Guid.Empty && (query.AncestorIds == null || query.AncestorIds.Length == 0));
+        Assert.Equal(1, service.PendingChangeCountForTest); // inconsistent foreign row retains retry ownership
+
+        var seasonEntry = service.GetEntryForTest(Key(seasonId));
+        var episodeEntry = service.GetEntryForTest(Key(episodeId));
+        Assert.Equal(new[] { "Updated" }, seasonEntry!.Genres);
+        Assert.Empty(episodeEntry!.Genres!); // Episode Genres are own-item data, not Series-inherited.
+    }
+
+    [Fact]
+    public void SeriesGenreOnlyChange_RebuildsSeasonsButNotEpisodes()
+    {
+        var seriesId = Guid.NewGuid();
+        var seasonId = Guid.NewGuid();
+        var episodeId = Guid.NewGuid();
+        var series = new StubSeries
+        {
+            Id = seriesId,
+            CommunityRating = 8,
+            CriticRating = 80,
+            Genres = new[] { "Updated" },
+            DateLastSaved = SavedAt,
+            ProviderIds = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Tmdb"] = "stable-series-tmdb",
+            },
+        };
+        var season = new StubSeason
+        {
+            Id = seasonId,
+            SeriesId = seriesId,
+            Genres = Array.Empty<string>(),
+            DateLastSaved = SavedAt,
+        };
+        var episode = new StubEpisode
+        {
+            Id = episodeId,
+            SeriesId = seriesId,
+            SeasonId = seasonId,
+            Genres = Array.Empty<string>(),
+            DateLastSaved = SavedAt,
+        };
+        var queries = new List<InternalItemsQuery>();
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => id == seriesId ? series : id == seasonId ? season : id == episodeId ? episode : null,
+            GetItemListHook = query =>
+            {
+                queries.Add(query);
+                if (query.AncestorIds?.Contains(seriesId) == true)
+                {
+                    // Return a broader result deliberately: relation/type verification must still
+                    // exclude Episodes for a Series genre-only change.
+                    return new BaseItem[] { season, episode };
+                }
+
+                return query.ParentId == seriesId || query.ParentId == seasonId
+                    ? new BaseItem[] { episode }
+                    : Array.Empty<BaseItem>();
+            },
+        };
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(seriesId), new TagCacheEntry
+        {
+            Type = "Series",
+            TmdbId = "stable-series-tmdb",
+            CommunityRating = 8,
+            CriticRating = 80,
+            Genres = new[] { "Old" },
+        });
+        service.SeedEntryForTest(Key(seasonId), new TagCacheEntry
+        {
+            Type = "Season",
+            SeriesId = Key(seriesId),
+            Genres = new[] { "Old" },
+        });
+        var episodeEntry = new TagCacheEntry
+        {
+            Type = "Episode",
+            SeriesId = Key(seriesId),
+            SeasonId = Key(seasonId),
+            Genres = Array.Empty<string>(),
+            CommunityRating = 8,
+            CriticRating = 80,
+            SeriesTmdbId = "stable-series-tmdb",
+            SourceRevision = SavedAt.Ticks,
+        };
+        service.SeedEntryForTest(Key(episodeId), episodeEntry);
+        using var monitor = new TagCacheMonitor(library, service, NullLogger<TagCacheMonitor>.Instance);
+        monitor.Initialize();
+
+        library.RaiseItemUpdated(series);
+        service.FlushPendingForTest();
+
+        Assert.Equal(new[] { "Updated" }, service.GetEntryForTest(Key(seasonId))!.Genres);
+        Assert.Same(episodeEntry, service.GetEntryForTest(Key(episodeId)));
+        var descendantQuery = Assert.Single(queries, query => query.AncestorIds?.Contains(seriesId) == true);
+        Assert.Equal(new[] { BaseItemKind.Episode, BaseItemKind.Season }, descendantQuery.IncludeItemTypes);
+    }
+
+    [Fact]
+    public void SeriesRatingChange_RebuildsOnlyDescendantsWithoutOwnRatings()
+    {
+        var seriesId = Guid.NewGuid();
+        var inheritingEpisodeId = Guid.NewGuid();
+        var ownEpisodeId = Guid.NewGuid();
+        var inheritingSeasonId = Guid.NewGuid();
+        var ownSeasonId = Guid.NewGuid();
+        var series = new StubSeries
+        {
+            Id = seriesId,
+            CommunityRating = 9,
+            CriticRating = 90,
+            Genres = new[] { "Stable" },
+            ProviderIds = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["Tmdb"] = "stable" },
+            DateLastSaved = SavedAt,
+        };
+        var inheritingEpisode = new StubEpisode { Id = inheritingEpisodeId, SeriesId = seriesId, DateLastSaved = SavedAt };
+        var ownEpisode = new StubEpisode { Id = ownEpisodeId, SeriesId = seriesId, CommunityRating = 6, CriticRating = 60, DateLastSaved = SavedAt };
+        var inheritingSeason = new StubSeason { Id = inheritingSeasonId, SeriesId = seriesId, Genres = new[] { "Stable" }, DateLastSaved = SavedAt };
+        var ownSeason = new StubSeason { Id = ownSeasonId, SeriesId = seriesId, CommunityRating = 7, CriticRating = 70, Genres = new[] { "Stable" }, DateLastSaved = SavedAt };
+        var items = new Dictionary<Guid, BaseItem>
+        {
+            [seriesId] = series,
+            [inheritingEpisodeId] = inheritingEpisode,
+            [ownEpisodeId] = ownEpisode,
+            [inheritingSeasonId] = inheritingSeason,
+            [ownSeasonId] = ownSeason,
+        };
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => items.GetValueOrDefault(id),
+            GetItemListHook = query => query.AncestorIds?.Contains(seriesId) == true
+                ? new BaseItem[] { inheritingEpisode, ownEpisode, inheritingSeason, ownSeason }
+                : Array.Empty<BaseItem>(),
+        };
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(seriesId), new TagCacheEntry
+        {
+            Type = "Series",
+            TmdbId = "stable",
+            CommunityRating = 1,
+            CriticRating = 10,
+            Genres = new[] { "Stable" },
+        });
+        service.SeedEntryForTest(Key(inheritingEpisodeId), new TagCacheEntry { Type = "Episode", SeriesId = Key(seriesId), SeriesTmdbId = "stable", CommunityRating = 1, CriticRating = 10, SourceRevision = SavedAt.Ticks });
+        service.SeedEntryForTest(Key(inheritingSeasonId), new TagCacheEntry { Type = "Season", SeriesId = Key(seriesId), SeriesTmdbId = "stable", CommunityRating = 1, CriticRating = 10, Genres = new[] { "Stable" }, SourceRevision = SavedAt.Ticks });
+        var ownEpisodeEntry = new TagCacheEntry { Type = "Episode", SeriesId = Key(seriesId), SeriesTmdbId = "stable", CommunityRating = 6, CriticRating = 60, SourceRevision = SavedAt.Ticks };
+        var ownSeasonEntry = new TagCacheEntry { Type = "Season", SeriesId = Key(seriesId), SeriesTmdbId = "stable", CommunityRating = 7, CriticRating = 70, Genres = new[] { "Stable" }, SourceRevision = SavedAt.Ticks };
+        service.SeedEntryForTest(Key(ownEpisodeId), ownEpisodeEntry);
+        service.SeedEntryForTest(Key(ownSeasonId), ownSeasonEntry);
+        using var monitor = new TagCacheMonitor(library, service, NullLogger<TagCacheMonitor>.Instance);
+        monitor.Initialize();
+
+        library.RaiseItemUpdated(series);
+        service.FlushPendingForTest();
+
+        Assert.Equal(9, service.GetEntryForTest(Key(inheritingEpisodeId))!.CommunityRating);
+        Assert.Equal(9, service.GetEntryForTest(Key(inheritingSeasonId))!.CommunityRating);
+        Assert.Same(ownEpisodeEntry, service.GetEntryForTest(Key(ownEpisodeId)));
+        Assert.Same(ownSeasonEntry, service.GetEntryForTest(Key(ownSeasonId)));
+    }
+
+    [Fact]
+    public void SeriesOwnGenreChange_RepairsSeasonWhenEffectiveSeriesGenreWasAlreadyEqual()
+    {
+        var seriesId = Guid.NewGuid();
+        var seasonId = Guid.NewGuid();
+        var seriesFirst = new StubEpisode { Id = Guid.NewGuid(), SeriesId = seriesId, Genres = new[] { "Drama" } };
+        var seasonFirst = new StubEpisode { Id = Guid.NewGuid(), SeriesId = seriesId, SeasonId = seasonId, Genres = Array.Empty<string>() };
+        var series = new StubSeries { Id = seriesId, Genres = new[] { "Drama" }, DateLastSaved = SavedAt };
+        var season = new StubSeason { Id = seasonId, SeriesId = seriesId, Genres = Array.Empty<string>(), DateLastSaved = SavedAt };
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => id == seriesId ? series : id == seasonId ? season : null,
+            GetItemListHook = query => query.AncestorIds?.Contains(seriesId) == true
+                ? new BaseItem[] { season }
+                : query.ParentId == seasonId
+                    ? new BaseItem[] { seasonFirst }
+                    : query.ParentId == seriesId
+                        ? new BaseItem[] { seriesFirst }
+                        : Array.Empty<BaseItem>(),
+        };
+        using var service = NewService(library);
+        // The old Series entry's effective genre came from its first Episode. Its value is
+        // already "Drama", but the raw Series genre newly becoming "Drama" must still flow to
+        // a different Season whose own/first-Episode genres are empty.
+        service.SeedEntryForTest(Key(seriesId), new TagCacheEntry { Type = "Series", Genres = new[] { "Drama" } });
+        service.SeedEntryForTest(Key(seasonId), new TagCacheEntry { Type = "Season", Genres = Array.Empty<string>() });
+        using var monitor = new TagCacheMonitor(library, service, NullLogger<TagCacheMonitor>.Instance);
+        monitor.Initialize();
+
+        library.RaiseItemUpdated(series);
+        service.FlushPendingForTest();
+
+        Assert.Equal(new[] { "Drama" }, service.GetEntryForTest(Key(seasonId))!.Genres);
+    }
+
+    [Fact]
+    public void NoOpSeriesUpdate_DoesNotDiscoverOrRebuildDescendants()
+    {
+        var seriesId = Guid.NewGuid();
+        var seasonId = Guid.NewGuid();
+        var episodeId = Guid.NewGuid();
+        var series = new StubSeries
+        {
+            Id = seriesId,
+            CommunityRating = 8,
+            CriticRating = 80,
+            Genres = Array.Empty<string>(),
+            DateLastSaved = SavedAt,
+            ProviderIds = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Tmdb"] = "stable-series-tmdb",
+            },
+        };
+        var episode = new StubEpisode
+        {
+            Id = episodeId,
+            SeriesId = seriesId,
+            SeasonId = seasonId,
+            Genres = new[] { "Fallback" },
+            DateLastSaved = SavedAt,
+        };
+        var resolvedIds = new List<Guid>();
+        var queries = new List<InternalItemsQuery>();
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id =>
+            {
+                resolvedIds.Add(id);
+                return id == seriesId ? series : null;
+            },
+            GetItemListHook = query =>
+            {
+                queries.Add(query);
+                return query.ParentId == seriesId ? new BaseItem[] { episode } : Array.Empty<BaseItem>();
+            },
+        };
+
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(seriesId), new TagCacheEntry
+        {
+            Type = "Series",
+            TmdbId = "stable-series-tmdb",
+            CommunityRating = 8,
+            CriticRating = 80,
+            Genres = new[] { "Fallback" },
+        });
+        var seasonEntry = StaleInherited();
+        var episodeEntry = StaleInherited();
+        service.SeedEntryForTest(Key(seasonId), seasonEntry);
+        service.SeedEntryForTest(Key(episodeId), episodeEntry);
+        using var monitor = new TagCacheMonitor(library, service, NullLogger<TagCacheMonitor>.Instance);
+        monitor.Initialize();
+
+        library.RaiseItemUpdated(series);
+        service.FlushPendingForTest();
+
+        Assert.All(resolvedIds, id => Assert.Equal(seriesId, id));
+        Assert.Single(queries, query => query.AncestorIds?.Contains(seriesId) == true);
+        Assert.Same(seasonEntry, service.GetEntryForTest(Key(seasonId)));
+        Assert.Same(episodeEntry, service.GetEntryForTest(Key(episodeId)));
+        Assert.Equal(1, service.ContentRevision);
+    }
+
+    [Fact]
+    public void LargeSeriesWorker_UsesOneAncestorQueryAndRebuildsOnlyOneInheritor()
+    {
+        const int DescendantCount = 1_000;
+        var seriesId = Guid.NewGuid();
+        var series = new StubSeries
+        {
+            Id = seriesId,
+            CommunityRating = 9,
+            CriticRating = 90,
+            ProviderIds = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["Tmdb"] = "stable" },
+            DateLastSaved = SavedAt,
+        };
+        var descendants = Enumerable.Range(0, DescendantCount)
+            .Select(index => new StubEpisode
+            {
+                Id = Guid.NewGuid(),
+                SeriesId = seriesId,
+                CommunityRating = index == 0 ? null : 5,
+                CriticRating = index == 0 ? null : 50,
+                DateLastSaved = SavedAt,
+            })
+            .ToArray();
+        var items = descendants.ToDictionary<BaseItem, Guid, BaseItem>(item => item.Id, item => item);
+        items[seriesId] = series;
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => items.GetValueOrDefault(id),
+            GetItemListHook = query => query.AncestorIds?.Contains(seriesId) == true
+                ? descendants
+                : Array.Empty<BaseItem>(),
+        };
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(seriesId), new TagCacheEntry { Type = "Series", TmdbId = "stable", CommunityRating = 1, CriticRating = 10 });
+        TagCacheEntry? ownRatingSentinel = null;
+        for (var index = 0; index < descendants.Length; index++)
+        {
+            var entry = new TagCacheEntry
+            {
+                Type = "Episode",
+                SeriesId = Key(seriesId),
+                SeriesTmdbId = "stable",
+                CommunityRating = index == 0 ? 1 : 5,
+                CriticRating = index == 0 ? 10 : 50,
+                SourceRevision = SavedAt.Ticks,
+            };
+            service.SeedEntryForTest(Key(descendants[index].Id), entry);
+            if (index == 1) ownRatingSentinel = entry;
+        }
+        using var monitor = new TagCacheMonitor(library, service, NullLogger<TagCacheMonitor>.Instance);
+        monitor.Initialize();
+
+        library.RaiseItemUpdated(series);
+        service.FlushPendingForTest();
+
+        Assert.Equal(2, library.GetItemListCallCount); // one ancestor query + Series first-Episode probe
+        Assert.Equal(2, library.GetItemByIdCallCount); // Series discovery + Series rebuild; descendant uses snapshot
+        Assert.Equal(9, service.GetEntryForTest(Key(descendants[0].Id))!.CommunityRating);
+        Assert.Same(ownRatingSentinel, service.GetEntryForTest(Key(descendants[1].Id)));
+    }
+
+    [Fact]
+    public void LargeSeriesEvent_RepairsOneThousandStaleEpisodeRelationshipsWithoutScalarRebuilds()
+    {
+        const int EpisodeCount = 1_000;
+        var oldSeriesId = Guid.NewGuid();
+        var newSeriesId = Guid.NewGuid();
+        var probeCount = 0;
+        var oldSeries = new StubSeries { Id = oldSeriesId, DateLastSaved = SavedAt };
+        var newSeries = new StubSeries
+        {
+            Id = newSeriesId,
+            ProviderIds = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["Tmdb"] = "stable" },
+            DateLastSaved = SavedAt,
+        };
+        var episodes = Enumerable.Range(0, EpisodeCount)
+            .Select(_ => new CountingEpisode
+            {
+                Id = Guid.NewGuid(),
+                SeriesId = newSeriesId,
+                CommunityRating = 5,
+                CriticRating = 50,
+                DateLastSaved = SavedAt,
+                OnProbe = () => probeCount++,
+            })
+            .ToArray();
+        var oldFirst = new CountingEpisode
+        {
+            Id = Guid.NewGuid(),
+            SeriesId = oldSeriesId,
+            DateLastSaved = SavedAt,
+            OnProbe = () => probeCount++,
+        };
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => id == oldSeriesId
+                ? oldSeries
+                : id == newSeriesId
+                    ? newSeries
+                    : throw new InvalidOperationException("relationship repair must not resolve Episodes individually"),
+            GetItemListHook = query => query.AncestorIds?.Contains(newSeriesId) == true
+                || query.ParentId == newSeriesId
+                    ? episodes
+                    : query.ItemIds?.Contains(oldSeriesId) == true
+                        ? new BaseItem[] { oldSeries }
+                    : query.ParentId == oldSeriesId
+                        ? new BaseItem[] { oldFirst }
+                        : throw new InvalidOperationException("unexpected relationship repair query"),
+        };
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(oldSeriesId), new TagCacheEntry { Type = "Series" });
+        service.SeedEntryForTest(Key(newSeriesId), new TagCacheEntry { Type = "Series", TmdbId = "stable" });
+        foreach (var episode in episodes)
+        {
+            service.SeedEntryForTest(Key(episode.Id), new TagCacheEntry
+            {
+                Type = "Episode",
+                SeriesId = Key(oldSeriesId),
+                SeriesTmdbId = "stable",
+                CommunityRating = 5,
+                CriticRating = 50,
+                StreamSourceId = Key(episode.Id),
+                SourceRevision = SavedAt.Ticks,
+            });
+        }
+
+        var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        service.EnqueueItemChange(newSeries, removed: false);
+        service.FlushPendingForTest();
+        var workerAllocatedBytes = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+
+        Assert.Equal(3, library.GetItemByIdCallCount); // discovery + old/new Series rebuilds
+        Assert.Equal(4, library.GetItemListCallCount); // subtree + old-owner confirmation + old/new first Episodes
+        Assert.Equal(2, probeCount); // old/new Series projections; no descendant probe
+        Assert.All(
+            episodes,
+            episode => Assert.Equal(Key(newSeriesId), service.GetEntryForTest(Key(episode.Id))!.SeriesId));
+        Assert.True(
+            workerAllocatedBytes < 1_650_000,
+            $"Large-Series worker allocated {workerAllocatedBytes:N0} bytes (budget: 1,650,000)");
+    }
+
+    [Fact]
+    public void PartialLargeSeriesSnapshot_RepairsTheOmittedStaleRelationshipByBulkId()
+    {
+        const int EpisodeCount = 1_000;
+        var oldSeriesId = Guid.NewGuid();
+        var newSeriesId = Guid.NewGuid();
+        var oldSeries = new StubSeries { Id = oldSeriesId, DateLastSaved = SavedAt };
+        var newSeries = new StubSeries { Id = newSeriesId, DateLastSaved = SavedAt };
+        var episodes = Enumerable.Range(0, EpisodeCount)
+            .Select(_ => new StubEpisode
+            {
+                Id = Guid.NewGuid(),
+                SeriesId = newSeriesId,
+                DateLastSaved = SavedAt,
+            })
+            .ToArray();
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => id == oldSeriesId ? oldSeries : id == newSeriesId ? newSeries : null,
+            GetItemListHook = query => query.AncestorIds?.Contains(newSeriesId) == true
+                ? episodes.Take(EpisodeCount - 1).ToArray()
+                : query.ItemIds?.Contains(oldSeriesId) == true
+                    ? new BaseItem[] { oldSeries }
+                    : query.ItemIds?.Length > 0
+                        ? episodes.Where(episode => query.ItemIds.Contains(episode.Id)).ToArray()
+                        : query.ParentId == newSeriesId
+                            ? episodes
+                            : query.ParentId == oldSeriesId
+                                ? Array.Empty<BaseItem>()
+                                : throw new InvalidOperationException("unexpected partial stale-relationship query"),
+        };
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(oldSeriesId), new TagCacheEntry { Type = "Series" });
+        service.SeedEntryForTest(Key(newSeriesId), new TagCacheEntry { Type = "Series" });
+        foreach (var episode in episodes)
+        {
+            service.SeedEntryForTest(Key(episode.Id), new TagCacheEntry
+            {
+                Type = "Episode",
+                SeriesId = Key(oldSeriesId),
+                SourceRevision = SavedAt.Ticks,
+            });
+        }
+
+        service.EnqueueItemChange(newSeries, removed: false);
+        service.FlushPendingForTest();
+
+        Assert.Equal(3, library.GetItemByIdCallCount); // new discovery + old/new rebuilds
+        Assert.Equal(5, library.GetItemListCallCount); // subtree + omitted id + owner + old/new probes
+        Assert.All(
+            episodes,
+            episode => Assert.Equal(Key(newSeriesId), service.GetEntryForTest(Key(episode.Id))!.SeriesId));
+        Assert.Equal(0, service.PendingChangeCountForTest);
+    }
+
+    [Fact]
+    public void PartialSeriesSnapshot_RetainsRetryUntilEveryCachedDescendantIsDiscovered()
+    {
+        var seriesId = Guid.NewGuid();
+        var series = new StubSeries
+        {
+            Id = seriesId,
+            CommunityRating = 9,
+            DateLastSaved = SavedAt,
+        };
+        var episodes = Enumerable.Range(0, 2)
+            .Select(_ => new StubEpisode
+            {
+                Id = Guid.NewGuid(),
+                SeriesId = seriesId,
+                DateLastSaved = SavedAt,
+            })
+            .ToArray();
+        var ancestorQueries = 0;
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => id == seriesId ? series : null,
+            GetItemListHook = query => query.AncestorIds?.Contains(seriesId) == true
+                ? ancestorQueries++ == 0 ? episodes.Take(1).ToArray() : episodes
+                : query.ParentId == seriesId
+                    ? episodes
+                    : Array.Empty<BaseItem>(),
+        };
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(seriesId), new TagCacheEntry
+        {
+            Type = "Series",
+            CommunityRating = 1,
+        });
+        foreach (var episode in episodes)
+        {
+            service.SeedEntryForTest(Key(episode.Id), new TagCacheEntry
+            {
+                Type = "Episode",
+                SeriesId = Key(seriesId),
+                CommunityRating = 1,
+                SourceRevision = SavedAt.Ticks,
+            });
+        }
+
+        service.EnqueueItemChange(series, removed: false);
+        service.FlushPendingForTest();
+
+        Assert.Equal(9, service.GetEntryForTest(Key(episodes[0].Id))!.CommunityRating);
+        Assert.Equal(1, service.GetEntryForTest(Key(episodes[1].Id))!.CommunityRating);
+        Assert.Equal(1, service.PendingChangeCountForTest);
+
+        service.FlushPendingForTest();
+
+        Assert.All(episodes, episode => Assert.Equal(9, service.GetEntryForTest(Key(episode.Id))!.CommunityRating));
+        Assert.Equal(0, service.PendingChangeCountForTest);
+        Assert.Equal(2, ancestorQueries);
+    }
+
+    [Fact]
+    public void MissingOldSeriesOwner_IsTombstonedWithoutAnUnboundedSyntheticRetry()
+    {
+        var oldSeriesId = Guid.NewGuid();
+        var newSeriesId = Guid.NewGuid();
+        var episodeId = Guid.NewGuid();
+        var orphanSeasonId = Guid.NewGuid();
+        var orphanEpisodeId = Guid.NewGuid();
+        var newSeries = new StubSeries { Id = newSeriesId, DateLastSaved = SavedAt };
+        var episode = new StubEpisode
+        {
+            Id = episodeId,
+            SeriesId = newSeriesId,
+            DateLastSaved = SavedAt,
+        };
+        var oldOwnerQueries = 0;
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => id == newSeriesId ? newSeries : null,
+            GetItemListHook = query =>
+            {
+                if (query.AncestorIds?.Contains(newSeriesId) == true || query.ParentId == newSeriesId)
+                {
+                    return new BaseItem[] { episode };
+                }
+
+                if (query.ItemIds?.Contains(oldSeriesId) == true)
+                {
+                    oldOwnerQueries++;
+                    return Array.Empty<BaseItem>();
+                }
+
+                if (query.ItemIds?.Length > 0)
+                {
+                    return Array.Empty<BaseItem>();
+                }
+
+                throw new InvalidOperationException("unexpected missing-owner query");
+            },
+        };
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(oldSeriesId), new TagCacheEntry { Type = "Series" });
+        service.SeedEntryForTest(Key(newSeriesId), new TagCacheEntry { Type = "Series" });
+        service.SeedEntryForTest(Key(orphanSeasonId), new TagCacheEntry
+        {
+            Type = "Season",
+            SeriesId = Key(oldSeriesId),
+        });
+        service.SeedEntryForTest(Key(orphanEpisodeId), new TagCacheEntry
+        {
+            Type = "Episode",
+            SeriesId = Key(oldSeriesId),
+            SeasonId = Key(orphanSeasonId),
+        });
+        service.SeedEntryForTest(Key(episodeId), new TagCacheEntry
+        {
+            Type = "Episode",
+            SeriesId = Key(oldSeriesId),
+            SourceRevision = SavedAt.Ticks,
+        });
+
+        service.EnqueueItemChange(newSeries, removed: false);
+        service.FlushPendingForTest();
+
+        Assert.False(service.ContainsKeyForTest(Key(oldSeriesId)));
+        Assert.False(service.ContainsKeyForTest(Key(orphanSeasonId)));
+        Assert.False(service.ContainsKeyForTest(Key(orphanEpisodeId)));
+        Assert.Equal(Key(newSeriesId), service.GetEntryForTest(Key(episodeId))!.SeriesId);
+        Assert.Equal(0, service.PendingChangeCountForTest);
+        Assert.Equal(1, oldOwnerQueries);
+    }
+
+    [Fact]
+    public void MissingOldSeasonOwner_IsTombstonedWithoutRetryingTheSyntheticTarget()
+    {
+        var seriesId = Guid.NewGuid();
+        var oldSeasonId = Guid.NewGuid();
+        var newSeasonId = Guid.NewGuid();
+        var episodeId = Guid.NewGuid();
+        var series = new StubSeries { Id = seriesId, DateLastSaved = SavedAt };
+        var newSeason = new StubSeason { Id = newSeasonId, SeriesId = seriesId, DateLastSaved = SavedAt };
+        var episode = new StubEpisode
+        {
+            Id = episodeId,
+            SeriesId = seriesId,
+            SeasonId = newSeasonId,
+            DateLastSaved = SavedAt,
+        };
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => id == seriesId ? series : id == newSeasonId ? newSeason : null,
+            GetItemListHook = query => query.AncestorIds?.Contains(seriesId) == true
+                ? new BaseItem[] { newSeason, episode }
+                : query.ItemIds?.Contains(oldSeasonId) == true
+                    ? Array.Empty<BaseItem>()
+                    : query.ParentId == seriesId || query.ParentId == newSeasonId
+                        ? new BaseItem[] { episode }
+                        : throw new InvalidOperationException("unexpected missing-Season query"),
+        };
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(seriesId), new TagCacheEntry { Type = "Series" });
+        service.SeedEntryForTest(Key(oldSeasonId), new TagCacheEntry { Type = "Season", SeriesId = Key(seriesId) });
+        service.SeedEntryForTest(Key(newSeasonId), new TagCacheEntry { Type = "Season", SeriesId = Key(seriesId) });
+        service.SeedEntryForTest(Key(episodeId), new TagCacheEntry
+        {
+            Type = "Episode",
+            SeriesId = Key(seriesId),
+            SeasonId = Key(oldSeasonId),
+            SourceRevision = SavedAt.Ticks,
+        });
+
+        service.EnqueueItemChange(series, removed: false);
+        service.FlushPendingForTest();
+
+        Assert.False(service.ContainsKeyForTest(Key(oldSeasonId)));
+        Assert.Equal(Key(newSeasonId), service.GetEntryForTest(Key(episodeId))!.SeasonId);
+        Assert.Equal(0, service.PendingChangeCountForTest);
+    }
+
+    [Fact]
+    public void PartialOldOwnerBulkResult_FallsBackBeforeRemovingALiveSeries()
+    {
+        var oldSeriesId = Guid.NewGuid();
+        var newSeriesId = Guid.NewGuid();
+        var episodeId = Guid.NewGuid();
+        var oldSeries = new StubSeries { Id = oldSeriesId, DateLastSaved = SavedAt };
+        var newSeries = new StubSeries { Id = newSeriesId, DateLastSaved = SavedAt };
+        var episode = new StubEpisode
+        {
+            Id = episodeId,
+            SeriesId = newSeriesId,
+            DateLastSaved = SavedAt,
+        };
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => id == oldSeriesId ? oldSeries : id == newSeriesId ? newSeries : null,
+            GetItemListHook = query => query.AncestorIds?.Contains(newSeriesId) == true
+                ? new BaseItem[] { episode }
+                : query.ItemIds?.Contains(oldSeriesId) == true
+                    ? Array.Empty<BaseItem>() // transiently partial owner lookup
+                    : query.ParentId == newSeriesId
+                        ? new BaseItem[] { episode }
+                        : query.ParentId == oldSeriesId
+                            ? Array.Empty<BaseItem>()
+                            : throw new InvalidOperationException("unexpected partial-owner query"),
+        };
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(oldSeriesId), new TagCacheEntry { Type = "Series" });
+        service.SeedEntryForTest(Key(newSeriesId), new TagCacheEntry { Type = "Series" });
+        service.SeedEntryForTest(Key(episodeId), new TagCacheEntry
+        {
+            Type = "Episode",
+            SeriesId = Key(oldSeriesId),
+            SourceRevision = SavedAt.Ticks,
+        });
+
+        service.EnqueueItemChange(newSeries, removed: false);
+        service.FlushPendingForTest();
+
+        Assert.True(service.ContainsKeyForTest(Key(oldSeriesId)));
+        Assert.Equal(Key(newSeriesId), service.GetEntryForTest(Key(episodeId))!.SeriesId);
+        Assert.Equal(0, service.PendingChangeCountForTest);
+    }
+
+    [Fact]
+    public void LargeSeriesRelationshipRepair_RebuildsOnlyTheOneRevisedDescendant()
+    {
+        const int EpisodeCount = 1_000;
+        var oldSeriesId = Guid.NewGuid();
+        var newSeriesId = Guid.NewGuid();
+        var probeCount = 0;
+        var oldSeries = new StubSeries { Id = oldSeriesId, DateLastSaved = SavedAt };
+        var newSeries = new StubSeries { Id = newSeriesId, DateLastSaved = SavedAt };
+        var episodes = Enumerable.Range(0, EpisodeCount)
+            .Select(index => new CountingEpisode
+            {
+                Id = Guid.NewGuid(),
+                SeriesId = newSeriesId,
+                DateLastSaved = index == 0 ? SavedAt.AddMinutes(1) : SavedAt,
+                OnProbe = () => probeCount++,
+            })
+            .ToArray();
+        var revisedEpisode = episodes[0];
+        var oldFirst = new CountingEpisode
+        {
+            Id = Guid.NewGuid(),
+            SeriesId = oldSeriesId,
+            DateLastSaved = SavedAt,
+            OnProbe = () => probeCount++,
+        };
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => id == oldSeriesId
+                ? oldSeries
+                : id == newSeriesId
+                    ? newSeries
+                    : id == revisedEpisode.Id
+                        ? revisedEpisode
+                        : throw new InvalidOperationException("unchanged descendants must use prepared repairs"),
+            GetItemListHook = query => query.AncestorIds?.Contains(newSeriesId) == true
+                || query.ParentId == newSeriesId
+                    ? episodes
+                    : query.ItemIds?.Contains(oldSeriesId) == true
+                        ? new BaseItem[] { oldSeries }
+                        : query.ParentId == oldSeriesId
+                            ? new BaseItem[] { oldFirst }
+                            : throw new InvalidOperationException("unexpected mixed relationship-repair query"),
+        };
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(oldSeriesId), new TagCacheEntry { Type = "Series" });
+        service.SeedEntryForTest(Key(newSeriesId), new TagCacheEntry { Type = "Series" });
+        foreach (var episode in episodes)
+        {
+            service.SeedEntryForTest(Key(episode.Id), new TagCacheEntry
+            {
+                Type = "Episode",
+                SeriesId = Key(oldSeriesId),
+                StreamSourceId = Key(episode.Id),
+                SourceRevision = SavedAt.Ticks,
+            });
+        }
+
+        service.EnqueueItemChange(newSeries, removed: false);
+        service.FlushPendingForTest();
+
+        Assert.Equal(5, library.GetItemByIdCallCount); // discovery + revised Episode/parent + old/new rebuilds
+        Assert.Equal(4, library.GetItemListCallCount); // subtree + old-owner confirmation + old/new probes
+        Assert.Equal(3, probeCount); // one revised Episode and the two Series projections
+        Assert.All(
+            episodes,
+            episode => Assert.Equal(Key(newSeriesId), service.GetEntryForTest(Key(episode.Id))!.SeriesId));
+        Assert.Equal(revisedEpisode.DateLastSaved.Ticks, service.GetEntryForTest(Key(revisedEpisode.Id))!.SourceRevision);
+    }
+
+    [Fact]
+    public void LargeSeriesGenreRepair_UpdatesOneThousandInheritingSeasonsWithinConstantQueryBudget()
+    {
+        const int SeasonCount = 1_000;
+        var seriesId = Guid.NewGuid();
+        var series = new StubSeries { Id = seriesId, Genres = new[] { "Series" }, DateLastSaved = SavedAt };
+        var seasons = Enumerable.Range(0, SeasonCount)
+            .Select(_ => new StubSeason { Id = Guid.NewGuid(), SeriesId = seriesId, Genres = Array.Empty<string>() })
+            .ToArray();
+        var episodes = seasons
+            .Select(season => new StubEpisode
+            {
+                Id = Guid.NewGuid(),
+                SeriesId = seriesId,
+                SeasonId = season.Id,
+                Genres = Array.Empty<string>(),
+            })
+            .ToArray();
+        var descendants = seasons.Cast<BaseItem>().Concat(episodes).ToArray();
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => id == seriesId ? series : null,
+            GetItemListHook = query => query.AncestorIds?.Contains(seriesId) == true
+                ? descendants
+                : query.ParentId == seriesId
+                    ? new BaseItem[] { episodes[0] }
+                    : throw new InvalidOperationException("per-Season dependency query is forbidden"),
+        };
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(seriesId), new TagCacheEntry { Type = "Series", Genres = new[] { "Old" } });
+        foreach (var season in seasons)
+        {
+            service.SeedEntryForTest(Key(season.Id), new TagCacheEntry
+            {
+                Type = "Season",
+                SeriesId = Key(seriesId),
+                Genres = new[] { "Old" },
+            });
+        }
+        foreach (var episode in episodes)
+        {
+            service.SeedEntryForTest(Key(episode.Id), new TagCacheEntry
+            {
+                Type = "Episode",
+                SeriesId = Key(seriesId),
+                SeasonId = Key(episode.SeasonId),
+                Genres = Array.Empty<string>(),
+            });
+        }
+        using var monitor = new TagCacheMonitor(library, service, NullLogger<TagCacheMonitor>.Instance);
+        monitor.Initialize();
+
+        library.RaiseItemUpdated(series);
+        service.FlushPendingForTest();
+
+        Assert.Equal(2, library.GetItemListCallCount); // one subtree snapshot + Series rebuild probe
+        Assert.Equal(2, library.GetItemByIdCallCount); // Series discovery + Series rebuild
+        Assert.All(
+            seasons,
+            season => Assert.Equal(new[] { "Series" }, service.GetEntryForTest(Key(season.Id))!.Genres));
+        Assert.Equal(SeasonCount + 1, service.ContentRevision); // Series + every inheriting Season
+    }
+
+    [Fact]
+    public void LargeSeasonReparent_RepairsOneThousandEpisodesWithinConstantLookupAndProbeBudget()
+    {
+        const int EpisodeCount = 1_000;
+        var oldSeriesId = Guid.NewGuid();
+        var newSeriesId = Guid.NewGuid();
+        var seasonId = Guid.NewGuid();
+        var probeCount = 0;
+        var oldSeries = new StubSeries { Id = oldSeriesId, DateLastSaved = SavedAt };
+        var newSeries = new StubSeries
+        {
+            Id = newSeriesId,
+            CommunityRating = 9,
+            CriticRating = 90,
+            ProviderIds = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["Tmdb"] = "new" },
+            DateLastSaved = SavedAt,
+        };
+        var season = new StubSeason
+        {
+            Id = seasonId,
+            SeriesId = newSeriesId,
+            CommunityRating = 1,
+            DateLastSaved = SavedAt,
+        };
+        var episodes = Enumerable.Range(0, EpisodeCount)
+            .Select(_ => new CountingEpisode
+            {
+                Id = Guid.NewGuid(),
+                SeriesId = newSeriesId,
+                SeasonId = seasonId,
+                DateLastSaved = SavedAt,
+                OnProbe = () => probeCount++,
+            })
+            .ToArray();
+        var oldFirst = new CountingEpisode
+        {
+            Id = Guid.NewGuid(),
+            SeriesId = oldSeriesId,
+            DateLastSaved = SavedAt,
+            OnProbe = () => probeCount++,
+        };
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => id == oldSeriesId
+                ? oldSeries
+                : id == newSeriesId
+                    ? newSeries
+                    : id == seasonId
+                        ? season
+                        : throw new InvalidOperationException("Season reparent must not resolve Episodes individually"),
+            GetItemListHook = query => query.AncestorIds?.Contains(seasonId) == true
+                ? episodes
+                : query.ParentId == seasonId || query.ParentId == newSeriesId
+                    ? episodes
+                    : query.ParentId == oldSeriesId
+                        ? new BaseItem[] { oldFirst }
+                        : throw new InvalidOperationException("unexpected dependency query"),
+        };
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(oldSeriesId), new TagCacheEntry { Type = "Series" });
+        service.SeedEntryForTest(Key(newSeriesId), new TagCacheEntry { Type = "Series" });
+        service.SeedEntryForTest(Key(seasonId), new TagCacheEntry
+        {
+            Type = "Season",
+            SeriesId = Key(oldSeriesId),
+        });
+        foreach (var episode in episodes)
+        {
+            service.SeedEntryForTest(Key(episode.Id), new TagCacheEntry
+            {
+                Type = "Episode",
+                SeriesId = Key(oldSeriesId),
+                SeasonId = Key(seasonId),
+                SeriesTmdbId = "old",
+                CommunityRating = 1,
+                CriticRating = 10,
+                StreamSourceId = Key(episode.Id),
+                SourceRevision = SavedAt.Ticks,
+            });
+        }
+
+        service.EnqueueItemChange(season, removed: false);
+        service.FlushPendingForTest();
+
+        Assert.Equal(5, library.GetItemByIdCallCount);
+        Assert.Equal(4, library.GetItemListCallCount);
+        Assert.Equal(3, probeCount); // old Series + moved Season + new Series container projections only
+        Assert.All(episodes, episode =>
+        {
+            var entry = service.GetEntryForTest(Key(episode.Id))!;
+            Assert.Equal(Key(newSeriesId), entry.SeriesId);
+            Assert.Equal("new", entry.SeriesTmdbId);
+            Assert.Equal(9, entry.CommunityRating);
+            Assert.Equal(90, entry.CriticRating);
+        });
+    }
+
+    [Fact]
+    public void LargeReconcile_ParentOnlySeriesChangeDoesNotReprobeOneThousandEpisodes()
+    {
+        const int EpisodeCount = 1_000;
+        var dir = Path.Combine(Path.GetTempPath(), "jc-tagcache-large-reconcile-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var seriesId = Guid.NewGuid();
+            var probeCount = 0;
+            var series = new StubSeries
+            {
+                Id = seriesId,
+                CommunityRating = 9,
+                CriticRating = 90,
+                ProviderIds = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["Tmdb"] = "new" },
+                DateLastSaved = SavedAt,
+            };
+            var episodes = Enumerable.Range(0, EpisodeCount)
+                .Select(_ => new CountingEpisode
+                {
+                    Id = Guid.NewGuid(),
+                    SeriesId = seriesId,
+                    DateLastSaved = SavedAt,
+                    OnProbe = () => probeCount++,
+                })
+                .ToArray();
+            var allItems = new BaseItem[] { series }.Concat(episodes).ToArray();
+            var library = new CountingLibraryManager
+            {
+                GetItemByIdHook = _ => throw new InvalidOperationException("reconcile snapshot must avoid scalar lookups"),
+                GetItemListHook = query => query.ParentId == Guid.Empty
+                    ? allItems
+                    : query.ParentId == seriesId
+                        ? episodes
+                        : throw new InvalidOperationException("unexpected reconcile query"),
+            };
+            using var service = new TagCacheService(
+                library,
+                new StubAppPaths(dir),
+                NullLogger<TagCacheService>.Instance);
+            service.SeedEntryForTest(Key(seriesId), new TagCacheEntry
+            {
+                Type = "Series",
+                TmdbId = "old",
+                CommunityRating = 1,
+                CriticRating = 10,
+                SourceRevision = SavedAt.Ticks,
+            });
+            foreach (var episode in episodes)
+            {
+                service.SeedEntryForTest(Key(episode.Id), new TagCacheEntry
+                {
+                    Type = "Episode",
+                    SeriesId = Key(seriesId),
+                    SeriesTmdbId = "old",
+                    CommunityRating = 1,
+                    CriticRating = 10,
+                    StreamSourceId = Key(episode.Id),
+                    StreamData = new TagStreamData { ItemPath = "unchanged.mkv" },
+                    SourceRevision = SavedAt.Ticks,
+                });
+            }
+
+            service.BuildFullCache(progress: null, CancellationToken.None);
+
+            Assert.Equal(2, library.GetItemListCallCount); // one library snapshot + Series first Episode
+            Assert.Equal(0, library.GetItemByIdCallCount);
+            Assert.Equal(1, probeCount); // Series projection only
+            Assert.All(episodes, episode =>
+            {
+                var entry = service.GetEntryForTest(Key(episode.Id))!;
+                Assert.Equal("new", entry.SeriesTmdbId);
+                Assert.Equal(9, entry.CommunityRating);
+                Assert.Equal(90, entry.CriticRating);
+                Assert.Equal("unchanged.mkv", entry.StreamData!.ItemPath);
+                Assert.Equal(SavedAt.Ticks, entry.SourceRevision);
+            });
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void ExplicitEpisodeRemoval_WinsOverSameBatchSeriesDerivedUpdate()
+    {
+        var seriesId = Guid.NewGuid();
+        var episodeId = Guid.NewGuid();
+        var series = new StubSeries { Id = seriesId, DateLastSaved = SavedAt };
+        var episode = new StubEpisode
+        {
+            Id = episodeId,
+            SeriesId = seriesId,
+            DateLastSaved = SavedAt,
+        };
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => id == seriesId ? series : id == episodeId ? episode : null,
+            // Simulate a stale descendant read that still returns the just-removed Episode.
+            GetItemListHook = query => query.AncestorIds?.Contains(seriesId) == true
+                ? new BaseItem[] { episode }
+                : Array.Empty<BaseItem>(),
+        };
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(seriesId), new TagCacheEntry { Type = "Series" });
+        service.SeedEntryForTest(Key(episodeId), new TagCacheEntry { Type = "Episode" });
+        using var monitor = new TagCacheMonitor(library, service, NullLogger<TagCacheMonitor>.Instance);
+        monitor.Initialize();
+
+        library.RaiseItemUpdated(series);
+        library.RaiseItemRemoved(episode);
+        service.FlushPendingForTest();
+
+        Assert.False(service.ContainsKeyForTest(Key(episodeId)));
+    }
+
+    [Fact]
+    public void DerivedSeriesRefresh_RetainsDirtyOwnershipAcrossProlongedOutage()
+    {
+        var episodeId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+        var seriesId = Guid.Parse("00000000-0000-0000-0000-000000000002");
+        var oldSeries = new StubSeries
+        {
+            Id = seriesId,
+            CommunityRating = 1,
+            DateLastSaved = SavedAt,
+        };
+        var newSeries = new StubSeries
+        {
+            Id = seriesId,
+            CommunityRating = 9,
+            DateLastSaved = SavedAt.AddMinutes(1),
+        };
+        var episode = new StubEpisode
+        {
+            Id = episodeId,
+            SeriesId = seriesId,
+            CommunityRating = null,
+            DateLastSaved = SavedAt,
+        };
+        var seriesReads = 0;
+        var ancestorQueries = 0;
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => id == episodeId
+                ? episode
+                : id == seriesId
+                    ? seriesReads++ == 0 ? oldSeries : newSeries
+                    : null,
+            GetItemListHook = query =>
+            {
+                if (query.AncestorIds?.Contains(seriesId) == true)
+                {
+                    ancestorQueries++;
+                    if (ancestorQueries <= 5)
+                    {
+                        throw new InvalidOperationException("transient descendant discovery failure");
+                    }
+
+                    return new BaseItem[] { episode };
+                }
+
+                return query.ParentId == seriesId
+                    ? new BaseItem[] { episode }
+                    : Array.Empty<BaseItem>();
+            },
+        };
+        using var service = NewService(library);
+        service.SeedEntryForTest(Key(seriesId), new TagCacheEntry
+        {
+            Type = "Series",
+            CommunityRating = 1,
+        });
+        service.SeedEntryForTest(Key(episodeId), new TagCacheEntry
+        {
+            Type = "Episode",
+            CommunityRating = 1,
+        });
+        using var monitor = new TagCacheMonitor(library, service, NullLogger<TagCacheMonitor>.Instance);
+        monitor.Initialize();
+
+        library.RaiseItemUpdated(episode);
+        service.FlushPendingForTest();
+
+        Assert.Equal(1, service.PendingChangeCountForTest);
+        Assert.Equal(1, service.GetEntryForTest(Key(episodeId))!.CommunityRating);
+        Assert.Equal(9, service.GetEntryForTest(Key(seriesId))!.CommunityRating);
+
+        // Five consecutive failures exceed the old three-attempt cap. Ownership remains queued
+        // after every pass and the sixth attempt repairs the inheriting Episode.
+        for (var attempt = 0; attempt < 5; attempt++)
+        {
+            service.FlushPendingForTest();
+            Assert.Equal(1, service.PendingChangeCountForTest);
+            Assert.Equal(1, service.GetEntryForTest(Key(episodeId))!.CommunityRating);
+        }
+
+        service.FlushPendingForTest();
+
+        Assert.Equal(0, service.PendingChangeCountForTest);
+        Assert.Equal(6, ancestorQueries);
+        Assert.Equal(9, service.GetEntryForTest(Key(episodeId))!.CommunityRating);
+    }
+
+    [Fact]
+    public void ItemAddedBeforeLibraryVisibility_IsRetriedUntilResolvable()
+    {
+        var episodeId = Guid.NewGuid();
+        var visible = false;
+        var episode = new StubEpisode { Id = episodeId, DateLastSaved = SavedAt };
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => visible && id == episodeId ? episode : null,
+            GetItemListHook = _ => Array.Empty<BaseItem>(),
+        };
+        using var service = NewService(library);
+        using var monitor = new TagCacheMonitor(library, service, NullLogger<TagCacheMonitor>.Instance);
+        monitor.Initialize();
+
+        library.RaiseItemAdded(episode);
+        service.FlushPendingForTest();
+
+        Assert.Equal(1, service.PendingChangeCountForTest);
+        Assert.False(service.ContainsKeyForTest(Key(episodeId)));
+
+        visible = true;
+        service.FlushPendingForTest();
+
+        Assert.Equal(0, service.PendingChangeCountForTest);
+        Assert.True(service.ContainsKeyForTest(Key(episodeId)));
+    }
+
+    [Theory]
+    [InlineData(1, 3)]
+    [InlineData(2, 6)]
+    [InlineData(3, 12)]
+    [InlineData(8, 300)]
+    [InlineData(255, 300)]
+    public void RetryDelay_UsesBoundedExponentialBackoff(byte attempts, int expectedSeconds)
+        => Assert.Equal(
+            TimeSpan.FromSeconds(expectedSeconds),
+            TagCacheService.ComputeRetryDelay(attempts));
+
+    [Fact]
+    public void Dispose_DoesNotResurrectFlushTimerWhenSeriesDiscoveryFails()
+    {
+        var seriesId = Guid.NewGuid();
+        var series = new StubSeries { Id = seriesId, CommunityRating = 9, DateLastSaved = SavedAt };
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => id == seriesId ? series : null,
+            GetItemListHook = query => query.AncestorIds?.Contains(seriesId) == true
+                ? throw new InvalidOperationException("shutdown discovery outage")
+                : Array.Empty<BaseItem>(),
+        };
+        var service = NewService(library);
+        service.SeedEntryForTest(Key(seriesId), new TagCacheEntry { Type = "Series", CommunityRating = 1 });
+        using var monitor = new TagCacheMonitor(library, service, NullLogger<TagCacheMonitor>.Instance);
+        monitor.Initialize();
+
+        library.RaiseItemUpdated(series);
+        Assert.True(service.HasFlushTimerForTest);
+
+        service.Dispose();
+
+        Assert.False(service.HasFlushTimerForTest);
+        Assert.Equal(0, service.PendingChangeCountForTest);
+        service.FlushPendingForTest();
+        Assert.False(service.HasFlushTimerForTest);
+    }
+
+    [Fact]
+    public void Dispose_UnresolvedRepairMarksDiskSnapshotIncompleteSoStartupDiscardsIt()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "jc-tagcache-incomplete-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var seriesId = Guid.NewGuid();
+            var retainedId = Guid.NewGuid();
+            var series = new StubSeries { Id = seriesId, CommunityRating = 9, DateLastSaved = SavedAt };
+            var library = new CountingLibraryManager
+            {
+                GetItemByIdHook = id => id == seriesId ? series : null,
+                GetItemListHook = query => query.AncestorIds?.Contains(seriesId) == true
+                    ? throw new InvalidOperationException("shutdown discovery outage")
+                    : Array.Empty<BaseItem>(),
+            };
+            var service = new TagCacheService(
+                library,
+                new StubAppPaths(dir),
+                NullLogger<TagCacheService>.Instance);
+            service.SeedEntryForTest(Key(retainedId), new TagCacheEntry { Type = "Movie" });
+            service.EnqueueItemChange(series, removed: false);
+
+            service.Dispose();
+
+            using var loaded = new TagCacheService(
+                library,
+                new StubAppPaths(dir),
+                NullLogger<TagCacheService>.Instance);
+            loaded.LoadFromDisk();
+            Assert.Equal(0, loaded.Count);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public async Task DisposeGuardTimeout_DuringCancelledReconcileMarksSnapshotIncomplete()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "jc-tagcache-reconcile-shutdown-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var movie = new StubMovie { Id = Guid.NewGuid(), DateLastSaved = SavedAt };
+            using var entered = new ManualResetEventSlim();
+            using var release = new ManualResetEventSlim();
+            var library = new CountingLibraryManager
+            {
+                GetItemListHook = _ => new BaseItem[] { movie },
+                GetItemByIdHook = id => id == movie.Id ? movie : null,
+            };
+            var service = new TagCacheService(
+                library,
+                new StubAppPaths(dir),
+                NullLogger<TagCacheService>.Instance);
+            service.SeedEntryForTest(Key(movie.Id), new TagCacheEntry { Type = "Movie" });
+            service.SetDisposeFlushGuardSpinsForTest(0);
+            service.OnBeforeSwapForTest = () =>
+            {
+                entered.Set();
+                Assert.True(release.Wait(TimeSpan.FromSeconds(10)));
+                throw new OperationCanceledException("shutdown cancelled reconcile");
+            };
+            var reconcile = Task.Run(() => Assert.Throws<OperationCanceledException>(
+                () => service.BuildFullCache(progress: null, CancellationToken.None)));
+            Assert.True(entered.Wait(TimeSpan.FromSeconds(10)));
+
+            service.Dispose();
+            release.Set();
+            await reconcile.WaitAsync(TimeSpan.FromSeconds(10));
+
+            using var loaded = new TagCacheService(
+                library,
+                new StubAppPaths(dir),
+                NullLogger<TagCacheService>.Instance);
+            loaded.LoadFromDisk();
+            Assert.Equal(0, loaded.Count);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public async Task DisposeGuardTimeout_MarksSnapshotIncompleteEvenWhenFlushFinishesItsHandoff()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "jc-tagcache-dispose-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var movie = new StubMovie { Id = Guid.NewGuid(), DateLastSaved = SavedAt };
+            var arrivedAfterDrain = new StubMovie { Id = Guid.NewGuid(), DateLastSaved = SavedAt };
+            using var entered = new ManualResetEventSlim();
+            using var release = new ManualResetEventSlim();
+            var library = new CountingLibraryManager
+            {
+                GetItemByIdHook = id =>
+                {
+                    if (id == movie.Id)
+                    {
+                        entered.Set();
+                        Assert.True(release.Wait(TimeSpan.FromSeconds(10)));
+                        return movie;
+                    }
+
+                    return id == arrivedAfterDrain.Id ? arrivedAfterDrain : null;
+                },
+                GetItemListHook = _ => Array.Empty<BaseItem>(),
+            };
+            var service = new TagCacheService(
+                library,
+                new StubAppPaths(dir),
+                NullLogger<TagCacheService>.Instance);
+            service.SetDisposeFlushGuardSpinsForTest(0);
+            service.EnqueueItemChange(movie, removed: false);
+            var flushTask = Task.Run(service.FlushPendingForTest);
+            Assert.True(entered.Wait(TimeSpan.FromSeconds(10)));
+
+            service.EnqueueItemChange(arrivedAfterDrain, removed: false);
+            service.Dispose();
+            release.Set();
+            await flushTask.WaitAsync(TimeSpan.FromSeconds(10));
+
+            using var loaded = new TagCacheService(
+                library,
+                new StubAppPaths(dir),
+                NullLogger<TagCacheService>.Instance);
+            loaded.LoadFromDisk();
+            Assert.Equal(0, loaded.Count); // startup rebuilds instead of trusting the timed-out handoff
+            Assert.Equal(0, service.PendingChangeCountForTest);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+
+    private static TagCacheService NewService(CountingLibraryManager library)
+        => new(library, new StubAppPaths(Path.GetTempPath()), NullLogger<TagCacheService>.Instance);
+
+    private static string Key(Guid id) => id.ToString("N").ToLowerInvariant();
+
+    private static TagCacheEntry StaleContainer() => new()
+    {
+        Type = "Series",
+        Genres = new[] { "Stale" },
+        StreamData = new TagStreamData
+        {
+            ItemPath = "removed.mkv",
+            Streams = new List<TagMediaStream> { new() { Codec = "old-codec" } },
+            Sources = new List<TagMediaSource> { new() { Path = "/library/removed.mkv" } },
+        },
+        AudioLanguages = new[] { "old" },
+    };
+
+    private static TagCacheEntry StaleInherited() => new()
+    {
+        CommunityRating = 1,
+        CriticRating = 2,
+        Genres = new[] { "Stale" },
+        SeriesTmdbId = "old-series-tmdb",
+    };
+
+    private static void AssertReplacement(TagCacheEntry? entry)
+    {
+        Assert.NotNull(entry);
+        Assert.Equal(new[] { "Fresh" }, entry!.Genres);
+        Assert.Equal("replacement.mkv", entry.StreamData?.ItemPath);
+        var stream = Assert.Single(entry.StreamData!.Streams!);
+        Assert.Equal("Audio", stream.Type);
+        Assert.Equal("aac", stream.Codec);
+        var source = Assert.Single(entry.StreamData.Sources!);
+        Assert.Equal("replacement-source.mkv", source.Path);
+        Assert.Equal("Replacement source", source.Name);
+        Assert.Equal(new[] { "eng" }, entry.AudioLanguages);
+    }
+
+    private static void AssertInheritedSeriesFields(TagCacheEntry? entry)
+    {
+        Assert.NotNull(entry);
+        Assert.Equal(9.1f, entry!.CommunityRating);
+        Assert.Equal(91, entry.CriticRating);
+        Assert.Equal("new-series-tmdb", entry.SeriesTmdbId);
+    }
+
+    private sealed class ControlledEpisode : MediaBrowser.Controller.Entities.TV.Episode
+    {
+        public bool ThrowOnProbe { get; init; }
+
+        public IReadOnlyList<MediaSourceInfo> MediaSources { get; init; } = Array.Empty<MediaSourceInfo>();
+
+        public override string GetClientTypeName() => "Episode";
+
+        public override IReadOnlyList<MediaSourceInfo> GetMediaSources(bool enablePathSubstitution)
+            => ThrowOnProbe
+                ? throw new InvalidOperationException("transient replacement probe failure")
+                : MediaSources;
+    }
+
+    private sealed class CountingEpisode : MediaBrowser.Controller.Entities.TV.Episode
+    {
+        public Action? OnProbe { get; init; }
+
+        public override string GetClientTypeName() => "Episode";
+
+        public override IReadOnlyList<MediaSourceInfo> GetMediaSources(bool enablePathSubstitution)
+        {
+            OnProbe?.Invoke();
+            return Array.Empty<MediaSourceInfo>();
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/TagCachePendingChangesTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/TagCachePendingChangesTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using Jellyfin.Data.Enums;
 using Jellyfin.Plugin.JellyfinCanopy.Services;
 using Xunit;
 
@@ -7,20 +8,112 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
 {
     /// <summary>
     /// Pins the coalescing core that keeps tag-cache maintenance off Jellyfin's
-    /// library-scan thread. The scan raises one event per item (and, for episodes,
-    /// the monitor also names the parent Series and Season), so the same id can be
-    /// recorded hundreds of times per scan — this must collapse to one rebuild.
+    /// library-scan thread. A scan can raise the same item repeatedly; the cheap event
+    /// tokens must collapse before worker-side relationship expansion and rebuilding.
     /// </summary>
     public class TagCachePendingChangesTests
     {
+        [Fact]
+        public void LaterRealUpdate_ResetsRetryBudget()
+        {
+            var id = Guid.NewGuid();
+            var pending = new TagCachePendingChanges();
+            pending.Record(Change(id, BaseItemKind.Series, retryAttempts: 2));
+            pending.Record(Change(id, BaseItemKind.Series));
+
+            var change = Assert.Single(pending.Drain());
+            Assert.False(change.Removed);
+            Assert.Equal(0, change.RetryAttempts);
+        }
+
+        [Fact]
+        public void RealRemoval_WinsOverLaterRetry()
+        {
+            var id = Guid.NewGuid();
+            var pending = new TagCachePendingChanges();
+            pending.Record(Change(id, BaseItemKind.Series, removed: true));
+            pending.Record(Change(id, BaseItemKind.Series, retryAttempts: 1));
+
+            var change = Assert.Single(pending.Drain());
+            Assert.True(change.Removed);
+            Assert.Equal(0, change.RetryAttempts);
+        }
+
+        [Fact]
+        public void RealUpdate_WinsOverLaterStaleRetryWithoutRestoringItsBudget()
+        {
+            var id = Guid.NewGuid();
+            var pending = new TagCachePendingChanges();
+            pending.Record(Change(id, BaseItemKind.Series));
+
+            var retryRetained = pending.Record(Change(id, BaseItemKind.Series, retryAttempts: 8));
+
+            Assert.False(retryRetained);
+            var change = Assert.Single(pending.Drain());
+            Assert.False(change.Removed);
+            Assert.Equal(0, change.RetryAttempts);
+        }
+
+        [Fact]
+        public void RepeatedScanThreadRecords_DoNotAllocatePerEventClosures()
+        {
+            var pending = new TagCachePendingChanges();
+            var change = Change(Guid.NewGuid(), BaseItemKind.Episode);
+            pending.Record(change); // warm dictionary/JIT paths
+            var before = GC.GetAllocatedBytesForCurrentThread();
+
+            for (var index = 0; index < 10_000; index++)
+            {
+                pending.Record(change);
+            }
+
+            var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+            Assert.True(allocated < 4_096, $"Repeated records allocated {allocated:N0} bytes");
+        }
+
+        [Fact]
+        public void EpisodeReparenting_PreservesOldParentsAndLatestNewParents()
+        {
+            var id = Guid.NewGuid();
+            var oldSeries = Guid.NewGuid();
+            var oldSeason = Guid.NewGuid();
+            var intermediateSeries = Guid.NewGuid();
+            var intermediateSeason = Guid.NewGuid();
+            var latestSeries = Guid.NewGuid();
+            var latestSeason = Guid.NewGuid();
+            var pending = new TagCachePendingChanges();
+            pending.Record(new TagCacheChange(
+                id,
+                BaseItemKind.Episode,
+                intermediateSeries,
+                intermediateSeason,
+                oldSeries,
+                oldSeason,
+                Removed: false));
+            pending.Record(new TagCacheChange(
+                id,
+                BaseItemKind.Episode,
+                latestSeries,
+                latestSeason,
+                oldSeries,
+                oldSeason,
+                Removed: false));
+
+            var change = Assert.Single(pending.Drain());
+            Assert.Equal(oldSeries, change.PreviousSeriesId);
+            Assert.Equal(oldSeason, change.PreviousSeasonId);
+            Assert.Equal(latestSeries, change.SeriesId);
+            Assert.Equal(latestSeason, change.SeasonId);
+        }
+
         [Fact]
         public void Record_CoalescesRepeatedIdsIntoOneUnitOfWork()
         {
             var pending = new TagCachePendingChanges();
             var seriesId = Guid.NewGuid();
 
-            // A 300-episode series scan touching the same parent series every time.
-            for (var i = 0; i < 300; i++) pending.Record(seriesId, removed: false);
+            // A large series scan touching the same parent series on every Episode event.
+            for (var i = 0; i < 10_000; i++) pending.Record(seriesId, removed: false);
 
             var batch = pending.Drain();
 
@@ -94,5 +187,20 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             Assert.False(byId[a]);
             Assert.True(byId[b]);
         }
+
+        private static TagCacheChange Change(
+            Guid id,
+            BaseItemKind? kind,
+            bool removed = false,
+            byte retryAttempts = 0)
+            => new(
+                id,
+                kind,
+                Guid.Empty,
+                Guid.Empty,
+                Guid.Empty,
+                Guid.Empty,
+                removed,
+                retryAttempts);
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/TagCacheReconcileTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/TagCacheReconcileTests.cs
@@ -344,12 +344,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
         }
 
         [Fact]
-        public void Reconcile_SeriesRatingChange_WithEpisodeProbeDown_KeepsCorrectInheritedRating_ThenRecoversDurably()
+        public void Reconcile_SeriesRatingChange_RefreshesInheritedEpisodeWithoutReprobingItsMedia()
         {
-            // The confirmation scenario: a series rating changes while an inheriting episode's probe
-            // is down. The episode's inherited rating comes from the series (probe-independent), so it
-            // must be correct even during the outage, and the unconfirmed revision must drive recovery
-            // on the next reconcile even though the series "changed" signal is not re-raised.
+            // Parent-only metadata is independent of Episode media. A reconcile can update the
+            // inherited field from its stable snapshot without turning an otherwise confirmed entry
+            // into an unconfirmed probe retry during an unrelated media outage.
             var dir = NewTempDir();
             try
             {
@@ -367,6 +366,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
 
                 svc.BuildFullCache(null, CT);
                 Assert.Equal(5.0f, svc.GetEntryForTest(Key(epId))!.CommunityRating); // inherited
+                var probesBeforeParentChange = ep.ProbeCount;
 
                 // Series rating changes; episode's own revision does NOT change; episode probe is down.
                 series.CommunityRating = 8.0f;
@@ -377,10 +377,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
                 var afterFail = svc.GetEntryForTest(Key(epId));
                 Assert.NotNull(afterFail);
                 Assert.Equal(8.0f, afterFail!.CommunityRating); // correct inherited rating despite probe down
-                Assert.Equal(0L, afterFail.SourceRevision);     // unconfirmed
+                Assert.Equal(T0.Ticks, afterFail.SourceRevision); // own Episode source stays confirmed
+                Assert.Equal(probesBeforeParentChange + 1, ep.ProbeCount); // Series container only
 
-                // Probe recovers. Even though seriesRatingChanged no longer fires (series entry settled)
-                // and the episode's own revision is unchanged, the unconfirmed revision forces a rebuild.
+                // Probe recovery does not churn the unchanged Episode either.
                 ep.ThrowOnProbe = false;
                 svc.BuildFullCache(null, CT);
                 var recovered = svc.GetEntryForTest(Key(epId));
@@ -415,10 +415,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
         {
             public bool ThrowOnProbe { get; set; }
 
+            public int ProbeCount { get; private set; }
+
             public override string GetClientTypeName() => "Episode";
 
             public override IReadOnlyList<MediaSourceInfo> GetMediaSources(bool enablePathSubstitution)
             {
+                ProbeCount++;
                 if (ThrowOnProbe) throw new InvalidOperationException("transient probe failure");
                 return Array.Empty<MediaSourceInfo>();
             }

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/TagCacheSpoilerStripTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/TagCacheSpoilerStripTests.cs
@@ -352,19 +352,21 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             return path;
         }
 
-        [Fact]
-        public void LoadFromDisk_OldSchema_DiscardsEntries()
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        public void LoadFromDisk_OldSchema_DiscardsEntries(int schemaVersion)
         {
             var dir = Path.Combine(Path.GetTempPath(), "jc-tagcache-" + Guid.NewGuid().ToString("N"));
             try
             {
                 var key = Guid.NewGuid().ToString("N");
-                WriteCache(dir, schemaVersion: 1, key, new TagCacheEntry { Type = "Episode", SeriesId = null });
+                WriteCache(dir, schemaVersion, key, new TagCacheEntry { Type = "Episode", SeriesId = null });
 
                 using var svc = NewServiceAt(dir);
                 svc.LoadFromDisk();
 
-                // v1 cache lacks SeriesId → discarded, so the strip can't be defeated by stale data.
+                // v1 lacks SeriesId; v2 lacks SeasonId/StreamSourceId. Both are discarded.
                 Assert.Equal(0, svc.Count);
             }
             finally
@@ -381,7 +383,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             {
                 var key = Guid.NewGuid().ToString("N");
                 var seriesN = Guid.NewGuid().ToString("N");
-                WriteCache(dir, schemaVersion: 2, key, new TagCacheEntry { Type = "Episode", SeriesId = seriesN });
+                WriteCache(dir, schemaVersion: 3, key, new TagCacheEntry { Type = "Episode", SeriesId = seriesN });
 
                 using var svc = NewServiceAt(dir);
                 svc.LoadFromDisk();

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/TestDoubles/CountingLibraryManager.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/TestDoubles/CountingLibraryManager.cs
@@ -64,6 +64,10 @@ public sealed class CountingLibraryManager : ILibraryManager
     public void RaiseItemAdded(BaseItem item)
         => _itemAdded?.Invoke(this, new ItemChangeEventArgs { Item = item });
 
+    /// <summary>Raise Jellyfin's synchronous item-updated event.</summary>
+    public void RaiseItemUpdated(BaseItem item)
+        => _itemUpdated?.Invoke(this, new ItemChangeEventArgs { Item = item });
+
     /// <summary>Raise Jellyfin's synchronous item-removed event.</summary>
     public void RaiseItemRemoved(BaseItem item)
         => _itemRemoved?.Invoke(this, new ItemChangeEventArgs { Item = item });

--- a/Jellyfin.Plugin.JellyfinCanopy/Model/TagCacheEntry.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Model/TagCacheEntry.cs
@@ -28,6 +28,17 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Model
         // without a per-episode library lookup on every request.
         public string? SeriesId { get; set; }
 
+        // Season ID in N format (lowercase). Set for Episodes only. This is persisted
+        // dependency metadata: an ItemUpdated event exposes the Episode's NEW parent,
+        // while invalidation also needs the cached OLD Season after a reparent.
+        public string? SeasonId { get; set; }
+
+        // ID in N format of the item that supplied StreamData/AudioLanguages. For a
+        // Series or Season this is its selected first Episode; for an ordinary item it
+        // is the item itself. Probe-failure fallback may retain last-good media only
+        // when this identity is unchanged, never across first-Episode replacement.
+        public string? StreamSourceId { get; set; }
+
         // Source item revision (BaseItem.DateLastSaved ticks) captured when this
         // entry was built. The daily reconcile (TagCacheService.BuildFullCache)
         // uses it as a cheap candidate gate: an item whose revision is unchanged
@@ -66,6 +77,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Model
             StreamData = StreamData,
             LastUpdated = LastUpdated,
             SeriesId = SeriesId,
+            SeasonId = SeasonId,
+            StreamSourceId = StreamSourceId,
             SourceRevision = SourceRevision,
         };
     }

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/TagCacheDependencyGraph.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/TagCacheDependencyGraph.cs
@@ -1,0 +1,382 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Jellyfin.Data.Enums;
+using Jellyfin.Plugin.JellyfinCanopy.Model;
+using MediaBrowser.Controller.Entities;
+using Episode = MediaBrowser.Controller.Entities.TV.Episode;
+using Season = MediaBrowser.Controller.Entities.TV.Season;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Services
+{
+    [Flags]
+    internal enum TagCacheFieldDependency
+    {
+        OwnItem = 1,
+        FirstEpisode = 2,
+        ParentSeries = 4,
+    }
+
+    /// <summary>
+    /// Cheap library-event identity captured on Jellyfin's synchronous scan thread.
+    /// Parent ids are copied from the event item; dependency discovery never runs there.
+    /// </summary>
+    internal readonly record struct TagCacheChange(
+        Guid Id,
+        BaseItemKind? Kind,
+        Guid SeriesId,
+        Guid SeasonId,
+        Guid PreviousSeriesId,
+        Guid PreviousSeasonId,
+        bool Removed,
+        byte RetryAttempts = 0);
+
+    /// <summary>
+    /// Authoritative dependency inventory for every <see cref="TagCacheEntry"/> field.
+    /// The background tag-cache worker uses the same graph to expand invalidations:
+    /// first-Episode fields invalidate their Series/Season containers, while fields
+    /// inherited from a Series invalidate only that Series' Episode/Season descendants.
+    /// </summary>
+    internal static class TagCacheDependencyGraph
+    {
+        internal static IReadOnlyDictionary<string, TagCacheFieldDependency> FieldDependencies { get; }
+            = new Dictionary<string, TagCacheFieldDependency>(StringComparer.Ordinal)
+            {
+                [nameof(TagCacheEntry.Type)] = TagCacheFieldDependency.OwnItem,
+                [nameof(TagCacheEntry.TmdbId)] = TagCacheFieldDependency.OwnItem,
+                [nameof(TagCacheEntry.SeriesTmdbId)] = TagCacheFieldDependency.OwnItem
+                    | TagCacheFieldDependency.ParentSeries,
+                [nameof(TagCacheEntry.SeasonNumber)] = TagCacheFieldDependency.OwnItem,
+                [nameof(TagCacheEntry.EpisodeNumber)] = TagCacheFieldDependency.OwnItem,
+                [nameof(TagCacheEntry.Genres)] = TagCacheFieldDependency.OwnItem
+                    | TagCacheFieldDependency.FirstEpisode
+                    | TagCacheFieldDependency.ParentSeries,
+                [nameof(TagCacheEntry.CommunityRating)] = TagCacheFieldDependency.OwnItem
+                    | TagCacheFieldDependency.ParentSeries,
+                [nameof(TagCacheEntry.CriticRating)] = TagCacheFieldDependency.OwnItem
+                    | TagCacheFieldDependency.ParentSeries,
+                [nameof(TagCacheEntry.AudioLanguages)] = TagCacheFieldDependency.OwnItem
+                    | TagCacheFieldDependency.FirstEpisode,
+                [nameof(TagCacheEntry.StreamData)] = TagCacheFieldDependency.OwnItem
+                    | TagCacheFieldDependency.FirstEpisode,
+                [nameof(TagCacheEntry.LastUpdated)] = TagCacheFieldDependency.OwnItem,
+                [nameof(TagCacheEntry.SeriesId)] = TagCacheFieldDependency.OwnItem,
+                [nameof(TagCacheEntry.SeasonId)] = TagCacheFieldDependency.OwnItem,
+                [nameof(TagCacheEntry.StreamSourceId)] = TagCacheFieldDependency.OwnItem
+                    | TagCacheFieldDependency.FirstEpisode,
+                [nameof(TagCacheEntry.SourceRevision)] = TagCacheFieldDependency.OwnItem,
+            };
+
+        /// <summary>
+        /// Exact descendant item kinds that can inherit each parent-Series field. Keeping this
+        /// beside <see cref="FieldDependencies"/> prevents a new field from silently widening
+        /// invalidation to descendants that never consume it.
+        /// </summary>
+        internal static IReadOnlyDictionary<string, BaseItemKind[]> ParentSeriesConsumers { get; }
+            = new Dictionary<string, BaseItemKind[]>(StringComparer.Ordinal)
+            {
+                [nameof(TagCacheEntry.SeriesTmdbId)] = new[] { BaseItemKind.Episode, BaseItemKind.Season },
+                [nameof(TagCacheEntry.Genres)] = new[] { BaseItemKind.Season },
+                [nameof(TagCacheEntry.CommunityRating)] = new[] { BaseItemKind.Episode, BaseItemKind.Season },
+                [nameof(TagCacheEntry.CriticRating)] = new[] { BaseItemKind.Episode, BaseItemKind.Season },
+            };
+
+        /// <summary>
+        /// Capture only O(1), already-materialized item identity. Safe on the scan thread.
+        /// </summary>
+        internal static TagCacheChange Capture(BaseItem item, bool removed, TagCacheEntry? previous)
+        {
+            var kind = item.GetBaseItemKind();
+            var previousSeriesId = ParseId(previous?.SeriesId);
+            var previousSeasonId = ParseId(previous?.SeasonId);
+            return item switch
+            {
+                Episode episode => new TagCacheChange(
+                    item.Id,
+                    kind,
+                    episode.SeriesId,
+                    episode.SeasonId,
+                    previousSeriesId,
+                    previousSeasonId,
+                    removed),
+                Season season => new TagCacheChange(
+                    item.Id,
+                    kind,
+                    season.SeriesId,
+                    Guid.Empty,
+                    previousSeriesId,
+                    Guid.Empty,
+                    removed),
+                _ => new TagCacheChange(
+                    item.Id,
+                    kind,
+                    Guid.Empty,
+                    Guid.Empty,
+                    Guid.Empty,
+                    Guid.Empty,
+                    removed),
+            };
+        }
+
+        private static Guid ParseId(string? value)
+            => Guid.TryParseExact(value, "N", out var id) ? id : Guid.Empty;
+
+        internal static bool NeedsSeriesDescendantDiscovery(TagCacheChange change)
+            => !change.Removed && change.Kind == BaseItemKind.Series;
+
+        internal static IEnumerable<(Guid Id, BaseItemKind Kind)> DirectDerivedTargets(TagCacheChange change)
+        {
+            if (change.Kind == BaseItemKind.Episode)
+            {
+                if (change.PreviousSeriesId != Guid.Empty) yield return (change.PreviousSeriesId, BaseItemKind.Series);
+                if (change.PreviousSeasonId != Guid.Empty) yield return (change.PreviousSeasonId, BaseItemKind.Season);
+                if (change.SeriesId != Guid.Empty) yield return (change.SeriesId, BaseItemKind.Series);
+                if (change.SeasonId != Guid.Empty) yield return (change.SeasonId, BaseItemKind.Season);
+            }
+            else if (change.Kind == BaseItemKind.Season)
+            {
+                // A Series' selected first Episode is recursive through its Seasons.
+                if (change.PreviousSeriesId != Guid.Empty) yield return (change.PreviousSeriesId, BaseItemKind.Series);
+                if (change.SeriesId != Guid.Empty) yield return (change.SeriesId, BaseItemKind.Series);
+            }
+        }
+
+        internal static bool ExplicitChangeEscapedRemovedContainers(
+            TagCacheChange explicitChange,
+            bool matchedRemovedSeries,
+            bool matchedRemovedSeason,
+            ISet<Guid> removedSeriesIds,
+            ISet<Guid> removedSeasonIds)
+        {
+            var escapedSeries = !matchedRemovedSeries
+                || (!explicitChange.Removed
+                    && (explicitChange.Kind == BaseItemKind.Episode
+                        || explicitChange.Kind == BaseItemKind.Season)
+                    && !removedSeriesIds.Contains(explicitChange.SeriesId));
+            var escapedSeason = !matchedRemovedSeason
+                || (!explicitChange.Removed
+                    && explicitChange.Kind == BaseItemKind.Episode
+                    && !removedSeasonIds.Contains(explicitChange.SeasonId));
+            return escapedSeries && escapedSeason;
+        }
+
+        internal static BaseItemKind[] DescendantKinds()
+            => ParentSeriesConsumers.Values
+                .SelectMany(static kinds => kinds)
+                .Distinct()
+                .OrderBy(static kind => kind)
+                .ToArray();
+
+        /// <summary>
+        /// Return true only when rebuilding this descendant would change a field it
+        /// actually inherits from <paramref name="series"/>. The worker queries one
+        /// Series subtree, then this authoritative graph prevents same-kind items
+        /// with their own ratings/genres from being journalled as unrelated upserts.
+        /// </summary>
+        internal static bool RequiresParentSeriesRefresh(
+            BaseItem series,
+            BaseItem descendant,
+            TagCacheEntry? existing,
+            Func<BaseItem, BaseItem?> firstEpisode)
+        {
+            var related = descendant is Episode relatedEpisode && relatedEpisode.SeriesId == series.Id
+                || descendant is Season relatedSeason && relatedSeason.SeriesId == series.Id;
+            if (!related)
+            {
+                return false;
+            }
+
+            if (existing == null)
+            {
+                return true;
+            }
+
+            return TryPrepareParentSeriesRefresh(
+                series,
+                descendant,
+                existing,
+                firstEpisode,
+                existing.LastUpdated,
+                out _);
+        }
+
+        internal static bool TryPrepareParentSeriesRefresh(
+            BaseItem series,
+            BaseItem descendant,
+            TagCacheEntry existing,
+            Func<BaseItem, BaseItem?> firstEpisode,
+            long lastUpdated,
+            out TagCacheEntry? refreshed)
+        {
+            var kind = descendant.GetBaseItemKind();
+            var related = descendant is Episode relatedEpisode && relatedEpisode.SeriesId == series.Id
+                || descendant is Season relatedSeason && relatedSeason.SeriesId == series.Id;
+            if (!related)
+            {
+                refreshed = null;
+                return false;
+            }
+
+            var requiresRefresh = false;
+            foreach (var dependency in ParentSeriesConsumers)
+            {
+                if (Array.IndexOf(dependency.Value, kind) >= 0
+                    && ParentSeriesFieldRequiresChange(
+                        dependency.Key,
+                        series,
+                        descendant,
+                        existing,
+                        firstEpisode))
+                {
+                    requiresRefresh = true;
+                    break;
+                }
+            }
+
+            if (!requiresRefresh)
+            {
+                refreshed = null;
+                return false;
+            }
+
+            refreshed = ApplyParentSeriesRefresh(series, descendant, existing, firstEpisode, lastUpdated);
+            return true;
+        }
+
+        internal static bool ParentSeriesSurfaceChanged(TagCacheEntry previous, TagCacheEntry current)
+            => previous.CommunityRating != current.CommunityRating
+                || previous.CriticRating != current.CriticRating
+                || !string.Equals(previous.TmdbId, current.TmdbId, StringComparison.Ordinal)
+                || !(previous.Genres ?? Array.Empty<string>())
+                    .SequenceEqual(current.Genres ?? Array.Empty<string>());
+
+        /// <summary>
+        /// Apply only the fields declared as ParentSeries dependencies. Expansion already owns
+        /// the live subtree snapshot, so descendant repair never re-resolves or media-probes an
+        /// otherwise unchanged Episode/Season merely because parent metadata changed.
+        /// </summary>
+        internal static TagCacheEntry ApplyParentSeriesRefresh(
+            BaseItem series,
+            BaseItem descendant,
+            TagCacheEntry existing,
+            Func<BaseItem, BaseItem?> firstEpisode,
+            long lastUpdated)
+        {
+            var refreshed = existing.Clone();
+            var kind = descendant.GetBaseItemKind();
+            var inheritsRatings = descendant.CommunityRating == null;
+            var inheritsGenres = descendant is Season season
+                && season.CommunityRating == null
+                && (season.Genres?.Length ?? 0) == 0
+                && (firstEpisode(season)?.Genres?.Length ?? 0) == 0;
+            foreach (var dependency in ParentSeriesConsumers)
+            {
+                if (Array.IndexOf(dependency.Value, kind) < 0)
+                {
+                    continue;
+                }
+
+                switch (dependency.Key)
+                {
+                    case nameof(TagCacheEntry.SeriesTmdbId):
+                        refreshed.SeriesTmdbId = series.ProviderIds?.TryGetValue("Tmdb", out var tmdbId) == true
+                            ? tmdbId
+                            : null;
+                        break;
+                    case nameof(TagCacheEntry.CommunityRating) when inheritsRatings:
+                        refreshed.CommunityRating = series.CommunityRating;
+                        break;
+                    case nameof(TagCacheEntry.CriticRating) when inheritsRatings:
+                        refreshed.CriticRating = series.CriticRating;
+                        break;
+                    case nameof(TagCacheEntry.Genres) when inheritsGenres:
+                        refreshed.Genres = series.Genres;
+                        break;
+                    case nameof(TagCacheEntry.CommunityRating):
+                    case nameof(TagCacheEntry.CriticRating):
+                    case nameof(TagCacheEntry.Genres):
+                        break;
+                    default:
+                        throw new InvalidOperationException($"Unhandled parent-Series dependency field: {dependency.Key}");
+                }
+            }
+
+            refreshed.LastUpdated = lastUpdated;
+            return refreshed;
+        }
+
+        internal static TagCacheEntry ApplySeasonRelationshipRefresh(
+            BaseItem? series,
+            Episode episode,
+            TagCacheEntry existing,
+            long lastUpdated)
+        {
+            var refreshed = existing.Clone();
+            refreshed.SeriesId = episode.SeriesId == Guid.Empty ? null : episode.SeriesId.ToString("N");
+            refreshed.SeasonId = episode.SeasonId == Guid.Empty ? null : episode.SeasonId.ToString("N");
+            refreshed.SeasonNumber = episode.ParentIndexNumber;
+            refreshed.SeriesTmdbId = series?.ProviderIds?.TryGetValue("Tmdb", out var tmdbId) == true
+                ? tmdbId
+                : null;
+            if (episode.CommunityRating == null)
+            {
+                refreshed.CommunityRating = series?.CommunityRating;
+                refreshed.CriticRating = series?.CriticRating;
+            }
+
+            refreshed.LastUpdated = lastUpdated;
+            return refreshed;
+        }
+
+        internal static TagCacheEntry ApplySeriesRelationshipRefresh(
+            BaseItem series,
+            BaseItem descendant,
+            TagCacheEntry existing,
+            Func<BaseItem, BaseItem?> firstEpisode,
+            long lastUpdated)
+        {
+            if (descendant is Episode episode)
+            {
+                return ApplySeasonRelationshipRefresh(series, episode, existing, lastUpdated);
+            }
+
+            var refreshed = ApplyParentSeriesRefresh(
+                series,
+                descendant,
+                existing,
+                firstEpisode,
+                lastUpdated);
+            if (descendant is Season)
+            {
+                refreshed.SeriesId = series.Id.ToString("N");
+            }
+
+            return refreshed;
+        }
+
+        private static bool ParentSeriesFieldRequiresChange(
+            string field,
+            BaseItem series,
+            BaseItem descendant,
+            TagCacheEntry existing,
+            Func<BaseItem, BaseItem?> firstEpisode)
+            => field switch
+            {
+                nameof(TagCacheEntry.SeriesTmdbId) => !string.Equals(
+                    existing.SeriesTmdbId,
+                    series.ProviderIds?.TryGetValue("Tmdb", out var tmdbId) == true ? tmdbId : null,
+                    StringComparison.Ordinal),
+                nameof(TagCacheEntry.CommunityRating) => descendant.CommunityRating == null
+                    && existing.CommunityRating != series.CommunityRating,
+                nameof(TagCacheEntry.CriticRating) => descendant.CommunityRating == null
+                    && existing.CriticRating != series.CriticRating,
+                nameof(TagCacheEntry.Genres) => descendant is Season season
+                    && season.CommunityRating == null
+                    && (season.Genres?.Length ?? 0) == 0
+                    && (firstEpisode(season)?.Genres?.Length ?? 0) == 0
+                    && !(existing.Genres ?? Array.Empty<string>())
+                        .SequenceEqual(series.Genres ?? Array.Empty<string>()),
+                _ => throw new InvalidOperationException($"Unhandled parent-Series dependency field: {field}"),
+            };
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/TagCacheMonitor.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/TagCacheMonitor.cs
@@ -56,28 +56,20 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             var kind = item.GetBaseItemKind();
             if (!TagCacheService.TaggableTypes.Contains(kind)) return;
 
-            // PERF(S1): only record ids here — no DB query, no media probe. Jellyfin raises
+            // PERF(S1): only record the already-materialized item identity here — no DB query,
+            // descendant discovery, or media probe. Jellyfin raises
             // these events synchronously on the library-scan thread (once per item, many times
             // during a scan), so the heavy BuildEntryForItem work is coalesced and run
-            // off-thread by the service. See TagCacheService.EnqueueUpdate and
+            // off-thread by the service. See TagCacheService.EnqueueItemChange and
             // docs/developers.md#performance-rules (S1).
-            _tagCacheService.EnqueueUpdate(item.Id);
-
-            // An episode change can alter its parent Series/Season derived data
-            // (first-episode genres/streams/ratings), so queue those too. SeriesId and
-            // SeasonId are in-memory properties, so reading them costs nothing and never
-            // touches the database. Empty guids are ignored by EnqueueUpdate.
-            if (kind == BaseItemKind.Episode && item is MediaBrowser.Controller.Entities.TV.Episode ep)
-            {
-                _tagCacheService.EnqueueUpdate(ep.SeriesId);
-                _tagCacheService.EnqueueUpdate(ep.SeasonId);
-            }
+            _tagCacheService.EnqueueItemChange(item, removed: false);
         }
 
         private void OnItemRemoved(object? sender, ItemChangeEventArgs e)
         {
-            if (e.Item == null) return;
-            _tagCacheService.EnqueueRemoval(e.Item.Id);
+            var item = e.Item;
+            if (item == null || !TagCacheService.TaggableTypes.Contains(item.GetBaseItemKind())) return;
+            _tagCacheService.EnqueueItemChange(item, removed: true);
         }
 
         public void Dispose()

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/TagCachePendingChanges.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/TagCachePendingChanges.cs
@@ -9,17 +9,17 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
     /// Thread-safe, coalescing set of pending tag-cache changes.
     ///
     /// Jellyfin raises ItemAdded/ItemUpdated/ItemRemoved synchronously on the
-    /// library-scan thread, once per item — and, for episodes, the monitor also
-    /// targets the parent Series and Season — so a single TV scan can name the
-    /// same parent id hundreds of times. Recording is O(1) and last-write-wins per
-    /// id, so a burst collapses to one entry per id; <see cref="Drain"/> then hands
+    /// library-scan thread, once per item, so a single TV scan can name the same
+    /// item repeatedly. Recording is O(1) and last-write-wins per id; dependency
+    /// expansion later coalesces shared parents on the worker. <see cref="Drain"/> hands
     /// the background worker exactly one unit of work per distinct id instead of one
     /// per event. This is what keeps the heavy per-item rebuild off the scan thread.
     /// </summary>
     internal sealed class TagCachePendingChanges
     {
-        // id -> true when the last observed change was a removal, false for an add/update.
-        private readonly ConcurrentDictionary<Guid, bool> _pending = new();
+        // Changed item id -> latest explicit event token. Dependency expansion happens only
+        // after Drain, on the background worker, so recording remains O(1).
+        private readonly ConcurrentDictionary<Guid, PendingSlot> _pending = new();
 
         /// <summary>
         /// Record the latest intent for an id. Last write wins, so a removal that
@@ -28,31 +28,111 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         /// </summary>
         public void Record(Guid id, bool removed)
         {
-            if (id == Guid.Empty) return;
-            _pending[id] = removed;
+            Record(new TagCacheChange(
+                id,
+                null,
+                Guid.Empty,
+                Guid.Empty,
+                Guid.Empty,
+                Guid.Empty,
+                removed));
         }
+
+        /// <summary>
+        /// Record a library event together with its already-materialized relationship ids.
+        /// </summary>
+        public bool Record(TagCacheChange change)
+        {
+            if (change.Id == Guid.Empty) return false;
+            while (true)
+            {
+                if (_pending.TryGetValue(change.Id, out var slot))
+                {
+                    lock (slot)
+                    {
+                        if (!slot.Active)
+                        {
+                            continue;
+                        }
+
+                        slot.Change = Merge(slot.Change, change);
+                        return change.RetryAttempts == 0 || slot.Change.RetryAttempts != 0;
+                    }
+                }
+
+                var candidate = new PendingSlot(change);
+                if (_pending.TryAdd(change.Id, candidate))
+                {
+                    return true;
+                }
+            }
+        }
+
+        private static TagCacheChange Merge(TagCacheChange existing, TagCacheChange incoming)
+        {
+            // A retry recorded by the worker must not overwrite a genuine event that arrived
+            // while discovery/rebuild was in flight. Conversely, a later genuine event resets
+            // the retry budget and keeps normal last-write-wins intent.
+            if (incoming.RetryAttempts != 0 && existing.RetryAttempts == 0)
+            {
+                return existing;
+            }
+
+            // The cache still represents the relationship present before this debounce window.
+            // Preserve that earliest parent while taking the latest current parent/intent. This
+            // fixed-size merge stays O(1) and repairs both sides of Episode reparenting.
+            return incoming with
+            {
+                PreviousSeriesId = FirstNonEmpty(existing.PreviousSeriesId, incoming.PreviousSeriesId),
+                PreviousSeasonId = FirstNonEmpty(existing.PreviousSeasonId, incoming.PreviousSeasonId),
+                RetryAttempts = incoming.RetryAttempts == 0
+                    ? (byte)0
+                    : existing.RetryAttempts >= incoming.RetryAttempts
+                        ? existing.RetryAttempts
+                        : incoming.RetryAttempts,
+            };
+        }
+
+        private static Guid FirstNonEmpty(Guid left, Guid right)
+            => left != Guid.Empty ? left : right;
 
         public bool IsEmpty => _pending.IsEmpty;
 
         public int Count => _pending.Count;
 
         /// <summary>
-        /// Atomically remove and return every pending change. Ids recorded after the
-        /// drain begins are left in the set for the next drain (their Record call
-        /// re-arms the worker), so no change is lost.
+        /// Remove and return every pending change. A concurrent record is either merged
+        /// into the slot this drain returns or observes the retired slot and creates one
+        /// for the next drain, so no change is lost at the handoff boundary.
         /// </summary>
-        public IReadOnlyList<(Guid Id, bool Removed)> Drain()
+        public IReadOnlyList<TagCacheChange> Drain()
         {
-            var batch = new List<(Guid, bool)>(_pending.Count);
+            var batch = new List<TagCacheChange>(_pending.Count);
             foreach (var id in _pending.Keys.ToList())
             {
-                if (_pending.TryRemove(id, out var removed))
+                if (_pending.TryRemove(id, out var slot))
                 {
-                    batch.Add((id, removed));
+                    lock (slot)
+                    {
+                        slot.Active = false;
+                        batch.Add(slot.Change);
+                    }
                 }
             }
 
             return batch;
+        }
+
+        private sealed class PendingSlot
+        {
+            public PendingSlot(TagCacheChange change)
+            {
+                Change = change;
+            }
+
+            public TagCacheChange Change { get; set; }
+
+            public bool Active { get; set; } = true;
         }
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/TagCacheService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/TagCacheService.cs
@@ -135,9 +135,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         // no DB/probe work) and drained by a debounced background worker so scans are
         // never blocked and repeated hits on the same id coalesce to one rebuild.
         private readonly TagCachePendingChanges _pending = new();
+        private readonly object _lifecycleGate = new();
         private Timer? _flushTimer;
         private long _firstPendingTicks; // 0 = nothing pending since last flush
         private int _flushing;           // 0/1 non-reentrancy guard for the worker
+        private int _disposed;           // 0/1; prevents timer resurrection during shutdown
+        private long _retryBackoffTicks;
+        private long _removedDependencyEntriesVisited;
+        private int _repairIncomplete;
         private static readonly TimeSpan FlushDebounce = TimeSpan.FromSeconds(3);
         private static readonly TimeSpan FlushMaxWait = TimeSpan.FromSeconds(30);
 
@@ -148,6 +153,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         // multi-second wait.
         private int _rebuildFlushGuardSpins = 3000;
         internal void SetRebuildFlushGuardSpinsForTest(int spins) => _rebuildFlushGuardSpins = spins;
+        private int _disposeFlushGuardSpins = 500;
+        internal void SetDisposeFlushGuardSpinsForTest(int spins) => _disposeFlushGuardSpins = spins;
 
         // Bump whenever a TagCacheEntry field the STRIP paths depend on is added,
         // so a cache serialized by an older build is discarded and rebuilt. v2
@@ -155,7 +162,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         // has null SeriesId on every episode, so the strip skips them and unstripped
         // ratings leak onto guarded cards via renderFromServerCache. Discarding
         // starts empty (client falls back to the live/per-batch strip) until rebuild.
-        private const int CurrentCacheSchemaVersion = 2;
+        // v3 adds persisted Episode SeasonId and stream-source identity. Both are
+        // correctness-critical dependency metadata, so older entries are rebuilt.
+        private const int CurrentCacheSchemaVersion = 3;
 
         // User access cache: avoids expensive GetItemIds query on every request.
         // Jellyfin increments User.RowVersion for every persisted policy update,
@@ -219,6 +228,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 DateTime.UtcNow);
 
         internal void FlushPendingForTest() => FlushPending();
+
+        internal int PendingChangeCountForTest => _pending.Count;
+
+        internal bool HasFlushTimerForTest => Volatile.Read(ref _flushTimer) != null;
+
+        internal long RemovedDependencyEntriesVisitedForTest
+            => Interlocked.Read(ref _removedDependencyEntriesVisited);
 
         internal bool ContainsKeyForTest(string key) => _cache.ContainsKey(key);
 
@@ -318,23 +334,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
 
                 _logger.LogInformation($"[TagCache] Found {allItems.Count} taggable items");
 
-                // Pass 1: which series' own rating changed since its cached entry was built. An
-                // Episode with no rating of its own inherits its parent series' rating, so a series
-                // rating change must re-derive those episodes even when the episode's own
-                // DateLastSaved is unchanged. A Series entry stores the series' own rating verbatim
-                // (no fallback), so comparing the live value against the old entry is exact.
-                var seriesRatingChanged = new HashSet<Guid>();
-                foreach (var item in allItems)
-                {
-                    if (item.GetBaseItemKind() != BaseItemKind.Series) continue;
-                    var sKey = item.Id.ToString("N").ToLowerInvariant();
-                    if (!oldCache.TryGetValue(sKey, out var oldSeries)
-                        || oldSeries.CommunityRating != item.CommunityRating
-                        || oldSeries.CriticRating != item.CriticRating)
-                    {
-                        seriesRatingChanged.Add(item.Id);
-                    }
-                }
+                // Parent-Series dependencies share the same authoritative graph as incremental
+                // events. This also heals a missed TMDB/rating event for an unchanged Episode;
+                // containers are rebuilt unconditionally below because they derive first-Episode
+                // data whose revision is independent of the container's own revision.
+                var seriesById = allItems
+                    .Where(static item => item.GetBaseItemKind() == BaseItemKind.Series)
+                    .ToDictionary(static item => item.Id);
 
                 var newCache = new ConcurrentDictionary<string, TagCacheEntry>();
                 var changed = false; // an add or a genuine content change (drives the ?since= delta)
@@ -350,12 +356,41 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     var revision = item.DateLastSaved.Ticks;
                     oldCache.TryGetValue(key, out var old);
 
-                    var parentSeriesRatingChanged =
-                        kind == BaseItemKind.Episode
+                    TagCacheEntry? parentSeriesRefresh = null;
+                    var parentOrRelationshipChanged = false;
+                    if (kind == BaseItemKind.Episode
                         && item is MediaBrowser.Controller.Entities.TV.Episode epDep
-                        && seriesRatingChanged.Contains(epDep.SeriesId);
+                        && old != null
+                        && old.SourceRevision == revision)
+                    {
+                        seriesById.TryGetValue(epDep.SeriesId, out var parentSeries);
+                        var relationshipChanged = !string.Equals(old.SeriesId, FormatId(epDep.SeriesId), StringComparison.Ordinal)
+                            || !string.Equals(old.SeasonId, FormatId(epDep.SeasonId), StringComparison.Ordinal);
+                        if (relationshipChanged)
+                        {
+                            parentOrRelationshipChanged = true;
+                            if (epDep.SeriesId == Guid.Empty || parentSeries != null)
+                            {
+                                parentSeriesRefresh = TagCacheDependencyGraph.ApplySeasonRelationshipRefresh(
+                                    parentSeries,
+                                    epDep,
+                                    old,
+                                    DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+                            }
+                        }
+                        else if (parentSeries != null)
+                        {
+                            parentOrRelationshipChanged = TagCacheDependencyGraph.TryPrepareParentSeriesRefresh(
+                                parentSeries,
+                                item,
+                                old,
+                                static _ => null,
+                                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                                out parentSeriesRefresh);
+                        }
+                    }
 
-                    if (!ShouldRebuild(kind, old, revision, parentSeriesRatingChanged))
+                    if (!ShouldRebuild(kind, old, revision, parentOrRelationshipChanged))
                     {
                         // Unchanged: reuse the existing entry verbatim — no media probe, timestamp
                         // preserved. old is non-null here (ShouldRebuild returns true when it is).
@@ -363,7 +398,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     }
                     else
                     {
-                        var entry = BuildEntryForItem(item);
+                        // A parent-only change must not re-probe unchanged Episode media. The
+                        // authoritative dependency graph already prepared exactly the inherited
+                        // fields from this reconcile's stable Series/Episode snapshot.
+                        var entry = parentSeriesRefresh ?? BuildEntryForItem(item);
                         if (entry == null)
                         {
                             // Unexpected build failure (a bug, not a media-probe failure — those return
@@ -378,10 +416,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                             // (unconfirmed): keep its fresh probe-independent data (own + inherited
                             // rating/genres) but retain the last-good streams, and leave it unconfirmed
                             // so the gate rebuilds it every cycle until the probe recovers.
-                            if (entry.SourceRevision == 0 && old != null)
+                            if (entry.SourceRevision == 0
+                                && old != null
+                                && string.Equals(
+                                    entry.StreamSourceId,
+                                    old.StreamSourceId,
+                                    StringComparison.Ordinal))
                             {
-                                entry.StreamData = old.StreamData;
-                                entry.AudioLanguages = old.AudioLanguages;
+                                RetainLastGoodProbeData(entry, old);
                             }
 
                             if (old != null && ContentEquals(old, entry))
@@ -479,7 +521,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         /// Pure so the gate can be unit-tested without a live library. A rebuild is required for a
         /// new item, for containers (Series/Season) whose derived data tracks their child episodes
         /// rather than their own timestamp, when the source revision changed, or when an Episode's
-        /// parent-series rating changed (the episode inherits it when it has none of its own).
+        /// parent-Series derived surface changed (rating or TMDB metadata that the Episode inherits).
         /// </summary>
         internal static bool ShouldRebuild(BaseItemKind kind, TagCacheEntry? old, long revision, bool parentSeriesRatingChanged)
         {
@@ -523,6 +565,32 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             return JsonSerializer.Serialize(copy);
         }
 
+        private static void RetainLastGoodProbeData(TagCacheEntry current, TagCacheEntry previous)
+        {
+            var freshIdentity = current.StreamData;
+            if (previous.StreamData != null)
+            {
+                current.StreamData = string.Equals(
+                        freshIdentity?.ItemName,
+                        previous.StreamData.ItemName,
+                        StringComparison.Ordinal)
+                    && string.Equals(
+                        freshIdentity?.ItemPath,
+                        previous.StreamData.ItemPath,
+                        StringComparison.Ordinal)
+                    ? previous.StreamData
+                    : new TagStreamData
+                    {
+                        Streams = previous.StreamData.Streams,
+                        Sources = previous.StreamData.Sources,
+                        ItemName = freshIdentity?.ItemName,
+                        ItemPath = freshIdentity?.ItemPath,
+                    };
+            }
+
+            current.AudioLanguages = previous.AudioLanguages;
+        }
+
         /// <summary>
         /// Queue an item to be (re)built in the cache. Called by TagCacheMonitor on
         /// ItemAdded/ItemUpdated. This only records the id and arms a debounced
@@ -534,8 +602,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         public void EnqueueUpdate(Guid itemId)
         {
             if (itemId == Guid.Empty) return;
-            _pending.Record(itemId, removed: false); // PERF(S1): O(1) record-and-defer, safe on the scan thread
-            ScheduleFlush();
+            lock (_lifecycleGate)
+            {
+                if (Volatile.Read(ref _disposed) != 0) return;
+                _pending.Record(itemId, removed: false); // PERF(S1): O(1) record-and-defer, safe on the scan thread
+                Interlocked.Exchange(ref _retryBackoffTicks, 0);
+                ScheduleFlush();
+            }
         }
 
         /// <summary>
@@ -546,8 +619,33 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         public void EnqueueRemoval(Guid itemId)
         {
             if (itemId == Guid.Empty) return;
-            _pending.Record(itemId, removed: true);
-            ScheduleFlush();
+            lock (_lifecycleGate)
+            {
+                if (Volatile.Read(ref _disposed) != 0) return;
+                _pending.Record(itemId, removed: true);
+                Interlocked.Exchange(ref _retryBackoffTicks, 0);
+                ScheduleFlush();
+            }
+        }
+
+        /// <summary>
+        /// Record one explicit library event with its cheap relationship identity. The synchronous
+        /// scan thread stops here; parent/descendant expansion and all library queries run later in
+        /// <see cref="FlushPending"/>.
+        /// </summary>
+        internal void EnqueueItemChange(BaseItem item, bool removed)
+        {
+            lock (_lifecycleGate)
+            {
+                if (Volatile.Read(ref _disposed) != 0) return;
+                var key = item.Id.ToString("N").ToLowerInvariant();
+                _cache.TryGetValue(key, out var previous);
+                var change = TagCacheDependencyGraph.Capture(item, removed, previous);
+                if (change.Id == Guid.Empty) return;
+                _pending.Record(change);
+                Interlocked.Exchange(ref _retryBackoffTicks, 0);
+                ScheduleFlush();
+            }
         }
 
         /// <summary>
@@ -555,6 +653,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         /// </summary>
         private void ScheduleFlush()
         {
+            if (Volatile.Read(ref _disposed) != 0) return;
             Interlocked.CompareExchange(ref _firstPendingTicks, DateTime.UtcNow.Ticks, 0);
             ArmFlushTimer(ComputeFlushDelay());
         }
@@ -564,22 +663,29 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         /// </summary>
         private void ArmFlushTimer(TimeSpan due)
         {
-            var existing = _flushTimer;
-            if (existing != null)
+            lock (_lifecycleGate)
             {
-                try
+                if (Volatile.Read(ref _disposed) != 0) return;
+                var existing = _flushTimer;
+                if (existing != null)
                 {
-                    existing.Change(due, Timeout.InfiniteTimeSpan);
-                    return;
+                    try
+                    {
+                        existing.Change(due, Timeout.InfiniteTimeSpan);
+                        return;
+                    }
+                    catch (ObjectDisposedException) { }
                 }
-                catch (ObjectDisposedException) { }
-            }
 
-            var timer = new Timer(_ => FlushPending(), null, due, Timeout.InfiniteTimeSpan);
-            var old = Interlocked.Exchange(ref _flushTimer, timer);
-            if (old != null && !ReferenceEquals(old, timer))
-            {
-                old.Dispose();
+                // Publication is serialized with Dispose's disposed transition. Either this timer
+                // is visible before shutdown (and Dispose takes it), or shutdown wins and no timer
+                // is created; there is no check-then-publish resurrection window.
+                var timer = new Timer(_ => FlushPending(), null, due, Timeout.InfiniteTimeSpan);
+                var old = Interlocked.Exchange(ref _flushTimer, timer);
+                if (old != null && !ReferenceEquals(old, timer))
+                {
+                    old.Dispose();
+                }
             }
         }
 
@@ -609,6 +715,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         /// </summary>
         private void FlushPending()
         {
+            if (Volatile.Read(ref _disposed) != 0) return;
             // Non-reentrant: if a flush already owns the batch, retry after the debounce.
             // (Retry via ArmFlushTimer, NOT ScheduleFlush: once the first pending change is older
             // than FlushMaxWait, ScheduleFlush would compute a zero delay and busy-spin the timer
@@ -619,25 +726,72 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 return;
             }
 
+            // Dispose may win after the callback's entry check but before it acquires the guard.
+            // Re-check while owning the guard so no callback can mutate after shutdown persistence.
+            if (Volatile.Read(ref _disposed) != 0)
+            {
+                Interlocked.Exchange(ref _flushing, 0);
+                return;
+            }
+
             try
             {
                 Interlocked.Exchange(ref _firstPendingTicks, 0);
-                if (ApplyPendingBatch(_pending.Drain(), out var removed))
+                var changed = ApplyPendingBatch(_pending.Drain(), out var removed);
+
+                OnAfterFlushApplyForTest?.Invoke();
+
+                // Dispose can time out while this owner is blocked after draining. Enqueue and
+                // Dispose share _lifecycleGate, so once _disposed is visible no new work can arrive;
+                // this final handoff drain captures every event recorded during the in-flight pass.
+                if (Volatile.Read(ref _disposed) != 0 && !_pending.IsEmpty)
+                {
+                    changed |= ApplyPendingBatch(_pending.Drain(), out var handoffRemoved);
+                    removed |= handoffRemoved;
+                }
+
+                if (changed)
                 {
                     Interlocked.Exchange(ref _lastModified, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
                     // Current clients consume the tombstone journal. Retain Version
                     // for an older cached bundle whose ?since= shape cannot delete.
                     if (removed) Interlocked.Increment(ref _version);
                     ScheduleDebouncedSave();
+                    // If shutdown timed out waiting for this in-flight callback, Dispose cannot
+                    // persist our later mutation. Complete the atomic save here instead of leaving
+                    // a dirty cache with no live debounce timer.
+                    if (Volatile.Read(ref _disposed) != 0)
+                    {
+                        SaveToDisk();
+                    }
                 }
-
-                OnAfterFlushApplyForTest?.Invoke();
+                else if (Volatile.Read(ref _disposed) != 0
+                    && Volatile.Read(ref _repairIncomplete) != 0)
+                {
+                    SaveToDisk();
+                }
             }
             finally
             {
                 Interlocked.Exchange(ref _flushing, 0);
-                // Ids recorded while we were draining/applying: run again (cap-aware).
-                if (!_pending.IsEmpty) ScheduleFlush();
+                // Ids recorded while we were draining/applying: run again. Retries use an
+                // exponential global delay; a genuine new event clears it in EnqueueItemChange.
+                lock (_lifecycleGate)
+                {
+                    if (!_pending.IsEmpty && Volatile.Read(ref _disposed) == 0)
+                    {
+                        var backoffTicks = Interlocked.Exchange(ref _retryBackoffTicks, 0);
+                        if (backoffTicks > 0)
+                        {
+                            Interlocked.Exchange(ref _firstPendingTicks, DateTime.UtcNow.Ticks);
+                            ArmFlushTimer(TimeSpan.FromTicks(backoffTicks));
+                        }
+                        else
+                        {
+                            ScheduleFlush();
+                        }
+                    }
+                }
             }
         }
 
@@ -705,46 +859,793 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         /// signal for cached pre-journal clients. Wrapping it keeps <see cref="ApplyBatch"/>'s
         /// tested signature untouched.
         /// </summary>
-        private bool ApplyPendingBatch(IReadOnlyList<(Guid Id, bool Removed)> batch, out bool removedFromCache)
+        private bool ApplyPendingBatch(IReadOnlyList<TagCacheChange> batch, out bool removedFromCache)
         {
             var removed = false;
-            var changed = ApplyBatch(
-                batch,
-                RebuildEntry,
-                id => { var r = RemoveEntry(id); if (r) removed = true; return r; });
+            var changed = false;
+            var expandedSeries = new HashSet<Guid>();
+            var preparedEntries = new Dictionary<Guid, TagCacheEntry>();
+            foreach (var change in ExpandDependencies(batch, expandedSeries, preparedEntries))
+            {
+                try
+                {
+                    if (change.Removed)
+                    {
+                        var didRemove = RemoveEntry(change.Id);
+                        removed |= didRemove;
+                        changed |= didRemove;
+                        continue;
+                    }
+
+                    var unavailable = false;
+                    var didRebuild = preparedEntries.TryGetValue(change.Id, out var prepared)
+                        ? PublishPreparedEntry(change.Id, prepared)
+                        : RebuildEntry(
+                            change.Id,
+                            expandedSeries.Contains(change.Id),
+                            out unavailable);
+                    changed |= didRebuild;
+                    if (unavailable)
+                    {
+                        QueueRetry(change, "item is not yet resolvable");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    QueueRetry(change, ex.Message);
+                }
+            }
+
+            if (changed)
+            {
+                _userAccessCache.Clear();
+            }
+
             removedFromCache = removed;
             return changed;
+        }
+
+        /// <summary>
+        /// Expand the centralized derived-entry graph on the background flush worker. Explicit
+        /// event intent is installed first, so a same-batch removal cannot be overwritten by a
+        /// derived parent/descendant rebuild. Series discovery is constrained to one ancestor and
+        /// every returned row is relationship-verified before it can enter the batch.
+        /// </summary>
+        private IReadOnlyList<TagCacheChange> ExpandDependencies(
+            IReadOnlyList<TagCacheChange> batch,
+            ISet<Guid> expandedSeries,
+            IDictionary<Guid, TagCacheEntry> preparedEntries)
+        {
+            var targets = new Dictionary<Guid, TagCacheChange>();
+            foreach (var change in batch)
+            {
+                if (change.Id != Guid.Empty) targets[change.Id] = change;
+            }
+
+            var removedSeriesIds = batch
+                .Where(static change => change.Removed && change.Kind == BaseItemKind.Series)
+                .Select(static change => change.Id)
+                .ToHashSet();
+            var removedSeasonIds = batch
+                .Where(static change => change.Removed && change.Kind == BaseItemKind.Season)
+                .Select(static change => change.Id)
+                .ToHashSet();
+            var explicitRemovedIds = batch
+                .Where(static change => change.Removed)
+                .Select(static change => change.Id)
+                .ToHashSet();
+            var explicitChangeIds = batch.Select(static change => change.Id).ToHashSet();
+            var movedSeasonExpectedEpisodes = batch
+                .Where(static change => !change.Removed
+                    && change.Kind == BaseItemKind.Season
+                    && change.SeriesId != change.PreviousSeriesId)
+                .ToDictionary(
+                    static change => change.Id,
+                    static _ => new HashSet<Guid>());
+            var seriesExpectedDescendants = batch
+                .Where(TagCacheDependencyGraph.NeedsSeriesDescendantDiscovery)
+                .ToDictionary(
+                    static change => change.Id,
+                    static _ => new HashSet<Guid>());
+            var cachedSeriesDescendants = new Dictionary<Guid, HashSet<Guid>>();
+            var cachedSeasonEpisodes = new Dictionary<Guid, HashSet<Guid>>();
+
+            // One O(cache-size) relationship-index pass covers every removed container and every
+            // descendant-completeness check in the batch. Rebuilding these expected sets from the
+            // cache on every retry prevents a transiently partial Jellyfin snapshot from becoming
+            // authoritative merely because the original removal event has already been consumed.
+            if (removedSeriesIds.Count != 0
+                || removedSeasonIds.Count != 0
+                || movedSeasonExpectedEpisodes.Count != 0
+                || seriesExpectedDescendants.Count != 0)
+            {
+                foreach (var cached in _cache)
+                {
+                    Interlocked.Increment(ref _removedDependencyEntriesVisited);
+                    if (!Guid.TryParseExact(cached.Key, "N", out var descendantId))
+                    {
+                        continue;
+                    }
+
+                    var cachedKind = ParseKind(cached.Value.Type);
+                    var cachedSeriesId = ParseId(cached.Value.SeriesId);
+                    var cachedSeasonId = ParseId(cached.Value.SeasonId);
+                    if ((cachedKind == BaseItemKind.Episode || cachedKind == BaseItemKind.Season)
+                        && cachedSeriesId is { } indexedSeriesId)
+                    {
+                        if (!cachedSeriesDescendants.TryGetValue(indexedSeriesId, out var indexedDescendants))
+                        {
+                            indexedDescendants = new HashSet<Guid>();
+                            cachedSeriesDescendants[indexedSeriesId] = indexedDescendants;
+                        }
+
+                        indexedDescendants.Add(descendantId);
+                    }
+
+                    if (cachedKind == BaseItemKind.Episode && cachedSeasonId is { } indexedSeasonId)
+                    {
+                        if (!cachedSeasonEpisodes.TryGetValue(indexedSeasonId, out var indexedEpisodes))
+                        {
+                            indexedEpisodes = new HashSet<Guid>();
+                            cachedSeasonEpisodes[indexedSeasonId] = indexedEpisodes;
+                        }
+
+                        indexedEpisodes.Add(descendantId);
+                    }
+
+                    if (!explicitChangeIds.Contains(descendantId)
+                        && cachedKind == BaseItemKind.Episode
+                        && cachedSeasonId is { } expectedSeasonId
+                        && movedSeasonExpectedEpisodes.TryGetValue(expectedSeasonId, out var expectedEpisodes))
+                    {
+                        expectedEpisodes.Add(descendantId);
+                    }
+
+                    if (!explicitChangeIds.Contains(descendantId)
+                        && (cachedKind == BaseItemKind.Episode || cachedKind == BaseItemKind.Season)
+                        && cachedSeriesId is { } expectedSeriesId
+                        && seriesExpectedDescendants.TryGetValue(expectedSeriesId, out var expectedDescendants))
+                    {
+                        expectedDescendants.Add(descendantId);
+                    }
+
+                    // Jellyfin reports only the top-level folder after recursively deleting
+                    // children, so synthesize descendant removals from the cached relationships.
+                    var matchedSeries = cachedSeriesId is { } removedSeriesId
+                        && removedSeriesIds.Contains(removedSeriesId);
+                    var matchedSeason = cachedSeasonId is { } removedSeasonId
+                        && removedSeasonIds.Contains(removedSeasonId);
+                    if (!matchedSeries && !matchedSeason)
+                    {
+                        continue;
+                    }
+
+                    // A Season explicitly escaping a removed Series owns its children. Until its
+                    // live descendant snapshot proves their disposition, keep cached Episodes
+                    // fail-safe instead of publishing synthetic tombstones from the old Series.
+                    if (!explicitChangeIds.Contains(descendantId)
+                        && string.Equals(cached.Value.Type, BaseItemKind.Episode.ToString(), StringComparison.Ordinal)
+                        && cachedSeasonId is { } protectedSeasonId
+                        && movedSeasonExpectedEpisodes.ContainsKey(protectedSeasonId))
+                    {
+                        continue;
+                    }
+
+                    if (targets.TryGetValue(descendantId, out var explicitChange)
+                        && TagCacheDependencyGraph.ExplicitChangeEscapedRemovedContainers(
+                            explicitChange,
+                            matchedSeries,
+                            matchedSeason,
+                            removedSeriesIds,
+                            removedSeasonIds))
+                    {
+                        continue;
+                    }
+
+                    targets[descendantId] = RemovalTarget(descendantId, ParseKind(cached.Value.Type));
+                    preparedEntries.Remove(descendantId);
+                }
+            }
+
+            void InstallConfirmedContainerRemoval(Guid containerId, BaseItemKind containerKind)
+            {
+                targets[containerId] = RemovalTarget(containerId, containerKind);
+                preparedEntries.Remove(containerId);
+                var descendants = containerKind == BaseItemKind.Series
+                    ? cachedSeriesDescendants.GetValueOrDefault(containerId)
+                    : cachedSeasonEpisodes.GetValueOrDefault(containerId);
+                if (descendants == null)
+                {
+                    return;
+                }
+
+                foreach (var descendantId in descendants)
+                {
+                    // A live, explicit or relationship-verified escape is newer evidence than
+                    // the cached owner index and must survive the synthetic recursive removal.
+                    if (targets.TryGetValue(descendantId, out var currentTarget) && !currentTarget.Removed)
+                    {
+                        continue;
+                    }
+
+                    _cache.TryGetValue(descendantId.ToString("N"), out var cachedDescendant);
+                    targets[descendantId] = RemovalTarget(descendantId, ParseKind(cachedDescendant?.Type));
+                    preparedEntries.Remove(descendantId);
+                }
+            }
+
+            foreach (var change in batch)
+            {
+                foreach (var parent in TagCacheDependencyGraph.DirectDerivedTargets(change))
+                {
+                    var isPreviousOnlyOwner = parent.Id == change.PreviousSeriesId
+                            && parent.Id != change.SeriesId
+                        || parent.Id == change.PreviousSeasonId
+                            && parent.Id != change.SeasonId;
+                    if (isPreviousOnlyOwner && !_cache.ContainsKey(parent.Id.ToString("N")))
+                    {
+                        continue;
+                    }
+
+                    targets.TryAdd(parent.Id, DependencyTarget(parent.Id, parent.Kind));
+                }
+
+                if (!change.Removed
+                    && change.Kind == BaseItemKind.Season
+                    && change.SeriesId != change.PreviousSeriesId)
+                {
+                    try
+                    {
+                        BaseItem? newSeries = null;
+                        if (change.SeriesId != Guid.Empty)
+                        {
+                            newSeries = _libraryManager.GetItemById<BaseItem>(change.SeriesId);
+                            if (newSeries == null || newSeries.GetBaseItemKind() != BaseItemKind.Series)
+                            {
+                                throw new InvalidOperationException("moved Season parent Series is not yet resolvable");
+                            }
+                        }
+
+                        var seasonEpisodes = _libraryManager.GetItemList(new InternalItemsQuery
+                        {
+                            AncestorIds = new[] { change.Id },
+                            IncludeItemTypes = new[] { BaseItemKind.Episode },
+                            IsVirtualItem = false,
+                            Recursive = true,
+                        });
+                        var inconsistentEpisodeRelationship = false;
+                        var discoveredEpisodeIds = new HashSet<Guid>();
+                        foreach (var episode in seasonEpisodes.OfType<MediaBrowser.Controller.Entities.TV.Episode>())
+                        {
+                            if (episode.SeasonId != change.Id)
+                            {
+                                continue;
+                            }
+
+                            if (episode.SeriesId != change.SeriesId)
+                            {
+                                inconsistentEpisodeRelationship = true;
+                                continue;
+                            }
+
+                            discoveredEpisodeIds.Add(episode.Id);
+
+                            var episodeTarget = DependencyTarget(episode.Id, BaseItemKind.Episode);
+                            var canReplaceSyntheticRemoval = targets.TryGetValue(episode.Id, out var currentTarget)
+                                && currentTarget.Removed
+                                && !explicitRemovedIds.Contains(episode.Id)
+                                && !removedSeriesIds.Contains(episode.SeriesId)
+                                && !removedSeasonIds.Contains(episode.SeasonId);
+                            if ((targets.TryAdd(episode.Id, episodeTarget) || canReplaceSyntheticRemoval)
+                                && _cache.TryGetValue(episode.Id.ToString("N").ToLowerInvariant(), out var existing))
+                            {
+                                targets[episode.Id] = episodeTarget;
+                                if (existing.SourceRevision == episode.DateLastSaved.Ticks)
+                                {
+                                    preparedEntries[episode.Id] = TagCacheDependencyGraph.ApplySeasonRelationshipRefresh(
+                                        newSeries,
+                                        episode,
+                                        existing,
+                                        DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+                                }
+                                else
+                                {
+                                    preparedEntries.Remove(episode.Id);
+                                }
+                            }
+                        }
+
+                        if (inconsistentEpisodeRelationship)
+                        {
+                            QueueRetry(change, "one or more Episodes still expose the old Series during Season reparent");
+                        }
+
+                        if (movedSeasonExpectedEpisodes.TryGetValue(change.Id, out var expectedEpisodes)
+                            && !expectedEpisodes.IsSubsetOf(discoveredEpisodeIds))
+                        {
+                            QueueRetry(change, "moved Season descendant discovery omitted one or more cached Episodes");
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        QueueRetry(change, $"moved Season descendant discovery failed: {ex.Message}");
+                    }
+                }
+
+                if (!TagCacheDependencyGraph.NeedsSeriesDescendantDiscovery(change)) continue;
+                try
+                {
+                    var series = _libraryManager.GetItemById<BaseItem>(change.Id);
+                    if (series == null || series.GetBaseItemKind() != BaseItemKind.Series)
+                    {
+                        throw new InvalidOperationException("Series is not yet resolvable");
+                    }
+
+                    var descendantSnapshot = _libraryManager.GetItemList(new InternalItemsQuery
+                    {
+                        AncestorIds = new[] { change.Id },
+                        IncludeItemTypes = TagCacheDependencyGraph.DescendantKinds(),
+                        IsVirtualItem = false,
+                        Recursive = true,
+                        OrderBy = new[] { (ItemSortBy.PremiereDate, JSortOrder.Ascending) },
+                    }).ToList();
+                    var formattedSeriesId = FormatId(change.Id);
+                    var snapshotIds = descendantSnapshot.Select(static item => item.Id).ToHashSet();
+                    var oldSeriesRepairIds = new HashSet<Guid>();
+                    foreach (var descendant in descendantSnapshot)
+                    {
+                        if (descendant is not MediaBrowser.Controller.Entities.TV.Episode
+                            && descendant is not MediaBrowser.Controller.Entities.TV.Season)
+                        {
+                            continue;
+                        }
+
+                        if (_cache.TryGetValue(descendant.Id.ToString("N"), out var cachedDescendant)
+                            && ParseId(cachedDescendant.SeriesId) is { } oldSeriesId
+                            && oldSeriesId != change.Id
+                            && (descendant is MediaBrowser.Controller.Entities.TV.Episode episode
+                                    && episode.SeriesId == change.Id
+                                || descendant is MediaBrowser.Controller.Entities.TV.Season season
+                                    && season.SeriesId == change.Id))
+                        {
+                            oldSeriesRepairIds.Add(oldSeriesId);
+                        }
+                    }
+
+                    // A partial new-Series snapshot can omit an item whose cache still points at
+                    // an old owner, so it is absent from the new owner's expected set. Once any
+                    // stale old owner is observed, bulk-confirm only that owner's omitted cached
+                    // rows and fold live rows that really moved to this Series into the snapshot.
+                    var staleRelationshipCandidates = oldSeriesRepairIds
+                        .SelectMany(id => cachedSeriesDescendants.GetValueOrDefault(id) ?? Enumerable.Empty<Guid>())
+                        .Where(id => !snapshotIds.Contains(id) && !explicitChangeIds.Contains(id))
+                        .ToHashSet();
+                    if (staleRelationshipCandidates.Count != 0)
+                    {
+                        var confirmedCandidates = _libraryManager.GetItemList(new InternalItemsQuery
+                        {
+                            ItemIds = staleRelationshipCandidates.ToArray(),
+                            IncludeItemTypes = TagCacheDependencyGraph.DescendantKinds(),
+                            IsVirtualItem = false,
+                        });
+                        var confirmedCandidateIds = confirmedCandidates.Select(static item => item.Id).ToHashSet();
+                        foreach (var candidate in confirmedCandidates)
+                        {
+                            var related = candidate is MediaBrowser.Controller.Entities.TV.Episode relatedEpisode
+                                    && relatedEpisode.SeriesId == change.Id
+                                || candidate is MediaBrowser.Controller.Entities.TV.Season relatedSeason
+                                    && relatedSeason.SeriesId == change.Id;
+                            if (related && snapshotIds.Add(candidate.Id))
+                            {
+                                descendantSnapshot.Add(candidate);
+                            }
+                        }
+
+                        const int MaximumScalarRelationshipConfirmations = 32;
+                        var scalarConfirmations = 0;
+                        foreach (var omittedCandidateId in staleRelationshipCandidates.Except(confirmedCandidateIds))
+                        {
+                            if (scalarConfirmations++ >= MaximumScalarRelationshipConfirmations)
+                            {
+                                QueueRetry(change, "partial relationship confirmation exceeded its bounded scalar budget");
+                                break;
+                            }
+
+                            var candidate = _libraryManager.GetItemById<BaseItem>(omittedCandidateId);
+                            if (candidate == null)
+                            {
+                                if (_cache.TryGetValue(omittedCandidateId.ToString("N"), out var missingCached)
+                                    && ParseKind(missingCached.Type) is { } missingKind)
+                                {
+                                    if (missingKind == BaseItemKind.Series || missingKind == BaseItemKind.Season)
+                                    {
+                                        InstallConfirmedContainerRemoval(omittedCandidateId, missingKind);
+                                    }
+                                    else
+                                    {
+                                        targets[omittedCandidateId] = RemovalTarget(omittedCandidateId, missingKind);
+                                        preparedEntries.Remove(omittedCandidateId);
+                                    }
+                                }
+
+                                continue;
+                            }
+
+                            var related = candidate is MediaBrowser.Controller.Entities.TV.Episode relatedEpisode
+                                    && relatedEpisode.SeriesId == change.Id
+                                || candidate is MediaBrowser.Controller.Entities.TV.Season relatedSeason
+                                    && relatedSeason.SeriesId == change.Id;
+                            if (related && snapshotIds.Add(candidate.Id))
+                            {
+                                descendantSnapshot.Add(candidate);
+                            }
+                        }
+                    }
+
+                    var firstEpisodesBySeason = new Dictionary<Guid, BaseItem>();
+                    var discoveredDescendantIds = new HashSet<Guid>();
+                    var inconsistentSeriesRelationship = false;
+                    foreach (var episode in descendantSnapshot.OfType<MediaBrowser.Controller.Entities.TV.Episode>())
+                    {
+                        if (episode.SeriesId != change.Id)
+                        {
+                            inconsistentSeriesRelationship = true;
+                            continue;
+                        }
+
+                        if (episode.SeasonId != Guid.Empty)
+                        {
+                            firstEpisodesBySeason.TryAdd(episode.SeasonId, episode);
+                        }
+                    }
+                    if (inconsistentSeriesRelationship)
+                    {
+                        QueueRetry(change, "Series descendant discovery returned one or more foreign Episodes");
+                    }
+                    BaseItem? FirstEpisodeFromSnapshot(BaseItem container)
+                        => firstEpisodesBySeason.GetValueOrDefault(container.Id);
+                    var oldSeasonRepairIds = new HashSet<Guid>();
+
+                    foreach (var descendant in descendantSnapshot)
+                    {
+                        var related = descendant is MediaBrowser.Controller.Entities.TV.Episode relatedEpisode
+                                && relatedEpisode.SeriesId == change.Id
+                            || descendant is MediaBrowser.Controller.Entities.TV.Season relatedSeason
+                                && relatedSeason.SeriesId == change.Id;
+                        if (!related)
+                        {
+                            continue;
+                        }
+
+                        discoveredDescendantIds.Add(descendant.Id);
+
+                        var key = descendant.Id.ToString("N").ToLowerInvariant();
+                        _cache.TryGetValue(key, out var existing);
+                        var lastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                        if (existing == null)
+                        {
+                            targets.TryAdd(
+                                descendant.Id,
+                                DependencyTarget(descendant.Id, descendant.GetBaseItemKind()));
+                        }
+                        else if (!string.Equals(existing.SeriesId, formattedSeriesId, StringComparison.Ordinal)
+                            || descendant is MediaBrowser.Controller.Entities.TV.Episode movedEpisode
+                                && !string.Equals(existing.SeasonId, FormatId(movedEpisode.SeasonId), StringComparison.Ordinal))
+                        {
+                            // The stable subtree can repair missed relationship metadata without
+                            // turning a parent event into N media probes. Also repair the old
+                            // relationship owner so a missed reparent cannot strand its projection.
+                            if (ParseId(existing.SeriesId) is { } oldSeriesId && oldSeriesId != change.Id)
+                            {
+                                oldSeriesRepairIds.Add(oldSeriesId);
+                            }
+
+                            if (descendant is MediaBrowser.Controller.Entities.TV.Episode episode)
+                            {
+                                var oldSeasonId = ParseId(existing.SeasonId);
+                                if (oldSeasonId.HasValue && oldSeasonId.Value != episode.SeasonId)
+                                {
+                                    oldSeasonRepairIds.Add(oldSeasonId.Value);
+                                    if (episode.SeasonId != Guid.Empty)
+                                    {
+                                        targets.TryAdd(
+                                            episode.SeasonId,
+                                            DependencyTarget(episode.SeasonId, BaseItemKind.Season));
+                                    }
+                                }
+                            }
+
+                            var descendantTarget = DependencyTarget(descendant.Id, descendant.GetBaseItemKind());
+                            var canReplaceSyntheticRemoval = targets.TryGetValue(descendant.Id, out var currentTarget)
+                                && currentTarget.Removed
+                                && !explicitRemovedIds.Contains(descendant.Id);
+                            if (targets.TryAdd(descendant.Id, descendantTarget) || canReplaceSyntheticRemoval)
+                            {
+                                targets[descendant.Id] = descendantTarget;
+                                if (existing.SourceRevision == descendant.DateLastSaved.Ticks)
+                                {
+                                    preparedEntries[descendant.Id] = TagCacheDependencyGraph.ApplySeriesRelationshipRefresh(
+                                        series,
+                                        descendant,
+                                        existing,
+                                        FirstEpisodeFromSnapshot,
+                                        lastUpdated);
+                                }
+                                else
+                                {
+                                    preparedEntries.Remove(descendant.Id);
+                                }
+                            }
+                        }
+                        else if (existing.SourceRevision != descendant.DateLastSaved.Ticks)
+                        {
+                            targets.TryAdd(
+                                descendant.Id,
+                                DependencyTarget(descendant.Id, descendant.GetBaseItemKind()));
+                            preparedEntries.Remove(descendant.Id);
+                        }
+                        else if (TagCacheDependencyGraph.TryPrepareParentSeriesRefresh(
+                                series,
+                                descendant,
+                                existing,
+                                FirstEpisodeFromSnapshot,
+                                lastUpdated,
+                                out var prepared)
+                            && targets.TryAdd(
+                                descendant.Id,
+                                DependencyTarget(descendant.Id, descendant.GetBaseItemKind())))
+                        {
+                            preparedEntries[descendant.Id] = prepared!;
+                        }
+                    }
+
+                    var oldOwnerKinds = oldSeriesRepairIds
+                        .Select(static id => (Id: id, Kind: BaseItemKind.Series))
+                        .Concat(oldSeasonRepairIds.Select(static id => (Id: id, Kind: BaseItemKind.Season)))
+                        .Where(owner => !explicitChangeIds.Contains(owner.Id)
+                            && _cache.ContainsKey(owner.Id.ToString("N")))
+                        .GroupBy(static owner => owner.Id)
+                        .ToDictionary(static group => group.Key, static group => group.First().Kind);
+                    if (oldOwnerKinds.Count != 0)
+                    {
+                        var liveOldOwners = _libraryManager.GetItemList(new InternalItemsQuery
+                        {
+                            ItemIds = oldOwnerKinds.Keys.ToArray(),
+                            IncludeItemTypes = new[] { BaseItemKind.Series, BaseItemKind.Season },
+                            IsVirtualItem = false,
+                        })
+                            .Where(item => oldOwnerKinds.TryGetValue(item.Id, out var expectedKind)
+                                && item.GetBaseItemKind() == expectedKind)
+                            .ToDictionary(static item => item.Id);
+                        const int MaximumScalarOwnerConfirmations = 32;
+                        var scalarOwnerConfirmations = 0;
+                        foreach (var oldOwner in oldOwnerKinds)
+                        {
+                            if (liveOldOwners.ContainsKey(oldOwner.Key))
+                            {
+                                targets[oldOwner.Key] = DependencyTarget(oldOwner.Key, oldOwner.Value);
+                                preparedEntries.Remove(oldOwner.Key);
+                                continue;
+                            }
+
+                            if (scalarOwnerConfirmations++ >= MaximumScalarOwnerConfirmations)
+                            {
+                                QueueRetry(change, "old relationship-owner confirmation exceeded its bounded scalar budget");
+                                break;
+                            }
+
+                            var liveOwner = _libraryManager.GetItemById<BaseItem>(oldOwner.Key);
+                            if (liveOwner != null && liveOwner.GetBaseItemKind() == oldOwner.Value)
+                            {
+                                targets[oldOwner.Key] = DependencyTarget(oldOwner.Key, oldOwner.Value);
+                                preparedEntries.Remove(oldOwner.Key);
+                            }
+                            else
+                            {
+                                InstallConfirmedContainerRemoval(oldOwner.Key, oldOwner.Value);
+                            }
+                        }
+                    }
+
+                    if (seriesExpectedDescendants.TryGetValue(change.Id, out var expectedDescendants)
+                        && expectedDescendants.Any(id => !discoveredDescendantIds.Contains(id)
+                            && (!targets.TryGetValue(id, out var target) || !target.Removed)))
+                    {
+                        QueueRetry(change, "Series descendant discovery omitted one or more cached descendants");
+                    }
+
+                    expandedSeries.Add(change.Id);
+                }
+                catch (Exception ex)
+                {
+                    QueueRetry(change, $"derived Series discovery failed: {ex.Message}");
+                }
+            }
+
+            // Apply relationship sources before their derived containers. Besides being linear,
+            // this closes the in-flight reparent window where a concurrently arriving event could
+            // otherwise capture the pre-batch cached parent after a new parent had already rebuilt.
+            var ordered = new List<TagCacheChange>(targets.Count);
+            for (var rank = 0; rank <= 2; rank++)
+            {
+                foreach (var target in targets.Values)
+                {
+                    if (DependencyRank(target.Kind) == rank)
+                    {
+                        ordered.Add(target);
+                    }
+                }
+            }
+
+            return ordered;
+        }
+
+        private static TagCacheChange DependencyTarget(Guid id, BaseItemKind? kind)
+            => new(
+                id,
+                kind,
+                Guid.Empty,
+                Guid.Empty,
+                Guid.Empty,
+                Guid.Empty,
+                Removed: false);
+
+        private static TagCacheChange RemovalTarget(Guid id, BaseItemKind? kind = null)
+            => new(
+                id,
+                kind,
+                Guid.Empty,
+                Guid.Empty,
+                Guid.Empty,
+                Guid.Empty,
+                Removed: true);
+
+        private static int DependencyRank(BaseItemKind? kind)
+            => kind switch
+            {
+                BaseItemKind.Season => 1,
+                BaseItemKind.Series => 2,
+                _ => 0,
+            };
+
+        private static BaseItemKind? ParseKind(string? value)
+            => Enum.TryParse<BaseItemKind>(value, ignoreCase: false, out var kind) ? kind : null;
+
+        private static string? FormatId(Guid id)
+            => id == Guid.Empty ? null : id.ToString("N");
+
+        private static Guid? ParseId(string? value)
+            => Guid.TryParseExact(value, "N", out var id) ? id : null;
+
+        private void QueueRetry(TagCacheChange change, string reason)
+        {
+            if (change.Removed)
+            {
+                return;
+            }
+
+            lock (_lifecycleGate)
+            {
+                if (Volatile.Read(ref _disposed) != 0)
+                {
+                    Interlocked.Exchange(ref _repairIncomplete, 1);
+                    MarkDirty();
+                    return;
+                }
+
+                var attempts = change.RetryAttempts == byte.MaxValue
+                    ? byte.MaxValue
+                    : (byte)(change.RetryAttempts + 1);
+                if (!_pending.Record(change with { RetryAttempts = attempts }))
+                {
+                    return;
+                }
+
+                var delay = ComputeRetryDelay(attempts);
+                SetMax(ref _retryBackoffTicks, delay.Ticks);
+                if (attempts <= 3 || (attempts & (attempts - 1)) == 0 || attempts == byte.MaxValue)
+                {
+                    _logger.LogWarning(
+                        $"[TagCache] Pending repair for {change.Id} remains owned; retry attempt {attempts} is queued after {delay}: {reason}");
+                }
+            }
+        }
+
+        internal static TimeSpan ComputeRetryDelay(byte attempts)
+        {
+            var exponent = Math.Min(Math.Max(attempts - 1, 0), 7);
+            return TimeSpan.FromTicks(Math.Min(
+                FlushDebounce.Ticks * (1L << exponent),
+                TimeSpan.FromMinutes(5).Ticks));
+        }
+
+        private bool PublishPreparedEntry(Guid id, TagCacheEntry entry)
+        {
+            var key = id.ToString("N").ToLowerInvariant();
+            lock (_contentGate)
+            {
+                _cache[key] = entry;
+                RecordContentChangeLocked(key, removed: false);
+            }
+
+            return true;
+        }
+
+        private static void SetMax(ref long location, long value)
+        {
+            var current = Interlocked.Read(ref location);
+            while (current < value)
+            {
+                var observed = Interlocked.CompareExchange(ref location, value, current);
+                if (observed == current) return;
+                current = observed;
+            }
         }
 
         /// <summary>
         /// Resolve an id to its live library item and (re)build its cache entry.
         /// Returns true if the cache was modified. Runs on the flush worker only.
         /// </summary>
-        private bool RebuildEntry(Guid id)
+        private bool RebuildEntry(Guid id, bool seriesDiscoveryAlreadyExpanded, out bool unavailable)
         {
             var item = _libraryManager.GetItemById<BaseItem>(id);
-            if (item == null) return false; // gone before we processed it; ItemRemoved cleans up
+            if (item == null)
+            {
+                unavailable = true;
+                return false;
+            }
 
             var kind = item.GetBaseItemKind();
-            if (!TaggableTypes.Contains(kind)) return false;
+            if (!TaggableTypes.Contains(kind))
+            {
+                unavailable = false;
+                return false;
+            }
 
             var entry = BuildEntryForItem(item);
-            if (entry == null) return false;
+            if (entry == null)
+            {
+                unavailable = true;
+                return false;
+            }
+            unavailable = false;
 
             var key = id.ToString("N").ToLowerInvariant();
             // A degraded entry (media probe failed) carries SourceRevision == 0: retain the last-good
             // streams and leave it unconfirmed so the next reconcile rebuilds it. Mirrors the
             // reconcile so an incremental event during a probe outage doesn't drop the streams.
-            if (entry.SourceRevision == 0 && _cache.TryGetValue(key, out var existing) && existing != null)
+            if (entry.SourceRevision == 0
+                && _cache.TryGetValue(key, out var existing)
+                && existing != null
+                && string.Equals(entry.StreamSourceId, existing.StreamSourceId, StringComparison.Ordinal))
             {
-                entry.StreamData = existing.StreamData;
-                entry.AudioLanguages = existing.AudioLanguages;
+                RetainLastGoodProbeData(entry, existing);
             }
+            var queueSeriesDiscovery = false;
             lock (_contentGate)
             {
+                _cache.TryGetValue(key, out existing);
+                queueSeriesDiscovery = kind == BaseItemKind.Series
+                    && !seriesDiscoveryAlreadyExpanded
+                    && existing != null
+                    && TagCacheDependencyGraph.ParentSeriesSurfaceChanged(existing, entry);
                 _cache[key] = entry;
                 RecordContentChangeLocked(key, removed: false);
             }
+
+            if (queueSeriesDiscovery && Volatile.Read(ref _disposed) == 0)
+            {
+                _pending.Record(new TagCacheChange(
+                    id,
+                    BaseItemKind.Series,
+                    Guid.Empty,
+                    Guid.Empty,
+                    Guid.Empty,
+                    Guid.Empty,
+                    Removed: false));
+                ScheduleFlush();
+            }
+
             return true;
         }
 
@@ -1376,6 +2277,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 var data = JsonSerializer.Deserialize<TagCacheDiskFormat>(json);
                 if (data?.Items != null)
                 {
+                    if (data.IncompleteRepair)
+                    {
+                        _logger.LogInformation("[TagCache] Discarding cache with an incomplete shutdown repair; rebuilding from the library.");
+                        return;
+                    }
+
                     // Discard a cache written by an older schema (e.g. predating
                     // SeriesId) rather than serving entries the strip paths can't
                     // process. Starting empty is safe — the Build task rebuilds it.
@@ -1419,6 +2326,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                         SchemaVersion = CurrentCacheSchemaVersion,
                         Version = Interlocked.Read(ref _version),
                         LastModified = Interlocked.Read(ref _lastModified),
+                        IncompleteRepair = Volatile.Read(ref _repairIncomplete) != 0,
                         Items = new Dictionary<string, TagCacheEntry>(_cache)
                     };
 
@@ -1461,31 +2369,44 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         private void ScheduleDebouncedSave()
         {
             MarkDirty();
-            // Reuse existing timer if possible, otherwise create a new one.
-            // Change() resets the countdown without creating a new object.
-            var existing = _debounceSaveTimer;
-            if (existing != null)
+            lock (_lifecycleGate)
             {
-                try
+                if (Volatile.Read(ref _disposed) != 0) return;
+                // Reuse existing timer if possible, otherwise create a new one.
+                // Change() resets the countdown without creating a new object.
+                var existing = _debounceSaveTimer;
+                if (existing != null)
                 {
-                    existing.Change(TimeSpan.FromSeconds(30), Timeout.InfiniteTimeSpan);
-                    return;
+                    try
+                    {
+                        existing.Change(TimeSpan.FromSeconds(30), Timeout.InfiniteTimeSpan);
+                        return;
+                    }
+                    catch (ObjectDisposedException) { }
                 }
-                catch (ObjectDisposedException) { }
-            }
-            var timer = new Timer(_ =>
-            {
-                if (_dirty) SaveToDisk();
-            }, null, TimeSpan.FromSeconds(30), Timeout.InfiniteTimeSpan);
-            var old = Interlocked.Exchange(ref _debounceSaveTimer, timer);
-            if (old != null && !ReferenceEquals(old, timer))
-            {
-                old.Dispose();
+
+                var timer = new Timer(_ =>
+                {
+                    if (_dirty) SaveToDisk();
+                }, null, TimeSpan.FromSeconds(30), Timeout.InfiniteTimeSpan);
+                var old = Interlocked.Exchange(ref _debounceSaveTimer, timer);
+                if (old != null && !ReferenceEquals(old, timer))
+                {
+                    old.Dispose();
+                }
             }
         }
 
         public void Dispose()
         {
+            lock (_lifecycleGate)
+            {
+                if (Interlocked.Exchange(ref _disposed, 1) != 0)
+                {
+                    return;
+                }
+            }
+
             var flush = Interlocked.Exchange(ref _flushTimer, null);
             flush?.Dispose(); // stops future callbacks; an in-flight one may still be applying
 
@@ -1494,7 +2415,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             // _pending, skip the save, and lose the in-flight flush's applied batch (it only
             // schedules a debounced save that never fires during shutdown). Waiting for _flushing
             // to release means that flush has finished and set _dirty, so the save below catches it.
-            var acquired = AcquireFlushGuard();
+            var acquired = AcquireFlushGuard(maxSpins: _disposeFlushGuardSpins, spinMs: 10);
 
             // Apply anything still queued in the debounce window so a change made moments before
             // shutdown is persisted — matching the old synchronous handler, which applied to the
@@ -1503,7 +2424,17 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             // would leave those items stale until the next event or the daily rebuild.
             try
             {
-                if (ApplyPendingBatch(_pending.Drain(), out var removed))
+                if (!acquired)
+                {
+                    // The owner may be an incremental flush (which self-persists) OR a full
+                    // reconcile that can still be cancelled/throw before its post-swap drain/save.
+                    // Persist a fail-closed marker now; startup discards this snapshot rather than
+                    // trusting pending work that shutdown could not prove was handed off.
+                    Interlocked.Exchange(ref _repairIncomplete, 1);
+                    MarkDirty();
+                    _logger.LogWarning("[TagCache] Shutdown timed out waiting for an in-flight cache writer; marking the disk snapshot incomplete for startup rebuild.");
+                }
+                else if (ApplyPendingBatch(_pending.Drain(), out var removed))
                 {
                     Interlocked.Exchange(ref _lastModified, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
                     // Persist a Version bump for a shutdown-time removal so clients reconnecting
@@ -1541,14 +2472,28 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 var kind = item.GetBaseItemKind();
                 var isContainer = kind == BaseItemKind.Series || kind == BaseItemKind.Season;
                 var probeFailed = false;
+                BaseItem? parentSeries = null;
+                var parentSeriesResolved = false;
+                BaseItem? ResolveParentSeriesOnce()
+                {
+                    if (!parentSeriesResolved)
+                    {
+                        parentSeriesResolved = true;
+                        parentSeries = GetParentSeries(item);
+                    }
+
+                    return parentSeries;
+                }
 
                 // Capture parent series ID for Episodes/Seasons so the Spoiler
                 // Guard filter can strip unwatched-episode entries without a
                 // library lookup per entry on every GetTagCache request.
                 string? seriesIdN = null;
+                string? seasonIdN = null;
                 if (item is MediaBrowser.Controller.Entities.TV.Episode tcEp)
                 {
                     if (tcEp.SeriesId != Guid.Empty) seriesIdN = tcEp.SeriesId.ToString("N");
+                    if (tcEp.SeasonId != Guid.Empty) seasonIdN = tcEp.SeasonId.ToString("N");
                 }
                 else if (item is MediaBrowser.Controller.Entities.TV.Season tcSeason)
                 {
@@ -1564,6 +2509,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     CriticRating = item.CriticRating,
                     LastUpdated = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
                     SeriesId = seriesIdN,
+                    SeasonId = seasonIdN,
                     // Capture the source revision so the reconcile can skip re-probing an
                     // item whose DateLastSaved is unchanged. Set here so BOTH the daily
                     // reconcile and the incremental RebuildEntry populate the gate key.
@@ -1575,6 +2521,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     var firstEp = GetFirstEpisode(item);
                     if (firstEp != null)
                     {
+                        entry.StreamSourceId = firstEp.Id.ToString("N");
                         if (entry.Genres == null || entry.Genres.Length == 0)
                         {
                             entry.Genres = firstEp.Genres;
@@ -1583,7 +2530,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                         var media = ExtractMediaData(firstEp);
                         if (media == null)
                         {
-                            probeFailed = true; // leave StreamData/AudioLanguages for the caller to retain last-good
+                            probeFailed = true;
+                            entry.StreamData = new TagStreamData
+                            {
+                                ItemName = firstEp.Name,
+                                ItemPath = string.IsNullOrEmpty(firstEp.Path) ? null : Path.GetFileName(firstEp.Path),
+                            };
                         }
                         else
                         {
@@ -1600,7 +2552,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
 
                     if (kind == BaseItemKind.Season && entry.CommunityRating == null)
                     {
-                        var series = GetParentSeries(item);
+                        var series = ResolveParentSeriesOnce();
                         if (series != null)
                         {
                             entry.CommunityRating = series.CommunityRating;
@@ -1615,7 +2567,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     // For Season: store parent series TMDB ID + season number for user review key
                     if (kind == BaseItemKind.Season && item is MediaBrowser.Controller.Entities.TV.Season season)
                     {
-                        var series = GetParentSeries(item);
+                        var series = ResolveParentSeriesOnce();
                         if (series?.ProviderIds?.TryGetValue("Tmdb", out var seriesTmdb) == true)
                             entry.SeriesTmdbId = seriesTmdb;
                         entry.SeasonNumber = season.IndexNumber;
@@ -1623,10 +2575,16 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 }
                 else
                 {
+                    entry.StreamSourceId = item.Id.ToString("N");
                     var media = ExtractMediaData(item);
                     if (media == null)
                     {
-                        probeFailed = true; // leave StreamData/AudioLanguages for the caller to retain last-good
+                        probeFailed = true;
+                        entry.StreamData = new TagStreamData
+                        {
+                            ItemName = item.Name,
+                            ItemPath = string.IsNullOrEmpty(item.Path) ? null : Path.GetFileName(item.Path),
+                        };
                     }
                     else
                     {
@@ -1642,7 +2600,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
 
                     if (kind == BaseItemKind.Episode && entry.CommunityRating == null)
                     {
-                        var series = GetParentSeries(item);
+                        var series = ResolveParentSeriesOnce();
                         if (series != null)
                         {
                             entry.CommunityRating = series.CommunityRating;
@@ -1653,7 +2611,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     // For Episode: store parent series TMDB ID + season/episode numbers for user review key
                     if (kind == BaseItemKind.Episode && item is MediaBrowser.Controller.Entities.TV.Episode ep)
                     {
-                        var series = GetParentSeries(item);
+                        var series = ResolveParentSeriesOnce();
                         if (series?.ProviderIds?.TryGetValue("Tmdb", out var seriesTmdb) == true)
                             entry.SeriesTmdbId = seriesTmdb;
                         entry.SeasonNumber = ep.ParentIndexNumber;
@@ -1742,45 +2700,37 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
 
         private BaseItem? GetFirstEpisode(BaseItem container)
         {
-            try
+            var epQuery = new InternalItemsQuery
             {
-                var epQuery = new InternalItemsQuery
-                {
-                    ParentId = container.Id,
-                    IncludeItemTypes = new[] { BaseItemKind.Episode },
-                    Recursive = true,
-                    Limit = 1,
-                    OrderBy = new[] { (ItemSortBy.PremiereDate, JSortOrder.Ascending) }
-                };
-                return _libraryManager.GetItemList(epQuery).FirstOrDefault();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning($"[TagCache] Failed to get first episode for {container.Id}: {ex.Message}");
-                return null;
-            }
+                ParentId = container.Id,
+                IncludeItemTypes = new[] { BaseItemKind.Episode },
+                Recursive = true,
+                Limit = 1,
+                OrderBy = new[] { (ItemSortBy.PremiereDate, JSortOrder.Ascending) },
+            };
+            return _libraryManager.GetItemList(epQuery).FirstOrDefault();
         }
 
         private BaseItem? GetParentSeries(BaseItem item)
         {
-            try
+            Guid? seriesId = null;
+            if (item is MediaBrowser.Controller.Entities.TV.Episode ep)
             {
-                Guid? seriesId = null;
-                if (item is MediaBrowser.Controller.Entities.TV.Episode ep)
-                    seriesId = ep.SeriesId;
-                else if (item is MediaBrowser.Controller.Entities.TV.Season season)
-                    seriesId = season.SeriesId;
+                seriesId = ep.SeriesId;
+            }
+            else if (item is MediaBrowser.Controller.Entities.TV.Season season)
+            {
+                seriesId = season.SeriesId;
+            }
 
-                if (seriesId.HasValue && seriesId.Value != Guid.Empty)
-                {
-                    return _libraryManager.GetItemById<BaseItem>(seriesId.Value);
-                }
-            }
-            catch (Exception ex)
+            if (!seriesId.HasValue || seriesId.Value == Guid.Empty)
             {
-                _logger.LogWarning($"[TagCache] Failed to get parent series for {item.Id}: {ex.Message}");
+                return null;
             }
-            return null;
+
+            return _libraryManager.GetItemById<BaseItem>(seriesId.Value)
+                ?? throw new InvalidOperationException(
+                    $"Parent Series {seriesId.Value} for {item.Id} is not yet resolvable");
         }
 
         private class TagCacheDiskFormat
@@ -1791,6 +2741,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             public int SchemaVersion { get; set; }
             public long Version { get; set; }
             public long LastModified { get; set; }
+            public bool IncompleteRepair { get; set; }
             public Dictionary<string, TagCacheEntry> Items { get; set; } = new();
         }
     }

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,16 +26,16 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2808, totalLines: 3201 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 30222, totalLines: 38901 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 31019, totalLines: 39687 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 3,
         minimumCoveredLines: 2808,
         maximumCoveredLines: 2808,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
-        cleanRuns: 5,
-        minimumCoveredLines: 30221,
-        maximumCoveredLines: 30222,
+        cleanRuns: 4,
+        minimumCoveredLines: 31018,
+        maximumCoveredLines: 31019,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 1);

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 30222,
-        "totalLines": 38901
+        "coveredLines": 31019,
+        "totalLines": 39687
       },
       "observations": {
-        "cleanRuns": 5,
-        "minimumCoveredLines": 30221,
-        "maximumCoveredLines": 30222
+        "cleanRuns": 4,
+        "minimumCoveredLines": 31018,
+        "maximumCoveredLines": 31019
       },
       "tolerance": {
         "missingCoveredLines": 1,
-        "rationale": "The final #88 review fixes add a worst-case escaping-bounded full-quota move request envelope, compact rich-episode duplicate indexing, whitespace-normalized legacy media aliases, deferred/coalesced backups for imports and ordinary mutations, final-file-only snapshot discovery, and owned-schema plus metadata-invariant recovery validation. Five clean Coverlet runs on the identical 2026-08-02 source and 38,901-line scope each passed all 2,583 server tests: four local runs observed 30,221 covered lines and the GitHub Actions run for PR #569 observed 30,222. Relative to the preceding #88 review baseline, the reviewed implementation adds 25 instrumented lines and 24 covered high-water lines while increasing the enforced floor to 30,221/38,901 (77.687%). The one-line allowance is exactly the observed local-versus-CI instrumentation envelope; the measured high-water is 30,222/38,901 (77.690%), and broader regressions still fail. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "rationale": "The #93 dependency-invalidation change adds an explicit tag-cache dependency graph, bounded descendant repair, relationship-aware pending-change coalescing, and regression coverage for episode, season, and series mutations. Four clean Coverlet runs on the identical 2026-08-02 source and 39,687-line scope each passed all 2,645 server tests: three runs observed 31,018 covered lines and the final official coverage entry point observed 31,019. Relative to the reviewed #88 main baseline of 30,222/38,901 (77.690%), the reviewed implementation adds 786 instrumented lines and 797 covered high-water lines while increasing the high-water to 31,019/39,687 (78.159%) and the enforced floor to 31,018/39,687 (78.157%). The one-line allowance is exactly the same-head fixed-scope instrumentation envelope tracked in #575; the measured high-water is retained and broader regressions still fail. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
Closes #93.

## What changed

- centralize every `TagCacheEntry` field dependency in an explicit dependency graph
- capture old and new Episode/Season/Series relationships at the O(1) event boundary
- coalesce pending identities while expanding and rebuilding derived targets on the worker
- repair first-episode replacement, parent metadata inheritance, removals, and relationship drift
- keep descendant discovery and large-series rebuilding bounded by indexed cache passes and capped library queries
- add comprehensive correctness, concurrency, removal, retry, and scale regressions

## Root cause and impact

Tag-cache invalidation previously followed only part of the derived data graph. Episode removal could leave Season and Series fields sourced from the deleted first episode, while Series rating, genre, or TMDB changes could leave inherited descendant entries stale until a daily rebuild. The new ownership model records cheap relationship tokens synchronously and performs verified dependency expansion off the scan thread, preserving tombstones and revisions without rebuilding unrelated items.

## Validation

- independent review approved exact commit `a0909a53201dfad59df46fdb9b90338224d5638b`; no blockers or distinct bugs found
- focused dependency/cache suite: 80/80
- full server suite: 2,645/2,645
- official server coverage: 31,018/39,687, within the reviewed one-line envelope from the 31,019 high-water; same-head variability remains tracked in #575
- client coverage: 244 files, 2,040/2,040, exact 2,808/3,201
- script suite and coverage-policy tests passed; Playwright discovered 176 tests
- both typechecks, syntax, translations, performance rules, strict docs/support contract, and lint passed
- Release build: 0 warnings, 0 errors; deterministic 173-file bundle ID `1788c55b5f8993ca1c69acbafde8c469ed97527dd27614c9e91191fc82de3506`
