### PR TITLE
test: stabilize locale allocation assertion

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/LocaleManifestTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/LocaleManifestTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using Jellyfin.Plugin.JellyfinCanopy.Controllers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -9,6 +10,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
 {
     public sealed class LocaleManifestTests
     {
+        private const int AllocationWarmupIterations = 10_000;
+        private const int AllocationSampleCount = 8;
+        private const int AllocationIterationsPerSample = 1_000;
+        private const long EvidencedHostAllocationBytes = 64;
+
         [Fact]
         public void SupportedLocaleInventory_MatchesEmbeddedCatalogsExactly()
         {
@@ -123,22 +129,60 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                     controller.Response.Headers.CacheControl.ToString());
             }
 
-            // Warm the method before measuring the length-first rejection path.
-            Assert.False(LocaleCodeParser.TryNormalize(overlong, out _));
-            var before = GC.GetAllocatedBytesForCurrentThread();
-            var accepted = 0;
-            for (var index = 0; index < 1_000; index++)
-            {
-                if (LocaleCodeParser.TryNormalize(overlong, out _))
-                {
-                    accepted++;
-                }
-            }
+            var measurement = MeasureSteadyStateAllocations(
+                () => LocaleCodeParser.TryNormalize(overlong, out _));
 
-            var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
-            Assert.Equal(0, accepted);
-            Assert.Equal(0, allocated);
+            Assert.Equal(0, measurement.Accepted);
+            Assert.True(
+                AllocationSamplesFollowEvidencedTolerance(
+                    measurement.AllocatedBytesBySample),
+                $"Unexpected allocation samples: [{string.Join(", ", measurement.AllocatedBytesBySample)}]");
             Assert.Empty(logger.Entries);
+        }
+
+        [Fact]
+        public void SteadyStateAllocationMeasurement_DetectsPlantedPerCallAllocation()
+        {
+            var measurement = MeasureSteadyStateAllocations(
+                AllocateForNegativeControl);
+
+            Assert.Equal(0, measurement.Accepted);
+            Assert.All(
+                measurement.AllocatedBytesBySample,
+                static allocatedBytes => Assert.True(allocatedBytes > 0));
+            Assert.False(
+                AllocationSamplesFollowEvidencedTolerance(
+                    measurement.AllocatedBytesBySample));
+        }
+
+        [Fact]
+        public void SteadyStateAllocationMeasurement_DetectsPlantedIntermittentAllocations()
+        {
+            var probe = new IntermittentAllocationProbe();
+            var measurement = MeasureSteadyStateAllocations(probe.Invoke);
+
+            Assert.Equal(0, measurement.Accepted);
+            Assert.True(
+                measurement.AllocatedBytesBySample.Count(
+                    static allocatedBytes => allocatedBytes > 0) >= 4);
+            Assert.False(
+                AllocationSamplesFollowEvidencedTolerance(
+                    measurement.AllocatedBytesBySample));
+        }
+
+        [Fact]
+        public void AllocationSampleTolerance_AcceptsOnlyTheEvidencedHostAnomaly()
+        {
+            Assert.True(AllocationSamplesFollowEvidencedTolerance(
+                new long[] { 0, 0, 0, 0, 0, 0, 0, 0 }));
+            Assert.True(AllocationSamplesFollowEvidencedTolerance(
+                new long[] { 0, 0, 0, 64, 0, 0, 0, 0 }));
+            Assert.False(AllocationSamplesFollowEvidencedTolerance(
+                new long[] { 0, 64, 0, 0, 0, 64, 0, 0 }));
+            Assert.False(AllocationSamplesFollowEvidencedTolerance(
+                new long[] { 0, 0, 0, 32, 0, 0, 0, 0 }));
+            Assert.False(AllocationSamplesFollowEvidencedTolerance(
+                new long[] { 0, 0, 0, 0, 0, 0, 0 }));
         }
 
         [Fact]
@@ -213,6 +257,73 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 LocaleMissLogLimiter.MaximumTrackedKeys);
         }
 
