### PR TITLE
Fix native Seerr proxy contracts for Android clients

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SeerrPartialRequestsGenerationFenceTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/SeerrPartialRequestsGenerationFenceTests.cs
@@ -21,6 +21,31 @@ public sealed class SeerrPartialRequestsGenerationFenceTests
     private const string SourceB = "http://source-b:5055";
 
     [Fact]
+    public async Task PartialSettings_UpstreamFailure_ServesOnlyTheExactLastKnownGeneration()
+    {
+        var provider = new FakePluginConfigProvider(Configuration(SourceA, "key-a"));
+        var handler = new SequentialSettingsHandler();
+        var cache = new SeerrCache(provider);
+        var controller = CreateController(provider, handler, cache, SourceA);
+
+        var fresh = Assert.IsType<OkObjectResult>(await controller.GetSeerrPartialRequestsSetting());
+        Assert.True(Property<bool>(fresh.Value, "partialRequestsEnabled"));
+        Assert.False(Property<bool>(fresh.Value, "enableSpecialEpisodes"));
+        Assert.False(Property<bool>(fresh.Value, "stale"));
+
+        handler.Fail = true;
+        var fallback = Assert.IsType<OkObjectResult>(await controller.GetSeerrPartialRequestsSetting());
+        Assert.True(Property<bool>(fallback.Value, "partialRequestsEnabled"));
+        Assert.False(Property<bool>(fallback.Value, "enableSpecialEpisodes"));
+        Assert.True(Property<bool>(fallback.Value, "stale"));
+
+        provider.Current = Configuration(SourceA, "key-b");
+        var changed = Assert.IsType<ObjectResult>(await controller.GetSeerrPartialRequestsSetting());
+        Assert.Equal(503, changed.StatusCode);
+        Assert.Equal("unreachable", Property<string>(changed.Value, "code"));
+    }
+
+    [Fact]
     public async Task PartialSettings_ConfigChangesWhileReadIsInFlight_UsesCapturedPairAndRejectsStaleReturn()
     {
         var initial = Configuration($"{SourceA}\n{SourceB}", "key-a");
@@ -74,6 +99,65 @@ public sealed class SeerrPartialRequestsGenerationFenceTests
         SeerrUrls = urls,
         SeerrApiKey = key,
     };
+
+    private static SeerrProxyController CreateController(
+        FakePluginConfigProvider provider,
+        HttpMessageHandler handler,
+        SeerrCache cache,
+        string sourceUrl)
+    {
+        var controller = new SeerrProxyController(
+            new RecordingHttpClientFactory(handler),
+            NullLogger<SeerrProxyController>.Instance,
+            new StubUserManager(),
+            cache,
+            provider,
+            new FixedSeerrClient(new SeerrUser
+            {
+                Id = 7,
+                JellyfinUserId = JellyfinUserId,
+                SourceUrl = sourceUrl,
+            }),
+            parentalFilter: null!,
+            spoilerPending: null!);
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(
+                    new[] { new Claim("Jellyfin-UserId", JellyfinUserId) },
+                    "TestAuth")),
+            },
+        };
+        return controller;
+    }
+
+    private static T Property<T>(object? value, string name)
+    {
+        Assert.NotNull(value);
+        return Assert.IsType<T>(value.GetType().GetProperty(name)!.GetValue(value));
+    }
+
+    private sealed class SequentialSettingsHandler : HttpMessageHandler
+    {
+        public bool Fail { get; set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+            => Task.FromResult(Fail
+                ? new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+                {
+                    Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+                }
+                : new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        """{"partialRequestsEnabled":true,"enableSpecialEpisodes":false}""",
+                        Encoding.UTF8,
+                        "application/json"),
+                });
+    }
 
     private sealed class BlockingSettingsHandler : HttpMessageHandler
     {

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Helpers/SeerrHttpHelperTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Helpers/SeerrHttpHelperTests.cs
@@ -50,6 +50,57 @@ public class SeerrHttpHelperTests
         Assert.Equal((int)status, error.HttpStatus);
     }
 
+    [Theory]
+    [InlineData(HttpStatusCode.Forbidden, "Movie Quota exceeded.", SeerrErrorCode.QuotaExceeded)]
+    [InlineData(HttpStatusCode.Forbidden, "This media is blocklisted.", SeerrErrorCode.Blocklisted)]
+    [InlineData(HttpStatusCode.Conflict, "Request already exists.", SeerrErrorCode.AlreadyRequested)]
+    public async Task ReadResponseAsync_RequestErrors_ClassifyOnlyTheBoundedSafeMessage(
+        HttpStatusCode status,
+        string message,
+        SeerrErrorCode expected)
+    {
+        using var response = JsonResponse(status, $$"""{"message":"{{message}}"}""");
+
+        var (json, error) = await SeerrHttpHelper.ReadResponseAsync(
+            response,
+            "http://seerr/api/v1/request");
+
+        Assert.Null(json);
+        Assert.Equal(expected, error!.Code);
+        Assert.DoesNotContain(message, error.UserMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ReadResponseAsync_NonRequest403_RemainsGenericForbidden()
+    {
+        using var response = JsonResponse(
+            HttpStatusCode.Forbidden,
+            """{"message":"Movie Quota exceeded."}""");
+
+        var (_, error) = await SeerrHttpHelper.ReadResponseAsync(
+            response,
+            "http://seerr/api/v1/settings/main");
+
+        Assert.Equal(SeerrErrorCode.Forbidden, error!.Code);
+    }
+
+    [Fact]
+    public async Task ReadResponseAsync_ChunkedErrorBody_StopsAtTheDedicatedSentinel()
+    {
+        var stream = new TrackingStream(new byte[SeerrHttpHelper.MaxErrorBodyBytes + 128]);
+        using var response = StreamingJsonResponse(stream);
+        response.StatusCode = HttpStatusCode.Forbidden;
+
+        var (json, error) = await SeerrHttpHelper.ReadResponseAsync(
+            response,
+            "http://seerr/api/v1/request");
+
+        Assert.Null(json);
+        Assert.Equal(SeerrErrorCode.ResponseTooLarge, error!.Code);
+        Assert.Equal(SeerrHttpHelper.MaxErrorBodyBytes + 1, stream.BytesRead);
+        Assert.True(stream.WasDisposed);
+    }
+
     [Fact]
     public async Task ReadResponseAsync_HtmlBody_IsClassifiedAsHtmlResponse()
     {

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformConcurrencyTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformConcurrencyTests.cs
@@ -351,7 +351,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
         private static async Task<HttpResponse> RunNegotiationAsync(int minimum, int maximum)
         {
             var controller = new PlatformDiscoveryController();
-            var action = Assert.IsType<OkObjectResult>(controller.Negotiate(minimum, maximum).Result);
+            controller.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() };
+            var action = Assert.IsType<OkObjectResult>((await controller.Negotiate(minimum, maximum)).Result);
             var method = typeof(PlatformDiscoveryController).GetMethod(nameof(PlatformDiscoveryController.Negotiate))!;
             return await RunAsync(method, action);
         }

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformDiscoveryControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformDiscoveryControllerTests.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Linq;
 using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http;
 using Xunit;
@@ -68,9 +70,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
         // A client that has dropped support for everything this host speaks. Its own
         // outcome, distinct from "unavailable" and from "denied".
         [InlineData(4, 9, false, null)]
-        public void Negotiate_PicksTheHighestCommonVersion(int clientMin, int clientMax, bool compatible, int? expected)
+        public async Task Negotiate_PicksTheHighestCommonVersion(int clientMin, int clientMax, bool compatible, int? expected)
         {
-            var response = Assert.IsType<OkObjectResult>(Controller().Negotiate(clientMin, clientMax).Result);
+            var response = Assert.IsType<OkObjectResult>((await Controller().Negotiate(clientMin, clientMax)).Result);
             var payload = Assert.IsType<PlatformNegotiationResponse>(response.Value);
 
             Assert.Equal(compatible, payload.Compatible);
@@ -78,11 +80,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
         }
 
         [Fact]
-        public void Negotiate_AlwaysEchoesTheHostRange()
+        public async Task Negotiate_AlwaysEchoesTheHostRange()
         {
             // Including on the incompatible path: a client that cannot talk to us should
             // be able to say WHY in its logs rather than just failing.
-            var response = Assert.IsType<OkObjectResult>(Controller().Negotiate(9, 9).Result);
+            var response = Assert.IsType<OkObjectResult>((await Controller().Negotiate(9, 9)).Result);
             var payload = Assert.IsType<PlatformNegotiationResponse>(response.Value);
 
             Assert.False(payload.Compatible);
@@ -91,15 +93,49 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
         }
 
         [Fact]
-        public void Negotiate_WithNoRangeSuppliedAssumesTheOldestProtocol()
+        public async Task Negotiate_WithNoRangeSuppliedAssumesTheOldestProtocol()
         {
             // A client that says nothing is treated as speaking v1 only. Assuming it
             // supports our newest would be optimistic about software we know nothing about.
-            var response = Assert.IsType<OkObjectResult>(Controller().Negotiate(null, null).Result);
+            var response = Assert.IsType<OkObjectResult>((await Controller().Negotiate(null, null)).Result);
             var payload = Assert.IsType<PlatformNegotiationResponse>(response.Value);
 
             Assert.True(payload.Compatible);
             Assert.Equal(PlatformConstants.ProtocolMinimum, payload.Protocol);
+        }
+
+        [Fact]
+        public async Task Negotiate_AdvertisesAvailabilityForTheAuthenticatedUser()
+        {
+            var userId = Guid.Parse("3f2504e0-4f89-41d3-9a0c-0305e82c3301");
+            var available = new RecordingAvailability(available: true);
+            var active = AuthenticatedController(available, userId);
+            var activePayload = Assert.IsType<PlatformNegotiationResponse>(
+                Assert.IsType<OkObjectResult>((await active.Negotiate(1, 1)).Result).Value);
+
+            var unlinked = AuthenticatedController(new RecordingAvailability(available: false), userId);
+            var unlinkedPayload = Assert.IsType<PlatformNegotiationResponse>(
+                Assert.IsType<OkObjectResult>((await unlinked.Negotiate(1, 1)).Result).Value);
+            var unavailablePayload = Assert.IsType<PlatformNegotiationResponse>(
+                Assert.IsType<OkObjectResult>((await Controller().Negotiate(1, 1)).Result).Value);
+
+            Assert.True(activePayload.SeerrAvailable);
+            Assert.Equal(userId, available.UserId);
+            Assert.False(unlinkedPayload.SeerrAvailable);
+            Assert.False(unavailablePayload.SeerrAvailable);
+        }
+
+        [Fact]
+        public async Task Negotiate_FailsClosedWhenAvailabilityLookupFails()
+        {
+            var controller = AuthenticatedController(
+                new RecordingAvailability(available: false, failure: new InvalidOperationException("provider unavailable")),
+                Guid.NewGuid());
+
+            var payload = Assert.IsType<PlatformNegotiationResponse>(
+                Assert.IsType<OkObjectResult>((await controller.Negotiate(1, 1)).Result).Value);
+
+            Assert.False(payload.SeerrAvailable);
         }
 
         [Fact]
@@ -110,6 +146,46 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
             // the plugin's own path, so it cannot collide with another plugin's routes -
             // Jellyfin applies no prefix convention of its own.
             Assert.Equal("JellyfinCanopy/Platform/v1", PlatformConstants.RoutePrefix);
+        }
+
+        private static PlatformDiscoveryController AuthenticatedController(
+            ISeerrUserAvailability availability,
+            Guid userId)
+        {
+            var controller = new PlatformDiscoveryController(availability)
+            {
+                ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() },
+            };
+            controller.HttpContext.Items["JellyfinCanopy.Platform.Actor"] = new PlatformActor(
+                userId,
+                false,
+                "correlation",
+                null,
+                null);
+            return controller;
+        }
+
+        private sealed class RecordingAvailability : ISeerrUserAvailability
+        {
+            private readonly bool _available;
+            private readonly Exception? _failure;
+
+            internal RecordingAvailability(bool available, Exception? failure = null)
+            {
+                _available = available;
+                _failure = failure;
+            }
+
+            internal Guid? UserId { get; private set; }
+
+            public Task<bool> IsAvailableAsync(Guid jellyfinUserId, CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                UserId = jellyfinUserId;
+                return _failure == null
+                    ? Task.FromResult(_available)
+                    : Task.FromException<bool>(_failure);
+            }
         }
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrPaginationIntegrationTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrPaginationIntegrationTests.cs
@@ -23,6 +23,55 @@ public class SeerrPaginationIntegrationTests
     private const string NormalizedJellyfinUserId = "3f2504e04f8941d39a0c0305e82c3301";
 
     [Fact]
