### PR TITLE
refactor(spoiler-guard): extract installed item action owner

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/AdminTargetPreferenceControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/AdminTargetPreferenceControllerTests.cs
@@ -2645,6 +2645,7 @@ public sealed class AdminTargetPreferenceControllerTests : IDisposable
             _provider,
             _manager,
             _library,
+            new SpoilerGuardItemActionOwner(_manager),
             _pending,
             resolver,
             new StubUserDataManager());

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SpoilerGuardControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SpoilerGuardControllerTests.cs
@@ -54,7 +54,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             }
         }
 
-        private static Harness Build(PluginConfiguration? cfg = null, bool includeUserInManager = true)
+        private static Harness Build(
+            PluginConfiguration? cfg = null,
+            bool includeUserInManager = true,
+            ISpoilerGuardItemActionOwner? itemActionOwner = null)
         {
             var dir = Path.Combine(Path.GetTempPath(), "jc-sg-" + Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(dir);
@@ -91,6 +94,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 provider,
                 mgr,
                 lib,
+                itemActionOwner ?? new SpoilerGuardItemActionOwner(mgr),
                 pending,
                 resolver,
                 userData);
@@ -284,6 +288,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 provider,
                 h.Mgr,
                 h.Lib,
+                new SpoilerGuardItemActionOwner(h.Mgr),
                 pending,
                 new SpoilerUserResolver(
                     h.Mgr,
@@ -1452,6 +1457,52 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             Assert.False(SpoilerUserResolver.IsUserStateCachedForTest(userKey));
         }
 
+        [Fact]
+        public void InstalledItemRoutes_InvokeSharedOwnerExactlyOnceAfterAdmission()
+        {
+            var owner = new RecordingItemActionOwner();
+            using var h = Build(itemActionOwner: owner);
+            var seriesId = Guid.NewGuid();
+            var movieId = Guid.NewGuid();
+            h.Lib.GetItemByIdUserHook = (id, _) =>
+                id == seriesId ? new Series { Id = id, Name = "Series" }
+                : id == movieId ? new Movie { Id = id, Name = "Movie" }
+                : null;
+
+            Assert.IsType<OkObjectResult>(
+                h.Controller.EnableSpoilerBlurForSeries(seriesId.ToString()));
+            Assert.IsType<OkObjectResult>(
+                h.Controller.DisableSpoilerBlurForSeries(seriesId.ToString()));
+            Assert.IsType<OkObjectResult>(
+                h.Controller.EnableSpoilerBlurForMovie(movieId.ToString()));
+            Assert.IsType<OkObjectResult>(
+                h.Controller.DisableSpoilerBlurForMovie(movieId.ToString()));
+
+            Assert.Collection(
+                owner.Calls,
+                call => AssertCall(call, h.User.Id, seriesId, SpoilerGuardItemKind.Series, enabled: true),
+                call => AssertCall(call, h.User.Id, seriesId, SpoilerGuardItemKind.Series, enabled: false),
+                call => AssertCall(call, h.User.Id, movieId, SpoilerGuardItemKind.Movie, enabled: true),
+                call => AssertCall(call, h.User.Id, movieId, SpoilerGuardItemKind.Movie, enabled: false));
+
+            Assert.IsType<NotFoundObjectResult>(
+                h.Controller.EnableSpoilerBlurForMovie(Guid.NewGuid().ToString()));
+            Assert.Equal(4, owner.Calls.Count);
+
+            static void AssertCall(
+                ItemActionCall call,
+                Guid userId,
+                Guid itemId,
+                SpoilerGuardItemKind kind,
+                bool enabled)
+            {
+                Assert.Equal(userId, call.Actor.UserId);
+                Assert.Equal(itemId, call.Item.ItemId);
+                Assert.Equal(kind, call.Item.Kind);
+                Assert.Equal(enabled, call.Configuration.Enabled);
+            }
+        }
+
         private static Guid CapacityGuid(int index)
             => new(index, 0, 0, new byte[8]);
 
@@ -1537,6 +1588,29 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 Exception? exception,
                 Func<TState, Exception?, string> formatter)
                 => Messages.Add(formatter(state, exception));
