### PR TITLE
test(seerr): stabilize late copied-marker replace race

### DIFF
--- a/e2e/seerr-modal-history.spec.ts
+++ b/e2e/seerr-modal-history.spec.ts
@@ -1096,7 +1096,13 @@ test.describe('Seerr modal history ownership', () => {
 
         await page.evaluate(() => {
             const stableHref = location.href;
-            const proof = { arrivals: [] as string[], writeState: null as unknown };
+            const proof = {
+                arrivals: [] as string[],
+                backDescriptorRestored: false,
+                phaseAtBack: null as string | null,
+                replaceRuns: 0,
+                writeState: null as unknown,
+            };
             (window as any).__jcLateReplaceProof = proof;
             window.addEventListener('popstate', (event) => {
                 const value = (event.state as { jcHistoryProof?: unknown } | null)?.jcHistoryProof;
@@ -1116,27 +1122,61 @@ test.describe('Seerr modal history ownership', () => {
                 onSave: () => undefined,
             });
             handle.show();
+
+            // The close owner defers its Back to a timer, but another timer
+            // cannot deterministically run after Back is issued and before its
+            // asynchronous pop. Interpose exactly one real Back, restoring any
+            // host-owned wrapper before calling it, then perform the adversarial
+            // copied-marker replace synchronously after the traversal is issued.
+            const owner = (window as any).__jellyfinCanopySeerrModalHistoryOwnerV2;
+            const ownBackDescriptor = Object.getOwnPropertyDescriptor(history, 'back');
+            const originalBack = history.back.bind(history);
+            const restoreBack = () => {
+                if (ownBackDescriptor) {
+                    Object.defineProperty(history, 'back', ownBackDescriptor);
+                } else {
+                    delete (history as { back?: () => void }).back;
+                }
+            };
+            Object.defineProperty(history, 'back', {
+                configurable: true,
+                writable: true,
+                value: () => {
+                    restoreBack();
+                    const restoredBackDescriptor = Object.getOwnPropertyDescriptor(history, 'back');
+                    proof.backDescriptorRestored = ownBackDescriptor
+                        ? restoredBackDescriptor?.configurable === ownBackDescriptor.configurable
+                            && restoredBackDescriptor?.enumerable === ownBackDescriptor.enumerable
+                            && restoredBackDescriptor?.get === ownBackDescriptor.get
+                            && restoredBackDescriptor?.set === ownBackDescriptor.set
+                            && restoredBackDescriptor?.value === ownBackDescriptor.value
+                            && restoredBackDescriptor?.writable === ownBackDescriptor.writable
+                        : restoredBackDescriptor === undefined;
+                    proof.phaseAtBack = owner.pendingOwnedTraversal?.phase ?? null;
+                    originalBack();
+                    proof.replaceRuns += 1;
+                    History.prototype.replaceState.call(
+                        history,
+                        {
+                            ...(history.state as Record<string, unknown>),
+                            jcHistoryProof: 'late-replace-route-b',
+                            preservedB: { exact: 29 },
+                            usr: null,
+                        },
+                        '',
+                        stableHref
+                    );
+                    owner.historyObserver?.({
+                        source: 'replaceState',
+                        action: 'REPLACE',
+                        state: history.state,
+                        href: location.href,
+                    });
+                    proof.writeState = structuredClone(history.state);
+                },
+            });
+
             handle.close();
-            setTimeout(() => {
-                History.prototype.replaceState.call(
-                    history,
-                    {
-                        ...(history.state as Record<string, unknown>),
-                        jcHistoryProof: 'late-replace-route-b',
-                        preservedB: { exact: 29 },
-                        usr: null,
-                    },
-                    '',
-                    stableHref
-                );
-                (window as any).__jellyfinCanopySeerrModalHistoryOwnerV2.historyObserver?.({
-                    source: 'replaceState',
-                    action: 'REPLACE',
-                    state: history.state,
-                    href: location.href,
-                });
-                proof.writeState = structuredClone(history.state);
-            }, 0);
         });
 
         await page.waitForFunction(() => {
@@ -1151,7 +1191,6 @@ test.describe('Seerr modal history ownership', () => {
             preservedB: { exact: 29 },
             usr: null,
         });
-
         await page.evaluate(() => history.back());
         await page.waitForFunction(
             () => (window as any).__jcLateReplaceProof.arrivals.at(-1) === 'late-replace-route-a',
@@ -1164,6 +1203,15 @@ test.describe('Seerr modal history ownership', () => {
             undefined,
             { timeout: 30_000 }
         );
+        expect(await page.evaluate(() => ({
+            backDescriptorRestored: (window as any).__jcLateReplaceProof.backDescriptorRestored,
+            phaseAtBack: (window as any).__jcLateReplaceProof.phaseAtBack,
+            replaceRuns: (window as any).__jcLateReplaceProof.replaceRuns,
+        }))).toEqual({
+            backDescriptorRestored: true,
+            phaseAtBack: 'issued',
+            replaceRuns: 1,
+        });
 
         assertNoRuntimeErrors(consoleErrors);
     });


### PR DESCRIPTION
## Outcome

Closes #620.

Stabilizes the remaining `late copied-marker replace` real-browser proof in the Seerr modal-history suite. The test previously scheduled an adversarial host `replaceState` with a second zero-delay timer after `handle.close()`. That did not guarantee the replacement ran after the owner's Back was issued but before the browser delivered its asynchronous pop, so CI could traverse first and wait forever for a state transition the fixture had scheduled too late.

## Change

The test now interposes exactly one `history.back()` call, restores any prior instance wrapper before invoking the real Back, records the owner's pending phase, and performs the adversarial copied-marker replacement synchronously after traversal issuance. It additionally proves the seam observed `issued` and ran exactly once.

The existing real browser traversal, byte-structural host-state preservation, modal cleanup, direct repair-to-B, Back-to-A, and Forward-to-B assertions remain intact. Production code is unchanged.

## Verification

- Jellyfin 12 focused test repeated 10 times: 10/10 passed.
- Complete `e2e/seerr-modal-history.spec.ts`: 26/26 passed.
- Script tests: 637/637 passed.
- Node v22.20.0 / npm 10.9.3 toolchain, syntax, source typecheck, and `git diff --check`: passed.
- Independent exact-head review of `dc83b14a10f3be3d4855ac4669718b22383ff9ce`: APPROVE.

## AI assistance

OpenAI coding agents were used for diagnosis, the test-only change, and independent review. The root cause and browser scheduling seam were verified from the failing Actions log and real Jellyfin 12 runs.
