### PR TITLE
feat(platform): add request lifecycle and idempotency kernel

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformContractTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformContractTests.cs
@@ -220,6 +220,53 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
             Assert.Equal(PlatformConstants.ProtocolMaximum, fixture.ProtocolMaximum);
         }
 
+        [Fact]
+        public void IdempotencyHeaderContractMatchesTheSharedParserBounds()
+        {
+            var parameter = Spec.RootElement.GetProperty("components").GetProperty("parameters")
+                .GetProperty("IdempotencyKey");
+            var schema = parameter.GetProperty("schema");
+
+            Assert.Equal(PlatformIdempotencyKey.HeaderName, parameter.GetProperty("name").GetString());
+            Assert.Equal("header", parameter.GetProperty("in").GetString());
+            Assert.True(parameter.GetProperty("required").GetBoolean());
+            Assert.Equal(1, schema.GetProperty("minLength").GetInt32());
+            Assert.Equal(PlatformIdempotencyKey.MaximumLength, schema.GetProperty("maxLength").GetInt32());
+            Assert.Equal("^[A-Za-z0-9._~-]+$", schema.GetProperty("pattern").GetString());
+
+            Assert.True(PlatformIdempotencyKey.TryParse(new string('a', schema.GetProperty("maxLength").GetInt32()), out _));
+            Assert.False(PlatformIdempotencyKey.TryParse(new string('a', schema.GetProperty("maxLength").GetInt32() + 1), out _));
+        }
+
+        [Fact]
+        public void EveryPlatformOperationDocumentsTheKernelTimeoutResponse()
+        {
+            var timeout = Spec.RootElement.GetProperty("components").GetProperty("responses")
+                .GetProperty("Timeout");
+            Assert.Equal(
+                "#/components/schemas/PlatformError",
+                timeout.GetProperty("content").GetProperty("application/json")
+                    .GetProperty("schema").GetProperty("$ref").GetString());
+
+            Assert.All(SpecOperations(), operation => Assert.Equal(
+                "#/components/responses/Timeout",
+                operation.Operation.GetProperty("responses").GetProperty("504").GetProperty("$ref").GetString()));
+        }
+
+        [Theory]
+        [InlineData("IdempotencyConflict")]
+        [InlineData("IdempotencyAtCapacity")]
+        public void FutureIdempotencyErrorsReuseThePlatformEnvelope(string responseName)
+        {
+            var response = Spec.RootElement.GetProperty("components").GetProperty("responses")
+                .GetProperty(responseName);
+
+            Assert.Equal(
+                "#/components/schemas/PlatformError",
+                response.GetProperty("content").GetProperty("application/json")
+                    .GetProperty("schema").GetProperty("$ref").GetString());
+        }
+
         [Theory]
         [InlineData("discovery.200.json", typeof(PlatformDiscoveryResponse))]
         [InlineData("negotiate.200.compatible.json", typeof(PlatformNegotiationResponse))]

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformCorrelationTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformCorrelationTests.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.JellyfinCanopy.Platform;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Authorization;
@@ -150,6 +152,123 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
             // Handled, so the host's default error page cannot replace the envelope with
             // a different shape.
             Assert.True(context.ExceptionHandled);