+    public async Task UserAvailability_IsTrueOnlyForAResolvedCurrentUser()
+    {
+        var handler = new QueryAwareHandler(_ => Page(
+            page: 1,
+            totalPages: 1,
+            totalResults: 1,
+            new[] { UserRow(7, NormalizedJellyfinUserId) }));
+        var (client, _) = NewClient(handler);
+
+        var available = await ((ISeerrUserAvailability)client).IsAvailableAsync(
+            Guid.Parse(JellyfinUserId),
+            CancellationToken.None);
+
+        Assert.True(available);
+    }
+
+    [Fact]
+    public async Task UserAvailability_FailsClosedForABlockedUserWithoutProviderTraffic()
+    {
+        var handler = new QueryAwareHandler(_ => throw new Xunit.Sdk.XunitException("No request expected."));
+        var config = Config();
+        config.SeerrImportBlockedUsers = NormalizedJellyfinUserId;
+        var (client, _) = NewClient(handler, config);
+
+        var available = await ((ISeerrUserAvailability)client).IsAvailableAsync(
+            Guid.Parse(JellyfinUserId),
+            CancellationToken.None);
+
+        Assert.False(available);
+        Assert.Empty(handler.Requests);
+    }
+
+    [Fact]
+    public async Task UserAvailability_FailsClosedWhenTheIntegrationIsDisabled()
+    {
+        var handler = new QueryAwareHandler(_ => throw new Xunit.Sdk.XunitException("No request expected."));
+        var config = Config();
+        config.SeerrEnabled = false;
+        var (client, _) = NewClient(handler, config);
+
+        var available = await ((ISeerrUserAvailability)client).IsAvailableAsync(
+            Guid.Parse(JellyfinUserId),
+            CancellationToken.None);
+
+        Assert.False(available);
+        Assert.Empty(handler.Requests);
+    }
+
+    [Fact]
     public async Task GetSeerrUser_FindsUserBeyondFirstReportedPage()
     {
         var handler = new QueryAwareHandler(request =>

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrProxyProjectionTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrProxyProjectionTests.cs
@@ -1,0 +1,75 @@
+using System.Text.Json;
+using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services;
+
+public sealed class SeerrProxyProjectionTests
+{
+    [Fact]
+    public void Watchlist_AddsUniformIdWithoutRemovingTmdbIdOrReplacingExistingId()
+    {
+        const string json = """
+            {"results":[{"tmdbId":42},{"id":9,"tmdbId":99},{"tmdbId":"17"}]}
+            """;
+
+        Assert.True(SeerrProxyProjection.TryProject(
+            json,
+            "/api/v1/discover/watchlist?page=1",
+            out var projected));
+
+        using var document = JsonDocument.Parse(projected);
+        var results = document.RootElement.GetProperty("results");
+        Assert.Equal(42, results[0].GetProperty("id").GetInt32());
+        Assert.Equal(42, results[0].GetProperty("tmdbId").GetInt32());
+        Assert.Equal(9, results[1].GetProperty("id").GetInt32());
+        Assert.Equal("17", results[2].GetProperty("tmdbId").GetString());
+        Assert.Equal(17, results[2].GetProperty("id").GetInt32());
+    }
+
+    [Fact]
+    public void TvDetail_PreservesExplicitStatusAndDerivesMissing4kSeasonStates()
+    {
+        const string json = """
+            {
+              "mediaInfo": {
+                "seasons": [
+                  {"seasonNumber":1,"status4k":4},
+                  {"seasonNumber":2},
+                  {"seasonNumber":3},
+                  {"seasonNumber":4}
+                ],
+                "requests": [
+                  {"is4k":true,"status":1,"seasons":[{"seasonNumber":2}]},
+                  {"is4k":true,"status":2,"seasons":[{"seasonNumber":3}]},
+                  {"is4k":true,"status":5,"seasons":[{"seasonNumber":3}]},
+                  {"is4k":false,"status":5,"seasons":[{"seasonNumber":4}]}
+                ]
+              }
+            }
+            """;
+
+        Assert.True(SeerrProxyProjection.TryProject(json, "/api/v1/tv/123", out var projected));
+
+        using var document = JsonDocument.Parse(projected);
+        var seasons = document.RootElement.GetProperty("mediaInfo").GetProperty("seasons");
+        Assert.Equal(4, seasons[0].GetProperty("status4k").GetInt32());
+        Assert.Equal(2, seasons[1].GetProperty("status4k").GetInt32());
+        Assert.Equal(5, seasons[2].GetProperty("status4k").GetInt32());
+        Assert.Equal(1, seasons[3].GetProperty("status4k").GetInt32());
+    }
+
+    [Fact]
+    public void UnknownOrLegitimatelySparseShape_IsByteIdentical()
+    {
+        const string json = "{ \"results\" : [] }";
+
+        Assert.True(SeerrProxyProjection.TryProject(json, "/api/v1/search", out var unchanged));
+        Assert.Equal(json, unchanged);
+        Assert.True(SeerrProxyProjection.TryProject("{}", "/api/v1/discover/watchlist", out var watchlist));
+        Assert.Equal("{}", watchlist);
+        Assert.True(SeerrProxyProjection.TryProject("{}", "/api/v1/tv/123", out var tv));
+        Assert.Equal("{}", tv);
+        Assert.False(SeerrProxyProjection.TryProject("[]", "/api/v1/tv/123", out _));
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrRequestOutcomeTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrRequestOutcomeTests.cs
@@ -1,0 +1,127 @@
+using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services;
+
+public sealed class SeerrRequestOutcomeTests
+{
+    [Fact]
+    public void CreatedResponse_IsSubmittedAndRetainsSourceStatus()
+    {
+        var outcome = Convert(new ContentResult
+        {
+            StatusCode = 201,
+            ContentType = "application/json",
+            Content = "{\"id\":9}",
+        });
+
+        Assert.Equal("submitted", outcome.Outcome);
+        Assert.True(outcome.Submitted);
+        Assert.False(outcome.Retryable);
+        Assert.Equal(201, outcome.SourceStatus);
+    }
+
+    [Fact]
+    public void NoAvailableSeasons_IsAlreadyRequestedInsteadOfSubmitted()
+    {
+        var outcome = Convert(new ContentResult
+        {
+            StatusCode = 202,
+            Content = "{\"message\":\"No seasons available to request\"}",
+        });
+
+        Assert.Equal("already_requested", outcome.Outcome);
+        Assert.False(outcome.Submitted);
+    }
+
+    [Fact]
+    public void AcceptedRequestWithSpoilerIntentFailure_IsSubmittedAndNeverRetryable()
+    {
+        var outcome = Convert(new ObjectResult(new
+        {
+            error = true,
+            code = "seerr_accepted_spoiler_intent_failed",
+            seerrAccepted = true,
+            spoilerIntentRecorded = false,
+        })
+        {
+            StatusCode = 500,
+        });
+
+        Assert.Equal("submitted", outcome.Outcome);
+        Assert.True(outcome.Submitted);
+        Assert.False(outcome.Retryable);
+        Assert.Equal(500, outcome.SourceStatus);
+        Assert.Contains("Do not retry", outcome.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ProviderAuthenticationFailure_IsUnavailableWithoutInvitingBlindRetry()
+    {
+        var outcome = Convert(new ObjectResult(new
+        {
+            error = true,
+            code = "Unauthorized",
+        })
+        {
+            StatusCode = 401,
+        });
+
+        Assert.Equal("unavailable", outcome.Outcome);
+        Assert.False(outcome.Submitted);
+        Assert.False(outcome.Retryable);
+        Assert.Contains("administrator", outcome.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [MemberData(nameof(AuthorizationResults))]
+    public void AuthorizationResultTypes_AreDeniedWithTheirRealStatus(
+        IActionResult source,
+        int expectedStatus)
+    {
+        var outcome = Convert(source);
+
+        Assert.Equal("denied", outcome.Outcome);
+        Assert.False(outcome.Submitted);
+        Assert.False(outcome.Retryable);
+        Assert.Equal(expectedStatus, outcome.SourceStatus);
+    }
+
+    public static TheoryData<IActionResult, int> AuthorizationResults => new()
+    {
+        { new ForbidResult(), 403 },
+        { new UnauthorizedResult(), 401 },
+    };
+
+    [Theory]
+    [InlineData(429, "QuotaExceeded", "quota_exceeded", false)]
+    [InlineData(409, "AlreadyRequested", "already_requested", false)]
+    [InlineData(422, "Blocklisted", "blocked", false)]
+    [InlineData(403, "Forbidden", "denied", false)]
+    [InlineData(503, "unreachable", "unavailable", true)]
+    [InlineData(409, "mutation_configuration_changed", "unavailable", true)]
+    public void FailureResponses_MapToStableBodyIndependentOutcomes(
+        int status,
+        string code,
+        string expected,
+        bool retryable)
+    {
+        var outcome = Convert(new ObjectResult(new { error = true, code, message = "ignored" })
+        {
+            StatusCode = status,
+        });
+
+        Assert.Equal(expected, outcome.Outcome);
+        Assert.False(outcome.Submitted);
+        Assert.Equal(retryable, outcome.Retryable);
+        Assert.Equal(status, outcome.SourceStatus);
+    }
+
+    private static SeerrRequestOutcomeResponse Convert(IActionResult source)
+    {
+        var result = Assert.IsType<OkObjectResult>(SeerrRequestOutcome.FromProxyResult(source));
+        Assert.Equal(200, result.StatusCode);
+        return Assert.IsType<SeerrRequestOutcomeResponse>(result.Value);
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/SeerrProxyController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/SeerrProxyController.cs
@@ -272,6 +272,23 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             return await ProxySeerrRequest("/api/v1/request", HttpMethod.Post, requestBody.ToString());
         }
 
+        /// <summary>
+        /// Native-safe request submission. Jellyfin's Kotlin SDK intentionally
+        /// discards non-2xx bodies, so this compatibility route returns every
+        /// business outcome in a typed 200 envelope. Authentication remains
+        /// Jellyfin-owned and the existing status-preserving route is unchanged.
+        /// </summary>
+        [HttpPost("seerr/request/outcome")]
+        [Authorize]
+        public async Task<IActionResult> SeerrRequestOutcome([FromBody] JsonElement requestBody)
+        {
+            var result = await ProxySeerrRequest(
+                "/api/v1/request",
+                HttpMethod.Post,
+                requestBody.ToString()).ConfigureAwait(false);
+            return Jellyfin.Plugin.JellyfinCanopy.Services.Seerr.SeerrRequestOutcome.FromProxyResult(result);
+        }
+
         [HttpGet("seerr/request")]
         [Authorize]
         public Task<IActionResult> GetSeerrRequests([FromQuery] int take = 500, [FromQuery] int skip = 0, [FromQuery] string filter = "all")
@@ -1133,6 +1150,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
 
             var config = integration.Configuration!;
             var configurationRevision = integration.ConfigurationRevision;
+            var configurationIdentity = SeerrClient.BuildConfigurationIdentity(config);
             var configStamp = SeerrMutationConfigStamp.Capture(config, configurationRevision);
             var apiKey = integration.ApiKey;
             var configuredUrls = integration.Urls;
@@ -1199,6 +1217,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 });
             }
 
+            var settingsCacheKey = $"{configurationIdentity.Length}:{configurationIdentity}:{sourceUrl}";
+            var failureStatus = 503;
+            var failureCode = "unreachable";
+            var failureMessage = "Could not reach Seerr to read partial-requests setting.";
+
             var httpClient = Helpers.Seerr.SeerrHttpHelper.CreateClient(_httpClientFactory);
             var requestUri = $"{sourceUrl.TrimEnd('/')}/api/v1/settings/main";
             try
@@ -1232,21 +1255,45 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                         || !settings.RootElement.TryGetProperty("enableSpecialEpisodes", out var specialsProp)
                         || specialsProp.ValueKind is not (JsonValueKind.True or JsonValueKind.False))
                     {
-                        return StatusCode(502, new
+                        failureStatus = 502;
+                        failureCode = "settings_invalid";
+                        failureMessage = "Seerr returned invalid request settings.";
+                        _logger.LogWarning("Seerr returned incomplete request settings; checking the exact-generation last-known value.");
+                    }
+                    else
+                    {
+                        var partialRequestsEnabled = partialProp.ValueKind == JsonValueKind.True;
+                        var enableSpecialEpisodes = specialsProp.ValueKind == JsonValueKind.True;
+                        var snapshot = new SeerrRequestSettingsSnapshot(
+                            partialRequestsEnabled,
+                            enableSpecialEpisodes,
+                            DateTime.UtcNow,
+                            configurationRevision,
+                            configurationIdentity);
+                        _seerrCache.RequestSettingsCache.TrySet(
+                            settingsCacheKey,
+                            snapshot,
+                            out var publication);
+
+                        if (!IsConfigurationCurrent())
                         {
-                            error = true,
-                            code = "settings_invalid",
-                            message = "Seerr returned invalid request settings."
+                            _seerrCache.RequestSettingsCache.Remove(publication);
+                            return ConfigurationChanged();
+                        }
+
+                        _logger.LogInformation($"Seerr settings — partialRequests: {partialRequestsEnabled}, specialEpisodes: {enableSpecialEpisodes}");
+                        return Ok(new
+                        {
+                            partialRequestsEnabled,
+                            enableSpecialEpisodes,
+                            stale = false,
                         });
                     }
-
-                    var partialRequestsEnabled = partialProp.ValueKind == JsonValueKind.True;
-                    var enableSpecialEpisodes = specialsProp.ValueKind == JsonValueKind.True;
-                    _logger.LogInformation($"Seerr settings — partialRequests: {partialRequestsEnabled}, specialEpisodes: {enableSpecialEpisodes}");
-                    return Ok(new { partialRequestsEnabled, enableSpecialEpisodes });
                 }
-
-                _logger.LogWarning($"Failed to fetch Seerr settings from {sourceUrl}: code={error!.Code} status={error.HttpStatus} cf-ray={error.CfRay} — {error.Message}");
+                else
+                {
+                    _logger.LogWarning($"Failed to fetch Seerr settings from {sourceUrl}: code={error!.Code} status={error.HttpStatus} cf-ray={error.CfRay} — {error.Message}");
+                }
             }
             catch (OperationCanceledException) when (HttpContext.RequestAborted.IsCancellationRequested)
             {
@@ -1267,16 +1314,32 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 return ConfigurationChanged();
             }
 
+            if (_seerrCache.RequestSettingsCache.TryGetValue(settingsCacheKey, out var cached)
+                && cached.ConfigurationRevision == configurationRevision
+                && string.Equals(
+                    cached.ConfigurationIdentity,
+                    configurationIdentity,
+                    StringComparison.Ordinal))
+            {
+                _logger.LogWarning(
+                    "Serving the last known Seerr request settings for the exact current configuration generation after an upstream failure.");
+                return Ok(new
+                {
+                    partialRequestsEnabled = cached.PartialRequestsEnabled,
+                    enableSpecialEpisodes = cached.EnableSpecialEpisodes,
+                    stale = true,
+                });
+            }
+
             // Do not fail over to another Seerr identity domain and do not
-            // silently default to false on outage — that
-            // hides admin-configured "partial requests off" UX state. Return
-            // 503 so the frontend can keep last-known state.
-            _logger.LogWarning("Could not fetch settings from the resolved Seerr source — surfacing as 503 unreachable");
-            return StatusCode(503, new
+            // silently default to false. Without an exact-generation
+            // last-known value, the client must preserve its own state.
+            _logger.LogWarning("Could not fetch settings from the resolved Seerr source — surfacing the upstream settings failure");
+            return StatusCode(failureStatus, new
             {
                 error = true,
-                code = "unreachable",
-                message = "Could not reach Seerr to read partial-requests setting."
+                code = failureCode,
+                message = failureMessage,
             });
         }
 

--- a/Jellyfin.Plugin.JellyfinCanopy/Helpers/Seerr/SeerrHttpHelper.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Helpers/Seerr/SeerrHttpHelper.cs
@@ -22,6 +22,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
         UpstreamRedirect,
         Cloudflare5xx,
         UpstreamError,
+        QuotaExceeded,
+        AlreadyRequested,
+        Blocklisted,
         ParseError,
         ResponseTooLarge,
         Timeout,
@@ -69,6 +72,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
             SeerrErrorCode.UpstreamRedirect  => "Seerr is unreachable. Ask your administrator to check the connection.",
             SeerrErrorCode.Cloudflare5xx     => "Seerr is having connection issues. Please try again in a moment.",
             SeerrErrorCode.UpstreamError     => "Seerr returned an error. Please try again in a moment.",
+            SeerrErrorCode.QuotaExceeded     => "Your Seerr request quota has been reached.",
+            SeerrErrorCode.AlreadyRequested  => "This title is already requested.",
+            SeerrErrorCode.Blocklisted       => "This title is blocked by Seerr policy.",
             SeerrErrorCode.ParseError        => "Got an unexpected response from Seerr. Please try again in a moment.",
             SeerrErrorCode.ResponseTooLarge  => "Seerr returned too much data. Please try again in a moment.",
             SeerrErrorCode.Timeout           => "Seerr took too long to respond. Please try again in a moment.",
@@ -117,6 +123,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
         }
 
         internal const int MaxBodyBytes = 8 * 1024 * 1024;
+        internal const int MaxErrorBodyBytes = 64 * 1024;
         private const int ReadBufferBytes = 64 * 1024;
         private static readonly UTF8Encoding StrictUtf8 = new(false, true);
 
@@ -315,10 +322,28 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
                 });
             }
 
