### PR TITLE
test(seerr): stabilize issued-back browser races

### DIFF
--- a/e2e/seerr-modal-history.spec.ts
+++ b/e2e/seerr-modal-history.spec.ts
@@ -282,25 +282,51 @@ test.describe('Seerr modal history ownership', () => {
             handle.show();
             (window as any).__jcLateCapProof = {
                 lengthBeforeClose: history.length,
+                phaseAtBack: null as string | null,
                 proof,
+                pushRuns: 0,
             };
+
+            const owner = (window as any).__jellyfinCanopySeerrModalHistoryOwnerV2;
+            const ownBackDescriptor = Object.getOwnPropertyDescriptor(history, 'back');
+            const originalBack = history.back.bind(history);
+            const restoreBack = () => {
+                if (ownBackDescriptor) {
+                    Object.defineProperty(history, 'back', ownBackDescriptor);
+                } else {
+                    delete (history as { back?: () => void }).back;
+                }
+            };
+            Object.defineProperty(history, 'back', {
+                configurable: true,
+                writable: true,
+                value: () => {
+                    restoreBack();
+                    (window as any).__jcLateCapProof.phaseAtBack =
+                        owner.pendingOwnedTraversal?.phase ?? null;
+                    originalBack();
+                    (window as any).__jcLateCapProof.pushRuns += 1;
+                    History.prototype.pushState.call(
+                        history,
+                        {
+                            jcHistoryProof: 'late-cap-route-b',
+                            payload: new Blob(
+                                ['capped-target'],
+                                { type: 'application/octet-stream' }
+                            ),
+                        },
+                        '',
+                        `${documentPath}#/search?jcHistoryProof=late-cap-route-b`
+                    );
+                    owner.historyObserver?.({
+                        source: 'pushState',
+                        state: history.state,
+                        href: location.href,
+                    });
+                },
+            });
+
             handle.close();
-            setTimeout(() => {
-                History.prototype.pushState.call(
-                    history,
-                    {
-                        jcHistoryProof: 'late-cap-route-b',
-                        payload: new Blob(['capped-target'], { type: 'application/octet-stream' }),
-                    },
-                    '',
-                    `${documentPath}#/search?jcHistoryProof=late-cap-route-b`
-                );
-                (window as any).__jellyfinCanopySeerrModalHistoryOwnerV2.historyObserver?.({
-                    source: 'pushState',
-                    state: history.state,
-                    href: location.href,
-                });
-            }, 0);
         });
 
         await page.waitForFunction(() => {
@@ -314,9 +340,13 @@ test.describe('Seerr modal history ownership', () => {
         const capProof = await page.evaluate(() => ({
             proof: [...(window as any).__jcLateCapProof.proof],
             lengthBeforeClose: (window as any).__jcLateCapProof.lengthBeforeClose,
+            phaseAtBack: (window as any).__jcLateCapProof.phaseAtBack,
+            pushRuns: (window as any).__jcLateCapProof.pushRuns,
             isFirefox: navigator.userAgent.includes('Firefox/'),
         }));
         expect(capProof.proof).toEqual(['closed']);
+        expect(capProof.phaseAtBack).toBe('issued');
+        expect(capProof.pushRuns).toBe(1);
         expect(capProof.lengthBeforeClose).toBeGreaterThanOrEqual(50);
         if (!capProof.isFirefox) expect(capProof.lengthBeforeClose).toBe(50);
 
@@ -550,6 +580,8 @@ test.describe('Seerr modal history ownership', () => {
             window.removeEventListener('popstate', modalListener, true);
             const proof = {
                 laterStates: [] as Array<string | null>,
+                phaseAtBack: null as string | null,
+                pushRuns: 0,
                 rewriteRuns: 0,
             };
             (window as any).__jcSyncCanonicalProof = proof;
@@ -574,14 +606,40 @@ test.describe('Seerr modal history ownership', () => {
                 );
             });
 
+            // The close owner deliberately defers its Back to a zero-delay
+            // timer. A second zero-delay timer is not a deterministic way to
+            // place B after that Back was issued but before its asynchronous
+            // pop: the browser may run the traversal task between the two timer
+            // tasks, making the later push too late for canonicalization.
+            // Interpose exactly one real history.back call so the adversarial
+            // push happens synchronously after Back is issued. Restore the
+            // instance method first and preserve any host-owned wrapper.
+            const ownBackDescriptor = Object.getOwnPropertyDescriptor(history, 'back');
+            const originalBack = history.back.bind(history);
+            const restoreBack = () => {
+                if (ownBackDescriptor) {
+                    Object.defineProperty(history, 'back', ownBackDescriptor);
+                } else {
+                    delete (history as { back?: () => void }).back;
+                }
+            };
+            Object.defineProperty(history, 'back', {
+                configurable: true,
+                writable: true,
+                value: () => {
+                    restoreBack();
+                    proof.phaseAtBack = owner.pendingOwnedTraversal?.phase ?? null;
+                    originalBack();
+                    proof.pushRuns += 1;
+                    history.pushState(
+                        { jcHistoryProof: 'sync-canonical-route-b' },
+                        '',
+                        stableHref
+                    );
+                },
+            });
+
             handle.close();
-            setTimeout(() => {
-                history.pushState(
-                    { jcHistoryProof: 'sync-canonical-route-b' },
-                    '',
-                    stableHref
-                );
-            }, 0);
         });
 
         await page.waitForFunction(() => {
@@ -597,6 +655,8 @@ test.describe('Seerr modal history ownership', () => {
         }, undefined, { polling: 50, timeout: 30_000 });
         expect(await page.evaluate(() => (window as any).__jcSyncCanonicalProof)).toEqual({
             laterStates: ['sync-canonical-route-b'],
+            phaseAtBack: 'issued',
+            pushRuns: 1,
             rewriteRuns: 1,
         });
 


### PR DESCRIPTION
Closes #614.

## What changed

- replace two independent zero-delay host-push timers with a one-shot `history.back` interposition in the two issued-Back browser tests;
- restore the original history descriptor before invoking the captured host Back implementation;
- preserve a real asynchronous browser traversal;
- assert that Canopy had reached the `issued` phase and that the interposition ran exactly once;
- retain all existing modal teardown and later Back/Forward reversibility assertions.

This changes E2E scheduling only. Production modal behavior, timeouts, and runtime-error checks are unchanged.

## Root cause

The production close transaction and the test host push were separate zero-delay timer tasks. Browser history traversal is itself asynchronous, so the browser could deliver the pop between those timer tasks. The synthetic host push then arrived outside the state-machine window the test intended to exercise.

The failure was reproduced locally before this change. The trace showed the real pop winning before the second timer while ordinary modal close still completed.

## Validation

- baseline reproduction: the original exact test produced one flaky timeout in the first 15 attempts;
- final issued-Back stress: 40/40 browser tests passed across the two affected cases;
- complete `seerr-modal-history.spec.ts`: 26/26 passed;
- focused modal history unit suite: 90/90 passed;
- exact rebased commit: both affected browser cases passed 2/2;
- Playwright discovery: all 26 tests in the file compile and list;
- `git diff --check`: passed.
