### PR TITLE
feat(platform): add authoritative first-party actor

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActorArchitectureTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActorArchitectureTests.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security.Claims;
+using System.Text.RegularExpressions;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
+{
+    /// <summary>
+    /// Dependency and source guards that keep request identity above the actor boundary.
+    /// A convenient future refactor must not turn the actor back into a principal-shaped
+    /// credential container or authorize from caller-shaped request metadata.
+    /// </summary>
+    public class PlatformActorArchitectureTests
+    {
+        private static readonly Regex ForbiddenActorProperty = new(
+            "token|bearer|claim|principal|context|request|header|route|query|body|cookie|marker|ip",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private static readonly Regex ForbiddenAuthorizationSource = new(
+            @"RequestIdentityService|Jellyfin-Token|ClaimTypes\.Role|Request\.Headers|Request\.Query|Request\.RouteValues|RouteData|Request\.Body|Request\.Cookies|RemoteIpAddress",
+            RegexOptions.Compiled);
+
+        private static readonly Regex ActorReference = new(@"\bPlatformActor\b", RegexOptions.Compiled);
+
+        private static readonly Regex ActorConstruction = new(
+            @"\bnew\s+PlatformActor\s*\(",
+            RegexOptions.Compiled);
+
+        [Fact]
+        public void ActorIsASealedImmutableDataOnlyAllowList()
+        {
+            var type = typeof(PlatformActor);
+
+            Assert.True(type.IsSealed);
+            Assert.Empty(type.GetConstructors(BindingFlags.Public | BindingFlags.Instance));
+
+            var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+            Assert.Equal(
+                new[] { "ClientName", "CorrelationId", "DeviceId", "IsElevated", "UserId" },
+                properties.Select(property => property.Name).OrderBy(name => name, StringComparer.Ordinal));
+            Assert.All(properties, property =>
+            {
+                Assert.True(property.CanRead);
+                Assert.False(property.CanWrite);
+                Assert.DoesNotMatch(ForbiddenActorProperty, property.Name);
+            });
+
+            Assert.Equal(typeof(Guid), type.GetProperty(nameof(PlatformActor.UserId))!.PropertyType);
+            Assert.Equal(typeof(bool), type.GetProperty(nameof(PlatformActor.IsElevated))!.PropertyType);
+            Assert.Equal(typeof(string), type.GetProperty(nameof(PlatformActor.CorrelationId))!.PropertyType);
+            Assert.Equal(typeof(string), type.GetProperty(nameof(PlatformActor.ClientName))!.PropertyType);
+            Assert.Equal(typeof(string), type.GetProperty(nameof(PlatformActor.DeviceId))!.PropertyType);
+        }
+
+        [Fact]
+        public void ActorDependencyGraphContainsNoCredentialOrRequestObjects()
+        {
+            var forbidden = new[]
+            {
+                typeof(ClaimsPrincipal),
+                typeof(ClaimsIdentity),
+                typeof(Claim),
+                typeof(HttpContext),
+                typeof(HttpRequest),
+                typeof(HttpResponse),
+            };
+
+            var exposed = typeof(PlatformActor)
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Select(property => property.PropertyType)
+                .Concat(typeof(PlatformActor)
+                    .GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)
+                    .SelectMany(constructor => constructor.GetParameters())
+                    .Select(parameter => parameter.ParameterType))
+                .Distinct()
+                .ToList();
+
+            Assert.DoesNotContain(exposed, type => forbidden.Any(candidate => candidate.IsAssignableFrom(type)));
+            Assert.DoesNotContain(exposed, type => type == typeof(byte[]) || typeof(Delegate).IsAssignableFrom(type));
+        }
+
+        [Fact]
+        public void BoundaryDoesNotConsultCallerShapedAuthorizationSources()
+        {
+            var source = PlatformHostSeamTests.CodeOnly(File.ReadAllText(SourceFile("PlatformActorBoundaryFilter.cs")));
+
+            Assert.DoesNotMatch(ForbiddenAuthorizationSource, source);
+            Assert.Contains("Jellyfin-UserId", source, StringComparison.Ordinal);
+            Assert.Contains("_host.Users.Find(userId)", source, StringComparison.Ordinal);
+
+            // Prove the guard catches every prohibited source rather than passing due to
+            // a typo or an empty pattern.
+            foreach (var violation in new[]
+            {
+                "RequestIdentityService.Resolve()",
+                "principal.FindFirst(\"Jellyfin-Token\")",
+                "principal.FindFirst(ClaimTypes.Role)",
+                "Request.Headers[\"X-Jellyfin-User-Id\"]",
+                "Request.Query[\"userId\"]",
+                "Request.RouteValues[\"userId\"]",
+                "RouteData.Values[\"userId\"]",
+                "Request.Body",
+                "Request.Cookies[\"marker\"]",
+                "RemoteIpAddress",
+            })
+            {
+                Assert.Matches(ForbiddenAuthorizationSource, violation);
+            }
+        }
+
+        [Fact]
+        public void AnyDownstreamActorConsumerCannotDependOnRequestIdentity()
+        {
+            var boundaryFiles = new HashSet<string>(StringComparer.Ordinal)
+            {
+                "PlatformActorBoundaryFilter.cs",
+                "PlatformControllerBase.cs",
+            };
+            var consumers = SourceFiles()
+                .Where(file => ActorReference.IsMatch(
+                    PlatformHostSeamTests.CodeOnly(File.ReadAllText(file))))
+                .Where(file => !boundaryFiles.Contains(Path.GetFileName(file)))
+                .ToList();
+
+            Assert.Contains(consumers, file => Path.GetFileName(file) == "PlatformActor.cs");
+
+            var offenders = consumers
+                .Where(file => ForbiddenAuthorizationSource.IsMatch(
+                    PlatformHostSeamTests.CodeOnly(File.ReadAllText(file))))
+                .Select(Path.GetFileName)
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToList();
+
+            Assert.True(
+                offenders.Count == 0,
+                "PlatformActor consumer(s) reached below the controller boundary for request identity: "
+                + string.Join(", ", offenders));
+        }
+
+        [Fact]
+        public void OnlyTheControllerBoundaryCanConstructAnActor()
+        {
+            var constructors = SourceFiles()
+                .Where(file => ActorConstruction.IsMatch(
+                    PlatformHostSeamTests.CodeOnly(File.ReadAllText(file))))
+                .Select(Path.GetFileName)
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToList();
+
+            Assert.Equal(new[] { "PlatformActorBoundaryFilter.cs" }, constructors);
+
+            Assert.Matches(
+                ActorConstruction,
+                "var forged = new PlatformActor(userId, true, correlation, client, device);");
+            Assert.DoesNotMatch(
+                ActorConstruction,
+                "void Accept(PlatformActor actor) { }");
+        }
+
+        [Fact]
+        public void EveryPlatformControllerCarriesTheActorBoundaryBeforeBodyAcquisition()
+        {
+            var attributes = typeof(PlatformControllerBase)
+                .GetCustomAttributes(typeof(TypeFilterAttribute), inherit: true)
+                .Cast<TypeFilterAttribute>()
+                .ToDictionary(attribute => attribute.ImplementationType, attribute => attribute.Order);
+
+            Assert.Contains(typeof(PlatformActorBoundaryFilter), attributes.Keys);
+            Assert.Equal(PlatformFilterOrder.ActorBoundary, attributes[typeof(PlatformActorBoundaryFilter)]);
+            Assert.Equal(PlatformFilterOrder.JsonMediaType, attributes[typeof(PlatformJsonMediaTypeFilter)]);
+            Assert.Equal(PlatformFilterOrder.BoundedBody, attributes[typeof(PlatformBoundedBodyFilter)]);
+            Assert.Equal(PlatformFilterOrder.RequestLifecycle, attributes[typeof(PlatformRequestLifecycleFilter)]);
+            Assert.True(attributes[typeof(PlatformActorBoundaryFilter)] < attributes[typeof(PlatformJsonMediaTypeFilter)]);
+            Assert.True(attributes[typeof(PlatformJsonMediaTypeFilter)] < attributes[typeof(PlatformBoundedBodyFilter)]);
+            Assert.True(attributes[typeof(PlatformBoundedBodyFilter)] < attributes[typeof(PlatformRequestLifecycleFilter)]);
+            Assert.Equal(PlatformFilterOrder.JsonMediaType, new PlatformJsonMediaTypeFilter().Order);
+            Assert.Equal(PlatformFilterOrder.BoundedBody, new PlatformBoundedBodyFilter().Order);
+            Assert.Equal(PlatformFilterOrder.RequestLifecycle, new PlatformRequestLifecycleFilter().Order);
+            Assert.True(typeof(IAsyncResourceFilter).IsAssignableFrom(typeof(PlatformActorBoundaryFilter)));
+            Assert.False(typeof(IAsyncAuthorizationFilter).IsAssignableFrom(typeof(PlatformActorBoundaryFilter)));
+
+            var controllers = typeof(PlatformControllerBase).Assembly
+                .GetTypes()
+                .Where(type => !type.IsAbstract && typeof(PlatformControllerBase).IsAssignableFrom(type));
+
+            Assert.All(controllers, controller => Assert.Contains(
+                controller.GetCustomAttributes(typeof(TypeFilterAttribute), inherit: true).Cast<TypeFilterAttribute>(),
+                attribute => attribute.ImplementationType == typeof(PlatformActorBoundaryFilter)));
+        }
+
+        private static IEnumerable<string> SourceFiles()
+            => Directory.EnumerateFiles(SourceRoot(), "*.cs", SearchOption.AllDirectories)
+                .Where(file => !file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                    && !file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal));
+
+        private static string SourceFile(string name) => SourceFiles().Single(file => Path.GetFileName(file) == name);
+
+        private static string SourceRoot([CallerFilePath] string sourceFile = "")
+            => Path.GetFullPath(Path.Combine(
+                Path.GetDirectoryName(sourceFile)!, "..", "..", "Jellyfin.Plugin.JellyfinCanopy", "Platform"));
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformBoundedBodyFilterTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformBoundedBodyFilterTests.cs
@@ -218,7 +218,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
             var filter = new PlatformBoundedBodyFilter();
 
             Assert.IsAssignableFrom<IAsyncResourceFilter>(filter);
-            Assert.Equal(int.MinValue, filter.Order);
+            Assert.Equal(PlatformFilterOrder.BoundedBody, filter.Order);
         }
 
         [Fact]

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformControllerBaseTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformControllerBaseTests.cs
@@ -1,127 +1,507 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
 using System.Security.Claims;
