### PR TITLE
feat(platform): coordinate first-party action invocation

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActionAdmissionLimiterTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActionAdmissionLimiterTests.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
+{
+    public class PlatformActionAdmissionLimiterTests
+    {
+        [Fact]
+        public async Task SameActorAndOperationAreSerializedInFifoOrderAndIdleKeyIsRemoved()
+        {
+            var limiter = new PlatformActionAdmissionLimiter();
+            var actor = Actor(1);
+            var first = await limiter.AcquireAsync(
+                actor,
+                PlatformOperationDefinition.SpoilerGuardConfigureItem,
+                CancellationToken.None);
+            var second = limiter.AcquireAsync(actor, PlatformOperationDefinition.SpoilerGuardConfigureItem, CancellationToken.None);
+            var third = limiter.AcquireAsync(actor, PlatformOperationDefinition.SpoilerGuardConfigureItem, CancellationToken.None);
+
+            Assert.Equal(PlatformActionAdmissionKind.Acquired, first.Kind);
+            Assert.False(second.IsCompleted);
+            Assert.False(third.IsCompleted);
+            Assert.Equal(2, limiter.WaiterCount);
+
+            first.Dispose();
+            var secondLease = await second;
+            Assert.False(third.IsCompleted);
+            secondLease.Dispose();
+            var thirdLease = await third;
+            thirdLease.Dispose();
+
+            Assert.Equal(0, limiter.WaiterCount);
+            Assert.Equal(0, limiter.KeyCount);
+        }
+
+        [Fact]
+        public async Task CanceledWaiterLeavesNoCapacityAndNeverConsumesTheLease()
+        {
+            var limiter = new PlatformActionAdmissionLimiter();
+            var actor = Actor(2);
+            using var active = await limiter.AcquireAsync(
+                actor,
+                PlatformOperationDefinition.HiddenContentConfigureItem,
+                CancellationToken.None);
+            using var cancellation = new CancellationTokenSource();
+            var canceled = limiter.AcquireAsync(
+                actor,
+                PlatformOperationDefinition.HiddenContentConfigureItem,
+                cancellation.Token);
+            var next = limiter.AcquireAsync(
+                actor,
+                PlatformOperationDefinition.HiddenContentConfigureItem,
+                CancellationToken.None);
+            cancellation.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceled);
+            Assert.Equal(1, limiter.WaiterCount);
+            active.Dispose();
+            using var promoted = await next;
+            Assert.Equal(PlatformActionAdmissionKind.Acquired, promoted.Kind);
+        }
+
+        [Fact]
+        public async Task PerKeyWaiterBoundRejectsTheExactNextAttempt()
+        {
+            var limiter = new PlatformActionAdmissionLimiter();
+            var actor = Actor(3);
+            var active = await limiter.AcquireAsync(actor, PlatformOperationDefinition.SeerrRequestItem, CancellationToken.None);
+            using var cancellation = new CancellationTokenSource();
+            var waiters = Enumerable.Range(0, PlatformActionAdmissionLimiter.MaximumWaitersPerKey)
+                .Select(_ => limiter.AcquireAsync(actor, PlatformOperationDefinition.SeerrRequestItem, cancellation.Token))
+                .ToArray();
+
+            var refused = await limiter.AcquireAsync(actor, PlatformOperationDefinition.SeerrRequestItem, CancellationToken.None);
+            Assert.Equal(PlatformActionAdmissionKind.AtCapacity, refused.Kind);
+            Assert.Equal(PlatformActionAdmissionLimiter.MaximumWaitersPerKey, limiter.WaiterCount);
+
+            cancellation.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => Task.WhenAll(waiters));
+            active.Dispose();
+            Assert.Equal(0, limiter.KeyCount);
+        }
+
+        [Fact]
+        public async Task KeyBoundNeverEvictsActiveWorkAndDifferentOperationsRemainIndependent()
+        {
+            var limiter = new PlatformActionAdmissionLimiter();
+            var leases = new PlatformActionAdmission[PlatformActionAdmissionLimiter.MaximumKeys];
+            for (var index = 0; index < leases.Length; index++)
+            {
+                leases[index] = await limiter.AcquireAsync(
+                    Actor(index + 10),
+                    PlatformOperationDefinition.SpoilerGuardConfigureItem,
+                    CancellationToken.None);
+                Assert.Equal(PlatformActionAdmissionKind.Acquired, leases[index].Kind);
+            }
+
+            var refused = await limiter.AcquireAsync(
+                Actor(5000),
+                PlatformOperationDefinition.SpoilerGuardConfigureItem,
+                CancellationToken.None);
+            Assert.Equal(PlatformActionAdmissionKind.AtCapacity, refused.Kind);
+            Assert.Equal(PlatformActionAdmissionLimiter.MaximumKeys, limiter.KeyCount);
+
+            foreach (var lease in leases)
+            {
+                lease.Dispose();
+            }
+
+            var sameActor = Actor(9000);
+            using var spoiler = await limiter.AcquireAsync(
+                sameActor,
+                PlatformOperationDefinition.SpoilerGuardConfigureItem,
+                CancellationToken.None);
+            using var hidden = await limiter.AcquireAsync(
+                sameActor,
+                PlatformOperationDefinition.HiddenContentConfigureItem,
+                CancellationToken.None);
+            Assert.Equal(PlatformActionAdmissionKind.Acquired, spoiler.Kind);
+            Assert.Equal(PlatformActionAdmissionKind.Acquired, hidden.Kind);
+        }
+
+        [Fact]
+        public async Task PreCanceledAdmissionRetainsNoKey()
+        {
+            var limiter = new PlatformActionAdmissionLimiter();
+            using var cancellation = new CancellationTokenSource();
+            cancellation.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => limiter.AcquireAsync(
+                Actor(4),
+                PlatformOperationDefinition.SpoilerGuardConfigureItem,
+                cancellation.Token));
+            Assert.Equal(0, limiter.KeyCount);
+        }
+
+        private static PlatformActor Actor(int suffix)
+        {
+            Span<byte> bytes = stackalloc byte[16];
+            BitConverter.TryWriteBytes(bytes, suffix);
+            return new PlatformActor(new Guid(bytes), false, new string('a', 32), null, null);
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActionCapabilityArchitectureTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActionCapabilityArchitectureTests.cs
@@ -57,12 +57,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
                 .GetMethods(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly)
                 .Where(method => !method.IsSpecialName)
                 .Select(method => method.Name)
-                .Where(name => name is "Mint" or "Inspect" or "ValidateCurrent" or "Consume" or "InvalidateOutstandingCapabilities")
+                .Where(name => name is "Mint" or "Inspect" or "IsInspectionFor" or "ValidateCurrent" or "Consume" or "InvalidateOutstandingCapabilities")
                 .OrderBy(name => name, StringComparer.Ordinal)
                 .ToArray();
 
             Assert.Equal(
-                new[] { "Consume", "Inspect", "InvalidateOutstandingCapabilities", "Mint", "ValidateCurrent" },
+                new[] { "Consume", "Inspect", "InvalidateOutstandingCapabilities", "IsInspectionFor", "Mint", "ValidateCurrent" },
                 methods);
             Assert.DoesNotContain(
                 typeof(PlatformActionCapabilityService).GetMethods(BindingFlags.Instance | BindingFlags.Public),

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActionInvocationArchitectureTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActionInvocationArchitectureTests.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
+{
+    /// <summary>Guards the fixed action coordinator against dispatch and authority drift.</summary>
+    public class PlatformActionInvocationArchitectureTests
+    {
+        [Fact]
+        public void DispatcherHasExactlyThreeNamedPortsAndNoExtensibleRegistry()
+        {
+            var dispatcher = typeof(PlatformFirstPartyActionDispatcher);
+            var fields = dispatcher.GetFields(BindingFlags.Instance | BindingFlags.NonPublic);
+
+            Assert.Equal(
+                new[]
+                {
+                    typeof(IHiddenContentPlatformActionPort),
+                    typeof(ISeerrPlatformActionPort),
+                    typeof(ISpoilerGuardPlatformActionPort),
+                },
+                fields.Select(field => field.FieldType).OrderBy(type => type.Name, StringComparer.Ordinal));
+            Assert.DoesNotContain(fields, field => IsRegistry(field.FieldType));
+
+            var source = Code("PlatformFirstPartyActionDispatcher.cs");
+            foreach (var forbidden in new[]
+            {
+                "IServiceProvider",
+                "System.Reflection",
+                "Dictionary<",
+                "ConcurrentDictionary<",
+                "IEnumerable<",
+                "Func<",
+                "Register",
+            })
+            {
+                Assert.DoesNotContain(forbidden, source, StringComparison.Ordinal);
+            }
+        }
+
+        [Fact]
+        public void OwnersReceiveOnlySafeProjectionsAndValidatedInputs()
+        {
+            foreach (var port in new[]
+            {
+                typeof(IHiddenContentPlatformActionPort),
+                typeof(ISeerrPlatformActionPort),
+                typeof(ISpoilerGuardPlatformActionPort),
+            })
+            {
+                var invoke = Assert.Single(port.GetMethods(), method => method.Name == "InvokeAsync");
+                var parameters = invoke.GetParameters().Select(parameter => parameter.ParameterType).ToArray();
+                Assert.Equal(typeof(PlatformActor), parameters[0]);
+                Assert.Equal(typeof(HostAccessibleItem), parameters[1]);
+                Assert.Equal(typeof(IPlatformValidatedActionInput), parameters[2]);
+                Assert.DoesNotContain(parameters, type => type == typeof(HttpContext)
+                    || type == typeof(PlatformPreparedActionContext)
+                    || type == typeof(PlatformActionInvokeRequest)
+                    || type == typeof(string)
+                    || type == typeof(byte[]));
+            }
+        }
+
+        [Fact]
+        public void CoordinatorPinsInspectReauthorizeIdempotencyConsumeOwnerOrder()
+        {
+            var source = Code("PlatformActionInvocationCoordinator.cs");
+            var inspect = source.IndexOf("_capabilities.Inspect(", StringComparison.Ordinal);
+            var initialAuthority = source.IndexOf("ResolveCurrent(", inspect, StringComparison.Ordinal);
+            var idempotency = source.IndexOf("_idempotency.ExecuteCoordinatedAsync(", initialAuthority, StringComparison.Ordinal);
+            var queuedAuthority = source.IndexOf("ResolveCurrent(", idempotency, StringComparison.Ordinal);
+            var consume = source.IndexOf("_capabilities.Consume(", queuedAuthority, StringComparison.Ordinal);
+            var owner = source.IndexOf("_dispatcher.InvokeAsync(", consume, StringComparison.Ordinal);
+
+            Assert.True(inspect >= 0);
+            Assert.True(inspect < initialAuthority);
+            Assert.True(initialAuthority < idempotency);
+            Assert.True(idempotency < queuedAuthority);
+            Assert.True(queuedAuthority < consume);
+            Assert.True(consume < owner);
+            Assert.True(
+                source.IndexOf("execution.MarkSideEffectStarted();", queuedAuthority, StringComparison.Ordinal)
+                    < consume);
+        }
+
+        [Fact]
+        public void PreparedAndAdmissionOwnersHaveExactBoundsAndSingletonLifetimes()
+        {
+            Assert.Equal(1024, PlatformPreparedActionContextOwner.MaximumEntries);
+            Assert.Equal(4096, PlatformPreparedActionContextOwner.MaximumPrivateStateBytes);
+            Assert.Equal(1024, PlatformActionAdmissionLimiter.MaximumKeys);
+            Assert.Equal(8, PlatformActionAdmissionLimiter.MaximumWaitersPerKey);
+            Assert.Equal(1024, PlatformActionAdmissionLimiter.MaximumWaiters);
+
+            var registrations = ProductionCode("PluginServiceRegistrator.cs");
+            Assert.Equal(1, Count(registrations, "AddSingleton<PlatformPreparedActionContextOwner>();"));
+            Assert.Equal(1, Count(registrations, "AddSingleton<PlatformActionAdmissionLimiter>();"));
+            Assert.DoesNotContain("AddTransient<PlatformPreparedActionContextOwner>", registrations, StringComparison.Ordinal);
+            Assert.DoesNotContain("AddScoped<PlatformActionAdmissionLimiter>", registrations, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void CoordinatorAndPreparedOwnerStayHttpFree()
+        {
+            foreach (var source in new[]
+            {
+                Code("PlatformActionInvocationCoordinator.cs"),
+                Code("PlatformPreparedActionContextOwner.cs"),
+                Code("PlatformFirstPartyActionDispatcher.cs"),
+            })
+            {
+                Assert.DoesNotContain("Microsoft.AspNetCore", source, StringComparison.Ordinal);
+                Assert.DoesNotContain("HttpContext", source, StringComparison.Ordinal);
+                Assert.DoesNotContain("ClaimsPrincipal", source, StringComparison.Ordinal);
+                Assert.DoesNotContain("MediaBrowser.", source, StringComparison.Ordinal);
+            }
+        }
+
+        private static bool IsRegistry(Type type)
+            => type.IsArray
+                || (type.IsGenericType && new[]
+                {
+                    typeof(IEnumerable<>),
+                    typeof(IReadOnlyCollection<>),
+                    typeof(IReadOnlyDictionary<,>),
+                    typeof(Dictionary<,>),
+                }.Contains(type.GetGenericTypeDefinition()));
+
+        private static int Count(string source, string value)
+        {
+            var count = 0;
+            var offset = 0;
+            while ((offset = source.IndexOf(value, offset, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                offset += value.Length;
+            }
+
+            return count;
+        }
+
+        private static string Code(string name)
+            => PlatformHostSeamTests.CodeOnly(File.ReadAllText(SourceFile(name)));
+
+        private static string ProductionCode(string name)
+            => PlatformHostSeamTests.CodeOnly(File.ReadAllText(ProductionFile(name)));
+
+        private static string SourceFile(string name, [CallerFilePath] string sourceFile = "")
+            => Path.GetFullPath(Path.Combine(
+                Path.GetDirectoryName(sourceFile)!,
+                "..",
+                "..",
+                "Jellyfin.Plugin.JellyfinCanopy",
+                "Platform",
+                name));
+
+        private static string ProductionFile(string name, [CallerFilePath] string sourceFile = "")
+            => Directory.EnumerateFiles(
+                    Path.GetFullPath(Path.Combine(Path.GetDirectoryName(sourceFile)!, "..", "..", "Jellyfin.Plugin.JellyfinCanopy")),
+                    name,
+                    SearchOption.AllDirectories)
+                .Single(file => !file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                    && !file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal));
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActionInvocationCoordinatorTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActionInvocationCoordinatorTests.cs
@@ -1,0 +1,838 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
+{
+    public class PlatformActionInvocationCoordinatorTests
+    {
+        [Fact]
+        public async Task ConcurrentDuplicateInvokesOneOwnerThenReplaysAfterCapabilityConsumption()
+        {
+            using var fixture = new Fixture();
+            fixture.Port.BlockOwner = true;
+            var prepared = fixture.Prepare();
+            var request = fixture.Request(prepared.Capability!, "same-key", enabled: true);
+
+            var first = fixture.Coordinator.InvokeAsync(fixture.BoundaryActor, request, NoCancellation());
+            await fixture.Port.OwnerEntered.Task;
+            var duplicate = fixture.Coordinator.InvokeAsync(fixture.BoundaryActor, request, NoCancellation());
+            fixture.Port.ReleaseOwner.TrySetResult();
+
+            var outcomes = await Task.WhenAll(first, duplicate);
+            Assert.Equal(1, fixture.Port.OwnerCalls);
+            Assert.Contains(outcomes, outcome => !outcome.Replayed);
+            Assert.Contains(outcomes, outcome => outcome.Replayed);
+            Assert.All(outcomes, outcome => Assert.Equal(200, outcome.Result.StatusCode));
+            Assert.Equal(
+                new[] { PlatformAuditResultCode.Succeeded, PlatformAuditResultCode.IdempotencyReplayed }.OrderBy(value => value),
+                fixture.Audit.Snapshot().Select(record => record.ResultCode).OrderBy(value => value));
+
+            var newKey = await fixture.Coordinator.InvokeAsync(
+                fixture.BoundaryActor,
+                fixture.Request(prepared.Capability!, "new-key", enabled: true),
+                NoCancellation());
+            Assert.Equal(409, newKey.Result.StatusCode);
+            Assert.Equal(PlatformErrorCode.Conflict, newKey.Result.OutcomeCode);
+            Assert.Equal(1, fixture.Port.OwnerCalls);
+            Assert.Equal(PlatformAuditResultCode.CapabilityReplayed, fixture.Audit.Snapshot()[^1].ResultCode);
+        }
+
+        [Fact]
+        public async Task SameTupleWithDifferentTypedInputConflictsBeforeSecondOwnerCall()
+        {
+            using var fixture = new Fixture();
+            var prepared = fixture.Prepare();
+            var enabled = await fixture.Coordinator.InvokeAsync(
+                fixture.BoundaryActor,
+                fixture.Request(prepared.Capability!, "same-key", enabled: true),
+                NoCancellation());
+            Assert.Equal(200, enabled.Result.StatusCode);
+
+            // A freshly prepared capability is required because the first was spent;
+            // idempotency must still conflict before this new capability is consumed.
+            var secondPrepared = fixture.Prepare();
+            var conflict = await fixture.Coordinator.InvokeAsync(
+                fixture.BoundaryActor,
+                fixture.Request(secondPrepared.Capability!, "same-key", enabled: false),
+                NoCancellation());
+
+            Assert.Equal(409, conflict.Result.StatusCode);
+            Assert.Equal(PlatformErrorCode.Conflict, conflict.Result.OutcomeCode);
+            Assert.Equal(1, fixture.Port.OwnerCalls);
+            Assert.Equal(PlatformAuditResultCode.Conflict, fixture.Audit.Snapshot()[^1].ResultCode);
+        }
+
+        [Fact]
+        public async Task QueuedLeaderReauthorizesItemBeforeCapabilitySpendAndCanRetrySafely()
+        {
+            using var fixture = new Fixture();
+            var prepared = fixture.Prepare();
+            var blocker = await fixture.Limiter.AcquireAsync(
+                fixture.BoundaryActor,
+                PlatformOperationDefinition.SpoilerGuardConfigureItem,
+                CancellationToken.None);
+            var request = fixture.Request(prepared.Capability!, "queued-key", enabled: true);
+            var invocation = fixture.Coordinator.InvokeAsync(fixture.BoundaryActor, request, NoCancellation());
+            await EventuallyAsync(() => fixture.Limiter.WaiterCount == 1);
+
+            fixture.Host.ItemAccessible = false;
+            blocker.Dispose();
+            var denied = await invocation;
+            Assert.Equal(404, denied.Result.StatusCode);
+            Assert.Equal(0, fixture.Port.OwnerCalls);
+
+            fixture.Host.ItemAccessible = true;
+            var retry = await fixture.Coordinator.InvokeAsync(
+                fixture.BoundaryActor,
+                request,
+                NoCancellation());
+            Assert.Equal(200, retry.Result.StatusCode);
+            Assert.Equal(1, fixture.Port.OwnerCalls);
+        }
+
+        [Fact]
+        public async Task AdmissionPressureIsRetryableWithTheSameKeyAndCapability()
+        {
+            using var fixture = new Fixture();
+            var blocker = await fixture.Limiter.AcquireAsync(
+                fixture.BoundaryActor,
+                PlatformOperationDefinition.SpoilerGuardConfigureItem,
+                CancellationToken.None);
+            var cancellations = new List<CancellationTokenSource>();
+            var waiters = new List<Task<PlatformActionAdmission>>();
+            for (var index = 0; index < PlatformActionAdmissionLimiter.MaximumWaitersPerKey; index++)
+            {
+                var cancellation = new CancellationTokenSource();
+                cancellations.Add(cancellation);
+                waiters.Add(fixture.Limiter.AcquireAsync(
+                    fixture.BoundaryActor,
+                    PlatformOperationDefinition.SpoilerGuardConfigureItem,
+                    cancellation.Token));
+            }
+
+            await EventuallyAsync(() => fixture.Limiter.WaiterCount == PlatformActionAdmissionLimiter.MaximumWaitersPerKey);
+            var prepared = fixture.Prepare();
+            var request = fixture.Request(prepared.Capability!, "capacity-retry", enabled: true);
+            var refused = await fixture.Coordinator.InvokeAsync(
+                fixture.BoundaryActor,
+                request,
+                NoCancellation());
+            Assert.Equal(429, refused.Result.StatusCode);
+            Assert.Equal(0, fixture.Idempotency.EntryCount);
+            Assert.Equal(0, fixture.Port.OwnerCalls);
+
+            foreach (var cancellation in cancellations)
+            {
+                cancellation.Cancel();
+            }
+
+            foreach (var waiter in waiters)
+            {
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => waiter);
+            }
+
+            foreach (var cancellation in cancellations)
+            {
+                cancellation.Dispose();
+            }
+
+            blocker.Dispose();
+            var retry = await fixture.Coordinator.InvokeAsync(
+                fixture.BoundaryActor,
+                request,
+                NoCancellation());
+            Assert.Equal(200, retry.Result.StatusCode);
+            Assert.Equal(1, fixture.Port.OwnerCalls);
+        }
+
+        [Fact]
+        public async Task CancellationWhileQueuedDoesNotPoisonIdempotencyOrConsumeCapability()
+        {
+            using var fixture = new Fixture();
+            var prepared = fixture.Prepare();
+            var blocker = await fixture.Limiter.AcquireAsync(
+                fixture.BoundaryActor,
+                PlatformOperationDefinition.SpoilerGuardConfigureItem,
+                CancellationToken.None);
+            using var caller = new CancellationTokenSource();
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(caller.Token);
+            var request = fixture.Request(prepared.Capability!, "cancel-key", enabled: true);
+            var canceled = fixture.Coordinator.InvokeAsync(
+                fixture.BoundaryActor,
+                request,
+                new PlatformInvocationCancellation(linked.Token, caller.Token, CancellationToken.None));
+            await EventuallyAsync(() => fixture.Limiter.WaiterCount == 1);
+            caller.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceled);
+            blocker.Dispose();
+            Assert.Equal(PlatformAuditResultCode.CallerCancelled, fixture.Audit.Snapshot()[^1].ResultCode);
+
+            var retry = await fixture.Coordinator.InvokeAsync(
+                fixture.BoundaryActor,
+                request,
+                NoCancellation());
+            Assert.Equal(200, retry.Result.StatusCode);
+            Assert.Equal(1, fixture.Port.OwnerCalls);
+        }
+
+        [Theory]
+        [InlineData("caller", (int)PlatformAuditResultCode.CallerCancelled)]
+        [InlineData("deadline", (int)PlatformAuditResultCode.DeadlineExceeded)]
+        [InlineData("simultaneous", (int)PlatformAuditResultCode.CallerCancelled)]
+        public async Task CancellationIgnoringOwnerStoresResultButCurrentRequestAuditsCancellation(
+            string cancellationKind,
+            int expectedAuditValue)
+        {
+            var expectedAudit = (PlatformAuditResultCode)expectedAuditValue;
+            using var fixture = new Fixture();
+            fixture.Port.BlockOwner = true;
+            fixture.Port.IgnoreCancellation = true;
+            var prepared = fixture.Prepare();
+            var request = fixture.Request(prepared.Capability!, "ignored-cancellation", enabled: true);
+            using var caller = new CancellationTokenSource();
+            using var deadline = new CancellationTokenSource();
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(caller.Token, deadline.Token);
+            var invocation = fixture.Coordinator.InvokeAsync(
+                fixture.BoundaryActor,
+                request,
+                new PlatformInvocationCancellation(linked.Token, caller.Token, deadline.Token));
+            await fixture.Port.OwnerEntered.Task;
+
+            if (cancellationKind is "caller" or "simultaneous")
+            {
+                caller.Cancel();
+            }
+
+            if (cancellationKind is "deadline" or "simultaneous")
+            {
+                deadline.Cancel();
+            }
+
+            fixture.Port.ReleaseOwner.TrySetResult();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => invocation);
+
+            Assert.Equal(1, fixture.Port.OwnerCalls);
+            Assert.Equal(expectedAudit, fixture.Audit.Snapshot()[^1].ResultCode);
+
+            var replay = await fixture.Coordinator.InvokeAsync(
+                fixture.BoundaryActor,
+                request,
+                NoCancellation());
+            Assert.True(replay.Replayed);
+            Assert.Equal(200, replay.Result.StatusCode);
+            Assert.Equal(1, fixture.Port.OwnerCalls);
+            Assert.Equal(PlatformAuditResultCode.IdempotencyReplayed, fixture.Audit.Snapshot()[^1].ResultCode);
+        }
+
+        [Theory]
+        [InlineData("caller", (int)PlatformAuditResultCode.CallerCancelled)]
+        [InlineData("deadline", (int)PlatformAuditResultCode.DeadlineExceeded)]
+        [InlineData("simultaneous", (int)PlatformAuditResultCode.CallerCancelled)]
+        public async Task PreCanceledInvalidCapabilityUsesCancellationPrecedence(
+            string cancellationKind,
+            int expectedAuditValue)
+        {
+            var expectedAudit = (PlatformAuditResultCode)expectedAuditValue;
+            using var fixture = new Fixture();
+            using var caller = new CancellationTokenSource();
+            using var deadline = new CancellationTokenSource();
+            if (cancellationKind is "caller" or "simultaneous")
+            {
+                caller.Cancel();
+            }
+
+            if (cancellationKind is "deadline" or "simultaneous")
+            {
+                deadline.Cancel();
+            }
+
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(caller.Token, deadline.Token);
+            var invocation = fixture.Coordinator.InvokeAsync(
+                fixture.BoundaryActor,
+                fixture.Request("forged", "pre-canceled", true),
+                new PlatformInvocationCancellation(linked.Token, caller.Token, deadline.Token));
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => invocation);
+            var record = Assert.Single(fixture.Audit.Snapshot());
+            Assert.Equal(expectedAudit, record.ResultCode);
+            Assert.Equal(PlatformAuditSubjectResolution.Unresolved, record.SubjectResolution);
+            Assert.Equal(0, fixture.Port.OwnerCalls);
+        }
+
+        [Theory]
+        [InlineData("user-deletion")]
+        [InlineData("library-removal")]
+        [InlineData("parental-policy-change")]
+        [InlineData("item-deletion")]
+        [InlineData("item-move")]
+        [InlineData("feature-disable")]
+        [InlineData("configuration-revision")]
+        [InlineData("authority-revision")]
+        public async Task CoalescedFollowerReauthorizesBeforeStoredReplayIsReleased(string revocation)
+        {
+            using var fixture = new Fixture();
+            fixture.Port.BlockOwner = true;
+            if (revocation == "item-move")
+            {
+                fixture.Host.UseEpisode();
+            }
+
+            var prepared = fixture.Prepare(
+                revocation == "item-move"
+                    ? PlatformOperationDefinition.HiddenContentConfigureItem
+                    : PlatformOperationDefinition.SpoilerGuardConfigureItem);
+            var request = fixture.Request(prepared.Capability!, "follower-reauth", enabled: true);
+            var leader = fixture.Coordinator.InvokeAsync(fixture.BoundaryActor, request, NoCancellation());
+            await fixture.Port.OwnerEntered.Task;
+            var follower = fixture.Coordinator.InvokeAsync(fixture.BoundaryActor, request, NoCancellation());
+            await EventuallyAsync(() => fixture.Idempotency.FollowerCount == 1);
+
+            fixture.Revoke(revocation);
+            fixture.Port.ReleaseOwner.TrySetResult();
+            var leaderResult = await leader;
+            var followerResult = await follower;
+
+            Assert.Equal(200, leaderResult.Result.StatusCode);
+            Assert.Equal(404, followerResult.Result.StatusCode);
+            Assert.False(followerResult.Replayed);
+            Assert.Equal(1, fixture.Port.OwnerCalls);
+            Assert.Contains(
+                fixture.Audit.Snapshot(),
+                record => record.ResultCode == PlatformAuditResultCode.AuthorityDenied);
+
+            fixture.RestoreCurrentAuthority();
+            var later = await fixture.Coordinator.InvokeAsync(
+                fixture.BoundaryActor,
+                request,
+                NoCancellation());
+            if (revocation == "authority-revision")
+            {
+                Assert.Equal(404, later.Result.StatusCode);
+            }
+            else
+            {
+                Assert.True(later.Replayed);
+                Assert.Equal(200, later.Result.StatusCode);
+                Assert.Equal(PlatformAuditResultCode.IdempotencyReplayed, fixture.Audit.Snapshot()[^1].ResultCode);
+            }
+
+            Assert.Equal(1, fixture.Port.OwnerCalls);
+        }
+
+        [Fact]
+        public async Task CurrentUserItemFeatureInputAndAuthorityChangesAllFailBeforeOwner()
+        {
+            using var fixture = new Fixture();
+
+            var deletedUser = fixture.Prepare();
+            fixture.Host.UserExists = false;
+            Assert.Equal(404, (await fixture.Coordinator.InvokeAsync(
+                fixture.BoundaryActor,
+                fixture.Request(deletedUser.Capability!, "deleted-user", true),
+                NoCancellation())).Result.StatusCode);
+            fixture.Host.UserExists = true;
+
+            var inaccessible = fixture.Prepare();
+            fixture.Host.ItemAccessible = false;
+            Assert.Equal(404, (await fixture.Coordinator.InvokeAsync(
+                fixture.BoundaryActor,
+                fixture.Request(inaccessible.Capability!, "inaccessible", true),
+                NoCancellation())).Result.StatusCode);
+            fixture.Host.ItemAccessible = true;
+
+            var disabled = fixture.Prepare();
+            fixture.Port.FeatureEnabled = false;
+            Assert.Equal(404, (await fixture.Coordinator.InvokeAsync(
+                fixture.BoundaryActor,
+                fixture.Request(disabled.Capability!, "disabled", true),
+                NoCancellation())).Result.StatusCode);
+            fixture.Port.FeatureEnabled = true;
+
+            var revised = fixture.Prepare();
+            fixture.Port.ConfigurationRevision++;
+            Assert.Equal(404, (await fixture.Coordinator.InvokeAsync(
+                fixture.BoundaryActor,
+                fixture.Request(revised.Capability!, "feature-revision", true),
+                NoCancellation())).Result.StatusCode);
+
+            var invalidInput = fixture.Prepare();
+            Assert.Equal(400, (await fixture.Coordinator.InvokeAsync(
+                fixture.BoundaryActor,
+                new PlatformActionInvokeRequest(
+                    invalidInput.Capability!,
+                    Key("bad-input"),
+                    ImmutableArray<PlatformActionAnswer>.Empty),
+                NoCancellation())).Result.StatusCode);
+
+            var stale = fixture.Prepare();
+            fixture.Capabilities.InvalidateOutstandingCapabilities();
+            Assert.Equal(404, (await fixture.Coordinator.InvokeAsync(
+                fixture.BoundaryActor,
+                fixture.Request(stale.Capability!, "stale", true),
+                NoCancellation())).Result.StatusCode);
+
+            Assert.Equal(0, fixture.Port.OwnerCalls);
+            Assert.Equal(
+                new[]
+                {
+                    PlatformAuditResultCode.AuthorityDenied,
+                    PlatformAuditResultCode.AuthorityDenied,
+                    PlatformAuditResultCode.AuthorityDenied,
+                    PlatformAuditResultCode.AuthorityDenied,
+                    PlatformAuditResultCode.InvalidInput,
+                    PlatformAuditResultCode.AuthorityDenied,
+                },
+                fixture.Audit.Snapshot().Select(record => record.ResultCode));
+        }
+
+        [Theory]
+        [InlineData("library-removal")]
+        [InlineData("parental-policy-change")]
+        [InlineData("item-deletion")]
+        [InlineData("item-move")]
+        public async Task CurrentItemPolicyRevocationsFailBeforeOwner(string revocation)
+        {
+            using var fixture = new Fixture();
+            if (revocation == "item-move")
+            {
+                fixture.Host.UseEpisode();
+            }
+
+            var prepared = fixture.Prepare(
+                revocation == "item-move"
+                    ? PlatformOperationDefinition.HiddenContentConfigureItem
+                    : PlatformOperationDefinition.SpoilerGuardConfigureItem);
+            if (revocation == "item-move")
+            {
+                fixture.Host.ReturnedItem = new HostAccessibleItem(
+                    fixture.Host.Item.Id,
+                    HostItemKind.Episode,
+                    Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+                    ImmutableArray<HostProviderReference>.Empty);
+            }
+            else
+            {
+                // Library membership, parental policy, and deletion are deliberately
+                // indistinguishable at the user-scoped host seam.
+                fixture.Host.ItemAccessible = false;
+            }
+
+            var result = await fixture.Coordinator.InvokeAsync(
+                fixture.BoundaryActor,
+                fixture.Request(prepared.Capability!, $"revoked-{revocation}", true),
+                NoCancellation());
+
+            Assert.Equal(404, result.Result.StatusCode);
+            Assert.Equal(0, fixture.Port.OwnerCalls);
+            Assert.Equal(PlatformAuditResultCode.AuthorityDenied, fixture.Audit.Snapshot()[^1].ResultCode);
+        }
+
+        [Theory]
+        [InlineData("caller", (int)PlatformAuditResultCode.CallerCancelled)]
+        [InlineData("deadline", (int)PlatformAuditResultCode.DeadlineExceeded)]
+        public async Task CancellationDuringSynchronousCurrentAccessWinsOverDenial(
+            string cancellationKind,
+            int expectedAuditValue)
+        {
+            using var fixture = new Fixture();
+            var prepared = fixture.Prepare();
+            fixture.Host.BlockAccessibleLookup = true;
+            fixture.Host.ItemAccessible = false;
+            using var caller = new CancellationTokenSource();
+            using var deadline = new CancellationTokenSource();
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(caller.Token, deadline.Token);
+            var invocation = Task.Run(() => fixture.Coordinator.InvokeAsync(
+                fixture.BoundaryActor,
+                fixture.Request(prepared.Capability!, "blocked-access", true),
+                new PlatformInvocationCancellation(linked.Token, caller.Token, deadline.Token)));
+            Assert.True(fixture.Host.AccessibleLookupEntered.Wait(TimeSpan.FromSeconds(5)));
+
+            if (cancellationKind == "caller")
+            {
+                caller.Cancel();
+            }
+            else
+            {
+                deadline.Cancel();
+            }
+
+            fixture.Host.ReleaseAccessibleLookup.Set();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => invocation);
+            var record = Assert.Single(fixture.Audit.Snapshot());
+            Assert.Equal((PlatformAuditResultCode)expectedAuditValue, record.ResultCode);
+            Assert.Equal(0, fixture.Port.OwnerCalls);
+        }
+
+        [Fact]
+        public async Task CurrentElevationIsDowngradedBeforeTheNamedPortWithoutPromotingAuthority()
+        {
+            using var fixture = new Fixture(boundaryElevated: true);
+            fixture.Host.IsAdministrator = false;
+            var prepared = fixture.Prepare();
+
+            var result = await fixture.Coordinator.InvokeAsync(
+                fixture.BoundaryActor,
+                fixture.Request(prepared.Capability!, "downgrade", true),
+                NoCancellation());
+
+            Assert.Equal(200, result.Result.StatusCode);
+            Assert.False(fixture.Port.LastActorWasElevated);
+        }
+
+        [Fact]
+        public async Task ForgedExpiredAndContextlessCapabilitiesAreUnresolvedAndNeverDispatch()
+        {
+            var clock = new ManualTimeProvider(new DateTimeOffset(2026, 8, 3, 0, 0, 0, TimeSpan.Zero));
+            using var fixture = new Fixture(clock: clock);
+            var forged = await fixture.Coordinator.InvokeAsync(
+                fixture.BoundaryActor,
+                fixture.Request("forged", "forged-key", true),
+                NoCancellation());
+            Assert.Equal(404, forged.Result.StatusCode);
+
+            var prepared = fixture.Prepare();
+            clock.Advance(PlatformActionCapabilityService.CapabilityTimeToLive);
+            var expired = await fixture.Coordinator.InvokeAsync(
+                fixture.BoundaryActor,
+                fixture.Request(prepared.Capability!, "expired-key", true),
+                NoCancellation());
+            Assert.Equal(404, expired.Result.StatusCode);
+            Assert.Equal(0, fixture.Port.OwnerCalls);
+            Assert.All(fixture.Audit.Snapshot(), record =>
+                Assert.Equal(PlatformAuditSubjectResolution.Unresolved, record.SubjectResolution));
+            Assert.Equal(PlatformAuditResultCode.CapabilityInvalid, fixture.Audit.Snapshot()[0].ResultCode);
+            Assert.Equal(PlatformAuditResultCode.CapabilityExpired, fixture.Audit.Snapshot()[1].ResultCode);
+        }
+
+        private static async Task EventuallyAsync(Func<bool> predicate)
+        {
+            for (var attempt = 0; attempt < 1000; attempt++)
+            {
+                if (predicate())
+                {
+                    return;
+                }
+
+                await Task.Yield();
+            }
+
+            Assert.True(predicate(), "The bounded asynchronous condition was not reached.");
+        }
+
+        private static PlatformInvocationCancellation NoCancellation()
+            => new(CancellationToken.None, CancellationToken.None, CancellationToken.None);
+
+        private static PlatformIdempotencyKey Key(string value)
+        {
+            Assert.True(PlatformIdempotencyKey.TryParse(value, out var key));
+            return key;
+        }
+
+        private sealed class Fixture : IDisposable
+        {
+            internal Fixture(bool boundaryElevated = false, ManualTimeProvider? clock = null)
+            {
+                Clock = clock ?? new ManualTimeProvider(DateTimeOffset.UtcNow);
+                Capabilities = new PlatformActionCapabilityService(
+                    Clock,
+                    Enumerable.Repeat((byte)7, 32).ToArray(),
+                    new SequentialNonceSource().GetBytes);
+                Contexts = new PlatformPreparedActionContextOwner(
+                    Capabilities,
+                    Clock,
+                    Enumerable.Repeat((byte)8, 32).ToArray());
+                Host = new FakeHost();
+                Port = new FakePort();
+                Limiter = new PlatformActionAdmissionLimiter();
+                Audit = new PlatformAuditStore(
+                    NullLogger<PlatformAuditStore>.Instance,
+                    Clock,
+                    Enumerable.Repeat((byte)9, 32).ToArray());
+                BoundaryActor = new PlatformActor(
+                    FakeHost.UserId,
+                    boundaryElevated,
+                    new string('a', 32),
+                    "android-tv",
+                    "device-a");
+                Idempotency = new PlatformIdempotencyStore(Clock);
+                Coordinator = new PlatformActionInvocationCoordinator(
+                    Host,
+                    Contexts,
+                    Capabilities,
+                    Idempotency,
+                    Limiter,
+                    new PlatformFirstPartyActionDispatcher(Port, Port, Port),
+                    Audit);
+            }
+
+            internal ManualTimeProvider Clock { get; }
+
+            internal PlatformActionCapabilityService Capabilities { get; }
+
+            internal PlatformPreparedActionContextOwner Contexts { get; }
+
+            internal FakeHost Host { get; }
+
+            internal FakePort Port { get; }
+
+            internal PlatformActionAdmissionLimiter Limiter { get; }
+
+            internal PlatformIdempotencyStore Idempotency { get; }
+
+            internal PlatformAuditStore Audit { get; }
+
+            internal PlatformActor BoundaryActor { get; }
+
+            internal PlatformActionInvocationCoordinator Coordinator { get; }
+
+            internal PlatformPreparedActionIssue Prepare(PlatformOperationDefinition? definition = null)
+                => Contexts.Issue(
+                    BoundaryActor,
+                    new PlatformPreparedActionRequest(
+                        definition ?? PlatformOperationDefinition.SpoilerGuardConfigureItem,
+                        Host.Item,
+                        Port.ConfigurationRevision,
+                        new byte[] { 1, 0, 0, 0 }),
+                    attenuateToCurrentDevice: false);
+
+            internal PlatformActionInvokeRequest Request(string capability, string key, bool enabled)
+                => new(
+                    capability,
+                    Key(key),
+                    ImmutableArray.Create(new PlatformActionAnswer(
+                        "enabled",
+                        enabled,
+                        optionIds: null)));
+
+            internal void Revoke(string revocation)
+            {
+                switch (revocation)
+                {
+                    case "user-deletion":
+                        Host.UserExists = false;
+                        break;
+                    case "library-removal":
+                    case "parental-policy-change":
+                    case "item-deletion":
+                        Host.ItemAccessible = false;
+                        break;
+                    case "item-move":
+                        Host.ReturnedItem = new HostAccessibleItem(
+                            Host.Item.Id,
+                            HostItemKind.Episode,
+                            Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+                            ImmutableArray<HostProviderReference>.Empty);
+                        break;
+                    case "feature-disable":
+                        Port.FeatureEnabled = false;
+                        break;
+                    case "configuration-revision":
+                        Port.ConfigurationRevision++;
+                        break;
+                    case "authority-revision":
+                        Capabilities.InvalidateOutstandingCapabilities();
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(revocation));
+                }
+            }
+
+            internal void RestoreCurrentAuthority()
+            {
+                Host.UserExists = true;
+                Host.ItemAccessible = true;
+                Host.ReturnedItem = null;
+                Port.FeatureEnabled = true;
+                Port.ConfigurationRevision = 1;
+            }
+
+            public void Dispose()
+            {
+                Contexts.Dispose();
+                Capabilities.Dispose();
+            }
+        }
+
+        private sealed class FakePort :
+            ISpoilerGuardPlatformActionPort,
+            IHiddenContentPlatformActionPort,
+            ISeerrPlatformActionPort
+        {
+            internal bool FeatureEnabled { get; set; } = true;
+
+            internal long ConfigurationRevision { get; set; } = 1;
+
+            internal bool BlockOwner { get; set; }
+
+            internal bool IgnoreCancellation { get; set; }
+
+            internal int OwnerCalls { get; private set; }
+
+            internal bool? LastActorWasElevated { get; private set; }
+
+            internal TaskCompletionSource OwnerEntered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            internal TaskCompletionSource ReleaseOwner { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public PlatformActionPortAdmission ValidateCurrent(
+                PlatformActor actor,
+                HostAccessibleItem item,
+                PlatformPreparedActionContext prepared,
+                ImmutableArray<PlatformActionAnswer> answers)
+            {
+                LastActorWasElevated = actor.IsElevated;
+                if (!FeatureEnabled || prepared.ConfigurationRevision != ConfigurationRevision)
+                {
+                    return PlatformActionPortAdmission.Refuse(PlatformActionPortDecision.AuthorityDenied);
+                }
+
+                if (answers.Length != 1
+                    || answers[0].FieldId != "enabled"
+                    || answers[0].BooleanValue is not bool enabled
+                    || answers[0].OptionIds is not null)
+                {
+                    return PlatformActionPortAdmission.Refuse(PlatformActionPortDecision.InvalidInput);
+                }
+
+                return PlatformActionPortAdmission.Admit(
+                    new BooleanInput(enabled),
+                    new[] { enabled ? (byte)1 : (byte)0 });
+            }
+
+            public async Task<PlatformActionOwnerResult> InvokeAsync(
+                PlatformActor actor,
+                HostAccessibleItem item,
+                IPlatformValidatedActionInput input,
+                PlatformIdempotencyKey idempotencyKey,
+                CancellationToken cancellationToken)
+            {
+                Assert.IsType<BooleanInput>(input);
+                OwnerCalls++;
+                OwnerEntered.TrySetResult();
+                if (BlockOwner)
+                {
+                    if (IgnoreCancellation)
+                    {
+                        await ReleaseOwner.Task;
+                    }
+                    else
+                    {
+                        await ReleaseOwner.Task.WaitAsync(cancellationToken);
+                    }
+                }
+
+                using var document = JsonDocument.Parse("{\"Outcome\":\"succeeded\"}");
+                return PlatformActionOwnerResult.Succeeded(document.RootElement);
+            }
+
+            private sealed record BooleanInput(bool Enabled) : IPlatformValidatedActionInput;
+        }
+
+        private sealed class FakeHost : IPlatformHost, IHostUsers, IHostLibrary, IHostSessions, IHostPlugins
+        {
+            internal static readonly Guid UserId = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+            private static readonly Guid ItemId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+
+            internal FakeHost()
+            {
+                Item = new HostAccessibleItem(
+                    ItemId,
+                    HostItemKind.Movie,
+                    seriesId: null,
+                    ImmutableArray<HostProviderReference>.Empty);
+            }
+
+            public IHostUsers Users => this;
+
+            public IHostLibrary Library => this;
+
+            public IHostSessions Sessions => this;
+
+            public IHostPlugins Plugins => this;
+
+            internal bool UserExists { get; set; } = true;
+
+            internal bool IsAdministrator { get; set; }
+
+            internal bool ItemAccessible { get; set; } = true;
+
+            internal HostAccessibleItem Item { get; private set; }
+
+            internal HostAccessibleItem? ReturnedItem { get; set; }
+
+            internal bool BlockAccessibleLookup { get; set; }
+
+            internal ManualResetEventSlim AccessibleLookupEntered { get; } = new(initialState: false);
+
+            internal ManualResetEventSlim ReleaseAccessibleLookup { get; } = new(initialState: false);
+
+            internal void UseEpisode()
+                => Item = new HostAccessibleItem(
+                    Item.Id,
+                    HostItemKind.Episode,
+                    Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+                    ImmutableArray<HostProviderReference>.Empty);
+
+            public HostUser? Find(Guid id)
+                => UserExists && id == UserId ? new HostUser(UserId, "user", IsAdministrator) : null;
+
+            HostItem? IHostLibrary.Find(Guid id) => null;
+
+            public HostItemAccessResult FindAccessible(Guid userId, Guid itemId)
+            {
+                if (BlockAccessibleLookup)
+                {
+                    AccessibleLookupEntered.Set();
+                    ReleaseAccessibleLookup.Wait();
+                }
+
+                return ItemAccessible && UserExists && userId == UserId && itemId == Item.Id
+                    ? HostItemAccessResult.Accessible(ReturnedItem ?? Item)
+                    : HostItemAccessResult.NotAccessible;
+            }
+
+            public IReadOnlyList<HostUser> All() => Array.Empty<HostUser>();
+
+            public IReadOnlyList<HostItem> ChildrenOf(Guid id) => Array.Empty<HostItem>();
+
+            public IReadOnlyList<HostSession> Active() => Array.Empty<HostSession>();
+
+            public IReadOnlyList<HostSession> ForUser(Guid userId) => Array.Empty<HostSession>();
+
+            public IReadOnlyList<HostPlugin> Installed() => Array.Empty<HostPlugin>();
+
+            HostPlugin? IHostPlugins.Find(Guid id) => null;
+        }
+
+        private sealed class SequentialNonceSource
+        {
+            private int _value;
+
+            internal byte[] GetBytes(int length)
+            {
+                var result = new byte[length];
+                BitConverter.GetBytes(++_value).CopyTo(result, 0);
+                return result;
+            }
+        }
+
+        internal sealed class ManualTimeProvider(DateTimeOffset now) : TimeProvider
+        {
+            private DateTimeOffset _now = now;
+
+            public override DateTimeOffset GetUtcNow() => _now;
+
+            internal void Advance(TimeSpan amount) => _now += amount;
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActionInvokeContractTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActionInvokeContractTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Linq;
+using System.Text.Json;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Microsoft.Extensions.Primitives;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
+{
+    public class PlatformActionInvokeContractTests
+    {
+        [Fact]
+        public void ExactAndroidBodyParsesThroughTheSharedIdempotencyKeyContract()
+        {
+            var request = Parse(
+                """
+                {
+                  "Capability":"opaque-capability",
+                  "IdempotencyKey":"9e30bb75-916e-48ac-984d-e65509cd2850",
+                  "Answers":[
+                    {"FieldId":"enabled","BooleanValue":true},
+                    {"FieldId":"scope","OptionIds":["global"]}
+                  ],
+                  "FutureOptionalProperty":true
+                }
+                """);
+
+            Assert.Equal("opaque-capability", request.Capability);
+            Assert.Equal("9e30bb75-916e-48ac-984d-e65509cd2850", request.IdempotencyKey.Value);
+            Assert.Equal(2, request.Answers.Length);
+            Assert.True(request.Answers[0].BooleanValue);
+            Assert.Equal(new[] { "global" }, request.Answers[1].OptionIds!.Value);
+            Assert.True(PlatformActionIdempotencyCarrier.TryResolve(request, StringValues.Empty, out var key));
+            Assert.Equal(request.IdempotencyKey, key);
+        }
+
+        [Theory]
+        [InlineData("{}")]
+        [InlineData("{\"Capability\":\"c\",\"Answers\":[]}")]
+        [InlineData("{\"Capability\":\"c\",\"IdempotencyKey\":\"\",\"Answers\":[]}")]
+        [InlineData("{\"Capability\":\"c\",\"IdempotencyKey\":\"space key\",\"Answers\":[]}")]
+        [InlineData("{\"Capability\":\"c\",\"Capability\":\"d\",\"IdempotencyKey\":\"k\",\"Answers\":[]}")]
+        [InlineData("{\"Capability\":\"c\",\"IdempotencyKey\":\"k\",\"IdempotencyKey\":\"k\",\"Answers\":[]}")]
+        [InlineData("{\"Capability\":\"c\",\"IdempotencyKey\":\"k\",\"Answers\":[],\"Answers\":[]}")]
+        [InlineData("{\"Capability\":\"c\",\"IdempotencyKey\":\"k\",\"Answers\":[{\"FieldId\":\"x\",\"BooleanValue\":true,\"BooleanValue\":false}]}")]
+        [InlineData("{\"Capability\":\"c\",\"IdempotencyKey\":\"k\",\"Answers\":[{\"FieldId\":\"x\",\"BooleanValue\":true,\"OptionIds\":[]}]}")]
+        [InlineData("{\"Capability\":\"c\",\"IdempotencyKey\":\"k\",\"Answers\":[{\"FieldId\":\"x\",\"OptionIds\":[\"a\",\"a\"]}]}")]
+        public void MissingMalformedDuplicateAndAmbiguousKnownFieldsFailClosed(string json)
+            => Assert.Throws<JsonException>(() => Parse(json));
+
+        [Fact]
+        public void AnswerAndOptionBoundsRejectTheExactNextElement()
+        {
+            var answers = string.Join(",", Enumerable.Range(0, PlatformActionInvokeRequestConverter.MaximumAnswers + 1)
+                .Select(index => $"{{\"FieldId\":\"f{index}\",\"BooleanValue\":true}}"));
+            Assert.Throws<JsonException>(() => Parse(Body(answers)));
+
+            var options = string.Join(",", Enumerable.Range(0, PlatformActionInvokeRequestConverter.MaximumOptionIds + 1)
+                .Select(index => $"\"o{index}\""));
+            Assert.Throws<JsonException>(() => Parse(Body($"{{\"FieldId\":\"field\",\"OptionIds\":[{options}]}}")));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("header-key")]
+        public void AnyCompetingHeaderCarrierIsRejected(string header)
+        {
+            var request = Parse(Body(string.Empty));
+            var values = new StringValues(header);
+
+            Assert.False(PlatformActionIdempotencyCarrier.TryResolve(request, values, out _));
+        }
+
+        [Fact]
+        public void MultipleHeaderValuesAreRejectedAndBodyKeyRemainsCaseSensitive()
+        {
+            var request = Parse(Body(string.Empty));
+            Assert.False(PlatformActionIdempotencyCarrier.TryResolve(
+                request,
+                new StringValues(new[] { "a", "b" }),
+                out _));
+            Assert.Throws<JsonException>(() => Parse(
+                "{\"Capability\":\"c\",\"idempotencyKey\":\"k\",\"Answers\":[]}"));
+        }
+
+        private static PlatformActionInvokeRequest Parse(string json)
+            => JsonSerializer.Deserialize<PlatformActionInvokeRequest>(json, PlatformJson.SerializerOptions)!;
+
+        private static string Body(string answers)
+            => $"{{\"Capability\":\"c\",\"IdempotencyKey\":\"key\",\"Answers\":[{answers}]}}";
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformIdempotencyArchitectureTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformIdempotencyArchitectureTests.cs
@@ -20,8 +20,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
         private static readonly Dictionary<string, string> AllowedStateOwners = new(StringComparer.Ordinal)
         {
             ["PlatformActionCapabilityService.cs:_ledger"] = "The sole reviewed bounded short-lived capability nonce owner.",
+            ["PlatformActionAdmissionLimiter.cs:_gates"] = "The reviewed fixed-cap actor/operation admission owner.",
             ["PlatformErrorCode.cs:Definitions"] = "Immutable error-code definition table, not request state.",
             ["PlatformIdempotencyStore.cs:_entries"] = "The sole reviewed bounded idempotency state owner.",
+            ["PlatformPreparedActionContextOwner.cs:_entries"] = "The reviewed fixed-cap prepared action context owner.",
         };
 
         [Fact]

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformIdempotencyTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformIdempotencyTests.cs
@@ -375,6 +375,151 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
         }
 
         [Fact]
+        public async Task CoordinatedLeaderCanceledBeforeSideEffectLetsFollowerRetryLeadership()
+        {
+            var store = new PlatformIdempotencyStore();
+            var request = Request("safe-abandonment", "payload");
+            var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var leaderCancellation = new CancellationTokenSource();
+
+            var leader = store.ExecuteCoordinatedAsync(
+                request,
+                async (_, cancellationToken) =>
+                {
+                    entered.TrySetResult();
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                    throw new Xunit.Sdk.XunitException("The canceled leader must not continue.");
+                },
+                leaderCancellation.Token);
+            await entered.Task;
+
+            var followerCalls = 0;
+            var follower = store.ExecuteCoordinatedAsync(
+                request,
+                (execution, _) =>
+                {
+                    followerCalls++;
+                    execution.MarkSideEffectStarted();
+                    return Task.FromResult(Result(17));
+                },
+                CancellationToken.None);
+            Assert.Equal(1, store.FollowerCount);
+
+            leaderCancellation.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => leader);
+            var promoted = await follower;
+            Assert.Equal(PlatformIdempotencyOutcomeKind.Executed, promoted.Kind);
+            Assert.Equal(17, promoted.Result!.Value.GetProperty("value").GetInt32());
+            Assert.Equal(1, followerCalls);
+            Assert.Equal(0, store.FollowerCount);
+            Assert.Equal(
+                PlatformIdempotencyOutcomeKind.Replay,
+                (await store.ExecuteAsync(request, _ => Task.FromResult(Result(99)), CancellationToken.None)).Kind);
+        }
+
+        [Fact]
+        public async Task CoordinatedFailureAfterSideEffectBoundaryRemainsIndeterminate()
+        {
+            var store = new PlatformIdempotencyStore();
+            var request = Request("marked-ambiguous", "payload");
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => store.ExecuteCoordinatedAsync(
+                request,
+                (execution, _) =>
+                {
+                    execution.MarkSideEffectStarted();
+                    throw new InvalidOperationException("owner outcome unknown");
+                },
+                CancellationToken.None));
+
+            var called = false;
+            var retry = await store.ExecuteCoordinatedAsync(
+                request,
+                (_, _) =>
+                {
+                    called = true;
+                    return Task.FromResult(Result(1));
+                },
+                CancellationToken.None);
+
+            Assert.Equal(PlatformIdempotencyOutcomeKind.Indeterminate, retry.Kind);
+            Assert.False(called);
+        }
+
+        [Fact]
+        public async Task CoordinatedPreMutationRefusalIsSharedWithFollowersButNotRetained()
+        {
+            var store = new PlatformIdempotencyStore();
+            var request = Request("unstored-refusal", "payload");
+            var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var leader = store.ExecuteCoordinatedAsync(
+                request,
+                async (execution, _) =>
+                {
+                    entered.TrySetResult();
+                    await release.Task;
+                    return execution.AbandonBeforeSideEffect(Result(17));
+                },
+                CancellationToken.None);
+            await entered.Task;
+
+            var followerCalls = 0;
+            var follower = store.ExecuteCoordinatedAsync(
+                request,
+                (_, _) =>
+                {
+                    followerCalls++;
+                    return Task.FromResult(Result(99));
+                },
+                CancellationToken.None);
+            Assert.Equal(1, store.FollowerCount);
+            release.TrySetResult();
+
+            var leaderOutcome = await leader;
+            var followerOutcome = await follower;
+            Assert.Equal(17, leaderOutcome.Result!.Value.GetProperty("value").GetInt32());
+            Assert.Equal(17, followerOutcome.Result!.Value.GetProperty("value").GetInt32());
+            Assert.False(leaderOutcome.WasCoalescedUnstored);
+            Assert.True(followerOutcome.WasCoalescedUnstored);
+            Assert.Equal(0, followerCalls);
+            Assert.Equal(0, store.EntryCount);
+
+            var retry = await store.ExecuteCoordinatedAsync(
+                request,
+                (execution, _) =>
+                {
+                    execution.MarkSideEffectStarted();
+                    return Task.FromResult(Result(99));
+                },
+                CancellationToken.None);
+            Assert.Equal(PlatformIdempotencyOutcomeKind.Executed, retry.Kind);
+            Assert.Equal(99, retry.Result!.Value.GetProperty("value").GetInt32());
+        }
+
+        [Fact]
+        public async Task CoordinatedPreMutationRefusalCannotBypassItsResultReservation()
+        {
+            var store = new PlatformIdempotencyStore();
+            var request = Request("bounded-refusal", "payload", maximumResultBytes: 8);
+
+            var outcome = await store.ExecuteCoordinatedAsync(
+                request,
+                (execution, _) => Task.FromResult(
+                    execution.AbandonBeforeSideEffect(Result(123))),
+                CancellationToken.None);
+
+            Assert.Equal(PlatformIdempotencyOutcomeKind.Indeterminate, outcome.Kind);
+            Assert.Equal(
+                PlatformIdempotencyOutcomeKind.Indeterminate,
+                (await store.ExecuteCoordinatedAsync(
+                    request,
+                    (_, _) => Task.FromResult(Result(1)),
+                    CancellationToken.None)).Kind);
+        }
+
+        [Fact]
         public async Task ResultLargerThanItsPreExecutionReservationBecomesIndeterminate()
         {
             var store = new PlatformIdempotencyStore();

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformPreparedActionContextOwnerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformPreparedActionContextOwnerTests.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
+{
+    public class PlatformPreparedActionContextOwnerTests
+    {
+        private static readonly DateTimeOffset Epoch = new(2026, 8, 3, 0, 0, 0, TimeSpan.Zero);
+
+        [Fact]
+        public void IssuedCapabilityResolvesOnlyItsExactAuthenticatedServerOwnedContext()
+        {
+            var clock = new ManualTimeProvider(Epoch);
+            using var capabilities = Capabilities(clock);
+            using var owner = Owner(capabilities, clock);
+            var state = new byte[] { 1, 2, 3 };
+            var issued = owner.Issue(Actor(), Request(state), attenuateToCurrentDevice: false);
+            state.AsSpan().Fill(9);
+
+            Assert.Equal(PlatformPreparedActionIssueKind.Issued, issued.Kind);
+            Assert.Equal(Epoch + PlatformActionCapabilityService.CapabilityTimeToLive, issued.ExpiresAt);
+            var inspection = capabilities.Inspect(issued.Capability);
+            var context = owner.Resolve(issued.Capability, inspection);
+
+            Assert.NotNull(context);
+            Assert.Same(PlatformOperationDefinition.HiddenContentConfigureItem, context!.Definition);
+            Assert.Equal(ItemId, context.Item.Id);
+            Assert.Equal(HostItemKind.Episode, context.Item.Kind);
+            Assert.Equal(7, context.ConfigurationRevision);
+            Assert.Equal(new byte[] { 1, 2, 3 }, context.PrivateState.ToArray());
+            Assert.Equal(32, context.Digest.Length);
+            var releasedState = context.PrivateState;
+            var releasedDigest = context.Digest;
+            var expectedDigest = releasedDigest.ToArray();
+            Assert.True(MemoryMarshal.TryGetArray(releasedState, out var stateArray));
+            Assert.True(MemoryMarshal.TryGetArray(releasedDigest, out var digestArray));
+            stateArray.AsSpan().Fill(8);
+            digestArray.AsSpan().Fill(8);
+            Assert.Equal(new byte[] { 1, 2, 3 }, context.PrivateState.ToArray());
+            Assert.Equal(expectedDigest, context.Digest.ToArray());
+            Assert.Equal(1, owner.EntryCount);
+        }
+
+        [Fact]
+        public void TokenInspectionSwapForgeryRestartExpiryAndInvalidationFailClosed()
+        {
+            var clock = new ManualTimeProvider(Epoch);
+            using var capabilities = Capabilities(clock);
+            using var owner = Owner(capabilities, clock);
+            var first = owner.Issue(Actor(), Request(new byte[] { 1 }), false);
+            var second = owner.Issue(Actor(), Request(new byte[] { 2 }), false);
+            var firstInspection = capabilities.Inspect(first.Capability);
+            var secondInspection = capabilities.Inspect(second.Capability);
+
+            Assert.Null(owner.Resolve(first.Capability, secondInspection));
+            Assert.Null(owner.Resolve(second.Capability, firstInspection));
+            Assert.Null(owner.Resolve(first.Capability + "x", firstInspection));
+            Assert.Null(owner.Resolve("forged", capabilities.Inspect("forged")));
+
+            using var restartedCapabilities = Capabilities(clock, keyByte: 8);
+            using var restarted = Owner(restartedCapabilities, clock, lookupByte: 9);
+            Assert.Null(restarted.Resolve(first.Capability, restartedCapabilities.Inspect(first.Capability)));
+
+            owner.InvalidateOutstanding();
+            Assert.Equal(0, owner.EntryCount);
+            Assert.Null(owner.Resolve(first.Capability, capabilities.Inspect(first.Capability)));
+
+            var afterInvalidation = owner.Issue(Actor(), Request(new byte[] { 3 }), false);
+            clock.Advance(PlatformActionCapabilityService.CapabilityTimeToLive);
+            Assert.Equal(PlatformCapabilityInspectionKind.Expired, capabilities.Inspect(afterInvalidation.Capability).Kind);
+            Assert.Equal(0, owner.EntryCount);
+        }
+
+        [Fact]
+        public void CapacityNeverEvictsALivePreparedContext()
+        {
+            var clock = new ManualTimeProvider(Epoch);
+            var nonces = new SequentialNonceSource();
+            using var capabilities = new PlatformActionCapabilityService(
+                clock,
+                Enumerable.Repeat((byte)4, 32).ToArray(),
+                nonces.GetBytes);
+            using var owner = Owner(capabilities, clock);
+            PlatformPreparedActionIssue? first = null;
+
+            for (var index = 0; index < PlatformPreparedActionContextOwner.MaximumEntries; index++)
+            {
+                var issued = owner.Issue(Actor(), Request(BitConverter.GetBytes(index)), false);
+                Assert.Equal(PlatformPreparedActionIssueKind.Issued, issued.Kind);
+                first ??= issued;
+            }
+
+            var refused = owner.Issue(Actor(), Request(new byte[] { 99 }), false);
+            Assert.Equal(PlatformPreparedActionIssueKind.AtCapacity, refused.Kind);
+            Assert.Equal(PlatformPreparedActionContextOwner.MaximumEntries, owner.EntryCount);
+            Assert.NotNull(owner.Resolve(first!.Capability, capabilities.Inspect(first.Capability)));
+        }
+
+        [Fact]
+        public void RequestRejectsUnknownDefinitionsKindsRevisionsAndOversizedPrivateState()
+        {
+            var unsupported = new HostAccessibleItem(
+                ItemId,
+                HostItemKind.Other,
+                seriesId: null,
+                ImmutableArray<HostProviderReference>.Empty);
+            Assert.Throws<ArgumentException>(() => new PlatformPreparedActionRequest(
+                PlatformOperationDefinition.HiddenContentConfigureItem,
+                unsupported,
+                0,
+                ReadOnlySpan<byte>.Empty));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new PlatformPreparedActionRequest(
+                PlatformOperationDefinition.HiddenContentConfigureItem,
+                Item(),
+                -1,
+                ReadOnlySpan<byte>.Empty));
+            Assert.Throws<ArgumentException>(() => new PlatformPreparedActionRequest(
+                PlatformOperationDefinition.HiddenContentConfigureItem,
+                Item(),
+                0,
+                new byte[PlatformPreparedActionContextOwner.MaximumPrivateStateBytes + 1]));
+        }
+
+        private static readonly Guid ItemId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+
+        private static PlatformPreparedActionRequest Request(byte[] state)
+            => new(PlatformOperationDefinition.HiddenContentConfigureItem, Item(), 7, state);
+
+        private static HostAccessibleItem Item()
+            => new(
+                ItemId,
+                HostItemKind.Episode,
+                Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
+                ImmutableArray<HostProviderReference>.Empty);
+
+        private static PlatformActor Actor()
+            => new(
+                Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
+                isElevated: false,
+                new string('a', 32),
+                "android-tv",
+                "device-a");
+
+        private static PlatformActionCapabilityService Capabilities(ManualTimeProvider clock, byte keyByte = 3)
+            => new(clock, Enumerable.Repeat(keyByte, 32).ToArray(), new SequentialNonceSource().GetBytes);
+
+        private static PlatformPreparedActionContextOwner Owner(
+            PlatformActionCapabilityService capabilities,
+            ManualTimeProvider clock,
+            byte lookupByte = 5)
+            => new(capabilities, clock, Enumerable.Repeat(lookupByte, 32).ToArray());
+
+        private sealed class SequentialNonceSource
+        {
+            private int _value;
+
+            internal byte[] GetBytes(int length)
+            {
+                var result = new byte[length];
+                BitConverter.GetBytes(++_value).CopyTo(result, 0);
+                return result;
+            }
+        }
+
+        private sealed class ManualTimeProvider(DateTimeOffset now) : TimeProvider
+        {
+            private DateTimeOffset _now = now;
+
+            public override DateTimeOffset GetUtcNow() => _now;
+
+            internal void Advance(TimeSpan amount) => _now += amount;
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformActionAdmissionLimiter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformActionAdmissionLimiter.cs
@@ -1,0 +1,244 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    internal enum PlatformActionAdmissionKind
+    {
+        Acquired,
+        AtCapacity,
+    }
+
+    internal sealed class PlatformActionAdmission : IDisposable
+    {
+        private readonly PlatformActionAdmissionLimiter? _owner;
+        private readonly PlatformActionAdmissionLimiter.ActionKey? _key;
+        private int _released;
+
+        internal PlatformActionAdmission(
+            PlatformActionAdmissionKind kind,
+            PlatformActionAdmissionLimiter? owner = null,
+            PlatformActionAdmissionLimiter.ActionKey? key = null)
+        {
+            Kind = kind;
+            _owner = owner;
+            _key = key;
+        }
+
+        internal PlatformActionAdmissionKind Kind { get; }
+
+        public void Dispose()
+        {
+            if (Kind == PlatformActionAdmissionKind.Acquired
+                && Interlocked.Exchange(ref _released, 1) == 0)
+            {
+                _owner!.Release(_key!.Value);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Fair bounded admission per authoritative actor and closed operation. One leader
+    /// runs per key; waiting and retained-key state are both independently capped.
+    /// </summary>
+    public sealed class PlatformActionAdmissionLimiter
+    {
+        public const int MaximumKeys = 1024;
+
+        public const int MaximumWaitersPerKey = 8;
+
+        public const int MaximumWaiters = 1024;
+
+        private readonly object _gate = new();
+        private readonly Dictionary<ActionKey, Gate> _gates = new();
+        private int _waiterCount;
+
+        internal Task<PlatformActionAdmission> AcquireAsync(
+            PlatformActor actor,
+            PlatformOperationDefinition operation,
+            CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(actor);
+            ArgumentNullException.ThrowIfNull(operation);
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!ReferenceEquals(PlatformOperationVocabulary.Find(operation.Id.Value), operation))
+            {
+                return Task.FromResult(new PlatformActionAdmission(PlatformActionAdmissionKind.AtCapacity));
+            }
+
+            var key = new ActionKey(actor.UserId, operation.Id.Value);
+            Waiter? waiter = null;
+            lock (_gate)
+            {
+                if (!_gates.TryGetValue(key, out var gate))
+                {
+                    if (_gates.Count >= MaximumKeys)
+                    {
+                        return Task.FromResult(new PlatformActionAdmission(PlatformActionAdmissionKind.AtCapacity));
+                    }
+
+                    gate = new Gate();
+                    _gates.Add(key, gate);
+                }
+
+                if (!gate.Active)
+                {
+                    gate.Active = true;
+                    return Task.FromResult(
+                        new PlatformActionAdmission(PlatformActionAdmissionKind.Acquired, this, key));
+                }
+
+                if (gate.Waiters.Count >= MaximumWaitersPerKey || _waiterCount >= MaximumWaiters)
+                {
+                    return Task.FromResult(new PlatformActionAdmission(PlatformActionAdmissionKind.AtCapacity));
+                }
+
+                waiter = new Waiter(cancellationToken);
+                waiter.Node = gate.Waiters.AddLast(waiter);
+                _waiterCount++;
+            }
+
+            waiter.Registration = cancellationToken.Register(
+                static state =>
+                {
+                    var registration = (CancellationRegistration)state!;
+                    registration.Owner.CancelWaiter(registration.Key, registration.Waiter);
+                },
+                new CancellationRegistration(this, key, waiter));
+            return AwaitWaiterAsync(waiter);
+        }
+
+        internal int KeyCount
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _gates.Count;
+                }
+            }
+        }
+
+        internal int WaiterCount
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _waiterCount;
+                }
+            }
+        }
+
+        private static async Task<PlatformActionAdmission> AwaitWaiterAsync(Waiter waiter)
+        {
+            try
+            {
+                return await waiter.Completion.Task.ConfigureAwait(false);
+            }
+            finally
+            {
+                await waiter.Registration.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
+        private void CancelWaiter(ActionKey key, Waiter waiter)
+        {
+            var removed = false;
+            lock (_gate)
+            {
+                if (_gates.TryGetValue(key, out var gate)
+                    && waiter.Node?.List is not null)
+                {
+                    gate.Waiters.Remove(waiter.Node);
+                    waiter.Node = null;
+                    _waiterCount--;
+                    removed = true;
+                    RemoveIdle(key, gate);
+                }
+            }
+
+            if (removed)
+            {
+                waiter.Completion.TrySetCanceled(waiter.CancellationToken);
+            }
+        }
+
+        internal void Release(ActionKey key)
+        {
+            Waiter? next = null;
+            lock (_gate)
+            {
+                if (!_gates.TryGetValue(key, out var gate) || !gate.Active)
+                {
+                    return;
+                }
+
+                while (gate.Waiters.First is LinkedListNode<Waiter> node)
+                {
+                    gate.Waiters.RemoveFirst();
+                    node.Value.Node = null;
+                    _waiterCount--;
+                    if (!node.Value.CancellationToken.IsCancellationRequested)
+                    {
+                        next = node.Value;
+                        break;
+                    }
+
+                    node.Value.Completion.TrySetCanceled(node.Value.CancellationToken);
+                }
+
+                if (next is null)
+                {
+                    gate.Active = false;
+                    RemoveIdle(key, gate);
+                }
+            }
+
+            next?.Completion.TrySetResult(
+                new PlatformActionAdmission(PlatformActionAdmissionKind.Acquired, this, key));
+        }
+
+        private void RemoveIdle(ActionKey key, Gate gate)
+        {
+            if (!gate.Active && gate.Waiters.Count == 0)
+            {
+                _gates.Remove(key);
+            }
+        }
+
+        internal readonly record struct ActionKey(Guid ActorUserId, string OperationId);
+
+        private sealed class Gate
+        {
+            internal bool Active { get; set; }
+
+            internal LinkedList<Waiter> Waiters { get; } = new();
+        }
+
+        private sealed class Waiter
+        {
+            internal Waiter(CancellationToken cancellationToken)
+            {
+                CancellationToken = cancellationToken;
+                Completion = new TaskCompletionSource<PlatformActionAdmission>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+            }
+
+            internal CancellationToken CancellationToken { get; }
+
+            internal TaskCompletionSource<PlatformActionAdmission> Completion { get; }
+
+            internal LinkedListNode<Waiter>? Node { get; set; }
+
+            internal CancellationTokenRegistration Registration { get; set; }
+        }
+
+        private sealed record CancellationRegistration(
+            PlatformActionAdmissionLimiter Owner,
+            ActionKey Key,
+            Waiter Waiter);
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformActionCapabilityService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformActionCapabilityService.cs
@@ -55,15 +55,21 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
     /// <summary>An opaque capability string, present only when minting succeeded.</summary>
     internal sealed class PlatformCapabilityMintOutcome
     {
-        internal PlatformCapabilityMintOutcome(PlatformCapabilityMintOutcomeKind kind, string? capability = null)
+        internal PlatformCapabilityMintOutcome(
+            PlatformCapabilityMintOutcomeKind kind,
+            string? capability = null,
+            DateTimeOffset? expiresAt = null)
         {
             Kind = kind;
             Capability = capability;
+            ExpiresAt = expiresAt;
         }
 
         internal PlatformCapabilityMintOutcomeKind Kind { get; }
 
         internal string? Capability { get; }
+
+        internal DateTimeOffset? ExpiresAt { get; }
     }
 
     /// <summary>An authenticated decoded capability. Inspection never consumes it.</summary>
@@ -73,12 +79,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
             PlatformCapabilityInspectionKind kind,
             PlatformActionCapabilityService? owner = null,
             object? claims = null,
-            byte[]? tag = null)
+            byte[]? tag = null,
+            byte[]? capabilityDigest = null)
         {
             Kind = kind;
             Owner = owner;
             Claims = claims;
             Tag = tag;
+            CapabilityDigest = capabilityDigest;
         }
 
         internal PlatformCapabilityInspectionKind Kind { get; }
@@ -88,6 +96,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
         internal object? Claims { get; }
 
         internal byte[]? Tag { get; }
+
+        internal byte[]? CapabilityDigest { get; }
     }
 
     /// <summary>
@@ -290,7 +300,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
                 var capability = ToBase64Url(raw);
 
                 _ledger.Add(nonceKey, new LedgerEntry(expiresAt, _authorityRevision, tag));
-                return new PlatformCapabilityMintOutcome(PlatformCapabilityMintOutcomeKind.Issued, capability);
+                return new PlatformCapabilityMintOutcome(
+                    PlatformCapabilityMintOutcomeKind.Issued,
+                    capability,
+                    expiresAt);
             }
         }
 
@@ -328,7 +341,31 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
                     PlatformCapabilityInspectionKind.Authentic,
                     this,
                     claims,
-                    expectedTag);
+                    expectedTag,
+                    SHA256.HashData(Encoding.ASCII.GetBytes(capability!)));
+            }
+        }
+
+        /// <summary>
+        /// Proves that an authentic inspection came from this service for the exact
+        /// opaque spelling a prepared-context owner is about to resolve.
+        /// </summary>
+        internal bool IsInspectionFor(
+            PlatformCapabilityInspection? inspection,
+            string? capability)
+        {
+            lock (_gate)
+            {
+                ThrowIfDisposed();
+                return inspection is not null
+                    && inspection.Kind == PlatformCapabilityInspectionKind.Authentic
+                    && ReferenceEquals(inspection.Owner, this)
+                    && inspection.CapabilityDigest is { Length: 32 } expected
+                    && capability is not null
+                    && capability.Length <= MaximumTokenCharacters
+                    && CryptographicOperations.FixedTimeEquals(
+                        expected,
+                        SHA256.HashData(Encoding.ASCII.GetBytes(capability)));
             }
         }
 

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformActionInvocationCoordinator.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformActionInvocationCoordinator.cs
@@ -1,0 +1,507 @@
+using System;
+using System.Buffers.Binary;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>The three cancellation signals kept distinct below the HTTP boundary.</summary>
+    internal readonly record struct PlatformInvocationCancellation(
+        CancellationToken ExecutionToken,
+        CancellationToken CallerToken,
+        CancellationToken DeadlineToken)
+    {
+        internal PlatformAuditResultCode AuditResult()
+        {
+            // A disconnected caller wins a simultaneous race, matching the Platform
+            // lifecycle filters and avoiding attribution of peer aborts to the host.
+            if (CallerToken.IsCancellationRequested)
+            {
+                return PlatformAuditResultCode.CallerCancelled;
+            }
+
+            return DeadlineToken.IsCancellationRequested
+                ? PlatformAuditResultCode.DeadlineExceeded
+                : PlatformAuditResultCode.InternalFailure;
+        }
+    }
+
+    /// <summary>A transport-neutral semantic result selected by the coordinator.</summary>
+    internal sealed class PlatformActionInvocationOutcome
+    {
+        internal PlatformActionInvocationOutcome(PlatformIdempotencyResult result, bool replayed)
+        {
+            Result = result ?? throw new ArgumentNullException(nameof(result));
+            Replayed = replayed;
+        }
+
+        internal PlatformIdempotencyResult Result { get; }
+
+        internal bool Replayed { get; }
+    }
+
+    /// <summary>
+    /// Single admission and invocation-time reauthorization coordinator for the fixed
+    /// first-party pilot actions.
+    /// </summary>
+    public sealed class PlatformActionInvocationCoordinator
+    {
+        internal const int MaximumSemanticResultBytes = 32 * 1024;
+
+        private static readonly byte[] FingerprintDomain =
+            Encoding.ASCII.GetBytes("jellyfin-canopy/platform-action-semantic-fingerprint/v1");
+
+        private readonly IPlatformHost _host;
+        private readonly PlatformPreparedActionContextOwner _preparedContexts;
+        private readonly PlatformActionCapabilityService _capabilities;
+        private readonly PlatformIdempotencyStore _idempotency;
+        private readonly PlatformActionAdmissionLimiter _admission;
+        private readonly PlatformFirstPartyActionDispatcher _dispatcher;
+        private readonly PlatformAuditStore _audit;
+
+        internal PlatformActionInvocationCoordinator(
+            IPlatformHost host,
+            PlatformPreparedActionContextOwner preparedContexts,
+            PlatformActionCapabilityService capabilities,
+            PlatformIdempotencyStore idempotency,
+            PlatformActionAdmissionLimiter admission,
+            PlatformFirstPartyActionDispatcher dispatcher,
+            PlatformAuditStore audit)
+        {
+            _host = host ?? throw new ArgumentNullException(nameof(host));
+            _preparedContexts = preparedContexts ?? throw new ArgumentNullException(nameof(preparedContexts));
+            _capabilities = capabilities ?? throw new ArgumentNullException(nameof(capabilities));
+            _idempotency = idempotency ?? throw new ArgumentNullException(nameof(idempotency));
+            _admission = admission ?? throw new ArgumentNullException(nameof(admission));
+            _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+            _audit = audit ?? throw new ArgumentNullException(nameof(audit));
+        }
+
+        internal async Task<PlatformActionInvocationOutcome> InvokeAsync(
+            PlatformActor boundaryActor,
+            PlatformActionInvokeRequest request,
+            PlatformInvocationCancellation cancellation)
+        {
+            ArgumentNullException.ThrowIfNull(boundaryActor);
+            ArgumentNullException.ThrowIfNull(request);
+            if (cancellation.ExecutionToken.IsCancellationRequested)
+            {
+                using var canceled = _audit.BeginUnresolved(boundaryActor);
+                canceled.Complete(cancellation.AuditResult());
+                cancellation.ExecutionToken.ThrowIfCancellationRequested();
+            }
+
+            var inspection = _capabilities.Inspect(request.Capability);
+            if (cancellation.ExecutionToken.IsCancellationRequested)
+            {
+                using var canceled = _audit.BeginUnresolved(boundaryActor);
+                canceled.Complete(cancellation.AuditResult());
+                cancellation.ExecutionToken.ThrowIfCancellationRequested();
+            }
+
+            if (inspection.Kind != PlatformCapabilityInspectionKind.Authentic)
+            {
+                using var unresolved = _audit.BeginUnresolved(boundaryActor);
+                var code = inspection.Kind == PlatformCapabilityInspectionKind.Expired
+                    ? PlatformAuditResultCode.CapabilityExpired
+                    : PlatformAuditResultCode.CapabilityInvalid;
+                unresolved.Complete(code);
+                return Reject(PlatformErrorCode.NotFound);
+            }
+
+            var prepared = _preparedContexts.Resolve(request.Capability, inspection);
+            if (cancellation.ExecutionToken.IsCancellationRequested)
+            {
+                using var canceled = _audit.BeginUnresolved(boundaryActor);
+                canceled.Complete(cancellation.AuditResult());
+                cancellation.ExecutionToken.ThrowIfCancellationRequested();
+            }
+
+            if (prepared is null)
+            {
+                using var unresolved = _audit.BeginUnresolved(boundaryActor);
+                unresolved.Complete(PlatformAuditResultCode.CapabilityInvalid);
+                return Reject(PlatformErrorCode.NotFound);
+            }
+
+            using var attempt = _audit.Begin(boundaryActor, prepared.Definition);
+            try
+            {
+                cancellation.ExecutionToken.ThrowIfCancellationRequested();
+                var current = ResolveCurrent(boundaryActor, prepared);
+                cancellation.ExecutionToken.ThrowIfCancellationRequested();
+                if (current is null)
+                {
+                    return Complete(attempt, PlatformAuditResultCode.AuthorityDenied, PlatformErrorCode.NotFound);
+                }
+
+                var capabilityValidation = _capabilities.ValidateCurrent(
+                    inspection,
+                    current.Actor,
+                    prepared.Definition.Id.Value,
+                    current.Item.Id,
+                    current.Item.Kind,
+                    prepared.Digest.Span);
+                cancellation.ExecutionToken.ThrowIfCancellationRequested();
+                if (capabilityValidation.Kind != PlatformCapabilityValidationKind.Valid)
+                {
+                    return CompleteCapabilityValidation(attempt, capabilityValidation.Kind);
+                }
+
+                var admittedInput = _dispatcher.ValidateCurrent(
+                    prepared.Definition,
+                    current.Actor,
+                    current.Item,
+                    prepared,
+                    request.Answers);
+                cancellation.ExecutionToken.ThrowIfCancellationRequested();
+                if (admittedInput.Decision != PlatformActionPortDecision.Admitted)
+                {
+                    return CompletePortRefusal(attempt, admittedInput.Decision);
+                }
+
+                var idempotencyRequest = new PlatformIdempotencyRequest(
+                    current.Actor.UserId,
+                    prepared.Definition.Id.Value,
+                    request.IdempotencyKey,
+                    CreateFingerprint(prepared, admittedInput.CanonicalInput.Span),
+                    MaximumSemanticResultBytes);
+                var leaderAudit = PlatformAuditResultCode.InternalFailure;
+                var idempotencyOutcome = await _idempotency.ExecuteCoordinatedAsync(
+                    idempotencyRequest,
+                    async (execution, executionToken) =>
+                    {
+                        using var lease = await _admission.AcquireAsync(
+                            current.Actor,
+                            prepared.Definition,
+                            executionToken).ConfigureAwait(false);
+                        if (lease.Kind != PlatformActionAdmissionKind.Acquired)
+                        {
+                            leaderAudit = PlatformAuditResultCode.RateLimited;
+                            return execution.AbandonBeforeSideEffect(ErrorResult(PlatformErrorCode.RateLimited));
+                        }
+
+                        executionToken.ThrowIfCancellationRequested();
+                        var refreshed = ResolveCurrent(boundaryActor, prepared);
+                        executionToken.ThrowIfCancellationRequested();
+                        if (refreshed is null)
+                        {
+                            leaderAudit = PlatformAuditResultCode.AuthorityDenied;
+                            return execution.AbandonBeforeSideEffect(ErrorResult(PlatformErrorCode.NotFound));
+                        }
+
+                        var refreshedCapability = _capabilities.ValidateCurrent(
+                            inspection,
+                            refreshed.Actor,
+                            prepared.Definition.Id.Value,
+                            refreshed.Item.Id,
+                            refreshed.Item.Kind,
+                            prepared.Digest.Span);
+                        executionToken.ThrowIfCancellationRequested();
+                        if (refreshedCapability.Kind != PlatformCapabilityValidationKind.Valid)
+                        {
+                            leaderAudit = AuditFor(refreshedCapability.Kind);
+                            return execution.AbandonBeforeSideEffect(ErrorResult(ErrorFor(refreshedCapability.Kind)));
+                        }
+
+                        var refreshedInput = _dispatcher.ValidateCurrent(
+                            prepared.Definition,
+                            refreshed.Actor,
+                            refreshed.Item,
+                            prepared,
+                            request.Answers);
+                        executionToken.ThrowIfCancellationRequested();
+                        if (refreshedInput.Decision != PlatformActionPortDecision.Admitted)
+                        {
+                            leaderAudit = AuditFor(refreshedInput.Decision);
+                            return execution.AbandonBeforeSideEffect(ErrorResult(ErrorFor(refreshedInput.Decision)));
+                        }
+
+                        if (!CanonicalInputMatches(admittedInput.CanonicalInput.Span, refreshedInput.CanonicalInput.Span))
+                        {
+                            leaderAudit = PlatformAuditResultCode.AuthorityDenied;
+                            return execution.AbandonBeforeSideEffect(ErrorResult(PlatformErrorCode.NotFound));
+                        }
+
+                        // Capability consumption is itself a durable replay decision.
+                        // From this exact point onward an exception must retain an
+                        // indeterminate idempotency tombstone.
+                        executionToken.ThrowIfCancellationRequested();
+                        execution.MarkSideEffectStarted();
+                        var consumed = _capabilities.Consume(refreshedCapability);
+                        if (consumed != PlatformCapabilityConsumeKind.Consumed)
+                        {
+                            leaderAudit = AuditFor(consumed);
+                            return ErrorResult(ErrorFor(consumed));
+                        }
+
+                        var owner = await _dispatcher.InvokeAsync(
+                            prepared.Definition,
+                            refreshed.Actor,
+                            refreshed.Item,
+                            refreshedInput.Input!,
+                            request.IdempotencyKey,
+                            executionToken).ConfigureAwait(false);
+                        leaderAudit = owner.AuditResultCode;
+                        return owner.Result;
+                    },
+                    cancellation.ExecutionToken).ConfigureAwait(false);
+
+                // A fixed owner may complete successfully without observing the linked
+                // token. Keep the semantic result safely stored for a later replay, but
+                // arbitrate cancellation before selecting this request's terminal audit
+                // and transport outcome. The lifecycle boundary then applies its normal
+                // caller-abort/no-write or deadline/timeout behavior.
+                cancellation.ExecutionToken.ThrowIfCancellationRequested();
+                if (idempotencyOutcome.WasCoalescedUnstored)
+                {
+                    return Complete(
+                        attempt,
+                        AuditForUnstored(idempotencyOutcome.Result!),
+                        idempotencyOutcome.Result!,
+                        replayed: false);
+                }
+
+                if (idempotencyOutcome.Kind == PlatformIdempotencyOutcomeKind.Replay)
+                {
+                    // A coalesced follower may have waited for the leader after its
+                    // initial checks. Never release the stored result across authority
+                    // or typed-input drift that happened during that wait.
+                    var replayCurrent = ResolveCurrent(boundaryActor, prepared);
+                    cancellation.ExecutionToken.ThrowIfCancellationRequested();
+                    if (replayCurrent is null)
+                    {
+                        return Complete(attempt, PlatformAuditResultCode.AuthorityDenied, PlatformErrorCode.NotFound);
+                    }
+
+                    var replayCapability = _capabilities.ValidateCurrent(
+                        inspection,
+                        replayCurrent.Actor,
+                        prepared.Definition.Id.Value,
+                        replayCurrent.Item.Id,
+                        replayCurrent.Item.Kind,
+                        prepared.Digest.Span);
+                    cancellation.ExecutionToken.ThrowIfCancellationRequested();
+                    if (replayCapability.Kind != PlatformCapabilityValidationKind.Valid)
+                    {
+                        return CompleteCapabilityValidation(attempt, replayCapability.Kind);
+                    }
+
+                    var replayInput = _dispatcher.ValidateCurrent(
+                        prepared.Definition,
+                        replayCurrent.Actor,
+                        replayCurrent.Item,
+                        prepared,
+                        request.Answers);
+                    cancellation.ExecutionToken.ThrowIfCancellationRequested();
+                    if (replayInput.Decision != PlatformActionPortDecision.Admitted)
+                    {
+                        return CompletePortRefusal(attempt, replayInput.Decision);
+                    }
+
+                    if (!CanonicalInputMatches(
+                            admittedInput.CanonicalInput.Span,
+                            replayInput.CanonicalInput.Span))
+                    {
+                        return Complete(attempt, PlatformAuditResultCode.AuthorityDenied, PlatformErrorCode.NotFound);
+                    }
+                }
+
+                return idempotencyOutcome.Kind switch
+                {
+                    PlatformIdempotencyOutcomeKind.Executed =>
+                        Complete(attempt, leaderAudit, idempotencyOutcome.Result!, replayed: false),
+                    PlatformIdempotencyOutcomeKind.Replay =>
+                        Complete(attempt, PlatformAuditResultCode.IdempotencyReplayed, idempotencyOutcome.Result!, replayed: true),
+                    PlatformIdempotencyOutcomeKind.Conflict =>
+                        Complete(attempt, PlatformAuditResultCode.Conflict, PlatformErrorCode.Conflict),
+                    PlatformIdempotencyOutcomeKind.AtCapacity =>
+                        Complete(attempt, PlatformAuditResultCode.RateLimited, PlatformErrorCode.RateLimited),
+                    PlatformIdempotencyOutcomeKind.Indeterminate =>
+                        Complete(attempt, PlatformAuditResultCode.Indeterminate, PlatformErrorCode.Conflict),
+                    _ => Complete(attempt, PlatformAuditResultCode.InternalFailure, PlatformErrorCode.InternalError),
+                };
+            }
+            catch (OperationCanceledException)
+            {
+                attempt.Complete(cancellation.AuditResult());
+                throw;
+            }
+        }
+
+        private CurrentAuthority? ResolveCurrent(
+            PlatformActor boundaryActor,
+            PlatformPreparedActionContext prepared)
+        {
+            var user = _host.Users.Find(boundaryActor.UserId);
+            var actor = PlatformActorBoundaryFilter.Reauthorize(boundaryActor, user);
+            if (actor is null)
+            {
+                return null;
+            }
+
+            if (!HasRequiredAuthority(prepared.Definition, actor))
+            {
+                return null;
+            }
+
+            var access = _host.Library.FindAccessible(actor.UserId, prepared.Item.Id);
+            if (access.Item is not HostAccessibleItem item
+                || item.Id != prepared.Item.Id
+                || item.Kind != prepared.Item.Kind
+                || item.SeriesId != prepared.Item.SeriesId
+                || !prepared.Definition.SupportedItemKinds.Contains(item.Kind))
+            {
+                return null;
+            }
+
+            return new CurrentAuthority(actor, item);
+        }
+
+        private static bool HasRequiredAuthority(
+            PlatformOperationDefinition definition,
+            PlatformActor actor)
+            => definition.Authority == PlatformAuthorityLevel.Authenticated
+                || (definition.Authority == PlatformAuthorityLevel.Elevated && actor.IsElevated);
+
+        private static PlatformSemanticFingerprint CreateFingerprint(
+            PlatformPreparedActionContext prepared,
+            ReadOnlySpan<byte> canonicalInput)
+        {
+            using var stream = new MemoryStream();
+            stream.Write(FingerprintDomain);
+            WriteString(stream, prepared.Definition.Id.Value);
+            WriteString(stream, prepared.Definition.InputSchemaId.Value);
+            Span<byte> item = stackalloc byte[16];
+            prepared.Item.Id.TryWriteBytes(item);
+            stream.Write(item);
+            stream.WriteByte((byte)prepared.Item.Kind);
+            stream.Write(prepared.Digest.Span);
+            Span<byte> length = stackalloc byte[4];
+            BinaryPrimitives.WriteInt32BigEndian(length, canonicalInput.Length);
+            stream.Write(length);
+            stream.Write(canonicalInput);
+            return new PlatformSemanticFingerprint(
+                SHA256.HashData(stream.GetBuffer().AsSpan(0, checked((int)stream.Length))));
+        }
+
+        private static bool CanonicalInputMatches(ReadOnlySpan<byte> first, ReadOnlySpan<byte> second)
+        {
+            var firstDigest = SHA256.HashData(first);
+            var secondDigest = SHA256.HashData(second);
+            return CryptographicOperations.FixedTimeEquals(firstDigest, secondDigest);
+        }
+
+        private static void WriteString(Stream stream, string value)
+        {
+            var bytes = Encoding.UTF8.GetBytes(value);
+            Span<byte> length = stackalloc byte[2];
+            BinaryPrimitives.WriteUInt16BigEndian(length, checked((ushort)bytes.Length));
+            stream.Write(length);
+            stream.Write(bytes);
+        }
+
+        private static PlatformActionInvocationOutcome CompleteCapabilityValidation(
+            IPlatformAuditAttempt attempt,
+            PlatformCapabilityValidationKind kind)
+            => Complete(attempt, AuditFor(kind), ErrorFor(kind));
+
+        private static PlatformActionInvocationOutcome CompletePortRefusal(
+            IPlatformAuditAttempt attempt,
+            PlatformActionPortDecision decision)
+            => Complete(attempt, AuditFor(decision), ErrorFor(decision));
+
+        private static PlatformActionInvocationOutcome Complete(
+            IPlatformAuditAttempt attempt,
+            PlatformAuditResultCode audit,
+            string errorCode)
+        {
+            attempt.Complete(audit);
+            return Reject(errorCode);
+        }
+
+        private static PlatformActionInvocationOutcome Complete(
+            IPlatformAuditAttempt attempt,
+            PlatformAuditResultCode audit,
+            PlatformIdempotencyResult result,
+            bool replayed)
+        {
+            attempt.Complete(audit);
+            return new PlatformActionInvocationOutcome(result, replayed);
+        }
+
+        private static PlatformActionInvocationOutcome Reject(string errorCode)
+            => new(ErrorResult(errorCode), replayed: false);
+
+        private static PlatformIdempotencyResult ErrorResult(string errorCode)
+        {
+            using var document = JsonDocument.Parse("{}");
+            return new PlatformIdempotencyResult(
+                PlatformErrorCode.StatusFor(errorCode),
+                errorCode,
+                document.RootElement);
+        }
+
+        private static PlatformAuditResultCode AuditFor(PlatformCapabilityValidationKind kind) => kind switch
+        {
+            PlatformCapabilityValidationKind.Expired => PlatformAuditResultCode.CapabilityExpired,
+            PlatformCapabilityValidationKind.StaleAuthority or PlatformCapabilityValidationKind.NotAuthorized
+                => PlatformAuditResultCode.AuthorityDenied,
+            _ => PlatformAuditResultCode.CapabilityInvalid,
+        };
+
+        private static string ErrorFor(PlatformCapabilityValidationKind kind) => kind switch
+        {
+            PlatformCapabilityValidationKind.Expired
+                or PlatformCapabilityValidationKind.StaleAuthority
+                or PlatformCapabilityValidationKind.NotAuthorized => PlatformErrorCode.NotFound,
+            _ => PlatformErrorCode.NotFound,
+        };
+
+        private static PlatformAuditResultCode AuditFor(PlatformCapabilityConsumeKind kind) => kind switch
+        {
+            PlatformCapabilityConsumeKind.Replay => PlatformAuditResultCode.CapabilityReplayed,
+            PlatformCapabilityConsumeKind.Expired => PlatformAuditResultCode.CapabilityExpired,
+            PlatformCapabilityConsumeKind.StaleAuthority => PlatformAuditResultCode.AuthorityDenied,
+            _ => PlatformAuditResultCode.CapabilityInvalid,
+        };
+
+        private static string ErrorFor(PlatformCapabilityConsumeKind kind) => kind switch
+        {
+            PlatformCapabilityConsumeKind.Replay => PlatformErrorCode.Conflict,
+            _ => PlatformErrorCode.NotFound,
+        };
+
+        private static PlatformAuditResultCode AuditFor(PlatformActionPortDecision decision) => decision switch
+        {
+            PlatformActionPortDecision.AuthorityDenied => PlatformAuditResultCode.AuthorityDenied,
+            PlatformActionPortDecision.InvalidInput => PlatformAuditResultCode.InvalidInput,
+            PlatformActionPortDecision.UnknownOwner => PlatformAuditResultCode.OwnerFailed,
+            _ => PlatformAuditResultCode.InternalFailure,
+        };
+
+        private static PlatformAuditResultCode AuditForUnstored(PlatformIdempotencyResult result)
+            => result.OutcomeCode switch
+            {
+                PlatformErrorCode.RateLimited => PlatformAuditResultCode.RateLimited,
+                PlatformErrorCode.NotFound => PlatformAuditResultCode.AuthorityDenied,
+                PlatformErrorCode.InvalidRequest => PlatformAuditResultCode.InvalidInput,
+                _ => PlatformAuditResultCode.InternalFailure,
+            };
+
+        private static string ErrorFor(PlatformActionPortDecision decision) => decision switch
+        {
+            PlatformActionPortDecision.AuthorityDenied => PlatformErrorCode.NotFound,
+            PlatformActionPortDecision.InvalidInput => PlatformErrorCode.InvalidRequest,
+            PlatformActionPortDecision.UnknownOwner => PlatformErrorCode.Unavailable,
+            _ => PlatformErrorCode.InternalError,
+        };
+
+        private sealed record CurrentAuthority(PlatformActor Actor, HostAccessibleItem Item);
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformActionInvokeContract.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformActionInvokeContract.cs
@@ -1,0 +1,347 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Primitives;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>One bounded generic answer submitted to a prepared native action.</summary>
+    internal sealed class PlatformActionAnswer
+    {
+        internal PlatformActionAnswer(
+            string fieldId,
+            bool? booleanValue,
+            ImmutableArray<string>? optionIds)
+        {
+            FieldId = fieldId;
+            BooleanValue = booleanValue;
+            OptionIds = optionIds;
+        }
+
+        internal string FieldId { get; }
+
+        internal bool? BooleanValue { get; }
+
+        internal ImmutableArray<string>? OptionIds { get; }
+    }
+
+    /// <summary>The exact Android-compatible Platform v1 invoke body.</summary>
+    [JsonConverter(typeof(PlatformActionInvokeRequestConverter))]
+    internal sealed class PlatformActionInvokeRequest
+    {
+        internal PlatformActionInvokeRequest(
+            string capability,
+            PlatformIdempotencyKey idempotencyKey,
+            ImmutableArray<PlatformActionAnswer> answers)
+        {
+            Capability = capability;
+            IdempotencyKey = idempotencyKey;
+            Answers = answers;
+        }
+
+        internal string Capability { get; }
+
+        internal PlatformIdempotencyKey IdempotencyKey { get; }
+
+        internal ImmutableArray<PlatformActionAnswer> Answers { get; }
+    }
+
+    /// <summary>Enforces the invoke route's single body-carrier decision.</summary>
+    internal static class PlatformActionIdempotencyCarrier
+    {
+        internal static bool TryResolve(
+            PlatformActionInvokeRequest? request,
+            StringValues headerValues,
+            out PlatformIdempotencyKey key)
+        {
+            if (request is not null
+                && headerValues.Count == 0
+                && !string.IsNullOrEmpty(request.IdempotencyKey.Value)
+                && PlatformIdempotencyKey.TryParse(request.IdempotencyKey.Value, out key))
+            {
+                return true;
+            }
+
+            key = default;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Strict known-field reader for the invoke body. Unknown optional fields remain
+    /// additive, while duplicate or missing known fields never acquire ambiguous
+    /// last-value-wins semantics.
+    /// </summary>
+    internal sealed class PlatformActionInvokeRequestConverter : JsonConverter<PlatformActionInvokeRequest>
+    {
+        internal const int MaximumAnswers = 8;
+        internal const int MaximumOptionIds = 32;
+        internal const int MaximumFieldIdCharacters = 128;
+
+        public override PlatformActionInvokeRequest Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException("The action invocation must be an object.");
+            }
+
+            string? capability = null;
+            PlatformIdempotencyKey idempotencyKey = default;
+            ImmutableArray<PlatformActionAnswer> answers = default;
+            var capabilitySeen = false;
+            var idempotencySeen = false;
+            var answersSeen = false;
+
+            while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+            {
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    throw new JsonException("The action invocation contains invalid JSON members.");
+                }
+
+                var property = reader.GetString();
+                if (!reader.Read())
+                {
+                    throw new JsonException("The action invocation ended before a property value.");
+                }
+
+                switch (property)
+                {
+                    case "Capability":
+                        RequireFirst(ref capabilitySeen, property);
+                        capability = ReadBoundedString(ref reader, PlatformActionCapabilityService.MaximumTokenCharacters, property);
+                        break;
+                    case "IdempotencyKey":
+                        RequireFirst(ref idempotencySeen, property);
+                        var rawKey = ReadBoundedString(ref reader, PlatformIdempotencyKey.MaximumLength, property);
+                        if (!PlatformIdempotencyKey.TryParse(rawKey, out idempotencyKey))
+                        {
+                            throw new JsonException("IdempotencyKey is malformed.");
+                        }
+
+                        break;
+                    case "Answers":
+                        RequireFirst(ref answersSeen, property);
+                        answers = ReadAnswers(ref reader);
+                        break;
+                    default:
+                        reader.Skip();
+                        break;
+                }
+            }
+
+            if (reader.TokenType != JsonTokenType.EndObject
+                || !capabilitySeen
+                || !idempotencySeen
+                || !answersSeen)
+            {
+                throw new JsonException("Capability, IdempotencyKey and Answers are required exactly once.");
+            }
+
+            return new PlatformActionInvokeRequest(capability!, idempotencyKey, answers);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            PlatformActionInvokeRequest value,
+            JsonSerializerOptions options)
+        {
+            ArgumentNullException.ThrowIfNull(writer);
+            ArgumentNullException.ThrowIfNull(value);
+            writer.WriteStartObject();
+            writer.WriteString("Capability", value.Capability);
+            writer.WriteString("IdempotencyKey", value.IdempotencyKey.Value);
+            writer.WritePropertyName("Answers");
+            writer.WriteStartArray();
+            foreach (var answer in value.Answers)
+            {
+                writer.WriteStartObject();
+                writer.WriteString("FieldId", answer.FieldId);
+                if (answer.BooleanValue is bool booleanValue)
+                {
+                    writer.WriteBoolean("BooleanValue", booleanValue);
+                }
+                else
+                {
+                    writer.WritePropertyName("OptionIds");
+                    writer.WriteStartArray();
+                    foreach (var optionId in answer.OptionIds!.Value)
+                    {
+                        writer.WriteStringValue(optionId);
+                    }
+
+                    writer.WriteEndArray();
+                }
+
+                writer.WriteEndObject();
+            }
+
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+        }
+
+        private static ImmutableArray<PlatformActionAnswer> ReadAnswers(ref Utf8JsonReader reader)
+        {
+            if (reader.TokenType != JsonTokenType.StartArray)
+            {
+                throw new JsonException("Answers must be an array.");
+            }
+
+            var result = ImmutableArray.CreateBuilder<PlatformActionAnswer>();
+            var fieldIds = new HashSet<string>(StringComparer.Ordinal);
+            while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+            {
+                if (result.Count >= MaximumAnswers)
+                {
+                    throw new JsonException("Answers exceeds its fixed element bound.");
+                }
+
+                var answer = ReadAnswer(ref reader);
+                if (!fieldIds.Add(answer.FieldId))
+                {
+                    throw new JsonException("Answer field ids must be unique.");
+                }
+
+                result.Add(answer);
+            }
+
+            if (reader.TokenType != JsonTokenType.EndArray)
+            {
+                throw new JsonException("Answers is incomplete.");
+            }
+
+            return result.ToImmutable();
+        }
+
+        private static PlatformActionAnswer ReadAnswer(ref Utf8JsonReader reader)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException("Each answer must be an object.");
+            }
+
+            string? fieldId = null;
+            bool? booleanValue = null;
+            ImmutableArray<string>? optionIds = null;
+            var fieldSeen = false;
+            var booleanSeen = false;
+            var optionsSeen = false;
+
+            while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+            {
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    throw new JsonException("An answer contains invalid JSON members.");
+                }
+
+                var property = reader.GetString();
+                if (!reader.Read())
+                {
+                    throw new JsonException("An answer ended before a property value.");
+                }
+
+                switch (property)
+                {
+                    case "FieldId":
+                        RequireFirst(ref fieldSeen, property);
+                        fieldId = ReadBoundedString(ref reader, MaximumFieldIdCharacters, property);
+                        if (!PlatformIdempotencyKey.TryParse(fieldId, out _))
+                        {
+                            throw new JsonException("FieldId is malformed.");
+                        }
+
+                        break;
+                    case "BooleanValue":
+                        RequireFirst(ref booleanSeen, property);
+                        if (reader.TokenType is not (JsonTokenType.True or JsonTokenType.False))
+                        {
+                            throw new JsonException("BooleanValue must be a boolean.");
+                        }
+
+                        booleanValue = reader.GetBoolean();
+                        break;
+                    case "OptionIds":
+                        RequireFirst(ref optionsSeen, property);
+                        optionIds = ReadOptionIds(ref reader);
+                        break;
+                    default:
+                        reader.Skip();
+                        break;
+                }
+            }
+
+            if (reader.TokenType != JsonTokenType.EndObject
+                || !fieldSeen
+                || booleanSeen == optionsSeen)
+            {
+                throw new JsonException("Each answer requires FieldId and exactly one value carrier.");
+            }
+
+            return new PlatformActionAnswer(fieldId!, booleanValue, optionIds);
+        }
+
+        private static ImmutableArray<string> ReadOptionIds(ref Utf8JsonReader reader)
+        {
+            if (reader.TokenType != JsonTokenType.StartArray)
+            {
+                throw new JsonException("OptionIds must be an array.");
+            }
+
+            var result = ImmutableArray.CreateBuilder<string>();
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+            {
+                if (result.Count >= MaximumOptionIds)
+                {
+                    throw new JsonException("OptionIds exceeds its fixed element bound.");
+                }
+
+                var optionId = ReadBoundedString(ref reader, MaximumFieldIdCharacters, "OptionIds");
+                if (!PlatformIdempotencyKey.TryParse(optionId, out _) || !seen.Add(optionId))
+                {
+                    throw new JsonException("OptionIds must contain unique bounded identifiers.");
+                }
+
+                result.Add(optionId);
+            }
+
+            if (reader.TokenType != JsonTokenType.EndArray)
+            {
+                throw new JsonException("OptionIds is incomplete.");
+            }
+
+            return result.ToImmutable();
+        }
+
+        private static string ReadBoundedString(ref Utf8JsonReader reader, int maximumCharacters, string field)
+        {
+            if (reader.TokenType != JsonTokenType.String)
+            {
+                throw new JsonException($"{field} must be a string.");
+            }
+
+            var value = reader.GetString();
+            if (string.IsNullOrEmpty(value) || value.Length > maximumCharacters)
+            {
+                throw new JsonException($"{field} is outside its fixed bound.");
+            }
+
+            return value;
+        }
+
+        private static void RequireFirst(ref bool seen, string? property)
+        {
+            if (seen)
+            {
+                throw new JsonException($"{property} must not be duplicated.");
+            }
+
+            seen = true;
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformActorBoundaryFilter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformActorBoundaryFilter.cs
@@ -120,6 +120,29 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
                 "The Platform actor boundary did not establish an authenticated actor.");
         }
 