-            // Preserve status-specific upstream errors without requiring an
-            // error body to be buffered or even well-formed JSON.
+            // Error bodies are read through their own much smaller streaming
+            // cap. Seerr uses the same 403 for permission, quota, and
+            // blocklist failures; retaining only a bounded message long enough
+            // to classify those outcomes lets body-blind native SDKs receive a
+            // useful status/outcome without exposing the upstream body.
             if (!response.IsSuccessStatusCode)
             {
+                var (errorBytes, observedErrorBytes) = await ReadBoundedBodyAsync(
+                    response.Content,
+                    MaxErrorBodyBytes,
+                    ct).ConfigureAwait(false);
+                if (errorBytes == null)
+                {
+                    return (null, ResponseTooLarge(
+                        url,
+                        status,
+                        cfRay,
+                        MaxErrorBodyBytes,
+                        observedErrorBytes));
+                }
+
+                var upstreamMessage = TryReadErrorMessage(errorBytes);
                 if (status == 401)
                 {
                     return (null, new SeerrError
@@ -334,71 +359,52 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
 
                 if (status == 403)
                 {
+                    var classified = ClassifyRequestError(url, status, upstreamMessage);
                     return (null, new SeerrError
                     {
-                        Code = SeerrErrorCode.Forbidden,
+                        Code = classified,
                         HttpStatus = 403,
                         CfRay = cfRay,
                         Url = url,
-                        Message = "Seerr returned 403. Common causes: API key rotated, user lacks permission, or CSRF protection enabled in Seerr.",
-                        UserMessage = "Seerr declined the request. Ask your administrator to check your account permissions."
+                        Message = classified switch
+                        {
+                            SeerrErrorCode.QuotaExceeded => "Seerr rejected the request because its quota was exceeded.",
+                            SeerrErrorCode.Blocklisted => "Seerr rejected the request because the media is blocklisted.",
+                            _ => "Seerr returned 403. Common causes: API key rotated, user lacks permission, or CSRF protection enabled in Seerr.",
+                        },
+                        UserMessage = classified switch
+                        {
+                            SeerrErrorCode.QuotaExceeded => "Your Seerr request quota has been reached.",
+                            SeerrErrorCode.Blocklisted => "This title is blocked by Seerr policy.",
+                            _ => "Seerr declined the request. Ask your administrator to check your account permissions.",
+                        },
                     });
                 }
 
+                var requestError = ClassifyRequestError(url, status, upstreamMessage);
+
                 return (null, new SeerrError
                 {
-                    Code = SeerrErrorCode.UpstreamError,
+                    Code = requestError,
                     HttpStatus = status,
                     CfRay = cfRay,
                     Url = url,
-                    Message = $"Seerr returned {status} from {url}.",
-                    UserMessage = "Seerr returned an error. Please try again in a moment."
+                    Message = requestError == SeerrErrorCode.AlreadyRequested
+                        ? $"Seerr reported that the media is already requested ({status}) at {url}."
+                        : $"Seerr returned {status} from {url}.",
+                    UserMessage = requestError == SeerrErrorCode.AlreadyRequested
+                        ? "This title is already requested."
+                        : "Seerr returned an error. Please try again in a moment."
                 });
             }
 
-            var declaredLength = response.Content.Headers.ContentLength;
-            if (declaredLength > maxBodyBytes)
+            var (bodyBytes, observedBytes) = await ReadBoundedBodyAsync(
+                response.Content,
+                maxBodyBytes,
+                ct).ConfigureAwait(false);
+            if (bodyBytes == null)
             {
-                return (null, ResponseTooLarge(url, status, cfRay, maxBodyBytes, declaredLength));
-            }
-
-            byte[] bodyBytes;
-            var readBuffer = ArrayPool<byte>.Shared.Rent(Math.Min(ReadBufferBytes, maxBodyBytes + 1));
-            try
-            {
-                using var body = new MemoryStream(
-                    declaredLength.HasValue
-                        ? Math.Min(checked((int)declaredLength.Value), ReadBufferBytes)
-                        : Math.Min(8192, maxBodyBytes));
-                using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
-                while (true)
-                {
-                    var remainingWithSentinel = (long)maxBodyBytes + 1 - body.Length;
-                    if (remainingWithSentinel <= 0)
-                    {
-                        return (null, ResponseTooLarge(url, status, cfRay, maxBodyBytes, body.Length));
-                    }
-
-                    var readSize = (int)Math.Min(readBuffer.Length, remainingWithSentinel);
-                    var read = await stream.ReadAsync(readBuffer.AsMemory(0, readSize), ct).ConfigureAwait(false);
-                    if (read == 0)
-                    {
-                        break;
-                    }
-
-                    body.Write(readBuffer, 0, read);
-                }
-
-                if (body.Length > maxBodyBytes)
-                {
-                    return (null, ResponseTooLarge(url, status, cfRay, maxBodyBytes, body.Length));
-                }
-
-                bodyBytes = body.ToArray();
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(readBuffer);
+                return (null, ResponseTooLarge(url, status, cfRay, maxBodyBytes, observedBytes));
             }
 
             string bodyText;
@@ -421,6 +427,109 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Helpers.Seerr
             }
 
             return (bodyText, null);
+        }
+
+        private static async Task<(byte[]? Bytes, long? ObservedBytes)> ReadBoundedBodyAsync(
+            HttpContent content,
+            int maximumBytes,
+            CancellationToken cancellationToken)
+        {
+            var declaredLength = content.Headers.ContentLength;
+            if (declaredLength > maximumBytes)
+            {
+                return (null, declaredLength);
+            }
+
+            var readBuffer = ArrayPool<byte>.Shared.Rent(Math.Min(ReadBufferBytes, maximumBytes + 1));
+            try
+            {
+                using var body = new MemoryStream(
+                    declaredLength.HasValue
+                        ? Math.Min(checked((int)declaredLength.Value), ReadBufferBytes)
+                        : Math.Min(8192, maximumBytes));
+                using var stream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+                while (true)
+                {
+                    var remainingWithSentinel = (long)maximumBytes + 1 - body.Length;
+                    if (remainingWithSentinel <= 0)
+                    {
+                        return (null, body.Length);
+                    }
+
+                    var readSize = (int)Math.Min(readBuffer.Length, remainingWithSentinel);
+                    var read = await stream.ReadAsync(
+                        readBuffer.AsMemory(0, readSize),
+                        cancellationToken).ConfigureAwait(false);
+                    if (read == 0)
+                    {
+                        break;
+                    }
+
+                    body.Write(readBuffer, 0, read);
+                }
+
+                return body.Length > maximumBytes
+                    ? (null, body.Length)
+                    : (body.ToArray(), body.Length);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(readBuffer);
+            }
+        }
+
+        private static string? TryReadErrorMessage(byte[] body)
+        {
+            try
+            {
+                using var document = JsonDocument.Parse(body);
+                return document.RootElement.ValueKind == JsonValueKind.Object
+                    && document.RootElement.TryGetProperty("message", out var message)
+                    && message.ValueKind == JsonValueKind.String
+                        ? message.GetString()
+                        : null;
+            }
+            catch (JsonException)
+            {
+                return null;
+            }
+        }
+
+        private static SeerrErrorCode ClassifyRequestError(
+            string url,
+            int status,
+            string? message)
+        {
+            if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)
+                || !string.Equals(
+                    uri.AbsolutePath.TrimEnd('/'),
+                    "/api/v1/request",
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                return status == 403
+                    ? SeerrErrorCode.Forbidden
+                    : SeerrErrorCode.UpstreamError;
+            }
+
+            if (status == 409)
+            {
+                return SeerrErrorCode.AlreadyRequested;
+            }
+
+            if (message?.Contains("quota", StringComparison.OrdinalIgnoreCase) == true
+                && message.Contains("exceed", StringComparison.OrdinalIgnoreCase))
+            {
+                return SeerrErrorCode.QuotaExceeded;
+            }
+
+            if (message?.Contains("blocklist", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                return SeerrErrorCode.Blocklisted;
+            }
+
+            return status == 403
+                ? SeerrErrorCode.Forbidden
+                : SeerrErrorCode.UpstreamError;
         }
 
         private static SeerrError ResponseTooLarge(

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformDiscoveryController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformDiscoveryController.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -10,6 +14,19 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
     [Route(PlatformConstants.RoutePrefix)]
     public class PlatformDiscoveryController : PlatformControllerBase
     {
+        private readonly ISeerrUserAvailability? _seerrAvailability;
+
+        /// <summary>Creates the controller for framework activation.</summary>
+        public PlatformDiscoveryController(ISeerrUserAvailability seerrAvailability)
+        {
+            _seerrAvailability = seerrAvailability ?? throw new ArgumentNullException(nameof(seerrAvailability));
+        }
+
+        /// <summary>Creates a fail-closed controller for direct compatibility tests.</summary>
+        public PlatformDiscoveryController()
+        {
+        }
+
         /// <summary>
         /// Anonymous availability probe.
         ///
@@ -43,10 +60,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
         /// </summary>
         [HttpGet("negotiate")]
         [PlatformCacheable]
-        public ActionResult<PlatformNegotiationResponse> Negotiate(
+        public async Task<ActionResult<PlatformNegotiationResponse>> Negotiate(
             [FromQuery] int? protocolMinimum,
             [FromQuery] int? protocolMaximum)
         {
+            var seerrAvailable = await GetSeerrAvailabilityAsync(HttpContext.RequestAborted).ConfigureAwait(false);
             var clientMinimum = protocolMinimum ?? PlatformConstants.ProtocolMinimum;
             var clientMaximum = protocolMaximum ?? PlatformConstants.ProtocolMinimum;
 
@@ -64,6 +82,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
                     Compatible = false,
                     HostProtocolMinimum = PlatformConstants.ProtocolMinimum,
                     HostProtocolMaximum = PlatformConstants.ProtocolMaximum,
+                    SeerrAvailable = seerrAvailable,
                 });
             }
 
@@ -73,7 +92,33 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
                 Protocol = negotiated,
                 HostProtocolMinimum = PlatformConstants.ProtocolMinimum,
                 HostProtocolMaximum = PlatformConstants.ProtocolMaximum,
+                SeerrAvailable = seerrAvailable,
             });
