### PR TITLE
Extract typed Seerr media request owner

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformWireFormatTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformWireFormatTests.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.JellyfinCanopy;
 using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
 using MediaBrowser.Controller;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -246,6 +247,16 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
                 services,
                 descriptor => descriptor.ServiceType == typeof(PlatformAuditStore));
             Assert.Equal(ServiceLifetime.Singleton, auditRegistration.Lifetime);
+
+            Assert.Equal(
+                ServiceLifetime.Singleton,
+                Assert.Single(services, descriptor => descriptor.ServiceType == typeof(ISeerrMediaRequestOwner)).Lifetime);
+            Assert.Equal(
+                ServiceLifetime.Singleton,
+                Assert.Single(services, descriptor => descriptor.ServiceType == typeof(ISeerrMediaRequestAdmission)).Lifetime);
+            Assert.Equal(
+                ServiceLifetime.Singleton,
+                Assert.Single(services, descriptor => descriptor.ServiceType == typeof(ISeerrSpoilerIntentStore)).Lifetime);
 
             Assert.True(CanRead(formatter, typeof(TestController)));
             Assert.False(CanRead(formatter, typeof(LegacyController)));

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/Seerr/SeerrParentalFilterTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/Seerr/SeerrParentalFilterTests.cs
@@ -397,6 +397,25 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services.Seerr
         }
 
         [Fact]
+        public async Task IsBlockedAsync_CallerCancellationPropagatesInsteadOfBecomingACompletedDecision()
+        {
+            var filter = BuildFilter(
+                maxScore: 13,
+                maxSub: null,
+                block: Array.Empty<UnratedItem>(),
+                featureEnabled: true,
+                seed: null);
+            using var cancellation = new CancellationTokenSource();
+            cancellation.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => filter.IsBlockedAsync(
+                "movie",
+                100,
+                new SeerrCaller(CallerGuid, false),
+                cancellation.Token));
+        }
+
+        [Fact]
         public async Task Gate_InactiveWhenSeerrNotConfigured()
         {
             // Without a Seerr URL/key the gate can't verify certs, so it stays inactive

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/Seerr/SeerrParentalFilterTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/Seerr/SeerrParentalFilterTests.cs
@@ -133,6 +133,24 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services.Seerr
                 provider);
         }
 
+        private static SeerrParentalFilter BuildStrictPolicyFilter(IUserManager userManager)
+        {
+            var provider = new FakePluginConfigProvider(new PluginConfiguration
+            {
+                SeerrEnabled = true,
+                SeerrRespectParentalRatings = true,
+                SeerrUrls = "http://seerr:5055",
+                SeerrApiKey = "key",
+            });
+            return new SeerrParentalFilter(
+                new RecordingHttpClientFactory(new RecordingHttpMessageHandler()),
+                NullLogger<SeerrParentalFilter>.Instance,
+                userManager,
+                new FakeLocalization(),
+                new SeerrCache(provider),
+                provider);
+        }
+
         private static Task<SeerrParentalResult> ApplyAsync(
             string body,
             string apiPath,
@@ -537,6 +555,58 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services.Seerr
                 "movie",
                 100,
                 new SeerrCaller(CallerGuid, false)));
+        }
+
+        [Fact]
+        public async Task ExactMutationGate_MissingUserOrPolicyFailsClosed_WithoutChangingLegacyReadPath()
+        {
+            var userId = Guid.Parse(CallerGuid);
+            var missingUser = BuildStrictPolicyFilter(
+                new StubPolicyUserManager(new Dictionary<Guid, (User, UserPolicy)>()));
+            Assert.True(await missingUser.IsBlockedAsync(
+                "movie",
+                100,
+                new SeerrCaller(CallerGuid, false),
+                CancellationToken.None));
+            Assert.False(await missingUser.IsBlockedAsync(
+                "movie",
+                100,
+                new SeerrCaller(CallerGuid, false)));
+
+            var user = new User("policy-missing", "Prov", "PwProv");
+            var registry = new Dictionary<Guid, (User, UserPolicy)>
+            {
+                [userId] = (user, new UserPolicy()),
+            };
+            var missingPolicy = BuildStrictPolicyFilter(new StubPolicyUserManager(
+                registry,
+                new HashSet<Guid> { userId }));
+            Assert.True(await missingPolicy.IsBlockedAsync(
+                "movie",
+                100,
+                new SeerrCaller(CallerGuid, false),
+                CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task ExactMutationGate_AuthoritativeUnrestrictedUserIsAllowed()
+        {
+            var userId = Guid.Parse(CallerGuid);
+            var user = new User("unrestricted", "Prov", "PwProv")
+            {
+                MaxParentalRatingScore = null,
+                MaxParentalRatingSubScore = null,
+            };
+            var filter = BuildStrictPolicyFilter(new StubPolicyUserManager(
+                userId,
+                user,
+                new UserPolicy { BlockUnratedItems = Array.Empty<UnratedItem>() }));
+
+            Assert.False(await filter.IsBlockedAsync(
+                "movie",
+                100,
+                new SeerrCaller(CallerGuid, false),
+                CancellationToken.None));
         }
 
         [Fact]

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/Seerr4kCapabilityTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/Seerr4kCapabilityTests.cs
@@ -1,6 +1,7 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Model.Seerr;
 using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
 using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -143,6 +144,36 @@ public class Seerr4kCapabilityTests
         Assert.True(cap.Series4kEnabled);
         Assert.False(cap.CanRequest4kMovie);
         Assert.False(cap.CanRequest4kTv);
+    }
+
+    [Fact]
+    public async Task ExactOwnerCapability_IsPinnedToAdmittedIdentityWithoutABASourceReresolution()
+    {
+        var config = Config();
+        config.SeerrUrls = "http://seerr-a:5055,http://seerr-b:5055";
+        config.SeerrEnable4KRequests = true;
+        var (client, handler) = NewClient(config);
+        handler.AddResponse(
+            "/api/v1/settings/public",
+            "{\"movie4kEnabled\":true,\"series4kEnabled\":true}");
+        var admission = (ISeerrMediaRequestAdmission)client;
+        var identity = new SeerrRequestIdentity(
+            42,
+            SeerrPermission.REQUEST_4K,
+            "http://seerr-a:5055");
+
+        var capability = await admission.Get4kCapabilityAsync(
+            identity,
+            isAdministrator: false,
+            CancellationToken.None);
+
+        Assert.True(capability.CanRequest4kMovie);
+        var settingsRequest = Assert.Single(handler.Requests);
+        Assert.Equal("seerr-a", settingsRequest.RequestUri!.Host);
+        Assert.Equal("/api/v1/settings/public", settingsRequest.RequestUri.AbsolutePath);
+        Assert.DoesNotContain(
+            handler.Requests,
+            request => request.RequestUri!.AbsolutePath == "/api/v1/user");
     }
 
     private sealed class PassthroughParentalFilter : ISeerrParentalFilter

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrIntentDurabilityTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrIntentDurabilityTests.cs
@@ -349,6 +349,22 @@ public sealed class SeerrIntentDurabilityTests : IDisposable
         Assert.True(ReadState(setup).PendingTmdb.ContainsKey("movie:878"));
     }
 
+    [Fact]
+    public void TypedOwnerIntent_DurablyUsesTrustedKindAndCanonicalPositiveTmdbId()
+    {
+        var setup = CreateClientHarness();
+
+        var registration = setup.Pending.RegisterSeerrIntent(
+            setup.User.Id,
+            SeerrMediaRequestKind.Series,
+            879);
+
+        Assert.True(registration.IsDurable);
+        var entry = Assert.IsType<SpoilerBlurPendingEntry>(ReadState(setup).PendingTmdb["tv:879"]);
+        Assert.Equal("tv", entry.MediaType);
+        Assert.Equal("879", entry.TmdbId);
+    }
+
     private ClientHarness CreateClientHarness(ISeerrParentalFilter? parentalFilter = null)
     {
         var user = new User("intent-harness", "provider", "password-provider");

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrMediaRequestOwnerArchitectureTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrMediaRequestOwnerArchitectureTests.cs
@@ -80,6 +80,15 @@ public sealed class SeerrMediaRequestOwnerArchitectureTests
             source.LastIndexOf("SeerrRequestIdentityResolutionMode.FinalPreDispatch", StringComparison.Ordinal)
                 < source.IndexOf("_host.Users.Find(actor.UserId)", StringComparison.Ordinal));
         Assert.True(
+            source.IndexOf("SeerrHttpHelper.CreateClient", StringComparison.Ordinal)
+                < source.IndexOf("_host.Users.Find(actor.UserId)", StringComparison.Ordinal));
+        Assert.True(
+            source.IndexOf("SeerrHttpHelper.BuildRequest", StringComparison.Ordinal)
+                < source.IndexOf("_host.Users.Find(actor.UserId)", StringComparison.Ordinal));
+        Assert.True(
+            source.IndexOf("PlatformIdempotencyKey.HeaderName, idempotencyKey.Value", StringComparison.Ordinal)
+                < source.IndexOf("_host.Users.Find(actor.UserId)", StringComparison.Ordinal));
+        Assert.True(
             source.IndexOf("_host.Library.FindAccessible(actor.UserId, item.Id)", StringComparison.Ordinal)
                 < source.IndexOf("SeerrHttpHelper.SendResponseHeadersReadAsync", StringComparison.Ordinal));
 

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrMediaRequestOwnerArchitectureTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrMediaRequestOwnerArchitectureTests.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr;
 using Jellyfin.Plugin.JellyfinCanopy.Platform;
 using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
 using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
@@ -71,6 +72,20 @@ public sealed class SeerrMediaRequestOwnerArchitectureTests
         Assert.DoesNotContain("Controller", source, StringComparison.Ordinal);
         Assert.DoesNotContain("foreach", source, StringComparison.Ordinal);
         Assert.DoesNotContain("while", source, StringComparison.Ordinal);
+
+        Assert.Contains("_host.Users.Find(actor.UserId)", source, StringComparison.Ordinal);
+        Assert.Contains("_host.Library.FindAccessible(actor.UserId, item.Id)", source, StringComparison.Ordinal);
+        Assert.Contains("admitted.ProviderReferences.SequenceEqual(current.ProviderReferences)", source, StringComparison.Ordinal);
+        Assert.True(
+            source.LastIndexOf("SeerrRequestIdentityResolutionMode.FinalPreDispatch", StringComparison.Ordinal)
+                < source.IndexOf("_host.Users.Find(actor.UserId)", StringComparison.Ordinal));
+        Assert.True(
+            source.IndexOf("_host.Library.FindAccessible(actor.UserId, item.Id)", StringComparison.Ordinal)
+                < source.IndexOf("SeerrHttpHelper.SendResponseHeadersReadAsync", StringComparison.Ordinal));
+
+        var constructor = Assert.Single(typeof(SeerrMediaRequestOwner).GetConstructors(
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic));
+        Assert.Contains(constructor.GetParameters(), parameter => parameter.ParameterType == typeof(IPlatformHost));
     }
 
     [Fact]
@@ -107,6 +122,9 @@ public sealed class SeerrMediaRequestOwnerArchitectureTests
                 || parameter.ParameterType == typeof(HttpMethod));
         Assert.DoesNotContain(methods, method => method.ReturnType == typeof(object));
 
