### PR TITLE
Enforce Platform deprecation and sunset policy

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActorArchitectureTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActorArchitectureTests.cs
@@ -181,12 +181,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
             Assert.Equal(PlatformFilterOrder.BoundedBody, attributes[typeof(PlatformBoundedBodyFilter)]);
             Assert.Equal(PlatformFilterOrder.RequestLifecycle, attributes[typeof(PlatformRequestLifecycleFilter)]);
             Assert.Equal(PlatformFilterOrder.JsonResult, attributes[typeof(PlatformJsonResultFilter)]);
+            Assert.Equal(PlatformFilterOrder.Deprecation, attributes[typeof(PlatformDeprecationFilter)]);
             Assert.Equal(PlatformFilterOrder.Concurrency, attributes[typeof(PlatformConcurrency)]);
             Assert.True(attributes[typeof(PlatformActorBoundaryFilter)] < attributes[typeof(PlatformAvailabilityFilter)]);
             Assert.True(attributes[typeof(PlatformAvailabilityFilter)] < attributes[typeof(PlatformJsonMediaTypeFilter)]);
             Assert.True(attributes[typeof(PlatformJsonMediaTypeFilter)] < attributes[typeof(PlatformBoundedBodyFilter)]);
             Assert.True(attributes[typeof(PlatformBoundedBodyFilter)] < attributes[typeof(PlatformRequestLifecycleFilter)]);
-            Assert.True(attributes[typeof(PlatformRequestLifecycleFilter)] < attributes[typeof(PlatformJsonResultFilter)]);
+            Assert.True(attributes[typeof(PlatformRequestLifecycleFilter)] < attributes[typeof(PlatformDeprecationFilter)]);
+            Assert.True(attributes[typeof(PlatformDeprecationFilter)] < attributes[typeof(PlatformJsonResultFilter)]);
             Assert.True(attributes[typeof(PlatformJsonResultFilter)] < attributes[typeof(PlatformConcurrency)]);
             Assert.Equal(PlatformFilterOrder.JsonMediaType, new PlatformJsonMediaTypeFilter().Order);
             Assert.Equal(PlatformFilterOrder.BoundedBody, new PlatformBoundedBodyFilter().Order);

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformContractTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformContractTests.cs
@@ -97,6 +97,63 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
             }
         }
 
