### PR TITLE
Bind installed manifests to verified host handles

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,38 @@ jobs:
           retention-days: 7
           overwrite: true
 
+  windows-manifest-tests:
+    name: Windows manifest handle tests
+    runs-on: windows-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Verify Node toolchain
+        run: npm run check:toolchain
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Run handle and reparse-point integration tests
+        run: >-
+          dotnet test Jellyfin.Plugin.JellyfinCanopy.Tests/JellyfinCanopy.Tests.csproj
+          --configuration Release
+          --filter FullyQualifiedName~PlatformInstalledManifestWindowsReaderTests
+          --logger "console;verbosity=normal"
+
   unit-tests:
     name: Unit tests
     runs-on: ubuntu-latest

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/JellyfinPlatformHostTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/JellyfinPlatformHostTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
 using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
 using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting.Jellyfin;
 using MediaBrowser.Common.Plugins;
@@ -24,12 +25,15 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
     {
         private static User NewUser(string name) => new(name, "provider", "resetProvider");
 
-        private static LocalPlugin NewPlugin(string name, PluginStatus status) => new(
+        private static LocalPlugin NewPlugin(
+            string name,
+            PluginStatus status,
+            Guid? id = null) => new(
             "/plugins/" + name,
             true,
             new PluginManifest
             {
-                Id = Guid.NewGuid(),
+                Id = id ?? Guid.NewGuid(),
                 Name = name,
                 Version = "1.2.3",
                 Status = status,
@@ -199,6 +203,122 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
         }
 
         [Fact]
+        public void AnInstalledPluginSnapshotCarriesAnImmutableHostIssuedObservation()
+        {
+            var plugin = NewPlugin("Canopy", PluginStatus.Active);
+            var dllFiles = new[]
+            {
+                "/plugins/Canopy/Jellyfin.Plugin.Canopy.dll",
+                "/plugins/Canopy/Canopy.Contracts.dll",
+            };
+            plugin.DllFiles = dllFiles;
+            plugin.Instance = new InertPluginInstance();
+            var host = Host(plugins: () => new[] { plugin });
+
+            var snapshot = Assert.Single(host.Plugins.InstalledSnapshots());
+            dllFiles[0] = "/changed-after-snapshot.dll";
+
+            Assert.Equal(plugin.Id, snapshot.PluginId);
+            Assert.Equal("Canopy", snapshot.Name);
+            Assert.Equal(new Version(1, 2, 3), snapshot.Version);
+            Assert.Equal(PlatformInstalledPluginHostStatus.Active, snapshot.Status);
+            Assert.Equal("/plugins/Canopy", snapshot.ReportedRoot);
+            Assert.Equal(
+                new[]
+                {
+                    "/plugins/Canopy/Jellyfin.Plugin.Canopy.dll",
+                    "/plugins/Canopy/Canopy.Contracts.dll",
+                },
+                snapshot.DllFiles);
+        }
+
+        [Fact]
+        public void InstalledPluginSnapshotCapsHostDllEnumerationAtOneOverTheSecurityBound()
+        {
+            var plugin = NewPlugin("Canopy", PluginStatus.Active);
+            plugin.DllFiles = Enumerable.Range(
+                    0,
+                    PlatformInstalledManifestLimits.MaximumDllFileCount + 100)
+                .Select(index => "/plugins/Canopy/Provider-" + index + ".dll")
+                .ToArray();
+
+            var snapshot = Assert.Single(Host(plugins: () => new[] { plugin })
+                .Plugins
+                .InstalledSnapshots());
+
+            Assert.Equal(
+                PlatformInstalledManifestLimits.MaximumDllFileCount + 1,
+                snapshot.DllFiles.Length);
+            Assert.False(PlatformInstalledManifestBinder.HasValidHostMetadata(snapshot));
+        }
+
+        [Theory]
+        [InlineData(PluginStatus.Restart, (int)PlatformInstalledPluginHostStatus.Restart)]
+        [InlineData(PluginStatus.Active, (int)PlatformInstalledPluginHostStatus.Active)]
+        [InlineData(PluginStatus.Disabled, (int)PlatformInstalledPluginHostStatus.Disabled)]
+        [InlineData(PluginStatus.NotSupported, (int)PlatformInstalledPluginHostStatus.NotSupported)]
+        [InlineData(PluginStatus.Malfunctioned, (int)PlatformInstalledPluginHostStatus.Malfunctioned)]
+        [InlineData(PluginStatus.Superseded, (int)PlatformInstalledPluginHostStatus.Superseded)]
+        [InlineData(PluginStatus.Deleted, (int)PlatformInstalledPluginHostStatus.Deleted)]
+        public void InstalledPluginSnapshotsMapEveryKnownHostStatusExactly(
+            PluginStatus hostStatus,
+            int expected)
+        {
+            var snapshot = Assert.Single(Host(
+                plugins: () => new[] { NewPlugin("Canopy", hostStatus) })
+                .Plugins
+                .InstalledSnapshots());
+
+            Assert.Equal(expected, (int)snapshot.Status);
+        }
+
+        [Fact]
+        public void AnUnknownFutureHostStatusKeepsItsNumericIdentity()
+        {
+            const int futureStatus = 731;
+            var plugin = NewPlugin("Canopy", (PluginStatus)futureStatus);
+
+            var snapshot = Assert.Single(Host(plugins: () => new[] { plugin })
+                .Plugins
+                .InstalledSnapshots());
+
+            Assert.Equal(futureStatus, (int)snapshot.Status);
+            Assert.False(Enum.IsDefined(snapshot.Status));
+        }
+
+        [Fact]
+        public void SnapshotEnumerationMaterializesOneHostReadAndFindReobservesByGuid()
+        {
+            var first = NewPlugin("First", PluginStatus.Active);
+            var second = NewPlugin("Second", PluginStatus.Restart);
+            var reads = 0;
+            var host = Host(plugins: () =>
+            {
+                reads++;
+                return new[] { first, second };
+            });
+
+            var installed = host.Plugins.InstalledSnapshots();
+
+            Assert.Equal(1, reads);
+            Assert.Equal(new[] { first.Id, second.Id }, installed.Select(plugin => plugin.PluginId));
+            Assert.Equal(second.Id, host.Plugins.FindSnapshot(second.Id)!.PluginId);
+            Assert.Equal(2, reads);
+            Assert.Null(host.Plugins.FindSnapshot(Guid.NewGuid()));
+            Assert.Equal(3, reads);
+        }
+
+        [Fact]
+        public void SnapshotReobservationRejectsANewDuplicateGuidInsteadOfSelectingOne()
+        {
+            var first = NewPlugin("First", PluginStatus.Active);
+            var duplicate = NewPlugin("Duplicate", PluginStatus.Active, first.Id);
+            var host = Host(plugins: () => new[] { first, duplicate });
+
+            Assert.Null(host.Plugins.FindSnapshot(first.Id));
+        }
+
+        [Fact]
         public void TheAdapterIsPureTranslationAndReReadsTheHostEachTime()
         {
             // No caching, deliberately. A cache here would be a second place where
@@ -215,6 +335,29 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
             host.Users.All();
 
             Assert.Equal(2, reads);
+        }
+
+        private sealed class InertPluginInstance : IPlugin
+        {
+            public string Name => "Inert test plugin";
+
+            public string Description => "Test-only instance used to expose assembly metadata.";
+
+            public Guid Id { get; } = Guid.NewGuid();
+
+            public Version Version { get; } = new(1, 2, 3);
+
+            public string AssemblyFilePath => typeof(InertPluginInstance).Assembly.Location;
+
+            public bool CanUninstall => false;
+
+            public string DataFolderPath => "/test-data";
+
+            public PluginInfo GetPluginInfo() => new(Name, Version, Description, Id, CanUninstall);
+
+            public void OnUninstalling()
+            {
+            }
         }
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActionInvocationCoordinatorTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformActionInvocationCoordinatorTests.cs
@@ -844,6 +844,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
             public IReadOnlyList<HostPlugin> Installed() => Array.Empty<HostPlugin>();
 
             HostPlugin? IHostPlugins.Find(Guid id) => null;
+
+            IReadOnlyList<PlatformInstalledPluginSnapshot> IHostPlugins.InstalledSnapshots() =>
+                Array.Empty<PlatformInstalledPluginSnapshot>();
+
+            PlatformInstalledPluginSnapshot? IHostPlugins.FindSnapshot(Guid id) => null;
         }
 
         private sealed class SequentialNonceSource

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformControllerBaseTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformControllerBaseTests.cs
@@ -85,6 +85,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
             public IReadOnlyList<HostPlugin> Installed() => Array.Empty<HostPlugin>();
 
             public HostPlugin? Find(Guid id) => null;
+
+            public IReadOnlyList<PlatformInstalledPluginSnapshot> InstalledSnapshots() =>
+                Array.Empty<PlatformInstalledPluginSnapshot>();
+
+            public PlatformInstalledPluginSnapshot? FindSnapshot(Guid id) => null;
         }
 
         private sealed class EmptyAuthenticationService : IAuthenticationService

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformExtensionManifestArchitectureTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformExtensionManifestArchitectureTests.cs
@@ -15,6 +15,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform;
 public sealed class PlatformExtensionManifestArchitectureTests
 {
     private const string ManifestDomainFileName = "PlatformExtensionManifestDomain.cs";
+    private const string InstalledManifestBindingDomainFileName =
+        "PlatformInstalledManifestBindingDomain.cs";
 
     private static readonly Regex IdentifierUnicodeEscape = new(
         @"\\(?:u(?<short>[0-9a-fA-F]{4})|U(?<long>[0-9a-fA-F]{8}))",
@@ -227,7 +229,7 @@ public sealed class PlatformExtensionManifestArchitectureTests
     public void ManifestParsingConstructionAndFingerprintEstablishmentAreSourceOwned()
     {
         Assert.Equal(
-            new[] { ManifestDomainFileName },
+            new[] { ManifestDomainFileName, InstalledManifestBindingDomainFileName },
             MemberOwners(nameof(PlatformExtensionManifestParser), nameof(PlatformExtensionManifestParser.TryParse)));
         Assert.Equal(
             new[] { "PlatformActorDomain.cs", ManifestDomainFileName },

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformHostSeamTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformHostSeamTests.cs
@@ -45,6 +45,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
         private static readonly Regex PositiveAccessMint = new(
             @"\bHostItemAccessResult\s*\.\s*Accessible\s*\(",
             RegexOptions.Compiled);
+        private static readonly Regex InstalledPluginSnapshotMint = new(
+            @"\bPlatformInstalledPluginSnapshot\s*\.\s*EstablishHostSnapshot\s*\(",
+            RegexOptions.Compiled);
 
         /// <summary>
         /// The only kernel files permitted to mention the host, each with its reason.
@@ -173,6 +176,27 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
             Assert.Matches(
                 PositiveAccessMint,
                 "return HostItemAccessResult.Accessible(item);");
+        }
+
+        [Fact]
+        public void OnlyTheJellyfinAdapterCanMintAnInstalledPluginSnapshot()
+        {
+            var offenders = ProductionSourceFiles()
+                .Where(file => Path.GetFileName(file) != "JellyfinPlatformHost.cs")
+                .Where(file => InstalledPluginSnapshotMint.IsMatch(CodeOnly(File.ReadAllText(file))))
+                .Select(file => Path.GetRelativePath(ProductionSourceRoot(), file))
+                .OrderBy(file => file, StringComparer.Ordinal)
+                .ToList();
+
+            Assert.True(
+                offenders.Count == 0,
+                "Only JellyfinPlatformHost may mint installed-plugin acquisition snapshots; "
+                + "manifest declarations and other kernel owners are not host identity. Offenders: "
+                + string.Join(", ", offenders));
+
+            Assert.Matches(
+                InstalledPluginSnapshotMint,
+                "return PlatformInstalledPluginSnapshot.EstablishHostSnapshot(id, name, version, status, root, dlls);");
         }
 
         [Fact]

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformInstalledManifestArchitectureTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformInstalledManifestArchitectureTests.cs
@@ -1,0 +1,263 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform;
+
+public sealed class PlatformInstalledManifestArchitectureTests
+{
+    private const string BindingFileName = "PlatformInstalledManifestBindingDomain.cs";
+    private const string AcquisitionFileName = "PlatformInstalledManifestAcquisition.cs";
+    private const string HostTypesFileName = "HostTypes.cs";
+    private const string JellyfinHostFileName = "JellyfinPlatformHost.cs";
+
+    private static readonly string[] ForbiddenBindingTokens =
+    {
+        "System.IO", "File.", "Directory", "Path.", "Stream", "SafeFileHandle", "DllImport",
+        "LibraryImport", "MediaBrowser", "IPluginManager", "LocalPlugin", "PluginStatus",
+        "HttpClient", "System.Net", "IConfiguration", "IServiceCollection", "AtomicFile",
+        "Persistence", "Repository", "Registry", "Lifecycle", "Approval", "GrantedCapability",
+        "PlatformApprovedProviderIdentity", "PlatformActorFactory", "CreateProvider",
+        "System.Reflection", "Activator", "Assembly.Load", "ProviderInvocation", "Controller",
+        "Route(", "IHostedService", "BackgroundService", "AddHostedService", "DateTime", "Random",
+        "Android",
+    };
+
+    [Fact]
+    public void ClosedOutcomeStatusAndCompatibilityVocabulariesAreExact()
+    {
+        Assert.Equal(
+            new[]
+            {
+                "Acquired", "ManifestAbsent", "HostMetadataInvalid", "AmbiguousHostIdentity",
+                "HostStatusNotActive", "UnsafeOrUnverifiableRoot", "UnsafeTarget", "OpenTimedOut",
+                "NotRegularFile", "DescriptorUnverifiable", "DocumentTooLarge", "ReadChanged",
+                "ReadFailed", "ManifestRejected", "PluginIdMismatch", "PluginVersionMismatch",
+                "AssemblyUnavailable", "AssemblyMismatch", "HostSnapshotChanged", "AcquisitionFailed",
+            },
+            Enum.GetNames<PlatformInstalledManifestOutcome>());
+        Assert.Equal(Enumerable.Range(0, 20),
+            Enum.GetValues<PlatformInstalledManifestOutcome>().Select(value => (int)value));
+        Assert.Equal(
+            new[] { "Compatible", "PlatformIncompatible", "HostIncompatible" },
+            Enum.GetNames<PlatformInstalledManifestCompatibility>());
+        Assert.Equal(
+            new[] { "Restart", "Active", "Disabled", "NotSupported", "Malfunctioned", "Superseded", "Deleted" },
+            Enum.GetNames<PlatformInstalledPluginHostStatus>());
+        Assert.Equal(1, PlatformInstalledManifestBinder.PlatformMajor);
+        Assert.Equal(12, PlatformInstalledManifestBinder.JellyfinHostMajor);
+        Assert.Equal(128, PlatformInstalledManifestLimits.MaximumDllFileCount);
+        Assert.True(PlatformInstalledManifestDiscovery.MaximumPluginCount > 0);
+        Assert.True(PlatformInstalledManifestDiscovery.MaximumConcurrentAcquisitions > 0);
+    }
+
+    [Fact]
+    public void BoundManifestAndObservationAreSealedImmutableRedactionSafeAllowLists()
+    {
+        AssertImmutableShape(
+            typeof(HostBoundInstalledManifest),
+            new[]
+            {
+                "AssemblyIdentity", "Compatibility", "Fingerprint", "HostName", "HostStatus",
+                "HostVersion", "Manifest", "PluginId",
+            });
+        AssertImmutableShape(
+            typeof(PlatformInstalledManifestObservation),
+            new[]
+            {
+                "BoundManifest", "Compatibility", "HostStatus", "ManifestRejectionReason",
+                "Outcome", "PluginId",
+            });
+
+        var forbiddenNames = new[]
+        {
+            "Approved", "Grant", "Effective", "Enabled", "Registered", "Callable", "Credential",
+            "Secret", "Actor", "Registry", "Lifecycle", "Root", "Path", "Dll", "Raw", "Bytes",
+            "Handle", "Exception",
+        };
+        foreach (var type in new[] { typeof(HostBoundInstalledManifest), typeof(PlatformInstalledManifestObservation) })
+        {
+            Assert.DoesNotContain(type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance),
+                property => forbiddenNames.Any(name =>
+                    property.Name.Contains(name, StringComparison.OrdinalIgnoreCase)));
+            Assert.DoesNotContain(type.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance),
+                field => field.FieldType == typeof(byte[]) || field.FieldType == typeof(Exception));
+        }
+    }
+
+    [Fact]
+    public void ReaderAndDiscoveryExposeNoCallerSelectedPathFilenameOrAuthorityInput()
+    {
+        var read = Assert.Single(typeof(IPlatformInstalledManifestReader).GetMethods());
+        Assert.Equal("ReadAsync", read.Name);
+        Assert.Equal(
+            new[] { typeof(PlatformInstalledPluginSnapshot), typeof(CancellationToken) },
+            read.GetParameters().Select(parameter => parameter.ParameterType));
+        Assert.DoesNotContain(read.GetParameters(), parameter => parameter.ParameterType == typeof(string));
+
+        var sweep = typeof(PlatformInstalledManifestDiscovery).GetMethod(
+            "SweepAsync",
+            BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(sweep);
+        Assert.DoesNotContain(sweep!.GetParameters(), parameter => parameter.ParameterType == typeof(string));
+        Assert.DoesNotContain(sweep.GetParameters(), parameter =>
+            parameter.Name is not null
+            && (parameter.Name.Contains("path", StringComparison.OrdinalIgnoreCase)
+                || parameter.Name.Contains("root", StringComparison.OrdinalIgnoreCase)
+                || parameter.Name.Contains("file", StringComparison.OrdinalIgnoreCase)));
+    }
+
+    [Fact]
+    public void PlantedCallerSelectedPathSignatureIsCaught()
+    {
+        var reviewed = Assert.Single(typeof(IPlatformInstalledManifestReader).GetMethods());
+        var planted = typeof(UnsafePathReaderFixture).GetMethod(nameof(UnsafePathReaderFixture.ReadAsync))!;
+
+        Assert.False(HasCallerSelectedPathInput(reviewed));
+        Assert.True(HasCallerSelectedPathInput(planted));
+    }
+
+    [Fact]
+    public void PureBindingOwnerHasNoFilesystemHostAuthorityRuntimeOrStartupDependencies()
+    {
+        var code = Code(SourceFile(BindingFileName));
+        Assert.Empty(ForbiddenBindingDependenciesIn(code));
+        Assert.Contains(nameof(PlatformExtensionManifestParser), code, StringComparison.Ordinal);
+        Assert.Contains(nameof(PlatformInstalledPluginSnapshot), code, StringComparison.Ordinal);
+        Assert.Contains(nameof(CancellationToken), code, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("using System.IO; var bytes = File.ReadAllBytes(path);", "System.IO")]
+    [InlineData("IPluginManager manager; LocalPlugin plugin;", "IPluginManager")]
+    [InlineData("var approved = new PlatformApprovedProviderIdentity();", "PlatformApprovedProviderIdentity")]
+    [InlineData("services.AddHostedService<DiscoveryWorker>();", "AddHostedService")]
+    [InlineData("[Route(\"manifest\")] sealed class ManifestController : Controller { }", "Controller")]
+    [InlineData("Assembly.Load(bytes); Activator.CreateInstance(type);", "Activator")]
+    public void PlantedArchitectureViolationsAreNamed(string source, string expected) =>
+        Assert.Contains(expected, ForbiddenBindingDependenciesIn(source), StringComparer.OrdinalIgnoreCase);
+
+    [Fact]
+    public void SnapshotBindingAndParserConstructionRemainSingleOwned()
+    {
+        Assert.Equal(
+            new[] { HostTypesFileName, JellyfinHostFileName },
+            MemberOwners(nameof(PlatformInstalledPluginSnapshot), "EstablishHostSnapshot"));
+        Assert.Equal(
+            new[] { BindingFileName },
+            MemberOwners(nameof(HostBoundInstalledManifest), "EstablishBoundManifest"));
+        Assert.Equal(
+            new[] { "PlatformExtensionManifestDomain.cs", BindingFileName },
+            MemberOwners(nameof(PlatformExtensionManifestParser), nameof(PlatformExtensionManifestParser.TryParse)));
+    }
+
+    [Fact]
+    public void HostSnapshotNeverInspectsOrInvokesTheProviderInstance()
+    {
+        var hostAdapter = Code(SourceFile(JellyfinHostFileName));
+        foreach (var forbidden in new[]
+        {
+            "plugin.Instance", ".Instance?.GetType()", "System.Reflection", "Assembly.Load",
+            "Activator.CreateInstance",
+        })
+        {
+            Assert.DoesNotContain(forbidden, hostAdapter, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void BindingSliceDoesNotWireRoutesPersistenceStartupActorsOrExistingActionPaths()
+    {
+        var production = ProductionFiles().ToDictionary(
+            file => Path.GetFileName(file)!,
+            Code,
+            StringComparer.Ordinal);
+        var bindingConsumers = production
+            .Where(pair => pair.Value.Contains(nameof(PlatformInstalledManifestDiscovery), StringComparison.Ordinal))
+            .Select(pair => pair.Key)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.Equal(new[] { AcquisitionFileName, BindingFileName }, bindingConsumers);
+
+        foreach (var pair in production)
+        {
+            Assert.DoesNotContain("new PlatformApprovedProviderIdentity", pair.Value, StringComparison.Ordinal);
+        }
+
+        foreach (var actionPath in new[]
+        {
+            "PlatformActionCapabilityService.cs", "PlatformActionInvocationCoordinator.cs",
+            "PlatformFirstPartyActionDispatcher.cs", "PlatformNativeCatalogService.cs",
+            "PlatformNativeController.cs",
+        })
+        {
+            Assert.DoesNotContain("PlatformInstalledManifest", production[actionPath], StringComparison.Ordinal);
+        }
+    }
+
+    private static void AssertImmutableShape(Type type, IReadOnlyList<string> expectedProperties)
+    {
+        Assert.True(type.IsSealed);
+        Assert.Empty(type.GetConstructors(BindingFlags.Public | BindingFlags.Instance));
+        var properties = type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+            .OrderBy(property => property.Name, StringComparer.Ordinal)
+            .ToArray();
+        Assert.Equal(expectedProperties, properties.Select(property => property.Name));
+        Assert.All(properties, property => Assert.False(property.CanWrite));
+    }
+
+    private static string[] ForbiddenBindingDependenciesIn(string source) => ForbiddenBindingTokens
+        .Where(token => source.Contains(token, StringComparison.OrdinalIgnoreCase))
+        .ToArray();
+
+    private static bool HasCallerSelectedPathInput(MethodInfo method) => method.GetParameters().Any(parameter =>
+        parameter.ParameterType == typeof(string)
+        || (parameter.Name is not null
+            && (parameter.Name.Contains("path", StringComparison.OrdinalIgnoreCase)
+                || parameter.Name.Contains("root", StringComparison.OrdinalIgnoreCase)
+                || parameter.Name.Contains("file", StringComparison.OrdinalIgnoreCase))));
+
+    private static string[] MemberOwners(string typeName, string memberName) => ProductionFiles()
+        .Where(file =>
+        {
+            var code = Code(file);
+            return code.Contains(typeName, StringComparison.Ordinal)
+                && code.Contains(memberName, StringComparison.Ordinal);
+        })
+        .Select(file => Path.GetFileName(file)!)
+        .OrderBy(name => name, StringComparer.Ordinal)
+        .ToArray();
+
+    private static string Code(string file) => PlatformHostSeamTests.CodeOnly(File.ReadAllText(file));
+
+    private static IEnumerable<string> ProductionFiles() =>
+        Directory.EnumerateFiles(ProductionRoot(), "*.cs", SearchOption.AllDirectories)
+            .Where(file => !file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}",
+                    StringComparison.Ordinal)
+                && !file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}",
+                    StringComparison.Ordinal));
+
+    private static string SourceFile(string name) => ProductionFiles()
+        .Single(file => Path.GetFileName(file) == name);
+
+    private static string ProductionRoot([CallerFilePath] string sourceFile = "") =>
+        Path.GetFullPath(Path.Combine(
+            Path.GetDirectoryName(sourceFile)!,
+            "..",
+            "..",
+            "Jellyfin.Plugin.JellyfinCanopy"));
+
+    private sealed class UnsafePathReaderFixture
+    {
+        public void ReadAsync(string root, string fileName)
+        {
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformInstalledManifestBindingTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformInstalledManifestBindingTests.cs
@@ -1,0 +1,283 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform;
+
+public sealed class PlatformInstalledManifestBindingTests
+{
+    private static readonly Guid PluginId = new("11111111-2222-3333-4444-555555555555");
+
+    [Fact]
+    public void HonestActiveObservationBindsEveryHostAndManifestFactWithoutAuthority()
+    {
+        var before = Snapshot();
+        var manifestBytes = ManifestBytes(capabilities: new[]
+        {
+            "jellyfin.canopy.storage.read",
+            "jellyfin.canopy.items.lookup",
+        });
+        Assert.True(PlatformExtensionManifestParser.TryParse(
+            manifestBytes,
+            out var independentlyParsed,
+            out var parseReason));
+        Assert.Equal(PlatformExtensionManifestRejectionReason.None, parseReason);
+
+        var observation = PlatformInstalledManifestBinder.Bind(
+            before,
+            Snapshot(),
+            PlatformInstalledManifestReadResult.Acquired(manifestBytes, "Example.Provider"));
+
+        Assert.Equal(PlatformInstalledManifestOutcome.Acquired, observation.Outcome);
+        Assert.Equal(PlatformInstalledPluginHostStatus.Active, observation.HostStatus);
+        Assert.Equal(PlatformInstalledManifestCompatibility.Compatible, observation.Compatibility);
+        Assert.Null(observation.ManifestRejectionReason);
+        var bound = Assert.IsType<HostBoundInstalledManifest>(observation.BoundManifest);
+        Assert.Equal(PluginId, bound.PluginId);
+        Assert.Equal(new Version(1, 2, 3, 4), bound.HostVersion);
+        Assert.Equal("Example.Provider", bound.AssemblyIdentity);
+        Assert.Equal(PlatformInstalledPluginHostStatus.Active, bound.HostStatus);
+        Assert.Equal(independentlyParsed!.Fingerprint.Value, bound.Manifest.Fingerprint.Value);
+        Assert.Equal(
+            new[] { "jellyfin.canopy.items.lookup", "jellyfin.canopy.storage.read" },
+            bound.Manifest.RequestedCapabilities.Capabilities.Select(value => value.Id.Value));
+
+        var forbiddenAuthorityShape = new[]
+        {
+            "Approved", "Granted", "Effective", "Enabled", "Registered", "Callable",
+            "Credential", "Secret", "Actor", "Registry", "Lifecycle", "RawBytes",
+            "RootPath", "AssemblyPath", "Exception",
+        };
+        Assert.DoesNotContain(
+            bound.GetType().GetProperties(),
+            property => forbiddenAuthorityShape.Contains(property.Name, StringComparer.OrdinalIgnoreCase));
+    }
+
+    [Theory]
+    [InlineData((int)PlatformInstalledPluginHostStatus.Restart)]
+    [InlineData((int)PlatformInstalledPluginHostStatus.Disabled)]
+    [InlineData((int)PlatformInstalledPluginHostStatus.NotSupported)]
+    [InlineData((int)PlatformInstalledPluginHostStatus.Malfunctioned)]
+    [InlineData((int)PlatformInstalledPluginHostStatus.Superseded)]
+    [InlineData((int)PlatformInstalledPluginHostStatus.Deleted)]
+    public void EveryKnownNonActiveHostStatusRemainsDistinctAndNeverBinds(int statusValue)
+    {
+        var status = (PlatformInstalledPluginHostStatus)statusValue;
+        var observation = Bind(status: status);
+
+        Assert.Equal(PlatformInstalledManifestOutcome.HostStatusNotActive, observation.Outcome);
+        Assert.Equal(status, observation.HostStatus);
+        Assert.Null(observation.BoundManifest);
+    }
+
+    [Fact]
+    public void UnknownFutureNumericStatusesRemainDistinctAndNeverBind()
+    {
+        var first = (PlatformInstalledPluginHostStatus)901;
+        var second = (PlatformInstalledPluginHostStatus)902;
+
+        var firstObservation = Bind(status: first);
+        var secondObservation = Bind(status: second);
+
+        Assert.Equal(first, firstObservation.HostStatus);
+        Assert.Equal(second, secondObservation.HostStatus);
+        Assert.NotEqual(firstObservation.HostStatus, secondObservation.HostStatus);
+        Assert.Equal(PlatformInstalledManifestOutcome.HostStatusNotActive, firstObservation.Outcome);
+        Assert.Equal(PlatformInstalledManifestOutcome.HostStatusNotActive, secondObservation.Outcome);
+        Assert.Null(firstObservation.BoundManifest);
+        Assert.Null(secondObservation.BoundManifest);
+    }
+
+    [Fact]
+    public void GuidVersionMismatchesAndAssemblyAbsenceAreDistinctClosedOutcomes()
+    {
+        AssertOutcome(
+            PlatformInstalledManifestOutcome.PluginIdMismatch,
+            ManifestBytes(pluginId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"));
+        AssertOutcome(
+            PlatformInstalledManifestOutcome.PluginVersionMismatch,
+            ManifestBytes(version: "1.2.3.5"));
+
+        var unavailable = PlatformInstalledManifestBinder.Bind(
+            Snapshot(),
+            Snapshot(),
+            PlatformInstalledManifestReadResult.Acquired(ManifestBytes(), null));
+        Assert.Equal(PlatformInstalledManifestOutcome.AssemblyUnavailable, unavailable.Outcome);
+        Assert.Null(unavailable.BoundManifest);
+
+        var componentCountMismatch = PlatformInstalledManifestBinder.Bind(
+            Snapshot(version: new Version(1, 2)),
+            Snapshot(version: new Version(1, 2)),
+            PlatformInstalledManifestReadResult.Acquired(
+                ManifestBytes(version: "1.2.0"),
+                "Example.Provider"));
+        Assert.Equal(
+            PlatformInstalledManifestOutcome.PluginVersionMismatch,
+            componentCountMismatch.Outcome);
+        Assert.Null(componentCountMismatch.BoundManifest);
+    }
+
+    [Fact]
+    public void EveryHostFactChangingDuringReadFailsClosed()
+    {
+        var changes = new[]
+        {
+            Snapshot(pluginId: Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")),
+            Snapshot(version: new Version(1, 2, 3, 5)),
+            Snapshot(status: PlatformInstalledPluginHostStatus.Restart),
+            Snapshot(root: "/plugins/example-moved"),
+            Snapshot(dllFiles: new[] { "/plugins/example/Other.dll" }),
+        };
+
+        Assert.All(changes, after =>
+        {
+            var observation = PlatformInstalledManifestBinder.Bind(
+                Snapshot(),
+                after,
+                PlatformInstalledManifestReadResult.Acquired(ManifestBytes(), "Example.Provider"));
+            Assert.Equal(PlatformInstalledManifestOutcome.HostSnapshotChanged, observation.Outcome);
+            Assert.Null(observation.BoundManifest);
+        });
+    }
+
+    [Theory]
+    [InlineData(1, 1, 12, 12, (int)PlatformInstalledManifestCompatibility.Compatible)]
+    [InlineData(2, 2, 12, 12, (int)PlatformInstalledManifestCompatibility.PlatformIncompatible)]
+    [InlineData(1, 1, 11, 11, (int)PlatformInstalledManifestCompatibility.HostIncompatible)]
+    [InlineData(2, 2, 13, 13, (int)PlatformInstalledManifestCompatibility.PlatformIncompatible)]
+    public void CompatibilityIsSeparateExactClosedMetadata(
+        int platformMin,
+        int platformMax,
+        int hostMin,
+        int hostMax,
+        int expectedValue)
+    {
+        var observation = Bind(bytes: ManifestBytes(
+            platformMin: platformMin,
+            platformMax: platformMax,
+            hostMin: hostMin,
+            hostMax: hostMax));
+
+        Assert.Equal(PlatformInstalledManifestOutcome.Acquired, observation.Outcome);
+        Assert.Equal((PlatformInstalledManifestCompatibility)expectedValue, observation.Compatibility!.Value);
+        Assert.NotNull(observation.BoundManifest);
+    }
+
+    [Fact]
+    public void ParserReceivesUnchangedBytesAndItsClosedReasonIsPreserved()
+    {
+        var cases = new[]
+        {
+            (new byte[] { 0xEF, 0xBB, 0xBF }.Concat(ManifestBytes()).ToArray(),
+                PlatformExtensionManifestRejectionReason.InvalidUtf8),
+            (new byte[] { (byte)'{', (byte)'"', 0xFF, (byte)'"', (byte)':', (byte)'1', (byte)'}' },
+                PlatformExtensionManifestRejectionReason.InvalidUtf8),
+            (Encoding.UTF8.GetBytes("{"), PlatformExtensionManifestRejectionReason.InvalidJson),
+            (Encoding.UTF8.GetBytes(new string('[', PlatformExtensionManifestBounds.MaximumJsonDepth + 1)
+                + "0" + new string(']', PlatformExtensionManifestBounds.MaximumJsonDepth + 1)),
+                PlatformExtensionManifestRejectionReason.InvalidJson),
+        };
+
+        foreach (var (bytes, reason) in cases)
+        {
+            var observation = Bind(bytes: bytes);
+            Assert.Equal(PlatformInstalledManifestOutcome.ManifestRejected, observation.Outcome);
+            Assert.Equal(reason, observation.ManifestRejectionReason);
+            Assert.Null(observation.BoundManifest);
+        }
+    }
+
+    [Fact]
+    public void AcquiredReadResultDefensivelyOwnsBytesBeforeBinding()
+    {
+        var source = ManifestBytes();
+        var readResult = PlatformInstalledManifestReadResult.Acquired(source, "Example.Provider");
+        source.AsSpan().Fill((byte)'x');
+
+        var observation = PlatformInstalledManifestBinder.Bind(Snapshot(), Snapshot(), readResult);
+
+        Assert.Equal(PlatformInstalledManifestOutcome.Acquired, observation.Outcome);
+        Assert.Equal("org.example.provider", observation.BoundManifest!.Manifest.Id);
+    }
+
+    [Theory]
+    [InlineData((int)PlatformInstalledManifestOutcome.ManifestAbsent)]
+    [InlineData((int)PlatformInstalledManifestOutcome.UnsafeOrUnverifiableRoot)]
+    [InlineData((int)PlatformInstalledManifestOutcome.UnsafeTarget)]
+    [InlineData((int)PlatformInstalledManifestOutcome.OpenTimedOut)]
+    [InlineData((int)PlatformInstalledManifestOutcome.NotRegularFile)]
+    [InlineData((int)PlatformInstalledManifestOutcome.DescriptorUnverifiable)]
+    [InlineData((int)PlatformInstalledManifestOutcome.DocumentTooLarge)]
+    [InlineData((int)PlatformInstalledManifestOutcome.ReadChanged)]
+    [InlineData((int)PlatformInstalledManifestOutcome.ReadFailed)]
+    public void ReaderFailuresPassThroughWithoutParsingOrPartialBinding(int outcomeValue)
+    {
+        var outcome = (PlatformInstalledManifestOutcome)outcomeValue;
+        var observation = PlatformInstalledManifestBinder.Bind(
+            Snapshot(),
+            Snapshot(),
+            PlatformInstalledManifestReadResult.Rejected(outcome));
+
+        Assert.Equal(outcome, observation.Outcome);
+        Assert.Null(observation.ManifestRejectionReason);
+        Assert.Null(observation.BoundManifest);
+    }
+
+    private static void AssertOutcome(PlatformInstalledManifestOutcome expected, byte[] bytes)
+    {
+        var observation = Bind(bytes: bytes);
+        Assert.Equal(expected, observation.Outcome);
+        Assert.Null(observation.BoundManifest);
+    }
+
+    private static PlatformInstalledManifestObservation Bind(
+        PlatformInstalledPluginHostStatus status = PlatformInstalledPluginHostStatus.Active,
+        byte[]? bytes = null) => PlatformInstalledManifestBinder.Bind(
+            Snapshot(status: status),
+            Snapshot(status: status),
+            PlatformInstalledManifestReadResult.Acquired(bytes ?? ManifestBytes(), "Example.Provider"));
+
+    internal static PlatformInstalledPluginSnapshot Snapshot(
+        Guid? pluginId = null,
+        string name = "Example Provider",
+        Version? version = null,
+        PlatformInstalledPluginHostStatus status = PlatformInstalledPluginHostStatus.Active,
+        string root = "/plugins/example",
+        IReadOnlyList<string>? dllFiles = null) =>
+        PlatformInstalledPluginSnapshot.EstablishHostSnapshot(
+            pluginId ?? PluginId,
+            name,
+            version ?? new Version(1, 2, 3, 4),
+            status,
+            root,
+            (dllFiles ?? new[] { "/plugins/example/Example.Provider.dll" }).ToImmutableArray());
+
+    internal static byte[] ManifestBytes(
+        string pluginId = "11111111-2222-3333-4444-555555555555",
+        string version = "1.2.3.4",
+        int platformMin = 1,
+        int platformMax = 1,
+        int hostMin = 12,
+        int hostMax = 12,
+        IReadOnlyList<string>? capabilities = null)
+    {
+        capabilities ??= Array.Empty<string>();
+        var quotedCapabilities = string.Join(',', capabilities.Select(value => "\"" + value + "\""));
+        return Encoding.UTF8.GetBytes("{"
+            + "\"schemaVersion\":1"
+            + ",\"id\":\"org.example.provider\""
+            + ",\"pluginId\":\"" + pluginId + "\""
+            + ",\"version\":\"" + version + "\""
+            + ",\"kind\":\"installed-provider\""
+            + ",\"displayName\":\"Example Provider\""
+            + ",\"platform\":{\"min\":" + platformMin + ",\"max\":" + platformMax + "}"
+            + ",\"host\":{\"minMajor\":" + hostMin + ",\"maxMajor\":" + hostMax + "}"
+            + ",\"requestedCapabilities\":[" + quotedCapabilities + "]}");
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformInstalledManifestDiscoveryTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformInstalledManifestDiscoveryTests.cs
@@ -1,0 +1,407 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform;
+
+public sealed class PlatformInstalledManifestDiscoveryTests
+{
+    [Fact]
+    public async Task HostEnumerationOrderCannotChangeTheCanonicalObservationSet()
+    {
+        var high = Snapshot("ffffffff-2222-3333-4444-555555555555", "High");
+        var low = Snapshot("11111111-2222-3333-4444-555555555555", "Low");
+        var reader = new FakeReader(ReadFor);
+
+        var forward = await Sweep(new[] { high, low }, reader);
+        var reverse = await Sweep(new[] { low, high }, reader);
+
+        var expected = new[] { low.PluginId, high.PluginId };
+        Assert.Equal(expected, forward.Select(value => value.PluginId));
+        Assert.Equal(expected, reverse.Select(value => value.PluginId));
+        Assert.All(forward, value => Assert.Equal(PlatformInstalledManifestOutcome.Acquired, value.Outcome));
+        Assert.All(reverse, value => Assert.Equal(PlatformInstalledManifestOutcome.Acquired, value.Outcome));
+    }
+
+    [Fact]
+    public async Task DuplicateOrDefaultHostIdentityRejectsTheWholeInventoryBeforeAnyRead()
+    {
+        var duplicated = Snapshot("11111111-2222-3333-4444-555555555555", "First");
+        var duplicate = Snapshot("11111111-2222-3333-4444-555555555555", "Second");
+        var innocent = Snapshot("22222222-2222-3333-4444-555555555555", "Innocent");
+        var reader = new FakeReader(ReadFor);
+
+        var ambiguous = await Sweep(new[] { innocent, duplicated, duplicate }, reader);
+
+        Assert.Equal(0, reader.CallCount);
+        Assert.Equal(3, ambiguous.Length);
+        Assert.Equal(2, ambiguous.Count(value =>
+            value.Outcome == PlatformInstalledManifestOutcome.AmbiguousHostIdentity));
+        Assert.All(ambiguous, value => Assert.Null(value.BoundManifest));
+
+        reader = new FakeReader(ReadFor);
+        var invalid = await Sweep(
+            new[] { innocent, Snapshot(Guid.Empty.ToString(), "Invalid") },
+            reader);
+        Assert.Equal(0, reader.CallCount);
+        Assert.Contains(invalid, value => value.Outcome == PlatformInstalledManifestOutcome.HostMetadataInvalid);
+        Assert.All(invalid, value => Assert.Null(value.BoundManifest));
+    }
+
+    [Fact]
+    public async Task EveryInvalidHostMetadataShapeRejectsAtomicallyBeforeAnyRead()
+    {
+        var valid = Snapshot("22222222-2222-3333-4444-555555555555", "Valid");
+        var invalid = new[]
+        {
+            PlatformInstalledManifestBindingTests.Snapshot(
+                pluginId: Guid.Parse("33333333-2222-3333-4444-555555555555"),
+                name: string.Empty),
+            PlatformInstalledManifestBindingTests.Snapshot(
+                pluginId: Guid.Parse("44444444-2222-3333-4444-555555555555"),
+                root: string.Empty),
+        };
+
+        foreach (var bad in invalid)
+        {
+            var reader = new FakeReader(ReadFor);
+            var observations = await Sweep(new[] { valid, bad }, reader);
+            Assert.Equal(0, reader.CallCount);
+            Assert.All(observations, observation => Assert.Null(observation.BoundManifest));
+            Assert.Contains(observations,
+                observation => observation.Outcome == PlatformInstalledManifestOutcome.HostMetadataInvalid);
+        }
+    }
+
+    [Fact]
+    public async Task OneAbsentMalformedThrowingOrInactivePluginCannotSuppressLaterSuccess()
+    {
+        var absent = Snapshot("10000000-2222-3333-4444-555555555555", "Absent");
+        var malformed = Snapshot("20000000-2222-3333-4444-555555555555", "Malformed");
+        var throwing = Snapshot("30000000-2222-3333-4444-555555555555", "Throwing");
+        var inactive = Snapshot(
+            "40000000-2222-3333-4444-555555555555",
+            "Restart",
+            PlatformInstalledPluginHostStatus.Restart);
+        var valid = Snapshot("50000000-2222-3333-4444-555555555555", "Valid");
+        var reader = new FakeReader(snapshot =>
+        {
+            if (snapshot.PluginId == absent.PluginId)
+            {
+                return PlatformInstalledManifestReadResult.Rejected(
+                    PlatformInstalledManifestOutcome.ManifestAbsent);
+            }
+
+            if (snapshot.PluginId == malformed.PluginId)
+            {
+                return PlatformInstalledManifestReadResult.Acquired(new byte[] { (byte)'{' }, "Example.Provider");
+            }
+
+            if (snapshot.PluginId == throwing.PluginId)
+            {
+                throw new InvalidOperationException("reader detail must not escape");
+            }
+
+            return ReadFor(snapshot);
+        });
+
+        var observations = await Sweep(
+            new[] { valid, inactive, throwing, malformed, absent },
+            reader);
+
+        Assert.Equal(PlatformInstalledManifestOutcome.ManifestAbsent, Find(absent).Outcome);
+        Assert.Equal(PlatformInstalledManifestOutcome.ManifestRejected, Find(malformed).Outcome);
+        Assert.Equal(PlatformInstalledManifestOutcome.AcquisitionFailed, Find(throwing).Outcome);
+        Assert.Equal(PlatformInstalledManifestOutcome.HostStatusNotActive, Find(inactive).Outcome);
+        Assert.Equal(PlatformInstalledManifestOutcome.Acquired, Find(valid).Outcome);
+        Assert.NotNull(Find(valid).BoundManifest);
+        Assert.DoesNotContain(observations.Select(value => value.Outcome.ToString()), value =>
+            value.Contains("reader detail", StringComparison.Ordinal));
+        Assert.DoesNotContain(inactive.PluginId, reader.Calls);
+
+        PlatformInstalledManifestObservation Find(PlatformInstalledPluginSnapshot snapshot) =>
+            observations.Single(value => value.PluginId == snapshot.PluginId);
+    }
+
+    [Fact]
+    public async Task ReobservationDisappearanceOrMutationFailsOnlyThatPluginClosed()
+    {
+        var disappeared = Snapshot("10000000-2222-3333-4444-555555555555", "Gone");
+        var changed = Snapshot("20000000-2222-3333-4444-555555555555", "Changed");
+        var valid = Snapshot("30000000-2222-3333-4444-555555555555", "Valid");
+        var inventory = new[] { disappeared, changed, valid };
+        var reader = new FakeReader(ReadFor);
+
+        var observations = await PlatformInstalledManifestDiscovery.SweepAsync(
+            inventory,
+            reader,
+            (id, _) => ValueTask.FromResult<PlatformInstalledPluginSnapshot?>(id == disappeared.PluginId
+                ? null
+                : id == changed.PluginId
+                    ? PlatformInstalledManifestBindingTests.Snapshot(
+                        pluginId: id,
+                        root: "/plugins/changed")
+                    : inventory.Single(value => value.PluginId == id)),
+            CancellationToken.None);
+
+        Assert.Equal(PlatformInstalledManifestOutcome.HostSnapshotChanged,
+            observations.Single(value => value.PluginId == disappeared.PluginId).Outcome);
+        Assert.Equal(PlatformInstalledManifestOutcome.HostSnapshotChanged,
+            observations.Single(value => value.PluginId == changed.PluginId).Outcome);
+        Assert.Equal(PlatformInstalledManifestOutcome.Acquired,
+            observations.Single(value => value.PluginId == valid.PluginId).Outcome);
+    }
+
+    [Fact]
+    public async Task CancellationBeforeAndBetweenPluginsPublishesNoPartialResult()
+    {
+        var first = Snapshot("10000000-2222-3333-4444-555555555555", "First");
+        var second = Snapshot("20000000-2222-3333-4444-555555555555", "Second");
+        using var alreadyCancelled = new CancellationTokenSource();
+        alreadyCancelled.Cancel();
+        var untouched = new FakeReader(ReadFor);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await Sweep(new[] { first }, untouched, alreadyCancelled.Token));
+        Assert.Equal(0, untouched.CallCount);
+
+        using var between = new CancellationTokenSource();
+        var cancellingReader = new FakeReader(snapshot =>
+        {
+            var result = ReadFor(snapshot);
+            between.Cancel();
+            return result;
+        });
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await Sweep(new[] { first, second }, cancellingReader, between.Token));
+        Assert.Equal(1, cancellingReader.CallCount);
+    }
+
+    [Fact]
+    public async Task HostOwnedBoundaryEnumeratesOnceAndPerformsFreshReobservation()
+    {
+        var first = Snapshot("10000000-2222-3333-4444-555555555555", "First");
+        var second = Snapshot("20000000-2222-3333-4444-555555555555", "Second");
+        var host = new FakeHostPlugins(new[] { second, first });
+        var reader = new FakeReader(ReadFor);
+        var acquisition = new PlatformInstalledManifestAcquisition(host, reader);
+
+        var observations = await acquisition.SweepAsync(CancellationToken.None);
+
+        Assert.Equal(1, host.InventoryReads);
+        Assert.Equal(new[] { first.PluginId, second.PluginId }, host.ReobservedIds);
+        Assert.Equal(new[] { first.PluginId, second.PluginId }, observations.Select(value => value.PluginId));
+        Assert.All(observations, value =>
+            Assert.Equal(PlatformInstalledManifestOutcome.Acquired, value.Outcome));
+    }
+
+    [Fact]
+    public async Task HostOwnedBoundaryChecksCancellationBeforeEnumeration()
+    {
+        var host = new FakeHostPlugins(new[]
+        {
+            Snapshot("10000000-2222-3333-4444-555555555555", "First"),
+        });
+        var acquisition = new PlatformInstalledManifestAcquisition(
+            host,
+            new FakeReader(ReadFor));
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await acquisition.SweepAsync(cancellation.Token));
+
+        Assert.Equal(0, host.InventoryReads);
+        Assert.Empty(host.ReobservedIds);
+    }
+
+    [Fact]
+    public async Task CancellationDuringReadIsObservedAndReleasesTheReader()
+    {
+        var snapshot = PlatformInstalledManifestBindingTests.Snapshot();
+        using var cancellation = new CancellationTokenSource();
+        var reader = new CancellationAwareReader();
+
+        var sweep = Sweep(new[] { snapshot }, reader, cancellation.Token).AsTask();
+        await reader.Entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await sweep);
+        Assert.True(await reader.Exited.Task.WaitAsync(TimeSpan.FromSeconds(5)));
+    }
+
+    [Fact]
+    public async Task ConcurrentExplicitSweepsAreDeterministicAndIndependent()
+    {
+        var inventory = new[]
+        {
+            Snapshot("30000000-2222-3333-4444-555555555555", "Three"),
+            Snapshot("10000000-2222-3333-4444-555555555555", "One"),
+            Snapshot("20000000-2222-3333-4444-555555555555", "Two"),
+        };
+
+        var sweeps = await Task.WhenAll(Enumerable.Range(0, 64).Select(async _ =>
+        {
+            var reader = new FakeReader(ReadFor);
+            var observations = await Sweep(inventory, reader);
+            return observations.Select(value =>
+                (value.PluginId, value.Outcome, value.BoundManifest!.Fingerprint.Value)).ToArray();
+        }));
+
+        Assert.All(sweeps, result => Assert.Equal(sweeps[0], result));
+        Assert.Equal(3, sweeps[0].Length);
+    }
+
+    [Fact]
+    public async Task SuccessfulObservationsOwnTheirStateAfterInputsMutate()
+    {
+        var bytes = PlatformInstalledManifestBindingTests.ManifestBytes();
+        var snapshot = PlatformInstalledManifestBindingTests.Snapshot();
+        var mutableInventory = new List<PlatformInstalledPluginSnapshot> { snapshot };
+        var reader = new FakeReader(_ =>
+            PlatformInstalledManifestReadResult.Acquired(bytes, "Example.Provider"));
+
+        var observations = await Sweep(mutableInventory, reader);
+        var bound = Assert.IsType<HostBoundInstalledManifest>(Assert.Single(observations).BoundManifest);
+        var fingerprint = bound.Fingerprint.Value;
+        bytes.AsSpan().Fill((byte)'x');
+        mutableInventory.Clear();
+
+        Assert.Equal(snapshot.PluginId, bound.PluginId);
+        Assert.Equal(new Version(1, 2, 3, 4), bound.HostVersion);
+        Assert.Equal(fingerprint, bound.Fingerprint.Value);
+        Assert.Equal("org.example.provider", bound.Manifest.Id);
+    }
+
+    [Fact]
+    public async Task PluginCountBoundaryIsAtomicAndConcurrencyRemainsPinned()
+    {
+        Assert.Equal(1024, PlatformInstalledManifestDiscovery.MaximumPluginCount);
+        Assert.Equal(1, PlatformInstalledManifestDiscovery.MaximumConcurrentAcquisitions);
+
+        var overBound = Enumerable.Range(1, PlatformInstalledManifestDiscovery.MaximumPluginCount + 1)
+            .Select(index => PlatformInstalledManifestBindingTests.Snapshot(
+                pluginId: Guid.Parse($"{index:x8}-2222-3333-4444-555555555555")))
+            .ToArray();
+        var reader = new FakeReader(ReadFor);
+
+        var observations = await Sweep(overBound, reader);
+
+        Assert.Equal(0, reader.CallCount);
+        Assert.Equal(overBound.Length, observations.Length);
+        Assert.All(observations, observation =>
+        {
+            Assert.Equal(PlatformInstalledManifestOutcome.HostMetadataInvalid, observation.Outcome);
+            Assert.Null(observation.BoundManifest);
+        });
+    }
+
+    private static PlatformInstalledPluginSnapshot Snapshot(
+        string id,
+        string name,
+        PlatformInstalledPluginHostStatus status = PlatformInstalledPluginHostStatus.Active) =>
+        PlatformInstalledManifestBindingTests.Snapshot(
+            pluginId: Guid.Parse(id),
+            name: name,
+            status: status);
+
+    private static PlatformInstalledManifestReadResult ReadFor(PlatformInstalledPluginSnapshot snapshot) =>
+        PlatformInstalledManifestReadResult.Acquired(
+            PlatformInstalledManifestBindingTests.ManifestBytes(
+                pluginId: snapshot.PluginId.ToString("D"),
+                version: snapshot.Version.ToString()),
+            "sha256:test-assembly-set");
+
+    private static ValueTask<ImmutableArray<PlatformInstalledManifestObservation>> Sweep(
+        IReadOnlyList<PlatformInstalledPluginSnapshot> inventory,
+        IPlatformInstalledManifestReader reader,
+        CancellationToken cancellationToken = default) =>
+        PlatformInstalledManifestDiscovery.SweepAsync(
+            inventory,
+            reader,
+            (id, _) => ValueTask.FromResult<PlatformInstalledPluginSnapshot?>(
+                inventory.SingleOrDefault(value => value.PluginId == id)),
+            cancellationToken);
+
+    private sealed class FakeReader : IPlatformInstalledManifestReader
+    {
+        private readonly Func<PlatformInstalledPluginSnapshot, PlatformInstalledManifestReadResult> _read;
+        private readonly ConcurrentQueue<Guid> _calls = new();
+
+        internal FakeReader(Func<PlatformInstalledPluginSnapshot, PlatformInstalledManifestReadResult> read) =>
+            _read = read;
+
+        internal int CallCount => _calls.Count;
+
+        internal IReadOnlyCollection<Guid> Calls => _calls.ToArray();
+
+        public ValueTask<PlatformInstalledManifestReadResult> ReadAsync(
+            PlatformInstalledPluginSnapshot snapshot,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            _calls.Enqueue(snapshot.PluginId);
+            return ValueTask.FromResult(_read(snapshot));
+        }
+    }
+
+    private sealed class CancellationAwareReader : IPlatformInstalledManifestReader
+    {
+        internal TaskCompletionSource<bool> Entered { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal TaskCompletionSource<bool> Exited { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public async ValueTask<PlatformInstalledManifestReadResult> ReadAsync(
+            PlatformInstalledPluginSnapshot snapshot,
+            CancellationToken cancellationToken)
+        {
+            Entered.TrySetResult(true);
+            try
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                throw new InvalidOperationException("unreachable");
+            }
+            finally
+            {
+                Exited.TrySetResult(true);
+            }
+        }
+    }
+
+    private sealed class FakeHostPlugins : IHostPlugins
+    {
+        private readonly IReadOnlyList<PlatformInstalledPluginSnapshot> _inventory;
+        private readonly ConcurrentQueue<Guid> _reobservedIds = new();
+
+        internal FakeHostPlugins(IReadOnlyList<PlatformInstalledPluginSnapshot> inventory) =>
+            _inventory = inventory;
+
+        internal int InventoryReads { get; private set; }
+
+        internal IReadOnlyList<Guid> ReobservedIds => _reobservedIds.ToArray();
+
+        public IReadOnlyList<HostPlugin> Installed() => Array.Empty<HostPlugin>();
+
+        public HostPlugin? Find(Guid id) => null;
+
+        public IReadOnlyList<PlatformInstalledPluginSnapshot> InstalledSnapshots()
+        {
+            InventoryReads++;
+            return _inventory;
+        }
+
+        public PlatformInstalledPluginSnapshot? FindSnapshot(Guid id)
+        {
+            _reobservedIds.Enqueue(id);
+            return _inventory.SingleOrDefault(snapshot => snapshot.PluginId == id);
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformInstalledManifestFileReaderTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformInstalledManifestFileReaderTests.cs
@@ -1,0 +1,962 @@
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform;
+
+[Collection("Installed manifest filesystem isolation")]
+public sealed class PlatformInstalledManifestFileReaderTests
+{
+    private static readonly byte[] HonestBytes = Encoding.UTF8.GetBytes("{\"honest\":true}");
+    private static readonly byte[] OutsideSentinel = Encoding.UTF8.GetBytes("OUTSIDE-SENTINEL");
+
+    [Fact]
+    public async Task OrdinaryExactMaximumAndMaximumPlusOneAreBounded()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        using var tree = new ReaderTree();
+        var reader = new PlatformInstalledManifestFileReader();
+
+        tree.WriteManifest(HonestBytes);
+        var ordinary = await reader.ReadAsync(tree.Snapshot(), CancellationToken.None);
+        Assert.Equal(PlatformInstalledManifestOutcome.Acquired, ordinary.Outcome);
+        Assert.Equal(HonestBytes, ordinary.Bytes);
+        Assert.StartsWith("sha256:", ordinary.AssemblyIdentity, StringComparison.Ordinal);
+        Assert.Equal(71, ordinary.AssemblyIdentity!.Length);
+
+        var exactBytes = new byte[PlatformExtensionManifestBounds.MaximumDocumentBytes];
+        Array.Fill(exactBytes, (byte)'x');
+        tree.WriteManifest(exactBytes);
+        var exact = await reader.ReadAsync(tree.Snapshot(), CancellationToken.None);
+        Assert.Equal(PlatformInstalledManifestOutcome.Acquired, exact.Outcome);
+        Assert.Equal(PlatformExtensionManifestBounds.MaximumDocumentBytes, exact.Bytes.Length);
+
+        tree.WriteManifest(new byte[PlatformExtensionManifestBounds.MaximumDocumentBytes + 1]);
+        var over = await reader.ReadAsync(tree.Snapshot(), CancellationToken.None);
+        Assert.Equal(PlatformInstalledManifestOutcome.DocumentTooLarge, over.Outcome);
+        Assert.Empty(over.Bytes);
+        Assert.Null(over.AssemblyIdentity);
+    }
+
+    [Fact]
+    public async Task AbsentAndAssemblyFailuresHaveClosedEmptyResults()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        using var tree = new ReaderTree();
+        var reader = new PlatformInstalledManifestFileReader();
+
+        AssertRejected(
+            PlatformInstalledManifestOutcome.ManifestAbsent,
+            await reader.ReadAsync(tree.Snapshot(), CancellationToken.None));
+
+        tree.WriteManifest(HonestBytes);
+        var withDllMetadata = await reader.ReadAsync(
+            tree.Snapshot(),
+            CancellationToken.None);
+        Assert.Equal(PlatformInstalledManifestOutcome.Acquired, withDllMetadata.Outcome);
+        Assert.StartsWith(
+            "sha256:",
+            withDllMetadata.AssemblyIdentity,
+            StringComparison.Ordinal);
+
+        AssertRejected(
+            PlatformInstalledManifestOutcome.AssemblyMismatch,
+            await reader.ReadAsync(
+                tree.Snapshot(
+                    dllFiles: ImmutableArray.Create(tree.OutsideFile)),
+                CancellationToken.None));
+
+        AssertRejected(
+            PlatformInstalledManifestOutcome.AssemblyUnavailable,
+            await reader.ReadAsync(
+                tree.Snapshot(dllFiles: ImmutableArray<string>.Empty),
+                CancellationToken.None));
+
+        var escapingDll = Path.Combine(tree.Root, "Escaping.Provider.dll");
+        File.CreateSymbolicLink(escapingDll, tree.OutsideFile);
+        AssertRejected(
+            PlatformInstalledManifestOutcome.AssemblyMismatch,
+            await reader.ReadAsync(
+                tree.Snapshot(dllFiles: ImmutableArray.Create(escapingDll)),
+                CancellationToken.None));
+
+        var duplicateDll = Path.Combine(tree.Root, "Duplicate.Provider.dll");
+        File.CreateSymbolicLink(duplicateDll, tree.AssemblyPath);
+        AssertRejected(
+            PlatformInstalledManifestOutcome.AssemblyMismatch,
+            await reader.ReadAsync(
+                tree.Snapshot(dllFiles: ImmutableArray.Create(
+                    tree.AssemblyPath,
+                    duplicateDll)),
+                CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task AssemblyFileCountIsExactBoundedAndCancellationDisposesEveryHandle()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        using var tree = new ReaderTree();
+        tree.WriteManifest(HonestBytes);
+        var dllFiles = Enumerable.Range(
+                0,
+                PlatformInstalledManifestLimits.MaximumDllFileCount)
+            .Select(index =>
+            {
+                var path = Path.Combine(tree.Root, $"Provider-{index:D3}.dll");
+                File.WriteAllBytes(path, [(byte)index]);
+                return path;
+            })
+            .ToImmutableArray();
+        var reader = new PlatformInstalledManifestFileReader();
+
+        var exact = await reader.ReadAsync(
+            tree.Snapshot(dllFiles: dllFiles),
+            CancellationToken.None);
+        Assert.Equal(PlatformInstalledManifestOutcome.Acquired, exact.Outcome);
+
+        var overBound = dllFiles.Add(tree.AssemblyPath);
+        AssertRejected(
+            PlatformInstalledManifestOutcome.AssemblyMismatch,
+            await reader.ReadAsync(
+                tree.Snapshot(dllFiles: overBound),
+                CancellationToken.None));
+
+        using var cancellation = new CancellationTokenSource();
+        var descriptorsBefore = DescriptorCount();
+        reader = new PlatformInstalledManifestFileReader(
+            afterManifestMetadataOpen: null,
+            afterManifestRead: null,
+            afterAssemblyMetadataOpen: cancellation.Cancel);
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await reader.ReadAsync(
+                tree.Snapshot(dllFiles: dllFiles),
+                cancellation.Token));
+        Assert.InRange(DescriptorCount() - descriptorsBefore, -2, 2);
+    }
+
+    [Fact]
+    public async Task BackslashMixedSeparatorAndTraversalMetadataFailClosed()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        using var tree = new ReaderTree();
+        tree.WriteManifest(HonestBytes);
+        var reader = new PlatformInstalledManifestFileReader();
+        var rootName = Path.GetFileName(tree.Root);
+
+        AssertRejected(
+            PlatformInstalledManifestOutcome.UnsafeOrUnverifiableRoot,
+            await reader.ReadAsync(
+                tree.Snapshot(reportedRoot: tree.Root + "\\..\\" + rootName),
+                CancellationToken.None));
+
+        var assemblyTraversal = Path.Combine(tree.Root, "nested")
+            + "\\..\\"
+            + Path.GetFileName(tree.AssemblyPath);
+        AssertRejected(
+            PlatformInstalledManifestOutcome.AssemblyMismatch,
+            await reader.ReadAsync(
+                tree.Snapshot(
+                    dllFiles: ImmutableArray.Create(assemblyTraversal)),
+                CancellationToken.None));
+
+        var dllTraversal = tree.Root + "\\nested\\..\\" + Path.GetFileName(tree.AssemblyPath);
+        AssertRejected(
+            PlatformInstalledManifestOutcome.AssemblyMismatch,
+            await reader.ReadAsync(
+                tree.Snapshot(dllFiles: ImmutableArray.Create(dllTraversal)),
+                CancellationToken.None));
+
+        foreach (var unsafeRoot in new[]
+        {
+            tree.Root + Path.DirectorySeparatorChar + ".",
+            Path.DirectorySeparatorChar + Path.DirectorySeparatorChar.ToString()
+                + tree.Root.TrimStart(Path.DirectorySeparatorChar),
+            @"\\?\" + tree.Root.TrimStart(Path.DirectorySeparatorChar),
+            Path.GetPathRoot(tree.Root)!,
+        })
+        {
+            AssertRejected(
+                PlatformInstalledManifestOutcome.UnsafeOrUnverifiableRoot,
+                await reader.ReadAsync(
+                    tree.Snapshot(reportedRoot: unsafeRoot),
+                    CancellationToken.None));
+        }
+
+        var dottedAssembly = Path.Combine(tree.Root, ".", Path.GetFileName(tree.AssemblyPath));
+        AssertRejected(
+            PlatformInstalledManifestOutcome.AssemblyMismatch,
+            await reader.ReadAsync(
+                tree.Snapshot(
+                    dllFiles: ImmutableArray.Create(dottedAssembly)),
+                CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task SymlinkedRootAndEquivalentDllLinkBindByFinalDescriptorIdentity()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        using var tree = new ReaderTree();
+        tree.WriteManifest(HonestBytes);
+        var direct = await new PlatformInstalledManifestFileReader().ReadAsync(
+            tree.Snapshot(),
+            CancellationToken.None);
+        var rootLink = Path.Combine(Path.GetDirectoryName(tree.Root)!, "plugin-link");
+        File.CreateSymbolicLink(rootLink, tree.Root);
+        var dllLink = Path.Combine(tree.Root, "Equivalent.Provider.dll");
+        File.CreateSymbolicLink(dllLink, tree.AssemblyPath);
+
+        var result = await new PlatformInstalledManifestFileReader().ReadAsync(
+            tree.Snapshot(
+                reportedRoot: rootLink,
+                dllFiles: ImmutableArray.Create(dllLink)),
+            CancellationToken.None);
+
+        Assert.Equal(PlatformInstalledManifestOutcome.Acquired, result.Outcome);
+        Assert.Equal(HonestBytes, result.Bytes);
+        Assert.Equal(direct.AssemblyIdentity, result.AssemblyIdentity);
+    }
+
+    [Fact]
+    public async Task AssemblySetIdentityIsIndependentOfDllInventoryOrder()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        using var tree = new ReaderTree();
+        tree.WriteManifest(HonestBytes);
+        var secondDll = Path.Combine(tree.Root, "Second.Provider.dll");
+        File.WriteAllBytes(secondDll, [4, 5, 6]);
+        var reader = new PlatformInstalledManifestFileReader();
+
+        var first = await reader.ReadAsync(
+            tree.Snapshot(
+                dllFiles: ImmutableArray.Create(tree.AssemblyPath, secondDll)),
+            CancellationToken.None);
+        var reversed = await reader.ReadAsync(
+            tree.Snapshot(
+                dllFiles: ImmutableArray.Create(secondDll, tree.AssemblyPath)),
+            CancellationToken.None);
+
+        Assert.Equal(PlatformInstalledManifestOutcome.Acquired, first.Outcome);
+        Assert.Equal(PlatformInstalledManifestOutcome.Acquired, reversed.Outcome);
+        Assert.Equal(first.AssemblyIdentity, reversed.AssemblyIdentity);
+    }
+
+    [Fact]
+    public async Task MetadataHandleSurvivesLeafReplacementButPostReadNameAgreementRejectsIt()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        using var tree = new ReaderTree();
+        var originalTarget = Path.Combine(tree.Root, "original.json");
+        var replacementTarget = Path.Combine(tree.Root, "replacement.json");
+        File.WriteAllBytes(originalTarget, HonestBytes);
+        File.WriteAllBytes(replacementTarget, OutsideSentinel);
+        File.CreateSymbolicLink(tree.ManifestPath, originalTarget);
+        var reader = new PlatformInstalledManifestFileReader(
+            afterManifestMetadataOpen: () => ReplaceSymbolicLink(
+                tree.ManifestPath,
+                replacementTarget),
+            afterManifestRead: null);
+
+        AssertRejected(
+            PlatformInstalledManifestOutcome.ReadChanged,
+            await reader.ReadAsync(tree.Snapshot(), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task DeletingTheFixedEntryAfterReadFailsPostReadNameAgreement()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        using var tree = new ReaderTree();
+        var target = Path.Combine(tree.Root, "manifest-target.json");
+        File.WriteAllBytes(target, HonestBytes);
+        File.CreateSymbolicLink(tree.ManifestPath, target);
+        var reader = new PlatformInstalledManifestFileReader(
+            afterManifestMetadataOpen: null,
+            afterManifestRead: () => File.Delete(tree.ManifestPath));
+
+        AssertRejected(
+            PlatformInstalledManifestOutcome.ReadChanged,
+            await reader.ReadAsync(tree.Snapshot(), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task RetargetingASymlinkedRootAfterReadFailsRootIdentityAgreement()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        using var tree = new ReaderTree();
+        tree.WriteManifest(HonestBytes);
+        var parent = Path.GetDirectoryName(tree.Root)!;
+        var rootLink = Path.Combine(parent, "plugin-link");
+        var replacementRoot = Directory.CreateDirectory(
+            Path.Combine(parent, "replacement-plugin")).FullName;
+        File.CreateSymbolicLink(rootLink, tree.Root);
+        var reader = new PlatformInstalledManifestFileReader(
+            afterManifestMetadataOpen: null,
+            afterManifestRead: () => ReplaceSymbolicLink(rootLink, replacementRoot));
+
+        AssertRejected(
+            PlatformInstalledManifestOutcome.ReadChanged,
+            await reader.ReadAsync(
+                tree.Snapshot(reportedRoot: rootLink),
+                CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task RetargetingAReportedDllAfterAssemblyOpenFailsFinalNameAgreement()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        using var tree = new ReaderTree();
+        tree.WriteManifest(HonestBytes);
+        var replacementDll = Path.Combine(tree.Root, "Replacement.Provider.dll");
+        File.WriteAllBytes(replacementDll, [9, 8, 7]);
+        var reportedDll = Path.Combine(tree.Root, "Reported.Provider.dll");
+        File.CreateSymbolicLink(reportedDll, tree.AssemblyPath);
+        var reader = new PlatformInstalledManifestFileReader(
+            afterManifestMetadataOpen: null,
+            afterManifestRead: null,
+            afterAssemblyMetadataOpen: () => ReplaceSymbolicLink(reportedDll, replacementDll));
+
+        AssertRejected(
+            PlatformInstalledManifestOutcome.AssemblyMismatch,
+            await reader.ReadAsync(
+                tree.Snapshot(dllFiles: ImmutableArray.Create(reportedDll)),
+                CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task RetargetingAReportedRootDuringAssemblyVerificationFailsFinalAgreement()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        using var tree = new ReaderTree();
+        tree.WriteManifest(HonestBytes);
+        var parent = Path.GetDirectoryName(tree.Root)!;
+        var reportedRoot = Path.Combine(parent, "reported-plugin-root");
+        var replacementRoot = Directory.CreateDirectory(
+            Path.Combine(parent, "replacement-after-assembly")).FullName;
+        File.CreateSymbolicLink(reportedRoot, tree.Root);
+        var reader = new PlatformInstalledManifestFileReader(
+            afterManifestMetadataOpen: null,
+            afterManifestRead: null,
+            afterAssemblyMetadataOpen: () => ReplaceSymbolicLink(reportedRoot, replacementRoot));
+
+        AssertRejected(
+            PlatformInstalledManifestOutcome.ReadChanged,
+            await reader.ReadAsync(
+                tree.Snapshot(reportedRoot: reportedRoot),
+                CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task MutatingTheManifestDuringAssemblyVerificationFailsFinalStableAgreement()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        using var tree = new ReaderTree();
+        tree.WriteManifest(HonestBytes);
+        var reader = new PlatformInstalledManifestFileReader(
+            afterManifestMetadataOpen: null,
+            afterManifestRead: null,
+            afterAssemblyMetadataOpen: () => tree.WriteManifest(OutsideSentinel));
+
+        AssertRejected(
+            PlatformInstalledManifestOutcome.ReadChanged,
+            await reader.ReadAsync(tree.Snapshot(), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ABindMountedFixedLeafIsRejectedWhenTheTestHostAllowsMounting()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        using var tree = new ReaderTree();
+        tree.WriteManifest(HonestBytes);
+        const ulong bindMount = 4096;
+        if (Mount(tree.OutsideFile, tree.ManifestPath, null, bindMount, null) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            AssertRejected(
+                PlatformInstalledManifestOutcome.UnsafeTarget,
+                await new PlatformInstalledManifestFileReader().ReadAsync(
+                    tree.Snapshot(),
+                    CancellationToken.None));
+        }
+        finally
+        {
+            Unmount(tree.ManifestPath, 0);
+        }
+    }
+
+    [Fact]
+    public async Task VerifiableInRootLinksWorkAndEscapesBrokenLinksAndCyclesFailClosed()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        using var tree = new ReaderTree();
+        var reader = new PlatformInstalledManifestFileReader();
+        var manifestPath = tree.ManifestPath;
+        var target = Path.Combine(tree.Root, "manifest-target.json");
+        File.WriteAllBytes(target, HonestBytes);
+
+        File.CreateSymbolicLink(manifestPath, target);
+        var inside = await reader.ReadAsync(tree.Snapshot(), CancellationToken.None);
+        Assert.Equal(PlatformInstalledManifestOutcome.Acquired, inside.Outcome);
+        Assert.Equal(HonestBytes, inside.Bytes);
+
+        File.Delete(manifestPath);
+        var secondHop = Path.Combine(tree.Root, "second-hop.json");
+        File.CreateSymbolicLink(secondHop, target);
+        File.CreateSymbolicLink(manifestPath, secondHop);
+        var multiHopInside = await reader.ReadAsync(tree.Snapshot(), CancellationToken.None);
+        Assert.Equal(PlatformInstalledManifestOutcome.Acquired, multiHopInside.Outcome);
+
+        File.Delete(manifestPath);
+        File.CreateSymbolicLink(manifestPath, tree.OutsideFile);
+        AssertRejected(
+            PlatformInstalledManifestOutcome.UnsafeTarget,
+            await reader.ReadAsync(tree.Snapshot(), CancellationToken.None));
+
+        File.Delete(manifestPath);
+        var nested = Directory.CreateDirectory(Path.Combine(tree.Root, "nested")).FullName;
+        var directoryHop = Path.Combine(tree.Root, "directory-hop");
+        File.CreateSymbolicLink(directoryHop, nested);
+        File.CreateSymbolicLink(Path.Combine(nested, "escape.json"), tree.OutsideFile);
+        File.CreateSymbolicLink(manifestPath, Path.Combine(directoryHop, "escape.json"));
+        AssertRejected(
+            PlatformInstalledManifestOutcome.UnsafeTarget,
+            await reader.ReadAsync(tree.Snapshot(), CancellationToken.None));
+
+        File.Delete(manifestPath);
+        File.CreateSymbolicLink(manifestPath, Path.Combine(tree.Root, "missing.json"));
+        AssertRejected(
+            PlatformInstalledManifestOutcome.UnsafeTarget,
+            await reader.ReadAsync(tree.Snapshot(), CancellationToken.None));
+
+        File.Delete(manifestPath);
+        var cycle = Path.Combine(tree.Root, "cycle.json");
+        File.CreateSymbolicLink(manifestPath, cycle);
+        File.CreateSymbolicLink(cycle, manifestPath);
+        AssertRejected(
+            PlatformInstalledManifestOutcome.UnsafeTarget,
+            await reader.ReadAsync(tree.Snapshot(), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task DirectoryFifoSocketAndAvailableDeviceAreRejectedWithoutBlockingOrFdGrowth()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        using var tree = new ReaderTree();
+        var reader = new PlatformInstalledManifestFileReader();
+
+        Directory.CreateDirectory(tree.ManifestPath);
+        AssertRejected(
+            PlatformInstalledManifestOutcome.NotRegularFile,
+            await reader.ReadAsync(tree.Snapshot(), CancellationToken.None));
+        Directory.Delete(tree.ManifestPath);
+
+        Assert.Equal(0, MakeFifo(tree.ManifestPath, Convert.ToUInt32("600", 8)));
+        var descriptorsBefore = DescriptorCount();
+        var stopwatch = Stopwatch.StartNew();
+        for (var index = 0; index < 64; index++)
+        {
+            AssertRejected(
+                PlatformInstalledManifestOutcome.NotRegularFile,
+                await reader.ReadAsync(tree.Snapshot(), CancellationToken.None));
+        }
+
+        stopwatch.Stop();
+        var descriptorsAfter = DescriptorCount();
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(2), stopwatch.Elapsed.ToString());
+        Assert.InRange(descriptorsAfter - descriptorsBefore, -2, 2);
+        File.Delete(tree.ManifestPath);
+
+        using (var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified))
+        {
+            socket.Bind(new UnixDomainSocketEndPoint(tree.ManifestPath));
+            AssertRejected(
+                PlatformInstalledManifestOutcome.NotRegularFile,
+                await reader.ReadAsync(tree.Snapshot(), CancellationToken.None));
+        }
+
+        File.Delete(tree.ManifestPath);
+
+        const uint characterDeviceWithOwnerReadWrite = 0x2000 | 0x180;
+        const ulong nullDevice = 0x103;
+        if (MakeNode(tree.ManifestPath, characterDeviceWithOwnerReadWrite, nullDevice) == 0)
+        {
+            AssertRejected(
+                PlatformInstalledManifestOutcome.NotRegularFile,
+                await reader.ReadAsync(tree.Snapshot(), CancellationToken.None));
+        }
+    }
+
+    [Fact]
+    public async Task S16SwapRaceNeverReturnsOutsideSentinelBytes()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        using var tree = new ReaderTree();
+        var reader = new PlatformInstalledManifestFileReader();
+        var honestTarget = Path.Combine(tree.Root, "honest.json");
+        File.WriteAllBytes(honestTarget, HonestBytes);
+        File.CreateSymbolicLink(tree.ManifestPath, honestTarget);
+
+        using var stop = new CancellationTokenSource();
+        var writer = Task.Run(() => SwapManifestLinks(tree, honestTarget, stop.Token));
+        var acquired = 0;
+        try
+        {
+            for (var index = 0; index < 2000; index++)
+            {
+                var result = await reader.ReadAsync(tree.Snapshot(), CancellationToken.None);
+                if (result.Outcome == PlatformInstalledManifestOutcome.Acquired)
+                {
+                    acquired++;
+                    Assert.Equal(HonestBytes, result.Bytes);
+                    Assert.NotEqual(OutsideSentinel, result.Bytes.ToArray());
+                }
+                else
+                {
+                    Assert.Empty(result.Bytes);
+                }
+            }
+        }
+        finally
+        {
+            stop.Cancel();
+            await writer;
+        }
+
+        Assert.True(acquired > 0);
+    }
+
+    [Fact]
+    public async Task ConcurrentContentMutationNeverPublishesAChangedOrPartialRead()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        using var tree = new ReaderTree();
+        var reader = new PlatformInstalledManifestFileReader();
+        tree.WriteManifest(new byte[PlatformExtensionManifestBounds.MaximumDocumentBytes]);
+
+        using var stream = new FileStream(
+            tree.ManifestPath,
+            FileMode.Open,
+            FileAccess.Write,
+            FileShare.ReadWrite | FileShare.Delete);
+        using var stop = new CancellationTokenSource();
+        var writer = Task.Run(() => MutateFile(stream, stop.Token));
+        var changed = 0;
+        try
+        {
+            for (var index = 0; index < 128; index++)
+            {
+                var result = await reader.ReadAsync(tree.Snapshot(), CancellationToken.None);
+                if (result.Outcome == PlatformInstalledManifestOutcome.ReadChanged)
+                {
+                    changed++;
+                }
+                else if (result.Outcome == PlatformInstalledManifestOutcome.Acquired)
+                {
+                    Assert.Equal(
+                        PlatformExtensionManifestBounds.MaximumDocumentBytes,
+                        result.Bytes.Length);
+                }
+                else
+                {
+                    Assert.Contains(
+                        result.Outcome,
+                        new[]
+                        {
+                            PlatformInstalledManifestOutcome.DocumentTooLarge,
+                            PlatformInstalledManifestOutcome.ReadFailed,
+                        });
+                }
+            }
+        }
+        finally
+        {
+            stop.Cancel();
+            await writer;
+        }
+
+        Assert.True(changed > 0);
+    }
+
+    [Fact]
+    public async Task ConcurrentGrowthAndShrinkNeverBypassTheCapOrPublishPartialBytes()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        using var tree = new ReaderTree();
+        var reader = new PlatformInstalledManifestFileReader();
+        var smaller = PlatformExtensionManifestBounds.MaximumDocumentBytes / 2;
+        tree.WriteManifest(new byte[smaller]);
+
+        using var stream = new FileStream(
+            tree.ManifestPath,
+            FileMode.Open,
+            FileAccess.Write,
+            FileShare.ReadWrite | FileShare.Delete);
+        using var stop = new CancellationTokenSource();
+        var writer = Task.Run(() => GrowAndShrinkFile(stream, smaller, stop.Token));
+        var rejectedChanges = 0;
+        try
+        {
+            for (var index = 0; index < 128; index++)
+            {
+                var result = await reader.ReadAsync(tree.Snapshot(), CancellationToken.None);
+                switch (result.Outcome)
+                {
+                    case PlatformInstalledManifestOutcome.Acquired:
+                        Assert.InRange(
+                            result.Bytes.Length,
+                            0,
+                            PlatformExtensionManifestBounds.MaximumDocumentBytes);
+                        break;
+                    case PlatformInstalledManifestOutcome.ReadChanged:
+                    case PlatformInstalledManifestOutcome.DocumentTooLarge:
+                    case PlatformInstalledManifestOutcome.ReadFailed:
+                        rejectedChanges++;
+                        Assert.Empty(result.Bytes);
+                        break;
+                    default:
+                        Assert.Fail("Unexpected growth/shrink outcome: " + result.Outcome);
+                        break;
+                }
+            }
+        }
+        finally
+        {
+            stop.Cancel();
+            await writer;
+        }
+
+        Assert.True(rejectedChanges > 0);
+    }
+
+    [Fact]
+    public void ReadersAreTheOnlyAcquisitionFilesOwningIoPathsAndNativeHandles()
+    {
+        var platformRoot = ProductionPlatformRoot();
+        var acquisitionFiles = Directory.EnumerateFiles(
+            platformRoot,
+            "PlatformInstalledManifest*.cs",
+            SearchOption.TopDirectoryOnly).ToArray();
+        var ownershipTokens = new[]
+        {
+            "using System.IO;",
+            "DllImport(",
+            "SafeHandle",
+            "SafeUnixDescriptor",
+            "Path.",
+            "OpenAt(",
+        };
+        var owners = acquisitionFiles
+            .Where(file => ownershipTokens.Any(token => File.ReadAllText(file).Contains(
+                token,
+                StringComparison.Ordinal)))
+            .Select(Path.GetFileName)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(
+            new[]
+            {
+                "PlatformInstalledManifestFileReader.cs",
+                "PlatformInstalledManifestWindowsReader.cs",
+            },
+            owners);
+        var reader = File.ReadAllText(Path.Combine(
+            platformRoot,
+            "PlatformInstalledManifestFileReader.cs"));
+        Assert.DoesNotContain("Task.Run", reader, StringComparison.Ordinal);
+        Assert.DoesNotContain("Directory.Enumerate", reader, StringComparison.Ordinal);
+        Assert.Contains("OpenNonBlocking", reader, StringComparison.Ordinal);
+        Assert.Contains("/proc/self/fd/", reader, StringComparison.Ordinal);
+        Assert.Contains("statx", reader, StringComparison.Ordinal);
+        Assert.Contains("fstatfs", reader, StringComparison.Ordinal);
+        Assert.Contains("SupportedLocalFileSystemTypes", reader, StringComparison.Ordinal);
+        Assert.Contains("AssemblySetIdentityDomain", reader, StringComparison.Ordinal);
+        Assert.DoesNotContain("InstanceAssembly", reader, StringComparison.Ordinal);
+        Assert.DoesNotContain("GetType()", reader, StringComparison.Ordinal);
+        Assert.Contains(
+            nameof(PlatformExtensionManifestParser.ManifestFileName),
+            reader,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PreCancelledReadPublishesNothingAndThrowsCancellation()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        using var tree = new ReaderTree();
+        tree.WriteManifest(HonestBytes);
+        var reader = new PlatformInstalledManifestFileReader();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await reader.ReadAsync(tree.Snapshot(), cancellation.Token));
+    }
+
+    private static void SwapManifestLinks(
+        ReaderTree tree,
+        string honestTarget,
+        CancellationToken cancellationToken)
+    {
+        var iteration = 0;
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var target = iteration++ % 2 == 0 ? honestTarget : tree.OutsideFile;
+            var temporary = Path.Combine(tree.Root, ".swap-" + Guid.NewGuid().ToString("N"));
+            try
+            {
+                File.CreateSymbolicLink(temporary, target);
+                File.Move(temporary, tree.ManifestPath, overwrite: true);
+            }
+            catch (IOException) when (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+            finally
+            {
+                try
+                {
+                    File.Delete(temporary);
+                }
+                catch (IOException)
+                {
+                    // A successful atomic rename consumes the temporary name.
+                }
+            }
+        }
+    }
+
+    private static void MutateFile(FileStream stream, CancellationToken cancellationToken)
+    {
+        var value = (byte)0;
+        var buffer = new byte[1];
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            buffer[0] = value++;
+            RandomAccess.Write(stream.SafeFileHandle, buffer, 0);
+        }
+    }
+
+    private static void GrowAndShrinkFile(
+        FileStream stream,
+        int smaller,
+        CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            stream.SetLength(PlatformExtensionManifestBounds.MaximumDocumentBytes + 1L);
+            stream.Flush(flushToDisk: false);
+            stream.SetLength(smaller);
+            stream.Flush(flushToDisk: false);
+        }
+    }
+
+    private static void ReplaceSymbolicLink(string linkPath, string target)
+    {
+        var replacement = linkPath + ".replacement";
+        File.Delete(replacement);
+        File.CreateSymbolicLink(replacement, target);
+        if (Rename(replacement, linkPath) != 0)
+        {
+            throw new IOException("Could not atomically replace the test link.");
+        }
+    }
+
+    private static int DescriptorCount() => Directory.GetFileSystemEntries("/proc/self/fd").Length;
+
+    private static string ProductionPlatformRoot([CallerFilePath] string sourceFile = "") =>
+        Path.GetFullPath(Path.Combine(
+            Path.GetDirectoryName(sourceFile)!,
+            "..",
+            "..",
+            "Jellyfin.Plugin.JellyfinCanopy",
+            "Platform"));
+
+    private static void AssertRejected(
+        PlatformInstalledManifestOutcome expected,
+        PlatformInstalledManifestReadResult result)
+    {
+        Assert.Equal(expected, result.Outcome);
+        Assert.Empty(result.Bytes);
+        Assert.Null(result.AssemblyIdentity);
+    }
+
+    private sealed class ReaderTree : IDisposable
+    {
+        private readonly string _container;
+
+        internal ReaderTree()
+        {
+            _container = Directory.CreateTempSubdirectory("canopy-manifest-reader-").FullName;
+            Root = Directory.CreateDirectory(Path.Combine(_container, "plugin")).FullName;
+            AssemblyPath = Path.Combine(Root, "Example.Provider.dll");
+            File.WriteAllBytes(AssemblyPath, [1, 2, 3]);
+            OutsideFile = Path.Combine(_container, "outside.json");
+            File.WriteAllBytes(OutsideFile, OutsideSentinel);
+        }
+
+        internal string Root { get; }
+
+        internal string ManifestPath => Path.Combine(
+            Root,
+            PlatformExtensionManifestParser.ManifestFileName);
+
+        internal string AssemblyPath { get; }
+
+        internal string OutsideFile { get; }
+
+        internal void WriteManifest(byte[] bytes)
+        {
+            if (Directory.Exists(ManifestPath))
+            {
+                Directory.Delete(ManifestPath);
+            }
+            else
+            {
+                File.Delete(ManifestPath);
+            }
+
+            File.WriteAllBytes(ManifestPath, bytes);
+        }
+
+        internal PlatformInstalledPluginSnapshot Snapshot(
+            ImmutableArray<string>? dllFiles = null,
+            string? reportedRoot = null) =>
+            PlatformInstalledPluginSnapshot.EstablishHostSnapshot(
+                Guid.Parse("11111111-2222-3333-4444-555555555555"),
+                "Example Provider",
+                new Version(1, 0),
+                PlatformInstalledPluginHostStatus.Active,
+                reportedRoot ?? Root,
+                dllFiles ?? ImmutableArray.Create(AssemblyPath));
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(_container, recursive: true);
+            }
+            catch (IOException)
+            {
+                // Best-effort cleanup for race fixtures on exceptional test exits.
+            }
+        }
+    }
+
+#pragma warning disable SYSLIB1054 // Linux-only fixture creation; generated marshalling is unnecessary.
+    [DllImport("libc", EntryPoint = "mkfifo", SetLastError = true)]
+    private static extern int MakeFifo(string path, uint mode);
+
+    [DllImport("libc", EntryPoint = "mknod", SetLastError = true)]
+    private static extern int MakeNode(string path, uint mode, ulong device);
+
+    [DllImport("libc", EntryPoint = "mount", SetLastError = true)]
+    private static extern int Mount(
+        string source,
+        string target,
+        string? filesystemType,
+        ulong flags,
+        string? data);
+
+    [DllImport("libc", EntryPoint = "umount2", SetLastError = true)]
+    private static extern int Unmount(string target, int flags);
+
+    [DllImport("libc", EntryPoint = "rename", SetLastError = true)]
+    private static extern int Rename(string oldPath, string newPath);
+#pragma warning restore SYSLIB1054
+}
+
+[CollectionDefinition("Installed manifest filesystem isolation", DisableParallelization = true)]
+public sealed class InstalledManifestFilesystemIsolationCollection
+{
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformInstalledManifestWindowsReaderTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformInstalledManifestWindowsReaderTests.cs
@@ -1,0 +1,711 @@
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.IO.Pipes;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+using Microsoft.Win32.SafeHandles;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform;
+
+public sealed class PlatformInstalledManifestWindowsReaderTests
+{
+    private const string ReaderFileName = "PlatformInstalledManifestWindowsReader.cs";
+
+    private static readonly string[] ForbiddenTokens =
+    {
+        "Task.Run", "File.ReadAll", "FileStream", "Directory.Enumerate", "Directory.GetFiles",
+        "HttpClient", "System.Net", "IConfiguration", "IServiceCollection", "AtomicFile",
+        "Registry", "Approval", "Grant", "PlatformActorFactory", "Assembly.Load", "Activator",
+        "ProviderInvocation", "Controller", "Route(", "IHostedService", "BackgroundService",
+        "AddHostedService", "Android",
+    };
+
+    [Fact]
+    public void ReadIsTheSingleInternalStaticBoundary()
+    {
+        var type = typeof(PlatformInstalledManifestWindowsReader);
+        Assert.True(type.IsAbstract && type.IsSealed);
+        Assert.False(type.IsPublic);
+        var read = Assert.Single(type.GetMethods(
+            BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.DeclaredOnly),
+            method => method.Name == "Read");
+        Assert.Equal(typeof(PlatformInstalledManifestReadResult), read.ReturnType);
+        Assert.Equal(
+            new[] { typeof(PlatformInstalledPluginSnapshot), typeof(CancellationToken) },
+            read.GetParameters().Select(parameter => parameter.ParameterType));
+        Assert.DoesNotContain(read.GetParameters(), parameter => parameter.ParameterType == typeof(string));
+    }
+
+    [Fact]
+    public void LinuxCoverageExclusionIsBackedByARealWindowsCiJob()
+    {
+        Assert.NotNull(typeof(PlatformInstalledManifestWindowsReader)
+            .GetCustomAttribute<ExcludeFromCodeCoverageAttribute>());
+        var workflow = File.ReadAllText(Path.Combine(RepositoryRoot(), ".github", "workflows", "build.yml"));
+        Assert.Contains("windows-manifest-tests:", workflow, StringComparison.Ordinal);
+        Assert.Contains("runs-on: windows-latest", workflow, StringComparison.Ordinal);
+        Assert.Contains("FullyQualifiedName~PlatformInstalledManifestWindowsReaderTests", workflow,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NonWindowsInvocationFailsClosedBeforeAnyNativeCall()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var result = PlatformInstalledManifestWindowsReader.Read(Snapshot(), CancellationToken.None);
+
+        Assert.Equal(PlatformInstalledManifestOutcome.DescriptorUnverifiable, result.Outcome);
+        Assert.Empty(result.Bytes);
+        Assert.Null(result.AssemblyIdentity);
+    }
+
+    [Fact]
+    public void NativeImportsAreExactSafeHandleWindowsContracts()
+    {
+        var type = typeof(PlatformInstalledManifestWindowsReader);
+        foreach (var methodName in new[]
+        {
+            "CreateFileW", "ReOpenFile", "GetFinalPathNameByHandleW", "GetFileType",
+            "GetDriveTypeW",
+            "GetFileInformationByHandleExIdentity", "GetFileInformationByHandleExBasic",
+            "GetFileInformationByHandleExStandard", "ReadFile", "CancelIoEx", "GetOverlappedResult",
+        })
+        {
+            var method = type.GetMethod(methodName, BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.NotNull(method);
+            var import = method!.GetCustomAttribute<DllImportAttribute>();
+            Assert.NotNull(import);
+            Assert.Equal("kernel32.dll", import!.Value);
+            Assert.True(import.ExactSpelling);
+            Assert.True(import.SetLastError);
+        }
+
+        Assert.Equal(typeof(SafeFileHandle), Method("CreateFileW").ReturnType);
+        Assert.Equal(typeof(SafeFileHandle), Method("ReOpenFile").ReturnType);
+        Assert.Equal(typeof(SafeFileHandle), Method("ReOpenFile").GetParameters()[0].ParameterType);
+        Assert.Equal(typeof(SafeFileHandle), Method("ReadFile").GetParameters()[0].ParameterType);
+        Assert.Equal(typeof(SafeFileHandle), Method("CancelIoEx").GetParameters()[0].ParameterType);
+        Assert.Equal(typeof(SafeFileHandle), Method("GetOverlappedResult").GetParameters()[0].ParameterType);
+        Assert.Equal(typeof(IntPtr), Method("ReadFile").GetParameters()[4].ParameterType);
+        Assert.Equal(typeof(IntPtr), Method("CancelIoEx").GetParameters()[1].ParameterType);
+
+        MethodInfo Method(string name) => type.GetMethod(name, BindingFlags.Static | BindingFlags.NonPublic)!;
+    }
+
+    [Fact]
+    public void NativeIdentityMetadataAndOverlappedLayoutsArePinned()
+    {
+        var nested = typeof(PlatformInstalledManifestWindowsReader).GetNestedTypes(
+            BindingFlags.NonPublic);
+        Assert.Equal(16, Size("NativeFileId128"));
+        Assert.Equal(24, Size("NativeFileIdInfo"));
+        Assert.Equal(40, Size("NativeFileBasicInfo"));
+        Assert.Equal(24, Size("NativeFileStandardInfo"));
+        Assert.Equal(IntPtr.Size == 8 ? 32 : 20, Size("NativeOverlappedData"));
+
+        int Size(string name) => Marshal.SizeOf(nested.Single(type => type.Name == name));
+    }
+
+    [Fact]
+    public void HandleVerificationOrderingAndBoundedCancellationArePresent()
+    {
+        var code = Code(SourceFile());
+        var readOwner = code[..code.IndexOf(
+            "private static AssemblyVerification VerifyAssembly",
+            StringComparison.Ordinal)];
+
+        AssertOrdered(
+            readOwner,
+            "rootHandle = CreateFileW",
+            "TryGetFinalPath(rootHandle",
+            "manifestMetadataHandle = CreateFileW",
+            "TryGetFinalPath(manifestMetadataHandle",
+            "manifestReadHandle = ReOpenFile",
+            "ReadBoundedOverlapped",
+            "FixedEntryStillNamesStableObject",
+            "RootStillNamesObject",
+            "VerifyAssembly");
+        Assert.Contains("MaximumDocumentBytes + 1", code, StringComparison.Ordinal);
+        Assert.Contains("FileFlagOverlapped", code, StringComparison.Ordinal);
+        Assert.Contains("CancelIoEx", code, StringComparison.Ordinal);
+        Assert.Contains("GetOverlappedResult", code, StringComparison.Ordinal);
+        Assert.Contains("GetFinalPathNameByHandleW", code, StringComparison.Ordinal);
+        Assert.Contains("GetFileInformationByHandleEx", code, StringComparison.Ordinal);
+        Assert.Contains("VolumeSerialNumber", code, StringComparison.Ordinal);
+        Assert.Contains("GetDriveTypeW", code, StringComparison.Ordinal);
+        Assert.Contains("DriveFixed", code, StringComparison.Ordinal);
+        Assert.Contains("foreach (var reportedDll in snapshot.DllFiles)", code, StringComparison.Ordinal);
+        Assert.True(
+            code.IndexOf("snapshot.DllFiles.Length > PlatformInstalledManifestLimits.MaximumDllFileCount", StringComparison.Ordinal)
+            < code.IndexOf("new List<SafeFileHandle>(snapshot.DllFiles.Length)", StringComparison.Ordinal));
+        Assert.Contains("verifiedDlls.Add(new VerifiedDll(", code, StringComparison.Ordinal);
+        Assert.Contains("FixedEntryStillNamesStableObject", code, StringComparison.Ordinal);
+        Assert.True(
+            readOwner.LastIndexOf("FixedEntryStillNamesStableObject", StringComparison.Ordinal)
+            > readOwner.IndexOf("VerifyAssembly(snapshot", StringComparison.Ordinal));
+        Assert.Contains("jellyfin-canopy:installed-assembly-set:v1", code, StringComparison.Ordinal);
+        Assert.Contains("IncrementalHash.CreateHash(HashAlgorithmName.SHA256)", code, StringComparison.Ordinal);
+        Assert.Contains("OrderBy(item => item.CanonicalRelativeName, StringComparer.Ordinal)", code, StringComparison.Ordinal);
+        Assert.Contains("foreach (var dllHandle in dllHandles)", code, StringComparison.Ordinal);
+        Assert.Contains(nameof(PlatformExtensionManifestParser.ManifestFileName), code, StringComparison.Ordinal);
+        Assert.Empty(Forbidden(code));
+    }
+
+    [Theory]
+    [InlineData("Task.Run(() => File.ReadAllBytes(path))", "Task.Run")]
+    [InlineData("services.AddHostedService<ManifestWorker>();", "AddHostedService")]
+    [InlineData("[Route(\"manifest\")] sealed class C : Controller { }", "Controller")]
+    [InlineData("Assembly.Load(bytes); Activator.CreateInstance(type);", "Assembly.Load")]
+    [InlineData("var approvedGrant = new RegistryApprovalGrant();", "Registry")]
+    public void PlantedForbiddenDependenciesAreNamed(string source, string expected) =>
+        Assert.Contains(expected, Forbidden(source), StringComparer.OrdinalIgnoreCase);
+
+    [Fact]
+    public void SourceHasNoValidateThenManagedOpenFallbackOrRawPathResult()
+    {
+        var code = Code(SourceFile());
+        Assert.DoesNotContain("File.Open", code, StringComparison.Ordinal);
+        Assert.DoesNotContain("new FileStream", code, StringComparison.Ordinal);
+        Assert.DoesNotContain("ReadAllBytes", code, StringComparison.Ordinal);
+        Assert.DoesNotContain("Task.Run", code, StringComparison.Ordinal);
+        Assert.DoesNotContain("snapshot.InstanceAssemblyIdentity", code, StringComparison.Ordinal);
+        Assert.DoesNotContain("snapshot.InstanceAssemblyPath", code, StringComparison.Ordinal);
+        Assert.DoesNotContain("PlatformInstalledManifestReadResult.Acquired(\n                read.Bytes,\n                snapshot.InstanceAssemblyPath",
+            code,
+            StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("C:\\plugins\\.\\example")]
+    [InlineData("C:\\plugins\\..\\example")]
+    [InlineData("C:\\plugins\\example:stream")]
+    [InlineData("C:plugins\\example")]
+    [InlineData("1:\\plugins\\example")]
+    [InlineData("\\\\server\\share\\plugins")]
+    [InlineData("\\\\?\\C:\\plugins")]
+    [InlineData("\\\\.\\C:\\plugins")]
+    [InlineData("\\??\\C:\\plugins")]
+    [InlineData("\\Device\\HarddiskVolume1\\plugins")]
+    public void RawDotAlternateDataStreamUncAndDeviceShapesAreRejectedBeforeNormalization(
+        string path)
+    {
+        var method = typeof(PlatformInstalledManifestWindowsReader).GetMethod(
+            "HasUnsafeLexicalShape",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+
+        Assert.True(Assert.IsType<bool>(method.Invoke(null, new object[] { path })));
+        Assert.False(Assert.IsType<bool>(method.Invoke(null, new object[] { "C:\\plugins\\example" })));
+    }
+
+    [Fact]
+    public void WindowsHonestFileAndExactMaximumAreAcquired()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var tree = new WindowsReaderTree();
+        var honest = PlatformInstalledManifestBindingTests.ManifestBytes();
+        tree.WriteManifest(honest);
+        var result = PlatformInstalledManifestWindowsReader.Read(tree.Snapshot(), CancellationToken.None);
+        Assert.Equal(PlatformInstalledManifestOutcome.Acquired, result.Outcome);
+        Assert.Equal(honest, result.Bytes);
+
+        var exact = new byte[PlatformExtensionManifestBounds.MaximumDocumentBytes];
+        honest.CopyTo(exact, 0);
+        exact.AsSpan(honest.Length).Fill((byte)' ');
+        tree.WriteManifest(exact);
+        result = PlatformInstalledManifestWindowsReader.Read(tree.Snapshot(), CancellationToken.None);
+        Assert.Equal(PlatformInstalledManifestOutcome.Acquired, result.Outcome);
+        Assert.Equal(exact.Length, result.Bytes.Length);
+    }
+
+    [Fact]
+    public void WindowsCapPlusOneFailsBeforePublishingBytes()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var tree = new WindowsReaderTree();
+        tree.WriteManifest(new byte[PlatformExtensionManifestBounds.MaximumDocumentBytes + 1]);
+
+        var result = PlatformInstalledManifestWindowsReader.Read(tree.Snapshot(), CancellationToken.None);
+
+        Assert.Equal(PlatformInstalledManifestOutcome.DocumentTooLarge, result.Outcome);
+        Assert.Empty(result.Bytes);
+    }
+
+    [Fact]
+    public void WindowsInRootLinkWorksAndOutsideLinkFailsClosed()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var tree = new WindowsReaderTree();
+        var bytes = PlatformInstalledManifestBindingTests.ManifestBytes();
+        var inside = Path.Combine(tree.Root, "inside-manifest.json");
+        File.WriteAllBytes(inside, bytes);
+        Assert.True(
+            TryCreateFileLink(tree.ManifestPath, inside),
+            "Windows CI must permit symbolic-link creation so handle containment is exercised.");
+
+        var result = PlatformInstalledManifestWindowsReader.Read(tree.Snapshot(), CancellationToken.None);
+        Assert.Equal(PlatformInstalledManifestOutcome.Acquired, result.Outcome);
+        File.Delete(tree.ManifestPath);
+
+        File.WriteAllBytes(tree.OutsideManifest, bytes);
+        Assert.True(
+            TryCreateFileLink(tree.ManifestPath, tree.OutsideManifest),
+            "Windows CI must permit symbolic-link creation so escape rejection is exercised.");
+
+        result = PlatformInstalledManifestWindowsReader.Read(tree.Snapshot(), CancellationToken.None);
+        Assert.Equal(PlatformInstalledManifestOutcome.UnsafeTarget, result.Outcome);
+        Assert.Empty(result.Bytes);
+    }
+
+    [Fact]
+    public void WindowsDllInventoryIsHandleVerifiedAndHasDeterministicSetIdentity()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var tree = new WindowsReaderTree();
+        tree.WriteManifest(PlatformInstalledManifestBindingTests.ManifestBytes());
+        var otherDll = Path.Combine(tree.Root, "Other.dll");
+        File.WriteAllBytes(otherDll, new byte[] { 7, 8, 9 });
+
+        var firstOrder = PlatformInstalledManifestWindowsReader.Read(
+            tree.Snapshot(ImmutableArray.Create(tree.AssemblyPath, otherDll)),
+            CancellationToken.None);
+        var secondOrder = PlatformInstalledManifestWindowsReader.Read(
+            tree.Snapshot(ImmutableArray.Create(otherDll, tree.AssemblyPath)),
+            CancellationToken.None);
+        Assert.Equal(PlatformInstalledManifestOutcome.Acquired, firstOrder.Outcome);
+        Assert.Equal(firstOrder.AssemblyIdentity, secondOrder.AssemblyIdentity);
+        Assert.StartsWith("dll-set-sha256:", firstOrder.AssemblyIdentity, StringComparison.Ordinal);
+        Assert.DoesNotContain("Example.Provider", firstOrder.AssemblyIdentity, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(tree.Root, firstOrder.AssemblyIdentity, StringComparison.OrdinalIgnoreCase);
+
+        var outsideDll = Path.Combine(Path.GetDirectoryName(tree.Root)!, "outside", "Outside.dll");
+        File.WriteAllBytes(outsideDll, new byte[] { 10, 11, 12 });
+        var outside = PlatformInstalledManifestWindowsReader.Read(
+            tree.Snapshot(ImmutableArray.Create(outsideDll)),
+            CancellationToken.None);
+        Assert.Equal(PlatformInstalledManifestOutcome.AssemblyMismatch, outside.Outcome);
+
+        var alias = Path.Combine(tree.Root, "Alias.dll");
+        var direct = PlatformInstalledManifestWindowsReader.Read(
+            tree.Snapshot(ImmutableArray.Create(tree.AssemblyPath)),
+            CancellationToken.None);
+        Assert.True(
+            TryCreateFileLink(alias, tree.AssemblyPath),
+            "Windows CI must permit symbolic-link creation so DLL alias identity is exercised.");
+
+        var inRootAlias = PlatformInstalledManifestWindowsReader.Read(
+            tree.Snapshot(ImmutableArray.Create(alias)),
+            CancellationToken.None);
+        Assert.Equal(PlatformInstalledManifestOutcome.Acquired, inRootAlias.Outcome);
+        Assert.Equal(direct.AssemblyIdentity, inRootAlias.AssemblyIdentity);
+    }
+
+    [Fact]
+    public void WindowsDllDirectoryEscapesBrokenLinksAndCyclesFailClosed()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var tree = new WindowsReaderTree();
+        tree.WriteManifest(PlatformInstalledManifestBindingTests.ManifestBytes());
+        var outsideDirectory = Path.GetDirectoryName(tree.OutsideManifest)!;
+        var outsideDll = Path.Combine(outsideDirectory, "Outside.Provider.dll");
+        File.WriteAllBytes(outsideDll, [5, 4, 3]);
+
+        var escapeDirectory = Path.Combine(tree.Root, "escape-directory");
+        Assert.True(
+            TryCreateDirectoryLink(escapeDirectory, outsideDirectory),
+            "Windows CI must permit directory links so component escapes are exercised.");
+        Assert.Equal(
+            PlatformInstalledManifestOutcome.AssemblyMismatch,
+            PlatformInstalledManifestWindowsReader.Read(
+                tree.Snapshot(ImmutableArray.Create(Path.Combine(escapeDirectory, "Outside.Provider.dll"))),
+                CancellationToken.None).Outcome);
+
+        Directory.Delete(escapeDirectory);
+        var secondHop = Path.Combine(tree.Root, "second-hop");
+        var firstHop = Path.Combine(tree.Root, "first-hop");
+        Assert.True(TryCreateDirectoryLink(secondHop, outsideDirectory));
+        Assert.True(TryCreateDirectoryLink(firstHop, secondHop));
+        Assert.Equal(
+            PlatformInstalledManifestOutcome.AssemblyMismatch,
+            PlatformInstalledManifestWindowsReader.Read(
+                tree.Snapshot(ImmutableArray.Create(Path.Combine(firstHop, "Outside.Provider.dll"))),
+                CancellationToken.None).Outcome);
+
+        Directory.Delete(firstHop);
+        Directory.Delete(secondHop);
+        var broken = Path.Combine(tree.Root, "Broken.Provider.dll");
+        Assert.True(TryCreateFileLink(broken, Path.Combine(tree.Root, "missing.dll")));
+        Assert.Equal(
+            PlatformInstalledManifestOutcome.AssemblyMismatch,
+            PlatformInstalledManifestWindowsReader.Read(
+                tree.Snapshot(ImmutableArray.Create(broken)),
+                CancellationToken.None).Outcome);
+
+        File.Delete(broken);
+        var cycleA = Path.Combine(tree.Root, "CycleA.Provider.dll");
+        var cycleB = Path.Combine(tree.Root, "CycleB.Provider.dll");
+        Assert.True(TryCreateFileLink(cycleA, cycleB));
+        Assert.True(TryCreateFileLink(cycleB, cycleA));
+        Assert.Equal(
+            PlatformInstalledManifestOutcome.AssemblyMismatch,
+            PlatformInstalledManifestWindowsReader.Read(
+                tree.Snapshot(ImmutableArray.Create(cycleA)),
+                CancellationToken.None).Outcome);
+    }
+
+    [Fact]
+    public async Task WindowsConcurrentValidFileOutsideLinkSwapNeverPublishesOutsideBytes()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var tree = new WindowsReaderTree();
+        var honest = PlatformInstalledManifestBindingTests.ManifestBytes();
+        var outside = Encoding.UTF8.GetBytes("OUTSIDE-WINDOWS-SENTINEL");
+        var honestTarget = Path.Combine(tree.Root, "honest-manifest.json");
+        File.WriteAllBytes(honestTarget, honest);
+        File.WriteAllBytes(tree.OutsideManifest, outside);
+        Assert.True(TryCreateFileLink(tree.ManifestPath, honestTarget));
+
+        using var stop = new CancellationTokenSource();
+        var honestSwaps = 0;
+        var outsideSwaps = 0;
+        var writer = Task.Run(() => SwapWindowsManifestLinks(
+            tree,
+            honestTarget,
+            stop.Token,
+            outside =>
+            {
+                if (outside)
+                {
+                    Interlocked.Increment(ref outsideSwaps);
+                }
+                else
+                {
+                    Interlocked.Increment(ref honestSwaps);
+                }
+            }));
+        var acquired = 0;
+        try
+        {
+            for (var index = 0; index < 2000; index++)
+            {
+                var result = PlatformInstalledManifestWindowsReader.Read(
+                    tree.Snapshot(),
+                    CancellationToken.None);
+                if (result.Outcome == PlatformInstalledManifestOutcome.Acquired)
+                {
+                    acquired++;
+                    Assert.Equal(honest, result.Bytes);
+                    Assert.NotEqual(outside, result.Bytes.ToArray());
+                }
+                else
+                {
+                    Assert.Empty(result.Bytes);
+                }
+            }
+        }
+        finally
+        {
+            stop.Cancel();
+            await writer;
+        }
+
+        Assert.True(acquired > 0);
+        Assert.True(Volatile.Read(ref honestSwaps) > 0);
+        Assert.True(Volatile.Read(ref outsideSwaps) > 0);
+    }
+
+    [Fact]
+    public void WindowsEmptyOrDuplicateDllInventoryFailsClosed()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var tree = new WindowsReaderTree();
+        tree.WriteManifest(PlatformInstalledManifestBindingTests.ManifestBytes());
+
+        var empty = PlatformInstalledManifestWindowsReader.Read(
+            tree.Snapshot(ImmutableArray<string>.Empty),
+            CancellationToken.None);
+        Assert.Equal(PlatformInstalledManifestOutcome.AssemblyUnavailable, empty.Outcome);
+
+        var duplicate = PlatformInstalledManifestWindowsReader.Read(
+            tree.Snapshot(ImmutableArray.Create(tree.AssemblyPath, tree.AssemblyPath)),
+            CancellationToken.None);
+        Assert.Equal(PlatformInstalledManifestOutcome.AssemblyMismatch, duplicate.Outcome);
+
+        var overBound = PlatformInstalledManifestWindowsReader.Read(
+            tree.Snapshot(Enumerable.Repeat(
+                    tree.AssemblyPath,
+                    PlatformInstalledManifestLimits.MaximumDllFileCount + 1)
+                .ToImmutableArray()),
+            CancellationToken.None);
+        Assert.Equal(PlatformInstalledManifestOutcome.AssemblyMismatch, overBound.Outcome);
+    }
+
+    [Fact]
+    public void WindowsPreCancelledReadThrowsWithoutPublishingAResult()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var tree = new WindowsReaderTree();
+        tree.WriteManifest(PlatformInstalledManifestBindingTests.ManifestBytes());
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        Assert.Throws<OperationCanceledException>(() =>
+            PlatformInstalledManifestWindowsReader.Read(tree.Snapshot(), cancellation.Token));
+    }
+
+    [Fact]
+    public async Task WindowsActiveOverlappedReadHonorsCancellationAndCompletesCleanup()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var pipeName = "jc-manifest-cancel-" + Guid.NewGuid().ToString("N");
+        using var server = new NamedPipeServerStream(
+            pipeName,
+            PipeDirection.InOut,
+            1,
+            PipeTransmissionMode.Byte,
+            PipeOptions.Asynchronous);
+        using var client = new NamedPipeClientStream(
+            ".",
+            pipeName,
+            PipeDirection.InOut,
+            PipeOptions.Asynchronous);
+        var clientConnect = client.ConnectAsync();
+        await server.WaitForConnectionAsync();
+        await clientConnect;
+
+        using var borrowedHandle = new SafeFileHandle(
+            server.SafePipeHandle.DangerousGetHandle(),
+            ownsHandle: false);
+        var buffer = Marshal.AllocHGlobal(1);
+        try
+        {
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+            var method = typeof(PlatformInstalledManifestWindowsReader).GetMethod(
+                "ReadOverlappedChunk",
+                BindingFlags.Static | BindingFlags.NonPublic)!;
+            var wrapper = Assert.Throws<TargetInvocationException>(() => method.Invoke(
+                null,
+                new object[] { borrowedHandle, buffer, 1U, 0UL, cancellation.Token }));
+            Assert.IsType<OperationCanceledException>(wrapper.InnerException);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(buffer);
+        }
+    }
+
+    private static string[] Forbidden(string source) => ForbiddenTokens
+        .Where(token => source.Contains(token, StringComparison.OrdinalIgnoreCase))
+        .ToArray();
+
+    private static void AssertOrdered(string source, params string[] values)
+    {
+        var previous = -1;
+        foreach (var value in values)
+        {
+            var current = source.IndexOf(value, previous + 1, StringComparison.Ordinal);
+            Assert.True(current > previous, $"Expected '{value}' after offset {previous}.");
+            previous = current;
+        }
+    }
+
+    private static PlatformInstalledPluginSnapshot Snapshot() =>
+        PlatformInstalledPluginSnapshot.EstablishHostSnapshot(
+            Guid.Parse("11111111-2222-3333-4444-555555555555"),
+            "Example Provider",
+            new Version(1, 2, 3, 4),
+            PlatformInstalledPluginHostStatus.Active,
+            "C:\\plugins\\example",
+            ImmutableArray.Create("C:\\plugins\\example\\Example.Provider.dll"));
+
+    private static bool TryCreateFileLink(string linkPath, string targetPath)
+    {
+        try
+        {
+            File.CreateSymbolicLink(linkPath, targetPath);
+            return true;
+        }
+        catch (Exception exception) when (exception is IOException
+            or UnauthorizedAccessException
+            or PlatformNotSupportedException)
+        {
+            return false;
+        }
+    }
+
+    private static bool TryCreateDirectoryLink(string linkPath, string targetPath)
+    {
+        try
+        {
+            Directory.CreateSymbolicLink(linkPath, targetPath);
+            return true;
+        }
+        catch (Exception exception) when (exception is IOException
+            or UnauthorizedAccessException
+            or PlatformNotSupportedException)
+        {
+            return false;
+        }
+    }
+
+    private static void SwapWindowsManifestLinks(
+        WindowsReaderTree tree,
+        string honestTarget,
+        CancellationToken cancellationToken,
+        Action<bool> swapped)
+    {
+        var iteration = 0;
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var target = iteration++ % 2 == 0 ? honestTarget : tree.OutsideManifest;
+            var temporary = Path.Combine(tree.Root, ".swap-" + Guid.NewGuid().ToString("N"));
+            try
+            {
+                File.CreateSymbolicLink(temporary, target);
+                File.Move(temporary, tree.ManifestPath, overwrite: true);
+                swapped(!string.Equals(target, honestTarget, StringComparison.Ordinal));
+            }
+            catch (IOException)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+            }
+            catch (UnauthorizedAccessException)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+            }
+            finally
+            {
+                try
+                {
+                    File.Delete(temporary);
+                }
+                catch (IOException)
+                {
+                    // A successful atomic rename consumes the temporary name.
+                }
+            }
+        }
+    }
+
+    private static string Code(string file) => PlatformHostSeamTests.CodeOnly(File.ReadAllText(file));
+
+    private static string SourceFile([CallerFilePath] string sourceFile = "") =>
+        Path.GetFullPath(Path.Combine(
+            Path.GetDirectoryName(sourceFile)!,
+            "..",
+            "..",
+            "Jellyfin.Plugin.JellyfinCanopy",
+            "Platform",
+            ReaderFileName));
+
+    private static string RepositoryRoot([CallerFilePath] string sourceFile = "") =>
+        Path.GetFullPath(Path.Combine(Path.GetDirectoryName(sourceFile)!, "..", ".."));
+
+    private sealed class WindowsReaderTree : IDisposable
+    {
+        private readonly string _top;
+
+        internal WindowsReaderTree()
+        {
+            _top = Path.Combine(Path.GetTempPath(), "jc-win-reader-" + Guid.NewGuid().ToString("N"));
+            Root = Path.Combine(_top, "plugin");
+            var outside = Path.Combine(_top, "outside");
+            Directory.CreateDirectory(Root);
+            Directory.CreateDirectory(outside);
+            ManifestPath = Path.Combine(Root, PlatformExtensionManifestParser.ManifestFileName);
+            OutsideManifest = Path.Combine(outside, "manifest.json");
+            AssemblyPath = Path.Combine(Root, "Example.Provider.dll");
+            File.WriteAllBytes(AssemblyPath, new byte[] { 1, 2, 3 });
+        }
+
+        internal string Root { get; }
+
+        internal string ManifestPath { get; }
+
+        internal string OutsideManifest { get; }
+
+        internal string AssemblyPath { get; }
+
+        internal void WriteManifest(byte[] bytes) => File.WriteAllBytes(ManifestPath, bytes);
+
+        internal PlatformInstalledPluginSnapshot Snapshot(ImmutableArray<string>? dllFiles = null) =>
+            PlatformInstalledPluginSnapshot.EstablishHostSnapshot(
+                Guid.Parse("11111111-2222-3333-4444-555555555555"),
+                "Example Provider",
+                new Version(1, 2, 3, 4),
+                PlatformInstalledPluginHostStatus.Active,
+                Root,
+                dllFiles ?? ImmutableArray.Create(AssemblyPath));
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(_top, recursive: true);
+            }
+            catch (IOException)
+            {
+                // Windows may briefly retain a just-cancelled overlapped handle.
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // Cleanup is best effort for a disposable test tree only.
+            }
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformNativeCatalogServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformNativeCatalogServiceTests.cs
@@ -735,6 +735,10 @@ public sealed class PlatformNativeCatalogServiceTests
         public IReadOnlyList<HostPlugin> Installed() => [];
 
         HostPlugin? IHostPlugins.Find(Guid id) => null;
+
+        IReadOnlyList<PlatformInstalledPluginSnapshot> IHostPlugins.InstalledSnapshots() => [];
+
+        PlatformInstalledPluginSnapshot? IHostPlugins.FindSnapshot(Guid id) => null;
     }
 
     private sealed class FakeSpoilerOwner : ISpoilerGuardItemActionOwner

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformNativePilotConformanceMatrixTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformNativePilotConformanceMatrixTests.cs
@@ -1109,6 +1109,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
             public IReadOnlyList<HostSession> ForUser(Guid userId) => Array.Empty<HostSession>();
             public IReadOnlyList<HostPlugin> Installed() => Array.Empty<HostPlugin>();
             HostPlugin? IHostPlugins.Find(Guid id) => null;
+            IReadOnlyList<PlatformInstalledPluginSnapshot> IHostPlugins.InstalledSnapshots() =>
+                Array.Empty<PlatformInstalledPluginSnapshot>();
+            PlatformInstalledPluginSnapshot? IHostPlugins.FindSnapshot(Guid id) => null;
         }
 
         private sealed class EmptyAuthenticationService : IAuthenticationService

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrItemRequestPresentationOwnerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrItemRequestPresentationOwnerTests.cs
@@ -969,6 +969,11 @@ public sealed class SeerrItemRequestPresentationOwnerTests
         public IReadOnlyList<HostPlugin> Installed() => Array.Empty<HostPlugin>();
 
         public HostPlugin? Find(Guid id) => null;
+
+        public IReadOnlyList<PlatformInstalledPluginSnapshot> InstalledSnapshots() =>
+            Array.Empty<PlatformInstalledPluginSnapshot>();
+
+        public PlatformInstalledPluginSnapshot? FindSnapshot(Guid id) => null;
     }
 
     private sealed class ThrowingHttpClientFactory : IHttpClientFactory

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrMediaRequestOwnerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/SeerrMediaRequestOwnerTests.cs
@@ -698,6 +698,11 @@ public sealed class SeerrMediaRequestOwnerTests
             public IReadOnlyList<HostPlugin> Installed() => Array.Empty<HostPlugin>();
 
             public HostPlugin? Find(Guid id) => null;
+
+            public IReadOnlyList<PlatformInstalledPluginSnapshot> InstalledSnapshots() =>
+                Array.Empty<PlatformInstalledPluginSnapshot>();
+
+            public PlatformInstalledPluginSnapshot? FindSnapshot(Guid id) => null;
         }
     }
 

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/Hosting/HostTypes.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/Hosting/HostTypes.cs
@@ -137,4 +137,101 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting
     /// <param name="Version">The installed version.</param>
     /// <param name="Status">The host's status string for the plugin, for example <c>Active</c> or <c>Restart</c>.</param>
     public readonly record struct HostPlugin(Guid Id, string Name, string Version, string Status);
+
+    /// <summary>
+    /// Jellyfin's closed installed-plugin states, kept independent of the host enum so
+    /// the rest of the Platform kernel does not acquire a host assembly dependency.
+    ///
+    /// Undefined numeric values are deliberately retained when the adapter sees a newer
+    /// host state. Acquisition can then fail closed without silently reclassifying it as
+    /// one of the states this version understands.
+    /// </summary>
+    internal enum PlatformInstalledPluginHostStatus
+    {
+        /// <summary>A restart is required before the host-side change takes effect.</summary>
+        Restart = 0,
+
+        /// <summary>The plugin is currently active.</summary>
+        Active = 1,
+
+        /// <summary>The plugin is disabled.</summary>
+        Disabled = 2,
+
+        /// <summary>The plugin does not meet the host ABI requirements.</summary>
+        NotSupported = 3,
+
+        /// <summary>The plugin failed while the host instantiated it.</summary>
+        Malfunctioned = 4,
+
+        /// <summary>Another installed version supersedes this plugin.</summary>
+        Superseded = 5,
+
+        /// <summary>The host has marked the plugin for deletion.</summary>
+        Deleted = 6,
+    }
+
+    /// <summary>
+    /// One immutable observation minted from a real Jellyfin <c>LocalPlugin</c>.
+    ///
+    /// The public facts are inert host identity only. Installation topology remains
+    /// internal so it cannot become a caller-selected path API or leak through the
+    /// long-standing public <see cref="HostPlugin"/> projection. This observation is
+    /// not approval, a grant, registry state, or proof that the plugin remains installed.
+    /// </summary>
+    internal sealed class PlatformInstalledPluginSnapshot
+    {
+        private PlatformInstalledPluginSnapshot(
+            Guid pluginId,
+            string name,
+            Version version,
+            PlatformInstalledPluginHostStatus status,
+            string reportedRoot,
+            ImmutableArray<string> reportedDllFiles)
+        {
+            PluginId = pluginId;
+            Name = name;
+            Version = version;
+            Status = status;
+            ReportedRoot = reportedRoot;
+            DllFiles = reportedDllFiles.IsDefault
+                ? ImmutableArray<string>.Empty
+                : reportedDllFiles;
+        }
+
+        /// <summary>Gets the GUID reported by Jellyfin for this installed plugin.</summary>
+        public Guid PluginId { get; }
+
+        /// <summary>Gets the host-reported display name. It is attribution, never identity.</summary>
+        public string Name { get; }
+
+        /// <summary>Gets the typed version reported by Jellyfin.</summary>
+        public Version Version { get; }
+
+        /// <summary>Gets the exact closed host status observed for this plugin.</summary>
+        public PlatformInstalledPluginHostStatus Status { get; }
+
+        /// <summary>Gets the untrusted installation root reported by Jellyfin.</summary>
+        internal string ReportedRoot { get; }
+
+        /// <summary>Gets an immutable copy of Jellyfin's inert DLL-file observations.</summary>
+        internal ImmutableArray<string> DllFiles { get; }
+
+        /// <summary>
+        /// Mints one observation inside the trusted Jellyfin adapter. Architecture tests
+        /// keep this factory out of every other production owner.
+        /// </summary>
+        internal static PlatformInstalledPluginSnapshot EstablishHostSnapshot(
+            Guid pluginId,
+            string name,
+            Version version,
+            PlatformInstalledPluginHostStatus status,
+            string reportedRoot,
+            ImmutableArray<string> reportedDllFiles) => new(
+                pluginId,
+                name,
+                version,
+                status,
+                reportedRoot,
+                reportedDllFiles);
+    }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/Hosting/IPlatformHost.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/Hosting/IPlatformHost.cs
@@ -105,5 +105,17 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting
 
         /// <summary>The installed plugin with <paramref name="id"/>, or <c>null</c>.</summary>
         HostPlugin? Find(Guid id);
+
+        /// <summary>
+        /// Takes one immutable host-issued observation of every installed plugin.
+        /// Internal because installation topology is acquisition input, not public API.
+        /// </summary>
+        internal IReadOnlyList<PlatformInstalledPluginSnapshot> InstalledSnapshots();
+
+        /// <summary>
+        /// Takes one host-issued observation for <paramref name="id"/>, or <c>null</c>.
+        /// This is a fresh host read and not authority that an earlier snapshot remains current.
+        /// </summary>
+        internal PlatformInstalledPluginSnapshot? FindSnapshot(Guid id);
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/Hosting/Jellyfin/JellyfinPlatformHost.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/Hosting/Jellyfin/JellyfinPlatformHost.cs
@@ -7,6 +7,7 @@ using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.JellyfinCanopy.Data;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
 using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
 using MediaBrowser.Common.Plugins;
 using MediaBrowser.Controller.Dto;
@@ -319,6 +320,24 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting.Jellyfin
                 return plugin is null ? null : Map(plugin);
             }
 
+            public IReadOnlyList<PlatformInstalledPluginSnapshot> InstalledSnapshots()
+            {
+                // Materialize the manager's view once. A later acquisition owner may
+                // re-observe a plugin explicitly, but one sweep must not combine two
+                // independently changing enumerations.
+                var installed = _installed().ToList();
+                return installed.Select(MapSnapshot).ToImmutableArray();
+            }
+
+            public PlatformInstalledPluginSnapshot? FindSnapshot(Guid id)
+            {
+                var matches = _installed()
+                    .Where(candidate => candidate.Id == id)
+                    .Take(2)
+                    .ToList();
+                return matches.Count == 1 ? MapSnapshot(matches[0]) : null;
+            }
+
             // EP-00 (spike-evidence S5/S6): the status lives on the MANIFEST, not on the
             // LocalPlugin - LocalPlugin.Status does not exist - and a runtime disable
             // produces Restart rather than Disabled, because nothing is ever unloaded.
@@ -327,6 +346,32 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting.Jellyfin
                 plugin.Name,
                 plugin.Version.ToString(),
                 plugin.Manifest.Status.ToString());
+
+            private static PlatformInstalledPluginSnapshot MapSnapshot(LocalPlugin plugin)
+            {
+                return PlatformInstalledPluginSnapshot.EstablishHostSnapshot(
+                    plugin.Id,
+                    plugin.Name,
+                    plugin.Version,
+                    MapStatus(plugin.Manifest.Status),
+                    plugin.Path,
+                    plugin.DllFiles
+                        .Take(PlatformInstalledManifestLimits.MaximumDllFileCount + 1)
+                        .ToImmutableArray());
+            }
+
+            private static PlatformInstalledPluginHostStatus MapStatus(
+                MediaBrowser.Model.Plugins.PluginStatus status) => status switch
+                {
+                    MediaBrowser.Model.Plugins.PluginStatus.Restart => PlatformInstalledPluginHostStatus.Restart,
+                    MediaBrowser.Model.Plugins.PluginStatus.Active => PlatformInstalledPluginHostStatus.Active,
+                    MediaBrowser.Model.Plugins.PluginStatus.Disabled => PlatformInstalledPluginHostStatus.Disabled,
+                    MediaBrowser.Model.Plugins.PluginStatus.NotSupported => PlatformInstalledPluginHostStatus.NotSupported,
+                    MediaBrowser.Model.Plugins.PluginStatus.Malfunctioned => PlatformInstalledPluginHostStatus.Malfunctioned,
+                    MediaBrowser.Model.Plugins.PluginStatus.Superseded => PlatformInstalledPluginHostStatus.Superseded,
+                    MediaBrowser.Model.Plugins.PluginStatus.Deleted => PlatformInstalledPluginHostStatus.Deleted,
+                    _ => (PlatformInstalledPluginHostStatus)(int)status,
+                };
         }
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformInstalledManifestAcquisition.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformInstalledManifestAcquisition.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>
+    /// Host-owned explicit acquisition boundary. Callers cannot provide inventory or
+    /// re-observation facts: both reads come from the same Jellyfin host seam.
+    /// </summary>
+    internal sealed class PlatformInstalledManifestAcquisition
+    {
+        private readonly IHostPlugins _plugins;
+        private readonly IPlatformInstalledManifestReader _reader;
+
+        internal PlatformInstalledManifestAcquisition(
+            IHostPlugins plugins,
+            IPlatformInstalledManifestReader reader)
+        {
+            ArgumentNullException.ThrowIfNull(plugins);
+            ArgumentNullException.ThrowIfNull(reader);
+            _plugins = plugins;
+            _reader = reader;
+        }
+
+        internal async ValueTask<ImmutableArray<PlatformInstalledManifestObservation>> SweepAsync(
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var inventory = _plugins.InstalledSnapshots();
+            cancellationToken.ThrowIfCancellationRequested();
+            return await PlatformInstalledManifestDiscovery.SweepAsync(
+                    inventory,
+                    _reader,
+                    (pluginId, token) =>
+                    {
+                        token.ThrowIfCancellationRequested();
+                        return ValueTask.FromResult(_plugins.FindSnapshot(pluginId));
+                    },
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformInstalledManifestBindingDomain.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformInstalledManifestBindingDomain.cs
@@ -1,0 +1,413 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>Hard acquisition limits applied before native resources are allocated.</summary>
+    internal static class PlatformInstalledManifestLimits
+    {
+        internal const int MaximumDllFileCount = 128;
+    }
+
+    /// <summary>Closed one-shot outcomes for installed manifest acquisition and binding.</summary>
+    internal enum PlatformInstalledManifestOutcome
+    {
+        Acquired = 0,
+        ManifestAbsent = 1,
+        HostMetadataInvalid = 2,
+        AmbiguousHostIdentity = 3,
+        HostStatusNotActive = 4,
+        UnsafeOrUnverifiableRoot = 5,
+        UnsafeTarget = 6,
+        OpenTimedOut = 7,
+        NotRegularFile = 8,
+        DescriptorUnverifiable = 9,
+        DocumentTooLarge = 10,
+        ReadChanged = 11,
+        ReadFailed = 12,
+        ManifestRejected = 13,
+        PluginIdMismatch = 14,
+        PluginVersionMismatch = 15,
+        AssemblyUnavailable = 16,
+        AssemblyMismatch = 17,
+        HostSnapshotChanged = 18,
+        AcquisitionFailed = 19,
+    }
+
+    /// <summary>Compatibility is an observation, never an acquisition or approval outcome.</summary>
+    internal enum PlatformInstalledManifestCompatibility
+    {
+        Compatible = 0,
+        PlatformIncompatible = 1,
+        HostIncompatible = 2,
+    }
+
+    /// <summary>Owned result returned by the fixed-name descriptor-safe reader.</summary>
+    internal sealed class PlatformInstalledManifestReadResult
+    {
+        private PlatformInstalledManifestReadResult(
+            PlatformInstalledManifestOutcome outcome,
+            ImmutableArray<byte> bytes,
+            string? assemblyIdentity)
+        {
+            Outcome = outcome;
+            Bytes = bytes;
+            AssemblyIdentity = assemblyIdentity;
+        }
+
+        internal PlatformInstalledManifestOutcome Outcome { get; }
+
+        internal ImmutableArray<byte> Bytes { get; }
+
+        internal string? AssemblyIdentity { get; }
+
+        internal static PlatformInstalledManifestReadResult Acquired(
+            byte[] bytes,
+            string? assemblyIdentity)
+        {
+            ArgumentNullException.ThrowIfNull(bytes);
+            return new PlatformInstalledManifestReadResult(
+                PlatformInstalledManifestOutcome.Acquired,
+                ImmutableArray.CreateRange(bytes),
+                assemblyIdentity);
+        }
+
+        internal static PlatformInstalledManifestReadResult Rejected(
+            PlatformInstalledManifestOutcome outcome)
+        {
+            if (outcome == PlatformInstalledManifestOutcome.Acquired)
+            {
+                throw new ArgumentOutOfRangeException(nameof(outcome));
+            }
+
+            return new PlatformInstalledManifestReadResult(outcome, ImmutableArray<byte>.Empty, null);
+        }
+    }
+
+    /// <summary>Reads only the fixed extension manifest for a host-issued plugin snapshot.</summary>
+    internal interface IPlatformInstalledManifestReader
+    {
+        ValueTask<PlatformInstalledManifestReadResult> ReadAsync(
+            PlatformInstalledPluginSnapshot snapshot,
+            CancellationToken cancellationToken);
+    }
+
+    /// <summary>
+    /// Immutable host-bound manifest facts. This remains unapproved and carries no authority.
+    /// </summary>
+    internal sealed class HostBoundInstalledManifest
+    {
+        private HostBoundInstalledManifest(
+            Guid pluginId,
+            string hostName,
+            Version hostVersion,
+            PlatformInstalledPluginHostStatus hostStatus,
+            string assemblyIdentity,
+            PlatformExtensionManifest manifest,
+            PlatformInstalledManifestCompatibility compatibility)
+        {
+            PluginId = pluginId;
+            HostName = hostName;
+            HostVersion = hostVersion;
+            HostStatus = hostStatus;
+            AssemblyIdentity = assemblyIdentity;
+            Manifest = manifest;
+            Compatibility = compatibility;
+        }
+
+        internal Guid PluginId { get; }
+
+        internal string HostName { get; }
+
+        internal Version HostVersion { get; }
+
+        internal PlatformInstalledPluginHostStatus HostStatus { get; }
+
+        internal string AssemblyIdentity { get; }
+
+        internal PlatformExtensionManifest Manifest { get; }
+
+        internal PlatformManifestFingerprint Fingerprint => Manifest.Fingerprint;
+
+        internal PlatformInstalledManifestCompatibility Compatibility { get; }
+
+        internal static HostBoundInstalledManifest EstablishBoundManifest(
+            PlatformInstalledPluginSnapshot snapshot,
+            string assemblyIdentity,
+            PlatformExtensionManifest manifest,
+            PlatformInstalledManifestCompatibility compatibility) => new(
+                snapshot.PluginId,
+                snapshot.Name,
+                snapshot.Version,
+                snapshot.Status,
+                assemblyIdentity,
+                manifest,
+                compatibility);
+    }
+
+    /// <summary>One immutable redaction-safe observation from an explicit sweep.</summary>
+    internal sealed class PlatformInstalledManifestObservation
+    {
+        private PlatformInstalledManifestObservation(
+            Guid pluginId,
+            PlatformInstalledPluginHostStatus hostStatus,
+            PlatformInstalledManifestOutcome outcome,
+            PlatformInstalledManifestCompatibility? compatibility,
+            HostBoundInstalledManifest? boundManifest,
+            PlatformExtensionManifestRejectionReason? manifestRejectionReason)
+        {
+            PluginId = pluginId;
+            HostStatus = hostStatus;
+            Outcome = outcome;
+            Compatibility = compatibility;
+            BoundManifest = boundManifest;
+            ManifestRejectionReason = manifestRejectionReason;
+        }
+
+        internal Guid PluginId { get; }
+
+        internal PlatformInstalledPluginHostStatus HostStatus { get; }
+
+        internal PlatformInstalledManifestOutcome Outcome { get; }
+
+        internal PlatformInstalledManifestCompatibility? Compatibility { get; }
+
+        internal HostBoundInstalledManifest? BoundManifest { get; }
+
+        internal PlatformExtensionManifestRejectionReason? ManifestRejectionReason { get; }
+
+        internal static PlatformInstalledManifestObservation Rejected(
+            PlatformInstalledPluginSnapshot snapshot,
+            PlatformInstalledManifestOutcome outcome,
+            PlatformExtensionManifestRejectionReason? manifestRejectionReason = null)
+        {
+            ArgumentNullException.ThrowIfNull(snapshot);
+            if (outcome == PlatformInstalledManifestOutcome.Acquired)
+            {
+                throw new ArgumentOutOfRangeException(nameof(outcome));
+            }
+
+            return new PlatformInstalledManifestObservation(
+                snapshot.PluginId,
+                snapshot.Status,
+                outcome,
+                null,
+                null,
+                manifestRejectionReason);
+        }
+
+        internal static PlatformInstalledManifestObservation Acquired(
+            PlatformInstalledPluginSnapshot snapshot,
+            HostBoundInstalledManifest manifest) => new(
+                snapshot.PluginId,
+                snapshot.Status,
+                PlatformInstalledManifestOutcome.Acquired,
+                manifest.Compatibility,
+                manifest,
+                null);
+    }
+
+    /// <summary>Pure parser handoff, host binding and compatibility observation.</summary>
+    internal static class PlatformInstalledManifestBinder
+    {
+        internal const int PlatformMajor = 1;
+        internal const int JellyfinHostMajor = 12;
+
+        internal static PlatformInstalledManifestObservation Bind(
+            PlatformInstalledPluginSnapshot before,
+            PlatformInstalledPluginSnapshot? after,
+            PlatformInstalledManifestReadResult readResult)
+        {
+            ArgumentNullException.ThrowIfNull(before);
+            ArgumentNullException.ThrowIfNull(readResult);
+
+            if (!HasValidHostMetadata(before))
+            {
+                return PlatformInstalledManifestObservation.Rejected(
+                    before,
+                    PlatformInstalledManifestOutcome.HostMetadataInvalid);
+            }
+
+            if (before.Status != PlatformInstalledPluginHostStatus.Active)
+            {
+                return PlatformInstalledManifestObservation.Rejected(
+                    before,
+                    PlatformInstalledManifestOutcome.HostStatusNotActive);
+            }
+
+            if (after is null || !SameSnapshot(before, after))
+            {
+                return PlatformInstalledManifestObservation.Rejected(
+                    before,
+                    PlatformInstalledManifestOutcome.HostSnapshotChanged);
+            }
+
+            if (readResult.Outcome != PlatformInstalledManifestOutcome.Acquired)
+            {
+                return PlatformInstalledManifestObservation.Rejected(before, readResult.Outcome);
+            }
+
+            if (string.IsNullOrWhiteSpace(readResult.AssemblyIdentity))
+            {
+                return PlatformInstalledManifestObservation.Rejected(
+                    before,
+                    PlatformInstalledManifestOutcome.AssemblyUnavailable);
+            }
+
+            if (!PlatformExtensionManifestParser.TryParse(
+                    readResult.Bytes.ToArray(),
+                    out var manifest,
+                    out var rejectionReason))
+            {
+                return PlatformInstalledManifestObservation.Rejected(
+                    before,
+                    PlatformInstalledManifestOutcome.ManifestRejected,
+                    rejectionReason);
+            }
+
+            if (manifest!.PluginId != before.PluginId)
+            {
+                return PlatformInstalledManifestObservation.Rejected(
+                    before,
+                    PlatformInstalledManifestOutcome.PluginIdMismatch);
+            }
+
+            if (!manifest.Version.Equals(before.Version))
+            {
+                return PlatformInstalledManifestObservation.Rejected(
+                    before,
+                    PlatformInstalledManifestOutcome.PluginVersionMismatch);
+            }
+
+            var compatibility = ObserveCompatibility(manifest);
+            var bound = HostBoundInstalledManifest.EstablishBoundManifest(
+                before,
+                readResult.AssemblyIdentity!,
+                manifest,
+                compatibility);
+            return PlatformInstalledManifestObservation.Acquired(before, bound);
+        }
+
+        internal static bool HasValidHostMetadata(PlatformInstalledPluginSnapshot snapshot) =>
+            snapshot.PluginId != Guid.Empty
+            && !string.IsNullOrWhiteSpace(snapshot.Name)
+            && snapshot.Version is not null
+            && snapshot.Version.Major >= 0
+            && snapshot.Version.Minor >= 0
+            && !string.IsNullOrWhiteSpace(snapshot.ReportedRoot)
+            && snapshot.DllFiles.Length <= PlatformInstalledManifestLimits.MaximumDllFileCount;
+
+        private static bool SameSnapshot(
+            PlatformInstalledPluginSnapshot left,
+            PlatformInstalledPluginSnapshot right) =>
+            left.PluginId == right.PluginId
+            && left.Version.Equals(right.Version)
+            && left.Status == right.Status
+            && string.Equals(left.ReportedRoot, right.ReportedRoot, StringComparison.Ordinal)
+            && left.DllFiles.SequenceEqual(right.DllFiles, StringComparer.Ordinal);
+
+        private static PlatformInstalledManifestCompatibility ObserveCompatibility(
+            PlatformExtensionManifest manifest)
+        {
+            if (PlatformMajor < manifest.PlatformRange.Min || PlatformMajor > manifest.PlatformRange.Max)
+            {
+                return PlatformInstalledManifestCompatibility.PlatformIncompatible;
+            }
+
+            return JellyfinHostMajor < manifest.HostRange.MinMajor
+                || JellyfinHostMajor > manifest.HostRange.MaxMajor
+                    ? PlatformInstalledManifestCompatibility.HostIncompatible
+                    : PlatformInstalledManifestCompatibility.Compatible;
+        }
+    }
+
+    /// <summary>One explicit, side-effect-free and fully materialized installed-plugin sweep.</summary>
+    internal static class PlatformInstalledManifestDiscovery
+    {
+        internal const int MaximumPluginCount = 1024;
+        internal const int MaximumConcurrentAcquisitions = 1;
+
+        internal static async ValueTask<ImmutableArray<PlatformInstalledManifestObservation>> SweepAsync(
+            IReadOnlyList<PlatformInstalledPluginSnapshot> inventory,
+            IPlatformInstalledManifestReader reader,
+            Func<Guid, CancellationToken, ValueTask<PlatformInstalledPluginSnapshot?>> reobserve,
+            CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(inventory);
+            ArgumentNullException.ThrowIfNull(reader);
+            ArgumentNullException.ThrowIfNull(reobserve);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var snapshots = inventory.ToArray();
+            if (snapshots.Length > MaximumPluginCount)
+            {
+                return snapshots
+                    .OrderBy(snapshot => snapshot.PluginId)
+                    .Select(snapshot => PlatformInstalledManifestObservation.Rejected(
+                        snapshot,
+                        PlatformInstalledManifestOutcome.HostMetadataInvalid))
+                    .ToImmutableArray();
+            }
+
+            var hasInvalidMetadata = snapshots.Any(
+                snapshot => !PlatformInstalledManifestBinder.HasValidHostMetadata(snapshot));
+            var duplicateIds = snapshots
+                .Where(snapshot => snapshot.PluginId != Guid.Empty)
+                .GroupBy(snapshot => snapshot.PluginId)
+                .Where(group => group.Count() > 1)
+                .Select(group => group.Key)
+                .ToHashSet();
+            var invalidInventory = hasInvalidMetadata || duplicateIds.Count > 0;
+            if (invalidInventory)
+            {
+                return snapshots
+                    .OrderBy(snapshot => snapshot.PluginId)
+                    .Select(snapshot => PlatformInstalledManifestObservation.Rejected(
+                        snapshot,
+                        duplicateIds.Contains(snapshot.PluginId)
+                            ? PlatformInstalledManifestOutcome.AmbiguousHostIdentity
+                            : PlatformInstalledManifestOutcome.HostMetadataInvalid))
+                    .ToImmutableArray();
+            }
+
+            var observations = ImmutableArray.CreateBuilder<PlatformInstalledManifestObservation>(
+                snapshots.Length);
+            foreach (var snapshot in snapshots.OrderBy(value => value.PluginId))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (snapshot.Status != PlatformInstalledPluginHostStatus.Active)
+                {
+                    observations.Add(PlatformInstalledManifestObservation.Rejected(
+                        snapshot,
+                        PlatformInstalledManifestOutcome.HostStatusNotActive));
+                    continue;
+                }
+
+                try
+                {
+                    var readResult = await reader.ReadAsync(snapshot, cancellationToken).ConfigureAwait(false);
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var current = await reobserve(snapshot.PluginId, cancellationToken).ConfigureAwait(false);
+                    observations.Add(PlatformInstalledManifestBinder.Bind(snapshot, current, readResult));
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception)
+                {
+                    observations.Add(PlatformInstalledManifestObservation.Rejected(
+                        snapshot,
+                        PlatformInstalledManifestOutcome.AcquisitionFailed));
+                }
+            }
+
+            return observations.MoveToImmutable();
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformInstalledManifestFileReader.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformInstalledManifestFileReader.cs
@@ -1,0 +1,1055 @@
+using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+using Microsoft.Win32.SafeHandles;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>
+    /// Reads only the fixed installed-provider manifest through Linux descriptors.
+    /// Unsupported operating systems fail closed; there is deliberately no
+    /// validate-then-open or background-thread fallback.
+    /// </summary>
+    internal sealed class PlatformInstalledManifestFileReader : IPlatformInstalledManifestReader
+    {
+        private const int OpenReadOnly = 0;
+        private const int OpenNonBlocking = 0x800;
+        private const int OpenDirectory = 0x10000;
+        private const int OpenCloseOnExec = 0x80000;
+        private const int OpenPath = 0x200000;
+
+        private const int AtEmptyPath = 0x1000;
+        private const uint StatxType = 0x0001;
+        private const uint StatxModificationTime = 0x0040;
+        private const uint StatxChangeTime = 0x0080;
+        private const uint StatxInode = 0x0100;
+        private const uint StatxSize = 0x0200;
+        private const uint StatxMountId = 0x1000;
+        private const uint RequiredStatxMask = StatxType
+            | StatxModificationTime
+            | StatxChangeTime
+            | StatxInode
+            | StatxSize
+            | StatxMountId;
+
+        private const ushort FileTypeMask = 0xF000;
+        private const ushort DirectoryType = 0x4000;
+        private const ushort RegularFileType = 0x8000;
+
+        private const int ErrorInterrupted = 4;
+        private const int ErrorNoEntry = 2;
+        private const int ErrorNotDirectory = 20;
+        private const int ErrorLoop = 40;
+
+        private const int MaximumDescriptorPathBytes = 4096;
+        private const string DeletedDescriptorSuffix = " (deleted)";
+        private const string AssemblySetIdentityDomain =
+            "jellyfin-canopy-installed-plugin-assembly-set-v1";
+
+        private static readonly UTF8Encoding StrictUtf8 = new(false, true);
+        private static readonly HashSet<long> SupportedLocalFileSystemTypes =
+        [
+            0x0000EF53, // ext2/3/4
+            0x01021994, // tmpfs
+            0x2FC12FC1, // zfs
+            0x3153464A, // jfs
+            0x3434, // nilfs
+            0x52654973, // reiserfs
+            0x5346544E, // ntfs
+            0x58465342, // xfs
+            0x794C7630, // overlayfs
+            0x9123683E, // btrfs
+            0xCAFE4A11, // bcachefs
+            0xF2F52010, // f2fs
+        ];
+
+        private readonly Action? _afterManifestMetadataOpen;
+        private readonly Action? _afterManifestRead;
+        private readonly Action? _afterAssemblyMetadataOpen;
+
+        /// <summary>Initializes the production reader without test race hooks.</summary>
+        public PlatformInstalledManifestFileReader()
+        {
+        }
+
+        /// <summary>Initializes a reader with deterministic race hooks for descriptor tests.</summary>
+        internal PlatformInstalledManifestFileReader(
+            Action? afterManifestMetadataOpen,
+            Action? afterManifestRead,
+            Action? afterAssemblyMetadataOpen = null)
+        {
+            _afterManifestMetadataOpen = afterManifestMetadataOpen;
+            _afterManifestRead = afterManifestRead;
+            _afterAssemblyMetadataOpen = afterAssemblyMetadataOpen;
+        }
+
+        /// <inheritdoc />
+        public ValueTask<PlatformInstalledManifestReadResult> ReadAsync(
+            PlatformInstalledPluginSnapshot snapshot,
+            CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(snapshot);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (OperatingSystem.IsWindows())
+            {
+                return ValueTask.FromResult(
+                    PlatformInstalledManifestWindowsReader.Read(snapshot, cancellationToken));
+            }
+
+            if (!OperatingSystem.IsLinux())
+            {
+                return ValueTask.FromResult(Rejected(
+                    PlatformInstalledManifestOutcome.DescriptorUnverifiable));
+            }
+
+            try
+            {
+                return ValueTask.FromResult(ReadLinux(snapshot, cancellationToken));
+            }
+            catch (Exception exception) when (exception is DllNotFoundException
+                or EntryPointNotFoundException
+                or BadImageFormatException
+                or MarshalDirectiveException
+                or PlatformNotSupportedException)
+            {
+                return ValueTask.FromResult(Rejected(
+                    PlatformInstalledManifestOutcome.DescriptorUnverifiable));
+            }
+        }
+
+        private PlatformInstalledManifestReadResult ReadLinux(
+            PlatformInstalledPluginSnapshot snapshot,
+            CancellationToken cancellationToken)
+        {
+            if (!TryCanonicalizeReportedRoot(snapshot.ReportedRoot, out var reportedRoot))
+            {
+                return Rejected(PlatformInstalledManifestOutcome.UnsafeOrUnverifiableRoot);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            var rootDescriptor = Open(
+                reportedRoot,
+                OpenReadOnly | OpenNonBlocking | OpenDirectory | OpenCloseOnExec);
+            if (rootDescriptor < 0)
+            {
+                return Rejected(PlatformInstalledManifestOutcome.UnsafeOrUnverifiableRoot);
+            }
+
+            using var rootHandle = new SafeUnixDescriptor(rootDescriptor);
+            if (!TryFStat(rootDescriptor, out var rootBefore)
+                || (rootBefore.Mode & FileTypeMask) != DirectoryType
+                || !IsSupportedLocalFileSystem(rootDescriptor)
+                || !TryDescribeDescriptor(rootDescriptor, out var descriptorRoot)
+                || IsFilesystemRoot(descriptorRoot))
+            {
+                return Rejected(PlatformInstalledManifestOutcome.UnsafeOrUnverifiableRoot);
+            }
+
+            var manifestOpen = OpenFixedManifest(rootDescriptor);
+            if (manifestOpen.MetadataDescriptor < 0 || manifestOpen.ContentDescriptor < 0)
+            {
+                return Rejected(manifestOpen.Outcome);
+            }
+
+            using var manifestMetadataHandle = new SafeUnixDescriptor(manifestOpen.MetadataDescriptor);
+            using var manifestContentHandle = new SafeUnixDescriptor(manifestOpen.ContentDescriptor);
+            if (!TryVerifyRegularDescriptor(
+                    manifestOpen.MetadataDescriptor,
+                    descriptorRoot,
+                    rootBefore,
+                    out var manifestMetadataBefore,
+                    out var manifestDescriptorPath,
+                    out var manifestFailure))
+            {
+                return Rejected(manifestFailure);
+            }
+
+            if (!TryVerifyRegularDescriptor(
+                    manifestOpen.ContentDescriptor,
+                    descriptorRoot,
+                    rootBefore,
+                    out var manifestBefore,
+                    out var manifestContentPath,
+                    out manifestFailure))
+            {
+                return Rejected(manifestFailure);
+            }
+
+            if (!SameObject(manifestMetadataBefore, manifestBefore)
+                || !string.Equals(
+                    manifestDescriptorPath,
+                    manifestContentPath,
+                    StringComparison.Ordinal))
+            {
+                return Rejected(PlatformInstalledManifestOutcome.ReadChanged);
+            }
+
+            if (manifestBefore.Size > PlatformExtensionManifestBounds.MaximumDocumentBytes)
+            {
+                return Rejected(PlatformInstalledManifestOutcome.DocumentTooLarge);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            var read = ReadBounded(manifestOpen.ContentDescriptor, cancellationToken);
+            if (read.Outcome != PlatformInstalledManifestOutcome.Acquired)
+            {
+                return Rejected(read.Outcome);
+            }
+
+            _afterManifestRead?.Invoke();
+
+            if (!TryFStat(manifestOpen.ContentDescriptor, out var manifestAfter)
+                || !TryFStat(manifestOpen.MetadataDescriptor, out var manifestMetadataAfter)
+                || !TryFStat(rootDescriptor, out var rootAfter)
+                || !TryDescribeDescriptor(manifestOpen.ContentDescriptor, out var manifestPathAfter)
+                || !TryDescribeDescriptor(manifestOpen.MetadataDescriptor, out var manifestMetadataPathAfter)
+                || !TryDescribeDescriptor(rootDescriptor, out var rootPathAfter))
+            {
+                return Rejected(PlatformInstalledManifestOutcome.DescriptorUnverifiable);
+            }
+
+            if (!rootBefore.Equals(rootAfter)
+                || !manifestBefore.Equals(manifestAfter)
+                || !SameObject(manifestMetadataBefore, manifestMetadataAfter)
+                || !string.Equals(descriptorRoot, rootPathAfter, StringComparison.Ordinal)
+                || !string.Equals(manifestDescriptorPath, manifestPathAfter, StringComparison.Ordinal)
+                || !string.Equals(manifestDescriptorPath, manifestMetadataPathAfter, StringComparison.Ordinal)
+                || manifestAfter.Size != (ulong)read.Bytes.Length)
+            {
+                return Rejected(PlatformInstalledManifestOutcome.ReadChanged);
+            }
+
+            if (!TryRevalidateNamedObjects(
+                    reportedRoot,
+                    rootDescriptor,
+                    descriptorRoot,
+                    rootBefore,
+                    manifestMetadataBefore,
+                    manifestDescriptorPath))
+            {
+                return Rejected(PlatformInstalledManifestOutcome.ReadChanged);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            var assembly = VerifyAssemblySet(
+                snapshot,
+                descriptorRoot,
+                rootBefore,
+                _afterAssemblyMetadataOpen,
+                cancellationToken);
+            if (assembly.Outcome != PlatformInstalledManifestOutcome.Acquired)
+            {
+                return Rejected(assembly.Outcome);
+            }
+
+            if (!TryRevalidateNamedObjects(
+                    reportedRoot,
+                    rootDescriptor,
+                    descriptorRoot,
+                    rootBefore,
+                    manifestMetadataBefore,
+                    manifestDescriptorPath))
+            {
+                return Rejected(PlatformInstalledManifestOutcome.ReadChanged);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            return PlatformInstalledManifestReadResult.Acquired(
+                read.Bytes,
+                assembly.AssemblyIdentity);
+        }
+
+        private DescriptorOpenResult OpenFixedManifest(int rootDescriptor)
+        {
+            var metadataDescriptor = OpenAt(
+                rootDescriptor,
+                PlatformExtensionManifestParser.ManifestFileName,
+                OpenPath | OpenCloseOnExec);
+            if (metadataDescriptor < 0)
+            {
+                return MapManifestOpenFailure(rootDescriptor, manifestExistedBeforeOpen: false);
+            }
+
+            var contentDescriptor = -1;
+            try
+            {
+                if (!TryFStat(metadataDescriptor, out var typeState))
+                {
+                    return new DescriptorOpenResult(
+                        -1,
+                        -1,
+                        PlatformInstalledManifestOutcome.DescriptorUnverifiable);
+                }
+
+                if ((typeState.Mode & FileTypeMask) != RegularFileType)
+                {
+                    return new DescriptorOpenResult(
+                        -1,
+                        -1,
+                        PlatformInstalledManifestOutcome.NotRegularFile);
+                }
+
+                _afterManifestMetadataOpen?.Invoke();
+
+                if (!TryGetDescriptorPath(metadataDescriptor, out var metadataDescriptorPath))
+                {
+                    return new DescriptorOpenResult(
+                        -1,
+                        -1,
+                        PlatformInstalledManifestOutcome.DescriptorUnverifiable);
+                }
+
+                contentDescriptor = Open(
+                    metadataDescriptorPath,
+                    OpenReadOnly | OpenNonBlocking | OpenCloseOnExec);
+                if (contentDescriptor < 0)
+                {
+                    return new DescriptorOpenResult(
+                        -1,
+                        -1,
+                        PlatformInstalledManifestOutcome.DescriptorUnverifiable);
+                }
+
+                var result = new DescriptorOpenResult(
+                    metadataDescriptor,
+                    contentDescriptor,
+                    PlatformInstalledManifestOutcome.Acquired);
+                metadataDescriptor = -1;
+                contentDescriptor = -1;
+                return result;
+            }
+            finally
+            {
+                if (contentDescriptor >= 0)
+                {
+                    Close(contentDescriptor);
+                }
+
+                if (metadataDescriptor >= 0)
+                {
+                    Close(metadataDescriptor);
+                }
+            }
+        }
+
+        private static DescriptorOpenResult MapManifestOpenFailure(
+            int rootDescriptor,
+            bool manifestExistedBeforeOpen)
+        {
+            var error = Marshal.GetLastPInvokeError();
+            if (error is ErrorNoEntry or ErrorNotDirectory)
+            {
+                return new DescriptorOpenResult(
+                    -1,
+                    -1,
+                    IsBrokenLink(rootDescriptor, PlatformExtensionManifestParser.ManifestFileName)
+                        ? PlatformInstalledManifestOutcome.UnsafeTarget
+                        : manifestExistedBeforeOpen
+                            ? PlatformInstalledManifestOutcome.ReadChanged
+                            : PlatformInstalledManifestOutcome.ManifestAbsent);
+            }
+
+            return new DescriptorOpenResult(
+                -1,
+                -1,
+                error == ErrorLoop
+                    ? PlatformInstalledManifestOutcome.UnsafeTarget
+                    : PlatformInstalledManifestOutcome.ReadFailed);
+        }
+
+        private static AssemblyVerification VerifyAssemblySet(
+            PlatformInstalledPluginSnapshot snapshot,
+            string descriptorRoot,
+            DescriptorState rootState,
+            Action? afterAssemblyMetadataOpen,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (snapshot.DllFiles.IsDefaultOrEmpty)
+            {
+                return new AssemblyVerification(
+                    PlatformInstalledManifestOutcome.AssemblyUnavailable,
+                    null);
+            }
+
+            if (snapshot.DllFiles.Length > PlatformInstalledManifestLimits.MaximumDllFileCount)
+            {
+                return new AssemblyVerification(
+                    PlatformInstalledManifestOutcome.AssemblyMismatch,
+                    null);
+            }
+
+            if (!TryGetHostFullPath(snapshot.ReportedRoot, out var reportedRoot))
+            {
+                return new AssemblyVerification(
+                    PlatformInstalledManifestOutcome.AssemblyMismatch,
+                    null);
+            }
+
+            var handles = new List<SafeUnixDescriptor>(snapshot.DllFiles.Length);
+            var observations = new List<DllDescriptorObservation>(snapshot.DllFiles.Length);
+            try
+            {
+                foreach (var reportedDll in snapshot.DllFiles)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (!TryGetHostFullPath(reportedDll, out var dllPath)
+                        || !IsInsideEitherRoot(dllPath, reportedRoot, descriptorRoot))
+                    {
+                        return new AssemblyVerification(
+                            PlatformInstalledManifestOutcome.AssemblyMismatch,
+                            null);
+                    }
+
+                    var dllDescriptor = Open(dllPath, OpenPath | OpenCloseOnExec);
+                    if (dllDescriptor < 0)
+                    {
+                        return new AssemblyVerification(
+                            PlatformInstalledManifestOutcome.AssemblyMismatch,
+                            null);
+                    }
+
+                    var dllHandle = new SafeUnixDescriptor(dllDescriptor);
+                    handles.Add(dllHandle);
+                    if (!TryVerifyRegularDescriptor(
+                            dllDescriptor,
+                            descriptorRoot,
+                            rootState,
+                            out var dllState,
+                            out var dllDescriptorPath,
+                            out _))
+                    {
+                        return new AssemblyVerification(
+                            PlatformInstalledManifestOutcome.AssemblyMismatch,
+                            null);
+                    }
+
+                    var relativeName = Path.GetRelativePath(
+                            descriptorRoot,
+                            dllDescriptorPath)
+                        .Replace(Path.DirectorySeparatorChar, '/');
+                    if (string.IsNullOrWhiteSpace(relativeName)
+                        || Path.IsPathFullyQualified(relativeName)
+                        || relativeName.Split('/').Any(segment => segment is "." or ".."))
+                    {
+                        return new AssemblyVerification(
+                            PlatformInstalledManifestOutcome.AssemblyMismatch,
+                            null);
+                    }
+
+                    observations.Add(new DllDescriptorObservation(
+                        dllPath,
+                        dllDescriptor,
+                        relativeName,
+                        dllDescriptorPath,
+                        dllState));
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+                afterAssemblyMetadataOpen?.Invoke();
+
+                foreach (var observation in observations)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (!TryVerifyRegularDescriptor(
+                            observation.Descriptor,
+                            descriptorRoot,
+                            rootState,
+                            out var retainedState,
+                            out var retainedPath,
+                            out _)
+                        || !observation.State.Equals(retainedState)
+                        || !string.Equals(
+                            observation.DescriptorPath,
+                            retainedPath,
+                            StringComparison.Ordinal))
+                    {
+                        return new AssemblyVerification(
+                            PlatformInstalledManifestOutcome.AssemblyMismatch,
+                            null);
+                    }
+
+                    var namedDescriptor = Open(
+                        observation.ReportedPath,
+                        OpenPath | OpenCloseOnExec);
+                    if (namedDescriptor < 0)
+                    {
+                        return new AssemblyVerification(
+                            PlatformInstalledManifestOutcome.AssemblyMismatch,
+                            null);
+                    }
+
+                    using var namedHandle = new SafeUnixDescriptor(namedDescriptor);
+                    if (!TryVerifyRegularDescriptor(
+                            namedDescriptor,
+                            descriptorRoot,
+                            rootState,
+                            out var namedState,
+                            out var namedPath,
+                            out _)
+                        || !observation.State.Equals(namedState)
+                        || !string.Equals(
+                            observation.DescriptorPath,
+                            namedPath,
+                            StringComparison.Ordinal))
+                    {
+                        return new AssemblyVerification(
+                            PlatformInstalledManifestOutcome.AssemblyMismatch,
+                            null);
+                    }
+                }
+
+                var ordered = observations
+                    .OrderBy(observation => observation.RelativeName, StringComparer.Ordinal)
+                    .ToList();
+                if (ordered
+                    .GroupBy(observation => observation.RelativeName, StringComparer.Ordinal)
+                    .Any(group => group.Count() != 1))
+                {
+                    return new AssemblyVerification(
+                        PlatformInstalledManifestOutcome.AssemblyMismatch,
+                        null);
+                }
+
+                using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+                hash.AppendData(Encoding.UTF8.GetBytes(AssemblySetIdentityDomain));
+                hash.AppendData([0]);
+                AppendUnsigned(hash, checked((ulong)ordered.Count));
+                foreach (var observation in ordered)
+                {
+                    var nameBytes = Encoding.UTF8.GetBytes(observation.RelativeName);
+                    AppendUnsigned(hash, checked((ulong)nameBytes.Length));
+                    hash.AppendData(nameBytes);
+                    AppendDescriptorState(hash, observation.State);
+                }
+
+                return new AssemblyVerification(
+                    PlatformInstalledManifestOutcome.Acquired,
+                    "sha256:" + Convert.ToHexString(hash.GetHashAndReset()).ToLowerInvariant());
+            }
+            finally
+            {
+                foreach (var handle in handles)
+                {
+                    handle.Dispose();
+                }
+            }
+        }
+
+        private static void AppendDescriptorState(
+            IncrementalHash hash,
+            DescriptorState state)
+        {
+            AppendUnsigned(hash, state.MountId);
+            AppendUnsigned(hash, state.DeviceMajor);
+            AppendUnsigned(hash, state.DeviceMinor);
+            AppendUnsigned(hash, state.Inode);
+            AppendUnsigned(hash, state.Size);
+            AppendSigned(hash, state.ModificationSeconds);
+            AppendUnsigned(hash, state.ModificationNanoseconds);
+            AppendSigned(hash, state.ChangeSeconds);
+            AppendUnsigned(hash, state.ChangeNanoseconds);
+        }
+
+        private static void AppendUnsigned(IncrementalHash hash, ulong value)
+        {
+            Span<byte> encoded = stackalloc byte[sizeof(ulong)];
+            BinaryPrimitives.WriteUInt64LittleEndian(encoded, value);
+            hash.AppendData(encoded);
+        }
+
+        private static void AppendSigned(IncrementalHash hash, long value)
+        {
+            Span<byte> encoded = stackalloc byte[sizeof(long)];
+            BinaryPrimitives.WriteInt64LittleEndian(encoded, value);
+            hash.AppendData(encoded);
+        }
+
+        private static bool TryRevalidateNamedObjects(
+            string reportedRoot,
+            int rootDescriptor,
+            string descriptorRoot,
+            DescriptorState rootState,
+            DescriptorState manifestState,
+            string manifestDescriptorPath)
+        {
+            var namedRootDescriptor = Open(
+                reportedRoot,
+                OpenPath | OpenDirectory | OpenCloseOnExec);
+            if (namedRootDescriptor < 0)
+            {
+                return false;
+            }
+
+            using var namedRootHandle = new SafeUnixDescriptor(namedRootDescriptor);
+            if (!TryFStat(namedRootDescriptor, out var namedRootState)
+                || (namedRootState.Mode & FileTypeMask) != DirectoryType
+                || !rootState.Equals(namedRootState)
+                || !TryDescribeDescriptor(namedRootDescriptor, out var namedRootPath)
+                || !string.Equals(descriptorRoot, namedRootPath, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            var namedManifestDescriptor = OpenAt(
+                rootDescriptor,
+                PlatformExtensionManifestParser.ManifestFileName,
+                OpenPath | OpenCloseOnExec);
+            if (namedManifestDescriptor < 0)
+            {
+                return false;
+            }
+
+            using var namedManifestHandle = new SafeUnixDescriptor(namedManifestDescriptor);
+            return TryVerifyRegularDescriptor(
+                    namedManifestDescriptor,
+                    descriptorRoot,
+                    rootState,
+                    out var namedManifestState,
+                    out var namedManifestPath,
+                    out _)
+                && manifestState.Equals(namedManifestState)
+                && string.Equals(
+                    manifestDescriptorPath,
+                    namedManifestPath,
+                    StringComparison.Ordinal);
+        }
+
+        private static bool TryVerifyRegularDescriptor(
+            int descriptor,
+            string descriptorRoot,
+            DescriptorState rootState,
+            out DescriptorState state,
+            out string descriptorPath,
+            out PlatformInstalledManifestOutcome failure)
+        {
+            state = default;
+            descriptorPath = string.Empty;
+            failure = PlatformInstalledManifestOutcome.DescriptorUnverifiable;
+            if (!TryFStat(descriptor, out state))
+            {
+                return false;
+            }
+
+            if ((state.Mode & FileTypeMask) != RegularFileType)
+            {
+                failure = PlatformInstalledManifestOutcome.NotRegularFile;
+                return false;
+            }
+
+            if (state.DeviceMajor != rootState.DeviceMajor
+                || state.DeviceMinor != rootState.DeviceMinor
+                || state.MountId != rootState.MountId)
+            {
+                failure = PlatformInstalledManifestOutcome.UnsafeTarget;
+                return false;
+            }
+
+            if (!TryDescribeDescriptor(descriptor, out descriptorPath))
+            {
+                return false;
+            }
+
+            if (!IsStrictlyInside(descriptorPath, descriptorRoot))
+            {
+                failure = PlatformInstalledManifestOutcome.UnsafeTarget;
+                return false;
+            }
+
+            return true;
+        }
+
+        private static BoundedReadResult ReadBounded(
+            int descriptor,
+            CancellationToken cancellationToken)
+        {
+            var capacity = PlatformExtensionManifestBounds.MaximumDocumentBytes + 1;
+            var nativeBuffer = Marshal.AllocHGlobal(capacity);
+            try
+            {
+                var total = 0;
+                while (total < capacity)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var count = Read(
+                        descriptor,
+                        IntPtr.Add(nativeBuffer, total),
+                        (nuint)(capacity - total));
+                    if (count == 0)
+                    {
+                        break;
+                    }
+
+                    if (count < 0)
+                    {
+                        if (Marshal.GetLastPInvokeError() == ErrorInterrupted)
+                        {
+                            continue;
+                        }
+
+                        return new BoundedReadResult(
+                            PlatformInstalledManifestOutcome.ReadFailed,
+                            []);
+                    }
+
+                    total += checked((int)count);
+                }
+
+                if (total > PlatformExtensionManifestBounds.MaximumDocumentBytes)
+                {
+                    return new BoundedReadResult(
+                        PlatformInstalledManifestOutcome.DocumentTooLarge,
+                        []);
+                }
+
+                var bytes = new byte[total];
+                if (total > 0)
+                {
+                    Marshal.Copy(nativeBuffer, bytes, 0, total);
+                }
+
+                return new BoundedReadResult(
+                    PlatformInstalledManifestOutcome.Acquired,
+                    bytes);
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(nativeBuffer);
+            }
+        }
+
+        private static bool TryCanonicalizeReportedRoot(string? root, out string canonical)
+        {
+            canonical = string.Empty;
+            if (string.IsNullOrWhiteSpace(root)
+                || !TryGetHostFullPath(root, out canonical))
+            {
+                return false;
+            }
+
+            return !IsFilesystemRoot(canonical);
+        }
+
+        private static bool TryGetFullPath(string path, out string fullPath)
+        {
+            fullPath = string.Empty;
+            try
+            {
+                fullPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
+                return fullPath.Length > 0;
+            }
+            catch (Exception exception) when (exception is ArgumentException
+                or IOException
+                or NotSupportedException
+                or PathTooLongException)
+            {
+                return false;
+            }
+        }
+
+        private static bool TryGetHostFullPath(string path, out string fullPath)
+        {
+            fullPath = string.Empty;
+            if (string.IsNullOrWhiteSpace(path) || path.Contains('\0', StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            var normalized = path
+                .Replace('\\', Path.DirectorySeparatorChar)
+                .Replace('/', Path.DirectorySeparatorChar);
+            var segments = normalized.Split(
+                Path.DirectorySeparatorChar,
+                StringSplitOptions.RemoveEmptyEntries);
+            if (!Path.IsPathFullyQualified(normalized)
+                || normalized.StartsWith(
+                    new string(Path.DirectorySeparatorChar, 2),
+                    StringComparison.Ordinal)
+                || normalized.StartsWith(
+                    Path.DirectorySeparatorChar + "??" + Path.DirectorySeparatorChar,
+                    StringComparison.Ordinal)
+                || normalized.AsSpan(1).Contains(
+                    new string(Path.DirectorySeparatorChar, 2),
+                    StringComparison.Ordinal)
+                || segments.Any(segment => segment is "." or ".."))
+            {
+                return false;
+            }
+
+            return TryGetFullPath(normalized, out fullPath);
+        }
+
+        private static bool IsFilesystemRoot(string path)
+        {
+            var trimmed = Path.TrimEndingDirectorySeparator(path);
+            var root = Path.GetPathRoot(path);
+            return !string.IsNullOrEmpty(root)
+                && string.Equals(trimmed, Path.TrimEndingDirectorySeparator(root), StringComparison.Ordinal);
+        }
+
+        private static bool IsStrictlyInside(string candidate, string root)
+        {
+            var canonicalRoot = Path.TrimEndingDirectorySeparator(root);
+            if (string.Equals(candidate, canonicalRoot, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            var prefix = canonicalRoot.EndsWith(Path.DirectorySeparatorChar)
+                ? canonicalRoot
+                : canonicalRoot + Path.DirectorySeparatorChar;
+            return candidate.StartsWith(prefix, StringComparison.Ordinal);
+        }
+
+        private static bool IsInsideEitherRoot(
+            string candidate,
+            string reportedRoot,
+            string descriptorRoot) =>
+            IsStrictlyInside(candidate, reportedRoot)
+            || IsStrictlyInside(candidate, descriptorRoot);
+
+        private static bool SameObject(DescriptorState left, DescriptorState right) =>
+            left.Inode == right.Inode
+            && left.DeviceMajor == right.DeviceMajor
+            && left.DeviceMinor == right.DeviceMinor
+            && left.MountId == right.MountId;
+
+        private static bool TryGetDescriptorPath(int descriptor, out string descriptorPath)
+        {
+            descriptorPath = string.Empty;
+            if (descriptor < 0)
+            {
+                return false;
+            }
+
+            descriptorPath = "/proc/self/fd/" + descriptor.ToString(
+                System.Globalization.CultureInfo.InvariantCulture);
+            return true;
+        }
+
+        private static bool TryDescribeDescriptor(int descriptor, out string path)
+        {
+            path = string.Empty;
+            var rented = ArrayPool<byte>.Shared.Rent(MaximumDescriptorPathBytes + 1);
+            try
+            {
+                if (!TryGetDescriptorPath(descriptor, out var descriptorPath))
+                {
+                    return false;
+                }
+
+                var count = ReadLink(descriptorPath, rented, (nuint)MaximumDescriptorPathBytes);
+                if (count <= 0 || count >= MaximumDescriptorPathBytes)
+                {
+                    return false;
+                }
+
+                string described;
+                try
+                {
+                    described = StrictUtf8.GetString(rented, 0, checked((int)count));
+                }
+                catch (DecoderFallbackException)
+                {
+                    return false;
+                }
+
+                if (!Path.IsPathFullyQualified(described)
+                    || described.EndsWith(DeletedDescriptorSuffix, StringComparison.Ordinal)
+                    || !TryGetFullPath(described, out path))
+                {
+                    path = string.Empty;
+                    return false;
+                }
+
+                return true;
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
+
+        private static bool TryFStat(int descriptor, out DescriptorState state)
+        {
+            state = default;
+            if (Statx(descriptor, string.Empty, AtEmptyPath, RequiredStatxMask, out var native) != 0
+                || (native.Mask & RequiredStatxMask) != RequiredStatxMask)
+            {
+                return false;
+            }
+
+            state = new DescriptorState(
+                native.Mode,
+                native.Inode,
+                native.Size,
+                native.DeviceMajor,
+                native.DeviceMinor,
+                native.MountId,
+                native.ModificationSeconds,
+                native.ModificationNanoseconds,
+                native.ChangeSeconds,
+                native.ChangeNanoseconds);
+            return true;
+        }
+
+        private static bool IsSupportedLocalFileSystem(int descriptor) =>
+            FStatFs(descriptor, out var native) == 0
+            && SupportedLocalFileSystemTypes.Contains(native.Type);
+
+        private static bool IsBrokenLink(int rootDescriptor, string name)
+        {
+            var buffer = ArrayPool<byte>.Shared.Rent(MaximumDescriptorPathBytes);
+            try
+            {
+                return ReadLinkAt(
+                    rootDescriptor,
+                    name,
+                    buffer,
+                    (nuint)MaximumDescriptorPathBytes) >= 0;
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+        }
+
+        private static PlatformInstalledManifestReadResult Rejected(
+            PlatformInstalledManifestOutcome outcome) =>
+            PlatformInstalledManifestReadResult.Rejected(outcome);
+
+        private readonly record struct DescriptorOpenResult(
+            int MetadataDescriptor,
+            int ContentDescriptor,
+            PlatformInstalledManifestOutcome Outcome);
+
+        private readonly record struct BoundedReadResult(
+            PlatformInstalledManifestOutcome Outcome,
+            byte[] Bytes);
+
+        private readonly record struct AssemblyVerification(
+            PlatformInstalledManifestOutcome Outcome,
+            string? AssemblyIdentity);
+
+        private readonly record struct DllDescriptorObservation(
+            string ReportedPath,
+            int Descriptor,
+            string RelativeName,
+            string DescriptorPath,
+            DescriptorState State);
+
+        private readonly record struct DescriptorState(
+            ushort Mode,
+            ulong Inode,
+            ulong Size,
+            uint DeviceMajor,
+            uint DeviceMinor,
+            ulong MountId,
+            long ModificationSeconds,
+            uint ModificationNanoseconds,
+            long ChangeSeconds,
+            uint ChangeNanoseconds);
+
+        [StructLayout(LayoutKind.Explicit, Size = 256)]
+        private struct NativeStatx
+        {
+            [FieldOffset(0)]
+            internal uint Mask;
+
+            [FieldOffset(28)]
+            internal ushort Mode;
+
+            [FieldOffset(32)]
+            internal ulong Inode;
+
+            [FieldOffset(40)]
+            internal ulong Size;
+
+            [FieldOffset(96)]
+            internal long ChangeSeconds;
+
+            [FieldOffset(104)]
+            internal uint ChangeNanoseconds;
+
+            [FieldOffset(112)]
+            internal long ModificationSeconds;
+
+            [FieldOffset(120)]
+            internal uint ModificationNanoseconds;
+
+            [FieldOffset(136)]
+            internal uint DeviceMajor;
+
+            [FieldOffset(140)]
+            internal uint DeviceMinor;
+
+            [FieldOffset(144)]
+            internal ulong MountId;
+        }
+
+        [StructLayout(LayoutKind.Explicit, Size = 120)]
+        private struct NativeStatFs
+        {
+            [FieldOffset(0)]
+            internal long Type;
+        }
+
+        private sealed class SafeUnixDescriptor : SafeHandleZeroOrMinusOneIsInvalid
+        {
+            internal SafeUnixDescriptor(int descriptor)
+                : base(true)
+            {
+                SetHandle((IntPtr)descriptor);
+            }
+
+            protected override bool ReleaseHandle() =>
+                PlatformInstalledManifestFileReader.Close(handle.ToInt32()) == 0;
+        }
+
+#pragma warning disable SYSLIB1054 // libc descriptor calls are guarded to Linux and require no generated marshalling.
+        [DllImport("libc", EntryPoint = "open", SetLastError = true)]
+        private static extern int Open(string path, int flags);
+
+        [DllImport("libc", EntryPoint = "openat", SetLastError = true)]
+        private static extern int OpenAt(int directoryDescriptor, string path, int flags);
+
+        [DllImport("libc", EntryPoint = "read", SetLastError = true)]
+        private static extern nint Read(int descriptor, IntPtr buffer, nuint count);
+
+        [DllImport("libc", EntryPoint = "readlink", SetLastError = true)]
+        private static extern nint ReadLink(string path, byte[] buffer, nuint count);
+
+        [DllImport("libc", EntryPoint = "readlinkat", SetLastError = true)]
+        private static extern nint ReadLinkAt(
+            int directoryDescriptor,
+            string path,
+            byte[] buffer,
+            nuint count);
+
+        [DllImport("libc", EntryPoint = "statx", SetLastError = true)]
+        private static extern int Statx(
+            int directoryDescriptor,
+            string path,
+            int flags,
+            uint mask,
+            out NativeStatx statx);
+
+        [DllImport("libc", EntryPoint = "fstatfs", SetLastError = true)]
+        private static extern int FStatFs(int descriptor, out NativeStatFs statfs);
+
+        [DllImport("libc", EntryPoint = "close", SetLastError = true)]
+        private static extern int Close(int descriptor);
+#pragma warning restore SYSLIB1054
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformInstalledManifestWindowsReader.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformInstalledManifestWindowsReader.cs
@@ -1,0 +1,892 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+using Microsoft.Win32.SafeHandles;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>
+    /// Windows handle-verification owner for the fixed installed-provider manifest.
+    /// Every containment decision is made from an open handle; lexical paths are
+    /// defense in depth and never become post-open evidence.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    internal static class PlatformInstalledManifestWindowsReader
+    {
+        private const uint GenericRead = 0x80000000;
+        private const uint FileListDirectory = 0x00000001;
+        private const uint FileReadAttributes = 0x00000080;
+        private const uint Synchronize = 0x00100000;
+        private const uint ShareReadWriteDelete = 0x00000007;
+        private const uint OpenExisting = 3;
+        private const uint FileFlagOpenReparsePoint = 0x00200000;
+        private const uint FileFlagBackupSemantics = 0x02000000;
+        private const uint FileFlagSequentialScan = 0x08000000;
+        private const uint FileFlagOverlapped = 0x40000000;
+
+        private const uint FileTypeDisk = 0x0001;
+        private const uint DriveFixed = 3;
+        private const int ErrorFileNotFound = 2;
+        private const int ErrorPathNotFound = 3;
+        private const int ErrorHandleEof = 38;
+        private const int ErrorIoPending = 997;
+        private const int ErrorOperationAborted = 995;
+        private const int MaximumFinalPathCharacters = 32768;
+        private const int ReadTimeoutMilliseconds = 2000;
+
+        /// <summary>
+        /// Reads one fixed manifest on Windows or returns a closed, redaction-safe outcome.
+        /// Cancellation is caller control and therefore propagates rather than becoming
+        /// plugin health.
+        /// </summary>
+        internal static PlatformInstalledManifestReadResult Read(
+            PlatformInstalledPluginSnapshot snapshot,
+            CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(snapshot);
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!OperatingSystem.IsWindows())
+            {
+                return Rejected(PlatformInstalledManifestOutcome.DescriptorUnverifiable);
+            }
+
+            try
+            {
+                return ReadWindows(snapshot, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception exception) when (exception is ArgumentException
+                or IOException
+                or UnauthorizedAccessException
+                or NotSupportedException
+                or OverflowException
+                or DllNotFoundException
+                or EntryPointNotFoundException
+                or BadImageFormatException
+                or MarshalDirectiveException
+                or PlatformNotSupportedException)
+            {
+                return Rejected(PlatformInstalledManifestOutcome.AcquisitionFailed);
+            }
+        }
+
+        private static PlatformInstalledManifestReadResult ReadWindows(
+            PlatformInstalledPluginSnapshot snapshot,
+            CancellationToken cancellationToken)
+        {
+            if (!TryNormalizeReportedRoot(snapshot.ReportedRoot, out var lexicalRoot))
+            {
+                return Rejected(PlatformInstalledManifestOutcome.UnsafeOrUnverifiableRoot);
+            }
+
+            using var rootHandle = CreateFileW(
+                lexicalRoot,
+                FileListDirectory | FileReadAttributes | Synchronize,
+                ShareReadWriteDelete,
+                IntPtr.Zero,
+                OpenExisting,
+                FileFlagBackupSemantics,
+                IntPtr.Zero);
+            if (rootHandle.IsInvalid
+                || !TryGetObjectState(rootHandle, requireDirectory: true, out var rootBefore)
+                || !TryGetFinalPath(rootHandle, out var descriptorRoot)
+                || !IsSupportedLocalRoot(descriptorRoot)
+                || IsFilesystemRoot(descriptorRoot))
+            {
+                return Rejected(PlatformInstalledManifestOutcome.UnsafeOrUnverifiableRoot);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            var fixedEntry = Path.Combine(descriptorRoot, PlatformExtensionManifestParser.ManifestFileName);
+            using var manifestMetadataHandle = CreateFileW(
+                fixedEntry,
+                FileReadAttributes | Synchronize,
+                ShareReadWriteDelete,
+                IntPtr.Zero,
+                OpenExisting,
+                FileFlagOverlapped,
+                IntPtr.Zero);
+            if (manifestMetadataHandle.IsInvalid)
+            {
+                return Rejected(MapFixedEntryOpenFailure(fixedEntry));
+            }
+
+            if (!TryGetObjectState(manifestMetadataHandle, requireDirectory: false, out var manifestBefore))
+            {
+                return Rejected(PlatformInstalledManifestOutcome.NotRegularFile);
+            }
+
+            if (manifestBefore.Identity.VolumeSerialNumber != rootBefore.Identity.VolumeSerialNumber
+                || !TryGetFinalPath(manifestMetadataHandle, out var manifestFinalPath))
+            {
+                return Rejected(PlatformInstalledManifestOutcome.DescriptorUnverifiable);
+            }
+
+            if (!IsStrictlyInside(manifestFinalPath, descriptorRoot))
+            {
+                return Rejected(PlatformInstalledManifestOutcome.UnsafeTarget);
+            }
+
+            if (manifestBefore.EndOfFile > PlatformExtensionManifestBounds.MaximumDocumentBytes)
+            {
+                return Rejected(PlatformInstalledManifestOutcome.DocumentTooLarge);
+            }
+
+            using var manifestReadHandle = ReOpenFile(
+                manifestMetadataHandle,
+                GenericRead | FileReadAttributes | Synchronize,
+                ShareReadWriteDelete,
+                FileFlagOverlapped | FileFlagSequentialScan);
+            if (manifestReadHandle.IsInvalid
+                || !TryGetObjectState(manifestReadHandle, requireDirectory: false, out var readBefore)
+                || !manifestBefore.Identity.Equals(readBefore.Identity)
+                || !TryGetFinalPath(manifestReadHandle, out var readFinalPath)
+                || !string.Equals(manifestFinalPath, readFinalPath, StringComparison.OrdinalIgnoreCase))
+            {
+                return Rejected(PlatformInstalledManifestOutcome.ReadChanged);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            var read = ReadBoundedOverlapped(manifestReadHandle, cancellationToken);
+            if (read.Outcome != PlatformInstalledManifestOutcome.Acquired)
+            {
+                return Rejected(read.Outcome);
+            }
+
+            if (!TryGetObjectState(manifestMetadataHandle, requireDirectory: false, out var manifestAfter)
+                || !TryGetObjectState(manifestReadHandle, requireDirectory: false, out var readAfter)
+                || !manifestBefore.StableEquals(manifestAfter)
+                || !manifestBefore.StableEquals(readAfter)
+                || manifestAfter.EndOfFile != read.Bytes.Length
+                || !TryGetFinalPath(manifestReadHandle, out var readPathAfter)
+                || !string.Equals(manifestFinalPath, readPathAfter, StringComparison.OrdinalIgnoreCase)
+                || !FixedEntryStillNamesStableObject(fixedEntry, manifestBefore, manifestFinalPath)
+                || !RootStillNamesObject(lexicalRoot, rootBefore.Identity, descriptorRoot))
+            {
+                return Rejected(PlatformInstalledManifestOutcome.ReadChanged);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            var assembly = VerifyAssembly(snapshot, descriptorRoot, rootBefore.Identity, cancellationToken);
+            if (assembly.Outcome != PlatformInstalledManifestOutcome.Acquired)
+            {
+                return Rejected(assembly.Outcome);
+            }
+
+            if (!TryGetObjectState(manifestMetadataHandle, requireDirectory: false, out var finalManifestState)
+                || !TryGetObjectState(manifestReadHandle, requireDirectory: false, out var finalReadState)
+                || !manifestBefore.StableEquals(finalManifestState)
+                || !manifestBefore.StableEquals(finalReadState)
+                || finalManifestState.EndOfFile != read.Bytes.Length
+                || !TryGetFinalPath(manifestMetadataHandle, out var finalMetadataPath)
+                || !TryGetFinalPath(manifestReadHandle, out var finalReadPath)
+                || !string.Equals(manifestFinalPath, finalMetadataPath, StringComparison.OrdinalIgnoreCase)
+                || !string.Equals(manifestFinalPath, finalReadPath, StringComparison.OrdinalIgnoreCase)
+                || !FixedEntryStillNamesStableObject(fixedEntry, manifestBefore, manifestFinalPath)
+                || !RootStillNamesObject(lexicalRoot, rootBefore.Identity, descriptorRoot))
+            {
+                return Rejected(PlatformInstalledManifestOutcome.ReadChanged);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            return PlatformInstalledManifestReadResult.Acquired(read.Bytes, assembly.AssemblyIdentity);
+        }
+
+        private static AssemblyVerification VerifyAssembly(
+            PlatformInstalledPluginSnapshot snapshot,
+            string descriptorRoot,
+            FileIdentity rootIdentity,
+            CancellationToken cancellationToken)
+        {
+            if (snapshot.DllFiles.IsDefaultOrEmpty)
+            {
+                return new AssemblyVerification(PlatformInstalledManifestOutcome.AssemblyUnavailable, null);
+            }
+
+            if (snapshot.DllFiles.Length > PlatformInstalledManifestLimits.MaximumDllFileCount)
+            {
+                return new AssemblyVerification(PlatformInstalledManifestOutcome.AssemblyMismatch, null);
+            }
+
+            var dllHandles = new List<SafeFileHandle>(snapshot.DllFiles.Length);
+            try
+            {
+                var verifiedDlls = new List<VerifiedDll>(snapshot.DllFiles.Length);
+                var canonicalNames = new HashSet<string>(StringComparer.Ordinal);
+                foreach (var reportedDll in snapshot.DllFiles)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (!TryGetRelativeReportedPath(
+                            snapshot.ReportedRoot,
+                            reportedDll,
+                            out var dllRelativePath))
+                    {
+                        return new AssemblyVerification(
+                            PlatformInstalledManifestOutcome.AssemblyMismatch,
+                            null);
+                    }
+
+                    var fixedDllEntry = Path.Combine(descriptorRoot, dllRelativePath);
+                    var dllHandle = CreateFileW(
+                        fixedDllEntry,
+                        FileReadAttributes | Synchronize,
+                        ShareReadWriteDelete,
+                        IntPtr.Zero,
+                        OpenExisting,
+                        FileFlagOverlapped,
+                        IntPtr.Zero);
+                    dllHandles.Add(dllHandle);
+                    if (dllHandle.IsInvalid
+                        || !TryGetObjectState(dllHandle, requireDirectory: false, out var dllState)
+                        || dllState.Identity.VolumeSerialNumber != rootIdentity.VolumeSerialNumber
+                        || !TryGetFinalPath(dllHandle, out var finalDllPath)
+                        || !IsStrictlyInside(finalDllPath, descriptorRoot)
+                        || !FixedEntryStillNamesStableObject(fixedDllEntry, dllState, finalDllPath))
+                    {
+                        return new AssemblyVerification(
+                            PlatformInstalledManifestOutcome.AssemblyMismatch,
+                            null);
+                    }
+
+                    var finalRelativePath = Path.GetRelativePath(descriptorRoot, finalDllPath);
+                    if (Path.IsPathFullyQualified(finalRelativePath)
+                        || finalRelativePath.Split('\\', '/').Any(part => part is "." or ".."))
+                    {
+                        return new AssemblyVerification(
+                            PlatformInstalledManifestOutcome.AssemblyMismatch,
+                            null);
+                    }
+
+                    var canonicalName = CanonicalizeRelativeName(finalRelativePath);
+                    if (!canonicalNames.Add(canonicalName))
+                    {
+                        return new AssemblyVerification(
+                            PlatformInstalledManifestOutcome.AssemblyMismatch,
+                            null);
+                    }
+
+                    verifiedDlls.Add(new VerifiedDll(
+                        fixedDllEntry,
+                        finalDllPath,
+                        canonicalName,
+                        dllState));
+                }
+
+                for (var index = 0; index < verifiedDlls.Count; index++)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var verifiedDll = verifiedDlls[index];
+                    if (!TryGetObjectState(
+                            dllHandles[index],
+                            requireDirectory: false,
+                            out var retainedState)
+                        || !verifiedDll.State.StableEquals(retainedState)
+                        || !TryGetFinalPath(dllHandles[index], out var retainedPath)
+                        || !string.Equals(
+                            verifiedDll.FinalPath,
+                            retainedPath,
+                            StringComparison.OrdinalIgnoreCase)
+                        || !FixedEntryStillNamesStableObject(
+                            verifiedDll.FixedEntry,
+                            verifiedDll.State,
+                            verifiedDll.FinalPath))
+                    {
+                        return new AssemblyVerification(
+                            PlatformInstalledManifestOutcome.AssemblyMismatch,
+                            null);
+                    }
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+                return new AssemblyVerification(
+                    PlatformInstalledManifestOutcome.Acquired,
+                    ComputeAssemblySetIdentity(verifiedDlls));
+            }
+            finally
+            {
+                foreach (var dllHandle in dllHandles)
+                {
+                    dllHandle.Dispose();
+                }
+            }
+        }
+
+        private static string CanonicalizeRelativeName(string relativePath) =>
+            relativePath.Replace('/', '\\').ToUpperInvariant();
+
+        private static string ComputeAssemblySetIdentity(List<VerifiedDll> verifiedDlls)
+        {
+            const string domain = "jellyfin-canopy:installed-assembly-set:v1";
+            using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+            AppendHashField(hash, Encoding.UTF8.GetBytes(domain));
+            foreach (var dll in verifiedDlls.OrderBy(item => item.CanonicalRelativeName, StringComparer.Ordinal))
+            {
+                AppendHashField(hash, Encoding.UTF8.GetBytes(dll.CanonicalRelativeName));
+                AppendHashUInt64(hash, dll.State.Identity.VolumeSerialNumber);
+                AppendHashUInt64(hash, dll.State.Identity.Low);
+                AppendHashUInt64(hash, dll.State.Identity.High);
+            }
+
+            return "dll-set-sha256:" + Convert.ToHexString(hash.GetHashAndReset());
+        }
+
+        private static void AppendHashField(IncrementalHash hash, byte[] value)
+        {
+            Span<byte> length = stackalloc byte[sizeof(int)];
+            System.Buffers.Binary.BinaryPrimitives.WriteInt32BigEndian(length, value.Length);
+            hash.AppendData(length);
+            hash.AppendData(value);
+        }
+
+        private static void AppendHashUInt64(IncrementalHash hash, ulong value)
+        {
+            Span<byte> encoded = stackalloc byte[sizeof(ulong)];
+            System.Buffers.Binary.BinaryPrimitives.WriteUInt64BigEndian(encoded, value);
+            hash.AppendData(encoded);
+        }
+
+        private static BoundedReadResult ReadBoundedOverlapped(
+            SafeFileHandle handle,
+            CancellationToken cancellationToken)
+        {
+            var capacity = PlatformExtensionManifestBounds.MaximumDocumentBytes + 1;
+            var buffer = new byte[capacity];
+            var pinned = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+            try
+            {
+                var total = 0;
+                while (total < capacity)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var chunk = ReadOverlappedChunk(
+                        handle,
+                        IntPtr.Add(pinned.AddrOfPinnedObject(), total),
+                        checked((uint)(capacity - total)),
+                        checked((ulong)total),
+                        cancellationToken);
+                    if (chunk.Outcome != PlatformInstalledManifestOutcome.Acquired)
+                    {
+                        return new BoundedReadResult(chunk.Outcome, []);
+                    }
+
+                    if (chunk.BytesRead == 0)
+                    {
+                        break;
+                    }
+
+                    total += checked((int)chunk.BytesRead);
+                }
+
+                if (total > PlatformExtensionManifestBounds.MaximumDocumentBytes)
+                {
+                    return new BoundedReadResult(PlatformInstalledManifestOutcome.DocumentTooLarge, []);
+                }
+
+                return new BoundedReadResult(
+                    PlatformInstalledManifestOutcome.Acquired,
+                    buffer.AsSpan(0, total).ToArray());
+            }
+            finally
+            {
+                pinned.Free();
+            }
+        }
+
+        private static OverlappedReadResult ReadOverlappedChunk(
+            SafeFileHandle handle,
+            IntPtr buffer,
+            uint count,
+            ulong offset,
+            CancellationToken cancellationToken)
+        {
+            using var completion = new EventWaitHandle(false, EventResetMode.ManualReset);
+            var native = new NativeOverlappedData
+            {
+                Offset = unchecked((uint)offset),
+                OffsetHigh = unchecked((uint)(offset >> 32)),
+                EventHandle = completion.SafeWaitHandle.DangerousGetHandle(),
+            };
+            var nativePointer = Marshal.AllocHGlobal(Marshal.SizeOf<NativeOverlappedData>());
+            try
+            {
+                Marshal.StructureToPtr(native, nativePointer, fDeleteOld: false);
+                var started = ReadFile(handle, buffer, count, IntPtr.Zero, nativePointer);
+                if (!started)
+                {
+                    var error = Marshal.GetLastPInvokeError();
+                    if (error == ErrorHandleEof)
+                    {
+                        return new OverlappedReadResult(PlatformInstalledManifestOutcome.Acquired, 0);
+                    }
+
+                    if (error != ErrorIoPending)
+                    {
+                        return new OverlappedReadResult(PlatformInstalledManifestOutcome.ReadFailed, 0);
+                    }
+
+                    var wait = WaitHandle.WaitAny(
+                        new[] { completion, cancellationToken.WaitHandle },
+                        ReadTimeoutMilliseconds);
+                    if (wait != 0)
+                    {
+                        _ = CancelIoEx(handle, nativePointer);
+                        _ = GetOverlappedResult(handle, nativePointer, out _, wait: true);
+                        if (cancellationToken.IsCancellationRequested)
+                        {
+                            throw new OperationCanceledException(cancellationToken);
+                        }
+
+                        return new OverlappedReadResult(PlatformInstalledManifestOutcome.OpenTimedOut, 0);
+                    }
+                }
+
+                if (!GetOverlappedResult(handle, nativePointer, out var transferred, wait: false))
+                {
+                    var error = Marshal.GetLastPInvokeError();
+                    return error is ErrorHandleEof
+                        ? new OverlappedReadResult(PlatformInstalledManifestOutcome.Acquired, 0)
+                        : error is ErrorOperationAborted && cancellationToken.IsCancellationRequested
+                            ? throw new OperationCanceledException(cancellationToken)
+                            : new OverlappedReadResult(PlatformInstalledManifestOutcome.ReadFailed, 0);
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+                return new OverlappedReadResult(PlatformInstalledManifestOutcome.Acquired, transferred);
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(nativePointer);
+            }
+        }
+
+        private static bool FixedEntryStillNamesStableObject(
+            string path,
+            ObjectState expectedState,
+            string expectedFinalPath)
+        {
+            using var current = CreateFileW(
+                path,
+                FileReadAttributes | Synchronize,
+                ShareReadWriteDelete,
+                IntPtr.Zero,
+                OpenExisting,
+                FileFlagOverlapped,
+                IntPtr.Zero);
+            return !current.IsInvalid
+                && TryGetObjectState(current, requireDirectory: false, out var state)
+                && expectedState.StableEquals(state)
+                && TryGetFinalPath(current, out var finalPath)
+                && string.Equals(expectedFinalPath, finalPath, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool RootStillNamesObject(
+            string path,
+            FileIdentity expectedIdentity,
+            string expectedFinalPath)
+        {
+            using var current = CreateFileW(
+                path,
+                FileListDirectory | FileReadAttributes | Synchronize,
+                ShareReadWriteDelete,
+                IntPtr.Zero,
+                OpenExisting,
+                FileFlagBackupSemantics,
+                IntPtr.Zero);
+            return !current.IsInvalid
+                && TryGetObjectState(current, requireDirectory: true, out var state)
+                && expectedIdentity.Equals(state.Identity)
+                && TryGetFinalPath(current, out var finalPath)
+                && string.Equals(expectedFinalPath, finalPath, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static PlatformInstalledManifestOutcome MapFixedEntryOpenFailure(string path)
+        {
+            var error = Marshal.GetLastPInvokeError();
+            if (error is not (ErrorFileNotFound or ErrorPathNotFound))
+            {
+                return PlatformInstalledManifestOutcome.ReadFailed;
+            }
+
+            using var link = CreateFileW(
+                path,
+                FileReadAttributes | Synchronize,
+                ShareReadWriteDelete,
+                IntPtr.Zero,
+                OpenExisting,
+                FileFlagOpenReparsePoint | FileFlagBackupSemantics,
+                IntPtr.Zero);
+            return link.IsInvalid
+                ? PlatformInstalledManifestOutcome.ManifestAbsent
+                : PlatformInstalledManifestOutcome.UnsafeTarget;
+        }
+
+        private static bool TryGetObjectState(
+            SafeFileHandle handle,
+            bool requireDirectory,
+            out ObjectState state)
+        {
+            state = default;
+            if (handle.IsInvalid
+                || GetFileType(handle) != FileTypeDisk
+                || !GetFileInformationByHandleExIdentity(
+                    handle,
+                    FileInfoByHandleClass.FileIdInfo,
+                    out var identity,
+                    (uint)Marshal.SizeOf<NativeFileIdInfo>())
+                || !GetFileInformationByHandleExBasic(
+                    handle,
+                    FileInfoByHandleClass.FileBasicInfo,
+                    out var basic,
+                    (uint)Marshal.SizeOf<NativeFileBasicInfo>())
+                || !GetFileInformationByHandleExStandard(
+                    handle,
+                    FileInfoByHandleClass.FileStandardInfo,
+                    out var standard,
+                    (uint)Marshal.SizeOf<NativeFileStandardInfo>())
+                || standard.DeletePending
+                || standard.Directory != requireDirectory)
+            {
+                return false;
+            }
+
+            state = new ObjectState(
+                new FileIdentity(identity.VolumeSerialNumber, identity.FileId.Low, identity.FileId.High),
+                basic.CreationTime,
+                basic.LastWriteTime,
+                basic.ChangeTime,
+                basic.FileAttributes,
+                standard.AllocationSize,
+                standard.EndOfFile,
+                standard.NumberOfLinks);
+            return true;
+        }
+
+        private static bool TryGetFinalPath(SafeFileHandle handle, out string path)
+        {
+            path = string.Empty;
+            var buffer = new char[MaximumFinalPathCharacters];
+            var length = GetFinalPathNameByHandleW(handle, buffer, (uint)buffer.Length, 0);
+            if (length == 0 || length >= buffer.Length)
+            {
+                return false;
+            }
+
+            var nativePath = new string(buffer, 0, checked((int)length));
+            if (nativePath.StartsWith("\\\\?\\UNC\\", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            var normalized = nativePath.StartsWith("\\\\?\\", StringComparison.Ordinal)
+                ? nativePath[4..]
+                : nativePath;
+            return TryGetComparableFullPath(normalized, out path);
+        }
+
+        private static bool TryNormalizeReportedRoot(string? path, out string normalized)
+        {
+            normalized = string.Empty;
+            if (string.IsNullOrWhiteSpace(path) || HasUnsafeLexicalShape(path))
+            {
+                return false;
+            }
+
+            var separators = path.Replace('/', '\\');
+            if (!Path.IsPathFullyQualified(separators)
+                || separators.Split('\\', StringSplitOptions.RemoveEmptyEntries).Any(part => part == "..")
+                || !TryGetComparableFullPath(separators, out normalized))
+            {
+                return false;
+            }
+
+            return !IsFilesystemRoot(normalized);
+        }
+
+        private static bool TryGetRelativeReportedPath(
+            string reportedRoot,
+            string candidate,
+            out string relativePath)
+        {
+            relativePath = string.Empty;
+            if (!TryNormalizeReportedRoot(reportedRoot, out var root)
+                || string.IsNullOrWhiteSpace(candidate)
+                || HasUnsafeLexicalShape(candidate)
+                || !TryGetComparableFullPath(candidate.Replace('/', '\\'), out var fullCandidate)
+                || !IsStrictlyInside(fullCandidate, root))
+            {
+                return false;
+            }
+
+            relativePath = Path.GetRelativePath(root, fullCandidate);
+            return !Path.IsPathFullyQualified(relativePath)
+                && !relativePath.Split('\\', '/').Any(part => part == "..");
+        }
+
+        private static bool TryGetComparableFullPath(string path, out string fullPath)
+        {
+            fullPath = string.Empty;
+            try
+            {
+                fullPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
+                return fullPath.Length > 0 && !IsUncOrDevicePath(fullPath);
+            }
+            catch (Exception exception) when (exception is ArgumentException
+                or IOException
+                or NotSupportedException
+                or PathTooLongException)
+            {
+                return false;
+            }
+        }
+
+        private static bool IsUncOrDevicePath(string path) =>
+            path.StartsWith("\\\\", StringComparison.Ordinal)
+            || path.StartsWith("\\??\\", StringComparison.Ordinal)
+            || path.StartsWith("\\Device\\", StringComparison.OrdinalIgnoreCase);
+
+        private static bool HasUnsafeLexicalShape(string path)
+        {
+            if (path.Contains('\0', StringComparison.Ordinal) || IsUncOrDevicePath(path))
+            {
+                return true;
+            }
+
+            var segments = path.Split(new[] { '\\', '/' }, StringSplitOptions.None);
+            if (segments.Any(segment => segment is "." or ".."))
+            {
+                return true;
+            }
+
+            var firstColon = path.IndexOf(':', StringComparison.Ordinal);
+            return firstColon != 1
+                || !char.IsAsciiLetter(path[0])
+                || path.Length < 3
+                || path[2] is not ('\\' or '/')
+                || path.IndexOf(':', firstColon + 1) >= 0;
+        }
+
+        private static bool IsFilesystemRoot(string path)
+        {
+            var root = Path.GetPathRoot(path);
+            return !string.IsNullOrEmpty(root)
+                && string.Equals(
+                    Path.TrimEndingDirectorySeparator(path),
+                    Path.TrimEndingDirectorySeparator(root),
+                    StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsSupportedLocalRoot(string path)
+        {
+            var root = Path.GetPathRoot(path);
+            return !string.IsNullOrEmpty(root) && GetDriveTypeW(root) == DriveFixed;
+        }
+
+        private static bool IsStrictlyInside(string candidate, string root)
+        {
+            var canonicalRoot = Path.TrimEndingDirectorySeparator(root);
+            if (string.Equals(candidate, canonicalRoot, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            var prefix = canonicalRoot.EndsWith(Path.DirectorySeparatorChar)
+                || canonicalRoot.EndsWith(Path.AltDirectorySeparatorChar)
+                    ? canonicalRoot
+                    : canonicalRoot + Path.DirectorySeparatorChar;
+            return candidate.StartsWith(prefix, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static PlatformInstalledManifestReadResult Rejected(
+            PlatformInstalledManifestOutcome outcome) =>
+            PlatformInstalledManifestReadResult.Rejected(outcome);
+
+        private readonly record struct FileIdentity(ulong VolumeSerialNumber, ulong Low, ulong High);
+
+        private readonly record struct ObjectState(
+            FileIdentity Identity,
+            long CreationTime,
+            long LastWriteTime,
+            long ChangeTime,
+            uint FileAttributes,
+            long AllocationSize,
+            long EndOfFile,
+            uint NumberOfLinks)
+        {
+            internal bool StableEquals(ObjectState other) =>
+                Identity.Equals(other.Identity)
+                && CreationTime == other.CreationTime
+                && LastWriteTime == other.LastWriteTime
+                && ChangeTime == other.ChangeTime
+                && FileAttributes == other.FileAttributes
+                && AllocationSize == other.AllocationSize
+                && EndOfFile == other.EndOfFile
+                && NumberOfLinks == other.NumberOfLinks;
+        }
+
+        private readonly record struct BoundedReadResult(
+            PlatformInstalledManifestOutcome Outcome,
+            byte[] Bytes);
+
+        private readonly record struct OverlappedReadResult(
+            PlatformInstalledManifestOutcome Outcome,
+            uint BytesRead);
+
+        private readonly record struct AssemblyVerification(
+            PlatformInstalledManifestOutcome Outcome,
+            string? AssemblyIdentity);
+
+        private readonly record struct VerifiedDll(
+            string FixedEntry,
+            string FinalPath,
+            string CanonicalRelativeName,
+            ObjectState State);
+
+        private enum FileInfoByHandleClass
+        {
+            FileBasicInfo = 0,
+            FileStandardInfo = 1,
+            FileIdInfo = 18,
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct NativeFileId128
+        {
+            internal ulong Low;
+            internal ulong High;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct NativeFileIdInfo
+        {
+            internal ulong VolumeSerialNumber;
+            internal NativeFileId128 FileId;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct NativeFileBasicInfo
+        {
+            internal long CreationTime;
+            internal long LastAccessTime;
+            internal long LastWriteTime;
+            internal long ChangeTime;
+            internal uint FileAttributes;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct NativeFileStandardInfo
+        {
+            internal long AllocationSize;
+            internal long EndOfFile;
+            internal uint NumberOfLinks;
+
+            [MarshalAs(UnmanagedType.U1)]
+            internal bool DeletePending;
+
+            [MarshalAs(UnmanagedType.U1)]
+            internal bool Directory;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct NativeOverlappedData
+        {
+            internal IntPtr Internal;
+            internal IntPtr InternalHigh;
+            internal uint Offset;
+            internal uint OffsetHigh;
+            internal IntPtr EventHandle;
+        }
+
+#pragma warning disable SYSLIB1054 // Win32 handle APIs require SafeFileHandle and explicit overlapped lifetime control.
+        [DllImport("kernel32.dll", EntryPoint = "CreateFileW", CharSet = CharSet.Unicode,
+            ExactSpelling = true, SetLastError = true)]
+        private static extern SafeFileHandle CreateFileW(
+            string fileName,
+            uint desiredAccess,
+            uint shareMode,
+            IntPtr securityAttributes,
+            uint creationDisposition,
+            uint flagsAndAttributes,
+            IntPtr templateFile);
+
+        [DllImport("kernel32.dll", EntryPoint = "ReOpenFile", ExactSpelling = true, SetLastError = true)]
+        private static extern SafeFileHandle ReOpenFile(
+            SafeFileHandle originalFile,
+            uint desiredAccess,
+            uint shareMode,
+            uint flagsAndAttributes);
+
+        [DllImport("kernel32.dll", EntryPoint = "GetFinalPathNameByHandleW", CharSet = CharSet.Unicode,
+            ExactSpelling = true, SetLastError = true)]
+        private static extern uint GetFinalPathNameByHandleW(
+            SafeFileHandle file,
+            char[] filePath,
+            uint filePathSize,
+            uint flags);
+
+        [DllImport("kernel32.dll", EntryPoint = "GetFileType", ExactSpelling = true, SetLastError = true)]
+        private static extern uint GetFileType(SafeFileHandle file);
+
+        [DllImport("kernel32.dll", EntryPoint = "GetDriveTypeW", CharSet = CharSet.Unicode,
+            ExactSpelling = true, SetLastError = true)]
+        private static extern uint GetDriveTypeW(string rootPathName);
+
+        [DllImport("kernel32.dll", EntryPoint = "GetFileInformationByHandleEx",
+            ExactSpelling = true, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool GetFileInformationByHandleExIdentity(
+            SafeFileHandle file,
+            FileInfoByHandleClass informationClass,
+            out NativeFileIdInfo information,
+            uint bufferSize);
+
+        [DllImport("kernel32.dll", EntryPoint = "GetFileInformationByHandleEx",
+            ExactSpelling = true, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool GetFileInformationByHandleExBasic(
+            SafeFileHandle file,
+            FileInfoByHandleClass informationClass,
+            out NativeFileBasicInfo information,
+            uint bufferSize);
+
+        [DllImport("kernel32.dll", EntryPoint = "GetFileInformationByHandleEx",
+            ExactSpelling = true, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool GetFileInformationByHandleExStandard(
+            SafeFileHandle file,
+            FileInfoByHandleClass informationClass,
+            out NativeFileStandardInfo information,
+            uint bufferSize);
+
+        [DllImport("kernel32.dll", EntryPoint = "ReadFile", ExactSpelling = true, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool ReadFile(
+            SafeFileHandle file,
+            IntPtr buffer,
+            uint bytesToRead,
+            IntPtr bytesRead,
+            IntPtr overlapped);
+
+        [DllImport("kernel32.dll", EntryPoint = "CancelIoEx", ExactSpelling = true, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool CancelIoEx(SafeFileHandle file, IntPtr overlapped);
+
+        [DllImport("kernel32.dll", EntryPoint = "GetOverlappedResult", ExactSpelling = true, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool GetOverlappedResult(
+            SafeFileHandle file,
+            IntPtr overlapped,
+            out uint bytesTransferred,
+            [MarshalAs(UnmanagedType.Bool)] bool wait);
+#pragma warning restore SYSLIB1054
+    }
+}

--- a/research/extension-platform/README.md
+++ b/research/extension-platform/README.md
@@ -49,7 +49,7 @@ not claims that a route already ships.
 | [0002](adr/0002-protocol-and-version-negotiation.md) | protocol, version negotiation, error envelope | accepted and implemented (EP-01) |
 | [0003](adr/0003-json-abi.md) | the load-context-safe JSON ABI | accepted design; EP-04 implementation pending |
 | [0004](adr/0004-provider-invocation.md) | provider binding and failure isolation | accepted design; EP-04 implementation pending |
-| [0005](adr/0005-manifest-discovery.md) | manifest discovery and registry binding | manifest contract/fingerprint implemented; host-bound discovery and lifecycle pending |
+| [0005](adr/0005-manifest-discovery.md) | manifest discovery and registry binding | manifest contract and host-bound descriptor-safe acquisition implemented; registry lifecycle pending |
 | [0006](adr/0006-client-event-transport.md) | client event transport | accepted for the registry/provider C5 subset; EP-05 implementation pending |
 | [0007](adr/0007-declarative-web-contributions.md) | declarative web contributions | proposed (1–6); the sandboxed-frame decision **deferred, not in v1** |
 | [0008](adr/0008-storage-ownership.md) | storage ownership | accepted design; EP-05 implementation pending |

--- a/research/extension-platform/adr/0005-manifest-discovery.md
+++ b/research/extension-platform/adr/0005-manifest-discovery.md
@@ -1,6 +1,6 @@
 # ADR-0005 — Manifest discovery and registry binding
 
-Status: **accepted; bounded manifest contract and semantic fingerprint implemented** (#645; host-bound discovery and registry lifecycle pending) · Owner: platform kernel · Evidence: [S4](../spike-evidence.md#s4--manifest-discovery-binds-to-the-real-plugin-identity-and-rejects-a-claim-to-another), [S5](../spike-evidence.md#s5--path-containment-holds-against-traversal-symlinks-and-link-cycles), [S13](../spike-evidence.md#s13--lifecycle-matrix)
+Status: **accepted; bounded manifest contract, descriptor-safe acquisition and immutable host binding implemented** (#645, #647; registry lifecycle pending) · Owner: platform kernel · Evidence: [S4](../spike-evidence.md#s4--manifest-discovery-binds-to-the-real-plugin-identity-and-rejects-a-claim-to-another), [S5](../spike-evidence.md#s5--path-containment-holds-against-traversal-symlinks-and-link-cycles), [S13](../spike-evidence.md#s13--lifecycle-matrix), [S16](../spike-evidence.md#s16--the-manifest-read-is-a-toctou-and-a-fifo-stalls-it)
 
 ## Context
 
@@ -24,11 +24,16 @@ declared scopes — are each a distinct vulnerability.
    ([S16](../spike-evidence.md#s16--the-manifest-read-is-a-toctou-and-a-fifo-stalls-it)).
    The kernel opens the file, resolves what the **descriptor** actually refers to,
    and refuses the read outright when that cannot be determined. It must also
-   **bound the open**: `open(2)` blocks forever on a FIFO, so a plugin shipping a
-   named pipe as its manifest would stall discovery for every plugin.
-4. **Containment before I/O.** The resolved path must canonicalize to a location
-   strictly inside the plugin root; absolute paths, embedded NUL, `..` traversal
-   and root-escaping symlinks are rejected before any file is opened.
+   prevent a blocking content open: `open(2)` blocks forever on a FIFO, so a
+   plugin shipping a named pipe as its manifest would stall discovery for every
+   plugin. The production reader type-probes through metadata/nonblocking handles
+   and supports only an explicit local-filesystem allow-list on Linux or fixed
+   local drives on Windows.
+4. **Lexical defence before I/O; descriptor containment after open.** Absolute
+   paths, embedded NUL, `..` traversal and unsafe separator shapes are rejected
+   before opening. Links and mount/reparse transitions cannot be trusted
+   lexically: after opening, the descriptor-resolved target must be strictly
+   inside the descriptor-verified plugin root or the observation is rejected.
    Verified ([S5](../spike-evidence.md#s5--path-containment-holds-against-traversal-symlinks-and-link-cycles)).
    **Three things the naive implementation gets wrong**, each found in the spike:
    separators must be normalised before any test; link resolution must cover every
@@ -46,6 +51,15 @@ declared scopes — are each a distinct vulnerability.
    stable across property, whitespace and request-set ordering, while every
    validated field change changes the fingerprint. This content fingerprint is
    not proof of installation, a signature, approval, a grant or registry identity.
+   Issue #647 adds the acquisition half: one materialized Jellyfin inventory,
+   one constant filename, nonblocking Linux descriptor opens and cancellable
+   overlapped Windows reads, regular-file and final-target verification, a
+   `MaximumDocumentBytes + 1` read, before/after
+   descriptor-state checks, exact GUID/version/assembly binding and a fresh host
+   re-observation. Unsupported platforms, Linux filesystem types and non-fixed
+   Windows roots fail closed.
+   Successful output is an immutable observation only; it still carries no
+   approval, grant, lifecycle, persistence or invocation authority.
 6. **A manifest is never a grant.** It states what an extension *requests*. An
    administrator approves. Requested and granted scopes are stored separately.
 7. **Fingerprint changes revoke approval.** Any change to the manifest
@@ -102,6 +116,16 @@ declared scopes — are each a distinct vulnerability.
 - **Uninstall does not reclaim anything.** The context stays alive with its
   assemblies loaded for the life of the process. Admin diagnostics should say so
   rather than implying the extension is gone.
+- In-process code cannot impose an absolute wall-clock deadline on a synchronous
+  path lookup or handle open after the operating-system kernel or storage driver
+  accepts it. Classification itself requires the first root lookup, so a
+  host-reported link into an unsupported target can wedge before Canopy can reject
+  it. Once classification succeeds, the v1 reader rejects user-space, network and
+  unknown filesystem roots, uses no abandoned `Task.Run` worker, and bounds all
+  application-controlled bytes, counts and concurrency. Windows cancellation must
+  await native I/O ownership returning before buffers can be reclaimed. Killable
+  isolation for both residuals is tracked by #648; #647 does not claim to sandbox
+  or kill a wedged kernel/driver.
 
 ## Rejected alternatives
 

--- a/research/extension-platform/spike-evidence.md
+++ b/research/extension-platform/spike-evidence.md
@@ -208,9 +208,11 @@ a symlink can therefore prevent the server from booting. Related to
 [T-16](threat-model.md#t-16--plugin-directory-deletion-by-manifest-name-collision--high-accepted),
 and the reason the fixtures moved out of `/config/plugins`.
 
-The remaining gap is TOCTOU: the path is validated and then opened, with no
-revalidation on the handle —
-[#494](https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/issues/494).
+The spike's remaining TOCTOU gap is closed by #647's production reader: the
+opened descriptor is the authority, its resolved target must remain inside the
+verified root, descriptor state is compared before and after the bounded read,
+and a fresh Jellyfin host snapshot must still match before an immutable bound
+observation can be returned. The pre-open resolution is defense in depth only.
 
 ## S6 — Provider failure modes all map to bounded host errors
 
@@ -566,8 +568,15 @@ declines rather than guessing. A real kernel retries; it does not relax the chec
 `open(2)` on a FIFO **blocks until a writer appears**. A plugin that ships a named
 pipe called `jellyfin-canopy-extension.json` would hang the reader indefinitely —
 and discovery iterates every plugin, so one such file stalls discovery for all of
-them. The open is now bounded and the candidate refused. Directories are rejected
-before the open rather than by failing it.
+them. The spike bounded the open and refused the candidate. The production #647
+reader instead avoids the blocking content open entirely: it opens metadata with
+nonblocking/descriptor semantics, rejects non-regular types, and accepts only an
+explicit local-filesystem allow-list on Linux or fixed local drives on Windows.
+Classification itself still requires a first root lookup, and this does not claim
+that in-process code can kill a synchronous kernel/driver operation after the OS
+accepts it or safely reclaim buffers before cancelled Windows I/O completes. That
+host-availability residual is recorded in ADR-0005 and the threat model and tracked
+by #648. Directories are rejected before content reading.
 
 Two related notes: a 5,000-character name is refused by the platform
 (`PathTooLongException`), and neither Unicode normalisation form of `café.json`

--- a/research/extension-platform/threat-model.md
+++ b/research/extension-platform/threat-model.md
@@ -162,12 +162,22 @@ extension, a compromised supply chain, a fork that copied a manifest, and a
 partially completed install. It is worth doing for exactly those cases.
 
 *Mitigation.* Manifests are read only from the root `IPluginManager` reports and
-fingerprint-bound to the GUID Jellyfin reports
+bound exactly to the GUID and canonical version Jellyfin reports
 ([S4](spike-evidence.md#s4--manifest-discovery-binds-to-the-real-plugin-identity-and-rejects-a-claim-to-another)).
-Traversal, absolute paths, embedded NUL and escaping symlinks are rejected before
-any file is opened
+The production reader opens only the fixed manifest leaf with nonblocking Linux
+descriptors or cancellable overlapped Windows reads, rejects non-regular or
+unverifiable descriptors before reading, and supports only an explicit
+local-filesystem allow-list on Linux or fixed local drives on Windows. It verifies
+the descriptor-resolved target inside the descriptor-verified root, caps the
+owned read at 256 KiB plus one detection byte, and rechecks root, file, DLL-name
+and host observations after the read. In-root links are accepted only when
+their resolved target and opened descriptor agree; traversal, separator aliases,
+embedded NUL, broken/cyclic links, root escapes and TOCTOU swaps fail closed
 ([S5](spike-evidence.md#s5--path-containment-holds-against-traversal-symlinks-and-link-cycles)).
-Size, malformed-JSON and non-object manifests are rejected before registration, and a fingerprint mismatch is a rejection rather than a flag — all verified. A manifest requests; an admin grants.
+FIFO, socket, device and directory leaves are type-probed without a blocking
+content open. Size, malformed-JSON and non-object manifests are rejected before
+any future registration, and identity mismatch is a rejection rather than a flag.
+The host-bound result is explicitly unapproved: a manifest requests; an admin grants.
 Issue #645 additionally freezes the pure pre-filesystem contract: strict bounded
 UTF-8 JSON, closed fields, canonical identifiers/versions/ranges, exact
 provider-eligible requests through the #639 vocabulary, stable closed rejection
@@ -186,7 +196,17 @@ opening it leaked a file from outside the root on 17% of successful reads under 
 swap race, and validating the open descriptor instead leaked zero
 ([S16](spike-evidence.md#s16--the-manifest-read-is-a-toctou-and-a-fifo-stalls-it)).
 A FIFO shipped as a manifest, which would otherwise block discovery for every
-plugin, is refused by a bounded open.
+plugin, is refused before a content open. The residual availability limit is
+stated rather than hidden: filesystem classification itself requires a first root
+lookup, so a host-reported link can enter an unsupported target before rejection.
+Once any synchronous path lookup/open or overlapped read enters the kernel or
+storage driver, in-process Canopy cannot guarantee an absolute wall-clock deadline
+or safely reclaim native buffers until I/O ownership returns. Unknown, network and
+user-space filesystem roots are rejected after successful classification;
+application-controlled bytes, counts and concurrency are bounded, and no
+background worker is abandoned. Killable syscall isolation is tracked by #648. A
+wedged kernel/driver remains a host failure under Z0 until that separate boundary
+lands, not a sandbox guarantee.
 
 ### T-05 · Token theft through the provider boundary — **high, accepted**
 

--- a/research/extension-platform/v1-capability-freeze.md
+++ b/research/extension-platform/v1-capability-freeze.md
@@ -36,10 +36,11 @@ requested-versus-granted scopes; the lifecycle states in
 [compatibility-terminology](compatibility-terminology.md#state-words); a
 user-filtered catalog and admin diagnostics.
 
-**Activated for the server tranche; contract foundation delivered by #645.** The
+**Activated for the server tranche; acquisition foundation delivered by #645 and #647.** The
 strict installed-provider manifest v1 envelope and its canonical semantic
-fingerprint are frozen without reading a file or creating authority. Host-bound
-safe acquisition, approval/grants, lifecycle and persistence remain undelivered.
+fingerprint are frozen. An explicit descriptor-safe sweep can now bind that
+declaration to an immutable Jellyfin host GUID/version/assembly observation
+without creating authority. Approval/grants, lifecycle and persistence remain undelivered.
 Built-in Canopy families continue to need no third-party manifest or grant. Their existing
 caller-filtered C1/C6 catalog is not evidence for C2. Delivery requires the
 separate-plugin fixture, fingerprint-bound approval, grant/lifecycle tests and
@@ -288,7 +289,7 @@ health/circuit contract and runtime.
 | Capability | Delivered by | v1 scope |
 |---|---|---|
 | C1 discovery/negotiation | EP-01, EP-06 | **in** |
-| C2 registry + lifecycle | EP-02, EP-03 | **active server tranche; not yet delivered** |
+| C2 registry + lifecycle | EP-02, EP-03 | **active server tranche; manifest contract and host-bound acquisition delivered; registry/lifecycle pending** |
 | C3 provider invocation | EP-04 | **active server tranche; not yet delivered** |
 | C4 namespaced state | EP-05 | **active server tranche; not yet delivered** |
 | C5 events | EP-05 | **registry/provider lifecycle-health-invalidation subset active; broader Jellyfin/Canopy events deferred** |

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,7 +26,7 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2808, totalLines: 3201 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 38465, totalLines: 47840 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 39220, totalLines: 48671 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 3,
         minimumCoveredLines: 2808,
@@ -34,8 +34,8 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
     });
     assert.deepEqual(baselines.profiles.server.observations, {
         cleanRuns: 3,
-        minimumCoveredLines: 38465,
-        maximumCoveredLines: 38465,
+        minimumCoveredLines: 39220,
+        maximumCoveredLines: 39220,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 0);

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 38465,
-        "totalLines": 47840
+        "coveredLines": 39220,
+        "totalLines": 48671
       },
       "observations": {
         "cleanRuns": 3,
-        "minimumCoveredLines": 38465,
-        "maximumCoveredLines": 38465
+        "minimumCoveredLines": 39220,
+        "maximumCoveredLines": 39220
       },
       "tolerance": {
         "missingCoveredLines": 0,
-        "rationale": "The #645 EP-03.1 manifest-contract change adds the strict installed-provider v1 schema and frozen inventory, a pure bounded fail-closed parser, immutable validated model, canonical domain-separated semantic fingerprint, exact provider capability ceiling, field-level schema/runtime drift gates, and hardened construction/dependency ownership guards without adding filesystem discovery, host binding, persistence, grants, routes, provider execution, or Android work. Three clean local .NET 10.0.9 Coverlet runs on the identical final 47,840-line source and test scope each passed all 3,574 tests and reproduced exactly 38,465 covered lines. The reviewed observed high-water and exact floor are therefore both 38,465/47,840 (80.403%), requiring no instrumentation tolerance. Relative to the #639 baseline of 38,132/47,506 (80.268%), the change adds 334 instrumented lines and 333 covered lines while increasing overall coverage. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "rationale": "The #647 EP-03.2 change adds host-issued installed-plugin snapshots, exact host reobservation, immutable manifest binding, bounded canonical discovery, Linux descriptor-safe fixed-leaf acquisition, Windows handle/reparse-aware acquisition, final root/manifest/DLL name and object revalidation, fixed byte/plugin/DLL/concurrency limits, fail-closed local/fixed-filesystem classification, adversarial filesystem tests, and a real Windows CI job without adding registry state, grants, routes, provider execution, startup work, or Android work. The Windows-native reader is excluded from Linux Coverlet because its P/Invoke branch cannot execute there; architecture tests bind that exclusion to the blocking windows-latest job. Three clean local .NET 10.0.9 Coverlet runs on the identical final 48,671-line source and test scope each passed all 3,689 tests and reproduced exactly 39,220 covered lines. The reviewed observed high-water and exact floor are therefore both 39,220/48,671 (80.582%), requiring no instrumentation tolerance. Relative to the #645 baseline of 38,465/47,840 (80.403%), the change adds 831 instrumented lines and 755 covered lines while increasing overall coverage. The initial-kernel-syscall/nonreturning-driver availability residual is explicitly decomposed to #648 rather than hidden by an abandoned worker. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
Closes #647
Parent: #42
Follow-up isolation boundary: #648

## What changed

- Adds immutable installed-plugin snapshots sourced only from Jellyfin host facts.
- Binds manifests to reobserved plugin GUID, typed version, exact status, root, and DLL inventory.
- Adds descriptor-safe Linux acquisition and handle-safe Windows acquisition with fixed-leaf lookup, local-filesystem checks, byte and DLL limits, mutation detection, cancellation, and final identity revalidation.
- Rejects duplicate host GUIDs, invalid metadata, links/escapes, special files, assembly mismatches, and over-limit inventories without partial discovery results.
- Adds a real Windows CI job plus extensive Linux and Windows adversarial coverage.
- Documents the remaining first-syscall/nonreturning-driver isolation boundary in #648.

## Authority boundaries

This PR does not add registry or grant authority, lifecycle/startup activation, provider invocation, routes, or Android-client behavior. It changes only the Canopy server/plugin repository.

## Validation

- Release build: 0 warnings, 0 errors
- Server tests: 3,689/3,689 across three clean coverage runs
- Server coverage: 39,220/48,671 (80.582%), exact baseline passed
- Existing client tests: 2,041/2,041; coverage 2,808/3,201 (87.723%), unchanged validation only
- Script tests: 641/641
- Docs, lint, type checks, syntax, performance rules, and translations passed
- Three independent agent reviews approved architecture/security/test completeness

## Security decomposition

The in-process boundary is deliberately honest: descriptor/handle verification, bounded reads, cancellation, and mutation resistance are implemented here. An absolute deadline against a nonreturning initial filesystem syscall requires a killable isolation boundary and remains tracked in #648.