+        var capability = Assert.Single(methods, method => method.Name == "Get4kCapabilityAsync");
+        Assert.Equal(typeof(SeerrRequestIdentity), capability.GetParameters()[0].ParameterType);
+
         var clientSource = PlatformHostSeamTests.CodeOnly(File.ReadAllText(Path.Combine(
             ProductionRoot(),
             "Services",
@@ -116,6 +134,37 @@ public sealed class SeerrMediaRequestOwnerArchitectureTests
             "allowAutoImport: mode == SeerrRequestIdentityResolutionMode.InitialAdmission",
             clientSource,
             StringComparison.Ordinal);
+
+        var boundStart = clientSource.IndexOf(
+            "private async Task<Seerr4kCapability> GetBoundSeerr4kCapabilityAsync",
+            StringComparison.Ordinal);
+        var legacyStart = clientSource.IndexOf(
+            "private async Task<Seerr4kCapability> GetSeerr4kCapabilityCoreAsync",
+            boundStart,
+            StringComparison.Ordinal);
+        Assert.True(boundStart >= 0 && legacyStart > boundStart);
+        Assert.DoesNotContain(
+            "ResolveSeerrUser",
+            clientSource[boundStart..legacyStart],
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DispatchFenceRejectionIsTypedAndConstructedOnlyOnThePreSendBranch()
+    {
+        Assert.True(typeof(InvalidOperationException).IsAssignableFrom(typeof(SeerrDispatchNotAttemptedException)));
+        Assert.True(typeof(SeerrDispatchNotAttemptedException).IsSealed);
+
+        var helperSource = PlatformHostSeamTests.CodeOnly(File.ReadAllText(Path.Combine(
+            ProductionRoot(),
+            "Helpers",
+            "Seerr",
+            "SeerrHttpHelper.cs")));
+        Assert.Matches(
+            new Regex(
+                @"dispatchFence\.CanDispatch\(request\.RequestUri\)\s*\?\s*httpClient\.SendAsync\([\s\S]{0,240}?\:\s*Task\.FromException<HttpResponseMessage>\(\s*new SeerrDispatchNotAttemptedException\(\)\)",
+                RegexOptions.CultureInvariant),
+            helperSource);
     }
 
     private static string OwnerSource([CallerFilePath] string sourceFile = "")

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrMediaRequestOwnerArchitectureTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrMediaRequestOwnerArchitectureTests.cs
@@ -1,0 +1,140 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.Platform;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services;
+
+public sealed class SeerrMediaRequestOwnerArchitectureTests
+{
+    [Fact]
+    public void OwnerInterfaceAcceptsOnlyAuthoritativeClosedInputs()
+    {
+        var method = Assert.Single(typeof(ISeerrMediaRequestOwner).GetMethods());
+
+        Assert.Equal("RequestAsync", method.Name);
+        Assert.Equal(typeof(Task<SeerrMediaRequestResult>), method.ReturnType);
+        Assert.Equal(
+            new[]
+            {
+                typeof(PlatformActor),
+                typeof(HostAccessibleItem),
+                typeof(SeerrMediaRequestVariant),
+                typeof(PlatformIdempotencyKey),
+                typeof(CancellationToken),
+            },
+            method.GetParameters().Select(parameter => parameter.ParameterType));
+        Assert.DoesNotContain(method.GetParameters(), parameter => parameter.ParameterType == typeof(string));
+        Assert.DoesNotContain(method.GetParameters(), parameter => parameter.ParameterType == typeof(Uri));
+        Assert.DoesNotContain(method.GetParameters(), parameter => parameter.ParameterType == typeof(HttpMethod));
+    }
+
+    [Fact]
+    public void ResultIsBoundedClosedAndCarriesNoProviderData()
+    {
+        Assert.Empty(typeof(SeerrMediaRequestResult).GetConstructors());
+        Assert.Equal(
+            new Dictionary<string, Type>(StringComparer.Ordinal)
+            {
+                ["Outcome"] = typeof(SeerrMediaRequestOutcome),
+                ["ProviderAccepted"] = typeof(bool),
+                ["SpoilerIntentRecorded"] = typeof(bool),
+                ["SpoilerIntentRequired"] = typeof(bool),
+            },
+            typeof(SeerrMediaRequestResult)
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .ToDictionary(property => property.Name, property => property.PropertyType, StringComparer.Ordinal));
+        Assert.DoesNotContain(
+            typeof(SeerrMediaRequestResult).GetProperties(BindingFlags.Public | BindingFlags.Instance),
+            property => property.PropertyType == typeof(string)
+                || property.PropertyType == typeof(object)
+                || property.PropertyType == typeof(JsonElement));
+    }
+
+    [Fact]
+    public void OwnerHasOneFixedMutationDispatchAndNoGenericProxyDependency()
+    {
+        var source = PlatformHostSeamTests.CodeOnly(File.ReadAllText(OwnerSource()));
+
+        Assert.Contains("private const string RequestPath = \"/api/v1/request\"", source, StringComparison.Ordinal);
+        Assert.Single(Regex.Matches(source, @"\bSeerrHttpHelper\.SendResponseHeadersReadAsync\s*\(").Cast<Match>());
+        Assert.Contains("PlatformIdempotencyKey.HeaderName, idempotencyKey.Value", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("ISeerrClient", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("ProxyRequestAsync", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("IActionResult", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("HttpContext", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("Controller", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("foreach", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("while", source, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PlatformAndLegacyCompatibilitySurfacesCannotCallEachOther()
+    {
+        var platformSources = Directory
+            .EnumerateFiles(PlatformRoot(), "*.cs", SearchOption.AllDirectories)
+            .Select(File.ReadAllText)
+            .Select(PlatformHostSeamTests.CodeOnly)
+            .ToArray();
+        Assert.DoesNotContain(platformSources, source => source.Contains("ISeerrClient", StringComparison.Ordinal));
+        Assert.DoesNotContain(platformSources, source => source.Contains("ProxyRequestAsync", StringComparison.Ordinal));
+
+        foreach (var controller in new[] { "SeerrProxyController.cs", "SeerrUserController.cs" })
+        {
+            var source = PlatformHostSeamTests.CodeOnly(File.ReadAllText(Path.Combine(ProductionRoot(), "Controllers", controller)));
+            Assert.DoesNotContain(nameof(ISeerrMediaRequestOwner), source, StringComparison.Ordinal);
+            Assert.DoesNotContain(nameof(SeerrMediaRequestOwner), source, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void AdmissionSeamCannotExposeGenericTransportAuthority()
+    {
+        var methods = typeof(ISeerrMediaRequestAdmission).GetMethods();
+
+        Assert.Equal(
+            new[] { "Get4kCapabilityAsync", "InvalidateIdentity", "ResolveAsync" },
+            methods.Select(method => method.Name).OrderBy(name => name, StringComparer.Ordinal));
+        Assert.DoesNotContain(
+            methods.SelectMany(method => method.GetParameters()),
+            parameter => parameter.ParameterType == typeof(string)
+                || parameter.ParameterType == typeof(Uri)
+                || parameter.ParameterType == typeof(HttpMethod));
+        Assert.DoesNotContain(methods, method => method.ReturnType == typeof(object));
+
+        var clientSource = PlatformHostSeamTests.CodeOnly(File.ReadAllText(Path.Combine(
+            ProductionRoot(),
+            "Services",
+            "Seerr",
+            "SeerrClient.cs")));
+        Assert.Contains(
+            "allowAutoImport: mode == SeerrRequestIdentityResolutionMode.InitialAdmission",
+            clientSource,
+            StringComparison.Ordinal);
+    }
+
+    private static string OwnerSource([CallerFilePath] string sourceFile = "")
+        => Path.GetFullPath(Path.Combine(
+            Path.GetDirectoryName(sourceFile)!,
+            "..",
+            "..",
+            "Jellyfin.Plugin.JellyfinCanopy",
+            "Services",
+            "Seerr",
+            "SeerrMediaRequestOwner.cs"));
+
+    private static string ProductionRoot([CallerFilePath] string sourceFile = "")
+        => Path.GetFullPath(Path.Combine(
+            Path.GetDirectoryName(sourceFile)!,
+            "..",
+            "..",
+            "Jellyfin.Plugin.JellyfinCanopy"));
+
+    private static string PlatformRoot([CallerFilePath] string sourceFile = "")
+        => Path.Combine(ProductionRoot(sourceFile), "Platform");
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrMediaRequestOwnerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrMediaRequestOwnerTests.cs
@@ -65,6 +65,7 @@ public sealed class SeerrMediaRequestOwnerTests
 
         Assert.Equal(SeerrMediaRequestOutcome.Requested, result.Outcome);
         Assert.Equal(1, harness.Admission.CapabilityCalls);
+        Assert.Equal(Found(permissions: SeerrPermission.REQUEST_4K_TV).Identity, harness.Admission.CapabilityIdentity);
         using var body = JsonDocument.Parse(Assert.Single(harness.Handler.Sent).Body);
         Assert.Equal("tv", body.RootElement.GetProperty("mediaType").GetString());
         Assert.Equal("all", body.RootElement.GetProperty("seasons").GetString());
@@ -219,6 +220,92 @@ public sealed class SeerrMediaRequestOwnerTests
     }
 
     [Fact]
+    public async Task FinalHostReauthorization_RejectsDeletedUser()
+    {
+        var harness = new Harness();
+        harness.Host.UserExists = false;
+
+        var result = await harness.InvokeAsync(Item(HostItemKind.Movie, "151"));
+
+        Assert.Equal(SeerrMediaRequestOutcome.HostAuthorizationChanged, result.Outcome);
+        Assert.Empty(harness.Handler.Sent);
+    }
+
+    [Fact]
+    public async Task FinalHostReauthorization_RejectsAdministratorDemotion()
+    {
+        var harness = new Harness(isElevated: true);
+        harness.Host.IsAdministrator = false;
+
+        var result = await harness.InvokeAsync(Item(HostItemKind.Movie, "152"));
+
+        Assert.Equal(SeerrMediaRequestOutcome.HostAuthorizationChanged, result.Outcome);
+        Assert.Empty(harness.Handler.Sent);
+    }
+
+    [Fact]
+    public async Task FinalHostReauthorization_RejectsItemDeletionMoveOrLibraryRemoval()
+    {
+        var harness = new Harness();
+        harness.Host.ItemAccessible = false;
+
+        var result = await harness.InvokeAsync(Item(HostItemKind.Movie, "153"));
+
+        Assert.Equal(SeerrMediaRequestOutcome.HostAuthorizationChanged, result.Outcome);
+        Assert.Empty(harness.Handler.Sent);
+    }
+
+    [Fact]
+    public async Task FinalHostProjection_RejectsAnyProviderReferenceDriftOrTargetAmbiguity()
+    {
+        var original = new HostAccessibleItem(
+            Guid.NewGuid(),
+            HostItemKind.Movie,
+            null,
+            ImmutableArray.Create(
+                new HostProviderReference("Tmdb", "154"),
+                new HostProviderReference("Tvdb", "7")));
+
+        var driftHarness = new Harness();
+        driftHarness.Host.ItemTransform = item => new HostAccessibleItem(
+            item.Id,
+            item.Kind,
+            item.SeriesId,
+            ImmutableArray.Create(
+                new HostProviderReference("Tmdb", "154"),
+                new HostProviderReference("Tvdb", "8")));
+        Assert.Equal(
+            SeerrMediaRequestOutcome.HostAuthorizationChanged,
+            (await driftHarness.InvokeAsync(original)).Outcome);
+        Assert.Empty(driftHarness.Handler.Sent);
+
+        var ambiguityHarness = new Harness();
+        ambiguityHarness.Host.ItemTransform = item => new HostAccessibleItem(
+            item.Id,
+            item.Kind,
+            item.SeriesId,
+            item.ProviderReferences.Add(new HostProviderReference("Tmdb", "155")));
+        Assert.Equal(
+            SeerrMediaRequestOutcome.HostAuthorizationChanged,
+            (await ambiguityHarness.InvokeAsync(original, idempotencyKey: Key("ambiguous-host"))).Outcome);
+        Assert.Empty(ambiguityHarness.Handler.Sent);
+    }
+
+    [Fact]
+    public async Task DispatchFenceDriftFromFactory_IsTypedAsNotAttemptedAndNeverReachesSendAsync()
+    {
+        var harness = new Harness(clientFactory: current => new CallbackHttpClientFactory(
+            new RecordingHttpClientFactory(current.Handler),
+            () => current.Provider.Current = ActiveConfig(apiKey: "rotated-before-send")));
+
+        var result = await harness.InvokeAsync(Item(HostItemKind.Movie, "156"));
+
+        Assert.Equal(SeerrMediaRequestOutcome.ConfigurationChanged, result.Outcome);
+        Assert.Empty(harness.Handler.Sent);
+        Assert.Empty(harness.Handler.Requests);
+    }
+
+    [Fact]
     public async Task CallerCancellationPropagatesBeforeMutation()
     {
         var harness = new Harness();
@@ -298,6 +385,8 @@ public sealed class SeerrMediaRequestOwnerTests
     [InlineData(HttpStatusCode.Conflict, SeerrMediaRequestOutcome.AlreadyRequested)]
     [InlineData(HttpStatusCode.Forbidden, SeerrMediaRequestOutcome.ProviderRejected)]
     [InlineData(HttpStatusCode.UnprocessableEntity, SeerrMediaRequestOutcome.ProviderRejected)]
+    [InlineData(HttpStatusCode.RequestTimeout, SeerrMediaRequestOutcome.ProviderUnavailable)]
+    [InlineData(HttpStatusCode.TooManyRequests, SeerrMediaRequestOutcome.ProviderUnavailable)]
     [InlineData(HttpStatusCode.InternalServerError, SeerrMediaRequestOutcome.ProviderUnavailable)]
     public async Task ProviderStatusesMapToClosedBodyFreeOutcomes(
         HttpStatusCode status,
@@ -366,30 +455,37 @@ public sealed class SeerrMediaRequestOwnerTests
 
     private sealed class Harness
     {
-        public Harness(HttpStatusCode status = HttpStatusCode.Created, bool isElevated = false)
+        public Harness(
+            HttpStatusCode status = HttpStatusCode.Created,
+            bool isElevated = false,
+            Func<Harness, IHttpClientFactory>? clientFactory = null)
         {
             Config = ActiveConfig();
             Provider = new FakePluginConfigProvider(Config);
             Admission.Resolutions.Add(Found());
             Handler.AddResponse("/api/v1/request", "{}", status);
-            Owner = new SeerrMediaRequestOwner(
-                new RecordingHttpClientFactory(Handler),
-                Provider,
-                Admission,
-                Parental,
-                Spoiler,
-                NullLogger<SeerrMediaRequestOwner>.Instance);
             Actor = new PlatformActor(
                 Guid.NewGuid(),
                 isElevated,
                 "correlation",
                 null,
                 null);
+            Host.IsAdministrator = isElevated;
+            Owner = new SeerrMediaRequestOwner(
+                clientFactory?.Invoke(this) ?? new RecordingHttpClientFactory(Handler),
+                Provider,
+                Host,
+                Admission,
+                Parental,
+                Spoiler,
+                NullLogger<SeerrMediaRequestOwner>.Instance);
         }
 
         public PluginConfiguration Config { get; }
 
         public FakePluginConfigProvider Provider { get; }
+
+        public FakePlatformHost Host { get; } = new();
 
         public FakeAdmission Admission { get; } = new();
 
@@ -408,12 +504,15 @@ public sealed class SeerrMediaRequestOwnerTests
             SeerrMediaRequestVariant variant = SeerrMediaRequestVariant.Standard,
             PlatformIdempotencyKey? idempotencyKey = null,
             CancellationToken cancellationToken = default)
-            => Owner.RequestAsync(
+        {
+            Host.AdmittedItem = item;
+            return Owner.RequestAsync(
                 Actor,
                 item,
                 variant,
                 idempotencyKey ?? Key(),
                 cancellationToken);
+        }
     }
 
     private sealed class FakeAdmission : ISeerrMediaRequestAdmission
@@ -427,6 +526,8 @@ public sealed class SeerrMediaRequestOwnerTests
         public int InvalidationCalls { get; private set; }
 
         public Seerr4kCapability Capability { get; set; } = new(true, true, true, true);
+
+        public SeerrRequestIdentity? CapabilityIdentity { get; private set; }
 
         public List<SeerrRequestIdentityResolutionMode> ResolutionModes { get; } = new();
 
@@ -443,12 +544,13 @@ public sealed class SeerrMediaRequestOwnerTests
         }
 
         public Task<Seerr4kCapability> Get4kCapabilityAsync(
-            Guid jellyfinUserId,
+            SeerrRequestIdentity admittedIdentity,
             bool isAdministrator,
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             CapabilityCalls++;
+            CapabilityIdentity = admittedIdentity;
             return Task.FromResult(Capability);
         }
 
@@ -461,6 +563,96 @@ public sealed class SeerrMediaRequestOwnerTests
         {
             Resolutions.Clear();
             Resolutions.Add(Found(userId, permissions, source));
+        }
+    }
+
+    private sealed class FakePlatformHost : IPlatformHost
+    {
+        public FakePlatformHost()
+        {
+            Users = new FakeUsers(this);
+            Library = new FakeLibrary(this);
+        }
+
+        public bool UserExists { get; set; } = true;
+
+        public bool IsAdministrator { get; set; }
+
+        public bool ItemAccessible { get; set; } = true;
+
+        public HostAccessibleItem AdmittedItem { get; set; }
+
+        public Func<HostAccessibleItem, HostAccessibleItem>? ItemTransform { get; set; }
+
+        public IHostUsers Users { get; }
+
+        public IHostLibrary Library { get; }
+
+        public IHostSessions Sessions { get; } = new EmptySessions();
+
+        public IHostPlugins Plugins { get; } = new EmptyPlugins();
+
+        private sealed class FakeUsers(FakePlatformHost owner) : IHostUsers
+        {
+            public HostUser? Find(Guid id)
+                => owner.UserExists
+                    ? new HostUser(id, "current-user", owner.IsAdministrator)
+                    : null;
+
+            public IReadOnlyList<HostUser> All() => Array.Empty<HostUser>();
+        }
+
+        private sealed class FakeLibrary(FakePlatformHost owner) : IHostLibrary
+        {
+            public HostItem? Find(Guid id) => null;
+
+            public HostItemAccessResult FindAccessible(Guid userId, Guid itemId)
+            {
+                if (!owner.ItemAccessible
+                    || !owner.UserExists
+                    || owner.AdmittedItem.Id != itemId)
+                {
+                    return HostItemAccessResult.NotAccessible;
+                }
+
+                var item = owner.ItemTransform?.Invoke(owner.AdmittedItem)
+                    ?? owner.AdmittedItem;
+                return HostItemAccessResult.Accessible(item);
+            }
+
+            public IReadOnlyList<HostItem> ChildrenOf(Guid id) => Array.Empty<HostItem>();
+        }
+
+        private sealed class EmptySessions : IHostSessions
+        {
+            public IReadOnlyList<HostSession> Active() => Array.Empty<HostSession>();
+
+            public IReadOnlyList<HostSession> ForUser(Guid userId) => Array.Empty<HostSession>();
+        }
+
+        private sealed class EmptyPlugins : IHostPlugins
+        {
+            public IReadOnlyList<HostPlugin> Installed() => Array.Empty<HostPlugin>();
+
+            public HostPlugin? Find(Guid id) => null;
+        }
+    }
+
+    private sealed class CallbackHttpClientFactory : IHttpClientFactory
+    {
+        private readonly IHttpClientFactory _inner;
+        private Action? _callback;
+
+        public CallbackHttpClientFactory(IHttpClientFactory inner, Action callback)
+        {
+            _inner = inner;
+            _callback = callback;
+        }
+
+        public HttpClient CreateClient(string name)
+        {
+            Interlocked.Exchange(ref _callback, null)?.Invoke();
+            return _inner.CreateClient(name);
         }
     }
 

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrMediaRequestOwnerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrMediaRequestOwnerTests.cs
@@ -1,0 +1,525 @@
+using System.Collections.Immutable;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Model.Seerr;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services;
+
+public sealed class SeerrMediaRequestOwnerTests
+{
+    [Fact]
+    public async Task MovieRequest_UsesOnlyAuthoritativeTmdbProjectionAndExactInvocationKey()
+    {
+        var harness = new Harness();
+        var key = Key("exact-Key_17");
+
+        var result = await harness.InvokeAsync(
+            Item(HostItemKind.Movie, "603"),
+            SeerrMediaRequestVariant.Standard,
+            key);
+
+        Assert.Equal(SeerrMediaRequestOutcome.Requested, result.Outcome);
+        Assert.True(result.ProviderAccepted);
+        Assert.False(result.SpoilerIntentRequired);
+        Assert.False(result.SpoilerIntentRecorded);
+        var sent = Assert.Single(harness.Handler.Sent);
+        Assert.Equal(HttpMethod.Post, sent.Method);
+        Assert.Equal("/root/api/v1/request", sent.Path);
+        using var body = JsonDocument.Parse(sent.Body);
+        Assert.Equal("movie", body.RootElement.GetProperty("mediaType").GetString());
+        Assert.Equal(603, body.RootElement.GetProperty("mediaId").GetInt32());
+        Assert.False(body.RootElement.GetProperty("is4k").GetBoolean());
+        Assert.False(body.RootElement.TryGetProperty("seasons", out _));
+        var request = Assert.Single(harness.Handler.Requests);
+        Assert.Equal("exact-Key_17", Assert.Single(request.Headers.GetValues(PlatformIdempotencyKey.HeaderName)));
+        Assert.Equal("27", Assert.Single(request.Headers.GetValues("X-Api-User")));
+        Assert.Equal("saved-api-key", Assert.Single(request.Headers.GetValues("X-Api-Key")));
+        Assert.Equal(
+            new[]
+            {
+                SeerrRequestIdentityResolutionMode.InitialAdmission,
+                SeerrRequestIdentityResolutionMode.FinalPreDispatch,
+            },
+            harness.Admission.ResolutionModes);
+    }
+
+    [Fact]
+    public async Task Series4kRequest_UsesClosedWholeSeriesShapeAndAllGates()
+    {
+        var harness = new Harness();
+        harness.Config.SeerrEnable4KTvRequests = true;
+        harness.Admission.SetIdentity(permissions: SeerrPermission.REQUEST_4K_TV);
+
+        var result = await harness.InvokeAsync(
+            Item(HostItemKind.Series, "1399"),
+            SeerrMediaRequestVariant.FourK);
+
+        Assert.Equal(SeerrMediaRequestOutcome.Requested, result.Outcome);
+        Assert.Equal(1, harness.Admission.CapabilityCalls);
+        using var body = JsonDocument.Parse(Assert.Single(harness.Handler.Sent).Body);
+        Assert.Equal("tv", body.RootElement.GetProperty("mediaType").GetString());
+        Assert.Equal("all", body.RootElement.GetProperty("seasons").GetString());
+        Assert.True(body.RootElement.GetProperty("is4k").GetBoolean());
+    }
+
+    [Theory]
+    [InlineData(HostItemKind.Episode, "603")]
+    [InlineData(HostItemKind.Movie, "0")]
+    [InlineData(HostItemKind.Movie, "caller-value")]
+    public async Task UnsupportedOrMalformedAuthoritativeTarget_FailsBeforeAdmission(
+        HostItemKind kind,
+        string tmdb)
+    {
+        var harness = new Harness();
+
+        var result = await harness.InvokeAsync(Item(kind, tmdb));
+
+        Assert.Equal(SeerrMediaRequestOutcome.InvalidTarget, result.Outcome);
+        Assert.Equal(0, harness.Admission.ResolutionCalls);
+        Assert.Empty(harness.Handler.Sent);
+    }
+
+    [Fact]
+    public async Task MissingOrAmbiguousTmdbProjection_FailsClosed()
+    {
+        var harness = new Harness();
+        var missing = new HostAccessibleItem(
+            Guid.NewGuid(),
+            HostItemKind.Movie,
+            null,
+            ImmutableArray.Create(new HostProviderReference("Tvdb", "7")));
+        var ambiguous = new HostAccessibleItem(
+            Guid.NewGuid(),
+            HostItemKind.Movie,
+            null,
+            ImmutableArray.Create(
+                new HostProviderReference("Tmdb", "7"),
+                new HostProviderReference("Tmdb", "8")));
+
+        Assert.Equal(
+            SeerrMediaRequestOutcome.InvalidTarget,
+            (await harness.InvokeAsync(missing)).Outcome);
+        Assert.Equal(
+            SeerrMediaRequestOutcome.InvalidTarget,
+            (await harness.InvokeAsync(ambiguous)).Outcome);
+        Assert.Equal(0, harness.Admission.ResolutionCalls);
+    }
+
+    [Theory]
+    [InlineData(1, SeerrMediaRequestOutcome.Unlinked)]
+    [InlineData(2, SeerrMediaRequestOutcome.IdentityBlocked)]
+    [InlineData(3, SeerrMediaRequestOutcome.IdentityUnavailable)]
+    public async Task LinkedIdentityFailuresAreClosedAndDoNotDispatch(
+        int statusValue,
+        SeerrMediaRequestOutcome expected)
+    {
+        var harness = new Harness();
+        harness.Admission.Resolutions.Clear();
+        harness.Admission.Resolutions.Add(new SeerrRequestIdentityResolution(
+            (SeerrRequestIdentityStatus)statusValue,
+            default));
+
+        var result = await harness.InvokeAsync(Item(HostItemKind.Movie, "9"));
+
+        Assert.Equal(expected, result.Outcome);
+        Assert.Empty(harness.Handler.Sent);
+    }
+
+    [Theory]
+    [InlineData(HostItemKind.Movie, SeerrPermission.REQUEST_TV)]
+    [InlineData(HostItemKind.Series, SeerrPermission.REQUEST_MOVIE)]
+    public async Task StandardRequest_RequiresGlobalOrMatchingMediaPermission(
+        HostItemKind kind,
+        SeerrPermission wrongPermission)
+    {
+        var harness = new Harness();
+        harness.Admission.SetIdentity(permissions: wrongPermission);
+
+        var result = await harness.InvokeAsync(Item(kind, "11"));
+
+        Assert.Equal(SeerrMediaRequestOutcome.PermissionDenied, result.Outcome);
+        Assert.Empty(harness.Handler.Sent);
+    }
+
+    [Fact]
+    public async Task FourKRequest_DoesNotTreatBaseRequestPermissionAsFourKPermission()
+    {
+        var harness = new Harness();
+        harness.Config.SeerrEnable4KRequests = true;
+        harness.Admission.SetIdentity(permissions: SeerrPermission.REQUEST);
+
+        var result = await harness.InvokeAsync(
+            Item(HostItemKind.Movie, "12"),
+            SeerrMediaRequestVariant.FourK);
+
+        Assert.Equal(SeerrMediaRequestOutcome.PermissionDenied, result.Outcome);
+        Assert.Equal(0, harness.Admission.CapabilityCalls);
+        Assert.Empty(harness.Handler.Sent);
+    }
+
+    [Fact]
+    public async Task JellyfinAdministrator_BypassesSeerrPermissionButNot4kMasterSwitch()
+    {
+        var harness = new Harness(isElevated: true);
+        harness.Admission.SetIdentity(permissions: SeerrPermission.NONE);
+
+        var standard = await harness.InvokeAsync(Item(HostItemKind.Movie, "13"));
+        var fourK = await harness.InvokeAsync(
+            Item(HostItemKind.Movie, "13"),
+            SeerrMediaRequestVariant.FourK,
+            Key("admin-4k"));
+
+        Assert.Equal(SeerrMediaRequestOutcome.Requested, standard.Outcome);
+        Assert.Equal(SeerrMediaRequestOutcome.FeatureUnavailable, fourK.Outcome);
+        Assert.Single(harness.Handler.Sent);
+    }
+
+    [Fact]
+    public async Task ParentalDenialAndConfigurationChangeBothPreventMutation()
+    {
+        var blockedHarness = new Harness();
+        blockedHarness.Parental.Blocked = true;
+        Assert.Equal(
+            SeerrMediaRequestOutcome.ParentalBlocked,
+            (await blockedHarness.InvokeAsync(Item(HostItemKind.Movie, "14"))).Outcome);
+        Assert.Empty(blockedHarness.Handler.Sent);
+
+        var changedHarness = new Harness();
+        changedHarness.Parental.Callback = _ =>
+        {
+            changedHarness.Provider.Current = ActiveConfig(apiKey: "rotated-key");
+            return Task.FromResult(false);
+        };
+        Assert.Equal(
+            SeerrMediaRequestOutcome.ConfigurationChanged,
+            (await changedHarness.InvokeAsync(Item(HostItemKind.Movie, "14"))).Outcome);
+        Assert.Empty(changedHarness.Handler.Sent);
+    }
+
+    [Fact]
+    public async Task FreshIdentityChangeImmediatelyBeforeDispatchFailsClosedAndInvalidatesCache()
+    {
+        var harness = new Harness();
+        harness.Admission.Resolutions.Add(Found(userId: 99));
+
+        var result = await harness.InvokeAsync(Item(HostItemKind.Movie, "15"));
+
+        Assert.Equal(SeerrMediaRequestOutcome.IdentityChanged, result.Outcome);
+        Assert.Equal(1, harness.Admission.InvalidationCalls);
+        Assert.Empty(harness.Handler.Sent);
+    }
+
+    [Fact]
+    public async Task CallerCancellationPropagatesBeforeMutation()
+    {
+        var harness = new Harness();
+        using var cancellation = new CancellationTokenSource();
+        harness.Parental.Callback = token =>
+        {
+            cancellation.Cancel();
+            token.ThrowIfCancellationRequested();
+            return Task.FromResult(false);
+        };
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => harness.InvokeAsync(
+            Item(HostItemKind.Movie, "16"),
+            cancellationToken: cancellation.Token));
+        Assert.Empty(harness.Handler.Sent);
+    }
+
+    [Fact]
+    public async Task ConfirmedSuccessRecordsTypedSpoilerIntentBeforeReturningWithoutReadingBody()
+    {
+        var harness = new Harness();
+        harness.Config.SpoilerBlurEnabled = true;
+        harness.Config.SpoilerAutoEnableOnSeerrRequest = true;
+        harness.Handler.ResponseFactory = _ => new HttpResponseMessage(HttpStatusCode.Created)
+        {
+            Content = new ThrowOnReadContent(),
+        };
+
+        var result = await harness.InvokeAsync(Item(HostItemKind.Series, "0017"));
+
+        Assert.Equal(SeerrMediaRequestOutcome.Requested, result.Outcome);
+        Assert.True(result.ProviderAccepted);
+        Assert.True(result.SpoilerIntentRequired);
+        Assert.True(result.SpoilerIntentRecorded);
+        Assert.Equal(1, harness.Spoiler.Calls);
+        Assert.Equal(SeerrMediaRequestKind.Series, harness.Spoiler.Kind);
+        Assert.Equal(17, harness.Spoiler.TmdbId);
+    }
+
+    [Fact]
+    public async Task AcceptedMutationWithIntentFailureReturnsTerminalPartialSuccess()
+    {
+        var harness = new Harness();
+        harness.Config.SpoilerBlurEnabled = true;
+        harness.Config.SpoilerAutoEnableOnSeerrRequest = true;
+        harness.Spoiler.Durable = false;
+
+        var result = await harness.InvokeAsync(Item(HostItemKind.Movie, "18"));
+
+        Assert.Equal(SeerrMediaRequestOutcome.AcceptedSpoilerIntentFailed, result.Outcome);
+        Assert.True(result.ProviderAccepted);
+        Assert.True(result.SpoilerIntentRequired);
+        Assert.False(result.SpoilerIntentRecorded);
+        Assert.Single(harness.Handler.Sent);
+    }
+
+    [Fact]
+    public async Task Definite2xxWithoutJsonContentTypeStillFulfilsIntentDurability()
+    {
+        var harness = new Harness();
+        harness.Config.SpoilerBlurEnabled = true;
+        harness.Config.SpoilerAutoEnableOnSeerrRequest = true;
+        harness.Handler.ResponseFactory = _ => new HttpResponseMessage(HttpStatusCode.Accepted)
+        {
+            Content = new StringContent("provider body is intentionally opaque", Encoding.UTF8, "text/plain"),
+        };
+
+        var result = await harness.InvokeAsync(Item(HostItemKind.Movie, "181"));
+
+        Assert.Equal(SeerrMediaRequestOutcome.Requested, result.Outcome);
+        Assert.True(result.ProviderAccepted);
+        Assert.True(result.SpoilerIntentRecorded);
+        Assert.Equal(1, harness.Spoiler.Calls);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.Conflict, SeerrMediaRequestOutcome.AlreadyRequested)]
+    [InlineData(HttpStatusCode.Forbidden, SeerrMediaRequestOutcome.ProviderRejected)]
+    [InlineData(HttpStatusCode.UnprocessableEntity, SeerrMediaRequestOutcome.ProviderRejected)]
+    [InlineData(HttpStatusCode.InternalServerError, SeerrMediaRequestOutcome.ProviderUnavailable)]
+    public async Task ProviderStatusesMapToClosedBodyFreeOutcomes(
+        HttpStatusCode status,
+        SeerrMediaRequestOutcome expected)
+    {
+        var harness = new Harness(status);
+
+        var result = await harness.InvokeAsync(Item(HostItemKind.Movie, "19"));
+
+        Assert.Equal(expected, result.Outcome);
+        Assert.False(result.ProviderAccepted);
+        Assert.Null(typeof(SeerrMediaRequestResult).GetProperty("ProviderResponse"));
+    }
+
+    [Fact]
+    public async Task AmbiguousTransportFailureIsNotRetriedAndCallerRetryReusesExactKey()
+    {
+        var harness = new Harness();
+        var observedKeys = new List<string>();
+        harness.Handler.ResponseFactory = request =>
+        {
+            observedKeys.Add(Assert.Single(request.Headers.GetValues(PlatformIdempotencyKey.HeaderName)));
+            throw new HttpRequestException("ambiguous send");
+        };
+        var key = Key("retry-same-key");
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => harness.InvokeAsync(
+            Item(HostItemKind.Movie, "20"),
+            idempotencyKey: key));
+        Assert.Single(observedKeys);
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => harness.InvokeAsync(
+            Item(HostItemKind.Movie, "20"),
+            idempotencyKey: key));
+        Assert.Equal(new[] { "retry-same-key", "retry-same-key" }, observedKeys);
+    }
+
+    private static HostAccessibleItem Item(HostItemKind kind, string tmdb)
+        => new(
+            Guid.NewGuid(),
+            kind,
+            null,
+            ImmutableArray.Create(new HostProviderReference("Tmdb", tmdb)));
+
+    private static PlatformIdempotencyKey Key(string value = "request-key")
+    {
+        Assert.True(PlatformIdempotencyKey.TryParse(value, out var key));
+        return key;
+    }
+
+    private static SeerrRequestIdentityResolution Found(
+        int userId = 27,
+        SeerrPermission permissions = SeerrPermission.REQUEST,
+        string source = "https://seerr.example/root")
+        => new(
+            SeerrRequestIdentityStatus.Found,
+            new SeerrRequestIdentity(userId, permissions, source));
+
+    private static PluginConfiguration ActiveConfig(string apiKey = "saved-api-key")
+        => new()
+        {
+            SeerrEnabled = true,
+            SeerrUrls = "https://seerr.example/root",
+            SeerrApiKey = apiKey,
+        };
+
+    private sealed class Harness
+    {
+        public Harness(HttpStatusCode status = HttpStatusCode.Created, bool isElevated = false)
+        {
+            Config = ActiveConfig();
+            Provider = new FakePluginConfigProvider(Config);
+            Admission.Resolutions.Add(Found());
+            Handler.AddResponse("/api/v1/request", "{}", status);
+            Owner = new SeerrMediaRequestOwner(
+                new RecordingHttpClientFactory(Handler),
+                Provider,
+                Admission,
+                Parental,
+                Spoiler,
+                NullLogger<SeerrMediaRequestOwner>.Instance);
+            Actor = new PlatformActor(
+                Guid.NewGuid(),
+                isElevated,
+                "correlation",
+                null,
+                null);
+        }
+
+        public PluginConfiguration Config { get; }
+
+        public FakePluginConfigProvider Provider { get; }
+
+        public FakeAdmission Admission { get; } = new();
+
+        public FakeParentalFilter Parental { get; } = new();
+
+        public FakeSpoilerIntentStore Spoiler { get; } = new();
+
+        public RecordingHttpMessageHandler Handler { get; } = new();
+
+        public SeerrMediaRequestOwner Owner { get; }
+
+        public PlatformActor Actor { get; }
+
+        public Task<SeerrMediaRequestResult> InvokeAsync(
+            HostAccessibleItem item,
+            SeerrMediaRequestVariant variant = SeerrMediaRequestVariant.Standard,
+            PlatformIdempotencyKey? idempotencyKey = null,
+            CancellationToken cancellationToken = default)
+            => Owner.RequestAsync(
+                Actor,
+                item,
+                variant,
+                idempotencyKey ?? Key(),
+                cancellationToken);
+    }
+
+    private sealed class FakeAdmission : ISeerrMediaRequestAdmission
+    {
+        public List<SeerrRequestIdentityResolution> Resolutions { get; } = new();
+
+        public int ResolutionCalls { get; private set; }
+
+        public int CapabilityCalls { get; private set; }
+
+        public int InvalidationCalls { get; private set; }
+
+        public Seerr4kCapability Capability { get; set; } = new(true, true, true, true);
+
+        public List<SeerrRequestIdentityResolutionMode> ResolutionModes { get; } = new();
+
+        public Task<SeerrRequestIdentityResolution> ResolveAsync(
+            Guid jellyfinUserId,
+            SeerrRequestIdentityResolutionMode mode,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ResolutionModes.Add(mode);
+            var index = Math.Min(ResolutionCalls, Resolutions.Count - 1);
+            ResolutionCalls++;
+            return Task.FromResult(Resolutions[index]);
+        }
+
+        public Task<Seerr4kCapability> Get4kCapabilityAsync(
+            Guid jellyfinUserId,
+            bool isAdministrator,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            CapabilityCalls++;
+            return Task.FromResult(Capability);
+        }
+
+        public void InvalidateIdentity(Guid jellyfinUserId) => InvalidationCalls++;
+
+        public void SetIdentity(
+            int userId = 27,
+            SeerrPermission permissions = SeerrPermission.REQUEST,
+            string source = "https://seerr.example/root")
+        {
+            Resolutions.Clear();
+            Resolutions.Add(Found(userId, permissions, source));
+        }
+    }
+
+    private sealed class FakeParentalFilter : ISeerrParentalFilter
+    {
+        public bool Blocked { get; set; }
+
+        public Func<CancellationToken, Task<bool>>? Callback { get; set; }
+
+        public Task<SeerrParentalResult> ApplyAsync(string json, string apiPath, SeerrCaller caller)
+            => Task.FromResult(new SeerrParentalResult(false, json));
+
+        public Task<bool> IsBlockedAsync(string mediaType, int tmdbId, SeerrCaller caller)
+            => Task.FromResult(Blocked);
+
+        public Task<bool> IsBlockedAsync(
+            string mediaType,
+            int tmdbId,
+            SeerrCaller caller,
+            CancellationToken cancellationToken)
+            => Callback?.Invoke(cancellationToken) ?? Task.FromResult(Blocked);
+
+        public Task<bool> IsTmdbProxyPathBlockedAsync(string tmdbApiPath, SeerrCaller caller)
+            => Task.FromResult(false);
+    }
+
+    private sealed class FakeSpoilerIntentStore : ISeerrSpoilerIntentStore
+    {
+        public bool Durable { get; set; } = true;
+
+        public int Calls { get; private set; }
+
+        public SeerrMediaRequestKind Kind { get; private set; }
+
+        public int TmdbId { get; private set; }
+
+        public bool TryRegister(Guid userId, SeerrMediaRequestKind kind, int tmdbId)
+        {
+            Calls++;
+            Kind = kind;
+            TmdbId = tmdbId;
+            return Durable;
+        }
+    }
+
+    private sealed class ThrowOnReadContent : HttpContent
+    {
+        public ThrowOnReadContent()
+        {
+            Headers.ContentType = new MediaTypeHeaderValue("application/json");
+        }
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+            => throw new InvalidOperationException("The owner must not read provider bodies.");
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return false;
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrMediaRequestOwnerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrMediaRequestOwnerTests.cs
@@ -306,6 +306,68 @@ public sealed class SeerrMediaRequestOwnerTests
     }
 
     [Fact]
+    public async Task FactoryCallbackUserDeletion_IsRejectedByLastEdgeHostCheckBeforeSendAsync()
+    {
+        var harness = new Harness(clientFactory: current => new CallbackHttpClientFactory(
+            new RecordingHttpClientFactory(current.Handler),
+            () => current.Host.UserExists = false));
+
+        var result = await harness.InvokeAsync(Item(HostItemKind.Movie, "157"));
+
+        Assert.Equal(SeerrMediaRequestOutcome.HostAuthorizationChanged, result.Outcome);
+        Assert.Empty(harness.Handler.Sent);
+        Assert.Empty(harness.Handler.Requests);
+    }
+
+    [Fact]
+    public async Task FactoryCallbackAdminDemotion_IsRejectedByLastEdgeHostCheckBeforeSendAsync()
+    {
+        var harness = new Harness(
+            isElevated: true,
+            clientFactory: current => new CallbackHttpClientFactory(
+                new RecordingHttpClientFactory(current.Handler),
+                () => current.Host.IsAdministrator = false));
+
+        var result = await harness.InvokeAsync(Item(HostItemKind.Movie, "158"));
+
+        Assert.Equal(SeerrMediaRequestOutcome.HostAuthorizationChanged, result.Outcome);
+        Assert.Empty(harness.Handler.Sent);
+        Assert.Empty(harness.Handler.Requests);
+    }
+
+    [Fact]
+    public async Task FactoryCallbackItemInaccessible_IsRejectedByLastEdgeHostCheckBeforeSendAsync()
+    {
+        var harness = new Harness(clientFactory: current => new CallbackHttpClientFactory(
+            new RecordingHttpClientFactory(current.Handler),
+            () => current.Host.ItemAccessible = false));
+
+        var result = await harness.InvokeAsync(Item(HostItemKind.Movie, "159"));
+
+        Assert.Equal(SeerrMediaRequestOutcome.HostAuthorizationChanged, result.Outcome);
+        Assert.Empty(harness.Handler.Sent);
+        Assert.Empty(harness.Handler.Requests);
+    }
+
+    [Fact]
+    public async Task FactoryCallbackProviderReferenceDrift_IsRejectedBeforeSendAsync()
+    {
+        var harness = new Harness(clientFactory: current => new CallbackHttpClientFactory(
+            new RecordingHttpClientFactory(current.Handler),
+            () => current.Host.ItemTransform = item => new HostAccessibleItem(
+                item.Id,
+                item.Kind,
+                item.SeriesId,
+                item.ProviderReferences.Add(new HostProviderReference("Tvdb", "factory-drift")))));
+
+        var result = await harness.InvokeAsync(Item(HostItemKind.Movie, "160"));
+
+        Assert.Equal(SeerrMediaRequestOutcome.HostAuthorizationChanged, result.Outcome);
+        Assert.Empty(harness.Handler.Sent);
+        Assert.Empty(harness.Handler.Requests);
+    }
+
+    [Fact]
     public async Task CallerCancellationPropagatesBeforeMutation()
     {
         var harness = new Harness();

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/TestDoubles/StubPolicyUserManager.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/TestDoubles/StubPolicyUserManager.cs
@@ -19,10 +19,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
     public sealed class StubPolicyUserManager : IUserManager
     {
         private readonly IReadOnlyDictionary<Guid, (User User, UserPolicy Policy)> _users;
+        private readonly IReadOnlySet<Guid> _unavailablePolicies;
 
-        public StubPolicyUserManager(IReadOnlyDictionary<Guid, (User User, UserPolicy Policy)> users)
+        public StubPolicyUserManager(
+            IReadOnlyDictionary<Guid, (User User, UserPolicy Policy)> users,
+            IReadOnlySet<Guid>? unavailablePolicies = null)
         {
             _users = users;
+            _unavailablePolicies = unavailablePolicies ?? new HashSet<Guid>();
         }
 
         /// <summary>Single-user convenience.</summary>
@@ -42,11 +46,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
         // so each caller's own BlockUnratedItems is applied — never a shared one.
         public UserDto GetUserDto(User user, string? remoteEndPoint = null)
         {
-            foreach (var entry in _users.Values)
+            foreach (var entry in _users)
             {
-                if (ReferenceEquals(entry.User, user))
+                if (ReferenceEquals(entry.Value.User, user))
                 {
-                    return new UserDto { Policy = entry.Policy };
+                    return _unavailablePolicies.Contains(entry.Key)
+                        ? null!
+                        : new UserDto { Policy = entry.Value.Policy };
                 }
             }
 

--- a/Jellyfin.Plugin.JellyfinCanopy/Helpers/Seerr/SeerrHttpHelper.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Helpers/Seerr/SeerrHttpHelper.cs
@@ -89,6 +89,18 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
         }
     }
 
+    /// <summary>
+    /// Typed evidence that the opaque saved-generation fence rejected a request
+    /// before transport <c>SendAsync</c> was invoked.
+    /// </summary>
+    internal sealed class SeerrDispatchNotAttemptedException : InvalidOperationException
+    {
+        internal SeerrDispatchNotAttemptedException()
+            : base("The Seerr dispatch fence rejected the request before transport dispatch.")
+        {
+        }
+    }
+
     public static class SeerrHttpHelper
     {
         public static string UserAgent { get; set; } = "JellyfinCanopy/unknown";
@@ -146,7 +158,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
             => dispatchFence.CanDispatch(request.RequestUri)
                 ? httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct)
                 : Task.FromException<HttpResponseMessage>(
-                    new InvalidOperationException("The Seerr dispatch fence is no longer current."));
+                    new SeerrDispatchNotAttemptedException());
 
         public static Task<(string? Json, SeerrError? Error, int HttpStatus)> SendAndReadJsonAsync(
             HttpClient httpClient,

--- a/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
@@ -144,7 +144,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy
             // All Seerr plumbing (user resolution + auto-import, proxy core,
             // watchlist/request helpers) extracted from the controller base.
             // Singleton: stateless besides the injected ISeerrCache.
-            serviceCollection.AddSingleton<Services.Seerr.ISeerrClient, Services.Seerr.SeerrClient>();
+            serviceCollection.AddSingleton<Services.Seerr.SeerrClient>();
+            serviceCollection.AddSingleton<Services.Seerr.ISeerrClient>(services =>
+                services.GetRequiredService<Services.Seerr.SeerrClient>());
+            serviceCollection.AddSingleton<Services.Seerr.ISeerrMediaRequestAdmission>(services =>
+                services.GetRequiredService<Services.Seerr.SeerrClient>());
             // Shared SSRF-guarded Sonarr/Radarr fetch plumbing for the Arr controllers.
             serviceCollection.AddSingleton<Services.Arr.ArrFetchService>();
             // Bounded, privacy-safe lifecycle/history owner shared by Requests and admin status.
@@ -226,6 +230,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy
             // auto-request success boundary. Depends only on the config store + library +
             // user managers (never ISeerrClient), so it stays cycle-free.
             serviceCollection.AddSingleton<SpoilerPendingService>();
+            serviceCollection.AddSingleton<Services.Seerr.ISeerrSpoilerIntentStore>(services =>
+                services.GetRequiredService<SpoilerPendingService>());
+            serviceCollection.AddSingleton<Services.Seerr.ISeerrMediaRequestOwner, Services.Seerr.SeerrMediaRequestOwner>();
             serviceCollection.AddHostedService<SpoilerSeerrPendingPromoter>();
             serviceCollection.AddScoped<IEventConsumer<PlaybackStartEventArgs>, SpoilerAutoEnableOnFirstPlayConsumer>();
             // Identity-cache invalidation on user create/delete — the

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/ISeerrParentalFilter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/ISeerrParentalFilter.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
@@ -43,6 +44,23 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
         /// title cannot be verified. Never throws.
         /// </summary>
         Task<bool> IsBlockedAsync(string mediaType, int tmdbId, SeerrCaller caller);
+
+        /// <summary>
+        /// Cancellation-aware request gate used by exact mutation owners. The
+        /// compatibility default keeps existing test doubles source-compatible;
+        /// production overrides it and cancels the caller's bounded wait.
+        /// </summary>
+        async Task<bool> IsBlockedAsync(
+            string mediaType,
+            int tmdbId,
+            SeerrCaller caller,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var blocked = await IsBlockedAsync(mediaType, tmdbId, caller).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+            return blocked;
+        }
 
         /// <summary>
         /// True when the raw-TMDB passthrough (<c>/tmdb/{**apiPath}</c>) must deny

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrClient.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrClient.cs
@@ -32,7 +32,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
     /// shared <see cref="ISeerrCache"/> user caches so every caller format
     /// (dashed/N/upper) hits the same entry.
     /// </summary>
-    public sealed class SeerrClient : ISeerrClient
+    public sealed class SeerrClient : ISeerrClient, ISeerrMediaRequestAdmission
     {
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly ILogger<SeerrClient> _logger;
@@ -105,6 +105,61 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                 normalizedCandidate,
                 StringComparison.Ordinal));
         }
+
+        async Task<SeerrRequestIdentityResolution> ISeerrMediaRequestAdmission.ResolveAsync(
+            Guid jellyfinUserId,
+            SeerrRequestIdentityResolutionMode mode,
+            CancellationToken cancellationToken)
+        {
+            if (!Enum.IsDefined(mode))
+            {
+                throw new ArgumentOutOfRangeException(nameof(mode));
+            }
+
+            var resolution = await ResolveSeerrUser(
+                jellyfinUserId.ToString("D"),
+                bypassCache: true,
+                allowAutoImport: mode == SeerrRequestIdentityResolutionMode.InitialAdmission,
+                cancellationToken).ConfigureAwait(false);
+            if (!resolution.IsFound || resolution.User == null)
+            {
+                return new SeerrRequestIdentityResolution(
+                    resolution.Status switch
+                    {
+                        SeerrUserResolutionStatus.NotFound => SeerrRequestIdentityStatus.NotFound,
+                        SeerrUserResolutionStatus.Blocked => SeerrRequestIdentityStatus.Blocked,
+                        _ => SeerrRequestIdentityStatus.Unavailable,
+                    },
+                    default);
+            }
+
+            var source = SeerrUrlIdentity.Normalize(resolution.User.SourceUrl);
+            if (resolution.User.Id <= 0 || string.IsNullOrEmpty(source))
+            {
+                return new SeerrRequestIdentityResolution(
+                    SeerrRequestIdentityStatus.Unavailable,
+                    default);
+            }
+
+            return new SeerrRequestIdentityResolution(
+                SeerrRequestIdentityStatus.Found,
+                new SeerrRequestIdentity(
+                    resolution.User.Id,
+                    resolution.User.Permissions,
+                    source));
+        }
+
+        Task<Seerr4kCapability> ISeerrMediaRequestAdmission.Get4kCapabilityAsync(
+            Guid jellyfinUserId,
+            bool isAdministrator,
+            CancellationToken cancellationToken)
+            => GetSeerr4kCapabilityCoreAsync(
+                jellyfinUserId.ToString("D"),
+                isAdministrator,
+                cancellationToken);
+
+        void ISeerrMediaRequestAdmission.InvalidateIdentity(Guid jellyfinUserId)
+            => InvalidateUserIdentityCache(jellyfinUserId.ToString("D"));
 
         // ── Status probe ─────────────────────────────────────────────────────
 
@@ -243,8 +298,17 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
 
         // ── 4K capability ────────────────────────────────────────────────────
 
-        public async Task<Seerr4kCapability> GetSeerr4kCapabilityAsync(string jellyfinUserId, bool isAdmin = false)
+        public Task<Seerr4kCapability> GetSeerr4kCapabilityAsync(
+            string jellyfinUserId,
+            bool isAdmin = false)
+            => GetSeerr4kCapabilityCoreAsync(jellyfinUserId, isAdmin, CancellationToken.None);
+
+        private async Task<Seerr4kCapability> GetSeerr4kCapabilityCoreAsync(
+            string jellyfinUserId,
+            bool isAdmin,
+            CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var integration = SeerrIntegrationPolicy.Capture(_configProvider);
             if (!integration.IsActive)
             {
@@ -274,7 +338,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             var resolution = await ResolveSeerrUser(
                 jellyfinUserId,
                 bypassCache: true,
-                allowAutoImport: false).ConfigureAwait(false);
+                allowAutoImport: false,
+                cancellationToken).ConfigureAwait(false);
             if (!IsConfigurationCurrent())
             {
                 return new Seerr4kCapability(false, false, false, false);
@@ -299,7 +364,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                 apiKey,
                 cacheDisabled,
                 configurationRevision,
-                configStamp).ConfigureAwait(false);
+                configStamp,
+                cancellationToken).ConfigureAwait(false);
             if (!IsConfigurationCurrent())
             {
                 return new Seerr4kCapability(false, false, false, false);
@@ -338,7 +404,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             string capturedApiKey,
             bool cacheDisabled,
             long configurationRevision,
-            SeerrMutationConfigStamp configStamp)
+            SeerrMutationConfigStamp configStamp,
+            CancellationToken cancellationToken)
         {
             bool IsConfigurationCurrent() => configStamp.Matches(
                 _configProvider.ConfigurationOrNull,
@@ -397,7 +464,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                     requestUri,
                     integration
                         .CreateDispatchFence(_configProvider)
-                        .Restrict(IsConfigurationCurrent)).ConfigureAwait(false);
+                        .Restrict(IsConfigurationCurrent),
+                    cancellationToken).ConfigureAwait(false);
                 if (!IsConfigurationCurrent())
                 {
                     return (false, false);
@@ -463,6 +531,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             catch (HttpRequestException ex)
             {
                 _logger.LogWarning(ex, "Transport error fetching Seerr public settings at {Url}", configuredSource);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (TaskCanceledException)
             {

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrClient.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrClient.cs
@@ -150,11 +150,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
         }
 
         Task<Seerr4kCapability> ISeerrMediaRequestAdmission.Get4kCapabilityAsync(
-            Guid jellyfinUserId,
+            SeerrRequestIdentity admittedIdentity,
             bool isAdministrator,
             CancellationToken cancellationToken)
-            => GetSeerr4kCapabilityCoreAsync(
-                jellyfinUserId.ToString("D"),
+            => GetBoundSeerr4kCapabilityAsync(
+                admittedIdentity,
                 isAdministrator,
                 cancellationToken);
 
@@ -302,6 +302,70 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             string jellyfinUserId,
             bool isAdmin = false)
             => GetSeerr4kCapabilityCoreAsync(jellyfinUserId, isAdmin, CancellationToken.None);
+
+        private async Task<Seerr4kCapability> GetBoundSeerr4kCapabilityAsync(
+            SeerrRequestIdentity admittedIdentity,
+            bool isAdmin,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (admittedIdentity.UserId <= 0 || string.IsNullOrEmpty(admittedIdentity.SourceUrl))
+            {
+                return new Seerr4kCapability(false, false, false, false);
+            }
+
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            if (!integration.IsActive)
+            {
+                return new Seerr4kCapability(false, false, false, false);
+            }
+
+            var config = integration.Configuration!;
+            var configurationRevision = integration.ConfigurationRevision;
+            var configStamp = SeerrMutationConfigStamp.Capture(config, configurationRevision);
+            var configuredUrls = integration.Urls;
+            var sourceUrl = configuredUrls.FirstOrDefault(url => string.Equals(
+                url,
+                admittedIdentity.SourceUrl,
+                StringComparison.Ordinal));
+            bool IsConfigurationCurrent() => integration.IsCurrent(_configProvider)
+                && configStamp.Matches(
+                    _configProvider.ConfigurationOrNull,
+                    _configProvider.ConfigurationRevision);
+            if (sourceUrl == null || !IsConfigurationCurrent())
+            {
+                return new Seerr4kCapability(false, false, false, false);
+            }
+
+            var (movie4k, series4k) = await GetPublic4kSettingsAsync(
+                sourceUrl,
+                configuredUrls,
+                integration.ApiKey,
+                config.SeerrDisableCache,
+                configurationRevision,
+                configStamp,
+                cancellationToken).ConfigureAwait(false);
+            if (!IsConfigurationCurrent())
+            {
+                return new Seerr4kCapability(false, false, false, false);
+            }
+
+            if (isAdmin)
+            {
+                return new Seerr4kCapability(
+                    movie4k,
+                    series4k,
+                    movie4k && config.SeerrEnable4KRequests,
+                    series4k && config.SeerrEnable4KTvRequests);
+            }
+
+            var permissions = admittedIdentity.Permissions;
+            return new Seerr4kCapability(
+                movie4k,
+                series4k,
+                movie4k && SeerrPermissionHelper.CanRequest4k(permissions, isTv: false),
+                series4k && SeerrPermissionHelper.CanRequest4k(permissions, isTv: true));
+        }
 
         private async Task<Seerr4kCapability> GetSeerr4kCapabilityCoreAsync(
             string jellyfinUserId,

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrMediaRequestOwner.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrMediaRequestOwner.cs
@@ -1,0 +1,536 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr;
+using Jellyfin.Plugin.JellyfinCanopy.Model.Seerr;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
+{
+    /// <summary>The only request editions admitted by the exact installed-item owner.</summary>
+    public enum SeerrMediaRequestVariant
+    {
+        /// <summary>Request the ordinary media edition.</summary>
+        Standard,
+
+        /// <summary>Request the 4K media edition.</summary>
+        FourK,
+    }
+
+    /// <summary>Closed, provider-body-free outcomes from one installed-item request.</summary>
+    public enum SeerrMediaRequestOutcome
+    {
+        /// <summary>Seerr accepted the exact request.</summary>
+        Requested,
+
+        /// <summary>Seerr reported that the exact request already exists.</summary>
+        AlreadyRequested,
+
+        /// <summary>The authoritative item did not carry one supported TMDB target.</summary>
+        InvalidTarget,
+
+        /// <summary>The integration or requested edition is not currently enabled.</summary>
+        FeatureUnavailable,
+
+        /// <summary>The acting Jellyfin account is not linked to Seerr.</summary>
+        Unlinked,
+
+        /// <summary>The acting Jellyfin account is administratively blocked from Seerr.</summary>
+        IdentityBlocked,
+
+        /// <summary>The linked identity could not be authoritatively resolved.</summary>
+        IdentityUnavailable,
+
+        /// <summary>The linked identity changed during admission.</summary>
+        IdentityChanged,
+
+        /// <summary>The linked identity lacks the exact media-edition permission.</summary>
+        PermissionDenied,
+
+        /// <summary>The current Jellyfin parental policy refused the title.</summary>
+        ParentalBlocked,
+
+        /// <summary>The complete saved integration generation changed before dispatch.</summary>
+        ConfigurationChanged,
+
+        /// <summary>Seerr returned a definite rejection for the fixed request.</summary>
+        ProviderRejected,
+
+        /// <summary>Seerr returned an unusable or unavailable response.</summary>
+        ProviderUnavailable,
+
+        /// <summary>
+        /// Seerr accepted the request, but the required Spoiler Guard intent could
+        /// not be durably recorded. Retrying would risk a duplicate provider mutation.
+        /// </summary>
+        AcceptedSpoilerIntentFailed,
+    }
+
+    /// <summary>Bounded semantic evidence returned by the installed-item owner.</summary>
+    public sealed class SeerrMediaRequestResult
+    {
+        private SeerrMediaRequestResult(
+            SeerrMediaRequestOutcome outcome,
+            bool providerAccepted,
+            bool spoilerIntentRequired,
+            bool spoilerIntentRecorded)
+        {
+            Outcome = outcome;
+            ProviderAccepted = providerAccepted;
+            SpoilerIntentRequired = spoilerIntentRequired;
+            SpoilerIntentRecorded = spoilerIntentRecorded;
+        }
+
+        /// <summary>Gets the closed semantic outcome.</summary>
+        public SeerrMediaRequestOutcome Outcome { get; }
+
+        /// <summary>Gets whether response headers authoritatively confirmed provider acceptance.</summary>
+        public bool ProviderAccepted { get; }
+
+        /// <summary>Gets whether the captured configuration required a durable Spoiler Guard intent.</summary>
+        public bool SpoilerIntentRequired { get; }
+
+        /// <summary>Gets whether that required intent was durably recorded.</summary>
+        public bool SpoilerIntentRecorded { get; }
+
+        internal static SeerrMediaRequestResult Refused(SeerrMediaRequestOutcome outcome)
+            => new(outcome, providerAccepted: false, spoilerIntentRequired: false, spoilerIntentRecorded: false);
+
+        internal static SeerrMediaRequestResult Accepted(bool intentRequired, bool intentRecorded)
+            => new(
+                intentRequired && !intentRecorded
+                    ? SeerrMediaRequestOutcome.AcceptedSpoilerIntentFailed
+                    : SeerrMediaRequestOutcome.Requested,
+                providerAccepted: true,
+                intentRequired,
+                intentRecorded);
+    }
+
+    /// <summary>
+    /// The sole native owner for exact installed Movie/Series Seerr requests. Its
+    /// inputs can only be minted by the authenticated Platform and host boundaries;
+    /// no caller-selected provider identity enters this contract.
+    /// </summary>
+    public interface ISeerrMediaRequestOwner
+    {
+        /// <summary>Requests one exact authoritative installed item.</summary>
+        Task<SeerrMediaRequestResult> RequestAsync(
+            PlatformActor actor,
+            HostAccessibleItem item,
+            SeerrMediaRequestVariant variant,
+            PlatformIdempotencyKey idempotencyKey,
+            CancellationToken cancellationToken);
+    }
+
+    internal enum SeerrMediaRequestKind
+    {
+        Movie,
+        Series,
+    }
+
+    internal enum SeerrRequestIdentityStatus
+    {
+        Found,
+        NotFound,
+        Blocked,
+        Unavailable,
+    }
+
+    internal enum SeerrRequestIdentityResolutionMode
+    {
+        InitialAdmission,
+        FinalPreDispatch,
+    }
+
+    internal readonly record struct SeerrRequestIdentity(
+        int UserId,
+        SeerrPermission Permissions,
+        string SourceUrl);
+
+    internal readonly record struct SeerrRequestIdentityResolution(
+        SeerrRequestIdentityStatus Status,
+        SeerrRequestIdentity Identity)
+    {
+        internal bool IsFound => Status == SeerrRequestIdentityStatus.Found
+            && Identity.UserId > 0
+            && !string.IsNullOrEmpty(Identity.SourceUrl);
+    }
+
+    /// <summary>
+    /// Narrow identity/capability seam implemented by the shared client without
+    /// releasing its generic proxy surface to the native owner.
+    /// </summary>
+    internal interface ISeerrMediaRequestAdmission
+    {
+        Task<SeerrRequestIdentityResolution> ResolveAsync(
+            Guid jellyfinUserId,
+            SeerrRequestIdentityResolutionMode mode,
+            CancellationToken cancellationToken);
+
+        Task<Seerr4kCapability> Get4kCapabilityAsync(
+            Guid jellyfinUserId,
+            bool isAdministrator,
+            CancellationToken cancellationToken);
+
+        void InvalidateIdentity(Guid jellyfinUserId);
+    }
+
+    /// <summary>Typed durability seam; raw request JSON never crosses it.</summary>
+    internal interface ISeerrSpoilerIntentStore
+    {
+        bool TryRegister(Guid userId, SeerrMediaRequestKind kind, int tmdbId);
+    }
+
+    /// <summary>Single-dispatch implementation behind the closed owner contract.</summary>
+    internal sealed class SeerrMediaRequestOwner : ISeerrMediaRequestOwner
+    {
+        private const string RequestPath = "/api/v1/request";
+        private static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(15);
+
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly IPluginConfigProvider _configProvider;
+        private readonly ISeerrMediaRequestAdmission _admission;
+        private readonly ISeerrParentalFilter _parentalFilter;
+        private readonly ISeerrSpoilerIntentStore _spoilerIntentStore;
+        private readonly ILogger<SeerrMediaRequestOwner> _logger;
+
+        public SeerrMediaRequestOwner(
+            IHttpClientFactory httpClientFactory,
+            IPluginConfigProvider configProvider,
+            ISeerrMediaRequestAdmission admission,
+            ISeerrParentalFilter parentalFilter,
+            ISeerrSpoilerIntentStore spoilerIntentStore,
+            ILogger<SeerrMediaRequestOwner> logger)
+        {
+            _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+            _configProvider = configProvider ?? throw new ArgumentNullException(nameof(configProvider));
+            _admission = admission ?? throw new ArgumentNullException(nameof(admission));
+            _parentalFilter = parentalFilter ?? throw new ArgumentNullException(nameof(parentalFilter));
+            _spoilerIntentStore = spoilerIntentStore ?? throw new ArgumentNullException(nameof(spoilerIntentStore));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task<SeerrMediaRequestResult> RequestAsync(
+            PlatformActor actor,
+            HostAccessibleItem item,
+            SeerrMediaRequestVariant variant,
+            PlatformIdempotencyKey idempotencyKey,
+            CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(actor);
+            if (!Enum.IsDefined(variant))
+            {
+                throw new ArgumentOutOfRangeException(nameof(variant));
+            }
+
+            if (string.IsNullOrEmpty(idempotencyKey.Value))
+            {
+                throw new ArgumentException("A validated Platform idempotency key is required.", nameof(idempotencyKey));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!TryProjectTarget(item, out var target))
+            {
+                return SeerrMediaRequestResult.Refused(SeerrMediaRequestOutcome.InvalidTarget);
+            }
+
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            var config = integration.Configuration;
+            if (!integration.IsActive || config == null)
+            {
+                return SeerrMediaRequestResult.Refused(SeerrMediaRequestOutcome.FeatureUnavailable);
+            }
+
+            var initialResolution = await _admission.ResolveAsync(
+                actor.UserId,
+                SeerrRequestIdentityResolutionMode.InitialAdmission,
+                cancellationToken).ConfigureAwait(false);
+            if (!integration.IsCurrent(_configProvider))
+            {
+                return SeerrMediaRequestResult.Refused(SeerrMediaRequestOutcome.ConfigurationChanged);
+            }
+
+            var initialIdentityResult = ValidateIdentity(
+                initialResolution,
+                integration.Urls,
+                target,
+                variant,
+                actor.IsElevated,
+                out var initialIdentity);
+            if (initialIdentityResult != null)
+            {
+                return initialIdentityResult;
+            }
+
+            if (variant == SeerrMediaRequestVariant.FourK)
+            {
+                var masterEnabled = target.Kind == SeerrMediaRequestKind.Series
+                    ? config.SeerrEnable4KTvRequests
+                    : config.SeerrEnable4KRequests;
+                if (!masterEnabled)
+                {
+                    return SeerrMediaRequestResult.Refused(SeerrMediaRequestOutcome.FeatureUnavailable);
+                }
+
+                var capability = await _admission.Get4kCapabilityAsync(
+                    actor.UserId,
+                    actor.IsElevated,
+                    cancellationToken).ConfigureAwait(false);
+                if (!integration.IsCurrent(_configProvider))
+                {
+                    return SeerrMediaRequestResult.Refused(SeerrMediaRequestOutcome.ConfigurationChanged);
+                }
+
+                var canRequest = target.Kind == SeerrMediaRequestKind.Series
+                    ? capability.CanRequest4kTv
+                    : capability.CanRequest4kMovie;
+                if (!canRequest)
+                {
+                    return SeerrMediaRequestResult.Refused(SeerrMediaRequestOutcome.FeatureUnavailable);
+                }
+            }
+
+            var caller = new SeerrCaller(actor.UserId.ToString("D"), actor.IsElevated);
+            var blocked = await _parentalFilter.IsBlockedAsync(
+                target.MediaType,
+                target.TmdbId,
+                caller,
+                cancellationToken).ConfigureAwait(false);
+            if (!integration.IsCurrent(_configProvider))
+            {
+                return SeerrMediaRequestResult.Refused(SeerrMediaRequestOutcome.ConfigurationChanged);
+            }
+
+            if (blocked)
+            {
+                return SeerrMediaRequestResult.Refused(SeerrMediaRequestOutcome.ParentalBlocked);
+            }
+
+            // Refresh immediately before dispatch. No auto-import is coupled to this
+            // mutation, and the exact id/permission/source binding must match every
+            // admission decision above.
+            var finalResolution = await _admission.ResolveAsync(
+                actor.UserId,
+                SeerrRequestIdentityResolutionMode.FinalPreDispatch,
+                cancellationToken).ConfigureAwait(false);
+            if (!integration.IsCurrent(_configProvider))
+            {
+                return SeerrMediaRequestResult.Refused(SeerrMediaRequestOutcome.ConfigurationChanged);
+            }
+
+            var finalIdentityResult = ValidateIdentity(
+                finalResolution,
+                integration.Urls,
+                target,
+                variant,
+                actor.IsElevated,
+                out var finalIdentity);
+            if (finalIdentityResult != null)
+            {
+                _admission.InvalidateIdentity(actor.UserId);
+                return finalIdentityResult;
+            }
+
+            if (!initialIdentity.Equals(finalIdentity))
+            {
+                _admission.InvalidateIdentity(actor.UserId);
+                return SeerrMediaRequestResult.Refused(SeerrMediaRequestOutcome.IdentityChanged);
+            }
+
+            var persistSpoilerIntent = config.SpoilerBlurEnabled
+                && config.SpoilerAutoEnableOnSeerrRequest;
+            var requestUri = finalIdentity.SourceUrl + RequestPath;
+            var requestBody = BuildRequestBody(target, variant);
+            var httpClient = SeerrHttpHelper.CreateClient(_httpClientFactory);
+            httpClient.Timeout = RequestTimeout;
+            using var request = SeerrHttpHelper.BuildRequest(
+                HttpMethod.Post,
+                requestUri,
+                integration.ApiKey,
+                finalIdentity.UserId.ToString(CultureInfo.InvariantCulture),
+                requestBody);
+            request.Headers.Add(PlatformIdempotencyKey.HeaderName, idempotencyKey.Value);
+
+            using var response = await SeerrHttpHelper.SendResponseHeadersReadAsync(
+                httpClient,
+                request,
+                integration.CreateDispatchFence(_configProvider),
+                cancellationToken).ConfigureAwait(false);
+
+            if (response.IsSuccessStatusCode)
+            {
+                // ResponseHeadersRead has confirmed the provider mutation. Fulfil the
+                // frozen local durability obligation synchronously before observing
+                // caller cancellation again or executing any fallible post-work.
+                var intentRecorded = false;
+                if (persistSpoilerIntent)
+                {
+                    try
+                    {
+                        intentRecorded = _spoilerIntentStore.TryRegister(
+                            actor.UserId,
+                            target.Kind,
+                            target.TmdbId);
+                    }
+                    catch (Exception exception)
+                    {
+                        _logger.LogError(
+                            exception,
+                            "Seerr accepted an installed-item request, but its Spoiler Guard intent could not be persisted.");
+                    }
+                }
+
+                if (persistSpoilerIntent && !intentRecorded)
+                {
+                    _logger.LogWarning(
+                        "Seerr accepted an installed-item request, but Spoiler Guard intent registration failed.");
+                }
+
+                return SeerrMediaRequestResult.Accepted(persistSpoilerIntent, intentRecorded);
+            }
+
+            if (response.StatusCode == HttpStatusCode.Conflict)
+            {
+                return SeerrMediaRequestResult.Refused(SeerrMediaRequestOutcome.AlreadyRequested);
+            }
+
+            if ((int)response.StatusCode is >= 400 and < 500)
+            {
+                return SeerrMediaRequestResult.Refused(SeerrMediaRequestOutcome.ProviderRejected);
+            }
+
+            return SeerrMediaRequestResult.Refused(SeerrMediaRequestOutcome.ProviderUnavailable);
+        }
+
+        private static SeerrMediaRequestResult? ValidateIdentity(
+            SeerrRequestIdentityResolution resolution,
+            string[] configuredSources,
+            RequestTarget target,
+            SeerrMediaRequestVariant variant,
+            bool isAdministrator,
+            out SeerrRequestIdentity identity)
+        {
+            identity = resolution.Identity;
+            if (!resolution.IsFound)
+            {
+                return SeerrMediaRequestResult.Refused(resolution.Status switch
+                {
+                    SeerrRequestIdentityStatus.NotFound => SeerrMediaRequestOutcome.Unlinked,
+                    SeerrRequestIdentityStatus.Blocked => SeerrMediaRequestOutcome.IdentityBlocked,
+                    _ => SeerrMediaRequestOutcome.IdentityUnavailable,
+                });
+            }
+
+            var sourceUrl = identity.SourceUrl;
+            var sourceIsCurrent = configuredSources.Any(source => string.Equals(
+                source,
+                sourceUrl,
+                StringComparison.Ordinal));
+            if (!sourceIsCurrent)
+            {
+                return SeerrMediaRequestResult.Refused(SeerrMediaRequestOutcome.IdentityUnavailable);
+            }
+
+            if (!isAdministrator && !HasPermission(identity.Permissions, target.Kind, variant))
+            {
+                return SeerrMediaRequestResult.Refused(SeerrMediaRequestOutcome.PermissionDenied);
+            }
+
+            return null;
+        }
+
+        private static bool HasPermission(
+            SeerrPermission permissions,
+            SeerrMediaRequestKind kind,
+            SeerrMediaRequestVariant variant)
+        {
+            if (SeerrPermissionHelper.HasPermission(permissions, SeerrPermission.ADMIN))
+            {
+                return true;
+            }
+
+            if (variant == SeerrMediaRequestVariant.FourK)
+            {
+                return SeerrPermissionHelper.CanRequest4k(
+                    permissions,
+                    isTv: kind == SeerrMediaRequestKind.Series);
+            }
+
+            var mediaPermission = kind == SeerrMediaRequestKind.Series
+                ? SeerrPermission.REQUEST_TV
+                : SeerrPermission.REQUEST_MOVIE;
+            return SeerrPermissionHelper.HasAnyPermission(
+                permissions,
+                SeerrPermission.REQUEST | mediaPermission);
+        }
+
+        private static bool TryProjectTarget(HostAccessibleItem item, out RequestTarget target)
+        {
+            target = default;
+            if (item.Id == Guid.Empty
+                || item.Kind is not (HostItemKind.Movie or HostItemKind.Series)
+                || item.ProviderReferences.IsDefaultOrEmpty)
+            {
+                return false;
+            }
+
+            var tmdbValues = item.ProviderReferences
+                .Where(reference => string.Equals(reference.Provider, "Tmdb", StringComparison.Ordinal))
+                .Select(reference => reference.Value)
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+            if (tmdbValues.Length != 1
+                || !int.TryParse(
+                    tmdbValues[0],
+                    NumberStyles.None,
+                    CultureInfo.InvariantCulture,
+                    out var tmdbId)
+                || tmdbId <= 0)
+            {
+                return false;
+            }
+
+            var kind = item.Kind == HostItemKind.Series
+                ? SeerrMediaRequestKind.Series
+                : SeerrMediaRequestKind.Movie;
+            target = new RequestTarget(
+                kind,
+                tmdbId,
+                kind == SeerrMediaRequestKind.Series ? "tv" : "movie");
+            return true;
+        }
+
+        private static string BuildRequestBody(
+            RequestTarget target,
+            SeerrMediaRequestVariant variant)
+        {
+            object body = target.Kind == SeerrMediaRequestKind.Series
+                ? new
+                {
+                    mediaType = target.MediaType,
+                    mediaId = target.TmdbId,
+                    seasons = "all",
+                    is4k = variant == SeerrMediaRequestVariant.FourK,
+                }
+                : new
+                {
+                    mediaType = target.MediaType,
+                    mediaId = target.TmdbId,
+                    is4k = variant == SeerrMediaRequestVariant.FourK,
+                };
+            return JsonSerializer.Serialize(body);
+        }
+
+        private readonly record struct RequestTarget(
+            SeerrMediaRequestKind Kind,
+            int TmdbId,
+            string MediaType);
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrMediaRequestOwner.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrMediaRequestOwner.cs
@@ -350,9 +350,24 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                 return SeerrMediaRequestResult.Refused(SeerrMediaRequestOutcome.IdentityChanged);
             }
 
-            // Every earlier projection is stale after an await. Re-enter the host's
-            // current user-scoped seam immediately before transport and require both
-            // the acting authority and the complete safe item projection to match.
+            var persistSpoilerIntent = config.SpoilerBlurEnabled
+                && config.SpoilerAutoEnableOnSeerrRequest;
+            var requestUri = finalIdentity.SourceUrl + RequestPath;
+            var requestBody = BuildRequestBody(target, variant);
+            var httpClient = SeerrHttpHelper.CreateClient(_httpClientFactory);
+            httpClient.Timeout = RequestTimeout;
+            using var request = SeerrHttpHelper.BuildRequest(
+                HttpMethod.Post,
+                requestUri,
+                integration.ApiKey,
+                finalIdentity.UserId.ToString(CultureInfo.InvariantCulture),
+                requestBody);
+            request.Headers.Add(PlatformIdempotencyKey.HeaderName, idempotencyKey.Value);
+
+            // Client factories and request/header construction are arbitrary code
+            // boundaries. Re-enter the host only after they finish, then dispatch
+            // synchronously through the typed configuration fence with no intervening
+            // authority-capable work.
             cancellationToken.ThrowIfCancellationRequested();
             var currentUser = _host.Users.Find(actor.UserId);
             var currentAccess = _host.Library.FindAccessible(actor.UserId, item.Id);
@@ -367,20 +382,6 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             }
 
             cancellationToken.ThrowIfCancellationRequested();
-
-            var persistSpoilerIntent = config.SpoilerBlurEnabled
-                && config.SpoilerAutoEnableOnSeerrRequest;
-            var requestUri = finalIdentity.SourceUrl + RequestPath;
-            var requestBody = BuildRequestBody(target, variant);
-            var httpClient = SeerrHttpHelper.CreateClient(_httpClientFactory);
-            httpClient.Timeout = RequestTimeout;
-            using var request = SeerrHttpHelper.BuildRequest(
-                HttpMethod.Post,
-                requestUri,
-                integration.ApiKey,
-                finalIdentity.UserId.ToString(CultureInfo.InvariantCulture),
-                requestBody);
-            request.Headers.Add(PlatformIdempotencyKey.HeaderName, idempotencyKey.Value);
 
             HttpResponseMessage response;
             try

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrMediaRequestOwner.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrMediaRequestOwner.cs
@@ -51,6 +51,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
         /// <summary>The linked identity changed during admission.</summary>
         IdentityChanged,
 
+        /// <summary>The current host user or authoritative item projection changed.</summary>
+        HostAuthorizationChanged,
+
         /// <summary>The linked identity lacks the exact media-edition permission.</summary>
         PermissionDenied,
 
@@ -175,7 +178,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             CancellationToken cancellationToken);
 
         Task<Seerr4kCapability> Get4kCapabilityAsync(
-            Guid jellyfinUserId,
+            SeerrRequestIdentity admittedIdentity,
             bool isAdministrator,
             CancellationToken cancellationToken);
 
@@ -196,6 +199,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
 
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly IPluginConfigProvider _configProvider;
+        private readonly IPlatformHost _host;
         private readonly ISeerrMediaRequestAdmission _admission;
         private readonly ISeerrParentalFilter _parentalFilter;
         private readonly ISeerrSpoilerIntentStore _spoilerIntentStore;
@@ -204,6 +208,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
         public SeerrMediaRequestOwner(
             IHttpClientFactory httpClientFactory,
             IPluginConfigProvider configProvider,
+            IPlatformHost host,
             ISeerrMediaRequestAdmission admission,
             ISeerrParentalFilter parentalFilter,
             ISeerrSpoilerIntentStore spoilerIntentStore,
@@ -211,6 +216,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
         {
             _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
             _configProvider = configProvider ?? throw new ArgumentNullException(nameof(configProvider));
+            _host = host ?? throw new ArgumentNullException(nameof(host));
             _admission = admission ?? throw new ArgumentNullException(nameof(admission));
             _parentalFilter = parentalFilter ?? throw new ArgumentNullException(nameof(parentalFilter));
             _spoilerIntentStore = spoilerIntentStore ?? throw new ArgumentNullException(nameof(spoilerIntentStore));
@@ -280,7 +286,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                 }
 
                 var capability = await _admission.Get4kCapabilityAsync(
-                    actor.UserId,
+                    initialIdentity,
                     actor.IsElevated,
                     cancellationToken).ConfigureAwait(false);
                 if (!integration.IsCurrent(_configProvider))
@@ -344,6 +350,24 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                 return SeerrMediaRequestResult.Refused(SeerrMediaRequestOutcome.IdentityChanged);
             }
 
+            // Every earlier projection is stale after an await. Re-enter the host's
+            // current user-scoped seam immediately before transport and require both
+            // the acting authority and the complete safe item projection to match.
+            cancellationToken.ThrowIfCancellationRequested();
+            var currentUser = _host.Users.Find(actor.UserId);
+            var currentAccess = _host.Library.FindAccessible(actor.UserId, item.Id);
+            if (!currentUser.HasValue
+                || (actor.IsElevated && !currentUser.Value.IsAdministrator)
+                || currentAccess.Item is not HostAccessibleItem currentItem
+                || !SameAuthoritativeItem(item, currentItem)
+                || !TryProjectTarget(currentItem, out var currentTarget)
+                || !target.Equals(currentTarget))
+            {
+                return SeerrMediaRequestResult.Refused(SeerrMediaRequestOutcome.HostAuthorizationChanged);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
             var persistSpoilerIntent = config.SpoilerBlurEnabled
                 && config.SpoilerAutoEnableOnSeerrRequest;
             var requestUri = finalIdentity.SourceUrl + RequestPath;
@@ -358,56 +382,81 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                 requestBody);
             request.Headers.Add(PlatformIdempotencyKey.HeaderName, idempotencyKey.Value);
 
-            using var response = await SeerrHttpHelper.SendResponseHeadersReadAsync(
-                httpClient,
-                request,
-                integration.CreateDispatchFence(_configProvider),
-                cancellationToken).ConfigureAwait(false);
-
-            if (response.IsSuccessStatusCode)
+            HttpResponseMessage response;
+            try
             {
-                // ResponseHeadersRead has confirmed the provider mutation. Fulfil the
-                // frozen local durability obligation synchronously before observing
-                // caller cancellation again or executing any fallible post-work.
-                var intentRecorded = false;
-                if (persistSpoilerIntent)
+                response = await SeerrHttpHelper.SendResponseHeadersReadAsync(
+                    httpClient,
+                    request,
+                    integration.CreateDispatchFence(_configProvider),
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch (SeerrDispatchNotAttemptedException)
+            {
+                return SeerrMediaRequestResult.Refused(SeerrMediaRequestOutcome.ConfigurationChanged);
+            }
+
+            using (response)
+            {
+                if (response.IsSuccessStatusCode)
                 {
-                    try
+                    // ResponseHeadersRead has confirmed the provider mutation. Fulfil the
+                    // frozen local durability obligation synchronously before observing
+                    // caller cancellation again or executing any fallible post-work.
+                    var intentRecorded = false;
+                    if (persistSpoilerIntent)
                     {
-                        intentRecorded = _spoilerIntentStore.TryRegister(
-                            actor.UserId,
-                            target.Kind,
-                            target.TmdbId);
+                        try
+                        {
+                            intentRecorded = _spoilerIntentStore.TryRegister(
+                                actor.UserId,
+                                target.Kind,
+                                target.TmdbId);
+                        }
+                        catch (Exception exception)
+                        {
+                            _logger.LogError(
+                                exception,
+                                "Seerr accepted an installed-item request, but its Spoiler Guard intent could not be persisted.");
+                        }
                     }
-                    catch (Exception exception)
+
+                    if (persistSpoilerIntent && !intentRecorded)
                     {
-                        _logger.LogError(
-                            exception,
-                            "Seerr accepted an installed-item request, but its Spoiler Guard intent could not be persisted.");
+                        _logger.LogWarning(
+                            "Seerr accepted an installed-item request, but Spoiler Guard intent registration failed.");
                     }
+
+                    return SeerrMediaRequestResult.Accepted(persistSpoilerIntent, intentRecorded);
                 }
 
-                if (persistSpoilerIntent && !intentRecorded)
+                if (response.StatusCode == HttpStatusCode.Conflict)
                 {
-                    _logger.LogWarning(
-                        "Seerr accepted an installed-item request, but Spoiler Guard intent registration failed.");
+                    return SeerrMediaRequestResult.Refused(SeerrMediaRequestOutcome.AlreadyRequested);
                 }
 
-                return SeerrMediaRequestResult.Accepted(persistSpoilerIntent, intentRecorded);
-            }
+                if (response.StatusCode is HttpStatusCode.RequestTimeout
+                    or HttpStatusCode.TooManyRequests)
+                {
+                    return SeerrMediaRequestResult.Refused(SeerrMediaRequestOutcome.ProviderUnavailable);
+                }
 
-            if (response.StatusCode == HttpStatusCode.Conflict)
-            {
-                return SeerrMediaRequestResult.Refused(SeerrMediaRequestOutcome.AlreadyRequested);
-            }
+                if ((int)response.StatusCode is >= 400 and < 500)
+                {
+                    return SeerrMediaRequestResult.Refused(SeerrMediaRequestOutcome.ProviderRejected);
+                }
 
-            if ((int)response.StatusCode is >= 400 and < 500)
-            {
-                return SeerrMediaRequestResult.Refused(SeerrMediaRequestOutcome.ProviderRejected);
+                return SeerrMediaRequestResult.Refused(SeerrMediaRequestOutcome.ProviderUnavailable);
             }
-
-            return SeerrMediaRequestResult.Refused(SeerrMediaRequestOutcome.ProviderUnavailable);
         }
+
+        private static bool SameAuthoritativeItem(
+            HostAccessibleItem admitted,
+            HostAccessibleItem current)
+            => admitted.Id == current.Id
+                && admitted.Kind == current.Kind
+                && admitted.SeriesId == current.SeriesId
+                && admitted.ProviderReferences.SequenceEqual(current.ProviderReferences);
 
         private static SeerrMediaRequestResult? ValidateIdentity(
             SeerrRequestIdentityResolution resolution,

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrParentalFilter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrParentalFilter.cs
@@ -202,10 +202,18 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             }
         }
 
-        public async Task<bool> IsBlockedAsync(string mediaType, int tmdbId, SeerrCaller caller)
+        public Task<bool> IsBlockedAsync(string mediaType, int tmdbId, SeerrCaller caller)
+            => IsBlockedAsync(mediaType, tmdbId, caller, CancellationToken.None);
+
+        public async Task<bool> IsBlockedAsync(
+            string mediaType,
+            int tmdbId,
+            SeerrCaller caller,
+            CancellationToken cancellationToken)
         {
             try
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 var gate = await ResolveGateAsync(caller).ConfigureAwait(false);
                 if (gate is null)
                 {
@@ -213,7 +221,15 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                 }
 
                 var normalized = string.Equals(mediaType, "tv", StringComparison.OrdinalIgnoreCase) ? "tv" : "movie";
-                return await IsTitleBlockedAsync(normalized, tmdbId, gate.Value).ConfigureAwait(false);
+                return await IsTitleBlockedAsync(
+                    normalized,
+                    tmdbId,
+                    gate.Value,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception ex)
             {
@@ -407,7 +423,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             return !IsAllowed(signature, mediaType, gate.Policy);
         }
 
-        private async Task<bool> IsTitleBlockedAsync(string mediaType, int tmdbId, GateContext gate)
+        private async Task<bool> IsTitleBlockedAsync(
+            string mediaType,
+            int tmdbId,
+            GateContext gate,
+            CancellationToken cancellationToken = default)
         {
             if (tmdbId <= 0)
             {
@@ -419,10 +439,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                 return true;
             }
 
-            using var cts = new CancellationTokenSource(PerFetchTimeout);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(PerFetchTimeout);
             var signature = await GetSignatureAsync(
                 CacheKey(mediaType, tmdbId, gate.Region), mediaType, tmdbId, gate,
                 needTags: gate.Policy.HasTagRules, cts.Token).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
             if (signature is null || !IsCurrentConfiguration(gate))
             {
                 return true; // fetch failed, stale generation, or unverifiable -> fail closed

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrParentalFilter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrParentalFilter.cs
@@ -202,8 +202,32 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             }
         }
 
-        public Task<bool> IsBlockedAsync(string mediaType, int tmdbId, SeerrCaller caller)
-            => IsBlockedAsync(mediaType, tmdbId, caller, CancellationToken.None);
+        public async Task<bool> IsBlockedAsync(string mediaType, int tmdbId, SeerrCaller caller)
+        {
+            try
+            {
+                var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+                var gate = await ResolveGateAsync(
+                    caller,
+                    requireAuthoritativePolicy: false,
+                    integration).ConfigureAwait(false);
+                if (gate is null)
+                {
+                    return false;
+                }
+
+                var normalized = string.Equals(mediaType, "tv", StringComparison.OrdinalIgnoreCase) ? "tv" : "movie";
+                return await IsTitleBlockedAsync(
+                    normalized,
+                    tmdbId,
+                    gate.Value).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Seerr parental request gate failed for {MediaType}/{TmdbId}; blocking.", mediaType, tmdbId);
+                return true;
+            }
+        }
 
         public async Task<bool> IsBlockedAsync(
             string mediaType,
@@ -214,7 +238,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             try
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                var gate = await ResolveGateAsync(caller).ConfigureAwait(false);
+                var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+                var gate = await ResolveGateAsync(
+                    caller,
+                    requireAuthoritativePolicy: true,
+                    integration).ConfigureAwait(false);
                 if (gate is null)
                 {
                     return false;
@@ -271,9 +299,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
         }
 
         // ── Gate resolution (shared fast paths) ───────────────────────────────
-        private async Task<GateContext?> ResolveGateAsync(SeerrCaller caller)
+        private async Task<GateContext?> ResolveGateAsync(
+            SeerrCaller caller,
+            bool requireAuthoritativePolicy = false,
+            SeerrIntegrationPolicy.SeerrIntegrationSnapshot? capturedIntegration = null)
         {
-            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            var integration = capturedIntegration
+                ?? SeerrIntegrationPolicy.Capture(_configProvider);
             var config = integration.Configuration;
             if (!integration.IsActive
                 || config == null
@@ -288,8 +320,18 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                 return null;
             }
 
-            if (!TryGetPolicy(caller.JellyfinUserId, config, out var policy))
+            if (!TryGetPolicy(
+                caller.JellyfinUserId,
+                config,
+                requireAuthoritativePolicy,
+                out var policy))
             {
+                if (requireAuthoritativePolicy)
+                {
+                    throw new InvalidOperationException(
+                        "The current Jellyfin user and parental policy could not be resolved.");
+                }
+
                 return null;
             }
 
@@ -344,7 +386,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             return Convert.ToHexString(SHA256.HashData(identityMaterial));
         }
 
-        private bool TryGetPolicy(string? jellyfinUserId, PluginConfiguration config, out PolicySnapshot policy)
+        private bool TryGetPolicy(
+            string? jellyfinUserId,
+            PluginConfiguration config,
+            bool requireAuthoritativePolicy,
+            out PolicySnapshot policy)
         {
             policy = default;
             if (string.IsNullOrEmpty(jellyfinUserId) || !Guid.TryParse(jellyfinUserId, out var userGuid))
@@ -364,6 +410,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             try
             {
                 var dtoPolicy = _userManager.GetUserDto(user, string.Empty)?.Policy;
+                if (dtoPolicy == null && requireAuthoritativePolicy)
+                {
+                    return false;
+                }
+
                 if (dtoPolicy?.BlockUnratedItems is { Length: > 0 } blocked)
                 {
                     blockUnrated = blocked;
@@ -390,6 +441,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             catch (Exception ex)
             {
                 _logger.LogDebug(ex, "Could not read parental policy lists for user {UserId}; treating as none.", jellyfinUserId);
+                if (requireAuthoritativePolicy)
+                {
+                    return false;
+                }
             }
 
             policy = new PolicySnapshot(user.MaxParentalRatingScore, user.MaxParentalRatingSubScore, blockUnrated, blockedTags, allowedTags);

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/SpoilerPendingService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/SpoilerGuard/SpoilerPendingService.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
@@ -25,7 +26,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
     /// ILibraryManager and IUserManager — never on ISeerrClient — so it can be
     /// consumed by the Seerr proxy controller without introducing a DI cycle.
     /// </summary>
-    public sealed class SpoilerPendingService
+    public sealed class SpoilerPendingService : ISeerrSpoilerIntentStore
     {
         // Hard cap on PendingTmdb — defensive against an auth'd user spamming the
         // modal/Seerr hook to grow spoilerblur.json without bound. 500 is well above
@@ -99,6 +100,28 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 return new SeerrIntentRegistration(false, parseFailureCode);
             }
 
+            var kind = mediaType == "tv"
+                ? SeerrMediaRequestKind.Series
+                : SeerrMediaRequestKind.Movie;
+            return RegisterSeerrIntent(
+                userId,
+                kind,
+                int.Parse(canonicalTmdb, NumberStyles.None, CultureInfo.InvariantCulture));
+        }
+
+        internal SeerrIntentRegistration RegisterSeerrIntent(
+            Guid userId,
+            SeerrMediaRequestKind kind,
+            int tmdbId)
+        {
+            if (userId == Guid.Empty || !Enum.IsDefined(kind) || tmdbId <= 0)
+            {
+                return new SeerrIntentRegistration(false, "invalid_request_target");
+            }
+
+            var mediaType = kind == SeerrMediaRequestKind.Series ? "tv" : "movie";
+            var canonicalTmdb = tmdbId.ToString(CultureInfo.InvariantCulture);
+
             var jUser = _userManager.GetUserById(userId);
             if (jUser == null)
             {
@@ -163,6 +186,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 _ => new SeerrIntentRegistration(false, "pending_cap_exceeded", pendingKey),
             };
         }
+
+        bool ISeerrSpoilerIntentStore.TryRegister(
+            Guid userId,
+            SeerrMediaRequestKind kind,
+            int tmdbId)
+            => RegisterSeerrIntent(userId, kind, tmdbId).IsDurable;
 
         private static bool TryParseSeerrRequestTarget(
             string? requestBody,

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,7 +26,7 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2808, totalLines: 3201 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 34405, totalLines: 43519 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 34744, totalLines: 43927 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 3,
         minimumCoveredLines: 2808,
@@ -34,11 +34,11 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
     });
     assert.deepEqual(baselines.profiles.server.observations, {
         cleanRuns: 3,
-        minimumCoveredLines: 34404,
-        maximumCoveredLines: 34405,
+        minimumCoveredLines: 34742,
+        maximumCoveredLines: 34744,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 1);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 34405,
-        "totalLines": 43519
+        "coveredLines": 34744,
+        "totalLines": 43927
       },
       "observations": {
         "cleanRuns": 3,
-        "minimumCoveredLines": 34404,
-        "maximumCoveredLines": 34405
+        "minimumCoveredLines": 34742,
+        "maximumCoveredLines": 34744
       },
       "tolerance": {
-        "missingCoveredLines": 1,
-        "rationale": "The rebased #591 tree retains main's installed Hidden Content and Spoiler Guard Platform owners and adapters, then adds the transport-neutral first-party invocation coordinator, server-private prepared contexts, named typed owner ports, cancellation-aware actor/operation admission, Android-compatible body-carried idempotency, series-ancestry binding, and cancellation checks after synchronous host seams. Three clean Coverlet runs on the identical 2026-08-03 combined source and 43,519-line scope each passed all 3,008 server tests and measured 34,405, 34,404, and 34,404 covered lines. Relative to the reviewed main high-water of 33,607/42,607 (78.877%), #591 adds 912 instrumented lines and raises the observed high-water by 798 covered lines to 34,405/43,519 (79.057%). The one-line observed instrumentation envelope sets a one-line tolerance and a 34,404-line floor. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 2,
+        "rationale": "The rebased combined #591 and #595 tree retains the transport-neutral first-party invocation coordinator and existing Hidden Content and Spoiler Guard owners, then adds the narrow exact installed-item Seerr request owner with typed identity, permission, source-affinity, parental, cancellation, feature, idempotency, final host reauthorization, configuration fencing, and Spoiler-intent durability boundaries without adding a generic route or catalog entry. Three clean Coverlet runs on the identical 2026-08-03 source and 43,927-line scope each passed all 3,054 server tests and measured 34,744, 34,742, and 34,743 covered lines. Relative to the reviewed #591 main high-water of 34,405/43,519 (79.057%), #595 adds 408 instrumented lines and raises the observed high-water by 339 covered lines to 34,744/43,927 (79.095%). The exact two-line 34,742-34,744 instrumentation envelope sets a 34,744 high-water with a two-line tolerance and a floor of 34,742/43,927 (79.090%). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
Closes #595.

## Summary

Extracts the narrow typed Seerr owner required by the native pilot for exact installed Movie/Series requests. The owner derives the provider target from the authoritative Jellyfin item and accepts only Standard or FourK; no caller provider ID, URL, API key, generic path/method, controller, HTTP context, or provider body crosses its public contract.

The broad legacy `/seerr/request` and partial-season compatibility routes remain unchanged and are never called by this owner. The fixed `ISeerrPlatformActionPort` adapter, descriptor/status query, and route/catalog composition remain owned by #606.

## Security and correctness

- Pins linked identity, source affinity, exact permission, configuration generation, and public 4K capability.
- Allows user import only during initial admission; the final pre-dispatch identity check cannot import.
- Re-authorizes the current Jellyfin user/admin policy and exact accessible item after request construction, immediately before dispatch.
- Applies mutation-grade parental checks and fails closed when authoritative policy is unavailable.
- Uses a typed configuration dispatch fence so ConfigurationChanged is returned only before `SendAsync` begins.
- Forwards the Platform idempotency key exactly; duplicate provider mutations remain owned by #591's coordinator/idempotency kernel.
- Treats 408/429 as unavailable, 409 as already requested, and any definite 2xx as accepted without parsing provider bodies.
- Records required Spoiler Guard intent synchronously; an accepted request with failed intent durability returns a closed non-resend outcome.
- Keeps service URLs, keys, provider bodies, raw errors, and foreign identity out of results/log surfaces.

## Composition

The rebase preserves all merged #591 registrations. `SeerrClient`/`ISeerrClient`/`ISeerrMediaRequestAdmission` share one singleton; `SpoilerPendingService`/`ISeerrSpoilerIntentStore` share one singleton; the exact owner is registered once. No Platform route, controller, catalog entry, or dispatcher binding is added by this slice.

## Verification

- 202 focused owner/admission/parental/intent tests
- 3,054/3,054 full server tests across three clean coverage runs
- coverage observations: 34,744 / 34,742 / 34,743 of 43,927 lines; reviewed high-water/floor tolerance 2
- coverage policy tests: 14/14
- script suite: 634/634
- Release build: 0 warnings, 0 errors
- lint: 0 errors (repository advisory warnings unchanged)
- new #595 files pass targeted format verification; repository-wide formatting still reports pre-existing unrelated whitespace debt
- `git diff --check`: clean
- independent rebased-head review: APPROVE

## Follow-up

#606 must provide the fixed Seerr Platform port, closed availability/status projection, descriptors, resolve/prepare/invoke routes, contract goldens, and live Android interoperability before the native client pilot is complete.
