### PR TITLE
fix(seerr): serialize modal history recovery

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/modal.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/modal.ts
@@ -1413,11 +1413,7 @@ function handlePendingOwnedTraversalPop(
 
     if (marker) {
         if (pending.phase === 'recovering-forward' && marker.token === pending.token) {
-            // The stale base repair has reached the retained private marker.
-            // Its durable direction is already Forward. Traverse it locally:
-            // the generic marker path treats every live record before a retired
-            // token as "above" it, which would incorrectly close an older live
-            // outer modal in A→M1→M2→B recovery.
+            // Cross recovery locally without closing an older live outer modal.
             event.stopImmediatePropagation();
             pending.recoveringMarkerCrossed = true;
             try {
@@ -1597,7 +1593,10 @@ function ensureHistoryOwner(): ModalHistoryOwnerState {
 
 function adoptCurrentHistoryMarker(owner: ModalHistoryOwnerState): void {
     const marker = readModalHistoryMarker(history.state);
-    if (!marker || owner.records.has(marker.token) || owner.adoptionToken === marker.token) return;
+    if (!marker
+        || owner.pendingOwnedTraversal
+        || owner.records.has(marker.token)
+        || owner.adoptionToken === marker.token) return;
     owner.adoptionToken = marker.token;
     const direction = retiredMarkerDirection(owner, marker);
     const preserveBidirectionalDirection = marker.traversal === 'bidirectional'

--- a/e2e/seerr-modal-history.spec.ts
+++ b/e2e/seerr-modal-history.spec.ts
@@ -304,7 +304,9 @@ test.describe('Seerr modal history ownership', () => {
         });
 
         await page.waitForFunction(() => {
+            const owner = (window as any).__jellyfinCanopySeerrModalHistoryOwnerV2;
             return location.hash === '#/search?jcHistoryProof=late-cap-route-b'
+                && !owner?.pendingOwnedTraversal
                 && !document.querySelector('.seerr-season-modal')
                 && !document.body.classList.contains('jc-modal-open')
                 && !document.body.classList.contains('seerr-modal-is-open');
@@ -371,6 +373,7 @@ test.describe('Seerr modal history ownership', () => {
                     rewriteSettled: false,
                 };
                 const originalForward = history.forward.bind(history);
+                const retainedMessageChannels = new Set<MessageChannel>();
                 let queuedRecoveryForward = false;
                 history.forward = () => {
                     if (proof.rewriteRuns > 0 && !proof.rewriteSettled) {
@@ -409,10 +412,15 @@ test.describe('Seerr modal history ownership', () => {
                         setTimeout(rewrite, 0);
                     } else if (asyncScheduler === 'MessageChannel') {
                         const channel = new MessageChannel();
+                        retainedMessageChannels.add(channel);
                         channel.port1.addEventListener('message', () => {
-                            rewrite();
-                            channel.port1.close();
-                            channel.port2.close();
+                            try {
+                                rewrite();
+                            } finally {
+                                channel.port1.close();
+                                channel.port2.close();
+                                retainedMessageChannels.delete(channel);
+                            }
                         }, { once: true });
                         channel.port1.start();
                         channel.port2.postMessage(undefined);
@@ -618,6 +626,7 @@ test.describe('Seerr modal history ownership', () => {
                         rewriteRuns: 0,
                         rewriteSettled: false,
                     };
+                    const retainedMessageChannels = new Set<MessageChannel>();
                     (window as any).__jcMarkerRewriteProof = proof;
                     window.addEventListener('popstate', (event) => {
                         const marker = (event.state as any)?.__jellyfinCanopySeerrModal;
@@ -634,10 +643,15 @@ test.describe('Seerr modal history ownership', () => {
                             setTimeout(rewrite, 0);
                         } else if (channel === 'MessageChannel') {
                             const messageChannel = new MessageChannel();
+                            retainedMessageChannels.add(messageChannel);
                             messageChannel.port1.addEventListener('message', () => {
-                                rewrite();
-                                messageChannel.port1.close();
-                                messageChannel.port2.close();
+                                try {
+                                    rewrite();
+                                } finally {
+                                    messageChannel.port1.close();
+                                    messageChannel.port2.close();
+                                    retainedMessageChannels.delete(messageChannel);
+                                }
                             }, { once: true });
                             messageChannel.port1.start();
                             messageChannel.port2.postMessage(undefined);

--- a/e2e/seerr-modal-history.spec.ts
+++ b/e2e/seerr-modal-history.spec.ts
@@ -320,15 +320,51 @@ test.describe('Seerr modal history ownership', () => {
         expect(capProof.lengthBeforeClose).toBeGreaterThanOrEqual(50);
         if (!capProof.isFirefox) expect(capProof.lengthBeforeClose).toBe(50);
 
-        await page.evaluate(() => history.back());
-        await page.waitForFunction(
-            () => (history.state as { jcHistoryProof?: string } | null)?.jcHistoryProof === 'late-cap-route-a',
-            undefined,
-            // Do not couple the assertion loop to requestAnimationFrame. CI can
-            // temporarily throttle rendering after a same-URL history pop even
-            // though the popstate transaction has already settled.
-            { polling: 50, timeout: 30_000 }
-        );
+        await page.evaluate(() => {
+            const proof = {
+                arrivals: [] as Array<{ marker: boolean; route: string | null }>,
+                genuineASeen: false,
+                stableSince: null as number | null,
+            };
+            const listener = (event: PopStateEvent) => {
+                const state = event.state as {
+                    __jellyfinCanopySeerrModal?: unknown;
+                    jcHistoryProof?: string;
+                } | null;
+                const marker = Boolean(state?.__jellyfinCanopySeerrModal);
+                const route = state?.jcHistoryProof ?? null;
+                proof.arrivals.push({ marker, route });
+                if (route === 'late-cap-route-a' && !marker) proof.genuineASeen = true;
+            };
+            window.addEventListener('popstate', listener);
+            (window as any).__jcLateCapTraversalProof = {
+                proof,
+                release: () => window.removeEventListener('popstate', listener),
+            };
+            history.back();
+        });
+        await page.waitForFunction(() => {
+            const owner = (window as any).__jellyfinCanopySeerrModalHistoryOwnerV2;
+            const proof = (window as any).__jcLateCapTraversalProof.proof as {
+                genuineASeen: boolean;
+                stableSince: number | null;
+            };
+            const state = history.state as {
+                __jellyfinCanopySeerrModal?: unknown;
+                jcHistoryProof?: string;
+            } | null;
+            const stable = proof.genuineASeen
+                && state?.jcHistoryProof === 'late-cap-route-a'
+                && !state.__jellyfinCanopySeerrModal
+                && !owner?.pendingOwnedTraversal;
+            if (!stable) {
+                proof.stableSince = null;
+                return false;
+            }
+            proof.stableSince ??= performance.now();
+            return performance.now() - proof.stableSince >= 100;
+        }, undefined, { polling: 25, timeout: 30_000 });
+        await page.evaluate(() => (window as any).__jcLateCapTraversalProof.release());
         await page.evaluate(() => history.forward());
         await page.waitForFunction(
             () => location.hash === '#/search?jcHistoryProof=late-cap-route-b',


### PR DESCRIPTION
Closes #612.

Serializes retired-marker adoption against an already-owned modal-history traversal. This prevents a second recovery traversal from reversing the retained marker direction and rebounding a genuine Back navigation. The existing one-shot MessageChannel retention fix remains included.

The E2E proof now distinguishes the private marker from genuine untagged route A, waits for an owner-idle stable A, and then verifies Forward returns to B.

Evidence on exact head `798f6c6f9e8c95d2bb7cb53fc7503c3a7d25a0b3`:

- late-cap race: 100/100 passes
- modal-history E2E: 26/26 passes
- MessageChannel cases: 60/60 passes
- modal-history unit tests: 90/90 passes
- TypeScript typechecks and deterministic bundle: pass
- Release plugin build: 0 warnings / 0 errors
- independent exact-head review: approve
- diff check: clean