+        }
+
+        private async Task<bool> GetSeerrAvailabilityAsync(CancellationToken cancellationToken)
+        {
+            if (_seerrAvailability == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                return await _seerrAvailability.IsAvailableAsync(
+                    Actor.UserId,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch
+            {
+                // Availability is an additive rendering hint. Provider failures and
+                // configuration races fail closed without breaking negotiation.
+                return false;
+            }
         }
     }
 
@@ -104,5 +149,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
 
         /// <summary>Echoed so a client can report the mismatch usefully rather than just failing.</summary>
         public int HostProtocolMaximum { get; set; }
+
+        /// <summary>
+        /// Whether this authenticated Jellyfin user currently has a usable,
+        /// non-blocked Seerr link. This avoids an extra user-status round trip;
+        /// each Seerr route still repeats its current authorization checks.
+        /// </summary>
+        public bool SeerrAvailable { get; set; }
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
@@ -174,6 +174,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy
                 services.GetRequiredService<Services.Seerr.SeerrClient>());
             serviceCollection.AddSingleton<Services.Seerr.ISeerrMediaRequestAdmission>(services =>
                 services.GetRequiredService<Services.Seerr.SeerrClient>());
+            serviceCollection.AddSingleton<Services.Seerr.ISeerrUserAvailability>(services =>
+                services.GetRequiredService<Services.Seerr.SeerrClient>());
             // Shared SSRF-guarded Sonarr/Radarr fetch plumbing for the Arr controllers.
             serviceCollection.AddSingleton<Services.Arr.ArrFetchService>();
             // Bounded, privacy-safe lifecycle/history owner shared by Requests and admin status.

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/ISeerrCache.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/ISeerrCache.cs
@@ -31,6 +31,17 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
     }
 
     /// <summary>
