### PR TITLE
Fix pre-session local shard cleanup timeout

### DIFF
--- a/scripts/e2e/local-shards.test.js
+++ b/scripts/e2e/local-shards.test.js
@@ -281,6 +281,58 @@ test('termination finds a shard process group after its tracked leader exits', (
     assert.equal(result.status, 0, `stdout: ${result.stdout}\nstderr: ${result.stderr}`);
 });
 
+test('termination stops a tracked launcher before its process group exists', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'jc-local-pre-group-'));
+    const command = [
+        'source "$1"',
+        'set -e',
+        "bash -c 'trap \"\" TERM; : > \"$1\"; sleep 30' bash \"$2/ready\" >/dev/null 2>&1 &",
+        'pid=$!',
+        'cleanup_direct_job() {',
+        '  kill -KILL "$pid" >/dev/null 2>&1 || true',
+        '  wait "$pid" >/dev/null 2>&1 || true',
+        '}',
+        'trap cleanup_direct_job EXIT',
+        'for _ in {1..50}; do [[ -f "$2/ready" ]] && break; sleep 0.02; done',
+        '[[ -f "$2/ready" ]]',
+        'SEED_PIDS[1]=$pid',
+        'terminate_active_jobs',
+        '! kill -0 "$pid" >/dev/null 2>&1',
+    ].join('\n');
+    try {
+        const result = spawnSync('bash', ['-c', command, 'bash', SCRIPT, root], {
+            cwd: ROOT,
+            encoding: 'utf8',
+            timeout: 5_000,
+        });
+        assert.equal(result.status, 0, `stdout: ${result.stdout}\nstderr: ${result.stderr}`);
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test('direct termination recognizes only exact running shell jobs', () => {
+    const command = [
+        'source "$1"',
+        'set -e',
+        'sleep 30 >/dev/null 2>&1 &',
+        'running_pid=$!',
+        'tracked_pid_is_running_job "$running_pid"',
+        '! tracked_pid_is_running_job "${running_pid}0"',
+        'kill -KILL "$running_pid"',
+        'wait "$running_pid" >/dev/null 2>&1 || true',
+        '! tracked_pid_is_running_job "$running_pid"',
+        'SEED_PIDS[1]=$running_pid',
+        'terminate_active_jobs',
+    ].join('\n');
+    const result = spawnSync('bash', ['-c', command, 'bash', SCRIPT], {
+        cwd: ROOT,
+        encoding: 'utf8',
+        timeout: 5_000,
+    });
+    assert.equal(result.status, 0, `stdout: ${result.stdout}\nstderr: ${result.stderr}`);
+});
+
 for (const [signal, expected] of [['INT', 130], ['TERM', 143]]) {
     test(`${signal} delivery preserves its exit code through owned cleanup`, () => {
         const root = fs.mkdtempSync(path.join(os.tmpdir(), `jc-local-${signal.toLowerCase()}-`));
@@ -326,6 +378,7 @@ test('launcher keeps runner passwords out of the tracked process argv', (t) => {
         fs.writeFileSync(fakeSeed, '#!/usr/bin/env bash\nsleep 30\n', { mode: 0o700 });
         const command = [
             'source "$1"',
+            'set -e',
             'SHARDS=1',
             'RUN_ID=argv-contract',
             'CPUS_PER_SERVER=2',

--- a/scripts/e2e/run-local-shards.sh
+++ b/scripts/e2e/run-local-shards.sh
@@ -289,12 +289,26 @@ print_resource_plan() {
     fi
 }
 
+tracked_pid_is_running_job() {
+    local tracked_pid="$1" job_pid
+    while IFS= read -r job_pid; do
+        [[ "${job_pid}" == "${tracked_pid}" ]] && return 0
+    done < <(jobs -pr)
+    return 1
+}
+
 terminate_active_jobs() {
     local pid attempt alive
     for pid in "${SEED_PIDS[@]:-}" "${TEST_PIDS[@]:-}"; do
         [[ "${pid}" =~ ^[1-9][0-9]*$ ]] || continue
         if kill -0 -- "-${pid}" >/dev/null 2>&1; then
             kill -TERM -- "-${pid}" >/dev/null 2>&1 || true
+        elif tracked_pid_is_running_job "${pid}" \
+            && kill -0 -- "${pid}" >/dev/null 2>&1; then
+            # The tracked launcher can be visible before setsid establishes
+            # the pid-named process group. Stop that process directly rather
+            # than blocking in wait until the seed or test exits naturally.
+            kill -TERM -- "${pid}" >/dev/null 2>&1 || true
         fi
     done
 
@@ -302,7 +316,9 @@ terminate_active_jobs() {
         alive=0
         for pid in "${SEED_PIDS[@]:-}" "${TEST_PIDS[@]:-}"; do
             [[ "${pid}" =~ ^[1-9][0-9]*$ ]] || continue
-            if kill -0 -- "-${pid}" >/dev/null 2>&1; then
+            if kill -0 -- "-${pid}" >/dev/null 2>&1 \
+                || { tracked_pid_is_running_job "${pid}" \
+                    && kill -0 -- "${pid}" >/dev/null 2>&1; }; then
                 alive=1
             fi
         done
@@ -314,6 +330,9 @@ terminate_active_jobs() {
         [[ "${pid}" =~ ^[1-9][0-9]*$ ]] || continue
         if kill -0 -- "-${pid}" >/dev/null 2>&1; then
             kill -KILL -- "-${pid}" >/dev/null 2>&1 || true
+        elif tracked_pid_is_running_job "${pid}" \
+            && kill -0 -- "${pid}" >/dev/null 2>&1; then
+            kill -KILL -- "${pid}" >/dev/null 2>&1 || true
         fi
         wait "${pid}" >/dev/null 2>&1 || true
     done


### PR DESCRIPTION
Closes #624.

## What changed

- retain process-group cleanup for local E2E shard descendants;
- add a direct-PID fallback only while the launcher remains an exact current Bash job;
- poll group and direct ownership through a bounded TERM grace period, then use group-first/direct KILL and reap the job;
- add deterministic coverage for the TERM-resistant pre-session race, running/completed job ownership, and password-free process arguments.

## Root cause

`setsid --wait` can become visible in `jobs -pr` before it establishes PGID = PID. Group-only termination can miss that launcher during the gap and then block in `wait`, which produced the first-attempt timeout in post-merge run `30786062951`.

## Safety

Direct PID signaling is permitted only after an exact `jobs -pr` ownership check. Completed or stale PIDs are not signaled. Password assertions run under `set -e`, so an earlier timeout cannot make the argv proof appear green.

## Validation

- focused cleanup/security tests: 6/6;
- single-CPU stress: 5/5;
- complete script suite: 639/639;
- toolchain, syntax, typecheck, targeted ESLint, Bash syntax, and diff checks: passed;
- independent exact-head review at `577143ee1bfccacf383a012897140156e15c5565`: APPROVE.

