### PR TITLE
feat(platform): close native operation vocabulary

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformOperationVocabularyArchitectureTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformOperationVocabularyArchitectureTests.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
+{
+    /// <summary>Guards the operation vocabulary against caller or manifest registration.</summary>
+    public class PlatformOperationVocabularyArchitectureTests
+    {
+        private static readonly Regex ExplicitVocabularyTypeConstruction = new(
+            @"\bnew\s+(?:(?:global::)?[A-Za-z_]\w*\.)*(?:PlatformOperationDefinition|PlatformOperationId|PlatformInputSchemaId)\s*\(",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        private static readonly Regex TargetTypedVocabularyTypeConstruction = new(
+            @"\b(?:PlatformOperationDefinition|PlatformOperationId|PlatformInputSchemaId)\s+[A-Za-z_]\w*\s*=\s*new\s*\(",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        private static readonly Regex VocabularyTypeAlias = new(
+            @"^\s*using\s+[A-Za-z_]\w*\s*=\s*(?:(?:global::)?[A-Za-z_]\w*\.)*(?:PlatformOperationDefinition|PlatformOperationId|PlatformInputSchemaId)\s*;",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Multiline);
+
+        [Fact]
+        public void DefinitionsAndIdentifiersHaveOnlyPrivateConstructors()
+        {
+            foreach (var type in new[]
+            {
+                typeof(PlatformOperationDefinition),
+                typeof(PlatformOperationId),
+                typeof(PlatformInputSchemaId),
+            })
+            {
+                var constructors = type.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                Assert.Single(constructors);
+                Assert.True(constructors[0].IsPrivate);
+            }
+        }
+
+        [Fact]
+        public void OnlyTheCodeOwnedVocabularySourceConstructsClosedTypes()
+        {
+            var constructionOwners = ProductionFiles()
+                .Where(file => HasVocabularyTypeConstruction(
+                    PlatformHostSeamTests.CodeOnly(File.ReadAllText(file))))
+                .Select(Path.GetFileName)
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToArray();
+
+            Assert.Equal(new[] { "PlatformOperationVocabulary.cs" }, constructionOwners);
+            Assert.True(HasVocabularyTypeConstruction(
+                "var planted = new PlatformOperationDefinition(id, family, authority, scope, kinds, true, schema, 1);"));
+            Assert.True(HasVocabularyTypeConstruction(
+                "var planted = new global::Jellyfin.Plugin.JellyfinCanopy.Platform.PlatformOperationId(value);"));
+            Assert.True(HasVocabularyTypeConstruction(
+                "var planted = new Jellyfin.Plugin.JellyfinCanopy.Platform.PlatformInputSchemaId(value);"));
+            Assert.True(HasVocabularyTypeConstruction(
+                "PlatformOperationDefinition planted = new(id, family, authority, scope, kinds, true, schema, 1);"));
+            Assert.True(HasVocabularyTypeConstruction(
+                "using Definition = global::Jellyfin.Plugin.JellyfinCanopy.Platform.PlatformOperationDefinition;\n"
+                + "Definition planted = new(id, family, authority, scope, kinds, true, schema, 1);"));
+        }
+
+        [Fact]
+        public void AssemblyVisibleInstancesAreTheExactFixedVocabularyOnly()
+        {
+            Assert.Equal(
+                new[] { "HiddenContentConfigureItem", "SeerrRequestItem", "SpoilerGuardConfigureItem" },
+                NonPublicStaticPropertyNames(typeof(PlatformOperationId)));
+            Assert.Equal(
+                new[] { "HiddenContentItemConfigurationV1", "SeerrItemRequestV1", "SpoilerGuardItemConfigurationV1" },
+                NonPublicStaticPropertyNames(typeof(PlatformInputSchemaId)));
+            Assert.Equal(
+                new[] { "HiddenContentConfigureItem", "SeerrRequestItem", "SpoilerGuardConfigureItem" },
+                NonPublicStaticPropertyNames(typeof(PlatformOperationDefinition)));
+
+            Assert.Empty(typeof(PlatformOperationId).GetProperties(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly));
+            Assert.Empty(typeof(PlatformInputSchemaId).GetProperties(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly));
+            Assert.Empty(typeof(PlatformOperationDefinition).GetProperties(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly));
+        }
+
+        [Fact]
+        public void VocabularyExposesLookupButNoRegistrationSurface()
+        {
+            var publicMethods = typeof(PlatformOperationVocabulary)
+                .GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
+                .Where(method => !method.IsSpecialName)
+                .Select(method => method.Name)
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToArray();
+
+            Assert.Equal(new[] { nameof(PlatformOperationVocabulary.Find) }, publicMethods);
+            Assert.DoesNotContain(
+                typeof(PlatformOperationVocabulary).GetProperties(BindingFlags.Public | BindingFlags.Static),
+                property => property.CanWrite);
+        }
+
+        [Fact]
+        public void DefinitionMetadataCannotNameRoutesMethodsOrServices()
+        {
+            var expectedProperties = new Dictionary<string, Type>(StringComparer.Ordinal)
+            {
+                [nameof(PlatformOperationDefinition.Authority)] = typeof(PlatformAuthorityLevel),
+                [nameof(PlatformOperationDefinition.Family)] = typeof(PlatformOperationFamily),
+                [nameof(PlatformOperationDefinition.Id)] = typeof(PlatformOperationId),
+                [nameof(PlatformOperationDefinition.InputSchemaId)] = typeof(PlatformInputSchemaId),
+                [nameof(PlatformOperationDefinition.InvalidationGeneration)] = typeof(long),
+                [nameof(PlatformOperationDefinition.IsMutation)] = typeof(bool),
+                [nameof(PlatformOperationDefinition.ItemScope)] = typeof(PlatformItemScope),
+                [nameof(PlatformOperationDefinition.SupportedItemKinds)] = typeof(System.Collections.Immutable.ImmutableArray<HostItemKind>),
+            };
+
+            var actualProperties = typeof(PlatformOperationDefinition)
+                .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                .ToDictionary(property => property.Name, property => property.PropertyType, StringComparer.Ordinal);
+            Assert.Equal(
+                expectedProperties.Keys.OrderBy(name => name, StringComparer.Ordinal),
+                actualProperties.Keys.OrderBy(name => name, StringComparer.Ordinal));
+            Assert.All(expectedProperties, expected => Assert.Equal(expected.Value, actualProperties[expected.Key]));
+            Assert.All(typeof(PlatformOperationDefinition).GetProperties(), property => Assert.False(property.CanWrite));
+
+            Assert.All(PlatformOperationVocabulary.All, definition =>
+            {
+                Assert.DoesNotContain('/', definition.Id.Value);
+                Assert.DoesNotContain(':', definition.Id.Value);
+                Assert.DoesNotContain("controller", definition.Id.Value, StringComparison.Ordinal);
+                Assert.DoesNotContain("service", definition.Id.Value, StringComparison.Ordinal);
+                Assert.DoesNotContain("proxy", definition.Id.Value, StringComparison.Ordinal);
+            });
+        }
+
+        [Fact]
+        public void VocabularySourceHasNoHttpManifestOrDependencyInjectionRegistration()
+        {
+            var code = PlatformHostSeamTests.CodeOnly(File.ReadAllText(SourceFile("PlatformOperationVocabulary.cs")));
+
+            foreach (var forbidden in new[]
+            {
+                "HttpGet",
+                "HttpPost",
+                "HttpPut",
+                "HttpDelete",
+                "Route(",
+                "ControllerBase",
+                "IServiceCollection",
+                "IServiceProvider",
+                "Manifest",
+                "Register(",
+            })
+            {
+                Assert.DoesNotContain(forbidden, code, StringComparison.Ordinal);
+            }
+        }
+
+        private static IEnumerable<string> ProductionFiles() =>
+            Directory.EnumerateFiles(ProductionRoot(), "*.cs", SearchOption.AllDirectories)
+                .Where(file => !file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                    && !file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal));
+
+        private static string SourceFile(string name) => ProductionFiles().Single(file => Path.GetFileName(file) == name);
+
+        private static bool HasVocabularyTypeConstruction(string code) =>
+            ExplicitVocabularyTypeConstruction.IsMatch(code)
+            || TargetTypedVocabularyTypeConstruction.IsMatch(code)
+            || VocabularyTypeAlias.IsMatch(code);
+
+        private static string[] NonPublicStaticPropertyNames(Type type) =>
+            type.GetProperties(BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly)
+                .Select(property => property.Name)
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToArray();
+
+        private static string ProductionRoot([CallerFilePath] string sourceFile = "") =>
+            Path.GetFullPath(Path.Combine(
+                Path.GetDirectoryName(sourceFile)!,
+                "..",
+                "..",
+                "Jellyfin.Plugin.JellyfinCanopy"));
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformOperationVocabularyTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformOperationVocabularyTests.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
+{
+    public class PlatformOperationVocabularyTests
+    {
+        [Fact]
+        public void VocabularyIsTheExactThreeFamilyNativePilotGolden()
+        {
+            var actual = PlatformOperationVocabulary.All
+                .Select(definition => new
+                {
+                    Id = definition.Id.Value,
+                    definition.Family,
+                    definition.Authority,
+                    definition.ItemScope,
+                    Kinds = string.Join(",", definition.SupportedItemKinds),
+                    definition.IsMutation,
+                    Schema = definition.InputSchemaId.Value,
+                    definition.InvalidationGeneration,
+                })
+                .ToArray();
+
+            Assert.Equal(
+                new[]
+                {
+                    new
+                    {
+                        Id = "jellyfin.canopy.spoiler-guard.configure-item",
+                        Family = PlatformOperationFamily.SpoilerGuard,
+                        Authority = PlatformAuthorityLevel.Authenticated,
+                        ItemScope = PlatformItemScope.ExactItem,
+                        Kinds = "Movie,Series",
+                        IsMutation = true,
+                        Schema = "jellyfin.canopy.spoiler-guard.item-configuration.v1",
+                        InvalidationGeneration = 1L,
+                    },
+                    new
+                    {
+                        Id = "jellyfin.canopy.hidden-content.configure-item",
+                        Family = PlatformOperationFamily.HiddenContent,
+                        Authority = PlatformAuthorityLevel.Authenticated,
+                        ItemScope = PlatformItemScope.ExactItem,
+                        Kinds = "Movie,Series,Episode",
+                        IsMutation = true,
+                        Schema = "jellyfin.canopy.hidden-content.item-configuration.v1",
+                        InvalidationGeneration = 1L,
+                    },
+                    new
+                    {
+                        Id = "jellyfin.canopy.seerr.request-item",
+                        Family = PlatformOperationFamily.Seerr,
+                        Authority = PlatformAuthorityLevel.Authenticated,
+                        ItemScope = PlatformItemScope.ExactItem,
+                        Kinds = "Movie,Series",
+                        IsMutation = true,
+                        Schema = "jellyfin.canopy.seerr.item-request.v1",
+                        InvalidationGeneration = 1L,
+                    },
+                },
+                actual);
+        }
+
+        [Fact]
+        public void EveryDefinitionIsUniqueBoundedAndClosed()
+        {
+            var definitions = PlatformOperationVocabulary.All;
+
+            Assert.Equal(definitions.Length, definitions.Select(definition => definition.Id.Value).Distinct(StringComparer.Ordinal).Count());
+            Assert.Equal(definitions.Length, definitions.Select(definition => definition.InputSchemaId.Value).Distinct(StringComparer.Ordinal).Count());
+            Assert.Equal(definitions.Length, definitions.Select(definition => definition.Family).Distinct().Count());
+            Assert.All(definitions, definition =>
+            {
+                Assert.True(PlatformOperationVocabulary.IsValidIdentifier(definition.Id.Value));
+                Assert.True(PlatformOperationVocabulary.IsValidIdentifier(definition.InputSchemaId.Value));
+                Assert.InRange(definition.Id.Value.Length, 1, PlatformOperationVocabulary.MaximumIdentifierLength);
+                Assert.InRange(definition.InputSchemaId.Value.Length, 1, PlatformOperationVocabulary.MaximumIdentifierLength);
+                Assert.Equal(PlatformAuthorityLevel.Authenticated, definition.Authority);
+                Assert.Equal(PlatformItemScope.ExactItem, definition.ItemScope);
+                Assert.True(definition.IsMutation);
+                Assert.True(definition.InvalidationGeneration > 0);
+                Assert.NotEmpty(definition.SupportedItemKinds);
+                Assert.DoesNotContain(HostItemKind.Other, definition.SupportedItemKinds);
+                Assert.Equal(definition.SupportedItemKinds.Length, definition.SupportedItemKinds.Distinct().Count());
+            });
+        }
+
+        [Fact]
+        public void FindUsesExactOrdinalKnownIdsAndFailsClosedForEverythingElse()
+        {
+            foreach (var expected in PlatformOperationVocabulary.All)
+            {
+                Assert.Same(expected, PlatformOperationVocabulary.Find(expected.Id.Value));
+            }
+
+            Assert.Null(PlatformOperationVocabulary.Find(null));
+            Assert.Null(PlatformOperationVocabulary.Find(string.Empty));
+            Assert.Null(PlatformOperationVocabulary.Find("jellyfin.canopy.unknown-operation"));
+            Assert.Null(PlatformOperationVocabulary.Find("JELLYFIN.CANOPY.SEERR.REQUEST-ITEM"));
+            Assert.Null(PlatformOperationVocabulary.Find(" jellyfin.canopy.seerr.request-item"));
+            Assert.Null(PlatformOperationVocabulary.Find("jellyfin.canopy.seerr.request-item "));
+        }
+
+        [Theory]
+        [InlineData("vendor.extension.operation")]
+        [InlineData("vendor.extension.operation-name.v1")]
+        [InlineData("a.b.c")]
+        public void IdentifierGrammarAcceptsBoundedLowerCaseNamespaces(string value)
+            => Assert.True(PlatformOperationVocabulary.IsValidIdentifier(value));
+
+        [Theory]
+        [InlineData("operation")]
+        [InlineData("vendor.operation")]
+        [InlineData("1vendor.extension.operation")]
+        [InlineData("Vendor.extension.operation")]
+        [InlineData("vendor..operation")]
+        [InlineData("vendor.extension.")]
+        [InlineData("vendor.extension.-operation")]
+        [InlineData("vendor.extension.operation-")]
+        [InlineData("vendor.extension.operation_name")]
+        [InlineData("vendor/extension/operation")]
+        [InlineData("vendor.extension.opération")]
+        public void IdentifierGrammarRejectsUnnamespacedOrNonAsciiValues(string value)
+            => Assert.False(PlatformOperationVocabulary.IsValidIdentifier(value));
+
+        [Fact]
+        public void IdentifierGrammarEnforcesItsExactLengthBoundary()
+        {
+            const string prefix = "vendor.extension.";
+            var maximum = prefix + new string('a', PlatformOperationVocabulary.MaximumIdentifierLength - prefix.Length);
+
+            Assert.True(PlatformOperationVocabulary.IsValidIdentifier(maximum));
+            Assert.False(PlatformOperationVocabulary.IsValidIdentifier(maximum + "a"));
+        }
+
+        [Fact]
+        public void IdentifierValueTypesRejectInvalidConstructionAndHaveSafeDefaults()
+        {
+            Assert.Throws<ArgumentException>(() => ConstructPrivately<PlatformOperationId>("free-form"));
+            Assert.Throws<ArgumentException>(() => ConstructPrivately<PlatformInputSchemaId>("free-form"));
+            Assert.Equal(string.Empty, default(PlatformOperationId).ToString());
+            Assert.Equal(string.Empty, default(PlatformInputSchemaId).ToString());
+        }
+
+        [Fact]
+        public void DefinitionRejectsInvalidOrOpenEndedMetadata()
+        {
+            var id = ConstructPrivately<PlatformOperationId>("vendor.extension.operation");
+            var schema = ConstructPrivately<PlatformInputSchemaId>("vendor.extension.input.v1");
+            var kinds = ImmutableArray.Create(HostItemKind.Movie);
+
+            Assert.Throws<ArgumentException>(() => New(default, kinds: kinds));
+            Assert.Throws<ArgumentOutOfRangeException>(() => New(id, family: (PlatformOperationFamily)99, kinds: kinds));
+            Assert.Throws<ArgumentOutOfRangeException>(() => New(id, authority: (PlatformAuthorityLevel)99, kinds: kinds));
+            Assert.Throws<ArgumentOutOfRangeException>(() => New(id, itemScope: (PlatformItemScope)99, kinds: kinds));
+            Assert.Throws<ArgumentException>(() => New(id, kinds: default));
+            Assert.Throws<ArgumentException>(() => New(id, kinds: [HostItemKind.Other]));
+            Assert.Throws<ArgumentException>(() => New(id, kinds: [(HostItemKind)99]));
+            Assert.Throws<ArgumentException>(() => New(id, kinds: [HostItemKind.Movie, HostItemKind.Movie]));
+            Assert.Throws<ArgumentException>(() => New(id, kinds: kinds, isMutation: false));
+            Assert.Throws<ArgumentException>(() => ConstructPrivately<PlatformOperationDefinition>(
+                id,
+                PlatformOperationFamily.Seerr,
+                PlatformAuthorityLevel.Authenticated,
+                PlatformItemScope.ExactItem,
+                kinds,
+                true,
+                default,
+                1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => New(id, kinds: kinds, invalidationGeneration: 0));
+
+            PlatformOperationDefinition New(
+                PlatformOperationId operationId,
+                PlatformOperationFamily family = PlatformOperationFamily.Seerr,
+                PlatformAuthorityLevel authority = PlatformAuthorityLevel.Authenticated,
+                PlatformItemScope itemScope = PlatformItemScope.ExactItem,
+                ImmutableArray<HostItemKind> kinds = default,
+                bool isMutation = true,
+                long invalidationGeneration = 1)
+                => ConstructPrivately<PlatformOperationDefinition>(
+                    operationId,
+                    family,
+                    authority,
+                    itemScope,
+                    kinds,
+                    isMutation,
+                    schema,
+                    invalidationGeneration);
+        }
+
+        private static T ConstructPrivately<T>(params object?[] arguments)
+        {
+            var constructor = typeof(T)
+                .GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)
+                .Single();
+
+            try
+            {
+                return (T)constructor.Invoke(arguments);
+            }
+            catch (TargetInvocationException exception) when (exception.InnerException is not null)
+            {
+                ExceptionDispatchInfo.Capture(exception.InnerException).Throw();
+                throw;
+            }
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformOperationVocabulary.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformOperationVocabulary.cs
@@ -1,0 +1,318 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>A code-owned, namespaced Platform operation identifier.</summary>
+    public readonly record struct PlatformOperationId
+    {
+        private PlatformOperationId(string value)
+        {
+            if (!PlatformOperationVocabulary.IsValidIdentifier(value))
+            {
+                throw new ArgumentException(
+                    "Operation ids must use the bounded lower-case Platform identifier grammar.",
+                    nameof(value));
+            }
+
+            Value = value;
+        }
+
+        /// <summary>Gets the stable, case-sensitive identifier.</summary>
+        public string Value { get; }
+
+        internal static PlatformOperationId SpoilerGuardConfigureItem { get; } =
+            new PlatformOperationId("jellyfin.canopy.spoiler-guard.configure-item");
+
+        internal static PlatformOperationId HiddenContentConfigureItem { get; } =
+            new PlatformOperationId("jellyfin.canopy.hidden-content.configure-item");
+
+        internal static PlatformOperationId SeerrRequestItem { get; } =
+            new PlatformOperationId("jellyfin.canopy.seerr.request-item");
+
+        /// <inheritdoc />
+        public override string ToString() => Value ?? string.Empty;
+    }
+
+    /// <summary>A code-owned identifier for one bounded action-input schema.</summary>
+    public readonly record struct PlatformInputSchemaId
+    {
+        private PlatformInputSchemaId(string value)
+        {
+            if (!PlatformOperationVocabulary.IsValidIdentifier(value))
+            {
+                throw new ArgumentException(
+                    "Input schema ids must use the bounded lower-case Platform identifier grammar.",
+                    nameof(value));
+            }
+
+            Value = value;
+        }
+
+        /// <summary>Gets the stable, case-sensitive identifier.</summary>
+        public string Value { get; }
+
+        internal static PlatformInputSchemaId SpoilerGuardItemConfigurationV1 { get; } =
+            new PlatformInputSchemaId("jellyfin.canopy.spoiler-guard.item-configuration.v1");
+
+        internal static PlatformInputSchemaId HiddenContentItemConfigurationV1 { get; } =
+            new PlatformInputSchemaId("jellyfin.canopy.hidden-content.item-configuration.v1");
+
+        internal static PlatformInputSchemaId SeerrItemRequestV1 { get; } =
+            new PlatformInputSchemaId("jellyfin.canopy.seerr.item-request.v1");
+
+        /// <inheritdoc />
+        public override string ToString() => Value ?? string.Empty;
+    }
+
+    /// <summary>The complete first-party product-family vocabulary for the native pilot.</summary>
+    public enum PlatformOperationFamily
+    {
+        /// <summary>Per-user Spoiler Guard item configuration.</summary>
+        SpoilerGuard,
+
+        /// <summary>Per-user Hidden Content item configuration.</summary>
+        HiddenContent,
+
+        /// <summary>Per-user Seerr media requests.</summary>
+        Seerr,
+    }
+
+    /// <summary>The Jellyfin authority an operation requires at invocation.</summary>
+    public enum PlatformAuthorityLevel
+    {
+        /// <summary>Any authoritative authenticated first-party actor.</summary>
+        Authenticated,
+
+        /// <summary>An actor whose current Jellyfin user is elevated.</summary>
+        Elevated,
+    }
+
+    /// <summary>The bounded context an operation may act on.</summary>
+    public enum PlatformItemScope
+    {
+        /// <summary>The exact user-accessible Jellyfin item bound to the action.</summary>
+        ExactItem,
+    }
+
+    /// <summary>Immutable authority metadata for one fixed first-party operation.</summary>
+    public sealed class PlatformOperationDefinition
+    {
+        private PlatformOperationDefinition(
+            PlatformOperationId id,
+            PlatformOperationFamily family,
+            PlatformAuthorityLevel authority,
+            PlatformItemScope itemScope,
+            ImmutableArray<HostItemKind> supportedItemKinds,
+            bool isMutation,
+            PlatformInputSchemaId inputSchemaId,
+            long invalidationGeneration)
+        {
+            if (string.IsNullOrEmpty(id.Value))
+            {
+                throw new ArgumentException("A code-owned operation id is required.", nameof(id));
+            }
+
+            if (!Enum.IsDefined(family))
+            {
+                throw new ArgumentOutOfRangeException(nameof(family));
+            }
+
+            if (!Enum.IsDefined(authority))
+            {
+                throw new ArgumentOutOfRangeException(nameof(authority));
+            }
+
+            if (!Enum.IsDefined(itemScope))
+            {
+                throw new ArgumentOutOfRangeException(nameof(itemScope));
+            }
+
+            if (supportedItemKinds.IsDefaultOrEmpty
+                || supportedItemKinds.Any(kind => kind == HostItemKind.Other || !Enum.IsDefined(kind))
+                || supportedItemKinds.Distinct().Count() != supportedItemKinds.Length)
+            {
+                throw new ArgumentException(
+                    "An operation must declare distinct supported closed item kinds.",
+                    nameof(supportedItemKinds));
+            }
+
+            if (!isMutation)
+            {
+                throw new ArgumentException(
+                    "Every native-pilot operation is a mutation and must use replay protection.",
+                    nameof(isMutation));
+            }
+
+            if (string.IsNullOrEmpty(inputSchemaId.Value))
+            {
+                throw new ArgumentException("A code-owned input schema id is required.", nameof(inputSchemaId));
+            }
+
+            if (invalidationGeneration <= 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(invalidationGeneration),
+                    "An operation invalidation generation must be positive.");
+            }
+
+            Id = id;
+            Family = family;
+            Authority = authority;
+            ItemScope = itemScope;
+            SupportedItemKinds = supportedItemKinds;
+            IsMutation = isMutation;
+            InputSchemaId = inputSchemaId;
+            InvalidationGeneration = invalidationGeneration;
+        }
+
+        /// <summary>Gets the code-owned stable operation identifier.</summary>
+        public PlatformOperationId Id { get; }
+
+        /// <summary>Gets the owning first-party product family.</summary>
+        public PlatformOperationFamily Family { get; }
+
+        /// <summary>Gets the current Jellyfin authority required from the actor.</summary>
+        public PlatformAuthorityLevel Authority { get; }
+
+        /// <summary>Gets the bounded item context this operation accepts.</summary>
+        public PlatformItemScope ItemScope { get; }
+
+        /// <summary>Gets the exact closed host item kinds this operation accepts.</summary>
+        public ImmutableArray<HostItemKind> SupportedItemKinds { get; }
+
+        /// <summary>Gets whether the operation changes state and therefore requires replay protection.</summary>
+        public bool IsMutation { get; }
+
+        /// <summary>Gets the code-owned bounded input-schema identifier.</summary>
+        public PlatformInputSchemaId InputSchemaId { get; }
+
+        /// <summary>
+        /// Gets the code generation bound into prepared actions. Incrementing it
+        /// invalidates capabilities prepared against older operation semantics.
+        /// </summary>
+        public long InvalidationGeneration { get; }
+
+        internal static PlatformOperationDefinition SpoilerGuardConfigureItem { get; } = new PlatformOperationDefinition(
+            PlatformOperationId.SpoilerGuardConfigureItem,
+            PlatformOperationFamily.SpoilerGuard,
+            PlatformAuthorityLevel.Authenticated,
+            PlatformItemScope.ExactItem,
+            [HostItemKind.Movie, HostItemKind.Series],
+            true,
+            PlatformInputSchemaId.SpoilerGuardItemConfigurationV1,
+            1);
+
+        internal static PlatformOperationDefinition HiddenContentConfigureItem { get; } = new PlatformOperationDefinition(
+            PlatformOperationId.HiddenContentConfigureItem,
+            PlatformOperationFamily.HiddenContent,
+            PlatformAuthorityLevel.Authenticated,
+            PlatformItemScope.ExactItem,
+            [HostItemKind.Movie, HostItemKind.Series, HostItemKind.Episode],
+            true,
+            PlatformInputSchemaId.HiddenContentItemConfigurationV1,
+            1);
+
+        internal static PlatformOperationDefinition SeerrRequestItem { get; } = new PlatformOperationDefinition(
+            PlatformOperationId.SeerrRequestItem,
+            PlatformOperationFamily.Seerr,
+            PlatformAuthorityLevel.Authenticated,
+            PlatformItemScope.ExactItem,
+            [HostItemKind.Movie, HostItemKind.Series],
+            true,
+            PlatformInputSchemaId.SeerrItemRequestV1,
+            1);
+    }
+
+    /// <summary>
+    /// The complete code-owned authority vocabulary for the three native pilot families.
+    /// </summary>
+    /// <remarks>
+    /// This is deliberately not a registry. There is no manifest, request or service
+    /// registration path: adding an operation is a reviewed source change. Callers may
+    /// look up a known id, but an unknown or differently-cased id returns no definition.
+    /// </remarks>
+    public static class PlatformOperationVocabulary
+    {
+        /// <summary>Maximum UTF-16/ASCII length of an operation or input-schema identifier.</summary>
+        public const int MaximumIdentifierLength = 128;
+
+        private static readonly ImmutableArray<PlatformOperationDefinition> Definitions =
+        [
+            PlatformOperationDefinition.SpoilerGuardConfigureItem,
+            PlatformOperationDefinition.HiddenContentConfigureItem,
+            PlatformOperationDefinition.SeerrRequestItem,
+        ];
+
+        /// <summary>Gets the immutable complete pilot definition set.</summary>
+        public static ImmutableArray<PlatformOperationDefinition> All => Definitions;
+
+        /// <summary>
+        /// Finds an exact known id. Invalid, unknown and case-variant values all fail
+        /// closed rather than creating caller-owned operation authority.
+        /// </summary>
+        public static PlatformOperationDefinition? Find(string? operationId)
+        {
+            if (!IsValidIdentifier(operationId))
+            {
+                return null;
+            }
+
+            foreach (var definition in Definitions)
+            {
+                if (string.Equals(definition.Id.Value, operationId, StringComparison.Ordinal))
+                {
+                    return definition;
+                }
+            }
+
+            return null;
+        }
+
+        internal static bool IsValidIdentifier(string? value)
+        {
+            if (value is null
+                || value.Length is < 1 or > MaximumIdentifierLength
+                || !IsLowerAsciiLetter(value[0]))
+            {
+                return false;
+            }
+
+            var dotCount = 0;
+            for (var index = 0; index < value.Length; index++)
+            {
+                var character = value[index];
+                if (IsLowerAsciiLetter(character) || IsAsciiDigit(character))
+                {
+                    continue;
+                }
+
+                if (character is not ('.' or '-')
+                    || index == 0
+                    || index == value.Length - 1
+                    || !IsLowerAsciiLetterOrDigit(value[index - 1])
+                    || !IsLowerAsciiLetterOrDigit(value[index + 1]))
+                {
+                    return false;
+                }
+
+                if (character == '.')
+                {
+                    dotCount++;
+                }
+            }
+
+            // vendor.extension.name is the smallest ADR-0001 namespace shape.
+            return dotCount >= 2;
+        }
+
+        private static bool IsLowerAsciiLetterOrDigit(char value) =>
+            IsLowerAsciiLetter(value) || IsAsciiDigit(value);
+
+        private static bool IsLowerAsciiLetter(char value) => value is >= 'a' and <= 'z';
+
+        private static bool IsAsciiDigit(char value) => value is >= '0' and <= '9';
+    }
+}

--- a/docs/platform-contract.md
+++ b/docs/platform-contract.md
@@ -191,6 +191,30 @@ or coordinate multiple server processes.
 Coalesced waits are bounded too: at most 64 followers per in-flight key and 1,024 across
 the process. Excess followers receive the same pre-execution `429 rate_limited` outcome.
 
+## Closed native-pilot operation vocabulary
+
+Native actions do not name a controller, route, HTTP method, service or upstream
+endpoint. They resolve one of three exact code-owned business operations:
+
+| Operation | Family | Authority | Item kinds | Input schema | Generation |
+|---|---|---|---|---|---:|
+| `jellyfin.canopy.spoiler-guard.configure-item` | Spoiler Guard | authenticated | Movie, Series | `jellyfin.canopy.spoiler-guard.item-configuration.v1` | 1 |
+| `jellyfin.canopy.hidden-content.configure-item` | Hidden Content | authenticated | Movie, Series, Episode | `jellyfin.canopy.hidden-content.item-configuration.v1` | 1 |
+| `jellyfin.canopy.seerr.request-item` | Seerr | authenticated | Movie, Series | `jellyfin.canopy.seerr.item-request.v1` | 1 |
+
+Every operation is an exact-item mutation. Its item is resolved through the current
+authenticated user's Jellyfin access policy, its bounded input schema is selected by
+the server, and its positive generation is bound into prepared actions so a later code
+generation can invalidate older authority. Lookup is case-sensitive and fail-closed:
+an unknown or caller-invented identifier has no definition and cannot be invoked.
+
+`request-item` means submitting a new item-derived Seerr media request. Existing
+request state can be presented as status without another mutation. It must not be
+overloaded to approve, decline, cancel or modify a request: those actions bind a Seerr
+request identity rather than only the current Jellyfin item, and any future pilot
+addition needs its own fixed operation, bounded schema, owning service and authority
+review.
+
 ## Pagination
 
 One dialect: opaque forward cursors. Pass the `NextCursor` you were given to fetch the

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,19 +26,19 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2808, totalLines: 3201 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 32248, totalLines: 40928 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 32249, totalLines: 40928 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 3,
         minimumCoveredLines: 2808,
         maximumCoveredLines: 2808,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
-        cleanRuns: 4,
+        cleanRuns: 5,
         minimumCoveredLines: 32247,
-        maximumCoveredLines: 32248,
+        maximumCoveredLines: 32249,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 1);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,19 +26,19 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2808, totalLines: 3201 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 32109, totalLines: 40790 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 32248, totalLines: 40928 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 3,
         minimumCoveredLines: 2808,
         maximumCoveredLines: 2808,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
-        cleanRuns: 3,
-        minimumCoveredLines: 32109,
-        maximumCoveredLines: 32109,
+        cleanRuns: 4,
+        minimumCoveredLines: 32247,
+        maximumCoveredLines: 32248,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 0);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 1);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 32248,
+        "coveredLines": 32249,
         "totalLines": 40928
       },
       "observations": {
-        "cleanRuns": 4,
+        "cleanRuns": 5,
         "minimumCoveredLines": 32247,
-        "maximumCoveredLines": 32248
+        "maximumCoveredLines": 32249
       },
       "tolerance": {
-        "missingCoveredLines": 1,
-        "rationale": "The #588 closed first-party operation vocabulary adds exactly three immutable code-owned pilot definitions, bounded namespaced operation and input-schema identifiers, exact ordinal fail-closed lookup, fixed authority/item-kind/mutation/generation metadata, private constructors with exact allowlisted instances, and production-wide construction guards including planted target-typed and alias escapes. Four clean local Coverlet observations on the identical combined #598/#523/#588 source and 40,928-line scope each passed all 2,849 server tests: one measured 32,248 covered lines and three measured 32,247. Relative to the reviewed #598/#523 main high-water of 32,109/40,790 (78.718%), #588 adds 138 instrumented lines and raises the observed high-water by 139 covered lines to 32,248/40,928 (78.792%). The exact one-line 32,247-32,248 instrumentation envelope therefore sets a 32,248 high-water with a one-line tolerance and a floor of 32,247/40,928 (78.790%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 2,
+        "rationale": "The #588 closed first-party operation vocabulary adds exactly three immutable code-owned pilot definitions, bounded namespaced operation and input-schema identifiers, exact ordinal fail-closed lookup, fixed authority/item-kind/mutation/generation metadata, private constructors with exact allowlisted instances, and production-wide construction guards including planted target-typed and alias escapes. Five clean Coverlet observations on the identical combined #598/#523/#588 source and 40,928-line scope each passed all 2,849 server tests: four local runs measured 32,248 once and 32,247 three times, while the clean GitHub Actions Ubuntu runner measured 32,249. Relative to the reviewed #598/#523 main high-water of 32,109/40,790 (78.718%), #588 adds 138 instrumented lines and raises the observed high-water by 140 covered lines to 32,249/40,928 (78.794%). The exact two-line 32,247-32,249 cross-runner instrumentation envelope therefore sets a 32,249 high-water with a two-line tolerance and a floor of 32,247/40,928 (78.790%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 32109,
-        "totalLines": 40790
+        "coveredLines": 32248,
+        "totalLines": 40928
       },
       "observations": {
-        "cleanRuns": 3,
-        "minimumCoveredLines": 32109,
-        "maximumCoveredLines": 32109
+        "cleanRuns": 4,
+        "minimumCoveredLines": 32247,
+        "maximumCoveredLines": 32248
       },
       "tolerance": {
-        "missingCoveredLines": 0,
-        "rationale": "The combined connected-service auto-discovery #598 and Platform concurrency #523 tree preserves the bounded SSRF-guarded discovery/import work while adding exact-byte SHA-256 validators, bounded RFC entity-tag parsing, conditional GET result wiring, identity content coding through host compression, and deterministic PlatformFilterOrder slots for JSON serialization and concurrency evaluation. Three clean Coverlet runs on the identical 2026-08-03 source and 40,790-line scope each passed all 2,823 server tests and reproduced exactly 32,109 covered lines. Relative to the reviewed #598 main high-water of 31,999/40,678 (78.664%), #523 adds 112 instrumented lines and 110 covered lines while raising coverage to 32,109/40,790 (78.718%). The exact observed envelope needs no instrumentation tolerance, so the new floor is 32,109/40,790 (78.718%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 1,
+        "rationale": "The #588 closed first-party operation vocabulary adds exactly three immutable code-owned pilot definitions, bounded namespaced operation and input-schema identifiers, exact ordinal fail-closed lookup, fixed authority/item-kind/mutation/generation metadata, private constructors with exact allowlisted instances, and production-wide construction guards including planted target-typed and alias escapes. Four clean local Coverlet observations on the identical combined #598/#523/#588 source and 40,928-line scope each passed all 2,849 server tests: one measured 32,248 covered lines and three measured 32,247. Relative to the reviewed #598/#523 main high-water of 32,109/40,790 (78.718%), #588 adds 138 instrumented lines and raises the observed high-water by 139 covered lines to 32,248/40,928 (78.792%). The exact one-line 32,247-32,248 instrumentation envelope therefore sets a 32,248 high-water with a one-line tolerance and a floor of 32,247/40,928 (78.790%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
Closes #588.

Defines the closed EP02 native operation vocabulary needed by the Android TV item-detail adapter:

- Spoiler Guard `configure-item` for Movie and Series
- Hidden Content `configure-item` for Movie, Series, and Episode
- Seerr `request-item` for Movie and Series

The authority records are exact allowlisted instances with private construction, stable schema identifiers, generation 1, authenticated actor scope, and exact-item target scope. Seerr request management (approve, decline, cancel, modify) is intentionally excluded rather than overloaded into the request operation.

Guards cover construction, aliases, target-typed creation, reflection-visible instances, operation uniqueness, schema/generation stability, and the documented contract.

Verification:

- focused vocabulary tests: 26/26
- full server suite: 2,849/2,849
- script suite: 634/634
- strict docs build: passed
- Release plugin build: 0 warnings, 0 errors
- coverage observations: 32,247–32,249 / 40,928 across local and clean GitHub runners (documented two-line deterministic envelope)