+    /// Last authoritative Seerr request-shape settings for one exact source
+    /// and Canopy configuration generation.
+    /// </summary>
+    public sealed record SeerrRequestSettingsSnapshot(
+        bool PartialRequestsEnabled,
+        bool EnableSpecialEpisodes,
+        DateTime CachedAt,
+        long ConfigurationRevision,
+        string ConfigurationIdentity);
+
+    /// <summary>
     /// Process-wide Seerr/TMDB caches shared by the JellyfinCanopy feature
     /// controllers and the Seerr user-import task. Formerly the static
     /// <c>Controllers.SeerrCaches</c> holder; now a DI singleton so consumers
@@ -111,6 +122,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
         object Public4kSettingsCacheLock { get; }
 
         TimeSpan Public4kSettingsCacheTtl { get; }
+
+        /// <summary>
+        /// Last known valid <c>/api/v1/settings/main</c> request-shape flags,
+        /// keyed by exact source URL plus configuration identity. Entries are
+        /// bounded and cleared on every configuration save; they intentionally
+        /// outlive a short upstream outage.
+        /// </summary>
+        BoundedTtlCache<string, SeerrRequestSettingsSnapshot> RequestSettingsCache { get; }
 
         /// <summary>Cache for request-page TMDB enrichments (movie/tv detail lookups via Seerr).</summary>
         BoundedTtlCache<string, (TmdbEnrichmentResult Data, DateTime CachedAt, long ConfigurationRevision)> TmdbEnrichmentCache { get; }

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/ISeerrClient.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/ISeerrClient.cs
@@ -9,6 +9,19 @@ using Microsoft.AspNetCore.Mvc;
 namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
 {
     /// <summary>
+    /// Narrow authenticated availability seam for native clients. It deliberately
+    /// exposes neither the generic proxy nor Seerr's provider-local user identity.
+    /// </summary>
+    public interface ISeerrUserAvailability
+    {
+        /// <summary>
+        /// Returns whether the current Jellyfin user has a usable, non-blocked Seerr
+        /// link under the current integration generation.
+        /// </summary>
+        Task<bool> IsAvailableAsync(Guid jellyfinUserId, CancellationToken cancellationToken);
+    }
+
+    /// <summary>
     /// The acting caller for proxied Seerr operations. Resolved by the
     /// controller from the authenticated principal (never from caller-controlled
     /// headers) and passed down so the singleton client stays HttpContext-free.

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrCache.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrCache.cs
@@ -27,6 +27,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
         internal const int CertificationMaximumEntries = 4096;
         internal const long CertificationMaximumBytes = 16 * 1024 * 1024;
         internal const int Public4kMaximumEntries = 64;
+        internal const int RequestSettingsMaximumEntries = 64;
 
         private readonly IPluginConfigProvider _configProvider;
         private readonly object _importThrottleLock = new();
@@ -70,6 +71,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                 maximumWeight: Public4kMaximumEntries, // unit-weight entries
                 comparer: StringComparer.Ordinal,
                 defaultTtl: () => Public4kSettingsCacheTtl);
