### PR TITLE
fix: harden Jellyfin cold-start concurrency

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/js/plugin.js
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/plugin.js
@@ -1912,7 +1912,14 @@
             ['elsewhere', 'elsewhere.json'],
             ['hiddenContent', 'hidden-content.json']
         ];
-        const results = await Promise.all(files.map(async ([name, file]) => {
+        const results = [];
+        // Jellyfin 12 can still be finishing its cold-start database work when
+        // the web client authenticates. Keep this one logical owner read
+        // strictly serial so its five host-authenticated requests cannot fan
+        // out against that shared database boundary. The snapshot remains
+        // unpublished until every file belongs to the current identity.
+        for (const [name, file] of files) {
+            requireCurrentIdentity(context);
             try {
                 const request = client.ajax({
                     type: 'GET',
@@ -1921,19 +1928,24 @@
                     signal: scope.signal
                 });
                 const value = await scope.race(request);
-                return { name, value, missing: false };
+                requireCurrentIdentity(context);
+                results.push({ name, value, missing: false });
             } catch (reason) {
                 // The bookmark controller represents a genuinely missing file
                 // as a valid revision-0 state. A 404 therefore means the
                 // versioned endpoint itself was unavailable; never fabricate a
                 // mutation-capable empty bookmark snapshot from it.
-                if (isNotFoundError(reason) && name !== 'bookmark') return { name, value: null, missing: true };
+                if (isNotFoundError(reason) && name !== 'bookmark') {
+                    requireCurrentIdentity(context);
+                    results.push({ name, value: null, missing: true });
+                    continue;
+                }
                 // Authentication, transport, server, cancellation, and malformed
                 // success failures must abort this initialization. Publishing a
                 // fabricated empty owner snapshot would erase real preferences.
                 throw reason;
             }
-        }));
+        }
         requireCurrentIdentity(context);
 
         const snapshot = emptyUserConfig();

--- a/Jellyfin.Plugin.JellyfinCanopy/src/test/plugin-loader.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/test/plugin-loader.test.ts
@@ -1398,9 +1398,10 @@ describe('plugin.js loader guards', () => {
         expect(isNotFound(new TypeError('network failed'))).toBe(false);
     });
 
