### PR TITLE
EP-02: define immutable Platform actor domain

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/HiddenContentPayloadControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/HiddenContentPayloadControllerTests.cs
@@ -9,6 +9,7 @@ using Jellyfin.Plugin.JellyfinCanopy.Platform;
 using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
 using Jellyfin.Plugin.JellyfinCanopy.Services;
 using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.Platform;
 using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
@@ -1577,7 +1578,7 @@ public sealed class HiddenContentPayloadControllerTests : IDisposable
             hiddenContentItemActionOwner: owner)
             .HideFromContinueWatching(legacyItemId.ToString());
         var platformResult = new HiddenContentPlatformItemActionAdapter(owner).Configure(
-            new PlatformActor(platformUserId, false, "correlation", null, null),
+            PlatformActorTestFactory.Create(platformUserId, false, "correlation", null, null),
             new HostAccessibleItem(
                 platformItemId,
                 HostItemKind.Movie,

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/HiddenContentPlatformItemActionAdapterTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/HiddenContentPlatformItemActionAdapterTests.cs
@@ -16,7 +16,7 @@ public sealed class HiddenContentPlatformItemActionAdapterTests
         var adapter = new HiddenContentPlatformItemActionAdapter(owner);
         var userId = Guid.NewGuid();
         var itemId = Guid.NewGuid();
-        var actor = new PlatformActor(userId, false, "correlation", null, null);
+        var actor = PlatformActorTestFactory.Create(userId, false, "correlation", null, null);
         var item = new HostAccessibleItem(
             itemId,
             HostItemKind.Movie,
@@ -45,7 +45,7 @@ public sealed class HiddenContentPlatformItemActionAdapterTests
         var adapter = new HiddenContentPlatformItemActionAdapter(owner);
 
         adapter.GetState(
-            new PlatformActor(Guid.NewGuid(), false, "correlation", null, null),
+            PlatformActorTestFactory.Create(Guid.NewGuid(), false, "correlation", null, null),
             new HostAccessibleItem(Guid.NewGuid(), HostItemKind.Episode, Guid.NewGuid(), []),
             HiddenContentItemScope.Global);
 
@@ -58,7 +58,7 @@ public sealed class HiddenContentPlatformItemActionAdapterTests
     {
         var owner = new RecordingOwner();
         var adapter = new HiddenContentPlatformItemActionAdapter(owner);
-        var actor = new PlatformActor(Guid.NewGuid(), false, "correlation", null, null);
+        var actor = PlatformActorTestFactory.Create(Guid.NewGuid(), false, "correlation", null, null);
         var item = new HostAccessibleItem(Guid.NewGuid(), HostItemKind.Other, null, []);
 
         Assert.Throws<ArgumentOutOfRangeException>(() => adapter.Configure(

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActionAdmissionLimiterTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActionAdmissionLimiterTests.cs
@@ -142,7 +142,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
         {
             Span<byte> bytes = stackalloc byte[16];
             BitConverter.TryWriteBytes(bytes, suffix);
-            return new PlatformActor(new Guid(bytes), false, new string('a', 32), null, null);
+            return PlatformActorTestFactory.Create(new Guid(bytes), false, new string('a', 32), null, null);
         }
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActionCapabilityServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActionCapabilityServiceTests.cs
@@ -492,7 +492,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
             new(clock, Enumerable.Range(1, 32).Select(value => (byte)value).ToArray(), new SequentialNonceSource().GetBytes);
 
         private static PlatformActor Actor(Guid userId, string? deviceId = "device-a", bool elevated = false) =>
-            new(userId, elevated, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "TestClient", deviceId);
+            PlatformActorTestFactory.Create(
+                userId,
+                elevated,
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "TestClient",
+                deviceId);
 
         private static byte[] Digest(string value) => SHA256.HashData(Encoding.UTF8.GetBytes(value));
 

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActionInvocationCoordinatorTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActionInvocationCoordinatorTests.cs
@@ -579,7 +579,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
                     NullLogger<PlatformAuditStore>.Instance,
                     Clock,
                     Enumerable.Repeat((byte)9, 32).ToArray());
-                BoundaryActor = new PlatformActor(
+                BoundaryActor = PlatformActorTestFactory.Create(
                     FakeHost.UserId,
                     boundaryElevated,
                     new string('a', 32),

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActorArchitectureTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActorArchitectureTests.cs
@@ -32,7 +32,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
         private static readonly Regex ActorReference = new(@"\bPlatformActor\b", RegexOptions.Compiled);
 
         private static readonly Regex ActorConstruction = new(
-            @"\bnew\s+PlatformActor\s*\(",
+            @"\bnew\s+(?:PlatformActor|PlatformInstalledProviderActor|PlatformCompanionServiceActor)\s*\(",
             RegexOptions.Compiled);
 
         [Fact]
@@ -45,7 +45,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
 
             var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
             Assert.Equal(
-                new[] { "ClientName", "CorrelationId", "DeviceId", "IsElevated", "UserId" },
+                new[] { "ClientName", "CorrelationId", "DeviceId", "IsElevated", "Kind", "UserId" },
                 properties.Select(property => property.Name).OrderBy(name => name, StringComparer.Ordinal));
             Assert.All(properties, property =>
             {
@@ -56,6 +56,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
 
             Assert.Equal(typeof(Guid), type.GetProperty(nameof(PlatformActor.UserId))!.PropertyType);
             Assert.Equal(typeof(bool), type.GetProperty(nameof(PlatformActor.IsElevated))!.PropertyType);
+            Assert.Equal(typeof(PlatformActorKind), type.GetProperty(nameof(PlatformActor.Kind))!.PropertyType);
             Assert.Equal(typeof(string), type.GetProperty(nameof(PlatformActor.CorrelationId))!.PropertyType);
             Assert.Equal(typeof(string), type.GetProperty(nameof(PlatformActor.ClientName))!.PropertyType);
             Assert.Equal(typeof(string), type.GetProperty(nameof(PlatformActor.DeviceId))!.PropertyType);
@@ -147,7 +148,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
         }
 
         [Fact]
-        public void OnlyTheControllerBoundaryCanConstructAnActor()
+        public void OnlyTheActorDomainFactoryCanConstructActors()
         {
             var constructors = SourceFiles()
                 .Where(file => ActorConstruction.IsMatch(
@@ -156,7 +157,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
                 .OrderBy(name => name, StringComparer.Ordinal)
                 .ToList();
 
-            Assert.Equal(new[] { "PlatformActorBoundaryFilter.cs" }, constructors);
+            Assert.Equal(new[] { "PlatformActorDomain.cs" }, constructors);
 
             Assert.Matches(
                 ActorConstruction,

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActorAuthorityArchitectureTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActorAuthorityArchitectureTests.cs
@@ -1,0 +1,325 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security.Claims;
+using System.Text;
+using System.Text.RegularExpressions;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform;
+
+/// <summary>Guards the closed actor domain and its kernel-only construction paths.</summary>
+public sealed class PlatformActorAuthorityArchitectureTests
+{
+    private static readonly Regex ExplicitActorConstruction = new(
+        @"\bnew\s+(?:(?:global::)?[A-Za-z_]\w*\.)*(?:PlatformActor|PlatformInstalledProviderActor|PlatformCompanionServiceActor)\s*\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex TargetTypedActorConstruction = new(
+        @"\b(?:PlatformActor|PlatformInstalledProviderActor|PlatformCompanionServiceActor)\s+[A-Za-z_]\w*\s*=\s*new\s*\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex ActorTypeAlias = new(
+        @"^\s*using\s+[A-Za-z_]\w*\s*=\s*(?:(?:global::)?[A-Za-z_]\w*\.)*(?:PlatformActor|PlatformInstalledProviderActor|PlatformCompanionServiceActor)\s*;",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.Multiline);
+
+    private static readonly Regex IdentifierUnicodeEscape = new(
+        @"\\(?:u(?<short>[0-9a-fA-F]{4})|U(?<long>[0-9a-fA-F]{8}))",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    [Fact]
+    public void ActorRepresentationsAreSealedDistinctAndImmutable()
+    {
+        var actorTypes = new[]
+        {
+            typeof(PlatformActor),
+            typeof(PlatformInstalledProviderActor),
+            typeof(PlatformCompanionServiceActor),
+        };
+
+        Assert.All(actorTypes, type =>
+        {
+            Assert.True(type.IsSealed);
+            Assert.Empty(type.GetConstructors(BindingFlags.Public | BindingFlags.Instance));
+            Assert.All(
+                type.GetProperties(BindingFlags.Public | BindingFlags.Instance),
+                property => Assert.False(property.CanWrite));
+            Assert.DoesNotContain(
+                type.GetMethods(BindingFlags.Public | BindingFlags.Static),
+                method => method.Name is "op_Implicit" or "op_Explicit");
+        });
+
+        Assert.All(actorTypes, type => Assert.Equal(typeof(object), type.BaseType));
+        Assert.Empty(actorTypes.SelectMany(type => type.GetInterfaces()));
+        Assert.Null(typeof(PlatformInstalledProviderActor).GetProperty("UserId"));
+        Assert.Null(typeof(PlatformInstalledProviderActor).GetProperty("IsElevated"));
+        Assert.Null(typeof(PlatformCompanionServiceActor).GetProperty("UserId"));
+        Assert.Null(typeof(PlatformCompanionServiceActor).GetProperty("IsElevated"));
+    }
+
+    [Fact]
+    public void AuthorityProjectionCarriesOnlyKindAndCurrentElevation()
+    {
+        var properties = typeof(PlatformActorAuthority)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .OrderBy(property => property.Name, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(new[] { "IsElevated", "Kind" }, properties.Select(property => property.Name));
+        Assert.Equal(typeof(bool), properties.Single(property => property.Name == "IsElevated").PropertyType);
+        Assert.Equal(typeof(PlatformActorKind), properties.Single(property => property.Name == "Kind").PropertyType);
+        Assert.All(properties, property => Assert.False(property.CanWrite));
+        Assert.Empty(typeof(PlatformActorAuthority).GetConstructors(BindingFlags.Public | BindingFlags.Instance));
+
+        var forbidden = new Regex(
+            "id|token|secret|credential|claim|principal|http|request|route|query|body|payload|manifest|grant|capability|correlation|client|device|ip",
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        Assert.All(properties, property => Assert.DoesNotMatch(forbidden, property.Name));
+    }
+
+    [Fact]
+    public void ConstructionProofsAreOpaqueAndHaveOnlyPrivateConstructors()
+    {
+        foreach (var type in new[]
+        {
+            typeof(PlatformUserBoundaryResult),
+            typeof(PlatformInstalledPluginId),
+            typeof(PlatformManifestFingerprint),
+            typeof(PlatformApprovedProviderIdentity),
+            typeof(PlatformServiceRegistrationId),
+            typeof(PlatformCredentialGeneration),
+            typeof(PlatformCurrentServiceIdentity),
+        })
+        {
+            Assert.Empty(type.GetConstructors(BindingFlags.Public | BindingFlags.Instance));
+            var constructors = type.GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.Single(constructors);
+            Assert.True(constructors[0].IsPrivate);
+        }
+    }
+
+    [Fact]
+    public void ActorFactoryAcceptsOnlyTypedProofs()
+    {
+        var methods = typeof(PlatformActorFactory)
+            .GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
+            .Where(method => !method.IsSpecialName)
+            .OrderBy(method => method.Name, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(
+            new[] { "CreateAuthenticatedUserActor", "CreateProvider", "CreateService" },
+            methods.Select(method => method.Name));
+        Assert.Equal(
+            new[] { typeof(PlatformApprovedProviderIdentity) },
+            Method("CreateProvider").GetParameters().Select(parameter => parameter.ParameterType));
+        Assert.Equal(
+            new[] { typeof(PlatformCurrentServiceIdentity) },
+            Method("CreateService").GetParameters().Select(parameter => parameter.ParameterType));
+        Assert.Equal(
+            new[] { typeof(PlatformUserBoundaryResult) },
+            Method("CreateAuthenticatedUserActor").GetParameters().Select(parameter => parameter.ParameterType));
+        var forbidden = new[]
+        {
+            typeof(Guid),
+            typeof(string),
+            typeof(byte[]),
+            typeof(Claim),
+            typeof(ClaimsIdentity),
+            typeof(ClaimsPrincipal),
+            typeof(HttpContext),
+            typeof(HttpRequest),
+            typeof(HttpResponse),
+        };
+        Assert.DoesNotContain(
+            methods.SelectMany(method => method.GetParameters()).Select(parameter => parameter.ParameterType),
+            parameterType => forbidden.Contains(parameterType));
+
+        MethodInfo Method(string name) => methods.Single(method => method.Name == name);
+    }
+
+    [Fact]
+    public void OnlyTheActorDomainConstructsActorsAndOnlyTheBoundaryCompletesUserProof()
+    {
+        var actorConstructionOwners = ProductionFiles()
+            .Where(file => HasActorConstruction(PlatformHostSeamTests.CodeOnly(File.ReadAllText(file))))
+            .Select(Path.GetFileName)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+        Assert.Equal(new[] { "PlatformActorDomain.cs" }, actorConstructionOwners);
+
+        Assert.Equal(
+            new[] { "PlatformActorBoundaryFilter.cs", "PlatformActorDomain.cs" },
+            SensitiveMemberOwners("EstablishAuthenticatedUserBoundary"));
+        Assert.Equal(
+            new[] { "PlatformActorBoundaryFilter.cs", "PlatformActorDomain.cs" },
+            SensitiveMemberOwners("EstablishReauthorizedUserBoundary"));
+        Assert.Equal(
+            new[] { "PlatformActorBoundaryFilter.cs", "PlatformActorDomain.cs" },
+            SensitiveMemberOwners("CreateAuthenticatedUserActor"));
+
+        Assert.True(HasSensitiveMemberUse(
+            "using Proof = PlatformUserBoundaryResult; var proof = Proof.EstablishAuthenticatedUserBoundary (user, id, null, null);",
+            "EstablishAuthenticatedUserBoundary"));
+        Assert.True(HasSensitiveMemberUse(
+            "using Factory = PlatformActorFactory; var actor = Factory\n .\n CreateAuthenticatedUserActor (proof);",
+            "CreateAuthenticatedUserActor"));
+        Assert.True(HasSensitiveMemberUse(
+            "using static PlatformActorFactory; var actor = CreateAuthenticatedUserActor(proof);",
+            "CreateAuthenticatedUserActor"));
+        Assert.True(HasSensitiveMemberUse(
+            "Func<PlatformUserBoundaryResult, PlatformActor> create = PlatformActorFactory.CreateAuthenticatedUserActor;",
+            "CreateAuthenticatedUserActor"));
+        Assert.True(HasSensitiveMemberUse(
+            """var proof = PlatformUserBoundaryResult.EstablishAuthenticatedUser\u0042oundary(user, id, null, null);""",
+            "EstablishAuthenticatedUserBoundary"));
+        Assert.True(HasSensitiveMemberUse(
+            """var actor = PlatformActorFactory.CreateAuthenticatedUser\u0041ctor(proof);""",
+            "CreateAuthenticatedUserActor"));
+        Assert.True(HasSensitiveMemberUse(
+            """var proof = PlatformUserBoundaryResult.EstablishAuthenticatedUser\u200cBoundary(user, id, null, null);""",
+            "EstablishAuthenticatedUserBoundary"));
+        Assert.True(HasSensitiveMemberUse(
+            "PlatformActorFactory.CreateAuthenticatedUser"
+                + '\u200C'
+                + "Actor(proof);",
+            "CreateAuthenticatedUserActor"));
+
+        Assert.True(HasActorConstruction("var actor = new global::Jellyfin.Plugin.JellyfinCanopy.Platform.PlatformActor(proof);"));
+        Assert.True(HasActorConstruction("PlatformActor actor = new(proof);"));
+        Assert.True(HasActorConstruction(
+            "using ActorAlias = Jellyfin.Plugin.JellyfinCanopy.Platform.PlatformActor;\nActorAlias actor = new(proof);"));
+    }
+
+    [Fact]
+    public void OnlyActorRepresentationsCanProjectAuthority()
+    {
+        Assert.Equal(
+            new[] { "PlatformActor.cs", "PlatformActorDomain.cs" },
+            SensitiveMemberOwners("ProjectAuthenticatedUserAuthority"));
+        Assert.Equal(
+            new[] { "PlatformActorDomain.cs" },
+            SensitiveMemberOwners("ProjectInstalledProviderAuthority"));
+        Assert.Equal(
+            new[] { "PlatformActorDomain.cs" },
+            SensitiveMemberOwners("ProjectCompanionServiceAuthority"));
+
+        Assert.True(HasSensitiveMemberUse(
+            "using Authority = PlatformActorAuthority; Func<bool, PlatformActorAuthority> project = Authority.ProjectAuthenticatedUserAuthority;",
+            "ProjectAuthenticatedUserAuthority"));
+    }
+
+    [Fact]
+    public void OnlyCurrentKernelOwnersCanRequestBoundaryReauthorization()
+    {
+        Assert.Equal(
+            new[]
+            {
+                "PlatformActionInvocationCoordinator.cs",
+                "PlatformActorBoundaryFilter.cs",
+                "PlatformNativeCatalogService.cs",
+            },
+            SensitiveMemberOwners("ReauthorizeUserActor"));
+
+        var parameters = typeof(PlatformActorBoundaryFilter)
+            .GetMethod("ReauthorizeUserActor", BindingFlags.Static | BindingFlags.NonPublic)!
+            .GetParameters()
+            .Select(parameter => parameter.ParameterType)
+            .ToArray();
+        Assert.Equal(new[] { typeof(PlatformActor), typeof(IPlatformHost) }, parameters);
+        Assert.DoesNotContain(typeof(HostUser), parameters);
+
+        Assert.True(HasSensitiveMemberUse(
+            "using Boundary = PlatformActorBoundaryFilter; var actor = Boundary . ReauthorizeUserActor (current, host);",
+            "ReauthorizeUserActor"));
+    }
+
+    [Fact]
+    public void ProviderAndServiceProofsHaveNoProductionIssuerOrRegistrationSurfaceYet()
+    {
+        var source = string.Join(
+            "\n",
+            ProductionFiles().Select(file => PlatformHostSeamTests.CodeOnly(File.ReadAllText(file))));
+
+        Assert.DoesNotContain("new PlatformApprovedProviderIdentity", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("new PlatformCurrentServiceIdentity", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("PlatformActorFactory.CreateProvider(", source.Replace(
+            "internal static PlatformInstalledProviderActor CreateProvider(",
+            string.Empty,
+            StringComparison.Ordinal), StringComparison.Ordinal);
+        Assert.DoesNotContain("PlatformActorFactory.CreateService(", source.Replace(
+            "internal static PlatformCompanionServiceActor CreateService(",
+            string.Empty,
+            StringComparison.Ordinal), StringComparison.Ordinal);
+        Assert.DoesNotContain("AddSingleton<PlatformActorFactory", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("AddScoped<PlatformActorFactory", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("AddTransient<PlatformActorFactory", source, StringComparison.Ordinal);
+    }
+
+    private static bool HasActorConstruction(string code) =>
+        ExplicitActorConstruction.IsMatch(code)
+        || TargetTypedActorConstruction.IsMatch(code)
+        || ActorTypeAlias.IsMatch(code);
+
+    private static string[] SensitiveMemberOwners(string memberName) => ProductionFiles()
+        .Where(file => HasSensitiveMemberUse(
+            PlatformHostSeamTests.CodeOnly(File.ReadAllText(file)),
+            memberName))
+        .Select(file => Path.GetFileName(file)!)
+        .OrderBy(name => name, StringComparer.Ordinal)
+        .ToArray();
+
+    private static bool HasSensitiveMemberUse(string code, string memberName) =>
+        Regex.IsMatch(
+            NormalizeIdentifierUnicodeEscapes(code),
+            $@"\b{Regex.Escape(memberName)}\b",
+            RegexOptions.CultureInvariant);
+
+    private static string NormalizeIdentifierUnicodeEscapes(string code)
+    {
+        var decoded = IdentifierUnicodeEscape.Replace(code, match =>
+        {
+            var shortHex = match.Groups["short"];
+            if (shortHex.Success)
+            {
+                return ((char)Convert.ToInt32(shortHex.Value, 16)).ToString();
+            }
+
+            var scalar = Convert.ToInt32(match.Groups["long"].Value, 16);
+            return scalar is >= 0 and <= 0x10FFFF
+                && scalar is not (>= 0xD800 and <= 0xDFFF)
+                    ? char.ConvertFromUtf32(scalar)
+                    : match.Value;
+        });
+
+        var normalized = new StringBuilder(decoded.Length);
+        foreach (var rune in decoded.EnumerateRunes())
+        {
+            if (Rune.GetUnicodeCategory(rune) != UnicodeCategory.Format)
+            {
+                normalized.Append(rune.ToString());
+            }
+        }
+
+        return normalized.ToString();
+    }
+
+    private static IEnumerable<string> ProductionFiles() =>
+        Directory.EnumerateFiles(ProductionRoot(), "*.cs", SearchOption.AllDirectories)
+            .Where(file => !file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                && !file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal));
+
+    private static string ProductionRoot([CallerFilePath] string sourceFile = "") =>
+        Path.GetFullPath(Path.Combine(
+            Path.GetDirectoryName(sourceFile)!,
+            "..",
+            "..",
+            "Jellyfin.Plugin.JellyfinCanopy"));
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActorAuthorityTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActorAuthorityTests.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform;
+
+public sealed class PlatformActorAuthorityTests
+{
+    [Fact]
+    public void ActorKindVocabularyIsExactClosedAndHasNoAdministratorKind()
+    {
+        Assert.Equal(
+            new[]
+            {
+                PlatformActorKind.JellyfinUserClient,
+                PlatformActorKind.InstalledProvider,
+                PlatformActorKind.CompanionService,
+            },
+            PlatformActorKindVocabulary.All);
+        Assert.Equal(
+            new[] { "JellyfinUserClient", "InstalledProvider", "CompanionService" },
+            Enum.GetNames<PlatformActorKind>());
+        Assert.Equal(new[] { 1, 2, 3 }, Enum.GetValues<PlatformActorKind>().Select(value => (int)value));
+        Assert.Equal("jellyfin-user-client", PlatformActorKindVocabulary.TokenFor(PlatformActorKind.JellyfinUserClient));
+        Assert.Equal("installed-provider", PlatformActorKindVocabulary.TokenFor(PlatformActorKind.InstalledProvider));
+        Assert.Equal("companion-service", PlatformActorKindVocabulary.TokenFor(PlatformActorKind.CompanionService));
+        Assert.Null(PlatformActorKindVocabulary.TokenFor(default));
+        Assert.Null(PlatformActorKindVocabulary.TokenFor((PlatformActorKind)99));
+        Assert.DoesNotContain(Enum.GetNames<PlatformActorKind>(), name => name.Contains("Admin", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void UserActorKeepsOneKindAcrossCurrentElevationChanges()
+    {
+        var userId = Guid.NewGuid();
+        var ordinary = PlatformActorTestFactory.Create(userId, false, "ordinary", null, null);
+        var elevated = PlatformActorTestFactory.Create(userId, true, "elevated", null, null);
+
+        Assert.Equal(PlatformActorKind.JellyfinUserClient, ordinary.Kind);
+        Assert.Equal(PlatformActorKind.JellyfinUserClient, elevated.Kind);
+        Assert.False(ordinary.Authority.IsElevated);
+        Assert.True(elevated.Authority.IsElevated);
+        Assert.Equal(PlatformActorKind.JellyfinUserClient, ordinary.Authority.Kind);
+        Assert.Equal(PlatformActorKind.JellyfinUserClient, elevated.Authority.Kind);
+    }
+
+    [Fact]
+    public void DefaultUnknownAndCrossKindAuthorityFailClosed()
+    {
+        var definition = PlatformOperationVocabulary.All[0];
+        var provider = Provider(Guid.NewGuid(), new string('a', 64));
+        var service = Service(Guid.NewGuid(), 1);
+
+        Assert.False(default(PlatformActorAuthority).IsValid);
+        Assert.False(definition.Allows(default));
+        Assert.False(definition.Allows(provider.Authority));
+        Assert.False(definition.Allows(service.Authority));
+        Assert.True(definition.Allows(
+            PlatformActorTestFactory.Create(Guid.NewGuid(), false, "correlation", null, null).Authority));
+        Assert.True(definition.Allows(
+            PlatformActorTestFactory.Create(Guid.NewGuid(), true, "correlation", null, null).Authority));
+    }
+
+    [Fact]
+    public void ProviderAndServiceActorsRemainDistinctEvenWhenIdentifiersMatch()
+    {
+        var shared = Guid.NewGuid();
+        var provider = Provider(shared, new string('b', 64));
+        var service = Service(shared, 7);
+
+        Assert.Equal(PlatformActorKind.InstalledProvider, provider.Kind);
+        Assert.Equal(PlatformActorKind.CompanionService, service.Kind);
+        Assert.Equal(shared, provider.InstalledPluginId);
+        Assert.Equal(shared, service.RegistrationId);
+        Assert.Equal(new string('b', 64), provider.ManifestFingerprint);
+        Assert.Equal(7, service.CredentialGeneration);
+        Assert.False(provider.Authority.IsElevated);
+        Assert.False(service.Authority.IsElevated);
+        Assert.NotEqual(provider.GetType(), service.GetType());
+    }
+
+    [Fact]
+    public void ProviderInputRequiresNonemptyPluginAndCanonicalFingerprint()
+    {
+        Assert.Throws<ArgumentException>(() => InstalledPluginId(Guid.Empty));
+        Assert.Throws<ArgumentNullException>(() => ManifestFingerprint(null!));
+        Assert.Throws<ArgumentException>(() => ManifestFingerprint(string.Empty));
+        Assert.Throws<ArgumentException>(() => ManifestFingerprint(new string('a', 63)));
+        Assert.Throws<ArgumentException>(() => ManifestFingerprint(new string('A', 64)));
+        Assert.Throws<ArgumentException>(() => ManifestFingerprint(new string('g', 64)));
+
+        var actor = Provider(Guid.NewGuid(), "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+        Assert.Equal(64, actor.ManifestFingerprint.Length);
+    }
+
+    [Fact]
+    public void ServiceInputRequiresRegistrationAndPositiveCredentialGeneration()
+    {
+        Assert.Throws<ArgumentException>(() => ServiceRegistrationId(Guid.Empty));
+        Assert.Throws<ArgumentOutOfRangeException>(() => CredentialGeneration(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => CredentialGeneration(-1));
+
+        var actor = Service(Guid.NewGuid(), 1);
+        Assert.Equal(1, actor.CredentialGeneration);
+    }
+
+    [Fact]
+    public void FactoriesRejectMissingTypedProofs()
+    {
+        Assert.Throws<ArgumentNullException>(() => PlatformActorFactory.CreateAuthenticatedUserActor(null!));
+        Assert.Throws<ArgumentNullException>(() => PlatformActorFactory.CreateProvider(null!));
+        Assert.Throws<ArgumentNullException>(() => PlatformActorFactory.CreateService(null!));
+    }
+
+    [Fact]
+    public void ReauthorizationOwnsTheFreshLookupAndCannotChangeBoundaryIdentity()
+    {
+        var userId = Guid.NewGuid();
+        var actor = PlatformActorTestFactory.Create(userId, false, "correlation", "client", "device");
+        var host = new ReauthorizationHost
+        {
+            Current = new HostUser(userId, "user", true),
+        };
+
+        var elevated = PlatformActorBoundaryFilter.ReauthorizeUserActor(actor, host);
+
+        Assert.NotNull(elevated);
+        Assert.Equal(userId, host.RequestedUserId);
+        Assert.Equal(userId, elevated.UserId);
+        Assert.True(elevated.IsElevated);
+        Assert.Equal(actor.CorrelationId, elevated.CorrelationId);
+        Assert.Equal(actor.ClientName, elevated.ClientName);
+        Assert.Equal(actor.DeviceId, elevated.DeviceId);
+
+        host.Current = new HostUser(Guid.NewGuid(), "other", true);
+        Assert.Null(PlatformActorBoundaryFilter.ReauthorizeUserActor(actor, host));
+
+        host.Current = null;
+        Assert.Null(PlatformActorBoundaryFilter.ReauthorizeUserActor(actor, host));
+    }
+
+    internal static PlatformInstalledProviderActor Provider(Guid pluginId, string fingerprint)
+    {
+        var identity = ConstructPrivately<PlatformApprovedProviderIdentity>(
+            InstalledPluginId(pluginId),
+            ManifestFingerprint(fingerprint));
+        return PlatformActorFactory.CreateProvider(identity);
+    }
+
+    internal static PlatformCompanionServiceActor Service(Guid registrationId, long generation)
+    {
+        var identity = ConstructPrivately<PlatformCurrentServiceIdentity>(
+            ServiceRegistrationId(registrationId),
+            CredentialGeneration(generation));
+        return PlatformActorFactory.CreateService(identity);
+    }
+
+    private static PlatformInstalledPluginId InstalledPluginId(Guid value) =>
+        ConstructPrivately<PlatformInstalledPluginId>(value);
+
+    private static PlatformManifestFingerprint ManifestFingerprint(string value) =>
+        ConstructPrivately<PlatformManifestFingerprint>(value);
+
+    private static PlatformServiceRegistrationId ServiceRegistrationId(Guid value) =>
+        ConstructPrivately<PlatformServiceRegistrationId>(value);
+
+    private static PlatformCredentialGeneration CredentialGeneration(long value) =>
+        ConstructPrivately<PlatformCredentialGeneration>(value);
+
+    private static T ConstructPrivately<T>(params object?[] arguments)
+    {
+        var constructor = typeof(T)
+            .GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)
+            .Single();
+
+        try
+        {
+            return (T)constructor.Invoke(arguments);
+        }
+        catch (TargetInvocationException exception) when (exception.InnerException is not null)
+        {
+            ExceptionDispatchInfo.Capture(exception.InnerException).Throw();
+            throw;
+        }
+    }
+
+    private sealed class ReauthorizationHost : IPlatformHost, IHostUsers
+    {
+        public HostUser? Current { get; set; }
+
+        public Guid RequestedUserId { get; private set; }
+
+        public IHostUsers Users => this;
+
+        public IHostLibrary Library => throw new NotSupportedException();
+
+        public IHostSessions Sessions => throw new NotSupportedException();
+
+        public IHostPlugins Plugins => throw new NotSupportedException();
+
+        public HostUser? Find(Guid id)
+        {
+            RequestedUserId = id;
+            return Current;
+        }
+
+        public System.Collections.Generic.IReadOnlyList<HostUser> All() => [];
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActorTestFactory.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActorTestFactory.cs
@@ -1,0 +1,24 @@
+using System;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform;
+
+/// <summary>Creates real typed-boundary user actors for downstream unit tests.</summary>
+internal static class PlatformActorTestFactory
+{
+    internal static PlatformActor Create(
+        Guid userId,
+        bool isElevated,
+        string correlationId,
+        string? clientName,
+        string? deviceId)
+    {
+        var boundaryResult = PlatformUserBoundaryResult.EstablishAuthenticatedUserBoundary(
+            new HostUser(userId, "Test user", isElevated),
+            correlationId,
+            clientName,
+            deviceId);
+        return PlatformActorFactory.CreateAuthenticatedUserActor(boundaryResult);
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformAuditStoreTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformAuditStoreTests.cs
@@ -298,7 +298,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
             var actualOversized = "bearer-" + new string('x', PlatformActorBoundaryFilter.MaxClientNameBytes);
             var logger = new RecordingLogger();
             var store = Store(logger);
-            var actor = new PlatformActor(Guid.NewGuid(), false, "canary-correlation", actualOversized, "device\ncanary");
+            var actor = PlatformActorTestFactory.Create(Guid.NewGuid(), false, "canary-correlation", actualOversized, "device\ncanary");
 
             using var attempt = store.Begin(actor, Operation(PlatformOperationFamily.Seerr));
             Assert.True(attempt.Complete(PlatformAuditResultCode.AuthorityDenied));
@@ -321,9 +321,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
                 timeProvider ?? new ManualTimeProvider(Start),
                 Enumerable.Repeat(keyByte, 32).Select(value => (byte)value).ToArray());
 
-        private static PlatformActor Actor(int value, string? client = "Android TV", string? device = "living-room") => new(
+        private static PlatformActor Actor(int value, string? client = "Android TV", string? device = "living-room") => PlatformActorTestFactory.Create(
             Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
-            isElevated: value % 2 == 0,
+            value % 2 == 0,
             Correlation(value),
             client,
             device);

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformContractTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformContractTests.cs
@@ -150,6 +150,54 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
                     : "authenticated";
         }
 
+        private static IReadOnlyList<string> LiveActorKinds(MethodInfo action) =>
+            string.Equals(LiveAuthority(action), "anonymous", StringComparison.Ordinal)
+                ? Array.Empty<string>()
+                : new[] { PlatformActorKindVocabulary.TokenFor(PlatformActorKind.JellyfinUserClient)! };
+
+        private static string OperationKey(string path, string method) => $"{method} {path}";
+
+        private static IReadOnlyList<string> OperationMetadataDrift(JsonElement frozen, JsonElement spec)
+        {
+            var drift = new List<string>();
+            var specified = SpecOperations(spec)
+                .ToDictionary(
+                    operation => OperationKey(operation.Path, operation.Method),
+                    operation => operation.Operation,
+                    StringComparer.Ordinal);
+            var frozenMetadata = frozen.GetProperty("operationMetadata");
+
+            foreach (var operation in specified)
+            {
+                if (!frozenMetadata.TryGetProperty(operation.Key, out var metadata))
+                {
+                    drift.Add($"{operation.Key} has no frozen authority metadata");
+                    continue;
+                }
+
+                var specAuthority = operation.Value.GetProperty("x-canopy-authority").GetString();
+                var frozenAuthority = metadata.GetProperty("authority").GetString();
+                if (!string.Equals(specAuthority, frozenAuthority, StringComparison.Ordinal))
+                {
+                    drift.Add($"{operation.Key} authority changed from {frozenAuthority} to {specAuthority}");
+                }
+
+                var specKinds = operation.Value.GetProperty("x-canopy-actor-kinds")
+                    .EnumerateArray().Select(value => value.GetString()).ToArray();
+                var frozenKinds = metadata.GetProperty("actorKinds")
+                    .EnumerateArray().Select(value => value.GetString()).ToArray();
+                if (!specKinds.SequenceEqual(frozenKinds, StringComparer.Ordinal))
+                {
+                    drift.Add($"{operation.Key} actor kinds changed");
+                }
+            }
+
+            drift.AddRange(frozenMetadata.EnumerateObject()
+                .Where(operation => !specified.ContainsKey(operation.Name))
+                .Select(operation => $"{operation.Name} has frozen metadata but no published operation"));
+            return drift.OrderBy(value => value, StringComparer.Ordinal).ToArray();
+        }
+
         private static IEnumerable<(string Path, string Method, JsonElement Operation)> SpecOperations(JsonElement spec)
         {
             foreach (var path in spec.GetProperty("paths").EnumerateObject())
@@ -720,6 +768,85 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
                 Assert.Contains(published, new[] { "anonymous", "authenticated", "elevated" });
                 Assert.Equal(LiveAuthority(action), published);
             }
+        }
+
+        [Fact]
+        public void ActorKindTokensMatchTheClosedRuntimeAndFrozenVocabulary()
+        {
+            var runtime = PlatformActorKindVocabulary.All
+                .Select(kind => PlatformActorKindVocabulary.TokenFor(kind)!)
+                .ToArray();
+            var authored = Spec.RootElement.GetProperty("x-canopy-actor-kind-vocabulary")
+                .EnumerateArray().Select(value => value.GetString()).ToArray();
+            var frozen = Frozen.RootElement.GetProperty("actorKindVocabulary")
+                .EnumerateArray().Select(value => value.GetString()).ToArray();
+
+            Assert.Equal(new[] { "jellyfin-user-client", "installed-provider", "companion-service" }, runtime);
+            Assert.Equal(runtime, authored);
+            Assert.Equal(runtime, frozen);
+            Assert.Equal(runtime.Length, runtime.Distinct(StringComparer.Ordinal).Count());
+        }
+
+        [Fact]
+        public void EveryOperationPublishesItsExactRuntimeActorKinds()
+        {
+            foreach (var (path, method, action) in LiveRoutes())
+            {
+                var operation = SpecOperations().Single(entry =>
+                    string.Equals(entry.Path, path, StringComparison.Ordinal)
+                    && string.Equals(entry.Method, method, StringComparison.Ordinal)).Operation;
+                var published = operation.GetProperty("x-canopy-actor-kinds")
+                    .EnumerateArray().Select(value => value.GetString()!).ToArray();
+
+                Assert.Equal(LiveActorKinds(action), published);
+                Assert.DoesNotContain("installed-provider", published);
+                Assert.DoesNotContain("companion-service", published);
+            }
+        }
+
+        [Fact]
+        public void FrozenOperationAuthorityMetadataMatchesTheAuthoredSpec()
+        {
+            var drift = OperationMetadataDrift(Frozen.RootElement, Spec.RootElement);
+
+            Assert.True(
+                drift.Count == 0,
+                "Frozen Platform authority metadata drifted: " + string.Join("; ", drift));
+            Assert.Equal(
+                SpecOperations().Count(),
+                Frozen.RootElement.GetProperty("operationMetadata").EnumerateObject().Count());
+        }
+
+        [Fact]
+        public void ActorMetadataDriftGateNamesMissingRemovedAndWidenedPolicy()
+        {
+            using var missingFrozen = JsonDocument.Parse("""
+                {"operationMetadata":{}}
+                """);
+            using var oneUserOperation = JsonDocument.Parse("""
+                {"paths":{"/operation":{"post":{
+                  "x-canopy-authority":"authenticated",
+                  "x-canopy-actor-kinds":["jellyfin-user-client"]
+                }}}}
+                """);
+            Assert.Equal(
+                new[] { "post /operation has no frozen authority metadata" },
+                OperationMetadataDrift(missingFrozen.RootElement, oneUserOperation.RootElement));
+
+            using var widenedFrozen = JsonDocument.Parse("""
+                {"operationMetadata":{"post /operation":{
+                  "authority":"authenticated",
+                  "actorKinds":["jellyfin-user-client","companion-service"]
+                }}}
+                """);
+            Assert.Equal(
+                new[] { "post /operation actor kinds changed" },
+                OperationMetadataDrift(widenedFrozen.RootElement, oneUserOperation.RootElement));
+
+            using var removedSpec = JsonDocument.Parse("""{"paths":{}}""");
+            Assert.Equal(
+                new[] { "post /operation has frozen metadata but no published operation" },
+                OperationMetadataDrift(widenedFrozen.RootElement, removedSpec.RootElement));
         }
 
         [Fact]

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformDiscoveryControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformDiscoveryControllerTests.cs
@@ -156,7 +156,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
             {
                 ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() },
             };
-            controller.HttpContext.Items["JellyfinCanopy.Platform.Actor"] = new PlatformActor(
+            controller.HttpContext.Items["JellyfinCanopy.Platform.Actor"] = PlatformActorTestFactory.Create(
                 userId,
                 false,
                 "correlation",

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformNativeActionPortTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformNativeActionPortTests.cs
@@ -19,7 +19,12 @@ public sealed class PlatformNativeActionPortTests
         HostItemKind.Movie,
         seriesId: null,
         [new HostProviderReference("tmdb", "123")]);
-    private static readonly PlatformActor Actor = new(UserId, false, "action-port-test", "Android TV", "device-a");
+    private static readonly PlatformActor Actor = PlatformActorTestFactory.Create(
+        UserId,
+        false,
+        "action-port-test",
+        "Android TV",
+        "device-a");
 
     [Fact]
     public async Task Spoiler_ExactAnswerAndCurrentRevisionAreRequired_ThenSuccessRefreshesItemAndSurface()

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformNativeCatalogServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformNativeCatalogServiceTests.cs
@@ -650,7 +650,7 @@ public sealed class PlatformNativeCatalogServiceTests
         }
 
         internal PlatformActor Actor(Guid userId, string? deviceId = "device-a")
-            => new(userId, false, "catalog-test", "Android TV", deviceId);
+            => PlatformActorTestFactory.Create(userId, false, "catalog-test", "Android TV", deviceId);
     }
 
     private sealed class BlockingLiveSessionRegistry : ILiveSessionRegistry, IDisposable

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformNativePilotConformanceMatrixTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformNativePilotConformanceMatrixTests.cs
@@ -608,7 +608,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
         {
             Span<byte> bytes = stackalloc byte[16];
             BitConverter.TryWriteBytes(bytes, index + 1);
-            return new PlatformActor(new Guid(bytes), false, new string('b', 32), null, null);
+            return PlatformActorTestFactory.Create(new Guid(bytes), false, new string('b', 32), null, null);
         }
 
         private static PlatformIdempotencyRequest IdempotencyRequest(
@@ -750,7 +750,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
 
             internal PlatformActor Actor(Guid userId)
             {
-                return new PlatformActor(
+                return PlatformActorTestFactory.Create(
                     userId,
                     userId == UserA,
                     new string('c', 32),

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformOperationVocabularyArchitectureTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformOperationVocabularyArchitectureTests.cs
@@ -54,16 +54,16 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
 
             Assert.Equal(new[] { "PlatformOperationVocabulary.cs" }, constructionOwners);
             Assert.True(HasVocabularyTypeConstruction(
-                "var planted = new PlatformOperationDefinition(id, family, authority, scope, kinds, true, schema, 1);"));
+                "var planted = new PlatformOperationDefinition(id, family, authority, actorKinds, scope, kinds, true, schema, 1);"));
             Assert.True(HasVocabularyTypeConstruction(
                 "var planted = new global::Jellyfin.Plugin.JellyfinCanopy.Platform.PlatformOperationId(value);"));
             Assert.True(HasVocabularyTypeConstruction(
                 "var planted = new Jellyfin.Plugin.JellyfinCanopy.Platform.PlatformInputSchemaId(value);"));
             Assert.True(HasVocabularyTypeConstruction(
-                "PlatformOperationDefinition planted = new(id, family, authority, scope, kinds, true, schema, 1);"));
+                "PlatformOperationDefinition planted = new(id, family, authority, actorKinds, scope, kinds, true, schema, 1);"));
             Assert.True(HasVocabularyTypeConstruction(
                 "using Definition = global::Jellyfin.Plugin.JellyfinCanopy.Platform.PlatformOperationDefinition;\n"
-                + "Definition planted = new(id, family, authority, scope, kinds, true, schema, 1);"));
+                + "Definition planted = new(id, family, authority, actorKinds, scope, kinds, true, schema, 1);"));
         }
 
         [Fact]
@@ -105,6 +105,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
         {
             var expectedProperties = new Dictionary<string, Type>(StringComparer.Ordinal)
             {
+                [nameof(PlatformOperationDefinition.AllowedActorKinds)] = typeof(System.Collections.Immutable.ImmutableArray<PlatformActorKind>),
                 [nameof(PlatformOperationDefinition.Authority)] = typeof(PlatformAuthorityLevel),
                 [nameof(PlatformOperationDefinition.Family)] = typeof(PlatformOperationFamily),
                 [nameof(PlatformOperationDefinition.Id)] = typeof(PlatformOperationId),
@@ -126,6 +127,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
 
             Assert.All(PlatformOperationVocabulary.All, definition =>
             {
+                Assert.Equal(new[] { PlatformActorKind.JellyfinUserClient }, definition.AllowedActorKinds);
                 Assert.DoesNotContain('/', definition.Id.Value);
                 Assert.DoesNotContain(':', definition.Id.Value);
                 Assert.DoesNotContain("controller", definition.Id.Value, StringComparison.Ordinal);
@@ -154,6 +156,22 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
             })
             {
                 Assert.DoesNotContain(forbidden, code, StringComparison.Ordinal);
+            }
+        }
+
+        [Fact]
+        public void CapabilityAndInvocationDelegateToTheSingleOperationPolicyOwner()
+        {
+            foreach (var fileName in new[]
+            {
+                "PlatformActionCapabilityService.cs",
+                "PlatformActionInvocationCoordinator.cs",
+            })
+            {
+                var code = PlatformHostSeamTests.CodeOnly(File.ReadAllText(SourceFile(fileName)));
+                Assert.Contains(".Allows(actor.Authority)", code, StringComparison.Ordinal);
+                Assert.DoesNotContain("HasRequiredAuthority", code, StringComparison.Ordinal);
+                Assert.DoesNotContain("definition.Authority ==", code, StringComparison.Ordinal);
             }
         }
 

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformOperationVocabularyTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformOperationVocabularyTests.cs
@@ -20,6 +20,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
                     Id = definition.Id.Value,
                     definition.Family,
                     definition.Authority,
+                    ActorKinds = string.Join(",", definition.AllowedActorKinds),
                     definition.ItemScope,
                     Kinds = string.Join(",", definition.SupportedItemKinds),
                     definition.IsMutation,
@@ -36,6 +37,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
                         Id = "jellyfin.canopy.spoiler-guard.configure-item",
                         Family = PlatformOperationFamily.SpoilerGuard,
                         Authority = PlatformAuthorityLevel.Authenticated,
+                        ActorKinds = "JellyfinUserClient",
                         ItemScope = PlatformItemScope.ExactItem,
                         Kinds = "Movie,Series",
                         IsMutation = true,
@@ -47,6 +49,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
                         Id = "jellyfin.canopy.hidden-content.configure-item",
                         Family = PlatformOperationFamily.HiddenContent,
                         Authority = PlatformAuthorityLevel.Authenticated,
+                        ActorKinds = "JellyfinUserClient",
                         ItemScope = PlatformItemScope.ExactItem,
                         Kinds = "Movie,Series,Episode",
                         IsMutation = true,
@@ -58,6 +61,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
                         Id = "jellyfin.canopy.seerr.request-item",
                         Family = PlatformOperationFamily.Seerr,
                         Authority = PlatformAuthorityLevel.Authenticated,
+                        ActorKinds = "JellyfinUserClient",
                         ItemScope = PlatformItemScope.ExactItem,
                         Kinds = "Movie,Series",
                         IsMutation = true,
@@ -83,6 +87,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
                 Assert.InRange(definition.Id.Value.Length, 1, PlatformOperationVocabulary.MaximumIdentifierLength);
                 Assert.InRange(definition.InputSchemaId.Value.Length, 1, PlatformOperationVocabulary.MaximumIdentifierLength);
                 Assert.Equal(PlatformAuthorityLevel.Authenticated, definition.Authority);
+                Assert.Equal(new[] { PlatformActorKind.JellyfinUserClient }, definition.AllowedActorKinds);
                 Assert.Equal(PlatformItemScope.ExactItem, definition.ItemScope);
                 Assert.True(definition.IsMutation);
                 Assert.True(definition.InvalidationGeneration > 0);
@@ -155,31 +160,37 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
             var id = ConstructPrivately<PlatformOperationId>("vendor.extension.operation");
             var schema = ConstructPrivately<PlatformInputSchemaId>("vendor.extension.input.v1");
             var kinds = ImmutableArray.Create(HostItemKind.Movie);
+            var actorKinds = ImmutableArray.Create(PlatformActorKind.JellyfinUserClient);
 
-            Assert.Throws<ArgumentException>(() => New(default, kinds: kinds));
-            Assert.Throws<ArgumentOutOfRangeException>(() => New(id, family: (PlatformOperationFamily)99, kinds: kinds));
-            Assert.Throws<ArgumentOutOfRangeException>(() => New(id, authority: (PlatformAuthorityLevel)99, kinds: kinds));
-            Assert.Throws<ArgumentOutOfRangeException>(() => New(id, itemScope: (PlatformItemScope)99, kinds: kinds));
-            Assert.Throws<ArgumentException>(() => New(id, kinds: default));
-            Assert.Throws<ArgumentException>(() => New(id, kinds: [HostItemKind.Other]));
-            Assert.Throws<ArgumentException>(() => New(id, kinds: [(HostItemKind)99]));
-            Assert.Throws<ArgumentException>(() => New(id, kinds: [HostItemKind.Movie, HostItemKind.Movie]));
-            Assert.Throws<ArgumentException>(() => New(id, kinds: kinds, isMutation: false));
+            Assert.Throws<ArgumentException>(() => New(default, actorKinds: actorKinds, kinds: kinds));
+            Assert.Throws<ArgumentOutOfRangeException>(() => New(id, family: (PlatformOperationFamily)99, actorKinds: actorKinds, kinds: kinds));
+            Assert.Throws<ArgumentOutOfRangeException>(() => New(id, authority: (PlatformAuthorityLevel)99, actorKinds: actorKinds, kinds: kinds));
+            Assert.Throws<ArgumentException>(() => New(id, actorKinds: default, kinds: kinds));
+            Assert.Throws<ArgumentException>(() => New(id, actorKinds: [(PlatformActorKind)99], kinds: kinds));
+            Assert.Throws<ArgumentException>(() => New(id, actorKinds: [PlatformActorKind.JellyfinUserClient, PlatformActorKind.JellyfinUserClient], kinds: kinds));
+            Assert.Throws<ArgumentOutOfRangeException>(() => New(id, actorKinds: actorKinds, itemScope: (PlatformItemScope)99, kinds: kinds));
+            Assert.Throws<ArgumentException>(() => New(id, actorKinds: actorKinds, kinds: default));
+            Assert.Throws<ArgumentException>(() => New(id, actorKinds: actorKinds, kinds: [HostItemKind.Other]));
+            Assert.Throws<ArgumentException>(() => New(id, actorKinds: actorKinds, kinds: [(HostItemKind)99]));
+            Assert.Throws<ArgumentException>(() => New(id, actorKinds: actorKinds, kinds: [HostItemKind.Movie, HostItemKind.Movie]));
+            Assert.Throws<ArgumentException>(() => New(id, actorKinds: actorKinds, kinds: kinds, isMutation: false));
             Assert.Throws<ArgumentException>(() => ConstructPrivately<PlatformOperationDefinition>(
                 id,
                 PlatformOperationFamily.Seerr,
                 PlatformAuthorityLevel.Authenticated,
+                actorKinds,
                 PlatformItemScope.ExactItem,
                 kinds,
                 true,
                 default,
                 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => New(id, kinds: kinds, invalidationGeneration: 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => New(id, actorKinds: actorKinds, kinds: kinds, invalidationGeneration: 0));
 
             PlatformOperationDefinition New(
                 PlatformOperationId operationId,
                 PlatformOperationFamily family = PlatformOperationFamily.Seerr,
                 PlatformAuthorityLevel authority = PlatformAuthorityLevel.Authenticated,
+                ImmutableArray<PlatformActorKind> actorKinds = default,
                 PlatformItemScope itemScope = PlatformItemScope.ExactItem,
                 ImmutableArray<HostItemKind> kinds = default,
                 bool isMutation = true,
@@ -188,11 +199,35 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
                     operationId,
                     family,
                     authority,
+                    actorKinds,
                     itemScope,
                     kinds,
                     isMutation,
                     schema,
                     invalidationGeneration);
+        }
+
+        [Fact]
+        public void AuthorityPolicyTreatsElevationAsAUserCeilingNotAnotherKind()
+        {
+            var id = ConstructPrivately<PlatformOperationId>("vendor.extension.operation");
+            var schema = ConstructPrivately<PlatformInputSchemaId>("vendor.extension.input.v1");
+            var definition = ConstructPrivately<PlatformOperationDefinition>(
+                id,
+                PlatformOperationFamily.Seerr,
+                PlatformAuthorityLevel.Elevated,
+                ImmutableArray.Create(PlatformActorKind.JellyfinUserClient),
+                PlatformItemScope.ExactItem,
+                ImmutableArray.Create(HostItemKind.Movie),
+                true,
+                schema,
+                1L);
+            var userId = Guid.NewGuid();
+
+            Assert.False(definition.Allows(PlatformActorTestFactory.Create(userId, false, "ordinary", null, null).Authority));
+            Assert.True(definition.Allows(PlatformActorTestFactory.Create(userId, true, "elevated", null, null).Authority));
+            Assert.False(definition.Allows(PlatformActorAuthorityTests.Provider(Guid.NewGuid(), new string('a', 64)).Authority));
+            Assert.False(definition.Allows(PlatformActorAuthorityTests.Service(Guid.NewGuid(), 1).Authority));
         }
 
         private static T ConstructPrivately<T>(params object?[] arguments)

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformPrepareHandleOwnerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformPrepareHandleOwnerTests.cs
@@ -433,7 +433,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
             string correlationId = "correlation",
             string? clientName = "android-tv",
             string? deviceId = "device-a")
-            => new(userId ?? UserId, elevated, correlationId, clientName, deviceId);
+            => PlatformActorTestFactory.Create(
+                userId ?? UserId,
+                elevated,
+                correlationId,
+                clientName,
+                deviceId);
 
         private static Guid User(int value)
         {

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformPreparedActionContextOwnerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformPreparedActionContextOwnerTests.cs
@@ -139,9 +139,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
                 ImmutableArray<HostProviderReference>.Empty);
 
         private static PlatformActor Actor()
-            => new(
+            => PlatformActorTestFactory.Create(
                 Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
-                isElevated: false,
+                false,
                 new string('a', 32),
                 "android-tv",
                 "device-a");

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/SpoilerGuardPlatformItemActionAdapterTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/SpoilerGuardPlatformItemActionAdapterTests.cs
@@ -29,7 +29,7 @@ public sealed class SpoilerGuardPlatformItemActionAdapterTests
             expectedOverridesRevision: 7);
 
         var result = adapter.Configure(
-            new PlatformActor(userId, false, "correlation", null, null),
+            PlatformActorTestFactory.Create(userId, false, "correlation", null, null),
             new HostAccessibleItem(itemId, hostKind, seriesId: null, ImmutableArray<HostProviderReference>.Empty),
             configuration);
 
@@ -58,7 +58,7 @@ public sealed class SpoilerGuardPlatformItemActionAdapterTests
         var itemId = Guid.NewGuid();
 
         var result = adapter.GetState(
-            new PlatformActor(userId, false, "correlation", "client", "device"),
+            PlatformActorTestFactory.Create(userId, false, "correlation", "client", "device"),
             new HostAccessibleItem(itemId, hostKind, seriesId: null, []));
 
         Assert.Same(owner.State, result);
@@ -78,11 +78,11 @@ public sealed class SpoilerGuardPlatformItemActionAdapterTests
         var adapter = new SpoilerGuardPlatformItemActionAdapter(owner);
 
         Assert.Throws<ArgumentOutOfRangeException>(() => adapter.Configure(
-            new PlatformActor(Guid.NewGuid(), false, "correlation", null, null),
+            PlatformActorTestFactory.Create(Guid.NewGuid(), false, "correlation", null, null),
             new HostAccessibleItem(Guid.NewGuid(), HostItemKind.Episode, Guid.NewGuid(), []),
             SpoilerGuardItemConfiguration.Exact(false, 0)));
         Assert.Throws<ArgumentOutOfRangeException>(() => adapter.GetState(
-            new PlatformActor(Guid.NewGuid(), false, "correlation", null, null),
+            PlatformActorTestFactory.Create(Guid.NewGuid(), false, "correlation", null, null),
             new HostAccessibleItem(Guid.NewGuid(), HostItemKind.Other, null, [])));
         Assert.Equal(0, owner.ConfigureCalls + owner.GetStateCalls);
     }
@@ -94,7 +94,7 @@ public sealed class SpoilerGuardPlatformItemActionAdapterTests
         var adapter = new SpoilerGuardPlatformItemActionAdapter(owner);
 
         var exception = Assert.Throws<ArgumentException>(() => adapter.Configure(
-            new PlatformActor(Guid.NewGuid(), false, "correlation", null, null),
+            PlatformActorTestFactory.Create(Guid.NewGuid(), false, "correlation", null, null),
             new HostAccessibleItem(Guid.NewGuid(), HostItemKind.Movie, null, []),
             new SpoilerGuardItemConfiguration(enabled: true)));
 
@@ -136,7 +136,7 @@ public sealed class SpoilerGuardPlatformItemActionAdapterTests
             var adapter = new SpoilerGuardPlatformItemActionAdapter(
                 new SpoilerGuardItemActionOwner(manager));
             var result = adapter.Configure(
-                new PlatformActor(userId, false, "correlation", null, null),
+                PlatformActorTestFactory.Create(userId, false, "correlation", null, null),
                 new HostAccessibleItem(itemId, HostItemKind.Movie, seriesId: null, []),
                 SpoilerGuardItemConfiguration.Exact(enabled: true, expectedOverridesRevision: 17));
             var stored = manager.GetUserConfigurationStrict<UserSpoilerBlur>(

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/MonitorSubscriptionLifecycleTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/MonitorSubscriptionLifecycleTests.cs
@@ -7,6 +7,7 @@ using Jellyfin.Plugin.JellyfinCanopy.Platform;
 using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
 using Jellyfin.Plugin.JellyfinCanopy.Services;
 using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.Platform;
 using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
@@ -261,7 +262,7 @@ public sealed class MonitorSubscriptionLifecycleTests
     public async Task ConfigurationSaveSynchronouslyRevokesNativeAuthorityAndReenableCannotReviveIt()
     {
         var fixture = new Fixture(new PluginConfiguration { PlatformEnabled = true });
-        var actor = new PlatformActor(
+        var actor = PlatformActorTestFactory.Create(
             Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
             isElevated: false,
             "correlation",

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrItemRequestPresentationOwnerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrItemRequestPresentationOwnerTests.cs
@@ -719,7 +719,7 @@ public sealed class SeerrItemRequestPresentationOwnerTests
             Provider = new GenerationConfigProvider(Config);
             Admission.SetResolutions(Found());
             Admission.SetCapabilities(new Seerr4kCapability(true, true, true, true));
-            Actor = new PlatformActor(
+            Actor = PlatformActorTestFactory.Create(
                 actorId ?? Guid.NewGuid(),
                 isElevated,
                 "correlation",

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrMediaRequestOwnerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrMediaRequestOwnerTests.cs
@@ -8,6 +8,7 @@ using Jellyfin.Plugin.JellyfinCanopy.Model.Seerr;
 using Jellyfin.Plugin.JellyfinCanopy.Platform;
 using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
 using Jellyfin.Plugin.JellyfinCanopy.Services.Seerr;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.Platform;
 using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
@@ -526,7 +527,7 @@ public sealed class SeerrMediaRequestOwnerTests
             Provider = new FakePluginConfigProvider(Config);
             Admission.Resolutions.Add(Found());
             Handler.AddResponse("/api/v1/request", "{}", status);
-            Actor = new PlatformActor(
+            Actor = PlatformActorTestFactory.Create(
                 Guid.NewGuid(),
                 isElevated,
                 "correlation",

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformActionCapabilityService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformActionCapabilityService.cs
@@ -227,7 +227,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
                 return new PlatformCapabilityMintOutcome(PlatformCapabilityMintOutcomeKind.InvalidRequest);
             }
 
-            if (!HasRequiredAuthority(definition, actor))
+            if (!definition.Allows(actor.Authority))
             {
                 return new PlatformCapabilityMintOutcome(PlatformCapabilityMintOutcomeKind.NotAuthorized);
             }
@@ -444,7 +444,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
                     return new PlatformCapabilityValidation(PlatformCapabilityValidationKind.StaleAuthority);
                 }
 
-                if (!HasRequiredAuthority(definition, actor))
+                if (!definition.Allows(actor.Authority))
                 {
                     return new PlatformCapabilityValidation(PlatformCapabilityValidationKind.NotAuthorized);
                 }
@@ -562,10 +562,6 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
                 _disposed = true;
             }
         }
-
-        private static bool HasRequiredAuthority(PlatformOperationDefinition definition, PlatformActor actor) =>
-            definition.Authority == PlatformAuthorityLevel.Authenticated
-            || (definition.Authority == PlatformAuthorityLevel.Elevated && actor.IsElevated);
 
         private static bool IsBoundedDeviceAttribution(string? value)
         {

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformActionInvocationCoordinator.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformActionInvocationCoordinator.cs
@@ -341,14 +341,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
             PlatformActor boundaryActor,
             PlatformPreparedActionContext prepared)
         {
-            var user = _host.Users.Find(boundaryActor.UserId);
-            var actor = PlatformActorBoundaryFilter.Reauthorize(boundaryActor, user);
+            var actor = PlatformActorBoundaryFilter.ReauthorizeUserActor(boundaryActor, _host);
             if (actor is null)
             {
                 return null;
             }
 
-            if (!HasRequiredAuthority(prepared.Definition, actor))
+            if (!prepared.Definition.Allows(actor.Authority))
             {
                 return null;
             }
@@ -366,12 +365,6 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
 
             return new CurrentAuthority(actor, item);
         }
-
-        private static bool HasRequiredAuthority(
-            PlatformOperationDefinition definition,
-            PlatformActor actor)
-            => definition.Authority == PlatformAuthorityLevel.Authenticated
-                || (definition.Authority == PlatformAuthorityLevel.Elevated && actor.IsElevated);
 
         private static PlatformSemanticFingerprint CreateFingerprint(
             PlatformPreparedActionContext prepared,

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformActor.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformActor.cs
@@ -15,26 +15,18 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
     /// </remarks>
     public sealed class PlatformActor
     {
-        internal PlatformActor(
-            Guid userId,
-            bool isElevated,
-            string correlationId,
-            string? clientName,
-            string? deviceId)
+        internal PlatformActor(PlatformUserBoundaryResult boundaryResult)
         {
-            if (userId == Guid.Empty)
-            {
-                throw new ArgumentException("An actor must have a non-empty user id.", nameof(userId));
-            }
-
-            ArgumentException.ThrowIfNullOrWhiteSpace(correlationId);
-
-            UserId = userId;
-            IsElevated = isElevated;
-            CorrelationId = correlationId;
-            ClientName = clientName;
-            DeviceId = deviceId;
+            ArgumentNullException.ThrowIfNull(boundaryResult);
+            UserId = boundaryResult.UserId;
+            IsElevated = boundaryResult.IsElevated;
+            CorrelationId = boundaryResult.CorrelationId;
+            ClientName = boundaryResult.ClientName;
+            DeviceId = boundaryResult.DeviceId;
         }
+
+        /// <summary>Gets the actor kind.</summary>
+        public PlatformActorKind Kind => PlatformActorKind.JellyfinUserClient;
 
         /// <summary>The authoritative authenticated Jellyfin user.</summary>
         public Guid UserId { get; }
@@ -50,5 +42,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
 
         /// <summary>Bounded caller-reported device identifier. Attribution only.</summary>
         public string? DeviceId { get; }
+
+        internal PlatformActorAuthority Authority =>
+            PlatformActorAuthority.ProjectAuthenticatedUserAuthority(IsElevated);
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformActorBoundaryFilter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformActorBoundaryFilter.cs
@@ -95,12 +95,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
                 return;
             }
 
-            var actor = new PlatformActor(
-                userId,
-                currentUser.Value.IsAdministrator,
+            var boundaryResult = PlatformUserBoundaryResult.EstablishAuthenticatedUserBoundary(
+                currentUser.Value,
                 PlatformCorrelation.For(context.HttpContext),
                 ReadAttribution(principal.Claims, ClientClaim, MaxClientNameBytes),
                 ReadAttribution(principal.Claims, DeviceIdClaim, MaxDeviceIdBytes));
+            var actor = PlatformActorFactory.CreateAuthenticatedUserActor(boundaryResult);
 
             context.HttpContext.Items[ActorItemsKey] = actor;
             await next().ConfigureAwait(false);
@@ -124,22 +124,27 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
         /// Actor construction remains confined to this authority boundary even when a
         /// long-running action repeats its user lookup immediately before mutation.
         /// </summary>
-        internal static PlatformActor? Reauthorize(
+        internal static PlatformActor? ReauthorizeUserActor(
             PlatformActor boundaryActor,
-            HostUser? currentUser)
+            IPlatformHost host)
         {
             ArgumentNullException.ThrowIfNull(boundaryActor);
-            if (currentUser is not HostUser user || user.Id != boundaryActor.UserId)
+            ArgumentNullException.ThrowIfNull(host);
+
+            // The authority boundary owns the fresh lookup. Callers cannot supply a
+            // shaped HostUser or choose the elevation bit that crosses into the actor.
+            var currentUser = host.Users.Find(boundaryActor.UserId);
+            if (currentUser is not HostUser user
+                || user.Id == Guid.Empty
+                || user.Id != boundaryActor.UserId)
             {
                 return null;
             }
 
-            return new PlatformActor(
-                user.Id,
-                user.IsAdministrator,
-                boundaryActor.CorrelationId,
-                boundaryActor.ClientName,
-                boundaryActor.DeviceId);
+            var boundaryResult = PlatformUserBoundaryResult.EstablishReauthorizedUserBoundary(
+                boundaryActor,
+                user);
+            return PlatformActorFactory.CreateAuthenticatedUserActor(boundaryResult);
         }
 
         private static string? ReadAttribution(

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformActorDomain.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformActorDomain.cs
@@ -1,0 +1,362 @@
+using System;
+using System.Collections.Immutable;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>The exact closed kinds of authoritative Platform actors.</summary>
+    public enum PlatformActorKind
+    {
+        /// <summary>An authenticated Jellyfin user client.</summary>
+        JellyfinUserClient = 1,
+
+        /// <summary>An installed provider approved by the future registry owner.</summary>
+        InstalledProvider = 2,
+
+        /// <summary>A companion service bound to a current credential generation.</summary>
+        CompanionService = 3,
+    }
+
+    /// <summary>Code-owned stable contract tokens for the closed actor-kind domain.</summary>
+    public static class PlatformActorKindVocabulary
+    {
+        private static readonly ImmutableArray<PlatformActorKind> Kinds =
+        [
+            PlatformActorKind.JellyfinUserClient,
+            PlatformActorKind.InstalledProvider,
+            PlatformActorKind.CompanionService,
+        ];
+
+        /// <summary>Gets the complete actor-kind vocabulary in stable contract order.</summary>
+        public static ImmutableArray<PlatformActorKind> All => Kinds;
+
+        /// <summary>Returns the exact v1 token for a known kind, or <c>null</c>.</summary>
+        public static string? TokenFor(PlatformActorKind kind) => kind switch
+        {
+            PlatformActorKind.JellyfinUserClient => "jellyfin-user-client",
+            PlatformActorKind.InstalledProvider => "installed-provider",
+            PlatformActorKind.CompanionService => "companion-service",
+            _ => null,
+        };
+
+        internal static bool IsDefined(PlatformActorKind kind) => TokenFor(kind) is not null;
+    }
+
+    /// <summary>
+    /// The immutable current-authority projection consumed by Platform policy and the
+    /// future grant-ceiling evaluator. It carries no identity, request, token, grant,
+    /// capability or attribution data.
+    /// </summary>
+    public readonly struct PlatformActorAuthority
+    {
+        private readonly bool _initialized;
+
+        private PlatformActorAuthority(PlatformActorKind kind, bool isElevated)
+        {
+            if (!PlatformActorKindVocabulary.IsDefined(kind))
+            {
+                throw new ArgumentOutOfRangeException(nameof(kind));
+            }
+
+            if (isElevated && kind != PlatformActorKind.JellyfinUserClient)
+            {
+                throw new ArgumentException(
+                    "Only a current Jellyfin user actor can be elevated.",
+                    nameof(isElevated));
+            }
+
+            Kind = kind;
+            IsElevated = isElevated;
+            _initialized = true;
+        }
+
+        /// <summary>Gets the closed actor kind.</summary>
+        public PlatformActorKind Kind { get; }
+
+        /// <summary>Gets current host elevation for a Jellyfin user actor.</summary>
+        public bool IsElevated { get; }
+
+        internal bool IsValid => _initialized
+            && PlatformActorKindVocabulary.IsDefined(Kind)
+            && (!IsElevated || Kind == PlatformActorKind.JellyfinUserClient);
+
+        internal static PlatformActorAuthority ProjectAuthenticatedUserAuthority(bool isElevated) =>
+            new(PlatformActorKind.JellyfinUserClient, isElevated);
+
+        internal static PlatformActorAuthority ProjectInstalledProviderAuthority() =>
+            new(PlatformActorKind.InstalledProvider, false);
+
+        internal static PlatformActorAuthority ProjectCompanionServiceAuthority() =>
+            new(PlatformActorKind.CompanionService, false);
+    }
+
+    /// <summary>
+    /// Opaque proof that the controller boundary completed canonical authenticated-user,
+    /// same-identity non-API-key and live-host validation.
+    /// </summary>
+    internal sealed class PlatformUserBoundaryResult
+    {
+        private PlatformUserBoundaryResult(
+            Guid userId,
+            bool isElevated,
+            string correlationId,
+            string? clientName,
+            string? deviceId)
+        {
+            if (userId == Guid.Empty)
+            {
+                throw new ArgumentException("A boundary result requires a live user.", nameof(userId));
+            }
+
+            ArgumentException.ThrowIfNullOrWhiteSpace(correlationId);
+            UserId = userId;
+            IsElevated = isElevated;
+            CorrelationId = correlationId;
+            ClientName = clientName;
+            DeviceId = deviceId;
+        }
+
+        internal Guid UserId { get; }
+
+        internal bool IsElevated { get; }
+
+        internal string CorrelationId { get; }
+
+        internal string? ClientName { get; }
+
+        internal string? DeviceId { get; }
+
+        internal static PlatformUserBoundaryResult EstablishAuthenticatedUserBoundary(
+            HostUser currentUser,
+            string correlationId,
+            string? clientName,
+            string? deviceId) =>
+            new(
+                currentUser.Id,
+                currentUser.IsAdministrator,
+                correlationId,
+                clientName,
+                deviceId);
+
+        internal static PlatformUserBoundaryResult EstablishReauthorizedUserBoundary(
+            PlatformActor boundaryActor,
+            HostUser currentUser)
+        {
+            ArgumentNullException.ThrowIfNull(boundaryActor);
+            if (currentUser.Id == Guid.Empty || currentUser.Id != boundaryActor.UserId)
+            {
+                throw new ArgumentException(
+                    "A reauthorization result must preserve the boundary identity.",
+                    nameof(currentUser));
+            }
+
+            return new(
+                currentUser.Id,
+                currentUser.IsAdministrator,
+                boundaryActor.CorrelationId,
+                boundaryActor.ClientName,
+                boundaryActor.DeviceId);
+        }
+    }
+
+    /// <summary>A typed installed-plugin identifier released only by a registry owner.</summary>
+    internal readonly struct PlatformInstalledPluginId
+    {
+        private PlatformInstalledPluginId(Guid value)
+        {
+            if (value == Guid.Empty)
+            {
+                throw new ArgumentException("An installed plugin id cannot be empty.", nameof(value));
+            }
+
+            Value = value;
+        }
+
+        internal Guid Value { get; }
+    }
+
+    /// <summary>An immutable canonical SHA-256 manifest fingerprint.</summary>
+    internal readonly struct PlatformManifestFingerprint
+    {
+        private PlatformManifestFingerprint(string value)
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            if (value.Length != 64 || !IsLowerHex(value))
+            {
+                throw new ArgumentException(
+                    "A manifest fingerprint must be exactly 64 lower-case hexadecimal characters.",
+                    nameof(value));
+            }
+
+            Value = value;
+        }
+
+        internal string Value { get; }
+
+        private static bool IsLowerHex(string value)
+        {
+            foreach (var character in value)
+            {
+                if (character is not (>= '0' and <= '9') and not (>= 'a' and <= 'f'))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+
+    /// <summary>Opaque registry approval proof for one installed provider.</summary>
+    internal sealed class PlatformApprovedProviderIdentity
+    {
+        private PlatformApprovedProviderIdentity(
+            PlatformInstalledPluginId installedPluginId,
+            PlatformManifestFingerprint manifestFingerprint)
+        {
+            if (installedPluginId.Value == Guid.Empty)
+            {
+                throw new ArgumentException("A provider approval requires an installed plugin.", nameof(installedPluginId));
+            }
+
+            if (string.IsNullOrEmpty(manifestFingerprint.Value))
+            {
+                throw new ArgumentException("A provider approval requires a manifest fingerprint.", nameof(manifestFingerprint));
+            }
+
+            InstalledPluginId = installedPluginId;
+            ManifestFingerprint = manifestFingerprint;
+        }
+
+        internal PlatformInstalledPluginId InstalledPluginId { get; }
+
+        internal PlatformManifestFingerprint ManifestFingerprint { get; }
+    }
+
+    /// <summary>A typed companion-service registration identifier.</summary>
+    internal readonly struct PlatformServiceRegistrationId
+    {
+        private PlatformServiceRegistrationId(Guid value)
+        {
+            if (value == Guid.Empty)
+            {
+                throw new ArgumentException("A service registration id cannot be empty.", nameof(value));
+            }
+
+            Value = value;
+        }
+
+        internal Guid Value { get; }
+    }
+
+    /// <summary>The positive current generation of a service credential.</summary>
+    internal readonly struct PlatformCredentialGeneration
+    {
+        private PlatformCredentialGeneration(long value)
+        {
+            if (value <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value));
+            }
+
+            Value = value;
+        }
+
+        internal long Value { get; }
+    }
+
+    /// <summary>Opaque registration and current-generation proof for a companion service.</summary>
+    internal sealed class PlatformCurrentServiceIdentity
+    {
+        private PlatformCurrentServiceIdentity(
+            PlatformServiceRegistrationId registrationId,
+            PlatformCredentialGeneration credentialGeneration)
+        {
+            if (registrationId.Value == Guid.Empty)
+            {
+                throw new ArgumentException("A current service identity requires a registration.", nameof(registrationId));
+            }
+
+            if (credentialGeneration.Value <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(credentialGeneration));
+            }
+
+            RegistrationId = registrationId;
+            CredentialGeneration = credentialGeneration;
+        }
+
+        internal PlatformServiceRegistrationId RegistrationId { get; }
+
+        internal PlatformCredentialGeneration CredentialGeneration { get; }
+    }
+
+    /// <summary>An immutable registry-approved installed-provider actor.</summary>
+    public sealed class PlatformInstalledProviderActor
+    {
+        internal PlatformInstalledProviderActor(PlatformApprovedProviderIdentity identity)
+        {
+            ArgumentNullException.ThrowIfNull(identity);
+            InstalledPluginId = identity.InstalledPluginId.Value;
+            ManifestFingerprint = identity.ManifestFingerprint.Value;
+        }
+
+        /// <summary>Gets the actor kind.</summary>
+        public PlatformActorKind Kind => PlatformActorKind.InstalledProvider;
+
+        /// <summary>Gets the registry-approved installed plugin identifier.</summary>
+        public Guid InstalledPluginId { get; }
+
+        /// <summary>Gets the immutable approved manifest fingerprint.</summary>
+        public string ManifestFingerprint { get; }
+
+        internal PlatformActorAuthority Authority => PlatformActorAuthority.ProjectInstalledProviderAuthority();
+    }
+
+    /// <summary>An immutable registered companion-service actor.</summary>
+    public sealed class PlatformCompanionServiceActor
+    {
+        internal PlatformCompanionServiceActor(PlatformCurrentServiceIdentity identity)
+        {
+            ArgumentNullException.ThrowIfNull(identity);
+            RegistrationId = identity.RegistrationId.Value;
+            CredentialGeneration = identity.CredentialGeneration.Value;
+        }
+
+        /// <summary>Gets the actor kind.</summary>
+        public PlatformActorKind Kind => PlatformActorKind.CompanionService;
+
+        /// <summary>Gets the server-owned service registration identifier.</summary>
+        public Guid RegistrationId { get; }
+
+        /// <summary>Gets the verified current credential generation, never the credential.</summary>
+        public long CredentialGeneration { get; }
+
+        internal PlatformActorAuthority Authority => PlatformActorAuthority.ProjectCompanionServiceAuthority();
+    }
+
+    /// <summary>The single kernel owner that converts typed proofs into actor objects.</summary>
+    internal static class PlatformActorFactory
+    {
+        internal static PlatformActor CreateAuthenticatedUserActor(PlatformUserBoundaryResult boundaryResult)
+        {
+            ArgumentNullException.ThrowIfNull(boundaryResult);
+            return new PlatformActor(boundaryResult);
+        }
+
+        internal static PlatformInstalledProviderActor CreateProvider(
+            PlatformApprovedProviderIdentity approvedIdentity)
+        {
+            ArgumentNullException.ThrowIfNull(approvedIdentity);
+            return new PlatformInstalledProviderActor(approvedIdentity);
+        }
+
+        internal static PlatformCompanionServiceActor CreateService(
+            PlatformCurrentServiceIdentity currentIdentity)
+        {
+            ArgumentNullException.ThrowIfNull(currentIdentity);
+            return new PlatformCompanionServiceActor(currentIdentity);
+        }
+
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformNativeCatalogService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformNativeCatalogService.cs
@@ -538,9 +538,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
 
         private CurrentAuthority? ResolveCurrent(PlatformActor boundaryActor, Guid itemId)
         {
-            var actor = PlatformActorBoundaryFilter.Reauthorize(
+            var actor = PlatformActorBoundaryFilter.ReauthorizeUserActor(
                 boundaryActor,
-                _host.Users.Find(boundaryActor.UserId));
+                _host);
             if (actor is null)
             {
                 return null;

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformOperationVocabulary.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformOperationVocabulary.cs
@@ -104,6 +104,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
             PlatformOperationId id,
             PlatformOperationFamily family,
             PlatformAuthorityLevel authority,
+            ImmutableArray<PlatformActorKind> allowedActorKinds,
             PlatformItemScope itemScope,
             ImmutableArray<HostItemKind> supportedItemKinds,
             bool isMutation,
@@ -123,6 +124,15 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
             if (!Enum.IsDefined(authority))
             {
                 throw new ArgumentOutOfRangeException(nameof(authority));
+            }
+
+            if (allowedActorKinds.IsDefaultOrEmpty
+                || allowedActorKinds.Any(kind => !PlatformActorKindVocabulary.IsDefined(kind))
+                || allowedActorKinds.Distinct().Count() != allowedActorKinds.Length)
+            {
+                throw new ArgumentException(
+                    "An operation must declare distinct closed actor kinds.",
+                    nameof(allowedActorKinds));
             }
 
             if (!Enum.IsDefined(itemScope))
@@ -161,6 +171,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
             Id = id;
             Family = family;
             Authority = authority;
+            AllowedActorKinds = allowedActorKinds;
             ItemScope = itemScope;
             SupportedItemKinds = supportedItemKinds;
             IsMutation = isMutation;
@@ -176,6 +187,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
 
         /// <summary>Gets the current Jellyfin authority required from the actor.</summary>
         public PlatformAuthorityLevel Authority { get; }
+
+        /// <summary>Gets the exact closed actor kinds eligible for this operation.</summary>
+        public ImmutableArray<PlatformActorKind> AllowedActorKinds { get; }
 
         /// <summary>Gets the bounded item context this operation accepts.</summary>
         public PlatformItemScope ItemScope { get; }
@@ -195,10 +209,32 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
         /// </summary>
         public long InvalidationGeneration { get; }
 
+        /// <summary>
+        /// Applies the single actor-kind and current-authority policy for this operation.
+        /// Unknown/default actors and all kind/ceiling mismatches fail closed.
+        /// </summary>
+        internal bool Allows(PlatformActorAuthority authority)
+        {
+            if (!authority.IsValid
+                || !AllowedActorKinds.Contains(authority.Kind)
+                || authority.Kind != PlatformActorKind.JellyfinUserClient)
+            {
+                return false;
+            }
+
+            return Authority switch
+            {
+                PlatformAuthorityLevel.Authenticated => true,
+                PlatformAuthorityLevel.Elevated => authority.IsElevated,
+                _ => false,
+            };
+        }
+
         internal static PlatformOperationDefinition SpoilerGuardConfigureItem { get; } = new PlatformOperationDefinition(
             PlatformOperationId.SpoilerGuardConfigureItem,
             PlatformOperationFamily.SpoilerGuard,
             PlatformAuthorityLevel.Authenticated,
+            [PlatformActorKind.JellyfinUserClient],
             PlatformItemScope.ExactItem,
             [HostItemKind.Movie, HostItemKind.Series],
             true,
@@ -209,6 +245,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
             PlatformOperationId.HiddenContentConfigureItem,
             PlatformOperationFamily.HiddenContent,
             PlatformAuthorityLevel.Authenticated,
+            [PlatformActorKind.JellyfinUserClient],
             PlatformItemScope.ExactItem,
             [HostItemKind.Movie, HostItemKind.Series, HostItemKind.Episode],
             true,
@@ -219,6 +256,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
             PlatformOperationId.SeerrRequestItem,
             PlatformOperationFamily.Seerr,
             PlatformAuthorityLevel.Authenticated,
+            [PlatformActorKind.JellyfinUserClient],
             PlatformItemScope.ExactItem,
             [HostItemKind.Movie, HostItemKind.Series],
             true,

--- a/contracts/platform/v1/frozen.json
+++ b/contracts/platform/v1/frozen.json
@@ -17,6 +17,41 @@
       "post"
     ]
   },
+  "actorKindVocabulary": [
+    "jellyfin-user-client",
+    "installed-provider",
+    "companion-service"
+  ],
+  "operationMetadata": {
+    "get /JellyfinCanopy/Platform/v1/discovery": {
+      "authority": "anonymous",
+      "actorKinds": []
+    },
+    "get /JellyfinCanopy/Platform/v1/negotiate": {
+      "authority": "authenticated",
+      "actorKinds": [
+        "jellyfin-user-client"
+      ]
+    },
+    "post /JellyfinCanopy/Platform/v1/surfaces/item-detail/resolve": {
+      "authority": "authenticated",
+      "actorKinds": [
+        "jellyfin-user-client"
+      ]
+    },
+    "post /JellyfinCanopy/Platform/v1/actions/prepare": {
+      "authority": "authenticated",
+      "actorKinds": [
+        "jellyfin-user-client"
+      ]
+    },
+    "post /JellyfinCanopy/Platform/v1/actions/invoke": {
+      "authority": "authenticated",
+      "actorKinds": [
+        "jellyfin-user-client"
+      ]
+    }
+  },
   "schemas": {
     "PlatformDiscoveryResponse": {
       "required": [

--- a/contracts/platform/v1/openapi.json
+++ b/contracts/platform/v1/openapi.json
@@ -6,6 +6,11 @@
     "summary": "The versioned, capability-scoped extension surface.",
     "description": "This document is AUTHORED, not generated from the running server. Generating it from the code would document whatever the code happens to do, mistakes included, and would make a breaking change undetectable \u2014 the spec would simply move with the bug. Here the spec is the source of truth and the server is checked against it by PlatformContractTests.\n\nOnly routes under /JellyfinCanopy/Platform/v1 are described. The pre-platform /JellyfinCanopy/* routes are compatibility surfaces with their own shapes and are deliberately absent; they are never promoted into the platform implicitly.\n\nPlatform responses use application/json. An absent Accept header, application/json, application/*, or */* permits that representation; a malformed, over-bound, or excluding Accept header receives a structured 406 after any required authorization. Body-bearing requests accept application/json only; a different or missing Content-Type is a structured 415 after authorization. Request readers ignore unknown object properties, reject unknown enum values as invalid_request, and require RFC 3339 UTC timestamps with an explicit UTC offset. GUIDs use lowercase canonical D form. Clients must ignore unknown response properties so additive v1 evolution remains usable.\n\nChanges within v1 are additive only (ADR-0010). Removing a path, removing a required property, or changing a property's type is a v2 concern, and contracts/platform/v1/frozen.json exists so CI can prove it rather than a reviewer having to notice."
   },
+  "x-canopy-actor-kind-vocabulary": [
+    "jellyfin-user-client",
+    "installed-provider",
+    "companion-service"
+  ],
   "servers": [
     {
       "url": ".",
@@ -17,6 +22,7 @@
       "get": {
         "operationId": "getDiscovery",
         "x-canopy-authority": "anonymous",
+        "x-canopy-actor-kinds": [],
         "summary": "Whether the platform is present, and which protocol versions it speaks.",
       "description": "The ONLY anonymous route in Platform v1. A client must be able to learn whether the native platform is serving requests before it has a reason to authenticate, and probing this reveals nothing an unauthenticated caller could not learn by noticing the plugin is installed. Available=false means the administrator has disabled Platform v1; the protocol range remains present so a client can distinguish a disabled compatible host from an unknown route. Disabled discovery responses use Cache-Control: no-store.\n\nThe payload is deliberately uninteresting: no users, no installed extensions, no topology, no configuration, no server identity. Adding a property here widens what an unauthenticated caller learns.",
       "security": [],
@@ -73,6 +79,9 @@
       "get": {
         "operationId": "negotiate",
         "x-canopy-authority": "authenticated",
+        "x-canopy-actor-kinds": [
+          "jellyfin-user-client"
+        ],
         "summary": "The highest protocol version both sides speak.",
         "description": "A client offers the range it supports; the host answers with what it will actually use.\n\nNo overlap is reported as a 200 with compatible=false, NOT as an error. A negotiation that concludes \"no common version\" has succeeded \u2014 it answered the question asked \u2014 and a client renders that differently from \"unavailable\" and from \"denied\". Collapsing the three would make a version mismatch indistinguishable from a permissions problem.\n\nA client that supplies no range is treated as speaking the oldest protocol only. Assuming it supports the newest would be optimistic about software the host knows nothing about.",
         "parameters": [
@@ -153,6 +162,9 @@
       "post": {
         "operationId": "resolveNativeItemDetail",
         "x-canopy-authority": "authenticated",
+        "x-canopy-actor-kinds": [
+          "jellyfin-user-client"
+        ],
         "summary": "Resolve the current actor's bounded native item-detail contributions.",
         "description": "Canopy re-authorizes the Jellyfin item and composes only the fixed Spoiler Guard, Hidden Content, and Seerr pilot families. Unknown or unavailable families are omitted. The response is capped at twelve contributions, retaining bounded headroom for another native-safe family. Opaque prepare handles carry no client-interpretable authority. This POST receives a strong ETag over its exact response bytes, but intentionally has no conditional-GET or 304 behavior because the bounded client capability body is part of the representation key.",
         "x-canopy-validated-representation": true,
@@ -216,6 +228,9 @@
       "post": {
         "operationId": "prepareNativeAction",
         "x-canopy-authority": "authenticated",
+        "x-canopy-actor-kinds": [
+          "jellyfin-user-client"
+        ],
         "summary": "Re-authorize an opaque catalog action and mint a short-lived invocation capability.",
         "description": "The prepare handle is resolved only for the current Jellyfin user. Canopy rechecks the user, item, configuration, feature state, client field support, and owner authorization before returning a bounded native form. Expired, restarted, cross-user, stale, or unauthorized handles are deliberately indistinguishable as not_found.",
         "requestBody": {
@@ -273,6 +288,9 @@
       "post": {
         "operationId": "invokeNativeAction",
         "x-canopy-authority": "authenticated",
+        "x-canopy-actor-kinds": [
+          "jellyfin-user-client"
+        ],
         "summary": "Invoke one prepared first-party action through Canopy's fixed dispatcher.",
         "description": "The idempotency key is carried exactly once in the JSON body; the Idempotency-Key header is forbidden on this route. Canopy consumes the opaque capability only after fresh Jellyfin and owning-service authorization, validates answers against the server-bound form and feature variant, and executes only one of the three fixed pilot ports. Clients must treat refresh targets as allowlisted hints and ignore unknown targets.",
         "requestBody": {

--- a/docs/platform-contract.md
+++ b/docs/platform-contract.md
@@ -53,9 +53,15 @@ body, cookie, header, marker, IP, client-name and device-id values cannot select
 elevate an actor. Client and device values are bounded attribution only. A missing,
 malformed or deleted authenticated user fails closed with a bare `403`. The
 completed native-first surface still accepts no service/API-key actor. The
-post-pilot server tranche may add independently authenticated service actors
-only through additive routes and contracts; it does not widen authority on any
-existing operation.
+runtime actor domain is now closed over exactly `jellyfin-user-client`,
+`installed-provider`, and `companion-service`. Administrator authority is the
+current elevation bit on the same user actor, never a fourth kind. Provider and
+service actors have distinct typed registry/credential-generation proofs and no
+user projection, but those proof issuers are deliberately dormant: this change
+adds no provider/service authentication, credential, route, grant, registry,
+state, event, or invocation surface. Later work may activate them only through
+additive owners and contracts; it does not widen authority on any existing
+operation.
 
 Before the first service route ships, the authored contract must add its
 deny-by-default service authentication scheme and exact actor metadata. Missing,
@@ -70,13 +76,17 @@ registration, grant, operation, or denial detail. Service routes never use
 `[AllowAnonymous]` and never accept Jellyfin authentication.
 
 Every current OpenAPI operation publishes `x-canopy-authority` as `anonymous`,
-`authenticated`, or `elevated`. The first service operation additively extends
-that vocabulary with `service` and adds an exact `x-canopy-actor-kinds` allowlist;
-existing operations gain their current anonymous/user actor metadata without
-widening eligibility. CI compares that value with the live controller attributes, and the live
-conformance matrix exercises anonymous, ordinary-user, and administrator callers for
-every operation in `frozen.json`. A newly added operation cannot omit either its frozen
-inventory entry or its authorization class.
+`authenticated`, or `elevated` and an exact `x-canopy-actor-kinds` allowlist.
+Anonymous discovery publishes `[]`; every current authenticated operation
+publishes only `["jellyfin-user-client"]`. The authored top-level vocabulary,
+runtime enum/tokens, and the separate frozen operation-metadata map must agree
+exactly. Existing authority strings remain unchanged. A future service operation
+must extend the contract additively and can admit only the separately authenticated
+no-user service actor. CI compares authority with live controller attributes,
+checks the exact actor metadata, and the live conformance matrix exercises anonymous,
+ordinary-user, and administrator callers for every operation in `frozen.json`.
+A newly added operation cannot omit its inventory entry, authorization class, actor
+allowlist, or frozen metadata.
 
 **Branch on `Code`, never on `Message`.** The message is human-readable and may be
 reworded or translated at any time. The code set is enumerated in the spec, and each code

--- a/e2e/platform-contract-smoke.spec.ts
+++ b/e2e/platform-contract-smoke.spec.ts
@@ -29,12 +29,14 @@ const FROZEN = JSON.parse(
 );
 
 type Authority = 'anonymous' | 'authenticated' | 'elevated';
+type ActorKind = 'jellyfin-user-client' | 'installed-provider' | 'companion-service';
 
 type FrozenOperation = {
     path: string;
     method: string;
     operation: any;
     authority: Authority;
+    actorKinds: ActorKind[];
 };
 
 type JellyfinApiKey = {
@@ -139,11 +141,24 @@ function frozenOperations(): FrozenOperation[] {
                 ['anonymous', 'authenticated', 'elevated'],
                 `${method.toUpperCase()} ${path} must publish x-canopy-authority`,
             ).toContain(operation['x-canopy-authority']);
+            const actorKinds = operation['x-canopy-actor-kinds'];
+            expect(Array.isArray(actorKinds), `${method.toUpperCase()} ${path} must publish x-canopy-actor-kinds`)
+                .toBe(true);
+            for (const actorKind of actorKinds) {
+                expect(CONTRACT['x-canopy-actor-kind-vocabulary'], `${method.toUpperCase()} ${path} actor kind`)
+                    .toContain(actorKind);
+            }
+            const key = `${method} ${path}`;
+            expect(FROZEN.operationMetadata[key], `${key} must freeze authority metadata`).toEqual({
+                authority: operation['x-canopy-authority'],
+                actorKinds,
+            });
             operations.push({
                 path,
                 method,
                 operation,
                 authority: operation['x-canopy-authority'] as Authority,
+                actorKinds: actorKinds as ActorKind[],
             });
         }
     }
@@ -158,6 +173,9 @@ function frozenOperations(): FrozenOperation[] {
         .sort();
     expect(frozenInventory, 'frozen.json and openapi.json must expose the same operation inventory')
         .toEqual(specInventory);
+    expect(Object.keys(FROZEN.operationMetadata).sort(), 'every frozen operation must have exact authority metadata')
+        .toEqual(Object.keys(FROZEN.paths).flatMap(path =>
+            FROZEN.paths[path].map((method: string) => `${method} ${path}`)).sort());
     return operations;
 }
 
@@ -487,6 +505,11 @@ test.describe('Platform v1 contract — live smoke client', () => {
         };
 
         for (const frozen of frozenOperations()) {
+            expect(frozen.actorKinds, `${frozen.method.toUpperCase()} ${frozen.path} actor policy`).toEqual(
+                frozen.authority === 'anonymous' ? [] : ['jellyfin-user-client'],
+            );
+            expect(frozen.actorKinds).not.toContain('installed-provider');
+            expect(frozen.actorKinds).not.toContain('companion-service');
             for (const [actor, session] of Object.entries(sessions)) {
                 const allowed = frozen.authority === 'anonymous'
                     || (frozen.authority === 'authenticated' && actor !== 'anonymous')

--- a/research/extension-platform/adr/0011-identity-and-authority.md
+++ b/research/extension-platform/adr/0011-identity-and-authority.md
@@ -1,6 +1,6 @@
 # ADR-0011 — Identity and authority
 
-Status: **accepted** (pilot subset implemented; ADR-0013 server-tranche remainder pending) · Owner: platform security · Evidence: [S9](../spike-evidence.md#s9--authorization-semantics-verified-on-plugin-routes), [S10](../spike-evidence.md#s10--host-cors-is-permissive), [S14](../spike-evidence.md#s14--forged-identity-is-fully-resisted-but-the-token-is-in-the-claims)
+Status: **accepted** (pilot, canonical user boundary, and closed actor domain implemented; grants/credentials/provider-service activation pending) · Owner: platform security · Evidence: [S9](../spike-evidence.md#s9--authorization-semantics-verified-on-plugin-routes), [S10](../spike-evidence.md#s10--host-cors-is-permissive), [S14](../spike-evidence.md#s14--forged-identity-is-fully-resisted-but-the-token-is-in-the-claims)
 
 ## Context
 
@@ -33,6 +33,11 @@ non-admin's own id. But the `ClaimsPrincipal` handed to a controller contains
    only from the unforgeable internal result of the full Platform boundary after
    explicit API-key rejection, a unique canonical user claim, live host-user
    lookup and current elevation; never from a parser GUID or `ClaimsPrincipal`.
+   The runtime kind vocabulary is closed over exactly Jellyfin user client,
+   registry-approved installed provider, and credential-bound companion service.
+   The latter two have distinct dormant proof and actor types with no user or
+   elevation projection; no production proof issuer exists until its owning
+   registry or credential boundary lands.
 2. **Attribution is not authority.** Client, device and extension identifiers are
    recorded for audit and never consulted for access decisions unless bound to an
    approved cryptographic credential.
@@ -96,6 +101,13 @@ non-admin's own id. But the `ClaimsPrincipal` handed to a controller contains
     makes the admin-only reference capability in
     [`v1-capability-freeze.md`](../v1-capability-freeze.md#c9--reference-capability-families)
     expressible.
+    The current implementation centralizes that decision on the operation
+    definition: all three native-pilot operations admit only the Jellyfin-user
+    kind, elevated users remain eligible for ordinary authenticated operations,
+    and default, unknown, provider, and service projections deny. The authored
+    OpenAPI and frozen metadata publish the same exact allowlists without
+    changing the existing `x-canopy-authority` tokens. Grant intersection remains
+    owned by #639 and is not implemented here.
 12. **v1 has no per-user consent.** Grants are administrator-approved and
     server-wide; a user cannot decline an approved extension. The admin and user
     kill switches in [ADR-0007](0007-declarative-web-contributions.md) turn a

--- a/research/extension-platform/threat-model.md
+++ b/research/extension-platform/threat-model.md
@@ -116,7 +116,13 @@ a fresh host-user/elevation lookup. A production-wide source guard prevents
 legacy `NameIdentifier` / `sub` / `Sid` fallback parsers from returning and
 confines marker, cookie and IP identity ladders to non-authoritative Spoiler
 preference disambiguation. Focused controller tests pin Active Streams and
-Maintenance control sessions to the same canonical result.
+Maintenance control sessions to the same canonical result. Issue #640 adds an
+exact nonzero actor-kind domain and kernel-only typed construction: current
+operations admit only the Jellyfin-user kind, elevation remains current state on
+that same actor, and provider/service actors have no user projection or production
+proof issuer. Source and reflection guards reject raw/caller-shaped construction,
+cross-kind conversion, default/unknown authority and service entry into the
+existing per-user operation surface.
 
 ### T-02 · Privilege escalation to administrator — **critical**
 
@@ -414,6 +420,8 @@ trust browser origin or caller-supplied URLs.
    generation-fences all kernel-owned commits/delivery, but cannot stop or roll
    back a provider-owned or external effect already begun; late/revoked outcomes
    are discarded and audited.
-5. Issue [#638](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/638)
-   owns convergence of authority-relevant callers on one authenticated,
-   claims-only, fail-closed resolver (**T-01**).
+5. Completed by [#638](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/638)
+   and [#640](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/640):
+   authority-relevant callers converge on one authenticated claims-only resolver,
+   then enter a closed typed actor domain with exact operation-kind ceilings
+   (**T-01**, **T-02**, **T-13**).

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,7 +26,7 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2808, totalLines: 3201 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 37759, totalLines: 47107 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 37908, totalLines: 47266 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 3,
         minimumCoveredLines: 2808,
@@ -34,11 +34,11 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
     });
     assert.deepEqual(baselines.profiles.server.observations, {
         cleanRuns: 3,
-        minimumCoveredLines: 37759,
-        maximumCoveredLines: 37759,
+        minimumCoveredLines: 37906,
+        maximumCoveredLines: 37908,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 0);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 37759,
-        "totalLines": 47107
+        "coveredLines": 37908,
+        "totalLines": 47266
       },
       "observations": {
         "cleanRuns": 3,
-        "minimumCoveredLines": 37759,
-        "maximumCoveredLines": 37759
+        "minimumCoveredLines": 37906,
+        "maximumCoveredLines": 37908
       },
       "tolerance": {
-        "missingCoveredLines": 0,
-        "rationale": "The #638 EP-02 caller-identity change converges authority-relevant Jellyfin user resolution on one authenticated claims-only owner, binds administrator and Platform API-key classification to that same identity, closes role-only cross-user selection, and adds behavioral session-control and negative architecture coverage. Three clean local .NET 10.0.9 Coverlet runs on the identical final 47,107-line source and test scope each passed all 3,392 tests and reproduced exactly 37,759 covered lines. The reviewed observed high-water and exact clean-run floor are therefore both 37,759/47,107 (80.156%), so no instrumentation tolerance is required. Relative to the prior 37,685/47,087 high-water baseline, the change adds 20 instrumented lines, raises covered lines by 74, and increases overall coverage from 80.033% to 80.156%. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 2,
+        "rationale": "The #640 EP-02 actor-domain change adds the exact closed user/provider/service actor vocabulary, typed kernel-only construction proofs, one immutable authority projection, centralized operation kind/ceiling policy, and runtime/OpenAPI/frozen drift guards without activating provider or service routes. Reauthorization owns its fresh host lookup and no longer accepts caller-constructible HostUser input. Three clean local .NET 10.0.9 Coverlet runs on the identical final 47,266-line source and test scope each passed all 3,414 tests and measured 37,908, 37,906 and 37,906 covered lines. The reviewed observed high-water is therefore 37,908/47,266 (80.201%) and the exact observed floor is 37,906/47,266 (80.197%); the two-line tolerance is only the reproduced instrumentation envelope. Relative to the #638 baseline of 37,759/47,107 (80.156%), the change adds 159 instrumented lines and at least 147 covered lines while increasing overall coverage. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
Closes #640. Advances #41.

## Summary

- define the exact closed actor domain for Jellyfin user clients, installed providers, and companion services, with administrator authority remaining current elevation on the same user actor
- route user construction and reauthorization through opaque typed proofs and a fresh host lookup, with fail-closed identity preservation
- centralize per-operation actor-kind and current-authority policy while keeping every existing Platform operation user-only
- publish exact actor vocabulary and operation allowlists in authored OpenAPI plus separate frozen conformance metadata
- add compiler-aware architecture guards covering aliases, method groups, function pointers, Unicode identifier escapes, and ignored formatting characters
- keep provider and service proof issuers dormant: no authentication, routes, credentials, grants, persistence, state/events, or provider invocation

## Verification

- focused authority and architecture suite: 16 passed
- full server suite: 3,414 passed in each of three final clean .NET 10.0.9 Coverlet runs
- server coverage: reviewed 37,908/47,266 high-water with exact observed 37,906 floor
- client suite: 2,041 passed; 2,808/3,201 covered lines
- repository script suite: 641 passed
- coverage policy suite: 14 passed
- Release production and test builds: 0 warnings, 0 errors
- docs, contract JSON, Playwright discovery, bundle, syntax, TypeScript, translations, performance rules, and advisory lint gates passed
- independent security review: APPROVE
- independent architecture/quality review: APPROVE
- independent test/guard review: APPROVE

No Android, deployment, release, authentication handler, route, credential, grant evaluator, persistence, registry activation, provider call, or service invocation work is included.

## AI assistance

This PR was developed with GPT/Codex agent assistance. The implementation, tests, security boundaries, contract changes, and verification evidence were reviewed before publication.