+using System.Text;
+using System.Threading.Tasks;
 using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
 {
     /// <summary>
-    /// Identity resolution is the hinge every later authorization decision hangs on,
-    /// so it is tested against claims directly rather than trusted to inspection.
-    ///
-    /// EP-00 established the fact these tests encode: with a non-admin token, injected
-    /// <c>Jellyfin-UserId</c> / <c>X-Jellyfin-User-Id</c> / <c>X-Emby-Authorization</c>
-    /// headers and a <c>jellyfin-userid</c> cookie all still resolved to the caller's
-    /// own id (spike-evidence S14). The base therefore reads the CLAIM and nothing
-    /// else, and these tests fail if it ever starts reading anything else.
+    /// Adversarial evidence for the first-party actor boundary. Every value a caller can
+    /// shape is present in these requests; only the authenticated Jellyfin user claim and
+    /// a fresh host lookup are allowed to establish authority.
     /// </summary>
     public class PlatformControllerBaseTests
     {
-        /// <summary>Minimal concrete controller; the base is abstract and has no behaviour of its own to host.</summary>
-        private sealed class TestController : PlatformControllerBase
+        private sealed class ProbeController : PlatformControllerBase
         {
-            public Guid? ExposedUserId => ActingUserId;
-
-            public string? ExposedDeviceId => ActingDeviceId;
+            public PlatformActor ExposedActor => Actor;
         }
 
-        private static TestController WithClaims(params Claim[] claims) => new()
+        private sealed class StubHost : IPlatformHost
         {
-            ControllerContext = new ControllerContext
+            public StubHost(Func<Guid, HostUser?> findUser)
             {
-                HttpContext = new DefaultHttpContext
-                {
-                    User = new ClaimsPrincipal(new ClaimsIdentity(claims, "Test")),
-                },
+                Users = new StubUsers(findUser);
+            }
 
-                // Not populated by default, and the forgery tests below write route values.
-                RouteData = new RouteData(),
-            },
-        };
+            public IHostUsers Users { get; }
 
-        [Fact]
-        public void ActingUserId_ComesFromTheJellyfinUserIdClaim()
+            public IHostLibrary Library { get; } = new StubLibrary();
+
+            public IHostSessions Sessions { get; } = new StubSessions();
+
+            public IHostPlugins Plugins { get; } = new StubPlugins();
+        }
+
+        private sealed class StubUsers : IHostUsers
         {
-            var id = Guid.NewGuid();
+            private readonly Func<Guid, HostUser?> _find;
 
-            Assert.Equal(id, WithClaims(new Claim("Jellyfin-UserId", id.ToString())).ExposedUserId);
+            public StubUsers(Func<Guid, HostUser?> find) => _find = find;
+
+            public HostUser? Find(Guid id) => _find(id);
+
+            public IReadOnlyList<HostUser> All() => Array.Empty<HostUser>();
+        }
+
+        private sealed class StubLibrary : IHostLibrary
+        {
+            public HostItem? Find(Guid id) => null;
+
+            public HostItemAccessResult FindAccessible(Guid userId, Guid itemId) =>
+                HostItemAccessResult.NotAccessible;
+
+            public IReadOnlyList<HostItem> ChildrenOf(Guid id) => Array.Empty<HostItem>();
+        }
+
+        private sealed class StubSessions : IHostSessions
+        {
+            public IReadOnlyList<HostSession> Active() => Array.Empty<HostSession>();
+
+            public IReadOnlyList<HostSession> ForUser(Guid userId) => Array.Empty<HostSession>();
+        }
+
+        private sealed class StubPlugins : IHostPlugins
+        {
+            public IReadOnlyList<HostPlugin> Installed() => Array.Empty<HostPlugin>();
+
+            public HostPlugin? Find(Guid id) => null;
+        }
+
+        private sealed class EmptyAuthenticationService : IAuthenticationService
+        {
+            public Task<AuthenticateResult> AuthenticateAsync(HttpContext context, string? scheme) =>
+                Task.FromResult(AuthenticateResult.NoResult());
+
+            public Task ChallengeAsync(HttpContext context, string? scheme, AuthenticationProperties? properties)
+            {
+                context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                return Task.CompletedTask;
+            }
+
+            public Task ForbidAsync(HttpContext context, string? scheme, AuthenticationProperties? properties)
+            {
+                context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                return Task.CompletedTask;
+            }
+
+            public Task SignInAsync(
+                HttpContext context,
+                string? scheme,
+                ClaimsPrincipal principal,
+                AuthenticationProperties? properties) => throw new NotSupportedException();
+
+            public Task SignOutAsync(
+                HttpContext context,
+                string? scheme,
+                AuthenticationProperties? properties) => throw new NotSupportedException();
+        }
+
+        private sealed record RunResult(ResourceExecutingContext Context, bool Continued, PlatformActor? Actor);
+
+        private static ClaimsPrincipal Principal(params Claim[] claims)
+        {
+            var allClaims = claims.ToList();
+            if (!allClaims.Any(claim => string.Equals(
+                claim.Type,
+                "Jellyfin-IsApiKey",
+                StringComparison.OrdinalIgnoreCase)))
+            {
+                allClaims.Add(new Claim("Jellyfin-IsApiKey", bool.FalseString));
+            }
+
+            return new ClaimsPrincipal(new ClaimsIdentity(allClaims, "JellyfinTestAuthentication"));
+        }
+
+        private static DefaultHttpContext Request(ClaimsPrincipal principal)
+        {
+            return new DefaultHttpContext
+            {
+                User = principal,
+            };
+        }
+
+        private static async Task<RunResult> RunAsync(
+            HttpContext http,
+            Func<Guid, HostUser?>? findUser = null,
+            IEnumerable<object>? endpointMetadata = null)
+        {
+            var descriptor = new ActionDescriptor
+            {
+                EndpointMetadata = endpointMetadata?.ToList() ?? new List<object>(),
+            };
+            var context = new ResourceExecutingContext(
+                new ActionContext(http, new RouteData(), descriptor),
+                new List<IFilterMetadata>(),
+                new List<IValueProviderFactory>());
+            var continued = false;
+
+            await new PlatformActorBoundaryFilter(new StubHost(findUser ?? (_ => null)))
+                .OnResourceExecutionAsync(context, () =>
+                {
+                    continued = true;
+                    return Task.FromResult(new ResourceExecutedContext(context, new List<IFilterMetadata>()));
+                });
+
+            PlatformActor? actor = null;
+            var isAnonymous = endpointMetadata?.Any(metadata => metadata is IAllowAnonymous) == true;
+            if (continued && !isAnonymous)
+            {
+                actor = new ProbeController
+                {
+                    ControllerContext = new ControllerContext
+                    {
+                        HttpContext = http,
+                        RouteData = context.RouteData,
+                    },
+                }.ExposedActor;
+            }
+
+            return new RunResult(context, continued, actor);
+        }
+
+        private static async Task ExecuteThroughPlatformResultFilterAsync(ActionResult result, HttpContext http)
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddMvcCore();
+            services.AddSingleton<IAuthenticationService>(new EmptyAuthenticationService());
+            using var provider = services.BuildServiceProvider();
+            http.RequestServices = provider;
+            http.Response.Body = new MemoryStream();
+
+            var action = new ActionContext(http, new RouteData(), new ActionDescriptor());
+            var filters = new List<IFilterMetadata>();
+            var context = new ResultExecutingContext(action, filters, result, new object());
+            await new PlatformJsonResultFilter().OnResultExecutionAsync(context, async () =>
+            {
+                await context.Result.ExecuteResultAsync(action);
+                return new ResultExecutedContext(action, filters, context.Result, new object());
+            });
         }
 
         [Fact]