+            RequestSettingsCache = new(
+                maximumEntries: RequestSettingsMaximumEntries,
+                maximumWeight: RequestSettingsMaximumEntries, // unit-weight entries
+                comparer: StringComparer.Ordinal,
+                // Configuration saves explicitly clear this cache. The long
+                // TTL makes it a last-known-good value across provider outages,
+                // not another short response cache.
+                defaultTtl: () => TimeSpan.FromDays(3650));
             TmdbEnrichmentCache = new(
                 TmdbEnrichmentMaximumEntries,
                 TmdbEnrichmentMaximumBytes,
@@ -168,6 +177,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
         public object Public4kSettingsCacheLock { get; } = new();
 
         public TimeSpan Public4kSettingsCacheTtl { get; } = TimeSpan.FromMinutes(5);
+
+        public BoundedTtlCache<string, SeerrRequestSettingsSnapshot> RequestSettingsCache { get; }
 
         // Cache for request-page TMDB enrichments (movie/tv detail lookups via Seerr)
         public BoundedTtlCache<string, (TmdbEnrichmentResult Data, DateTime CachedAt, long ConfigurationRevision)> TmdbEnrichmentCache { get; }
@@ -313,6 +324,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
             // Flush the cached 4K capability so a changed Seerr URL / key
             // re-resolves movie4kEnabled/series4kEnabled immediately.
             lock (Public4kSettingsCacheLock) { Public4kSettingsCache.Clear(); }
+            RequestSettingsCache.Clear();
             lock (_importThrottleLock)
             {
                 _lastManualImport = DateTime.MinValue;

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrClient.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrClient.cs
@@ -32,7 +32,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
     /// shared <see cref="ISeerrCache"/> user caches so every caller format
     /// (dashed/N/upper) hits the same entry.
     /// </summary>
-    public sealed class SeerrClient : ISeerrClient, ISeerrMediaRequestAdmission
+    public sealed class SeerrClient : ISeerrClient, ISeerrMediaRequestAdmission, ISeerrUserAvailability
     {
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly ILogger<SeerrClient> _logger;
@@ -147,6 +147,23 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                     resolution.User.Id,
                     resolution.User.Permissions,
                     source));
+        }
+
+        async Task<bool> ISeerrUserAvailability.IsAvailableAsync(
+            Guid jellyfinUserId,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var integration = SeerrIntegrationPolicy.Capture(_configProvider);
+            if (!integration.IsActive)
+            {
+                return false;
+            }
+
+            var resolution = await ResolveSeerrUser(
+                jellyfinUserId.ToString("D"),
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+            return integration.IsCurrent(_configProvider) && resolution.IsFound;
         }
 
         Task<Seerr4kCapability> ISeerrMediaRequestAdmission.Get4kCapabilityAsync(
@@ -2473,7 +2490,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                     if (content != null) _logger.LogDebug($"Request body: {content}");
 
                     IActionResult? spoilerIntentFailure = null;
-                    var (json, error, _) = await SeerrHttpHelper.SendAndReadJsonAsync(
+                    var (json, error, upstreamStatus) = await SeerrHttpHelper.SendAndReadJsonAsync(
                         httpClient,
                         request,
                         requestUri,
@@ -2519,6 +2536,19 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                             })
                             { StatusCode = 409 };
                         }
+
+                        if (!SeerrProxyProjection.TryProject(json, apiPath, out var projectedJson))
+                        {
+                            return new ObjectResult(new
+                            {
+                                error = true,
+                                code = "proxy_projection_invalid",
+                                message = "Seerr returned an unexpected response shape. Please try again."
+                            })
+                            { StatusCode = 502 };
+                        }
+
+                        json = projectedJson;
 
                         // Cache only complete, size-bounded, parsed JSON 2xx responses.
                         // SendAndReadJsonAsync also prevents HTML challenge pages from
@@ -2582,6 +2612,15 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                             { StatusCode = 409 };
                         }
 
+                        if (filtered is ContentResult contentResult)
+                        {
+                            // Preserve Seerr's successful mutation status. In
+                            // particular, 202 means no new TV seasons were
+                            // available and is classified by the native outcome
+                            // route rather than being mistaken for a submission.
+                            contentResult.StatusCode = upstreamStatus;
+                        }
+
                         return filtered;
                     }
 
@@ -2597,6 +2636,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
                         SeerrErrorCode.Cloudflare5xx => 502,
                         SeerrErrorCode.Unauthorized => 401,
                         SeerrErrorCode.Forbidden => 403,