+        }
+
+        [Fact]
+        public async Task CallerCancellationIsHandledWithoutAWriteOrServerFaultLog()
+        {
+            var logger = new RecordingLogger();
+            using var caller = new CancellationTokenSource();
+            using var deadline = new CancellationTokenSource();
+            var http = new DefaultHttpContext();
+            http.Items[PlatformRequestLifecycleState.ItemKey] = new PlatformRequestLifecycleState(caller.Token, deadline.Token);
+            caller.Cancel();
+            var context = new ExceptionContext(
+                new ActionContext(http, new RouteData(), new ControllerActionDescriptor()),
+                new List<IFilterMetadata>())
+            {
+                Exception = new OperationCanceledException(),
+            };
+
+            await new PlatformRequestFilter(logger).OnExceptionAsync(context);
+
+            Assert.True(context.ExceptionHandled);
+            Assert.IsType<EmptyResult>(context.Result);
+            Assert.Empty(http.Response.Headers);
+            Assert.Empty(logger.Entries);
+        }
+
+        [Fact]
+        public async Task CallerCancellationDuringActionPublishesNoDeferredCorrelationHeader()
+        {
+            var logger = new RecordingLogger();
+            using var caller = new CancellationTokenSource();
+            using var deadline = new CancellationTokenSource();
+            var http = new DefaultHttpContext();
+            http.Items[PlatformRequestLifecycleState.ItemKey] = new PlatformRequestLifecycleState(caller.Token, deadline.Token);
+            var context = ActionContext(http);
+
+            await new PlatformRequestFilter(logger).OnActionExecutionAsync(context, () =>
+            {
+                caller.Cancel();
+                return Task.FromResult(new ActionExecutedContext(context, new List<IFilterMetadata>(), new object())
+                {
+                    Result = new EmptyResult(),
+                });
+            });
+
+            Assert.Empty(http.Response.Headers);
+            Assert.Empty(logger.Entries);
+        }
+
+        [Fact]
+        public async Task DeadlineCancellationUsesTimeoutWithoutAFalseServerFaultLog()
+        {
+            var logger = new RecordingLogger();
+            using var caller = new CancellationTokenSource();
+            using var deadline = new CancellationTokenSource();
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(caller.Token, deadline.Token);
+            var http = new DefaultHttpContext { RequestAborted = linked.Token };
+            http.Items[PlatformRequestLifecycleState.ItemKey] = new PlatformRequestLifecycleState(caller.Token, deadline.Token);
+            deadline.Cancel();
+            var context = new ExceptionContext(
+                new ActionContext(http, new RouteData(), new ControllerActionDescriptor()),
+                new List<IFilterMetadata>())
+            {
+                Exception = new OperationCanceledException(),
+            };
+
+            await new PlatformRequestFilter(logger).OnExceptionAsync(context);
+
+            var result = Assert.IsType<ObjectResult>(context.Result);
+            Assert.Equal(504, result.StatusCode);
+            Assert.Equal(PlatformErrorCode.Timeout, Assert.IsType<PlatformError>(result.Value).Code);
+            Assert.Equal(caller.Token, http.RequestAborted);
+            Assert.DoesNotContain(logger.Entries, entry => entry.Level == LogLevel.Error);
+        }
+
+        [Fact]
+        public async Task UnrelatedCancellationRemainsAnInternalErrorAndIsLogged()
+        {
+            var logger = new RecordingLogger();
+            using var caller = new CancellationTokenSource();
+            using var deadline = new CancellationTokenSource();
+            var http = new DefaultHttpContext();
+            http.Items[PlatformRequestLifecycleState.ItemKey] = new PlatformRequestLifecycleState(caller.Token, deadline.Token);
+            var context = new ExceptionContext(
+                new ActionContext(http, new RouteData(), new ControllerActionDescriptor()),
+                new List<IFilterMetadata>())
+            {
+                Exception = new OperationCanceledException("not a Platform token"),
+            };
+
+            await new PlatformRequestFilter(logger).OnExceptionAsync(context);
+
+            var result = Assert.IsType<ObjectResult>(context.Result);
+            Assert.Equal(PlatformErrorCode.InternalError, Assert.IsType<PlatformError>(result.Value).Code);
+            Assert.Contains(logger.Entries, entry => entry.Level == LogLevel.Error);
+        }
+
+        [Fact]
+        public async Task StartedResponseGenericFailureLogsButAttemptsNoReplacementWrite()
+        {
+            var logger = new RecordingLogger();
+            var http = new DefaultHttpContext();
+            http.Features.Set<IHttpResponseFeature>(new StartedResponseFeature());
+            Assert.True(http.Response.HasStarted);
+            var context = new ExceptionContext(
+                new ActionContext(http, new RouteData(), new ControllerActionDescriptor()),
+                new List<IFilterMetadata>())
+            {
+                Exception = new InvalidOperationException("after response start"),
+            };
+
+            await new PlatformRequestFilter(logger).OnExceptionAsync(context);
+
+            Assert.True(context.ExceptionHandled);
+            Assert.IsType<EmptyResult>(context.Result);
+            Assert.Contains(logger.Entries, entry => entry.Level == LogLevel.Error);
+            Assert.Empty(http.Response.Headers);
         }
 
         [Fact]

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformIdempotencyArchitectureTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformIdempotencyArchitectureTests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
+{
+    /// <summary>Prevents the bounded store from being replaced by an unbounded cache owner.</summary>
+    public class PlatformIdempotencyArchitectureTests
+    {
+        private static readonly Regex StateOwner = new(
+            @"^\s*(?:private|internal|public|protected)\s+(?:static\s+)?(?:readonly\s+)?"
+            + @"(?:ReadOnlyDictionary|Dictionary|ConcurrentDictionary|IMemoryCache|MemoryCache|BoundedTtlCache)"
+            + @"(?:<[^;\r\n]+>)?\s+(?<name>[A-Za-z_][A-Za-z0-9_]*)\s*(?:=|;)",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Multiline);
+
+        private static readonly Dictionary<string, string> AllowedStateOwners = new(StringComparer.Ordinal)
+        {
+            ["PlatformErrorCode.cs:Definitions"] = "Immutable error-code definition table, not request state.",
+            ["PlatformIdempotencyStore.cs:_entries"] = "The sole reviewed bounded idempotency state owner.",
+        };
+
+        [Fact]
+        public void IdempotencyStateHasOneSpecializedBoundedOwner()
+        {
+            var owners = Directory.EnumerateFiles(PlatformSourceDirectory(), "*.cs", SearchOption.AllDirectories)
+                .SelectMany(file => FindStateOwners(Path.GetFileName(file), File.ReadAllText(file)))
+                .OrderBy(owner => owner, StringComparer.Ordinal)
+                .ToArray();
+
+            Assert.Equal(AllowedStateOwners.Keys.OrderBy(owner => owner, StringComparer.Ordinal), owners);
+            var source = File.ReadAllText(SourcePath("PlatformIdempotencyStore.cs"));
+            var code = PlatformHostSeamTests.CodeOnly(source);
+            Assert.Contains("MaximumEntries", code, StringComparison.Ordinal);
+            Assert.Contains("MaximumStoredResultBytes", code, StringComparison.Ordinal);
+            Assert.Contains("MaximumResultBytes", code, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void TheGuardWouldRejectUnboundedCacheWrites()
+        {
+            const string planted = "private static readonly Dictionary<string, object> IdempotencyCache = new();";
+            Assert.Equal(
+                new[] { "RoguePlatformController.cs:IdempotencyCache" },
+                FindStateOwners("RoguePlatformController.cs", planted));
+            Assert.False(AllowedStateOwners.ContainsKey("RoguePlatformController.cs:IdempotencyCache"));
+        }
+
+        [Fact]
+        public void FollowerRegistrationIsBoundedAndTheGuardRejectsAnUnboundedWaitPath()
+        {
+            var source = File.ReadAllText(SourcePath("PlatformIdempotencyStore.cs"));
+            const string planted = "return await entry.Completion.Task.WaitAsync(requestCancellationToken);";
+
+            Assert.False(HasUnboundedFollowerRegistration(source));
+            Assert.True(HasUnboundedFollowerRegistration(planted));
+        }
+
+        [Fact]
+        public void SemanticResultsExposeNoMvcOrRequestCorrelationState()
+        {
+            var properties = typeof(Jellyfin.Plugin.JellyfinCanopy.Platform.PlatformIdempotencyResult)
+                .GetProperties()
+                .Select(property => property.Name)
+                .ToArray();
+
+            Assert.DoesNotContain("CorrelationId", properties);
+            Assert.DoesNotContain(properties, name => name.Contains("ActionResult", StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public void SemanticSizingUsesTheBoundedWriterRatherThanAllocatingTheWholePayload()
+        {
+            var code = PlatformHostSeamTests.CodeOnly(File.ReadAllText(SourcePath("PlatformIdempotency.cs")));
+
+            Assert.Contains("IBufferWriter<byte>", code, StringComparison.Ordinal);
+            Assert.DoesNotContain("SerializeToUtf8Bytes", code, StringComparison.Ordinal);
+        }
+
+        private static string SourcePath(string name, [CallerFilePath] string sourceFile = "") =>
+            Path.GetFullPath(Path.Combine(
+                Path.GetDirectoryName(sourceFile)!,
+                "..",
+                "..",
+                "Jellyfin.Plugin.JellyfinCanopy",
+                "Platform",
+                name));
+
+        internal static string[] FindStateOwners(string fileName, string source)
+        {
+            var code = PlatformHostSeamTests.CodeOnly(source);
+            return StateOwner.Matches(code)
+                .Select(match => $"{fileName}:{match.Groups["name"].Value}")
+                .ToArray();
+        }
+
+        internal static bool HasUnboundedFollowerRegistration(string source)
+        {
+            var code = PlatformHostSeamTests.CodeOnly(source);
+            return code.Contains(".WaitAsync(", StringComparison.Ordinal)
+                && (!code.Contains("MaximumFollowersPerEntry", StringComparison.Ordinal)
+                    || !code.Contains("MaximumFollowers", StringComparison.Ordinal)
+                    || !code.Contains("_followerCount", StringComparison.Ordinal)
+                    || !code.Contains("finally", StringComparison.Ordinal));
+        }
+
+        private static string PlatformSourceDirectory() => Path.GetDirectoryName(SourcePath("placeholder.cs"))!;
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformIdempotencyTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformIdempotencyTests.cs
@@ -1,0 +1,480 @@
+using System;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Microsoft.Extensions.Primitives;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
+{
+    public class PlatformIdempotencyTests
+    {
+        [Theory]
+        [InlineData("a")]
+        [InlineData("Request_01.~-")]
+        [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._~-")]
+        public void KeyParserAcceptsOnlyThePinnedTransportNeutralAlphabet(string raw)
+        {
+            Assert.True(PlatformIdempotencyKey.TryParse(raw, out var parsed));
+            Assert.Equal(raw, parsed.Value);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("space here")]
+        [InlineData("comma,join")]
+        [InlineData("slash/not-allowed")]
+        [InlineData("unicode-é")]
+        public void KeyParserRejectsInvalidValues(string raw)
+        {
+            Assert.False(PlatformIdempotencyKey.TryParse(raw, out _));
+        }
+
+        [Fact]
+        public void HeaderRequiresExactlyOneValueAndTheSameParserCanServeABody()
+        {
+            Assert.True(PlatformIdempotencyKey.TryParseHeader(new StringValues("body-safe-key"), out var header));
+            Assert.True(PlatformIdempotencyKey.TryParse(header.Value, out var body));
+            Assert.Equal(header, body);
+
+            Assert.False(PlatformIdempotencyKey.TryParseHeader(
+                new StringValues(new[] { "one", "two" }),
+                out _));
+        }
+
+        [Fact]
+        public async Task SameTupleAndFingerprintReplaysWithoutExecutingTwice()
+        {
+            var store = new PlatformIdempotencyStore();
+            var request = Request("key", "same-payload");
+            var calls = 0;
+
+            var first = await store.ExecuteAsync(request, _ =>
+            {
+                calls++;
+                return Task.FromResult(Result(42));
+            }, CancellationToken.None);
+            var replay = await store.ExecuteAsync(request, _ =>
+            {
+                calls++;
+                return Task.FromResult(Result(99));
+            }, CancellationToken.None);
+
+            Assert.Equal(PlatformIdempotencyOutcomeKind.Executed, first.Kind);
+            Assert.Equal(PlatformIdempotencyOutcomeKind.Replay, replay.Kind);
+            Assert.Equal(1, calls);
+            Assert.Equal("ok", replay.Result!.OutcomeCode);
+            Assert.Equal(42, replay.Result.Value.GetProperty("value").GetInt32());
+        }
+
+        [Fact]
+        public async Task SameTupleWithDifferentFingerprintConflictsBeforeExecution()
+        {
+            var store = new PlatformIdempotencyStore();
+            await store.ExecuteAsync(Request("key", "payload-a"), _ => Task.FromResult(Result(1)), CancellationToken.None);
+            var called = false;
+
+            var conflict = await store.ExecuteAsync(Request("key", "payload-b"), _ =>
+            {
+                called = true;
+                return Task.FromResult(Result(2));
+            }, CancellationToken.None);
+
+            Assert.Equal(PlatformIdempotencyOutcomeKind.Conflict, conflict.Kind);
+            Assert.False(called);
+        }
+
+        [Fact]
+        public async Task TupleIncludesActingUserAndOperation()
+        {
+            var store = new PlatformIdempotencyStore();
+            var userA = Guid.NewGuid();
+            var userB = Guid.NewGuid();
+            var calls = 0;
+
+            foreach (var request in new[]
+            {
+                Request("shared", "payload", userA, "request.create"),
+                Request("shared", "payload", userB, "request.create"),
+                Request("shared", "payload", userA, "request.cancel"),
+            })
+            {
+                var outcome = await store.ExecuteAsync(request, _ =>
+                {
+                    calls++;
+                    return Task.FromResult(Result(calls));
+                }, CancellationToken.None);
+                Assert.Equal(PlatformIdempotencyOutcomeKind.Executed, outcome.Kind);
+            }
+
+            Assert.Equal(3, calls);
+        }
+
+        [Fact]
+        public async Task FollowerCancellationNeverCancelsTheLeader()
+        {
+            var store = new PlatformIdempotencyStore();
+            var request = Request("coalesce", "payload");
+            var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var release = new TaskCompletionSource<PlatformIdempotencyResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var leaderToken = new CancellationTokenSource();
+
+            var leader = store.ExecuteAsync(request, async token =>
+            {
+                Assert.Equal(leaderToken.Token, token);
+                entered.TrySetResult();
+                return await release.Task;
+            }, leaderToken.Token);
+            await entered.Task;
+
+            using var followerToken = new CancellationTokenSource();
+            var follower = store.ExecuteAsync(
+                request,
+                _ => throw new Xunit.Sdk.XunitException("A follower must not become a leader."),
+                followerToken.Token);
+            followerToken.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => follower);
+            Assert.False(leader.IsCompleted);
+            Assert.False(leaderToken.IsCancellationRequested);
+
+            release.TrySetResult(Result(7));
+            Assert.Equal(PlatformIdempotencyOutcomeKind.Executed, (await leader).Kind);
+            Assert.Equal(
+                PlatformIdempotencyOutcomeKind.Replay,
+                (await store.ExecuteAsync(request, _ => Task.FromResult(Result(8)), CancellationToken.None)).Kind);
+        }
+
+        [Fact]
+        public async Task FollowerBoundRejectsBeforeAttachingAndCanceledWaitersReleaseCapacity()
+        {
+            var store = new PlatformIdempotencyStore();
+            var request = Request("bounded-followers", "payload");
+            var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var release = new TaskCompletionSource<PlatformIdempotencyResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var leader = store.ExecuteAsync(request, _ =>
+            {
+                entered.TrySetResult();
+                return release.Task;
+            }, CancellationToken.None);
+            await entered.Task;
+
+            var cancellations = Enumerable.Range(0, PlatformIdempotencyStore.MaximumFollowersPerEntry)
+                .Select(_ => new CancellationTokenSource())
+                .ToArray();
+            var followers = cancellations.Select(cancellation => store.ExecuteAsync(
+                request,
+                _ => throw new Xunit.Sdk.XunitException("A follower must not execute."),
+                cancellation.Token)).ToArray();
+
+            Assert.Equal(PlatformIdempotencyStore.MaximumFollowersPerEntry, store.FollowerCount);
+            var called = false;
+            var refused = await store.ExecuteAsync(request, _ =>
+            {
+                called = true;
+                return Task.FromResult(Result(0));
+            }, CancellationToken.None);
+            Assert.Equal(PlatformIdempotencyOutcomeKind.AtCapacity, refused.Kind);
+            Assert.False(called);
+
+            foreach (var cancellation in cancellations)
+            {
+                cancellation.Cancel();
+            }
+
+            foreach (var follower in followers)
+            {
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => follower);
+            }
+
+            Assert.Equal(0, store.FollowerCount);
+            var replacement = store.ExecuteAsync(
+                request,
+                _ => throw new Xunit.Sdk.XunitException("A replacement follower must not execute."),
+                CancellationToken.None);
+            Assert.Equal(1, store.FollowerCount);
+
+            release.TrySetResult(Result(1));
+            Assert.Equal(PlatformIdempotencyOutcomeKind.Executed, (await leader).Kind);
+            Assert.Equal(PlatformIdempotencyOutcomeKind.Replay, (await replacement).Kind);
+            Assert.Equal(0, store.FollowerCount);
+
+            foreach (var cancellation in cancellations)
+            {
+                cancellation.Dispose();
+            }
+        }
+
+        [Fact]
+        public async Task PreCanceledRequestCreatesNoEntryAndInvokesNoMutation()
+        {
+            var store = new PlatformIdempotencyStore();
+            using var cancellation = new CancellationTokenSource();
+            cancellation.Cancel();
+            var called = false;
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => store.ExecuteAsync(
+                Request("pre-canceled", "payload"),
+                _ =>
+                {
+                    called = true;
+                    return Task.FromResult(Result(1));
+                },
+                cancellation.Token));
+
+            Assert.False(called);
+            Assert.Equal(0, store.EntryCount);
+            Assert.Equal(0, store.FollowerCount);
+        }
+
+        [Fact]
+        public async Task ProcessWideFollowerBoundRejectsTheExactNextWaiter()
+        {
+            var store = new PlatformIdempotencyStore();
+            var release = new TaskCompletionSource<PlatformIdempotencyResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var requests = Enumerable.Range(0, 17)
+                .Select(index => Request("global-followers-" + index, "payload"))
+                .ToArray();
+            var leaders = requests.Select(request => store.ExecuteAsync(
+                request,
+                _ => release.Task,
+                CancellationToken.None)).ToArray();
+            using var followersCancellation = new CancellationTokenSource();
+            var followers = requests.Take(16)
+                .SelectMany(request => Enumerable.Range(0, PlatformIdempotencyStore.MaximumFollowersPerEntry)
+                    .Select(_ => store.ExecuteAsync(
+                        request,
+                        _ => throw new Xunit.Sdk.XunitException("A follower must not execute."),
+                        followersCancellation.Token)))
+                .ToArray();
+
+            Assert.Equal(PlatformIdempotencyStore.MaximumFollowers, store.FollowerCount);
+            var refused = await store.ExecuteAsync(
+                requests[16],
+                _ => throw new Xunit.Sdk.XunitException("An excess follower must not execute."),
+                CancellationToken.None);
+            Assert.Equal(PlatformIdempotencyOutcomeKind.AtCapacity, refused.Kind);
+
+            followersCancellation.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => Task.WhenAll(followers));
+            Assert.Equal(0, store.FollowerCount);
+
+            release.TrySetResult(Result(1));
+            Assert.All(await Task.WhenAll(leaders), outcome =>
+                Assert.Equal(PlatformIdempotencyOutcomeKind.Executed, outcome.Kind));
+        }
+
+        [Fact]
+        public async Task CapacityIsRejectedBeforeExecutionAndNoLiveEntryIsEvicted()
+        {
+            var store = new PlatformIdempotencyStore();
+            for (var index = 0; index < PlatformIdempotencyStore.MaximumEntries; index++)
+            {
+                var outcome = await store.ExecuteAsync(
+                    Request("key-" + index, "payload"),
+                    _ => Task.FromResult(Result(index)),
+                    CancellationToken.None);
+                Assert.Equal(PlatformIdempotencyOutcomeKind.Executed, outcome.Kind);
+            }
+
+            var called = false;
+            var refused = await store.ExecuteAsync(Request("overflow", "payload"), _ =>
+            {
+                called = true;
+                return Task.FromResult(Result(-1));
+            }, CancellationToken.None);
+
+            Assert.Equal(PlatformIdempotencyOutcomeKind.AtCapacity, refused.Kind);
+            Assert.False(called);
+            Assert.Equal(PlatformIdempotencyStore.MaximumEntries, store.EntryCount);
+            Assert.Equal(
+                PlatformIdempotencyOutcomeKind.Replay,
+                (await store.ExecuteAsync(Request("key-0", "payload"), _ => Task.FromResult(Result(0)), CancellationToken.None)).Kind);
+        }
+
+        [Fact]
+        public async Task TotalResultBytesAreReservedBeforeAnyMutationExecutes()
+        {
+            var store = new PlatformIdempotencyStore();
+            var release = new TaskCompletionSource<PlatformIdempotencyResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var leaders = new Task<PlatformIdempotencyOutcome>[
+                PlatformIdempotencyStore.MaximumStoredResultBytes / PlatformIdempotencyStore.MaximumResultBytes];
+
+            for (var index = 0; index < leaders.Length; index++)
+            {
+                leaders[index] = store.ExecuteAsync(
+                    Request(
+                        "reservation-" + index,
+                        "payload",
+                        maximumResultBytes: PlatformIdempotencyStore.MaximumResultBytes),
+                    _ => release.Task,
+                    CancellationToken.None);
+            }
+
+            var called = false;
+            var refused = await store.ExecuteAsync(
+                Request(
+                    "reservation-overflow",
+                    "payload",
+                    maximumResultBytes: PlatformIdempotencyStore.MaximumResultBytes),
+                _ =>
+                {
+                    called = true;
+                    return Task.FromResult(Result(0));
+                },
+                CancellationToken.None);
+
+            Assert.Equal(PlatformIdempotencyOutcomeKind.AtCapacity, refused.Kind);
+            Assert.False(called);
+
+            release.TrySetResult(Result(1));
+            Assert.All(await Task.WhenAll(leaders), outcome =>
+                Assert.Equal(PlatformIdempotencyOutcomeKind.Executed, outcome.Kind));
+        }
+
+        [Fact]
+        public async Task ExpiredTerminalEntryCanBeReused()
+        {
+            var clock = new ManualTimeProvider(new DateTimeOffset(2026, 8, 3, 0, 0, 0, TimeSpan.Zero));
+            var store = new PlatformIdempotencyStore(clock);
+            await store.ExecuteAsync(Request("expiry", "before"), _ => Task.FromResult(Result(1)), CancellationToken.None);
+
+            clock.Advance(PlatformIdempotencyStore.EntryTimeToLive + TimeSpan.FromTicks(1));
+            var after = await store.ExecuteAsync(
+                Request("expiry", "after"),
+                _ => Task.FromResult(Result(2)),
+                CancellationToken.None);
+
+            Assert.Equal(PlatformIdempotencyOutcomeKind.Executed, after.Kind);
+            Assert.Equal(2, after.Result!.Value.GetProperty("value").GetInt32());
+        }
+
+        [Fact]
+        public async Task FailedLeaderLeavesAnAmbiguousTombstone()
+        {
+            var store = new PlatformIdempotencyStore();
+            var request = Request("ambiguous", "payload");
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => store.ExecuteAsync(
+                request,
+                _ => throw new InvalidOperationException("provider outcome unknown"),
+                CancellationToken.None));
+
+            var called = false;
+            var retry = await store.ExecuteAsync(request, _ =>
+            {
+                called = true;
+                return Task.FromResult(Result(1));
+            }, CancellationToken.None);
+
+            Assert.Equal(PlatformIdempotencyOutcomeKind.Indeterminate, retry.Kind);
+            Assert.False(called);
+        }
+
+        [Fact]
+        public async Task ResultLargerThanItsPreExecutionReservationBecomesIndeterminate()
+        {
+            var store = new PlatformIdempotencyStore();
+            var request = Request("bounded-result", "payload", maximumResultBytes: 8);
+            var outcome = await store.ExecuteAsync(request, _ => Task.FromResult(Result(123)), CancellationToken.None);
+
+            Assert.Equal(PlatformIdempotencyOutcomeKind.Indeterminate, outcome.Kind);
+            Assert.Equal(
+                PlatformIdempotencyOutcomeKind.Indeterminate,
+                (await store.ExecuteAsync(request, _ => Task.FromResult(Result(456)), CancellationToken.None)).Kind);
+        }
+
+        [Fact]
+        public void SemanticResultAndFingerprintDefensivelyOwnTheirInputs()
+        {
+            var bytes = System.Security.Cryptography.SHA256.HashData(Encoding.UTF8.GetBytes("original"));
+            var fingerprint = new PlatformSemanticFingerprint(bytes);
+            Array.Fill<byte>(bytes, 0);
+
+            using var document = JsonDocument.Parse("{\"value\":1}");
+            var result = new PlatformIdempotencyResult(409, "already-exists", document.RootElement);
+            document.Dispose();
+
+            Assert.Equal(1, result.Value.GetProperty("value").GetInt32());
+            Assert.True(fingerprint.Matches(new PlatformSemanticFingerprint(
+                System.Security.Cryptography.SHA256.HashData(Encoding.UTF8.GetBytes("original")))));
+        }
+
+        [Fact]
+        public void OversizedSemanticResultIsRejectedByTheBoundedWriter()
+        {
+            using var document = JsonDocument.Parse(
+                "{\"value\":\"" + new string('x', PlatformIdempotencyStore.MaximumResultBytes) + "\"}");
+
+            Assert.Throws<ArgumentException>(() => new PlatformIdempotencyResult(200, "ok", document.RootElement));
+        }
+
+        [Fact]
+        public void SemanticResultAcceptsTheExactByteCeiling()
+        {
+            // Four status bytes + two outcome-code bytes + 12 bytes of JSON syntax.
+            var payloadBytes = PlatformIdempotencyStore.MaximumResultBytes - sizeof(int) - 2 - 12;
+            using var document = JsonDocument.Parse("{\"value\":\"" + new string('x', payloadBytes) + "\"}");
+
+            var result = new PlatformIdempotencyResult(200, "ok", document.RootElement);
+
+            Assert.Equal(PlatformIdempotencyStore.MaximumResultBytes, result.SerializedSizeBytes);
+        }
+
+        [Theory]
+        [InlineData(PlatformIdempotencyOutcomeKind.Executed, null, null, null)]
+        [InlineData(PlatformIdempotencyOutcomeKind.Replay, null, null, null)]
+        [InlineData(PlatformIdempotencyOutcomeKind.Conflict, PlatformErrorCode.Conflict, 409, false)]
+        [InlineData(PlatformIdempotencyOutcomeKind.AtCapacity, PlatformErrorCode.RateLimited, 429, true)]
+        [InlineData(PlatformIdempotencyOutcomeKind.Indeterminate, PlatformErrorCode.Conflict, 409, false)]
+        public void NonResultOutcomesPinExistingErrorSemantics(
+            PlatformIdempotencyOutcomeKind kind,
+            string? code,
+            int? status,
+            bool? retryable)
+        {
+            var outcome = new PlatformIdempotencyOutcome(kind);
+
+            Assert.Equal(code, outcome.ErrorCode);
+            if (code is not null)
+            {
+                Assert.Equal(status, PlatformErrorCode.StatusFor(code));
+                Assert.Equal(retryable, PlatformErrorCode.IsRetryable(code));
+            }
+        }
+
+        private static PlatformIdempotencyRequest Request(
+            string key,
+            string payload,
+            Guid? user = null,
+            string operation = "request.create",
+            int maximumResultBytes = 1024)
+        {
+            Assert.True(PlatformIdempotencyKey.TryParse(key, out var parsed));
+            return new PlatformIdempotencyRequest(
+                user ?? Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
+                operation,
+                parsed,
+                new PlatformSemanticFingerprint(System.Security.Cryptography.SHA256.HashData(Encoding.UTF8.GetBytes(payload))),
+                maximumResultBytes);
+        }
+
+        private static PlatformIdempotencyResult Result(int value)
+        {
+            using var document = JsonDocument.Parse($"{{\"value\":{value}}}");
+            return new PlatformIdempotencyResult(200, "ok", document.RootElement);
+        }
+
+        private sealed class ManualTimeProvider(DateTimeOffset now) : TimeProvider
+        {
+            private DateTimeOffset _now = now;
+
+            public override DateTimeOffset GetUtcNow() => _now;
+
+            internal void Advance(TimeSpan amount) => _now += amount;
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformRequestLifecycleTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformRequestLifecycleTests.cs
@@ -1,0 +1,363 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
+{
+    public class PlatformRequestLifecycleTests
+    {
+        [Fact]
+        public async Task ResourceFilterInstallsLinkedTokenBeforeModelBindingAndRestoresCallerToken()
+        {
+            using var caller = new CancellationTokenSource();
+            var http = new DefaultHttpContext { RequestAborted = caller.Token };
+            var context = ResourceContext(http);
+            var observed = default(CancellationToken);
+
+            await new PlatformRequestLifecycleFilter().OnResourceExecutionAsync(context, () =>
+            {
+                observed = http.RequestAborted;
+                Assert.NotEqual(caller.Token, observed);
+                caller.Cancel();
+                Assert.True(observed.IsCancellationRequested);
+                return Task.FromResult(new ResourceExecutedContext(context, new List<IFilterMetadata>()));
+            });
+
+            Assert.Equal(caller.Token, http.RequestAborted);
+        }
+
+        [Fact]
+        public async Task AdvancingDeadlineCancelsLinkedTokenButNotCallerToken()
+        {
+            var clock = new ManualTimeProvider(new DateTimeOffset(2026, 8, 3, 0, 0, 0, TimeSpan.Zero));
+            using var caller = new CancellationTokenSource();
+            var http = new DefaultHttpContext { RequestAborted = caller.Token };
+            var context = ResourceContext(http);
+
+            await new PlatformRequestLifecycleFilter(clock).OnResourceExecutionAsync(context, () =>
+            {
+                var linked = http.RequestAborted;
+                clock.Advance(PlatformConstants.RequestDeadline);
+
+                Assert.True(linked.IsCancellationRequested);
+                Assert.False(caller.IsCancellationRequested);
+                return Task.FromResult(new ResourceExecutedContext(context, new List<IFilterMetadata>()));
+            });
+        }
+
+        [Fact]
+        public async Task DeadlineTokenMapsTo504WithoutPretendingCallerAborted()
+        {
+            using var caller = new CancellationTokenSource();
+            using var deadline = new CancellationTokenSource();
+            var http = new DefaultHttpContext { RequestAborted = CancellationTokenSource.CreateLinkedTokenSource(caller.Token, deadline.Token).Token };
+            http.Items[PlatformRequestLifecycleState.ItemKey] = new PlatformRequestLifecycleState(caller.Token, deadline.Token);
+            deadline.Cancel();
+            var context = ActionContext(http);
+            var executed = new ActionExecutedContext(context, new List<IFilterMetadata>(), new object())
+            {
+                Result = new OkObjectResult(new { ignored = true }),
+            };
+
+            await new PlatformRequestLifecycleFilter().OnActionExecutionAsync(context, () =>
+                Task.FromResult(executed));
+
+            Assert.False(caller.IsCancellationRequested);
+            Assert.Equal(caller.Token, http.RequestAborted);
+            var result = Assert.IsType<ObjectResult>(executed.Result);
+            var error = Assert.IsType<PlatformError>(result.Value);
+            Assert.Equal(504, result.StatusCode);
+            Assert.Equal(PlatformErrorCode.Timeout, error.Code);
+        }
+
+        [Fact]
+        public async Task CancellationIgnoringActionIsAwaitedThenItsSuccessBecomesTimeout()
+        {
+            using var caller = new CancellationTokenSource();
+            using var deadline = new CancellationTokenSource();
+            var http = new DefaultHttpContext();
+            http.Items[PlatformRequestLifecycleState.ItemKey] = new PlatformRequestLifecycleState(caller.Token, deadline.Token);
+            var context = ActionContext(http);
+            var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var executed = new ActionExecutedContext(context, new List<IFilterMetadata>(), new object())
+            {
+                Result = new OkObjectResult(new { ignoredCancellation = true }),
+            };
+
+            var filtering = new PlatformRequestLifecycleFilter().OnActionExecutionAsync(context, async () =>
+            {
+                entered.TrySetResult();
+                await release.Task;
+                return executed;
+            });
+            await entered.Task;
+            deadline.Cancel();
+
+            Assert.False(filtering.IsCompleted);
+            release.TrySetResult();
+            await filtering;
+
+            var timeout = Assert.IsType<ObjectResult>(executed.Result);
+            Assert.Equal(PlatformErrorCode.Timeout, Assert.IsType<PlatformError>(timeout.Value).Code);
+        }
+
+        [Fact]
+        public async Task CallerCancellationWinsASimultaneousRaceAndSelectsNoPayload()
+        {
+            using var caller = new CancellationTokenSource();
+            using var deadline = new CancellationTokenSource();
+            var http = new DefaultHttpContext();
+            http.Items[PlatformRequestLifecycleState.ItemKey] = new PlatformRequestLifecycleState(caller.Token, deadline.Token);
+            caller.Cancel();
+            deadline.Cancel();
+            var context = ActionContext(http);
+            var executed = new ActionExecutedContext(context, new List<IFilterMetadata>(), new object())
+            {
+                Exception = new OperationCanceledException(),
+            };
+
+            await new PlatformRequestLifecycleFilter().OnActionExecutionAsync(context, () =>
+                Task.FromResult(executed));
+
+            Assert.IsType<EmptyResult>(executed.Result);
+            Assert.Empty(http.Response.Headers);
+        }
+
+        [Fact]
+        public void LifecycleIsImmediatelyInsideBoundedBodyAndBeforeModelBinding()
+        {
+            var filters = typeof(PlatformControllerBase)
+                .GetCustomAttributes(typeof(TypeFilterAttribute), inherit: true)
+                .Cast<TypeFilterAttribute>()
+                .ToDictionary(attribute => attribute.ImplementationType, attribute => attribute.Order);
+
+            Assert.Equal(filters[typeof(PlatformBoundedBodyFilter)] + 1, filters[typeof(PlatformRequestLifecycleFilter)]);
+            Assert.IsAssignableFrom<IAsyncResourceFilter>(new PlatformRequestLifecycleFilter());
+            Assert.IsAssignableFrom<IAsyncActionFilter>(new PlatformRequestLifecycleFilter());
+            Assert.IsAssignableFrom<IAsyncAlwaysRunResultFilter>(new PlatformRequestLifecycleFilter());
+            Assert.False(typeof(IAuthorizationFilter).IsAssignableFrom(typeof(PlatformRequestLifecycleFilter)));
+            Assert.False(typeof(IAsyncAuthorizationFilter).IsAssignableFrom(typeof(PlatformRequestLifecycleFilter)));
+            Assert.Equal(TimeSpan.FromSeconds(30), PlatformConstants.RequestDeadline);
+
+            var derived = typeof(PlatformControllerBase).Assembly.GetTypes()
+                .Where(type => !type.IsAbstract && typeof(PlatformControllerBase).IsAssignableFrom(type));
+            Assert.All(derived, type => Assert.Contains(
+                type.GetCustomAttributes(typeof(TypeFilterAttribute), inherit: true).Cast<TypeFilterAttribute>(),
+                attribute => attribute.ImplementationType == typeof(PlatformRequestLifecycleFilter)));
+        }
+
+        [Fact]
+        public void LifecycleContainmentDoesNotRaceWorkAgainstDetachedDelayTasks()
+        {
+            var root = FindRepositoryRoot();
+            var source = File.ReadAllText(Path.Combine(
+                root,
+                "Jellyfin.Plugin.JellyfinCanopy",
+                "Platform",
+                "PlatformRequestLifecycleFilter.cs"));
+
+            Assert.DoesNotContain("Task.WhenAny", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("Task.Delay", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("ExecuteResultAsync", source, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public async Task InvalidModelStateRestoresCallerTokenBeforeSelectingError()
+        {
+            using var caller = new CancellationTokenSource();
+            using var deadline = new CancellationTokenSource();
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(caller.Token, deadline.Token);
+            var http = new DefaultHttpContext { RequestAborted = linked.Token };
+            http.Items[PlatformRequestLifecycleState.ItemKey] = new PlatformRequestLifecycleState(caller.Token, deadline.Token);
+            var context = ActionContext(http);
+            context.ModelState.AddModelError("Name", "invalid");
+
+            await new PlatformRequestFilter(NullLogger<PlatformRequestFilter>.Instance)
+                .OnActionExecutionAsync(context, () => throw new Xunit.Sdk.XunitException("Invalid model must short-circuit."));
+
+            Assert.Equal(caller.Token, http.RequestAborted);
+            Assert.IsType<ObjectResult>(context.Result);
+        }
+
+        [Fact]
+        public async Task ResourceExceptionRestoresOriginalTokenAndRemovesLifecycleState()
+        {
+            using var caller = new CancellationTokenSource();
+            var http = new DefaultHttpContext { RequestAborted = caller.Token };
+            var context = ResourceContext(http);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                new PlatformRequestLifecycleFilter().OnResourceExecutionAsync(
+                    context,
+                    () => throw new InvalidOperationException("resource failure")));
+
+            Assert.Equal(caller.Token, http.RequestAborted);
+            Assert.False(http.Items.ContainsKey(PlatformRequestLifecycleState.ItemKey));
+        }
+
+        [Fact]
+        public async Task StartedResponseDeadlineSuppressesFurtherResultWrites()
+        {
+            using var caller = new CancellationTokenSource();
+            using var deadline = new CancellationTokenSource();
+            var http = new DefaultHttpContext();
+            http.Features.Set<IHttpResponseFeature>(new StartedResponseFeature());
+            http.Items[PlatformRequestLifecycleState.ItemKey] = new PlatformRequestLifecycleState(caller.Token, deadline.Token);
+            deadline.Cancel();
+            Assert.True(http.Response.HasStarted);
+            var action = new ActionContext(http, new RouteData(), new ControllerActionDescriptor());
+            var context = new ResultExecutingContext(
+                action,
+                new List<IFilterMetadata>(),
+                new OkObjectResult(new { tooLate = true }),
+                new object());
+            var continued = false;
+
+            await new PlatformRequestLifecycleFilter().OnResultExecutionAsync(context, () =>
+            {
+                continued = true;
+                return Task.FromResult(new ResultExecutedContext(action, new List<IFilterMetadata>(), context.Result, new object()));
+            });
+
+            Assert.True(context.Cancel);
+            Assert.False(continued);
+            Assert.Empty(http.Response.Headers);
+        }
+
+        private static ResourceExecutingContext ResourceContext(HttpContext http) => new(
+            new ActionContext(http, new RouteData(), new ControllerActionDescriptor()),
+            new List<IFilterMetadata>(),
+            new List<IValueProviderFactory>());
+
+        private static ActionExecutingContext ActionContext(HttpContext http) => new(
+            new ActionContext(http, new RouteData(), new ControllerActionDescriptor()),
+            new List<IFilterMetadata>(),
+            new Dictionary<string, object?>(),
+            new object());
+
+        private static string FindRepositoryRoot()
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "JellyfinCanopy.slnx")))
+            {
+                directory = directory.Parent;
+            }
+
+            return directory?.FullName ?? throw new DirectoryNotFoundException("Repository root not found.");
+        }
+
+        private sealed class ManualTimeProvider(DateTimeOffset now) : TimeProvider
+        {
+            private readonly List<ManualTimer> _timers = new();
+            private DateTimeOffset _now = now;
+
+            public override DateTimeOffset GetUtcNow() => _now;
+
+            public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+            {
+                var timer = new ManualTimer(this, callback, state, dueTime, period);
+                _timers.Add(timer);
+                return timer;
+            }
+
+            internal void Advance(TimeSpan amount)
+            {
+                _now += amount;
+                foreach (var timer in _timers.ToArray())
+                {
+                    timer.FireIfDue(_now);
+                }
+            }
+
+            private sealed class ManualTimer : ITimer
+            {
+                private readonly ManualTimeProvider _owner;
+                private readonly TimerCallback _callback;
+                private readonly object? _state;
+                private TimeSpan _period;
+                private DateTimeOffset? _dueAt;
+                private bool _disposed;
+
+                internal ManualTimer(
+                    ManualTimeProvider owner,
+                    TimerCallback callback,
+                    object? state,
+                    TimeSpan dueTime,
+                    TimeSpan period)
+                {
+                    _owner = owner;
+                    _callback = callback;
+                    _state = state;
+                    Change(dueTime, period);
+                }
+
+                public bool Change(TimeSpan dueTime, TimeSpan period)
+                {
+                    if (_disposed)
+                    {
+                        return false;
+                    }
+
+                    _period = period;
+                    _dueAt = dueTime == Timeout.InfiniteTimeSpan ? null : _owner._now + dueTime;
+                    return true;
+                }
+
+                public void Dispose() => _disposed = true;
+
+                public ValueTask DisposeAsync()
+                {
+                    Dispose();
+                    return ValueTask.CompletedTask;
+                }
+
+                internal void FireIfDue(DateTimeOffset now)
+                {
+                    if (_disposed || _dueAt is null || _dueAt > now)
+                    {
+                        return;
+                    }
+
+                    _dueAt = _period == Timeout.InfiniteTimeSpan ? null : now + _period;
+                    _callback(_state);
+                }
+            }
+        }
+    }
+
+    internal sealed class StartedResponseFeature : IHttpResponseFeature
+    {
+        public int StatusCode { get; set; } = StatusCodes.Status200OK;
+
+        public string? ReasonPhrase { get; set; }
+
+        public IHeaderDictionary Headers { get; set; } = new HeaderDictionary();
+
+        public Stream Body { get; set; } = Stream.Null;
+
+        public bool HasStarted => true;
+
+        public void OnStarting(Func<object, Task> callback, object state)
+        {
+        }
+
+        public void OnCompleted(Func<object, Task> callback, object state)
+        {
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformWireFormatTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformWireFormatTests.cs
@@ -223,6 +223,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
 
             Assert.Contains(typeof(PlatformJsonMediaTypeFilter), filters);
             Assert.Contains(typeof(PlatformJsonResultFilter), filters);
+            Assert.IsAssignableFrom<IAsyncAlwaysRunResultFilter>(new PlatformJsonResultFilter());
         }
 
         [Fact]
@@ -235,6 +236,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
             using var provider = services.BuildServiceProvider();
             var options = provider.GetRequiredService<IOptions<MvcOptions>>().Value;
             var formatter = Assert.IsType<PlatformJsonInputFormatter>(options.InputFormatters[0]);
+
+            var idempotencyRegistration = Assert.Single(
+                services,
+                descriptor => descriptor.ServiceType == typeof(PlatformIdempotencyStore));
+            Assert.Equal(ServiceLifetime.Singleton, idempotencyRegistration.Lifetime);
 
             Assert.True(CanRead(formatter, typeof(TestController)));
             Assert.False(CanRead(formatter, typeof(LegacyController)));
@@ -274,6 +280,24 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
             Assert.Equal(
                 "2026-08-02T04:05:06.0000000+00:00",
                 json.RootElement.GetProperty("At").GetString());
+        }
+
+        [Fact]
+        public async Task AlwaysRunJsonFilterKeepsAuthorizationResultsBare()
+        {
+            var http = new DefaultHttpContext();
+            var action = new ActionContext(http, new RouteData(), new ActionDescriptor());
+            var challenge = new ChallengeResult();
+            var context = new ResultExecutingContext(
+                action,
+                new List<IFilterMetadata>(),
+                challenge,
+                new object());
+
+            await new PlatformJsonResultFilter().OnResultExecutionAsync(context, () =>
+                Task.FromResult(new ResultExecutedContext(action, new List<IFilterMetadata>(), context.Result, new object())));
+
+            Assert.Same(challenge, context.Result);
         }
 
         private static async Task<(ResourceExecutingContext Context, bool Continued)> RunMediaTypeFilterAsync(string? contentType)

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformConstants.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformConstants.cs
@@ -11,6 +11,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
     public static class PlatformConstants
     {
         /// <summary>
+        /// Maximum time spent in Platform v1 model binding and action execution.
+        /// Request-body buffering is separately bounded and deliberately happens first.
+        /// </summary>
+        public static readonly System.TimeSpan RequestDeadline = System.TimeSpan.FromSeconds(30);
+
+        /// <summary>
         /// The Platform v1 route family.
         ///
         /// The <c>v1</c> segment is a MAJOR version. Incompatible majors coexist as

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformControllerBase.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformControllerBase.cs
@@ -40,6 +40,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
     [TypeFilter(typeof(PlatformJsonResultFilter))]
     [TypeFilter(typeof(PlatformJsonMediaTypeFilter), Order = int.MinValue)]
     [TypeFilter(typeof(PlatformBoundedBodyFilter), Order = int.MinValue + 1)]
+    [TypeFilter(typeof(PlatformRequestLifecycleFilter), Order = int.MinValue + 2)]
     public abstract class PlatformControllerBase : ControllerBase
     {
         /// <summary>

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformIdempotency.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformIdempotency.cs
@@ -1,0 +1,319 @@
+using System;
+using System.Buffers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Primitives;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>A validated, transport-neutral Platform idempotency key.</summary>
+    public readonly record struct PlatformIdempotencyKey
+    {
+        /// <summary>The HTTP spelling of this value.</summary>
+        public const string HeaderName = "Idempotency-Key";
+
+        /// <summary>Maximum key length accepted by every transport.</summary>
+        public const int MaximumLength = 128;
+
+        private PlatformIdempotencyKey(string value)
+        {
+            Value = value;
+        }
+
+        /// <summary>The validated, case-sensitive value.</summary>
+        public string Value { get; }
+
+        /// <summary>Validates a key from an HTTP header or a future request body.</summary>
+        public static bool TryParse(string? value, out PlatformIdempotencyKey key)
+        {
+            if (value is not null && value.Length is >= 1 and <= MaximumLength)
+            {
+                foreach (var character in value)
+                {
+                    if (!IsAllowed(character))
+                    {
+                        key = default;
+                        return false;
+                    }
+                }
+
+                key = new PlatformIdempotencyKey(value);
+                return true;
+            }
+
+            key = default;
+            return false;
+        }
+
+        /// <summary>Reads exactly one header value and applies the shared parser.</summary>
+        public static bool TryParseHeader(StringValues values, out PlatformIdempotencyKey key)
+        {
+            if (values.Count == 1)
+            {
+                return TryParse(values[0], out key);
+            }
+
+            key = default;
+            return false;
+        }
+
+        /// <inheritdoc />
+        public override string ToString() => Value ?? string.Empty;
+
+        private static bool IsAllowed(char value) =>
+            (value >= 'A' && value <= 'Z')
+            || (value >= 'a' && value <= 'z')
+            || (value >= '0' && value <= '9')
+            || value is '.' or '_' or '~' or '-';
+    }
+
+    /// <summary>An exact SHA-256 digest of a mutation's caller-defined semantics.</summary>
+    public sealed class PlatformSemanticFingerprint
+    {
+        private const int Sha256Length = 32;
+        private readonly byte[] _bytes;
+
+        /// <summary>Initializes a fingerprint from exactly 32 caller-computed bytes.</summary>
+        public PlatformSemanticFingerprint(ReadOnlySpan<byte> bytes)
+        {
+            if (bytes.Length != Sha256Length)
+            {
+                throw new ArgumentException("A semantic SHA-256 fingerprint must contain exactly 32 bytes.", nameof(bytes));
+            }
+
+            _bytes = bytes.ToArray();
+        }
+
+        internal bool Matches(PlatformSemanticFingerprint other) =>
+            CryptographicOperations.FixedTimeEquals(_bytes, other._bytes);
+    }
+
+    /// <summary>The bounded declaration used to admit an idempotent mutation.</summary>
+    public sealed class PlatformIdempotencyRequest
+    {
+        /// <summary>Initializes one mutation identity and its result-size reservation.</summary>
+        public PlatformIdempotencyRequest(
+            Guid actingUserId,
+            string operation,
+            PlatformIdempotencyKey key,
+            PlatformSemanticFingerprint fingerprint,
+            int maximumResultBytes)
+        {
+            if (actingUserId == Guid.Empty)
+            {
+                throw new ArgumentException("An acting user is required.", nameof(actingUserId));
+            }
+
+            if (!IsValidOperation(operation))
+            {
+                throw new ArgumentException("The operation must be 1-128 ASCII letters, digits, '.', '_', '~', or '-'.", nameof(operation));
+            }
+
+            if (string.IsNullOrEmpty(key.Value))
+            {
+                throw new ArgumentException("A parsed idempotency key is required.", nameof(key));
+            }
+
+            ArgumentNullException.ThrowIfNull(fingerprint);
+            if (maximumResultBytes is < 1 or > PlatformIdempotencyStore.MaximumResultBytes)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maximumResultBytes));
+            }
+
+            ActingUserId = actingUserId;
+            Operation = operation;
+            Key = key;
+            Fingerprint = fingerprint;
+            MaximumResultBytes = maximumResultBytes;
+        }
+
+        /// <summary>The authenticated principal; never a request payload field.</summary>
+        public Guid ActingUserId { get; }
+
+        /// <summary>A code-owned stable mutation name.</summary>
+        public string Operation { get; }
+
+        /// <summary>The caller's validated retry key.</summary>
+        public PlatformIdempotencyKey Key { get; }
+
+        /// <summary>The caller-defined hash of fields that change mutation semantics.</summary>
+        public PlatformSemanticFingerprint Fingerprint { get; }
+
+        /// <summary>Bytes reserved before execution for the immutable semantic result.</summary>
+        public int MaximumResultBytes { get; }
+
+        private static bool IsValidOperation(string? operation)
+        {
+            if (operation is null || operation.Length is < 1 or > 128)
+            {
+                return false;
+            }
+
+            return PlatformIdempotencyKey.TryParse(operation, out _);
+        }
+    }
+
+    /// <summary>
+    /// Immutable semantic mutation output. It deliberately contains neither an MVC
+    /// result nor request-specific metadata such as a correlation id.
+    /// </summary>
+    public sealed class PlatformIdempotencyResult
+    {
+        private readonly JsonElement _value;
+
+        /// <summary>Initializes semantic output suitable for a fresh response envelope.</summary>
+        public PlatformIdempotencyResult(int statusCode, string outcomeCode, JsonElement value)
+        {
+            if (statusCode is < 200 or > 599)
+            {
+                throw new ArgumentOutOfRangeException(nameof(statusCode));
+            }
+
+            if (string.IsNullOrEmpty(outcomeCode) || outcomeCode.Length > 128
+                || !PlatformIdempotencyKey.TryParse(outcomeCode, out _))
+            {
+                throw new ArgumentException("The outcome code must use the bounded Platform token alphabet.", nameof(outcomeCode));
+            }
+
+            if (value.ValueKind == JsonValueKind.Undefined)
+            {
+                throw new ArgumentException("A defined semantic JSON value is required.", nameof(value));
+            }
+
+            var fixedSize = sizeof(int) + Encoding.UTF8.GetByteCount(outcomeCode);
+            var counter = new BoundedCountingBufferWriter(PlatformIdempotencyStore.MaximumResultBytes - fixedSize);
+            try
+            {
+                using var writer = new Utf8JsonWriter(counter);
+                JsonSerializer.Serialize(writer, value, PlatformJson.SerializerOptions);
+                writer.Flush();
+            }
+            catch (InvalidOperationException exception)
+            {
+                throw new ArgumentException(
+                    $"The semantic result must not exceed {PlatformIdempotencyStore.MaximumResultBytes} bytes.",
+                    nameof(value),
+                    exception);
+            }
+
+            StatusCode = statusCode;
+            OutcomeCode = outcomeCode;
+            SerializedSizeBytes = fixedSize + counter.BytesWritten;
+            _value = value.Clone();
+        }
+
+        /// <summary>The completed HTTP status a caller may reconstruct.</summary>
+        public int StatusCode { get; }
+
+        /// <summary>A stable semantic outcome code.</summary>
+        public string OutcomeCode { get; }
+
+        /// <summary>A defensive clone of the semantic value.</summary>
+        public JsonElement Value => _value.Clone();
+
+        internal int SerializedSizeBytes { get; }
+
+        private sealed class BoundedCountingBufferWriter : IBufferWriter<byte>
+        {
+            private readonly int _maximumBytes;
+            private byte[] _buffer;
+
+            internal BoundedCountingBufferWriter(int maximumBytes)
+            {
+                _maximumBytes = maximumBytes;
+                _buffer = new byte[Math.Min(maximumBytes, 4096)];
+            }
+
+            internal int BytesWritten { get; private set; }
+
+            public void Advance(int count)
+            {
+                if (count < 0 || count > _buffer.Length || BytesWritten + count > _maximumBytes)
+                {
+                    throw new InvalidOperationException("The bounded semantic result writer exceeded its limit.");
+                }
+
+                BytesWritten += count;
+            }
+
+            public Memory<byte> GetMemory(int sizeHint = 0)
+            {
+                EnsureCapacity(sizeHint);
+                return _buffer;
+            }
+
+            public Span<byte> GetSpan(int sizeHint = 0)
+            {
+                EnsureCapacity(sizeHint);
+                return _buffer;
+            }
+
+            private void EnsureCapacity(int sizeHint)
+            {
+                var required = Math.Max(sizeHint, 1);
+                // The IBufferWriter contract requires at least sizeHint bytes even when
+                // the writer will advance by far less. Bound the temporary segment by
+                // the per-result ceiling, then enforce the exact cumulative limit in
+                // Advance so a result near the boundary is not rejected on a size hint.
+                if (required > _maximumBytes)
+                {
+                    throw new InvalidOperationException("The bounded semantic result writer exceeded its limit.");
+                }
+
+                if (_buffer.Length < required)
+                {
+                    _buffer = new byte[required];
+                }
+            }
+        }
+    }
+
+    /// <summary>The non-exceptional decision returned by the idempotency kernel.</summary>
+    public enum PlatformIdempotencyOutcomeKind
+    {
+        /// <summary>This caller was admitted and executed the mutation.</summary>
+        Executed,
+
+        /// <summary>A prior or coalesced execution supplied the same semantic result.</summary>
+        Replay,
+
+        /// <summary>The tuple was already used with a different semantic fingerprint.</summary>
+        Conflict,
+
+        /// <summary>The bounded process-local store could not admit new work.</summary>
+        AtCapacity,
+
+        /// <summary>An earlier execution may have mutated state but did not publish a result.</summary>
+        Indeterminate,
+    }
+
+    /// <summary>An idempotency decision and optional immutable semantic result.</summary>
+    public sealed class PlatformIdempotencyOutcome
+    {
+        internal PlatformIdempotencyOutcome(PlatformIdempotencyOutcomeKind kind, PlatformIdempotencyResult? result = null)
+        {
+            Kind = kind;
+            Result = result;
+        }
+
+        /// <summary>The decision.</summary>
+        public PlatformIdempotencyOutcomeKind Kind { get; }
+
+        /// <summary>Present only for executed or replayed work.</summary>
+        public PlatformIdempotencyResult? Result { get; }
+
+        /// <summary>
+        /// Existing Platform error code a future mutation route must use for this
+        /// non-result outcome. Capacity is retryable; conflicts and ambiguous prior
+        /// execution are deliberately not automatic-retry signals.
+        /// </summary>
+        public string? ErrorCode => Kind switch
+        {
+            PlatformIdempotencyOutcomeKind.Conflict => PlatformErrorCode.Conflict,
+            PlatformIdempotencyOutcomeKind.AtCapacity => PlatformErrorCode.RateLimited,
+            PlatformIdempotencyOutcomeKind.Indeterminate => PlatformErrorCode.Conflict,
+            _ => null,
+        };
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformIdempotencyStore.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformIdempotencyStore.cs
@@ -1,0 +1,272 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>
+    /// Process-local, bounded idempotency owner for future Platform mutations.
+    /// Live entries are never evicted to make room: new work is rejected before its
+    /// delegate runs whenever admitting it would cross any bound.
+    /// </summary>
+    public sealed class PlatformIdempotencyStore
+    {
+        /// <summary>Terminal entries are reusable for this long.</summary>
+        public static readonly TimeSpan EntryTimeToLive = TimeSpan.FromMinutes(10);
+
+        /// <summary>Maximum number of live tuples.</summary>
+        public const int MaximumEntries = 1024;
+
+        /// <summary>Maximum total stored and reserved semantic result bytes.</summary>
+        public const int MaximumStoredResultBytes = 8 * 1024 * 1024;
+
+        /// <summary>Maximum semantic result bytes for one tuple.</summary>
+        public const int MaximumResultBytes = 64 * 1024;
+
+        /// <summary>Maximum coalesced followers retained behind one leader.</summary>
+        public const int MaximumFollowersPerEntry = 64;
+
+        /// <summary>Maximum coalesced followers retained across the process.</summary>
+        public const int MaximumFollowers = 1024;
+
+        private readonly object _gate = new();
+        private readonly Dictionary<StoreKey, Entry> _entries = new();
+        private readonly TimeProvider _timeProvider;
+        private int _storedBytes;
+        private int _reservedBytes;
+        private int _followerCount;
+
+        /// <summary>Initializes the process-wide store with the system clock.</summary>
+        public PlatformIdempotencyStore()
+            : this(TimeProvider.System)
+        {
+        }
+
+        internal PlatformIdempotencyStore(TimeProvider timeProvider)
+        {
+            _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        }
+
+        /// <summary>
+        /// Executes a leader or joins/replays the same tuple. A follower's cancellation
+        /// token only abandons its own wait and can never cancel the leader.
+        /// </summary>
+        public async Task<PlatformIdempotencyOutcome> ExecuteAsync(
+            PlatformIdempotencyRequest request,
+            Func<CancellationToken, Task<PlatformIdempotencyResult>> execute,
+            CancellationToken requestCancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(request);
+            ArgumentNullException.ThrowIfNull(execute);
+            requestCancellationToken.ThrowIfCancellationRequested();
+
+            var key = new StoreKey(request.ActingUserId, request.Operation, request.Key.Value);
+            Task<PlatformIdempotencyOutcome>? followerTask = null;
+            Entry? leaderEntry = null;
+            Entry? followerEntry = null;
+
+            lock (_gate)
+            {
+                RemoveExpiredEntries(_timeProvider.GetUtcNow());
+
+                if (_entries.TryGetValue(key, out var existing))
+                {
+                    if (!existing.Fingerprint.Matches(request.Fingerprint))
+                    {
+                        return new PlatformIdempotencyOutcome(PlatformIdempotencyOutcomeKind.Conflict);
+                    }
+
+                    if (existing.State == EntryState.Completed)
+                    {
+                        return new PlatformIdempotencyOutcome(PlatformIdempotencyOutcomeKind.Replay, existing.Result);
+                    }
+
+                    if (existing.State == EntryState.Tombstone)
+                    {
+                        return new PlatformIdempotencyOutcome(PlatformIdempotencyOutcomeKind.Indeterminate);
+                    }
+
+                    if (existing.FollowerCount >= MaximumFollowersPerEntry
+                        || _followerCount >= MaximumFollowers)
+                    {
+                        return new PlatformIdempotencyOutcome(PlatformIdempotencyOutcomeKind.AtCapacity);
+                    }
+
+                    existing.FollowerCount++;
+                    _followerCount++;
+                    followerEntry = existing;
+                    followerTask = existing.Completion.Task;
+                }
+                else
+                {
+                    if (_entries.Count >= MaximumEntries
+                        || _storedBytes + _reservedBytes + request.MaximumResultBytes > MaximumStoredResultBytes)
+                    {
+                        return new PlatformIdempotencyOutcome(PlatformIdempotencyOutcomeKind.AtCapacity);
+                    }
+
+                    leaderEntry = new Entry(request.Fingerprint, request.MaximumResultBytes);
+                    _entries.Add(key, leaderEntry);
+                    _reservedBytes += request.MaximumResultBytes;
+                }
+            }
+
+            if (followerTask is not null)
+            {
+                try
+                {
+                    return await followerTask.WaitAsync(requestCancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    lock (_gate)
+                    {
+                        followerEntry!.FollowerCount--;
+                        _followerCount--;
+                    }
+                }
+            }
+
+            var executionStarted = false;
+            try
+            {
+                requestCancellationToken.ThrowIfCancellationRequested();
+                executionStarted = true;
+                var result = await execute(requestCancellationToken).ConfigureAwait(false);
+                ArgumentNullException.ThrowIfNull(result);
+
+                lock (_gate)
+                {
+                    _reservedBytes -= leaderEntry!.ReservedBytes;
+                    if (result.SerializedSizeBytes > leaderEntry.ReservedBytes
+                        || result.SerializedSizeBytes > MaximumResultBytes)
+                    {
+                        MarkTombstone(leaderEntry, _timeProvider.GetUtcNow());
+                        return new PlatformIdempotencyOutcome(PlatformIdempotencyOutcomeKind.Indeterminate);
+                    }
+
+                    leaderEntry.State = EntryState.Completed;
+                    leaderEntry.Result = result;
+                    leaderEntry.ExpiresAt = _timeProvider.GetUtcNow() + EntryTimeToLive;
+                    _storedBytes += result.SerializedSizeBytes;
+                    leaderEntry.Completion.TrySetResult(
+                        new PlatformIdempotencyOutcome(PlatformIdempotencyOutcomeKind.Replay, result));
+                }
+
+                return new PlatformIdempotencyOutcome(PlatformIdempotencyOutcomeKind.Executed, result);
+            }
+            catch
+            {
+                lock (_gate)
+                {
+                    _reservedBytes -= leaderEntry!.ReservedBytes;
+                    if (executionStarted)
+                    {
+                        MarkTombstone(leaderEntry, _timeProvider.GetUtcNow());
+                    }
+                    else
+                    {
+                        _entries.Remove(key);
+                        leaderEntry.Completion.TrySetResult(
+                            new PlatformIdempotencyOutcome(PlatformIdempotencyOutcomeKind.Indeterminate));
+                    }
+                }
+
+                throw;
+            }
+        }
+
+        internal int EntryCount
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    RemoveExpiredEntries(_timeProvider.GetUtcNow());
+                    return _entries.Count;
+                }
+            }
+        }
+
+        internal int FollowerCount
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _followerCount;
+                }
+            }
+        }
+
+        private void MarkTombstone(Entry entry, DateTimeOffset now)
+        {
+            entry.State = EntryState.Tombstone;
+            entry.Result = null;
+            entry.ExpiresAt = now + EntryTimeToLive;
+            entry.Completion.TrySetResult(
+                new PlatformIdempotencyOutcome(PlatformIdempotencyOutcomeKind.Indeterminate));
+        }
+
+        private void RemoveExpiredEntries(DateTimeOffset now)
+        {
+            List<StoreKey>? expired = null;
+            foreach (var pair in _entries)
+            {
+                var entry = pair.Value;
+                if (entry.State != EntryState.InFlight && entry.ExpiresAt <= now)
+                {
+                    if (entry.State == EntryState.Completed)
+                    {
+                        _storedBytes -= entry.Result!.SerializedSizeBytes;
+                    }
+
+                    (expired ??= new List<StoreKey>()).Add(pair.Key);
+                }
+            }
+
+            if (expired is not null)
+            {
+                foreach (var key in expired)
+                {
+                    _entries.Remove(key);
+                }
+            }
+        }
+
+        private readonly record struct StoreKey(Guid ActingUserId, string Operation, string Key);
+
+        private enum EntryState
+        {
+            InFlight,
+            Completed,
+            Tombstone,
+        }
+
+        private sealed class Entry
+        {
+            internal Entry(PlatformSemanticFingerprint fingerprint, int reservedBytes)
+            {
+                Fingerprint = fingerprint;
+                ReservedBytes = reservedBytes;
+                Completion = new TaskCompletionSource<PlatformIdempotencyOutcome>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+            }
+
+            internal PlatformSemanticFingerprint Fingerprint { get; }
+
+            internal int ReservedBytes { get; }
+
+            internal EntryState State { get; set; }
+
+            internal DateTimeOffset ExpiresAt { get; set; }
+
+            internal PlatformIdempotencyResult? Result { get; set; }
+
+            internal int FollowerCount { get; set; }
+
+            internal TaskCompletionSource<PlatformIdempotencyOutcome> Completion { get; }
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformJsonResultFilter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformJsonResultFilter.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Mvc.Filters;
 namespace Jellyfin.Plugin.JellyfinCanopy.Platform
 {
     /// <summary>Routes Platform results through the pinned Platform JSON serializer.</summary>
-    public sealed class PlatformJsonResultFilter : IAsyncResultFilter
+    public sealed class PlatformJsonResultFilter : IAsyncAlwaysRunResultFilter
     {
         /// <inheritdoc />
         public async Task OnResultExecutionAsync(ResultExecutingContext context, ResultExecutionDelegate next)

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformRequestFilter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformRequestFilter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.Logging;
@@ -42,17 +43,21 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
             ArgumentNullException.ThrowIfNull(context);
             ArgumentNullException.ThrowIfNull(next);
 
-            var correlationId = PlatformCorrelation.For(context.HttpContext);
+            if (IsCallerCancelled(context.HttpContext))
+            {
+                RestoreCallerToken(context.HttpContext);
+                context.Result = new Microsoft.AspNetCore.Mvc.EmptyResult();
+                return;
+            }
 
-            // Set before the action runs: once the response has started, headers are no
-            // longer writable, and a streaming action would otherwise silently lose it.
-            context.HttpContext.Response.Headers[PlatformCorrelation.HeaderName] = correlationId;
+            var correlationId = PlatformCorrelation.For(context.HttpContext);
 
             // ApiController's automatic model-state filter normally emits ProblemDetails.
             // This filter is ordered ahead of it so malformed JSON and unknown enum values
             // stay inside the one Platform error contract without exposing serializer text.
             if (!context.ModelState.IsValid)
             {
+                RestoreCallerToken(context.HttpContext);
                 var field = context.ModelState
                     .Where(entry => entry.Value?.Errors.Count > 0)
                     .Select(entry => NormalizeField(entry.Key))
@@ -64,6 +69,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
                         ? "The request body is invalid."
                         : $"The request field '{field}' is invalid.",
                     correlationId);
+                context.HttpContext.Response.Headers[PlatformCorrelation.HeaderName] = correlationId;
                 return;
             }
 
@@ -76,6 +82,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
             }))
             {
                 await next().ConfigureAwait(false);
+            }
+
+            // Platform v1 is deliberately non-streaming. Publishing after action
+            // execution means a caller cancellation never receives a synthetic write,
+            // while ordinary result serialization has not started yet.
+            if (!IsCallerCancelled(context.HttpContext) && !context.HttpContext.Response.HasStarted)
+            {
+                context.HttpContext.Response.Headers[PlatformCorrelation.HeaderName] = correlationId;
             }
         }
 