+        /// <summary>
+        /// Reissues the same boundary identity with the host's current elevation bit.
+        /// Actor construction remains confined to this authority boundary even when a
+        /// long-running action repeats its user lookup immediately before mutation.
+        /// </summary>
+        internal static PlatformActor? Reauthorize(
+            PlatformActor boundaryActor,
+            HostUser? currentUser)
+        {
+            ArgumentNullException.ThrowIfNull(boundaryActor);
+            if (currentUser is not HostUser user || user.Id != boundaryActor.UserId)
+            {
+                return null;
+            }
+
+            return new PlatformActor(
+                user.Id,
+                user.IsAdministrator,
+                boundaryActor.CorrelationId,
+                boundaryActor.ClientName,
+                boundaryActor.DeviceId);
+        }
+
         private static string? ReadAttribution(
             System.Collections.Generic.IEnumerable<System.Security.Claims.Claim> claims,
             string claimType,

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformFirstPartyActionDispatcher.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformFirstPartyActionDispatcher.cs
@@ -1,0 +1,224 @@
+using System;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>Marker implemented only by one named first-party port's typed input.</summary>
+    internal interface IPlatformValidatedActionInput
+    {
+    }
+
+    internal enum PlatformActionPortDecision
+    {
+        Admitted,
+        AuthorityDenied,
+        InvalidInput,
+        UnknownOwner,
+    }
+
+    /// <summary>A named port's current feature-authority and typed-input decision.</summary>
+    internal sealed class PlatformActionPortAdmission
+    {
+        private readonly byte[] _canonicalInput;
+
+        private PlatformActionPortAdmission(
+            PlatformActionPortDecision decision,
+            IPlatformValidatedActionInput? input,
+            ReadOnlySpan<byte> canonicalInput)
+        {
+            Decision = decision;
+            Input = input;
+            _canonicalInput = canonicalInput.ToArray();
+        }
+
+        internal PlatformActionPortDecision Decision { get; }
+
+        internal IPlatformValidatedActionInput? Input { get; }
+
+        internal ReadOnlyMemory<byte> CanonicalInput => _canonicalInput;
+
+        internal static PlatformActionPortAdmission Admit(
+            IPlatformValidatedActionInput input,
+            ReadOnlySpan<byte> canonicalInput)
+        {
+            ArgumentNullException.ThrowIfNull(input);
+            if (canonicalInput.Length is < 1 or > PlatformPreparedActionContextOwner.MaximumPrivateStateBytes)
+            {
+                throw new ArgumentException("Canonical typed input is outside its fixed byte bound.", nameof(canonicalInput));
+            }
+
+            return new PlatformActionPortAdmission(PlatformActionPortDecision.Admitted, input, canonicalInput);
+        }
+
+        internal static PlatformActionPortAdmission Refuse(PlatformActionPortDecision decision)
+        {
+            if (decision == PlatformActionPortDecision.Admitted || !Enum.IsDefined(decision))
+            {
+                throw new ArgumentOutOfRangeException(nameof(decision));
+            }
+
+            return new PlatformActionPortAdmission(decision, input: null, ReadOnlySpan<byte>.Empty);
+        }
+    }
+
+    /// <summary>Closed HTTP-free semantic output from a first-party owning adapter.</summary>
+    internal sealed class PlatformActionOwnerResult
+    {
+        internal PlatformActionOwnerResult(
+            PlatformIdempotencyResult result,
+            PlatformAuditResultCode auditResultCode)
+        {
+            Result = result ?? throw new ArgumentNullException(nameof(result));
+            if (auditResultCode is not (PlatformAuditResultCode.Succeeded or PlatformAuditResultCode.OwnerFailed))
+            {
+                throw new ArgumentOutOfRangeException(nameof(auditResultCode));
+            }
+
+            AuditResultCode = auditResultCode;
+        }
+
+        internal PlatformIdempotencyResult Result { get; }
+
+        internal PlatformAuditResultCode AuditResultCode { get; }
+
+        internal static PlatformActionOwnerResult Succeeded(JsonElement value)
+            => new(new PlatformIdempotencyResult(200, "succeeded", value), PlatformAuditResultCode.Succeeded);
+
+        internal static PlatformActionOwnerResult Failed(string errorCode, JsonElement value)
+            => new(
+                new PlatformIdempotencyResult(PlatformErrorCode.StatusFor(errorCode), errorCode, value),
+                PlatformAuditResultCode.OwnerFailed);
+    }
+
+    internal interface ISpoilerGuardPlatformActionPort
+    {
+        PlatformActionPortAdmission ValidateCurrent(
+            PlatformActor actor,
+            HostAccessibleItem item,
+            PlatformPreparedActionContext prepared,
+            System.Collections.Immutable.ImmutableArray<PlatformActionAnswer> answers);
+
+        Task<PlatformActionOwnerResult> InvokeAsync(
+            PlatformActor actor,
+            HostAccessibleItem item,
+            IPlatformValidatedActionInput input,
+            PlatformIdempotencyKey idempotencyKey,
+            CancellationToken cancellationToken);
+    }
+
+    internal interface IHiddenContentPlatformActionPort
+    {
+        PlatformActionPortAdmission ValidateCurrent(
+            PlatformActor actor,
+            HostAccessibleItem item,
+            PlatformPreparedActionContext prepared,
+            System.Collections.Immutable.ImmutableArray<PlatformActionAnswer> answers);
+
+        Task<PlatformActionOwnerResult> InvokeAsync(
+            PlatformActor actor,
+            HostAccessibleItem item,
+            IPlatformValidatedActionInput input,
+            PlatformIdempotencyKey idempotencyKey,
+            CancellationToken cancellationToken);
+    }
+
+    internal interface ISeerrPlatformActionPort
+    {
+        PlatformActionPortAdmission ValidateCurrent(
+            PlatformActor actor,
+            HostAccessibleItem item,
+            PlatformPreparedActionContext prepared,
+            System.Collections.Immutable.ImmutableArray<PlatformActionAnswer> answers);
+
+        Task<PlatformActionOwnerResult> InvokeAsync(
+            PlatformActor actor,
+            HostAccessibleItem item,
+            IPlatformValidatedActionInput input,
+            PlatformIdempotencyKey idempotencyKey,
+            CancellationToken cancellationToken);
+    }
+
+    /// <summary>
+    /// The complete fixed pilot dispatch table. There is deliberately no handler
+    /// registry, collection, service locator, reflection, or caller-selected owner.
+    /// </summary>
+    internal sealed class PlatformFirstPartyActionDispatcher
+    {
+        private readonly ISpoilerGuardPlatformActionPort _spoilerGuard;
+        private readonly IHiddenContentPlatformActionPort _hiddenContent;
+        private readonly ISeerrPlatformActionPort _seerr;
+
+        internal PlatformFirstPartyActionDispatcher(
+            ISpoilerGuardPlatformActionPort spoilerGuard,
+            IHiddenContentPlatformActionPort hiddenContent,
+            ISeerrPlatformActionPort seerr)
+        {
+            _spoilerGuard = spoilerGuard ?? throw new ArgumentNullException(nameof(spoilerGuard));
+            _hiddenContent = hiddenContent ?? throw new ArgumentNullException(nameof(hiddenContent));
+            _seerr = seerr ?? throw new ArgumentNullException(nameof(seerr));
+        }
+
+        internal PlatformActionPortAdmission ValidateCurrent(
+            PlatformOperationDefinition definition,
+            PlatformActor actor,
+            HostAccessibleItem item,
+            PlatformPreparedActionContext prepared,
+            System.Collections.Immutable.ImmutableArray<PlatformActionAnswer> answers)
+        {
+            if (ReferenceEquals(definition, PlatformOperationDefinition.SpoilerGuardConfigureItem))
+            {
+                return _spoilerGuard.ValidateCurrent(actor, item, prepared, answers);
+            }
+
+            if (ReferenceEquals(definition, PlatformOperationDefinition.HiddenContentConfigureItem))
+            {
+                return _hiddenContent.ValidateCurrent(actor, item, prepared, answers);
+            }
+
+            if (ReferenceEquals(definition, PlatformOperationDefinition.SeerrRequestItem))
+            {
+                return _seerr.ValidateCurrent(actor, item, prepared, answers);
+            }
+
+            return PlatformActionPortAdmission.Refuse(PlatformActionPortDecision.UnknownOwner);
+        }
+
+        internal Task<PlatformActionOwnerResult> InvokeAsync(
+            PlatformOperationDefinition definition,
+            PlatformActor actor,
+            HostAccessibleItem item,
+            IPlatformValidatedActionInput input,
+            PlatformIdempotencyKey idempotencyKey,
+            CancellationToken cancellationToken)
+        {
+            if (ReferenceEquals(definition, PlatformOperationDefinition.SpoilerGuardConfigureItem))
+            {
+                return _spoilerGuard.InvokeAsync(actor, item, input, idempotencyKey, cancellationToken);
+            }
+
+            if (ReferenceEquals(definition, PlatformOperationDefinition.HiddenContentConfigureItem))
+            {
+                return _hiddenContent.InvokeAsync(actor, item, input, idempotencyKey, cancellationToken);
+            }
+
+            if (ReferenceEquals(definition, PlatformOperationDefinition.SeerrRequestItem))
+            {
+                return _seerr.InvokeAsync(actor, item, input, idempotencyKey, cancellationToken);
+            }
+
+            return Task.FromResult(
+                PlatformActionOwnerResult.Failed(
+                    PlatformErrorCode.Unavailable,
+                    EmptyValue()));
+        }
+
+        private static JsonElement EmptyValue()
+        {
+            using var document = JsonDocument.Parse("{}");
+            return document.RootElement.Clone();
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformIdempotency.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformIdempotency.cs
@@ -291,10 +291,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
     /// <summary>An idempotency decision and optional immutable semantic result.</summary>
     public sealed class PlatformIdempotencyOutcome
     {
-        internal PlatformIdempotencyOutcome(PlatformIdempotencyOutcomeKind kind, PlatformIdempotencyResult? result = null)
+        internal PlatformIdempotencyOutcome(
+            PlatformIdempotencyOutcomeKind kind,
+            PlatformIdempotencyResult? result = null,
+            bool wasCoalescedUnstored = false)
         {
             Kind = kind;
             Result = result;
+            WasCoalescedUnstored = wasCoalescedUnstored;
         }
 
         /// <summary>The decision.</summary>
@@ -302,6 +306,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
 
         /// <summary>Present only for executed or replayed work.</summary>
         public PlatformIdempotencyResult? Result { get; }
+
+        /// <summary>
+        /// Marks a coordinated follower that shared a pre-mutation refusal which was
+        /// deliberately not retained for later replay.
+        /// </summary>
+        internal bool WasCoalescedUnstored { get; }
 
         /// <summary>
         /// Existing Platform error code a future mutation route must use for this

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformIdempotencyStore.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformIdempotencyStore.cs
@@ -12,6 +12,47 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
     /// </summary>
     public sealed class PlatformIdempotencyStore
     {
+        /// <summary>
+        /// Store-issued evidence for one idempotency leader. The invocation
+        /// coordinator marks it immediately before spending a capability or entering
+        /// an owner; cancellation before that point is known not to have mutated state.
+        /// </summary>
+        internal sealed class PlatformIdempotencyExecution
+        {
+            private int _sideEffectStarted;
+            private PlatformIdempotencyResult? _abandonedResult;
+
+            internal PlatformIdempotencyExecution()
+            {
+            }
+
+            internal bool SideEffectStarted => Volatile.Read(ref _sideEffectStarted) != 0;
+
+            internal PlatformIdempotencyResult? AbandonedResult => Volatile.Read(ref _abandonedResult);
+
+            internal void MarkSideEffectStarted()
+            {
+                if (AbandonedResult is not null)
+                {
+                    throw new InvalidOperationException("An abandoned execution cannot cross the side-effect boundary.");
+                }
+
+                Interlocked.Exchange(ref _sideEffectStarted, 1);
+            }
+
+            internal PlatformIdempotencyResult AbandonBeforeSideEffect(PlatformIdempotencyResult result)
+            {
+                ArgumentNullException.ThrowIfNull(result);
+                if (SideEffectStarted
+                    || Interlocked.CompareExchange(ref _abandonedResult, result, comparand: null) is not null)
+                {
+                    throw new InvalidOperationException("The execution can be abandoned exactly once before side effects.");
+                }
+
+                return result;
+            }
+        }
+
         /// <summary>Terminal entries are reusable for this long.</summary>
         public static readonly TimeSpan EntryTimeToLive = TimeSpan.FromMinutes(10);
 
@@ -57,123 +98,180 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
             Func<CancellationToken, Task<PlatformIdempotencyResult>> execute,
             CancellationToken requestCancellationToken)
         {
+            ArgumentNullException.ThrowIfNull(execute);
+            return await ExecuteCoreAsync(
+                request,
+                async (execution, cancellationToken) =>
+                {
+                    // Preserve the original public contract: once its delegate is
+                    // entered, the store must conservatively treat an exception as an
+                    // ambiguous mutation.
+                    execution.MarkSideEffectStarted();
+                    return await execute(cancellationToken).ConfigureAwait(false);
+                },
+                requestCancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Executes a coordinator-owned leader with an explicit side-effect boundary.
+        /// A leader abandoned before that boundary is removed and one coalesced
+        /// follower retries admission; after it, ambiguity is retained as a tombstone.
+        /// </summary>
+        internal async Task<PlatformIdempotencyOutcome> ExecuteCoordinatedAsync(
+            PlatformIdempotencyRequest request,
+            Func<PlatformIdempotencyExecution, CancellationToken, Task<PlatformIdempotencyResult>> execute,
+            CancellationToken requestCancellationToken)
+            => await ExecuteCoreAsync(request, execute, requestCancellationToken).ConfigureAwait(false);
+
+        private async Task<PlatformIdempotencyOutcome> ExecuteCoreAsync(
+            PlatformIdempotencyRequest request,
+            Func<PlatformIdempotencyExecution, CancellationToken, Task<PlatformIdempotencyResult>> execute,
+            CancellationToken requestCancellationToken)
+        {
             ArgumentNullException.ThrowIfNull(request);
             ArgumentNullException.ThrowIfNull(execute);
             requestCancellationToken.ThrowIfCancellationRequested();
 
             var key = new StoreKey(request.ActingUserId, request.Operation, request.Key.Value);
-            Task<PlatformIdempotencyOutcome>? followerTask = null;
-            Entry? leaderEntry = null;
-            Entry? followerEntry = null;
-
-            lock (_gate)
+            while (true)
             {
-                RemoveExpiredEntries(_timeProvider.GetUtcNow());
-
-                if (_entries.TryGetValue(key, out var existing))
-                {
-                    if (!existing.Fingerprint.Matches(request.Fingerprint))
-                    {
-                        return new PlatformIdempotencyOutcome(PlatformIdempotencyOutcomeKind.Conflict);
-                    }
-
-                    if (existing.State == EntryState.Completed)
-                    {
-                        return new PlatformIdempotencyOutcome(PlatformIdempotencyOutcomeKind.Replay, existing.Result);
-                    }
-
-                    if (existing.State == EntryState.Tombstone)
-                    {
-                        return new PlatformIdempotencyOutcome(PlatformIdempotencyOutcomeKind.Indeterminate);
-                    }
-
-                    if (existing.FollowerCount >= MaximumFollowersPerEntry
-                        || _followerCount >= MaximumFollowers)
-                    {
-                        return new PlatformIdempotencyOutcome(PlatformIdempotencyOutcomeKind.AtCapacity);
-                    }
-
-                    existing.FollowerCount++;
-                    _followerCount++;
-                    followerEntry = existing;
-                    followerTask = existing.Completion.Task;
-                }
-                else
-                {
-                    if (_entries.Count >= MaximumEntries
-                        || _storedBytes + _reservedBytes + request.MaximumResultBytes > MaximumStoredResultBytes)
-                    {
-                        return new PlatformIdempotencyOutcome(PlatformIdempotencyOutcomeKind.AtCapacity);
-                    }
-
-                    leaderEntry = new Entry(request.Fingerprint, request.MaximumResultBytes);
-                    _entries.Add(key, leaderEntry);
-                    _reservedBytes += request.MaximumResultBytes;
-                }
-            }
-
-            if (followerTask is not null)
-            {
-                try
-                {
-                    return await followerTask.WaitAsync(requestCancellationToken).ConfigureAwait(false);
-                }
-                finally
-                {
-                    lock (_gate)
-                    {
-                        followerEntry!.FollowerCount--;
-                        _followerCount--;
-                    }
-                }
-            }
-
-            var executionStarted = false;
-            try
-            {
-                requestCancellationToken.ThrowIfCancellationRequested();
-                executionStarted = true;
-                var result = await execute(requestCancellationToken).ConfigureAwait(false);
-                ArgumentNullException.ThrowIfNull(result);
+                Task<EntryCompletion>? followerTask = null;
+                Entry? leaderEntry = null;
+                Entry? followerEntry = null;
 
                 lock (_gate)
                 {
-                    _reservedBytes -= leaderEntry!.ReservedBytes;
-                    if (result.SerializedSizeBytes > leaderEntry.ReservedBytes
-                        || result.SerializedSizeBytes > MaximumResultBytes)
-                    {
-                        MarkTombstone(leaderEntry, _timeProvider.GetUtcNow());
-                        return new PlatformIdempotencyOutcome(PlatformIdempotencyOutcomeKind.Indeterminate);
-                    }
+                    RemoveExpiredEntries(_timeProvider.GetUtcNow());
 
-                    leaderEntry.State = EntryState.Completed;
-                    leaderEntry.Result = result;
-                    leaderEntry.ExpiresAt = _timeProvider.GetUtcNow() + EntryTimeToLive;
-                    _storedBytes += result.SerializedSizeBytes;
-                    leaderEntry.Completion.TrySetResult(
-                        new PlatformIdempotencyOutcome(PlatformIdempotencyOutcomeKind.Replay, result));
-                }
-
-                return new PlatformIdempotencyOutcome(PlatformIdempotencyOutcomeKind.Executed, result);
-            }
-            catch
-            {
-                lock (_gate)
-                {
-                    _reservedBytes -= leaderEntry!.ReservedBytes;
-                    if (executionStarted)
+                    if (_entries.TryGetValue(key, out var existing))
                     {
-                        MarkTombstone(leaderEntry, _timeProvider.GetUtcNow());
+                        if (!existing.Fingerprint.Matches(request.Fingerprint))
+                        {
+                            return new PlatformIdempotencyOutcome(PlatformIdempotencyOutcomeKind.Conflict);
+                        }
+
+                        if (existing.State == EntryState.Completed)
+                        {
+                            return new PlatformIdempotencyOutcome(PlatformIdempotencyOutcomeKind.Replay, existing.Result);
+                        }
+
+                        if (existing.State == EntryState.Tombstone)
+                        {
+                            return new PlatformIdempotencyOutcome(PlatformIdempotencyOutcomeKind.Indeterminate);
+                        }
+
+                        if (existing.FollowerCount >= MaximumFollowersPerEntry
+                            || _followerCount >= MaximumFollowers)
+                        {
+                            return new PlatformIdempotencyOutcome(PlatformIdempotencyOutcomeKind.AtCapacity);
+                        }
+
+                        existing.FollowerCount++;
+                        _followerCount++;
+                        followerEntry = existing;
+                        followerTask = existing.Completion.Task;
                     }
                     else
                     {
-                        _entries.Remove(key);
-                        leaderEntry.Completion.TrySetResult(
-                            new PlatformIdempotencyOutcome(PlatformIdempotencyOutcomeKind.Indeterminate));
+                        if (_entries.Count >= MaximumEntries
+                            || _storedBytes + _reservedBytes + request.MaximumResultBytes > MaximumStoredResultBytes)
+                        {
+                            return new PlatformIdempotencyOutcome(PlatformIdempotencyOutcomeKind.AtCapacity);
+                        }
+
+                        leaderEntry = new Entry(request.Fingerprint, request.MaximumResultBytes);
+                        _entries.Add(key, leaderEntry);
+                        _reservedBytes += request.MaximumResultBytes;
                     }
                 }
 
-                throw;
+                if (followerTask is not null)
+                {
+                    EntryCompletion completion;
+                    try
+                    {
+                        completion = await followerTask.WaitAsync(requestCancellationToken).ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        lock (_gate)
+                        {
+                            followerEntry!.FollowerCount--;
+                            _followerCount--;
+                        }
+                    }
+
+                    if (completion.Retry)
+                    {
+                        requestCancellationToken.ThrowIfCancellationRequested();
+                        continue;
+                    }
+
+                    return completion.Outcome!;
+                }
+
+                var execution = new PlatformIdempotencyExecution();
+                try
+                {
+                    requestCancellationToken.ThrowIfCancellationRequested();
+                    var result = await execute(execution, requestCancellationToken).ConfigureAwait(false);
+                    ArgumentNullException.ThrowIfNull(result);
+
+                    lock (_gate)
+                    {
+                        _reservedBytes -= leaderEntry!.ReservedBytes;
+                        var abandoned = execution.AbandonedResult;
+                        if ((abandoned is not null && !ReferenceEquals(abandoned, result))
+                            || result.SerializedSizeBytes > leaderEntry.ReservedBytes
+                            || result.SerializedSizeBytes > MaximumResultBytes)
+                        {
+                            MarkTombstone(leaderEntry, _timeProvider.GetUtcNow());
+                            return new PlatformIdempotencyOutcome(PlatformIdempotencyOutcomeKind.Indeterminate);
+                        }
+
+                        if (abandoned is not null)
+                        {
+                            _entries.Remove(key);
+                            leaderEntry.Completion.TrySetResult(
+                                EntryCompletion.FromOutcome(
+                                    new PlatformIdempotencyOutcome(
+                                        PlatformIdempotencyOutcomeKind.Executed,
+                                        abandoned,
+                                        wasCoalescedUnstored: true)));
+                            return new PlatformIdempotencyOutcome(
+                                PlatformIdempotencyOutcomeKind.Executed,
+                                abandoned);
+                        }
+
+                        leaderEntry.State = EntryState.Completed;
+                        leaderEntry.Result = result;
+                        leaderEntry.ExpiresAt = _timeProvider.GetUtcNow() + EntryTimeToLive;
+                        _storedBytes += result.SerializedSizeBytes;
+                        leaderEntry.Completion.TrySetResult(
+                            EntryCompletion.FromOutcome(
+                                new PlatformIdempotencyOutcome(PlatformIdempotencyOutcomeKind.Replay, result)));
+                    }
+
+                    return new PlatformIdempotencyOutcome(PlatformIdempotencyOutcomeKind.Executed, result);
+                }
+                catch
+                {
+                    lock (_gate)
+                    {
+                        _reservedBytes -= leaderEntry!.ReservedBytes;
+                        if (execution.SideEffectStarted)
+                        {
+                            MarkTombstone(leaderEntry, _timeProvider.GetUtcNow());
+                        }
+                        else
+                        {
+                            _entries.Remove(key);
+                            leaderEntry.Completion.TrySetResult(EntryCompletion.RetryAdmission);
+                        }
+                    }
+
+                    throw;
+                }
             }
         }
 
@@ -206,7 +304,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
             entry.Result = null;
             entry.ExpiresAt = now + EntryTimeToLive;
             entry.Completion.TrySetResult(
-                new PlatformIdempotencyOutcome(PlatformIdempotencyOutcomeKind.Indeterminate));
+                EntryCompletion.FromOutcome(
+                    new PlatformIdempotencyOutcome(PlatformIdempotencyOutcomeKind.Indeterminate)));
         }
 
         private void RemoveExpiredEntries(DateTimeOffset now)
@@ -250,7 +349,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
             {
                 Fingerprint = fingerprint;
                 ReservedBytes = reservedBytes;
-                Completion = new TaskCompletionSource<PlatformIdempotencyOutcome>(
+                Completion = new TaskCompletionSource<EntryCompletion>(
                     TaskCreationOptions.RunContinuationsAsynchronously);
             }
 
@@ -266,7 +365,25 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
 
             internal int FollowerCount { get; set; }
 
-            internal TaskCompletionSource<PlatformIdempotencyOutcome> Completion { get; }
+            internal TaskCompletionSource<EntryCompletion> Completion { get; }
+        }
+
+        private sealed class EntryCompletion
+        {
+            private EntryCompletion(bool retry, PlatformIdempotencyOutcome? outcome)
+            {
+                Retry = retry;
+                Outcome = outcome;
+            }
+
+            internal static EntryCompletion RetryAdmission { get; } = new(true, outcome: null);
+
+            internal bool Retry { get; }
+
+            internal PlatformIdempotencyOutcome? Outcome { get; }
+
+            internal static EntryCompletion FromOutcome(PlatformIdempotencyOutcome outcome)
+                => new(false, outcome);
         }
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformPreparedActionContextOwner.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformPreparedActionContextOwner.cs
@@ -1,0 +1,350 @@
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>The bounded server-owned state attached to one prepared action.</summary>
+    internal sealed class PlatformPreparedActionRequest
+    {
+        private readonly byte[] _privateState;
+
+        internal PlatformPreparedActionRequest(
+            PlatformOperationDefinition definition,
+            HostAccessibleItem item,
+            long configurationRevision,
+            ReadOnlySpan<byte> privateState)
+        {
+            ArgumentNullException.ThrowIfNull(definition);
+            if (!ReferenceEquals(PlatformOperationVocabulary.Find(definition.Id.Value), definition))
+            {
+                throw new ArgumentException("The prepared operation must come from the code-owned vocabulary.", nameof(definition));
+            }
+
+            if (item.Id == Guid.Empty || !definition.SupportedItemKinds.Contains(item.Kind))
+            {
+                throw new ArgumentException("A supported accessible item projection is required.", nameof(item));
+            }
+
+            if (configurationRevision < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(configurationRevision));
+            }
+
+            if (privateState.Length > PlatformPreparedActionContextOwner.MaximumPrivateStateBytes)
+            {
+                throw new ArgumentException("Prepared private state exceeds its fixed byte bound.", nameof(privateState));
+            }
+
+            Definition = definition;
+            Item = item;
+            ConfigurationRevision = configurationRevision;
+            _privateState = privateState.ToArray();
+        }
+
+        internal PlatformOperationDefinition Definition { get; }
+
+        internal HostAccessibleItem Item { get; }
+
+        internal long ConfigurationRevision { get; }
+
+        internal ReadOnlyMemory<byte> PrivateState => _privateState.ToArray();
+    }
+
+    /// <summary>An immutable context released only after exact capability authentication.</summary>
+    internal sealed class PlatformPreparedActionContext
+    {
+        private readonly byte[] _privateState;
+        private readonly byte[] _digest;
+
+        internal PlatformPreparedActionContext(
+            PlatformPreparedActionRequest request,
+            ReadOnlySpan<byte> digest)
+        {
+            Definition = request.Definition;
+            Item = request.Item;
+            ConfigurationRevision = request.ConfigurationRevision;
+            _privateState = request.PrivateState.ToArray();
+            _digest = digest.ToArray();
+        }
+
+        internal PlatformOperationDefinition Definition { get; }
+
+        internal HostAccessibleItem Item { get; }
+
+        internal long ConfigurationRevision { get; }
+
+        internal ReadOnlyMemory<byte> PrivateState => _privateState.ToArray();
+
+        internal ReadOnlyMemory<byte> Digest => _digest.ToArray();
+    }
+
+    internal enum PlatformPreparedActionIssueKind
+    {
+        Issued,
+        InvalidRequest,
+        NotAuthorized,
+        AtCapacity,
+        EntropyUnavailable,
+    }
+
+    internal sealed class PlatformPreparedActionIssue
+    {
+        internal PlatformPreparedActionIssue(
+            PlatformPreparedActionIssueKind kind,
+            string? capability = null,
+            DateTimeOffset? expiresAt = null)
+        {
+            Kind = kind;
+            Capability = capability;
+            ExpiresAt = expiresAt;
+        }
+
+        internal PlatformPreparedActionIssueKind Kind { get; }
+
+        internal string? Capability { get; }
+
+        internal DateTimeOffset? ExpiresAt { get; }
+    }
+
+    /// <summary>
+    /// Process-local, fixed-cap owner joining opaque capabilities to server-private
+    /// prepared preconditions. Tokens are never retained; a process-keyed digest is the
+    /// lookup key, and every resolve also proves the exact authenticated inspection.
+    /// </summary>
+    public sealed class PlatformPreparedActionContextOwner : IDisposable
+    {
+        /// <summary>Maximum live prepared contexts retained process-wide.</summary>
+        public const int MaximumEntries = 1024;
+
+        /// <summary>Maximum server-private state attached to one prepared action.</summary>
+        public const int MaximumPrivateStateBytes = 4096;
+
+        private const int LookupKeyBytes = 32;
+
+        private static readonly byte[] ContextDomain =
+            Encoding.ASCII.GetBytes("jellyfin-canopy/platform-prepared-context/v1");
+
+        private static readonly byte[] LookupDomain =
+            Encoding.ASCII.GetBytes("jellyfin-canopy/platform-prepared-context/lookup/v1");
+
+        private readonly object _gate = new();
+        private readonly Dictionary<string, Entry> _entries = new(StringComparer.Ordinal);
+        private readonly PlatformActionCapabilityService _capabilities;
+        private readonly TimeProvider _timeProvider;
+        private readonly byte[] _lookupKey;
+        private bool _disposed;
+
+        /// <summary>Initializes the process-local owner.</summary>
+        public PlatformPreparedActionContextOwner(PlatformActionCapabilityService capabilities)
+            : this(capabilities, TimeProvider.System, RandomNumberGenerator.GetBytes(LookupKeyBytes))
+        {
+        }
+
+        internal PlatformPreparedActionContextOwner(
+            PlatformActionCapabilityService capabilities,
+            TimeProvider timeProvider,
+            ReadOnlySpan<byte> lookupKey)
+        {
+            _capabilities = capabilities ?? throw new ArgumentNullException(nameof(capabilities));
+            _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+            if (lookupKey.Length != LookupKeyBytes)
+            {
+                throw new ArgumentException($"The prepared-context lookup key must contain {LookupKeyBytes} bytes.", nameof(lookupKey));
+            }
+
+            _lookupKey = lookupKey.ToArray();
+        }
+
+        internal PlatformPreparedActionIssue Issue(
+            PlatformActor actor,
+            PlatformPreparedActionRequest request,
+            bool attenuateToCurrentDevice)
+        {
+            ArgumentNullException.ThrowIfNull(actor);
+            ArgumentNullException.ThrowIfNull(request);
+            var digest = CreateContextDigest(request);
+
+            lock (_gate)
+            {
+                ThrowIfDisposed();
+                RemoveExpired(_timeProvider.GetUtcNow());
+                if (_entries.Count >= MaximumEntries)
+                {
+                    return new PlatformPreparedActionIssue(PlatformPreparedActionIssueKind.AtCapacity);
+                }
+
+                var minted = _capabilities.Mint(
+                    actor,
+                    request.Definition.Id.Value,
+                    request.Item.Id,
+                    request.Item.Kind,
+                    digest,
+                    attenuateToCurrentDevice);
+                if (minted.Kind != PlatformCapabilityMintOutcomeKind.Issued
+                    || minted.Capability is null
+                    || minted.ExpiresAt is null)
+                {
+                    return new PlatformPreparedActionIssue(Map(minted.Kind));
+                }
+
+                var lookup = Lookup(minted.Capability);
+                if (_entries.ContainsKey(lookup))
+                {
+                    // A keyed SHA-256 collision is treated as entropy failure. Never
+                    // replace a live context with a different action.
+                    return new PlatformPreparedActionIssue(PlatformPreparedActionIssueKind.EntropyUnavailable);
+                }
+
+                _entries.Add(
+                    lookup,
+                    new Entry(new PlatformPreparedActionContext(request, digest), minted.ExpiresAt.Value));
+                return new PlatformPreparedActionIssue(
+                    PlatformPreparedActionIssueKind.Issued,
+                    minted.Capability,
+                    minted.ExpiresAt);
+            }
+        }
+
+        internal PlatformPreparedActionContext? Resolve(
+            string? capability,
+            PlatformCapabilityInspection? inspection)
+        {
+            if (!_capabilities.IsInspectionFor(inspection, capability) || capability is null)
+            {
+                return null;
+            }
+
+            lock (_gate)
+            {
+                ThrowIfDisposed();
+                RemoveExpired(_timeProvider.GetUtcNow());
+                return _entries.TryGetValue(Lookup(capability), out var entry)
+                    ? entry.Context
+                    : null;
+            }
+        }
+
+        internal void InvalidateOutstanding()
+        {
+            lock (_gate)
+            {
+                ThrowIfDisposed();
+                _capabilities.InvalidateOutstandingCapabilities();
+                _entries.Clear();
+            }
+        }
+
+        internal int EntryCount
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    ThrowIfDisposed();
+                    RemoveExpired(_timeProvider.GetUtcNow());
+                    return _entries.Count;
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            lock (_gate)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _entries.Clear();
+                CryptographicOperations.ZeroMemory(_lookupKey);
+                _disposed = true;
+            }
+        }
+
+        private static byte[] CreateContextDigest(PlatformPreparedActionRequest request)
+        {
+            using var stream = new MemoryStream();
+            stream.Write(ContextDomain);
+            WriteString(stream, request.Definition.Id.Value);
+            WriteString(stream, request.Definition.InputSchemaId.Value);
+            Span<byte> number = stackalloc byte[8];
+            BinaryPrimitives.WriteInt64BigEndian(number, request.Definition.InvalidationGeneration);
+            stream.Write(number);
+            Span<byte> item = stackalloc byte[16];
+            request.Item.Id.TryWriteBytes(item);
+            stream.Write(item);
+            stream.WriteByte((byte)request.Item.Kind);
+            stream.WriteByte(request.Item.SeriesId.HasValue ? (byte)1 : (byte)0);
+            if (request.Item.SeriesId is Guid seriesId)
+            {
+                seriesId.TryWriteBytes(item);
+                stream.Write(item);
+            }
+
+            BinaryPrimitives.WriteInt64BigEndian(number, request.ConfigurationRevision);
+            stream.Write(number);
+            BinaryPrimitives.WriteInt32BigEndian(number[..4], request.PrivateState.Length);
+            stream.Write(number[..4]);
+            stream.Write(request.PrivateState.Span);
+            return SHA256.HashData(stream.GetBuffer().AsSpan(0, checked((int)stream.Length)));
+        }
+
+        private string Lookup(string capability)
+        {
+            var token = Encoding.ASCII.GetBytes(capability);
+            var input = new byte[LookupDomain.Length + token.Length];
+            LookupDomain.CopyTo(input, 0);
+            token.CopyTo(input, LookupDomain.Length);
+            return Convert.ToHexString(HMACSHA256.HashData(_lookupKey, input));
+        }
+
+        private static void WriteString(Stream stream, string value)
+        {
+            var bytes = Encoding.UTF8.GetBytes(value);
+            Span<byte> length = stackalloc byte[2];
+            BinaryPrimitives.WriteUInt16BigEndian(length, checked((ushort)bytes.Length));
+            stream.Write(length);
+            stream.Write(bytes);
+        }
+
+        private void RemoveExpired(DateTimeOffset now)
+        {
+            List<string>? expired = null;
+            foreach (var pair in _entries)
+            {
+                if (pair.Value.ExpiresAt <= now)
+                {
+                    (expired ??= new List<string>()).Add(pair.Key);
+                }
+            }
+
+            if (expired is not null)
+            {
+                foreach (var key in expired)
+                {
+                    _entries.Remove(key);
+                }
+            }
+        }
+
+        private static PlatformPreparedActionIssueKind Map(PlatformCapabilityMintOutcomeKind kind) => kind switch
+        {
+            PlatformCapabilityMintOutcomeKind.InvalidRequest => PlatformPreparedActionIssueKind.InvalidRequest,
+            PlatformCapabilityMintOutcomeKind.NotAuthorized => PlatformPreparedActionIssueKind.NotAuthorized,
+            PlatformCapabilityMintOutcomeKind.AtCapacity => PlatformPreparedActionIssueKind.AtCapacity,
+            PlatformCapabilityMintOutcomeKind.EntropyUnavailable => PlatformPreparedActionIssueKind.EntropyUnavailable,
+            _ => PlatformPreparedActionIssueKind.EntropyUnavailable,
+        };
+
+        private void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(_disposed, this);
+
+        private sealed record Entry(PlatformPreparedActionContext Context, DateTimeOffset ExpiresAt);
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
@@ -40,6 +40,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy
             // One process-local 256-bit authority and nonce ledger for short-lived
             // native action capabilities. Restart intentionally invalidates every token.
             serviceCollection.AddSingleton<PlatformActionCapabilityService>();
+            // Server-private prepared preconditions remain process-local and expire no
+            // later than their opaque capability. Invocation concurrency is bounded by
+            // authoritative actor and the closed operation vocabulary.
+            serviceCollection.AddSingleton<PlatformPreparedActionContextOwner>();
+            serviceCollection.AddSingleton<PlatformActionAdmissionLimiter>();
             // One process-wide, fixed-capacity owner for redacted terminal Platform
             // action audit. It exposes no route and retains no caller payload.
             serviceCollection.AddSingleton<PlatformAuditStore>();

--- a/docs/platform-contract.md
+++ b/docs/platform-contract.md
@@ -162,10 +162,13 @@ bounded, non-streaming results and must not write directly to the response.
 
 ## Idempotent mutations
 
-Platform v1 ships the bounded idempotency kernel before adding mutation routes. Every
-future mutation will require exactly one `Idempotency-Key` value: 1–128 ASCII letters,
-digits, `.`, `_`, `~`, or `-`. The parser is transport-neutral, so a later body-carried
-key has exactly the same normalization and validation rules.
+Platform v1 ships one bounded idempotency kernel for all mutations. Each mutation
+requires exactly one idempotency key containing 1–128 ASCII letters, digits, `.`, `_`,
+`~`, or `-`. The native `/actions/invoke` kernel contract carries `IdempotencyKey` in its
+JSON body because Jellyfin SDK Kotlin's authenticated request seam has no per-request
+header facility. Its production route binding will reject an `Idempotency-Key` header as
+a competing carrier. Other future mutation routes may use the header, but both carriers
+use the same transport-neutral parser and kernel semantics.
 
 The process-local store keys an attempt by authenticated acting user, code-owned
 operation, and idempotency key. The operation supplies a SHA-256 fingerprint of the
@@ -289,6 +292,57 @@ capability, return a previously stored identical idempotent result without consu
 again, and consume only when admitting a new owner execution. Concurrent or later
 consumption of the same nonce is refused as replay. This primitive has no HTTP route,
 controller, provider credential, durable token or long-running operation handle.
+
+### Native action invocation coordinator
+
+This layer is the transport-neutral kernel contract. It deliberately does not register a
+controller, coordinator, dispatcher, or feature adapter in dependency injection yet;
+the production resolve/prepare/invoke routes and the three feature-owner bindings land
+only after their owning services exist. Until that binding lands, the rules below are
+enforced and tested as kernel contracts rather than advertised as a callable endpoint.
+
+The native invocation body contains exactly one `Capability`, one body-carried
+`IdempotencyKey`, and one `Answers` array. Known fields are case-sensitive and duplicate
+known properties are rejected; unknown optional properties remain forward compatible.
+There are at most eight answers, each names one bounded field and carries exactly one
+boolean or bounded unique option-id array. The platform's ordinary 1 MiB/depth/key/string
+bounds still run before this narrower schema.
+
+An authentic capability resolves a server-private prepared context retained in a
+process-local, non-evicting 1,024-entry store until the capability's expiry. That context
+binds the code-owned operation and schema, exact accessible item, kind, and series
+ancestry, operation generation, feature configuration revision, and at most 4 KiB of
+owner-private prepared state. Losing it on expiry or restart fails closed; clients cannot
+reconstruct it by adding operation, item, provider, or precondition fields to the
+invocation body.
+
+Every invocation follows one order: authenticate and inspect the capability; resolve the
+prepared context; reload the current user and exact user-scoped item; re-evaluate the
+operation and feature authority and project typed input; consult idempotency; acquire the
+bounded actor/operation admission lease; repeat the current checks after any queue wait;
+atomically consume the capability; then call one fixed first-party owner. The dispatcher
+has exactly three named ports (Spoiler Guard, Hidden Content, and Seerr), not a registry.
+Owners receive only the reduced actor, accessible-item projection, validated typed input,
+idempotency key, and cancellation token.
+
+Only one owner runs for an actor/operation at a time. At most eight waiters are retained
+per actor/operation, with 1,024 actor/operation keys and 1,024 waiters process-wide;
+excess work fails before capability consumption. Cancellation while queued removes the
+waiter. Cancellation or failure before the explicit capability-consumption boundary lets
+an identical later request retry leadership, while failure after that boundary retains an
+indeterminate tombstone. A bounded admission or current-authority refusal before that
+boundary is shared with followers already waiting on the attempt but is not retained for
+10-minute replay, so a later retry with the same key and still-unconsumed capability can
+succeed after the transient condition clears. If an owner ignores cancellation and
+returns a result, that semantic result remains stored for safe retry, while the canceled
+request still receives the lifecycle's caller-abort or deadline outcome and audit.
+
+An identical `(actor, operation, key, semantic input)` replays its stored result without
+re-consuming the capability. Reusing the key with changed semantic input conflicts, and
+using a fresh key with a consumed capability is a replay refusal. Current user, library,
+parental, item, feature, schema, generation, and authority checks run before any replay is
+released, so stored success never bypasses a later revocation. Unknown operations,
+schemas, owners, missing prepared state, and inconsistent revalidation all fail closed.
 
 ## Pagination
 

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,7 +26,7 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2808, totalLines: 3201 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 33607, totalLines: 42607 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 34405, totalLines: 43519 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 3,
         minimumCoveredLines: 2808,
@@ -34,11 +34,11 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
     });
     assert.deepEqual(baselines.profiles.server.observations, {
         cleanRuns: 3,
-        minimumCoveredLines: 33607,
-        maximumCoveredLines: 33607,
+        minimumCoveredLines: 34404,
+        maximumCoveredLines: 34405,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 0);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 1);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 33607,
-        "totalLines": 42607
+        "coveredLines": 34405,
+        "totalLines": 43519
       },
       "observations": {
         "cleanRuns": 3,
-        "minimumCoveredLines": 33607,
-        "maximumCoveredLines": 33607
+        "minimumCoveredLines": 34404,
+        "maximumCoveredLines": 34405
       },
       "tolerance": {
-        "missingCoveredLines": 0,
-        "rationale": "The #593 follow-up adds the transport-free Spoiler Guard Platform adapter that maps only authoritative actor and freshly accessible Movie/Series projections into the already shared installed-item owner. Its tests cover both admitted kinds, preserve the owner's exact semantic result, prove exactly one owner call, and reject unsupported kinds before the owner. Independent review also found and corrected a real parity edge: because the safe Platform projection has no title, re-enabling an existing movie now preserves its durable display metadata and revision instead of erasing the name. A real adapter-plus-owner persistence regression pins that behavior. The adapter measures 100% line coverage. Three clean Coverlet runs on the identical corrected 2026-08-03 source and 42,607-line scope each passed all 2,947 server tests and reproduced exactly 33,607 covered lines. Relative to the reviewed #594 main high-water of 33,585/42,586 (78.864%), this change adds 21 instrumented lines and 22 covered lines, raising the high-water to 33,607/42,607 (78.877%). The identical observation envelope needs no instrumentation tolerance, so the floor and high-water are both 33,607/42,607. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 1,
+        "rationale": "The rebased #591 tree retains main's installed Hidden Content and Spoiler Guard Platform owners and adapters, then adds the transport-neutral first-party invocation coordinator, server-private prepared contexts, named typed owner ports, cancellation-aware actor/operation admission, Android-compatible body-carried idempotency, series-ancestry binding, and cancellation checks after synchronous host seams. Three clean Coverlet runs on the identical 2026-08-03 combined source and 43,519-line scope each passed all 3,008 server tests and measured 34,405, 34,404, and 34,404 covered lines. Relative to the reviewed main high-water of 33,607/42,607 (78.877%), #591 adds 912 instrumented lines and raises the observed high-water by 798 covered lines to 34,405/43,519 (79.057%). The one-line observed instrumentation envelope sets a one-line tolerance and a 34,404-line floor. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
Closes #591

## Outcome

Adds the transport-neutral admission and invocation kernel for the three fixed native-pilot operations. It joins current actor/item reauthorization, server-private prepared context, opaque capability validation/consumption, bounded actor+operation admission, typed fixed-owner dispatch, body-carried idempotency, cancellation/deadline arbitration, and one terminal redacted audit decision.

The invoke body has exactly one required `IdempotencyKey`; malformed, duplicate-known-property, or competing header+body carriers fail closed. Same-key identical work coalesces/replays once, changed input conflicts, pre-side-effect refusals remain retryable without poisoning the key, and post-side-effect uncertainty retains an indeterminate tombstone. Followers and stored replays reauthorize current user/item/library/parental/feature/config/input state before receiving a result.

Prepared actions bind item ancestry as well as item id/kind, so a same-kind Episode move is refused. Caller cancellation wins simultaneous deadline races and is rechecked after synchronous host/input seams.

This PR intentionally publishes no production action route and registers no unavailable coordinator/dispatcher. #606 owns the real three family ports plus resolve/prepare/invoke route binding after #592–#595.

## Validation

- Platform-focused tests: 427/427
- full server coverage: 3,008/3,008; three clean 34,404–34,405/43,519 observations; one-line measured envelope
- script tests: 634/634
- strict documentation checks: pass
- Release build: 0 warnings, 0 errors
- diff check: pass
- independent security/concurrency review and post-rebase review: APPROVE