+        private static AllocationMeasurement MeasureSteadyStateAllocations(
+            Func<bool> operation)
+        {
+            // Reach steady-state before measuring: tiered runtime and coverage
+            // transitions are test-host work, not allocations by the operation.
+            var accepted = 0;
+            for (var index = 0; index < AllocationWarmupIterations; index++)
+            {
+                if (operation())
+                {
+                    accepted++;
+                }
+            }
+
+            var allocatedBytesBySample = new long[AllocationSampleCount];
+            for (var sample = 0; sample < allocatedBytesBySample.Length; sample++)
+            {
+                var before = GC.GetAllocatedBytesForCurrentThread();
+                for (var index = 0; index < AllocationIterationsPerSample; index++)
+                {
+                    if (operation())
+                    {
+                        accepted++;
+                    }
+                }
+
+                allocatedBytesBySample[sample] =
+                    GC.GetAllocatedBytesForCurrentThread() - before;
+            }
+
+            return new AllocationMeasurement(accepted, allocatedBytesBySample);
+        }
+
+        private static bool AllocationSamplesFollowEvidencedTolerance(
+            IReadOnlyList<long> allocatedBytesBySample)
+        {
+            if (allocatedBytesBySample.Count != AllocationSampleCount)
+            {
+                return false;
+            }
+
+            var nonzeroSamples = 0;
+            foreach (var allocatedBytes in allocatedBytesBySample)
+            {
+                if (allocatedBytes == 0)
+                {
+                    continue;
+                }
+
+                nonzeroSamples++;
+                if (allocatedBytes != EvidencedHostAllocationBytes
+                    || nonzeroSamples > 1)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static bool AllocateForNegativeControl()
+        {
+            GC.KeepAlive(new object());
+            return false;
+        }
+
         private static ConfigController CreateController(
             CapturingLogger logger,
             LocaleMissLogLimiter limiter)
@@ -240,6 +351,23 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             public override DateTimeOffset GetUtcNow() => _utcNow;
 
             public void Advance(TimeSpan elapsed) => _utcNow += elapsed;
+        }
+
+        private sealed class IntermittentAllocationProbe
+        {
+            private int _calls;
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public bool Invoke()
+            {
+                _calls++;
+                if (_calls % 2_000 == 0)
+                {
+                    GC.KeepAlive(new object());
+                }
+
+                return false;
+            }
         }
 
         private sealed class CapturingLogger : ILogger<ConfigController>
@@ -274,5 +402,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
         }
 
         private sealed record LogEntry(LogLevel Level, string Message);
+
+        private readonly record struct AllocationMeasurement(
+            int Accepted,
+            long[] AllocatedBytesBySample);
     }
 }


### PR DESCRIPTION
Closes #618.

## What changed

- replace the locale parser allocation guard's single measurement window with a shared steady-state measurement helper;
- warm the operation for 10,000 calls, then retain all eight independent 1,000-call measurement windows;
- accept only eight zero-byte windows or the precisely evidenced anomaly of one 64-byte window plus seven zero-byte windows;
- continue requiring every overlong locale to be rejected;
- add `[NoInlining]` planted per-call and every-2,000-call intermittent allocator controls that the policy must reject;
- pin the exact policy boundaries: all-zero and one-64 acceptance, and rejection of two 64-byte samples, a different nonzero size, or the wrong sample count.

Production locale parsing, bounds, logging, and normalization are unchanged.

## Root cause

The original test attributed every byte observed in one window to the parser. Repeated full Coverlet runs twice observed a one-off 64-byte delta even though the overlong path returns after assigning interned `string.Empty` and checking length. Independent 100-window diagnostics measured zero bytes in every window, including inside the complete pilot suite. The one-off delta came from test-host/runtime/coverage transition work, not steady-state parser allocation.

Multiple steady-state windows exclude one-off harness work without permitting a broader tolerance. The complete sample vector is retained: only one exact 64-byte anomaly is tolerated. Deterministic and intermittent planted allocators prove that repeated allocation cannot hide behind a zero window.

## Validation

- focused Release: 4/4;
- focused Coverlet: 4/4 in each of six separate processes;
- exact full server coverage gate on current `main`: 3,078/3,078, 34,753/43,927 lines, matching the reviewed high-water;
- pre-factored 10,000-warm/eight-window strategy: three complete pilot Coverlet suites passed 3,278/3,278 each;
- original parser path diagnostic: 100/100 measured 1,000-call windows allocated zero bytes;
- `git diff --check`: passed.