@@ -101,7 +115,48 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
         {
             ArgumentNullException.ThrowIfNull(context);
 
+            if (context.Exception is OperationCanceledException
+                && PlatformRequestLifecycleState.TryGet(context.HttpContext, out var lifecycle))
+            {
+                // Caller cancellation wins when both tokens race. A disconnected caller
+                // gets no attempted write and no synthetic server-fault log.
+                if (lifecycle.CallerToken.IsCancellationRequested)
+                {
+                    context.HttpContext.RequestAborted = lifecycle.CallerToken;
+                    lifecycle.StopDeadline();
+                    context.Result = new Microsoft.AspNetCore.Mvc.EmptyResult();
+                    context.ExceptionHandled = true;
+                    return Task.CompletedTask;
+                }
+
+                if (lifecycle.DeadlineToken.IsCancellationRequested)
+                {
+                    context.HttpContext.RequestAborted = lifecycle.CallerToken;
+                    lifecycle.StopDeadline();
+                    if (context.HttpContext.Response.HasStarted)
+                    {
+                        context.Result = new Microsoft.AspNetCore.Mvc.EmptyResult();
+                        context.ExceptionHandled = true;
+                        return Task.CompletedTask;
+                    }
+
+                    var timeoutCorrelationId = PlatformCorrelation.For(context.HttpContext);
+                    context.HttpContext.Response.Headers[PlatformCorrelation.HeaderName] = timeoutCorrelationId;
+                    context.Result = PlatformResults.Error(
+                        PlatformErrorCode.Timeout,
+                        "The request exceeded the Platform v1 deadline.",
+                        timeoutCorrelationId);
+                    context.ExceptionHandled = true;
+                    return Task.CompletedTask;
+                }
+            }
+
             var correlationId = PlatformCorrelation.For(context.HttpContext);
+            RestoreCallerToken(context.HttpContext);
+            if (!context.HttpContext.Response.HasStarted)
+            {
+                context.HttpContext.Response.Headers[PlatformCorrelation.HeaderName] = correlationId;
+            }
 
             // The detail goes HERE and only here. The caller gets a fixed message and the
             // id; everything that would help an attacker - type, message, stack, paths -
@@ -110,6 +165,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
                 context.Exception,
                 "Unhandled Platform v1 failure. CorrelationId={CorrelationId}",
                 correlationId);