-        public void ActingUserId_MatchesTheClaimNameCaseInsensitively()
+        public async Task ActorUsesTheAuthenticatedClaimAndFreshHostElevation()
         {
-            // Claim type casing is not something a plugin controls, and a casing change
-            // in the host must not silently turn every caller anonymous.
-            var id = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+            var calls = 0;
+            HostUser? Find(Guid requested)
+            {
+                calls++;
+                return new HostUser(requested, "current", true);
+            }
 
-            Assert.Equal(id, WithClaims(new Claim("jellyfin-userid", id.ToString())).ExposedUserId);
+            var http = Request(Principal(
+                new Claim("Jellyfin-UserId", userId.ToString("N")),
+                new Claim("Jellyfin-Client", " Android TV "),
+                new Claim("Jellyfin-DeviceId", " living-room-tv ")));
+
+            var result = await RunAsync(http, Find);
+
+            Assert.True(result.Continued);
+            Assert.NotNull(result.Actor);
+            Assert.Equal(userId, result.Actor!.UserId);
+            Assert.True(result.Actor.IsElevated);
+            Assert.Equal("Android TV", result.Actor.ClientName);
+            Assert.Equal("living-room-tv", result.Actor.DeviceId);
+            Assert.Equal(PlatformCorrelation.For(http), result.Actor.CorrelationId);
+            Assert.Equal(1, calls);
+        }
+
+        [Fact]
+        public async Task ForgedRequestSourcesCannotReplaceTheAuthenticatedUser()
+        {
+            var real = Guid.NewGuid();
+            var forged = Guid.NewGuid();
+            var http = Request(Principal(new Claim("Jellyfin-UserId", real.ToString())));
+            http.Request.Headers["Jellyfin-UserId"] = forged.ToString();
+            http.Request.Headers["X-Jellyfin-User-Id"] = forged.ToString();
+            http.Request.Headers["X-Emby-Authorization"] = $"MediaBrowser UserId=\"{forged}\"";
+            http.Request.Headers.Cookie = $"jellyfin-userid={forged}; marker={forged}";
+            http.Request.QueryString = new QueryString($"?userId={forged}&client=admin");
+            http.Request.RouteValues["userId"] = forged.ToString();
+            http.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes($"{{\"UserId\":\"{forged}\"}}"));
+            http.Request.ContentLength = http.Request.Body.Length;
+            http.Items["RequestIdentityService"] = forged;
+            http.Items["JellyfinCanopy.UserMarker"] = forged;
+
+            var result = await RunAsync(http, id => new HostUser(id, "real", false));
+
+            Assert.True(result.Continued);
+            Assert.Equal(real, result.Actor!.UserId);
+            Assert.False(result.Actor.IsElevated);
+        }
+
+        [Fact]
+        public async Task RoleAndAttributionClaimsCannotElevateANonAdministrator()
+        {
+            var userId = Guid.NewGuid();
+            var result = await RunAsync(
+                Request(Principal(
+                    new Claim("Jellyfin-UserId", userId.ToString()),
+                    new Claim(ClaimTypes.Role, "Administrator"),
+                    new Claim("Jellyfin-Client", "administrator"),
+                    new Claim("Jellyfin-DeviceId", "administrator"))),
+                id => new HostUser(id, "non-admin", false));
+
+            Assert.True(result.Continued);
+            Assert.False(result.Actor!.IsElevated);
         }
 
         [Theory]
