### PR TITLE
EP-03.1: freeze installed-provider manifest contract

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformCapabilityArchitectureTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformCapabilityArchitectureTests.cs
@@ -168,8 +168,12 @@ public sealed class PlatformCapabilityArchitectureTests
     {
         foreach (var (typeName, memberName) in SensitiveMembers)
         {
+            var expectedOwners = typeName == nameof(PlatformRequestedCapabilitySet)
+                && memberName == nameof(PlatformRequestedCapabilitySet.TryCreate)
+                    ? new[] { CapabilityDomainFileName, "PlatformExtensionManifestDomain.cs" }
+                    : new[] { CapabilityDomainFileName };
             Assert.Equal(
-                new[] { CapabilityDomainFileName },
+                expectedOwners,
                 SensitiveMemberOwners(typeName, memberName));
         }
 

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformExtensionManifestArchitectureTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformExtensionManifestArchitectureTests.cs
@@ -1,0 +1,466 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.RegularExpressions;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform;
+
+/// <summary>Guards the pure manifest contract before filesystem discovery or registry ownership exists.</summary>
+public sealed class PlatformExtensionManifestArchitectureTests
+{
+    private const string ManifestDomainFileName = "PlatformExtensionManifestDomain.cs";
+
+    private static readonly Regex IdentifierUnicodeEscape = new(
+        @"\\(?:u(?<short>[0-9a-fA-F]{4})|U(?<long>[0-9a-fA-F]{8}))",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly string[] ForbiddenManifestDependencyTokens =
+    {
+        "System.IO",
+        "File.",
+        "FileInfo",
+        "Directory",
+        "DirectoryInfo",
+        "Path.",
+        "Stream",
+        "System.Net",
+        "HttpClient",
+        "IPluginManager",
+        "MediaBrowser",
+        "IPlatformHost",
+        "HostPlugin",
+        "Microsoft.AspNetCore",
+        "HttpContext",
+        "HttpRequest",
+        "Controller",
+        "Route(",
+        "Microsoft.Extensions.Configuration",
+        "Microsoft.Extensions.DependencyInjection",
+        "IConfiguration",
+        "IServiceCollection",
+        "IServiceProvider",
+        "AddSingleton",
+        "AddScoped",
+        "AddTransient",
+        "System.Data",
+        "DbConnection",
+        "DbContext",
+        "Microsoft.Data.Sqlite",
+        "SqliteConnection",
+        "Persistence",
+        "Repository",
+        "Registry",
+        "Lifecycle",
+        "Approval",
+        "GrantedCapability",
+        "GrantCeiling",
+        "PlatformApprovedProviderIdentity",
+        "PlatformActorFactory",
+        "CreateProvider",
+        "PlatformInstalledProviderActor",
+        "ProviderInvocation",
+        "Credential",
+        "Secret",
+        "Asset",
+        "System.Reflection",
+        "Activator",
+        "Assembly.Load",
+        "DateTime",
+        "DateTimeOffset",
+        "Random",
+        "Guid.NewGuid",
+        "Environment.",
+    };
+
+    [Fact]
+    public void ManifestModelIsASealedImmutableBoundedAllowList()
+    {
+        var type = typeof(PlatformExtensionManifest);
+        Assert.True(type.IsSealed);
+        Assert.Empty(type.GetConstructors(BindingFlags.Public | BindingFlags.Instance));
+
+        var properties = type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+            .OrderBy(property => property.Name, StringComparer.Ordinal)
+            .ToArray();
+        Assert.Equal(
+            new[]
+            {
+                "Description",
+                "DisplayName",
+                "Fingerprint",
+                "HostRange",
+                "Id",
+                "Kind",
+                "PlatformRange",
+                "PluginId",
+                "RequestedCapabilities",
+                "SchemaVersion",
+                "Version",
+            },
+            properties.Select(property => property.Name));
+        Assert.All(properties, property => Assert.False(property.CanWrite));
+
+        Assert.Equal(typeof(int), Property("SchemaVersion").PropertyType);
+        Assert.Equal(typeof(string), Property("Id").PropertyType);
+        Assert.Equal(typeof(Guid), Property("PluginId").PropertyType);
+        Assert.Equal(typeof(Version), Property("Version").PropertyType);
+        Assert.Equal(typeof(PlatformActorKind), Property("Kind").PropertyType);
+        Assert.Equal(typeof(string), Property("DisplayName").PropertyType);
+        Assert.Equal(typeof(string), Property("Description").PropertyType);
+        Assert.Equal(typeof(PlatformExtensionProtocolRange), Property("PlatformRange").PropertyType);
+        Assert.Equal(typeof(PlatformExtensionHostRange), Property("HostRange").PropertyType);
+        Assert.Equal(typeof(PlatformRequestedCapabilitySet), Property("RequestedCapabilities").PropertyType);
+        Assert.Equal(typeof(PlatformManifestFingerprint), Property("Fingerprint").PropertyType);
+
+        var forbiddenShape = new[]
+        {
+            "approved",
+            "grant",
+            "effective",
+            "enabled",
+            "installed",
+            "registered",
+            "callable",
+            "credential",
+            "secret",
+            "path",
+            "url",
+            "assembly",
+            "type",
+            "method",
+            "script",
+            "operation",
+            "contribution",
+            "asset",
+            "raw",
+            "bytes",
+            "exception",
+        };
+        Assert.DoesNotContain(
+            properties,
+            property => forbiddenShape.Contains(property.Name, StringComparer.OrdinalIgnoreCase));
+        Assert.DoesNotContain(
+            type.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance),
+            field => field.FieldType == typeof(byte[])
+                || field.FieldType == typeof(ReadOnlyMemory<byte>)
+                || field.FieldType == typeof(Memory<byte>));
+
+        PropertyInfo Property(string name) => properties.Single(property => property.Name == name);
+    }
+
+    [Fact]
+    public void ParserExposesOnlyTheBoundedTryParseBoundaryAndClosedRejectionReasons()
+    {
+        var methods = typeof(PlatformExtensionManifestParser)
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly)
+            .Where(method => !method.IsSpecialName)
+            .ToArray();
+        var parse = Assert.Single(methods, method => method.Name == "TryParse");
+        Assert.All(methods.Where(method => method != parse), method => Assert.True(method.IsPrivate));
+        Assert.False(parse.IsPublic);
+        Assert.Equal(typeof(bool), parse.ReturnType);
+        Assert.Equal(
+            new[]
+            {
+                typeof(byte[]),
+                typeof(PlatformExtensionManifest).MakeByRefType(),
+                typeof(PlatformExtensionManifestRejectionReason).MakeByRefType(),
+            },
+            parse.GetParameters().Select(parameter => parameter.ParameterType));
+
+        Assert.True(typeof(PlatformExtensionManifestRejectionReason).IsEnum);
+        var reasons = Enum.GetValues<PlatformExtensionManifestRejectionReason>();
+        Assert.Equal(
+            new[]
+            {
+                "None",
+                "MissingDocument",
+                "DocumentTooLarge",
+                "InvalidUtf8",
+                "InvalidJson",
+                "DuplicateProperty",
+                "UnknownProperty",
+                "MissingProperty",
+                "InvalidPropertyType",
+                "UnsupportedSchemaVersion",
+                "InvalidIdentifier",
+                "InvalidPluginId",
+                "InvalidVersion",
+                "InvalidKind",
+                "InvalidDisplayName",
+                "InvalidDescription",
+                "InvalidPlatformRange",
+                "InvalidHostRange",
+                "InvalidRequestedCapabilities",
+                "IncompatibleRequestedCapability",
+            },
+            Enum.GetNames<PlatformExtensionManifestRejectionReason>());
+        Assert.Equal(Enumerable.Range(0, 20), reasons.Select(reason => (int)reason));
+    }
+
+    [Fact]
+    public void ManifestDomainHasNoFilesystemHostHttpRegistryAuthorityOrExecutionDependencies()
+    {
+        var code = Code(SourceFile(ManifestDomainFileName));
+        Assert.Empty(ForbiddenManifestDependenciesIn(code));
+        Assert.Contains("SHA256", code, StringComparison.Ordinal);
+        Assert.Contains("UTF8", code, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(nameof(PlatformRequestedCapabilitySet), code, StringComparison.Ordinal);
+        Assert.Contains(nameof(PlatformManifestFingerprint), code, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("using System.Net.Http; var client = new HttpClient();", "System.Net")]
+    [InlineData("using System.Data.Common; DbConnection connection;", "System.Data")]
+    [InlineData("using Microsoft.Data.Sqlite; var db = new SqliteConnection();", "Microsoft.Data.Sqlite")]
+    [InlineData("sealed class ManifestRepository { }", "Repository")]
+    public void DependencyGuardRejectsPlantedHttpAndPersistenceReferences(string source, string expected) =>
+        Assert.Contains(expected, ForbiddenManifestDependenciesIn(source));
+
+    [Fact]
+    public void ManifestParsingConstructionAndFingerprintEstablishmentAreSourceOwned()
+    {
+        Assert.Equal(
+            new[] { ManifestDomainFileName },
+            MemberOwners(nameof(PlatformExtensionManifestParser), nameof(PlatformExtensionManifestParser.TryParse)));
+        Assert.Equal(
+            new[] { "PlatformActorDomain.cs", ManifestDomainFileName },
+            MemberOwners(nameof(PlatformManifestFingerprint), "EstablishValidatedManifestFingerprint"));
+        Assert.Equal(
+            new[] { ManifestDomainFileName },
+            MemberOwners(nameof(PlatformExtensionManifest), "EstablishValidatedManifest"));
+        Assert.Equal(
+            new[] { ManifestDomainFileName },
+            ConstructorOwners(nameof(PlatformExtensionManifest)));
+        Assert.Equal(
+            new[] { ManifestDomainFileName },
+            ConstructorOwners(nameof(PlatformExtensionProtocolRange)));
+        Assert.Equal(
+            new[] { ManifestDomainFileName },
+            ConstructorOwners(nameof(PlatformExtensionHostRange)));
+
+        Assert.True(HasMemberUse(
+            "var ok = global::Jellyfin.Plugin.JellyfinCanopy.Platform.PlatformExtensionManifestParser.TryParse(bytes, out var manifest, out var reason);",
+            nameof(PlatformExtensionManifestParser),
+            nameof(PlatformExtensionManifestParser.TryParse)));
+        Assert.True(HasConstructorUse(
+            "var range = new PlatformExtensionProtocolRange(1, 1);",
+            nameof(PlatformExtensionProtocolRange)));
+        Assert.True(HasConstructorUse(
+            "PlatformExtensionProtocolRange range = new(1, 1);",
+            nameof(PlatformExtensionProtocolRange)));
+        Assert.True(HasConstructorUse(
+            "using HostRange = Jellyfin.Plugin.JellyfinCanopy.Platform.PlatformExtensionHostRange; var range = new HostRange(12, 12);",
+            nameof(PlatformExtensionHostRange)));
+        Assert.True(HasMemberUse(
+            "using Parser = Jellyfin.Plugin.JellyfinCanopy.Platform.PlatformExtensionManifestParser; var ok = Parser.TryParse(bytes, out var manifest, out var reason);",
+            nameof(PlatformExtensionManifestParser),
+            nameof(PlatformExtensionManifestParser.TryParse)));
+        Assert.True(HasMemberUse(
+            "var ok = PlatformExtensionManifestParser.Try\\u0050arse(bytes, out var manifest, out var reason);",
+            nameof(PlatformExtensionManifestParser),
+            nameof(PlatformExtensionManifestParser.TryParse)));
+    }
+
+    [Fact]
+    public void CrossFileGlobalAliasesCannotHideManifestAuthorityOwners()
+    {
+        var sensitiveTypes = new[]
+        {
+            nameof(PlatformExtensionManifestParser),
+            nameof(PlatformExtensionManifest),
+            nameof(PlatformManifestFingerprint),
+            nameof(PlatformExtensionProtocolRange),
+            nameof(PlatformExtensionHostRange),
+        };
+        var aliases = ProductionFiles()
+            .Where(file => Regex.IsMatch(
+                Code(file),
+                @"^\s*global\s+using(?:\s+static)?\s+[^;]*(?:"
+                    + string.Join('|', sensitiveTypes.Select(Regex.Escape))
+                    + @")\s*;",
+                RegexOptions.CultureInvariant | RegexOptions.Multiline))
+            .Select(file => Path.GetFileName(file))
+            .ToArray();
+
+        Assert.Empty(aliases);
+        Assert.Matches(
+            @"^\s*global\s+using",
+            "global using Parser = Jellyfin.Plugin.JellyfinCanopy.Platform.PlatformExtensionManifestParser;");
+    }
+
+    [Fact]
+    public void ManifestSliceDoesNotIssueApprovedProviderIdentityOrActivateExistingPaths()
+    {
+        var production = ProductionFiles()
+            .ToDictionary(file => Path.GetFileName(file)!, Code, StringComparer.Ordinal);
+        Assert.All(production, pair => Assert.DoesNotContain(
+            "new PlatformApprovedProviderIdentity",
+            pair.Value,
+            StringComparison.Ordinal));
+        Assert.All(production.Where(pair => pair.Key != "PlatformActorDomain.cs"), pair => Assert.DoesNotContain(
+            "PlatformActorFactory.CreateProvider",
+            pair.Value,
+            StringComparison.Ordinal));
+
+        var existingActionPathFiles = new[]
+        {
+            "PlatformActionCapabilityService.cs",
+            "PlatformActionInvocationCoordinator.cs",
+            "PlatformFirstPartyActionDispatcher.cs",
+            "PlatformNativeCatalogService.cs",
+            "PlatformNativeController.cs",
+            "PlatformOperationVocabulary.cs",
+        };
+        foreach (var fileName in existingActionPathFiles)
+        {
+            Assert.DoesNotContain("PlatformExtensionManifest", production[fileName], StringComparison.Ordinal);
+        }
+
+        Assert.Equal(3, PlatformOperationVocabulary.All.Length);
+    }
+
+    private static string[] MemberOwners(string typeName, string memberName) => ProductionFiles()
+        .Where(file => HasMemberUse(Code(file), typeName, memberName))
+        .Select(file => Path.GetFileName(file)!)
+        .OrderBy(name => name, StringComparer.Ordinal)
+        .ToArray();
+
+    private static string[] ConstructorOwners(string typeName) => ProductionFiles()
+        .Where(file => HasConstructorUse(Code(file), typeName))
+        .Select(file => Path.GetFileName(file)!)
+        .OrderBy(name => name, StringComparer.Ordinal)
+        .ToArray();
+
+    private static bool HasConstructorUse(string source, string typeName)
+    {
+        var code = NormalizeIdentifierUnicodeEscapes(source);
+        var escapedType = Regex.Escape(typeName);
+        var identifier = @"[A-Za-z_]\w*";
+
+        // A local or global alias/import naming the sensitive type is conservatively
+        // treated as ownership so aliases cannot hide either explicit or target-typed new.
+        if (HasUsingDirectiveNamingType(code, escapedType))
+        {
+            return true;
+        }
+
+        if (Regex.IsMatch(
+                code,
+                $@"\bnew\s+(?:(?:global\s*::\s*)?{identifier}\s*\.\s*)*{escapedType}\s*\(",
+                RegexOptions.CultureInvariant)
+            || Regex.IsMatch(
+                code,
+                $@"\b{escapedType}\b\s+{identifier}\s*=\s*new\s*\(",
+                RegexOptions.CultureInvariant))
+        {
+            return true;
+        }
+
+        return Regex.IsMatch(
+                code,
+                $@"\b(?:class|struct)\s+{escapedType}\b",
+                RegexOptions.CultureInvariant)
+            && Regex.IsMatch(code, $@"\b{escapedType}\s*\(", RegexOptions.CultureInvariant);
+    }
+
+    private static bool HasUsingDirectiveNamingType(string code, string escapedTypePattern) => Regex.IsMatch(
+        code,
+        $@"^\s*(?:global\s+)?using\s+(?:static\s+)?[^;]*\b(?:{escapedTypePattern})\b\s*;",
+        RegexOptions.CultureInvariant | RegexOptions.Multiline);
+
+    private static string[] ForbiddenManifestDependenciesIn(string source) =>
+        ForbiddenManifestDependencyTokens
+            .Where(value => source.Contains(value, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+
+    private static bool HasMemberUse(string source, string typeName, string memberName)
+    {
+        var code = NormalizeIdentifierUnicodeEscapes(source)
+            .Replace("global::", string.Empty, StringComparison.Ordinal);
+        var compact = new string(code.Where(character => !char.IsWhiteSpace(character)).ToArray());
+        var direct = typeName + "." + memberName;
+        if (compact.Contains(direct, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        foreach (var line in code.Split('\n'))
+        {
+            var trimmed = line.Trim();
+            if (!trimmed.StartsWith("using ", StringComparison.Ordinal)
+                || !trimmed.Contains('=')
+                || !trimmed.Contains(typeName, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var alias = trimmed[6..trimmed.IndexOf('=')].Trim();
+            if (compact.Contains(alias + "." + memberName, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return (code.Contains("class " + typeName, StringComparison.Ordinal)
+                || code.Contains("struct " + typeName, StringComparison.Ordinal))
+            && code.Contains(memberName, StringComparison.Ordinal);
+    }
+
+    private static string Code(string file) => NormalizeIdentifierUnicodeEscapes(
+        PlatformHostSeamTests.CodeOnly(File.ReadAllText(file)));
+
+    private static string NormalizeIdentifierUnicodeEscapes(string code)
+    {
+        var decoded = IdentifierUnicodeEscape.Replace(code, match =>
+        {
+            var shortHex = match.Groups["short"];
+            if (shortHex.Success)
+            {
+                return ((char)Convert.ToInt32(shortHex.Value, 16)).ToString();
+            }
+
+            var scalar = Convert.ToInt32(match.Groups["long"].Value, 16);
+            return scalar is >= 0 and <= 0x10FFFF
+                && scalar is not (>= 0xD800 and <= 0xDFFF)
+                    ? char.ConvertFromUtf32(scalar)
+                    : match.Value;
+        });
+
+        var normalized = new StringBuilder(decoded.Length);
+        foreach (var rune in decoded.EnumerateRunes())
+        {
+            if (Rune.GetUnicodeCategory(rune) != System.Globalization.UnicodeCategory.Format)
+            {
+                normalized.Append(rune.ToString());
+            }
+        }
+
+        return normalized.ToString();
+    }
+
+    private static IEnumerable<string> ProductionFiles() =>
+        Directory.EnumerateFiles(ProductionRoot(), "*.cs", SearchOption.AllDirectories)
+            .Where(file => !file.Contains(
+                    $"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}",
+                    StringComparison.Ordinal)
+                && !file.Contains(
+                    $"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}",
+                    StringComparison.Ordinal));
+
+    private static string SourceFile(string name) => ProductionFiles()
+        .Single(file => Path.GetFileName(file) == name);
+
+    private static string ProductionRoot([CallerFilePath] string sourceFile = "") =>
+        Path.GetFullPath(Path.Combine(
+            Path.GetDirectoryName(sourceFile)!,
+            "..",
+            "..",
+            "Jellyfin.Plugin.JellyfinCanopy"));
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformExtensionManifestContractTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformExtensionManifestContractTests.cs
@@ -1,0 +1,385 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform;
+
+public sealed class PlatformExtensionManifestContractTests
+{
+    private static readonly JsonDocument Schema = JsonDocument.Parse(
+        File.ReadAllText(ContractPath("extension-manifest.schema.json")));
+    private static readonly JsonDocument Frozen = JsonDocument.Parse(
+        File.ReadAllText(ContractPath("frozen.json")));
+
+    private static readonly string[] RequiredProperties =
+    {
+        "schemaVersion",
+        "id",
+        "pluginId",
+        "version",
+        "kind",
+        "displayName",
+        "platform",
+        "host",
+        "requestedCapabilities",
+    };
+
+    private static readonly string[] ProviderCapabilities = PlatformCapabilityVocabulary.All
+        .Where(definition => definition.AllowedActorKinds.Contains(PlatformActorKind.InstalledProvider))
+        .Select(definition => definition.Id.Value)
+        .ToArray();
+
+    [Fact]
+    public void RuntimeSchemaFrozenAndGoldenFixtureAreExact()
+    {
+        Assert.Empty(ManifestContractDrift(Schema.RootElement, Frozen.RootElement));
+
+        var fixture = File.ReadAllBytes(ContractPath(Path.Combine(
+            "fixtures",
+            "extension-manifest.valid.json")));
+        Assert.True(PlatformExtensionManifestParser.TryParse(fixture, out var manifest, out var reason));
+        Assert.Equal(PlatformExtensionManifestRejectionReason.None, reason);
+        Assert.NotNull(manifest);
+        Assert.Equal(1, manifest.SchemaVersion);
+        Assert.Equal("org.example.provider", manifest.Id);
+        Assert.Equal(Guid.Parse("12345678-9abc-4def-8123-456789abcdef"), manifest.PluginId);
+        Assert.Equal(new Version(1, 2, 3, 4), manifest.Version);
+        Assert.Equal(PlatformActorKind.InstalledProvider, manifest.Kind);
+        Assert.Equal("Example Provider", manifest.DisplayName);
+        Assert.Equal("A bounded installed-provider fixture.", manifest.Description);
+        Assert.Equal((1, 1), (manifest.PlatformRange.Min, manifest.PlatformRange.Max));
+        Assert.Equal((12, 12), (manifest.HostRange.MinMajor, manifest.HostRange.MaxMajor));
+        Assert.Equal(
+            ProviderCapabilities,
+            manifest.RequestedCapabilities.Capabilities.Select(value => value.Id.Value));
+        Assert.Equal(
+            Frozen.RootElement.GetProperty("extensionManifest").GetProperty("goldenFingerprint").GetString(),
+            manifest.Fingerprint.Value);
+    }
+
+    [Fact]
+    public void VersionSchemaPinsTheExactSystemVersionComponentCeiling()
+    {
+        var pattern = Schema.RootElement.GetProperty("properties")
+            .GetProperty("version").GetProperty("pattern").GetString()!;
+        var regex = new Regex(pattern, RegexOptions.CultureInvariant);
+
+        Assert.Matches(regex, "0.0");
+        Assert.Matches(regex, "2147483647.2147483647.2147483647.2147483647");
+        Assert.DoesNotMatch(regex, "2147483648.1");
+        Assert.DoesNotMatch(regex, "9999999999.1");
+        Assert.DoesNotMatch(regex, "01.1");
+    }
+
+    [Fact]
+    public void DriftGateNamesSchemaFrozenBoundsFieldsAndCapabilities()
+    {
+        var frozen = JsonNode.Parse(Frozen.RootElement.GetRawText())!.AsObject();
+        frozen["extensionManifest"]!["maximumJsonDepth"] = 17;
+        using var changedBound = JsonDocument.Parse(frozen.ToJsonString());
+        Assert.Contains(
+            "maximumJsonDepth changed",
+            ManifestContractDrift(Schema.RootElement, changedBound.RootElement));
+
+        frozen = JsonNode.Parse(Frozen.RootElement.GetRawText())!.AsObject();
+        frozen["extensionManifest"]!["providerEligibleCapabilities"]!.AsArray().RemoveAt(0);
+        using var removedCapability = JsonDocument.Parse(frozen.ToJsonString());
+        Assert.Contains(
+            "providerEligibleCapabilities changed",
+            ManifestContractDrift(Schema.RootElement, removedCapability.RootElement));
+
+        var schema = JsonNode.Parse(Schema.RootElement.GetRawText())!.AsObject();
+        schema["properties"]!.AsObject().Remove("displayName");
+        using var removedProperty = JsonDocument.Parse(schema.ToJsonString());
+        Assert.Contains(
+            "schema properties changed",
+            ManifestContractDrift(removedProperty.RootElement, Frozen.RootElement));
+
+        schema = JsonNode.Parse(Schema.RootElement.GetRawText())!.AsObject();
+        schema["required"]!.AsArray().RemoveAt(0);
+        using var removedRequired = JsonDocument.Parse(schema.ToJsonString());
+        Assert.Contains(
+            "requiredProperties changed",
+            ManifestContractDrift(removedRequired.RootElement, Frozen.RootElement));
+    }
+
+    [Fact]
+    public void DriftGateNamesEveryFieldLevelManifestContract()
+    {
+        AssertSchemaDrift("root type changed", schema => schema["type"] = "array");
+        AssertSchemaDrift("schemaVersion changed", schema =>
+            schema["properties"]!["schemaVersion"]!["const"] = 2);
+        AssertSchemaDrift("id changed", schema =>
+            schema["properties"]!["id"]!["x-canopy-maximum-segment-length"] = 63);
+        AssertSchemaDrift("pluginId changed", schema =>
+            schema["properties"]!["pluginId"]!["pattern"] = "changed");
+        AssertSchemaDrift("version changed", schema =>
+            schema["properties"]!["version"]!["pattern"] = "changed");
+        AssertSchemaDrift("kind changed", schema =>
+            schema["properties"]!["kind"]!["const"] = "companion-service");
+        AssertSchemaDrift("displayName changed", schema =>
+            schema["properties"]!["displayName"]!["maxLength"] = 95);
+        AssertSchemaDrift("description changed", schema =>
+            schema["properties"]!["description"]!["x-canopy-text-policy"] = "changed");
+        AssertSchemaDrift("platform changed", schema =>
+            schema["properties"]!["platform"]!["properties"]!["max"]!["maximum"] = 65534);
+        AssertSchemaDrift("host changed", schema =>
+            schema["properties"]!["host"]!["required"]!.AsArray().RemoveAt(0));
+        AssertSchemaDrift("maximumRequestedCapabilities changed", schema =>
+            schema["properties"]!["requestedCapabilities"]!["maxItems"] = 8);
+        AssertSchemaDrift("requestedCapabilities changed", schema =>
+            schema["properties"]!["requestedCapabilities"]!["minItems"] = 1);
+        AssertSchemaDrift("requestedCapabilities changed", schema =>
+            schema["properties"]!["requestedCapabilities"]!["items"]!["type"] = "number");
+    }
+
+    private static IReadOnlyList<string> ManifestContractDrift(JsonElement schema, JsonElement frozenRoot)
+    {
+        var drift = new List<string>();
+        var frozen = frozenRoot.GetProperty("extensionManifest");
+        var properties = schema.GetProperty("properties");
+        AddIf(!schema.TryGetProperty("type", out var rootType)
+            || rootType.GetString() != "object", "root type changed");
+        var expectedProperties = RequiredProperties.Append("description").Order(StringComparer.Ordinal).ToArray();
+        var schemaProperties = properties.EnumerateObject()
+            .Select(property => property.Name)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        AddIf(!schemaProperties.SequenceEqual(expectedProperties, StringComparer.Ordinal), "schema properties changed");
+
+        var schemaRequired = schema.GetProperty("required").EnumerateArray()
+            .Select(value => value.GetString()!)
+            .ToArray();
+        var frozenRequired = frozen.GetProperty("requiredProperties").EnumerateArray()
+            .Select(value => value.GetString()!)
+            .ToArray();
+        AddIf(!schemaRequired.SequenceEqual(RequiredProperties, StringComparer.Ordinal)
+            || !frozenRequired.SequenceEqual(RequiredProperties, StringComparer.Ordinal), "requiredProperties changed");
+        AddIf(!frozen.GetProperty("optionalProperties").EnumerateArray()
+            .Select(value => value.GetString())
+            .SequenceEqual(new[] { "description" }, StringComparer.Ordinal), "optionalProperties changed");
+
+        CompareText("fileName", PlatformExtensionManifestParser.ManifestFileName);
+        CompareText("schemaId", PlatformExtensionManifestParser.SchemaId);
+        CompareText("kind", PlatformActorKindVocabulary.TokenFor(PlatformActorKind.InstalledProvider)!);
+        CompareText("fingerprintAlgorithm", PlatformExtensionManifestParser.FingerprintAlgorithm);
+        CompareText("fingerprintDomain", PlatformExtensionManifestParser.FingerprintDomain);
+        CompareText("unknownProperties", "reject");
+        CompareNumber("schemaVersion", PlatformExtensionManifestParser.SchemaVersion);
+        CompareNumber("maximumDocumentBytes", PlatformExtensionManifestBounds.MaximumDocumentBytes);
+        CompareNumber("maximumJsonDepth", PlatformExtensionManifestBounds.MaximumJsonDepth);
+        CompareNumber("maximumIdBytes", PlatformExtensionManifestBounds.MaximumIdBytes);
+        CompareNumber("maximumIdentifierSegmentLength", PlatformExtensionManifestParser.MaximumIdentifierSegmentLength);
+        CompareNumber("maximumVersionBytes", PlatformExtensionManifestBounds.MaximumVersionBytes);
+        CompareNumber("maximumDisplayNameBytes", PlatformExtensionManifestBounds.MaximumDisplayNameBytes);
+        CompareNumber("maximumDescriptionBytes", PlatformExtensionManifestBounds.MaximumDescriptionBytes);
+        CompareNumber("maximumCompatibilityMajor", PlatformExtensionManifestBounds.MaximumCompatibilityMajor);
+        CompareNumber("maximumRequestedCapabilities", PlatformExtensionManifestBounds.MaximumRequestedCapabilities);
+
+        AddIf(schema.GetProperty("$id").GetString() != PlatformExtensionManifestParser.SchemaId, "schemaId changed");
+        AddIf(schema.GetProperty("additionalProperties").GetBoolean(), "unknownProperties changed");
+        AddIf(schema.GetProperty("x-canopy-unknown-properties").GetString() != "reject", "unknownProperties changed");
+        AddIf(schema.GetProperty("x-canopy-maximum-document-bytes").GetInt32()
+            != PlatformExtensionManifestBounds.MaximumDocumentBytes, "maximumDocumentBytes changed");
+        AddIf(schema.GetProperty("x-canopy-maximum-json-depth").GetInt32()
+            != PlatformExtensionManifestBounds.MaximumJsonDepth, "maximumJsonDepth changed");
+        AddIf(schema.GetProperty("x-canopy-fingerprint-algorithm").GetString()
+            != PlatformExtensionManifestParser.FingerprintAlgorithm, "fingerprintAlgorithm changed");
+        AddIf(schema.GetProperty("x-canopy-fingerprint-domain").GetString()
+            != PlatformExtensionManifestParser.FingerprintDomain, "fingerprintDomain changed");
+
+        if (!properties.TryGetProperty("schemaVersion", out var schemaVersion))
+        {
+            AddIf(true, "schemaVersion changed");
+        }
+        else
+        {
+            AddIf(schemaVersion.GetProperty("type").GetString() != "integer"
+                || schemaVersion.GetProperty("const").GetInt32() != PlatformExtensionManifestParser.SchemaVersion,
+                "schemaVersion changed");
+        }
+
+        if (!properties.TryGetProperty("id", out var identifier))
+        {
+            AddIf(true, "id changed");
+        }
+        else
+        {
+            AddIf(identifier.GetProperty("type").GetString() != "string"
+                || identifier.GetProperty("minLength").GetInt32() != 3
+                || identifier.GetProperty("maxLength").GetInt32() != PlatformExtensionManifestBounds.MaximumIdBytes
+                || identifier.GetProperty("x-canopy-maximum-segment-length").GetInt32()
+                    != PlatformExtensionManifestParser.MaximumIdentifierSegmentLength
+                || identifier.GetProperty("pattern").GetString()
+                    != frozen.GetProperty("identifierPattern").GetString(),
+                "id changed");
+        }
+
+        if (!properties.TryGetProperty("pluginId", out var pluginId))
+        {
+            AddIf(true, "pluginId changed");
+        }
+        else
+        {
+            AddIf(pluginId.GetProperty("type").GetString() != "string"
+                || pluginId.GetProperty("minLength").GetInt32() != 36
+                || pluginId.GetProperty("maxLength").GetInt32() != 36
+                || pluginId.GetProperty("pattern").GetString()
+                    != frozen.GetProperty("pluginIdPattern").GetString()
+                || pluginId.GetProperty("not").GetProperty("const").GetString()
+                    != "00000000-0000-0000-0000-000000000000",
+                "pluginId changed");
+        }
+
+        if (!properties.TryGetProperty("version", out var version))
+        {
+            AddIf(true, "version changed");
+        }
+        else
+        {
+            AddIf(version.GetProperty("type").GetString() != "string"
+                || version.GetProperty("minLength").GetInt32() != 3
+                || version.GetProperty("maxLength").GetInt32()
+                    != PlatformExtensionManifestBounds.MaximumVersionBytes
+                || version.GetProperty("pattern").GetString()
+                    != frozen.GetProperty("versionPattern").GetString(),
+                "version changed");
+        }
+
+        if (!properties.TryGetProperty("kind", out var kind))
+        {
+            AddIf(true, "kind changed");
+        }
+        else
+        {
+            AddIf(kind.GetProperty("type").GetString() != "string"
+                || kind.GetProperty("const").GetString()
+                    != PlatformActorKindVocabulary.TokenFor(PlatformActorKind.InstalledProvider),
+                "kind changed");
+        }
+
+        CompareTextField("displayName", 1, PlatformExtensionManifestBounds.MaximumDisplayNameBytes);
+        CompareTextField("description", 0, PlatformExtensionManifestBounds.MaximumDescriptionBytes);
+        CompareRange(
+            "platform",
+            new[] { "min", "max" },
+            "min<=max");
+        CompareRange(
+            "host",
+            new[] { "minMajor", "maxMajor" },
+            "minMajor<=maxMajor");
+
+        var frozenCapabilities = frozen.GetProperty("providerEligibleCapabilities").EnumerateArray()
+            .Select(value => value.GetString()!)
+            .ToArray();
+        AddIf(!frozenCapabilities.SequenceEqual(ProviderCapabilities, StringComparer.Ordinal),
+            "providerEligibleCapabilities changed");
+        if (!properties.TryGetProperty("requestedCapabilities", out var requestedCapabilities))
+        {
+            AddIf(true, "requestedCapabilities changed");
+        }
+        else
+        {
+            var items = requestedCapabilities.GetProperty("items");
+            var schemaCapabilities = items.GetProperty("enum").EnumerateArray()
+                .Select(value => value.GetString()!)
+                .ToArray();
+            AddIf(!schemaCapabilities.SequenceEqual(ProviderCapabilities, StringComparer.Ordinal),
+                "providerEligibleCapabilities changed");
+            AddIf(requestedCapabilities.GetProperty("type").GetString() != "array"
+                || requestedCapabilities.GetProperty("minItems").GetInt32() != 0
+                || items.GetProperty("type").GetString() != "string",
+                "requestedCapabilities changed");
+            AddIf(requestedCapabilities.GetProperty("maxItems").GetInt32()
+                != PlatformExtensionManifestBounds.MaximumRequestedCapabilities,
+                "maximumRequestedCapabilities changed");
+            AddIf(!requestedCapabilities.GetProperty("uniqueItems").GetBoolean(),
+                "requestedCapabilities uniqueness changed");
+        }
+
+        return drift.Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray();
+
+        void CompareText(string name, string expected) =>
+            AddIf(frozen.GetProperty(name).GetString() != expected, $"{name} changed");
+
+        void CompareNumber(string name, int expected) =>
+            AddIf(frozen.GetProperty(name).GetInt32() != expected, $"{name} changed");
+
+        void CompareTextField(string name, int minimum, int maximum)
+        {
+            if (!properties.TryGetProperty(name, out var field))
+            {
+                AddIf(true, $"{name} changed");
+                return;
+            }
+
+            AddIf(field.GetProperty("type").GetString() != "string"
+                || field.GetProperty("minLength").GetInt32() != minimum
+                || field.GetProperty("maxLength").GetInt32() != maximum
+                || field.GetProperty("x-canopy-maximum-utf8-bytes").GetInt32() != maximum
+                || field.GetProperty("x-canopy-text-policy").GetString()
+                    != frozen.GetProperty("textPolicy").GetString(),
+                $"{name} changed");
+        }
+
+        void CompareRange(string name, IReadOnlyList<string> required, string order)
+        {
+            if (!properties.TryGetProperty(name, out var range))
+            {
+                AddIf(true, $"{name} changed");
+                return;
+            }
+
+            var actualRequired = range.GetProperty("required").EnumerateArray()
+                .Select(value => value.GetString()!)
+                .ToArray();
+            var members = range.GetProperty("properties");
+            var memberNames = members.EnumerateObject().Select(member => member.Name).ToArray();
+            var invalidMember = members.EnumerateObject().Any(member =>
+                member.Value.GetProperty("type").GetString() != "integer"
+                || member.Value.GetProperty("minimum").GetInt32() != 1
+                || member.Value.GetProperty("maximum").GetInt32()
+                    != PlatformExtensionManifestBounds.MaximumCompatibilityMajor);
+            AddIf(range.GetProperty("type").GetString() != "object"
+                || range.GetProperty("additionalProperties").GetBoolean()
+                || !actualRequired.SequenceEqual(required, StringComparer.Ordinal)
+                || !memberNames.SequenceEqual(required, StringComparer.Ordinal)
+                || invalidMember
+                || range.GetProperty("x-canopy-range-order").GetString() != order,
+                $"{name} changed");
+        }
+
+        void AddIf(bool changed, string message)
+        {
+            if (changed)
+            {
+                drift.Add(message);
+            }
+        }
+    }
+
+    private static void AssertSchemaDrift(string expected, Action<JsonObject> mutation)
+    {
+        var schema = JsonNode.Parse(Schema.RootElement.GetRawText())!.AsObject();
+        mutation(schema);
+        using var changed = JsonDocument.Parse(schema.ToJsonString());
+        Assert.Contains(expected, ManifestContractDrift(changed.RootElement, Frozen.RootElement));
+    }
+
+    private static string ContractPath(string name, [CallerFilePath] string sourceFile = "") =>
+        Path.GetFullPath(Path.Combine(
+            Path.GetDirectoryName(sourceFile)!,
+            "..",
+            "..",
+            "contracts",
+            "platform",
+            "v1",
+            name));
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformExtensionManifestTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformExtensionManifestTests.cs
@@ -1,0 +1,579 @@
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform;
+
+public sealed class PlatformExtensionManifestTests
+{
+    private const string Items = "jellyfin.canopy.items.lookup";
+    private const string UserData = "jellyfin.canopy.user-data.read";
+    private const string Storage = "jellyfin.canopy.storage.read";
+    private const string Ui = "jellyfin.canopy.ui.contribute";
+    private const string Integrations = "jellyfin.canopy.integrations.invoke";
+
+    private static readonly string[] ProviderCapabilities =
+    [
+        Items,
+        UserData,
+        Storage,
+        Ui,
+        Integrations,
+    ];
+
+    [Fact]
+    public void GoldenManifestParsesIntoTheExactCanonicalImmutableModel()
+    {
+        var manifest = Parse(ManifestBytes(
+            capabilities: ProviderCapabilities.Reverse().ToArray()));
+
+        Assert.Equal(1, manifest.SchemaVersion);
+        Assert.Equal("org.example.media-tools", manifest.Id);
+        Assert.Equal(Guid.Parse("11111111-2222-3333-4444-555555555555"), manifest.PluginId);
+        Assert.Equal(new Version(1, 2, 3, 4), manifest.Version);
+        Assert.Equal(PlatformActorKind.InstalledProvider, manifest.Kind);
+        Assert.Equal("Example Provider", manifest.DisplayName);
+        Assert.Equal("A bounded installed-provider fixture.", manifest.Description);
+        Assert.Equal(1, manifest.PlatformRange.Min);
+        Assert.Equal(1, manifest.PlatformRange.Max);
+        Assert.Equal(12, manifest.HostRange.MinMajor);
+        Assert.Equal(12, manifest.HostRange.MaxMajor);
+        Assert.Equal(
+            ProviderCapabilities,
+            manifest.RequestedCapabilities.Capabilities.Select(value => value.Id.Value));
+        Assert.Matches("^[0-9a-f]{64}$", manifest.Fingerprint.Value);
+        Assert.Equal("9095ca0868174f31ea74f435713e11fa14a64a8322395cff9a516e757f54695c",
+            manifest.Fingerprint.Value);
+        Assert.Equal(IndependentFingerprint(manifest), manifest.Fingerprint.Value);
+    }
+
+    [Fact]
+    public void RuntimeBoundsPinTheReviewedV1Limits()
+    {
+        Assert.Equal(256 * 1024, PlatformExtensionManifestBounds.MaximumDocumentBytes);
+        Assert.Equal(16, PlatformExtensionManifestBounds.MaximumJsonDepth);
+        Assert.Equal(128, PlatformExtensionManifestBounds.MaximumIdBytes);
+        Assert.Equal(64, PlatformExtensionManifestBounds.MaximumVersionBytes);
+        Assert.Equal(96, PlatformExtensionManifestBounds.MaximumDisplayNameBytes);
+        Assert.Equal(512, PlatformExtensionManifestBounds.MaximumDescriptionBytes);
+        Assert.Equal(65535, PlatformExtensionManifestBounds.MaximumCompatibilityMajor);
+        Assert.Equal(64, PlatformExtensionManifestParser.MaximumIdentifierSegmentLength);
+        Assert.Equal("jellyfin-canopy-extension.json", PlatformExtensionManifestParser.ManifestFileName);
+        Assert.Equal("urn:jellyfin-canopy:platform:v1:extension-manifest", PlatformExtensionManifestParser.SchemaId);
+        Assert.Equal(1, PlatformExtensionManifestParser.SchemaVersion);
+        Assert.Equal("sha-256", PlatformExtensionManifestParser.FingerprintAlgorithm);
+        Assert.Equal("jellyfin-canopy-extension-manifest-v1", PlatformExtensionManifestParser.FingerprintDomain);
+        Assert.Equal(
+            PlatformCapabilityVocabulary.MaximumCapabilityCount,
+            PlatformExtensionManifestBounds.MaximumRequestedCapabilities);
+    }
+
+    [Fact]
+    public void ExactDocumentAndJsonDepthBoundsAreDistinguishedFromOverBoundInputs()
+    {
+        var ordinary = ManifestBytes();
+        var exact = new byte[PlatformExtensionManifestBounds.MaximumDocumentBytes];
+        ordinary.CopyTo(exact, 0);
+        exact.AsSpan(ordinary.Length).Fill((byte)' ');
+
+        Assert.NotNull(Parse(exact));
+        Assert.NotEqual(
+            default,
+            Reject(exact.Concat(new byte[] { (byte)' ' }).ToArray()));
+
+        var atDepth = Encoding.UTF8.GetBytes(
+            new string('[', PlatformExtensionManifestBounds.MaximumJsonDepth)
+            + "0"
+            + new string(']', PlatformExtensionManifestBounds.MaximumJsonDepth));
+        var overDepth = Encoding.UTF8.GetBytes(
+            new string('[', PlatformExtensionManifestBounds.MaximumJsonDepth + 1)
+            + "0"
+            + new string(']', PlatformExtensionManifestBounds.MaximumJsonDepth + 1));
+
+        var atDepthReason = Reject(atDepth);
+        var overDepthReason = Reject(overDepth);
+        Assert.Equal(PlatformExtensionManifestRejectionReason.InvalidPropertyType, atDepthReason);
+        Assert.Equal(PlatformExtensionManifestRejectionReason.InvalidJson, overDepthReason);
+    }
+
+    [Fact]
+    public void ExactStringAndRangeBoundariesParseAndEveryNextValueFails()
+    {
+        var exactId = new string('a', 31) + "." + new string('b', 32) + "." + new string('c', 63);
+        var overlongId = new string('a', 32) + "." + new string('b', 32) + "." + new string('c', 63);
+        Assert.Equal(128, Encoding.ASCII.GetByteCount(exactId));
+        Assert.Equal(exactId, Parse(ManifestBytes(id: exactId)).Id);
+        Assert.Equal(129, Encoding.ASCII.GetByteCount(overlongId));
+        Reject(ManifestBytes(id: overlongId));
+
+        var exactSegment = "a.b." + new string('c', PlatformExtensionManifestParser.MaximumIdentifierSegmentLength);
+        Assert.Equal(exactSegment, Parse(ManifestBytes(id: exactSegment)).Id);
+        Reject(ManifestBytes(id: exactSegment + "c"));
+
+        var exactDisplayName = new string('\u00e9', 48);
+        Assert.Equal(96, Encoding.UTF8.GetByteCount(exactDisplayName));
+        Assert.Equal(exactDisplayName, Parse(ManifestBytes(displayName: exactDisplayName)).DisplayName);
+        Reject(ManifestBytes(displayName: exactDisplayName + "a"));
+
+        var exactDescription = new string('\u00e9', 256);
+        Assert.Equal(512, Encoding.UTF8.GetByteCount(exactDescription));
+        Assert.Equal(exactDescription, Parse(ManifestBytes(description: exactDescription)).Description);
+        Reject(ManifestBytes(description: exactDescription + "a"));
+
+        var maximumVersion = string.Join('.', Enumerable.Repeat(int.MaxValue.ToString(CultureInfo.InvariantCulture), 4));
+        Assert.True(Encoding.ASCII.GetByteCount(maximumVersion) <= PlatformExtensionManifestBounds.MaximumVersionBytes);
+        Assert.Equal(new Version(int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue),
+            Parse(ManifestBytes(version: maximumVersion)).Version);
+        Reject(ManifestBytes(version: new string('1', PlatformExtensionManifestBounds.MaximumVersionBytes + 1)));
+
+        var maximum = PlatformExtensionManifestBounds.MaximumCompatibilityMajor;
+        var ranges = Parse(ManifestBytes(platformMin: maximum, platformMax: maximum, hostMin: maximum, hostMax: maximum));
+        Assert.Equal(maximum, ranges.PlatformRange.Max);
+        Assert.Equal(maximum, ranges.HostRange.MaxMajor);
+        Reject(ManifestBytes(platformMax: maximum + 1));
+        Reject(ManifestBytes(hostMax: maximum + 1));
+    }
+
+    [Fact]
+    public void DescriptionIsOptionalAndRequestedCapabilitiesMayBeEmptyOrAllProviderEligible()
+    {
+        var absentDescription = Parse(ManifestBytes(description: null));
+        Assert.Null(absentDescription.Description);
+        Assert.Empty(Parse(ManifestBytes(capabilities: Array.Empty<string>()))
+            .RequestedCapabilities.Capabilities);
+        Assert.Equal(
+            ProviderCapabilities,
+            Parse(ManifestBytes(capabilities: ProviderCapabilities)).RequestedCapabilities.Capabilities
+                .Select(value => value.Id.Value));
+    }
+
+    [Theory]
+    [InlineData("ab")]
+    [InlineData("A.b.c")]
+    [InlineData("a.B.c")]
+    [InlineData("a.b.1c")]
+    [InlineData("a.b.-c")]
+    [InlineData("a.b.c-")]
+    [InlineData("a.b.c--d")]
+    [InlineData("a.b.c_d")]
+    [InlineData("a.b.c*d")]
+    [InlineData("a.b.caf\u00e9")]
+    public void NonCanonicalExtensionIdsFailClosed(string id) => Reject(ManifestBytes(id: id));
+
+    [Theory]
+    [InlineData("a.b")]
+    [InlineData("vendor.extension2")]
+    [InlineData("vendor-name.extension-name")]
+    public void CanonicalTwoOrMoreSegmentExtensionIdsParse(string id) =>
+        Assert.Equal(id, Parse(ManifestBytes(id: id)).Id);
+
+    [Theory]
+    [InlineData(" Example Provider")]
+    [InlineData("Example Provider ")]
+    [InlineData("Example\u0001Provider")]
+    [InlineData("Example\u200bProvider")]
+    public void NonCanonicalDisplayMetadataFailsClosed(string displayName) =>
+        Reject(ManifestBytes(displayName: displayName));
+
+    [Theory]
+    [InlineData("11111111222233334444555555555555")]
+    [InlineData("11111111-2222-3333-4444-55555555555A")]
+    [InlineData("{11111111-2222-3333-4444-555555555555}")]
+    [InlineData("00000000-0000-0000-0000-000000000000")]
+    [InlineData("not-a-guid")]
+    public void NonCanonicalOrEmptyPluginIdsFailClosed(string pluginId) =>
+        Reject(ManifestBytes(pluginId: pluginId));
+
+    [Theory]
+    [InlineData("1")]
+    [InlineData("1.2.3.4.5")]
+    [InlineData("01.2")]
+    [InlineData("1.02")]
+    [InlineData("+1.2")]
+    [InlineData("1.2-alpha")]
+    [InlineData("1.2 ")]
+    [InlineData("1.\u0662")]
+    public void NonCanonicalSystemVersionsFailClosed(string version) => Reject(ManifestBytes(version: version));
+
+    [Fact]
+    public void SystemVersionComponentsAcceptInt32MaximumAndRejectTheNextValue()
+    {
+        Assert.Equal(
+            new Version(int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue),
+            Parse(ManifestBytes(version: "2147483647.2147483647.2147483647.2147483647")).Version);
+        Reject(ManifestBytes(version: "2147483648.1"));
+        Reject(ManifestBytes(version: "9999999999.1"));
+    }
+
+    [Theory]
+    [InlineData(0, 1, 12, 12)]
+    [InlineData(2, 1, 12, 12)]
+    [InlineData(1, 1, 0, 12)]
+    [InlineData(1, 1, 13, 12)]
+    public void ZeroOrDescendingCompatibilityRangesFailClosed(
+        int platformMin,
+        int platformMax,
+        int hostMin,
+        int hostMax) => Reject(ManifestBytes(
+            platformMin: platformMin,
+            platformMax: platformMax,
+            hostMin: hostMin,
+            hostMax: hostMax));
+
+    [Theory]
+    [InlineData("jellyfin.canopy.discovery.read")]
+    [InlineData("jellyfin.canopy.events.subscribe")]
+    [InlineData("jellyfin.canopy.administration.manage")]
+    [InlineData("jellyfin.canopy.diagnostics.read")]
+    public void CapabilitiesOutsideTheInstalledProviderActorCeilingFailClosed(string capability) =>
+        Reject(ManifestBytes(capabilities: new[] { capability }));
+
+    [Theory]
+    [InlineData("jellyfin.canopy.unknown.read")]
+    [InlineData("JELLYFIN.CANOPY.ITEMS.LOOKUP")]
+    [InlineData("jellyfin.canopy.items.*")]
+    [InlineData("jellyfin.canopy.items")]
+    [InlineData("jellyfin.canopy.items.lookup ")]
+    public void UnknownCaseVariantWildcardAndMalformedCapabilitiesFailClosed(string capability) =>
+        Reject(ManifestBytes(capabilities: new[] { capability }));
+
+    [Fact]
+    public void DuplicateAndOverBoundCapabilityArraysFailClosed()
+    {
+        Reject(ManifestBytes(capabilities: new[] { Items, Items }));
+        Reject(ManifestBytes(capabilities: Enumerable.Repeat(
+            Items,
+            PlatformExtensionManifestBounds.MaximumRequestedCapabilities + 1).ToArray()));
+    }
+
+    [Theory]
+    [InlineData("grantedCapabilities", "[]")]
+    [InlineData("effectiveCapabilities", "[]")]
+    [InlineData("approved", "true")]
+    [InlineData("enabled", "true")]
+    [InlineData("credential", "\"secret\"")]
+    [InlineData("secret", "\"secret\"")]
+    [InlineData("path", "\"provider.dll\"")]
+    [InlineData("url", "\"https://example.invalid\"")]
+    [InlineData("assembly", "\"Provider\"")]
+    [InlineData("type", "\"Provider.Entry\"")]
+    [InlineData("method", "\"Invoke\"")]
+    [InlineData("script", "\"run()\"")]
+    [InlineData("operations", "[]")]
+    [InlineData("contributions", "[]")]
+    [InlineData("assets", "[]")]
+    public void UnknownAndAuthorityOrExecutionShapedPropertiesFailClosed(string property, string value) =>
+        Reject(AddRootProperty(ManifestBytes(), property, value));
+
+    [Fact]
+    public void BomInvalidUtf8CommentsTrailingCommasAndTrailingDataFailClosed()
+    {
+        Reject(new byte[] { 0xEF, 0xBB, 0xBF }.Concat(ManifestBytes()).ToArray());
+        Reject(new byte[] { (byte)'{', (byte)'"', 0xFF, (byte)'"', (byte)':', (byte)'1', (byte)'}' });
+        Reject(Encoding.UTF8.GetBytes("/* comment */" + Encoding.UTF8.GetString(ManifestBytes())));
+        Reject(Encoding.UTF8.GetBytes(Encoding.UTF8.GetString(ManifestBytes()).Replace(
+            "}",
+            ",}",
+            StringComparison.Ordinal)));
+        Reject(ManifestBytes().Concat(Encoding.UTF8.GetBytes("{}")).ToArray());
+    }
+
+    [Fact]
+    public void MissingNullWrongTypeCaseVariantAndDuplicatePropertiesFailClosed()
+    {
+        Reject(null);
+        Reject(Array.Empty<byte>());
+        Reject(Encoding.UTF8.GetBytes("null"));
+        Reject(Encoding.UTF8.GetBytes("[]"));
+        Reject(Encoding.UTF8.GetBytes("{}"));
+
+        foreach (var property in new[]
+        {
+            "schemaVersion",
+            "id",
+            "pluginId",
+            "version",
+            "kind",
+            "displayName",
+            "platform",
+            "host",
+            "requestedCapabilities",
+        })
+        {
+            Reject(RemoveRootProperty(ManifestBytes(), property));
+        }
+
+        foreach (var invalid in new[]
+        {
+            Replace(ManifestBytes(), "\"schemaVersion\":1", "\"schemaVersion\":\"1\""),
+            Replace(ManifestBytes(), "\"id\":\"org.example.media-tools\"", "\"id\":null"),
+            Replace(ManifestBytes(), "\"pluginId\":\"11111111-2222-3333-4444-555555555555\"", "\"pluginId\":1"),
+            Replace(ManifestBytes(), "\"version\":\"1.2.3.4\"", "\"version\":false"),
+            Replace(ManifestBytes(), "\"kind\":\"installed-provider\"", "\"kind\":\"InstalledProvider\""),
+            Replace(ManifestBytes(), "\"kind\":\"installed-provider\"", "\"kind\":1"),
+            Replace(ManifestBytes(), "\"displayName\":\"Example Provider\"", "\"displayName\":\"\""),
+            Replace(ManifestBytes(), "\"displayName\":\"Example Provider\"", "\"displayName\":false"),
+            Replace(ManifestBytes(), "\"description\":\"A bounded installed-provider fixture.\"", "\"description\":null"),
+            Replace(ManifestBytes(), "\"platform\":{\"min\":1,\"max\":1}", "\"platform\":[]"),
+            Replace(ManifestBytes(), "\"host\":{\"minMajor\":12,\"maxMajor\":12}", "\"host\":{}"),
+            Replace(ManifestBytes(), "\"platform\":{\"min\":1,\"max\":1}", "\"platform\":{\"min\":1.0,\"max\":1}"),
+            Replace(ManifestBytes(), "\"host\":{\"minMajor\":12,\"maxMajor\":12}", "\"host\":{\"minMajor\":\"12\",\"maxMajor\":12}"),
+            Replace(ManifestBytes(), "\"requestedCapabilities\":[]", "\"requestedCapabilities\":null"),
+            Replace(ManifestBytes(), "\"requestedCapabilities\":[]", "\"requestedCapabilities\":[null]"),
+            Replace(ManifestBytes(), "\"schemaVersion\":1", "\"SchemaVersion\":1"),
+            AddRootProperty(ManifestBytes(), "schemaVersion", "1"),
+            AddNestedProperty(ManifestBytes(), "platform", "min", "1"),
+            AddNestedProperty(ManifestBytes(), "platform", "future", "1"),
+            AddNestedProperty(ManifestBytes(), "host", "future", "1"),
+        })
+        {
+            Reject(invalid);
+        }
+
+        Reject(ManifestBytes(schemaVersion: 2));
+        Reject(ManifestBytes(kind: "companion-service"));
+    }
+
+    [Fact]
+    public void RepresentativeFailuresReturnStableClosedReasons()
+    {
+        Assert.Equal(PlatformExtensionManifestRejectionReason.MissingDocument, Reject(null));
+        Assert.Equal(PlatformExtensionManifestRejectionReason.DocumentTooLarge, Reject(
+            new byte[PlatformExtensionManifestBounds.MaximumDocumentBytes + 1]));
+        Assert.Equal(PlatformExtensionManifestRejectionReason.InvalidUtf8, Reject(
+            new byte[] { 0xEF, 0xBB, 0xBF }.Concat(ManifestBytes()).ToArray()));
+        Assert.Equal(PlatformExtensionManifestRejectionReason.InvalidJson, Reject(
+            Encoding.UTF8.GetBytes("{")));
+        Assert.Equal(PlatformExtensionManifestRejectionReason.DuplicateProperty, Reject(
+            AddRootProperty(ManifestBytes(), "schemaVersion", "1")));
+        Assert.Equal(PlatformExtensionManifestRejectionReason.UnknownProperty, Reject(
+            AddRootProperty(ManifestBytes(), "future", "true")));
+        Assert.Equal(PlatformExtensionManifestRejectionReason.InvalidRequestedCapabilities, Reject(
+            ManifestBytes(capabilities: new[] { "jellyfin.canopy.unknown.read" })));
+        Assert.Equal(PlatformExtensionManifestRejectionReason.IncompatibleRequestedCapability, Reject(
+            ManifestBytes(capabilities: new[] { "jellyfin.canopy.administration.manage" })));
+    }
+
+    [Fact]
+    public void SemanticFingerprintIgnoresJsonAndCapabilityOrderingButNotValidatedMutations()
+    {
+        var baseline = Parse(ManifestBytes(capabilities: new[] { Items, Storage }));
+        var reordered = Parse(Encoding.UTF8.GetBytes("""
+            {
+              "requestedCapabilities": ["jellyfin.canopy.storage.read", "jellyfin.canopy.items.lookup"],
+              "host": { "maxMajor": 12, "minMajor": 12 },
+              "description": "A bounded installed-provider fixture.",
+              "displayName": "Example Provider",
+              "kind": "installed-provider",
+              "platform": { "max": 1, "min": 1 },
+              "version": "1.2.3.4",
+              "pluginId": "11111111-2222-3333-4444-555555555555",
+              "id": "org.example.media-tools",
+              "schemaVersion": 1
+            }
+            """));
+
+        Assert.Equal(baseline.Fingerprint.Value, reordered.Fingerprint.Value);
+
+        var mutations = new[]
+        {
+            ManifestBytes(schemaVersion: 1, id: "org.example.other-tools", capabilities: new[] { Items, Storage }),
+            ManifestBytes(pluginId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", capabilities: new[] { Items, Storage }),
+            ManifestBytes(version: "1.2.3.5", capabilities: new[] { Items, Storage }),
+            ManifestBytes(displayName: "Other Provider", capabilities: new[] { Items, Storage }),
+            ManifestBytes(description: "Other description.", capabilities: new[] { Items, Storage }),
+            ManifestBytes(platformMax: 2, capabilities: new[] { Items, Storage }),
+            ManifestBytes(hostMax: 13, capabilities: new[] { Items, Storage }),
+            ManifestBytes(capabilities: new[] { Items }),
+            ManifestBytes(capabilities: new[] { Items, Storage, Ui }),
+        };
+
+        Assert.All(mutations, bytes => Assert.NotEqual(
+            baseline.Fingerprint.Value,
+            Parse(bytes).Fingerprint.Value));
+
+        Assert.NotEqual(
+            Parse(ManifestBytes(description: null)).Fingerprint.Value,
+            Parse(ManifestBytes(description: string.Empty)).Fingerprint.Value);
+    }
+
+    [Fact]
+    public async Task FingerprintIsCultureIndependentAndConcurrentParsingIsDeterministic()
+    {
+        var bytes = ManifestBytes(
+            displayName: "M\u00e9dia Provider",
+            description: "D\u00e9terministic \u0131n every culture.",
+            capabilities: ProviderCapabilities.Reverse().ToArray());
+        var expected = Parse(bytes).Fingerprint.Value;
+        var originalCulture = CultureInfo.CurrentCulture;
+        var originalUiCulture = CultureInfo.CurrentUICulture;
+        try
+        {
+            foreach (var cultureName in new[] { "tr-TR", "ar-SA", "fr-FR" })
+            {
+                CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(cultureName);
+                CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo(cultureName);
+                Assert.Equal(expected, Parse(bytes).Fingerprint.Value);
+            }
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+            CultureInfo.CurrentUICulture = originalUiCulture;
+        }
+
+        var fingerprints = await Task.WhenAll(Enumerable.Range(0, 64).Select(_ => Task.Run(() =>
+            Parse(bytes.ToArray()).Fingerprint.Value)));
+        Assert.All(fingerprints, fingerprint => Assert.Equal(expected, fingerprint));
+    }
+
+    [Fact]
+    public void ParsedManifestDefensivelyOwnsAllInputAndRetainsNoRawDocument()
+    {
+        var bytes = ManifestBytes(capabilities: ProviderCapabilities.Reverse().ToArray());
+        var manifest = Parse(bytes);
+        var fingerprint = manifest.Fingerprint.Value;
+        var ids = manifest.RequestedCapabilities.Capabilities.Select(value => value.Id.Value).ToArray();
+
+        bytes.AsSpan().Fill((byte)'x');
+
+        Assert.Equal("org.example.media-tools", manifest.Id);
+        Assert.Equal("Example Provider", manifest.DisplayName);
+        Assert.Equal(fingerprint, manifest.Fingerprint.Value);
+        Assert.Equal(ProviderCapabilities, ids);
+        Assert.Equal(ProviderCapabilities,
+            manifest.RequestedCapabilities.Capabilities.Select(value => value.Id.Value));
+    }
+
+    private static PlatformExtensionManifest Parse(byte[] bytes)
+    {
+        var parsed = PlatformExtensionManifestParser.TryParse(bytes, out var manifest, out var reason);
+        Assert.True(parsed, reason.ToString());
+        Assert.Equal(default, reason);
+        return Assert.IsType<PlatformExtensionManifest>(manifest);
+    }
+
+    private static PlatformExtensionManifestRejectionReason Reject(byte[]? bytes)
+    {
+        var parsed = PlatformExtensionManifestParser.TryParse(bytes, out var manifest, out var reason);
+        Assert.False(parsed);
+        Assert.Null(manifest);
+        Assert.True(Enum.IsDefined(reason));
+        Assert.NotEqual(default, reason);
+        return reason;
+    }
+
+    private static byte[] ManifestBytes(
+        int schemaVersion = 1,
+        string id = "org.example.media-tools",
+        string pluginId = "11111111-2222-3333-4444-555555555555",
+        string version = "1.2.3.4",
+        string kind = "installed-provider",
+        string displayName = "Example Provider",
+        string? description = "A bounded installed-provider fixture.",
+        int platformMin = 1,
+        int platformMax = 1,
+        int hostMin = 12,
+        int hostMax = 12,
+        IReadOnlyList<string>? capabilities = null)
+    {
+        capabilities ??= Array.Empty<string>();
+        var descriptionProperty = description is null
+            ? string.Empty
+            : ",\"description\":" + JsonSerializer.Serialize(description);
+        var json = "{"
+            + "\"schemaVersion\":" + schemaVersion.ToString(CultureInfo.InvariantCulture)
+            + ",\"id\":" + JsonSerializer.Serialize(id)
+            + ",\"pluginId\":" + JsonSerializer.Serialize(pluginId)
+            + ",\"version\":" + JsonSerializer.Serialize(version)
+            + ",\"kind\":" + JsonSerializer.Serialize(kind)
+            + ",\"displayName\":" + JsonSerializer.Serialize(displayName)
+            + descriptionProperty
+            + ",\"platform\":{\"min\":" + platformMin.ToString(CultureInfo.InvariantCulture)
+            + ",\"max\":" + platformMax.ToString(CultureInfo.InvariantCulture) + "}"
+            + ",\"host\":{\"minMajor\":" + hostMin.ToString(CultureInfo.InvariantCulture)
+            + ",\"maxMajor\":" + hostMax.ToString(CultureInfo.InvariantCulture) + "}"
+            + ",\"requestedCapabilities\":["
+            + string.Join(',', capabilities.Select(value => JsonSerializer.Serialize(value)))
+            + "]}";
+        return Encoding.UTF8.GetBytes(json);
+    }
+
+    private static byte[] AddRootProperty(byte[] source, string property, string value)
+    {
+        var json = Encoding.UTF8.GetString(source);
+        return Encoding.UTF8.GetBytes(json[..^1] + "," + JsonSerializer.Serialize(property) + ":" + value + "}");
+    }
+
+    private static byte[] AddNestedProperty(byte[] source, string owner, string property, string value)
+    {
+        var json = Encoding.UTF8.GetString(source);
+        var marker = "\"" + owner + "\":{";
+        var start = json.IndexOf(marker, StringComparison.Ordinal);
+        Assert.True(start >= 0);
+        var objectEnd = json.IndexOf('}', start);
+        return Encoding.UTF8.GetBytes(json.Insert(
+            objectEnd,
+            ",\"" + property + "\":" + value));
+    }
+
+    private static byte[] RemoveRootProperty(byte[] source, string property)
+    {
+        var root = JsonNode.Parse(source)!.AsObject();
+        Assert.True(root.Remove(property));
+        return Encoding.UTF8.GetBytes(root.ToJsonString());
+    }
+
+    private static string IndependentFingerprint(PlatformExtensionManifest manifest)
+    {
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        Append("jellyfin-canopy-extension-manifest-v1");
+        Append(manifest.SchemaVersion.ToString(CultureInfo.InvariantCulture));
+        Append(manifest.Id);
+        Append(manifest.PluginId.ToString("D"));
+        Append(manifest.Version.ToString());
+        Append("installed-provider");
+        Append(manifest.DisplayName);
+        Append(manifest.Description is null ? "0" : "1");
+        if (manifest.Description is not null)
+        {
+            Append(manifest.Description);
+        }
+
+        Append(manifest.PlatformRange.Min.ToString(CultureInfo.InvariantCulture));
+        Append(manifest.PlatformRange.Max.ToString(CultureInfo.InvariantCulture));
+        Append(manifest.HostRange.MinMajor.ToString(CultureInfo.InvariantCulture));
+        Append(manifest.HostRange.MaxMajor.ToString(CultureInfo.InvariantCulture));
+        Append(manifest.RequestedCapabilities.Capabilities.Length.ToString(CultureInfo.InvariantCulture));
+        foreach (var capability in manifest.RequestedCapabilities.Capabilities)
+        {
+            Append(capability.Id.Value);
+        }
+
+        return Convert.ToHexString(hash.GetHashAndReset()).ToLowerInvariant();
+
+        void Append(string value)
+        {
+            var bytes = Encoding.UTF8.GetBytes(value);
+            Span<byte> length = stackalloc byte[sizeof(int)];
+            BinaryPrimitives.WriteInt32BigEndian(length, bytes.Length);
+            hash.AppendData(length);
+            hash.AppendData(bytes);
+        }
+    }
+
+    private static byte[] Replace(byte[] source, string oldValue, string newValue) =>
+        Encoding.UTF8.GetBytes(Encoding.UTF8.GetString(source).Replace(
+            oldValue,
+            newValue,
+            StringComparison.Ordinal));
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformActorDomain.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformActorDomain.cs
@@ -193,6 +193,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
 
         internal string Value { get; }
 
+        internal static PlatformManifestFingerprint EstablishValidatedManifestFingerprint(string value) =>
+            new(value);
+
         private static bool IsLowerHex(string value)
         {
             foreach (var character in value)

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformExtensionManifestDomain.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformExtensionManifestDomain.cs
@@ -1,0 +1,650 @@
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>Frozen byte, depth, count and compatibility bounds for manifest v1.</summary>
+    internal static class PlatformExtensionManifestBounds
+    {
+        internal const int MaximumDocumentBytes = 256 * 1024;
+        internal const int MaximumJsonDepth = 16;
+        internal const int MaximumIdBytes = 128;
+        internal const int MaximumVersionBytes = 64;
+        internal const int MaximumDisplayNameBytes = 96;
+        internal const int MaximumDescriptionBytes = 512;
+        internal const int MaximumCompatibilityMajor = 65535;
+        internal const int MaximumRequestedCapabilities = PlatformCapabilityVocabulary.MaximumCapabilityCount;
+    }
+
+    /// <summary>Closed rejection reasons for the bounded Platform extension manifest parser.</summary>
+    internal enum PlatformExtensionManifestRejectionReason
+    {
+        None = 0,
+        MissingDocument = 1,
+        DocumentTooLarge = 2,
+        InvalidUtf8 = 3,
+        InvalidJson = 4,
+        DuplicateProperty = 5,
+        UnknownProperty = 6,
+        MissingProperty = 7,
+        InvalidPropertyType = 8,
+        UnsupportedSchemaVersion = 9,
+        InvalidIdentifier = 10,
+        InvalidPluginId = 11,
+        InvalidVersion = 12,
+        InvalidKind = 13,
+        InvalidDisplayName = 14,
+        InvalidDescription = 15,
+        InvalidPlatformRange = 16,
+        InvalidHostRange = 17,
+        InvalidRequestedCapabilities = 18,
+        IncompatibleRequestedCapability = 19,
+    }
+
+    /// <summary>An immutable inclusive Platform protocol-major compatibility range.</summary>
+    internal readonly struct PlatformExtensionProtocolRange
+    {
+        internal PlatformExtensionProtocolRange(int min, int max)
+        {
+            Min = min;
+            Max = max;
+        }
+
+        internal int Min { get; }
+
+        internal int Max { get; }
+    }
+
+    /// <summary>An immutable inclusive Jellyfin host-major compatibility range.</summary>
+    internal readonly struct PlatformExtensionHostRange
+    {
+        internal PlatformExtensionHostRange(int minMajor, int maxMajor)
+        {
+            MinMajor = minMajor;
+            MaxMajor = maxMajor;
+        }
+
+        internal int MinMajor { get; }
+
+        internal int MaxMajor { get; }
+    }
+
+    /// <summary>
+    /// One validated immutable installed-provider manifest. This value requests
+    /// capabilities only; it is not installation evidence, approval or authority.
+    /// </summary>
+    internal sealed class PlatformExtensionManifest
+    {
+        private PlatformExtensionManifest(
+            int schemaVersion,
+            string id,
+            Guid pluginId,
+            Version version,
+            PlatformActorKind kind,
+            string displayName,
+            string? description,
+            PlatformExtensionProtocolRange platformRange,
+            PlatformExtensionHostRange hostRange,
+            PlatformRequestedCapabilitySet requestedCapabilities,
+            PlatformManifestFingerprint fingerprint)
+        {
+            SchemaVersion = schemaVersion;
+            Id = id;
+            PluginId = pluginId;
+            Version = version;
+            Kind = kind;
+            DisplayName = displayName;
+            Description = description;
+            PlatformRange = platformRange;
+            HostRange = hostRange;
+            RequestedCapabilities = requestedCapabilities;
+            Fingerprint = fingerprint;
+        }
+
+        internal int SchemaVersion { get; }
+
+        internal string Id { get; }
+
+        internal Guid PluginId { get; }
+
+        internal Version Version { get; }
+
+        internal PlatformActorKind Kind { get; }
+
+        internal string DisplayName { get; }
+
+        internal string? Description { get; }
+
+        internal PlatformExtensionProtocolRange PlatformRange { get; }
+
+        internal PlatformExtensionHostRange HostRange { get; }
+
+        internal PlatformRequestedCapabilitySet RequestedCapabilities { get; }
+
+        internal PlatformManifestFingerprint Fingerprint { get; }
+
+        internal static PlatformExtensionManifest EstablishValidatedManifest(
+            int schemaVersion,
+            string id,
+            Guid pluginId,
+            Version version,
+            PlatformActorKind kind,
+            string displayName,
+            string? description,
+            PlatformExtensionProtocolRange platformRange,
+            PlatformExtensionHostRange hostRange,
+            PlatformRequestedCapabilitySet requestedCapabilities,
+            PlatformManifestFingerprint fingerprint) => new(
+                schemaVersion,
+                id,
+                pluginId,
+                version,
+                kind,
+                displayName,
+                description,
+                platformRange,
+                hostRange,
+                requestedCapabilities,
+                fingerprint);
+    }
+
+    /// <summary>Pure bounded parser and canonical semantic fingerprint owner.</summary>
+    internal static class PlatformExtensionManifestParser
+    {
+        internal const string ManifestFileName = "jellyfin-canopy-extension.json";
+        internal const string SchemaId = "urn:jellyfin-canopy:platform:v1:extension-manifest";
+        internal const int SchemaVersion = 1;
+        internal const int MaximumIdentifierSegmentLength = 64;
+
+        internal const string FingerprintAlgorithm = "sha-256";
+        internal const string FingerprintDomain = "jellyfin-canopy-extension-manifest-v1";
+        private static readonly UTF8Encoding StrictUtf8 = new(false, true);
+        private static readonly HashSet<string> RootProperties = new(StringComparer.Ordinal)
+        {
+            "schemaVersion",
+            "id",
+            "pluginId",
+            "version",
+            "kind",
+            "displayName",
+            "description",
+            "platform",
+            "host",
+            "requestedCapabilities",
+        };
+
+        private static readonly string[] RequiredRootProperties =
+        {
+            "schemaVersion",
+            "id",
+            "pluginId",
+            "version",
+            "kind",
+            "displayName",
+            "platform",
+            "host",
+            "requestedCapabilities",
+        };
+
+        internal static bool TryParse(
+            byte[]? utf8Json,
+            out PlatformExtensionManifest? manifest,
+            out PlatformExtensionManifestRejectionReason reason)
+        {
+            manifest = null;
+            reason = PlatformExtensionManifestRejectionReason.None;
+            if (utf8Json is null || utf8Json.Length == 0)
+            {
+                reason = PlatformExtensionManifestRejectionReason.MissingDocument;
+                return false;
+            }
+
+            if (utf8Json.Length > PlatformExtensionManifestBounds.MaximumDocumentBytes)
+            {
+                reason = PlatformExtensionManifestRejectionReason.DocumentTooLarge;
+                return false;
+            }
+
+            if (utf8Json.Length >= 3
+                && utf8Json[0] == 0xEF
+                && utf8Json[1] == 0xBB
+                && utf8Json[2] == 0xBF)
+            {
+                reason = PlatformExtensionManifestRejectionReason.InvalidUtf8;
+                return false;
+            }
+
+            try
+            {
+                _ = StrictUtf8.GetString(utf8Json);
+            }
+            catch (DecoderFallbackException)
+            {
+                reason = PlatformExtensionManifestRejectionReason.InvalidUtf8;
+                return false;
+            }
+
+            JsonDocument document;
+            try
+            {
+                document = JsonDocument.Parse(
+                    utf8Json,
+                    new JsonDocumentOptions
+                    {
+                        AllowTrailingCommas = false,
+                        CommentHandling = JsonCommentHandling.Disallow,
+                        MaxDepth = PlatformExtensionManifestBounds.MaximumJsonDepth,
+                    });
+            }
+            catch (JsonException)
+            {
+                reason = PlatformExtensionManifestRejectionReason.InvalidJson;
+                return false;
+            }
+
+            using (document)
+            {
+                var root = document.RootElement;
+                if (root.ValueKind != JsonValueKind.Object)
+                {
+                    reason = PlatformExtensionManifestRejectionReason.InvalidPropertyType;
+                    return false;
+                }
+
+                if (!HasExactProperties(root, RootProperties, RequiredRootProperties, out reason))
+                {
+                    return false;
+                }
+
+                if (!TryReadInteger(root, "schemaVersion", out var schemaVersion))
+                {
+                    reason = PlatformExtensionManifestRejectionReason.InvalidPropertyType;
+                    return false;
+                }
+
+                if (schemaVersion != SchemaVersion)
+                {
+                    reason = PlatformExtensionManifestRejectionReason.UnsupportedSchemaVersion;
+                    return false;
+                }
+
+                if (!TryReadString(root, "id", out var id) || !IsValidIdentifier(id))
+                {
+                    reason = PlatformExtensionManifestRejectionReason.InvalidIdentifier;
+                    return false;
+                }
+
+                if (!TryReadString(root, "pluginId", out var pluginIdText)
+                    || !Guid.TryParseExact(pluginIdText, "D", out var pluginId)
+                    || pluginId == Guid.Empty
+                    || !string.Equals(pluginId.ToString("D"), pluginIdText, StringComparison.Ordinal))
+                {
+                    reason = PlatformExtensionManifestRejectionReason.InvalidPluginId;
+                    return false;
+                }
+
+                if (!TryReadString(root, "version", out var versionText)
+                    || Encoding.UTF8.GetByteCount(versionText) > PlatformExtensionManifestBounds.MaximumVersionBytes
+                    || !IsAsciiVersion(versionText)
+                    || !Version.TryParse(versionText, out var version)
+                    || version.Major < 0
+                    || version.Minor < 0
+                    || !string.Equals(version.ToString(), versionText, StringComparison.Ordinal))
+                {
+                    reason = PlatformExtensionManifestRejectionReason.InvalidVersion;
+                    return false;
+                }
+
+                if (!TryReadString(root, "kind", out var kindText)
+                    || !string.Equals(
+                        kindText,
+                        PlatformActorKindVocabulary.TokenFor(PlatformActorKind.InstalledProvider),
+                        StringComparison.Ordinal))
+                {
+                    reason = PlatformExtensionManifestRejectionReason.InvalidKind;
+                    return false;
+                }
+
+                if (!TryReadString(root, "displayName", out var displayName)
+                    || !IsBoundedDisplayText(
+                        displayName,
+                        1,
+                        PlatformExtensionManifestBounds.MaximumDisplayNameBytes))
+                {
+                    reason = PlatformExtensionManifestRejectionReason.InvalidDisplayName;
+                    return false;
+                }
+
+                string? description = null;
+                if (root.TryGetProperty("description", out var descriptionElement))
+                {
+                    if (descriptionElement.ValueKind != JsonValueKind.String
+                        || (description = descriptionElement.GetString()) is null
+                        || !IsBoundedDisplayText(
+                            description,
+                            0,
+                            PlatformExtensionManifestBounds.MaximumDescriptionBytes))
+                    {
+                        reason = PlatformExtensionManifestRejectionReason.InvalidDescription;
+                        return false;
+                    }
+                }
+
+                if (!TryReadProtocolRange(root.GetProperty("platform"), out var platformRange, out reason))
+                {
+                    if (reason is PlatformExtensionManifestRejectionReason.None
+                        or PlatformExtensionManifestRejectionReason.MissingProperty
+                        or PlatformExtensionManifestRejectionReason.InvalidPropertyType)
+                    {
+                        reason = PlatformExtensionManifestRejectionReason.InvalidPlatformRange;
+                    }
+
+                    return false;
+                }
+
+                if (!TryReadHostRange(root.GetProperty("host"), out var hostRange, out reason))
+                {
+                    if (reason is PlatformExtensionManifestRejectionReason.None
+                        or PlatformExtensionManifestRejectionReason.MissingProperty
+                        or PlatformExtensionManifestRejectionReason.InvalidPropertyType)
+                    {
+                        reason = PlatformExtensionManifestRejectionReason.InvalidHostRange;
+                    }
+
+                    return false;
+                }
+
+                var requestedElement = root.GetProperty("requestedCapabilities");
+                if (requestedElement.ValueKind != JsonValueKind.Array
+                    || requestedElement.GetArrayLength()
+                        > PlatformExtensionManifestBounds.MaximumRequestedCapabilities)
+                {
+                    reason = PlatformExtensionManifestRejectionReason.InvalidRequestedCapabilities;
+                    return false;
+                }
+
+                var requestedValues = new List<string>(requestedElement.GetArrayLength());
+                foreach (var value in requestedElement.EnumerateArray())
+                {
+                    if (value.ValueKind != JsonValueKind.String || value.GetString() is not { } token)
+                    {
+                        reason = PlatformExtensionManifestRejectionReason.InvalidRequestedCapabilities;
+                        return false;
+                    }
+
+                    requestedValues.Add(token);
+                }
+
+                if (!PlatformRequestedCapabilitySet.TryCreate(requestedValues, out var requestedCapabilities))
+                {
+                    reason = PlatformExtensionManifestRejectionReason.InvalidRequestedCapabilities;
+                    return false;
+                }
+
+                if (requestedCapabilities.Capabilities.Any(definition =>
+                        !definition.AllowedActorKinds.Contains(PlatformActorKind.InstalledProvider)))
+                {
+                    reason = PlatformExtensionManifestRejectionReason.IncompatibleRequestedCapability;
+                    return false;
+                }
+
+                var fingerprint = PlatformManifestFingerprint.EstablishValidatedManifestFingerprint(
+                    ComputeFingerprint(
+                        schemaVersion,
+                        id,
+                        pluginId,
+                        version,
+                        displayName,
+                        description,
+                        platformRange,
+                        hostRange,
+                        requestedCapabilities));
+                manifest = PlatformExtensionManifest.EstablishValidatedManifest(
+                    schemaVersion,
+                    id,
+                    pluginId,
+                    version,
+                    PlatformActorKind.InstalledProvider,
+                    displayName,
+                    description,
+                    platformRange,
+                    hostRange,
+                    requestedCapabilities,
+                    fingerprint);
+                return true;
+            }
+        }
+
+        private static bool TryReadProtocolRange(
+            JsonElement element,
+            out PlatformExtensionProtocolRange range,
+            out PlatformExtensionManifestRejectionReason reason)
+        {
+            range = default;
+            reason = PlatformExtensionManifestRejectionReason.None;
+            var properties = new HashSet<string>(StringComparer.Ordinal) { "min", "max" };
+            if (element.ValueKind != JsonValueKind.Object
+                || !HasExactProperties(element, properties, ["min", "max"], out reason)
+                || !TryReadInteger(element, "min", out var min)
+                || !TryReadInteger(element, "max", out var max)
+                || !IsValidRange(min, max))
+            {
+                return false;
+            }
+
+            range = new PlatformExtensionProtocolRange(min, max);
+            return true;
+        }
+
+        private static bool TryReadHostRange(
+            JsonElement element,
+            out PlatformExtensionHostRange range,
+            out PlatformExtensionManifestRejectionReason reason)
+        {
+            range = default;
+            reason = PlatformExtensionManifestRejectionReason.None;
+            var properties = new HashSet<string>(StringComparer.Ordinal) { "minMajor", "maxMajor" };
+            if (element.ValueKind != JsonValueKind.Object
+                || !HasExactProperties(element, properties, ["minMajor", "maxMajor"], out reason)
+                || !TryReadInteger(element, "minMajor", out var min)
+                || !TryReadInteger(element, "maxMajor", out var max)
+                || !IsValidRange(min, max))
+            {
+                return false;
+            }
+
+            range = new PlatformExtensionHostRange(min, max);
+            return true;
+        }
+
+        private static bool HasExactProperties(
+            JsonElement element,
+            HashSet<string> allowed,
+            IReadOnlyList<string> required,
+            out PlatformExtensionManifestRejectionReason reason)
+        {
+            reason = PlatformExtensionManifestRejectionReason.None;
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var property in element.EnumerateObject())
+            {
+                if (!seen.Add(property.Name))
+                {
+                    reason = PlatformExtensionManifestRejectionReason.DuplicateProperty;
+                    return false;
+                }
+
+                if (!allowed.Contains(property.Name))
+                {
+                    reason = PlatformExtensionManifestRejectionReason.UnknownProperty;
+                    return false;
+                }
+            }
+
+            if (required.Any(name => !seen.Contains(name)))
+            {
+                reason = PlatformExtensionManifestRejectionReason.MissingProperty;
+                return false;
+            }
+
+            return true;
+        }
+
+        private static bool TryReadString(JsonElement element, string name, out string value)
+        {
+            value = string.Empty;
+            var property = element.GetProperty(name);
+            if (property.ValueKind != JsonValueKind.String || property.GetString() is not { } text)
+            {
+                return false;
+            }
+
+            value = text;
+            return true;
+        }
+
+        private static bool TryReadInteger(JsonElement element, string name, out int value)
+        {
+            value = 0;
+            var property = element.GetProperty(name);
+            return property.ValueKind == JsonValueKind.Number && property.TryGetInt32(out value);
+        }
+
+        private static bool IsValidRange(int min, int max) =>
+            min >= 1 && max >= min && max <= PlatformExtensionManifestBounds.MaximumCompatibilityMajor;
+
+        private static bool IsValidIdentifier(string value)
+        {
+            if (value.Length is < 3 or > PlatformExtensionManifestBounds.MaximumIdBytes)
+            {
+                return false;
+            }
+
+            var segments = value.Split('.');
+            if (segments.Length < 2)
+            {
+                return false;
+            }
+
+            foreach (var segment in segments)
+            {
+                if (segment.Length is < 1 or > MaximumIdentifierSegmentLength
+                    || segment[0] is < 'a' or > 'z')
+                {
+                    return false;
+                }
+
+                for (var index = 1; index < segment.Length; index++)
+                {
+                    var character = segment[index];
+                    var asciiLetterOrDigit = character is >= 'a' and <= 'z' or >= '0' and <= '9';
+                    if (asciiLetterOrDigit)
+                    {
+                        continue;
+                    }
+
+                    if (character != '-'
+                        || segment[index - 1] == '-'
+                        || index == segment.Length - 1)
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        private static bool IsAsciiVersion(string value)
+        {
+            var components = 1;
+            foreach (var character in value)
+            {
+                if (character == '.')
+                {
+                    components++;
+                }
+                else if (character is < '0' or > '9')
+                {
+                    return false;
+                }
+            }
+
+            return components is >= 2 and <= 4;
+        }
+
+        private static bool IsBoundedDisplayText(string value, int minimumBytes, int maximumBytes)
+        {
+            var bytes = Encoding.UTF8.GetByteCount(value);
+            if (bytes < minimumBytes
+                || bytes > maximumBytes
+                || !string.Equals(value, value.Trim(), StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            foreach (var rune in value.EnumerateRunes())
+            {
+                var category = Rune.GetUnicodeCategory(rune);
+                if (category is UnicodeCategory.Control or UnicodeCategory.Format)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static string ComputeFingerprint(
+            int schemaVersion,
+            string id,
+            Guid pluginId,
+            Version version,
+            string displayName,
+            string? description,
+            PlatformExtensionProtocolRange platformRange,
+            PlatformExtensionHostRange hostRange,
+            PlatformRequestedCapabilitySet requestedCapabilities)
+        {
+            using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+            Append(hash, FingerprintDomain);
+            Append(hash, schemaVersion.ToString(CultureInfo.InvariantCulture));
+            Append(hash, id);
+            Append(hash, pluginId.ToString("D"));
+            Append(hash, version.ToString());
+            Append(hash, PlatformActorKindVocabulary.TokenFor(PlatformActorKind.InstalledProvider)!);
+            Append(hash, displayName);
+            Append(hash, description is null ? "0" : "1");
+            if (description is not null)
+            {
+                Append(hash, description);
+            }
+
+            Append(hash, platformRange.Min.ToString(CultureInfo.InvariantCulture));
+            Append(hash, platformRange.Max.ToString(CultureInfo.InvariantCulture));
+            Append(hash, hostRange.MinMajor.ToString(CultureInfo.InvariantCulture));
+            Append(hash, hostRange.MaxMajor.ToString(CultureInfo.InvariantCulture));
+            Append(hash, requestedCapabilities.Capabilities.Length.ToString(CultureInfo.InvariantCulture));
+            foreach (var capability in requestedCapabilities.Capabilities)
+            {
+                Append(hash, capability.Id.Value);
+            }
+
+            return Convert.ToHexString(hash.GetHashAndReset()).ToLowerInvariant();
+        }
+
+        private static void Append(IncrementalHash hash, string value)
+        {
+            var bytes = Encoding.UTF8.GetBytes(value);
+            Span<byte> length = stackalloc byte[sizeof(int)];
+            BinaryPrimitives.WriteInt32BigEndian(length, bytes.Length);
+            hash.AppendData(length);
+            hash.AppendData(bytes);
+        }
+    }
+}

--- a/contracts/platform/v1/extension-manifest.schema.json
+++ b/contracts/platform/v1/extension-manifest.schema.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:jellyfin-canopy:platform:v1:extension-manifest",
+  "title": "Jellyfin Canopy installed-provider extension manifest v1",
+  "description": "The closed, bounded declaration carried by jellyfin-canopy-extension.json. A valid manifest requests capabilities only; it is not installation proof, approval, a grant, registry identity, or authority.",
+  "type": "object",
+  "additionalProperties": false,
+  "x-canopy-maximum-document-bytes": 262144,
+  "x-canopy-maximum-json-depth": 16,
+  "x-canopy-fingerprint-algorithm": "sha-256",
+  "x-canopy-fingerprint-domain": "jellyfin-canopy-extension-manifest-v1",
+  "x-canopy-unknown-properties": "reject",
+  "required": [
+    "schemaVersion",
+    "id",
+    "pluginId",
+    "version",
+    "kind",
+    "displayName",
+    "platform",
+    "host",
+    "requestedCapabilities"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "integer",
+      "const": 1
+    },
+    "id": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 128,
+      "x-canopy-maximum-segment-length": 64,
+      "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*(?:\\.[a-z][a-z0-9]*(?:-[a-z0-9]+)*)+$",
+      "description": "Stable lower-case ASCII namespace with at least two dot-separated segments. Every segment begins with a letter and may contain letters, digits, and internal hyphens."
+    },
+    "pluginId": {
+      "type": "string",
+      "minLength": 36,
+      "maxLength": 36,
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+      "not": {
+        "const": "00000000-0000-0000-0000-000000000000"
+      },
+      "description": "Canonical lower-case Guid D text. Later discovery must bind it to Jellyfin-reported plugin identity."
+    },
+    "version": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 64,
+      "pattern": "^(?:0|[1-9][0-9]{0,8}|1[0-9]{9}|20[0-9]{8}|21[0-3][0-9]{7}|214[0-6][0-9]{6}|2147[0-3][0-9]{5}|21474[0-7][0-9]{4}|214748[0-2][0-9]{3}|2147483[0-5][0-9]{2}|21474836[0-3][0-9]|214748364[0-7])(?:\\.(?:0|[1-9][0-9]{0,8}|1[0-9]{9}|20[0-9]{8}|21[0-3][0-9]{7}|214[0-6][0-9]{6}|2147[0-3][0-9]{5}|21474[0-7][0-9]{4}|214748[0-2][0-9]{3}|2147483[0-5][0-9]{2}|21474836[0-3][0-9]|214748364[0-7])){1,3}$",
+      "description": "Canonical two-to-four-component System.Version text with every component bounded to Int32.MaxValue. Runtime validation also requires a successful invariant parse and exact round trip."
+    },
+    "kind": {
+      "type": "string",
+      "const": "installed-provider"
+    },
+    "displayName": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 96,
+      "x-canopy-maximum-utf8-bytes": 96,
+      "x-canopy-text-policy": "trimmed-no-control-or-format"
+    },
+    "description": {
+      "type": "string",
+      "minLength": 0,
+      "maxLength": 512,
+      "x-canopy-maximum-utf8-bytes": 512,
+      "x-canopy-text-policy": "trimmed-no-control-or-format"
+    },
+    "platform": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "min",
+        "max"
+      ],
+      "properties": {
+        "min": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "max": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        }
+      },
+      "x-canopy-range-order": "min<=max",
+      "description": "Inclusive Platform major range. Runtime validation rejects min greater than max."
+    },
+    "host": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "minMajor",
+        "maxMajor"
+      ],
+      "properties": {
+        "minMajor": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "maxMajor": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        }
+      },
+      "x-canopy-range-order": "minMajor<=maxMajor",
+      "description": "Inclusive Jellyfin host-major range. Runtime validation rejects minMajor greater than maxMajor."
+    },
+    "requestedCapabilities": {
+      "type": "array",
+      "minItems": 0,
+      "maxItems": 9,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": [
+          "jellyfin.canopy.items.lookup",
+          "jellyfin.canopy.user-data.read",
+          "jellyfin.canopy.storage.read",
+          "jellyfin.canopy.ui.contribute",
+          "jellyfin.canopy.integrations.invoke"
+        ]
+      },
+      "description": "Exact case-sensitive requested capabilities eligible for the installed-provider actor ceiling. Input order is semantically irrelevant and runtime canonicalizes to frozen vocabulary order."
+    }
+  }
+}

--- a/contracts/platform/v1/fixtures/extension-manifest.valid.json
+++ b/contracts/platform/v1/fixtures/extension-manifest.valid.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": 1,
+  "id": "org.example.provider",
+  "pluginId": "12345678-9abc-4def-8123-456789abcdef",
+  "version": "1.2.3.4",
+  "kind": "installed-provider",
+  "displayName": "Example Provider",
+  "description": "A bounded installed-provider fixture.",
+  "platform": {
+    "min": 1,
+    "max": 1
+  },
+  "host": {
+    "minMajor": 12,
+    "maxMajor": 12
+  },
+  "requestedCapabilities": [
+    "jellyfin.canopy.items.lookup",
+    "jellyfin.canopy.user-data.read",
+    "jellyfin.canopy.storage.read",
+    "jellyfin.canopy.ui.contribute",
+    "jellyfin.canopy.integrations.invoke"
+  ]
+}

--- a/contracts/platform/v1/frozen.json
+++ b/contracts/platform/v1/frozen.json
@@ -22,6 +22,50 @@
     "installed-provider",
     "companion-service"
   ],
+  "extensionManifest": {
+    "fileName": "jellyfin-canopy-extension.json",
+    "schemaId": "urn:jellyfin-canopy:platform:v1:extension-manifest",
+    "schemaVersion": 1,
+    "kind": "installed-provider",
+    "fingerprintAlgorithm": "sha-256",
+    "fingerprintDomain": "jellyfin-canopy-extension-manifest-v1",
+    "unknownProperties": "reject",
+    "maximumDocumentBytes": 262144,
+    "maximumJsonDepth": 16,
+    "maximumIdBytes": 128,
+    "maximumIdentifierSegmentLength": 64,
+    "maximumVersionBytes": 64,
+    "maximumDisplayNameBytes": 96,
+    "maximumDescriptionBytes": 512,
+    "maximumCompatibilityMajor": 65535,
+    "maximumRequestedCapabilities": 9,
+    "identifierPattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*(?:\\.[a-z][a-z0-9]*(?:-[a-z0-9]+)*)+$",
+    "pluginIdPattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    "versionPattern": "^(?:0|[1-9][0-9]{0,8}|1[0-9]{9}|20[0-9]{8}|21[0-3][0-9]{7}|214[0-6][0-9]{6}|2147[0-3][0-9]{5}|21474[0-7][0-9]{4}|214748[0-2][0-9]{3}|2147483[0-5][0-9]{2}|21474836[0-3][0-9]|214748364[0-7])(?:\\.(?:0|[1-9][0-9]{0,8}|1[0-9]{9}|20[0-9]{8}|21[0-3][0-9]{7}|214[0-6][0-9]{6}|2147[0-3][0-9]{5}|21474[0-7][0-9]{4}|214748[0-2][0-9]{3}|2147483[0-5][0-9]{2}|21474836[0-3][0-9]|214748364[0-7])){1,3}$",
+    "textPolicy": "trimmed-no-control-or-format",
+    "requiredProperties": [
+      "schemaVersion",
+      "id",
+      "pluginId",
+      "version",
+      "kind",
+      "displayName",
+      "platform",
+      "host",
+      "requestedCapabilities"
+    ],
+    "optionalProperties": [
+      "description"
+    ],
+    "providerEligibleCapabilities": [
+      "jellyfin.canopy.items.lookup",
+      "jellyfin.canopy.user-data.read",
+      "jellyfin.canopy.storage.read",
+      "jellyfin.canopy.ui.contribute",
+      "jellyfin.canopy.integrations.invoke"
+    ],
+    "goldenFingerprint": "3510a48671fac91da7b2d46f98e6f1bddaa04dd9198217d47974163b24e0de1b"
+  },
   "capabilityVocabulary": [
     "jellyfin.canopy.discovery.read",
     "jellyfin.canopy.items.lookup",

--- a/research/extension-platform/README.md
+++ b/research/extension-platform/README.md
@@ -49,7 +49,7 @@ not claims that a route already ships.
 | [0002](adr/0002-protocol-and-version-negotiation.md) | protocol, version negotiation, error envelope | accepted and implemented (EP-01) |
 | [0003](adr/0003-json-abi.md) | the load-context-safe JSON ABI | accepted design; EP-04 implementation pending |
 | [0004](adr/0004-provider-invocation.md) | provider binding and failure isolation | accepted design; EP-04 implementation pending |
-| [0005](adr/0005-manifest-discovery.md) | manifest discovery and registry binding | accepted design; EP-03 implementation pending |
+| [0005](adr/0005-manifest-discovery.md) | manifest discovery and registry binding | manifest contract/fingerprint implemented; host-bound discovery and lifecycle pending |
 | [0006](adr/0006-client-event-transport.md) | client event transport | accepted for the registry/provider C5 subset; EP-05 implementation pending |
 | [0007](adr/0007-declarative-web-contributions.md) | declarative web contributions | proposed (1–6); the sandboxed-frame decision **deferred, not in v1** |
 | [0008](adr/0008-storage-ownership.md) | storage ownership | accepted design; EP-05 implementation pending |

--- a/research/extension-platform/adr/0005-manifest-discovery.md
+++ b/research/extension-platform/adr/0005-manifest-discovery.md
@@ -1,6 +1,6 @@
 # ADR-0005 — Manifest discovery and registry binding
 
-Status: **accepted design** (ADR-0013; EP-03 implementation pending) · Owner: platform kernel · Evidence: [S4](../spike-evidence.md#s4--manifest-discovery-binds-to-the-real-plugin-identity-and-rejects-a-claim-to-another), [S5](../spike-evidence.md#s5--path-containment-holds-against-traversal-symlinks-and-link-cycles), [S13](../spike-evidence.md#s13--lifecycle-matrix)
+Status: **accepted; bounded manifest contract and semantic fingerprint implemented** (#645; host-bound discovery and registry lifecycle pending) · Owner: platform kernel · Evidence: [S4](../spike-evidence.md#s4--manifest-discovery-binds-to-the-real-plugin-identity-and-rejects-a-claim-to-another), [S5](../spike-evidence.md#s5--path-containment-holds-against-traversal-symlinks-and-link-cycles), [S13](../spike-evidence.md#s13--lifecycle-matrix)
 
 ## Context
 
@@ -38,6 +38,14 @@ declared scopes — are each a distinct vulnerability.
    discovery iterates every plugin and one bad root must not take out the rest.
 5. **Bounded.** Manifest size, id/version lengths, operation and contribution
    counts, nesting depth and local-asset counts are all capped.
+   Issue #645 freezes the first pure installed-provider envelope before any
+   filesystem reader exists: strict UTF-8 JSON at 256 KiB and depth 16; exact
+   schema, identity, version, actor-kind and compatibility fields; only exact
+   provider-eligible capability requests; closed properties; and immutable
+   bounded parse results. Its domain-separated semantic SHA-256 fingerprint is
+   stable across property, whitespace and request-set ordering, while every
+   validated field change changes the fingerprint. This content fingerprint is
+   not proof of installation, a signature, approval, a grant or registry identity.
 6. **A manifest is never a grant.** It states what an extension *requests*. An
    administrator approves. Requested and granted scopes are stored separately.
 7. **Fingerprint changes revoke approval.** Any change to the manifest

--- a/research/extension-platform/adr/0011-identity-and-authority.md
+++ b/research/extension-platform/adr/0011-identity-and-authority.md
@@ -1,6 +1,6 @@
 # ADR-0011 — Identity and authority
 
-Status: **accepted** (pilot, canonical user boundary, and closed actor domain implemented; grants/credentials/provider-service activation pending) · Owner: platform security · Evidence: [S9](../spike-evidence.md#s9--authorization-semantics-verified-on-plugin-routes), [S10](../spike-evidence.md#s10--host-cors-is-permissive), [S14](../spike-evidence.md#s14--forged-identity-is-fully-resisted-but-the-token-is-in-the-claims)
+Status: **accepted** (pilot, canonical user boundary, closed actor/capability domains and pure manifest fingerprint implemented; grants/credentials/provider-service activation pending) · Owner: platform security · Evidence: [S9](../spike-evidence.md#s9--authorization-semantics-verified-on-plugin-routes), [S10](../spike-evidence.md#s10--host-cors-is-permissive), [S14](../spike-evidence.md#s14--forged-identity-is-fully-resisted-but-the-token-is-in-the-claims)
 
 ## Context
 

--- a/research/extension-platform/adr/0013-server-platform-tranche.md
+++ b/research/extension-platform/adr/0013-server-platform-tranche.md
@@ -256,3 +256,8 @@ slice is [#639](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/63
 versioned exact capability identifiers and a pure grant-ceiling evaluator; it
 depends on #640 for the actor-authority input. Routes, grant persistence,
 credentials, manifests and provider calls are explicitly later children.
+Issue [#645](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/645)
+is the next bounded child: it freezes only the strict installed-provider manifest
+v1 contract and deterministic semantic content fingerprint. Filesystem acquisition,
+Jellyfin plugin binding, approval/grants, registry persistence and every route
+remain later slices.

--- a/research/extension-platform/threat-model.md
+++ b/research/extension-platform/threat-model.md
@@ -168,6 +168,12 @@ Traversal, absolute paths, embedded NUL and escaping symlinks are rejected befor
 any file is opened
 ([S5](spike-evidence.md#s5--path-containment-holds-against-traversal-symlinks-and-link-cycles)).
 Size, malformed-JSON and non-object manifests are rejected before registration, and a fingerprint mismatch is a rejection rather than a flag — all verified. A manifest requests; an admin grants.
+Issue #645 additionally freezes the pure pre-filesystem contract: strict bounded
+UTF-8 JSON, closed fields, canonical identifiers/versions/ranges, exact
+provider-eligible requests through the #639 vocabulary, stable closed rejection
+reasons and a domain-separated semantic SHA-256 fingerprint over every validated
+field. Parse success still proves no installation, host binding, compatibility,
+approval, grant, enablement or authority; those remain registry-owned checks.
 *Residual.* **Low.** Four defects found during the spike were fixed rather than
 documented away: separators are normalised before any test; every path component
 is resolved, not just the leaf; resolution runs to a **fixed point**, because one

--- a/research/extension-platform/v1-capability-freeze.md
+++ b/research/extension-platform/v1-capability-freeze.md
@@ -36,8 +36,11 @@ requested-versus-granted scopes; the lifecycle states in
 [compatibility-terminology](compatibility-terminology.md#state-words); a
 user-filtered catalog and admin diagnostics.
 
-**Activated for the server tranche; not yet delivered.** Built-in Canopy
-families continue to need no third-party manifest or grant. Their existing
+**Activated for the server tranche; contract foundation delivered by #645.** The
+strict installed-provider manifest v1 envelope and its canonical semantic
+fingerprint are frozen without reading a file or creating authority. Host-bound
+safe acquisition, approval/grants, lifecycle and persistence remain undelivered.
+Built-in Canopy families continue to need no third-party manifest or grant. Their existing
 caller-filtered C1/C6 catalog is not evidence for C2. Delivery requires the
 separate-plugin fixture, fingerprint-bound approval, grant/lifecycle tests and
 the EP-03 exit gate. ADR [0005](adr/0005-manifest-discovery.md).

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,7 +26,7 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2808, totalLines: 3201 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 38132, totalLines: 47506 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 38465, totalLines: 47840 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 3,
         minimumCoveredLines: 2808,
@@ -34,8 +34,8 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
     });
     assert.deepEqual(baselines.profiles.server.observations, {
         cleanRuns: 3,
-        minimumCoveredLines: 38132,
-        maximumCoveredLines: 38132,
+        minimumCoveredLines: 38465,
+        maximumCoveredLines: 38465,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 0);

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 38132,
-        "totalLines": 47506
+        "coveredLines": 38465,
+        "totalLines": 47840
       },
       "observations": {
         "cleanRuns": 3,
-        "minimumCoveredLines": 38132,
-        "maximumCoveredLines": 38132
+        "minimumCoveredLines": 38465,
+        "maximumCoveredLines": 38465
       },
       "tolerance": {
         "missingCoveredLines": 0,
-        "rationale": "The #639 EP-02 capability-domain change adds the exact nine-scope Platform v1 vocabulary, closed actor-kind and elevation ceilings, distinct immutable requested/granted inputs, a pure fail-closed grant intersection, deterministic bounded preview reasons, runtime/OpenAPI/frozen drift gates, and hardened single-owner architecture guards without adding routes or wiring the existing first-party action path. Three clean local .NET 10.0.9 Coverlet runs on the identical final 47,506-line source and test scope each passed all 3,489 tests and reproduced exactly 38,132 covered lines. The reviewed observed high-water and exact floor are therefore both 38,132/47,506 (80.268%), requiring no instrumentation tolerance. Relative to the #640 baseline of 37,908/47,266 (80.201%), the change adds 240 instrumented lines and 224 covered lines while increasing overall coverage. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "rationale": "The #645 EP-03.1 manifest-contract change adds the strict installed-provider v1 schema and frozen inventory, a pure bounded fail-closed parser, immutable validated model, canonical domain-separated semantic fingerprint, exact provider capability ceiling, field-level schema/runtime drift gates, and hardened construction/dependency ownership guards without adding filesystem discovery, host binding, persistence, grants, routes, provider execution, or Android work. Three clean local .NET 10.0.9 Coverlet runs on the identical final 47,840-line source and test scope each passed all 3,574 tests and reproduced exactly 38,465 covered lines. The reviewed observed high-water and exact floor are therefore both 38,465/47,840 (80.403%), requiring no instrumentation tolerance. Relative to the #639 baseline of 38,132/47,506 (80.268%), the change adds 334 instrumented lines and 333 covered lines while increasing overall coverage. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
Closes #645
Parent: #42

## Outcome

Freezes the smallest safe installed-provider manifest v1 contract and deterministic semantic fingerprint for later host-bound discovery and registry work.

## Included

- strict bounded UTF-8 JSON parser and immutable validated model
- checked-in JSON Schema, golden fixture, and frozen inventory
- canonical domain-separated SHA-256 semantic fingerprint
- exact installed-provider capability ceiling through the existing EP-02 vocabulary
- fail-closed boundary, adversarial, mutation, concurrency, culture, drift, and architecture coverage
- reviewed zero-tolerance server coverage ratchet at 38,465/47,840 (80.403%)
- security and architecture documentation updates

## Deliberately deferred

No filesystem acquisition, Jellyfin host binding, registry/lifecycle persistence, approval or grants, routes, provider execution, UI, Android work, deployment, or release.

## Verification

- Release build: 0 warnings, 0 errors
- server: 3 identical clean runs, 3,574/3,574 tests each
- client: 2,041/2,041 tests; 2,808/3,201 lines (87.723%)
- focused manifest/capability architecture: 91/91
- scripts, lint, typechecks, syntax, translations, performance rules, docs, JSON parse, formatting, and diff checks pass
- three independent security/architecture/test reviews: APPROVE