+
+            if (context.HttpContext.Response.HasStarted)
+            {
+                context.Result = new Microsoft.AspNetCore.Mvc.EmptyResult();
+                context.ExceptionHandled = true;
+                return Task.CompletedTask;
+            }
 
             context.Result = PlatformResults.Error(
                 PlatformErrorCode.InternalError,
@@ -122,5 +184,18 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
 
             return Task.CompletedTask;
         }
+
+        private static void RestoreCallerToken(Microsoft.AspNetCore.Http.HttpContext context)
+        {
+            if (PlatformRequestLifecycleState.TryGet(context, out var lifecycle))
+            {
+                context.RequestAborted = lifecycle.CallerToken;
+                lifecycle.StopDeadline();
+            }
+        }
+
+        private static bool IsCallerCancelled(Microsoft.AspNetCore.Http.HttpContext context) =>
+            PlatformRequestLifecycleState.TryGet(context, out var lifecycle)
+            && lifecycle.CallerToken.IsCancellationRequested;
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformRequestLifecycleFilter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformRequestLifecycleFilter.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>
+    /// Gives model binding and every Platform v1 action one linked cancellation token:
+    /// the caller's disconnect token plus the kernel's fixed request deadline.
+    /// </summary>
+    /// <remarks>
+    /// This is a resource filter so the linked token is installed before model binding.
+    /// Its order places it immediately inside <see cref="PlatformBoundedBodyFilter"/>:
+    /// bounded body acquisition observes the caller token, then the deadline begins.
+    /// Platform v1 actions are non-streaming; a response that has started cannot safely
+    /// be replaced with the timeout envelope.
+    /// </remarks>
+    public sealed class PlatformRequestLifecycleFilter :
+        IAsyncResourceFilter,
+        IAsyncActionFilter,
+        IAsyncAlwaysRunResultFilter,
+        IOrderedFilter
+    {
+        private readonly TimeProvider _timeProvider;
+
+        /// <summary>Initializes the production lifecycle with the system clock.</summary>
+        public PlatformRequestLifecycleFilter()
+            : this(TimeProvider.System)
+        {
+        }
+
+        internal PlatformRequestLifecycleFilter(TimeProvider timeProvider)
+        {
+            _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        }
+
+        /// <inheritdoc />
+        public int Order => int.MinValue + 2;
+
+        /// <inheritdoc />
+        public async Task OnResourceExecutionAsync(ResourceExecutingContext context, ResourceExecutionDelegate next)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            ArgumentNullException.ThrowIfNull(next);
+
+            var callerToken = context.HttpContext.RequestAborted;
+            using var deadlineSource = new CancellationTokenSource(PlatformConstants.RequestDeadline, _timeProvider);
+            using var linkedSource = CancellationTokenSource.CreateLinkedTokenSource(callerToken, deadlineSource.Token);
+            var lifecycle = new PlatformRequestLifecycleState(callerToken, deadlineSource);
+            var originalToken = context.HttpContext.RequestAborted;
+
+            context.HttpContext.Items[PlatformRequestLifecycleState.ItemKey] = lifecycle;
+            context.HttpContext.RequestAborted = linkedSource.Token;
+
+            try
+            {
+                await next().ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (callerToken.IsCancellationRequested)
+            {
+                context.HttpContext.RequestAborted = callerToken;
+                // A disconnected caller receives no attempted write and this is not a
+                // server failure. The caller token intentionally wins a simultaneous race.
+            }
+            finally
+            {
+                context.HttpContext.RequestAborted = originalToken;
+                context.HttpContext.Items.Remove(PlatformRequestLifecycleState.ItemKey);
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            ArgumentNullException.ThrowIfNull(next);
+
+            if (!PlatformRequestLifecycleState.TryGet(context.HttpContext, out var lifecycle))
+            {
+                await next().ConfigureAwait(false);
+                return;
+            }
+
+            try
+            {
+                var executed = await next().ConfigureAwait(false);
+                if (lifecycle.CallerToken.IsCancellationRequested)
+                {
+                    executed.Result = new Microsoft.AspNetCore.Mvc.EmptyResult();
+                    if (executed.Exception is OperationCanceledException)
+                    {
+                        executed.ExceptionHandled = true;
+                    }
+
+                    return;
+                }
+
+                if (lifecycle.DeadlineToken.IsCancellationRequested
+                    && (executed.Exception is null || executed.Exception is OperationCanceledException)
+                    && !context.HttpContext.Response.HasStarted)
+                {
+                    if (executed.Exception is OperationCanceledException)
+                    {
+                        executed.ExceptionHandled = true;
+                    }
+
+                    executed.Result = TimeoutResult(context.HttpContext);
+                }
+            }
+            finally
+            {
+                // The deadline contains model binding and action execution, not result
+                // serialization. Leaving a canceled linked token installed would prevent
+                // the selected 504 envelope from being written at all.
+                context.HttpContext.RequestAborted = lifecycle.CallerToken;
+                lifecycle.StopDeadline();
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task OnResultExecutionAsync(ResultExecutingContext context, ResultExecutionDelegate next)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            ArgumentNullException.ThrowIfNull(next);
+
+            if (!PlatformRequestLifecycleState.TryGet(context.HttpContext, out var lifecycle))
+            {
+                await next().ConfigureAwait(false);
+                return;
+            }
+
+            // Result serialization is outside the kernel deadline and remains cancelable
+            // only by the caller. This also covers model-state short circuits that never
+            // entered the lifecycle action filter.
+            context.HttpContext.RequestAborted = lifecycle.CallerToken;
+            lifecycle.StopDeadline();
+
+            if (lifecycle.CallerToken.IsCancellationRequested)
+            {
+                context.Cancel = true;
+                return;
+            }
+
+            if (lifecycle.DeadlineToken.IsCancellationRequested
+                && !context.HttpContext.Response.HasStarted)
+            {
+                context.Result = TimeoutResult(context.HttpContext);
+            }
+            else if (lifecycle.DeadlineToken.IsCancellationRequested)
+            {
+                context.Cancel = true;
+                return;
+            }
+
+            await next().ConfigureAwait(false);
+        }
+
+        private static Microsoft.AspNetCore.Mvc.ObjectResult TimeoutResult(HttpContext httpContext)
+        {
+            var correlationId = PlatformCorrelation.For(httpContext);
+            httpContext.Response.Headers[PlatformCorrelation.HeaderName] = correlationId;
+            return PlatformResults.Error(
+                PlatformErrorCode.Timeout,
+                "The request exceeded the Platform v1 deadline.",
+                correlationId);
+        }
+    }
+
+    /// <summary>Typed lifecycle state shared only by the Platform filter pipeline.</summary>
+    internal sealed class PlatformRequestLifecycleState
+    {
+        private readonly CancellationTokenSource? _deadlineSource;
+
+        internal static readonly object ItemKey = new();
+
+        internal PlatformRequestLifecycleState(CancellationToken callerToken, CancellationToken deadlineToken)
+        {
+            CallerToken = callerToken;
+            DeadlineToken = deadlineToken;
+        }
+
+        internal PlatformRequestLifecycleState(CancellationToken callerToken, CancellationTokenSource deadlineSource)
+            : this(callerToken, deadlineSource.Token)
+        {
+            _deadlineSource = deadlineSource;
+        }
+
+        internal CancellationToken CallerToken { get; }
+
+        internal CancellationToken DeadlineToken { get; }
+
+        internal void StopDeadline() => _deadlineSource?.CancelAfter(Timeout.InfiniteTimeSpan);
+
+        internal static bool TryGet(HttpContext context, out PlatformRequestLifecycleState lifecycle)
+        {
+            if (context.Items.TryGetValue(ItemKey, out var candidate)
+                && candidate is PlatformRequestLifecycleState typed)
+            {
+                lifecycle = typed;
+                return true;
+            }
+
+            lifecycle = null!;
+            return false;
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
@@ -34,6 +34,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy
             // Platform v1 owns a wire format without changing any legacy controller.
             serviceCollection.Configure<MvcOptions>(options =>
                 options.InputFormatters.Insert(0, new PlatformJsonInputFormatter()));
+            // The sole process-wide owner of bounded idempotency state. Future mutation
+            // endpoints consume this singleton; no current read route changes behavior.
+            serviceCollection.AddSingleton<PlatformIdempotencyStore>();
 
             // a named HttpClient with AllowAutoRedirect=false so
             // forward-auth proxies (Authelia / Pangolin / Authentik) returning

--- a/contracts/platform/v1/openapi.json
+++ b/contracts/platform/v1/openapi.json
@@ -29,6 +29,9 @@
                 }
               }
             }
+          },
+          "504": {
+            "$ref": "#/components/responses/Timeout"
           }
         }
       }