-        // Nothing to read.
         [InlineData(null)]
-        // Present but unusable. Treated as "no identity" rather than throwing: an
-        // unparseable claim is the host's problem, not a 500 for the caller.
-        [InlineData("not-a-guid")]
         [InlineData("")]
-        // The empty GUID is a real value that means "nobody". Accepting it would let a
-        // caller with no identity look like a user whose id happens to be all zeroes.
+        [InlineData("not-a-boolean")]
+        [InlineData("True")]
+        public async Task ApiKeyOrUnprovenFirstPartyStatusFailsClosed(string? raw)
+        {
+            var userId = Guid.NewGuid();
+            var claims = new List<Claim> { new("Jellyfin-UserId", userId.ToString()) };
+            if (raw is not null)
+            {
+                claims.Add(new Claim("Jellyfin-IsApiKey", raw));
+            }
+
+            var principal = raw is null
+                ? new ClaimsPrincipal(new ClaimsIdentity(claims, "JellyfinTestAuthentication"))
+                : Principal(claims.ToArray());
+            var result = await RunAsync(
+                Request(principal),
+                _ => throw new InvalidOperationException("API/service actors must not query the first-party user seam"));
+
+            Assert.False(result.Continued);
+            Assert.IsType<ForbidResult>(result.Context.Result);
+        }
+
+        [Fact]
+        public async Task DuplicateApiKeyClaimsFailClosed()
+        {
+            var userId = Guid.NewGuid();
+            var result = await RunAsync(
+                Request(Principal(
+                    new Claim("Jellyfin-UserId", userId.ToString()),
+                    new Claim("Jellyfin-IsApiKey", bool.FalseString),
+                    new Claim("jellyfin-isapikey", bool.FalseString))),
+                _ => throw new InvalidOperationException("ambiguous actor class must not query host"));
+
+            Assert.False(result.Continued);
+            Assert.IsType<ForbidResult>(result.Context.Result);
+        }
+
+        [Fact]
+        public async Task CurrentHostPermissionCanElevateWithoutARoleClaim()
+        {
+            var userId = Guid.NewGuid();
+            var result = await RunAsync(
+                Request(Principal(new Claim("Jellyfin-UserId", userId.ToString()))),
+                id => new HostUser(id, "admin", true));
+
+            Assert.True(result.Actor!.IsElevated);
+        }
+
+        [Fact]
+        public async Task SameIpDoesNotMergeTwoAuthenticatedUsers()
+        {
+            var userA = Guid.NewGuid();
+            var userB = Guid.NewGuid();
+            var requestA = Request(Principal(new Claim("Jellyfin-UserId", userA.ToString())));
+            var requestB = Request(Principal(new Claim("Jellyfin-UserId", userB.ToString())));
+            requestA.Connection.RemoteIpAddress = IPAddress.Parse("192.0.2.10");
+            requestB.Connection.RemoteIpAddress = IPAddress.Parse("192.0.2.10");
+
+            var resultA = await RunAsync(requestA, id => new HostUser(id, "a", false));
+            var resultB = await RunAsync(requestB, id => new HostUser(id, "b", false));
+
+            Assert.Equal(userA, resultA.Actor!.UserId);
+            Assert.Equal(userB, resultB.Actor!.UserId);
+            Assert.NotEqual(resultA.Actor.UserId, resultB.Actor.UserId);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("not-a-guid")]
         [InlineData("00000000-0000-0000-0000-000000000000")]
-        public void ActingUserId_IsNullWhenTheClaimIsAbsentOrUnusable(string? raw)
+        public async Task MissingMalformedOrEmptyIdentityFailsClosed(string? raw)
         {
-            var controller = raw is null
-                ? WithClaims()
-                : WithClaims(new Claim("Jellyfin-UserId", raw));
+            var principal = raw is null
+                ? Principal()
+                : Principal(new Claim("Jellyfin-UserId", raw));
 
-            Assert.Null(controller.ExposedUserId);
+            var result = await RunAsync(Request(principal), _ => throw new InvalidOperationException("must not query host"));
+
+            Assert.False(result.Continued);
+            Assert.IsType<ForbidResult>(result.Context.Result);
         }
 
         [Fact]
-        public void ActingDeviceId_IsReadForAttributionAndIsAllowedToBeAbsent()
+        public async Task ConflictingOrDuplicateAuthoritativeClaimsFailClosed()
         {
-            Assert.Equal("living-room-tv", WithClaims(new Claim("Jellyfin-DeviceId", "living-room-tv")).ExposedDeviceId);
+            var userA = Guid.NewGuid();
+            var userB = Guid.NewGuid();
 
-            // Absent is normal, not an error: a device id is attribution only and never
-            // authority, so nothing may refuse to serve a caller that has none (ADR-0011).
-            Assert.Null(WithClaims().ExposedDeviceId);
+            foreach (var claims in new[]
+            {
+                new[] { new Claim("Jellyfin-UserId", userA.ToString()), new Claim("Jellyfin-UserId", userA.ToString()) },
+                new[] { new Claim("Jellyfin-UserId", userA.ToString()), new Claim("jellyfin-userid", userB.ToString()) },
+            })
+            {
+                var result = await RunAsync(Request(Principal(claims)));
+
+                Assert.False(result.Continued);
+                Assert.IsType<ForbidResult>(result.Context.Result);
+            }
         }
 
         [Fact]
