### PR TITLE
feat(platform): add prepared action capabilities

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActionCapabilityArchitectureTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActionCapabilityArchitectureTests.cs
@@ -1,0 +1,174 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
+{
+    /// <summary>Guards the action-capability authority against route and secret-surface drift.</summary>
+    public class PlatformActionCapabilityArchitectureTests
+    {
+        [Fact]
+        public void ServiceIsHttpFreeAndHasNoLoggingOrCallerRegistrationSurface()
+        {
+            var code = PlatformHostSeamTests.CodeOnly(File.ReadAllText(SourceFile("PlatformActionCapabilityService.cs")));
+            foreach (var forbidden in new[]
+            {
+                "Microsoft.AspNetCore",
+                "HttpContext",
+                "Controller",
+                "Route(",
+                "HttpGet",
+                "HttpPost",
+                "ILogger",
+                "IServiceCollection",
+                "IServiceProvider",
+                "Register",
+                "Manifest",
+            })
+            {
+                Assert.DoesNotContain(forbidden, code, StringComparison.Ordinal);
+            }
+        }
+
+        [Fact]
+        public void OnlyTheParameterlessConstructorIsPublicAndNoKeyMaterialIsExposed()
+        {
+            var publicConstructors = typeof(PlatformActionCapabilityService)
+                .GetConstructors(BindingFlags.Instance | BindingFlags.Public);
+            Assert.Single(publicConstructors);
+            Assert.Empty(publicConstructors[0].GetParameters());
+
+            Assert.DoesNotContain(
+                typeof(PlatformActionCapabilityService).GetProperties(BindingFlags.Instance | BindingFlags.Public),
+                property => property.PropertyType == typeof(byte[]) || property.PropertyType == typeof(string));
+            Assert.DoesNotContain(
+                typeof(PlatformActionCapabilityService).GetFields(BindingFlags.Instance | BindingFlags.Public),
+                field => field.FieldType == typeof(byte[]) || field.FieldType == typeof(string));
+        }
+
+        [Fact]
+        public void CapabilityLifecycleIsExplicitlyInspectValidateThenConsume()
+        {
+            var methods = typeof(PlatformActionCapabilityService)
+                .GetMethods(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly)
+                .Where(method => !method.IsSpecialName)
+                .Select(method => method.Name)
+                .Where(name => name is "Mint" or "Inspect" or "ValidateCurrent" or "Consume" or "InvalidateOutstandingCapabilities")
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToArray();
+
+            Assert.Equal(
+                new[] { "Consume", "Inspect", "InvalidateOutstandingCapabilities", "Mint", "ValidateCurrent" },
+                methods);
+            Assert.DoesNotContain(
+                typeof(PlatformActionCapabilityService).GetMethods(BindingFlags.Instance | BindingFlags.Public),
+                method => method.Name.Contains("Invoke", StringComparison.Ordinal)
+                    || method.Name.Contains("Execute", StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public void CryptographicAndLedgerBoundsAreExact()
+        {
+            Assert.Equal(32, PlatformActionCapabilityService.AuthorityKeyBytes);
+            Assert.Equal(32, PlatformActionCapabilityService.AuthenticationTagBytes);
+            Assert.Equal(32, PlatformActionCapabilityService.NonceBytes);
+            Assert.Equal(32, PlatformActionCapabilityService.InputDigestBytes);
+            Assert.Equal(1024, PlatformActionCapabilityService.MaximumLedgerEntries);
+            Assert.Equal(TimeSpan.FromSeconds(60), PlatformActionCapabilityService.CapabilityTimeToLive);
+            Assert.InRange(PlatformActionCapabilityService.MaximumTokenCharacters, 512, 1024);
+        }
+
+        [Fact]
+        public void PluginRegistersExactlyOneSingletonAuthority()
+        {
+            var code = PlatformHostSeamTests.CodeOnly(File.ReadAllText(ProductionFile("PluginServiceRegistrator.cs")));
+            const string registration = "serviceCollection.AddSingleton<PlatformActionCapabilityService>();";
+
+            Assert.Equal(1, Count(code, registration));
+            Assert.DoesNotContain("AddTransient<PlatformActionCapabilityService>", code, StringComparison.Ordinal);
+            Assert.DoesNotContain("AddScoped<PlatformActionCapabilityService>", code, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void OutcomeObjectsCannotLeakCapabilitiesThroughToStringOverrides()
+        {
+            foreach (var type in new[]
+            {
+                typeof(PlatformCapabilityMintOutcome),
+                typeof(PlatformCapabilityInspection),
+                typeof(PlatformActionCapabilityService.PlatformCapabilityValidation),
+            })
+            {
+                Assert.DoesNotContain(
+                    type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly),
+                    method => method.Name == nameof(ToString));
+            }
+        }
+
+        [Fact]
+        public void SuccessfulValidationEvidenceRequiresAnUnexposedServiceOwnedSeal()
+        {
+            var evidenceType = typeof(PlatformActionCapabilityService.PlatformCapabilityValidation);
+            var serviceSeal = typeof(PlatformActionCapabilityService).GetField(
+                "_validationSeal",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            var evidenceSeal = evidenceType.GetField("_seal", BindingFlags.Instance | BindingFlags.NonPublic);
+
+            Assert.Equal(typeof(PlatformActionCapabilityService), evidenceType.DeclaringType);
+            Assert.NotNull(serviceSeal);
+            Assert.True(serviceSeal!.IsPrivate);
+            Assert.True(serviceSeal.IsInitOnly);
+            Assert.Equal(typeof(object), serviceSeal.FieldType);
+            Assert.NotNull(evidenceSeal);
+            Assert.True(evidenceSeal!.IsPrivate);
+            Assert.True(evidenceSeal.IsInitOnly);
+            Assert.Equal(typeof(object), evidenceSeal.FieldType);
+            Assert.DoesNotContain(
+                evidenceType.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic),
+                property => property.PropertyType == typeof(object));
+            Assert.Equal(PlatformCapabilityValidationKind.InvalidCapability, default);
+        }
+
+        private static int Count(string source, string value)
+        {
+            var count = 0;
+            var offset = 0;
+            while ((offset = source.IndexOf(value, offset, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                offset += value.Length;
+            }
+
+            return count;
+        }
+
+        private static string SourceFile(string name) =>
+            Directory.EnumerateFiles(PlatformRoot(), "*.cs", SearchOption.TopDirectoryOnly)
+                .Single(file => Path.GetFileName(file) == name);
+
+        private static string ProductionFile(string name) =>
+            Directory.EnumerateFiles(ProductionRoot(), "*.cs", SearchOption.AllDirectories)
+                .Where(file => !file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                    && !file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+                .Single(file => Path.GetFileName(file) == name);
+
+        private static string PlatformRoot([CallerFilePath] string sourceFile = "") =>
+            Path.GetFullPath(Path.Combine(
+                Path.GetDirectoryName(sourceFile)!,
+                "..",
+                "..",
+                "Jellyfin.Plugin.JellyfinCanopy",
+                "Platform"));
+
+        private static string ProductionRoot([CallerFilePath] string sourceFile = "") =>
+            Path.GetFullPath(Path.Combine(
+                Path.GetDirectoryName(sourceFile)!,
+                "..",
+                "..",
+                "Jellyfin.Plugin.JellyfinCanopy"));
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActionCapabilityServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActionCapabilityServiceTests.cs
@@ -1,0 +1,575 @@
+using System;
+using System.Buffers.Binary;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+using Xunit;
+using PlatformCapabilityValidation = Jellyfin.Plugin.JellyfinCanopy.Platform.PlatformActionCapabilityService.PlatformCapabilityValidation;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
+{
+    public class PlatformActionCapabilityServiceTests
+    {
+        private static readonly DateTimeOffset Epoch =
+            new(2026, 8, 3, 0, 0, 0, TimeSpan.Zero);
+
+        private static readonly Guid UserA = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+        private static readonly Guid UserB = Guid.Parse("11111111-2222-3333-4444-555555555555");
+        private static readonly Guid ItemA = Guid.Parse("12345678-1234-5678-9abc-def012345678");
+        private static readonly Guid ItemB = Guid.Parse("87654321-4321-8765-cba9-876543210fed");
+
+        [Fact]
+        public void MintedCapabilityIsCanonicalDeterministicAndLengthPrefixed()
+        {
+            var key = Enumerable.Range(0, 32).Select(value => (byte)value).ToArray();
+            var nonce = Enumerable.Range(32, 32).Select(value => (byte)value).ToArray();
+            var clock = new ManualTimeProvider(Epoch);
+            using var first = new PlatformActionCapabilityService(clock, key, _ => nonce);
+            using var second = new PlatformActionCapabilityService(clock, key, _ => nonce);
+            var digest = Digest("{\"blur\":true}");
+
+            var firstToken = Mint(first, Actor(UserA, "living|room"), SpoilerOperation, ItemA, HostItemKind.Movie, digest, true);
+            var secondToken = Mint(second, Actor(UserA, "living|room"), SpoilerOperation, ItemA, HostItemKind.Movie, digest, true);
+
+            Assert.Equal(firstToken, secondToken);
+            var tokenHash = Convert.ToHexString(SHA256.HashData(Encoding.ASCII.GetBytes(firstToken)));
+            Assert.Equal("E51ECBF74AB7534424391CE85555434F", tokenHash[..32]);
+            Assert.Equal("488A17DAAEC6AF5AD70D2BAC719252CE", tokenHash[32..]);
+            Assert.DoesNotContain('=', firstToken);
+            Assert.All(firstToken, character => Assert.True(IsBase64Url(character)));
+            Assert.InRange(firstToken.Length, 1, PlatformActionCapabilityService.MaximumTokenCharacters);
+
+            var raw = Decode(firstToken);
+            Assert.Equal(PlatformActionCapabilityService.AuthenticationTagBytes, raw.Length - PayloadLength(raw));
+            var payload = raw.AsSpan(0, raw.Length - PlatformActionCapabilityService.AuthenticationTagBytes);
+            Assert.Equal(1, payload[0]);
+            Assert.Equal(UserA, new Guid(payload.Slice(1, 16), bigEndian: true));
+            Assert.Equal(ItemA, new Guid(payload.Slice(17, 16), bigEndian: true));
+            Assert.Equal((int)HostItemKind.Movie, BinaryPrimitives.ReadInt32BigEndian(payload.Slice(33, 4)));
+            Assert.Equal(1, BinaryPrimitives.ReadInt64BigEndian(payload.Slice(37, 8)));
+            Assert.Equal(1, BinaryPrimitives.ReadInt64BigEndian(payload.Slice(45, 8)));
+            Assert.Equal((Epoch + PlatformActionCapabilityService.CapabilityTimeToLive).ToUnixTimeMilliseconds(),
+                BinaryPrimitives.ReadInt64BigEndian(payload.Slice(53, 8)));
+            Assert.Equal(nonce, payload.Slice(61, 32).ToArray());
+            Assert.Equal(digest, payload.Slice(93, 32).ToArray());
+
+            var offset = 125;
+            Assert.Equal(SpoilerOperation, ReadLengthPrefixed(payload, ref offset));
+            Assert.Equal("jellyfin.canopy.spoiler-guard.item-configuration.v1", ReadLengthPrefixed(payload, ref offset));
+            var deviceDigest = ReadLengthPrefixedBytes(payload, ref offset);
+            Assert.Equal(PlatformActionCapabilityService.AuthenticationTagBytes, deviceDigest.Length);
+            Assert.Equal(-1, payload.IndexOf(Encoding.UTF8.GetBytes("living|room")));
+            Assert.Equal(-1, payload.IndexOf(Encoding.UTF8.GetBytes("{\"blur\":true}")));
+            Assert.Equal(payload.Length, offset);
+        }
+
+        [Fact]
+        public void ExactActorOperationItemAndInputBindingsAreRechecked()
+        {
+            var clock = new ManualTimeProvider(Epoch);
+            using var service = Service(clock);
+            var digest = Digest("prepared input");
+            var actor = Actor(UserA, "device-a");
+            var token = Mint(service, actor, SpoilerOperation, ItemA, HostItemKind.Movie, digest, false);
+            var inspection = service.Inspect(token);
+
+            Assert.Equal(PlatformCapabilityInspectionKind.Authentic, inspection.Kind);
+            Assert.Equal(PlatformCapabilityValidationKind.Valid,
+                Validate(service, inspection, actor, SpoilerOperation, ItemA, HostItemKind.Movie, digest).Kind);
+            Assert.Equal(PlatformCapabilityValidationKind.WrongActor,
+                Validate(service, inspection, Actor(UserB, "device-a"), SpoilerOperation, ItemA, HostItemKind.Movie, digest).Kind);
+            Assert.Equal(PlatformCapabilityValidationKind.WrongOperation,
+                Validate(service, inspection, actor, SeerrOperation, ItemA, HostItemKind.Movie, digest).Kind);
+            Assert.Equal(PlatformCapabilityValidationKind.WrongItem,
+                Validate(service, inspection, actor, SpoilerOperation, ItemB, HostItemKind.Movie, digest).Kind);
+            Assert.Equal(PlatformCapabilityValidationKind.WrongItem,
+                Validate(service, inspection, actor, SpoilerOperation, ItemA, HostItemKind.Series, digest).Kind);
+            Assert.Equal(PlatformCapabilityValidationKind.WrongInput,
+                Validate(service, inspection, actor, SpoilerOperation, ItemA, HostItemKind.Movie, Digest("other input")).Kind);
+            Assert.Equal(PlatformCapabilityValidationKind.WrongInput,
+                Validate(service, inspection, actor, SpoilerOperation, ItemA, HostItemKind.Movie, new byte[31]).Kind);
+        }
+
+        [Fact]
+        public void DeviceBindingIsOptionalOneWayAttenuationNotAnAuthoritySource()
+        {
+            var clock = new ManualTimeProvider(Epoch);
+            using var service = Service(clock);
+            var digest = Digest("input");
+            var original = Actor(UserA, "device-a");
+
+            var unbound = service.Inspect(Mint(service, original, SeerrOperation, ItemA, HostItemKind.Movie, digest, false));
+            Assert.Equal(PlatformCapabilityValidationKind.Valid,
+                Validate(service, unbound, Actor(UserA, "device-b"), SeerrOperation, ItemA, HostItemKind.Movie, digest).Kind);
+            Assert.Equal(PlatformCapabilityValidationKind.WrongActor,
+                Validate(service, unbound, Actor(UserB, "device-a"), SeerrOperation, ItemA, HostItemKind.Movie, digest).Kind);
+
+            var bound = service.Inspect(Mint(service, original, SeerrOperation, ItemA, HostItemKind.Movie, digest, true));
+            Assert.Equal(PlatformCapabilityValidationKind.Valid,
+                Validate(service, bound, original, SeerrOperation, ItemA, HostItemKind.Movie, digest).Kind);
+            Assert.Equal(PlatformCapabilityValidationKind.WrongDevice,
+                Validate(service, bound, Actor(UserA, "device-b"), SeerrOperation, ItemA, HostItemKind.Movie, digest).Kind);
+            Assert.Equal(PlatformCapabilityValidationKind.WrongDevice,
+                Validate(service, bound, Actor(UserA, null), SeerrOperation, ItemA, HostItemKind.Movie, digest).Kind);
+
+            Assert.Equal(
+                PlatformCapabilityMintOutcomeKind.InvalidRequest,
+                service.Mint(Actor(UserA, null), SeerrOperation, ItemA, HostItemKind.Movie, digest, true).Kind);
+        }
+
+        [Fact]
+        public void DelimiterShapedAttributionCannotConfuseCanonicalClaims()
+        {
+            var key = Enumerable.Repeat((byte)7, 32).ToArray();
+            var clock = new ManualTimeProvider(Epoch);
+            var nonce = 0;
+            using var service = new PlatformActionCapabilityService(
+                clock,
+                key,
+                length => Enumerable.Repeat((byte)++nonce, length).ToArray());
+            var digest = Digest("same");
+
+            var first = Mint(service, Actor(UserA, "alpha|beta"), SpoilerOperation, ItemA, HostItemKind.Movie, digest, true);
+            var second = Mint(service, Actor(UserA, "alpha"), SpoilerOperation, ItemA, HostItemKind.Movie, digest, true);
+
+            Assert.NotEqual(first, second);
+            var firstInspection = service.Inspect(first);
+            var secondInspection = service.Inspect(second);
+            Assert.Equal(PlatformCapabilityValidationKind.WrongDevice,
+                Validate(service, firstInspection, Actor(UserA, "alpha"), SpoilerOperation, ItemA, HostItemKind.Movie, digest).Kind);
+            Assert.Equal(PlatformCapabilityValidationKind.WrongDevice,
+                Validate(service, secondInspection, Actor(UserA, "alpha|beta"), SpoilerOperation, ItemA, HostItemKind.Movie, digest).Kind);
+        }
+
+        [Fact]
+        public void ForgedTruncatedMalformedAndNonCanonicalTokensFailClosed()
+        {
+            var clock = new ManualTimeProvider(Epoch);
+            using var service = Service(clock);
+            var token = Mint(service, Actor(UserA), HiddenOperation, ItemA, HostItemKind.Episode, Digest("input"), false);
+            var tampered = token.ToCharArray();
+            tampered[tampered.Length / 2] = tampered[tampered.Length / 2] == 'A' ? 'B' : 'A';
+
+            foreach (var candidate in new string?[]
+            {
+                null,
+                string.Empty,
+                "A",
+                "%%%%",
+                token + "=",
+                token + "\n",
+                token[..^1],
+                token[..20],
+                new string(tampered),
+                new string('A', PlatformActionCapabilityService.MaximumTokenCharacters + 1),
+            })
+            {
+                Assert.Equal(PlatformCapabilityInspectionKind.Invalid, service.Inspect(candidate).Kind);
+            }
+        }
+
+        [Fact]
+        public void ExpiryBoundaryIsExactAndExpiredEntriesAreDeterministicallyReclaimed()
+        {
+            var clock = new ManualTimeProvider(Epoch);
+            using var service = Service(clock);
+            var digest = Digest("input");
+            var actor = Actor(UserA);
+            var token = Mint(service, actor, HiddenOperation, ItemA, HostItemKind.Series, digest, false);
+            var inspection = service.Inspect(token);
+            var validation = Validate(service, inspection, actor, HiddenOperation, ItemA, HostItemKind.Series, digest);
+
+            clock.Advance(PlatformActionCapabilityService.CapabilityTimeToLive - TimeSpan.FromTicks(1));
+            Assert.Equal(PlatformCapabilityValidationKind.Valid,
+                Validate(service, inspection, actor, HiddenOperation, ItemA, HostItemKind.Series, digest).Kind);
+            Assert.Equal(1, service.LedgerEntryCount);
+
+            clock.Advance(TimeSpan.FromTicks(1));
+            Assert.Equal(PlatformCapabilityInspectionKind.Expired, service.Inspect(token).Kind);
+            Assert.Equal(PlatformCapabilityValidationKind.Expired,
+                Validate(service, inspection, actor, HiddenOperation, ItemA, HostItemKind.Series, digest).Kind);
+            Assert.Equal(PlatformCapabilityConsumeKind.Expired, service.Consume(validation));
+            Assert.Equal(0, service.LedgerEntryCount);
+        }
+
+        [Fact]
+        public void SubMillisecondMintTimeUsesTheSameCanonicalExpiryInClaimsAndLedger()
+        {
+            var clock = new ManualTimeProvider(Epoch.AddTicks(1));
+            using var service = Service(clock);
+            var actor = Actor(UserA);
+            var digest = Digest("input");
+            var inspection = service.Inspect(Mint(
+                service,
+                actor,
+                HiddenOperation,
+                ItemA,
+                HostItemKind.Series,
+                digest,
+                false));
+            var validation = Validate(
+                service,
+                inspection,
+                actor,
+                HiddenOperation,
+                ItemA,
+                HostItemKind.Series,
+                digest);
+
+            Assert.Equal(PlatformCapabilityValidationKind.Valid, validation.Kind);
+            Assert.Equal(PlatformCapabilityConsumeKind.Consumed, service.Consume(validation));
+        }
+
+        [Fact]
+        public void SameTimestampMintsHaveDistinctReservedNonces()
+        {
+            var clock = new ManualTimeProvider(Epoch);
+            var counter = 0;
+            using var service = new PlatformActionCapabilityService(
+                clock,
+                Enumerable.Repeat((byte)3, 32).ToArray(),
+                length => Enumerable.Repeat((byte)++counter, length).ToArray());
+
+            var tokens = Enumerable.Range(0, 128)
+                .Select(_ => Mint(service, Actor(UserA), SpoilerOperation, ItemA, HostItemKind.Movie, Digest("input"), false))
+                .ToArray();
+
+            Assert.Equal(tokens.Length, tokens.Distinct(StringComparer.Ordinal).Count());
+            Assert.Equal(tokens.Length, service.LedgerEntryCount);
+            Assert.All(tokens, token => Assert.Equal(PlatformCapabilityInspectionKind.Authentic, service.Inspect(token).Kind));
+        }
+
+        [Fact]
+        public async Task FirstConsumeIsAtomicAndConcurrentReuseIsReplay()
+        {
+            var clock = new ManualTimeProvider(Epoch);
+            using var service = Service(clock);
+            var actor = Actor(UserA);
+            var digest = Digest("input");
+            var inspection = service.Inspect(Mint(service, actor, SeerrOperation, ItemA, HostItemKind.Movie, digest, false));
+            var validation = Validate(service, inspection, actor, SeerrOperation, ItemA, HostItemKind.Movie, digest);
+            var outcomes = new ConcurrentBag<PlatformCapabilityConsumeKind>();
+
+            await Task.WhenAll(Enumerable.Range(0, 64).Select(_ => Task.Run(() => outcomes.Add(service.Consume(validation)))));
+
+            Assert.Equal(1, outcomes.Count(outcome => outcome == PlatformCapabilityConsumeKind.Consumed));
+            Assert.Equal(63, outcomes.Count(outcome => outcome == PlatformCapabilityConsumeKind.Replay));
+        }
+
+        [Fact]
+        public void InspectionAndCurrentValidationStaySeparateFromConsumptionForIdempotentReplay()
+        {
+            var clock = new ManualTimeProvider(Epoch);
+            using var service = Service(clock);
+            var actor = Actor(UserA);
+            var digest = Digest("input");
+            var token = Mint(service, actor, SeerrOperation, ItemA, HostItemKind.Movie, digest, false);
+
+            var firstValidation = Validate(
+                service,
+                service.Inspect(token),
+                actor,
+                SeerrOperation,
+                ItemA,
+                HostItemKind.Movie,
+                digest);
+            Assert.Equal(PlatformCapabilityConsumeKind.Consumed, service.Consume(firstValidation));
+
+            // A coordinator may return a matching stored idempotent result here without
+            // calling Consume again. Authenticity and current authority still validate.
+            var replayValidation = Validate(
+                service,
+                service.Inspect(token),
+                actor,
+                SeerrOperation,
+                ItemA,
+                HostItemKind.Movie,
+                digest);
+            Assert.Equal(PlatformCapabilityValidationKind.Valid, replayValidation.Kind);
+            Assert.Equal(PlatformCapabilityConsumeKind.Replay, service.Consume(replayValidation));
+        }
+
+        [Fact]
+        public void LedgerCapacityNeverEvictsAnUnexpiredMintedOrConsumedEntry()
+        {
+            var clock = new ManualTimeProvider(Epoch);
+            var counter = 0;
+            using var service = new PlatformActionCapabilityService(
+                clock,
+                Enumerable.Repeat((byte)9, 32).ToArray(),
+                length => BitConverter.GetBytes(++counter).Concat(new byte[length]).Take(length).ToArray());
+            var actor = Actor(UserA);
+            var digest = Digest("input");
+            string? firstToken = null;
+
+            for (var index = 0; index < PlatformActionCapabilityService.MaximumLedgerEntries; index++)
+            {
+                var token = Mint(service, actor, SpoilerOperation, ItemA, HostItemKind.Movie, digest, false);
+                firstToken ??= token;
+            }
+
+            var firstInspection = service.Inspect(firstToken);
+            var firstValidation = Validate(service, firstInspection, actor, SpoilerOperation, ItemA, HostItemKind.Movie, digest);
+            Assert.Equal(PlatformCapabilityConsumeKind.Consumed, service.Consume(firstValidation));
+            Assert.Equal(
+                PlatformCapabilityMintOutcomeKind.AtCapacity,
+                service.Mint(actor, SpoilerOperation, ItemA, HostItemKind.Movie, digest, false).Kind);
+            Assert.Equal(PlatformCapabilityInspectionKind.Authentic, service.Inspect(firstToken).Kind);
+            Assert.Equal(PlatformCapabilityConsumeKind.Replay, service.Consume(firstValidation));
+            Assert.Equal(PlatformActionCapabilityService.MaximumLedgerEntries, service.LedgerEntryCount);
+
+            clock.Advance(PlatformActionCapabilityService.CapabilityTimeToLive);
+            Assert.Equal(0, service.LedgerEntryCount);
+            Assert.Equal(
+                PlatformCapabilityMintOutcomeKind.Issued,
+                service.Mint(actor, SpoilerOperation, ItemA, HostItemKind.Movie, digest, false).Kind);
+        }
+
+        [Fact]
+        public void NonceCollisionsRetryBoundedlyAndBadEntropyFailsClosed()
+        {
+            var clock = new ManualTimeProvider(Epoch);
+            var duplicate = Enumerable.Repeat((byte)1, 32).ToArray();
+            var unique = Enumerable.Repeat((byte)2, 32).ToArray();
+            var calls = 0;
+            using var service = new PlatformActionCapabilityService(
+                clock,
+                Enumerable.Repeat((byte)8, 32).ToArray(),
+                _ => ++calls <= 2 ? duplicate : unique);
+            var actor = Actor(UserA);
+            var digest = Digest("input");
+
+            Assert.Equal(PlatformCapabilityMintOutcomeKind.Issued,
+                service.Mint(actor, SpoilerOperation, ItemA, HostItemKind.Movie, digest, false).Kind);
+            Assert.Equal(PlatformCapabilityMintOutcomeKind.Issued,
+                service.Mint(actor, SpoilerOperation, ItemA, HostItemKind.Movie, digest, false).Kind);
+            Assert.Equal(3, calls);
+
+            using var wrongLength = new PlatformActionCapabilityService(clock, new byte[32], _ => new byte[31]);
+            Assert.Equal(PlatformCapabilityMintOutcomeKind.EntropyUnavailable,
+                wrongLength.Mint(actor, SpoilerOperation, ItemA, HostItemKind.Movie, digest, false).Kind);
+
+            using var collisions = new PlatformActionCapabilityService(clock, new byte[32], _ => duplicate);
+            Assert.Equal(PlatformCapabilityMintOutcomeKind.Issued,
+                collisions.Mint(actor, SpoilerOperation, ItemA, HostItemKind.Movie, digest, false).Kind);
+            Assert.Equal(PlatformCapabilityMintOutcomeKind.EntropyUnavailable,
+                collisions.Mint(actor, SpoilerOperation, ItemA, HostItemKind.Movie, digest, false).Kind);
+        }
+
+        [Fact]
+        public void AuthorityRevisionChangesImmediatelyInvalidateOutstandingCapabilities()
+        {
+            var clock = new ManualTimeProvider(Epoch);
+            using var service = Service(clock);
+            var actor = Actor(UserA);
+            var digest = Digest("input");
+            var inspection = service.Inspect(Mint(service, actor, SpoilerOperation, ItemA, HostItemKind.Movie, digest, false));
+            var validation = Validate(service, inspection, actor, SpoilerOperation, ItemA, HostItemKind.Movie, digest);
+            var oldRevision = service.CurrentAuthorityRevision;
+
+            service.InvalidateOutstandingCapabilities();
+
+            Assert.Equal(oldRevision + 1, service.CurrentAuthorityRevision);
+            Assert.Equal(0, service.LedgerEntryCount);
+            Assert.Equal(PlatformCapabilityValidationKind.StaleAuthority,
+                Validate(service, inspection, actor, SpoilerOperation, ItemA, HostItemKind.Movie, digest).Kind);
+            Assert.Equal(PlatformCapabilityConsumeKind.StaleAuthority, service.Consume(validation));
+            Assert.Equal(
+                PlatformCapabilityMintOutcomeKind.Issued,
+                service.Mint(actor, SpoilerOperation, ItemA, HostItemKind.Movie, digest, false).Kind);
+        }
+
+        [Fact]
+        public void NewProcessAuthorityRejectsOldTokensEvenAtTheSameTime()
+        {
+            var clock = new ManualTimeProvider(Epoch);
+            using var oldProcess = new PlatformActionCapabilityService(clock, Enumerable.Repeat((byte)1, 32).ToArray(), _ => new byte[32]);
+            using var newProcess = new PlatformActionCapabilityService(clock, Enumerable.Repeat((byte)2, 32).ToArray(), _ => new byte[32]);
+            var token = Mint(oldProcess, Actor(UserA), SpoilerOperation, ItemA, HostItemKind.Movie, Digest("input"), false);
+
+            Assert.Equal(PlatformCapabilityInspectionKind.Authentic, oldProcess.Inspect(token).Kind);
+            Assert.Equal(PlatformCapabilityInspectionKind.Invalid, newProcess.Inspect(token).Kind);
+        }
+
+        [Fact]
+        public void InspectionObjectsAreBoundToTheExactSingletonThatAuthenticatedThem()
+        {
+            var clock = new ManualTimeProvider(Epoch);
+            var key = Enumerable.Repeat((byte)4, 32).ToArray();
+            using var first = new PlatformActionCapabilityService(clock, key, _ => new byte[32]);
+            using var second = new PlatformActionCapabilityService(clock, key, _ => new byte[32]);
+            var actor = Actor(UserA);
+            var digest = Digest("input");
+            var token = Mint(first, actor, SpoilerOperation, ItemA, HostItemKind.Movie, digest, false);
+            var foreignInspection = first.Inspect(token);
+
+            Assert.Equal(PlatformCapabilityInspectionKind.Authentic, second.Inspect(token).Kind);
+            Assert.Equal(
+                PlatformCapabilityValidationKind.InvalidCapability,
+                Validate(second, foreignInspection, actor, SpoilerOperation, ItemA, HostItemKind.Movie, digest).Kind);
+        }
+
+        [Fact]
+        public void OnlyExactServiceIssuedCurrentValidationEvidenceCanConsume()
+        {
+            var clock = new ManualTimeProvider(Epoch);
+            var key = Enumerable.Repeat((byte)4, 32).ToArray();
+            using var first = new PlatformActionCapabilityService(clock, key, new SequentialNonceSource().GetBytes);
+            using var second = new PlatformActionCapabilityService(clock, key, new SequentialNonceSource().GetBytes);
+            var actor = Actor(UserA);
+            var digest = Digest("input");
+            var inspection = first.Inspect(Mint(first, actor, SpoilerOperation, ItemA, HostItemKind.Movie, digest, false));
+            var valid = Validate(first, inspection, actor, SpoilerOperation, ItemA, HostItemKind.Movie, digest);
+            var rejected = Validate(first, inspection, actor, SpoilerOperation, ItemA, HostItemKind.Movie, Digest("wrong"));
+            var forged = new PlatformCapabilityValidation(
+                PlatformCapabilityValidationKind.Valid,
+                new object(),
+                inspection);
+            var rawAllocation = (PlatformCapabilityValidation)System.Runtime.CompilerServices.RuntimeHelpers
+                .GetUninitializedObject(typeof(PlatformCapabilityValidation));
+
+            Assert.Equal(PlatformCapabilityConsumeKind.Invalid, first.Consume(rejected));
+            Assert.Equal(PlatformCapabilityConsumeKind.Invalid, first.Consume(forged));
+            Assert.Equal(PlatformCapabilityConsumeKind.Invalid, first.Consume(rawAllocation));
+            Assert.Equal(PlatformCapabilityConsumeKind.Invalid, second.Consume(valid));
+            Assert.Equal(PlatformCapabilityConsumeKind.Consumed, first.Consume(valid));
+        }
+
+        [Fact]
+        public void UnknownUnsupportedAndInvalidMintRequestsFailWithoutReservingNonce()
+        {
+            var clock = new ManualTimeProvider(Epoch);
+            using var service = Service(clock);
+            var actor = Actor(UserA);
+            var digest = Digest("input");
+
+            Assert.Equal(PlatformCapabilityMintOutcomeKind.InvalidRequest,
+                service.Mint(null, SpoilerOperation, ItemA, HostItemKind.Movie, digest, false).Kind);
+            Assert.Equal(PlatformCapabilityMintOutcomeKind.InvalidRequest,
+                service.Mint(actor, "jellyfin.canopy.unknown", ItemA, HostItemKind.Movie, digest, false).Kind);
+            Assert.Equal(PlatformCapabilityMintOutcomeKind.InvalidRequest,
+                service.Mint(actor, SpoilerOperation, Guid.Empty, HostItemKind.Movie, digest, false).Kind);
+            Assert.Equal(PlatformCapabilityMintOutcomeKind.InvalidRequest,
+                service.Mint(actor, SpoilerOperation, ItemA, HostItemKind.Episode, digest, false).Kind);
+            Assert.Equal(PlatformCapabilityMintOutcomeKind.InvalidRequest,
+                service.Mint(actor, SpoilerOperation, ItemA, (HostItemKind)99, digest, false).Kind);
+            Assert.Equal(PlatformCapabilityMintOutcomeKind.InvalidRequest,
+                service.Mint(actor, SpoilerOperation, ItemA, HostItemKind.Movie, new byte[31], false).Kind);
+            Assert.Equal(0, service.LedgerEntryCount);
+        }
+
+        [Fact]
+        public void KeyIsExactly256BitsAndDisposalDestroysTheAuthority()
+        {
+            var clock = new ManualTimeProvider(Epoch);
+            Assert.Throws<ArgumentException>(() => new PlatformActionCapabilityService(clock, new byte[31], _ => new byte[32]));
+            Assert.Throws<ArgumentException>(() => new PlatformActionCapabilityService(clock, new byte[33], _ => new byte[32]));
+
+            var service = Service(clock);
+            var token = Mint(service, Actor(UserA), SpoilerOperation, ItemA, HostItemKind.Movie, Digest("input"), false);
+            service.Dispose();
+            service.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => service.Inspect(token));
+            Assert.Throws<ObjectDisposedException>(() => service.Mint(
+                Actor(UserA), SpoilerOperation, ItemA, HostItemKind.Movie, Digest("input"), false));
+        }
+
+        private static string SpoilerOperation => Definition(PlatformOperationFamily.SpoilerGuard).Id.Value;
+
+        private static string HiddenOperation => Definition(PlatformOperationFamily.HiddenContent).Id.Value;
+
+        private static string SeerrOperation => Definition(PlatformOperationFamily.Seerr).Id.Value;
+
+        private static PlatformOperationDefinition Definition(PlatformOperationFamily family) =>
+            PlatformOperationVocabulary.All.Single(definition => definition.Family == family);
+
+        private static PlatformActionCapabilityService Service(ManualTimeProvider clock) =>
+            new(clock, Enumerable.Range(1, 32).Select(value => (byte)value).ToArray(), new SequentialNonceSource().GetBytes);
+
+        private static PlatformActor Actor(Guid userId, string? deviceId = "device-a", bool elevated = false) =>
+            new(userId, elevated, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "TestClient", deviceId);
+
+        private static byte[] Digest(string value) => SHA256.HashData(Encoding.UTF8.GetBytes(value));
+
+        private static string Mint(
+            PlatformActionCapabilityService service,
+            PlatformActor actor,
+            string operation,
+            Guid itemId,
+            HostItemKind itemKind,
+            byte[] digest,
+            bool deviceBound)
+        {
+            var outcome = service.Mint(actor, operation, itemId, itemKind, digest, deviceBound);
+            Assert.Equal(PlatformCapabilityMintOutcomeKind.Issued, outcome.Kind);
+            return Assert.IsType<string>(outcome.Capability);
+        }
+
+        private static PlatformCapabilityValidation Validate(
+            PlatformActionCapabilityService service,
+            PlatformCapabilityInspection inspection,
+            PlatformActor actor,
+            string operation,
+            Guid itemId,
+            HostItemKind itemKind,
+            byte[] digest) =>
+            service.ValidateCurrent(inspection, actor, operation, itemId, itemKind, digest);
+
+        private static byte[] Decode(string value)
+        {
+            var base64 = value.Replace('-', '+').Replace('_', '/');
+            base64 += new string('=', (4 - (base64.Length % 4)) % 4);
+            return Convert.FromBase64String(base64);
+        }
+
+        private static int PayloadLength(byte[] raw) => raw.Length - PlatformActionCapabilityService.AuthenticationTagBytes;
+
+        private static string ReadLengthPrefixed(ReadOnlySpan<byte> source, ref int offset)
+        {
+            var length = BinaryPrimitives.ReadUInt16BigEndian(source.Slice(offset, 2));
+            offset += 2;
+            var value = Encoding.UTF8.GetString(source.Slice(offset, length));
+            offset += length;
+            return value;
+        }
+
+        private static byte[] ReadLengthPrefixedBytes(ReadOnlySpan<byte> source, ref int offset)
+        {
+            var length = BinaryPrimitives.ReadUInt16BigEndian(source.Slice(offset, 2));
+            offset += 2;
+            var value = source.Slice(offset, length).ToArray();
+            offset += length;
+            return value;
+        }
+
+        private static bool IsBase64Url(char value) =>
+            value is >= 'A' and <= 'Z'
+            || value is >= 'a' and <= 'z'
+            || value is >= '0' and <= '9'
+            || value is '-' or '_';
+
+        private sealed class ManualTimeProvider(DateTimeOffset now) : TimeProvider
+        {
+            public override DateTimeOffset GetUtcNow() => now;
+
+            internal void Advance(TimeSpan amount) => now += amount;
+        }
+
+        private sealed class SequentialNonceSource
+        {
+            private int _value;
+
+            internal byte[] GetBytes(int length)
+            {
+                var bytes = new byte[length];
+                BinaryPrimitives.WriteInt32BigEndian(bytes.AsSpan(length - 4), ++_value);
+                return bytes;
+            }
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformIdempotencyArchitectureTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformIdempotencyArchitectureTests.cs
@@ -19,6 +19,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
 
         private static readonly Dictionary<string, string> AllowedStateOwners = new(StringComparer.Ordinal)
         {
+            ["PlatformActionCapabilityService.cs:_ledger"] = "The sole reviewed bounded short-lived capability nonce owner.",
             ["PlatformErrorCode.cs:Definitions"] = "Immutable error-code definition table, not request state.",
             ["PlatformIdempotencyStore.cs:_entries"] = "The sole reviewed bounded idempotency state owner.",
         };
@@ -37,6 +38,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
             Assert.Contains("MaximumEntries", code, StringComparison.Ordinal);
             Assert.Contains("MaximumStoredResultBytes", code, StringComparison.Ordinal);
             Assert.Contains("MaximumResultBytes", code, StringComparison.Ordinal);
+
+            var capabilityCode = PlatformHostSeamTests.CodeOnly(
+                File.ReadAllText(SourcePath("PlatformActionCapabilityService.cs")));
+            Assert.Contains("MaximumLedgerEntries", capabilityCode, StringComparison.Ordinal);
+            Assert.Contains("CapabilityTimeToLive", capabilityCode, StringComparison.Ordinal);
+            Assert.Contains("RemoveExpiredEntries", capabilityCode, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformActionCapabilityService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformActionCapabilityService.cs
@@ -1,0 +1,962 @@
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>The bounded result of preparing one opaque native action capability.</summary>
+    internal enum PlatformCapabilityMintOutcomeKind
+    {
+        Issued,
+        InvalidRequest,
+        NotAuthorized,
+        AtCapacity,
+        EntropyUnavailable,
+    }
+
+    /// <summary>Intrinsic inspection outcomes that reveal no unauthenticated claim data.</summary>
+    internal enum PlatformCapabilityInspectionKind
+    {
+        Authentic,
+        Invalid,
+        Expired,
+    }
+
+    /// <summary>Current-authority validation outcomes for an authentic capability.</summary>
+    internal enum PlatformCapabilityValidationKind
+    {
+        InvalidCapability,
+        Valid,
+        Expired,
+        WrongActor,
+        WrongOperation,
+        WrongItem,
+        WrongInput,
+        WrongDevice,
+        StaleAuthority,
+        NotAuthorized,
+    }
+
+    /// <summary>Atomic single-use decisions for a currently valid capability.</summary>
+    internal enum PlatformCapabilityConsumeKind
+    {
+        Consumed,
+        Replay,
+        Invalid,
+        Expired,
+        StaleAuthority,
+    }
+
+    /// <summary>An opaque capability string, present only when minting succeeded.</summary>
+    internal sealed class PlatformCapabilityMintOutcome
+    {
+        internal PlatformCapabilityMintOutcome(PlatformCapabilityMintOutcomeKind kind, string? capability = null)
+        {
+            Kind = kind;
+            Capability = capability;
+        }
+
+        internal PlatformCapabilityMintOutcomeKind Kind { get; }
+
+        internal string? Capability { get; }
+    }
+
+    /// <summary>An authenticated decoded capability. Inspection never consumes it.</summary>
+    internal sealed class PlatformCapabilityInspection
+    {
+        internal PlatformCapabilityInspection(
+            PlatformCapabilityInspectionKind kind,
+            PlatformActionCapabilityService? owner = null,
+            object? claims = null,
+            byte[]? tag = null)
+        {
+            Kind = kind;
+            Owner = owner;
+            Claims = claims;
+            Tag = tag;
+        }
+
+        internal PlatformCapabilityInspectionKind Kind { get; }
+
+        internal PlatformActionCapabilityService? Owner { get; }
+
+        internal object? Claims { get; }
+
+        internal byte[]? Tag { get; }
+    }
+
+    /// <summary>
+    /// Process-local HMAC authority for short-lived, single-use native action capabilities.
+    /// This service is deliberately HTTP-free: a future coordinator owns request handling,
+    /// current Jellyfin access checks, idempotency and audit around these primitives.
+    /// </summary>
+    public sealed class PlatformActionCapabilityService : IDisposable
+    {
+        /// <summary>
+        /// A service-issued current-validation decision. Its private constructor prevents
+        /// same-assembly code from upgrading an authentic inspection into valid evidence.
+        /// </summary>
+        internal sealed class PlatformCapabilityValidation
+        {
+            private readonly object? _seal;
+            private readonly PlatformCapabilityInspection? _inspection;
+
+            internal PlatformCapabilityValidation(
+                PlatformCapabilityValidationKind kind,
+                object? seal = null,
+                PlatformCapabilityInspection? inspection = null)
+            {
+                Kind = kind;
+                _seal = seal;
+                _inspection = inspection;
+            }
+
+            internal PlatformCapabilityValidationKind Kind { get; }
+
+            internal bool TryGetInspection(object seal, out PlatformCapabilityInspection? inspection)
+            {
+                inspection = null;
+                if (!ReferenceEquals(_seal, seal))
+                {
+                    return false;
+                }
+
+                inspection = _inspection;
+                return inspection is not null;
+            }
+        }
+
+        /// <summary>Capabilities are valid for one short prepare/invoke round trip.</summary>
+        public static readonly TimeSpan CapabilityTimeToLive = TimeSpan.FromSeconds(60);
+
+        /// <summary>Maximum number of minted, unexpired nonces retained process-wide.</summary>
+        public const int MaximumLedgerEntries = 1024;
+
+        /// <summary>Exact SHA-256 prepared-input digest size.</summary>
+        public const int InputDigestBytes = 32;
+
+        internal const int AuthorityKeyBytes = 32;
+        internal const int NonceBytes = 32;
+        internal const int AuthenticationTagBytes = 32;
+        internal const int MaximumDeviceIdBytes = 128;
+        internal const int MaximumTokenCharacters = 604;
+
+        private const byte FormatVersion = 1;
+        private const int MaximumNonceAttempts = 8;
+        private const ushort NullStringLength = ushort.MaxValue;
+        private const int FixedPayloadBytes = 1 + 16 + 16 + 4 + 8 + 8 + 8 + 32 + 32;
+
+        private static readonly byte[] HmacDomain =
+            Encoding.ASCII.GetBytes("jellyfin-canopy/platform-action-capability/hmac-sha256/v1");
+
+        private static readonly byte[] DeviceHmacDomain =
+            Encoding.ASCII.GetBytes("jellyfin-canopy/platform-action-capability/device-attenuation/hmac-sha256/v1");
+
+        private static readonly UTF8Encoding StrictUtf8 = new(false, true);
+
+        private readonly object _gate = new();
+        private readonly Dictionary<string, LedgerEntry> _ledger = new(StringComparer.Ordinal);
+        private readonly TimeProvider _timeProvider;
+        private readonly Func<int, byte[]> _randomBytes;
+        private readonly byte[] _authorityKey;
+        private readonly object _validationSeal = new();
+        private long _authorityRevision = 1;
+        private bool _disposed;
+
+        /// <summary>Creates the process authority with a fresh 256-bit HMAC key.</summary>
+        public PlatformActionCapabilityService()
+            : this(TimeProvider.System, RandomNumberGenerator.GetBytes(AuthorityKeyBytes), RandomNumberGenerator.GetBytes)
+        {
+        }
+
+        internal PlatformActionCapabilityService(
+            TimeProvider timeProvider,
+            byte[] authorityKey,
+            Func<int, byte[]> randomBytes)
+        {
+            _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+            ArgumentNullException.ThrowIfNull(authorityKey);
+            _randomBytes = randomBytes ?? throw new ArgumentNullException(nameof(randomBytes));
+
+            if (authorityKey.Length != AuthorityKeyBytes)
+            {
+                throw new ArgumentException("The action-capability HMAC key must be exactly 256 bits.", nameof(authorityKey));
+            }
+
+            _authorityKey = (byte[])authorityKey.Clone();
+        }
+
+        /// <summary>
+        /// Mints and reserves one nonce. Caller data may select only a known operation;
+        /// schema, authority and generation are derived from the closed vocabulary.
+        /// </summary>
+        internal PlatformCapabilityMintOutcome Mint(
+            PlatformActor? actor,
+            string? operationId,
+            Guid itemId,
+            HostItemKind itemKind,
+            ReadOnlySpan<byte> preparedInputDigest,
+            bool attenuateToCurrentDevice)
+        {
+            if (actor is null
+                || itemId == Guid.Empty
+                || preparedInputDigest.Length != InputDigestBytes
+                || !Enum.IsDefined(itemKind))
+            {
+                return new PlatformCapabilityMintOutcome(PlatformCapabilityMintOutcomeKind.InvalidRequest);
+            }
+
+            var definition = PlatformOperationVocabulary.Find(operationId);
+            if (definition is null || !definition.SupportedItemKinds.Contains(itemKind))
+            {
+                return new PlatformCapabilityMintOutcome(PlatformCapabilityMintOutcomeKind.InvalidRequest);
+            }
+
+            if (!HasRequiredAuthority(definition, actor))
+            {
+                return new PlatformCapabilityMintOutcome(PlatformCapabilityMintOutcomeKind.NotAuthorized);
+            }
+
+            string? boundDeviceId = null;
+            if (attenuateToCurrentDevice)
+            {
+                if (!IsBoundedDeviceAttribution(actor.DeviceId))
+                {
+                    return new PlatformCapabilityMintOutcome(PlatformCapabilityMintOutcomeKind.InvalidRequest);
+                }
+
+                boundDeviceId = actor.DeviceId;
+            }
+
+            lock (_gate)
+            {
+                ThrowIfDisposed();
+                var now = _timeProvider.GetUtcNow();
+                RemoveExpiredEntries(now);
+
+                if (_ledger.Count >= MaximumLedgerEntries)
+                {
+                    return new PlatformCapabilityMintOutcome(PlatformCapabilityMintOutcomeKind.AtCapacity);
+                }
+
+                byte[]? nonce = null;
+                string? nonceKey = null;
+                for (var attempt = 0; attempt < MaximumNonceAttempts; attempt++)
+                {
+                    var candidate = _randomBytes(NonceBytes);
+                    if (candidate is null || candidate.Length != NonceBytes)
+                    {
+                        return new PlatformCapabilityMintOutcome(PlatformCapabilityMintOutcomeKind.EntropyUnavailable);
+                    }
+
+                    var candidateKey = Convert.ToHexString(candidate);
+                    if (!_ledger.ContainsKey(candidateKey))
+                    {
+                        nonce = (byte[])candidate.Clone();
+                        nonceKey = candidateKey;
+                        break;
+                    }
+                }
+
+                if (nonce is null || nonceKey is null)
+                {
+                    return new PlatformCapabilityMintOutcome(PlatformCapabilityMintOutcomeKind.EntropyUnavailable);
+                }
+
+                var expiresAt = DateTimeOffset.FromUnixTimeMilliseconds(
+                    (now + CapabilityTimeToLive).ToUnixTimeMilliseconds());
+                var claims = new CapabilityClaims(
+                    actor.UserId,
+                    definition.Id.Value,
+                    itemId,
+                    itemKind,
+                    definition.InputSchemaId.Value,
+                    preparedInputDigest.ToArray(),
+                    boundDeviceId is null ? null : DigestDevice(boundDeviceId),
+                    definition.InvalidationGeneration,
+                    _authorityRevision,
+                    expiresAt,
+                    nonce);
+                var payload = EncodeClaims(claims);
+                var tag = Sign(payload);
+                var raw = new byte[payload.Length + AuthenticationTagBytes];
+                payload.CopyTo(raw, 0);
+                tag.CopyTo(raw, payload.Length);
+                var capability = ToBase64Url(raw);
+
+                _ledger.Add(nonceKey, new LedgerEntry(expiresAt, _authorityRevision, tag));
+                return new PlatformCapabilityMintOutcome(PlatformCapabilityMintOutcomeKind.Issued, capability);
+            }
+        }
+
+        /// <summary>Authenticates and decodes without consuming or checking invocation context.</summary>
+        internal PlatformCapabilityInspection Inspect(string? capability)
+        {
+            lock (_gate)
+            {
+                ThrowIfDisposed();
+                var now = _timeProvider.GetUtcNow();
+                RemoveExpiredEntries(now);
+
+                if (!TryFromCanonicalBase64Url(capability, out var raw)
+                    || raw.Length <= AuthenticationTagBytes)
+                {
+                    return new PlatformCapabilityInspection(PlatformCapabilityInspectionKind.Invalid);
+                }
+
+                var payloadLength = raw.Length - AuthenticationTagBytes;
+                var payload = raw.AsSpan(0, payloadLength);
+                var suppliedTag = raw.AsSpan(payloadLength, AuthenticationTagBytes);
+                var expectedTag = Sign(payload);
+                if (!CryptographicOperations.FixedTimeEquals(suppliedTag, expectedTag)
+                    || !TryDecodeClaims(payload, out var claims))
+                {
+                    return new PlatformCapabilityInspection(PlatformCapabilityInspectionKind.Invalid);
+                }
+
+                if (claims.ExpiresAt <= now)
+                {
+                    return new PlatformCapabilityInspection(PlatformCapabilityInspectionKind.Expired);
+                }
+
+                return new PlatformCapabilityInspection(
+                    PlatformCapabilityInspectionKind.Authentic,
+                    this,
+                    claims,
+                    expectedTag);
+            }
+        }
+
+        /// <summary>
+        /// Rechecks an inspected token against the current actor, closed vocabulary,
+        /// invocation item and prepared-input digest. It deliberately does not consume.
+        /// </summary>
+        internal PlatformCapabilityValidation ValidateCurrent(
+            PlatformCapabilityInspection? inspection,
+            PlatformActor? actor,
+            string? operationId,
+            Guid itemId,
+            HostItemKind itemKind,
+            ReadOnlySpan<byte> preparedInputDigest)
+        {
+            lock (_gate)
+            {
+                ThrowIfDisposed();
+                var now = _timeProvider.GetUtcNow();
+                RemoveExpiredEntries(now);
+
+                if (inspection is null
+                    || inspection.Kind != PlatformCapabilityInspectionKind.Authentic
+                    || !ReferenceEquals(inspection.Owner, this)
+                    || inspection.Claims is not CapabilityClaims claims)
+                {
+                    return new PlatformCapabilityValidation(PlatformCapabilityValidationKind.InvalidCapability);
+                }
+
+                if (claims.ExpiresAt <= now)
+                {
+                    return new PlatformCapabilityValidation(PlatformCapabilityValidationKind.Expired);
+                }
+
+                if (claims.AuthorityRevision != _authorityRevision)
+                {
+                    return new PlatformCapabilityValidation(PlatformCapabilityValidationKind.StaleAuthority);
+                }
+
+                if (actor is null || claims.UserId != actor.UserId)
+                {
+                    return new PlatformCapabilityValidation(PlatformCapabilityValidationKind.WrongActor);
+                }
+
+                var definition = PlatformOperationVocabulary.Find(operationId);
+                if (definition is null
+                    || !string.Equals(claims.OperationId, operationId, StringComparison.Ordinal))
+                {
+                    return new PlatformCapabilityValidation(PlatformCapabilityValidationKind.WrongOperation);
+                }
+
+                if (claims.ItemId != itemId || claims.ItemKind != itemKind)
+                {
+                    return new PlatformCapabilityValidation(PlatformCapabilityValidationKind.WrongItem);
+                }
+
+                if (preparedInputDigest.Length != InputDigestBytes
+                    || !CryptographicOperations.FixedTimeEquals(claims.InputDigest, preparedInputDigest))
+                {
+                    return new PlatformCapabilityValidation(PlatformCapabilityValidationKind.WrongInput);
+                }
+
+                if (claims.BoundDeviceDigest is not null
+                    && (!IsBoundedDeviceAttribution(actor.DeviceId)
+                        || !CryptographicOperations.FixedTimeEquals(
+                            claims.BoundDeviceDigest,
+                            DigestDevice(actor.DeviceId!))))
+                {
+                    return new PlatformCapabilityValidation(PlatformCapabilityValidationKind.WrongDevice);
+                }
+
+                if (claims.OperationGeneration != definition.InvalidationGeneration
+                    || !string.Equals(claims.InputSchemaId, definition.InputSchemaId.Value, StringComparison.Ordinal)
+                    || !definition.SupportedItemKinds.Contains(itemKind))
+                {
+                    return new PlatformCapabilityValidation(PlatformCapabilityValidationKind.StaleAuthority);
+                }
+
+                if (!HasRequiredAuthority(definition, actor))
+                {
+                    return new PlatformCapabilityValidation(PlatformCapabilityValidationKind.NotAuthorized);
+                }
+
+                return new PlatformCapabilityValidation(
+                    PlatformCapabilityValidationKind.Valid,
+                    _validationSeal,
+                    inspection);
+            }
+        }
+
+        /// <summary>
+        /// Atomically consumes a currently validated capability. A coordinator can first
+        /// return a stored idempotent result and omit this call; a new execution must call
+        /// it immediately before invoking an owner.
+        /// </summary>
+        internal PlatformCapabilityConsumeKind Consume(PlatformCapabilityValidation? validation)
+        {
+            lock (_gate)
+            {
+                ThrowIfDisposed();
+                var now = _timeProvider.GetUtcNow();
+                RemoveExpiredEntries(now);
+
+                if (validation is null
+                    || validation.Kind != PlatformCapabilityValidationKind.Valid
+                    || !validation.TryGetInspection(_validationSeal, out var inspection)
+                    || inspection?.Claims is not CapabilityClaims claims
+                    || inspection.Tag is null)
+                {
+                    return PlatformCapabilityConsumeKind.Invalid;
+                }
+
+                if (claims.ExpiresAt <= now)
+                {
+                    return PlatformCapabilityConsumeKind.Expired;
+                }
+
+                if (claims.AuthorityRevision != _authorityRevision)
+                {
+                    return PlatformCapabilityConsumeKind.StaleAuthority;
+                }
+
+                var nonceKey = Convert.ToHexString(claims.Nonce);
+                if (!_ledger.TryGetValue(nonceKey, out var entry)
+                    || entry.AuthorityRevision != claims.AuthorityRevision
+                    || entry.ExpiresAt != claims.ExpiresAt
+                    || !CryptographicOperations.FixedTimeEquals(entry.Tag, inspection.Tag))
+                {
+                    return PlatformCapabilityConsumeKind.Invalid;
+                }
+
+                if (entry.Consumed)
+                {
+                    return PlatformCapabilityConsumeKind.Replay;
+                }
+
+                entry.Consumed = true;
+                return PlatformCapabilityConsumeKind.Consumed;
+            }
+        }
+
+        /// <summary>
+        /// Invalidates every outstanding token after an authority or catalog change.
+        /// Removed entries are no longer live; ordinary capacity cleanup never evicts a
+        /// live entry.
+        /// </summary>
+        internal void InvalidateOutstandingCapabilities()
+        {
+            lock (_gate)
+            {
+                ThrowIfDisposed();
+                _authorityRevision = checked(_authorityRevision + 1);
+                _ledger.Clear();
+            }
+        }
+
+        internal int LedgerEntryCount
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    ThrowIfDisposed();
+                    RemoveExpiredEntries(_timeProvider.GetUtcNow());
+                    return _ledger.Count;
+                }
+            }
+        }
+
+        internal long CurrentAuthorityRevision
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    ThrowIfDisposed();
+                    return _authorityRevision;
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            lock (_gate)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                CryptographicOperations.ZeroMemory(_authorityKey);
+                _ledger.Clear();
+                _disposed = true;
+            }
+        }
+
+        private static bool HasRequiredAuthority(PlatformOperationDefinition definition, PlatformActor actor) =>
+            definition.Authority == PlatformAuthorityLevel.Authenticated
+            || (definition.Authority == PlatformAuthorityLevel.Elevated && actor.IsElevated);
+
+        private static bool IsBoundedDeviceAttribution(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return false;
+            }
+
+            try
+            {
+                if (StrictUtf8.GetByteCount(value) > MaximumDeviceIdBytes)
+                {
+                    return false;
+                }
+            }
+            catch (EncoderFallbackException)
+            {
+                return false;
+            }
+
+            return value.All(character => !char.IsControl(character)
+                && character is not ('\u2028' or '\u2029'));
+        }
+
+        private byte[] Sign(ReadOnlySpan<byte> payload)
+        {
+            var signingInput = new byte[HmacDomain.Length + payload.Length];
+            HmacDomain.CopyTo(signingInput, 0);
+            payload.CopyTo(signingInput.AsSpan(HmacDomain.Length));
+            return HMACSHA256.HashData(_authorityKey, signingInput);
+        }
+
+        private byte[] DigestDevice(string deviceId)
+        {
+            var device = StrictUtf8.GetBytes(deviceId);
+            var signingInput = new byte[DeviceHmacDomain.Length + 2 + device.Length];
+            DeviceHmacDomain.CopyTo(signingInput, 0);
+            BinaryPrimitives.WriteUInt16BigEndian(signingInput.AsSpan(DeviceHmacDomain.Length, 2), (ushort)device.Length);
+            device.CopyTo(signingInput, DeviceHmacDomain.Length + 2);
+            return HMACSHA256.HashData(_authorityKey, signingInput);
+        }
+
+        private static byte[] EncodeClaims(CapabilityClaims claims)
+        {
+            var operation = StrictUtf8.GetBytes(claims.OperationId);
+            var schema = StrictUtf8.GetBytes(claims.InputSchemaId);
+            var device = claims.BoundDeviceDigest;
+            using var stream = new MemoryStream(FixedPayloadBytes + operation.Length + schema.Length + (device?.Length ?? 0) + 6);
+
+            stream.WriteByte(FormatVersion);
+            WriteGuid(stream, claims.UserId);
+            WriteGuid(stream, claims.ItemId);
+            WriteInt32(stream, (int)claims.ItemKind);
+            WriteInt64(stream, claims.OperationGeneration);
+            WriteInt64(stream, claims.AuthorityRevision);
+            WriteInt64(stream, claims.ExpiresAt.ToUnixTimeMilliseconds());
+            stream.Write(claims.Nonce);
+            stream.Write(claims.InputDigest);
+            WriteBytes(stream, operation);
+            WriteBytes(stream, schema);
+            WriteNullableBytes(stream, device);
+            return stream.ToArray();
+        }
+
+        private static bool TryDecodeClaims(ReadOnlySpan<byte> payload, out CapabilityClaims claims)
+        {
+            claims = null!;
+            var offset = 0;
+            if (!TryReadByte(payload, ref offset, out var version)
+                || version != FormatVersion
+                || !TryReadGuid(payload, ref offset, out var userId)
+                || userId == Guid.Empty
+                || !TryReadGuid(payload, ref offset, out var itemId)
+                || itemId == Guid.Empty
+                || !TryReadInt32(payload, ref offset, out var rawItemKind)
+                || !Enum.IsDefined((HostItemKind)rawItemKind)
+                || !TryReadInt64(payload, ref offset, out var operationGeneration)
+                || operationGeneration <= 0
+                || !TryReadInt64(payload, ref offset, out var authorityRevision)
+                || authorityRevision <= 0
+                || !TryReadInt64(payload, ref offset, out var expiresUnixMilliseconds)
+                || !TryReadFixedBytes(payload, ref offset, NonceBytes, out var nonce)
+                || !TryReadFixedBytes(payload, ref offset, InputDigestBytes, out var inputDigest)
+                || !TryReadString(payload, ref offset, PlatformOperationVocabulary.MaximumIdentifierLength, out var operationId)
+                || !TryReadString(payload, ref offset, PlatformOperationVocabulary.MaximumIdentifierLength, out var inputSchemaId)
+                || !TryReadNullableFixedBytes(payload, ref offset, AuthenticationTagBytes, out var boundDeviceDigest)
+                || offset != payload.Length
+                || PlatformOperationVocabulary.Find(operationId) is null
+                || !PlatformOperationVocabulary.IsValidIdentifier(inputSchemaId))
+            {
+                return false;
+            }
+
+            DateTimeOffset expiresAt;
+            try
+            {
+                expiresAt = DateTimeOffset.FromUnixTimeMilliseconds(expiresUnixMilliseconds);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                return false;
+            }
+
+            claims = new CapabilityClaims(
+                userId,
+                operationId,
+                itemId,
+                (HostItemKind)rawItemKind,
+                inputSchemaId,
+                inputDigest,
+                boundDeviceDigest,
+                operationGeneration,
+                authorityRevision,
+                expiresAt,
+                nonce);
+            return true;
+        }
+
+        private static void WriteGuid(Stream stream, Guid value)
+        {
+            Span<byte> bytes = stackalloc byte[16];
+            if (!value.TryWriteBytes(bytes, bigEndian: true, out var bytesWritten) || bytesWritten != bytes.Length)
+            {
+                throw new InvalidOperationException("A Platform capability GUID could not be encoded.");
+            }
+
+            stream.Write(bytes);
+        }
+
+        private static void WriteInt32(Stream stream, int value)
+        {
+            Span<byte> bytes = stackalloc byte[4];
+            BinaryPrimitives.WriteInt32BigEndian(bytes, value);
+            stream.Write(bytes);
+        }
+
+        private static void WriteInt64(Stream stream, long value)
+        {
+            Span<byte> bytes = stackalloc byte[8];
+            BinaryPrimitives.WriteInt64BigEndian(bytes, value);
+            stream.Write(bytes);
+        }
+
+        private static void WriteBytes(Stream stream, byte[] value)
+        {
+            if (value.Length >= NullStringLength)
+            {
+                throw new InvalidOperationException("A Platform capability string exceeded its canonical length prefix.");
+            }
+
+            Span<byte> length = stackalloc byte[2];
+            BinaryPrimitives.WriteUInt16BigEndian(length, (ushort)value.Length);
+            stream.Write(length);
+            stream.Write(value);
+        }
+
+        private static void WriteNullableBytes(Stream stream, byte[]? value)
+        {
+            if (value is null)
+            {
+                Span<byte> marker = stackalloc byte[2];
+                BinaryPrimitives.WriteUInt16BigEndian(marker, NullStringLength);
+                stream.Write(marker);
+                return;
+            }
+
+            WriteBytes(stream, value);
+        }
+
+        private static bool TryReadByte(ReadOnlySpan<byte> source, ref int offset, out byte value)
+        {
+            value = 0;
+            if (offset >= source.Length)
+            {
+                return false;
+            }
+
+            value = source[offset++];
+            return true;
+        }
+
+        private static bool TryReadGuid(ReadOnlySpan<byte> source, ref int offset, out Guid value)
+        {
+            value = default;
+            if (source.Length - offset < 16)
+            {
+                return false;
+            }
+
+            value = new Guid(source.Slice(offset, 16), bigEndian: true);
+            offset += 16;
+            return true;
+        }
+
+        private static bool TryReadInt32(ReadOnlySpan<byte> source, ref int offset, out int value)
+        {
+            value = 0;
+            if (source.Length - offset < 4)
+            {
+                return false;
+            }
+
+            value = BinaryPrimitives.ReadInt32BigEndian(source.Slice(offset, 4));
+            offset += 4;
+            return true;
+        }
+
+        private static bool TryReadInt64(ReadOnlySpan<byte> source, ref int offset, out long value)
+        {
+            value = 0;
+            if (source.Length - offset < 8)
+            {
+                return false;
+            }
+
+            value = BinaryPrimitives.ReadInt64BigEndian(source.Slice(offset, 8));
+            offset += 8;
+            return true;
+        }
+
+        private static bool TryReadFixedBytes(ReadOnlySpan<byte> source, ref int offset, int length, out byte[] value)
+        {
+            value = Array.Empty<byte>();
+            if (source.Length - offset < length)
+            {
+                return false;
+            }
+
+            value = source.Slice(offset, length).ToArray();
+            offset += length;
+            return true;
+        }
+
+        private static bool TryReadString(
+            ReadOnlySpan<byte> source,
+            ref int offset,
+            int maximumBytes,
+            out string value)
+        {
+            value = string.Empty;
+            if (!TryReadUInt16(source, ref offset, out var length)
+                || length == NullStringLength
+                || length == 0
+                || length > maximumBytes
+                || source.Length - offset < length)
+            {
+                return false;
+            }
+
+            try
+            {
+                value = StrictUtf8.GetString(source.Slice(offset, length));
+            }
+            catch (DecoderFallbackException)
+            {
+                return false;
+            }
+
+            offset += length;
+            return true;
+        }
+
+        private static bool TryReadNullableFixedBytes(
+            ReadOnlySpan<byte> source,
+            ref int offset,
+            int expectedLength,
+            out byte[]? value)
+        {
+            value = null;
+            if (!TryReadUInt16(source, ref offset, out var length))
+            {
+                return false;
+            }
+
+            if (length == NullStringLength)
+            {
+                return true;
+            }
+
+            if (length != expectedLength || source.Length - offset < length)
+            {
+                return false;
+            }
+
+            value = source.Slice(offset, length).ToArray();
+            offset += length;
+            return true;
+        }
+
+        private static bool TryReadUInt16(ReadOnlySpan<byte> source, ref int offset, out ushort value)
+        {
+            value = 0;
+            if (source.Length - offset < 2)
+            {
+                return false;
+            }
+
+            value = BinaryPrimitives.ReadUInt16BigEndian(source.Slice(offset, 2));
+            offset += 2;
+            return true;
+        }
+
+        private static string ToBase64Url(ReadOnlySpan<byte> bytes) =>
+            Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+        private static bool TryFromCanonicalBase64Url(string? value, out byte[] bytes)
+        {
+            bytes = Array.Empty<byte>();
+            if (string.IsNullOrEmpty(value)
+                || value.Length > MaximumTokenCharacters
+                || value.Length % 4 == 1
+                || value.Any(character => !IsBase64UrlCharacter(character)))
+            {
+                return false;
+            }
+
+            var padding = (4 - (value.Length % 4)) % 4;
+            var canonicalBase64 = value.Replace('-', '+').Replace('_', '/') + new string('=', padding);
+            try
+            {
+                bytes = Convert.FromBase64String(canonicalBase64);
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
+
+            return string.Equals(ToBase64Url(bytes), value, StringComparison.Ordinal);
+        }
+
+        private static bool IsBase64UrlCharacter(char value) =>
+            value is >= 'A' and <= 'Z'
+            || value is >= 'a' and <= 'z'
+            || value is >= '0' and <= '9'
+            || value is '-' or '_';
+
+        private void RemoveExpiredEntries(DateTimeOffset now)
+        {
+            List<string>? expired = null;
+            foreach (var pair in _ledger)
+            {
+                if (pair.Value.ExpiresAt <= now)
+                {
+                    (expired ??= new List<string>()).Add(pair.Key);
+                }
+            }
+
+            if (expired is not null)
+            {
+                foreach (var key in expired)
+                {
+                    _ledger.Remove(key);
+                }
+            }
+        }
+
+        private void ThrowIfDisposed()
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+        }
+
+        private sealed class CapabilityClaims
+        {
+            internal CapabilityClaims(
+                Guid userId,
+                string operationId,
+                Guid itemId,
+                HostItemKind itemKind,
+                string inputSchemaId,
+                byte[] inputDigest,
+                byte[]? boundDeviceDigest,
+                long operationGeneration,
+                long authorityRevision,
+                DateTimeOffset expiresAt,
+                byte[] nonce)
+            {
+                UserId = userId;
+                OperationId = operationId;
+                ItemId = itemId;
+                ItemKind = itemKind;
+                InputSchemaId = inputSchemaId;
+                InputDigest = inputDigest;
+                BoundDeviceDigest = boundDeviceDigest;
+                OperationGeneration = operationGeneration;
+                AuthorityRevision = authorityRevision;
+                ExpiresAt = expiresAt;
+                Nonce = nonce;
+            }
+
+            internal Guid UserId { get; }
+
+            internal string OperationId { get; }
+
+            internal Guid ItemId { get; }
+
+            internal HostItemKind ItemKind { get; }
+
+            internal string InputSchemaId { get; }
+
+            internal byte[] InputDigest { get; }
+
+            internal byte[]? BoundDeviceDigest { get; }
+
+            internal long OperationGeneration { get; }
+
+            internal long AuthorityRevision { get; }
+
+            internal DateTimeOffset ExpiresAt { get; }
+
+            internal byte[] Nonce { get; }
+        }
+
+        private sealed class LedgerEntry
+        {
+            internal LedgerEntry(DateTimeOffset expiresAt, long authorityRevision, byte[] tag)
+            {
+                ExpiresAt = expiresAt;
+                AuthorityRevision = authorityRevision;
+                Tag = tag;
+            }
+
+            internal DateTimeOffset ExpiresAt { get; }
+
+            internal long AuthorityRevision { get; }
+
+            internal byte[] Tag { get; }
+
+            internal bool Consumed { get; set; }
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
@@ -37,6 +37,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy
             // The sole process-wide owner of bounded idempotency state. Future mutation
             // endpoints consume this singleton; no current read route changes behavior.
             serviceCollection.AddSingleton<PlatformIdempotencyStore>();
+            // One process-local 256-bit authority and nonce ledger for short-lived
+            // native action capabilities. Restart intentionally invalidates every token.
+            serviceCollection.AddSingleton<PlatformActionCapabilityService>();
 
             // a named HttpClient with AllowAutoRedirect=false so
             // forward-auth proxies (Authelia / Pangolin / Authentik) returning

--- a/docs/platform-contract.md
+++ b/docs/platform-contract.md
@@ -215,6 +215,36 @@ request identity rather than only the current Jellyfin item, and any future pilo
 addition needs its own fixed operation, bounded schema, owning service and authority
 review.
 
+### Prepared action capabilities
+
+Preparing one of these operations issues an opaque capability for 60 seconds. The
+process-local singleton signs a canonical, length-prefixed binary claim set with a
+fresh 256-bit HMAC-SHA-256 authority and the complete 256-bit tag. It binds the exact
+operation and server-selected schema, authenticated user, item id and kind, prepared
+input SHA-256 digest, operation generation, current authority revision, expiry and a
+unique 256-bit nonce. The base64url spelling is canonical and unpadded; its binary
+layout is an implementation detail, not a client contract.
+
+Optional device binding is attenuation only. A client cannot name a device: the
+server may bind the current actor's bounded device attribution as a domain-separated
+keyed digest. The raw device id is never placed in the decodable token. An unbound
+capability remains portable between the same user's devices because device attribution
+is not authority; a bound capability additionally requires an exact current-device
+digest match and can never widen access or change the acting user.
+
+The nonce is reserved when minting, not on first invocation. At most 1,024 unexpired
+minted nonces exist process-wide, consumed entries remain until expiry, and capacity
+never evicts a live entry. Expired entries are removed deterministically. An authority
+or catalog revision change invalidates outstanding claims immediately; a process
+restart creates a new HMAC authority and invalidates every earlier capability.
+
+Inspection, current-authority validation and atomic consumption are deliberately
+separate operations. The invocation coordinator can authenticate and reauthorize a
+capability, return a previously stored identical idempotent result without consuming
+again, and consume only when admitting a new owner execution. Concurrent or later
+consumption of the same nonce is refused as replay. This primitive has no HTTP route,
+controller, provider credential, durable token or long-running operation handle.
+
 ## Pagination
 
 One dialect: opaque forward cursors. Pass the `NextCursor` you were given to fetch the

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,7 +26,7 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2808, totalLines: 3201 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 32364, totalLines: 41049 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 32799, totalLines: 41516 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 3,
         minimumCoveredLines: 2808,
@@ -34,8 +34,8 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
     });
     assert.deepEqual(baselines.profiles.server.observations, {
         cleanRuns: 3,
-        minimumCoveredLines: 32363,
-        maximumCoveredLines: 32364,
+        minimumCoveredLines: 32798,
+        maximumCoveredLines: 32799,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 1);

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 32364,
-        "totalLines": 41049
+        "coveredLines": 32799,
+        "totalLines": 41516
       },
       "observations": {
         "cleanRuns": 3,
-        "minimumCoveredLines": 32363,
-        "maximumCoveredLines": 32364
+        "minimumCoveredLines": 32798,
+        "maximumCoveredLines": 32799
       },
       "tolerance": {
         "missingCoveredLines": 1,
-        "rationale": "The combined #588 and Spoiler Guard installed-item owner #593 tree preserves the closed first-party operation vocabulary while extracting the legacy Movie/Series locked persistence core behind an HTTP-free typed seam, with user-scoped admission, capacity, corruption, revision, timestamp, cache-invalidation, and exactly-once legacy delegation tests. Three clean Coverlet runs on the identical rebased 2026-08-03 source and 41,049-line scope each passed all 2,857 server tests: one measured 32,364 covered lines and two measured 32,363. Relative to the reviewed #588 main high-water of 32,249/40,928 (78.794%), #593 adds 121 instrumented lines and raises the observed high-water by 115 covered lines to 32,364/41,049 (78.842%). The exact one-line 32,363-32,364 local instrumentation envelope therefore sets a 32,364 high-water with a one-line tolerance and a floor of 32,363/41,049 (78.840%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "rationale": "The #589 HTTP-free prepared-action capability service builds on the combined #588/#593 tree with a process-local 256-bit HMAC authority, canonical length-prefixed claims, full tags and keyed device attenuation, a bounded mint-time nonce ledger, exact current-vocabulary validation, service-sealed current-validation evidence, one-shot consumption, and revision/restart invalidation. Three clean Coverlet runs on the identical rebased 2026-08-03 source and 41,516-line scope each passed all 2,882 server tests: two measured 32,799 covered lines and one measured 32,798. Relative to the reviewed #593 main high-water of 32,364/41,049 (78.842%), #589 adds 467 instrumented lines and raises the observed high-water by 435 covered lines to 32,799/41,516 (79.003%). The exact one-line 32,798-32,799 instrumentation envelope therefore sets a 32,799 high-water with a one-line tolerance and a floor of 32,798/41,516 (79.001%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
Closes #589.\n\nAdds the process-local, short-lived action-capability authority for the closed native pilot vocabulary. Capabilities bind actor, operation, accessible item context, prepared-input digest, optional device attenuation, operation/authority revision, expiry, and a unique reserved nonce. Inspection, current validation, and atomic consumption remain separate so the invocation coordinator can replay an identical stored idempotent result before consumption.\n\nSecurity and bounds:\n- full HMAC-SHA-256 over a canonical length-prefixed binary claim set\n- 60-second lifetime and 1,024-entry process-wide ledger with no live eviction\n- exact actor/operation/item/input/device checks and service-owned validation evidence\n- restart and authority/catalog revision invalidation\n- no HTTP surface, handler registration, provider credentials, or business logic\n\nVerification:\n- focused capability and idempotency architecture tests: 30/30\n- three clean full coverage observations: 2,882/2,882 each; 32,799, 32,798, 32,799 of 41,516 sequence points\n- final coverage ratchet: 32,799/41,516 (79.003%)\n- script suite: 634/634\n- strict docs checks: pass\n- Release build: zero warnings/errors\n- independent adversarial rereview: approved after expiry-canonicalization and validation-evidence fixes