@@ -79,6 +82,9 @@
           },
           "413": {
             "$ref": "#/components/responses/PayloadTooLarge"
+          },
+          "504": {
+            "$ref": "#/components/responses/Timeout"
           }
         }
       }
@@ -91,6 +97,20 @@
         "in": "header",
         "name": "Authorization",
         "description": "Jellyfin's own scheme: `Authorization: MediaBrowser Token=\"<token>\"`. EP-00 verified that the 10.x `?api_key=` query parameter has been removed in Jellyfin 12, while `?apikey=` and `?ApiKey=` still work; the platform documents only the header because a credential in a query string lands in logs and referrers."
+      }
+    },
+    "parameters": {
+      "IdempotencyKey": {
+        "name": "Idempotency-Key",
+        "in": "header",
+        "required": true,
+        "description": "Required on Platform mutation routes. One case-sensitive value identifies a retry together with the authenticated acting user and operation. Reusing it with the same semantic payload replays the stored semantic outcome; reusing it with different semantics conflicts. Current v1 routes are reads, so none references this component yet.",
+        "schema": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "pattern": "^[A-Za-z0-9._~-]+$"
+        }
       }
     },
     "responses": {
@@ -112,6 +132,36 @@
       },
       "UnsupportedMediaType": {
         "description": "The authenticated request carries a body with a missing or non-JSON Content-Type.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/PlatformError"
+            }
+          }
+        }
+      },
+      "Timeout": {
+        "description": "Model binding or action execution exceeded the fixed 30-second Platform v1 deadline. The deadline is cooperative and excludes bounded body acquisition and result serialization.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/PlatformError"
+            }
+          }
+        }
+      },
+      "IdempotencyConflict": {
+        "description": "A mutation key was reused with different semantics, or a prior execution is indeterminate. Returned as non-retryable 409 conflict.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/PlatformError"
+            }
+          }
+        }
+      },
+      "IdempotencyAtCapacity": {
+        "description": "The bounded process-local idempotency store or follower budget cannot admit work. Rejected before mutation execution as retryable 429 rate_limited.",
         "content": {
           "application/json": {
             "schema": {

--- a/docs/platform-contract.md
+++ b/docs/platform-contract.md
@@ -110,6 +110,52 @@ One gap to be aware of: a request at or above **30,000,000 bytes** is rejected b
 Jellyfin itself before Canopy sees it, and surfaces as an opaque `500` rather than a
 `413`. The platform covers everything below that; it cannot cover the ceiling.
 
+## Request lifecycle
+
+After a bounded request body has been accepted, Platform v1 gives model binding and
+action execution a **30-second** deadline. `HttpContext.RequestAborted` is a linked token
+during that interval, so provider calls observe both a caller disconnect and the kernel
+deadline through the ordinary cancellation path. Result serialization is outside the
+deadline and remains cancelable by the caller; this is what lets a selected timeout
+envelope be written after the deadline token has fired.
+
+A deadline returns `504` with code `timeout`. A caller disconnect wins if both signals
+race: Canopy attempts no response write and does not log it as a server fault. Cancellation
+is cooperative — a provider that ignores its token cannot be killed safely, and Canopy
+does not abandon it on a background task. Platform v1 actions must therefore return
+bounded, non-streaming results and must not write directly to the response.
+
+## Idempotent mutations
+
+Platform v1 ships the bounded idempotency kernel before adding mutation routes. Every
+future mutation will require exactly one `Idempotency-Key` value: 1–128 ASCII letters,
+digits, `.`, `_`, `~`, or `-`. The parser is transport-neutral, so a later body-carried
+key has exactly the same normalization and validation rules.
+
+The process-local store keys an attempt by authenticated acting user, code-owned
+operation, and idempotency key. The operation supplies a SHA-256 fingerprint of the
+fields that determine mutation semantics:
+
+- the same tuple and fingerprint replays an immutable semantic result in a fresh
+  request envelope
+- the same tuple with a different fingerprint conflicts
+- a canceled or failed leader leaves an indeterminate tombstone, because the provider
+  may already have applied the mutation
+- canceling a coalesced follower abandons only that wait and never cancels the leader
+
+Future routes map a different fingerprint or an indeterminate prior execution to
+`409 conflict` (not automatically retryable). Admission pressure maps to retryable
+`429 rate_limited`; it is rejected before mutation execution.
+
+Terminal entries live for 10 minutes. The store admits at most 1,024 entries, 8 MiB of
+stored or pre-reserved results, and 64 KiB for one result. It never pressure-evicts live
+entries; it rejects new work before execution when a bound would be exceeded. State is
+neither persistent nor distributed, so retry guarantees do not cross a process restart
+or coordinate multiple server processes.
+
+Coalesced waits are bounded too: at most 64 followers per in-flight key and 1,024 across
+the process. Excess followers receive the same pre-execution `429 rate_limited` outcome.
+
 ## Pagination
 
 One dialect: opaque forward cursors. Pass the `NextCursor` you were given to fetch the

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,7 +26,7 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2808, totalLines: 3201 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 31298, totalLines: 39890 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 31619, totalLines: 40248 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 3,
         minimumCoveredLines: 2808,
@@ -34,8 +34,8 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
     });
     assert.deepEqual(baselines.profiles.server.observations, {
         cleanRuns: 3,
-        minimumCoveredLines: 31297,
-        maximumCoveredLines: 31298,
+        minimumCoveredLines: 31618,
+        maximumCoveredLines: 31619,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 1);

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -33,12 +33,12 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         maximumCoveredLines: 2808,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
-        cleanRuns: 3,
-        minimumCoveredLines: 31618,
+        cleanRuns: 4,
+        minimumCoveredLines: 31617,
         maximumCoveredLines: 31619,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 1);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -31,13 +31,13 @@
         "totalLines": 40248
       },
       "observations": {
-        "cleanRuns": 3,
-        "minimumCoveredLines": 31618,
+        "cleanRuns": 4,
+        "minimumCoveredLines": 31617,
         "maximumCoveredLines": 31619
       },
       "tolerance": {
-        "missingCoveredLines": 1,
-        "rationale": "The #522 request-lifecycle and idempotency kernel adds a linked 30-second model-binding/action deadline, caller-first cancellation handling, bounded semantic replay state, bounded same-key follower coalescing, and focused lifecycle, concurrency, architecture, and contract coverage. Three clean Coverlet runs on the identical 2026-08-03 source and 40,248-line scope each passed all 2,736 server tests: two observed 31,618 covered lines and one observed 31,619. Relative to the reviewed #587 baseline of 31,298/39,890 (78.461%), the reviewed implementation adds 358 instrumented lines and 321 covered high-water lines while increasing the high-water to 31,619/40,248 (78.560%) and the enforced floor to 31,618/40,248 (78.558%). The one-line allowance is exactly the observed same-head, fixed-scope instrumentation envelope; the 31,619 high-water is retained and broader regressions still fail. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 2,
+        "rationale": "The #522 request-lifecycle and idempotency kernel adds a linked 30-second model-binding/action deadline, caller-first cancellation handling, bounded semantic replay state, bounded same-key follower coalescing, and focused lifecycle, concurrency, architecture, and contract coverage. Four clean Coverlet runs on the identical 2026-08-03 source and 40,248-line scope each passed all 2,736 server tests: the three local runs observed 31,618, 31,618, and 31,619 covered lines, while GitHub Actions run 30758176581 observed 31,617. Relative to the reviewed #587 baseline of 31,298/39,890 (78.461%), the reviewed implementation adds 358 instrumented lines and 321 covered high-water lines while increasing the high-water to 31,619/40,248 (78.560%) and the enforced floor to 31,617/40,248 (78.555%). The two-line allowance is exactly the observed same-head, fixed-scope local-and-CI instrumentation envelope; the 31,619 high-water is retained and broader regressions still fail. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 31298,
-        "totalLines": 39890
+        "coveredLines": 31619,
+        "totalLines": 40248
       },
       "observations": {
         "cleanRuns": 3,
-        "minimumCoveredLines": 31297,
-        "maximumCoveredLines": 31298
+        "minimumCoveredLines": 31618,
+        "maximumCoveredLines": 31619
       },
       "tolerance": {
         "missingCoveredLines": 1,
-        "rationale": "The #587 user-scoped item-access seam adds a fail-closed Jellyfin query, a bounded host-neutral projection, adapter-only positive authorization state, and focused authorization and architecture coverage. Three clean Coverlet runs on the identical 2026-08-03 source and 39,890-line scope each passed all 2,682 server tests: two observed 31,297 covered lines and one observed 31,298. Relative to the reviewed #521 baseline of 31,221/39,804 (78.437%), the reviewed implementation adds 86 instrumented lines and 77 covered high-water lines while increasing the high-water to 31,298/39,890 (78.461%) and the enforced floor to 31,297/39,890 (78.458%). The one-line allowance is exactly the observed same-head, fixed-scope instrumentation envelope; the 31,298 high-water is retained and broader regressions still fail. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "rationale": "The #522 request-lifecycle and idempotency kernel adds a linked 30-second model-binding/action deadline, caller-first cancellation handling, bounded semantic replay state, bounded same-key follower coalescing, and focused lifecycle, concurrency, architecture, and contract coverage. Three clean Coverlet runs on the identical 2026-08-03 source and 40,248-line scope each passed all 2,736 server tests: two observed 31,618 covered lines and one observed 31,619. Relative to the reviewed #587 baseline of 31,298/39,890 (78.461%), the reviewed implementation adds 358 instrumented lines and 321 covered high-water lines while increasing the high-water to 31,619/40,248 (78.560%) and the enforced floor to 31,618/40,248 (78.558%). The one-line allowance is exactly the observed same-head, fixed-scope instrumentation envelope; the 31,619 high-water is retained and broader regressions still fail. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
## Summary

- give Platform v1 model binding and actions a cooperative 30-second kernel deadline linked to caller cancellation
- distinguish caller disconnects from deadline expiry without racing or abandoning provider work
- add a bounded process-local idempotency kernel for future mutation routes
- pin the `Idempotency-Key` header and reusable `504 timeout` response in the contract

## Lifecycle behavior

- bounded body acquisition remains outside the deadline; model binding and action execution are inside it
- caller cancellation wins a simultaneous race, attempts no response write, and is not logged as a server fault
- deadline expiry maps to the existing `timeout` envelope with HTTP 504
- result serialization restores the caller token and uses always-run Platform JSON handling
- already-started responses are never given a second body
- cancellation is cooperative; no `Task.WhenAny`, detached delay, or abandoned provider task is used

## Idempotency behavior

- validates exactly one 1–128 character key using the pinned ASCII token alphabet
- keys state by authenticated user, code-owned operation, and key; fingerprints semantic input with SHA-256
- identical retries replay immutable semantic output; different input conflicts
- failed or ambiguous leaders leave conservative TTL tombstones
- follower cancellation never cancels the leader
- entries, reserved/stored bytes, per-result bytes, per-key followers, and process-wide followers are all bounded before retention
- excess work maps to `rate_limited`; indeterminate outcomes map to non-retryable `conflict`
- state is intentionally process-local with a 10-minute terminal TTL

## Verification

- focused Platform suite: 100 passed
- full server suite: 2,736 passed
- four clean coverage observations across local and CI: 31,617–31,619 / 40,248 lines; ratchet passed
- script tests: 634 passed
- strict MkDocs, docs/assets, Markdown links, and diff checks: passed
- two independent adversarial reviews: approved after fixes

Closes #522.