-        public void ActingUserId_IgnoresHeadersCookiesAndRouteValuesEntirely()
+        public async Task DeletedOrMismatchedCurrentUserFailsClosed()
         {
-            // The forgery attempt EP-00 actually ran, reproduced as a unit test so a
-            // future refactor toward "just read the header, it is simpler" fails loudly.
-            var real = Guid.NewGuid();
-            var forged = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+            var request = Request(Principal(new Claim("Jellyfin-UserId", userId.ToString())));
 
-            var controller = WithClaims(new Claim("Jellyfin-UserId", real.ToString()));
-            var context = controller.ControllerContext.HttpContext;
+            var deleted = await RunAsync(request, _ => null);
+            var mismatched = await RunAsync(
+                Request(Principal(new Claim("Jellyfin-UserId", userId.ToString()))),
+                _ => new HostUser(Guid.NewGuid(), "wrong", true));
 
-            context.Request.Headers["Jellyfin-UserId"] = forged.ToString();
-            context.Request.Headers["X-Jellyfin-User-Id"] = forged.ToString();
-            context.Request.Headers["X-Emby-Authorization"] = $"MediaBrowser UserId=\"{forged}\"";
-            context.Request.Headers["Cookie"] = $"jellyfin-userid={forged}";
-            controller.ControllerContext.RouteData.Values["userId"] = forged.ToString();
-
-            Assert.Equal(real, controller.ExposedUserId);
+            Assert.False(deleted.Continued);
+            Assert.IsType<ForbidResult>(deleted.Context.Result);
+            Assert.False(mismatched.Continued);
+            Assert.IsType<ForbidResult>(mismatched.Context.Result);
         }
 
         [Fact]