+        }
+
+        private sealed record ItemActionCall(
+            SpoilerGuardActorProjection Actor,
+            SpoilerGuardItemProjection Item,
+            SpoilerGuardItemConfiguration Configuration);
+
+        private sealed class RecordingItemActionOwner : ISpoilerGuardItemActionOwner
+        {
+            public List<ItemActionCall> Calls { get; } = new();
+
+            public SpoilerGuardItemActionResult Configure(
+                SpoilerGuardActorProjection actor,
+                SpoilerGuardItemProjection item,
+                SpoilerGuardItemConfiguration configuration)
+            {
+                Calls.Add(new ItemActionCall(actor, item, configuration));
+                return SpoilerGuardItemActionResult.Configured(
+                    configuration.Enabled,
+                    changed: true,
+                    removed: !configuration.Enabled,
+                    revision: Calls.Count);
+            }
         }
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SpoilerGuardItemActionOwnerArchitectureTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SpoilerGuardItemActionOwnerArchitectureTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using Jellyfin.Plugin.JellyfinCanopy.Services;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.Platform;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services;
+
+public sealed class SpoilerGuardItemActionOwnerArchitectureTests
+{
+    private static readonly Regex ForbiddenOwnerDependency = new(
+        @"\b(?:Microsoft\.AspNetCore|MediaBrowser|ControllerBase|IActionResult|HttpContext|HttpRequest|ClaimsPrincipal|BaseItem)\b",
+        RegexOptions.Compiled);
+
+    [Fact]
+    public void OwnerContractIsHttpFreeAndAcceptsOnlySafeProjections()
+    {
+        var method = typeof(ISpoilerGuardItemActionOwner).GetMethod(
+            nameof(ISpoilerGuardItemActionOwner.Configure));
+
+        Assert.NotNull(method);
+        Assert.Equal(
+            new[]
+            {
+                typeof(SpoilerGuardActorProjection),
+                typeof(SpoilerGuardItemProjection),
+                typeof(SpoilerGuardItemConfiguration),
+            },
+            method!.GetParameters().Select(parameter => parameter.ParameterType));
+        Assert.Equal(typeof(SpoilerGuardItemActionResult), method.ReturnType);
+
+        foreach (var type in new[]
+        {
+            typeof(SpoilerGuardActorProjection),
+            typeof(SpoilerGuardItemProjection),
+            typeof(SpoilerGuardItemConfiguration),
+            typeof(SpoilerGuardItemActionResult),
+        })
+        {
+            Assert.True(type.IsSealed);
+            Assert.Empty(type.GetConstructors(BindingFlags.Instance | BindingFlags.Public));
+        }
+    }
+
+    [Fact]
+    public void OwnerSourceHasNoHttpControllerOrJellyfinEntityDependency()
+    {
+        var code = PlatformHostSeamTests.CodeOnly(File.ReadAllText(OwnerSource()));
+
+        Assert.DoesNotMatch(ForbiddenOwnerDependency, code);
+        Assert.Contains("RmwUserConfiguration<UserSpoilerBlur>", code, StringComparison.Ordinal);
+        Assert.Contains("SpoilerUserResolver.InvalidateUser", code, StringComparison.Ordinal);
+
+        Assert.Matches(ForbiddenOwnerDependency, "using Microsoft.AspNetCore.Mvc;");
+        Assert.Matches(ForbiddenOwnerDependency, "private BaseItem _item;");
+    }
+
+    [Fact]
+    public void LegacyInstalledItemActionsDelegatePersistenceToTheOwner()
+    {
+        var source = PlatformHostSeamTests.CodeOnly(File.ReadAllText(ControllerSource()));
+        var installedActions = source.Substring(
+            source.IndexOf("EnableSpoilerBlurForSeries", StringComparison.Ordinal),
+            source.IndexOf("GetMovieSpoilerScope", StringComparison.Ordinal)
+                - source.IndexOf("EnableSpoilerBlurForSeries", StringComparison.Ordinal));
+
+        Assert.Equal(4, Regex.Matches(installedActions, @"_itemActionOwner\s*\.\s*Configure\s*\(").Count);
+        Assert.DoesNotContain("RmwUserConfiguration<UserSpoilerBlur>", installedActions, StringComparison.Ordinal);
+        Assert.DoesNotContain("SpoilerUserResolver.InvalidateUser", installedActions, StringComparison.Ordinal);
+    }
+
+    private static string OwnerSource([CallerFilePath] string sourceFile = "")
+        => Path.GetFullPath(Path.Combine(
+            Path.GetDirectoryName(sourceFile)!,
+            "..", "..", "Jellyfin.Plugin.JellyfinCanopy", "Services", "SpoilerGuard",
+            "SpoilerGuardItemActionOwner.cs"));
+
+    private static string ControllerSource([CallerFilePath] string sourceFile = "")
+        => Path.GetFullPath(Path.Combine(
+            Path.GetDirectoryName(sourceFile)!,
+            "..", "..", "Jellyfin.Plugin.JellyfinCanopy", "Controllers",
+            "SpoilerGuardController.cs"));
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SpoilerGuardItemActionOwnerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SpoilerGuardItemActionOwnerTests.cs
@@ -1,0 +1,210 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Services;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services;
+
+public sealed class SpoilerGuardItemActionOwnerTests : IDisposable
+{
+    private const string SpoilerFile = "spoilerblur.json";
+    private readonly string _directory = Path.Combine(
+        Path.GetTempPath(),
+        "jc-sg-item-owner-" + Guid.NewGuid().ToString("N"));
+    private readonly UserConfigurationManager _manager;
+
+    public SpoilerGuardItemActionOwnerTests()
+    {
+        _manager = new UserConfigurationManager(
+            new StubAppPaths(_directory),
+            NullLogger<UserConfigurationManager>.Instance);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+        catch
+        {
+            // Best-effort test cleanup.
+        }
+    }
+
+    [Fact]
+    public void Configure_SeriesInsertNoOpAndRename_PreserveTimestampAndAdvanceOncePerChange()
+    {
+        var now = new DateTimeOffset(2026, 8, 3, 1, 2, 3, TimeSpan.Zero);
+        var owner = new SpoilerGuardItemActionOwner(_manager, new ManualTimeProvider(now));
+        var actor = Actor();
+        var itemId = Guid.NewGuid();
+        var userKey = actor.UserId.ToString("N");
+        var itemKey = itemId.ToString("N");
+
+        var inserted = owner.Configure(
+            actor,
+            Accessible(itemId, SpoilerGuardItemKind.Series, "First name"),
+            Enabled());
+        var first = Read(userKey);
+        var enabledAt = first.Series[itemKey].EnabledAt;
+
+        Assert.Equal(SpoilerGuardItemActionOutcome.Configured, inserted.Outcome);
+        Assert.True(inserted.Changed);
+        Assert.Equal(1, inserted.Revision);
+        Assert.Equal(now.UtcDateTime.ToString("o"), enabledAt);
+        Assert.Equal("First name", first.Series[itemKey].SeriesName);
+
+        SpoilerUserResolver.SeedUserStateCacheForTest(userKey);
+        var noOp = owner.Configure(
+            actor,
+            Accessible(itemId, SpoilerGuardItemKind.Series, "First name"),
+            Enabled());
+
+        Assert.False(noOp.Changed);
+        Assert.Equal(1, noOp.Revision);
+        Assert.False(SpoilerUserResolver.IsUserStateCachedForTest(userKey));
+
+        var renamed = owner.Configure(
+            actor,
+            Accessible(itemId, SpoilerGuardItemKind.Series, "Renamed"),
+            Enabled());
+        var final = Read(userKey);
+
+        Assert.True(renamed.Changed);
+        Assert.Equal(2, renamed.Revision);
+        Assert.Equal("Renamed", final.Series[itemKey].SeriesName);
+        Assert.Equal(enabledAt, final.Series[itemKey].EnabledAt);
+    }
+
+    [Fact]
+    public void Configure_MovieInsertAndActorOwnedRemoval_AreBoundedAndIdempotent()
+    {
+        var owner = new SpoilerGuardItemActionOwner(_manager);
+        var actor = Actor();
+        var itemId = Guid.NewGuid();
+        var itemKey = itemId.ToString("N");
+        var longName = new string('m', PersistedPayloadPolicy.MaximumStandardStringLength + 50);
+
+        var inserted = owner.Configure(
+            actor,
+            Accessible(itemId, SpoilerGuardItemKind.Movie, longName),
+            Enabled());
+        var stored = Read(actor.UserId.ToString("N"));
+
+        Assert.True(inserted.Changed);
+        Assert.Equal(
+            PersistedPayloadPolicy.MaximumStandardStringLength,
+            stored.Movies[itemKey].MovieName.Length);
+
+        var removed = owner.Configure(
+            actor,
+            SpoilerGuardItemProjection.ActorOwnedRemoval(itemId, SpoilerGuardItemKind.Movie),
+            Disabled());
+        var noOp = owner.Configure(
+            actor,
+            SpoilerGuardItemProjection.ActorOwnedRemoval(itemId, SpoilerGuardItemKind.Movie),
+            Disabled());
+
+        Assert.True(removed.Changed);
+        Assert.True(removed.Removed);
+        Assert.Equal(2, removed.Revision);
+        Assert.False(noOp.Changed);
+        Assert.False(noOp.Removed);
+        Assert.Equal(2, noOp.Revision);
+    }
+
+    [Fact]
+    public void Configure_NewEntryAtCapacity_RefusesWithoutRevisionWriteOrCacheInvalidation()
+    {
+        var actor = Actor();
+        var userKey = actor.UserId.ToString("N");
+        var state = new UserSpoilerBlur
+        {
+            OverridesRevision = 41,
+            Series = BuildSeriesOverrides(PersistedPayloadPolicy.MaximumSpoilerEntriesPerDictionary),
+        };
+        _manager.SaveUserConfiguration(userKey, SpoilerFile, state);
+        var before = File.ReadAllBytes(SpoilerPath(userKey));
+        SpoilerUserResolver.SeedUserStateCacheForTest(userKey);
+
+        var result = new SpoilerGuardItemActionOwner(_manager).Configure(
+            actor,
+            Accessible(Guid.NewGuid(), SpoilerGuardItemKind.Series, "Over cap"),
+            Enabled());
+
+        Assert.Equal(SpoilerGuardItemActionOutcome.CapacityExceeded, result.Outcome);
+        Assert.Equal("series", result.CapacityCategory);
+        Assert.False(result.Changed);
+        Assert.Equal(41, result.Revision);
+        Assert.Equal(before, File.ReadAllBytes(SpoilerPath(userKey)));
+        Assert.True(SpoilerUserResolver.IsUserStateCachedForTest(userKey));
+    }
+
+    [Fact]
+    public void Configure_RemovalProofCannotBeReusedToEnableContent()
+    {
+        var actor = Actor();
+        var item = SpoilerGuardItemProjection.ActorOwnedRemoval(
+            Guid.NewGuid(),
+            SpoilerGuardItemKind.Series);
+
+        var exception = Assert.Throws<ArgumentException>(() =>
+            new SpoilerGuardItemActionOwner(_manager).Configure(actor, item, Enabled()));
+
+        Assert.Equal("item", exception.ParamName);
+        Assert.False(File.Exists(SpoilerPath(actor.UserId.ToString("N"))));
+    }
+
+    private static SpoilerGuardActorProjection Actor()
+        => new(Guid.NewGuid());
+
+    private static SpoilerGuardItemProjection Accessible(
+        Guid itemId,
+        SpoilerGuardItemKind kind,
+        string? name)
+        => SpoilerGuardItemProjection.CurrentAccessible(itemId, kind, name);
+
+    private static SpoilerGuardItemConfiguration Enabled() => new(enabled: true);
+
+    private static SpoilerGuardItemConfiguration Disabled() => new(enabled: false);
+
+    private UserSpoilerBlur Read(string userKey)
+        => _manager.GetUserConfigurationStrict<UserSpoilerBlur>(userKey, SpoilerFile);
+
+    private string SpoilerPath(string userKey)
+        => Path.Combine(
+            _directory,
+            "configurations",
+            "Jellyfin.Plugin.JellyfinCanopy",
+            userKey,
+            SpoilerFile);
+
+    private static Dictionary<string, SpoilerBlurSeriesEntry> BuildSeriesOverrides(int count)
+    {
+        var entries = new Dictionary<string, SpoilerBlurSeriesEntry>(
+            count,
+            StringComparer.OrdinalIgnoreCase);
+        for (var index = 1; index <= count; index++)
+        {
+            var id = new Guid(index, 0, 0, new byte[8]);
+            var key = id.ToString("N");
+            entries[key] = new SpoilerBlurSeriesEntry
+            {
+                SeriesId = key,
+                SeriesName = "Series " + index,
+            };
+        }
+
+        return entries;
+    }
+
+    private sealed class ManualTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/SpoilerGuardController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/SpoilerGuardController.cs
@@ -37,6 +37,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
     {
         private readonly UserConfigurationManager _userConfigurationManager;
         private readonly ILibraryManager _libraryManager;
+        private readonly ISpoilerGuardItemActionOwner _itemActionOwner;
         private readonly SpoilerPendingService _pendingService;
         private readonly SpoilerUserResolver _resolver;
         private readonly IUserDataManager _userDataManager;
@@ -49,6 +50,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             IPluginConfigProvider configProvider,
             UserConfigurationManager userConfigurationManager,
             ILibraryManager libraryManager,
+            ISpoilerGuardItemActionOwner itemActionOwner,
             SpoilerPendingService pendingService,
             SpoilerUserResolver resolver,
             IUserDataManager userDataManager)
@@ -56,6 +58,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
         {
             _userConfigurationManager = userConfigurationManager;
             _libraryManager = libraryManager;
+            _itemActionOwner = itemActionOwner;
             _pendingService = pendingService;
             _resolver = resolver;
             _userDataManager = userDataManager;
@@ -1321,49 +1324,20 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             var userKey = userId.Value.ToString("N");
             try
             {
-                var capacityExceeded = false;
-                _userConfigurationManager.RmwUserConfiguration<UserSpoilerBlur>(
-                    userKey, SpoilerFileName, state =>
-                    {
-                        // Preserve original EnabledAt on re-toggle; refresh SeriesName
-                        // opportunistically (covers renames). Return 0 (no-write) when
-                        // truly unchanged so a re-toggle doesn't burn a disk write.
-                        if (state.Series.TryGetValue(key, out var existing))
-                        {
-                            var newName = PersistedPayloadPolicy
-                                .ClampPersistedDisplayName(
-                                    series.Name ?? existing.SeriesName);
-                            if (string.Equals(existing.SeriesName, newName, StringComparison.Ordinal))
-                            {
-                                return 0;
-                            }
-                            existing.SeriesName = newName;
-                            SpoilerGuardOverridesRevision.Advance(state);
-                            return 1;
-                        }
-                        if (!SpoilerGuardOverrideCapacity.CanInsert(state.Series, key))
-                        {
-                            capacityExceeded = true;
-                            return 0;
-                        }
-                        state.Series[key] = new SpoilerBlurSeriesEntry
-                        {
-                            SeriesId = key,
-                            SeriesName = PersistedPayloadPolicy
-                                .ClampPersistedDisplayName(series.Name),
-                            EnabledAt = DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture),
-                        };
-                        SpoilerGuardOverridesRevision.Advance(state);
-                        return 1;
-                    });
-                if (capacityExceeded)
+                var result = _itemActionOwner.Configure(
+                    new SpoilerGuardActorProjection(userId.Value),
+                    SpoilerGuardItemProjection.CurrentAccessible(
+                        seriesGuid,
+                        SpoilerGuardItemKind.Series,
+                        series.Name),
+                    new SpoilerGuardItemConfiguration(enabled: true));
+                if (result.Outcome == SpoilerGuardItemActionOutcome.CapacityExceeded)
                 {
                     _logger.LogWarning(
                         $"Spoiler Guard series cap reached for {ResolveUserDisplay(userKey)}; " +
                         $"rejecting new series {key}.");
                     return SpoilerOverrideCapacityExceeded("series");
                 }
-                SpoilerUserResolver.InvalidateUser(userKey);
                 _logger.LogInformation($"Spoiler Guard enabled for series '{series.Name}' ({key}) by {ResolveUserDisplay(userKey)}");
                 return Ok(new { success = true, seriesId = key, name = series.Name });
             }
@@ -1395,15 +1369,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             var userKey = userId.Value.ToString("N");
             try
             {
-                bool removed = false;
-                _userConfigurationManager.RmwUserConfiguration<UserSpoilerBlur>(
-                    userKey, SpoilerFileName, state =>
-                    {
-                        removed = state.Series.Remove(key);
-                        if (removed) SpoilerGuardOverridesRevision.Advance(state);
-                        return removed ? 1 : 0;
-                    });
-                SpoilerUserResolver.InvalidateUser(userKey);
+                var result = _itemActionOwner.Configure(
+                    new SpoilerGuardActorProjection(userId.Value),
+                    SpoilerGuardItemProjection.ActorOwnedRemoval(
+                        seriesGuid,
+                        SpoilerGuardItemKind.Series),
+                    new SpoilerGuardItemConfiguration(enabled: false));
+                var removed = result.Removed;
                 if (!removed)
                 {
                     _logger.LogInformation($"Spoiler Guard disable was a no-op for series {key} by {ResolveUserDisplay(userKey)} — series was not in the user's spoiler-blur list.");
@@ -1470,42 +1442,20 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
 
             try
             {
-                var capacityExceeded = false;
-                _userConfigurationManager.RmwUserConfiguration<UserSpoilerBlur>(
-                    userKey, SpoilerFileName, state =>
-                    {
-                        if (state.Movies.TryGetValue(key, out var existing))
-                        {
-                            if (string.Equals(existing.MovieName, movieNameSanitized, StringComparison.Ordinal))
-                            {
-                                return 0;
-                            }
-                            existing.MovieName = movieNameSanitized;
-                            SpoilerGuardOverridesRevision.Advance(state);
-                            return 1;
-                        }
-                        if (!SpoilerGuardOverrideCapacity.CanInsert(state.Movies, key))
-                        {
-                            capacityExceeded = true;
-                            return 0;
-                        }
-                        state.Movies[key] = new SpoilerBlurMovieEntry
-                        {
-                            MovieId = key,
-                            MovieName = movieNameSanitized,
-                            EnabledAt = DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture),
-                        };
-                        SpoilerGuardOverridesRevision.Advance(state);
-                        return 1;
-                    });
-                if (capacityExceeded)
+                var result = _itemActionOwner.Configure(
+                    new SpoilerGuardActorProjection(userId.Value),
+                    SpoilerGuardItemProjection.CurrentAccessible(
+                        movieGuid,
+                        SpoilerGuardItemKind.Movie,
+                        movieNameSanitized),
+                    new SpoilerGuardItemConfiguration(enabled: true));
+                if (result.Outcome == SpoilerGuardItemActionOutcome.CapacityExceeded)
                 {
                     _logger.LogWarning(
                         $"Spoiler Guard movie cap reached for {ResolveUserDisplay(userKey)}; " +
                         $"rejecting new movie {key}.");
                     return SpoilerOverrideCapacityExceeded("movies");
                 }
-                SpoilerUserResolver.InvalidateUser(userKey);
                 _logger.LogInformation($"Spoiler Guard enabled for movie '{movie.Name}' ({key}) by {ResolveUserDisplay(userKey)}");
                 return Ok(new { success = true, movieId = key, name = movie.Name });
             }
@@ -1537,15 +1487,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             var userKey = userId.Value.ToString("N");
             try
             {
-                bool removed = false;
-                _userConfigurationManager.RmwUserConfiguration<UserSpoilerBlur>(
-                    userKey, SpoilerFileName, state =>
-                    {
-                        removed = state.Movies.Remove(key);
-                        if (removed) SpoilerGuardOverridesRevision.Advance(state);
-                        return removed ? 1 : 0;
-                    });
-                SpoilerUserResolver.InvalidateUser(userKey);
+                var result = _itemActionOwner.Configure(
+                    new SpoilerGuardActorProjection(userId.Value),
+                    SpoilerGuardItemProjection.ActorOwnedRemoval(
+                        movieGuid,
+                        SpoilerGuardItemKind.Movie),
+                    new SpoilerGuardItemConfiguration(enabled: false));
+                var removed = result.Removed;
                 if (!removed)
                 {
                     _logger.LogInformation($"Spoiler Guard disable was a no-op for movie {key} by {ResolveUserDisplay(userKey)} — movie was not in the user's spoiler-blur list.");

--- a/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
@@ -202,6 +202,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy
             serviceCollection.AddSingleton<RequestIdentityService>();
             serviceCollection.AddSingleton<SpoilerIdentityTagFilter>();
             serviceCollection.AddSingleton<SpoilerUserResolver>();
+            serviceCollection.AddSingleton<ISpoilerGuardItemActionOwner, SpoilerGuardItemActionOwner>();
             serviceCollection.AddSingleton<SpoilerBlurImageFilter>();
             serviceCollection.AddSingleton<SpoilerFieldStripFilter>();
             // Shared pre-acquisition ("pending") pending-add core used by BOTH the

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/SpoilerGuardItemActionOwner.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/SpoilerGuardItemActionOwner.cs
@@ -1,0 +1,374 @@
+using System;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Services
+{
+    /// <summary>The installed item kinds supported by Spoiler Guard's shared action owner.</summary>
+    public enum SpoilerGuardItemKind
+    {
+        /// <summary>A Jellyfin movie.</summary>
+        Movie,
+
+        /// <summary>A Jellyfin series.</summary>
+        Series,
+    }
+
+    /// <summary>
+    /// The authoritative acting-user projection accepted below the HTTP and Platform
+    /// admission boundaries. It deliberately carries no principal, token, target user,
+    /// request context, or caller attribution.
+    /// </summary>
+    public sealed class SpoilerGuardActorProjection
+    {
+        internal SpoilerGuardActorProjection(Guid userId)
+        {
+            if (userId == Guid.Empty)
+            {
+                throw new ArgumentException("A Spoiler Guard actor must have a non-empty user id.", nameof(userId));
+            }
+
+            UserId = userId;
+        }
+
+        /// <summary>Gets the authenticated acting Jellyfin user.</summary>
+        public Guid UserId { get; }
+    }
+
+    /// <summary>
+    /// The bounded installed-item projection accepted by the owner. Positive
+    /// configuration requires a current user-scoped item lookup. Legacy removal may
+    /// instead carry an actor-owned-removal proof because deleting an entry from the
+    /// actor's own store cannot widen access and must keep working after content is gone.
+    /// </summary>
+    public sealed class SpoilerGuardItemProjection
+    {
+        private SpoilerGuardItemProjection(
+            Guid itemId,
+            SpoilerGuardItemKind kind,
+            string? displayName,
+            bool actorOwnedRemovalOnly)
+        {
+            if (itemId == Guid.Empty)
+            {
+                throw new ArgumentException("A Spoiler Guard item must have a non-empty id.", nameof(itemId));
+            }
+
+            if (!Enum.IsDefined(kind))
+            {
+                throw new ArgumentOutOfRangeException(nameof(kind));
+            }
+
+            ItemId = itemId;
+            Kind = kind;
+            DisplayName = displayName;
+            ActorOwnedRemovalOnly = actorOwnedRemovalOnly;
+        }
+
+        /// <summary>Gets the exact Jellyfin item id admitted by the calling boundary.</summary>
+        public Guid ItemId { get; }
+
+        /// <summary>Gets the closed server-derived item kind.</summary>
+        public SpoilerGuardItemKind Kind { get; }
+
+        /// <summary>Gets the server-derived, presentation-only display name.</summary>
+        public string? DisplayName { get; }
+
+        internal bool ActorOwnedRemovalOnly { get; }
+
+        internal static SpoilerGuardItemProjection CurrentAccessible(
+            Guid itemId,
+            SpoilerGuardItemKind kind,
+            string? displayName)
+            => new(itemId, kind, displayName, actorOwnedRemovalOnly: false);
+
+        internal static SpoilerGuardItemProjection ActorOwnedRemoval(
+            Guid itemId,
+            SpoilerGuardItemKind kind)
+            => new(itemId, kind, displayName: null, actorOwnedRemovalOnly: true);
+    }
+
+    /// <summary>The validated desired state for the v1 installed-item configuration owner.</summary>
+    public sealed class SpoilerGuardItemConfiguration
+    {
+        internal SpoilerGuardItemConfiguration(bool enabled) => Enabled = enabled;
+
+        /// <summary>Gets whether Spoiler Guard should be enabled for the item.</summary>
+        public bool Enabled { get; }
+    }
+
+    /// <summary>The closed semantic outcomes returned by the shared item owner.</summary>
+    public enum SpoilerGuardItemActionOutcome
+    {
+        /// <summary>The desired state was reached, including an idempotent no-op.</summary>
+        Configured,
+
+        /// <summary>A new entry could not be admitted because its dictionary is full.</summary>
+        CapacityExceeded,
+    }
+
+    /// <summary>HTTP-independent evidence returned by one owner invocation.</summary>
+    public sealed class SpoilerGuardItemActionResult
+    {
+        private SpoilerGuardItemActionResult(
+            SpoilerGuardItemActionOutcome outcome,
+            bool enabled,
+            bool changed,
+            bool removed,
+            long revision,
+            string? capacityCategory)
+        {
+            Outcome = outcome;
+            Enabled = enabled;
+            Changed = changed;
+            Removed = removed;
+            Revision = revision;
+            CapacityCategory = capacityCategory;
+        }
+
+        /// <summary>Gets the closed semantic outcome.</summary>
+        public SpoilerGuardItemActionOutcome Outcome { get; }
+
+        /// <summary>Gets the desired enabled state.</summary>
+        public bool Enabled { get; }
+
+        /// <summary>Gets whether the durable graph changed.</summary>
+        public bool Changed { get; }
+
+        /// <summary>Gets whether a disable removed an existing entry.</summary>
+        public bool Removed { get; }
+
+        /// <summary>Gets the authoritative override revision observed after the decision.</summary>
+        public long Revision { get; }
+
+        /// <summary>Gets <c>series</c> or <c>movies</c> for a capacity refusal.</summary>
+        public string? CapacityCategory { get; }
+
+        internal static SpoilerGuardItemActionResult Configured(
+            bool enabled,
+            bool changed,
+            bool removed,
+            long revision)
+            => new(
+                SpoilerGuardItemActionOutcome.Configured,
+                enabled,
+                changed,
+                removed,
+                revision,
+                capacityCategory: null);
+
+        internal static SpoilerGuardItemActionResult CapacityExceeded(
+            bool enabled,
+            long revision,
+            string category)
+            => new(
+                SpoilerGuardItemActionOutcome.CapacityExceeded,
+                enabled,
+                changed: false,
+                removed: false,
+                revision,
+                category);
+    }
+
+    /// <summary>
+    /// Shared business owner for installed Movie/Series Spoiler Guard configuration.
+    /// The interface contains no controller, HTTP, Jellyfin entity, or request type so
+    /// the future Platform adapter can reuse it after the invocation coordinator lands.
+    /// </summary>
+    public interface ISpoilerGuardItemActionOwner
+    {
+        /// <summary>Applies one validated desired state for the authoritative actor and item.</summary>
+        SpoilerGuardItemActionResult Configure(
+            SpoilerGuardActorProjection actor,
+            SpoilerGuardItemProjection item,
+            SpoilerGuardItemConfiguration configuration);
+    }
+
+    /// <summary>The single locked persistence owner for installed item configuration.</summary>
+    public sealed class SpoilerGuardItemActionOwner : ISpoilerGuardItemActionOwner
+    {
+        private readonly UserConfigurationManager _userConfigurationManager;
+        private readonly TimeProvider _timeProvider;
+
+        /// <summary>Initializes the production owner with the system UTC clock.</summary>
+        public SpoilerGuardItemActionOwner(UserConfigurationManager userConfigurationManager)
+            : this(userConfigurationManager, TimeProvider.System)
+        {
+        }
+
+        internal SpoilerGuardItemActionOwner(
+            UserConfigurationManager userConfigurationManager,
+            TimeProvider timeProvider)
+        {
+            _userConfigurationManager = userConfigurationManager
+                ?? throw new ArgumentNullException(nameof(userConfigurationManager));
+            _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        }
+
+        /// <inheritdoc />
+        public SpoilerGuardItemActionResult Configure(
+            SpoilerGuardActorProjection actor,
+            SpoilerGuardItemProjection item,
+            SpoilerGuardItemConfiguration configuration)
+        {
+            ArgumentNullException.ThrowIfNull(actor);
+            ArgumentNullException.ThrowIfNull(item);
+            ArgumentNullException.ThrowIfNull(configuration);
+
+            if (item.ActorOwnedRemovalOnly && configuration.Enabled)
+            {
+                throw new ArgumentException(
+                    "An actor-owned removal projection cannot authorize enabling an item.",
+                    nameof(item));
+            }
+
+            var userKey = actor.UserId.ToString("N");
+            var itemKey = item.ItemId.ToString("N");
+            var changed = false;
+            var removed = false;
+            var capacityExceeded = false;
+            var revision = 0L;
+
+            _userConfigurationManager.RmwUserConfiguration<UserSpoilerBlur>(
+                userKey,
+                SpoilerBlurImageFilter.SpoilerBlurFileName,
+                state =>
+                {
+                    if (configuration.Enabled)
+                    {
+                        changed = Enable(state, item, itemKey, ref capacityExceeded);
+                    }
+                    else
+                    {
+                        removed = item.Kind switch
+                        {
+                            SpoilerGuardItemKind.Series => state.Series.Remove(itemKey),
+                            SpoilerGuardItemKind.Movie => state.Movies.Remove(itemKey),
+                            _ => throw new ArgumentOutOfRangeException(nameof(item)),
+                        };
+                        changed = removed;
+                        if (changed)
+                        {
+                            SpoilerGuardOverridesRevision.Advance(state);
+                        }
+                    }
+
+                    revision = state.OverridesRevision;
+                    return changed ? 1 : 0;
+                });
+
+            if (capacityExceeded)
+            {
+                return SpoilerGuardItemActionResult.CapacityExceeded(
+                    configuration.Enabled,
+                    revision,
+                    item.Kind == SpoilerGuardItemKind.Series ? "series" : "movies");
+            }
+
+            // A completed strict RMW proves the policy graph is currently readable and
+            // valid. Invalidate even for an idempotent no-op so stale fail-closed/LKG
+            // enforcement state cannot linger after a successful mutation probe.
+            SpoilerUserResolver.InvalidateUser(userKey);
+            return SpoilerGuardItemActionResult.Configured(
+                configuration.Enabled,
+                changed,
+                removed,
+                revision);
+        }
+
+        private bool Enable(
+            UserSpoilerBlur state,
+            SpoilerGuardItemProjection item,
+            string itemKey,
+            ref bool capacityExceeded)
+        {
+            return item.Kind switch
+            {
+                SpoilerGuardItemKind.Series => EnableSeries(
+                    state,
+                    item,
+                    itemKey,
+                    ref capacityExceeded),
+                SpoilerGuardItemKind.Movie => EnableMovie(
+                    state,
+                    item,
+                    itemKey,
+                    ref capacityExceeded),
+                _ => throw new ArgumentOutOfRangeException(nameof(item)),
+            };
+        }
+
+        private bool EnableSeries(
+            UserSpoilerBlur state,
+            SpoilerGuardItemProjection item,
+            string itemKey,
+            ref bool capacityExceeded)
+        {
+            if (state.Series.TryGetValue(itemKey, out var existing))
+            {
+                var newName = PersistedPayloadPolicy.ClampPersistedDisplayName(
+                    item.DisplayName ?? existing.SeriesName);
+                if (string.Equals(existing.SeriesName, newName, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+
+                existing.SeriesName = newName;
+                SpoilerGuardOverridesRevision.Advance(state);
+                return true;
+            }
+
+            if (!SpoilerGuardOverrideCapacity.CanInsert(state.Series, itemKey))
+            {
+                capacityExceeded = true;
+                return false;
+            }
+
+            state.Series[itemKey] = new SpoilerBlurSeriesEntry
+            {
+                SeriesId = itemKey,
+                SeriesName = PersistedPayloadPolicy.ClampPersistedDisplayName(item.DisplayName),
+                EnabledAt = UtcTimestamp(),
+            };
+            SpoilerGuardOverridesRevision.Advance(state);
+            return true;
+        }
+
+        private bool EnableMovie(
+            UserSpoilerBlur state,
+            SpoilerGuardItemProjection item,
+            string itemKey,
+            ref bool capacityExceeded)
+        {
+            var newName = PersistedPayloadPolicy.ClampPersistedDisplayName(item.DisplayName);
+            if (state.Movies.TryGetValue(itemKey, out var existing))
+            {
+                if (string.Equals(existing.MovieName, newName, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+
+                existing.MovieName = newName;
+                SpoilerGuardOverridesRevision.Advance(state);
+                return true;
+            }
+
+            if (!SpoilerGuardOverrideCapacity.CanInsert(state.Movies, itemKey))
+            {
+                capacityExceeded = true;
+                return false;
+            }
+
+            state.Movies[itemKey] = new SpoilerBlurMovieEntry
+            {
+                MovieId = itemKey,
+                MovieName = newName,
+                EnabledAt = UtcTimestamp(),
+            };
+            SpoilerGuardOverridesRevision.Advance(state);
+            return true;
+        }
+
+        private string UtcTimestamp()
+            => _timeProvider.GetUtcNow().UtcDateTime.ToString("o", System.Globalization.CultureInfo.InvariantCulture);
+    }
+}

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,19 +26,19 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2808, totalLines: 3201 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 32249, totalLines: 40928 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 32364, totalLines: 41049 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 3,
         minimumCoveredLines: 2808,
         maximumCoveredLines: 2808,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
-        cleanRuns: 5,
-        minimumCoveredLines: 32247,
-        maximumCoveredLines: 32249,
+        cleanRuns: 3,
+        minimumCoveredLines: 32363,
+        maximumCoveredLines: 32364,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 1);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 32249,
-        "totalLines": 40928
+        "coveredLines": 32364,
+        "totalLines": 41049
       },
       "observations": {
-        "cleanRuns": 5,
-        "minimumCoveredLines": 32247,
-        "maximumCoveredLines": 32249
+        "cleanRuns": 3,
+        "minimumCoveredLines": 32363,
+        "maximumCoveredLines": 32364
       },
       "tolerance": {
-        "missingCoveredLines": 2,
-        "rationale": "The #588 closed first-party operation vocabulary adds exactly three immutable code-owned pilot definitions, bounded namespaced operation and input-schema identifiers, exact ordinal fail-closed lookup, fixed authority/item-kind/mutation/generation metadata, private constructors with exact allowlisted instances, and production-wide construction guards including planted target-typed and alias escapes. Five clean Coverlet observations on the identical combined #598/#523/#588 source and 40,928-line scope each passed all 2,849 server tests: four local runs measured 32,248 once and 32,247 three times, while the clean GitHub Actions Ubuntu runner measured 32,249. Relative to the reviewed #598/#523 main high-water of 32,109/40,790 (78.718%), #588 adds 138 instrumented lines and raises the observed high-water by 140 covered lines to 32,249/40,928 (78.794%). The exact two-line 32,247-32,249 cross-runner instrumentation envelope therefore sets a 32,249 high-water with a two-line tolerance and a floor of 32,247/40,928 (78.790%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 1,
+        "rationale": "The combined #588 and Spoiler Guard installed-item owner #593 tree preserves the closed first-party operation vocabulary while extracting the legacy Movie/Series locked persistence core behind an HTTP-free typed seam, with user-scoped admission, capacity, corruption, revision, timestamp, cache-invalidation, and exactly-once legacy delegation tests. Three clean Coverlet runs on the identical rebased 2026-08-03 source and 41,049-line scope each passed all 2,857 server tests: one measured 32,364 covered lines and two measured 32,363. Relative to the reviewed #588 main high-water of 32,249/40,928 (78.794%), #593 adds 121 instrumented lines and raises the observed high-water by 115 covered lines to 32,364/41,049 (78.842%). The exact one-line 32,363-32,364 local instrumentation envelope therefore sets a 32,364 high-water with a one-line tolerance and a floor of 32,363/41,049 (78.840%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
Prerequisite work toward #593; this PR intentionally does **not** close the issue.

Extracts the installed Movie/Series Spoiler Guard mutation core from the legacy controller into one singleton, HTTP-free owner. The four legacy enable/disable routes retain their admission, response, error, and logging behavior, then invoke the shared owner exactly once.

The owner now owns strict locked read/modify/write behavior, per-kind capacity, one-step revision advancement, original `EnabledAt` preservation, bounded display-name refresh, idempotent removal, and successful-probe cache invalidation. A narrowly typed actor-owned removal projection preserves legacy cleanup after content disappears but is structurally unable to authorize enablement.

Remaining #593 work: the real Platform adapter must be wired through #591's bounded coordinator, with Legacy↔Platform equivalent-outcome and exactly-one-owner-invocation tests. No placeholder adapter or controller-to-controller call is introduced here.

Verification:

- focused owner/controller tests: 46/46
- full server suite: 2,857/2,857
- coverage observations: 32,363–32,364 / 41,049; ratchet green
- script suite: 634/634
- Release plugin build: 0 warnings, 0 errors
- root review: clean
