### PR TITLE
feat(platform): pin v1 wire format (#521)

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformContractTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformContractTests.cs
@@ -214,7 +214,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
             // The fixture is the documented example, so it has to agree with the server's
             // real range or the example teaches a consumer the wrong thing.
             var fixtureText = File.ReadAllText(ContractPath(Path.Combine("fixtures", "discovery.200.json")));
-            var fixture = JsonSerializer.Deserialize<PlatformDiscoveryResponse>(fixtureText)!;
+            var fixture = JsonSerializer.Deserialize<PlatformDiscoveryResponse>(fixtureText, PlatformJson.SerializerOptions)!;
 
             Assert.Equal(PlatformConstants.ProtocolMinimum, fixture.ProtocolMinimum);
             Assert.Equal(PlatformConstants.ProtocolMaximum, fixture.ProtocolMaximum);
@@ -232,8 +232,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
             // this gate is meant to catch.
             var original = File.ReadAllText(ContractPath(Path.Combine("fixtures", fixtureName)));
 
-            var parsed = JsonSerializer.Deserialize(original, type)!;
-            var reserialized = JsonSerializer.Serialize(parsed, type);
+            var parsed = JsonSerializer.Deserialize(original, type, PlatformJson.SerializerOptions)!;
+            var reserialized = JsonSerializer.Serialize(parsed, type, PlatformJson.SerializerOptions);
 
             using var before = JsonDocument.Parse(original);
             using var after = JsonDocument.Parse(reserialized);
@@ -250,7 +250,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
         public void TheErrorFixtureUsesADocumentedCodeAndAConformingCorrelationId()
         {
             var error = JsonSerializer.Deserialize<PlatformError>(
-                File.ReadAllText(ContractPath(Path.Combine("fixtures", "error.413.json"))))!;
+                File.ReadAllText(ContractPath(Path.Combine("fixtures", "error.413.json"))),
+                PlatformJson.SerializerOptions)!;
 
             Assert.True(PlatformErrorCode.IsKnown(error.Code));
             Assert.Equal(413, PlatformErrorCode.StatusFor(error.Code));

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformErrorEnvelopeTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformErrorEnvelopeTests.cs
@@ -67,6 +67,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
                     "rate_limited",
                     "timeout",
                     "unavailable",
+                    "unsupported_media_type",
                     "unsupported_protocol",
                 },
                 PlatformErrorCode.All.OrderBy(code => code, StringComparer.Ordinal));
@@ -74,6 +75,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
 
         [Theory]
         [InlineData(PlatformErrorCode.InvalidRequest, 400, false)]
