### PR TITLE
Define Platform capability grant ceiling

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformCapabilityArchitectureTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformCapabilityArchitectureTests.cs
@@ -1,0 +1,474 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.RegularExpressions;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform;
+
+/// <summary>Guards the closed capability vocabulary and its pure grant-ceiling owner.</summary>
+public sealed class PlatformCapabilityArchitectureTests
+{
+    private const string CapabilityDomainFileName = "PlatformCapabilityDomain.cs";
+
+    private static readonly string[] ClosedConstructionTypeNames =
+    {
+        nameof(PlatformCapabilityDecision),
+        nameof(PlatformCapabilityDefinition),
+        nameof(PlatformCapabilityId),
+        nameof(PlatformGrantedCapabilitySet),
+        nameof(PlatformGrantPreview),
+        nameof(PlatformRequestedCapabilitySet),
+    };
+
+    private static readonly (string TypeName, string MemberName)[] SensitiveMembers =
+    {
+        (nameof(PlatformCapabilityId), nameof(PlatformCapabilityId.EstablishCodeOwnedId)),
+        (nameof(PlatformCapabilityDefinition), nameof(PlatformCapabilityDefinition.EstablishCodeOwnedDefinition)),
+        (nameof(PlatformCapabilityVocabulary), nameof(PlatformCapabilityVocabulary.Find)),
+        (nameof(PlatformRequestedCapabilitySet), nameof(PlatformRequestedCapabilitySet.TryCreate)),
+        (nameof(PlatformGrantedCapabilitySet), nameof(PlatformGrantedCapabilitySet.TryCreate)),
+        (nameof(PlatformGrantedCapabilitySet), nameof(PlatformGrantedCapabilitySet.Missing)),
+        ("PlatformCapabilitySetResolver", "TryResolve"),
+        (nameof(PlatformCapabilityDecision), nameof(PlatformCapabilityDecision.EstablishDecision)),
+        (nameof(PlatformGrantPreview), nameof(PlatformGrantPreview.EstablishPreview)),
+        (nameof(PlatformGrantCeilingEvaluator), nameof(PlatformGrantCeilingEvaluator.Evaluate)),
+    };
+
+    private static readonly Regex IdentifierUnicodeEscape = new(
+        @"\\(?:u(?<short>[0-9a-fA-F]{4})|U(?<long>[0-9a-fA-F]{8}))",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    [Fact]
+    public void CapabilityIdentifiersAndDefinitionsHaveOnlyPrivateConstructors()
+    {
+        foreach (var type in new[]
+        {
+            typeof(PlatformCapabilityDecision),
+            typeof(PlatformCapabilityId),
+            typeof(PlatformCapabilityDefinition),
+            typeof(PlatformRequestedCapabilitySet),
+            typeof(PlatformGrantedCapabilitySet),
+            typeof(PlatformGrantPreview),
+        })
+        {
+            var constructors = type.GetConstructors(
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+            Assert.Single(constructors);
+            Assert.True(constructors[0].IsPrivate);
+        }
+    }
+
+    [Fact]
+    public void CrossFileGlobalAliasesCannotHideSensitiveCapabilityOwners()
+    {
+        var owners = ProductionFiles()
+            .Where(file => HasSensitiveGlobalAliasDeclaration(Code(file)))
+            .Select(Path.GetFileName)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Empty(owners);
+
+        const string aliasSource =
+            "global using Grants = Jellyfin.Plugin.JellyfinCanopy.Platform.PlatformGrantedCapabilitySet;";
+        const string useSource =
+            "internal class OtherOwner { void Use() => Grants.TryCreate(values, out var grants); }";
+        Assert.True(HasCrossFileSensitiveMemberUse(
+            aliasSource,
+            useSource,
+            nameof(PlatformGrantedCapabilitySet),
+            nameof(PlatformGrantedCapabilitySet.TryCreate)));
+
+        const string staticAliasSource =
+            "global using static Jellyfin.Plugin.JellyfinCanopy.Platform.PlatformGrantCeilingEvaluator;";
+        const string staticUseSource =
+            "internal class OtherOwner { void Use() => Evaluate(requested, granted, authority); }";
+        Assert.True(HasCrossFileSensitiveMemberUse(
+            staticAliasSource,
+            staticUseSource,
+            nameof(PlatformGrantCeilingEvaluator),
+            nameof(PlatformGrantCeilingEvaluator.Evaluate)));
+
+        const string verbatimAliasSource =
+            "global using @Grants = Jellyfin.Plugin.JellyfinCanopy.Platform.PlatformGrantedCapabilitySet;";
+        const string verbatimUseSource =
+            "internal class OtherOwner { void Use() => @Grants.TryCreate(values, out var grants); }";
+        Assert.True(HasCrossFileSensitiveMemberUse(
+            verbatimAliasSource,
+            verbatimUseSource,
+            nameof(PlatformGrantedCapabilitySet),
+            nameof(PlatformGrantedCapabilitySet.TryCreate)));
+
+        const string unicodeAliasSource =
+            "global using 授權 = Jellyfin.Plugin.JellyfinCanopy.Platform.PlatformGrantPreview;";
+        const string unicodeUseSource =
+            "internal class OtherOwner { void Use() => 授權.EstablishPreview(status, decisions); }";
+        Assert.True(HasCrossFileSensitiveMemberUse(
+            unicodeAliasSource,
+            unicodeUseSource,
+            nameof(PlatformGrantPreview),
+            nameof(PlatformGrantPreview.EstablishPreview)));
+
+        Assert.True(HasSensitiveGlobalAliasDeclaration(
+            "global using @Grants =\n"
+            + "    Jellyfin.Plugin.JellyfinCanopy.Platform.PlatformGrantedCapabilitySet;"));
+        Assert.True(HasSensitiveGlobalAliasDeclaration(
+            "global using 授權 =\n"
+            + "    Jellyfin.Plugin.JellyfinCanopy.Platform.PlatformGrantPreview;"));
+        Assert.False(HasSensitiveGlobalAliasDeclaration(
+            "global using Platform = Jellyfin.Plugin.JellyfinCanopy.Platform;"));
+        Assert.False(HasSensitiveGlobalAliasDeclaration(
+            "global using Similar = Example.PlatformGrantPreviewLike;"));
+    }
+
+    [Fact]
+    public void OnlyTheCapabilityDomainConstructsClosedCapabilityTypes()
+    {
+        var owners = ProductionFiles()
+            .Where(file => HasClosedTypeConstruction(Code(file)))
+            .Select(Path.GetFileName)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(new[] { CapabilityDomainFileName }, owners);
+
+        Assert.True(HasClosedTypeConstruction(
+            "var id = new global::Jellyfin.Plugin.JellyfinCanopy.Platform.PlatformCapabilityId(value);"));
+        Assert.True(HasClosedTypeConstruction(
+            "PlatformCapabilityDefinition definition = new(id, domain, actorKind, false);"));
+        Assert.True(HasClosedTypeConstruction(
+            "using Definition = Jellyfin.Plugin.JellyfinCanopy.Platform.PlatformCapabilityDefinition;\n"
+            + "Definition definition = new(id, domain, actorKind, false);"));
+        Assert.True(HasClosedTypeConstruction(
+            "using Id = global::Jellyfin.Plugin.JellyfinCanopy.Platform.PlatformCapabilityId;\n"
+            + "var id = new Id(value);"));
+        Assert.True(HasClosedTypeConstruction(
+            "using @Id = global::Jellyfin.Plugin.JellyfinCanopy.Platform.PlatformCapabilityId;\n"
+            + "var id = new @Id(value);"));
+        Assert.True(HasClosedTypeConstruction(
+            "using 識別碼 = global::Jellyfin.Plugin.JellyfinCanopy.Platform.PlatformCapabilityId;\n"
+            + "var id = new 識別碼(value);"));
+        Assert.True(HasClosedTypeConstruction(
+            "var id = new PlatformCapability\\u0049d(value);"));
+        Assert.True(HasClosedTypeConstruction(
+            "var id = new PlatformCapability\u200cId(value);"));
+    }
+
+    [Fact]
+    public void RawResolutionSetFactoriesMissingSentinelAndEvaluatorHaveOneOwner()
+    {
+        foreach (var (typeName, memberName) in SensitiveMembers)
+        {
+            Assert.Equal(
+                new[] { CapabilityDomainFileName },
+                SensitiveMemberOwners(typeName, memberName));
+        }
+
+        Assert.True(HasSensitiveMemberUse(
+            "var result = global::Jellyfin.Plugin.JellyfinCanopy.Platform.PlatformCapabilityVocabulary . Find (value);",
+            nameof(PlatformCapabilityVocabulary),
+            nameof(PlatformCapabilityVocabulary.Find)));
+        Assert.True(HasSensitiveMemberUse(
+            "using Vocabulary = Jellyfin.Plugin.JellyfinCanopy.Platform.PlatformCapabilityVocabulary;\n"
+            + "var result = Vocabulary.Find(value);",
+            nameof(PlatformCapabilityVocabulary),
+            nameof(PlatformCapabilityVocabulary.Find)));
+        Assert.True(HasSensitiveMemberUse(
+            "using static Jellyfin.Plugin.JellyfinCanopy.Platform.PlatformCapabilityVocabulary;\n"
+            + "var result = Find(value);",
+            nameof(PlatformCapabilityVocabulary),
+            nameof(PlatformCapabilityVocabulary.Find)));
+        Assert.True(HasSensitiveMemberUse(
+            "Func<string, PlatformCapabilityDefinition?> resolve = PlatformCapabilityVocabulary.Find;",
+            nameof(PlatformCapabilityVocabulary),
+            nameof(PlatformCapabilityVocabulary.Find)));
+        Assert.True(HasSensitiveMemberUse(
+            "var result = PlatformRequestedCapabilitySet.TryCreate (values, out var requested);",
+            nameof(PlatformRequestedCapabilitySet),
+            nameof(PlatformRequestedCapabilitySet.TryCreate)));
+        Assert.True(HasSensitiveMemberUse(
+            "using Grants = PlatformGrantedCapabilitySet; var missing = Grants . Missing;",
+            nameof(PlatformGrantedCapabilitySet),
+            nameof(PlatformGrantedCapabilitySet.Missing)));
+        Assert.True(HasSensitiveMemberUse(
+            "using @Grants = PlatformGrantedCapabilitySet; var missing = @Grants.Missing;",
+            nameof(PlatformGrantedCapabilitySet),
+            nameof(PlatformGrantedCapabilitySet.Missing)));
+        Assert.True(HasSensitiveMemberUse(
+            "using 授權 = PlatformGrantPreview; var preview = 授權.EstablishPreview(status, decisions);",
+            nameof(PlatformGrantPreview),
+            nameof(PlatformGrantPreview.EstablishPreview)));
+        Assert.True(HasSensitiveMemberUse(
+            "var preview = PlatformGrantCeilingEvaluator.Eval\\u0075ate(requested, granted, authority);",
+            nameof(PlatformGrantCeilingEvaluator),
+            nameof(PlatformGrantCeilingEvaluator.Evaluate)));
+        Assert.True(HasSensitiveMemberUse(
+            "var preview = PlatformGrantCeilingEvaluator.Eval\u200cuate(requested, granted, authority);",
+            nameof(PlatformGrantCeilingEvaluator),
+            nameof(PlatformGrantCeilingEvaluator.Evaluate)));
+    }
+
+    [Fact]
+    public void CapabilityDomainHasNoHostManifestRequestSecretOrRegistrationDependencies()
+    {
+        var code = Code(SourceFile(CapabilityDomainFileName));
+        var forbidden = new[]
+        {
+            "Microsoft.AspNetCore",
+            "Microsoft.Extensions.Configuration",
+            "Microsoft.Extensions.DependencyInjection",
+            "Microsoft.Extensions.Options",
+            "Configuration",
+            "HttpContext",
+            "HttpRequest",
+            "Controller",
+            "Route(",
+            "Manifest",
+            "IConfiguration",
+            "IOptions",
+            "IServiceCollection",
+            "IServiceProvider",
+            "ClaimsPrincipal",
+            "Token",
+            "SecurityToken",
+            "BearerToken",
+            "Credential",
+            "Secret",
+            "Register(",
+            "TryRegister(",
+            "AddSingleton",
+            "AddScoped",
+            "AddTransient",
+            "Activator.CreateInstance",
+            "Assembly.Load",
+            "AppDomain",
+            "Type.GetType",
+        };
+
+        Assert.All(forbidden, value => Assert.DoesNotContain(value, code, StringComparison.OrdinalIgnoreCase));
+
+        var vocabularyMethods = typeof(PlatformCapabilityVocabulary)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
+            .Where(method => !method.IsSpecialName)
+            .Select(method => method.Name)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+        Assert.Equal(new[] { nameof(PlatformCapabilityVocabulary.Find) }, vocabularyMethods);
+        Assert.DoesNotContain(
+            typeof(PlatformCapabilityVocabulary).GetProperties(BindingFlags.Public | BindingFlags.Static),
+            property => property.CanWrite);
+
+        var vocabularyFields = typeof(PlatformCapabilityVocabulary)
+            .GetFields(BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly);
+        Assert.Single(vocabularyFields);
+        Assert.True(vocabularyFields[0].IsInitOnly);
+        Assert.Equal(typeof(ImmutableArray<PlatformCapabilityDefinition>), vocabularyFields[0].FieldType);
+    }
+
+    [Fact]
+    public void ExistingFirstPartyActionPathDoesNotReferenceCapabilityGrants()
+    {
+        var existingActionPathFiles = new[]
+        {
+            "HiddenContentPlatformItemActionAdapter.cs",
+            "PlatformActionAdmissionLimiter.cs",
+            "PlatformActionCapabilityService.cs",
+            "PlatformActionInvocationCoordinator.cs",
+            "PlatformActionInvokeContract.cs",
+            "PlatformAuditStore.cs",
+            "PlatformFirstPartyActionDispatcher.cs",
+            "PlatformNativeActionPorts.cs",
+            "PlatformNativeCatalogService.cs",
+            "PlatformNativeController.cs",
+            "PlatformOperationVocabulary.cs",
+            "PlatformPreparedActionContextOwner.cs",
+            "PlatformPrepareHandleOwner.cs",
+            "SpoilerGuardPlatformItemActionAdapter.cs",
+        };
+        var forbidden = new[]
+        {
+            "PlatformCapabilityVocabulary",
+            "PlatformCapabilityDefinition",
+            "PlatformCapabilityId",
+            "PlatformRequestedCapabilitySet",
+            "PlatformGrantedCapabilitySet",
+            "PlatformGrantCeilingEvaluator",
+            "PlatformGrantPreview",
+            "grant",
+        };
+
+        foreach (var fileName in existingActionPathFiles)
+        {
+            var code = Code(SourceFile(fileName));
+            Assert.All(
+                forbidden,
+                value => Assert.DoesNotContain(value, code, StringComparison.OrdinalIgnoreCase));
+        }
+
+        Assert.Equal(3, PlatformOperationVocabulary.All.Length);
+        Assert.Equal(
+            new[]
+            {
+                "jellyfin.canopy.spoiler-guard.configure-item",
+                "jellyfin.canopy.hidden-content.configure-item",
+                "jellyfin.canopy.seerr.request-item",
+            },
+            PlatformOperationVocabulary.All.Select(definition => definition.Id.Value));
+    }
+
+    private static string[] SensitiveMemberOwners(string typeName, string memberName) => ProductionFiles()
+        .Where(file => HasSensitiveMemberUse(Code(file), typeName, memberName))
+        .Select(file => Path.GetFileName(file)!)
+        .OrderBy(name => name, StringComparer.Ordinal)
+        .ToArray();
+
+    private static bool HasSensitiveMemberUse(string source, string typeName, string memberName)
+    {
+        var code = NormalizeIdentifierUnicodeEscapes(source);
+        var escapedType = Regex.Escape(typeName);
+        var escapedMember = Regex.Escape(memberName);
+        var identifier = @"[A-Za-z_]\w*";
+
+        // Any alias or static import of a sensitive owner is itself ownership. This is
+        // deliberately conservative and does not attempt to reimplement C#'s identifier
+        // grammar, so verbatim and Unicode aliases cannot hide a sensitive member use.
+        if (HasUsingDirectiveNamingType(code, escapedType, globalOnly: false))
+        {
+            return true;
+        }
+
+        if (Regex.IsMatch(
+            code,
+            $@"(?:(?:global\s*::\s*)?{identifier}\s*\.\s*)*\b{escapedType}\b\s*\.\s*\b{escapedMember}\b",
+            RegexOptions.CultureInvariant))
+        {
+            return true;
+        }
+
+        return Regex.IsMatch(
+                code,
+                $@"\b(?:class|struct)\s+{escapedType}\b",
+                RegexOptions.CultureInvariant)
+            && Regex.IsMatch(code, $@"\b{escapedMember}\b", RegexOptions.CultureInvariant);
+    }
+
+    private static bool HasClosedTypeConstruction(string source)
+    {
+        var code = NormalizeIdentifierUnicodeEscapes(source);
+        var typeAlternation = string.Join("|", ClosedConstructionTypeNames.Select(Regex.Escape));
+        var identifier = @"[A-Za-z_]\w*";
+
+        if (HasUsingDirectiveNamingType(code, typeAlternation, globalOnly: false))
+        {
+            return true;
+        }
+
+        if (Regex.IsMatch(
+            code,
+            $@"\bnew\s+(?:(?:global\s*::\s*)?{identifier}\s*\.\s*)*(?:{typeAlternation})\s*\(",
+            RegexOptions.CultureInvariant)
+            || Regex.IsMatch(
+                code,
+                $@"\b(?:{typeAlternation})\b\s+{identifier}\s*=\s*new\s*\(",
+                RegexOptions.CultureInvariant))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool HasSensitiveGlobalAliasDeclaration(string source)
+    {
+        var code = NormalizeIdentifierUnicodeEscapes(source);
+        var types = string.Join("|", ClosedConstructionTypeNames
+            .Concat(SensitiveMembers.Select(member => member.TypeName))
+            .Distinct(StringComparer.Ordinal)
+            .Select(Regex.Escape));
+        return HasUsingDirectiveNamingType(code, types, globalOnly: true);
+    }
+
+    private static bool HasCrossFileSensitiveMemberUse(
+        string aliasSource,
+        string useSource,
+        string typeName,
+        string memberName)
+    {
+        var aliases = NormalizeIdentifierUnicodeEscapes(aliasSource);
+        _ = useSource;
+        _ = memberName;
+        return HasUsingDirectiveNamingType(aliases, Regex.Escape(typeName), globalOnly: true);
+    }
+
+    private static bool HasUsingDirectiveNamingType(
+        string code,
+        string escapedTypePattern,
+        bool globalOnly)
+    {
+        var prefix = globalOnly ? @"global\s+using" : @"(?:global\s+)?using";
+        return Regex.IsMatch(
+            code,
+            $@"^\s*{prefix}\s+(?:static\s+)?[^;]*\b(?:{escapedTypePattern})\b\s*;",
+            RegexOptions.CultureInvariant | RegexOptions.Multiline);
+    }
+
+    private static string NormalizeIdentifierUnicodeEscapes(string code)
+    {
+        var decoded = IdentifierUnicodeEscape.Replace(code, match =>
+        {
+            var shortHex = match.Groups["short"];
+            if (shortHex.Success)
+            {
+                return ((char)Convert.ToInt32(shortHex.Value, 16)).ToString();
+            }
+
+            var scalar = Convert.ToInt32(match.Groups["long"].Value, 16);
+            return scalar is >= 0 and <= 0x10FFFF
+                && scalar is not (>= 0xD800 and <= 0xDFFF)
+                    ? char.ConvertFromUtf32(scalar)
+                    : match.Value;
+        });
+
+        var normalized = new StringBuilder(decoded.Length);
+        foreach (var rune in decoded.EnumerateRunes())
+        {
+            if (Rune.GetUnicodeCategory(rune) != UnicodeCategory.Format)
+            {
+                normalized.Append(rune.ToString());
+            }
+        }
+
+        return normalized.ToString();
+    }
+
+    private static string Code(string file) =>
+        NormalizeIdentifierUnicodeEscapes(PlatformHostSeamTests.CodeOnly(File.ReadAllText(file)));
+
+    private static IEnumerable<string> ProductionFiles() =>
+        Directory.EnumerateFiles(ProductionRoot(), "*.cs", SearchOption.AllDirectories)
+            .Where(file => !file.Contains(
+                    $"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}",
+                    StringComparison.Ordinal)
+                && !file.Contains(
+                    $"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}",
+                    StringComparison.Ordinal));
+
+    private static string SourceFile(string name) => ProductionFiles()
+        .Single(file => Path.GetFileName(file) == name);
+
+    private static string ProductionRoot([CallerFilePath] string sourceFile = "") =>
+        Path.GetFullPath(Path.Combine(
+            Path.GetDirectoryName(sourceFile)!,
+            "..",
+            "..",
+            "Jellyfin.Plugin.JellyfinCanopy"));
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformCapabilityVocabularyTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformCapabilityVocabularyTests.cs
@@ -1,0 +1,224 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform;
+
+public sealed class PlatformCapabilityVocabularyTests
+{
+    private sealed record ExpectedDefinition(
+        string Id,
+        PlatformCapabilityDomain Domain,
+        string ActorKinds,
+        bool RequiresElevation = false);
+
+    private static readonly string[] ExpectedIds =
+    [
+        "jellyfin.canopy.discovery.read",
+        "jellyfin.canopy.items.lookup",
+        "jellyfin.canopy.user-data.read",
+        "jellyfin.canopy.events.subscribe",
+        "jellyfin.canopy.storage.read",
+        "jellyfin.canopy.ui.contribute",
+        "jellyfin.canopy.integrations.invoke",
+        "jellyfin.canopy.administration.manage",
+        "jellyfin.canopy.diagnostics.read",
+    ];
+
+    [Fact]
+    public void VocabularyIsTheExactOrderedV1Golden()
+    {
+        var actual = PlatformCapabilityVocabulary.All
+            .Select(definition => new ExpectedDefinition(
+                definition.Id.Value,
+                definition.Domain,
+                string.Join(",", definition.AllowedActorKinds),
+                definition.RequiresElevation))
+            .ToArray();
+
+        Assert.Equal(
+            new[]
+            {
+                new ExpectedDefinition("jellyfin.canopy.discovery.read", PlatformCapabilityDomain.Discovery, "JellyfinUserClient"),
+                new ExpectedDefinition("jellyfin.canopy.items.lookup", PlatformCapabilityDomain.ItemLookup, "JellyfinUserClient,InstalledProvider"),
+                new ExpectedDefinition("jellyfin.canopy.user-data.read", PlatformCapabilityDomain.UserData, "JellyfinUserClient,InstalledProvider"),
+                new ExpectedDefinition("jellyfin.canopy.events.subscribe", PlatformCapabilityDomain.Events, "CompanionService"),
+                new ExpectedDefinition("jellyfin.canopy.storage.read", PlatformCapabilityDomain.Storage, "JellyfinUserClient,InstalledProvider"),
+                new ExpectedDefinition("jellyfin.canopy.ui.contribute", PlatformCapabilityDomain.UiContributions, "InstalledProvider"),
+                new ExpectedDefinition("jellyfin.canopy.integrations.invoke", PlatformCapabilityDomain.IntegrationActions, "JellyfinUserClient,InstalledProvider"),
+                new ExpectedDefinition("jellyfin.canopy.administration.manage", PlatformCapabilityDomain.Administration, "JellyfinUserClient", true),
+                new ExpectedDefinition("jellyfin.canopy.diagnostics.read", PlatformCapabilityDomain.Diagnostics, "JellyfinUserClient", true),
+            },
+            actual);
+    }
+
+    [Fact]
+    public void VocabularyPinsCountOrderDomainsAndExactResolution()
+    {
+        Assert.Equal(9, PlatformCapabilityVocabulary.MaximumCapabilityCount);
+        Assert.Equal(ExpectedIds, PlatformCapabilityVocabulary.All.Select(value => value.Id.Value));
+        Assert.Equal(
+            new[]
+            {
+                PlatformCapabilityDomain.Discovery,
+                PlatformCapabilityDomain.ItemLookup,
+                PlatformCapabilityDomain.UserData,
+                PlatformCapabilityDomain.Events,
+                PlatformCapabilityDomain.Storage,
+                PlatformCapabilityDomain.UiContributions,
+                PlatformCapabilityDomain.IntegrationActions,
+                PlatformCapabilityDomain.Administration,
+                PlatformCapabilityDomain.Diagnostics,
+            },
+            Enum.GetValues<PlatformCapabilityDomain>());
+
+        Assert.Equal(
+            PlatformCapabilityVocabulary.All.Length,
+            PlatformCapabilityVocabulary.All.Select(value => value.Id.Value).Distinct(StringComparer.Ordinal).Count());
+        Assert.Equal(
+            PlatformCapabilityVocabulary.All.Length,
+            PlatformCapabilityVocabulary.All.Select(value => value.Domain).Distinct().Count());
+
+        foreach (var definition in PlatformCapabilityVocabulary.All)
+        {
+            Assert.Same(definition, PlatformCapabilityVocabulary.Find(definition.Id.Value));
+        }
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("jellyfin.canopy.unknown.read")]
+    [InlineData("JELLYFIN.CANOPY.DISCOVERY.READ")]
+    [InlineData("jellyfin.canopy.discovery.*")]
+    [InlineData("jellyfin.canopy.discovery")]
+    [InlineData(" jellyfin.canopy.discovery.read")]
+    [InlineData("jellyfin.canopy.discovery.read ")]
+    public void FindRejectsUnknownMalformedWildcardAndCaseVariantValues(string? value)
+        => Assert.Null(PlatformCapabilityVocabulary.Find(value));
+
+    [Theory]
+    [InlineData("jellyfin.canopy.discovery.read")]
+    [InlineData("jellyfin.canopy.user-data.read")]
+    [InlineData("jellyfin.canopy.a.a")]
+    [InlineData("jellyfin.canopy.a1-b2.c3-d4")]
+    public void IdentifierGrammarAcceptsOnlyTheExactFourSegmentNamespace(string value)
+        => Assert.True(PlatformCapabilityVocabulary.IsValidIdentifier(value));
+
+    [Theory]
+    [InlineData("jellyfin.canopy.discovery")]
+    [InlineData("jellyfin.canopy.discovery.read.extra")]
+    [InlineData("vendor.canopy.discovery.read")]
+    [InlineData("jellyfin.other.discovery.read")]
+    [InlineData("Jellyfin.canopy.discovery.read")]
+    [InlineData("jellyfin.canopy.Discovery.read")]
+    [InlineData("jellyfin.canopy.1discovery.read")]
+    [InlineData("jellyfin.canopy.discovery.1read")]
+    [InlineData("jellyfin.canopy.-discovery.read")]
+    [InlineData("jellyfin.canopy.discovery-.read")]
+    [InlineData("jellyfin.canopy.discovery.-read")]
+    [InlineData("jellyfin.canopy.discovery.read-")]
+    [InlineData("jellyfin.canopy.user--data.read")]
+    [InlineData("jellyfin.canopy.discovery.read_write")]
+    [InlineData("jellyfin.canopy.discovery/read")]
+    [InlineData("jellyfin.canopy.discovery:read")]
+    [InlineData("jellyfin.canopy.discovéry.read")]
+    [InlineData("jellyfin.canopy.discovery.reаd")]
+    [InlineData("jellyfin.canopy.discovery.*")]
+    [InlineData("jellyfin.canopy.*.read")]
+    [InlineData("jellyfin.canopy.discovery.**")]
+    public void IdentifierGrammarRejectsOpenEndedNonAsciiOrMalformedValues(string value)
+        => Assert.False(PlatformCapabilityVocabulary.IsValidIdentifier(value));
+
+    [Fact]
+    public void IdentifierGrammarPinsSegmentCountAndBothLengthBoundaries()
+    {
+        Assert.Equal(4, PlatformCapabilityVocabulary.IdentifierSegmentCount);
+        Assert.Equal(64, PlatformCapabilityVocabulary.MaximumVariableSegmentLength);
+        Assert.Equal(128, PlatformCapabilityVocabulary.MaximumIdentifierLength);
+
+        var maximumDomain = "jellyfin.canopy." + new string('a', 64) + ".read";
+        var overlongDomain = "jellyfin.canopy." + new string('a', 65) + ".read";
+        var maximumIdentifier = "jellyfin.canopy." + new string('a', 55) + "." + new string('b', 56);
+
+        Assert.True(PlatformCapabilityVocabulary.IsValidIdentifier(maximumDomain));
+        Assert.False(PlatformCapabilityVocabulary.IsValidIdentifier(overlongDomain));
+        Assert.Equal(128, maximumIdentifier.Length);
+        Assert.True(PlatformCapabilityVocabulary.IsValidIdentifier(maximumIdentifier));
+        Assert.False(PlatformCapabilityVocabulary.IsValidIdentifier(maximumIdentifier + "b"));
+    }
+
+    [Fact]
+    public void AdministrationAndDiagnosticsCannotBeDefinedWithoutElevation()
+    {
+        var constructor = Assert.Single(typeof(PlatformCapabilityDefinition).GetConstructors(
+            BindingFlags.Instance | BindingFlags.NonPublic));
+        var id = PlatformCapabilityVocabulary.Find("jellyfin.canopy.administration.manage")!.Id;
+        var userKind = ImmutableArray.Create(PlatformActorKind.JellyfinUserClient);
+
+        foreach (var domain in new[]
+        {
+            PlatformCapabilityDomain.Administration,
+            PlatformCapabilityDomain.Diagnostics,
+        })
+        {
+            var exception = Assert.Throws<TargetInvocationException>(() => constructor.Invoke(
+                new object[] { id, domain, userKind, false }));
+            Assert.IsType<ArgumentException>(exception.InnerException);
+        }
+    }
+
+    [Fact]
+    public void RequestedAndGrantedSetsAreDistinctBoundedCanonicalTypes()
+    {
+        Assert.NotEqual(typeof(PlatformRequestedCapabilitySet), typeof(PlatformGrantedCapabilitySet));
+        Assert.Null(default(PlatformRequestedCapabilitySet));
+        Assert.Null(default(PlatformGrantedCapabilitySet));
+        Assert.True(PlatformGrantedCapabilitySet.Missing.IsValid);
+
+        Assert.True(PlatformRequestedCapabilitySet.TryCreate(
+            ExpectedIds.Reverse().ToArray(),
+            out var requested));
+        Assert.True(PlatformGrantedCapabilitySet.TryCreate(
+            ExpectedIds.Reverse().ToArray(),
+            out var granted));
+
+        Assert.Equal(ExpectedIds, requested.Capabilities.Select(value => value.Id.Value));
+        Assert.Equal(ExpectedIds, granted.Capabilities.Select(value => value.Id.Value));
+        Assert.True(granted.IsPresent);
+        Assert.False(PlatformGrantedCapabilitySet.Missing.IsPresent);
+    }
+
+    [Fact]
+    public void SetFactoriesRejectNullDefaultDuplicateUnknownCaseVariantAndOverBoundInputs()
+    {
+        Assert.False(PlatformRequestedCapabilitySet.TryCreate(null, out _));
+        Assert.False(PlatformGrantedCapabilitySet.TryCreate(null, out _));
+        Assert.False(PlatformRequestedCapabilitySet.TryCreate(
+            new[] { ExpectedIds[0], ExpectedIds[0] },
+            out _));
+        Assert.False(PlatformGrantedCapabilitySet.TryCreate(
+            new[] { ExpectedIds[0], ExpectedIds[0] },
+            out _));
+
+        foreach (var invalid in new[]
+        {
+            "jellyfin.canopy.unknown.read",
+            "JELLYFIN.CANOPY.DISCOVERY.READ",
+            "jellyfin.canopy.discovery.*",
+            "jellyfin.canopy.discovery",
+        })
+        {
+            Assert.False(PlatformRequestedCapabilitySet.TryCreate(new[] { invalid }, out _));
+            Assert.False(PlatformGrantedCapabilitySet.TryCreate(new[] { invalid }, out _));
+        }
+
+        var overBound = ExpectedIds.Concat(new[] { ExpectedIds[0] }).ToArray();
+        Assert.Equal(PlatformCapabilityVocabulary.MaximumCapabilityCount + 1, overBound.Length);
+        Assert.False(PlatformRequestedCapabilitySet.TryCreate(overBound, out _));
+        Assert.False(PlatformGrantedCapabilitySet.TryCreate(overBound, out _));
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformContractTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformContractTests.cs
@@ -198,6 +198,140 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
             return drift.OrderBy(value => value, StringComparer.Ordinal).ToArray();
         }
 
+        private static IReadOnlyList<string> CapabilityMetadataDrift(JsonElement frozen, JsonElement spec)
+        {
+            var drift = new List<string>();
+            var authoredVocabulary = spec.GetProperty("x-canopy-capability-vocabulary")
+                .EnumerateArray().Select(value => value.GetString()!).ToArray();
+            var frozenVocabulary = frozen.GetProperty("capabilityVocabulary")
+                .EnumerateArray().Select(value => value.GetString()!).ToArray();
+            var authoredSet = authoredVocabulary.ToHashSet(StringComparer.Ordinal);
+            var frozenSet = frozenVocabulary.ToHashSet(StringComparer.Ordinal);
+            var authoredMetadata = spec.GetProperty("x-canopy-capability-metadata");
+            var frozenMetadata = frozen.GetProperty("capabilityMetadata");
+
+            drift.AddRange(authoredVocabulary
+                .Where(capability => !frozenSet.Contains(capability))
+                .Select(capability => $"{capability} is absent from the frozen capability vocabulary"));
+            drift.AddRange(frozenVocabulary
+                .Where(capability => !authoredSet.Contains(capability))
+                .Select(capability => $"{capability} is frozen but absent from the authored capability vocabulary"));
+
+            foreach (var capability in authoredVocabulary)
+            {
+                if (!authoredMetadata.TryGetProperty(capability, out var authored))
+                {
+                    drift.Add($"{capability} has no authored capability metadata");
+                    continue;
+                }
+
+                if (!frozenMetadata.TryGetProperty(capability, out var pinned))
+                {
+                    drift.Add($"{capability} has no frozen capability metadata");
+                    continue;
+                }
+
+                if (!string.Equals(
+                    authored.GetProperty("domain").GetString(),
+                    pinned.GetProperty("domain").GetString(),
+                    StringComparison.Ordinal))
+                {
+                    drift.Add($"{capability} domain changed");
+                }
+
+                var authoredKinds = authored.GetProperty("actorKinds")
+                    .EnumerateArray().Select(value => value.GetString()).ToArray();
+                var pinnedKinds = pinned.GetProperty("actorKinds")
+                    .EnumerateArray().Select(value => value.GetString()).ToArray();
+                if (!authoredKinds.SequenceEqual(pinnedKinds, StringComparer.Ordinal))
+                {
+                    drift.Add($"{capability} actor kinds changed");
+                }
+
+                if (authored.GetProperty("requiresElevation").GetBoolean()
+                    != pinned.GetProperty("requiresElevation").GetBoolean())
+                {
+                    drift.Add($"{capability} elevation ceiling changed");
+                }
+            }
+
+            drift.AddRange(authoredMetadata.EnumerateObject()
+                .Where(metadata => !authoredSet.Contains(metadata.Name))
+                .Select(metadata => $"{metadata.Name} has authored metadata but is not in the capability vocabulary"));
+            drift.AddRange(frozenMetadata.EnumerateObject()
+                .Where(metadata => !frozenSet.Contains(metadata.Name))
+                .Select(metadata => $"{metadata.Name} has frozen metadata but is not in the capability vocabulary"));
+
+            return drift.OrderBy(value => value, StringComparer.Ordinal).ToArray();
+        }
+
+        private static IReadOnlyList<string> CapabilityVocabularyDrift(
+            IReadOnlyList<string> runtime,
+            JsonElement frozen,
+            JsonElement spec)
+        {
+            var authored = spec.GetProperty("x-canopy-capability-vocabulary")
+                .EnumerateArray().Select(value => value.GetString()!).ToArray();
+            var pinned = frozen.GetProperty("capabilityVocabulary")
+                .EnumerateArray().Select(value => value.GetString()!).ToArray();
+            var runtimeSet = runtime.ToHashSet(StringComparer.Ordinal);
+            var authoredSet = authored.ToHashSet(StringComparer.Ordinal);
+            var pinnedSet = pinned.ToHashSet(StringComparer.Ordinal);
+            var drift = new List<string>();
+
+            drift.AddRange(runtime
+                .Where(capability => !authoredSet.Contains(capability))
+                .Select(capability => $"runtime capability {capability} is absent from the authored vocabulary"));
+            drift.AddRange(runtime
+                .Where(capability => !pinnedSet.Contains(capability))
+                .Select(capability => $"runtime capability {capability} is absent from the frozen vocabulary"));
+            drift.AddRange(authored
+                .Where(capability => !runtimeSet.Contains(capability))
+                .Select(capability => $"authored capability {capability} is absent from runtime"));
+            drift.AddRange(pinned
+                .Where(capability => !runtimeSet.Contains(capability))
+                .Select(capability => $"frozen capability {capability} was removed from runtime"));
+
+            drift.AddRange(Duplicates(runtime, "runtime"));
+            drift.AddRange(Duplicates(authored, "authored"));
+            drift.AddRange(Duplicates(pinned, "frozen"));
+
+            if (runtimeSet.SetEquals(authoredSet)
+                && runtime.Count == authored.Length
+                && !runtime.SequenceEqual(authored, StringComparer.Ordinal))
+            {
+                drift.Add("authored capability order differs from runtime");
+            }
+
+            if (runtimeSet.SetEquals(pinnedSet)
+                && runtime.Count == pinned.Length
+                && !runtime.SequenceEqual(pinned, StringComparer.Ordinal))
+            {
+                drift.Add("frozen capability order differs from runtime");
+            }
+
+            return drift.OrderBy(value => value, StringComparer.Ordinal).ToArray();
+
+            static IEnumerable<string> Duplicates(IEnumerable<string> values, string owner) => values
+                .GroupBy(value => value, StringComparer.Ordinal)
+                .Where(group => group.Count() > 1)
+                .Select(group => $"{owner} capability {group.Key} is duplicated");
+        }
+
+        private static string CapabilityDomainToken(object domain) => domain.ToString() switch
+        {
+            "Discovery" => "discovery",
+            "ItemLookup" => "item-lookup",
+            "UserData" => "user-data",
+            "Events" => "events",
+            "Storage" => "storage",
+            "UiContributions" => "ui-contributions",
+            "IntegrationActions" => "integration-actions",
+            "Administration" => "administration",
+            "Diagnostics" => "diagnostics",
+            _ => throw new InvalidOperationException($"Unknown Platform capability domain '{domain}'."),
+        };
+
         private static IEnumerable<(string Path, string Method, JsonElement Operation)> SpecOperations(JsonElement spec)
         {
             foreach (var path in spec.GetProperty("paths").EnumerateObject())
@@ -785,6 +919,196 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
             Assert.Equal(runtime, authored);
             Assert.Equal(runtime, frozen);
             Assert.Equal(runtime.Length, runtime.Distinct(StringComparer.Ordinal).Count());
+        }
+
+        [Fact]
+        public void CapabilityTokensAndAuthorityMetadataMatchRuntimeAuthoredAndFrozenContracts()
+        {
+            var expected = new[]
+            {
+                "jellyfin.canopy.discovery.read",
+                "jellyfin.canopy.items.lookup",
+                "jellyfin.canopy.user-data.read",
+                "jellyfin.canopy.events.subscribe",
+                "jellyfin.canopy.storage.read",
+                "jellyfin.canopy.ui.contribute",
+                "jellyfin.canopy.integrations.invoke",
+                "jellyfin.canopy.administration.manage",
+                "jellyfin.canopy.diagnostics.read",
+            };
+            var runtime = PlatformCapabilityVocabulary.All
+                .Select(definition => definition.Id.Value)
+                .ToArray();
+            var authored = Spec.RootElement.GetProperty("x-canopy-capability-vocabulary")
+                .EnumerateArray().Select(value => value.GetString()).ToArray();
+            var frozen = Frozen.RootElement.GetProperty("capabilityVocabulary")
+                .EnumerateArray().Select(value => value.GetString()).ToArray();
+            var authoredMetadata = Spec.RootElement.GetProperty("x-canopy-capability-metadata");
+            var frozenMetadata = Frozen.RootElement.GetProperty("capabilityMetadata");
+
+            Assert.Equal(expected, runtime);
+            Assert.Equal(runtime, authored);
+            Assert.Equal(runtime, frozen);
+            Assert.Equal(runtime.Length, runtime.Distinct(StringComparer.Ordinal).Count());
+            Assert.Equal(runtime.Length, authoredMetadata.EnumerateObject().Count());
+            Assert.Equal(runtime.Length, frozenMetadata.EnumerateObject().Count());
+            Assert.Empty(CapabilityVocabularyDrift(runtime, Frozen.RootElement, Spec.RootElement));
+
+            foreach (var definition in PlatformCapabilityVocabulary.All)
+            {
+                var id = definition.Id.Value;
+                var runtimeKinds = definition.AllowedActorKinds
+                    .Select(kind => PlatformActorKindVocabulary.TokenFor(kind)!)
+                    .ToArray();
+                var published = authoredMetadata.GetProperty(id);
+                var pinned = frozenMetadata.GetProperty(id);
+
+                Assert.Equal(CapabilityDomainToken(definition.Domain), published.GetProperty("domain").GetString());
+                Assert.Equal(
+                    runtimeKinds,
+                    published.GetProperty("actorKinds").EnumerateArray().Select(value => value.GetString()).ToArray());
+                Assert.Equal(definition.RequiresElevation, published.GetProperty("requiresElevation").GetBoolean());
+                Assert.Equal(CapabilityDomainToken(definition.Domain), pinned.GetProperty("domain").GetString());
+                Assert.Equal(
+                    runtimeKinds,
+                    pinned.GetProperty("actorKinds").EnumerateArray().Select(value => value.GetString()).ToArray());
+                Assert.Equal(definition.RequiresElevation, pinned.GetProperty("requiresElevation").GetBoolean());
+            }
+
+            Assert.Empty(CapabilityMetadataDrift(Frozen.RootElement, Spec.RootElement));
+        }
+
+        [Fact]
+        public void CapabilityVocabularyDriftGateNamesUnknownRuntimeRemovedFrozenDuplicatesAndOrder()
+        {
+            const string discovery = "jellyfin.canopy.discovery.read";
+            const string unknown = "jellyfin.canopy.unknown.read";
+            using var empty = JsonDocument.Parse("""
+                {
+                  "x-canopy-capability-vocabulary":[],
+                  "capabilityVocabulary":[]
+                }
+                """);
+
+            Assert.Equal(
+                new[]
+                {
+                    $"runtime capability {unknown} is absent from the authored vocabulary",
+                    $"runtime capability {unknown} is absent from the frozen vocabulary",
+                },
+                CapabilityVocabularyDrift(
+                    new[] { unknown },
+                    empty.RootElement,
+                    empty.RootElement));
+
+            using var frozenOnly = JsonDocument.Parse($$"""
+                {
+                  "x-canopy-capability-vocabulary":[],
+                  "capabilityVocabulary":["{{discovery}}"]
+                }
+                """);
+            Assert.Equal(
+                new[] { $"frozen capability {discovery} was removed from runtime" },
+                CapabilityVocabularyDrift(
+                    Array.Empty<string>(),
+                    frozenOnly.RootElement,
+                    frozenOnly.RootElement));
+
+            using var duplicateAndReordered = JsonDocument.Parse($$"""
+                {
+                  "x-canopy-capability-vocabulary":["{{unknown}}","{{discovery}}","{{discovery}}"],
+                  "capabilityVocabulary":["{{unknown}}","{{discovery}}"]
+                }
+                """);
+            Assert.Contains(
+                $"authored capability {discovery} is duplicated",
+                CapabilityVocabularyDrift(
+                    new[] { discovery, unknown },
+                    duplicateAndReordered.RootElement,
+                    duplicateAndReordered.RootElement));
+
+            using var reordered = JsonDocument.Parse($$"""
+                {
+                  "x-canopy-capability-vocabulary":["{{unknown}}","{{discovery}}"],
+                  "capabilityVocabulary":["{{unknown}}","{{discovery}}"]
+                }
+                """);
+            var orderDrift = CapabilityVocabularyDrift(
+                new[] { discovery, unknown },
+                reordered.RootElement,
+                reordered.RootElement);
+            Assert.Contains("authored capability order differs from runtime", orderDrift);
+            Assert.Contains("frozen capability order differs from runtime", orderDrift);
+        }
+
+        [Fact]
+        public void CapabilityDriftGateNamesMissingRemovedWidenedAndChangedMetadata()
+        {
+            using var oneUserCapability = JsonDocument.Parse("""
+                {
+                  "x-canopy-capability-vocabulary":["jellyfin.canopy.discovery.read"],
+                  "x-canopy-capability-metadata":{
+                    "jellyfin.canopy.discovery.read":{
+                      "domain":"discovery",
+                      "actorKinds":["jellyfin-user-client"],
+                      "requiresElevation":false
+                    }
+                  }
+                }
+                """);
+            using var missingFrozen = JsonDocument.Parse("""
+                {"capabilityVocabulary":[],"capabilityMetadata":{}}
+                """);
+            Assert.Equal(
+                new[]
+                {
+                    "jellyfin.canopy.discovery.read has no frozen capability metadata",
+                    "jellyfin.canopy.discovery.read is absent from the frozen capability vocabulary",
+                },
+                CapabilityMetadataDrift(missingFrozen.RootElement, oneUserCapability.RootElement));
+
+            using var widenedFrozen = JsonDocument.Parse("""
+                {
+                  "capabilityVocabulary":["jellyfin.canopy.discovery.read"],
+                  "capabilityMetadata":{
+                    "jellyfin.canopy.discovery.read":{
+                      "domain":"discovery",
+                      "actorKinds":["jellyfin-user-client","companion-service"],
+                      "requiresElevation":false
+                    }
+                  }
+                }
+                """);
+            Assert.Equal(
+                new[] { "jellyfin.canopy.discovery.read actor kinds changed" },
+                CapabilityMetadataDrift(widenedFrozen.RootElement, oneUserCapability.RootElement));
+
+            using var changedFrozen = JsonDocument.Parse("""
+                {
+                  "capabilityVocabulary":["jellyfin.canopy.discovery.read"],
+                  "capabilityMetadata":{
+                    "jellyfin.canopy.discovery.read":{
+                      "domain":"diagnostics",
+                      "actorKinds":["jellyfin-user-client"],
+                      "requiresElevation":true
+                    }
+                  }
+                }
+                """);
+            Assert.Equal(
+                new[]
+                {
+                    "jellyfin.canopy.discovery.read domain changed",
+                    "jellyfin.canopy.discovery.read elevation ceiling changed",
+                },
+                CapabilityMetadataDrift(changedFrozen.RootElement, oneUserCapability.RootElement));
+
+            using var removedSpec = JsonDocument.Parse("""
+                {"x-canopy-capability-vocabulary":[],"x-canopy-capability-metadata":{}}
+                """);
+            Assert.Equal(
+                new[] { "jellyfin.canopy.discovery.read is frozen but absent from the authored capability vocabulary" },
+                CapabilityMetadataDrift(widenedFrozen.RootElement, removedSpec.RootElement));
         }
 
         [Fact]

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformGrantCeilingEvaluatorTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformGrantCeilingEvaluatorTests.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Linq;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform;
+
+public sealed class PlatformGrantCeilingEvaluatorTests
+{
+    private const string Discovery = "jellyfin.canopy.discovery.read";
+    private const string Items = "jellyfin.canopy.items.lookup";
+    private const string UserData = "jellyfin.canopy.user-data.read";
+    private const string Events = "jellyfin.canopy.events.subscribe";
+    private const string Storage = "jellyfin.canopy.storage.read";
+    private const string Ui = "jellyfin.canopy.ui.contribute";
+    private const string Integrations = "jellyfin.canopy.integrations.invoke";
+    private const string Administration = "jellyfin.canopy.administration.manage";
+    private const string Diagnostics = "jellyfin.canopy.diagnostics.read";
+
+    [Fact]
+    public void RequestedGrantedAndCurrentAuthorityIntersectionIsFailClosed()
+    {
+        var preview = Evaluate(
+            Requested(Administration, Events, Items, Discovery),
+            Granted(Administration, Events, Items),
+            User(elevated: false));
+
+        Assert.Equal(PlatformGrantEvaluationStatus.Valid, preview.Status);
+        Assert.Equal(
+            new[]
+            {
+                Decision(Discovery, false, PlatformGrantDecisionReason.MissingGrant),
+                Decision(Items, true, PlatformGrantDecisionReason.Allowed),
+                Decision(Events, false, PlatformGrantDecisionReason.ActorKindNotAllowed),
+                Decision(Administration, false, PlatformGrantDecisionReason.ElevationRequired),
+            },
+            preview.Decisions.Select(value => Decision(
+                value.Capability.Id.Value,
+                value.IsAllowed,
+                value.Reason)));
+    }
+
+    [Fact]
+    public void MissingAndPresentEmptyGrantSetsDenyEveryRequestedCapability()
+    {
+        foreach (var grants in new[]
+        {
+            PlatformGrantedCapabilitySet.Missing,
+            Granted(),
+        })
+        {
+            var preview = Evaluate(Requested(Discovery, Items), grants, User(elevated: true));
+
+            Assert.Equal(PlatformGrantEvaluationStatus.Valid, preview.Status);
+            Assert.All(preview.Decisions, decision =>
+            {
+                Assert.False(decision.IsAllowed);
+                Assert.Equal(PlatformGrantDecisionReason.MissingGrant, decision.Reason);
+            });
+        }
+    }
+
+    [Fact]
+    public void UnrequestedGrantInvalidatesTheWholeRecordAndDeniesTheDeterministicUnion()
+    {
+        var preview = Evaluate(
+            Requested(Administration, Discovery),
+            Granted(Items, Administration, Discovery),
+            User(elevated: true));
+
+        Assert.Equal(PlatformGrantEvaluationStatus.InvalidGrantSet, preview.Status);
+        Assert.Equal(
+            new[] { Discovery, Items, Administration },
+            preview.Decisions.Select(value => value.Capability.Id.Value));
+        Assert.All(preview.Decisions, decision =>
+        {
+            Assert.False(decision.IsAllowed);
+            Assert.Equal(PlatformGrantDecisionReason.InvalidGrantRecord, decision.Reason);
+        });
+    }
+
+    [Fact]
+    public void DefaultInputsAndUnknownAuthorityReturnNoPartialPreview()
+    {
+        var validRequested = Requested(Discovery);
+        var validGranted = Granted(Discovery);
+
+        AssertInvalid(
+            Evaluate(null, validGranted, User(elevated: false)),
+            PlatformGrantEvaluationStatus.InvalidRequestedSet);
+        AssertInvalid(
+            Evaluate(validRequested, null, User(elevated: false)),
+            PlatformGrantEvaluationStatus.InvalidGrantSet);
+        AssertInvalid(
+            Evaluate(validRequested, validGranted, default),
+            PlatformGrantEvaluationStatus.InvalidActorAuthority);
+
+        static void AssertInvalid(
+            PlatformGrantPreview preview,
+            PlatformGrantEvaluationStatus expected)
+        {
+            Assert.Equal(expected, preview.Status);
+            Assert.Empty(preview.Decisions);
+        }
+    }
+
+    [Fact]
+    public void FailedFactoriesReturnSentinelsThatRemainInvalidAtEvaluation()
+    {
+        Assert.False(PlatformRequestedCapabilitySet.TryCreate(
+            new[] { "jellyfin.canopy.unknown.read" },
+            out var invalidRequested));
+        Assert.False(PlatformGrantedCapabilitySet.TryCreate(
+            new[] { Discovery, Discovery },
+            out var invalidGranted));
+        Assert.NotNull(invalidRequested);
+        Assert.NotNull(invalidGranted);
+
+        var requested = Requested(Discovery);
+        var granted = Granted(Discovery);
+        var authority = User(elevated: false);
+
+        var requestedPreview = Evaluate(invalidRequested, granted, authority);
+        Assert.Equal(PlatformGrantEvaluationStatus.InvalidRequestedSet, requestedPreview.Status);
+        Assert.Empty(requestedPreview.Decisions);
+
+        var grantedPreview = Evaluate(requested, invalidGranted, authority);
+        Assert.Equal(PlatformGrantEvaluationStatus.InvalidGrantSet, grantedPreview.Status);
+        Assert.Empty(grantedPreview.Decisions);
+    }
+
+    [Theory]
+    [InlineData(Discovery, "user", false, PlatformGrantDecisionReason.Allowed)]
+    [InlineData(Discovery, "provider", false, PlatformGrantDecisionReason.ActorKindNotAllowed)]
+    [InlineData(Items, "user", false, PlatformGrantDecisionReason.Allowed)]
+    [InlineData(Items, "provider", false, PlatformGrantDecisionReason.Allowed)]
+    [InlineData(Items, "service", false, PlatformGrantDecisionReason.ActorKindNotAllowed)]
+    [InlineData(UserData, "user", false, PlatformGrantDecisionReason.Allowed)]
+    [InlineData(UserData, "provider", false, PlatformGrantDecisionReason.Allowed)]
+    [InlineData(Events, "service", false, PlatformGrantDecisionReason.Allowed)]
+    [InlineData(Events, "user", true, PlatformGrantDecisionReason.ActorKindNotAllowed)]
+    [InlineData(Storage, "user", false, PlatformGrantDecisionReason.Allowed)]
+    [InlineData(Storage, "provider", false, PlatformGrantDecisionReason.Allowed)]
+    [InlineData(Storage, "service", false, PlatformGrantDecisionReason.ActorKindNotAllowed)]
+    [InlineData(Ui, "provider", false, PlatformGrantDecisionReason.Allowed)]
+    [InlineData(Ui, "user", true, PlatformGrantDecisionReason.ActorKindNotAllowed)]
+    [InlineData(Integrations, "user", false, PlatformGrantDecisionReason.Allowed)]
+    [InlineData(Integrations, "provider", false, PlatformGrantDecisionReason.Allowed)]
+    [InlineData(Administration, "user", false, PlatformGrantDecisionReason.ElevationRequired)]
+    [InlineData(Administration, "user", true, PlatformGrantDecisionReason.Allowed)]
+    [InlineData(Diagnostics, "user", false, PlatformGrantDecisionReason.ElevationRequired)]
+    [InlineData(Diagnostics, "user", true, PlatformGrantDecisionReason.Allowed)]
+    [InlineData(Diagnostics, "provider", false, PlatformGrantDecisionReason.ActorKindNotAllowed)]
+    public void ActorKindAndElevationCeilingsNeverPromote(
+        string capability,
+        string actorKind,
+        bool elevated,
+        PlatformGrantDecisionReason expected)
+    {
+        var preview = Evaluate(
+            Requested(capability),
+            Granted(capability),
+            Authority(actorKind, elevated));
+
+        Assert.Equal(PlatformGrantEvaluationStatus.Valid, preview.Status);
+        var decision = Assert.Single(preview.Decisions);
+        Assert.Equal(expected == PlatformGrantDecisionReason.Allowed, decision.IsAllowed);
+        Assert.Equal(expected, decision.Reason);
+    }
+
+    [Fact]
+    public void PreviewOrderAndValuesAreDeterministicAndBounded()
+    {
+        var reverse = PlatformCapabilityVocabulary.All
+            .Select(value => value.Id.Value)
+            .Reverse()
+            .ToArray();
+        var requested = Requested(reverse);
+        var granted = Granted(reverse);
+
+        var first = Evaluate(requested, granted, User(elevated: true));
+        var second = Evaluate(requested, granted, User(elevated: true));
+
+        Assert.Equal(PlatformGrantEvaluationStatus.Valid, first.Status);
+        Assert.Equal(PlatformCapabilityVocabulary.All.Select(value => value.Id.Value),
+            first.Decisions.Select(value => value.Capability.Id.Value));
+        Assert.Equal(first.Decisions.Length, second.Decisions.Length);
+        Assert.InRange(
+            first.Decisions.Length,
+            0,
+            PlatformCapabilityVocabulary.MaximumCapabilityCount);
+        Assert.Equal(
+            first.Decisions.Select(value => (value.Capability.Id.Value, value.IsAllowed, value.Reason)),
+            second.Decisions.Select(value => (value.Capability.Id.Value, value.IsAllowed, value.Reason)));
+    }
+
+    private static PlatformGrantPreview Evaluate(
+        PlatformRequestedCapabilitySet? requested,
+        PlatformGrantedCapabilitySet? granted,
+        PlatformActorAuthority authority) =>
+        PlatformGrantCeilingEvaluator.Evaluate(requested, granted, authority);
+
+    private static PlatformRequestedCapabilitySet Requested(params string[] capabilities)
+    {
+        Assert.True(PlatformRequestedCapabilitySet.TryCreate(capabilities, out var result));
+        return result;
+    }
+
+    private static PlatformGrantedCapabilitySet Granted(params string[] capabilities)
+    {
+        Assert.True(PlatformGrantedCapabilitySet.TryCreate(capabilities, out var result));
+        return result;
+    }
+
+    private static PlatformActorAuthority Authority(string actorKind, bool elevated) => actorKind switch
+    {
+        "user" => User(elevated),
+        "provider" => PlatformActorAuthorityTests.Provider(Guid.NewGuid(), new string('a', 64)).Authority,
+        "service" => PlatformActorAuthorityTests.Service(Guid.NewGuid(), 1).Authority,
+        _ => throw new ArgumentOutOfRangeException(nameof(actorKind)),
+    };
+
+    private static PlatformActorAuthority User(bool elevated) =>
+        PlatformActorTestFactory.Create(Guid.NewGuid(), elevated, "correlation", null, null).Authority;
+
+    private static object Decision(
+        string capability,
+        bool isAllowed,
+        PlatformGrantDecisionReason reason) => new
+        {
+            Capability = capability,
+            IsAllowed = isAllowed,
+            Reason = reason,
+        };
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformCapabilityDomain.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformCapabilityDomain.cs
@@ -1,0 +1,577 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>The closed Platform v1 capability domains.</summary>
+    public enum PlatformCapabilityDomain
+    {
+        /// <summary>Platform discovery and negotiation.</summary>
+        Discovery = 1,
+
+        /// <summary>Bounded Jellyfin item lookup.</summary>
+        ItemLookup = 2,
+
+        /// <summary>Current-user data access.</summary>
+        UserData = 3,
+
+        /// <summary>Bounded Platform event subscriptions.</summary>
+        Events = 4,
+
+        /// <summary>Kernel-owned namespaced state.</summary>
+        Storage = 5,
+
+        /// <summary>Declarative UI contributions.</summary>
+        UiContributions = 6,
+
+        /// <summary>Approved integration actions.</summary>
+        IntegrationActions = 7,
+
+        /// <summary>Elevated Platform administration.</summary>
+        Administration = 8,
+
+        /// <summary>Elevated redacted diagnostics.</summary>
+        Diagnostics = 9,
+    }
+
+    /// <summary>A code-owned exact Platform v1 capability identifier.</summary>
+    public readonly record struct PlatformCapabilityId
+    {
+        private PlatformCapabilityId(string value)
+        {
+            if (!PlatformCapabilityVocabulary.IsValidIdentifier(value))
+            {
+                throw new ArgumentException(
+                    "Capability ids must use the exact bounded Platform v1 grammar.",
+                    nameof(value));
+            }
+
+            Value = value;
+        }
+
+        /// <summary>Gets the stable, case-sensitive identifier.</summary>
+        public string Value { get; }
+
+        /// <inheritdoc />
+        public override string ToString() => Value ?? string.Empty;
+
+        internal static PlatformCapabilityId EstablishCodeOwnedId(string value) =>
+            new PlatformCapabilityId(value);
+    }
+
+    /// <summary>Immutable authority metadata for one code-owned capability.</summary>
+    public sealed class PlatformCapabilityDefinition
+    {
+        private PlatformCapabilityDefinition(
+            PlatformCapabilityId id,
+            PlatformCapabilityDomain domain,
+            ImmutableArray<PlatformActorKind> allowedActorKinds,
+            bool requiresElevation)
+        {
+            if (string.IsNullOrEmpty(id.Value))
+            {
+                throw new ArgumentException("A code-owned capability id is required.", nameof(id));
+            }
+
+            if (!Enum.IsDefined(domain))
+            {
+                throw new ArgumentOutOfRangeException(nameof(domain));
+            }
+
+            if (allowedActorKinds.IsDefaultOrEmpty
+                || allowedActorKinds.Any(kind => !PlatformActorKindVocabulary.IsDefined(kind))
+                || allowedActorKinds.Distinct().Count() != allowedActorKinds.Length)
+            {
+                throw new ArgumentException(
+                    "A capability must declare distinct closed actor kinds.",
+                    nameof(allowedActorKinds));
+            }
+
+            if (requiresElevation
+                && (allowedActorKinds.Length != 1
+                    || allowedActorKinds[0] != PlatformActorKind.JellyfinUserClient))
+            {
+                throw new ArgumentException(
+                    "An elevated capability must admit only the Jellyfin user actor kind.",
+                    nameof(requiresElevation));
+            }
+
+            if (domain is PlatformCapabilityDomain.Administration or PlatformCapabilityDomain.Diagnostics
+                && !requiresElevation)
+            {
+                throw new ArgumentException(
+                    "Administration and diagnostics capabilities must require current user elevation.",
+                    nameof(requiresElevation));
+            }
+
+            Id = id;
+            Domain = domain;
+            AllowedActorKinds = allowedActorKinds;
+            RequiresElevation = requiresElevation;
+        }
+
+        /// <summary>Gets the exact capability id.</summary>
+        public PlatformCapabilityId Id { get; }
+
+        /// <summary>Gets the closed capability domain.</summary>
+        public PlatformCapabilityDomain Domain { get; }
+
+        /// <summary>Gets the exact actor kinds eligible to exercise this capability.</summary>
+        public ImmutableArray<PlatformActorKind> AllowedActorKinds { get; }
+
+        /// <summary>Gets whether a current Jellyfin administrator is required.</summary>
+        public bool RequiresElevation { get; }
+
+        internal static PlatformCapabilityDefinition EstablishCodeOwnedDefinition(
+            PlatformCapabilityId id,
+            PlatformCapabilityDomain domain,
+            ImmutableArray<PlatformActorKind> allowedActorKinds,
+            bool requiresElevation) => new PlatformCapabilityDefinition(
+                id,
+                domain,
+                allowedActorKinds,
+                requiresElevation);
+    }
+
+    /// <summary>
+    /// The single immutable Platform v1 capability owner. Vocabulary membership names
+    /// authority; it does not activate a route, provider, event, state store or UI surface.
+    /// </summary>
+    public static class PlatformCapabilityVocabulary
+    {
+        /// <summary>The exact identifier segment count.</summary>
+        public const int IdentifierSegmentCount = 4;
+
+        /// <summary>The maximum ASCII identifier length.</summary>
+        public const int MaximumIdentifierLength = 128;
+
+        /// <summary>The maximum domain or action segment length.</summary>
+        public const int MaximumVariableSegmentLength = 64;
+
+        /// <summary>The exact current v1 vocabulary count and raw set bound.</summary>
+        public const int MaximumCapabilityCount = 9;
+
+        private static readonly ImmutableArray<PlatformCapabilityDefinition> Definitions =
+        [
+            Definition(
+                "jellyfin.canopy.discovery.read",
+                PlatformCapabilityDomain.Discovery,
+                [PlatformActorKind.JellyfinUserClient]),
+            Definition(
+                "jellyfin.canopy.items.lookup",
+                PlatformCapabilityDomain.ItemLookup,
+                [PlatformActorKind.JellyfinUserClient, PlatformActorKind.InstalledProvider]),
+            Definition(
+                "jellyfin.canopy.user-data.read",
+                PlatformCapabilityDomain.UserData,
+                [PlatformActorKind.JellyfinUserClient, PlatformActorKind.InstalledProvider]),
+            Definition(
+                "jellyfin.canopy.events.subscribe",
+                PlatformCapabilityDomain.Events,
+                [PlatformActorKind.CompanionService]),
+            Definition(
+                "jellyfin.canopy.storage.read",
+                PlatformCapabilityDomain.Storage,
+                [PlatformActorKind.JellyfinUserClient, PlatformActorKind.InstalledProvider]),
+            Definition(
+                "jellyfin.canopy.ui.contribute",
+                PlatformCapabilityDomain.UiContributions,
+                [PlatformActorKind.InstalledProvider]),
+            Definition(
+                "jellyfin.canopy.integrations.invoke",
+                PlatformCapabilityDomain.IntegrationActions,
+                [PlatformActorKind.JellyfinUserClient, PlatformActorKind.InstalledProvider]),
+            Definition(
+                "jellyfin.canopy.administration.manage",
+                PlatformCapabilityDomain.Administration,
+                [PlatformActorKind.JellyfinUserClient],
+                requiresElevation: true),
+            Definition(
+                "jellyfin.canopy.diagnostics.read",
+                PlatformCapabilityDomain.Diagnostics,
+                [PlatformActorKind.JellyfinUserClient],
+                requiresElevation: true),
+        ];
+
+        /// <summary>Gets the complete vocabulary in append-only contract order.</summary>
+        public static ImmutableArray<PlatformCapabilityDefinition> All => Definitions;
+
+        /// <summary>Finds an exact known id or fails closed.</summary>
+        public static PlatformCapabilityDefinition? Find(string? capabilityId)
+        {
+            if (!IsValidIdentifier(capabilityId))
+            {
+                return null;
+            }
+
+            foreach (var definition in Definitions)
+            {
+                if (string.Equals(definition.Id.Value, capabilityId, StringComparison.Ordinal))
+                {
+                    return definition;
+                }
+            }
+
+            return null;
+        }
+
+        internal static bool IsValidIdentifier(string? value)
+        {
+            if (value is null
+                || value.Length > MaximumIdentifierLength
+                || !value.StartsWith("jellyfin.canopy.", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            var segments = value.Split('.');
+            if (segments.Length != IdentifierSegmentCount
+                || !string.Equals(segments[0], "jellyfin", StringComparison.Ordinal)
+                || !string.Equals(segments[1], "canopy", StringComparison.Ordinal)
+                || segments[2].Length is < 1 or > MaximumVariableSegmentLength
+                || segments[3].Length is < 1 or > MaximumVariableSegmentLength)
+            {
+                return false;
+            }
+
+            return IsValidVariableSegment(segments[2]) && IsValidVariableSegment(segments[3]);
+        }
+
+        private static PlatformCapabilityDefinition Definition(
+            string value,
+            PlatformCapabilityDomain domain,
+            ImmutableArray<PlatformActorKind> allowedActorKinds,
+            bool requiresElevation = false) =>
+            PlatformCapabilityDefinition.EstablishCodeOwnedDefinition(
+                PlatformCapabilityId.EstablishCodeOwnedId(value),
+                domain,
+                allowedActorKinds,
+                requiresElevation);
+
+        private static bool IsValidVariableSegment(string value)
+        {
+            if (!IsLowerAsciiLetter(value[0]))
+            {
+                return false;
+            }
+
+            for (var index = 1; index < value.Length; index++)
+            {
+                var character = value[index];
+                if (IsLowerAsciiLetter(character) || IsAsciiDigit(character))
+                {
+                    continue;
+                }
+
+                if (character != '-'
+                    || !IsLowerAsciiLetterOrDigit(value[index - 1])
+                    || index == value.Length - 1
+                    || !IsLowerAsciiLetterOrDigit(value[index + 1]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool IsLowerAsciiLetterOrDigit(char value) =>
+            IsLowerAsciiLetter(value) || IsAsciiDigit(value);
+
+        private static bool IsLowerAsciiLetter(char value) => value is >= 'a' and <= 'z';
+
+        private static bool IsAsciiDigit(char value) => value is >= '0' and <= '9';
+    }
+
+    /// <summary>An immutable, validated requested-capability set.</summary>
+    public sealed class PlatformRequestedCapabilitySet
+    {
+        private static readonly PlatformRequestedCapabilitySet Invalid = new(false, []);
+        private readonly ImmutableArray<PlatformCapabilityDefinition> _capabilities;
+
+        private PlatformRequestedCapabilitySet(
+            bool isValid,
+            ImmutableArray<PlatformCapabilityDefinition> capabilities)
+        {
+            IsValid = isValid;
+            _capabilities = capabilities;
+        }
+
+        internal bool IsValid { get; }
+
+        internal ImmutableArray<PlatformCapabilityDefinition> Capabilities => _capabilities;
+
+        internal static bool TryCreate(
+            IReadOnlyList<string>? values,
+            out PlatformRequestedCapabilitySet result)
+        {
+            if (!PlatformCapabilitySetResolver.TryResolve(values, out var capabilities))
+            {
+                result = Invalid;
+                return false;
+            }
+
+            result = new PlatformRequestedCapabilitySet(true, capabilities);
+            return true;
+        }
+    }
+
+    /// <summary>An immutable, validated administrator-granted capability set.</summary>
+    public sealed class PlatformGrantedCapabilitySet
+    {
+        private static readonly PlatformGrantedCapabilitySet Invalid = new(false, false, []);
+        private readonly ImmutableArray<PlatformCapabilityDefinition> _capabilities;
+
+        private PlatformGrantedCapabilitySet(
+            bool isValid,
+            bool isPresent,
+            ImmutableArray<PlatformCapabilityDefinition> capabilities)
+        {
+            IsValid = isValid;
+            IsPresent = isPresent;
+            _capabilities = capabilities;
+        }
+
+        /// <summary>Gets the explicit absence of a persisted grant record.</summary>
+        internal static PlatformGrantedCapabilitySet Missing { get; } = new(true, false, []);
+
+        internal bool IsValid { get; }
+
+        internal bool IsPresent { get; }
+
+        internal ImmutableArray<PlatformCapabilityDefinition> Capabilities => _capabilities;
+
+        internal static bool TryCreate(
+            IReadOnlyList<string>? values,
+            out PlatformGrantedCapabilitySet result)
+        {
+            if (!PlatformCapabilitySetResolver.TryResolve(values, out var capabilities))
+            {
+                result = Invalid;
+                return false;
+            }
+
+            result = new PlatformGrantedCapabilitySet(true, true, capabilities);
+            return true;
+        }
+    }
+
+    file static class PlatformCapabilitySetResolver
+    {
+        internal static bool TryResolve(
+            IReadOnlyList<string>? values,
+            out ImmutableArray<PlatformCapabilityDefinition> capabilities)
+        {
+            capabilities = [];
+            if (values is null)
+            {
+                return false;
+            }
+
+            var count = values.Count;
+            if (count > PlatformCapabilityVocabulary.MaximumCapabilityCount)
+            {
+                return false;
+            }
+
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            var requested = new HashSet<string>(StringComparer.Ordinal);
+            for (var index = 0; index < count; index++)
+            {
+                var value = values[index];
+                var definition = PlatformCapabilityVocabulary.Find(value);
+                if (definition is null || !seen.Add(value))
+                {
+                    return false;
+                }
+
+                requested.Add(definition.Id.Value);
+            }
+
+            capabilities = PlatformCapabilityVocabulary.All
+                .Where(definition => requested.Contains(definition.Id.Value))
+                .ToImmutableArray();
+            return true;
+        }
+    }
+
+    /// <summary>The bounded outcome of one pure grant-ceiling evaluation.</summary>
+    public enum PlatformGrantEvaluationStatus
+    {
+        /// <summary>The inputs formed a valid grant preview.</summary>
+        Valid = 1,
+
+        /// <summary>The requested set was absent or invalid.</summary>
+        InvalidRequestedSet = 2,
+
+        /// <summary>The grant set was invalid or granted an unrequested capability.</summary>
+        InvalidGrantSet = 3,
+
+        /// <summary>The actor authority projection was default or invalid.</summary>
+        InvalidActorAuthority = 4,
+    }
+
+    /// <summary>A closed, redaction-safe reason for one preview decision.</summary>
+    public enum PlatformGrantDecisionReason
+    {
+        /// <summary>The capability is requested, granted and within current authority.</summary>
+        Allowed = 1,
+
+        /// <summary>No current grant exists for the requested capability.</summary>
+        MissingGrant = 2,
+
+        /// <summary>The current actor kind cannot exercise the capability.</summary>
+        ActorKindNotAllowed = 3,
+
+        /// <summary>The current Jellyfin user is not elevated.</summary>
+        ElevationRequired = 4,
+
+        /// <summary>The grant contains at least one unrequested capability.</summary>
+        InvalidGrantRecord = 5,
+    }
+
+    /// <summary>One immutable, vocabulary-owned capability preview decision.</summary>
+    public readonly record struct PlatformCapabilityDecision
+    {
+        private PlatformCapabilityDecision(
+            PlatformCapabilityDefinition capability,
+            PlatformGrantDecisionReason reason)
+        {
+            ArgumentNullException.ThrowIfNull(capability);
+            if (!Enum.IsDefined(reason))
+            {
+                throw new ArgumentOutOfRangeException(nameof(reason));
+            }
+
+            Capability = capability;
+            Reason = reason;
+        }
+
+        /// <summary>Gets the code-owned capability definition.</summary>
+        public PlatformCapabilityDefinition Capability { get; }
+
+        /// <summary>Gets whether the current intersection allows the capability.</summary>
+        public bool IsAllowed => Reason == PlatformGrantDecisionReason.Allowed;
+
+        /// <summary>Gets the closed decision reason.</summary>
+        public PlatformGrantDecisionReason Reason { get; }
+
+        internal static PlatformCapabilityDecision EstablishDecision(
+            PlatformCapabilityDefinition capability,
+            PlatformGrantDecisionReason reason) =>
+            new PlatformCapabilityDecision(capability, reason);
+    }
+
+    /// <summary>An immutable, bounded and non-authoritative effective-grant preview.</summary>
+    public sealed class PlatformGrantPreview
+    {
+        private PlatformGrantPreview(
+            PlatformGrantEvaluationStatus status,
+            ImmutableArray<PlatformCapabilityDecision> decisions)
+        {
+            if (!Enum.IsDefined(status)
+                || decisions.IsDefault
+                || decisions.Length > PlatformCapabilityVocabulary.MaximumCapabilityCount)
+            {
+                throw new ArgumentException("The grant preview is invalid.", nameof(decisions));
+            }
+
+            Status = status;
+            Decisions = decisions;
+        }
+
+        /// <summary>Gets the structural evaluation status.</summary>
+        public PlatformGrantEvaluationStatus Status { get; }
+
+        /// <summary>Gets the canonical decisions in frozen vocabulary order.</summary>
+        public ImmutableArray<PlatformCapabilityDecision> Decisions { get; }
+
+        internal static PlatformGrantPreview EstablishPreview(
+            PlatformGrantEvaluationStatus status,
+            ImmutableArray<PlatformCapabilityDecision> decisions) =>
+            new PlatformGrantPreview(status, decisions);
+    }
+
+    /// <summary>Pure bounded evaluator for requested ∩ granted ∩ current actor authority.</summary>
+    public static class PlatformGrantCeilingEvaluator
+    {
+        /// <summary>
+        /// Computes a diagnostic preview. The returned value carries no reusable authority;
+        /// every protected operation must evaluate current inputs again at admission/release.
+        /// </summary>
+        internal static PlatformGrantPreview Evaluate(
+            PlatformRequestedCapabilitySet? requested,
+            PlatformGrantedCapabilitySet? granted,
+            PlatformActorAuthority authority)
+        {
+            if (requested is null || !requested.IsValid)
+            {
+                return Invalid(PlatformGrantEvaluationStatus.InvalidRequestedSet);
+            }
+
+            if (granted is null || !granted.IsValid)
+            {
+                return Invalid(PlatformGrantEvaluationStatus.InvalidGrantSet);
+            }
+
+            if (!authority.IsValid)
+            {
+                return Invalid(PlatformGrantEvaluationStatus.InvalidActorAuthority);
+            }
+
+            var requestedIds = requested.Capabilities
+                .Select(definition => definition.Id.Value)
+                .ToHashSet(StringComparer.Ordinal);
+            var unrequestedGrant = granted.Capabilities.Any(definition => !requestedIds.Contains(definition.Id.Value));
+            if (unrequestedGrant)
+            {
+                var union = requestedIds;
+                union.UnionWith(granted.Capabilities.Select(definition => definition.Id.Value));
+                return PlatformGrantPreview.EstablishPreview(
+                    PlatformGrantEvaluationStatus.InvalidGrantSet,
+                    PlatformCapabilityVocabulary.All
+                        .Where(definition => union.Contains(definition.Id.Value))
+                        .Select(definition => PlatformCapabilityDecision.EstablishDecision(
+                            definition,
+                            PlatformGrantDecisionReason.InvalidGrantRecord))
+                        .ToImmutableArray());
+            }
+
+            var grantedIds = granted.Capabilities
+                .Select(definition => definition.Id.Value)
+                .ToHashSet(StringComparer.Ordinal);
+            var decisions = requested.Capabilities
+                .Select(definition => PlatformCapabilityDecision.EstablishDecision(
+                    definition,
+                    !granted.IsPresent || !grantedIds.Contains(definition.Id.Value)
+                        ? PlatformGrantDecisionReason.MissingGrant
+                        : DecisionFor(definition, authority)))
+                .ToImmutableArray();
+
+            return PlatformGrantPreview.EstablishPreview(PlatformGrantEvaluationStatus.Valid, decisions);
+        }
+
+        private static PlatformGrantPreview Invalid(PlatformGrantEvaluationStatus status) =>
+            PlatformGrantPreview.EstablishPreview(status, []);
+
+        private static PlatformGrantDecisionReason DecisionFor(
+            PlatformCapabilityDefinition definition,
+            PlatformActorAuthority authority)
+        {
+            if (!authority.IsValid || !definition.AllowedActorKinds.Contains(authority.Kind))
+            {
+                return PlatformGrantDecisionReason.ActorKindNotAllowed;
+            }
+
+            if (definition.RequiresElevation
+                && (authority.Kind != PlatformActorKind.JellyfinUserClient || !authority.IsElevated))
+            {
+                return PlatformGrantDecisionReason.ElevationRequired;
+            }
+
+            return PlatformGrantDecisionReason.Allowed;
+        }
+    }
+}

--- a/contracts/platform/v1/frozen.json
+++ b/contracts/platform/v1/frozen.json
@@ -22,6 +22,86 @@
     "installed-provider",
     "companion-service"
   ],
+  "capabilityVocabulary": [
+    "jellyfin.canopy.discovery.read",
+    "jellyfin.canopy.items.lookup",
+    "jellyfin.canopy.user-data.read",
+    "jellyfin.canopy.events.subscribe",
+    "jellyfin.canopy.storage.read",
+    "jellyfin.canopy.ui.contribute",
+    "jellyfin.canopy.integrations.invoke",
+    "jellyfin.canopy.administration.manage",
+    "jellyfin.canopy.diagnostics.read"
+  ],
+  "capabilityMetadata": {
+    "jellyfin.canopy.discovery.read": {
+      "domain": "discovery",
+      "actorKinds": [
+        "jellyfin-user-client"
+      ],
+      "requiresElevation": false
+    },
+    "jellyfin.canopy.items.lookup": {
+      "domain": "item-lookup",
+      "actorKinds": [
+        "jellyfin-user-client",
+        "installed-provider"
+      ],
+      "requiresElevation": false
+    },
+    "jellyfin.canopy.user-data.read": {
+      "domain": "user-data",
+      "actorKinds": [
+        "jellyfin-user-client",
+        "installed-provider"
+      ],
+      "requiresElevation": false
+    },
+    "jellyfin.canopy.events.subscribe": {
+      "domain": "events",
+      "actorKinds": [
+        "companion-service"
+      ],
+      "requiresElevation": false
+    },
+    "jellyfin.canopy.storage.read": {
+      "domain": "storage",
+      "actorKinds": [
+        "jellyfin-user-client",
+        "installed-provider"
+      ],
+      "requiresElevation": false
+    },
+    "jellyfin.canopy.ui.contribute": {
+      "domain": "ui-contributions",
+      "actorKinds": [
+        "installed-provider"
+      ],
+      "requiresElevation": false
+    },
+    "jellyfin.canopy.integrations.invoke": {
+      "domain": "integration-actions",
+      "actorKinds": [
+        "jellyfin-user-client",
+        "installed-provider"
+      ],
+      "requiresElevation": false
+    },
+    "jellyfin.canopy.administration.manage": {
+      "domain": "administration",
+      "actorKinds": [
+        "jellyfin-user-client"
+      ],
+      "requiresElevation": true
+    },
+    "jellyfin.canopy.diagnostics.read": {
+      "domain": "diagnostics",
+      "actorKinds": [
+        "jellyfin-user-client"
+      ],
+      "requiresElevation": true
+    }
+  },
   "operationMetadata": {
     "get /JellyfinCanopy/Platform/v1/discovery": {
       "authority": "anonymous",

--- a/contracts/platform/v1/openapi.json
+++ b/contracts/platform/v1/openapi.json
@@ -11,6 +11,86 @@
     "installed-provider",
     "companion-service"
   ],
+  "x-canopy-capability-vocabulary": [
+    "jellyfin.canopy.discovery.read",
+    "jellyfin.canopy.items.lookup",
+    "jellyfin.canopy.user-data.read",
+    "jellyfin.canopy.events.subscribe",
+    "jellyfin.canopy.storage.read",
+    "jellyfin.canopy.ui.contribute",
+    "jellyfin.canopy.integrations.invoke",
+    "jellyfin.canopy.administration.manage",
+    "jellyfin.canopy.diagnostics.read"
+  ],
+  "x-canopy-capability-metadata": {
+    "jellyfin.canopy.discovery.read": {
+      "domain": "discovery",
+      "actorKinds": [
+        "jellyfin-user-client"
+      ],
+      "requiresElevation": false
+    },
+    "jellyfin.canopy.items.lookup": {
+      "domain": "item-lookup",
+      "actorKinds": [
+        "jellyfin-user-client",
+        "installed-provider"
+      ],
+      "requiresElevation": false
+    },
+    "jellyfin.canopy.user-data.read": {
+      "domain": "user-data",
+      "actorKinds": [
+        "jellyfin-user-client",
+        "installed-provider"
+      ],
+      "requiresElevation": false
+    },
+    "jellyfin.canopy.events.subscribe": {
+      "domain": "events",
+      "actorKinds": [
+        "companion-service"
+      ],
+      "requiresElevation": false
+    },
+    "jellyfin.canopy.storage.read": {
+      "domain": "storage",
+      "actorKinds": [
+        "jellyfin-user-client",
+        "installed-provider"
+      ],
+      "requiresElevation": false
+    },
+    "jellyfin.canopy.ui.contribute": {
+      "domain": "ui-contributions",
+      "actorKinds": [
+        "installed-provider"
+      ],
+      "requiresElevation": false
+    },
+    "jellyfin.canopy.integrations.invoke": {
+      "domain": "integration-actions",
+      "actorKinds": [
+        "jellyfin-user-client",
+        "installed-provider"
+      ],
+      "requiresElevation": false
+    },
+    "jellyfin.canopy.administration.manage": {
+      "domain": "administration",
+      "actorKinds": [
+        "jellyfin-user-client"
+      ],
+      "requiresElevation": true
+    },
+    "jellyfin.canopy.diagnostics.read": {
+      "domain": "diagnostics",
+      "actorKinds": [
+        "jellyfin-user-client"
+      ],
+      "requiresElevation": true
+    }
+  },
   "servers": [
     {
       "url": ".",

--- a/research/extension-platform/adr/0011-identity-and-authority.md
+++ b/research/extension-platform/adr/0011-identity-and-authority.md
@@ -106,8 +106,31 @@ non-admin's own id. But the `ClaimsPrincipal` handed to a controller contains
     kind, elevated users remain eligible for ordinary authenticated operations,
     and default, unknown, provider, and service projections deny. The authored
     OpenAPI and frozen metadata publish the same exact allowlists without
-    changing the existing `x-canopy-authority` tokens. Grant intersection remains
-    owned by #639 and is not implemented here.
+    changing the existing `x-canopy-authority` tokens.
+
+    Issue #639 fixes the v1 capability vocabulary, in authored order, as
+    `jellyfin.canopy.discovery.read`, `jellyfin.canopy.items.lookup`,
+    `jellyfin.canopy.user-data.read`, `jellyfin.canopy.events.subscribe`,
+    `jellyfin.canopy.storage.read`, `jellyfin.canopy.ui.contribute`,
+    `jellyfin.canopy.integrations.invoke`,
+    `jellyfin.canopy.administration.manage`, and
+    `jellyfin.canopy.diagnostics.read`. Each identifier has exactly four
+    dot-separated segments, the fixed lower-case ASCII `jellyfin.canopy`
+    namespace, lower-case ASCII letter/digit segments with internal hyphens only,
+    and a maximum length of 128 characters. Matching is ordinal and exact;
+    wildcard, prefix, case-folded, dynamically registered and implicitly inherited
+    authority do not exist. The authored OpenAPI, frozen conformance artifact and
+    runtime definitions carry the same order and exact metadata.
+
+    Discovery admits a Jellyfin user. Item lookup, user-data read, storage read
+    and integration invocation admit Jellyfin users and installed providers.
+    Event subscription admits only a companion service; UI contribution admits
+    only an installed provider. Administration and diagnostics admit only a
+    currently elevated Jellyfin user. Elevation remains a property of that user,
+    never another actor kind. Vocabulary membership names a possible authority;
+    it does not activate a route, grant, manifest, provider, service, state,
+    event, UI surface or diagnostic, and later v1 additions remain reviewed
+    additive changes.
 12. **v1 has no per-user consent.** Grants are administrator-approved and
     server-wide; a user cannot decline an approved extension. The admin and user
     kill switches in [ADR-0007](0007-declarative-web-contributions.md) turn a

--- a/research/extension-platform/threat-model.md
+++ b/research/extension-platform/threat-model.md
@@ -412,10 +412,19 @@ trust browser origin or caller-supplied URLs.
 2. Can a write-only secret reference be protected meaningfully in a
    single-process plugin, or should v1 simply not offer one
    ([ADR-0008](adr/0008-storage-ownership.md) §9)?
-3. ADR-0013 decides exact, case-sensitive, namespaced scopes with no wildcard or
-   prefix authority, plus a bounded effective grant ceiling. Issue
-   [#639](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/639)
-   owns the concrete vocabulary and preview decisions.
+3. Decided by
+   [#639](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/639):
+   v1 has exactly nine authored capability identifiers, in discovery, item lookup,
+   user data, events, storage, UI contribution, integration action,
+   administration and diagnostics order. They use the exact four-segment
+   `jellyfin.canopy.<domain>.<verb>` lower-case ASCII namespace, internal hyphens
+   only and a 128-character maximum. Unknown, duplicate, wildcard, prefix,
+   malformed, over-bound and case-variant requested or granted inputs fail closed.
+   Companion services are eligible only for event subscription; installed
+   providers cannot administer or read diagnostics; administration and diagnostics
+   require current Jellyfin-user elevation. Runtime, authored and frozen metadata
+   pin those actor/elevation ceilings. Vocabulary membership does not activate a
+   route or implementation.
 4. Decided by ADR-0013: revoke denies admission, requests cancellation and
    generation-fences all kernel-owned commits/delivery, but cannot stop or roll
    back a provider-owned or external effect already begun; late/revoked outcomes

--- a/research/extension-platform/v1-capability-freeze.md
+++ b/research/extension-platform/v1-capability-freeze.md
@@ -42,6 +42,25 @@ caller-filtered C1/C6 catalog is not evidence for C2. Delivery requires the
 separate-plugin fixture, fingerprint-bound approval, grant/lifecycle tests and
 the EP-03 exit gate. ADR [0005](adr/0005-manifest-discovery.md).
 
+The immutable v1 authority-name floor is authored in this order:
+
+1. `jellyfin.canopy.discovery.read`
+2. `jellyfin.canopy.items.lookup`
+3. `jellyfin.canopy.user-data.read`
+4. `jellyfin.canopy.events.subscribe`
+5. `jellyfin.canopy.storage.read`
+6. `jellyfin.canopy.ui.contribute`
+7. `jellyfin.canopy.integrations.invoke`
+8. `jellyfin.canopy.administration.manage`
+9. `jellyfin.canopy.diagnostics.read`
+
+These exact, case-sensitive names reserve bounded authority domains; they do
+not claim that the corresponding routes or implementations are active. Runtime,
+authored Platform v1 and frozen conformance metadata pin their exact actor-kind
+and elevation ceilings. A later v1 capability is an additive reviewed change to
+all three owners; wildcard, prefix, inherited and caller-registered authority
+remain forbidden.
+
 ## C3 — Server-plugin provider invocation
 
 A convention-based entrypoint invoked over the JSON ABI with a derived context,

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,7 +26,7 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2808, totalLines: 3201 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 37908, totalLines: 47266 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 38132, totalLines: 47506 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 3,
         minimumCoveredLines: 2808,
@@ -34,11 +34,11 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
     });
     assert.deepEqual(baselines.profiles.server.observations, {
         cleanRuns: 3,
-        minimumCoveredLines: 37906,
-        maximumCoveredLines: 37908,
+        minimumCoveredLines: 38132,
+        maximumCoveredLines: 38132,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 0);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 37908,
-        "totalLines": 47266
+        "coveredLines": 38132,
+        "totalLines": 47506
       },
       "observations": {
         "cleanRuns": 3,
-        "minimumCoveredLines": 37906,
-        "maximumCoveredLines": 37908
+        "minimumCoveredLines": 38132,
+        "maximumCoveredLines": 38132
       },
       "tolerance": {
-        "missingCoveredLines": 2,
-        "rationale": "The #640 EP-02 actor-domain change adds the exact closed user/provider/service actor vocabulary, typed kernel-only construction proofs, one immutable authority projection, centralized operation kind/ceiling policy, and runtime/OpenAPI/frozen drift guards without activating provider or service routes. Reauthorization owns its fresh host lookup and no longer accepts caller-constructible HostUser input. Three clean local .NET 10.0.9 Coverlet runs on the identical final 47,266-line source and test scope each passed all 3,414 tests and measured 37,908, 37,906 and 37,906 covered lines. The reviewed observed high-water is therefore 37,908/47,266 (80.201%) and the exact observed floor is 37,906/47,266 (80.197%); the two-line tolerance is only the reproduced instrumentation envelope. Relative to the #638 baseline of 37,759/47,107 (80.156%), the change adds 159 instrumented lines and at least 147 covered lines while increasing overall coverage. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 0,
+        "rationale": "The #639 EP-02 capability-domain change adds the exact nine-scope Platform v1 vocabulary, closed actor-kind and elevation ceilings, distinct immutable requested/granted inputs, a pure fail-closed grant intersection, deterministic bounded preview reasons, runtime/OpenAPI/frozen drift gates, and hardened single-owner architecture guards without adding routes or wiring the existing first-party action path. Three clean local .NET 10.0.9 Coverlet runs on the identical final 47,506-line source and test scope each passed all 3,489 tests and reproduced exactly 38,132 covered lines. The reviewed observed high-water and exact floor are therefore both 38,132/47,506 (80.268%), requiring no instrumentation tolerance. Relative to the #640 baseline of 37,908/47,266 (80.201%), the change adds 240 instrumented lines and 224 covered lines while increasing overall coverage. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
Closes #639

Parent: #41

## Outcome

- freezes the exact nine-capability Platform v1 vocabulary and actor/elevation ceilings
- adds distinct immutable requested and granted sets plus a pure fail-closed intersection evaluator
- pins runtime, authored OpenAPI, and frozen contract equality with negative drift gates
- preserves the existing three pilot operations and adds no routes, persistence, activation, Android, deployment, or release changes

## Verification

- 3,489 server tests pass across three clean coverage runs
- coverage: 38,132/47,506 lines (80.268%), exact zero-tolerance ratchet
- 2,041 client tests pass with 2,808/3,201 line coverage
- Release build: 0 warnings, 0 errors
- script, lint, typecheck, syntax, translations, performance, docs, and contract gates pass
- independent architecture, security, and test reviews: APPROVE