-        public void ActingUserId_PrefersNothingWhenOnlyAForgedSourceIsPresent()
+        public async Task ElevationIsReReadForEveryRequestAndExistingActorsStayImmutable()
         {
-            // The dangerous half of the previous test: with NO claim, every caller-supplied
-            // source saying "I am this user" must still resolve to no identity at all.
-            var forged = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+            var elevated = false;
+            HostUser? Find(Guid id) => new(id, "current", elevated);
 
-            var controller = WithClaims();
-            controller.ControllerContext.HttpContext.Request.Headers["Jellyfin-UserId"] = forged.ToString();
-            controller.ControllerContext.RouteData.Values["userId"] = forged.ToString();
+            var first = await RunAsync(
+                Request(Principal(new Claim("Jellyfin-UserId", userId.ToString()))),
+                Find);
+            elevated = true;
+            var second = await RunAsync(
+                Request(Principal(new Claim("Jellyfin-UserId", userId.ToString()))),
+                Find);
 
-            Assert.Null(controller.ExposedUserId);
+            Assert.False(first.Actor!.IsElevated);
+            Assert.True(second.Actor!.IsElevated);
+            Assert.False(first.Actor.IsElevated);
+        }
+
+        [Fact]
+        public async Task AttributionIsBoundedAndAmbiguityOrControlTextIsDiscarded()
+        {
+            var userId = Guid.NewGuid();
+            var result = await RunAsync(
+                Request(Principal(
+                    new Claim("Jellyfin-UserId", userId.ToString()),
+                    new Claim("Jellyfin-Client", new string('c', PlatformActorBoundaryFilter.MaxClientNameBytes + 1)),
+                    new Claim("Jellyfin-DeviceId", "good"),
+                    new Claim("jellyfin-deviceid", "ambiguous"))),
+                id => new HostUser(id, "user", false));
+
+            Assert.True(result.Continued);
+            Assert.Null(result.Actor!.ClientName);
+            Assert.Null(result.Actor.DeviceId);
+
+            var controls = await RunAsync(
+                Request(Principal(
+                    new Claim("Jellyfin-UserId", userId.ToString()),
+                    new Claim("Jellyfin-Client", "client\nforged-log"),
+                    new Claim("Jellyfin-DeviceId", "device\u2028forged-log"))),
+                id => new HostUser(id, "user", false));
+
+            Assert.Null(controls.Actor!.ClientName);
+            Assert.Null(controls.Actor.DeviceId);
+        }
+
+        [Fact]
+        public async Task AttributionLimitsAreUtf8ByteBoundsNotCharacterCounts()
+        {
+            var userId = Guid.NewGuid();
+            var accepted = await RunAsync(
+                Request(Principal(
+                    new Claim("Jellyfin-UserId", userId.ToString()),
+                    new Claim("Jellyfin-Client", new string('c', PlatformActorBoundaryFilter.MaxClientNameBytes)),
+                    new Claim("Jellyfin-DeviceId", new string('d', PlatformActorBoundaryFilter.MaxDeviceIdBytes)))),
+                id => new HostUser(id, "user", false));
+            var rejected = await RunAsync(
+                Request(Principal(
+                    new Claim("Jellyfin-UserId", userId.ToString()),
+                    new Claim("Jellyfin-Client", new string('\u00e9', (PlatformActorBoundaryFilter.MaxClientNameBytes / 2) + 1)),
+                    new Claim("Jellyfin-DeviceId", new string('\u00e9', (PlatformActorBoundaryFilter.MaxDeviceIdBytes / 2) + 1)))),
+                id => new HostUser(id, "user", false));
+
+            Assert.Equal(PlatformActorBoundaryFilter.MaxClientNameBytes, accepted.Actor!.ClientName!.Length);
+            Assert.Equal(PlatformActorBoundaryFilter.MaxDeviceIdBytes, accepted.Actor.DeviceId!.Length);
+            Assert.Null(rejected.Actor!.ClientName);
+            Assert.Null(rejected.Actor.DeviceId);
+        }
+
+        [Fact]
+        public async Task UnauthenticatedDirectInvocationFailsClosedWithoutAnEnvelope()
+        {
+            var result = await RunAsync(Request(new ClaimsPrincipal(new ClaimsIdentity())));
+
+            Assert.False(result.Continued);
+            Assert.IsType<UnauthorizedResult>(result.Context.Result);
+            Assert.False(result.Context.Result is ObjectResult);
+        }
+
+        [Fact]
+        public async Task ExplicitAnonymousDiscoveryBypassesActorResolution()
+        {
+            var result = await RunAsync(
+                Request(new ClaimsPrincipal(new ClaimsIdentity())),
+                _ => throw new InvalidOperationException("anonymous discovery has no actor"),
+                new object[] { new AllowAnonymousAttribute() });
+
+            Assert.True(result.Continued);
+            Assert.Null(result.Context.Result);
+            Assert.Null(result.Actor);
+        }
+
+        [Fact]
+        public async Task ActorRejectionsRemainZeroByteThroughThePlatformResultFilter()
+        {
+            var unauthenticated = await RunAsync(Request(new ClaimsPrincipal(new ClaimsIdentity())));
+            var userId = Guid.NewGuid();
+            var deletedUser = await RunAsync(
+                Request(Principal(new Claim("Jellyfin-UserId", userId.ToString()))),
+                _ => null);
+
+            foreach (var rejected in new[] { unauthenticated, deletedUser })
+            {
+                await ExecuteThroughPlatformResultFilterAsync(
+                    Assert.IsAssignableFrom<ActionResult>(rejected.Context.Result),
+                    rejected.Context.HttpContext);
+
+                var expected = rejected.Context.Result is UnauthorizedResult
+                    ? StatusCodes.Status401Unauthorized
+                    : StatusCodes.Status403Forbidden;
+                Assert.Equal(expected, rejected.Context.HttpContext.Response.StatusCode);
+                Assert.Equal(0, rejected.Context.HttpContext.Response.Body.Length);
+                Assert.Null(rejected.Context.HttpContext.Response.ContentType);
+                Assert.False(rejected.Context.HttpContext.Response.Headers.ContainsKey(PlatformCorrelation.HeaderName));
+            }
         }
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformActor.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformActor.cs
@@ -1,0 +1,54 @@
+using System;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>
+    /// The immutable first-party identity and attribution carried below the Platform
+    /// controller boundary.
+    /// </summary>
+    /// <remarks>
+    /// This is deliberately a data-only allow-list. In particular it cannot carry the
+    /// request principal (which contains the bearer token), an HTTP context, or any
+    /// caller-selected target identity. <see cref="ClientName"/> and
+    /// <see cref="DeviceId"/> are audit attribution only and must never participate in
+    /// an authorization decision.
+    /// </remarks>
+    public sealed class PlatformActor
+    {
+        internal PlatformActor(
+            Guid userId,
+            bool isElevated,
+            string correlationId,
+            string? clientName,
+            string? deviceId)
+        {
+            if (userId == Guid.Empty)
+            {
+                throw new ArgumentException("An actor must have a non-empty user id.", nameof(userId));
+            }
+
+            ArgumentException.ThrowIfNullOrWhiteSpace(correlationId);
+
+            UserId = userId;
+            IsElevated = isElevated;
+            CorrelationId = correlationId;
+            ClientName = clientName;
+            DeviceId = deviceId;
+        }
+
+        /// <summary>The authoritative authenticated Jellyfin user.</summary>
+        public Guid UserId { get; }
+
+        /// <summary>The current host elevation result for <see cref="UserId"/>.</summary>
+        public bool IsElevated { get; }
+
+        /// <summary>The host-generated identifier joining this action to its audit record.</summary>
+        public string CorrelationId { get; }
+
+        /// <summary>Bounded caller-reported client name. Attribution only.</summary>
+        public string? ClientName { get; }
+
+        /// <summary>Bounded caller-reported device identifier. Attribution only.</summary>
+        public string? DeviceId { get; }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformActorBoundaryFilter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformActorBoundaryFilter.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>
+    /// Resolves one authenticated first-party actor before a Platform request enters the
+    /// kernel.
+    /// </summary>
+    /// <remarks>
+    /// This resource filter is the controller boundary: it is allowed to inspect the
+    /// authenticated principal, but only the immutable <see cref="PlatformActor"/>
+    /// crosses below it. Running before model binding also means a missing, malformed or
+    /// deleted authoritative user is refused before any caller body is acquired.
+    /// </remarks>
+    public sealed class PlatformActorBoundaryFilter : IAsyncResourceFilter, IOrderedFilter
+    {
+        internal const int MaxClientNameBytes = 64;
+        internal const int MaxDeviceIdBytes = 128;
+
+        private const string UserIdClaim = "Jellyfin-UserId";
+        private const string IsApiKeyClaim = "Jellyfin-IsApiKey";
+        private const string ClientClaim = "Jellyfin-Client";
+        private const string DeviceIdClaim = "Jellyfin-DeviceId";
+        private const string ActorItemsKey = "JellyfinCanopy.Platform.Actor";
+
+        private readonly IPlatformHost _host;
+
+        /// <summary>Initializes a new instance of the <see cref="PlatformActorBoundaryFilter"/> class.</summary>
+        /// <param name="host">Fresh host user and elevation lookup.</param>
+        public PlatformActorBoundaryFilter(IPlatformHost host)
+        {
+            ArgumentNullException.ThrowIfNull(host);
+            _host = host;
+        }
+
+        /// <inheritdoc />
+        public int Order => PlatformFilterOrder.ActorBoundary;
+
+        /// <inheritdoc />
+        public async Task OnResourceExecutionAsync(ResourceExecutingContext context, ResourceExecutionDelegate next)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            ArgumentNullException.ThrowIfNull(next);
+
+            // The one explicitly anonymous discovery route cannot have a first-party
+            // actor by definition. The architecture inventory pins that allowlist; all
+            // other Platform routes continue through the authenticated path below.
+            if (context.ActionDescriptor.EndpointMetadata.Any(metadata => metadata is IAllowAnonymous))
+            {
+                await next().ConfigureAwait(false);
+                return;
+            }
+
+            var principal = context.HttpContext.User;
+            if (principal.Identity?.IsAuthenticated != true)
+            {
+                // Normally [Authorize] short-circuits before resource filters. Keeping
+                // this explicit makes direct invocation fail closed too.
+                context.Result = new UnauthorizedResult();
+                return;
+            }
+
+            var userClaims = principal.Claims
+                .Where(claim => string.Equals(claim.Type, UserIdClaim, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            var apiKeyClaims = principal.Claims
+                .Where(claim => string.Equals(claim.Type, IsApiKeyClaim, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            if (apiKeyClaims.Count != 1
+                || !bool.TryParse(apiKeyClaims[0].Value, out var isApiKey)
+                || isApiKey
+                || userClaims.Count != 1
+                || !Guid.TryParse(userClaims[0].Value, out var userId)
+                || userId == Guid.Empty)
+            {
+                context.Result = new ForbidResult();
+                return;
+            }
+
+            // This read is intentionally per request. A deleted user or permission
+            // change must take effect without waiting for a token, catalog or actor cache
+            // to expire.
+            var currentUser = _host.Users.Find(userId);
+            if (currentUser is null || currentUser.Value.Id != userId)
+            {
+                context.Result = new ForbidResult();
+                return;
+            }
+
+            var actor = new PlatformActor(
+                userId,
+                currentUser.Value.IsAdministrator,
+                PlatformCorrelation.For(context.HttpContext),
+                ReadAttribution(principal.Claims, ClientClaim, MaxClientNameBytes),
+                ReadAttribution(principal.Claims, DeviceIdClaim, MaxDeviceIdBytes));
+
+            context.HttpContext.Items[ActorItemsKey] = actor;
+            await next().ConfigureAwait(false);
+        }
+
+        internal static PlatformActor Require(HttpContext context)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+
+            if (context.Items.TryGetValue(ActorItemsKey, out var value) && value is PlatformActor actor)
+            {
+                return actor;
+            }
+
+            throw new InvalidOperationException(
+                "The Platform actor boundary did not establish an authenticated actor.");
+        }
+
+        private static string? ReadAttribution(
+            System.Collections.Generic.IEnumerable<System.Security.Claims.Claim> claims,
+            string claimType,
+            int maximumUtf8Bytes)
+        {
+            var matches = claims
+                .Where(claim => string.Equals(claim.Type, claimType, StringComparison.OrdinalIgnoreCase))
+                .Select(claim => claim.Value)
+                .ToList();
+
+            // Ambiguous attribution is discarded rather than guessed. It carries no
+            // authority, so losing it cannot make an authorization decision broader.
+            if (matches.Count != 1)
+            {
+                return null;
+            }
+
+            var value = matches[0].Trim();
+            if (value.Length == 0
+                || Encoding.UTF8.GetByteCount(value) > maximumUtf8Bytes
+                || value.Any(character => char.IsControl(character)
+                    || character is '\u2028' or '\u2029'))
+            {
+                return null;
+            }
+
+            return value;
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformBoundedBodyFilter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformBoundedBodyFilter.cs
@@ -11,11 +11,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
     /// Enforces <see cref="PlatformRequestBounds"/> on every Platform v1 request body.
     ///
     /// <para>
-    /// <b>Why a resource filter, and why <see cref="Order"/> is <see cref="int.MinValue"/>.</b>
+    /// <b>Why a resource filter, and why <see cref="Order"/> is near <see cref="int.MinValue"/>.</b>
     /// Resource filters run after authorization but <i>before</i> model binding, which is
     /// the only window where a body can be refused without first deserializing it —
     /// deserializing to find out whether it was too big to deserialize is the cost this
-    /// exists to avoid. The same placement the existing
+    /// exists to avoid. Actor and media-type checks occupy the two earlier deterministic
+    /// resource-filter slots, so no body byte is acquired before they pass. The same
+    /// placement the existing
     /// <c>PersistedPayloadLimitAttribute</c> uses, for the same reason.
     /// </para>
     /// <para>
@@ -35,7 +37,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
         private const int CopyBufferBytes = 81_920;
 
         /// <inheritdoc />
-        public int Order => int.MinValue;
+        public int Order => PlatformFilterOrder.BoundedBody;
 
         /// <inheritdoc />
         public async Task OnResourceExecutionAsync(ResourceExecutingContext context, ResourceExecutionDelegate next)

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformControllerBase.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformControllerBase.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Linq;
-using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -36,13 +33,21 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
     [ApiController]
     [Authorize]
     [Produces("application/json")]
+    [TypeFilter(typeof(PlatformActorBoundaryFilter), Order = PlatformFilterOrder.ActorBoundary)]
     [TypeFilter(typeof(PlatformRequestFilter), Order = int.MinValue)]
     [TypeFilter(typeof(PlatformJsonResultFilter))]
-    [TypeFilter(typeof(PlatformJsonMediaTypeFilter), Order = int.MinValue)]
-    [TypeFilter(typeof(PlatformBoundedBodyFilter), Order = int.MinValue + 1)]
-    [TypeFilter(typeof(PlatformRequestLifecycleFilter), Order = int.MinValue + 2)]
+    [TypeFilter(typeof(PlatformJsonMediaTypeFilter), Order = PlatformFilterOrder.JsonMediaType)]
+    [TypeFilter(typeof(PlatformBoundedBodyFilter), Order = PlatformFilterOrder.BoundedBody)]
+    [TypeFilter(typeof(PlatformRequestLifecycleFilter), Order = PlatformFilterOrder.RequestLifecycle)]
     public abstract class PlatformControllerBase : ControllerBase
     {
+        /// <summary>
+        /// The immutable authenticated actor established at the controller boundary.
+        /// Only this allow-listed value may be passed into Platform services; the
+        /// principal and HTTP context remain above the boundary.
+        /// </summary>
+        protected PlatformActor Actor => PlatformActorBoundaryFilter.Require(HttpContext);
+
         /// <summary>
         /// The correlation id for the current request, tying this response to the server
         /// log lines it produced.
@@ -63,34 +68,5 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
         protected ObjectResult PlatformProblem(string code, string message) =>
             PlatformResults.Error(code, message, CorrelationId);
 
-        /// <summary>
-        /// The acting user, derived from Jellyfin's authentication claims and nothing
-        /// else.
-        ///
-        /// EP-00 verified that this cannot be forged: with a non-admin token, injected
-        /// <c>Jellyfin-UserId</c>, <c>X-Jellyfin-User-Id</c>, <c>X-Emby-Authorization</c>
-        /// header values and a <c>jellyfin-userid</c> cookie all still resolved to the
-        /// caller's own id (spike-evidence S14). No route value, header, cookie or
-        /// payload field may ever be consulted instead of this.
-        /// </summary>
-        protected Guid? ActingUserId
-        {
-            get
-            {
-                var raw = User.Claims.FirstOrDefault(claim =>
-                    string.Equals(claim.Type, "Jellyfin-UserId", StringComparison.OrdinalIgnoreCase))?.Value;
-
-                return Guid.TryParse(raw, out var parsed) && parsed != Guid.Empty ? parsed : null;
-            }
-        }
-
-        /// <summary>
-        /// The device the caller is using, for attribution only.
-        ///
-        /// Attribution is never authority: a device identifier is caller-supplied and
-        /// may not influence any access decision (ADR-0011).
-        /// </summary>
-        protected string? ActingDeviceId => User.Claims.FirstOrDefault(claim =>
-            string.Equals(claim.Type, "Jellyfin-DeviceId", StringComparison.OrdinalIgnoreCase))?.Value;
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformFilterOrder.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformFilterOrder.cs
@@ -1,0 +1,18 @@
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>Deterministic ordering for the pre-model-binding Platform boundary.</summary>
+    internal static class PlatformFilterOrder
+    {
+        /// <summary>Authenticate the first-party actor before inspecting caller input.</summary>
+        internal const int ActorBoundary = int.MinValue;
+
+        /// <summary>Reject an unsupported body media type before acquiring the body.</summary>
+        internal const int JsonMediaType = int.MinValue + 1;
+
+        /// <summary>Acquire and validate the bounded body only after actor and media checks.</summary>
+        internal const int BoundedBody = int.MinValue + 2;
+
+        /// <summary>Start the model-binding/action deadline after body acquisition.</summary>
+        internal const int RequestLifecycle = int.MinValue + 3;
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformJsonMediaTypeFilter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformJsonMediaTypeFilter.cs
@@ -9,7 +9,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
     public sealed class PlatformJsonMediaTypeFilter : IAsyncResourceFilter, IOrderedFilter
     {
         /// <inheritdoc />
-        public int Order => int.MinValue;
+        public int Order => PlatformFilterOrder.JsonMediaType;
 
         /// <inheritdoc />
         public async Task OnResourceExecutionAsync(ResourceExecutingContext context, ResourceExecutionDelegate next)

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformRequestLifecycleFilter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformRequestLifecycleFilter.cs
@@ -37,7 +37,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
         }
 
         /// <inheritdoc />
-        public int Order => int.MinValue + 2;
+        public int Order => PlatformFilterOrder.RequestLifecycle;
 
         /// <inheritdoc />
         public async Task OnResourceExecutionAsync(ResourceExecutingContext context, ResourceExecutionDelegate next)

--- a/docs/platform-contract.md
+++ b/docs/platform-contract.md
@@ -34,12 +34,20 @@ The older `/JellyfinCanopy/*` routes are **compatibility surfaces**. They keep t
 existing shapes, they are not documented here, and they are never promoted into the
 platform implicitly. If you are starting something new, use the platform routes.
 
-## Two things worth knowing before you write a client
+## Three things worth knowing before you write a client
 
 **`401` and `403` have no body.** Jellyfin returns both with zero bytes, so the contract
 documents them without a schema. Do not try to parse an error envelope from them — you
-will get an empty string. Every *other* failure, after authentication has succeeded,
-carries the one error envelope.
+will get an empty string. Business and protocol failures reached after the authenticated
+actor boundary carry the one error envelope.
+
+**The acting user is the authenticated Jellyfin user.** For every authenticated
+Platform route, Canopy accepts only Jellyfin's `Jellyfin-UserId` authentication claim,
+then re-reads that current host user and elevation state for the request. Route, query,
+body, cookie, header, marker, IP, client-name and device-id values cannot select or
+elevate an actor. Client and device values are bounded attribution only. A missing,
+malformed or deleted authenticated user fails closed with a bare `403`; service/API-key
+actors remain outside the native-first pilot.
 
 **Branch on `Code`, never on `Message`.** The message is human-readable and may be
 reworded or translated at any time. The code set is enumerated in the spec, and each code

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,19 +26,19 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2808, totalLines: 3201 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 31619, totalLines: 40248 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 31688, totalLines: 40320 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 3,
         minimumCoveredLines: 2808,
         maximumCoveredLines: 2808,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
-        cleanRuns: 4,
-        minimumCoveredLines: 31617,
-        maximumCoveredLines: 31619,
+        cleanRuns: 3,
+        minimumCoveredLines: 31688,
+        maximumCoveredLines: 31688,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 0);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,19 +26,19 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2808, totalLines: 3201 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 31688, totalLines: 40320 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 31689, totalLines: 40320 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 3,
         minimumCoveredLines: 2808,
         maximumCoveredLines: 2808,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
-        cleanRuns: 3,
+        cleanRuns: 4,
         minimumCoveredLines: 31688,
-        maximumCoveredLines: 31688,
+        maximumCoveredLines: 31689,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 0);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 1);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 31688,
+        "coveredLines": 31689,
         "totalLines": 40320
       },
       "observations": {
-        "cleanRuns": 3,
+        "cleanRuns": 4,
         "minimumCoveredLines": 31688,
-        "maximumCoveredLines": 31688
+        "maximumCoveredLines": 31689
       },
       "tolerance": {
-        "missingCoveredLines": 0,
-        "rationale": "The #586 first-party actor boundary adds an immutable authenticated actor, fresh authoritative Jellyfin user and administrator resolution, bounded non-authoritative client/device attribution, fail-closed claim validation, and focused boundary, MVC-wire, architecture, and filter-order coverage. Three clean Coverlet runs on the identical 2026-08-03 source and 40,320-line scope each passed all 2,755 server tests and reproduced exactly 31,688 covered lines. Relative to the reviewed #522 baseline of 31,619/40,248 (78.560%), the reviewed implementation adds 72 instrumented lines and 69 covered lines while increasing the high-water to 31,688/40,320 (78.591%). The exact observed envelope needs no instrumentation tolerance, so the new floor is 31,688/40,320 (78.591%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 1,
+        "rationale": "The #586 first-party actor boundary adds an immutable authenticated actor, fresh authoritative Jellyfin user and administrator resolution, bounded non-authoritative client/device attribution, fail-closed claim validation, and focused boundary, MVC-wire, architecture, and filter-order coverage. Four clean Coverlet observations on the identical 2026-08-03 source and 40,320-line scope each passed all 2,755 server tests: three local runs measured 31,688 covered lines, while GitHub Actions run 30759339499 measured 31,689. Relative to the reviewed #522 baseline of 31,619/40,248 (78.560%), the reviewed implementation adds 72 instrumented lines and raises the observed high-water by 70 covered lines to 31,689/40,320 (78.594%). The exact one-line 31,688-31,689 instrumentation envelope therefore sets a 31,689 high-water with a one-line tolerance and a floor of 31,688/40,320 (78.591%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 31619,
-        "totalLines": 40248
+        "coveredLines": 31688,
+        "totalLines": 40320
       },
       "observations": {
-        "cleanRuns": 4,
-        "minimumCoveredLines": 31617,
-        "maximumCoveredLines": 31619
+        "cleanRuns": 3,
+        "minimumCoveredLines": 31688,
+        "maximumCoveredLines": 31688
       },
       "tolerance": {
-        "missingCoveredLines": 2,
-        "rationale": "The #522 request-lifecycle and idempotency kernel adds a linked 30-second model-binding/action deadline, caller-first cancellation handling, bounded semantic replay state, bounded same-key follower coalescing, and focused lifecycle, concurrency, architecture, and contract coverage. Four clean Coverlet runs on the identical 2026-08-03 source and 40,248-line scope each passed all 2,736 server tests: the three local runs observed 31,618, 31,618, and 31,619 covered lines, while GitHub Actions run 30758176581 observed 31,617. Relative to the reviewed #587 baseline of 31,298/39,890 (78.461%), the reviewed implementation adds 358 instrumented lines and 321 covered high-water lines while increasing the high-water to 31,619/40,248 (78.560%) and the enforced floor to 31,617/40,248 (78.555%). The two-line allowance is exactly the observed same-head, fixed-scope local-and-CI instrumentation envelope; the 31,619 high-water is retained and broader regressions still fail. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 0,
+        "rationale": "The #586 first-party actor boundary adds an immutable authenticated actor, fresh authoritative Jellyfin user and administrator resolution, bounded non-authoritative client/device attribution, fail-closed claim validation, and focused boundary, MVC-wire, architecture, and filter-order coverage. Three clean Coverlet runs on the identical 2026-08-03 source and 40,320-line scope each passed all 2,755 server tests and reproduced exactly 31,688 covered lines. Relative to the reviewed #522 baseline of 31,619/40,248 (78.560%), the reviewed implementation adds 72 instrumented lines and 69 covered lines while increasing the high-water to 31,688/40,320 (78.591%). The exact observed envelope needs no instrumentation tolerance, so the new floor is 31,688/40,320 (78.591%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
Closes #586.

## Summary
- establish one immutable first-party Platform actor at the controller resource boundary
- derive user identity and elevation from Jellyfin claims plus a fresh host user lookup, rejecting API-key and malformed identity paths
- keep caller-reported client/device values bounded and attribution-only
- pin actor → media type → bounded body → request lifecycle ordering before model binding
- add production-wide architecture guards and bare zero-byte 401/403 coverage

## Verification
- focused actor/lifecycle suite: 130/130
- full server suite: 2755/2755
- coverage: local observations 31688/40320; Actions run 30759339499 observed 31689/40320; reviewed one-line envelope and ratchet pass
- script tests: 634/634
- strict docs, Release build, and diff check pass
- independent review approved after fixing API-key classification

## Scope
This is the EP-02 actor primitive only. It adds no feature routes, client DTOs, or alternate authentication path.