+        [InlineData(PlatformErrorCode.UnsupportedMediaType, 415, false)]
         [InlineData(PlatformErrorCode.UnsupportedProtocol, 400, false)]
         [InlineData(PlatformErrorCode.NotFound, 404, false)]
         [InlineData(PlatformErrorCode.Conflict, 409, false)]

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformWireFormatTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformWireFormatTests.cs
@@ -1,0 +1,359 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinCanopy;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using MediaBrowser.Controller;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
+{
+    public class PlatformWireFormatTests
+    {
+        private enum RequestMode
+        {
+            Standard,
+        }
+
+        private sealed class WireRequest
+        {
+            public Guid Id { get; set; }
+
+            public DateTimeOffset At { get; set; }
+
+            public RequestMode Mode { get; set; }
+        }
+
+        private sealed class TestController : PlatformControllerBase
+        {
+        }
+
+        private sealed class LegacyController : ControllerBase
+        {
+        }
+
+        public class ServerApplicationHostProxy : DispatchProxy
+        {
+            protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+            {
+                if (targetMethod?.Name is "get_SystemId" or "get_ApplicationVersionString")
+                {
+                    return "platform-wire-format-test";
+                }
+
+                throw new NotSupportedException(targetMethod?.Name);
+            }
+        }
+
+        [Theory]
+        [InlineData("application/json")]
+        [InlineData("application/json; charset=utf-8")]
+        public async Task JsonMediaTypesReachThePipeline(string contentType)
+        {
+            var (context, continued) = await RunMediaTypeFilterAsync(contentType);
+
+            Assert.True(continued);
+            Assert.Null(context.Result);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("text/plain")]
+        [InlineData("application/xml")]
+        [InlineData("application/problem+json")]
+        public async Task BodyWithANonJsonMediaTypeGetsStructured415(string? contentType)
+        {
+            var (context, continued) = await RunMediaTypeFilterAsync(contentType);
+
+            Assert.False(continued);
+            var result = Assert.IsType<ObjectResult>(context.Result);
+            var error = Assert.IsType<PlatformError>(result.Value);
+            Assert.Equal(415, result.StatusCode);
+            Assert.Equal(PlatformErrorCode.UnsupportedMediaType, error.Code);
+            Assert.False(error.Retryable);
+            Assert.Equal(error.CorrelationId, context.HttpContext.Response.Headers[PlatformCorrelation.HeaderName]);
+        }
+
+        [Fact]
+        public void MediaTypeHandlingIsPostAuthorizationAndPreBodyBuffering()
+        {
+            Assert.IsAssignableFrom<IAsyncResourceFilter>(new PlatformJsonMediaTypeFilter());
+            Assert.NotEmpty(typeof(PlatformControllerBase).GetCustomAttributes(typeof(AuthorizeAttribute), inherit: true));
+
+            var filters = typeof(PlatformControllerBase)
+                .GetCustomAttributes(typeof(TypeFilterAttribute), inherit: true)
+                .Cast<TypeFilterAttribute>()
+                .ToDictionary(attribute => attribute.ImplementationType, attribute => attribute.Order);
+
+            Assert.True(filters[typeof(PlatformJsonMediaTypeFilter)] < filters[typeof(PlatformBoundedBodyFilter)]);
+        }
+
+        [Fact]
+        public async Task UnknownRequestPropertiesAreIgnoredByThePlatformInputFormatter()
+        {
+            var result = await ReadAsync("""{"Id":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","At":"2026-08-02T04:05:06Z","Mode":"standard","Future":true}""");
+
+            Assert.True(result.HasError is false);
+            var value = Assert.IsType<WireRequest>(result.Model);
+            Assert.Equal(Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"), value.Id);
+            Assert.Equal(RequestMode.Standard, value.Mode);
+            Assert.Equal(TimeSpan.Zero, value.At.Offset);
+        }
+
+        [Theory]
+        [InlineData("AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE", "2026-08-02T04:05:06+00:00", "Id")]
+        [InlineData("aaaaaaaabbbbccccddddeeeeeeeeeeee", "2026-08-02T04:05:06+00:00", "Id")]
+        [InlineData("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "2026-08-02T12:05:06+08:00", "At")]
+        [InlineData("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "2026-08-02T04:05:06", "At")]
+        [InlineData("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "2026-08-02 04:05:06+00:00", "At")]
+        public async Task NonCanonicalGuidOrNonUtcTimestampIsRejected(string id, string at, string field)
+        {
+            var http = PlatformHttp($"{{\"Id\":\"{id}\",\"At\":\"{at}\",\"Mode\":\"standard\"}}");
+            var modelState = new ModelStateDictionary();
+
+            var result = await ReadAsync(http, modelState);
+
+            Assert.True(result.HasError);
+            Assert.Contains(modelState, entry => entry.Key == field);
+        }
+
+        [Theory]
+        [InlineData("7", "\"2026-08-02T04:05:06Z\"", "Id")]
+        [InlineData("\"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\"", "{}", "At")]
+        public async Task NonStringGuidOrTimestampBecomesSafeInvalidRequest(string id, string at, string field)
+        {
+            var http = PlatformHttp($"{{\"Id\":{id},\"At\":{at},\"Mode\":\"standard\"}}");
+            var modelState = new ModelStateDictionary();
+            var formatterResult = await ReadAsync(http, modelState);
+
+            Assert.True(formatterResult.HasError);
+            Assert.Contains(modelState, entry => entry.Key == field);
+
+            var action = new ActionContext(http, new RouteData(), new ControllerActionDescriptor(), modelState);
+            var context = new ActionExecutingContext(action, new List<IFilterMetadata>(), new Dictionary<string, object?>(), new object());
+            var continued = false;
+
+            await new PlatformRequestFilter(NullLogger<PlatformRequestFilter>.Instance).OnActionExecutionAsync(context, () =>
+            {
+                continued = true;
+                return Task.FromResult(new ActionExecutedContext(action, new List<IFilterMetadata>(), new object()));
+            });
+
+            Assert.False(continued);
+            var result = Assert.IsType<ObjectResult>(context.Result);
+            var error = Assert.IsType<PlatformError>(result.Value);
+            Assert.Equal(400, result.StatusCode);
+            Assert.Equal(PlatformErrorCode.InvalidRequest, error.Code);
+            Assert.Contains(field, error.Message, StringComparison.Ordinal);
+            Assert.DoesNotContain(id, error.Message, StringComparison.Ordinal);
+            Assert.DoesNotContain(at, error.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public async Task UnknownRequestEnumBecomesInvalidRequestNamingOnlyTheField()
+        {
+            var http = PlatformHttp("""{"Id":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","At":"2026-08-02T04:05:06Z","Mode":"future"}""");
+            var modelState = new ModelStateDictionary();
+            var formatterResult = await ReadAsync(http, modelState);
+
+            Assert.True(formatterResult.HasError);
+            Assert.Contains(modelState, entry => entry.Key == nameof(WireRequest.Mode));
+
+            var action = new ActionContext(http, new RouteData(), new ControllerActionDescriptor(), modelState);
+            var context = new ActionExecutingContext(action, new List<IFilterMetadata>(), new Dictionary<string, object?>(), new object());
+            var continued = false;
+
+            await new PlatformRequestFilter(NullLogger<PlatformRequestFilter>.Instance).OnActionExecutionAsync(context, () =>
+            {
+                continued = true;
+                return Task.FromResult(new ActionExecutedContext(action, new List<IFilterMetadata>(), new object()));
+            });
+
+            Assert.False(continued);
+            var result = Assert.IsType<ObjectResult>(context.Result);
+            var error = Assert.IsType<PlatformError>(result.Value);
+            Assert.Equal(400, result.StatusCode);
+            Assert.Equal(PlatformErrorCode.InvalidRequest, error.Code);
+            Assert.Contains(nameof(WireRequest.Mode), error.Message, StringComparison.Ordinal);
+            Assert.DoesNotContain("JsonException", error.Message, StringComparison.Ordinal);
+            Assert.DoesNotContain("future", error.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void OutputWireValuesAreCanonicalAndUtc()
+        {
+            var value = new WireRequest
+            {
+                Id = Guid.Parse("AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"),
+                At = new DateTimeOffset(2026, 8, 2, 12, 5, 6, TimeSpan.FromHours(8)),
+                Mode = RequestMode.Standard,
+            };
+
+            using var json = JsonDocument.Parse(JsonSerializer.Serialize(value, PlatformJson.SerializerOptions));
+
+            Assert.Equal("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", json.RootElement.GetProperty("Id").GetString());
+            Assert.Equal("2026-08-02T04:05:06.0000000+00:00", json.RootElement.GetProperty("At").GetString());
+            Assert.Equal("standard", json.RootElement.GetProperty("Mode").GetString());
+        }
+
+        [Fact]
+        public void PlatformBasePinsBothInputAndOutputSerializerSeams()
+        {
+            var filters = typeof(PlatformControllerBase)
+                .GetCustomAttributes(typeof(TypeFilterAttribute), inherit: true)
+                .Cast<TypeFilterAttribute>()
+                .Select(attribute => attribute.ImplementationType)
+                .ToList();
+
+            Assert.Contains(typeof(PlatformJsonMediaTypeFilter), filters);
+            Assert.Contains(typeof(PlatformJsonResultFilter), filters);
+        }
+
+        [Fact]
+        public void PluginRegistrationInstallsPlatformFormatterFirstAndExcludesLegacyControllers()
+        {
+            var services = new ServiceCollection();
+            var applicationHost = DispatchProxy.Create<IServerApplicationHost, ServerApplicationHostProxy>();
+            new PluginServiceRegistrator().RegisterServices(services, applicationHost);
+
+            using var provider = services.BuildServiceProvider();
+            var options = provider.GetRequiredService<IOptions<MvcOptions>>().Value;
+            var formatter = Assert.IsType<PlatformJsonInputFormatter>(options.InputFormatters[0]);
+
+            Assert.True(CanRead(formatter, typeof(TestController)));
+            Assert.False(CanRead(formatter, typeof(LegacyController)));
+        }
+
+        [Fact]
+        public async Task MvcOutputFilterUsesThePinnedSerializerAndPreservesStatus()
+        {
+            var http = new DefaultHttpContext();
+            var action = new ActionContext(http, new RouteData(), new ActionDescriptor());
+            var context = new ResultExecutingContext(
+                action,
+                new List<IFilterMetadata>(),
+                new ObjectResult(new WireRequest
+                {
+                    Id = Guid.Parse("AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"),
+                    At = new DateTimeOffset(2026, 8, 2, 12, 5, 6, TimeSpan.FromHours(8)),
+                    Mode = RequestMode.Standard,
+                })
+                {
+                    StatusCode = 202,
+                },
+                new object());
+
+            await new PlatformJsonResultFilter().OnResultExecutionAsync(context, () =>
+                Task.FromResult(new ResultExecutedContext(action, new List<IFilterMetadata>(), context.Result, new object())));
+
+            var result = Assert.IsType<JsonResult>(context.Result);
+            Assert.Same(PlatformJson.SerializerOptions, result.SerializerSettings);
+            Assert.Equal(202, result.StatusCode);
+
+            using var json = JsonDocument.Parse(
+                JsonSerializer.Serialize(result.Value, result.Value!.GetType(), PlatformJson.SerializerOptions));
+            Assert.Equal(
+                "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                json.RootElement.GetProperty("Id").GetString());
+            Assert.Equal(
+                "2026-08-02T04:05:06.0000000+00:00",
+                json.RootElement.GetProperty("At").GetString());
+        }
+
+        private static async Task<(ResourceExecutingContext Context, bool Continued)> RunMediaTypeFilterAsync(string? contentType)
+        {
+            var http = new DefaultHttpContext();
+            http.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes("{}"));
+            http.Request.ContentLength = 2;
+            http.Request.ContentType = contentType;
+            var context = new ResourceExecutingContext(
+                new ActionContext(http, new RouteData(), new ControllerActionDescriptor()),
+                new List<IFilterMetadata>(),
+                new List<IValueProviderFactory>());
+            var continued = false;
+
+            await new PlatformJsonMediaTypeFilter().OnResourceExecutionAsync(context, () =>
+            {
+                continued = true;
+                return Task.FromResult(new ResourceExecutedContext(context, new List<IFilterMetadata>()));
+            });
+
+            return (context, continued);
+        }
+
+        private static Task<InputFormatterResult> ReadAsync(string json)
+        {
+            var http = PlatformHttp(json);
+            return ReadAsync(http, new ModelStateDictionary());
+        }
+
+        private static Task<InputFormatterResult> ReadAsync(HttpContext http, ModelStateDictionary modelState)
+        {
+            var metadata = new EmptyModelMetadataProvider().GetMetadataForType(typeof(WireRequest));
+            var context = new InputFormatterContext(
+                http,
+                string.Empty,
+                modelState,
+                metadata,
+                (stream, encoding) => new StreamReader(stream, encoding));
+            var formatter = new PlatformJsonInputFormatter();
+
+            Assert.True(formatter.CanRead(context));
+            return formatter.ReadAsync(context);
+        }
+
+        private static bool CanRead(PlatformJsonInputFormatter formatter, Type controllerType)
+        {
+            var http = PlatformHttp("{}");
+            http.SetEndpoint(new Endpoint(
+                requestDelegate: null,
+                new EndpointMetadataCollection(new ControllerActionDescriptor
+                {
+                    ControllerTypeInfo = controllerType.GetTypeInfo(),
+                }),
+                "formatter selection test"));
+            var metadata = new EmptyModelMetadataProvider().GetMetadataForType(typeof(WireRequest));
+            var context = new InputFormatterContext(
+                http,
+                string.Empty,
+                new ModelStateDictionary(),
+                metadata,
+                (stream, encoding) => new StreamReader(stream, encoding));
+
+            return formatter.CanRead(context);
+        }
+
+        private static HttpContext PlatformHttp(string json)
+        {
+            var http = new DefaultHttpContext();
+            var body = Encoding.UTF8.GetBytes(json);
+            http.Request.Body = new MemoryStream(body);
+            http.Request.ContentLength = body.Length;
+            http.Request.ContentType = "application/json";
+            http.SetEndpoint(new Endpoint(
+                requestDelegate: null,
+                new EndpointMetadataCollection(new ControllerActionDescriptor
+                {
+                    ControllerTypeInfo = typeof(TestController).GetTypeInfo(),
+                }),
+                "Platform test"));
+            return http;
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformControllerBase.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformControllerBase.cs
@@ -36,8 +36,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
     [ApiController]
     [Authorize]
     [Produces("application/json")]
-    [TypeFilter(typeof(PlatformRequestFilter))]
-    [TypeFilter(typeof(PlatformBoundedBodyFilter))]
+    [TypeFilter(typeof(PlatformRequestFilter), Order = int.MinValue)]
+    [TypeFilter(typeof(PlatformJsonResultFilter))]
+    [TypeFilter(typeof(PlatformJsonMediaTypeFilter), Order = int.MinValue)]
+    [TypeFilter(typeof(PlatformBoundedBodyFilter), Order = int.MinValue + 1)]
     public abstract class PlatformControllerBase : ControllerBase
     {
         /// <summary>

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformErrorCode.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformErrorCode.cs
@@ -22,6 +22,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
         /// <summary>The request was malformed, missing something required, or self-contradictory.</summary>
         public const string InvalidRequest = "invalid_request";
 
+        /// <summary>The request body is not carried as a JSON media type.</summary>
+        public const string UnsupportedMediaType = "unsupported_media_type";
+
         /// <summary>No protocol version is common to the client and this host. See the negotiate endpoint.</summary>
         public const string UnsupportedProtocol = "unsupported_protocol";
 
@@ -58,6 +61,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
             new(new Dictionary<string, (int, bool)>(StringComparer.Ordinal)
             {
                 [InvalidRequest] = (400, false),
+                [UnsupportedMediaType] = (415, false),
                 [UnsupportedProtocol] = (400, false),
                 [NotFound] = (404, false),
                 [Conflict] = (409, false),

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformJson.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformJson.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>The pinned Platform v1 JSON wire format.</summary>
+    internal static class PlatformJson
+    {
+        internal static JsonSerializerOptions SerializerOptions { get; } = CreateOptions();
+
+        private static JsonSerializerOptions CreateOptions()
+        {
+            var options = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = null,
+                PropertyNameCaseInsensitive = false,
+                UnmappedMemberHandling = JsonUnmappedMemberHandling.Skip,
+            };
+
+            options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase, allowIntegerValues: false));
+            options.Converters.Add(new PlatformDateTimeConverter());
+            options.Converters.Add(new PlatformDateTimeOffsetConverter());
+            options.Converters.Add(new PlatformGuidConverter());
+            return options;
+        }
+
+        private static DateTimeOffset ReadUtc(ref Utf8JsonReader reader)
+        {
+            if (reader.TokenType != JsonTokenType.String)
+            {
+                throw new JsonException("Expected an RFC 3339 timestamp string with an explicit UTC offset.");
+            }
+
+            var raw = reader.GetString();
+            var zulu = raw is not null && raw.EndsWith('Z');
+            var explicitZero = raw is not null && raw.EndsWith("+00:00", StringComparison.Ordinal);
+            var value = default(DateTimeOffset);
+            var valid = zulu
+                ? DateTimeOffset.TryParseExact(
+                    raw,
+                    new[] { "yyyy-MM-dd'T'HH:mm:ss'Z'", "yyyy-MM-dd'T'HH:mm:ss.FFFFFFF'Z'" },
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                    out value)
+                : explicitZero && DateTimeOffset.TryParseExact(
+                    raw,
+                    new[] { "yyyy-MM-dd'T'HH:mm:sszzz", "yyyy-MM-dd'T'HH:mm:ss.FFFFFFFzzz" },
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.None,
+                    out value);
+
+            if (!valid || value.Offset != TimeSpan.Zero)
+            {
+                throw new JsonException("Expected an RFC 3339 timestamp with an explicit UTC offset.");
+            }
+
+            return value.ToUniversalTime();
+        }
+
+        private sealed class PlatformDateTimeConverter : JsonConverter<DateTime>
+        {
+            public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+                => ReadUtc(ref reader).UtcDateTime;
+
+            public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+            {
+                var utc = value.Kind == DateTimeKind.Unspecified
+                    ? DateTime.SpecifyKind(value, DateTimeKind.Utc)
+                    : value.ToUniversalTime();
+                writer.WriteStringValue(new DateTimeOffset(utc).ToString("O", CultureInfo.InvariantCulture));
+            }
+        }
+
+        private sealed class PlatformDateTimeOffsetConverter : JsonConverter<DateTimeOffset>
+        {
+            public override DateTimeOffset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+                => ReadUtc(ref reader);
+
+            public override void Write(Utf8JsonWriter writer, DateTimeOffset value, JsonSerializerOptions options)
+                => writer.WriteStringValue(value.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture));
+        }
+
+        private sealed class PlatformGuidConverter : JsonConverter<Guid>
+        {
+            public override Guid Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                if (reader.TokenType != JsonTokenType.String)
+                {
+                    throw new JsonException("Expected a lowercase canonical GUID string.");
+                }
+
+                var raw = reader.GetString();
+                if (!Guid.TryParseExact(raw, "D", out var value)
+                    || !string.Equals(raw, value.ToString("D", CultureInfo.InvariantCulture), StringComparison.Ordinal))
+                {
+                    throw new JsonException("Expected a lowercase canonical GUID.");
+                }
+
+                return value;
+            }
+
+            public override void Write(Utf8JsonWriter writer, Guid value, JsonSerializerOptions options)
+                => writer.WriteStringValue(value.ToString("D", CultureInfo.InvariantCulture).ToLowerInvariant());
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformJsonInputFormatter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformJsonInputFormatter.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Reflection;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Formatters;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>Uses the Platform wire serializer for Platform body parameters only.</summary>
+    public sealed class PlatformJsonInputFormatter : IInputFormatter
+    {
+        /// <inheritdoc />
+        public bool CanRead(InputFormatterContext context)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+
+            var descriptor = context.HttpContext.GetEndpoint()?.Metadata.GetMetadata<ControllerActionDescriptor>();
+            return descriptor?.ControllerTypeInfo is TypeInfo controller
+                && typeof(PlatformControllerBase).IsAssignableFrom(controller.AsType())
+                && PlatformJsonMediaTypeFilter.IsJson(context.HttpContext.Request.ContentType);
+        }
+
+        /// <inheritdoc />
+        public async Task<InputFormatterResult> ReadAsync(InputFormatterContext context)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+
+            try
+            {
+                var value = await JsonSerializer.DeserializeAsync(
+                    context.HttpContext.Request.Body,
+                    context.ModelType,
+                    PlatformJson.SerializerOptions,
+                    context.HttpContext.RequestAborted).ConfigureAwait(false);
+
+                return await InputFormatterResult.SuccessAsync(value).ConfigureAwait(false);
+            }
+            catch (JsonException exception)
+            {
+                context.ModelState.TryAddModelError(
+                    PlatformRequestFilter.NormalizeField(exception.Path),
+                    "The JSON value is invalid.");
+                return await InputFormatterResult.FailureAsync().ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformJsonMediaTypeFilter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformJsonMediaTypeFilter.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>Refuses non-JSON Platform request bodies before model binding.</summary>
+    public sealed class PlatformJsonMediaTypeFilter : IAsyncResourceFilter, IOrderedFilter
+    {
+        /// <inheritdoc />
+        public int Order => int.MinValue;
+
+        /// <inheritdoc />
+        public async Task OnResourceExecutionAsync(ResourceExecutingContext context, ResourceExecutionDelegate next)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            ArgumentNullException.ThrowIfNull(next);
+
+            var request = context.HttpContext.Request;
+            var bodyFeature = context.HttpContext.Features.Get<IHttpRequestBodyDetectionFeature>();
+            var hasBody = bodyFeature?.CanHaveBody
+                ?? request.ContentLength > 0
+                || request.Headers.ContainsKey("Transfer-Encoding");
+
+            if (!hasBody || IsJson(request.ContentType))
+            {
+                await next().ConfigureAwait(false);
+                return;
+            }
+
+            var correlationId = PlatformCorrelation.For(context.HttpContext);
+            context.HttpContext.Response.Headers[PlatformCorrelation.HeaderName] = correlationId;
+            context.Result = PlatformResults.Error(
+                PlatformErrorCode.UnsupportedMediaType,
+                "Platform request bodies must use a JSON media type.",
+                correlationId);
+        }
+
+        internal static bool IsJson(string? contentType)
+        {
+            var mediaType = contentType?.Split(';', 2, StringSplitOptions.TrimEntries)[0];
+            return string.Equals(mediaType, "application/json", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformJsonResultFilter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformJsonResultFilter.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>Routes Platform results through the pinned Platform JSON serializer.</summary>
+    public sealed class PlatformJsonResultFilter : IAsyncResultFilter
+    {
+        /// <inheritdoc />
+        public async Task OnResultExecutionAsync(ResultExecutingContext context, ResultExecutionDelegate next)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            ArgumentNullException.ThrowIfNull(next);
+
+            if (context.Result is ObjectResult { Value: not null } result)
+            {
+                context.Result = new JsonResult(result.Value, PlatformJson.SerializerOptions)
+                {
+                    StatusCode = result.StatusCode,
+                    ContentType = "application/json",
+                };
+            }
+
+            await next().ConfigureAwait(false);
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformRequestFilter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformRequestFilter.cs
@@ -22,7 +22,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
     /// not an implementation detail.
     /// </para>
     /// </summary>
-    public sealed class PlatformRequestFilter : IAsyncActionFilter, IAsyncExceptionFilter
+    public sealed class PlatformRequestFilter : IAsyncActionFilter, IAsyncExceptionFilter, IOrderedFilter
     {
         private readonly ILogger<PlatformRequestFilter> _logger;
 
@@ -32,6 +32,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
         {
             _logger = logger;
         }
+
+        /// <inheritdoc />
+        public int Order => int.MinValue;
 
         /// <inheritdoc />
         public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
@@ -45,6 +48,25 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
             // longer writable, and a streaming action would otherwise silently lose it.
             context.HttpContext.Response.Headers[PlatformCorrelation.HeaderName] = correlationId;
 
+            // ApiController's automatic model-state filter normally emits ProblemDetails.
+            // This filter is ordered ahead of it so malformed JSON and unknown enum values
+            // stay inside the one Platform error contract without exposing serializer text.
+            if (!context.ModelState.IsValid)
+            {
+                var field = context.ModelState
+                    .Where(entry => entry.Value?.Errors.Count > 0)
+                    .Select(entry => NormalizeField(entry.Key))
+                    .FirstOrDefault(value => value.Length > 0);
+
+                context.Result = PlatformResults.Error(
+                    PlatformErrorCode.InvalidRequest,
+                    field is null
+                        ? "The request body is invalid."
+                        : $"The request field '{field}' is invalid.",
+                    correlationId);
+                return;
+            }
+
             // The scope is what makes the id appear on log lines written by the action
             // itself, not just on the ones written here. That is the whole point - an id
             // that only appears in the envelope correlates a response with nothing.
@@ -55,6 +77,23 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
             {
                 await next().ConfigureAwait(false);
             }
+        }
+
+        internal static string NormalizeField(string? path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return string.Empty;
+            }
+
+            var field = path.Trim().TrimStart('$', '.');
+            var separator = field.LastIndexOfAny(new[] { '.', '[', ']' });
+            if (separator >= 0 && separator + 1 < field.Length)
+            {
+                field = field[(separator + 1)..];
+            }
+
+            return new string(field.Where(character => char.IsLetterOrDigit(character) || character == '_').ToArray());
         }
 
         /// <inheritdoc />

--- a/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
@@ -3,6 +3,7 @@ using Jellyfin.Plugin.JellyfinCanopy.Configuration;
 using Jellyfin.Plugin.JellyfinCanopy.EventHandlers;
 using Jellyfin.Plugin.JellyfinCanopy.Services;
 using Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
 using MediaBrowser.Controller.Events;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Plugins;
@@ -29,6 +30,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy
             serviceCollection.AddSingleton<IStartupFilter, BrandingAssetStartupFilter>();
 
             serviceCollection.AddHttpClient();
+
+            // Platform v1 owns a wire format without changing any legacy controller.
+            serviceCollection.Configure<MvcOptions>(options =>
+                options.InputFormatters.Insert(0, new PlatformJsonInputFormatter()));
 
             // a named HttpClient with AllowAutoRedirect=false so
             // forward-auth proxies (Authelia / Pangolin / Authentik) returning

--- a/contracts/platform/v1/frozen.json
+++ b/contracts/platform/v1/frozen.json
@@ -60,6 +60,7 @@
         "rate_limited",
         "timeout",
         "unavailable",
+        "unsupported_media_type",
         "unsupported_protocol"
       ]
     }

--- a/contracts/platform/v1/openapi.json
+++ b/contracts/platform/v1/openapi.json
@@ -4,7 +4,7 @@
     "title": "Jellyfin Canopy \u2014 Platform v1",
     "version": "1.0.0",
     "summary": "The versioned, capability-scoped extension surface.",
-    "description": "This document is AUTHORED, not generated from the running server. Generating it from the code would document whatever the code happens to do, mistakes included, and would make a breaking change undetectable \u2014 the spec would simply move with the bug. Here the spec is the source of truth and the server is checked against it by PlatformContractTests.\n\nOnly routes under /JellyfinCanopy/Platform/v1 are described. The pre-platform /JellyfinCanopy/* routes are compatibility surfaces with their own shapes and are deliberately absent; they are never promoted into the platform implicitly.\n\nChanges within v1 are additive only (ADR-0010). Removing a path, removing a required property, or changing a property's type is a v2 concern, and contracts/platform/v1/frozen.json exists so CI can prove it rather than a reviewer having to notice."
+    "description": "This document is AUTHORED, not generated from the running server. Generating it from the code would document whatever the code happens to do, mistakes included, and would make a breaking change undetectable \u2014 the spec would simply move with the bug. Here the spec is the source of truth and the server is checked against it by PlatformContractTests.\n\nOnly routes under /JellyfinCanopy/Platform/v1 are described. The pre-platform /JellyfinCanopy/* routes are compatibility surfaces with their own shapes and are deliberately absent; they are never promoted into the platform implicitly.\n\nBody-bearing requests accept application/json only; a different or missing Content-Type is a structured 415 after authorization. Request readers ignore unknown object properties, reject unknown enum values as invalid_request, and require RFC 3339 UTC timestamps with an explicit UTC offset. GUIDs use lowercase canonical D form. Clients must ignore unknown response properties so additive v1 evolution remains usable.\n\nChanges within v1 are additive only (ADR-0010). Removing a path, removing a required property, or changing a property's type is a v2 concern, and contracts/platform/v1/frozen.json exists so CI can prove it rather than a reviewer having to notice."
   },
   "servers": [
     {
@@ -102,6 +102,16 @@
       },
       "PayloadTooLarge": {
         "description": "A kernel-owned request bound was exceeded. The message names which axis, so a client knows whether to send fewer items, shorter strings, or a flatter shape.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/PlatformError"
+            }
+          }
+        }
+      },
+      "UnsupportedMediaType": {
+        "description": "The authenticated request carries a body with a missing or non-JSON Content-Type.",
         "content": {
           "application/json": {
             "schema": {
@@ -210,6 +220,7 @@
         "description": "Machine-readable failure code. Branch on this, never on the message. An unfamiliar code must be treated as a generic failure of its HTTP status class, which is why each code maps to exactly one status.",
         "enum": [
           "invalid_request",
+          "unsupported_media_type",
           "unsupported_protocol",
           "not_found",
           "conflict",

--- a/docs/platform-contract.md
+++ b/docs/platform-contract.md
@@ -46,6 +46,23 @@ reworded or translated at any time. The code set is enumerated in the spec, and 
 maps to exactly one HTTP status. Treat a code you do not recognise as a generic failure of
 its status class.
 
+## JSON wire format
+
+Platform v1 pins one JSON format without changing any older `/JellyfinCanopy/*` route:
+
+- requests with a body must use `application/json`; after authentication, any other or
+  missing `Content-Type` returns a structured `415` with code `unsupported_media_type`
+- unknown request object properties are ignored, so a newer client can send optional
+  data to an older host
+- an unknown request enum value returns `400 invalid_request`; the safe message names
+  the field but never includes serializer internals or the rejected value
+- timestamps are RFC 3339 UTC values and always carry an explicit UTC offset
+- GUIDs use lowercase canonical `D` form (`aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee`)
+
+Response readers must ignore properties they do not recognise. New optional response
+properties are additive within v1; rejecting the whole response would turn a compatible
+host upgrade into a client failure.
+
 ## Versioning
 
 The `v1` in the path is a **major** version. Within it, changes are additive only

--- a/e2e/platform-contract-smoke.spec.ts
+++ b/e2e/platform-contract-smoke.spec.ts
@@ -87,6 +87,15 @@ function assertMatchesSchema(payload: any, schema: any, where: string): void {
     }
 }
 
+/** A generated-client-shaped reader: consume known response fields, ignore future ones. */
+function readKnownResponse(payload: any, schema: any): any {
+    return Object.fromEntries(
+        Object.keys(schema.properties ?? {})
+            .filter((name) => name in payload)
+            .map((name) => [name, payload[name]]),
+    );
+}
+
 /** The one operation the contract marks anonymous. */
 function anonymousPath(): string {
     const entries = Object.entries<any>(CONTRACT.paths).filter(
@@ -157,6 +166,31 @@ test.describe('Platform v1 contract — live smoke client', () => {
         // If this ever fails, the two routes disagree about the same server.
         expect(negotiated.body.Compatible).toBe(true);
         expect(negotiated.body.Protocol).toBe(discovery.body.ProtocolMaximum);
+
+        // Additive v1 evolution may put a property on a future host that this
+        // contract-driven client does not know yet. Prove the reader preserves
+        // every known field and ignores that injected future field.
+        const negotiationSchema = responseSchema(negotiatePath, 'get', '200');
+        const forwardPayload = { ...negotiated.body, FutureCapability: { version: 2 } };
+        const forwardCompatible = readKnownResponse(forwardPayload, negotiationSchema);
+        expect(forwardCompatible).toEqual(negotiated.body);
+        expect(forwardCompatible.FutureCapability).toBeUndefined();
+
+        // Enum sets also grow additively. A client must preserve an unfamiliar
+        // response value so its default branch can treat the HTTP status class
+        // as a generic failure; schema validation belongs on the server, not in
+        // a forward-compatible response reader.
+        const errorSchema = CONTRACT.components.schemas.PlatformError;
+        const futureError = readKnownResponse({
+            Error: true,
+            Code: 'future_platform_code',
+            Message: 'A newer host returned a code this client does not know.',
+            Retryable: false,
+            CorrelationId: '0123456789abcdef0123456789abcdef',
+            FutureDetail: { revision: 2 },
+        }, errorSchema);
+        expect(futureError.Code).toBe('future_platform_code');
+        expect(futureError.FutureDetail).toBeUndefined();
 
         assertNoRuntimeErrors(consoleErrors);
     });

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -33,12 +33,12 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         maximumCoveredLines: 2808,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
-        cleanRuns: 4,
-        minimumCoveredLines: 31220,
+        cleanRuns: 5,
+        minimumCoveredLines: 31219,
         maximumCoveredLines: 31220,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 0);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 1);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,7 +26,7 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2808, totalLines: 3201 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 31019, totalLines: 39687 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 31220, totalLines: 39804 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 3,
         minimumCoveredLines: 2808,
@@ -34,11 +34,11 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
     });
     assert.deepEqual(baselines.profiles.server.observations, {
         cleanRuns: 4,
-        minimumCoveredLines: 31018,
-        maximumCoveredLines: 31019,
+        minimumCoveredLines: 31220,
+        maximumCoveredLines: 31220,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 1);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 0);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,19 +26,19 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2808, totalLines: 3201 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 31220, totalLines: 39804 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 31221, totalLines: 39804 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 3,
         minimumCoveredLines: 2808,
         maximumCoveredLines: 2808,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
-        cleanRuns: 5,
+        cleanRuns: 10,
         minimumCoveredLines: 31219,
-        maximumCoveredLines: 31220,
+        maximumCoveredLines: 31221,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 1);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 31019,
-        "totalLines": 39687
+        "coveredLines": 31220,
+        "totalLines": 39804
       },
       "observations": {
         "cleanRuns": 4,
-        "minimumCoveredLines": 31018,
-        "maximumCoveredLines": 31019
+        "minimumCoveredLines": 31220,
+        "maximumCoveredLines": 31220
       },
       "tolerance": {
-        "missingCoveredLines": 1,
-        "rationale": "The #93 dependency-invalidation change adds an explicit tag-cache dependency graph, bounded descendant repair, relationship-aware pending-change coalescing, and regression coverage for episode, season, and series mutations. Four clean Coverlet runs on the identical 2026-08-02 source and 39,687-line scope each passed all 2,645 server tests: three runs observed 31,018 covered lines and the final official coverage entry point observed 31,019. Relative to the reviewed #88 main baseline of 30,222/38,901 (77.690%), the reviewed implementation adds 786 instrumented lines and 797 covered high-water lines while increasing the high-water to 31,019/39,687 (78.159%) and the enforced floor to 31,018/39,687 (78.157%). The one-line allowance is exactly the same-head fixed-scope instrumentation envelope tracked in #575; the measured high-water is retained and broader regressions still fail. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 0,
+        "rationale": "The #521 v1 wire-format change adds strict platform JSON/media-type handling, canonical UTC timestamp and GUID serialization, safe request binding, response formatting, and focused regression coverage. Four clean Coverlet runs on the identical 2026-08-02 source and 39,804-line scope each passed all 2,666 server tests and reproduced exactly 31,220 covered lines. Relative to the reviewed #93 main baseline of 31,019/39,687 (78.159%), the reviewed implementation adds 117 instrumented lines and 201 covered lines while increasing coverage to 31,220/39,804 (78.434%). The exact observed envelope needs no instrumentation tolerance, so the new floor is 31,220/39,804 (78.434%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -31,13 +31,13 @@
         "totalLines": 39804
       },
       "observations": {
-        "cleanRuns": 4,
-        "minimumCoveredLines": 31220,
+        "cleanRuns": 5,
+        "minimumCoveredLines": 31219,
         "maximumCoveredLines": 31220
       },
       "tolerance": {
-        "missingCoveredLines": 0,
-        "rationale": "The #521 v1 wire-format change adds strict platform JSON/media-type handling, canonical UTC timestamp and GUID serialization, safe request binding, response formatting, and focused regression coverage. Four clean Coverlet runs on the identical 2026-08-02 source and 39,804-line scope each passed all 2,666 server tests and reproduced exactly 31,220 covered lines. Relative to the reviewed #93 main baseline of 31,019/39,687 (78.159%), the reviewed implementation adds 117 instrumented lines and 201 covered lines while increasing coverage to 31,220/39,804 (78.434%). The exact observed envelope needs no instrumentation tolerance, so the new floor is 31,220/39,804 (78.434%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 1,
+        "rationale": "The #521 v1 wire-format change adds strict platform JSON/media-type handling, canonical UTC timestamp and GUID serialization, safe request binding, response formatting, and focused regression coverage. Five clean Coverlet runs on the identical 2026-08-02 source and 39,804-line scope each passed all 2,666 server tests: the first CI run and three local runs reproduced 31,220 covered lines, while the follow-up CI run observed 31,219. Relative to the reviewed #93 main baseline of 31,019/39,687 (78.159%), the reviewed implementation adds 117 instrumented lines and 201 covered high-water lines while increasing the high-water to 31,220/39,804 (78.434%) and the enforced floor to 31,219/39,804 (78.432%). The one-line allowance is exactly the observed same-head, fixed-scope instrumentation envelope; the 31,220 high-water is retained and broader regressions still fail. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 31220,
+        "coveredLines": 31221,
         "totalLines": 39804
       },
       "observations": {
-        "cleanRuns": 5,
+        "cleanRuns": 10,
         "minimumCoveredLines": 31219,
-        "maximumCoveredLines": 31220
+        "maximumCoveredLines": 31221
       },
       "tolerance": {
-        "missingCoveredLines": 1,
-        "rationale": "The #521 v1 wire-format change adds strict platform JSON/media-type handling, canonical UTC timestamp and GUID serialization, safe request binding, response formatting, and focused regression coverage. Five clean Coverlet runs on the identical 2026-08-02 source and 39,804-line scope each passed all 2,666 server tests: the first CI run and three local runs reproduced 31,220 covered lines, while the follow-up CI run observed 31,219. Relative to the reviewed #93 main baseline of 31,019/39,687 (78.159%), the reviewed implementation adds 117 instrumented lines and 201 covered high-water lines while increasing the high-water to 31,220/39,804 (78.434%) and the enforced floor to 31,219/39,804 (78.432%). The one-line allowance is exactly the observed same-head, fixed-scope instrumentation envelope; the 31,220 high-water is retained and broader regressions still fail. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 2,
+        "rationale": "The #521 v1 wire-format change adds strict platform JSON/media-type handling, canonical UTC timestamp and GUID serialization, safe request binding, response formatting, and focused regression coverage. Ten clean Coverlet runs on the identical 2026-08-02 source and 39,804-line scope each passed all 2,666 server tests: one observed 31,219 covered lines, seven observed 31,220, and two observed 31,221. Preserved local reports identify the one-line local variance as the valid concurrent cleanup ordering at ImageBlurService.cs:740; CI supplied the lower edge. Relative to the reviewed #93 main baseline of 31,019/39,687 (78.159%), the reviewed implementation adds 117 instrumented lines and 202 covered high-water lines while increasing the high-water to 31,221/39,804 (78.437%) and the enforced floor to 31,219/39,804 (78.432%). The two-line allowance is exactly the observed same-head, fixed-scope instrumentation envelope; the 31,221 high-water is retained and broader regressions still fail. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
## Summary

- pin a Platform-v1-only `System.Text.Json` wire format without changing legacy routes
- require `application/json` for body-bearing Platform actions and return structured post-auth `415 unsupported_media_type` failures otherwise
- require strict RFC 3339 UTC timestamps and lowercase canonical-D GUIDs
- ignore unknown request fields, reject malformed/unknown enum input through safe `invalid_request`, and keep response readers additive
- route actual MVC input/output through the pinned serializer and preserve bare host-owned 401/403 behavior
- update OpenAPI, the frozen compatibility baseline, docs, and the headless smoke client

## Verification

- focused Platform tests: **53/53 passed**
- full server suite: **2666/2666 passed**
- server coverage: ten clean same-commit runs established a reviewed **31,219–31,221 / 39,804** envelope; the **31,221** high-water remains enforced
- `npm run lint`: 0 errors; existing warning ratchet remained below its cap
- `npm run typecheck`
- `npm run typecheck:src`
- `npm run test:scripts`: **634/634 passed**
- Platform Playwright discovery: 2 required tests parsed
- required E2E inventory: **7/7 passed**
- OpenAPI/frozen JSON parse and `git diff --check`
- independent review: approved after all findings were resolved
- independent coverage review: approved the exact fixed-scope envelope and two-line allowance

The `UnsupportedMediaType` response component remains intentionally unattached until the first body-bearing Platform operation lands; that operation must reference it.

Closes #521
