### PR TITLE
feat(platform): add bounded redacted action audit

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformAuditArchitectureTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformAuditArchitectureTests.cs
@@ -1,0 +1,272 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security.Claims;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
+{
+    /// <summary>Guards the audit allowlist, sole bounded owner and absent HTTP surface.</summary>
+    public class PlatformAuditArchitectureTests
+    {
+        private static readonly Regex ForbiddenRecordName = new(
+            "payload|token|bearer|capability|idempotencykey|request|body|title|url|upstream|response|message|exception|principal|context|itemid|provider",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private static readonly Regex UnboundedAuditOwner = new(
+            @"(?:Dictionary|ConcurrentDictionary|Queue|ConcurrentQueue|List|BoundedTtlCache)\s*<[^;\r\n]+>\s+_[A-Za-z_]\w*\s*(?:=|;)",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        [Fact]
+        public void TerminalRecordIsAnImmutableTypedAllowList()
+        {
+            var type = typeof(PlatformAuditRecord);
+            var expected = new Dictionary<string, Type>(StringComparer.Ordinal)
+            {
+                ["ActorUserId"] = typeof(Guid),
+                ["ActorWasElevated"] = typeof(bool),
+                ["ClientAttributionDigest"] = typeof(string),
+                ["CompletedAtUtc"] = typeof(DateTimeOffset),
+                ["CorrelationId"] = typeof(string),
+                ["Decision"] = typeof(PlatformAuditDecision),
+                ["DeviceAttributionDigest"] = typeof(string),
+                ["DurationMilliseconds"] = typeof(long),
+                ["Family"] = typeof(PlatformOperationFamily?),
+                ["Operation"] = typeof(PlatformOperationId?),
+                ["ResultCode"] = typeof(PlatformAuditResultCode),
+                ["StartedAtUtc"] = typeof(DateTimeOffset),
+                ["SubjectResolution"] = typeof(PlatformAuditSubjectResolution),
+            };
+
+            Assert.True(type.IsSealed);
+            Assert.Empty(type.GetConstructors(BindingFlags.Public | BindingFlags.Instance));
+            Assert.Equal(
+                expected,
+                type.GetProperties(BindingFlags.NonPublic | BindingFlags.Instance)
+                    .ToDictionary(property => property.Name, property => property.PropertyType, StringComparer.Ordinal));
+            Assert.All(
+                type.GetProperties(BindingFlags.NonPublic | BindingFlags.Instance),
+                property => Assert.False(property.CanWrite));
+            Assert.DoesNotContain(expected.Keys, name => ForbiddenRecordName.IsMatch(name));
+            Assert.Equal(
+                new[] { "ClientAttributionDigest", "CorrelationId", "DeviceAttributionDigest" },
+                expected.Where(pair => pair.Value == typeof(string)).Select(pair => pair.Key).OrderBy(name => name, StringComparer.Ordinal));
+        }
+
+        [Fact]
+        public void AuditTypesCannotCarryCredentialRequestOrFreeFormObjects()
+        {
+            var forbiddenTypes = new[]
+            {
+                typeof(object),
+                typeof(byte[]),
+                typeof(Exception),
+                typeof(ClaimsPrincipal),
+                typeof(ClaimsIdentity),
+                typeof(Claim),
+                typeof(HttpContext),
+                typeof(HttpRequest),
+                typeof(HttpResponse),
+                typeof(JsonDocument),
+                typeof(JsonElement),
+            };
+            var auditedTypes = new[]
+            {
+                typeof(PlatformAuditRecord),
+                typeof(PlatformAuditHealthSnapshot),
+            };
+
+            foreach (var type in auditedTypes)
+            {
+                var exposed = type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                    .Select(property => property.PropertyType)
+                    .Concat(type.GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance)
+                        .SelectMany(constructor => constructor.GetParameters())
+                        .Select(parameter => parameter.ParameterType));
+
+                Assert.DoesNotContain(exposed, exposedType => forbiddenTypes.Any(forbidden =>
+                    forbidden == exposedType
+                    || (forbidden != typeof(object) && forbidden.IsAssignableFrom(exposedType))));
+            }
+        }
+
+        [Fact]
+        public void AuditStateHasOneFixedRingAndNoUnboundedCollectionOwner()
+        {
+            var source = PlatformHostSeamTests.CodeOnly(File.ReadAllText(SourceFile("PlatformAuditStore.cs")));
+
+            Assert.Contains("new PlatformAuditRecord?[MaximumRecords]", source, StringComparison.Ordinal);
+            Assert.Contains("_nextIndex = (_nextIndex + 1) % MaximumRecords", source, StringComparison.Ordinal);
+            Assert.DoesNotMatch(UnboundedAuditOwner, source);
+            Assert.Equal(1024, PlatformAuditStore.MaximumRecords);
+
+            const string planted = "private readonly Queue<PlatformAuditRecord> _auditRecords = new();";
+            Assert.Matches(UnboundedAuditOwner, planted);
+        }
+
+        [Fact]
+        public void AuditStoreExposesNeitherGlobalReadsNorAnyControllerDependency()
+        {
+            Assert.Empty(typeof(PlatformAuditStore)
+                .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly));
+            Assert.Empty(typeof(PlatformAuditStore)
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly));
+
+            var controllers = typeof(PlatformAuditStore).Assembly.GetTypes()
+                .Where(type => typeof(ControllerBase).IsAssignableFrom(type))
+                .ToList();
+
+            Assert.NotEmpty(controllers);
+            foreach (var controller in controllers)
+            {
+                var surfaceTypes = controller
+                    .GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static)
+                    .Select(field => field.FieldType)
+                    .Concat(controller.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static)
+                        .Select(property => property.PropertyType))
+                    .Concat(controller.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                        .SelectMany(constructor => constructor.GetParameters())
+                        .Select(parameter => parameter.ParameterType))
+                    .Concat(controller.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static)
+                        .Select(method => method.ReturnType))
+                    .Concat(controller.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static)
+                        .SelectMany(method => method.GetParameters())
+                        .Select(parameter => parameter.ParameterType));
+
+                Assert.DoesNotContain(surfaceTypes, ContainsAuditStorageType);
+
+                var sourceFiles = Directory.GetFiles(ProductionRoot(), "*.cs", SearchOption.AllDirectories)
+                    .Where(file => File.ReadAllText(file).Contains($"class {controller.Name}", StringComparison.Ordinal))
+                    .ToList();
+                Assert.NotEmpty(sourceFiles);
+                Assert.All(sourceFiles, file =>
+                {
+                    var source = PlatformHostSeamTests.CodeOnly(File.ReadAllText(file));
+                    Assert.DoesNotContain(nameof(PlatformAuditStore), source, StringComparison.Ordinal);
+                    Assert.DoesNotContain(nameof(PlatformAuditRecord), source, StringComparison.Ordinal);
+                    Assert.DoesNotContain(nameof(PlatformAuditHealthSnapshot), source, StringComparison.Ordinal);
+                });
+            }
+        }
+
+        [Fact]
+        public void CallerOperationTextHasNoAuditEntryPoint()
+        {
+            var beginMethods = typeof(PlatformAuditStore)
+                .GetMethods(BindingFlags.NonPublic | BindingFlags.Instance)
+                .Where(method => method.Name.StartsWith("Begin", StringComparison.Ordinal))
+                .ToList();
+
+            Assert.NotEmpty(beginMethods);
+            Assert.DoesNotContain(beginMethods.SelectMany(method => method.GetParameters()), parameter => parameter.ParameterType == typeof(string));
+            Assert.Contains(beginMethods, method => method.Name == "Begin"
+                && method.GetParameters().Select(parameter => parameter.ParameterType)
+                    .SequenceEqual(new[] { typeof(PlatformActor), typeof(PlatformOperationDefinition) }));
+            Assert.Contains(beginMethods, method => method.Name == "BeginUnresolved"
+                && method.GetParameters().Select(parameter => parameter.ParameterType)
+                    .SequenceEqual(new[] { typeof(PlatformActor) }));
+        }
+
+        [Fact]
+        public void AttributionIsReducedBeforeItCanEnterARecordOrLog()
+        {
+            var source = PlatformHostSeamTests.CodeOnly(File.ReadAllText(SourceFile("PlatformAuditStore.cs")));
+            var logStart = source.IndexOf("_logger.LogInformation(", StringComparison.Ordinal);
+            var logEnd = source.IndexOf("catch (Exception)", logStart, StringComparison.Ordinal);
+            var logBlock = source[logStart..logEnd];
+
+            Assert.Contains("HMACSHA256.HashData", source, StringComparison.Ordinal);
+            Assert.Contains("DigestAttribution(actor.ClientName, \"client\"", source, StringComparison.Ordinal);
+            Assert.Contains("DigestAttribution(actor.DeviceId, \"device\"", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("actor.ClientName", logBlock, StringComparison.Ordinal);
+            Assert.DoesNotContain("actor.DeviceId", logBlock, StringComparison.Ordinal);
+            Assert.DoesNotContain("Exception", logBlock, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void TheOneShotClosesBeforePublicationAndNeverRetries()
+        {
+            var source = PlatformHostSeamTests.CodeOnly(File.ReadAllText(SourceFile("PlatformAuditStore.cs")));
+            var completionStart = source.IndexOf("public bool Complete(PlatformAuditResultCode resultCode)", StringComparison.Ordinal);
+            Assert.True(completionStart >= 0);
+            var completionEnd = source.IndexOf("public void Dispose()", completionStart, StringComparison.Ordinal);
+            Assert.True(completionEnd > completionStart);
+            var completion = source[completionStart..completionEnd];
+
+            Assert.True(
+                completion.IndexOf("Interlocked.CompareExchange", StringComparison.Ordinal)
+                    < completion.IndexOf("_owner.TryComplete", StringComparison.Ordinal));
+            Assert.Single(Regex.Matches(completion, @"_owner\.TryComplete\s*\(").Cast<Match>());
+            Assert.DoesNotContain("catch", completion, StringComparison.Ordinal);
+            Assert.DoesNotContain("while", completion, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CompletionEvidenceCannotBeConstructedOutsideTheStore()
+        {
+            var store = typeof(PlatformAuditStore);
+            var attempt = store.GetNestedType("AuditAttempt", BindingFlags.NonPublic);
+            var prefix = store.GetNestedType("AuditPrefix", BindingFlags.NonPublic);
+
+            Assert.NotNull(attempt);
+            Assert.NotNull(prefix);
+            Assert.True(attempt!.IsNestedPrivate);
+            Assert.True(prefix!.IsNestedPrivate);
+            Assert.Empty(attempt.GetConstructors(BindingFlags.Public | BindingFlags.Instance));
+            Assert.Empty(prefix.GetConstructors(BindingFlags.Public | BindingFlags.Instance));
+            Assert.Equal(typeof(IPlatformAuditAttempt), store.GetMethod("Begin", BindingFlags.NonPublic | BindingFlags.Instance)!.ReturnType);
+            Assert.Equal(typeof(IPlatformAuditAttempt), store.GetMethod("BeginUnresolved", BindingFlags.NonPublic | BindingFlags.Instance)!.ReturnType);
+
+            var nonPrivateCompletionPaths = store
+                .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                .Where(method => !method.IsPrivate)
+                .Concat(typeof(IPlatformAuditAttempt).GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                    .Where(method => !method.IsPrivate));
+
+            Assert.DoesNotContain(
+                nonPrivateCompletionPaths.SelectMany(method => method.GetParameters()),
+                parameter => parameter.ParameterType == typeof(string));
+        }
+
+        private static string SourceFile(string name, [CallerFilePath] string sourceFile = "") =>
+            Path.GetFullPath(Path.Combine(
+                Path.GetDirectoryName(sourceFile)!,
+                "..",
+                "..",
+                "Jellyfin.Plugin.JellyfinCanopy",
+                "Platform",
+                name));
+
+        private static string ProductionRoot([CallerFilePath] string sourceFile = "") =>
+            Path.GetFullPath(Path.Combine(
+                Path.GetDirectoryName(sourceFile)!,
+                "..",
+                "..",
+                "Jellyfin.Plugin.JellyfinCanopy"));
+
+        private static bool ContainsAuditStorageType(Type type)
+        {
+            if (type == typeof(PlatformAuditStore)
+                || type == typeof(PlatformAuditRecord)
+                || type == typeof(PlatformAuditHealthSnapshot))
+            {
+                return true;
+            }
+
+            if (type.HasElementType && type.GetElementType() is Type elementType)
+            {
+                return ContainsAuditStorageType(elementType);
+            }
+
+            return type.IsGenericType && type.GetGenericArguments().Any(ContainsAuditStorageType);
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformAuditStoreTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformAuditStoreTests.cs
@@ -1,0 +1,454 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
+{
+    /// <summary>Behavior, bounds, redaction, concurrency and failure isolation for action audit.</summary>
+    public class PlatformAuditStoreTests
+    {
+        private static readonly DateTimeOffset Start = new(2026, 8, 3, 1, 2, 3, TimeSpan.Zero);
+
+        [Fact]
+        public void KnownTerminalRecordContainsOnlyTypedRedactedFieldsAndSafeStructuredLogState()
+        {
+            const string clientCanary = "bearer-canary-must-never-appear";
+            const string deviceCanary = "capability-canary-must-never-appear";
+            var logger = new RecordingLogger();
+            var clock = new ManualTimeProvider(Start);
+            var store = Store(logger, clock);
+            var actor = Actor(1, clientCanary, deviceCanary);
+            var operation = Operation(PlatformOperationFamily.Seerr);
+
+            using var attempt = store.Begin(actor, operation);
+            clock.Advance(TimeSpan.FromMilliseconds(1234));
+
+            Assert.True(attempt.Complete(PlatformAuditResultCode.Succeeded));
+            var record = Assert.Single(store.Snapshot());
+
+            Assert.Equal(PlatformAuditSubjectResolution.Resolved, record.SubjectResolution);
+            Assert.Equal(operation.Id, record.Operation);
+            Assert.Equal(operation.Family, record.Family);
+            Assert.Equal(actor.UserId, record.ActorUserId);
+            Assert.Equal(actor.IsElevated, record.ActorWasElevated);
+            AssertDigest(record.ClientAttributionDigest);
+            AssertDigest(record.DeviceAttributionDigest);
+            Assert.NotEqual(record.ClientAttributionDigest, record.DeviceAttributionDigest);
+            Assert.Equal(PlatformAuditDecision.Allowed, record.Decision);
+            Assert.Equal(PlatformAuditResultCode.Succeeded, record.ResultCode);
+            Assert.Equal(1234, record.DurationMilliseconds);
+            Assert.Equal(actor.CorrelationId, record.CorrelationId);
+            Assert.Equal(Start, record.StartedAtUtc);
+            Assert.Equal(Start.AddMilliseconds(1234), record.CompletedAtUtc);
+
+            var entry = Assert.Single(logger.Entries);
+            Assert.Equal(LogLevel.Information, entry.Level);
+            Assert.DoesNotContain(clientCanary, entry.Rendered, StringComparison.Ordinal);
+            Assert.DoesNotContain(deviceCanary, entry.Rendered, StringComparison.Ordinal);
+            Assert.DoesNotContain(clientCanary, string.Join('|', entry.State.Values), StringComparison.Ordinal);
+            Assert.DoesNotContain(deviceCanary, string.Join('|', entry.State.Values), StringComparison.Ordinal);
+            Assert.Equal("seerr", entry.State["AuditFamily"]);
+            Assert.Equal(operation.Id.Value, entry.State["AuditOperation"]);
+            Assert.Equal(actor.CorrelationId, entry.State["CorrelationId"]);
+            Assert.Equal("succeeded", entry.State["AuditResultCode"]);
+            Assert.Null(entry.Exception);
+        }
+
+        [Theory]
+        [InlineData("bearer-token-canary")]
+        [InlineData("capability-string-canary")]
+        [InlineData("request-body-canary")]
+        [InlineData("library-title-canary")]
+        [InlineData("seerr-api-key-canary")]
+        [InlineData("https://seerr.example.invalid/canary")]
+        [InlineData("upstream-response-canary")]
+        public void EverySensitiveCanaryIsIrreversiblyReducedAtTheOnlyRawAttributionInputs(string canary)
+        {
+            var logger = new RecordingLogger();
+            var store = Store(logger);
+
+            using var attempt = store.Begin(Actor(3, canary, canary), Operation(PlatformOperationFamily.Seerr));
+            Assert.True(attempt.Complete(PlatformAuditResultCode.OwnerFailed));
+
+            var record = Assert.Single(store.Snapshot());
+            AssertDigest(record.ClientAttributionDigest);
+            AssertDigest(record.DeviceAttributionDigest);
+            Assert.DoesNotContain(canary, record.ClientAttributionDigest!, StringComparison.Ordinal);
+            Assert.DoesNotContain(canary, record.DeviceAttributionDigest!, StringComparison.Ordinal);
+
+            var entry = Assert.Single(logger.Entries);
+            Assert.DoesNotContain(canary, entry.Rendered, StringComparison.Ordinal);
+            Assert.DoesNotContain(canary, string.Join('|', entry.State.Values), StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void UnresolvedAttemptRetainsOnlyTheFixedSentinel()
+        {
+            const string rejectedCallerText = "jellyfin.canopy.attacker.bearer-canary";
+            var logger = new RecordingLogger();
+            var store = Store(logger);
+
+            using var attempt = store.BeginUnresolved(Actor(2));
+            Assert.True(attempt.Complete(PlatformAuditResultCode.UnknownOperation));
+
+            var record = Assert.Single(store.Snapshot());
+            Assert.Equal(PlatformAuditSubjectResolution.Unresolved, record.SubjectResolution);
+            Assert.Null(record.Operation);
+            Assert.Null(record.Family);
+            Assert.Equal(PlatformAuditDecision.Denied, record.Decision);
+            Assert.DoesNotContain(rejectedCallerText, logger.Entries.Single().Rendered, StringComparison.Ordinal);
+            Assert.Equal("unresolved", logger.Entries.Single().State["AuditFamily"]);
+            Assert.Equal("unresolved", logger.Entries.Single().State["AuditOperation"]);
+        }
+
+        [Fact]
+        public void EveryClosedResultHasOneStableAuthorityDecision()
+        {
+            var denied = new HashSet<PlatformAuditResultCode>
+            {
+                PlatformAuditResultCode.AuthorityDenied,
+                PlatformAuditResultCode.CapabilityInvalid,
+                PlatformAuditResultCode.CapabilityReplayed,
+                PlatformAuditResultCode.CapabilityExpired,
+                PlatformAuditResultCode.UnknownOperation,
+            };
+
+            foreach (var resultCode in Enum.GetValues<PlatformAuditResultCode>())
+            {
+                var store = Store();
+                using var attempt = store.Begin(Actor((int)resultCode + 10), Operation(PlatformOperationFamily.SpoilerGuard));
+
+                Assert.True(attempt.Complete(resultCode));
+
+                Assert.Equal(
+                    denied.Contains(resultCode) ? PlatformAuditDecision.Denied : PlatformAuditDecision.Allowed,
+                    Assert.Single(store.Snapshot()).Decision);
+            }
+        }
+
+        [Fact]
+        public void CompletionAndExceptionalDisposalEachAppendExactlyOnce()
+        {
+            var store = Store();
+            var completed = store.Begin(Actor(30), Operation(PlatformOperationFamily.HiddenContent));
+
+            Assert.True(completed.Complete(PlatformAuditResultCode.IdempotencyReplayed));
+            Assert.False(completed.Complete(PlatformAuditResultCode.OwnerFailed));
+            completed.Dispose();
+
+            var abandoned = store.Begin(Actor(31), Operation(PlatformOperationFamily.HiddenContent));
+            abandoned.Dispose();
+            abandoned.Dispose();
+
+            var records = store.Snapshot();
+            Assert.Equal(2, records.Count);
+            Assert.Equal(PlatformAuditResultCode.IdempotencyReplayed, records[0].ResultCode);
+            Assert.Equal(PlatformAuditResultCode.InternalFailure, records[1].ResultCode);
+        }
+
+        [Fact]
+        public void InvalidInternalEnumCannotCreateAnUnclassifiedRecord()
+        {
+            var store = Store();
+            using var attempt = store.Begin(Actor(32), Operation(PlatformOperationFamily.Seerr));
+
+            Assert.True(attempt.Complete((PlatformAuditResultCode)int.MaxValue));
+
+            Assert.Equal(PlatformAuditResultCode.InternalFailure, Assert.Single(store.Snapshot()).ResultCode);
+        }
+
+        [Fact]
+        public void FullRingEvictsExactlyTheOldestTerminalRecord()
+        {
+            var store = Store();
+            for (var index = 1; index <= PlatformAuditStore.MaximumRecords + 2; index++)
+            {
+                using var attempt = store.Begin(Actor(index), Operation(PlatformOperationFamily.SpoilerGuard));
+                Assert.True(attempt.Complete(PlatformAuditResultCode.Succeeded));
+            }
+
+            var records = store.Snapshot();
+            Assert.Equal(PlatformAuditStore.MaximumRecords, records.Count);
+            Assert.Equal(Correlation(3), records[0].CorrelationId);
+            Assert.Equal(Correlation(PlatformAuditStore.MaximumRecords + 2), records[^1].CorrelationId);
+            Assert.DoesNotContain(records, record => record.CorrelationId == Correlation(1));
+            Assert.DoesNotContain(records, record => record.CorrelationId == Correlation(2));
+        }
+
+        [Fact]
+        public void ParallelWritersRemainBoundedAndUncorrupted()
+        {
+            const int writes = 10_000;
+            var store = Store();
+
+            Parallel.For(1, writes + 1, index =>
+            {
+                using var attempt = store.Begin(Actor(index), Operation(PlatformOperationFamily.Seerr));
+                Assert.True(attempt.Complete(PlatformAuditResultCode.Succeeded));
+            });
+
+            var records = store.Snapshot();
+            Assert.Equal(PlatformAuditStore.MaximumRecords, records.Count);
+            Assert.Equal(records.Count, records.Select(record => record.CorrelationId).Distinct(StringComparer.Ordinal).Count());
+            Assert.All(records, record =>
+            {
+                Assert.Equal(PlatformAuditResultCode.Succeeded, record.ResultCode);
+                Assert.Equal(PlatformOperationFamily.Seerr, record.Family);
+            });
+            AssertHealthy(store);
+        }
+
+        [Fact]
+        public void ConcurrentCompletionOfOneAttemptHasOneWinnerAndOneRecord()
+        {
+            var store = Store();
+            using var attempt = store.Begin(Actor(40), Operation(PlatformOperationFamily.Seerr));
+
+            var winners = Enumerable.Range(0, 256)
+                .AsParallel()
+                .Count(_ => attempt.Complete(PlatformAuditResultCode.Succeeded));
+
+            Assert.Equal(1, winners);
+            Assert.Single(store.Snapshot());
+        }
+
+        [Fact]
+        public void StructuredLogFailureKeepsRecordPreservesOutcomeAndDoesNotRetry()
+        {
+            var logger = new RecordingLogger { ThrowInformation = true };
+            var store = Store(logger);
+            using var attempt = store.Begin(Actor(50), Operation(PlatformOperationFamily.Seerr));
+            var selectedActionOutcome = "success";
+
+            var exception = Record.Exception(() => Assert.True(attempt.Complete(PlatformAuditResultCode.Succeeded)));
+            Assert.Null(exception);
+            Assert.Equal("success", selectedActionOutcome);
+            Assert.Single(store.Snapshot());
+            Assert.False(attempt.Complete(PlatformAuditResultCode.Succeeded));
+
+            var health = store.HealthSnapshot();
+            Assert.Equal(0, health.AppendFailureCount);
+            Assert.Equal(1, health.StructuredLogFailureCount);
+            Assert.Equal(Correlation(50), health.LastStructuredLogFailureCorrelationId);
+            Assert.Equal(1, logger.InformationAttempts);
+        }
+
+        [Fact]
+        public void AppendFailureIsVisibleBoundedAndNeverRetriedAcrossTheActionBoundary()
+        {
+            var logger = new RecordingLogger();
+            var clock = new ThrowOnSecondUtcReadTimeProvider(Start);
+            var store = Store(logger, clock);
+            using var attempt = store.Begin(Actor(51), Operation(PlatformOperationFamily.Seerr));
+            var selectedActionOutcome = "success";
+
+            var exception = Record.Exception(() => Assert.True(attempt.Complete(PlatformAuditResultCode.Succeeded)));
+            Assert.Null(exception);
+            Assert.Equal("success", selectedActionOutcome);
+            Assert.Empty(store.Snapshot());
+            Assert.False(attempt.Complete(PlatformAuditResultCode.Succeeded));
+
+            var health = store.HealthSnapshot();
+            Assert.Equal(1, health.AppendFailureCount);
+            Assert.Equal(Correlation(51), health.LastAppendFailureCorrelationId);
+            Assert.Equal(1, logger.WarningAttempts);
+            Assert.Equal(0, logger.InformationAttempts);
+            Assert.DoesNotContain(logger.Entries, entry => entry.Exception is not null);
+        }
+
+        [Fact]
+        public void BeginFailureReturnsDisabledAttemptAndCoalescesFallbackWarnings()
+        {
+            var logger = new RecordingLogger();
+            var clock = new AlwaysThrowingTimeProvider();
+            var store = Store(logger, clock);
+
+            using var first = store.Begin(Actor(52), Operation(PlatformOperationFamily.Seerr));
+            using var second = store.BeginUnresolved(Actor(53));
+
+            Assert.False(first.Complete(PlatformAuditResultCode.Succeeded));
+            Assert.False(second.Complete(PlatformAuditResultCode.UnknownOperation));
+            Assert.Empty(store.Snapshot());
+            Assert.Equal(2, store.HealthSnapshot().BeginFailureCount);
+            Assert.Equal(1, logger.WarningAttempts);
+        }
+
+        [Fact]
+        public void FailingFallbackLoggerCannotEscapeOrRecurse()
+        {
+            var logger = new RecordingLogger { ThrowWarning = true };
+            var store = Store(logger, new AlwaysThrowingTimeProvider());
+
+            var exception = Record.Exception(() => store.Begin(Actor(54), Operation(PlatformOperationFamily.Seerr)));
+
+            Assert.Null(exception);
+            var health = store.HealthSnapshot();
+            Assert.Equal(1, health.BeginFailureCount);
+            Assert.Equal(1, health.StructuredLogFailureCount);
+            Assert.Equal(1, logger.WarningAttempts);
+        }
+
+        [Fact]
+        public void InvalidAttributionAndCorrelationAreDiscardedRatherThanLogged()
+        {
+            var actualOversized = "bearer-" + new string('x', PlatformActorBoundaryFilter.MaxClientNameBytes);
+            var logger = new RecordingLogger();
+            var store = Store(logger);
+            var actor = new PlatformActor(Guid.NewGuid(), false, "canary-correlation", actualOversized, "device\ncanary");
+
+            using var attempt = store.Begin(actor, Operation(PlatformOperationFamily.Seerr));
+            Assert.True(attempt.Complete(PlatformAuditResultCode.AuthorityDenied));
+
+            var record = Assert.Single(store.Snapshot());
+            Assert.Null(record.ClientAttributionDigest);
+            Assert.Null(record.DeviceAttributionDigest);
+            Assert.Equal("unavailable", record.CorrelationId);
+            var rendered = logger.Entries.Single().Rendered;
+            Assert.DoesNotContain(actualOversized, rendered, StringComparison.Ordinal);
+            Assert.DoesNotContain("device\ncanary", rendered, StringComparison.Ordinal);
+            Assert.DoesNotContain("canary-correlation", rendered, StringComparison.Ordinal);
+        }
+
+        private static PlatformAuditStore Store(
+            RecordingLogger? logger = null,
+            TimeProvider? timeProvider = null,
+            byte keyByte = 0x5a) => new(
+                logger ?? new RecordingLogger(),
+                timeProvider ?? new ManualTimeProvider(Start),
+                Enumerable.Repeat(keyByte, 32).Select(value => (byte)value).ToArray());
+
+        private static PlatformActor Actor(int value, string? client = "Android TV", string? device = "living-room") => new(
+            Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
+            isElevated: value % 2 == 0,
+            Correlation(value),
+            client,
+            device);
+
+        private static PlatformOperationDefinition Operation(PlatformOperationFamily family) =>
+            PlatformOperationVocabulary.All.Single(definition => definition.Family == family);
+
+        private static string Correlation(int value) => value.ToString("x32", System.Globalization.CultureInfo.InvariantCulture);
+
+        private static void AssertDigest(string? digest)
+        {
+            Assert.NotNull(digest);
+            Assert.Equal(PlatformAuditStore.AttributionDigestCharacters, digest!.Length);
+            Assert.All(digest, character => Assert.Contains(character, "0123456789abcdef"));
+        }
+
+        private static void AssertHealthy(PlatformAuditStore store)
+        {
+            var health = store.HealthSnapshot();
+            Assert.Equal(0, health.BeginFailureCount);
+            Assert.Equal(0, health.AppendFailureCount);
+            Assert.Equal(0, health.StructuredLogFailureCount);
+        }
+
+        private sealed class RecordingLogger : ILogger<PlatformAuditStore>
+        {
+            internal bool ThrowInformation { get; init; }
+
+            internal bool ThrowWarning { get; init; }
+
+            internal int InformationAttempts { get; private set; }
+
+            internal int WarningAttempts { get; private set; }
+
+            internal List<LogEntry> Entries { get; } = new();
+
+            public IDisposable? BeginScope<TState>(TState state)
+                where TState : notnull => NullScope.Instance;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                if (logLevel == LogLevel.Information)
+                {
+                    InformationAttempts++;
+                    if (ThrowInformation)
+                    {
+                        throw new InvalidOperationException("injected logger failure");
+                    }
+                }
+
+                if (logLevel == LogLevel.Warning)
+                {
+                    WarningAttempts++;
+                    if (ThrowWarning)
+                    {
+                        throw new InvalidOperationException("injected logger failure");
+                    }
+                }
+
+                var values = state is IEnumerable<KeyValuePair<string, object?>> pairs
+                    ? pairs.Where(pair => pair.Key != "{OriginalFormat}")
+                        .ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.Ordinal)
+                    : new Dictionary<string, object?>();
+                Entries.Add(new LogEntry(logLevel, formatter(state, exception), values, exception));
+            }
+        }
+
+        private sealed record LogEntry(
+            LogLevel Level,
+            string Rendered,
+            IReadOnlyDictionary<string, object?> State,
+            Exception? Exception);
+
+        private sealed class NullScope : IDisposable
+        {
+            internal static NullScope Instance { get; } = new();
+
+            public void Dispose()
+            {
+            }
+        }
+
+        private class ManualTimeProvider(DateTimeOffset now) : TimeProvider
+        {
+            private DateTimeOffset _now = now;
+            private long _timestamp;
+
+            public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+            public override DateTimeOffset GetUtcNow() => _now;
+
+            public override long GetTimestamp() => _timestamp;
+
+            internal void Advance(TimeSpan duration)
+            {
+                _now += duration;
+                _timestamp += duration.Ticks;
+            }
+        }
+
+        private sealed class ThrowOnSecondUtcReadTimeProvider(DateTimeOffset now) : ManualTimeProvider(now)
+        {
+            private int _reads;
+
+            public override DateTimeOffset GetUtcNow()
+            {
+                if (++_reads == 2)
+                {
+                    throw new InvalidOperationException("injected append-time failure");
+                }
+
+                return base.GetUtcNow();
+            }
+        }
+
+        private sealed class AlwaysThrowingTimeProvider : TimeProvider
+        {
+            public override DateTimeOffset GetUtcNow() => throw new InvalidOperationException("injected begin-time failure");
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformWireFormatTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformWireFormatTests.cs
@@ -242,6 +242,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
                 descriptor => descriptor.ServiceType == typeof(PlatformIdempotencyStore));
             Assert.Equal(ServiceLifetime.Singleton, idempotencyRegistration.Lifetime);
 
+            var auditRegistration = Assert.Single(
+                services,
+                descriptor => descriptor.ServiceType == typeof(PlatformAuditStore));
+            Assert.Equal(ServiceLifetime.Singleton, auditRegistration.Lifetime);
+
             Assert.True(CanRead(formatter, typeof(TestController)));
             Assert.False(CanRead(formatter, typeof(LegacyController)));
         }

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformAudit.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformAudit.cs
@@ -1,0 +1,202 @@
+using System;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>Whether current Platform authority admitted or denied an action attempt.</summary>
+    internal enum PlatformAuditDecision
+    {
+        /// <summary>The action passed authority checks, regardless of its later result.</summary>
+        Allowed,
+
+        /// <summary>The action was refused before an owner could run.</summary>
+        Denied,
+    }
+
+    /// <summary>The closed terminal result vocabulary retained by the audit journal.</summary>
+    internal enum PlatformAuditResultCode
+    {
+        /// <summary>The owner completed the mutation successfully.</summary>
+        Succeeded,
+
+        /// <summary>A prior identical idempotent execution supplied the result.</summary>
+        IdempotencyReplayed,
+
+        /// <summary>Current Jellyfin or feature authority denied the attempt.</summary>
+        AuthorityDenied,
+
+        /// <summary>The opaque capability was malformed or did not match its context.</summary>
+        CapabilityInvalid,
+
+        /// <summary>The opaque capability had already been consumed.</summary>
+        CapabilityReplayed,
+
+        /// <summary>The opaque capability had expired.</summary>
+        CapabilityExpired,
+
+        /// <summary>No code-owned operation matched the caller's request.</summary>
+        UnknownOperation,
+
+        /// <summary>The bounded typed operation input was invalid.</summary>
+        InvalidInput,
+
+        /// <summary>The idempotency tuple conflicted with different input.</summary>
+        Conflict,
+
+        /// <summary>A bounded admission or concurrency limit rejected the attempt.</summary>
+        RateLimited,
+
+        /// <summary>A prior mutation may have committed without a publishable result.</summary>
+        Indeterminate,
+
+        /// <summary>The connected caller canceled the admitted attempt.</summary>
+        CallerCancelled,
+
+        /// <summary>The Platform request deadline canceled the admitted attempt.</summary>
+        DeadlineExceeded,
+
+        /// <summary>The fixed first-party owner returned a bounded failure.</summary>
+        OwnerFailed,
+
+        /// <summary>The Platform kernel failed to classify or complete the attempt.</summary>
+        InternalFailure,
+    }
+
+    /// <summary>Whether the journal subject was resolved through the code-owned vocabulary.</summary>
+    internal enum PlatformAuditSubjectResolution
+    {
+        /// <summary>A known operation and family are retained.</summary>
+        Resolved,
+
+        /// <summary>The fixed unresolved sentinel is retained; caller text is discarded.</summary>
+        Unresolved,
+    }
+
+    /// <summary>The fixed stages at which audit infrastructure can fail safely.</summary>
+    internal enum PlatformAuditFailureStage
+    {
+        /// <summary>An attempt could not be initialized.</summary>
+        Begin,
+
+        /// <summary>A terminal record could not be appended to the bounded journal.</summary>
+        Append,
+
+        /// <summary>The already-bounded record could not be published to structured logging.</summary>
+        StructuredLog,
+    }
+
+    /// <summary>
+    /// One immutable, redacted terminal action record. Its shape is an allowlist: there
+    /// is deliberately no payload, item, title, capability, key, URL, response, message,
+    /// exception, principal, or HTTP object.
+    /// </summary>
+    internal sealed class PlatformAuditRecord
+    {
+        internal PlatformAuditRecord(
+            PlatformAuditSubjectResolution subjectResolution,
+            PlatformOperationId? operation,
+            PlatformOperationFamily? family,
+            Guid actorUserId,
+            bool actorWasElevated,
+            string? clientAttributionDigest,
+            string? deviceAttributionDigest,
+            PlatformAuditDecision decision,
+            PlatformAuditResultCode resultCode,
+            long durationMilliseconds,
+            string correlationId,
+            DateTimeOffset startedAtUtc,
+            DateTimeOffset completedAtUtc)
+        {
+            SubjectResolution = subjectResolution;
+            Operation = operation;
+            Family = family;
+            ActorUserId = actorUserId;
+            ActorWasElevated = actorWasElevated;
+            ClientAttributionDigest = clientAttributionDigest;
+            DeviceAttributionDigest = deviceAttributionDigest;
+            Decision = decision;
+            ResultCode = resultCode;
+            DurationMilliseconds = durationMilliseconds;
+            CorrelationId = correlationId;
+            StartedAtUtc = startedAtUtc;
+            CompletedAtUtc = completedAtUtc;
+        }
+
+        internal PlatformAuditSubjectResolution SubjectResolution { get; }
+
+        internal PlatformOperationId? Operation { get; }
+
+        internal PlatformOperationFamily? Family { get; }
+
+        internal Guid ActorUserId { get; }
+
+        internal bool ActorWasElevated { get; }
+
+        internal string? ClientAttributionDigest { get; }
+
+        internal string? DeviceAttributionDigest { get; }
+
+        internal PlatformAuditDecision Decision { get; }
+
+        internal PlatformAuditResultCode ResultCode { get; }
+
+        internal long DurationMilliseconds { get; }
+
+        internal string CorrelationId { get; }
+
+        internal DateTimeOffset StartedAtUtc { get; }
+
+        internal DateTimeOffset CompletedAtUtc { get; }
+    }
+
+    /// <summary>A constant-size view of failures inside the non-throwing audit owner.</summary>
+    internal sealed class PlatformAuditHealthSnapshot
+    {
+        internal PlatformAuditHealthSnapshot(
+            long beginFailureCount,
+            long appendFailureCount,
+            long structuredLogFailureCount,
+            DateTimeOffset? lastBeginFailureAtUtc,
+            DateTimeOffset? lastAppendFailureAtUtc,
+            DateTimeOffset? lastStructuredLogFailureAtUtc,
+            string? lastBeginFailureCorrelationId,
+            string? lastAppendFailureCorrelationId,
+            string? lastStructuredLogFailureCorrelationId)
+        {
+            BeginFailureCount = beginFailureCount;
+            AppendFailureCount = appendFailureCount;
+            StructuredLogFailureCount = structuredLogFailureCount;
+            LastBeginFailureAtUtc = lastBeginFailureAtUtc;
+            LastAppendFailureAtUtc = lastAppendFailureAtUtc;
+            LastStructuredLogFailureAtUtc = lastStructuredLogFailureAtUtc;
+            LastBeginFailureCorrelationId = lastBeginFailureCorrelationId;
+            LastAppendFailureCorrelationId = lastAppendFailureCorrelationId;
+            LastStructuredLogFailureCorrelationId = lastStructuredLogFailureCorrelationId;
+        }
+
+        internal long BeginFailureCount { get; }
+
+        internal long AppendFailureCount { get; }
+
+        internal long StructuredLogFailureCount { get; }
+
+        internal DateTimeOffset? LastBeginFailureAtUtc { get; }
+
+        internal DateTimeOffset? LastAppendFailureAtUtc { get; }
+
+        internal DateTimeOffset? LastStructuredLogFailureAtUtc { get; }
+
+        internal string? LastBeginFailureCorrelationId { get; }
+
+        internal string? LastAppendFailureCorrelationId { get; }
+
+        internal string? LastStructuredLogFailureCorrelationId { get; }
+    }
+
+    /// <summary>The only coordinator-facing surface of a store-owned audit attempt.</summary>
+    internal interface IPlatformAuditAttempt : IDisposable
+    {
+        /// <summary>Completes the attempt once with a closed terminal result.</summary>
+        bool Complete(PlatformAuditResultCode resultCode);
+    }
+
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformAuditStore.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformAuditStore.cs
@@ -1,0 +1,487 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>
+    /// Process-local owner of bounded, redacted first-party action audit records.
+    /// </summary>
+    /// <remarks>
+    /// The fixed ring retains at most <see cref="MaximumRecords"/> records and evicts
+    /// strictly in terminal insertion order. All writers share one short lock; there is
+    /// no work proportional to users or library size. Structured publication happens
+    /// after the lock and cannot delay another append.
+    /// </remarks>
+    public sealed class PlatformAuditStore
+    {
+        /// <summary>The exact process-wide recent-record capacity.</summary>
+        public const int MaximumRecords = 1024;
+
+        internal const int AttributionDigestCharacters = 64;
+
+        private const int AttributionKeyBytes = 32;
+        private const string UnresolvedSubject = "unresolved";
+        private const string UnavailableAttribution = "unavailable";
+        private const string UnavailableCorrelation = "unavailable";
+
+        private readonly object _gate = new();
+        private readonly object _healthGate = new();
+        private readonly PlatformAuditRecord?[] _records = new PlatformAuditRecord?[MaximumRecords];
+        private readonly ILogger<PlatformAuditStore> _logger;
+        private readonly TimeProvider _timeProvider;
+        private readonly byte[] _attributionKey;
+        private int _nextIndex;
+        private int _count;
+        private bool _failureWarningEmitted;
+        private long _beginFailureCount;
+        private long _appendFailureCount;
+        private long _structuredLogFailureCount;
+        private DateTimeOffset? _lastBeginFailureAtUtc;
+        private DateTimeOffset? _lastAppendFailureAtUtc;
+        private DateTimeOffset? _lastStructuredLogFailureAtUtc;
+        private string? _lastBeginFailureCorrelationId;
+        private string? _lastAppendFailureCorrelationId;
+        private string? _lastStructuredLogFailureCorrelationId;
+
+        /// <summary>
+        /// One-shot terminal completion handle used by the future action coordinator.
+        /// Its constructor and redacted prefix are store-private, so same-assembly code
+        /// cannot bypass <see cref="Begin"/> and inject raw text into audit or logging.
+        /// </summary>
+        private sealed class AuditAttempt : IPlatformAuditAttempt
+        {
+            private readonly PlatformAuditStore? _owner;
+            private readonly AuditPrefix? _prefix;
+            private int _completed;
+
+            internal AuditAttempt(PlatformAuditStore owner, AuditPrefix prefix)
+            {
+                _owner = owner;
+                _prefix = prefix;
+            }
+
+            private AuditAttempt()
+            {
+                _completed = 1;
+            }
+
+            internal static IPlatformAuditAttempt Disabled { get; } = new AuditAttempt();
+
+            /// <summary>
+            /// Publishes at most one terminal record. Audit failures are retained in
+            /// bounded health state and never escape across the action boundary.
+            /// </summary>
+            public bool Complete(PlatformAuditResultCode resultCode)
+            {
+                if (Interlocked.CompareExchange(ref _completed, 1, 0) != 0)
+                {
+                    return false;
+                }
+
+                if (_owner is not null && _prefix is not null)
+                {
+                    _owner.TryComplete(
+                        _prefix,
+                        Enum.IsDefined(resultCode) ? resultCode : PlatformAuditResultCode.InternalFailure);
+                }
+
+                return true;
+            }
+
+            /// <inheritdoc />
+            public void Dispose() => Complete(PlatformAuditResultCode.InternalFailure);
+        }
+
+        /// <summary>Store-private redacted evidence captured before an action begins.</summary>
+        private sealed class AuditPrefix
+        {
+            internal AuditPrefix(
+                PlatformAuditSubjectResolution subjectResolution,
+                PlatformOperationId? operation,
+                PlatformOperationFamily? family,
+                Guid actorUserId,
+                bool actorWasElevated,
+                string? clientAttributionDigest,
+                string? deviceAttributionDigest,
+                string correlationId,
+                DateTimeOffset startedAtUtc,
+                long startedTimestamp)
+            {
+                SubjectResolution = subjectResolution;
+                Operation = operation;
+                Family = family;
+                ActorUserId = actorUserId;
+                ActorWasElevated = actorWasElevated;
+                ClientAttributionDigest = clientAttributionDigest;
+                DeviceAttributionDigest = deviceAttributionDigest;
+                CorrelationId = correlationId;
+                StartedAtUtc = startedAtUtc;
+                StartedTimestamp = startedTimestamp;
+            }
+
+            internal PlatformAuditSubjectResolution SubjectResolution { get; }
+
+            internal PlatformOperationId? Operation { get; }
+
+            internal PlatformOperationFamily? Family { get; }
+
+            internal Guid ActorUserId { get; }
+
+            internal bool ActorWasElevated { get; }
+
+            internal string? ClientAttributionDigest { get; }
+
+            internal string? DeviceAttributionDigest { get; }
+
+            internal string CorrelationId { get; }
+
+            internal DateTimeOffset StartedAtUtc { get; }
+
+            internal long StartedTimestamp { get; }
+        }
+
+        /// <summary>Initializes the production journal with a process-local attribution key.</summary>
+        public PlatformAuditStore(ILogger<PlatformAuditStore> logger)
+            : this(logger, TimeProvider.System, RandomNumberGenerator.GetBytes(AttributionKeyBytes))
+        {
+        }
+
+        internal PlatformAuditStore(
+            ILogger<PlatformAuditStore> logger,
+            TimeProvider timeProvider,
+            ReadOnlySpan<byte> attributionKey)
+        {
+            ArgumentNullException.ThrowIfNull(logger);
+            ArgumentNullException.ThrowIfNull(timeProvider);
+            if (attributionKey.Length != AttributionKeyBytes)
+            {
+                throw new ArgumentException($"The audit attribution key must contain {AttributionKeyBytes} bytes.", nameof(attributionKey));
+            }
+
+            _logger = logger;
+            _timeProvider = timeProvider;
+            _attributionKey = attributionKey.ToArray();
+        }
+
+        /// <summary>Begins an attempt for one definition from the code-owned vocabulary.</summary>
+        internal IPlatformAuditAttempt Begin(PlatformActor actor, PlatformOperationDefinition operation)
+        {
+            try
+            {
+                ArgumentNullException.ThrowIfNull(actor);
+                ArgumentNullException.ThrowIfNull(operation);
+                var owned = PlatformOperationVocabulary.Find(operation.Id.Value);
+                if (!ReferenceEquals(owned, operation))
+                {
+                    throw new ArgumentException("The audit subject must be a code-owned Platform operation.", nameof(operation));
+                }
+
+                return BeginCore(actor, PlatformAuditSubjectResolution.Resolved, operation.Id, operation.Family);
+            }
+            catch (Exception)
+            {
+                ReportFailure(PlatformAuditFailureStage.Begin, SafeCorrelation(actor?.CorrelationId), tryFallbackWarning: true);
+                return AuditAttempt.Disabled;
+            }
+        }
+
+        /// <summary>
+        /// Begins an unresolved action attempt without accepting or retaining the
+        /// caller-supplied operation spelling.
+        /// </summary>
+        internal IPlatformAuditAttempt BeginUnresolved(PlatformActor actor)
+        {
+            try
+            {
+                ArgumentNullException.ThrowIfNull(actor);
+                return BeginCore(actor, PlatformAuditSubjectResolution.Unresolved, operation: null, family: null);
+            }
+            catch (Exception)
+            {
+                ReportFailure(PlatformAuditFailureStage.Begin, SafeCorrelation(actor?.CorrelationId), tryFallbackWarning: true);
+                return AuditAttempt.Disabled;
+            }
+        }
+
+        internal IReadOnlyList<PlatformAuditRecord> Snapshot()
+        {
+            lock (_gate)
+            {
+                var result = new List<PlatformAuditRecord>(_count);
+                var first = _count == MaximumRecords ? _nextIndex : 0;
+                for (var offset = 0; offset < _count; offset++)
+                {
+                    var record = _records[(first + offset) % MaximumRecords];
+                    if (record is not null)
+                    {
+                        result.Add(record);
+                    }
+                }
+
+                return result;
+            }
+        }
+
+        internal PlatformAuditHealthSnapshot HealthSnapshot()
+        {
+            lock (_healthGate)
+            {
+                return new PlatformAuditHealthSnapshot(
+                    _beginFailureCount,
+                    _appendFailureCount,
+                    _structuredLogFailureCount,
+                    _lastBeginFailureAtUtc,
+                    _lastAppendFailureAtUtc,
+                    _lastStructuredLogFailureAtUtc,
+                    _lastBeginFailureCorrelationId,
+                    _lastAppendFailureCorrelationId,
+                    _lastStructuredLogFailureCorrelationId);
+            }
+        }
+
+        private void TryComplete(AuditPrefix prefix, PlatformAuditResultCode resultCode)
+        {
+            PlatformAuditRecord record;
+            try
+            {
+                var completedAtUtc = _timeProvider.GetUtcNow().ToUniversalTime();
+                if (completedAtUtc < prefix.StartedAtUtc)
+                {
+                    completedAtUtc = prefix.StartedAtUtc;
+                }
+
+                var elapsed = _timeProvider.GetElapsedTime(prefix.StartedTimestamp);
+                var durationMilliseconds = Math.Max(0, elapsed.Ticks / TimeSpan.TicksPerMillisecond);
+                record = new PlatformAuditRecord(
+                    prefix.SubjectResolution,
+                    prefix.Operation,
+                    prefix.Family,
+                    prefix.ActorUserId,
+                    prefix.ActorWasElevated,
+                    prefix.ClientAttributionDigest,
+                    prefix.DeviceAttributionDigest,
+                    DecisionFor(resultCode),
+                    resultCode,
+                    durationMilliseconds,
+                    prefix.CorrelationId,
+                    prefix.StartedAtUtc,
+                    completedAtUtc);
+
+                lock (_gate)
+                {
+                    _records[_nextIndex] = record;
+                    _nextIndex = (_nextIndex + 1) % MaximumRecords;
+                    if (_count < MaximumRecords)
+                    {
+                        _count++;
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                ReportFailure(PlatformAuditFailureStage.Append, prefix.CorrelationId, tryFallbackWarning: true);
+                return;
+            }
+
+            try
+            {
+                _logger.LogInformation(
+                    "Platform action audit. Family={AuditFamily} Operation={AuditOperation} ActorUserId={AuditActorUserId} ActorElevated={AuditActorElevated} ClientAttribution={AuditClientAttribution} DeviceAttribution={AuditDeviceAttribution} Decision={AuditDecision} ResultCode={AuditResultCode} DurationMilliseconds={AuditDurationMilliseconds} CorrelationId={CorrelationId} StartedAtUtc={AuditStartedAtUtc} CompletedAtUtc={AuditCompletedAtUtc}",
+                    FamilyToken(record.Family),
+                    record.Operation?.Value ?? UnresolvedSubject,
+                    record.ActorUserId,
+                    record.ActorWasElevated,
+                    record.ClientAttributionDigest ?? UnavailableAttribution,
+                    record.DeviceAttributionDigest ?? UnavailableAttribution,
+                    DecisionToken(record.Decision),
+                    ResultToken(record.ResultCode),
+                    record.DurationMilliseconds,
+                    record.CorrelationId,
+                    record.StartedAtUtc,
+                    record.CompletedAtUtc);
+            }
+            catch (Exception)
+            {
+                ReportFailure(PlatformAuditFailureStage.StructuredLog, record.CorrelationId, tryFallbackWarning: false);
+            }
+        }
+
+        private IPlatformAuditAttempt BeginCore(
+            PlatformActor actor,
+            PlatformAuditSubjectResolution subjectResolution,
+            PlatformOperationId? operation,
+            PlatformOperationFamily? family)
+        {
+            var startedAtUtc = _timeProvider.GetUtcNow().ToUniversalTime();
+            var startedTimestamp = _timeProvider.GetTimestamp();
+            var prefix = new AuditPrefix(
+                subjectResolution,
+                operation,
+                family,
+                actor.UserId,
+                actor.IsElevated,
+                DigestAttribution(actor.ClientName, "client", PlatformActorBoundaryFilter.MaxClientNameBytes),
+                DigestAttribution(actor.DeviceId, "device", PlatformActorBoundaryFilter.MaxDeviceIdBytes),
+                SafeCorrelation(actor.CorrelationId),
+                startedAtUtc,
+                startedTimestamp);
+
+            return new AuditAttempt(this, prefix);
+        }
+
+        private string? DigestAttribution(string? value, string domain, int maximumUtf8Bytes)
+        {
+            if (string.IsNullOrWhiteSpace(value)
+                || value.Any(character => char.IsControl(character) || character is '\u2028' or '\u2029'))
+            {
+                return null;
+            }
+
+            var byteCount = Encoding.UTF8.GetByteCount(value);
+            if (byteCount > maximumUtf8Bytes)
+            {
+                return null;
+            }
+
+            var domainBytes = Encoding.UTF8.GetBytes(domain + "\0");
+            var input = new byte[domainBytes.Length + byteCount];
+            domainBytes.CopyTo(input, 0);
+            Encoding.UTF8.GetBytes(value, input.AsSpan(domainBytes.Length));
+            return Convert.ToHexString(HMACSHA256.HashData(_attributionKey, input)).ToLowerInvariant();
+        }
+
+        private void ReportFailure(PlatformAuditFailureStage stage, string correlationId, bool tryFallbackWarning)
+        {
+            var atUtc = SafeUtcNow();
+            var emitWarning = false;
+            lock (_healthGate)
+            {
+                switch (stage)
+                {
+                    case PlatformAuditFailureStage.Begin:
+                        _beginFailureCount = SaturatingIncrement(_beginFailureCount);
+                        _lastBeginFailureAtUtc = atUtc;
+                        _lastBeginFailureCorrelationId = correlationId;
+                        break;
+                    case PlatformAuditFailureStage.Append:
+                        _appendFailureCount = SaturatingIncrement(_appendFailureCount);
+                        _lastAppendFailureAtUtc = atUtc;
+                        _lastAppendFailureCorrelationId = correlationId;
+                        break;
+                    case PlatformAuditFailureStage.StructuredLog:
+                        _structuredLogFailureCount = SaturatingIncrement(_structuredLogFailureCount);
+                        _lastStructuredLogFailureAtUtc = atUtc;
+                        _lastStructuredLogFailureCorrelationId = correlationId;
+                        break;
+                    default:
+                        return;
+                }
+
+                if (tryFallbackWarning && !_failureWarningEmitted)
+                {
+                    _failureWarningEmitted = true;
+                    emitWarning = true;
+                }
+            }
+
+            if (!emitWarning)
+            {
+                return;
+            }
+
+            try
+            {
+                _logger.LogWarning(
+                    "Platform audit failed internally. Stage={AuditFailureStage} CorrelationId={CorrelationId}",
+                    FailureStageToken(stage),
+                    correlationId);
+            }
+            catch (Exception)
+            {
+                ReportFailure(PlatformAuditFailureStage.StructuredLog, correlationId, tryFallbackWarning: false);
+            }
+        }
+
+        private DateTimeOffset SafeUtcNow()
+        {
+            try
+            {
+                return _timeProvider.GetUtcNow().ToUniversalTime();
+            }
+            catch (Exception)
+            {
+                return DateTimeOffset.UtcNow;
+            }
+        }
+
+        private static PlatformAuditDecision DecisionFor(PlatformAuditResultCode resultCode) => resultCode switch
+        {
+            PlatformAuditResultCode.AuthorityDenied
+                or PlatformAuditResultCode.CapabilityInvalid
+                or PlatformAuditResultCode.CapabilityReplayed
+                or PlatformAuditResultCode.CapabilityExpired
+                or PlatformAuditResultCode.UnknownOperation => PlatformAuditDecision.Denied,
+            _ => PlatformAuditDecision.Allowed,
+        };
+
+        private static string SafeCorrelation(string? value)
+        {
+            if (value is null || value.Length != 32 || value.Any(character => character is not (>= '0' and <= '9') and not (>= 'a' and <= 'f')))
+            {
+                return UnavailableCorrelation;
+            }
+
+            return value;
+        }
+
+        private static long SaturatingIncrement(long value) => value == long.MaxValue ? value : value + 1;
+
+        private static string FamilyToken(PlatformOperationFamily? family) => family switch
+        {
+            PlatformOperationFamily.SpoilerGuard => "spoiler_guard",
+            PlatformOperationFamily.HiddenContent => "hidden_content",
+            PlatformOperationFamily.Seerr => "seerr",
+            _ => UnresolvedSubject,
+        };
+
+        private static string DecisionToken(PlatformAuditDecision decision) => decision switch
+        {
+            PlatformAuditDecision.Allowed => "allowed",
+            PlatformAuditDecision.Denied => "denied",
+            _ => "allowed",
+        };
+
+        private static string ResultToken(PlatformAuditResultCode resultCode) => resultCode switch
+        {
+            PlatformAuditResultCode.Succeeded => "succeeded",
+            PlatformAuditResultCode.IdempotencyReplayed => "idempotency_replayed",
+            PlatformAuditResultCode.AuthorityDenied => "authority_denied",
+            PlatformAuditResultCode.CapabilityInvalid => "capability_invalid",
+            PlatformAuditResultCode.CapabilityReplayed => "capability_replayed",
+            PlatformAuditResultCode.CapabilityExpired => "capability_expired",
+            PlatformAuditResultCode.UnknownOperation => "unknown_operation",
+            PlatformAuditResultCode.InvalidInput => "invalid_input",
+            PlatformAuditResultCode.Conflict => "conflict",
+            PlatformAuditResultCode.RateLimited => "rate_limited",
+            PlatformAuditResultCode.Indeterminate => "indeterminate",
+            PlatformAuditResultCode.CallerCancelled => "caller_cancelled",
+            PlatformAuditResultCode.DeadlineExceeded => "deadline_exceeded",
+            PlatformAuditResultCode.OwnerFailed => "owner_failed",
+            PlatformAuditResultCode.InternalFailure => "internal_failure",
+            _ => "internal_failure",
+        };
+
+        private static string FailureStageToken(PlatformAuditFailureStage stage) => stage switch
+        {
+            PlatformAuditFailureStage.Begin => "begin",
+            PlatformAuditFailureStage.Append => "append",
+            PlatformAuditFailureStage.StructuredLog => "structured_log",
+            _ => "append",
+        };
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
@@ -40,6 +40,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy
             // One process-local 256-bit authority and nonce ledger for short-lived
             // native action capabilities. Restart intentionally invalidates every token.
             serviceCollection.AddSingleton<PlatformActionCapabilityService>();
+            // One process-wide, fixed-capacity owner for redacted terminal Platform
+            // action audit. It exposes no route and retains no caller payload.
+            serviceCollection.AddSingleton<PlatformAuditStore>();
 
             // a named HttpClient with AllowAutoRedirect=false so
             // forward-auth proxies (Authelia / Pangolin / Authentik) returning

--- a/docs/platform-contract.md
+++ b/docs/platform-contract.md
@@ -191,6 +191,40 @@ or coordinate multiple server processes.
 Coalesced waits are bounded too: at most 64 followers per in-flight key and 1,024 across
 the process. Excess followers receive the same pre-execution `429 rate_limited` outcome.
 
+## Native action audit
+
+Every action admitted to the native Platform coordinator creates one internal attempt.
+Closing that attempt appends exactly one terminal record for success, denial,
+idempotency replay, capability replay or expiry, cancellation, timeout, conflict,
+rate limiting, indeterminate execution, or owner failure. Exceptional disposal closes
+the attempt as an internal failure. Pre-admission HTTP failures, including a request
+rejected before an authoritative actor or operation is established, are outside this
+action audit.
+
+The record is a closed allowlist: a typed code-owned operation and family (or the fixed
+`unresolved` sentinel), actor user ID and elevated-state bit, decision, result code,
+duration, host correlation ID, and start/completion timestamps. Optional client and
+device attribution is HMAC-SHA-256 reduced with a process-random key and separate
+`client` and `device` domains. Invalid attribution and correlation are discarded rather
+than copied. Caller operation text is discarded on failed resolution.
+
+No token, capability, idempotency key, request body, item ID or title, Seerr key or URL,
+upstream response, exception, or arbitrary message has a record or logging field. The
+corresponding structured log uses only the same fixed, reduced values; its correlation
+ID is the same one returned by an ordinary action response. A caller disconnect has no
+response to join, but the terminal audit still carries the host correlation ID.
+
+Retention is an in-process fixed ring of exactly 1,024 records. Appends are serialized,
+constant-time, and evict the oldest completed record deterministically at capacity.
+The ring therefore has constant cardinality independent of users, library size, and
+request volume. Audit append or logging failures never replace or retry the selected
+action outcome. Only constant-size per-stage failure counters and last-failure metadata
+are retained, and the fallback warning is coalesced.
+
+There is deliberately no audit HTTP route or global read surface in Platform v1.
+Persistent or distributed retention, admin UI, export, and telemetry integration are
+future work and require a separate authority and privacy review.
+
 ## Closed native-pilot operation vocabulary
 
 Native actions do not name a controller, route, HTTP method, service or upstream

--- a/research/extension-platform/threat-model.md
+++ b/research/extension-platform/threat-model.md
@@ -218,7 +218,11 @@ this reason — Jellyfin 12 *does* accept `?apikey=`, so the safe choice must be
 made deliberately
 ([S8](spike-evidence.md#s8--browser-eventsource-cannot-authenticate-safely),
 [ADR-0006](adr/0006-client-event-transport.md)). Audit and diagnostics are
-redacted by construction.
+redacted by construction: terminal native-action records have a closed typed
+allowlist, client and device attribution is domain-separated HMAC-SHA-256, and
+caller operation text is discarded when resolution fails. Tokens, capabilities,
+request bodies, titles, Seerr keys and URLs, and upstream responses have no audit
+or structured-log field.
 *Residual.* **Low.**
 
 ### T-09 · SSRF via extension-supplied URLs — **medium**
@@ -244,7 +248,9 @@ host's only free limit is Kestrel's 30,000,000 bytes and exceeding it produces a
 opaque `500`, not a `413`
 ([S11](spike-evidence.md#s11--request-size-and-json-depth-boundaries)). Per-extension
 concurrency caps, bulkheads, circuit breakers, coalescing, bounded retention and
-disconnect-and-resync for slow consumers.
+disconnect-and-resync for slow consumers. Native-action audit uses one fixed
+1,024-record FIFO ring with constant-size failure health state; concurrent appends
+cannot grow storage, and audit/logging failure never retries an action.
 *Residual.* **Medium.** No load or concurrency testing has been done; every spike
 probe was sequential.
 

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,7 +26,7 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2808, totalLines: 3201 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 32799, totalLines: 41516 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 33118, totalLines: 41847 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 3,
         minimumCoveredLines: 2808,
@@ -34,8 +34,8 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
     });
     assert.deepEqual(baselines.profiles.server.observations, {
         cleanRuns: 3,
-        minimumCoveredLines: 32798,
-        maximumCoveredLines: 32799,
+        minimumCoveredLines: 33117,
+        maximumCoveredLines: 33118,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 1);

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 32799,
-        "totalLines": 41516
+        "coveredLines": 33118,
+        "totalLines": 41847
       },
       "observations": {
         "cleanRuns": 3,
-        "minimumCoveredLines": 32798,
-        "maximumCoveredLines": 32799
+        "minimumCoveredLines": 33117,
+        "maximumCoveredLines": 33118
       },
       "tolerance": {
         "missingCoveredLines": 1,
-        "rationale": "The #589 HTTP-free prepared-action capability service builds on the combined #588/#593 tree with a process-local 256-bit HMAC authority, canonical length-prefixed claims, full tags and keyed device attenuation, a bounded mint-time nonce ledger, exact current-vocabulary validation, service-sealed current-validation evidence, one-shot consumption, and revision/restart invalidation. Three clean Coverlet runs on the identical rebased 2026-08-03 source and 41,516-line scope each passed all 2,882 server tests: two measured 32,799 covered lines and one measured 32,798. Relative to the reviewed #593 main high-water of 32,364/41,049 (78.842%), #589 adds 467 instrumented lines and raises the observed high-water by 435 covered lines to 32,799/41,516 (79.003%). The exact one-line 32,798-32,799 instrumentation envelope therefore sets a 32,799 high-water with a one-line tolerance and a floor of 32,798/41,516 (79.001%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "rationale": "The rebased #589 plus bounded native-action audit #590 tree retains the process-local prepared-action capability authority and adds a closed typed terminal record, irreversible domain-separated client/device attribution, one-shot completion, deterministic 1,024-record FIFO retention, failure isolation, and architecture guards against audit HTTP exposure or free-form data paths. Three clean Coverlet runs on the identical rebased 2026-08-03 source and 41,847-line scope each passed all 2,910 server tests: one measured 33,118 covered lines and two measured 33,117. Relative to the reviewed #589 main high-water of 32,799/41,516 (79.003%), #590 adds 331 instrumented lines and raises the observed high-water by 319 covered lines to 33,118/41,847 (79.141%). The exact one-line 33,117-33,118 local instrumentation envelope therefore sets a 33,118 high-water with a one-line tolerance and a floor of 33,117/41,847 (79.138%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
Closes #590.\n\nAdds the process-local audit owner required by the native first-party action coordinator. Every attempt completes through a sealed one-shot handle into a typed terminal record with a closed operation/family/decision/result vocabulary, bounded actor attribution, correlation, duration, and timestamps. There is no payload/message/exception field and no audit HTTP or global controller surface.\n\nSecurity and bounds:\n- client/device attribution is reduced with process-keyed domain-separated HMAC-SHA-256\n- caller operation text is discarded for unresolved actions\n- private store-owned completion evidence prevents same-assembly raw-string injection\n- deterministic concurrency-safe FIFO ring retains at most 1,024 records\n- append/log failures never replace the selected action outcome and surface only bounded health counters\n- architecture guards inventory every controller namespace and reject audit store/record exposure\n\nVerification on capability-enabled main:\n- combined focused capability/audit/wire tests: 74/74\n- three clean full coverage observations: 2,910/2,910 each; 33,117, 33,118, 33,117 of 41,847 sequence points\n- coverage ratchet: pass with high-water 33,118 and unchanged one-line tolerance\n- script suite: 634/634\n- strict docs: pass\n- Release build: zero warnings/errors\n- independent adversarial rereview: APPROVE after sealed-evidence and all-controller guard fixes