-    it('fails a five-file owner read on transient errors but defaults a genuine 404', async () => {
+    it('serializes the five-file owner read and fails closed before publication', async () => {
         const fetchSource = extractFunctionSource('fetchUserConfig');
         const notFoundSource = extractFunctionSource('isNotFoundError');
+        const runSource = extractFunctionSource('runInitialization') || '';
         expect(fetchSource, 'fetchUserConfig not found').toBeTruthy();
         expect(notFoundSource, 'isNotFoundError not found').toBeTruthy();
         type AjaxOptions = { url: string };
@@ -1454,21 +1455,25 @@ describe('plugin.js loader guards', () => {
                     }
                 }
                 : {};
-        const transientError = Object.assign(new Error('temporary server failure'), { status: 503 });
-        const transientAjax = vi.fn((options: AjaxOptions) => options.url.includes('settings.json')
-            ? Promise.reject(transientError)
-            : Promise.resolve(validUserFile(options)));
-
-        await expect(fetchUserConfig({ getUrl: (path) => path, ajax: transientAjax }, context, scope))
-            .rejects.toBe(transientError);
-        expect(transientAjax).toHaveBeenCalledTimes(5);
-
-        const malformedAjax = vi.fn((options: AjaxOptions) => options.url.includes('settings.json')
-            ? Promise.resolve(null)
-            : Promise.resolve(validUserFile(options)));
-        await expect(fetchUserConfig({ getUrl: (path) => path, ajax: malformedAjax }, context, scope))
-            .rejects.toThrow('Invalid settings user-settings response');
-        expect(malformedAjax).toHaveBeenCalledTimes(5);
+        let inFlight = 0;
+        let maxInFlight = 0;
+        const serialAjax = vi.fn(async (options: AjaxOptions) => {
+            inFlight++;
+            maxInFlight = Math.max(maxInFlight, inFlight);
+            await Promise.resolve();
+            inFlight--;
+            return validUserFile(options);
+        });
+        const completeSnapshot = await fetchUserConfig(
+            { getUrl: (path) => path, ajax: serialAjax },
+            context,
+            scope,
+        );
+        expect(serialAjax).toHaveBeenCalledTimes(5);
+        expect(maxInFlight).toBe(1);
+        expect(Object.keys(completeSnapshot)).toEqual([
+            'settings', 'shortcuts', 'bookmark', 'elsewhere', 'hiddenContent',
+        ]);
 
         const missingError = Object.assign(new Error('missing'), { status: 404 });
         const missingAjax = vi.fn((options: AjaxOptions) => options.url.includes('shortcuts.json')
@@ -1491,6 +1496,31 @@ describe('plugin.js loader guards', () => {
             : Promise.resolve({}));
         await expect(fetchUserConfig({ getUrl: (path) => path, ajax: missingBookmarkAjax }, context, scope))
             .rejects.toBe(missingError);
+        expect(missingBookmarkAjax).toHaveBeenCalledTimes(3);
+
+        const transientError = Object.assign(new Error('temporary server failure'), { status: 503 });
+        const transientAjax = vi.fn((options: AjaxOptions) => options.url.includes('bookmark.json')
+            ? Promise.reject(transientError)
+            : Promise.resolve(validUserFile(options)));
+        const published = { value: 'unchanged' as unknown };
+
+        await expect(fetchUserConfig({ getUrl: (path) => path, ajax: transientAjax }, context, scope)
+            .then((value) => { published.value = value; }))
+            .rejects.toBe(transientError);
+        expect(transientAjax).toHaveBeenCalledTimes(3);
+        expect(published.value).toBe('unchanged');
+
+        const malformedAjax = vi.fn((options: AjaxOptions) => options.url.includes('settings.json')
+            ? Promise.resolve(null)
+            : Promise.resolve(validUserFile(options)));
+        await expect(fetchUserConfig({ getUrl: (path) => path, ajax: malformedAjax }, context, scope))
+            .rejects.toThrow('Invalid settings user-settings response');
+        expect(malformedAjax).toHaveBeenCalledTimes(5);
+
+        const aggregate = runSource.indexOf('const [userConfig, currentUser, pluginData, privateConfig, translations] = await Promise.all([');
+        const publication = runSource.indexOf('publishIdentitySnapshot(context, {');
+        expect(aggregate).toBeGreaterThanOrEqual(0);
+        expect(publication).toBeGreaterThan(aggregate);
     });
 
     it('does not downgrade current-user failure and encodes every loader user path', () => {

--- a/e2e/docker/seed.sh
+++ b/e2e/docker/seed.sh
@@ -441,10 +441,59 @@ api() { # <method> <path> [json-body]
     fi
 }
 
+library_refresh_completed_successfully() { # <state> <last-result-status>
+    [ "${1:-}" = Idle ] && [ "${2:-}" = Completed ]
+}
+
+startup_library_task_json() { # <maximum-seconds>
+    local maximum_seconds="${1:?startup library task request requires a deadline}"
+    # Keep this timeout local to cold-start readiness: other seed API calls
+    # retain their established semantics. --max-time bounds the complete
+    # transfer, including a peer that connects and then never sends a byte.
+    curl -fsS --connect-timeout "${maximum_seconds}" --max-time "${maximum_seconds}" \
+        "${BASE}/ScheduledTasks" -H "${AUTHED}"
+}
+
 log "verifying the plugin loaded"
 api GET /Plugins | jq -e --arg id "${PLUGIN_ID}" \
     'map(select((.Id // "" | ascii_downcase | gsub("-"; "")) == ($id | ascii_downcase | gsub("-"; "")))) | length > 0' >/dev/null \
     || fail "Jellyfin Canopy plugin did not load (check config/log/)"
+
+# System/Info/Public, startup completion, authentication, and even /Plugins
+# can all succeed while Jellyfin 12's clean-server RefreshLibrary task still
+# owns startup database statements. Fail closed before the first virtual-folder
+# mutation instead of overlapping that host-owned work. A wall-clock deadline
+# bounds both polling and each transport to two minutes in total, and only the
+# task's explicit successful terminal state is accepted.
+log "waiting for Jellyfin startup library activity to settle before library creation"
+STARTUP_LIBRARY_READY=false
+STARTUP_LIBRARY_STATE=""
+STARTUP_LIBRARY_STATUS=""
+STARTUP_LIBRARY_WAIT_SECONDS=120
+STARTUP_LIBRARY_DEADLINE=$((SECONDS + STARTUP_LIBRARY_WAIT_SECONDS))
+while [ "${SECONDS}" -lt "${STARTUP_LIBRARY_DEADLINE}" ]; do
+    STARTUP_LIBRARY_REMAINING=$((STARTUP_LIBRARY_DEADLINE - SECONDS))
+    STARTUP_LIBRARY_TASK=""
+    if STARTUP_LIBRARY_TASK_RESPONSE="$(startup_library_task_json "${STARTUP_LIBRARY_REMAINING}")"; then
+        STARTUP_LIBRARY_TASK="$(printf '%s' "${STARTUP_LIBRARY_TASK_RESPONSE}" | jq -ec \
+            '[.[] | select(.Key == "RefreshLibrary")][0] // empty' || true)"
+    fi
+    if [ -n "${STARTUP_LIBRARY_TASK}" ]; then
+        STARTUP_LIBRARY_STATE="$(printf '%s' "${STARTUP_LIBRARY_TASK}" | jq -r '.State // ""')"
+        STARTUP_LIBRARY_STATUS="$(printf '%s' "${STARTUP_LIBRARY_TASK}" | jq -r \
+            '.LastExecutionResult.Status // ""')"
+        if library_refresh_completed_successfully \
+            "${STARTUP_LIBRARY_STATE}" "${STARTUP_LIBRARY_STATUS}"; then
+            STARTUP_LIBRARY_READY=true
+            break
+        fi
+    fi
+    [ "${SECONDS}" -lt "${STARTUP_LIBRARY_DEADLINE}" ] || break
+    sleep 1
+done
+[ "${STARTUP_LIBRARY_READY}" = true ] \
+    || fail "Jellyfin startup Scan Media Library task did not complete successfully before library creation (state=${STARTUP_LIBRARY_STATE:-missing}, status=${STARTUP_LIBRARY_STATUS:-missing})"
+log "Jellyfin startup library activity completed successfully"
 
 log "creating the Movies library"
 api POST "/Library/VirtualFolders?name=Movies&collectionType=movies&paths=%2Fmedia%2FMovies&refreshLibrary=false" \

--- a/scripts/e2e/library-scan-seed.test.js
+++ b/scripts/e2e/library-scan-seed.test.js
@@ -1,12 +1,107 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const childProcess = require('node:child_process');
 const fs = require('node:fs');
+const net = require('node:net');
 const path = require('node:path');
+const { performance } = require('node:perf_hooks');
 const test = require('node:test');
 
 const ROOT = path.resolve(__dirname, '../..');
 const seed = fs.readFileSync(path.join(ROOT, 'e2e/docker/seed.sh'), 'utf8');
+
+function extractShellFunction(name) {
+    const start = seed.indexOf(`${name}() {`);
+    assert.ok(start >= 0, `${name} shell function is missing`);
+    const end = seed.indexOf('\n}', start);
+    assert.ok(end > start, `${name} shell function is unterminated`);
+    return seed.slice(start, end + 2);
+}
+
+test('seed waits for successful startup library readiness before its first mutation', () => {
+    const authenticated = seed.indexOf('AUTHED="Authorization:');
+    const pluginVerified = seed.indexOf('|| fail "Jellyfin Canopy plugin did not load');
+    const readiness = seed.indexOf('waiting for Jellyfin startup library activity to settle before library creation');
+    const readinessComplete = seed.indexOf('Jellyfin startup library activity completed successfully');
+    const firstMutation = seed.indexOf('/Library/VirtualFolders?name=Movies');
+
+    assert.ok(authenticated >= 0);
+    assert.ok(pluginVerified > authenticated);
+    assert.ok(readiness > pluginVerified);
+    assert.ok(readinessComplete > readiness);
+    assert.ok(firstMutation > readinessComplete);
+});
+
+test('startup library readiness is bounded and rejects missing or failed task state', () => {
+    const readiness = seed.indexOf('waiting for Jellyfin startup library activity to settle before library creation');
+    const firstMutation = seed.indexOf('/Library/VirtualFolders?name=Movies');
+    const block = seed.slice(readiness, firstMutation);
+
+    assert.match(block, /STARTUP_LIBRARY_WAIT_SECONDS=120/);
+    assert.match(block, /STARTUP_LIBRARY_DEADLINE=\$\(\(SECONDS \+ STARTUP_LIBRARY_WAIT_SECONDS\)\)/);
+    assert.match(block, /while \[ "\$\{SECONDS\}" -lt "\$\{STARTUP_LIBRARY_DEADLINE\}" \]; do/);
+    assert.match(block, /STARTUP_LIBRARY_REMAINING=\$\(\(STARTUP_LIBRARY_DEADLINE - SECONDS\)\)/);
+    assert.match(block, /STARTUP_LIBRARY_TASK=""/);
+    assert.match(block, /if STARTUP_LIBRARY_TASK_RESPONSE="\$\(startup_library_task_json "\$\{STARTUP_LIBRARY_REMAINING\}"\)"; then/);
+    assert.match(block, /select\(\.Key == "RefreshLibrary"\)/);
+    assert.match(block, /STARTUP_LIBRARY_READY=false/);
+    assert.match(block, /\[ "\$\{STARTUP_LIBRARY_READY\}" = true \] \\\n+\s+\|\| fail "Jellyfin startup Scan Media Library task did not complete successfully/);
+
+    const predicate = extractShellFunction('library_refresh_completed_successfully');
+    const evaluate = (state, status) => childProcess.spawnSync(
+        'bash',
+        ['-c', `${predicate}\nlibrary_refresh_completed_successfully "$1" "$2"`, 'readiness-test', state, status],
+        { encoding: 'utf8' },
+    ).status;
+
+    assert.equal(evaluate('Idle', 'Completed'), 0);
+    assert.equal(evaluate('', ''), 1);
+    assert.equal(evaluate('Idle', ''), 1);
+    assert.equal(evaluate('Idle', 'Failed'), 1);
+    assert.equal(evaluate('Running', 'Completed'), 1);
+});
+
+test('startup readiness transport enforces its complete-transfer deadline', async (t) => {
+    const transport = extractShellFunction('startup_library_task_json');
+    const sockets = new Set();
+    const server = net.createServer((socket) => {
+        // Accept the connection but deliberately never send an HTTP byte.
+        sockets.add(socket);
+        socket.once('close', () => sockets.delete(socket));
+    });
+    await new Promise((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', resolve);
+    });
+    t.after(() => {
+        for (const socket of sockets) socket.destroy();
+        return new Promise((resolve) => server.close(resolve));
+    });
+    const address = server.address();
+    assert.ok(address && typeof address === 'object');
+
+    const started = performance.now();
+    const child = childProcess.spawn(
+        'bash',
+        [
+            '-c',
+            `${transport}\nBASE="$1" AUTHED='Authorization: deadline-proof' startup_library_task_json 1`,
+            'transport-deadline-test',
+            `http://127.0.0.1:${address.port}`,
+        ],
+        { stdio: 'ignore' },
+    );
+    const status = await new Promise((resolve, reject) => {
+        child.once('error', reject);
+        child.once('close', resolve);
+    });
+    const elapsed = performance.now() - started;
+
+    assert.notEqual(status, 0);
+    assert.ok(elapsed >= 750, `curl deadline fired implausibly early after ${elapsed}ms`);
+    assert.ok(elapsed < 4_000, `curl exceeded the one-second transport deadline: ${elapsed}ms`);
+});
 
 test('seed starts one explicit scan only after all seed-owned libraries exist', () => {
     const precreatedCollections = seed.indexOf('"${CONFIG_DIR}/data/collections"');


### PR DESCRIPTION
Closes #616.

## What changed

- serialize the five authenticated user-configuration owner reads while preserving identity checks, cancellation, missing-file handling, and fail-closed publication;
- wait for Jellyfin 12's `RefreshLibrary` task to report `Idle` with a completed-success result after authentication/plugin verification and before the first virtual-folder mutation;
- bound the readiness gate with one absolute 120-second deadline, passing the remaining budget to a readiness-only curl complete-transfer/connect timeout;
- discard timed-out or failed transport output and fail closed when readiness is missing, malformed, failed, or late;
- add concurrency, ordering, state-matrix, remaining-budget, and accepted-but-silent peer regression coverage.

The generic seed `api` helper is unchanged, and no Canopy request retry or assertion was weakened.

## Root cause

Jellyfin 12 can authenticate and expose the plugin while its startup `RefreshLibrary` task still owns database statements. The web bootstrap fanned out five owner reads during that window, and the seed began virtual-folder mutations without proving startup library work had reached a successful terminal state. This amplified a host SQLite collation/active-statement failure before requests reached Canopy controllers.

## Validation

- focused plugin loader: 43/43;
- full client suite: 2,040/2,040 with unchanged 2,808/3,201 high-water coverage;
- focused seed contracts: 5/5, including a real accepted-but-silent socket terminating near the one-second test deadline;
- full script suite: 637/637;
- source and legacy typechecks: passed;
- syntax, performance guard, and advisory lint: passed;
- deterministic bundle: `ba5b5389847690a1acffa98bdc5aee37c78284b2f84e1f33e49103dc146f2840`;
- Release build: zero warnings/errors;
- fresh pinned Jellyfin 12 full seed: passed with readiness before mutations;
- targeted rich-card browser E2E: 6/6;
- Jellyfin logs contained no SQLite Error 5 or HTTP 500 signature;
- independent review: approved after the transport deadline finding was fixed.