+        private static IReadOnlyList<string> RemovedFrozenOperations(JsonElement frozen, JsonElement spec)
+        {
+            var live = SpecOperations(spec)
+                .Select(entry => $"{entry.Method} {entry.Path}")
+                .ToHashSet(StringComparer.Ordinal);
+            var removed = new List<string>();
+
+            foreach (var path in frozen.GetProperty("paths").EnumerateObject())
+            {
+                foreach (var method in path.Value.EnumerateArray())
+                {
+                    var entry = $"{method.GetString()} {path.Name}";
+                    if (!live.Contains(entry))
+                    {
+                        removed.Add(entry);
+                    }
+                }
+            }
+
+            return removed;
+        }
+
+        private static IEnumerable<(string Path, string Method, JsonElement Operation)> SpecOperations(JsonElement spec)
+        {
+            foreach (var path in spec.GetProperty("paths").EnumerateObject())
+            {
+                foreach (var operation in path.Value.EnumerateObject())
+                {
+                    yield return (path.Name, operation.Name, operation.Value);
+                }
+            }
+        }
+
+        private static IReadOnlyList<string> DeprecationsWithoutPublishedAnsweringOperation(
+            PlatformDeprecationRegistry registry,
+            JsonElement frozen,
+            JsonElement spec,
+            IEnumerable<string> liveOperations)
+        {
+            var frozenOperations = frozen.GetProperty("paths").EnumerateObject()
+                .SelectMany(path => path.Value.EnumerateArray()
+                    .Select(method => $"{method.GetString()!.ToUpperInvariant()} {path.Name}"))
+                .ToHashSet(StringComparer.Ordinal);
+            var specifiedOperations = SpecOperations(spec)
+                .Select(operation => $"{operation.Method.ToUpperInvariant()} {operation.Path}")
+                .ToHashSet(StringComparer.Ordinal);
+            var live = liveOperations.ToHashSet(StringComparer.Ordinal);
+
+            return registry.Operations
+                .Select(operation => $"{operation.Method} {operation.Path}")
+                .Where(operation => !frozenOperations.Contains(operation)
+                    || !specifiedOperations.Contains(operation)
+                    || !live.Contains(operation))
+                .OrderBy(operation => operation, StringComparer.Ordinal)
+                .ToList();
+        }
+
         [Fact]
         public void EveryLiveRouteIsDescribedBySpec()
         {
@@ -571,29 +628,98 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
         {
             // ADR-0010: changes within v1 are additive only. Enforced here rather than
             // left to a reviewer noticing a deletion in a large diff.
-            var live = SpecOperations()
-                .Select(entry => $"{entry.Method} {entry.Path}")
-                .ToHashSet(StringComparer.Ordinal);
-
-            var removed = new List<string>();
-
-            foreach (var path in Frozen.RootElement.GetProperty("paths").EnumerateObject())
-            {
-                foreach (var method in path.Value.EnumerateArray())
-                {
-                    var entry = $"{method.GetString()} {path.Name}";
-                    if (!live.Contains(entry))
-                    {
-                        removed.Add(entry);
-                    }
-                }
-            }
+            var removed = RemovedFrozenOperations(Frozen.RootElement, Spec.RootElement);
 
             Assert.True(
                 removed.Count == 0,
                 "Published Platform v1 route(s) were removed or renamed: " + string.Join(", ", removed) + ".\n"
                 + "Within v1 the surface may only grow (ADR-0010). An incompatible change belongs in a v2 "
                 + "route family, which can coexist, rather than mutating v1 under existing consumers.");
+        }
+
+        [Fact]
+        public void DriftGateNamesAFrozenOperationRemovedEvenWhenDeprecated()
+        {
+            using var plantedFrozen = JsonDocument.Parse("""
+                {"paths":{"/JellyfinCanopy/Platform/v1/discovery":["get"]}}
+                """);
+            using var plantedSpec = JsonDocument.Parse("""{"paths":{}}""");
+
+            var removed = RemovedFrozenOperations(plantedFrozen.RootElement, plantedSpec.RootElement);
+
+            Assert.Equal(new[] { "get /JellyfinCanopy/Platform/v1/discovery" }, removed);
+        }
+
+        [Fact]
+        public void EveryDeprecationNamesAFrozenSpecifiedOperationThatStillAnswers()
+        {
+            var live = LiveRoutes().Select(route => $"{route.Method.ToUpperInvariant()} {route.Path}");
+            var missing = DeprecationsWithoutPublishedAnsweringOperation(
+                PlatformDeprecationRegistry.Shipped,
+                Frozen.RootElement,
+                Spec.RootElement,
+                live);
+
+            Assert.True(
+                missing.Count == 0,
+                "Platform deprecation entries do not name a frozen, specified, live operation: "
+                    + string.Join(", ", missing));
+        }
+
+        [Fact]
+        public void OpenApiDefinesTheLifecycleHeaderFormatsUsedByTheRegistry()
+        {
+            var headers = Spec.RootElement.GetProperty("components").GetProperty("headers");
+
+            Assert.Equal(
+                "^@[0-9]+$",
+                headers.GetProperty("Deprecation").GetProperty("schema").GetProperty("pattern").GetString());
+            Assert.Equal(
+                "string",
+                headers.GetProperty("Sunset").GetProperty("schema").GetProperty("type").GetString());
+        }
+
+        [Fact]
+        public void DriftGateNamesADeprecationForAnOperationThatDoesNotAnswer()
+        {
+            var registry = PlatformDeprecationRegistry.Parse("""
+                {
+                  "schemaVersion": 1,
+                  "operations": [{
+                    "method": "GET",
+                    "path": "/JellyfinCanopy/Platform/v1/missing",
+                    "deprecatedAtUtc": "2026-08-04T00:00:00Z",
+                    "sunsetAtUtc": "2026-11-02T00:00:00Z",
+                    "deprecatedInCanopyVersion": "2.4.0.0",
+                    "removalNotBeforeCanopyVersion": "2.5.0.0"
+                  }]
+                }
+                """);
+            var live = LiveRoutes().Select(route => $"{route.Method.ToUpperInvariant()} {route.Path}");
+
+            var missing = DeprecationsWithoutPublishedAnsweringOperation(
+                registry,
+                Frozen.RootElement,
+                Spec.RootElement,
+                live);
+
+            Assert.Equal(new[] { "GET /JellyfinCanopy/Platform/v1/missing" }, missing);
+        }
+
+        [Fact]
+        public void PlatformRoutesAreVersionLiteralAndNeverExposeALatestAlias()
+        {
+            Assert.Equal("JellyfinCanopy/Platform/v1", PlatformConstants.RoutePrefix);
+            Assert.All(LiveRoutes(), route =>
+            {
+                Assert.StartsWith("/JellyfinCanopy/Platform/v1/", route.Path, StringComparison.Ordinal);
+                Assert.DoesNotContain("/latest", route.Path, StringComparison.OrdinalIgnoreCase);
+            });
+            Assert.All(SpecOperations(), operation =>
+            {
+                Assert.StartsWith("/JellyfinCanopy/Platform/v1/", operation.Path, StringComparison.Ordinal);
+                Assert.DoesNotContain("/latest", operation.Path, StringComparison.OrdinalIgnoreCase);
+            });
         }
 
         [Fact]

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformDeprecationTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformDeprecationTests.cs
@@ -1,0 +1,226 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Net.Http.Headers;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
+{
+    public class PlatformDeprecationTests
+    {
+        private const string DiscoveryPath = "/JellyfinCanopy/Platform/v1/discovery";
+
+        [Fact]
+        public void ShippedRegistryIsEmptyAndItsShapeIsPinned()
+        {
+            var raw = File.ReadAllText(ContractPath("deprecations.json"));
+            using var json = JsonDocument.Parse(raw);
+
+            Assert.Equal(
+                new[] { "operations", "schemaVersion" },
+                json.RootElement.EnumerateObject().Select(property => property.Name).OrderBy(name => name, StringComparer.Ordinal));
+            Assert.Equal(PlatformDeprecationRegistry.SchemaVersion, json.RootElement.GetProperty("schemaVersion").GetInt32());
+            Assert.Equal(JsonValueKind.Array, json.RootElement.GetProperty("operations").ValueKind);
+            Assert.Empty(json.RootElement.GetProperty("operations").EnumerateArray());
+            Assert.Empty(PlatformDeprecationRegistry.Parse(raw).Operations);
+            Assert.Empty(PlatformDeprecationRegistry.Shipped.Operations);
+            using var resource = typeof(PlatformDeprecationRegistry).Assembly.GetManifestResourceStream(
+                PlatformDeprecationRegistry.ResourceName);
+            Assert.NotNull(resource);
+        }
+
+        [Fact]
+        public async Task FixtureDeprecatedOperationStillAnswersAndEmitsBothHeaders()
+        {
+            var registry = PlatformDeprecationRegistry.Parse(RegistryWith(
+                sunsetAtUtc: "2026-11-02T00:00:00Z",
+                removalNotBeforeCanopyVersion: "2.5.0.0"));
+            var http = new DefaultHttpContext();
+            http.Response.Body = new MemoryStream();
+            http.Request.Method = "GET";
+            http.Request.Path = DiscoveryPath;
+            var descriptor = new ControllerActionDescriptor
+            {
+                MethodInfo = typeof(PlatformDiscoveryController).GetMethod(nameof(PlatformDiscoveryController.GetDiscovery))!,
+            };
+            var action = new ActionContext(http, new RouteData(), descriptor);
+            var result = new ContentResult
+            {
+                Content = "still answers",
+                ContentType = "text/plain",
+                StatusCode = StatusCodes.Status200OK,
+            };
+            var context = new ResultExecutingContext(
+                action,
+                new List<IFilterMetadata>(),
+                result,
+                new object());
+
+            await new PlatformDeprecationFilter(registry).OnResultExecutionAsync(context, async () =>
+            {
+                http.Response.StatusCode = StatusCodes.Status200OK;
+                http.Response.ContentType = "text/plain";
+                await http.Response.WriteAsync("still answers");
+                return new ResultExecutedContext(
+                    action,
+                    new List<IFilterMetadata>(),
+                    context.Result,
+                    new object());
+            });
+
+            http.Response.Body.Position = 0;
+            using var reader = new StreamReader(http.Response.Body);
+            Assert.Equal(StatusCodes.Status200OK, http.Response.StatusCode);
+            Assert.Equal("still answers", await reader.ReadToEndAsync());
+            Assert.Equal("@1785801600", http.Response.Headers["Deprecation"].ToString());
+            Assert.Equal("Mon, 02 Nov 2026 00:00:00 GMT", http.Response.Headers["Sunset"].ToString());
+        }
+
+        [Fact]
+        public async Task EmptyOrUnlistedRegistryEmitsNoLifecycleHeaders()
+        {
+            var registry = PlatformDeprecationRegistry.Parse("""{"schemaVersion":1,"operations":[]}""");
+            var http = new DefaultHttpContext();
+            http.Request.Method = "GET";
+            var descriptor = new ControllerActionDescriptor
+            {
+                MethodInfo = typeof(PlatformDiscoveryController).GetMethod(nameof(PlatformDiscoveryController.GetDiscovery))!,
+            };
+            var action = new ActionContext(http, new RouteData(), descriptor);
+            var context = new ResultExecutingContext(
+                action,
+                new List<IFilterMetadata>(),
+                new OkResult(),
+                new object());
+
+            await new PlatformDeprecationFilter(registry).OnResultExecutionAsync(context, () => Task.FromResult(
+                new ResultExecutedContext(action, new List<IFilterMetadata>(), context.Result, new object())));
+
+            Assert.False(http.Response.Headers.ContainsKey("Deprecation"));
+            Assert.False(http.Response.Headers.ContainsKey("Sunset"));
+        }
+
+        [Fact]
+        public async Task DeprecationHeadersSurviveAConditional304Transformation()
+        {
+            var registry = PlatformDeprecationRegistry.Parse(RegistryWith(
+                sunsetAtUtc: "2026-11-02T00:00:00Z",
+                removalNotBeforeCanopyVersion: "2.5.0.0"));
+            var http = new DefaultHttpContext();
+            http.Response.Body = new MemoryStream();
+            http.Request.Method = "GET";
+            var descriptor = new ControllerActionDescriptor
+            {
+                MethodInfo = typeof(PlatformDiscoveryController).GetMethod(nameof(PlatformDiscoveryController.GetDiscovery))!,
+            };
+            var action = new ActionContext(http, new RouteData(), descriptor);
+            var result = PlatformJsonBodyResult.Create(
+                new PlatformDiscoveryResponse { Available = true, ProtocolMinimum = 1, ProtocolMaximum = 1 },
+                StatusCodes.Status200OK);
+            http.Request.Headers.IfNoneMatch = PlatformConcurrency.CreateStrongEntityTag(result.Body).ToString();
+            var outer = new ResultExecutingContext(
+                action,
+                new List<IFilterMetadata>(),
+                result,
+                new object());
+
+            await new PlatformDeprecationFilter(registry).OnResultExecutionAsync(outer, async () =>
+            {
+                var inner = new ResultExecutingContext(
+                    action,
+                    new List<IFilterMetadata>(),
+                    outer.Result,
+                    new object());
+                await new PlatformConcurrency().OnResultExecutionAsync(inner, async () =>
+                {
+                    await inner.Result.ExecuteResultAsync(action);
+                    return new ResultExecutedContext(action, new List<IFilterMetadata>(), inner.Result, new object());
+                });
+                return new ResultExecutedContext(action, new List<IFilterMetadata>(), inner.Result, new object());
+            });
+
+            Assert.Equal(StatusCodes.Status304NotModified, http.Response.StatusCode);
+            Assert.Equal("@1785801600", http.Response.Headers["Deprecation"].ToString());
+            Assert.Equal("Mon, 02 Nov 2026 00:00:00 GMT", http.Response.Headers["Sunset"].ToString());
+            Assert.NotNull(EntityTagHeaderValue.Parse(http.Response.Headers.ETag.ToString()));
+            Assert.Empty(Assert.IsType<MemoryStream>(http.Response.Body).ToArray());
+        }
+
+        [Fact]
+        public void DriftGateRejectsTooShortSunsetByOperationName()
+        {
+            var error = Assert.Throws<InvalidDataException>(() => PlatformDeprecationRegistry.Parse(RegistryWith(
+                sunsetAtUtc: "2026-11-01T23:59:59Z",
+                removalNotBeforeCanopyVersion: "2.5.0.0")));
+
+            Assert.Contains("GET " + DiscoveryPath, error.Message, StringComparison.Ordinal);
+            Assert.Contains("at least 90 days", error.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void DriftGateRejectsLessThanOneMinorByOperationName()
+        {
+            var error = Assert.Throws<InvalidDataException>(() => PlatformDeprecationRegistry.Parse(RegistryWith(
+                sunsetAtUtc: "2026-11-02T00:00:00Z",
+                removalNotBeforeCanopyVersion: "2.4.1.0")));
+
+            Assert.Contains("GET " + DiscoveryPath, error.Message, StringComparison.Ordinal);
+            Assert.Contains("at least one Canopy minor", error.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void RegistryLookupIsMethodAndPathExactWithoutARequestTimeScan()
+        {
+            var registry = PlatformDeprecationRegistry.Parse(RegistryWith(
+                sunsetAtUtc: "2026-11-02T00:00:00Z",
+                removalNotBeforeCanopyVersion: "2.5.0.0"));
+
+            Assert.True(registry.TryGet("GET", DiscoveryPath, out _));
+            Assert.False(registry.TryGet("POST", DiscoveryPath, out _));
+            Assert.False(registry.TryGet("GET", DiscoveryPath + "/child", out _));
+        }
+
+        [Fact]
+        public void MalformedUnknownAndDuplicateRegistryEntriesFailClosed()
+        {
+            Assert.Throws<InvalidDataException>(() => PlatformDeprecationRegistry.Parse(
+                """{"schemaVersion":1,"operations":[],"surprise":true}"""));
+            Assert.Throws<InvalidDataException>(() => PlatformDeprecationRegistry.Parse(
+                RegistryWithEntries(
+                    RegistryEntry("2026-11-02T00:00:00Z", "2.5.0.0"),
+                    RegistryEntry("2026-11-02T00:00:00Z", "2.5.0.0"))));
+        }
+
+        private static string RegistryWith(string sunsetAtUtc, string removalNotBeforeCanopyVersion) =>
+            RegistryWithEntries(RegistryEntry(sunsetAtUtc, removalNotBeforeCanopyVersion));
+
+        private static string RegistryWithEntries(params string[] entries) =>
+            "{\"schemaVersion\":1,\"operations\":[" + string.Join(',', entries) + "]}";
+
+        private static string RegistryEntry(string sunsetAtUtc, string removalNotBeforeCanopyVersion) => $$"""
+                {
+                  "method": "GET",
+                  "path": "{{DiscoveryPath}}",
+                  "deprecatedAtUtc": "2026-08-04T00:00:00Z",
+                  "sunsetAtUtc": "{{sunsetAtUtc}}",
+                  "deprecatedInCanopyVersion": "2.4.0.0",
+                  "removalNotBeforeCanopyVersion": "{{removalNotBeforeCanopyVersion}}"
+                }
+            """;
+
+        private static string ContractPath(string name, [CallerFilePath] string sourceFile = "")
+            => Path.GetFullPath(Path.Combine(
+                Path.GetDirectoryName(sourceFile)!, "..", "..", "contracts", "platform", "v1", name));
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/JellyfinCanopy.csproj
+++ b/Jellyfin.Plugin.JellyfinCanopy/JellyfinCanopy.csproj
@@ -63,6 +63,11 @@
     <!-- Canonical locale inventory consumed by the server endpoints and CI. -->
     <EmbeddedResource Include="locale-manifest.json"
                       LogicalName="Jellyfin.Plugin.JellyfinCanopy.locale-manifest.json" />
+    <!-- The empty-by-default Platform deprecation schedule is a runtime contract,
+         embedded so deployed filters never read the install tree per request. -->
+    <EmbeddedResource Include="..\contracts\platform\v1\deprecations.json"
+                      Link="Platform\deprecations.json"
+                      LogicalName="Jellyfin.Plugin.JellyfinCanopy.Platform.deprecations.json" />
     <!-- Ship-safe assets served by AssetsController (guaranteed-available tier of the
          third-party asset cache; see Services/AssetCacheManifest.cs). -->
     <None Remove="Assets\poster-fallback.svg"/>

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformControllerBase.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformControllerBase.cs
@@ -39,6 +39,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
     [TypeFilter(typeof(PlatformJsonMediaTypeFilter), Order = PlatformFilterOrder.JsonMediaType)]
     [TypeFilter(typeof(PlatformBoundedBodyFilter), Order = PlatformFilterOrder.BoundedBody)]
     [TypeFilter(typeof(PlatformRequestLifecycleFilter), Order = PlatformFilterOrder.RequestLifecycle)]
+    [TypeFilter(typeof(PlatformDeprecationFilter), Order = PlatformFilterOrder.Deprecation)]
     [TypeFilter(typeof(PlatformJsonResultFilter), Order = PlatformFilterOrder.JsonResult)]
     [TypeFilter(typeof(PlatformConcurrency), Order = PlatformFilterOrder.Concurrency)]
     public abstract class PlatformControllerBase : ControllerBase

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformDeprecationFilter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformDeprecationFilter.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>Adds RFC deprecation metadata to operations named by the shipped registry.</summary>
+    public sealed class PlatformDeprecationFilter : IAsyncAlwaysRunResultFilter, IOrderedFilter
+    {
+        private readonly PlatformDeprecationRegistry _registry;
+
+        /// <summary>Initializes the filter over the immutable shipped registry.</summary>
+        public PlatformDeprecationFilter()
+            : this(PlatformDeprecationRegistry.Shipped)
+        {
+        }
+
+        internal PlatformDeprecationFilter(PlatformDeprecationRegistry registry)
+        {
+            _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+        }
+
+        /// <inheritdoc />
+        public int Order => PlatformFilterOrder.Deprecation;
+
+        /// <inheritdoc />
+        public async Task OnResultExecutionAsync(ResultExecutingContext context, ResultExecutionDelegate next)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            ArgumentNullException.ThrowIfNull(next);
+
+            var request = context.HttpContext.Request;
+            if (!context.HttpContext.Response.HasStarted
+                && PlatformOperationIdentity.TryDescribe(context.ActionDescriptor, request.Method, out var method, out var path)
+                && _registry.TryGet(method, path, out var entry))
+            {
+                context.HttpContext.Response.Headers["Deprecation"] = entry.DeprecationHeader;
+                context.HttpContext.Response.Headers["Sunset"] = entry.SunsetHeader;
+            }
+
+            await next().ConfigureAwait(false);
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformDeprecationRegistry.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformDeprecationRegistry.cs
@@ -1,0 +1,309 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Routing;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>One versioned Platform operation's in-band deprecation schedule.</summary>
+    internal sealed class PlatformDeprecationEntry
+    {
+        internal PlatformDeprecationEntry(
+            string method,
+            string path,
+            DateTimeOffset deprecatedAtUtc,
+            DateTimeOffset sunsetAtUtc,
+            Version deprecatedInVersion,
+            Version removalNotBeforeVersion)
+        {
+            Method = method;
+            Path = path;
+            DeprecatedAtUtc = deprecatedAtUtc;
+            SunsetAtUtc = sunsetAtUtc;
+            DeprecatedInVersion = deprecatedInVersion;
+            RemovalNotBeforeVersion = removalNotBeforeVersion;
+        }
+
+        internal string Method { get; }
+
+        internal string Path { get; }
+
+        internal DateTimeOffset DeprecatedAtUtc { get; }
+
+        internal DateTimeOffset SunsetAtUtc { get; }
+
+        internal Version DeprecatedInVersion { get; }
+
+        internal Version RemovalNotBeforeVersion { get; }
+
+        /// <summary>RFC 9745 structured-field date.</summary>
+        internal string DeprecationHeader => "@" + DeprecatedAtUtc.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture);
+
+        /// <summary>RFC 8594 HTTP-date.</summary>
+        internal string SunsetHeader => SunsetAtUtc.ToUniversalTime().ToString("R", CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// Immutable, bounded lookup over the machine-owned Platform deprecation registry.
+    /// The shipped registry is parsed once; request handling performs no file I/O.
+    /// </summary>
+    internal sealed class PlatformDeprecationRegistry
+    {
+        internal const int SchemaVersion = 1;
+        internal const int MaximumOperations = 64;
+        internal const int MaximumRegistryBytes = 32 * 1024;
+        internal const string ResourceName = "Jellyfin.Plugin.JellyfinCanopy.Platform.deprecations.json";
+
+        private static readonly Regex CanopyVersion = new(
+            "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$",
+            RegexOptions.CultureInvariant);
+
+        private static readonly JsonSerializerOptions RegistryJson = new()
+        {
+            PropertyNameCaseInsensitive = false,
+            UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+            MaxDepth = 8,
+        };
+
+        private readonly IReadOnlyDictionary<string, PlatformDeprecationEntry> _operations;
+        private readonly IReadOnlyCollection<PlatformDeprecationEntry> _entries;
+
+        private PlatformDeprecationRegistry(IReadOnlyDictionary<string, PlatformDeprecationEntry> operations)
+        {
+            _operations = operations;
+            _entries = operations.Values.ToArray();
+        }
+
+        internal static PlatformDeprecationRegistry Shipped { get; } = LoadShipped();
+
+        internal IReadOnlyCollection<PlatformDeprecationEntry> Operations => _entries;
+
+        internal bool TryGet(string method, string path, out PlatformDeprecationEntry entry)
+        {
+            ArgumentNullException.ThrowIfNull(method);
+            ArgumentNullException.ThrowIfNull(path);
+            return _operations.TryGetValue(Key(method, path), out entry!);
+        }
+
+        internal static PlatformDeprecationRegistry Parse(string json)
+        {
+            ArgumentNullException.ThrowIfNull(json);
+            if (Encoding.UTF8.GetByteCount(json) > MaximumRegistryBytes)
+            {
+                throw new InvalidDataException(
+                    $"The Platform deprecation registry exceeds its {MaximumRegistryBytes}-byte bound.");
+            }
+
+            RegistryDocument document;
+            try
+            {
+                document = JsonSerializer.Deserialize<RegistryDocument>(json, RegistryJson)
+                    ?? throw new InvalidDataException("The Platform deprecation registry was empty.");
+            }
+            catch (JsonException exception)
+            {
+                throw new InvalidDataException("The Platform deprecation registry does not match schema version 1.", exception);
+            }
+
+            if (document.SchemaVersion != SchemaVersion)
+            {
+                throw new InvalidDataException(
+                    $"Unsupported Platform deprecation registry schemaVersion {document.SchemaVersion}.");
+            }
+
+            if (document.Operations is null)
+            {
+                throw new InvalidDataException("The Platform deprecation registry must contain an operations array.");
+            }
+
+            if (document.Operations.Count > MaximumOperations)
+            {
+                throw new InvalidDataException(
+                    $"The Platform deprecation registry exceeds its {MaximumOperations}-operation bound.");
+            }
+
+            var operations = new Dictionary<string, PlatformDeprecationEntry>(StringComparer.OrdinalIgnoreCase);
+            foreach (var candidate in document.Operations)
+            {
+                if (candidate is null)
+                {
+                    throw new InvalidDataException("The Platform deprecation registry contains a null operation.");
+                }
+
+                var entry = ParseEntry(candidate);
+                if (!operations.TryAdd(Key(entry.Method, entry.Path), entry))
+                {
+                    throw new InvalidDataException($"Duplicate Platform deprecation entry: {entry.Method} {entry.Path}.");
+                }
+            }
+
+            return new PlatformDeprecationRegistry(operations);
+        }
+
+        private static PlatformDeprecationRegistry LoadShipped()
+        {
+            using var stream = typeof(PlatformDeprecationRegistry).Assembly.GetManifestResourceStream(ResourceName)
+                ?? throw new InvalidOperationException($"Embedded Platform deprecation registry {ResourceName} is missing.");
+            using var reader = new StreamReader(stream);
+            return Parse(reader.ReadToEnd());
+        }
+
+        private static PlatformDeprecationEntry ParseEntry(RegistryEntry candidate)
+        {
+            var method = candidate.Method;
+            var path = candidate.Path;
+            var operation = $"{method ?? "<missing-method>"} {path ?? "<missing-path>"}";
+
+            if (string.IsNullOrEmpty(method)
+                || !string.Equals(method, method.Trim(), StringComparison.Ordinal)
+                || !string.Equals(method, method.ToUpperInvariant(), StringComparison.Ordinal)
+                || method.Any(character => character < 'A' || character > 'Z'))
+            {
+                throw new InvalidDataException($"{operation}: method must be a non-empty uppercase HTTP token.");
+            }
+
+            var routePrefix = "/" + PlatformConstants.RoutePrefix + "/";
+            if (path is null
+                || !string.Equals(path, path.Trim(), StringComparison.Ordinal)
+                || !path.StartsWith(routePrefix, StringComparison.Ordinal)
+                || path.Length > 256)
+            {
+                throw new InvalidDataException($"{operation}: path must be a literal Platform v1 operation path.");
+            }
+
+            var deprecatedAt = ParseUtc(candidate.DeprecatedAtUtc, operation, "deprecatedAtUtc");
+            var sunsetAt = ParseUtc(candidate.SunsetAtUtc, operation, "sunsetAtUtc");
+            if (sunsetAt - deprecatedAt < TimeSpan.FromDays(90))
+            {
+                throw new InvalidDataException(
+                    $"{operation}: sunsetAtUtc must be at least 90 days after deprecatedAtUtc.");
+            }
+
+            var deprecatedIn = ParseVersion(candidate.DeprecatedInCanopyVersion, operation, "deprecatedInCanopyVersion");
+            var removalNotBefore = ParseVersion(candidate.RemovalNotBeforeCanopyVersion, operation, "removalNotBeforeCanopyVersion");
+            var minimumRemoval = new Version(deprecatedIn.Major, deprecatedIn.Minor + 1, 0, 0);
+            if (removalNotBefore < minimumRemoval)
+            {
+                throw new InvalidDataException(
+                    $"{operation}: removalNotBeforeCanopyVersion must be at least one Canopy minor after deprecatedInCanopyVersion ({minimumRemoval}).");
+            }
+
+            return new PlatformDeprecationEntry(
+                method,
+                path,
+                deprecatedAt,
+                sunsetAt,
+                deprecatedIn,
+                removalNotBefore);
+        }
+
+        private static DateTimeOffset ParseUtc(string? raw, string operation, string field)
+        {
+            var value = default(DateTimeOffset);
+            var valid = raw is not null && DateTimeOffset.TryParseExact(
+                raw,
+                new[] { "yyyy-MM-dd'T'HH:mm:ss'Z'", "yyyy-MM-dd'T'HH:mm:ss.FFFFFFF'Z'" },
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out value);
+            if (!valid || value.Offset != TimeSpan.Zero)
+            {
+                throw new InvalidDataException($"{operation}: {field} must be a canonical RFC 3339 UTC timestamp ending in Z.");
+            }
+
+            return value;
+        }
+
+        private static Version ParseVersion(string? raw, string operation, string field)
+        {
+            if (raw is null || !CanopyVersion.IsMatch(raw) || !Version.TryParse(raw, out var version))
+            {
+                throw new InvalidDataException($"{operation}: {field} must be a four-part stable Canopy version.");
+            }
+
+            return version;
+        }
+
+        private static string Key(string method, string path) => method.ToUpperInvariant() + " " + path;
+
+        private sealed class RegistryDocument
+        {
+            [JsonPropertyName("schemaVersion")]
+            public int SchemaVersion { get; set; }
+
+            [JsonPropertyName("operations")]
+            public List<RegistryEntry?>? Operations { get; set; }
+        }
+
+        private sealed class RegistryEntry
+        {
+            [JsonPropertyName("method")]
+            public string? Method { get; set; }
+
+            [JsonPropertyName("path")]
+            public string? Path { get; set; }
+
+            [JsonPropertyName("deprecatedAtUtc")]
+            public string? DeprecatedAtUtc { get; set; }
+
+            [JsonPropertyName("sunsetAtUtc")]
+            public string? SunsetAtUtc { get; set; }
+
+            [JsonPropertyName("deprecatedInCanopyVersion")]
+            public string? DeprecatedInCanopyVersion { get; set; }
+
+            [JsonPropertyName("removalNotBeforeCanopyVersion")]
+            public string? RemovalNotBeforeCanopyVersion { get; set; }
+        }
+    }
+
+    /// <summary>Canonical method/path identity derived from MVC-owned route metadata.</summary>
+    internal static class PlatformOperationIdentity
+    {
+        internal static bool TryDescribe(
+            ActionDescriptor descriptor,
+            string requestMethod,
+            out string method,
+            out string path)
+        {
+            method = string.Empty;
+            path = string.Empty;
+            if (descriptor is not ControllerActionDescriptor controller
+                || controller.MethodInfo.DeclaringType is not { } controllerType)
+            {
+                return false;
+            }
+
+            var combinedTemplate = controller.AttributeRouteInfo?.Template;
+            if (!string.IsNullOrEmpty(combinedTemplate))
+            {
+                method = requestMethod.ToUpperInvariant();
+                path = "/" + combinedTemplate.TrimStart('/');
+                return true;
+            }
+
+            var prefix = controllerType.GetCustomAttribute<RouteAttribute>()?.Template;
+            var verb = controller.MethodInfo.GetCustomAttributes<HttpMethodAttribute>()
+                .FirstOrDefault(attribute => attribute.HttpMethods.Any(candidate =>
+                    string.Equals(candidate, requestMethod, StringComparison.OrdinalIgnoreCase)));
+            if (string.IsNullOrEmpty(prefix) || verb is null)
+            {
+                return false;
+            }
+
+            method = requestMethod.ToUpperInvariant();
+            path = "/" + (string.IsNullOrEmpty(verb.Template) ? prefix : prefix + "/" + verb.Template);
+            return true;
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformFilterOrder.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformFilterOrder.cs
@@ -18,10 +18,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
         /// <summary>Start the model-binding/action deadline after body acquisition.</summary>
         internal const int RequestLifecycle = int.MinValue + 4;
 
+        /// <summary>Add in-band lifecycle metadata before the representation executes.</summary>
+        internal const int Deprecation = int.MinValue + 5;
+
         /// <summary>Serialize Platform results to their exact bytes outside the deadline.</summary>
-        internal const int JsonResult = int.MinValue + 5;
+        internal const int JsonResult = int.MinValue + 6;
 
         /// <summary>Evaluate representation preconditions after exact serialization.</summary>
-        internal const int Concurrency = int.MinValue + 6;
+        internal const int Concurrency = int.MinValue + 7;
     }
 }

--- a/contracts/platform/v1/deprecations.json
+++ b/contracts/platform/v1/deprecations.json
@@ -1,0 +1,4 @@
+{
+  "schemaVersion": 1,
+  "operations": []
+}

--- a/contracts/platform/v1/openapi.json
+++ b/contracts/platform/v1/openapi.json
@@ -324,6 +324,19 @@
         "schema": {
           "$ref": "#/components/schemas/PlatformEntityTag"
         }
+      },
+      "Deprecation": {
+        "description": "RFC 9745 structured-field date announcing when the operation was deprecated. Present only for operations listed in deprecations.json.",
+        "schema": {
+          "type": "string",
+          "pattern": "^@[0-9]+$"
+        }
+      },
+      "Sunset": {
+        "description": "RFC 8594 HTTP-date naming the earliest time the deprecated operation may be removed, subject also to the Canopy release window.",
+        "schema": {
+          "type": "string"
+        }
       }
     },
     "securitySchemes": {

--- a/docs/platform-contract.md
+++ b/docs/platform-contract.md
@@ -83,6 +83,9 @@ The `v1` in the path is a **major** version. Within it, changes are additive onl
 An incompatible change becomes a `v2` route family that coexists with `v1`, so you upgrade
 on your own schedule rather than on ours.
 
+The [Platform support and deprecation policy](platform-support-policy.md) defines the
+N/N-1 support window, machine-readable registry, and in-band lifecycle headers.
+
 ## The handshake
 
 An administrator can turn the native Platform surface off with **Advanced → Native

--- a/docs/platform-support-policy.md
+++ b/docs/platform-support-policy.md
@@ -1,0 +1,68 @@
+# Platform support and deprecation policy
+
+Platform versions are promises to independent clients, not labels for the current
+server implementation. The version in `/JellyfinCanopy/Platform/v1` is therefore a
+literal protocol major. Compatible changes add to `v1`; an incompatible change is a
+new route family such as `v2`. There is no mutable `latest` alias.
+
+## Supported protocol window
+
+Canopy supports protocol majors **N and N-1**. When `v2` ships, `v1` continues to
+run beside it so clients can upgrade on their own schedules. A later major never
+changes the meaning of an earlier route family.
+
+Inside one protocol major, the contract is additive only. Published operations and
+required fields remain present even if an operation is deprecated. The
+`contracts/platform/v1/frozen.json` drift gate rejects their removal or
+incompatible retyping.
+
+The older `/JellyfinCanopy/*` routes are a separate compatibility surface. The
+arrival of Platform routes does not deprecate them, and this registry does not
+govern them.
+
+## Deprecation registry
+
+`contracts/platform/v1/deprecations.json` is the machine-readable source for
+in-band notices. It deliberately ships with an empty
+`operations` array: no Platform operation is currently deprecated.
+
+Each future entry must identify one literal method and path and record:
+
+- `deprecatedAtUtc`: the UTC instant announced in `Deprecation`;
+- `sunsetAtUtc`: the earliest removal instant announced in `Sunset`;
+- `deprecatedInCanopyVersion`: the Canopy release that announces the deprecation;
+- `removalNotBeforeCanopyVersion`: the earliest Canopy release that may remove it.
+
+CI rejects duplicate or unknown entries, a sunset less than 90 days after the
+announcement, or a removal release less than one Canopy minor later. Removal is
+never allowed in a patch release. The time and release windows are both minimums;
+the later one wins.
+
+After Jellyfin authorizes a request and MVC selects an operation in the registry,
+its responses carry:
+
+- `Deprecation: @<unix-seconds>` — the RFC 9745 structured-field date;
+- `Sunset: <HTTP-date>` — the RFC 8594 sunset instant.
+
+The registry is embedded in the plugin and parsed once. Request handling performs
+one bounded operation lookup and no file I/O.
+
+Authorization failures produced before MVC selects an operation remain host-owned
+responses and do not carry these headers.
+
+## Announcement and removal
+
+A deprecation is complete only when it appears in all three places:
+
+1. the response headers driven by the registry;
+2. the release changelog;
+3. the supported-client compatibility matrix.
+
+Headers announce a schedule; they do not remove or disable an operation. The
+operation must continue to answer throughout its support window, and every frozen
+route remains protected by the additive-contract gate whether or not it is listed in
+the registry. Security fixes may require a coordinated exception, documented in a
+security advisory, the compatibility matrix, and release notes.
+
+See the [Platform v1 contract](platform-contract.md) for wire-format and handshake
+details.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,5 +73,6 @@ nav:
   - Developer Guide: developers.md
   - Android TV Client Guide: androidtv-client.md
   - Platform v1 Contract: platform-contract.md
+  - Platform Support Policy: platform-support-policy.md
   - Help & Community: help.md
   - About: about.md

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,19 +26,19 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2808, totalLines: 3201 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 37616, totalLines: 47018 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 37618, totalLines: 47018 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 3,
         minimumCoveredLines: 2808,
         maximumCoveredLines: 2808,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
-        cleanRuns: 3,
+        cleanRuns: 4,
         minimumCoveredLines: 37616,
-        maximumCoveredLines: 37616,
+        maximumCoveredLines: 37618,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 0);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,7 +26,7 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2808, totalLines: 3201 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 37479, totalLines: 46859 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 37616, totalLines: 47018 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 3,
         minimumCoveredLines: 2808,
@@ -34,8 +34,8 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
     });
     assert.deepEqual(baselines.profiles.server.observations, {
         cleanRuns: 3,
-        minimumCoveredLines: 37479,
-        maximumCoveredLines: 37479,
+        minimumCoveredLines: 37616,
+        maximumCoveredLines: 37616,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 0);

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 37616,
+        "coveredLines": 37618,
         "totalLines": 47018
       },
       "observations": {
-        "cleanRuns": 3,
+        "cleanRuns": 4,
         "minimumCoveredLines": 37616,
-        "maximumCoveredLines": 37616
+        "maximumCoveredLines": 37618
       },
       "tolerance": {
-        "missingCoveredLines": 0,
-        "rationale": "The #524 Platform deprecation-policy change adds a strict embedded operation registry, bounded immutable lookup, MVC action-identity resolution, RFC 9745 Deprecation and RFC 8594 Sunset response headers, and frozen-route/version-window enforcement. Three clean .NET 10.0.9 Coverlet runs on the identical final 47,018-line source and test scope each passed all 3,329 tests and reproduced exactly 37,616 covered lines. The reviewed high-water and exact clean-run floor are therefore both 37,616/47,018 (80.003%), so no instrumentation tolerance is needed. Relative to the prior 37,479/46,859 baseline, the change adds 159 instrumented lines, raises the high-water by 137 covered lines, and increases overall coverage from 79.983% to 80.003%. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 2,
+        "rationale": "The #524 Platform deprecation-policy change adds a strict embedded operation registry, bounded immutable lookup, MVC action-identity resolution, RFC 9745 Deprecation and RFC 8594 Sunset response headers, and frozen-route/version-window enforcement. Four clean .NET 10.0.9 Coverlet runs on the identical final 47,018-line source and test scope each passed all 3,329 tests: three local runs reproduced 37,616 covered lines and the Linux GitHub Actions run measured 37,618. The reviewed observed high-water is therefore 37,618/47,018 (80.008%), while the exact clean-run floor is 37,616/47,018 (80.003%); the two-line tolerance records only that observed instrumentation envelope. Relative to the prior 37,479/46,859 baseline, the change adds 159 instrumented lines, raises the high-water by 139 covered lines, and increases overall coverage from 79.983% to 80.008%. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 37479,
-        "totalLines": 46859
+        "coveredLines": 37616,
+        "totalLines": 47018
       },
       "observations": {
         "cleanRuns": 3,
-        "minimumCoveredLines": 37479,
-        "maximumCoveredLines": 37479
+        "minimumCoveredLines": 37616,
+        "maximumCoveredLines": 37616
       },
       "tolerance": {
         "missingCoveredLines": 0,
-        "rationale": "The #627-#632 native Seerr compatibility change adds the typed request-outcome contract, bounded upstream error classification, watchlist and per-season 4K projections, authenticated per-user negotiation availability, and exact-generation last-known request settings. Three clean .NET 10.0.9 Coverlet runs on the identical final 46,859-line source and test scope each passed all 3,316 tests and reproduced exactly 37,479 covered lines. The reviewed high-water and exact clean-run floor are therefore both 37,479/46,859 (79.983%), so no instrumentation tolerance is needed. Relative to the prior 37,095/46,442 baseline, the change adds 417 instrumented lines, raises the high-water by 384 covered lines, and increases overall coverage from 79.874% to 79.983%. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "rationale": "The #524 Platform deprecation-policy change adds a strict embedded operation registry, bounded immutable lookup, MVC action-identity resolution, RFC 9745 Deprecation and RFC 8594 Sunset response headers, and frozen-route/version-window enforcement. Three clean .NET 10.0.9 Coverlet runs on the identical final 47,018-line source and test scope each passed all 3,329 tests and reproduced exactly 37,616 covered lines. The reviewed high-water and exact clean-run floor are therefore both 37,616/47,018 (80.003%), so no instrumentation tolerance is needed. Relative to the prior 37,479/46,859 baseline, the change adds 159 instrumented lines, raises the high-water by 137 covered lines, and increases overall coverage from 79.983% to 80.003%. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
Closes #524

## Summary
- ship an empty, strict, embedded Platform v1 deprecation registry
- emit RFC 9745 Deprecation and RFC 8594 Sunset headers for listed MVC operations
- enforce the 90-day and next-minor removal windows plus frozen/live route drift gates
- document N/N-1 support and literal versioned routes
- ratchet server coverage to the reviewed 37,618/47,018 high-water with the exact observed 37,616 floor

## Validation
- 3,329 server tests pass; reviewed server high-water 80.008%
- 2,041 client tests pass; client coverage 87.723%
- strict docs build, release build, deterministic bundle, type checks, syntax, scripts, and lint invocation pass
- independent agent review: APPROVE, no findings
- CI coverage follow-up review: APPROVE; two-line same-scope Coverlet envelope only

AI assistance was used for implementation, tests, validation, and review.