### PR TITLE
feat(platform): bridge Spoiler Guard item owner

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/SpoilerGuardPlatformItemActionAdapterTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/SpoilerGuardPlatformItemActionAdapterTests.cs
@@ -1,7 +1,12 @@
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
 using Jellyfin.Plugin.JellyfinCanopy.Platform;
 using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
 using Jellyfin.Plugin.JellyfinCanopy.Services;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform;
@@ -47,6 +52,67 @@ public sealed class SpoilerGuardPlatformItemActionAdapterTests
             new HostAccessibleItem(Guid.NewGuid(), HostItemKind.Episode, Guid.NewGuid(), []),
             new SpoilerGuardItemConfiguration(enabled: false)));
         Assert.Equal(0, owner.ConfigureCalls);
+    }
+
+    [Fact]
+    public void ExistingMovie_WithNoPlatformDisplayName_PreservesOwnerStateAndRevision()
+    {
+        var directory = Path.Combine(
+            Path.GetTempPath(),
+            "jc-sg-platform-adapter-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var manager = new UserConfigurationManager(
+                new StubAppPaths(directory),
+                NullLogger<UserConfigurationManager>.Instance);
+            var userId = Guid.NewGuid();
+            var itemId = Guid.NewGuid();
+            var itemKey = itemId.ToString("N");
+            manager.SaveUserConfiguration(
+                userId.ToString("N"),
+                "spoilerblur.json",
+                new UserSpoilerBlur
+                {
+                    OverridesRevision = 17,
+                    Movies = new Dictionary<string, SpoilerBlurMovieEntry>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        [itemKey] = new SpoilerBlurMovieEntry
+                        {
+                            MovieId = itemKey,
+                            MovieName = "Preserve this title",
+                            EnabledAt = "2026-08-03T01:02:03.0000000Z",
+                        },
+                    },
+                });
+
+            var adapter = new SpoilerGuardPlatformItemActionAdapter(
+                new SpoilerGuardItemActionOwner(manager));
+            var result = adapter.Configure(
+                new PlatformActor(userId, false, "correlation", null, null),
+                new HostAccessibleItem(itemId, HostItemKind.Movie, seriesId: null, []),
+                new SpoilerGuardItemConfiguration(enabled: true));
+            var stored = manager.GetUserConfigurationStrict<UserSpoilerBlur>(
+                userId.ToString("N"),
+                "spoilerblur.json");
+
+            Assert.Equal(SpoilerGuardItemActionOutcome.Configured, result.Outcome);
+            Assert.False(result.Changed);
+            Assert.Equal(17, result.Revision);
+            Assert.Equal(17, stored.OverridesRevision);
+            Assert.Equal("Preserve this title", stored.Movies[itemKey].MovieName);
+            Assert.Equal("2026-08-03T01:02:03.0000000Z", stored.Movies[itemKey].EnabledAt);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch
+            {
+                // Best-effort test cleanup.
+            }
+        }
     }
 
     private sealed class RecordingOwner : ISpoilerGuardItemActionOwner

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/SpoilerGuardPlatformItemActionAdapterTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/SpoilerGuardPlatformItemActionAdapterTests.cs
@@ -1,0 +1,85 @@
+using System.Collections.Immutable;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+using Jellyfin.Plugin.JellyfinCanopy.Services;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform;
+
+public sealed class SpoilerGuardPlatformItemActionAdapterTests
+{
+    [Theory]
+    [InlineData(HostItemKind.Movie, SpoilerGuardItemKind.Movie)]
+    [InlineData(HostItemKind.Series, SpoilerGuardItemKind.Series)]
+    public void Configure_MapsAuthoritativeProjections_AndInvokesOwnerExactlyOnce(
+        HostItemKind hostKind,
+        SpoilerGuardItemKind ownerKind)
+    {
+        var owner = new RecordingOwner();
+        var adapter = new SpoilerGuardPlatformItemActionAdapter(owner);
+        var userId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+        var configuration = new SpoilerGuardItemConfiguration(enabled: true);
+
+        var result = adapter.Configure(
+            new PlatformActor(userId, false, "correlation", null, null),
+            new HostAccessibleItem(itemId, hostKind, seriesId: null, ImmutableArray<HostProviderReference>.Empty),
+            configuration);
+
+        Assert.Same(owner.Result, result);
+        Assert.Equal(1, owner.ConfigureCalls);
+        Assert.Equal(userId, owner.Actor?.UserId);
+        Assert.Equal(itemId, owner.Item?.ItemId);
+        Assert.Equal(ownerKind, owner.Item?.Kind);
+        Assert.False(owner.Item?.ActorOwnedRemovalOnly);
+        Assert.Null(owner.Item?.DisplayName);
+        Assert.Same(configuration, owner.Configuration);
+    }
+
+    [Fact]
+    public void UnsupportedAccessibleKind_FailsBeforeOwnerInvocation()
+    {
+        var owner = new RecordingOwner();
+        var adapter = new SpoilerGuardPlatformItemActionAdapter(owner);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => adapter.Configure(
+            new PlatformActor(Guid.NewGuid(), false, "correlation", null, null),
+            new HostAccessibleItem(Guid.NewGuid(), HostItemKind.Episode, Guid.NewGuid(), []),
+            new SpoilerGuardItemConfiguration(enabled: false)));
+        Assert.Equal(0, owner.ConfigureCalls);
+    }
+
+    private sealed class RecordingOwner : ISpoilerGuardItemActionOwner
+    {
+        internal RecordingOwner()
+        {
+            Result = SpoilerGuardItemActionResult.Configured(
+                enabled: true,
+                changed: true,
+                removed: false,
+                revision: 7);
+        }
+
+        internal SpoilerGuardItemActionResult Result { get; }
+
+        internal int ConfigureCalls { get; private set; }
+
+        internal SpoilerGuardActorProjection? Actor { get; private set; }
+
+        internal SpoilerGuardItemProjection? Item { get; private set; }
+
+        internal SpoilerGuardItemConfiguration? Configuration { get; private set; }
+
+        public SpoilerGuardItemActionResult Configure(
+            SpoilerGuardActorProjection actor,
+            SpoilerGuardItemProjection item,
+            SpoilerGuardItemConfiguration configuration)
+        {
+            ConfigureCalls++;
+            Actor = actor;
+            Item = item;
+            Configuration = configuration;
+            return Result;
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/SpoilerGuardPlatformItemActionAdapter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/SpoilerGuardPlatformItemActionAdapter.cs
@@ -1,0 +1,45 @@
+using System;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+using Jellyfin.Plugin.JellyfinCanopy.Services;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>
+    /// Maps the Platform kernel's authoritative actor and accessible-item projections
+    /// to the shared Spoiler Guard owner. It cannot accept a raw item or user id.
+    /// </summary>
+    public sealed class SpoilerGuardPlatformItemActionAdapter
+    {
+        private readonly ISpoilerGuardItemActionOwner _owner;
+
+        /// <summary>Initializes the Platform adapter.</summary>
+        public SpoilerGuardPlatformItemActionAdapter(ISpoilerGuardItemActionOwner owner)
+        {
+            _owner = owner ?? throw new ArgumentNullException(nameof(owner));
+        }
+
+        /// <summary>Configures one exact accessible item with one owner invocation.</summary>
+        public SpoilerGuardItemActionResult Configure(
+            PlatformActor actor,
+            HostAccessibleItem item,
+            SpoilerGuardItemConfiguration configuration)
+        {
+            ArgumentNullException.ThrowIfNull(actor);
+            ArgumentNullException.ThrowIfNull(configuration);
+
+            var kind = item.Kind switch
+            {
+                HostItemKind.Movie => SpoilerGuardItemKind.Movie,
+                HostItemKind.Series => SpoilerGuardItemKind.Series,
+                _ => throw new ArgumentOutOfRangeException(
+                    nameof(item),
+                    "The accessible item kind is not supported by Spoiler Guard."),
+            };
+
+            return _owner.Configure(
+                new SpoilerGuardActorProjection(actor.UserId),
+                SpoilerGuardItemProjection.CurrentAccessible(item.Id, kind, displayName: null),
+                configuration);
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
@@ -213,6 +213,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy
             serviceCollection.AddSingleton<SpoilerIdentityTagFilter>();
             serviceCollection.AddSingleton<SpoilerUserResolver>();
             serviceCollection.AddSingleton<ISpoilerGuardItemActionOwner, SpoilerGuardItemActionOwner>();
+            serviceCollection.AddSingleton<SpoilerGuardPlatformItemActionAdapter>();
             serviceCollection.AddSingleton<SpoilerBlurImageFilter>();
             serviceCollection.AddSingleton<SpoilerFieldStripFilter>();
             // Shared pre-acquisition ("pending") pending-add core used by BOTH the

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/SpoilerGuardItemActionOwner.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/SpoilerGuardItemActionOwner.cs
@@ -339,9 +339,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             string itemKey,
             ref bool capacityExceeded)
         {
-            var newName = PersistedPayloadPolicy.ClampPersistedDisplayName(item.DisplayName);
             if (state.Movies.TryGetValue(itemKey, out var existing))
             {
+                // The Platform's access projection intentionally carries no title.
+                // Treat that absence as "no authoritative rename" so a native
+                // idempotent enable cannot erase legacy presentation metadata.
+                var newName = item.DisplayName is null
+                    ? existing.MovieName
+                    : PersistedPayloadPolicy.ClampPersistedDisplayName(item.DisplayName);
                 if (string.Equals(existing.MovieName, newName, StringComparison.Ordinal))
                 {
                     return false;
@@ -352,6 +357,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 return true;
             }
 
+            var insertedName = PersistedPayloadPolicy.ClampPersistedDisplayName(item.DisplayName);
+
             if (!SpoilerGuardOverrideCapacity.CanInsert(state.Movies, itemKey))
             {
                 capacityExceeded = true;
@@ -361,7 +368,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             state.Movies[itemKey] = new SpoilerBlurMovieEntry
             {
                 MovieId = itemKey,
-                MovieName = newName,
+                MovieName = insertedName,
                 EnabledAt = UtcTimestamp(),
             };
             SpoilerGuardOverridesRevision.Advance(state);

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,7 +26,7 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2808, totalLines: 3201 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 33602, totalLines: 42604 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 33607, totalLines: 42607 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 3,
         minimumCoveredLines: 2808,
@@ -34,8 +34,8 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
     });
     assert.deepEqual(baselines.profiles.server.observations, {
         cleanRuns: 3,
-        minimumCoveredLines: 33602,
-        maximumCoveredLines: 33602,
+        minimumCoveredLines: 33607,
+        maximumCoveredLines: 33607,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 0);

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,7 +26,7 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2808, totalLines: 3201 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 33585, totalLines: 42586 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 33602, totalLines: 42604 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 3,
         minimumCoveredLines: 2808,
@@ -34,11 +34,11 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
     });
     assert.deepEqual(baselines.profiles.server.observations, {
         cleanRuns: 3,
-        minimumCoveredLines: 33584,
-        maximumCoveredLines: 33585,
+        minimumCoveredLines: 33602,
+        maximumCoveredLines: 33602,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 1);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 0);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 33602,
-        "totalLines": 42604
+        "coveredLines": 33607,
+        "totalLines": 42607
       },
       "observations": {
         "cleanRuns": 3,
-        "minimumCoveredLines": 33602,
-        "maximumCoveredLines": 33602
+        "minimumCoveredLines": 33607,
+        "maximumCoveredLines": 33607
       },
       "tolerance": {
         "missingCoveredLines": 0,
-        "rationale": "The #593 follow-up adds the transport-free Spoiler Guard Platform adapter that maps only authoritative actor and freshly accessible Movie/Series projections into the already shared installed-item owner. Its tests cover both admitted kinds, preserve the owner's exact semantic result, prove exactly one owner call, and reject unsupported kinds before the owner. The adapter measures 100% line coverage. Three clean Coverlet runs on the identical 2026-08-03 source and 42,604-line scope each passed all 2,946 server tests and reproduced exactly 33,602 covered lines. Relative to the reviewed #594 main high-water of 33,585/42,586 (78.864%), this change adds 18 instrumented lines and 17 covered lines, raising the high-water to 33,602/42,604 (78.871%). The identical observation envelope needs no instrumentation tolerance, so the floor and high-water are both 33,602/42,604. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "rationale": "The #593 follow-up adds the transport-free Spoiler Guard Platform adapter that maps only authoritative actor and freshly accessible Movie/Series projections into the already shared installed-item owner. Its tests cover both admitted kinds, preserve the owner's exact semantic result, prove exactly one owner call, and reject unsupported kinds before the owner. Independent review also found and corrected a real parity edge: because the safe Platform projection has no title, re-enabling an existing movie now preserves its durable display metadata and revision instead of erasing the name. A real adapter-plus-owner persistence regression pins that behavior. The adapter measures 100% line coverage. Three clean Coverlet runs on the identical corrected 2026-08-03 source and 42,607-line scope each passed all 2,947 server tests and reproduced exactly 33,607 covered lines. Relative to the reviewed #594 main high-water of 33,585/42,586 (78.864%), this change adds 21 instrumented lines and 22 covered lines, raising the high-water to 33,607/42,607 (78.877%). The identical observation envelope needs no instrumentation tolerance, so the floor and high-water are both 33,607/42,607. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 33585,
-        "totalLines": 42586
+        "coveredLines": 33602,
+        "totalLines": 42604
       },
       "observations": {
         "cleanRuns": 3,
-        "minimumCoveredLines": 33584,
-        "maximumCoveredLines": 33585
+        "minimumCoveredLines": 33602,
+        "maximumCoveredLines": 33602
       },
       "tolerance": {
-        "missingCoveredLines": 1,
-        "rationale": "The independently reviewed combined #590/#594 tree retains the bounded redacted action-audit authority and adds the shared Hidden Content installed-item owner for accessible Movie/Series/Episode configuration. The Hidden Content scope includes authoritative actor/item projections, native exact-scope replacement/removal with revision preconditions, exact legacy home-surface merge/delete/TMDB/episode/poster parity, an opaque-data-free bounded Platform action-result projection below the 64 KiB idempotency ceiling, a separate assembly-internal legacy-only deep-cloned response channel preserving bounded future identity fields and nested extension data, durable forward-compatible extension preservation, deterministic linear first-wins alias merging with early aggregate bounds, full-graph validation, capacity and corruption fail-closed behavior, cache invalidation, strict access-boundary construction guards, and isolated orphan repair. The owner measures 93.840% line coverage, its legacy response/result projections, mutation-evidence, owner-completion and legacy-row helpers 100%, the Platform adapter 96.960%, and shared defaults 100%. Three clean Coverlet runs on the identical rebased 2026-08-03 source and 42,586-line scope each passed all 2,943 server tests: two measured 33,584 covered lines and one measured 33,585. Relative to the reviewed #590 main high-water of 33,118/41,847 (79.141%), #594 adds 739 reviewed instrumented lines and raises the observed high-water by 467 covered lines to 33,585/42,586 (78.864%). The exact one-line 33,584-33,585 local instrumentation envelope therefore sets a 33,585 high-water with a one-line tolerance and a floor of 33,584/42,586 (78.862%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 0,
+        "rationale": "The #593 follow-up adds the transport-free Spoiler Guard Platform adapter that maps only authoritative actor and freshly accessible Movie/Series projections into the already shared installed-item owner. Its tests cover both admitted kinds, preserve the owner's exact semantic result, prove exactly one owner call, and reject unsupported kinds before the owner. The adapter measures 100% line coverage. Three clean Coverlet runs on the identical 2026-08-03 source and 42,604-line scope each passed all 2,946 server tests and reproduced exactly 33,602 covered lines. Relative to the reviewed #594 main high-water of 33,585/42,586 (78.864%), this change adds 18 instrumented lines and 17 covered lines, raising the high-water to 33,602/42,604 (78.871%). The identical observation envelope needs no instrumentation tolerance, so the floor and high-water are both 33,602/42,604. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
Closes #593

## Outcome

Adds the transport-free Platform projection adapter for the already-shared Spoiler Guard installed-item owner. Only an authoritative Platform actor and freshly accessible Movie/Series projection can reach the owner; unsupported kinds fail before invocation. The adapter returns the exact owner result and introduces no controller call, HTTP dependency, or second persistence path.

Independent review found that Platform intentionally has no display title, which could make an idempotent movie enable erase legacy presentation metadata. The shared owner now treats a missing authoritative title as no rename and a real adapter-plus-owner persistence regression pins the name and revision.

The production coordinator port and fixed catalog composition remain owned by #606 after #591; this PR does not publish an inert route.

## Validation

- focused Spoiler Guard owner/adapter: 11/11
- full server coverage: 2,947/2,947; three identical 33,607/42,607 runs; zero tolerance
- script tests: 634/634
- Release build: 0 warnings, 0 errors
- lint and diff check: pass
- independent final review: APPROVE