+                        SeerrErrorCode.QuotaExceeded => 429,
+                        SeerrErrorCode.AlreadyRequested => 409,
+                        SeerrErrorCode.Blocklisted => 422,
                         _ => error.HttpStatus > 0 ? error.HttpStatus : 502,
                     };
                     // admins keep the upstream URL in the response;

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrProxyProjection.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrProxyProjection.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
+{
+    /// <summary>
+    /// Applies the small compatibility projections owned by Canopy's Seerr
+    /// proxy. The upstream body has already passed the shared streaming byte
+    /// limit and JSON parser before it reaches this class.
+    /// </summary>
+    internal static class SeerrProxyProjection
+    {
+        private const int MediaStatusUnknown = 1;
+        private const int MediaStatusPending = 2;
+        private const int MediaStatusProcessing = 3;
+        private const int MediaStatusAvailable = 5;
+
+        /// <summary>
+        /// Normalizes only exact, reviewed response shapes. Unknown routes are
+        /// returned byte-for-byte so this layer cannot become a generic JSON
+        /// rewriting surface.
+        /// </summary>
+        internal static bool TryProject(string json, string apiPath, out string projected)
+        {
+            projected = json;
+            var path = PathOnly(apiPath);
+            var isWatchlist = string.Equals(
+                path,
+                "/api/v1/discover/watchlist",
+                StringComparison.OrdinalIgnoreCase);
+            var isTvDetail = IsExactTvDetailPath(path);
+            if (!isWatchlist && !isTvDetail)
+            {
+                return true;
+            }
+
+            try
+            {
+                if (JsonNode.Parse(json) is not JsonObject root)
+                {
+                    return false;
+                }
+
+                bool changed;
+                var valid = isWatchlist
+                    ? TryAddUniformWatchlistIds(root, out changed)
+                    : TryAddPerSeason4kStatus(root, out changed);
+                if (!valid)
+                {
+                    return false;
+                }
+
+                if (changed)
+                {
+                    projected = root.ToJsonString();
+                }
+
+                return true;
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+            catch (InvalidOperationException)
+            {
+                return false;
+            }
+        }
+
+        private static bool TryAddUniformWatchlistIds(JsonObject root, out bool changed)
+        {
+            changed = false;
+            if (root["results"] is not JsonArray results)
+            {
+                // Keep compatibility with upstream variants and test doubles
+                // that omit the collection on an otherwise valid response.
+                return true;
+            }
+
+            foreach (var node in results)
+            {
+                if (node is not JsonObject item
+                    || item.ContainsKey("id")
+                    || !TryReadPositiveInt(item["tmdbId"], out var tmdbId))
+                {
+                    continue;
+                }
+
+                // Retain tmdbId for every existing consumer and add the same
+                // id key used by search/discovery rows.
+                item["id"] = tmdbId;
+                changed = true;
+            }
+
+            return true;
+        }
+
+        private static bool TryAddPerSeason4kStatus(JsonObject root, out bool changed)
+        {
+            changed = false;
+            if (root["mediaInfo"] is not JsonObject mediaInfo
+                || mediaInfo["seasons"] is not JsonArray seasons)
+            {
+                // Unrequested shows can legitimately have no mediaInfo yet.
+                // There is no season-owned state to project in that shape.
+                return true;
+            }
+
+            var derived = Derive4kRequestStates(mediaInfo["requests"] as JsonArray);
+            foreach (var node in seasons)
+            {
+                if (node is not JsonObject season
+                    || TryReadPositiveInt(season["status4k"], out _))
+                {
+                    continue;
+                }
+
+                var status = MediaStatusUnknown;
+                if (TryReadPositiveInt(season["seasonNumber"], out var seasonNumber)
+                    && derived.TryGetValue(seasonNumber, out var requestStatus))
+                {
+                    status = requestStatus;
+                }
+
+                season["status4k"] = status;
+                changed = true;
+            }
+
+            return true;
+        }
+
+        private static Dictionary<int, int> Derive4kRequestStates(JsonArray? requests)
+        {
+            var states = new Dictionary<int, int>();
+            if (requests == null)
+            {
+                return states;
+            }
+
+            foreach (var node in requests)
+            {
+                if (node is not JsonObject request
+                    || !IsTrue(request["is4k"])
+                    || request["seasons"] is not JsonArray requestSeasons)
+                {
+                    continue;
+                }
+
+                TryReadPositiveInt(request["status"], out var parentStatus);
+                foreach (var seasonNode in requestSeasons)
+                {
+                    if (seasonNode is not JsonObject requestSeason
+                        || !TryReadPositiveInt(requestSeason["seasonNumber"], out var seasonNumber))
+                    {
+                        continue;
+                    }
+
+                    var requestStatus = TryReadPositiveInt(requestSeason["status"], out var childStatus)
+                        ? childStatus
+                        : parentStatus;
+                    var mediaStatus = RequestStatusToMediaStatus(requestStatus);
+                    if (mediaStatus == MediaStatusUnknown)
+                    {
+                        continue;
+                    }
+
+                    if (!states.TryGetValue(seasonNumber, out var current)
+                        || StatusPriority(mediaStatus) > StatusPriority(current))
+                    {
+                        states[seasonNumber] = mediaStatus;
+                    }
+                }
+            }
+
+            return states;
+        }
+
+        private static int RequestStatusToMediaStatus(int requestStatus) => requestStatus switch
+        {
+            // Seerr MediaRequestStatus: pending=1, approved=2,
+            // declined=3, failed=4, completed=5.
+            1 => MediaStatusPending,
+            2 => MediaStatusProcessing,
+            5 => MediaStatusAvailable,
+            _ => MediaStatusUnknown,
+        };
+
+        private static int StatusPriority(int status) => status switch
+        {
+            MediaStatusAvailable => 3,
+            MediaStatusProcessing => 2,
+            MediaStatusPending => 1,
+            _ => 0,
+        };
+
+        private static bool IsTrue(JsonNode? node)
+        {
+            if (node is not JsonValue value)
+            {
+                return false;
+            }
+
+            if (value.TryGetValue<bool>(out var boolean))
+            {
+                return boolean;
+            }
+
+            if (value.TryGetValue<int>(out var number))
+            {
+                return number != 0;
+            }
+
+            return value.TryGetValue<string>(out var text)
+                && (string.Equals(text, "true", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(text, "1", StringComparison.Ordinal));
+        }
+
+        private static bool TryReadPositiveInt(JsonNode? node, out int value)
+        {
+            value = 0;
+            if (node is not JsonValue jsonValue)
+            {
+                return false;
+            }
+
+            if (jsonValue.TryGetValue<int>(out value))
+            {
+                return value > 0;
+            }
+
+            return jsonValue.TryGetValue<string>(out var text)
+                && int.TryParse(text, NumberStyles.None, CultureInfo.InvariantCulture, out value)
+                && value > 0;
+        }
+
+        private static bool IsExactTvDetailPath(string path)
+        {
+            const string prefix = "/api/v1/tv/";
+            return path.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+                && int.TryParse(
+                    path.Substring(prefix.Length),
+                    NumberStyles.None,
+                    CultureInfo.InvariantCulture,
+                    out var tmdbId)
+                && tmdbId > 0;
+        }
+
+        private static string PathOnly(string apiPath)
+        {
+            var query = apiPath.IndexOf('?', StringComparison.Ordinal);
+            return query >= 0 ? apiPath.Substring(0, query) : apiPath;
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrRequestOutcome.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrRequestOutcome.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
+{
+    /// <summary>
+    /// Status-code-independent request result for native SDKs that discard
+    /// non-success response bodies.
+    /// </summary>
+    public sealed class SeerrRequestOutcomeResponse
+    {
+        /// <summary>
+        /// Stable outcome token: submitted, already_requested, quota_exceeded,
+        /// blocked, denied, unavailable, or failed.
+        /// </summary>
+        public string Outcome { get; set; } = "failed";
+
+        /// <summary>Whether Seerr accepted a new media request.</summary>
+        public bool Submitted { get; set; }
+
+        /// <summary>Whether retrying later can reasonably change the result.</summary>
+        public bool Retryable { get; set; }
+
+        /// <summary>
+        /// The status produced by the compatibility route before normalization.
+        /// This is diagnostic only; callers branch on <see cref="Outcome"/>.
+        /// </summary>
+        public int SourceStatus { get; set; }
+
+        /// <summary>Safe user-facing summary with no provider URL or credential.</summary>
+        public string Message { get; set; } = "The request could not be completed.";
+    }
+
+    internal static class SeerrRequestOutcome
+    {
+        internal static IActionResult FromProxyResult(IActionResult result)
+        {
+            ArgumentNullException.ThrowIfNull(result);
+            var (status, body) = ReadResult(result);
+            var code = ReadString(body, "code");
+            var message = ReadString(body, "message");
+
+            if (EqualsCode(code, "seerr_accepted_spoiler_intent_failed")
+                && ReadBoolean(body, "seerrAccepted") == true)
+            {
+                return Ok(
+                    "submitted",
+                    submitted: true,
+                    retryable: false,
+                    status,
+                    "Request accepted, but Spoiler Guard needs manual setup. Do not retry the request.");
+            }
+
+            if (status >= 200 && status < 300)
+            {
+                if (status == 202
+                    && message?.Contains(
+                        "No seasons available to request",
+                        StringComparison.OrdinalIgnoreCase) == true)
+                {
+                    return Ok(
+                        "already_requested",
+                        submitted: false,
+                        retryable: false,
+                        status,
+                        "All selected seasons are already requested or available.");
+                }
+
+                return Ok(
+                    "submitted",
+                    submitted: true,
+                    retryable: false,
+                    status,
+                    "Request submitted.");
+            }
+
+            if (EqualsCode(code, "QuotaExceeded") || status == 429)
+            {
+                return Ok(
+                    "quota_exceeded",
+                    submitted: false,
+                    retryable: false,
+                    status,
+                    "Your Seerr request quota has been reached.");
+            }
+
+            if (EqualsCode(code, "AlreadyRequested")
+                || (status == 409 && !IsRetryableConflict(code)))
+            {
+                return Ok(
+                    "already_requested",
+                    submitted: false,
+                    retryable: false,
+                    status,
+                    "This title is already requested.");
+            }
+
+            if (EqualsCode(code, "Blocklisted") || EqualsCode(code, "blocked"))
+            {
+                return Ok(
+                    "blocked",
+                    submitted: false,
+                    retryable: false,
+                    status,
+                    "This request is blocked by server policy.");
+            }
+
+            if (EqualsCode(code, "Unauthorized"))
+            {
+                return Ok(
+                    "unavailable",
+                    submitted: false,
+                    retryable: false,
+                    status,
+                    "The Seerr connection requires administrator attention.");
+            }
+
+            if (status == 401 || status == 403 || IsDeniedCode(code))
+            {
+                return Ok(
+                    "denied",
+                    submitted: false,
+                    retryable: false,
+                    status,
+                    "You do not have permission to make this request.");
+            }
+
+            if (status is 408 or 502 or 503 or 504
+                || EqualsCode(code, "unreachable")
+                || EqualsCode(code, "unavailable")
+                || IsRetryableConflict(code))
+            {
+                return Ok(
+                    "unavailable",
+                    submitted: false,
+                    retryable: true,
+                    status,
+                    "Seerr is temporarily unavailable. Please try again.");
+            }
+
+            return Ok(
+                "failed",
+                submitted: false,
+                retryable: status >= 500,
+                status,
+                "The request could not be completed.");
+        }
+
+        private static OkObjectResult Ok(
+            string outcome,
+            bool submitted,
+            bool retryable,
+            int status,
+            string message)
+            => new(new SeerrRequestOutcomeResponse
+            {
+                Outcome = outcome,
+                Submitted = submitted,
+                Retryable = retryable,
+                SourceStatus = status,
+                Message = message,
+            });
+
+        private static (int Status, JsonElement? Body) ReadResult(IActionResult result)
+        {
+            try
+            {
+                return result switch
+                {
+                    ContentResult content => (
+                        content.StatusCode ?? 200,
+                        string.IsNullOrWhiteSpace(content.Content)
+                            ? null
+                            : ParseContent(content.Content)),
+                    ObjectResult value => (
+                        value.StatusCode ?? 200,
+                        value.Value == null
+                            ? null
+                            : JsonSerializer.SerializeToElement(value.Value)),
+                    ForbidResult => (403, null),
+                    UnauthorizedResult => (401, null),
+                    StatusCodeResult status => (status.StatusCode, null),
+                    _ => (500, null),
+                };
+            }
+            catch (JsonException)
+            {
+                return (500, null);
+            }
+            catch (NotSupportedException)
+            {
+                return (500, null);
+            }
+        }
+
+        private static JsonElement ParseContent(string content)
+        {
+            using var document = JsonDocument.Parse(content);
+            return document.RootElement.Clone();
+        }
+
+        private static string? ReadString(JsonElement? body, string property)
+        {
+            if (!body.HasValue
+                || body.Value.ValueKind != JsonValueKind.Object
+                || !body.Value.TryGetProperty(property, out var value)
+                || value.ValueKind != JsonValueKind.String)
+            {
+                return null;
+            }
+
+            return value.GetString();
+        }
+
+        private static bool? ReadBoolean(JsonElement? body, string property)
+        {
+            if (!body.HasValue
+                || body.Value.ValueKind != JsonValueKind.Object
+                || !body.Value.TryGetProperty(property, out var value)
+                || value.ValueKind is not (JsonValueKind.True or JsonValueKind.False))
+            {
+                return null;
+            }
+
+            return value.GetBoolean();
+        }
+
+        private static bool IsDeniedCode(string? code)
+            => EqualsCode(code, "no_request_permission")
+                || EqualsCode(code, "no_4k_request_permission")
+                || EqualsCode(code, "4k_requests_disabled");
+
+        private static bool IsRetryableConflict(string? code)
+            => EqualsCode(code, "mutation_configuration_changed")
+                || EqualsCode(code, "mutation_identity_changed")
+                || EqualsCode(code, "mutation_identity_unavailable");
+
+        private static bool EqualsCode(string? actual, string expected)
+            => string.Equals(actual, expected, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/api.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/api.ts
@@ -74,6 +74,7 @@ export type SeerrRequestSettings =
         available: true;
         partialRequestsEnabled: boolean;
         enableSpecialEpisodes: boolean;
+        stale: boolean;
     }
     | {
         available: false;
@@ -1048,14 +1049,14 @@ api.fetchRequestSettings = async function() {
         return {
             available: true,
             partialRequestsEnabled: result.partialRequestsEnabled,
-            enableSpecialEpisodes: result.enableSpecialEpisodes
+            enableSpecialEpisodes: result.enableSpecialEpisodes,
+            stale: result.stale === true
         };
     } catch (error: any) {
         console.warn(`${logPrefix} Failed to fetch request settings:`, error);
-        // These settings determine whether a click means selected seasons or
-        // the whole show. No source/config-scoped last-good cache exists in the
-        // browser, so an outage must remain unavailable rather than silently
-        // changing the mutation shape.
+        // The server may safely return an exact source/config-generation
+        // last-known value with stale=true. A rejected request means it has no
+        // such authoritative fallback, so the mutation shape stays unavailable.
         return { available: false };
     }
 };

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/request-settings-fail-closed.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/request-settings-fail-closed.test.ts
@@ -78,6 +78,7 @@ describe('Seerr request settings fail closed', () => {
             available: true,
             partialRequestsEnabled: true,
             enableSpecialEpisodes: true,
+            stale: false,
         });
         await expect(jc().seerrAPI.fetchRequestSettings()).resolves.toEqual({ available: false });
     });
@@ -89,6 +90,22 @@ describe('Seerr request settings fail closed', () => {
             available: true,
             partialRequestsEnabled: false,
             enableSpecialEpisodes: false,
+            stale: false,
+        });
+    });
+
+    it('surfaces an exact-generation server fallback as stale but available', async () => {
+        fetchMock.mockResolvedValue({
+            partialRequestsEnabled: true,
+            enableSpecialEpisodes: false,
+            stale: true,
+        });
+
+        await expect(jc().seerrAPI.fetchRequestSettings()).resolves.toEqual({
+            available: true,
+            partialRequestsEnabled: true,
+            enableSpecialEpisodes: false,
+            stale: true,
         });
     });
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/season-modal-refresh.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/season-modal-refresh.test.ts
@@ -59,6 +59,7 @@ describe('season modal refresh lifecycle', () => {
                 available: true,
                 partialRequestsEnabled: true,
                 enableSpecialEpisodes: false,
+                stale: false,
             }),
             fetchTvShowDetails,
             fetchTvSeasonDetails,

--- a/contracts/platform/v1/fixtures/negotiate.200.compatible.json
+++ b/contracts/platform/v1/fixtures/negotiate.200.compatible.json
@@ -2,5 +2,6 @@
   "Compatible": true,
   "Protocol": 1,
   "HostProtocolMinimum": 1,
-  "HostProtocolMaximum": 1
+  "HostProtocolMaximum": 1,
+  "SeerrAvailable": false
 }

--- a/contracts/platform/v1/fixtures/negotiate.200.incompatible.json
+++ b/contracts/platform/v1/fixtures/negotiate.200.incompatible.json
@@ -2,5 +2,6 @@
   "Compatible": false,
   "Protocol": null,
   "HostProtocolMinimum": 1,
-  "HostProtocolMaximum": 1
+  "HostProtocolMaximum": 1,
+  "SeerrAvailable": false
 }

--- a/contracts/platform/v1/openapi.json
+++ b/contracts/platform/v1/openapi.json
@@ -1056,6 +1056,10 @@
             "type": "integer",
             "format": "int32",
             "description": "Echoed so a client can report a mismatch usefully rather than just failing."
+          },
+          "SeerrAvailable": {
+            "type": "boolean",
+            "description": "Whether the authenticated Jellyfin user currently has a usable, non-blocked Seerr link. Seerr operations repeat their authorization checks before use."
           }
         }
       },

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -633,6 +633,27 @@ curl -X POST \
   "<JELLYFIN_URL>/JellyfinCanopy/seerr/request"
 ```
 
+Native clients whose HTTP SDK discards non-success bodies can use
+`POST /JellyfinCanopy/seerr/request/outcome` with the same body. Authentication
+failures remain bare `401`/`403`; after authentication, the route always returns
+`200` with `{ Outcome, Submitted, Retryable, SourceStatus, Message }`. Stable
+`Outcome` values are `submitted`, `already_requested`, `quota_exceeded`,
+`blocked`, `denied`, `unavailable`, and `failed`. The original `/seerr/request`
+route keeps Seerr's status-preserving behavior for existing consumers.
+
+The native compatibility projection is deliberately additive and route-scoped:
+
+- `/seerr/discover/watchlist` retains `tmdbId` and also supplies the uniform
+  numeric `id` used by the other discovery lists.
+- `/seerr/tv/{tmdbId}` guarantees a numeric `status4k` for every season,
+  deriving it from 4K request records when an older Seerr omits it.
+- `/seerr/settings/partial-requests` returns `stale: false` after a fresh read.
+  After an outage it may return the exact source and configuration generation's
+  last-known settings with `stale: true`; without that evidence it fails rather
+  than guessing mutation settings.
+- Every proxied JSON response is streamed through the shared 8 MiB cap. Error
+  classification uses a separate 64 KiB cap and never forwards the raw body.
+
 ### Maintainerr read-only integration
 
 The Maintainerr surface is a server-mediated, typed projection; it is not a

--- a/docs/platform-contract.md
+++ b/docs/platform-contract.md
@@ -109,7 +109,10 @@ Two routes, meant to be used as a pair:
    platform is serving requests and which protocol versions it speaks, and deliberately
    nothing else. Check `Available` before you have any reason to authenticate.
 2. **`GET /JellyfinCanopy/Platform/v1/negotiate`** — authenticated. You offer the range
-   you support; the host answers with what it will actually use.
+   you support; the host answers with what it will actually use. Its additive
+   `SeerrAvailable` hint reports whether the authenticated Jellyfin user currently
+   has a usable, non-blocked Seerr link. This replaces a separate user-status probe;
+   Seerr operations still repeat their current authorization checks independently.
 
 `negotiate` answers `200` with `Compatible: false` when there is no common version. That
 is **not** an error — the negotiation succeeded, it just concluded "no". Render it

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,16 +26,16 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2808, totalLines: 3201 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 37095, totalLines: 46442 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 37479, totalLines: 46859 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 3,
         minimumCoveredLines: 2808,
         maximumCoveredLines: 2808,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
-        cleanRuns: 4,
-        minimumCoveredLines: 37095,
-        maximumCoveredLines: 37095,
+        cleanRuns: 3,
+        minimumCoveredLines: 37479,
+        maximumCoveredLines: 37479,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 0);

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 37095,
-        "totalLines": 46442
+        "coveredLines": 37479,
+        "totalLines": 46859
       },
       "observations": {
-        "cleanRuns": 4,
-        "minimumCoveredLines": 37095,
-        "maximumCoveredLines": 37095
+        "cleanRuns": 3,
+        "minimumCoveredLines": 37479,
+        "maximumCoveredLines": 37479
       },
       "tolerance": {
         "missingCoveredLines": 0,
-        "rationale": "The previous 37,089-37,091/46,435 envelope was disproved by GitHub Actions Unit tests job 91614321192 at exact head 3517a2f0e43efe975852b571899c8002e763b436: all 3,288 tests passed, but Coverlet measured 37,080/46,435. A retained constrained reproduction compared with a retained 37,089 report on the identical source and scope found exactly nine missing lines and no gains: SpoilerSeerrPendingPromoter.cs lines 769 and 771-777, whose exception contract had only incidental coverage when a lifecycle fake happened to throw, and ReviewsStore.cs line 216, whose inner readiness return depended on initialization contenders accidentally passing the outer check together. An explicit library-lookup-failure test now pins the promoter's fail-closed StillPending result. A test-only post-check seam plus a two-caller barrier deterministically makes the second review-store caller observe completed initialization under the lock. The previously documented ImageBlurService.cs line 740 race is also fixed as coverage evidence: its test-only cancellation seam holds the final participant until the background flight completes, then exercises the cancellation-completion disposal branch on every run. Four clean .NET 10.0.9 Coverlet runs on the final identical 46,442-line scope each passed all 3,290 tests and reproduced exactly 37,095/46,442 (79.874%); three used the ordinary unconstrained runner, and the fourth reproduced the former low condition with DOTNET_PROCESSOR_COUNT=2 on one pinned CPU. The two narrow concurrency seams account for the seven-line scope increase; the meaningful exception, double-check, and cancellation outcomes are now explicit deterministic tests rather than scheduler side effects. The maintained floor and reviewed high-water are both 37,095/46,442 with zero tolerance. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "rationale": "The #627-#632 native Seerr compatibility change adds the typed request-outcome contract, bounded upstream error classification, watchlist and per-season 4K projections, authenticated per-user negotiation availability, and exact-generation last-known request settings. Three clean .NET 10.0.9 Coverlet runs on the identical final 46,859-line source and test scope each passed all 3,316 tests and reproduced exactly 37,479 covered lines. The reviewed high-water and exact clean-run floor are therefore both 37,479/46,859 (79.983%), so no instrumentation tolerance is needed. Relative to the prior 37,095/46,442 baseline, the change adds 417 instrumented lines, raises the high-water by 384 covered lines, and increases overall coverage from 79.874% to 79.983%. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
## Summary

- add a native-friendly `POST /JellyfinCanopy/seerr/request/outcome` contract that returns stable `200` business outcomes while preserving bare Jellyfin authentication failures
- classify duplicate, quota, blocklist, provider-auth, and accepted-with-warning results without exposing upstream bodies or encouraging duplicate retries
- normalize watchlist `id` values and project season-level `status4k` while retaining existing Seerr fields
- include authenticated per-user `SeerrAvailable` in Platform negotiation so native clients can avoid a separate user-status probe
- keep exact-generation last-known partial-request settings during transient outages, with explicit `stale` semantics
- retain the existing 8 MiB success-body limit and add a 64 KiB bounded error-classification read

## Compatibility and safety

The legacy request route remains unchanged. The new outcome route and negotiation field are additive. Projection is limited to the exact affected Seerr routes, preserves existing fields, and leaves unknown or sparse response shapes unchanged. Cached fallback settings are bound to the exact configuration generation and source identity.

No credentials, raw upstream error bodies, or provider-local identities are added to client-facing error messages.

## Validation

- independent review: approved after remediation
- server coverage: 3,316/3,316 tests; 37,479/46,859 lines (79.983%), reproduced across three clean .NET 10.0.9 runs with zero tolerance
- canonical server coverage ratchet: passed
- Platform/architecture suite: 608 tests passed
- focused Seerr and Platform suite: 84 tests passed
- client coverage: 2,041 tests across 244 files; exact 2,808/3,201 baseline passed
- scripts/docs suite: 639 tests passed
- deterministic bundle, TypeScript checks, syntax checks, Release build, and lint gate passed

Closes #627
Closes #628
Closes #629
Closes #630
Closes #631
Closes #632
